### PR TITLE
Move AlreadyPrintedSet from STPManager to LispPrinter and eliminate IsAlreadyPrinted and MarkAlreadyPrinted from ASTNode.

### DIFF
--- a/src/AST/ASTNode.cpp
+++ b/src/AST/ASTNode.cpp
@@ -131,21 +131,6 @@ namespace BEEV
     return ParserBM;
   } //End of GetSTPMgr()
 
-  // Checks if the node has alreadybeen printed or not
-  bool ASTNode::IsAlreadyPrinted() const
-  {
-    STPMgr * bm = GetSTPMgr();
-    return (bm->AlreadyPrintedSet.find(*this) != 
-            bm->AlreadyPrintedSet.end());
-  } //End of IsAlreadyPrinted()
-
-  // Mark the node as printed if it has been already printed
-  void ASTNode::MarkAlreadyPrinted() const
-  {
-    STPMgr * bm = GetSTPMgr();
-    bm->AlreadyPrintedSet.insert(*this);
-  } //End of MarkAlreadyPrinted()
-
   // Print the node
   void ASTNode::nodeprint(ostream& os, bool c_friendly) const
   {

--- a/src/AST/ASTNode.h
+++ b/src/AST/ASTNode.h
@@ -233,11 +233,6 @@ namespace BEEV
     } //End of isPred()
 
 
-    // For lisp DAG printing.  Has it been printed already, so we can
-    // just print the node number?
-    bool IsAlreadyPrinted() const;
-    void MarkAlreadyPrinted() const;
-
     // delegates to the ASTInternal node.
     void nodeprint(ostream& os, bool c_friendly = false) const;
 

--- a/src/AST/TestAST/bbtest.cpp
+++ b/src/AST/TestAST/bbtest.cpp
@@ -23,7 +23,6 @@ int main()
   cout << "bitblasted c1 " << endl;
   LispPrintVec(cout, bbc1, 0);
   cout << endl;
-  bm->AlreadyPrintedSet.clear();
 
   ASTNode c2 = bm->CreateBVConst(size, 1);
   c2.SetValueWidth(size);
@@ -32,7 +31,6 @@ int main()
   cout << "bitblasted c2 " << endl;
   LispPrintVec(cout, bbc2, 0);
   cout << endl;
-  bm->AlreadyPrintedSet.clear();
 
   ASTNode c3 = bm->CreateBVConst(size, 0xFFFFFFFF);
   c3.SetValueWidth(size);
@@ -41,7 +39,6 @@ int main()
   cout << "bitblasted c3 " << endl;
   LispPrintVec(cout, bbc3, 0);
   cout << endl;
-  bm->AlreadyPrintedSet.clear();
 
   ASTNode c4 = bm->CreateBVConst(size, 0xAAAAAAAA);
   c4.SetValueWidth(size);
@@ -50,7 +47,6 @@ int main()
   cout << "bitblasted c4 " << endl;
   LispPrintVec(cout, bbc4, 0);
   cout << endl;
-  bm->AlreadyPrintedSet.clear();
 
   //   ASTNode b1 = bm->CreateBVConst(12);
   //   ASTNode b2 = bm->CreateBVConst(36);
@@ -64,7 +60,6 @@ int main()
   cout << "bitblasted a1 " << endl;
   LispPrintVec(cout, bba1, 0);
   cout << endl;
-  bm->AlreadyPrintedSet.clear();
 
   ASTNode a2 = bm->CreateNode(BVPLUS, s1, s2, s3);
   a1.SetValueWidth(2);
@@ -73,7 +68,6 @@ int main()
   cout << "bitblasted a2 " << endl;
   LispPrintVec(cout, bba2, 0);
   cout << endl;
-  bm->AlreadyPrintedSet.clear();
 
   ASTNode a3 = bm->CreateNode(BVXOR, s1, s2);
   a3.SetValueWidth(2);
@@ -82,7 +76,6 @@ int main()
   cout << "bitblasted a3 " << endl;
   LispPrintVec(cout, bba3, 0);
   cout << endl;
