### PR TITLE
Clear ArrayTransformer::ack_pair to avoid carrying stale information between queries.

### DIFF
--- a/src/AST/ArrayTransformer.h
+++ b/src/AST/ArrayTransformer.h
@@ -130,6 +130,7 @@ namespace BEEV
     void ClearAllTables(void)
     {
       arrayToIndexToRead.clear();
+      ack_pair.clear();
     }
 
     void printArrayStats()


### PR DESCRIPTION
This fixes a crashing bug if you make more than one STP query involving arrays in the same context. 
