### PR TITLE
Small tweaks to satisfy strict GCC/Clang warnings

### DIFF
--- a/include/stp/AST/AST.h
+++ b/include/stp/AST/AST.h
@@ -37,8 +37,8 @@ namespace BEEV
 // TODO remove -- only used in c_interface.cpp NOT from main.cpp
 void process_argument(const char ch, STPMgr* bm);
 
-void FatalError(const char* str, const ASTNode& a, int w = 0);
-void FatalError(const char* str);
+void FatalError [[noreturn]] (const char* str, const ASTNode& a, int w = 0);
+void FatalError [[noreturn]] (const char* str);
 void SortByExprNum(ASTVec& c);
 void SortByArith(ASTVec& c);
 bool exprless(const ASTNode n1, const ASTNode n2);

--- a/include/stp/AST/ASTBVConst.h
+++ b/include/stp/AST/ASTBVConst.h
@@ -28,7 +28,6 @@ THE SOFTWARE.
 namespace BEEV
 {
 class STPMgr;
-void FatalError(const char* str);
 
 /******************************************************************
  *  Class ASTBVConst:                                             *

--- a/include/stp/AST/ArrayTransformer.h
+++ b/include/stp/AST/ArrayTransformer.h
@@ -83,9 +83,6 @@ private:
   // formulas and terms
   ASTNodeMap* TransformMap;
 
-  // Flag for debuggin the transformer
-  const bool debug_transform;
-
   // Ptr to an external simplifier
   Simplifier* simp;
 
@@ -123,7 +120,7 @@ public:
 
   // Constructor
   ArrayTransformer(STPMgr* bm, Simplifier* s)
-      : TransformMap(NULL), debug_transform(0), simp(s), bm(bm)
+      : TransformMap(NULL), simp(s), bm(bm)
   {
     nf = bm->defaultNodeFactory;
 

--- a/include/stp/STPManager/NodeIterator.h
+++ b/include/stp/STPManager/NodeIterator.h
@@ -87,13 +87,13 @@ public:
 
   ASTNode end() { return sentinel; }
 
-  virtual bool ok(const ASTNode n) { return true; }
+  virtual bool ok(const ASTNode& n) { return true; }
 };
 
 // Iterator that omits return atoms.
 class NonAtomIterator : public NodeIterator
 {
-  virtual bool ok(const ASTNode& n) { return !n.isAtom(); }
+  virtual bool ok(const ASTNode& n) override { return !n.isAtom(); }
 
 public:
   NonAtomIterator(const ASTNode& n, const ASTNode& uf, STPMgr& stp)

--- a/include/stp/Sat/MinisatCore_prop.h
+++ b/include/stp/Sat/MinisatCore_prop.h
@@ -26,7 +26,7 @@ THE SOFTWARE.
  * Wraps around minisat with array propagators
  */
 #ifndef MINISATCORE_PROP_H_
-#define MINIASTCORE_PROP_H_
+#define MINISATCORE_PROP_H_
 
 #include "SATSolver.h"
 

--- a/include/stp/Simplifier/constantBitP/ConstantBitP_TransferFunctions.h
+++ b/include/stp/Simplifier/constantBitP/ConstantBitP_TransferFunctions.h
@@ -30,7 +30,7 @@ namespace simplifier
 {
 namespace constantBitP
 {
-class MultiplicationStats;
+struct MultiplicationStats;
 
 // Multiply is not yet  maximally precise.
 //!!!!!!!

--- a/include/stp/Simplifier/constantBitP/FixedBits.h
+++ b/include/stp/Simplifier/constantBitP/FixedBits.h
@@ -36,7 +36,6 @@ namespace BEEV
 {
 class ASTNode;
 typedef unsigned int* CBV;
-void FatalError(const char* str);
 }
 
 namespace simplifier

--- a/lib/AST/ASTmisc.cpp
+++ b/lib/AST/ASTmisc.cpp
@@ -253,10 +253,7 @@ void FatalError(const char* str, const ASTNode& a, int w)
   {
     vc_error_hdlr(str);
   }
-  else
-  {
-    exit(-1);
-  }
+  exit(-1);
 }
 
 void FatalError(const char* str)
@@ -266,10 +263,7 @@ void FatalError(const char* str)
   {
     vc_error_hdlr(str);
   }
-  else
-  {
-    exit(-1);
-  }
+  exit(-1);
 }
 
 void SortByExprNum(ASTVec& v)

--- a/lib/Sat/cryptominisat2/Logger.cpp
+++ b/lib/Sat/cryptominisat2/Logger.cpp
@@ -374,7 +374,7 @@ void Logger::end(const finish_type finish)
 
         int res = fclose(proof);
         if (!res) {
-            assert(!"Unexpected failure of fclose()");
+            assert(0 && "Unexpected failure of fclose()");
         }
         proof = NULL;
         assert(proof == NULL);

--- a/lib/Sat/minisat/core_prop/Solver_prop.cc
+++ b/lib/Sat/minisat/core_prop/Solver_prop.cc
@@ -345,8 +345,6 @@ void Solver_prop::assertIndexesEqual(ArrayAccess &a, ArrayAccess &b)
         }
 }
 
