### PR TITLE
Build STP shared library using CMake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,17 +147,8 @@ find_package(FLEX REQUIRED)
 add_subdirectory(src)
 
 # -----------------------------------------------------------------------------
-# Copy built binaries to root (build) dir
+# Testing
 # -----------------------------------------------------------------------------
-
-add_custom_target(copy ALL COMMENT "Copying binaries from subdirs to build directory")
-add_custom_command(
-  TARGET copy
-  COMMAND ${CMAKE_COMMAND} -E copy src/main/stp .
-)
-add_dependencies(copy
-  stp
-)
 
 enable_testing()
 

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -1,14 +1,14 @@
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/../AST/)
 
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/GitSHA1.cpp.in" "${CMAKE_CURRENT_BINARY_DIR}/GitSHA1.cpp" @ONLY)
-add_executable(stp
-    main.cpp
-    #versionString.cpp
+
+add_library(stp-lib
     Globals.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/GitSHA1.cpp
 )
-
-target_link_libraries(stp
+set_target_properties(stp-lib PROPERTIES OUTPUT_NAME stp)
+set_target_properties(stp-lib PROPERTIES ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
+target_link_libraries(stp-lib
     stpmgr
     abstractionrefinement
     tosat
@@ -18,4 +18,12 @@ target_link_libraries(stp
     abc
     cinterface
     parser
+)
+
+add_executable(stp
+    main.cpp
+)
+set_target_properties(stp-lib PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
+target_link_libraries(stp
+    stp-lib
 )


### PR DESCRIPTION
Also use {ARCHIVE,RUNTIME}_OUTPUT_DIRECTORY properties to relocate build products rather than a custom target.

This addresses #38.
