### PR TITLE
Attempt to hide all symbols apart from those we want to be public in

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,6 +221,18 @@ include(CheckCxxHashMap)
 check_cxx_hashmap()
 
 # -----------------------------------------------------------------------------
+# Setup symbol visibility flags
+# -----------------------------------------------------------------------------
+include(GenerateExportHeader)
+# FIXME: YUCK! I know this is deprecated but *_VISIBILITY_PRESET and VISIBILITY_INLINES_HIDDEN
+# properties don't work on shared libraries built from OBJECT libraries.
+add_compiler_export_flags(CXX_SYMBOL_VISIBILITY_FLAGS)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_SYMBOL_VISIBILITY_FLAGS}")
+# Note -fvisibility-inlines-hidden is not a valid option when compiling C
+string(REPLACE -fvisibility-inlines-hidden "" C_SYMBOL_VISIBILITY_FLAGS ${CXX_SYMBOL_VISIBILITY_FLAGS})
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${C_SYMBOL_VISIBILITY_FLAGS}")
+
+# -----------------------------------------------------------------------------
 # Add GIT version
 # -----------------------------------------------------------------------------
 function(SetVersionNumber PREFIX VERSION_MAJOR VERSION_MINOR VERSION_PATCH)
@@ -367,6 +379,7 @@ endif()
 # -----------------------------------------------------------------------------
 
 message(STATUS "Final CXX flags ${CMAKE_CXX_FLAGS}")
+message(STATUS "Final C flags ${CMAKE_C_FLAGS}")
 add_subdirectory(lib)
 add_subdirectory(tools)
 add_subdirectory(bindings)

--- a/include/stp/c_interface.h
+++ b/include/stp/c_interface.h
@@ -31,6 +31,8 @@ THE SOFTWARE.
 #define _CVCL_DEFAULT_ARG(v)
 #endif
 
+#include "stp/stp_export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -58,8 +60,8 @@ typedef void* WholeCounterExample;
 // The "num_absrefine" argument isn't used at all. It's left for compatibility
 // with existing code.
 // TODO remove these two functions, it's an ugly way of controlling settings
-void vc_setFlags(VC vc, char c, int num_absrefine _CVCL_DEFAULT_ARG(0));
-void vc_setFlag(VC vc, char c);
+LIBSTP_EXPORT void vc_setFlags(VC vc, char c, int num_absrefine _CVCL_DEFAULT_ARG(0));
+LIBSTP_EXPORT void vc_setFlag(VC vc, char c);
 
 //! Interface-only flags.
 enum ifaceflag_t
@@ -76,20 +78,20 @@ enum ifaceflag_t
   MSP
 
 };
-void vc_setInterfaceFlags(VC vc, enum ifaceflag_t f, int param_value);
+LIBSTP_EXPORT void vc_setInterfaceFlags(VC vc, enum ifaceflag_t f, int param_value);
 
 // defines division by zero to equal 1, x%0 to equal x.
 // avoids division by zero errors.
-void make_division_total(VC vc);
+LIBSTP_EXPORT void make_division_total(VC vc);
 
 //! Flags can be NULL
-VC vc_createValidityChecker(void);
+LIBSTP_EXPORT VC vc_createValidityChecker(void);
 
 // Basic types
-Type vc_boolType(VC vc);
+LIBSTP_EXPORT Type vc_boolType(VC vc);
 
 //! Create an array type
-Type vc_arrayType(VC vc, Type typeIndex, Type typeData);
+LIBSTP_EXPORT Type vc_arrayType(VC vc, Type typeIndex, Type typeData);
 
 /////////////////////////////////////////////////////////////////////////////
 // Expr manipulation methods                                               //
@@ -99,23 +101,23 @@ Type vc_arrayType(VC vc, Type typeIndex, Type typeData);
 /*! The type cannot be a function type. The var name can contain
   only variables, numerals and underscore. If you use any other
   symbol, you will get a segfault. */
