### PR TITLE
SimplifyingMinisat: return value from bool function

### DIFF
--- a/lib/Sat/SimplifyingMinisat.cpp
+++ b/lib/Sat/SimplifyingMinisat.cpp
@@ -73,6 +73,7 @@ bool SimplifyingMinisat::solve(bool& timeout_expired) // Search without assumpti
   if (ret == (Minisat::lbool)l_Undef) {
     timeout_expired = true;
   }
+  return true;
 }
 
 bool SimplifyingMinisat::simplify() // Removes already satisfied clauses.


### PR DESCRIPTION
compiler complains: control reaches end of non-void function