### PR TITLE
MSVC Compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,6 +218,8 @@ if(WIN32)
       set(STP_DEFS_COMM ${STP_DEFS_COMM} -D_CRT_SECURE_NO_WARNINGS)
       set(STP_INCL_COMM windows/winports windows/winports/msc99hdr ${STP_INCL_COMM})
       include_directories(${STP_INCL_COMM})
+      add_subdirectory(windows)
+      set(PLATFORM_COMPAT_LIBRARIES ${PLATFORM_COMPAT_LIBRARIES} windows_compat)
 
       # stack size of MSVC must be specified
       string(REGEX REPLACE "/STACK:[0-9]+" "" CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS})

--- a/include/stp/AST/AST.h
+++ b/include/stp/AST/AST.h
@@ -27,13 +27,12 @@ THE SOFTWARE.
 
 #include "UsefulDefs.h"
 #include "ASTNode.h"
-
+#include "stp/Util/Attributes.h"
 
 namespace stp
 {
-void FatalError(const char* str, const ASTNode& a, int w = 0)
-                __attribute__((noreturn));
-void FatalError(const char* str) __attribute__((noreturn));
+ATTR_NORETURN void FatalError(const char* str, const ASTNode& a, int w = 0);
+ATTR_NORETURN void FatalError(const char* str);
 void SortByExprNum(ASTVec& c);
 void SortByArith(ASTVec& c);
 bool exprless(const ASTNode n1, const ASTNode n2);

--- a/include/stp/AST/ASTBVConst.h
+++ b/include/stp/AST/ASTBVConst.h
@@ -30,7 +30,6 @@ THE SOFTWARE.
 namespace stp
 {
 class STPMgr;
-void FatalError(const char* str);
 
 /******************************************************************
  *  Class to represent internals of a bitvector constant          *

--- a/include/stp/Simplifier/constantBitP/FixedBits.h
+++ b/include/stp/Simplifier/constantBitP/FixedBits.h
@@ -25,6 +25,8 @@ THE SOFTWARE.
 #ifndef FIXEDBITS_H_
 #define FIXEDBITS_H_
 
+#include <stp/Util/Attributes.h>
+
 #include <vector>
 #include <iostream>
 #include <cassert>
@@ -35,7 +37,7 @@ namespace stp
 {
 class ASTNode;
 typedef unsigned int* CBV;
-void FatalError(const char* str);
+ATTR_NORETURN void FatalError(const char* str);
 }
 
 namespace simplifier

--- a/include/stp/Simplifier/constantBitP/FixedBits.h
+++ b/include/stp/Simplifier/constantBitP/FixedBits.h
@@ -30,6 +30,7 @@ THE SOFTWARE.
 #include <vector>
 #include <iostream>
 #include <cassert>
+#include <algorithm>
 
 class MTRand;
 

--- a/include/stp/Util/Attributes.h
+++ b/include/stp/Util/Attributes.h
@@ -1,0 +1,36 @@
+/********************************************************************
+ * AUTHOR: Felix Kutzner
+ *
+ * BEGIN DATE: Apr, 2017
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#ifndef ATTRIBUTES_H_
+#define ATTRIBUTES_H_
+
+#if defined(_MSC_VER)
+#define ATTR_NORETURN _declspec(noreturn)
+#elif defined(__GNUC__) || defined(__clang__)
+#define ATTR_NORETURN __attribute__((noreturn))
+#else
+#define ATTR_NORETURN
+#endif
+
+#endif

--- a/lib/AST/ASTmisc.cpp
+++ b/lib/AST/ASTmisc.cpp
@@ -25,11 +25,8 @@ THE SOFTWARE.
 #include "stp/AST/AST.h"
 #include "stp/STPManager/STPManager.h"
 #include "stp/Util/NodeIterator.h"
-#ifdef _MSC_VER
-// avoid TRUE and FALSE to be set to 1 and 0 in winmin.h
-#define TRUE TRUE
-#define FALSE FALSE
-#else
+
+#if !defined(_MSC_VER)
 // Needed for signal()
 #include <unistd.h>
 #endif

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -53,6 +53,7 @@ set(stp_lib_targets
     parser
     printer
     util
+    ${PLATFORM_COMPAT_LIBRARIES}
 )
 
 # Create list of objects and gather list of

--- a/lib/Parser/CMakeLists.txt
+++ b/lib/Parser/CMakeLists.txt
@@ -36,13 +36,23 @@
 # bison --debug -v -o parsesmt2.cpp -d -p smt2 smt2.y
 # flex -Cfe -olexsmt2.cpp -Psmt2 smt2.lex
 
+include(CheckIncludeFile)
+
 set(SOURCES LetMgr.cpp)
 set(TOLEX cvc smt2 smt)
+
+check_include_file("unistd.h" HAVE_UNISTD_H)
+if (HAVE_UNISTD_H)
+  set(FLEX_COMPATIBILITY_ARGS "")
+else()
+  set(FLEX_COMPATIBILITY_ARGS "--nounistd")
+endif()
+
 foreach(_file ${TOLEX})
     add_custom_command(
         OUTPUT  ${CMAKE_CURRENT_BINARY_DIR}/parse${_file}.cpp  ${CMAKE_CURRENT_BINARY_DIR}/lex${_file}.cpp
         COMMAND ${BISON_EXECUTABLE} --debug -v -o ${CMAKE_CURRENT_BINARY_DIR}/parse${_file}.cpp -d -p ${_file} ${CMAKE_CURRENT_SOURCE_DIR}/${_file}.y
-        COMMAND ${FLEX_EXECUTABLE} -Ce -o${CMAKE_CURRENT_BINARY_DIR}/lex${_file}.cpp -P${_file} ${CMAKE_CURRENT_SOURCE_DIR}/${_file}.lex
+        COMMAND ${FLEX_EXECUTABLE} ${FLEX_COMPATIBILITY_ARGS} -Ce -o${CMAKE_CURRENT_BINARY_DIR}/lex${_file}.cpp -P${_file} ${CMAKE_CURRENT_SOURCE_DIR}/${_file}.lex
         DEPENDS ${_file}.lex ${_file}.y
     )
     add_custom_target(parser_header${_file} ALL

--- a/lib/Simplifier/constantBitP/ConstantBitP_Utility.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_Utility.cpp
@@ -23,6 +23,7 @@ THE SOFTWARE.
 ********************************************************************/
 
 #include "stp/Simplifier/constantBitP/ConstantBitP_Utility.h"
+#include "stp/Util/Attributes.h"
 #include "extlib-constbv/constantbv.h"
 
 // Utility functions used by the transfer functions.
@@ -32,7 +33,7 @@ using std::vector;
 namespace stp
 {
 typedef unsigned int* CBV;
-void FatalError(const char* str);
+ATTR_NORETURN void FatalError(const char* str);
 }
 
 namespace simplifier

--- a/lib/Util/RunTimes.cpp
+++ b/lib/Util/RunTimes.cpp
@@ -37,6 +37,7 @@ THE SOFTWARE.
 #include <iostream>
 #include <utility>
 #include "stp/Util/RunTimes.h"
+#include "stp/Util/Attributes.h"
 #include "minisat/utils/System.h"
 
 // BE VERY CAREFUL> Update the Category Names to match.
@@ -54,7 +55,7 @@ std::string RunTimes::CategoryNames[] = {
 
 namespace stp
 {
-void FatalError(const char* str);
+ATTR_NORETURN void FatalError(const char* str);
 }
 
 long RunTimes::getCurrentTime()

--- a/lib/extlib-abc/leaks.h
+++ b/lib/extlib-abc/leaks.h
@@ -28,7 +28,7 @@ SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 #ifndef __LEAKS_H__
 #define __LEAKS_H__
 
-#ifdef _DEBUG
+#if defined(_DEBUG) && !defined(__cplusplus)
 #define _CRTDBG_MAP_ALLOC // include Microsoft memory leak detection procedures
 //#define _INC_MALLOC	     // exclude standard memory alloc procedures
 

--- a/tools/stp/STPProgramGlobals.h
+++ b/tools/stp/STPProgramGlobals.h
@@ -29,10 +29,12 @@ THE SOFTWARE.
 #include <string>
 #include <algorithm>
 #include <ctime>
-#include <unistd.h>
 #include <stdio.h>
-#include <unistd.h>
 #include <vector>
+
+#if !defined(__MINGW32__) && !defined(__MINGW64__) && !defined(_MSC_VER)
+#include <unistd.h>
+#endif
 
 namespace stp
 {

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -1,0 +1,23 @@
+# AUTHORS: Felix Kutzner
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+add_library(windows_compat OBJECT
+    winports/time.cpp
+)

--- a/windows/winports/time.cpp
+++ b/windows/winports/time.cpp
@@ -25,36 +25,49 @@ THE SOFTWARE.
 
 // C++ windows related time implementation
 
-#ifndef __TIME_H__
-#define __TIME_H__ 1
-
 #if defined(_MSC_VER)
-// windows missed gettimeofday function
-struct timezone
-{
-  int tz_minuteswest; /* minutes W of Greenwich */
-  int tz_dsttime;     /* type of dst correction */
-};
+#include <windows.h>
+#define WINDOWS_H_INCLUDED
+#include <ctime>
+#include <sys/time.h>
 
-#if !defined(WINDOWS_H_INCLUDED)
-struct timeval
-{
-  long tv_sec;
-  long tv_usec;
-};
+#if defined(_MSC_EXTENSIONS)
+#define DELTA_EPOCH_IN_MICROSECS 11644473600000000Ui64
+#else
+#define DELTA_EPOCH_IN_MICROSECS 11644473600000000ULL
 #endif
 
-namespace stp
+int stp::gettimeofdayWin32(struct timeval* tv, struct timezone* tz)
 {
-int gettimeofdayWin32(struct timeval* tv, struct timezone* tz);
+  FILETIME ft;
+  unsigned __int64 tmpres = 0;
+  static int tzflag;
+
+  if (NULL != tv)
+  {
+    GetSystemTimeAsFileTime(&ft);
+
+    tmpres |= ft.dwHighDateTime;
+    tmpres <<= 32;
+    tmpres |= ft.dwLowDateTime;
+
+    /*converting file time to unix epoch*/
+    tmpres /= 10; /*convert into microseconds*/
+    tmpres -= DELTA_EPOCH_IN_MICROSECS;
+    tv->tv_sec = (long)(tmpres / 1000000UL);
+    tv->tv_usec = (long)(tmpres % 1000000UL);
+  }
+
+  if (NULL != tz)
+  {
+    if (!tzflag)
+    {
+      _tzset();
+      tzflag++;
+    }
+    tz->tz_minuteswest = _timezone / 60;
+    tz->tz_dsttime = _daylight;
+  }
+  return 0;
 }
-
-#if !defined(gettimeofday)
-// #define'ing gettimeofday to avoid generating the symbol gettimeofday
-#define gettimeofday(tv, tz) stp::gettimeofdayWin32(tv, tz);
-#endif
-
 #endif // defined(_MSC_VER)
-
-/************************************************************************/
-#endif


### PR DESCRIPTION
I've made some small changes to STP in order to build it with MSVC on Win64. The largest one is related to the Kind enum clashing with the definitions of TRUE and FALSE via `Windows.h`. I wasn't sure whether renaming constants in the enum Kind would break third-party code, so I restructured the code in `windows/` so that `Windows.h` does not get included in STP header files.

Hope you like the commits. This PR touches several parts of the code, so if you'd like to have several smaller PRs instead of this one, let me know.