-Expr vc_varExpr(VC vc, const char* name, Type type);
+LIBSTP_EXPORT Expr vc_varExpr(VC vc, const char* name, Type type);
 
 // The var name can contain only variables, numerals and
 // underscore. If you use any other symbol, you will get a segfault.
-Expr vc_varExpr1(VC vc, const char* name, int indexwidth, int valuewidth);
+LIBSTP_EXPORT Expr vc_varExpr1(VC vc, const char* name, int indexwidth, int valuewidth);
 
 //! Get the expression and type associated with a name.
 /*!  If there is no such Expr, a NULL Expr is returned. */
 // Expr vc_lookupVar(VC vc, char* name, Type* type);
 
 //! Get the type of the Expr.
-Type vc_getType(VC vc, Expr e);
+LIBSTP_EXPORT Type vc_getType(VC vc, Expr e);
 
-int vc_getBVLength(VC vc, Expr e);
+LIBSTP_EXPORT int vc_getBVLength(VC vc, Expr e);
 
 //! Create an equality expression.  The two children must have the same type.
-Expr vc_eqExpr(VC vc, Expr child0, Expr child1);
+LIBSTP_EXPORT Expr vc_eqExpr(VC vc, Expr child0, Expr child1);
 
 // Boolean expressions
 
@@ -125,48 +127,48 @@ Expr vc_eqExpr(VC vc, Expr child0, Expr child1);
 // conditional must always be Boolean, but the ifthenpart
 // (resp. elsepart) can be bit-vector or Boolean type. But, the
 // ifthenpart and elsepart must be both of the same type)
-Expr vc_trueExpr(VC vc);
-Expr vc_falseExpr(VC vc);
-Expr vc_notExpr(VC vc, Expr child);
-Expr vc_andExpr(VC vc, Expr left, Expr right);
-Expr vc_andExprN(VC vc, Expr* children, int numOfChildNodes);
-Expr vc_orExpr(VC vc, Expr left, Expr right);
-Expr vc_xorExpr(VC vc, Expr left, Expr right);
-Expr vc_orExprN(VC vc, Expr* children, int numOfChildNodes);
-Expr vc_impliesExpr(VC vc, Expr hyp, Expr conc);
-Expr vc_iffExpr(VC vc, Expr left, Expr right);
+LIBSTP_EXPORT Expr vc_trueExpr(VC vc);
+LIBSTP_EXPORT Expr vc_falseExpr(VC vc);
+LIBSTP_EXPORT Expr vc_notExpr(VC vc, Expr child);
+LIBSTP_EXPORT Expr vc_andExpr(VC vc, Expr left, Expr right);
+LIBSTP_EXPORT Expr vc_andExprN(VC vc, Expr* children, int numOfChildNodes);
+LIBSTP_EXPORT Expr vc_orExpr(VC vc, Expr left, Expr right);
+LIBSTP_EXPORT Expr vc_xorExpr(VC vc, Expr left, Expr right);
+LIBSTP_EXPORT Expr vc_orExprN(VC vc, Expr* children, int numOfChildNodes);
+LIBSTP_EXPORT Expr vc_impliesExpr(VC vc, Expr hyp, Expr conc);
+LIBSTP_EXPORT Expr vc_iffExpr(VC vc, Expr left, Expr right);
 // The output type of vc_iteExpr can be Boolean (formula-level ite)
 // or bit-vector (word-level ite)
-Expr vc_iteExpr(VC vc, Expr conditional, Expr ifthenpart, Expr elsepart);
+LIBSTP_EXPORT Expr vc_iteExpr(VC vc, Expr conditional, Expr ifthenpart, Expr elsepart);
 
 // Boolean to single bit BV Expression
-Expr vc_boolToBVExpr(VC vc, Expr form);
+LIBSTP_EXPORT Expr vc_boolToBVExpr(VC vc, Expr form);
 
 // Parameterized Boolean Expression (PARAMBOOL, Boolean_Var, parameter)
