### PR TITLE
fix python3 version comparison

### DIFF
--- a/bindings/python/stp/stp.py
+++ b/bindings/python/stp/stp.py
@@ -35,7 +35,7 @@ __all__ = [
     'Expr', 'Solver', 'stp', 'add', 'bitvec', 'bitvecs', 'check', 'model',
 ]
 
-Py3 = sys.version > '3'
+Py3 = sys.version_info >= (3, 0, 0)
 
 if Py3:
     long = int


### PR DESCRIPTION
The current implementation fails eg. for::

    >>> sys.version_info
    sys.version_info(major=21, minor=0, micro=1, releaselevel='final',
    serial=0)
    >>> '21.0.1' > '3'
    False
    >>> sys.version_info >= (3, 0, 0)
    True

I admit it takes some time to get to python21 ;)