### PR TITLE
fix CMAKE_INSTALL_LIBDIR bug I introduced

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ endif()
 # Search paths for custom CMake modules
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules)
 
-set(CMAKE_INSTALL_LIBDIR lib CACHE PATH "Output directory for libraries")
+set(CMAKE_INSTALL_LIBDIR lib CACHE STRING "Output directory for libraries")
 
 set(STP_TIMESTAMPS ON CACHE BOOL "Enable build with timestamps")
 


### PR DESCRIPTION
Commit ffa79942584bc61919f93a97c2394809c9291ff9 (CMakeLists: support
different lib dirs) added possibility to override the directory where
libraries are installed. But when using the PATH type, the path is
being evaluated absolute to the current working directory. The
libraries then end up in a weird local directory suffixed by the lib
string.

In fact we want CMAKE_INSTALL_LIBDIR to be a string like lib or lib64,
so switch PATH to STRING.

Signed-off-by: Jiri Slaby <jslaby@suse.cz>