### PR TITLE
removed never-interactive in smt2.lex ...

### DIFF
--- a/lib/Parser/smt2.lex
+++ b/lib/Parser/smt2.lex
@@ -48,6 +48,11 @@
   extern char *smt2text;
   extern int smt2error (const char *msg);
 
+#ifdef _MSC_VER
+  #include <io.h>
+  int isatty(int fd) { return _isatty(fd); }
+#endif
+
   // File-static (local to this file) variables and functions
   static std::string _string_lit;  
   static char escapeChar(char c) {
@@ -113,7 +118,6 @@
 	}
 %}
 
-%option never-interactive
 %option noyywrap
 %option nounput
 %option noreject


### PR DESCRIPTION
Without never-interactive, lex generates code that calls the function
isatty(), which fails with Visual Studio 2013 (didn't check for other
version). According to [1], isatty() is deprecated and _isatty() should be
used instead. _isatty() is in io.h, so this patch inludes io.h and defines
isatty() to call _isatty() for windows.

Seems to work fine on my system now, but did not check on Linux. This
patch only does this for smt2, not for smt or cvc, because AFAIK those are not
interactive.

[1] http://msdn.microsoft.com/library/ms235388.aspx
