### PR TITLE
Fixed issue #244

### DIFF
--- a/include/stp/c_interface.h
+++ b/include/stp/c_interface.h
@@ -349,7 +349,6 @@ Expr vc_bvCreateMemoryArray(VC vc, const char* arrayName);
 Expr vc_bvReadMemoryArray(VC vc, Expr array, Expr byteIndex, int numOfBytes);
 Expr vc_bvWriteToMemoryArray(VC vc, Expr array, Expr byteIndex, Expr element,
                              int numOfBytes);
-Expr vc_bv32ConstExprFromInt(VC vc, unsigned int value);
 
 // return a string representation of the Expr e. The caller is responsible
 // for deallocating the string with free()


### PR DESCRIPTION
Fixed the redundant redeclaration of vc_bv32ConstExprFromInt in c_interface.h.
GCC 6.3 is reporting an error here! (See issue for more details.)