### PR TITLE
GitSHA1: really disable timestamp when requested

### DIFF
--- a/lib/Util/GitSHA1.cpp.in
+++ b/lib/Util/GitSHA1.cpp.in
@@ -36,6 +36,8 @@ const char* stp::get_git_version_tag()
     return version_tag;
 }
 
+#cmakedefine STP_TIMESTAMPS 1
+
 const char* stp::get_compilation_env()
 {
     static const char compilation_env[] =
@@ -54,7 +56,12 @@ const char* stp::get_compilation_env()
     "PYTHON_EXECUTABLE = @PYTHON_EXECUTABLE@ | "
     "PYTHON_LIBRARY = @PYTHON_LIBRARY@ | "
     "PYTHON_INCLUDE_DIRS = @PYTHON_INCLUDE_DIRS@ | "
-    "compilation date time = " __DATE__ " " __TIME__
+    " | compilation date time = "
+#ifdef STP_TIMESTAMPS
+    __DATE__ " " __TIME__
+#else
+    "unknown"
+#endif
     ;
     return compilation_env;
 }


### PR DESCRIPTION
__DATE__ and __TIME__ prevent reproducible builds. Shot those in head
in case STP_TIMESTAMPS was selected.