### PR TITLE
Enabled tests on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,9 +71,11 @@ build_script:
   - mkdir myinstall
   - cd build
   - cmake -G %CMAKE_GENERATOR% -DCMAKE_INSTALL_PREFIX=%ZLIB_ROOT% ..
-  - if %PLATFORM%==x86 call msbuild %MSBUILD_FLAGS% /t:Build /p:Configuration=%CONFIGURATION% /p:Platform="x86" zlib.sln
-  - if %PLATFORM%==x64 call msbuild %MSBUILD_FLAGS% /t:Build /p:Configuration=%CONFIGURATION% /p:Platform="x64" zlib.sln
-  - msbuild %MSBUILD_FLAGS% INSTALL.vcxproj
+  - #if %PLATFORM%==x86 call msbuild %MSBUILD_FLAGS% /t:Build /p:Configuration=%CONFIGURATION% /p:Platform="x86" zlib.sln
+  - #if %PLATFORM%==x64 call msbuild %MSBUILD_FLAGS% /t:Build /p:Configuration=%CONFIGURATION% /p:Platform="x64" zlib.sln
+  - #msbuild %MSBUILD_FLAGS% INSTALL.vcxproj
+  - cmake --build . --config %BUILD_TYPE%
+  - cmake --build . --config %BUILD_TYPE% --target install
   - dir ..\myinstall\
 
   # minisat
@@ -85,7 +87,8 @@ build_script:
   - mkdir myinstall
   - cd build
   - cmake -G %CMAKE_GENERATOR% -DCMAKE_INSTALL_PREFIX=%MINISAT_ROOT% -DZLIB_ROOT=%ZLIB_ROOT% ..
-  - msbuild %MSBUILD_FLAGS% INSTALL.vcxproj
+  - cmake --build . --config %BUILD_TYPE%
+  - cmake --build . --config %BUILD_TYPE% --target install
   - dir ..\myinstall\
   - dir ..\myinstall\lib\
   - dir ..\myinstall\bin\
@@ -98,11 +101,14 @@ build_script:
   # finally STP
   - cd c:\projects\stp
   - git submodule update --init --recursive
-  - mkdir build
-  - cd build
+  # building in c:\projects\stp\build causes ASTKind.h not to be found
+  - mkdir ..\stp.build
+  - cd ..\stp.build
   - cmake --version
-  - cmake -G %CMAKE_GENERATOR% -DCMAKE_BUILD_TYPE=%CONFIGURATION% -DPYTHON_EXECUTABLE="%PYTHON%\\python.exe" -DPYTHON_LIB_INSTALL_DIR="%PYTHON%" -DLIT_TOOL="%PYTHON%\\Scripts\\lit.exe" -DMINISAT_LIBDIR=%MINISAT_ROOT% -DMINISAT_INCLUDE_DIRS=%MINISAT_ROOT%\include -DZLIB_ROOT=%ZLIB_ROOT% -DCMAKE_PREFIX_PATH=C:\cygwin64 ..
-  - msbuild %MSBUILD_FLAGS% INSTALL.vcxproj
+  - cmake -G %CMAKE_GENERATOR% -DENABLE_TESTING=ON -DCMAKE_BUILD_TYPE=%CONFIGURATION% -DPYTHON_EXECUTABLE="%PYTHON%\\python.exe" -DPYTHON_LIB_INSTALL_DIR="%PYTHON%" -DLIT_TOOL="%PYTHON%\\Scripts\\lit.exe" -DMINISAT_LIBDIR=%MINISAT_ROOT% -DMINISAT_INCLUDE_DIRS=%MINISAT_ROOT%\include -DZLIB_ROOT=%ZLIB_ROOT% -DCMAKE_PREFIX_PATH=C:\cygwin64 ..\stp
+  - cmake --build . --config %BUILD_TYPE%
+  - cmake --build . --config %BUILD_TYPE% --target check
+  - cmake --build . --config %BUILD_TYPE% --target install
 
 
 build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,6 +60,16 @@ build_script:
   #- cat project-config.jam
   #- b2 --with-program_options address-model=64 toolset=msvc-14.0 variant=release link=static threading=multi runtime-link=static install --prefix="C:\projects\stp\boost_1_59_0_install" > boost_install.out
 
