### PR TITLE
Python: attempt to dynamically locate libstp.{so, dll}

### DIFF
--- a/bindings/python/stp/library_path.py.in
+++ b/bindings/python/stp/library_path.py.in
@@ -1,4 +1,4 @@
-# AUTHORS: Dan Liew
+# AUTHORS: Dan Liew, Andrew V. Jones
 #
 # BEGIN DATE: May, 2014
 #
@@ -27,6 +27,12 @@
 # a good idea.
 
 # Search paths for the stp shared library
-PATHS = [
-    '@CMAKE_LIBRARY_OUTPUT_DIRECTORY@/@LIBSTP_FILENAME@'
+
+import os
+
+PATHS = ["@CMAKE_LIBRARY_OUTPUT_DIRECTORY@/@LIBSTP_FILENAME@"] + [
+    os.path.join(directory, "@LIBSTP_FILENAME@")
+    for directory in os.environ["PYTHONPATH"].split(os.pathsep)
 ]
+
+# EOF

--- a/bindings/python/stp/library_path.py.in
+++ b/bindings/python/stp/library_path.py.in
@@ -31,11 +31,17 @@
 import os
 import sys
 
-path_var = 'PATH' if sys.platform in ('win32', 'cygwin') else 'DYLD_LIBRARY_PATH' if sys.platform == 'darwin' else 'LD_LIBRARY_PATH'
+path_var = (
+    "PATH"
+    if sys.platform in ("win32", "cygwin")
+    else "DYLD_LIBRARY_PATH"
+    if sys.platform == "darwin"
+    else "LD_LIBRARY_PATH"
+)
 
-PATHS = ['@CMAKE_LIBRARY_OUTPUT_DIRECTORY@/@LIBSTP_FILENAME@'] + [
-    os.path.join(directory, '@LIBSTP_FILENAME@')
-    for directory in os.environ.get(path_var, '').split(os.pathsep)
+PATHS = ["@CMAKE_LIBRARY_OUTPUT_DIRECTORY@/@LIBSTP_FILENAME@"] + [
+    os.path.join(directory, "@LIBSTP_FILENAME@")
+    for directory in os.environ.get(path_var, "").split(os.pathsep)
 ]
 
 # EOF

--- a/bindings/python/stp/library_path.py.in
+++ b/bindings/python/stp/library_path.py.in
@@ -29,10 +29,13 @@
 # Search paths for the stp shared library
 
 import os
+import sys
 
-PATHS = ["@CMAKE_LIBRARY_OUTPUT_DIRECTORY@/@LIBSTP_FILENAME@"] + [
-    os.path.join(directory, "@LIBSTP_FILENAME@")
-    for directory in os.environ["PYTHONPATH"].split(os.pathsep)
+path_var = 'PATH' if sys.platform in ('win32', 'cygwin') else 'DYLD_LIBRARY_PATH' if sys.platform == 'darwin' else 'LD_LIBRARY_PATH'
+
+PATHS = ['@CMAKE_LIBRARY_OUTPUT_DIRECTORY@/@LIBSTP_FILENAME@'] + [
+    os.path.join(directory, '@LIBSTP_FILENAME@')
+    for directory in os.environ.get(path_var, '').split(os.pathsep)
 ]
 
 # EOF

--- a/bindings/python/stp/library_path.py.in
+++ b/bindings/python/stp/library_path.py.in
@@ -41,5 +41,3 @@ PATHS = ["@CMAKE_LIBRARY_OUTPUT_DIRECTORY@/@LIBSTP_FILENAME@"] + [
     os.path.join(directory, "@LIBSTP_FILENAME@")
     for directory in os.environ.get(path_var, "").split(os.pathsep)
 ]
-
-# EOF


### PR DESCRIPTION
Currently, the file `library_path.py` hard-codes the path to the libstp.so, based on the path that was used for CMake. This means that the STP build is tied to the build location, which isn't ideal.

This PR changes `library_path.py` to use both the CMake location and then to check PYTHONPATH.