### PR TITLE
Fix bison prefix

### DIFF
--- a/lib/Parser/CMakeLists.txt
+++ b/lib/Parser/CMakeLists.txt
@@ -34,7 +34,7 @@ foreach(_file ${TOLEX})
     add_custom_command(
         OUTPUT  ${CMAKE_CURRENT_BINARY_DIR}/parse${_file}.tab.cpp ${CMAKE_CURRENT_BINARY_DIR}/parse${_file}.tab.h ${CMAKE_CURRENT_BINARY_DIR}/lex${_file}.cpp
 
-        COMMAND ${BISON_EXECUTABLE} --debug -v -b ${CMAKE_CURRENT_BINARY_DIR}/parse${_file} -d -Dapi.prefix={${_file}} ${CMAKE_CURRENT_SOURCE_DIR}/${_file}.y
+        COMMAND ${BISON_EXECUTABLE} --debug -v -b ${CMAKE_CURRENT_BINARY_DIR}/parse${_file} -d -Dapi.prefix=${_file} ${CMAKE_CURRENT_SOURCE_DIR}/${_file}.y
 
         COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/parse${_file}.tab.c ${CMAKE_CURRENT_BINARY_DIR}/parse${_file}.tab.cpp
 


### PR DESCRIPTION
Previously `bison` was being called with `-Dapi.prefix={cvc}` for example, and the braces literally ended up in my `parsecvc.tab.h` header, which upset the C compiler (see sample error messages below). Is it a known quirk of a different version of `bison`?

```
/home1/x/xialiyao/code/stp/build/lib/Parser/parsecvc.tab.h:36:9: error: macro names must be identifiers
 #ifndef {CVC}DEBUG
         ^
/home1/x/xialiyao/code/stp/build/lib/Parser/parsecvc.tab.h:47:5: error: token "{" is not valid in preprocessor expressions
 #if {CVC}DEBUG
     ^
/home1/x/xialiyao/code/stp/build/lib/Parser/parsecvc.tab.h:52:9: error: macro names must be identifiers
 #ifndef {CVC}TOKENTYPE
         ^
/home1/x/xialiyao/code/stp/build/lib/Parser/parsecvc.tab.h:133:15: error: operator "defined" requires an identifier
 #if ! defined {CVC}STYPE && ! defined {CVC}STYPE_IS_DECLARED
               ^
/home1/x/xialiyao/code/stp/build/lib/Parser/parsecvc.tab.h:133:16: error: missing binary operator before token "CVC"
 #if ! defined {CVC}STYPE && ! defined {CVC}STYPE_IS_DECLARED
                ^
```