+  # The STP query-file-tests require the "not" tool. For now, we use the one
+  # provided by LLVM.
+  - cd C:\projects\stp
+  - git clone --depth=1 --branch release_40 http://github.com/llvm-mirror/llvm
+  - cd llvm
+  - mkdir build
+  - cmake -G %CMAKE_GENERATOR% -DPYTHON_EXECUTABLE=%PYTHON%\python.exe ..\llvm
+  - cmake --build . --config Release --target not
+  - set PATH=%PATH%;%cd%\Release\bin
+
   # zlib
   # TODO check out http://stackoverflow.com/questions/10507893/libzip-with-visual-studio-2010
   - cd C:\projects\stp
@@ -71,9 +81,6 @@ build_script:
   - mkdir myinstall
   - cd build
   - cmake -G %CMAKE_GENERATOR% -DCMAKE_INSTALL_PREFIX=%ZLIB_ROOT% ..
-  - #if %PLATFORM%==x86 call msbuild %MSBUILD_FLAGS% /t:Build /p:Configuration=%CONFIGURATION% /p:Platform="x86" zlib.sln
-  - #if %PLATFORM%==x64 call msbuild %MSBUILD_FLAGS% /t:Build /p:Configuration=%CONFIGURATION% /p:Platform="x64" zlib.sln
-  - #msbuild %MSBUILD_FLAGS% INSTALL.vcxproj
   - cmake --build . --config %BUILD_TYPE%
   - cmake --build . --config %BUILD_TYPE% --target install
   - dir ..\myinstall\
@@ -101,7 +108,6 @@ build_script:
   # finally STP
   - cd c:\projects\stp
   - git submodule update --init --recursive
-  # building in c:\projects\stp\build causes ASTKind.h not to be found
   - mkdir ..\stp.build
   - cd ..\stp.build
   - cmake --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,17 +22,22 @@ platform:
 
 environment:
   global:
-    BOOST_ROOT: C:\projects\stp\boost_1_59_0_install
+    BOOST_ROOT: C:\Libraries\boost_1_59_0
     MINISAT_ROOT: C:\projects\stp\minisat\myinstall
     ZLIB_ROOT: C:\projects\stp\zlib\myinstall
     MSBUILD_FLAGS: /maxcpucount /nologo
     PYTHON: "C:\\Python36-x64"
+    APPVEYOR_SAVE_CACHE_ON_ERROR: true
 
 install:
     "%PYTHON%\\python.exe -m pip install lit"
 
 configuration:
   - Release
+
+cache:
+  - C:\projects\stp\llvm -> appveyor.yml
+  - C:\projects\stp\llvm.build -> appveyor.yml
 
 build_script:
   - IF "%PLATFORM%" == "x86" ( SET BOOST_LIBRARYDIR=C:/Libraries/boost_1_59_0/lib32-msvc-14.0)
@@ -48,25 +53,14 @@ build_script:
   - echo %APPVEYOR_BUILD_FOLDER%
   - echo %cd%
 
-  # boost
-  - cd c:\projects\stp
-  - mkdir boost_1_59_0_install
-  - ps: . .\scripts\build\appveyor.ps1
-  - cd boost_1_59_0
-  - echo "Building boost.."
-  - bootstrap.bat --with-libraries=program_options
-  - cat project-config.jam
-  - b2 --with-program_options address-model=64 toolset=msvc-14.0 variant=release link=static threading=multi runtime-link=static install --prefix="C:\projects\stp\boost_1_59_0_install" > boost_install.out
-
   # The STP query-file-tests require the "not" tool. For now, we use the one
   # provided by LLVM.
   - cd C:\projects\stp
-  - git clone --depth=1 --branch release_40 https://github.com/llvm-mirror/llvm
-  - cd llvm
-  - mkdir build
-  - cd build
-  - cmake -G %CMAKE_GENERATOR% -DPYTHON_EXECUTABLE=%PYTHON%\python.exe ..
-  - cmake --build . --config Release --target not
+  - if not exist llvm git clone --depth=1 --branch release_40 https://github.com/llvm-mirror/llvm
+  - if not exist llvm.build mkdir llvm.build
+  - cd llvm.build
+  - if not exist Release\bin\not.exe cmake -G %CMAKE_GENERATOR% -DPYTHON_EXECUTABLE=%PYTHON%\python.exe ..\llvm
+  - if not exist Release\bin\not.exe cmake --build . --config Release --target not
   - set PATH=%PATH%;%cd%\Release\bin
 
   # zlib

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,11 +22,9 @@ platform:
 
 environment:
   global:
-    # TODO: building STP with boost is not supported yet on Windows (the problem seems to be easily fixable: stp.pdb gets generated for stp.dll as well as stp.exe, which causes an error.)
-    #BOOST_ROOT: C:\projects\stp\boost_1_59_0_install
+    BOOST_ROOT: C:\projects\stp\boost_1_59_0_install
     MINISAT_ROOT: C:\projects\stp\minisat\myinstall
     ZLIB_ROOT: C:\projects\stp\zlib\myinstall
-    BUILD_TYPE: Release
     MSBUILD_FLAGS: /maxcpucount /nologo
     PYTHON: "C:\\Python36-x64"
 
@@ -37,36 +35,37 @@ configuration:
   - Release
 
 build_script:
-  #- IF "%PLATFORM%" == "x86" ( SET BOOST_LIBRARYDIR=C:/Libraries/boost_1_59_0/lib32-msvc-14.0)
+  - IF "%PLATFORM%" == "x86" ( SET BOOST_LIBRARYDIR=C:/Libraries/boost_1_59_0/lib32-msvc-14.0)
   - IF "%PLATFORM%" == "x86" ( SET CMAKE_GENERATOR="Visual Studio 14 2015")
 
-  #- IF "%PLATFORM%" == "x64" ( SET BOOST_LIBRARYDIR=C:/Libraries/boost_1_59_0/lib64-msvc-14.0)
+  - IF "%PLATFORM%" == "x64" ( SET BOOST_LIBRARYDIR=C:/Libraries/boost_1_59_0/lib64-msvc-14.0)
   - IF "%PLATFORM%" == "x64" ( SET CMAKE_GENERATOR="Visual Studio 14 2015 Win64")
 
   - echo %PLATFORM%
-  #- echo %BOOST_LIBRARYDIR%
+  - echo %BOOST_LIBRARYDIR%
   - echo %CMAKE_GENERATOR%
   - echo %configuration%
   - echo %APPVEYOR_BUILD_FOLDER%
   - echo %cd%
 
   # boost
-  #- cd c:\projects\stp
-  #- mkdir boost_1_59_0_install
-  #- ps: . .\scripts\build\appveyor.ps1
-  #- cd boost_1_59_0
-  #- echo "Building boost.."
-  #- bootstrap.bat --with-libraries=program_options
-  #- cat project-config.jam
-  #- b2 --with-program_options address-model=64 toolset=msvc-14.0 variant=release link=static threading=multi runtime-link=static install --prefix="C:\projects\stp\boost_1_59_0_install" > boost_install.out
+  - cd c:\projects\stp
+  - mkdir boost_1_59_0_install
+  - ps: . .\scripts\build\appveyor.ps1
+  - cd boost_1_59_0
+  - echo "Building boost.."
+  - bootstrap.bat --with-libraries=program_options
+  - cat project-config.jam
+  - b2 --with-program_options address-model=64 toolset=msvc-14.0 variant=release link=static threading=multi runtime-link=static install --prefix="C:\projects\stp\boost_1_59_0_install" > boost_install.out
 
   # The STP query-file-tests require the "not" tool. For now, we use the one
   # provided by LLVM.
   - cd C:\projects\stp
-  - git clone --depth=1 --branch release_40 http://github.com/llvm-mirror/llvm
+  - git clone --depth=1 --branch release_40 https://github.com/llvm-mirror/llvm
   - cd llvm
   - mkdir build
-  - cmake -G %CMAKE_GENERATOR% -DPYTHON_EXECUTABLE=%PYTHON%\python.exe ..\llvm
+  - cd build
+  - cmake -G %CMAKE_GENERATOR% -DPYTHON_EXECUTABLE=%PYTHON%\python.exe ..
   - cmake --build . --config Release --target not
   - set PATH=%PATH%;%cd%\Release\bin
 
@@ -81,8 +80,8 @@ build_script:
   - mkdir myinstall
   - cd build
   - cmake -G %CMAKE_GENERATOR% -DCMAKE_INSTALL_PREFIX=%ZLIB_ROOT% ..
