### PR TITLE
Fix unitialized values in aig library

### DIFF
--- a/lib/extlib-abc/aig/aig/aigMem.c
+++ b/lib/extlib-abc/aig/aig/aigMem.c
@@ -190,6 +190,8 @@ char * Aig_MmFixedEntryFetch( Aig_MmFixed_t * p )
             p->pChunks = REALLOC( char *, p->pChunks, p->nChunksAlloc ); 
         }
         p->pEntriesFree = ALLOC( char, p->nEntrySize * p->nChunkSize );
+        if (p->pEntriesFree)
+            memset(p->pEntriesFree,0, p->nEntrySize * p->nChunkSize );
         p->nMemoryAlloc += p->nEntrySize * p->nChunkSize;
         // transform these entries into a linked list
         pTemp = p->pEntriesFree;


### PR DESCRIPTION
Fix warning generated by valgrind:  Conditional jump or move depends on uninitialised value(s)