### PR TITLE
Added CMake option ENABLE_ASSERTIONS which is enabled for default.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,9 +7,8 @@ set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules)
 # -----------------------------------------------------------------------------
 # Make RelWithDebInfo the default build type if otherwise not set
 # -----------------------------------------------------------------------------
-
+set(build_types Debug Release RelWithDebInfo MinSizeRel)
 if(NOT CMAKE_BUILD_TYPE)
-      set(build_types Debug Release RelWithDebInfo MinSizeRel)
 
       message(STATUS "You can choose the type of build, options are:${build_types}")
       set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE String
@@ -21,6 +20,34 @@ if(NOT CMAKE_BUILD_TYPE)
       set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS ${build_types})
 endif()
 message(STATUS "Doing a ${CMAKE_BUILD_TYPE} build")
+
+# -----------------------------------------------------------------------------
+# Option to enable/disable assertions
+# -----------------------------------------------------------------------------
+
+# Filter out definition of NDEBUG from the default build configuration flags.
+# We will add this ourselves if we want to disable assertions
+foreach (build_config ${build_types})
+    string(TOUPPER ${build_config} upper_case_build_config)
+    foreach (language CXX C)
+        set(VAR_TO_MODIFY "CMAKE_${language}_FLAGS_${upper_case_build_config}")
+        string(REGEX REPLACE "(^| )[/-]D *NDEBUG($| )"
+                             " "
+                             replacement
+                             "${${VAR_TO_MODIFY}}"
+              )
+        #message("Original (${VAR_TO_MODIFY}) is ${${VAR_TO_MODIFY}} replacement is ${replacement}")
+        set(${VAR_TO_MODIFY} "${replacement}" CACHE STRING "Default flags for ${build_config} configuration" FORCE)
+    endforeach()
+endforeach()
+
+option(ENABLE_ASSERTIONS "Build with assertions enabled" ON)
+if (ENABLE_ASSERTIONS)
+    # NDEBUG was already removed.
+else()
+    # Note this definition doesn't appear in the cache variables.
+    add_definitions(-DNDEBUG)
+endif()
 
 # -----------------------------------------------------------------------------
 # Enable LLVM sanitizations.


### PR DESCRIPTION
This will cause any build configuration (that we support) to be
built with assertions.

Internally this implemented by removing any `-DDEBUG` flags
from the CMAKE_CXX_FLAGS_<CONFIGURATION> and
CMAKE_C_FLAGS_<CONFIGURATION> cache variables. The `-DDEBUG` is
then manually added or removed using add_defintions() (note this
does not add the flags to cache variables).
