### PR TITLE
Actually print the version.

### DIFF
--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -369,6 +369,11 @@ int parse_options(int argc, char** argv)
         }
     }
 
+    if (vm.count("version")) {
+        cout << get_git_version() << std::endl;
+        exit(0);
+    }
+
     return 0;
 }
 


### PR DESCRIPTION
The "--version" command line option currently does not do anything.  This commit adds version printing to main.cpp