-  - cmake --build . --config %BUILD_TYPE%
-  - cmake --build . --config %BUILD_TYPE% --target install
+  - cmake --build . --config %CONFIGURATION%
+  - cmake --build . --config %CONFIGURATION% --target install
   - dir ..\myinstall\
 
   # minisat
@@ -94,8 +93,8 @@ build_script:
   - mkdir myinstall
   - cd build
   - cmake -G %CMAKE_GENERATOR% -DCMAKE_INSTALL_PREFIX=%MINISAT_ROOT% -DZLIB_ROOT=%ZLIB_ROOT% ..
-  - cmake --build . --config %BUILD_TYPE%
-  - cmake --build . --config %BUILD_TYPE% --target install
+  - cmake --build . --config %CONFIGURATION%
+  - cmake --build . --config %CONFIGURATION% --target install
   - dir ..\myinstall\
   - dir ..\myinstall\lib\
   - dir ..\myinstall\bin\
@@ -108,13 +107,15 @@ build_script:
   # finally STP
   - cd c:\projects\stp
   - git submodule update --init --recursive
+  # Building in c:\projects\stp\build fails with cmake --build since ASTKind.h
+  # cannot be found, so build it in ..\stp.build
   - mkdir ..\stp.build
   - cd ..\stp.build
   - cmake --version
-  - cmake -G %CMAKE_GENERATOR% -DENABLE_TESTING=ON -DCMAKE_BUILD_TYPE=%CONFIGURATION% -DPYTHON_EXECUTABLE="%PYTHON%\\python.exe" -DPYTHON_LIB_INSTALL_DIR="%PYTHON%" -DLIT_TOOL="%PYTHON%\\Scripts\\lit.exe" -DMINISAT_LIBDIR=%MINISAT_ROOT% -DMINISAT_INCLUDE_DIRS=%MINISAT_ROOT%\include -DZLIB_ROOT=%ZLIB_ROOT% -DCMAKE_PREFIX_PATH=C:\cygwin64 ..\stp
-  - cmake --build . --config %BUILD_TYPE%
-  - cmake --build . --config %BUILD_TYPE% --target check
-  - cmake --build . --config %BUILD_TYPE% --target install
+  - cmake -G %CMAKE_GENERATOR% -DBoost_USE_STATIC_LIBS=ON -DENABLE_TESTING=ON -DPYTHON_EXECUTABLE="%PYTHON%\\python.exe" -DPYTHON_LIB_INSTALL_DIR="%PYTHON%" -DLIT_TOOL="%PYTHON%\\Scripts\\lit.exe" -DMINISAT_LIBDIR=%MINISAT_ROOT% -DMINISAT_INCLUDE_DIRS=%MINISAT_ROOT%\include -DZLIB_ROOT=%ZLIB_ROOT% -DCMAKE_PREFIX_PATH=C:\cygwin64 ..\stp
+  - cmake --build . --config %CONFIGURATION%
+  - cmake --build . --config %CONFIGURATION% --target check
+  - cmake --build . --config %CONFIGURATION% --target install
 
 
 build:
@@ -125,7 +126,7 @@ build:
 
 # scripts to run after build
 after_build:
-  - 7z a c:\projects\stp\stp.zip %APPVEYOR_BUILD_FOLDER%\build -tzip
+  - 7z a c:\projects\stp\stp.zip %APPVEYOR_BUILD_FOLDER%\..\stp.build -tzip
   - cd c:\projects\stp
 
 artifacts:

--- a/bindings/python/stp/CMakeLists.txt
+++ b/bindings/python/stp/CMakeLists.txt
@@ -64,17 +64,16 @@ endif()
 
 # Install main files
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}/stp.py
-              ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}/__init__.py
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/stp.py
+              ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/__init__.py
         DESTINATION "${PYTHON_LIB_INSTALL_DIR}/stp")
 
 # Generate and install file describing install location of stp shared library
-get_target_property(LIBSTP_OUTPUTNAME libstp OUTPUT_NAME)
-get_filename_component(LIBSTP_FILENAME ${LIBSTP_OUTPUTNAME} DIRECTORY)
-get_target_property(LIBSTP_SUFFIX libstp SUFFIX)
 set(LIBSTP_PATH ${CMAKE_INSTALL_PREFIX}/lib/${LIBSTP_FILENAME}) # FIXME: This is also set in libstp/CMakeLists.txt which could be fragile