-Expr vc_paramBoolExpr(VC vc, Expr var, Expr param);
+LIBSTP_EXPORT Expr vc_paramBoolExpr(VC vc, Expr var, Expr param);
 
 // Arrays
 
 //! Create an expression for the value of array at the given index
-Expr vc_readExpr(VC vc, Expr array, Expr index);
+LIBSTP_EXPORT Expr vc_readExpr(VC vc, Expr array, Expr index);
 
 //! Array update; equivalent to "array WITH [index] := newValue"
-Expr vc_writeExpr(VC vc, Expr array, Expr index, Expr newValue);
+LIBSTP_EXPORT Expr vc_writeExpr(VC vc, Expr array, Expr index, Expr newValue);
 
 // Expr I/O: Parses directly from file in the c_interface. pretty cool!!
-Expr vc_parseExpr(VC vc, const char* s);
+LIBSTP_EXPORT Expr vc_parseExpr(VC vc, const char* s);
 
 //! Prints 'e' to stdout.
-void vc_printExpr(VC vc, Expr e);
+LIBSTP_EXPORT void vc_printExpr(VC vc, Expr e);
 
 //! Prints 'e' to stdout as C code
-void vc_printExprCCode(VC vc, Expr e);
+LIBSTP_EXPORT void vc_printExprCCode(VC vc, Expr e);
 
 //! print in smtlib format
-char* vc_printSMTLIB(VC vc, Expr e);
+LIBSTP_EXPORT char* vc_printSMTLIB(VC vc, Expr e);
 
 //! Prints 'e' into an open file descriptor 'fd'
-void vc_printExprFile(VC vc, Expr e, int fd);
+LIBSTP_EXPORT void vc_printExprFile(VC vc, Expr e, int fd);
 
 //! Prints state of 'vc' into malloc'd buffer '*buf' and stores the
 //  length into '*len'.  It is the responsibility of the caller to
@@ -175,37 +177,37 @@ void vc_printExprFile(VC vc, Expr e, int fd);
 
 //! Prints 'e' to malloc'd buffer '*buf'.  Sets '*len' to the length of
 //  the buffer. It is the responsibility of the caller to free the buffer.
-void vc_printExprToBuffer(VC vc, Expr e, char** buf, unsigned long* len);
+LIBSTP_EXPORT void vc_printExprToBuffer(VC vc, Expr e, char** buf, unsigned long* len);
 
 //! Prints counterexample to stdout.
-void vc_printCounterExample(VC vc);
+LIBSTP_EXPORT void vc_printCounterExample(VC vc);
 
 //! Prints variable declarations to stdout.
-void vc_printVarDecls(VC vc);
+LIBSTP_EXPORT void vc_printVarDecls(VC vc);
 
 //! Clear the internal list of variables to declare maintained for
 //  vc_printVarDecls. Do this after you've printed them, or if you
 //  never want to print them, to prevent a memory leak.
-void vc_clearDecls(VC vc);
+LIBSTP_EXPORT void vc_clearDecls(VC vc);
 
 //! Prints asserts to stdout. The flag simplify_print must be set to
 //"1" if you wish simplification to occur dring printing. It must be
 // set to "0" otherwise
-void vc_printAsserts(VC vc, int simplify_print _CVCL_DEFAULT_ARG(0));
+LIBSTP_EXPORT void vc_printAsserts(VC vc, int simplify_print _CVCL_DEFAULT_ARG(0));
 
 //! Prints the state of the query to malloc'd buffer '*buf' and
 // stores ! the length of the buffer to '*len'.  It is the
 // responsibility of the caller to free the buffer. The flag
 // simplify_print must be set to "1" if you wish simplification to
 // occur dring printing. It must be set to "0" otherwise
