### PR TITLE
Mark two more global variables as thread_local

### DIFF
--- a/include/stp/Simplifier/UnsignedIntervalAnalysis.h
+++ b/include/stp/Simplifier/UnsignedIntervalAnalysis.h
@@ -45,8 +45,8 @@ namespace stp
 {
 using std::make_pair;
 
-unsigned propagatorNotImplemented =0;
-unsigned iterations =0;
+THREAD_LOCAL unsigned propagatorNotImplemented =0;
+THREAD_LOCAL unsigned iterations =0;
 
 void print_stats()
 {


### PR DESCRIPTION
I missed these in the first version of the "thread-safe" code.

I discovered this by running my fork of KLEE (with 24 instances of STP) under Intel Inspector. Neither of these affects correctness of the solver, but one does affect correctness of diagnostic output. In any case, we should avoid all data races.