### PR TITLE
Fix operator overloading in Python bindings

### DIFF
--- a/bindings/python/stp/stp.py
+++ b/bindings/python/stp/stp.py
@@ -382,11 +382,13 @@ class Expr(object):
         return self._2w(_lib.vc_bvDivExpr, self, other)
 
     __div__ = div
+    __floordiv__ = div
 
     def rdiv(self, other):
         return self._2w(_lib.vc_bvDivExpr, other, self)
 
     __rdiv__ = rdiv
+    __rfloordiv__ = rdiv
 
     def mod(self, other):
         return self._2w(_lib.vc_bvModExpr, self, other)
@@ -481,6 +483,14 @@ class Expr(object):
 
     __xor__ = xor
     __rxor__ = xor
+
+    def neg(self):
+        return self._1(_lib.vc_bvUMinusExpr)
+
+    __neg__ = neg
+
+    def __pos__(self):
+        return self
 
     def not_(self):
         return self._1(_lib.vc_bvNotExpr)

--- a/bindings/python/stp/stp.py
+++ b/bindings/python/stp/stp.py
@@ -344,56 +344,83 @@ class Expr(object):
         expr = cb(self.s.vc, self.expr, other.expr)
         return Expr(self.s, self.width, expr)
 
-    def _2w(self, cb, other):
+    def _2w(self, cb, a, b):
         """Wrapper around double-expression with width STP functions."""
-        other = self._toexpr(other)
-        assert isinstance(other, Expr), \
-            'Other object must be an Expr instance'
-        assert self.width == other.width, 'Width must be equal'
-        expr = cb(self.s.vc, self.width, self.expr, other.expr)
+        a, b = self._toexpr(a), self._toexpr(b)
+        assert isinstance(a, Expr), \
+            'Left operand must be an Expr instance'
+        assert isinstance(b, Expr), \
+            'Right operand must be an Expr instance'
+        assert self.width == a.width, 'Width must be equal'
+        assert self.width == b.width, 'Width must be equal'
+        expr = cb(self.s.vc, self.width, a.expr, b.expr)
         return Expr(self.s, self.width, expr)
 
     def add(self, other):
-        return self._2w(_lib.vc_bvPlusExpr, other)
+        return self._2w(_lib.vc_bvPlusExpr, self, other)
 
     __add__ = add
     __radd__ = add
 
     def sub(self, other):
-        return self._2w(_lib.vc_bvMinusExpr, other)
+        return self._2w(_lib.vc_bvMinusExpr, self, other)
 
     __sub__ = sub
-    __rsub__ = sub
+
+    def rsub(self, other):
+        return self._2w(_lib.vc_bvMinusExpr, other, self)
+
+    __rsub__ = rsub
 
     def mul(self, other):
-        return self._2w(_lib.vc_bvMultExpr, other)
+        return self._2w(_lib.vc_bvMultExpr, self, other)
 
     __mul__ = mul
     __rmul__ = mul
 
     def div(self, other):
-        return self._2w(_lib.vc_bvDivExpr, other)
+        return self._2w(_lib.vc_bvDivExpr, self, other)
 
     __div__ = div
-    __rdiv__ = div
+
+    def rdiv(self, other):
+        return self._2w(_lib.vc_bvDivExpr, other, self)
+
+    __rdiv__ = rdiv
 
     def mod(self, other):
-        return self._2w(_lib.vc_bvModExpr, other)
+        return self._2w(_lib.vc_bvModExpr, self, other)
 
     __mod__ = mod
-    __rmod__ = mod
+
+    def rmod(self, other):
+        return self._2w(_lib.vc_bvModExpr, other, self)
+
+    __rmod__ = rmod
 
     def rem(self, other):
-        return self._2w(_lib.vc_bvRemExpr, other)
+        return self._2w(_lib.vc_bvRemExpr, self, other)
+
+    def rrem(self, other):
+        return self._2w(_lib.vc_bvRemExpr, other, self)
 
     def sdiv(self, other):
-        return self._2w(_lib.vc_sbvDivExpr, other)
+        return self._2w(_lib.vc_sbvDivExpr, self, other)
+
+    def rsdiv(self, other):
+        return self._2w(_lib.vc_sbvDivExpr, other, self)
 
     def smod(self, other):
-        return self._2w(_lib.vc_sbvModExpr, other)
+        return self._2w(_lib.vc_sbvModExpr, self, other)
+
+    def rsmod(self, other):
+        return self._2w(_lib.vc_sbvModExpr, other, self)
 
     def srem(self, other):
-        return self._2w(_lib.vc_sbvRemExpr, other)
+        return self._2w(_lib.vc_sbvRemExpr, self, other)
+
+    def rsrem(self, other):
+        return self._2w(_lib.vc_sbvRemExpr, other, self)
 
     def eq(self, other):
         return self._2(_lib.vc_eqExpr, other)