-void vc_printQueryStateToBuffer(VC vc, Expr e, char** buf, unsigned long* len,
+LIBSTP_EXPORT void vc_printQueryStateToBuffer(VC vc, Expr e, char** buf, unsigned long* len,
                                 int simplify_print);
 
 //! Similar to vc_printQueryStateToBuffer()
-void vc_printCounterExampleToBuffer(VC vc, char** buf, unsigned long* len);
+LIBSTP_EXPORT void vc_printCounterExampleToBuffer(VC vc, char** buf, unsigned long* len);
 
 //! Prints query to stdout.
-void vc_printQuery(VC vc);
+LIBSTP_EXPORT void vc_printQuery(VC vc);
 
 /////////////////////////////////////////////////////////////////////////////
 // Context-related methods                                                 //
@@ -213,10 +215,10 @@ void vc_printQuery(VC vc);
 
 //! Assert a new formula in the current context.
 /*! The formula must have Boolean type. */
-void vc_assertFormula(VC vc, Expr e);
+LIBSTP_EXPORT void vc_assertFormula(VC vc, Expr e);
 
 //! Simplify e with respect to the current context
-Expr vc_simplify(VC vc, Expr e);
+LIBSTP_EXPORT Expr vc_simplify(VC vc, Expr e);
 
 //! Check validity of e in the current context. e must be a FORMULA
 // returns 0 -> the input is INVALID
@@ -234,155 +236,155 @@ Expr vc_simplify(VC vc, Expr e);
 
 // The C-language doesn't allow default arguments, so to get it compiling, I've
 // split it into two functions.
-int vc_query_with_timeout(VC vc, Expr e, int timeout_ms);
-int vc_query(VC vc, Expr e);
+LIBSTP_EXPORT int vc_query_with_timeout(VC vc, Expr e, int timeout_ms);
+LIBSTP_EXPORT int vc_query(VC vc, Expr e);
 
 //! Return the counterexample after a failed query.
-Expr vc_getCounterExample(VC vc, Expr e);
+LIBSTP_EXPORT Expr vc_getCounterExample(VC vc, Expr e);
 
 //! Return an array from a counterexample after a failed query.
-void vc_getCounterExampleArray(VC vc, Expr e, Expr** indices, Expr** values,
+LIBSTP_EXPORT void vc_getCounterExampleArray(VC vc, Expr e, Expr** indices, Expr** values,
                                int* size);
 
 //! get size of counterexample, i.e. the number of variables/array
 // locations in the counterexample.
-int vc_counterexample_size(VC vc);
+LIBSTP_EXPORT int vc_counterexample_size(VC vc);
 
 //! Checkpoint the current context and increase the scope level
-void vc_push(VC vc);
+LIBSTP_EXPORT void vc_push(VC vc);
 
 //! Restore the current context to its state at the last checkpoint
-void vc_pop(VC vc);
+LIBSTP_EXPORT void vc_pop(VC vc);
 
 //! Return an int from a constant bitvector expression
-int getBVInt(Expr e);
+LIBSTP_EXPORT int getBVInt(Expr e);
 //! Return an unsigned int from a constant bitvector expression
-unsigned int getBVUnsigned(Expr e);
+LIBSTP_EXPORT unsigned int getBVUnsigned(Expr e);
 //! Return an unsigned long long int from a constant bitvector expressions
-unsigned long long int getBVUnsignedLongLong(Expr e);
+LIBSTP_EXPORT unsigned long long int getBVUnsignedLongLong(Expr e);
 
 /**************************/
 /* BIT VECTOR OPERATIONS  */
 /**************************/
-Type vc_bvType(VC vc, int no_bits);
-Type vc_bv32Type(VC vc);
+LIBSTP_EXPORT Type vc_bvType(VC vc, int no_bits);
+LIBSTP_EXPORT Type vc_bv32Type(VC vc);
 
 //Const expressions for string, int, long-long, etc
-Expr vc_bvConstExprFromDecStr(VC vc, int width, const char* decimalInput);
-Expr vc_bvConstExprFromStr(VC vc, const char* binary_repr);
-Expr vc_bvConstExprFromInt(VC vc, int n_bits, unsigned int value);
-Expr vc_bvConstExprFromLL(VC vc, int n_bits, unsigned long long value);
-Expr vc_bv32ConstExprFromInt(VC vc, unsigned int value);
+LIBSTP_EXPORT Expr vc_bvConstExprFromDecStr(VC vc, int width, const char* decimalInput);
+LIBSTP_EXPORT Expr vc_bvConstExprFromStr(VC vc, const char* binary_repr);
+LIBSTP_EXPORT Expr vc_bvConstExprFromInt(VC vc, int n_bits, unsigned int value);
+LIBSTP_EXPORT Expr vc_bvConstExprFromLL(VC vc, int n_bits, unsigned long long value);
+LIBSTP_EXPORT Expr vc_bv32ConstExprFromInt(VC vc, unsigned int value);
 
-Expr vc_bvConcatExpr(VC vc, Expr left, Expr right);
-Expr vc_bvPlusExpr(VC vc, int n_bits, Expr left, Expr right);
-Expr vc_bvPlusExprN(VC vc, int n_bits, Expr* children, int numOfChildNodes);
-Expr vc_bv32PlusExpr(VC vc, Expr left, Expr right);
-Expr vc_bvMinusExpr(VC vc, int n_bits, Expr left, Expr right);
-Expr vc_bv32MinusExpr(VC vc, Expr left, Expr right);
-Expr vc_bvMultExpr(VC vc, int n_bits, Expr left, Expr right);
-Expr vc_bv32MultExpr(VC vc, Expr left, Expr right);
+LIBSTP_EXPORT Expr vc_bvConcatExpr(VC vc, Expr left, Expr right);
+LIBSTP_EXPORT Expr vc_bvPlusExpr(VC vc, int n_bits, Expr left, Expr right);
+LIBSTP_EXPORT Expr vc_bvPlusExprN(VC vc, int n_bits, Expr* children, int numOfChildNodes);
+LIBSTP_EXPORT Expr vc_bv32PlusExpr(VC vc, Expr left, Expr right);
+LIBSTP_EXPORT Expr vc_bvMinusExpr(VC vc, int n_bits, Expr left, Expr right);
+LIBSTP_EXPORT Expr vc_bv32MinusExpr(VC vc, Expr left, Expr right);
+LIBSTP_EXPORT Expr vc_bvMultExpr(VC vc, int n_bits, Expr left, Expr right);
+LIBSTP_EXPORT Expr vc_bv32MultExpr(VC vc, Expr left, Expr right);
 // left divided by right i.e. left/right
-Expr vc_bvDivExpr(VC vc, int n_bits, Expr left, Expr right);
+LIBSTP_EXPORT Expr vc_bvDivExpr(VC vc, int n_bits, Expr left, Expr right);
 // left modulo right i.e. left%right
-Expr vc_bvModExpr(VC vc, int n_bits, Expr left, Expr right);
+LIBSTP_EXPORT Expr vc_bvModExpr(VC vc, int n_bits, Expr left, Expr right);
 // signed left divided by right i.e. left/right
-Expr vc_sbvDivExpr(VC vc, int n_bits, Expr left, Expr right);
+LIBSTP_EXPORT Expr vc_sbvDivExpr(VC vc, int n_bits, Expr left, Expr right);
 // signed left modulo right i.e. left%right
-Expr vc_sbvModExpr(VC vc, int n_bits, Expr left, Expr right);
-Expr vc_sbvRemExpr(VC vc, int n_bits, Expr left, Expr right);
+LIBSTP_EXPORT Expr vc_sbvModExpr(VC vc, int n_bits, Expr left, Expr right);
+LIBSTP_EXPORT Expr vc_sbvRemExpr(VC vc, int n_bits, Expr left, Expr right);
 
-Expr vc_bvLtExpr(VC vc, Expr left, Expr right);
-Expr vc_bvLeExpr(VC vc, Expr left, Expr right);
-Expr vc_bvGtExpr(VC vc, Expr left, Expr right);
-Expr vc_bvGeExpr(VC vc, Expr left, Expr right);
+LIBSTP_EXPORT Expr vc_bvLtExpr(VC vc, Expr left, Expr right);
+LIBSTP_EXPORT Expr vc_bvLeExpr(VC vc, Expr left, Expr right);
+LIBSTP_EXPORT Expr vc_bvGtExpr(VC vc, Expr left, Expr right);
+LIBSTP_EXPORT Expr vc_bvGeExpr(VC vc, Expr left, Expr right);
 
-Expr vc_sbvLtExpr(VC vc, Expr left, Expr right);
-Expr vc_sbvLeExpr(VC vc, Expr left, Expr right);
-Expr vc_sbvGtExpr(VC vc, Expr left, Expr right);
-Expr vc_sbvGeExpr(VC vc, Expr left, Expr right);
+LIBSTP_EXPORT Expr vc_sbvLtExpr(VC vc, Expr left, Expr right);
+LIBSTP_EXPORT Expr vc_sbvLeExpr(VC vc, Expr left, Expr right);
+LIBSTP_EXPORT Expr vc_sbvGtExpr(VC vc, Expr left, Expr right);
+LIBSTP_EXPORT Expr vc_sbvGeExpr(VC vc, Expr left, Expr right);
 
-Expr vc_bvUMinusExpr(VC vc, Expr child);
+LIBSTP_EXPORT Expr vc_bvUMinusExpr(VC vc, Expr child);
 
 // bitwise operations: these are terms not formulas
-Expr vc_bvAndExpr(VC vc, Expr left, Expr right);
-Expr vc_bvOrExpr(VC vc, Expr left, Expr right);
-Expr vc_bvXorExpr(VC vc, Expr left, Expr right);
-Expr vc_bvNotExpr(VC vc, Expr child);
+LIBSTP_EXPORT Expr vc_bvAndExpr(VC vc, Expr left, Expr right);
+LIBSTP_EXPORT Expr vc_bvOrExpr(VC vc, Expr left, Expr right);
+LIBSTP_EXPORT Expr vc_bvXorExpr(VC vc, Expr left, Expr right);
+LIBSTP_EXPORT Expr vc_bvNotExpr(VC vc, Expr child);
 
 // Shift an expression by another expression. This is newstyle.
-Expr vc_bvLeftShiftExprExpr(VC vc, int n_bits, Expr left, Expr right);
-Expr vc_bvRightShiftExprExpr(VC vc, int n_bits, Expr left, Expr right);
-Expr vc_bvSignedRightShiftExprExpr(VC vc, int n_bits, Expr left, Expr right);
+LIBSTP_EXPORT Expr vc_bvLeftShiftExprExpr(VC vc, int n_bits, Expr left, Expr right);
+LIBSTP_EXPORT Expr vc_bvRightShiftExprExpr(VC vc, int n_bits, Expr left, Expr right);
+LIBSTP_EXPORT Expr vc_bvSignedRightShiftExprExpr(VC vc, int n_bits, Expr left, Expr right);
 
 // These shifts are old-style. Kept for compatability---oldstyle.
-Expr vc_bvLeftShiftExpr(VC vc, int sh_amt, Expr child);
-Expr vc_bvRightShiftExpr(VC vc, int sh_amt, Expr child);
+LIBSTP_EXPORT Expr vc_bvLeftShiftExpr(VC vc, int sh_amt, Expr child);
+LIBSTP_EXPORT Expr vc_bvRightShiftExpr(VC vc, int sh_amt, Expr child);
 /* Same as vc_bvLeftShift only that the answer in 32 bits long */
-Expr vc_bv32LeftShiftExpr(VC vc, int sh_amt, Expr child);
+LIBSTP_EXPORT Expr vc_bv32LeftShiftExpr(VC vc, int sh_amt, Expr child);
 /* Same as vc_bvRightShift only that the answer in 32 bits long */
-Expr vc_bv32RightShiftExpr(VC vc, int sh_amt, Expr child);
-Expr vc_bvVar32LeftShiftExpr(VC vc, Expr sh_amt, Expr child);
-Expr vc_bvVar32RightShiftExpr(VC vc, Expr sh_amt, Expr child);
-Expr vc_bvVar32DivByPowOfTwoExpr(VC vc, Expr child, Expr rhs);
+LIBSTP_EXPORT Expr vc_bv32RightShiftExpr(VC vc, int sh_amt, Expr child);
+LIBSTP_EXPORT Expr vc_bvVar32LeftShiftExpr(VC vc, Expr sh_amt, Expr child);
+LIBSTP_EXPORT Expr vc_bvVar32RightShiftExpr(VC vc, Expr sh_amt, Expr child);
+LIBSTP_EXPORT Expr vc_bvVar32DivByPowOfTwoExpr(VC vc, Expr child, Expr rhs);
 
-Expr vc_bvExtract(VC vc, Expr child, int high_bit_no, int low_bit_no);
+LIBSTP_EXPORT Expr vc_bvExtract(VC vc, Expr child, int high_bit_no, int low_bit_no);
 
 // accepts a bitvector and position, and returns a boolean
 // corresponding to that position. More precisely, it return the
 // equation (x[bit_no:bit_no] == 0)
-Expr vc_bvBoolExtract(VC vc, Expr x, int bit_no);
-Expr vc_bvBoolExtract_Zero(VC vc, Expr x, int bit_no);
+LIBSTP_EXPORT Expr vc_bvBoolExtract(VC vc, Expr x, int bit_no);
+LIBSTP_EXPORT Expr vc_bvBoolExtract_Zero(VC vc, Expr x, int bit_no);
 
 // accepts a bitvector and position, and returns a boolean
 // corresponding to that position. More precisely, it return the
 // equation (x[bit_no:bit_no] == 1)
-Expr vc_bvBoolExtract_One(VC vc, Expr x, int bit_no);
-Expr vc_bvSignExtend(VC vc, Expr child, int nbits);
+LIBSTP_EXPORT Expr vc_bvBoolExtract_One(VC vc, Expr x, int bit_no);
+LIBSTP_EXPORT Expr vc_bvSignExtend(VC vc, Expr child, int nbits);
 
 /*C pointer support:  C interface to support C memory arrays in CVCL */
-Expr vc_bvCreateMemoryArray(VC vc, const char* arrayName);
-Expr vc_bvReadMemoryArray(VC vc, Expr array, Expr byteIndex, int numOfBytes);
-Expr vc_bvWriteToMemoryArray(VC vc, Expr array, Expr byteIndex, Expr element,
+LIBSTP_EXPORT Expr vc_bvCreateMemoryArray(VC vc, const char* arrayName);
+LIBSTP_EXPORT Expr vc_bvReadMemoryArray(VC vc, Expr array, Expr byteIndex, int numOfBytes);
+LIBSTP_EXPORT Expr vc_bvWriteToMemoryArray(VC vc, Expr array, Expr byteIndex, Expr element,
                              int numOfBytes);
-Expr vc_bv32ConstExprFromInt(VC vc, unsigned int value);
+LIBSTP_EXPORT Expr vc_bv32ConstExprFromInt(VC vc, unsigned int value);
 
 // return a string representation of the Expr e. The caller is responsible
 // for deallocating the string with free()
-char* exprString(Expr e);
+LIBSTP_EXPORT char* exprString(Expr e);
 
 // return a string representation of the Type t. The caller is responsible
 // for deallocating the string with free()
-char* typeString(Type t);
+LIBSTP_EXPORT char* typeString(Type t);
 
-Expr getChild(Expr e, int i);
+LIBSTP_EXPORT Expr getChild(Expr e, int i);
 
 // 1.if input expr is TRUE then the function returns 1;
 //
 // 2.if input expr is FALSE then function returns 0;
 //
 // 3.otherwise the function returns -1
-int vc_isBool(Expr e);
+LIBSTP_EXPORT int vc_isBool(Expr e);
 
 /* Register the given error handler to be called for each fatal error.*/
-void vc_registerErrorHandler(void (*error_hdlr)(const char* err_msg));
+LIBSTP_EXPORT void vc_registerErrorHandler(void (*error_hdlr)(const char* err_msg));
 
-int vc_getHashQueryStateToBuffer(VC vc, Expr query);
+LIBSTP_EXPORT int vc_getHashQueryStateToBuffer(VC vc, Expr query);
 
 // destroys the STP instance, and removes all the created expressions
-void vc_Destroy(VC vc);
+LIBSTP_EXPORT void vc_Destroy(VC vc);
 
 // deletes the expression e
-void vc_DeleteExpr(Expr e);
+LIBSTP_EXPORT void vc_DeleteExpr(Expr e);
 
 // Get the whole counterexample from the current context
-WholeCounterExample vc_getWholeCounterExample(VC vc);
+LIBSTP_EXPORT WholeCounterExample vc_getWholeCounterExample(VC vc);
 
 // Get the value of a term expression from the CounterExample
-Expr vc_getTermFromCounterExample(VC vc, Expr e, WholeCounterExample c);
+LIBSTP_EXPORT Expr vc_getTermFromCounterExample(VC vc, Expr e, WholeCounterExample c);
 
 // Free the return value of vc_getWholeCounterExample
-void vc_deleteWholeCounterExample(WholeCounterExample cc);
+LIBSTP_EXPORT void vc_deleteWholeCounterExample(WholeCounterExample cc);
 
 // Kinds of Expr
 enum exprkind_t
@@ -454,34 +456,34 @@ enum type_t
 };
 
 // get the kind of the expression
-enum exprkind_t getExprKind(Expr e);
+LIBSTP_EXPORT enum exprkind_t getExprKind(Expr e);
 
 // get the number of children nodes
-int getDegree(Expr e);
+LIBSTP_EXPORT int getDegree(Expr e);
 
 // get the bv length
-int getBVLength(Expr e);
+LIBSTP_EXPORT int getBVLength(Expr e);
 
 // get expression type
-enum type_t getType(Expr e);
+LIBSTP_EXPORT enum type_t getType(Expr e);
 
 // get value bit width
-int getVWidth(Expr e);
+LIBSTP_EXPORT int getVWidth(Expr e);
 
 // get index bit width
-int getIWidth(Expr e);
+LIBSTP_EXPORT int getIWidth(Expr e);
 
 // Prints counterexample to an open file descriptor 'fd'
-void vc_printCounterExampleFile(VC vc, int fd);
+LIBSTP_EXPORT void vc_printCounterExampleFile(VC vc, int fd);
 
 // get name of expression. must be a variable.
-const char* exprName(Expr e);
+LIBSTP_EXPORT const char* exprName(Expr e);
 
 // get the node ID of an Expr.
-int getExprID(Expr ex);
+LIBSTP_EXPORT int getExprID(Expr ex);
 
 // parse the expr from memory string!
-int vc_parseMemExpr(VC vc, const char* s, Expr* oquery, Expr* oasserts);
+LIBSTP_EXPORT int vc_parseMemExpr(VC vc, const char* s, Expr* oquery, Expr* oasserts);
 #ifdef __cplusplus
 }
 #endif

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -58,6 +58,11 @@ set_target_properties(libstp PROPERTIES
                         SOVERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
                      )
 
+generate_export_header(libstp EXPORT_FILE_NAME "${PROJECT_BINARY_DIR}/include/stp/stp_export.h")
+# Make sure the header file gets installed
+install(FILES "${PROJECT_BINARY_DIR}/include/stp/stp_export.h"
+        DESTINATION "${CMAKE_INSTALL_PREFIX}/include/stp/")
+
 # -----------------------------------------------------------------------------
 # Support building both static and dynamic library
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
the STP shared library. This unfortunately completely breaks compilation
of stp (and several other executables) because they use STP's internal
API. This is gross!

We need to come up with a way of fixing this.
