### PR TITLE
Fixed pointer->long->pointer conversions in aig.h

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -96,7 +96,10 @@ before_build:
 
   # get flex, bison, perl
   - C:\cygwin64\setup-x86_64.exe  -qnNd -R C:/cygwin64 -s http://cygwin.mirror.constant.com -l C:/cygwin64/var/cache/setup --packages "flex,bison,perl"
-
+  # prepend cygwin to %PATH% so that Cygwin's cat.exe is used instead of Git's
+  # one. This had caused Cygwin version conflicts (probably due to the wrong
+  # Cygwin DLL being loaded for cat.exe)
+  - SET PATH=C:/cygwin64/bin;%PATH%
 
 
   # finally STP

--- a/lib/extlib-abc/aig.h
+++ b/lib/extlib-abc/aig.h
@@ -49,6 +49,7 @@ extern "C" {
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <string.h>
 #include <assert.h>
 #include <time.h>
@@ -195,10 +196,29 @@ static inline int          Aig_WordCountOnes( unsigned uWord )
     return  (uWord & 0x0000FFFF) + (uWord>>16);
 }
 
-static inline Aig_Obj_t *  Aig_Regular( Aig_Obj_t * p )           { return (Aig_Obj_t *)((unsigned long)(p) & ~01); }
-static inline Aig_Obj_t *  Aig_Not( Aig_Obj_t * p )               { return (Aig_Obj_t *)((unsigned long)(p) ^  01); }
-static inline Aig_Obj_t *  Aig_NotCond( Aig_Obj_t * p, int c )    { return (Aig_Obj_t *)((unsigned long)(p) ^ (c)); }
-static inline int          Aig_IsComplement( Aig_Obj_t * p )      { return (int )(((unsigned long)p) & 01);         }
+static inline Aig_Obj_t *  Aig_Regular( Aig_Obj_t * p )
+{
+    uintptr_t mask = 01;
+    return (Aig_Obj_t *)((uintptr_t)(p) & ~mask);
+}
+
+static inline Aig_Obj_t *  Aig_Not( Aig_Obj_t * p )
+{
+    uintptr_t mask = 01;
+    return (Aig_Obj_t *)((uintptr_t)(p) ^ mask);
+}
+
+static inline Aig_Obj_t *  Aig_NotCond( Aig_Obj_t * p, int c )
+{
+    intptr_t mask = c;
+    return (Aig_Obj_t *)((intptr_t)(p) ^ (mask));
+}
+
+static inline int Aig_IsComplement( Aig_Obj_t * p )
+{
+    uintptr_t mask = 01;
+    return (int )(((uintptr_t)p) & mask);
+}
 
 static inline int          Aig_ManPiNum( Aig_Man_t * p )          { return p->nObjs[AIG_OBJ_PI];                    }
 static inline int          Aig_ManPoNum( Aig_Man_t * p )          { return p->nObjs[AIG_OBJ_PO];                    }


### PR DESCRIPTION
The STP tests started to fail on my machine when I upgraded to Windows 10. This PR fixes some pointer->long->pointer conversions in aig.h causing trouble when compiling with MSVC, which uses 4-byte longs both for 32-bit and 64-bit binaries.

With this fix, all tests pass on my machine. The `query-files` tests still fail on AppVeyor, but I've seen them pass on AppVeyor when I reactivated the build of `not`.

Edit: this fixes #271.