-const bool debug_equals_lit=false;
-
 CRef
 Solver_prop::addExtraClause(vec<Lit>& c)
 {

--- a/lib/Simplifier/RemoveUnconstrained.cpp
+++ b/lib/Simplifier/RemoveUnconstrained.cpp
@@ -42,8 +42,6 @@ RemoveUnconstrained::RemoveUnconstrained(STPMgr& _bm) : bm(_bm)
   nf = _bm.defaultNodeFactory;
 }
 
-const bool debug_unconstrained = false;
-
 ASTNode RemoveUnconstrained::topLevel(const ASTNode& n, Simplifier* simplifier)
 {
   ASTNode result(n);

--- a/lib/Simplifier/SubstitutionMap.cpp
+++ b/lib/Simplifier/SubstitutionMap.cpp
@@ -38,10 +38,6 @@ SubstitutionMap::~SubstitutionMap()
   delete SolverMap;
 }
 
-// if false. Don't simplify while creating the substitution map.
-// This makes it easier to spot how long is spent in the simplifier.
-const bool simplify_during_create_subM = false;
-
 // if a is READ(Arr,const) and b is BVCONST then return 1.
 // if a is a symbol SYMBOL, return 1.
 // if b is READ(Arr,const) and a is BVCONST then return -1

--- a/lib/Simplifier/bvsolver.cpp
+++ b/lib/Simplifier/bvsolver.cpp
@@ -54,7 +54,6 @@ THE SOFTWARE.
 namespace BEEV
 {
 const bool flatten_ands = true;
-const bool sort_extracts_last = false;
 const bool debug_bvsolver = false;
 
 // The simplify functions can increase the size of the DAG,

--- a/lib/Simplifier/constantBitP/ConstantBitP_Arithmetic.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_Arithmetic.cpp
@@ -439,7 +439,7 @@ Result bvAddBothWays(vector<FixedBits*>& children, FixedBits& output)
     // go from high to low, making each of the sums consistent.
     for (int i = /**/ (int)bitWidth - 1 /**/; i >= 1; i--)
     {
-      if ((sumH[i] == sumL[i]))
+      if (sumH[i] == sumL[i])
       {
         stats s = getStats(children, i);
 

--- a/lib/Simplifier/constantBitP/ConstantBitP_Comparison.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_Comparison.cpp
@@ -162,6 +162,7 @@ bool fast_exit(FixedBits& c0, FixedBits& c1)
     }
     return false;
   }
+  return false;
 }
 
 ///////// Signed operations.


### PR DESCRIPTION
Specifically, the following flags are no longer needed when building
within Chromium:

-Wno-header-guard
  Originally needed due to a typo in MinisatCore_prop.h
-Wno-mismatched-tags
  MultiplicationStats is a struct, but was forward declared as a class
-Wno-overloaded-virtual
  NonAtomIterator::ok(const ASTNode&) presumably meant to overload
  NodeIterator::ok(const ASTNode)
-Wno-parentheses-equality
  GCC/Clang suggest using "if (x == y)" and "if ((x = y))", and warn
  against "if (x = y)" and "if ((x == y))" as typos.
-Wno-return-type
  Some functions didn't always return a value;
  notably some functions didn't return because they called FatalError(),
  but the compiler didn't know that FatalError() doesn't return.
-Wno-string-conversion
  Clang doesn't like the string-literal-to-bool conversion in assert(!"foo");
  LLVM style is to write assert(0 && "foo").
-Wno-unused-const-variable
-Wno-unused-private-field
  A handful of debug variables that are never tested.
