### PR TITLE
Expose STP's versioning information via the C API and the Python API

### DIFF
--- a/bindings/python/stp/stp.py.in
+++ b/bindings/python/stp/stp.py.in
@@ -3,6 +3,7 @@ The MIT License
 
 Copyright (c) 2008 Vijay Ganesh
               2014 Jurriaan Bremer, jurriaanbremer@gmail.com
+              2018 Andrew V. Jones, andrewvaughanj@gmail.com
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
@@ -33,6 +34,7 @@ import sys
 
 __all__ = [
     'Expr', 'Solver', 'stp', 'add', 'bitvec', 'bitvecs', 'check', 'model',
+    'get_git_version_sha', 'get_git_version_tag', 'get_compilation_env'
 ]
 
 Py3 = sys.version_info >= (3, 0, 0)
@@ -61,6 +63,9 @@ _Expr = c_void_p
 _Type = c_void_p
 _WholeCounterExample = c_void_p
 
+_set_func('get_git_version_sha', c_char_p)
+_set_func('get_git_version_tag', c_char_p)
+_set_func('get_compilation_env', c_char_p)
 _set_func('vc_createValidityChecker', _VC)
 _set_func('vc_boolType', _Type, _VC)
 _set_func('vc_arrayType', _Type, _VC, _Type, _Type)
@@ -693,3 +698,14 @@ def check(*args, **kwargs):
 
 def model(*args, **kwargs):
     return Solver.current.model(*args, **kwargs)
+
+def get_git_version_sha():
+    return _lib.get_git_version_sha()
+
+def get_git_version_tag():
+    return _lib.get_git_version_tag()
+
+def get_compilation_env():
+    return _lib.get_compilation_env()
+
+# EOF

--- a/include/stp/c_interface.h
+++ b/include/stp/c_interface.h
@@ -1,5 +1,5 @@
 /********************************************************************
- * AUTHORS: Michael Katelman, Vijay Ganesh, Trevor Hansen
+ * AUTHORS: Michael Katelman, Vijay Ganesh, Trevor Hansen, Andrew V. Jones
  *
  * BEGIN DATE: Apr, 2008
  *
@@ -85,6 +85,18 @@ typedef void* WholeCounterExample;
 /////////////////////////////////////////////////////////////////////////////
 /// START API
 /////////////////////////////////////////////////////////////////////////////
+
+//! \brief Returns the C string for the git sha of STP
+//!
+DLL_PUBLIC const char* get_git_version_sha(void);
+
+//! \brief Returns the C string for the git tag of STP
+//!
+DLL_PUBLIC const char* get_git_version_tag(void);
+
+//! \brief Returns the C string for the compilation env of STP
+//!
+DLL_PUBLIC const char* get_compilation_env(void);
 
 //! \brief Processes the given flag represented as char for the given validity checker.
 //!

--- a/lib/Interface/c_interface.cpp
+++ b/lib/Interface/c_interface.cpp
@@ -1,5 +1,5 @@
 /********************************************************************
- * AUTHORS: Vijay Ganesh
+ * AUTHORS: Vijay Ganesh, Andrew V. Jones
  *
  * BEGIN DATE: November, 2005
  *
@@ -31,6 +31,7 @@ THE SOFTWARE.
 #include "stp/Parser/parser.h"
 #include "stp/Printer/printers.h"
 #include "stp/cpp_interface.h"
+#include "stp/Util/GitSHA1.h"
 // FIXME: External library
 #include "extlib-abc/cnf_short.h"
 
@@ -44,6 +45,24 @@ using std::endl;
 // GLOBAL FUNCTION: parser
 extern int cvcparse(void*);
 extern int smtparse(void*);
+
+/* wraps get_git_version_sha in stp namespace */
+const char* get_git_version_sha(void)
+{
+  return stp::get_git_version_sha();
+}
+
+/* wraps get_git_version_tag in stp namespace */
+const char* get_git_version_tag(void)
+{
+  return stp::get_git_version_tag();
+}
+
+/* wraps get_compilation_env in stp namespace */
+const char* get_compilation_env(void)
+{
+  return stp::get_compilation_env();
+}
 
 // TODO remove this, it's really ugly
 void vc_setFlags(VC vc, char c, int /*param_value*/)

--- a/tests/api/python/tests.py.in
+++ b/tests/api/python/tests.py.in
@@ -4,6 +4,7 @@ The MIT License
 
 Copyright (c) 2008 Vijay Ganesh
               2014 Jurriaan Bremer, jurriaanbremer@gmail.com
+              2018 Andrew V. Jones, andrewvaughanj@gmail.com
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
@@ -29,24 +30,24 @@ import sys
 # Make sure we can find the STP python package
 sys.path.insert(0, "@PYTHON_INTERFACE_DIR@/stp")
 
-from stp import stp, Solver
+import stp
 import unittest
 
 
-@stp
+@stp.stp
 def test0_foo(a, b):
     assert b != 0
     return (a + 42) % b
 
 
-@stp
+@stp.stp
 def test0_bar(a, b):
     return a * b == 12345
 
 
 class TestSTP(unittest.TestCase):
     def setUp(self):
-        self.s = Solver()
+        self.s = stp.Solver()
 
     def test_simple(self):
         s = self.s
@@ -124,7 +125,7 @@ class TestSTP(unittest.TestCase):
             {'y': 489153109, 'x': 489153109},
         ]
 
-        with Solver() as s:
+        with stp.Solver() as s:
             x, y = s.bitvecs('x y')
             count = 0
             while s.check(test0_foo(x, y) == test0_foo(y, x),
@@ -263,7 +264,27 @@ class TestSTP(unittest.TestCase):
             s.check(c == op(a))
             self.assertEqual(s.model()['c'], op(A) % 2**32)
 
+    def test_git_version_sha(self):
+        """
+        Test verifies that the returned git sha is of non-zero length
+        """
+        self.assertNotEqual(len(stp.get_git_version_sha()), 0)
+
+    def test_git_version_tag(self):
+        """
+        Test verifies that the returned git tag is of non-zero length
+        """
+        self.assertNotEqual(len(stp.get_git_version_tag()), 0)
+
+    def test_compilation_env(self):
+        """
+        Test verifies that the returned compilation env is of non-zero length
+        """
+        self.assertNotEqual(len(stp.get_compilation_env()), 0)
+
 
 if __name__ == '__main__':
     suite = unittest.TestLoader().loadTestsFromTestCase(TestSTP)
     unittest.TextTestRunner(verbosity=2).run(suite)
+
+# EOF


### PR DESCRIPTION
Currently, for a pre-build version of STP, it is not possible to (dynamically) find out which version of STP you are running.

This PR:

- Adds versioning calls to the C and Python API
- Adds test-cases to the Python API