### PR TITLE
AST: simplify FatalError and mark as noreturn

### DIFF
--- a/include/stp/AST/AST.h
+++ b/include/stp/AST/AST.h
@@ -37,8 +37,9 @@ namespace stp
 // TODO remove -- only used in c_interface.cpp NOT from main.cpp
 void process_argument(const char ch, STPMgr* bm);
 
-void FatalError(const char* str, const ASTNode& a, int w = 0);
-void FatalError(const char* str);
+void FatalError(const char* str, const ASTNode& a, int w = 0)
+                __attribute__((noreturn));
+void FatalError(const char* str) __attribute__((noreturn));
 void SortByExprNum(ASTVec& c);
 void SortByArith(ASTVec& c);
 bool exprless(const ASTNode n1, const ASTNode n2);

--- a/lib/AST/ASTmisc.cpp
+++ b/lib/AST/ASTmisc.cpp
@@ -253,12 +253,7 @@ void FatalError(const char* str, const ASTNode& a, int w)
   {
     vc_error_hdlr(str);
   }
-  else
-  {
-    assert(false);
-  }
-  assert(false);
-  exit(-1);
+  abort();
 }
 
 void FatalError(const char* str)
@@ -267,14 +262,8 @@ void FatalError(const char* str)
   if (vc_error_hdlr)
   {
     vc_error_hdlr(str);
-    assert(false);
-    exit(-1);
   }
-  else
-  {
-    assert(false);
-    exit(-1);
-  }
+  abort();
 }
 
 void SortByExprNum(ASTVec& v)


### PR DESCRIPTION
There is duplicated code in FatalError implementations. Remove that
and since now FatalError is de facto "noreturn", mark it as such to
silence the compiler yelling.

Signed-off-by: Jiri Slaby <jslaby@suse.cz>