### PR TITLE
circumvent Xcode bug with CMake's TARGET_OBJECTS

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -73,6 +73,17 @@ foreach(target ${stp_lib_targets})
     endif()
 endforeach()
 
+if(CMAKE_GENERATOR STREQUAL Xcode)
+    # Code has a serious bug where the XCode project produces an invalid target that will not get
+    # linked if it consists only of objects from object libraries, it will not generate any
+    # products (executables, libraries). The only work around is to add a dummy source
+    # file to the library definition. This is an XCode, not a CMake bug.
+    # see https://itk.org/Bug/view.php?id=14044
+    set(XCODE_DUMMY_FILE "${CMAKE_BINARY_DIR}/xcode_dummy.cpp")
+    file(WRITE ${XCODE_DUMMY_FILE} "")
+    list(APPEND stp_lib_objects ${XCODE_DUMMY_FILE})
+endif()
+
 if (STATICCOMPILE)
     add_library(libstp STATIC
         ${stp_lib_objects}


### PR DESCRIPTION
STP currently cannot be built with CMake using Xcode as a generator.
This is due to a bug that occurs with TARGET_OBJECTS in current Xcode versions.
The submitted fix is also used similarly in other projects.