### PR TITLE
[CMake] Fix #192

### DIFF
--- a/lib/Parser/CMakeLists.txt
+++ b/lib/Parser/CMakeLists.txt
@@ -53,7 +53,7 @@ foreach(_file ${TOLEX})
         OUTPUT  ${CMAKE_CURRENT_BINARY_DIR}/parse${_file}.cpp  ${CMAKE_CURRENT_BINARY_DIR}/lex${_file}.cpp
         COMMAND ${BISON_EXECUTABLE} --debug -v -o ${CMAKE_CURRENT_BINARY_DIR}/parse${_file}.cpp -d -p ${_file} ${CMAKE_CURRENT_SOURCE_DIR}/${_file}.y
         COMMAND ${FLEX_EXECUTABLE} ${FLEX_COMPATIBILITY_ARGS} -Ce -o${CMAKE_CURRENT_BINARY_DIR}/lex${_file}.cpp -P${_file} ${CMAKE_CURRENT_SOURCE_DIR}/${_file}.lex
-        DEPENDS ${_file}.lex ${_file}.y
+        DEPENDS ${_file}.lex ${_file}.y ASTKind_header
     )
     add_custom_target(parser_header${_file} ALL
         DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/parse${_file}.cpp ${CMAKE_CURRENT_BINARY_DIR}/lex${_file}.cpp


### PR DESCRIPTION
The build steps for the `parser` step were missing a dependency
on the `ASTKind_header` target which would trigger a compilation
failure on macOS when using the "UNIX Makefiles" generator.

This was discovered recently in https://github.com/klee/klee/issues/714
.

I first tried a different approach to fixing this by generating
`ASTKind.cpp` and `ASTKind.h` at configure time and having
CMAKE_CONFIGURE_DEPENDS directory property depend on the files used for
generation. Although this worked it caused STP to be rebuilt from
scratch everytime a re-configure happened.  Although it would be
possible to work around this by only replacing the files if they've
changed at configure time this seems too much work for very little
return. So I went for the simpler change in this commit.