### PR TITLE
starexec: add multicore configuration

### DIFF
--- a/scripts/starexec/bin/starexec_run_multicore
+++ b/scripts/starexec/bin/starexec_run_multicore
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Use STP to create CNF from SMT input, and use Cryptominisat to solve it
+# Note: Cryptominisat will run in multicore mode, and will start a thread
+#       for each core it's allowed to use.
+
+SOLVERDIR="$(dirname "${BASH_SOURCE[0]}" )"
+
+# clean last call
+rm -f output_0.cnf
+"$SOLVERDIR"/stp-2.1.2  --SMTLIB2 --output-CNF --exit-after-CNF "$1"
+
+# In case a file was created, call the SAT solver
+if [ -f output_0.cnf ]
+then
+	result=`$SOLVERDIR/cryptominisat5 --verb 0 --threads $(nproc) --printsol 0 output_0.cnf`
+
+	if [[ "$result" == *"s SATISFIABLE"* ]]; then
+		echo "sat"
+	elif [[ "$result" == *"s UNSATISFIABLE"* ]]; then
+		echo "unsat"
+	fi
+fi


### PR DESCRIPTION
As the SMT competition supports the parallel execution of SAT solvers,
allow to use cryptominisat in its parallel mode, using all cores that
are available automatically.