-  bm->AlreadyPrintedSet.clear();
 
   ASTNode a4 = bm->CreateNode(EQ, s1, s2);
   ASTNode bba4 = bm->BBForm(a4);

--- a/src/STPManager/STPManager.cpp
+++ b/src/STPManager/STPManager.cpp
@@ -411,6 +411,7 @@ namespace BEEV
   /** Print a vector of ASTNodes in lisp format */
   ostream &LispPrintVec(ostream &os, const ASTVec &v, int indentation)
   {
+    printer::Lisp_AlreadyPrintedSet.clear();
     // Print the children
     ASTVec::const_iterator iend = v.end();
     for (ASTVec::const_iterator i = v.begin(); i != iend; i++)

--- a/src/STPManager/STPManager.h
+++ b/src/STPManager/STPManager.h
@@ -409,9 +409,6 @@ namespace BEEV
     // Not filled in by the smtlib parser.
     ASTVec ListOfDeclaredVars;
     
-    // Table for DAG printing.
-    ASTNodeSet AlreadyPrintedSet;
-    
     //Nodes seen so far
     ASTNodeSet PLPrintNodeSet;
 
@@ -474,7 +471,6 @@ namespace BEEV
       NodeLetVarMap.clear();
       NodeLetVarMap1.clear();
       PLPrintNodeSet.clear();
-      AlreadyPrintedSet.clear();
       TermsAlreadySeenMap.clear();
       NodeLetVarVec.clear();
       ListOfDeclaredVars.clear();

--- a/src/printer/AssortedPrinters.cpp
+++ b/src/printer/AssortedPrinters.cpp
@@ -66,7 +66,6 @@ namespace BEEV
 
   void lpvec(const ASTVec &vec)
   {
-    (vec[0].GetSTPMgr())->AlreadyPrintedSet.clear();
     LispPrintVec(cout, vec, 0);
     cout << endl;
   }

--- a/src/printer/LispPrinter.cpp
+++ b/src/printer/LispPrinter.cpp
@@ -15,6 +15,7 @@ namespace printer
   using std::string;
   using namespace BEEV;
 
+  ASTNodeSet Lisp_AlreadyPrintedSet;
   ostream &Lisp_Print_indent(ostream &os,  const ASTNode& n,int indentation);
 
 
@@ -63,7 +64,7 @@ namespace printer
         // os << "(" << _int_node_ptr->_ref_count << ")";
         // os << "{" << GetValueWidth() << "}";
       }
-    else if (n.IsAlreadyPrinted())
+    else if (Lisp_AlreadyPrintedSet.find(n) != Lisp_AlreadyPrintedSet.end())
       {
         // print non-symbols as "[index]" if seen before.
         os << "[" << n.GetNodeNum() << "]";
@@ -71,7 +72,7 @@ namespace printer
       }
     else
       {
-        n.MarkAlreadyPrinted();
+        Lisp_AlreadyPrintedSet.insert(n);
         const ASTVec &children = n.GetChildren();
         os << n.GetNodeNum() << ":"
           //<< "(" << _int_node_ptr->_ref_count << ")"
@@ -91,8 +92,7 @@ namespace printer
   ostream &Lisp_Print(ostream &os, const ASTNode& n,  int indentation)
   {
     // Clear the PrintMap
-    STPMgr* bm = n.GetSTPMgr();
-    bm->AlreadyPrintedSet.clear();
+    Lisp_AlreadyPrintedSet.clear();
     Lisp_Print_indent(os, n, indentation);
     printf("\n");
     return os;

--- a/src/printer/printers.h
+++ b/src/printer/printers.h
@@ -31,6 +31,7 @@ namespace printer
 
   ostream& Lisp_Print(ostream &os, 
                       const BEEV::ASTNode& n,  int indentation=0);
+  extern BEEV::ASTNodeSet Lisp_AlreadyPrintedSet;
   ostream& Lisp_Print_indent(ostream &os,  
                              const BEEV::ASTNode& n,int indentation=0);
 


### PR DESCRIPTION
This refactoring eliminates a coupling between STPManager, LispPrinter and ASTNode.
