### PR TITLE
Add missing memUsedPeak functions to cryptominisat2 (mostly copied from minisat).

### DIFF
--- a/src/sat/cryptominisat2/CMakeLists.txt
+++ b/src/sat/cryptominisat2/CMakeLists.txt
@@ -19,4 +19,5 @@ add_library(cryptominisat2 OBJECT
     VarReplacer.cpp
     XorFinder.cpp
     XorSubsumer.cpp
+    time_mem.cpp
 )

--- a/src/sat/cryptominisat2/time_mem.cpp
+++ b/src/sat/cryptominisat2/time_mem.cpp
@@ -1,0 +1,10 @@
+#if defined(__APPLE__)
+/* the #include below #define TRUE, which conflicts with STP's TRUE in ASTKind.h */
+#include <malloc/malloc.h>
+
+double memUsed(void) {
+    malloc_statistics_t t;
+    malloc_zone_statistics(NULL, &t);
+    return (double)t.max_size_in_use / (1024*1024);
+}
+#endif

--- a/src/sat/cryptominisat2/time_mem.h
+++ b/src/sat/cryptominisat2/time_mem.h
@@ -89,11 +89,25 @@ static inline double memUsedPeak() {
 static inline uint64_t memUsed(void) {
     struct rusage ru;
     getrusage(RUSAGE_SELF, &ru);
-    return ru.ru_maxrss*1024; }
+    return ru.ru_maxrss*1024;
+}
+static inline double memUsedPeak(void) {
+    return memUsed();
+}
+
+
+#elif defined(__APPLE__)
+double memUsed(void);
+static inline double memUsedPeak(void) {
+    return memUsed();
+}
 
 
 #else
 static inline uint64_t memUsed() { return 0; }
+static inline double memUsedPeak(void) { return 0; }
+
+
 #endif
 
 #if defined(__linux__)


### PR DESCRIPTION
Since 0aea31b broke compilation on OS X (and probably other systems) due to a missing memUsedPeak.
