### PR TITLE
Alias analysis fixes.

### DIFF
--- a/src/STPManager/STP.cpp
+++ b/src/STPManager/STP.cpp
@@ -588,7 +588,7 @@ namespace BEEV {
 
     ToSATAIG toSATAIG(bm, cb, arrayTransformer);
 
-    ToSATBase* satBase = bm->UserFlags.isSet("traditional-cnf", "0") ? tosat : &toSATAIG) ;
+    ToSATBase* satBase = bm->UserFlags.isSet("traditional-cnf", "0") ? tosat : &toSATAIG;
 
     if (bm->soft_timeout_expired)
         return SOLVER_TIMEOUT;

--- a/src/extlib-abc/aig/dar/darRefact.c
+++ b/src/extlib-abc/aig/dar/darRefact.c
@@ -230,16 +230,16 @@ int Dar_RefactTryGraph( Aig_Man_t * pAig, Aig_Obj_t * pRoot, Vec_Ptr_t * vCut, K
     Kit_GraphForEachNode( pGraph, pNode, i )
     {
         // get the children of this node
-        pNode0 = Kit_GraphNode( pGraph, pNode->eEdge0.Node );
-        pNode1 = Kit_GraphNode( pGraph, pNode->eEdge1.Node );
+        pNode0 = Kit_GraphNode( pGraph, pNode->eEdge0.bits.Node );
+        pNode1 = Kit_GraphNode( pGraph, pNode->eEdge1.bits.Node );
         // get the AIG nodes corresponding to the children 
         pAnd0 = pNode0->pFunc; 
         pAnd1 = pNode1->pFunc; 
         if ( pAnd0 && pAnd1 )
         {
             // if they are both present, find the resulting node
-            pAnd0 = Aig_NotCond( pAnd0, pNode->eEdge0.fCompl );
-            pAnd1 = Aig_NotCond( pAnd1, pNode->eEdge1.fCompl );
+            pAnd0 = Aig_NotCond( pAnd0, pNode->eEdge0.bits.fCompl );
+            pAnd1 = Aig_NotCond( pAnd1, pNode->eEdge1.bits.fCompl );
             pAnd  = Aig_TableLookupTwo( pAig, pAnd0, pAnd1 );
             // return -1 if the node is the same as the original root
             if ( Aig_Regular(pAnd) == pRoot )
@@ -312,8 +312,8 @@ Aig_Obj_t * Dar_RefactBuildGraph( Aig_Man_t * pAig, Vec_Ptr_t * vCut, Kit_Graph_
 //printf( "Building (current number %d):\n", Aig_ManObjNumMax(pAig) );
     Kit_GraphForEachNode( pGraph, pNode, i )
     {
-        pAnd0 = Aig_NotCond( Kit_GraphNode(pGraph, pNode->eEdge0.Node)->pFunc, pNode->eEdge0.fCompl ); 
-        pAnd1 = Aig_NotCond( Kit_GraphNode(pGraph, pNode->eEdge1.Node)->pFunc, pNode->eEdge1.fCompl ); 
+        pAnd0 = Aig_NotCond( Kit_GraphNode(pGraph, pNode->eEdge0.bits.Node)->pFunc, pNode->eEdge0.bits.fCompl ); 
+        pAnd1 = Aig_NotCond( Kit_GraphNode(pGraph, pNode->eEdge1.bits.Node)->pFunc, pNode->eEdge1.bits.fCompl ); 
         pNode->pFunc = Aig_And( pAig, pAnd0, pAnd1 );
 /*
 printf( "Checking " );

--- a/src/extlib-abc/aig/kit/kitAig.c
+++ b/src/extlib-abc/aig/kit/kitAig.c
@@ -54,8 +54,8 @@ Aig_Obj_t * Kit_GraphToAigInternal( Aig_Man_t * pMan, Kit_Graph_t * pGraph )
     // build the AIG nodes corresponding to the AND gates of the graph
     Kit_GraphForEachNode( pGraph, pNode, i )
     {
-        pAnd0 = Aig_NotCond( Kit_GraphNode(pGraph, pNode->eEdge0.Node)->pFunc, pNode->eEdge0.fCompl ); 
-        pAnd1 = Aig_NotCond( Kit_GraphNode(pGraph, pNode->eEdge1.Node)->pFunc, pNode->eEdge1.fCompl ); 
+        pAnd0 = Aig_NotCond( Kit_GraphNode(pGraph, pNode->eEdge0.bits.Node)->pFunc, pNode->eEdge0.bits.fCompl ); 
+        pAnd1 = Aig_NotCond( Kit_GraphNode(pGraph, pNode->eEdge1.bits.Node)->pFunc, pNode->eEdge1.bits.fCompl ); 
         pNode->pFunc = Aig_And( pMan, pAnd0, pAnd1 );
     }
     // complement the result if necessary

--- a/src/extlib-abc/kit.h
+++ b/src/extlib-abc/kit.h
@@ -59,7 +59,7 @@ union Kit_Edge_t_
     struct {
         unsigned      fCompl   :  1;   // the complemented bit
         unsigned      Node     : 30;   // the decomposition node pointed by the edge
-    };
+    } bits;
     unsigned          edgeInt;
 };
 
@@ -207,17 +207,17 @@ static inline void         Kit_SopPushCube( Kit_Sop_t * cSop, unsigned uCube )  
 static inline void         Kit_SopWriteCube( Kit_Sop_t * cSop, unsigned uCube, int i )    { cSop->pCubes[i] = uCube;                }
 
 static inline Kit_Edge_t   Kit_EdgeCreate( int Node, int fCompl )                         { Kit_Edge_t eEdge = { { fCompl, Node } }; return eEdge; }
-static inline unsigned     Kit_EdgeToInt( Kit_Edge_t eEdge )                              { return (eEdge.Node << 1) | eEdge.fCompl;            }
+static inline unsigned     Kit_EdgeToInt( Kit_Edge_t eEdge )                              { return (eEdge.bits.Node << 1) | eEdge.bits.fCompl;  }
 static inline Kit_Edge_t   Kit_IntToEdge( unsigned Edge )                                 { return Kit_EdgeCreate( Edge >> 1, Edge & 1 );       }
 static inline unsigned     Kit_EdgeToInt_( Kit_Edge_t eEdge )                             { return eEdge.edgeInt;                               }
 static inline Kit_Edge_t   Kit_IntToEdge_( unsigned Edge )                                { Kit_Edge_t eEdge; eEdge.edgeInt = Edge; return eEdge; }
 
 static inline int          Kit_GraphIsConst( Kit_Graph_t * pGraph )                       { return pGraph->fConst;                              }
-static inline int          Kit_GraphIsConst0( Kit_Graph_t * pGraph )                      { return pGraph->fConst && pGraph->eRoot.fCompl;      }
-static inline int          Kit_GraphIsConst1( Kit_Graph_t * pGraph )                      { return pGraph->fConst && !pGraph->eRoot.fCompl;     }
-static inline int          Kit_GraphIsComplement( Kit_Graph_t * pGraph )                  { return pGraph->eRoot.fCompl;                        }
-static inline int          Kit_GraphIsVar( Kit_Graph_t * pGraph )                         { return pGraph->eRoot.Node < (unsigned)pGraph->nLeaves; }
-static inline void         Kit_GraphComplement( Kit_Graph_t * pGraph )                    { pGraph->eRoot.fCompl ^= 1;                          }
+static inline int          Kit_GraphIsConst0( Kit_Graph_t * pGraph )                      { return pGraph->fConst && pGraph->eRoot.bits.fCompl; }
+static inline int          Kit_GraphIsConst1( Kit_Graph_t * pGraph )                      { return pGraph->fConst && !pGraph->eRoot.bits.fCompl; }
+static inline int          Kit_GraphIsComplement( Kit_Graph_t * pGraph )                  { return pGraph->eRoot.bits.fCompl;                   }
+static inline int          Kit_GraphIsVar( Kit_Graph_t * pGraph )                         { return pGraph->eRoot.bits.Node < (unsigned)pGraph->nLeaves; }
+static inline void         Kit_GraphComplement( Kit_Graph_t * pGraph )                    { pGraph->eRoot.bits.fCompl ^= 1;                     }
 static inline void         Kit_GraphSetRoot( Kit_Graph_t * pGraph, Kit_Edge_t eRoot )     { pGraph->eRoot = eRoot;                              }
 static inline int          Kit_GraphLeaveNum( Kit_Graph_t * pGraph )                      { return pGraph->nLeaves;                             }
 static inline int          Kit_GraphNodeNum( Kit_Graph_t * pGraph )                       { return pGraph->nSize - pGraph->nLeaves;             }
@@ -225,11 +225,11 @@ static inline Kit_Node_t * Kit_GraphNode( Kit_Graph_t * pGraph, int i )         
 static inline Kit_Node_t * Kit_GraphNodeLast( Kit_Graph_t * pGraph )                      { return pGraph->pNodes + pGraph->nSize - 1;          }
 static inline int          Kit_GraphNodeInt( Kit_Graph_t * pGraph, Kit_Node_t * pNode )   { return pNode - pGraph->pNodes;                      }
 static inline int          Kit_GraphNodeIsVar( Kit_Graph_t * pGraph, Kit_Node_t * pNode ) { return Kit_GraphNodeInt(pGraph,pNode) < pGraph->nLeaves; }
-static inline Kit_Node_t * Kit_GraphVar( Kit_Graph_t * pGraph )                           { assert( Kit_GraphIsVar( pGraph ) );    return Kit_GraphNode( pGraph, pGraph->eRoot.Node );      }
+static inline Kit_Node_t * Kit_GraphVar( Kit_Graph_t * pGraph )                           { assert( Kit_GraphIsVar( pGraph ) );    return Kit_GraphNode( pGraph, pGraph->eRoot.bits.Node ); }
 static inline int          Kit_GraphVarInt( Kit_Graph_t * pGraph )                        { assert( Kit_GraphIsVar( pGraph ) );    return Kit_GraphNodeInt( pGraph, Kit_GraphVar(pGraph) ); }
-static inline Kit_Node_t * Kit_GraphNodeFanin0( Kit_Graph_t * pGraph, Kit_Node_t * pNode ){ return Kit_GraphNodeIsVar(pGraph, pNode)? NULL : Kit_GraphNode(pGraph, pNode->eEdge0.Node);     }
-static inline Kit_Node_t * Kit_GraphNodeFanin1( Kit_Graph_t * pGraph, Kit_Node_t * pNode ){ return Kit_GraphNodeIsVar(pGraph, pNode)? NULL : Kit_GraphNode(pGraph, pNode->eEdge1.Node);     }
-static inline int          Kit_GraphRootLevel( Kit_Graph_t * pGraph )                     { return Kit_GraphNode(pGraph, pGraph->eRoot.Node)->Level;                                        }
+static inline Kit_Node_t * Kit_GraphNodeFanin0( Kit_Graph_t * pGraph, Kit_Node_t * pNode ){ return Kit_GraphNodeIsVar(pGraph, pNode)? NULL : Kit_GraphNode(pGraph, pNode->eEdge0.bits.Node); }
+static inline Kit_Node_t * Kit_GraphNodeFanin1( Kit_Graph_t * pGraph, Kit_Node_t * pNode ){ return Kit_GraphNodeIsVar(pGraph, pNode)? NULL : Kit_GraphNode(pGraph, pNode->eEdge1.bits.Node); }
+static inline int          Kit_GraphRootLevel( Kit_Graph_t * pGraph )                     { return Kit_GraphNode(pGraph, pGraph->eRoot.bits.Node)->Level;                                   }
 
 static inline int          Kit_BitWordNum( int nBits )    { return nBits/(8*sizeof(unsigned)) + ((nBits%(8*sizeof(unsigned))) > 0); }
 static inline int          Kit_TruthWordNum( int nVars )  { return nVars <= 5 ? 1 : (1 << (nVars - 5));                             }


### PR DESCRIPTION
GCC complains about violations of the alias analysis rules, necessitating use of -fno-strict-aliasing when compiling to be sure that good code is generated.  This patch fixes the violations so that -fstrict-aliasing is safe.

The first fix is trivial: remove a typecast from STP.cpp.  The ToSATAIG class already inherits directly from ToSATBase, so the typecast isn't merely unnecessary and confusing to the alias analysis code, but actually wrong.

The second fix introduces a union and an anonymous struct to fix aliasing problems in the ABC code.  If some compiler of interest does not like the anonymous struct, a more invasive change can be made by naming the struct and fixing up all references to the fCompl and Node fields.  Note that the Kit_Float2Int and Kit_Int2Float definitions are simply removed, because they are unused and fixing them properly would require an invasive change.
