### PR TITLE
Public C interface is now copied into include/stp by build system.

### DIFF
--- a/include/stp/c_interface.h
+++ b/include/stp/c_interface.h
@@ -1,1 +1,0 @@
-../../src/c_interface/c_interface.h

--- a/src/c_interface/CMakeLists.txt
+++ b/src/c_interface/CMakeLists.txt
@@ -6,3 +6,18 @@ add_library(cinterface
 )
 
 add_dependencies(cinterface ASTKind_header)
+
+# -----------------------------------------------------------------------------
+# Copy over public headers
+# -----------------------------------------------------------------------------
+
+set(public_headers c_interface.h)
+foreach(public_header ${public_headers})
+    add_custom_command(TARGET cinterface PRE_BUILD
+                       COMMAND ${CMAKE_COMMAND} -E
+                           echo Copying public header ${public_header}
+                       COMMAND ${CMAKE_COMMAND} -E
+                           copy ${CMAKE_CURRENT_SOURCE_DIR}/${public_header}
+                                ${CMAKE_BINARY_DIR}/include/stp/${public_header}
+                      )
+endforeach()


### PR DESCRIPTION
This fixes the problem where doing an out of souce build where
include/stp/c_interface.h would not be present.