-configure_file(library_path.py.in_install "${PROJECT_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/library_path.py" @ONLY)
+configure_file(library_path.py.in_install "${PROJECT_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/library_path.py.g" @ONLY)
+file(GENERATE OUTPUT "${PROJECT_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/$<CONFIG>/library_path.py"
+              INPUT "${PROJECT_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/library_path.py.g")
 
-install(FILES "${PROJECT_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/library_path.py"
+install(FILES "${PROJECT_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/$<CONFIG>/library_path.py"
         DESTINATION "${PYTHON_LIB_INSTALL_DIR}/stp"
        )

--- a/bindings/python/stp/CMakeLists.txt
+++ b/bindings/python/stp/CMakeLists.txt
@@ -26,15 +26,15 @@
 # (e.g. when building with MSBuild), so generate the file lately.)
 
 get_property(STP_LIB_LOCATION TARGET libstp PROPERTY LOCATION)
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/library_path.py.in
-              ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}/library_path.py)
+file(GENERATE OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/library_path.py
+              INPUT  ${CMAKE_CURRENT_SOURCE_DIR}/library_path.py.in)
 
 # Copy rest of files to build directory
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/stp.py.in
-              ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}/stp.py)
+file(GENERATE OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/stp.py
+              INPUT  ${CMAKE_CURRENT_SOURCE_DIR}/stp.py.in)
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/__init__.py.in
-              ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}/__init__.py)
+file(GENERATE OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/__init__.py
+              INPUT  ${CMAKE_CURRENT_SOURCE_DIR}/__init__.py.in)
 
 # -----------------------------------------------------------------------------
 # Handle installation

--- a/bindings/python/stp/library_path.py.in
+++ b/bindings/python/stp/library_path.py.in
@@ -28,5 +28,5 @@
 
 # Search paths for the stp shared library
 PATHS = [
-    '@STP_LIB_LOCATION@'
+    '$<TARGET_FILE:libstp>'
 ]

--- a/bindings/python/stp/library_path.py.in_install
+++ b/bindings/python/stp/library_path.py.in_install
@@ -28,5 +28,5 @@
 
 # Search paths for the stp shared library
 PATHS = [
-    '@LIBSTP_PATH@/@CMAKE_SHARED_LIBRARY_PREFIX@@LIBSTP_FILENAME@@CMAKE_SHARED_LIBRARY_SUFFIX@',
+    '@LIBSTP_PATH@/$<TARGET_FILE_NAME:libstp>',
 ]

--- a/tests/api/python/CMakeLists.txt
+++ b/tests/api/python/CMakeLists.txt
@@ -19,12 +19,14 @@
 # THE SOFTWARE.
 
 set(PYTHON_INTERFACE_DIR ${PROJECT_BINARY_DIR}/bindings/python)
-configure_file(tests.py.in ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}/tests.py @ONLY)
+configure_file(tests.py.in tests.py.in.g @ONLY)
+file(GENERATE OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/tests.py
+              INPUT  ${CMAKE_CURRENT_BINARY_DIR}/tests.py.in.g)
 
 add_custom_target(python-interface-tests
                   DEPENDS libstp
                   COMMAND ${PYTHON_EXECUTABLE}
-                          ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}/tests.py
+                          ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/tests.py
                   COMMENT "Running python-interface-tests"
                  )
 

--- a/tests/api/python/tests.py.in
+++ b/tests/api/python/tests.py.in
@@ -27,7 +27,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import sys
 # Make sure we can find the STP python package
-sys.path.insert(0, "@PYTHON_INTERFACE_DIR@/stp/@CMAKE_BUILD_TYPE@")
+sys.path.insert(0, "@PYTHON_INTERFACE_DIR@/stp/$<CONFIG>")
 
 from stp import stp, Solver
 import unittest


### PR DESCRIPTION
This PR enables testing in AppVeyor. Curiously, the tests pass on my local Windows machine and fail in AppVeyor (running in Release mode in both cases - see the comments in #247).

Also, building against static boost libraries is enabled now and a tiny part of LLVM is built to get a _not_ utility on Windows for running the tests. To keep build times down, the boost build coming with AppVeyor is used and the LLVM files are cached between AppVeyor runs.

GitHub does not display CI information for me right now. The logs for the most recent commit are:
https://travis-ci.org/fkutzner/stp/builds/230315036
https://ci.appveyor.com/project/fkutzner/stp/build/1.0.49