@@ -461,19 +488,30 @@ class Expr(object):
     __invert__ = not_
 
     def shl(self, other):
-        return self._2w(_lib.vc_bvLeftShiftExprExpr, other)
+        return self._2w(_lib.vc_bvLeftShiftExprExpr, self, other)
 
     __lshift__ = shl
-    __rlshift__ = shl
+
+    def rshl(self, other):
+        return self._2w(_lib.vc_bvLeftShiftExprExpr, other, self)
+
+    __rlshift__ = rshl
 
     def shr(self, other):
-        return self._2w(_lib.vc_bvRightShiftExprExpr, other)
+        return self._2w(_lib.vc_bvRightShiftExprExpr, self, other)
 
     __rshift__ = shr
-    __rrshift__ = shr
+
+    def rshr(self, other):
+        return self._2w(_lib.vc_bvRightShiftExprExpr, other, self)
+
+    __rrshift__ = rshr
 
     def sar(self, other):
-        return self._2w(_lib.vc_bvSignedRightShiftExprExpr, other)
+        return self._2w(_lib.vc_bvSignedRightShiftExprExpr, self, other)
+
+    def rsar(self, other):
+        return self._2w(_lib.vc_bvSignedRightShiftExprExpr, other, self)
 
     def extract(self, high, low):
         expr = _lib.vc_bvExtract(self.s.vc, self.expr, high, low)

--- a/tests/api/python/tests.py.in
+++ b/tests/api/python/tests.py.in
@@ -217,17 +217,43 @@ class TestSTP(unittest.TestCase):
         self.assertTrue(s.check(b == 2))
         s.pop()
 
-    def test_reflected(self):
-        # Reflected/swapped stuff is like "y+x" instead of "x+y" where "y"
-        # is not an Expr instance, e.g., a plain integer.
+    def test_operator_overloading(self):
         s = self.s
+        a, b, c = s.bitvecs('a b c')
+        A, B = 42, 52
+        s.add(a == 42, b == 52)
 
-        a, b = s.bitvecs('a b')
-        self.assertTrue(s.check(42 == a))
-        self.assertEqual(s['a'], 42)
+        # bv OP bv => bv
+        for opname in "+ - * / % << >> & | ^".split():
+            op = eval("lambda a, b: a %s b" % opname)
 
-        self.assertTrue(s.check(456 == 123 + a))
-        self.assertEqual(s['a'], 456-123)
+            # Test symbolic OP symbolic.
+            s.check(c == op(a, b))
+            self.assertEqual(s.model()['c'], op(A, B) % 2**32)
+            s.check(c == op(b, a))
+            self.assertEqual(s.model()['c'], op(B, A) % 2**32)
+
+            # Test symbolic OP constant.
+            s.check(c == op(a, B))
+            self.assertEqual(s.model()['c'], op(A, B) % 2**32)
+
+            # Test constant OP symbolic.
+            s.check(c == op(B, a))
+            self.assertEqual(s.model()['c'], op(B, A) % 2**32)
+
+        # bv OP bv => bool
+        for opname in "< > <= >= == !=".split():
+            op = eval("lambda a, b: a %s b" % opname)
+
+            # Test symbolic OP symbolic.
+            self.assertEqual(s.check(op(a, b)), op(A, B))
+            self.assertEqual(s.check(op(b, a)), op(B, A))
+
+            # Test symbolic OP constant.
+            self.assertEqual(s.check(op(a, B)), op(A, B))
+
+            # Test constant OP symbolic.
+            self.assertEqual(s.check(op(B, a)), op(B, A))
 
 
 if __name__ == '__main__':

--- a/tests/api/python/tests.py.in
+++ b/tests/api/python/tests.py.in
@@ -224,7 +224,7 @@ class TestSTP(unittest.TestCase):
         s.add(a == 42, b == 52)
 
         # bv OP bv => bv
-        for opname in "+ - * / % << >> & | ^".split():
+        for opname in "+ - * // % << >> & | ^".split():
             op = eval("lambda a, b: a %s b" % opname)
 
             # Test symbolic OP symbolic.
@@ -254,6 +254,13 @@ class TestSTP(unittest.TestCase):
 
             # Test constant OP symbolic.
             self.assertEqual(s.check(op(B, a)), op(B, A))
+
+        # OP bv => bv
+        for opname in "- + ~".split():
+            op = eval("lambda a: %s a" % opname)
+
+            s.check(c == op(a))
+            self.assertEqual(s.model()['c'], op(A) % 2**32)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This fixes various issues with operator overloading in the Python bindings.

Part of this is equivalent to PR #196, but doesn't have the confusing merges and multiple changes. This also adds a thorough test of overloaded operators to the Python API test suite.