### PR TITLE
simplifier: use abort() instead of assert(false)

### DIFF
--- a/lib/Simplifier/Simplifier.cpp
+++ b/lib/Simplifier/Simplifier.cpp
@@ -501,6 +501,7 @@ unsigned getConstantBit(const ASTNode& n, const int i)
     return getConstantBit(n[0], i);
 
   assert(false);
+  abort();
 }
 
 ASTNode replaceIteConst(const ASTNode& n, const ASTNode& newVal,


### PR DESCRIPTION
assert becomes nop when built with -DNDEBUG. So use abort in
getConstantBit instead of assert.

Signed-off-by: Jiri Slaby <jslaby@suse.cz>