### PR TITLE
Use internal unique ID for ASTNodes for ordering

### DIFF
--- a/include/stp/AST/ASTInternal.h
+++ b/include/stp/AST/ASTInternal.h
@@ -104,6 +104,9 @@ protected:
    *******************************************************************/
   unsigned int _value_width;
 
+  uint64_t node_uid;
+  static uint64_t node_uid_cntr;
+
   /****************************************************************
    * Protected Member Functions                                   *
    ****************************************************************/
@@ -130,7 +133,7 @@ public:
   // Constructor (kind only, empty children, int nodenum)
   ASTInternal(STPMgr* mgr, Kind kind, int nodenum = 0)
       : nodeManager(mgr), iteration(0), _ref_count(0), _kind(kind), _node_num(nodenum),
-        _index_width(0), _value_width(0)
+        _index_width(0), _value_width(0), node_uid(++node_uid_cntr)
   {
   }
 
@@ -142,7 +145,7 @@ public:
   ASTInternal(const ASTInternal& int_node)
       : nodeManager(int_node.nodeManager), iteration(0), _ref_count(0), _kind(int_node._kind),
         _node_num(int_node._node_num), _index_width(int_node._index_width),
-        _value_width(int_node._value_width)
+        _value_width(int_node._value_width), node_uid(int_node.node_uid)
   {
   }
 

--- a/include/stp/AST/ASTNode.h
+++ b/include/stp/AST/ASTNode.h
@@ -55,7 +55,7 @@ class ASTNode
   // Equal iff ASTIntNode pointers are the same.
   friend bool operator==(const ASTNode& node1, const ASTNode& node2)
   {
-    return ((size_t)node1._int_node_ptr) == ((size_t)node2._int_node_ptr);
+    return (node1.Hash() == node2.Hash());
   }
 
   friend bool operator!=(const ASTNode& node1, const ASTNode& node2)
@@ -65,7 +65,7 @@ class ASTNode
 
   friend bool operator<(const ASTNode& node1, const ASTNode& node2)
   {
-    return ((size_t)node1._int_node_ptr) < ((size_t)node2._int_node_ptr);
+    return (node1.Hash() < node2.Hash());
   }
 
 public:
@@ -174,7 +174,7 @@ public:
   types GetType(void) const;
 
   // Hash using pointer value of _int_node_ptr.
-  size_t Hash() const { return (size_t)_int_node_ptr; }
+  size_t Hash() const ;
 
   void NFASTPrint(int l, int max, int prefix) const;
 
@@ -212,7 +212,7 @@ public:
   public:
     size_t operator()(const ASTNode& n) const
     {
-      return (size_t)n._int_node_ptr;
+      return n.Hash();
       // return (size_t)n.GetNodeNum();
     };
   };
@@ -227,7 +227,7 @@ public:
   public:
     bool operator()(const ASTNode& n1, const ASTNode& n2) const
     {
-      return (n1._int_node_ptr == n2._int_node_ptr);
+      return (n1.Hash() == n2.Hash());
     }
   };
 

--- a/lib/AST/ASTNode.cpp
+++ b/lib/AST/ASTNode.cpp
@@ -185,6 +185,9 @@ unsigned int ASTNode::GetUnsignedConst() const
   return (unsigned int)*((unsigned int*)n.GetBVConst());
 }
 
+size_t ASTNode::Hash() const { return (_int_node_ptr? _int_node_ptr->node_uid: 0); }
+
+
 void ASTNode::NFASTPrint(int l, int max, int prefix) const
 {
   //****************************************

--- a/lib/AST/ASTmisc.cpp
+++ b/lib/AST/ASTmisc.cpp
@@ -43,6 +43,8 @@ using std::cout;
 using std::cerr;
 using std::endl;
 
+uint64_t ASTInternal::node_uid_cntr = 0;
+
 /****************************************************************
  * Universal Helper Functions                                   *
  ****************************************************************/


### PR DESCRIPTION
Hashing based on memory addresses changes the
order of elements being iterated over depending on the assigned addresses.

This patch introduces a unique ID generated during creation
of the node. And use this for comparison and
hashing functions.

This is one step towards solving #218, it doesn't solve the whole problem yet.
There are a couple of more cases in the code.