### PR TITLE
Add support in Python and C API to dynamically get/set underlying SAT solver

### DIFF
--- a/bindings/python/stp/stp.py.in
+++ b/bindings/python/stp/stp.py.in
@@ -3,6 +3,7 @@ The MIT License
 
 Copyright (c) 2008 Vijay Ganesh
               2014 Jurriaan Bremer, jurriaanbremer@gmail.com
+              2018 Andrew V. Jones, andrewvaughanj@gmail.com
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
@@ -26,7 +27,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import ast
 from ctypes import cdll, POINTER, CFUNCTYPE
-from ctypes import c_char_p, c_void_p, c_int32, c_uint32, c_uint64, c_ulong
+from ctypes import c_char_p, c_void_p, c_int32, c_uint32, c_uint64, c_ulong, c_ubyte
 import inspect
 import os.path
 import sys
@@ -62,6 +63,16 @@ _Type = c_void_p
 _WholeCounterExample = c_void_p
 
 _set_func('vc_createValidityChecker', _VC)
+_set_func('vc_setMinisat', c_ubyte, _VC)
+_set_func('vc_usingMinisat', c_ubyte, _VC)
+_set_func('vc_setSimplifyingMinisat', c_ubyte, _VC)
+_set_func('vc_usingSimplifyingMinisat', c_ubyte, _VC)
+_set_func('vc_supportsCryptoMinisat', c_ubyte, _VC)
+_set_func('vc_setCryptoMinisat', c_ubyte, _VC)
+_set_func('vc_usingCryptoMinisat', c_ubyte, _VC)
+_set_func('vc_supportsRiss', c_ubyte, _VC)
+_set_func('vc_setRiss', c_ubyte, _VC)
+_set_func('vc_usingRiss', c_ubyte, _VC)
 _set_func('vc_boolType', _Type, _VC)
 _set_func('vc_arrayType', _Type, _VC, _Type, _Type)
 _set_func('vc_varExpr', _Expr, _VC, c_char_p, _Type)
@@ -201,6 +212,36 @@ class Solver(object):
 
     def __exit__(self, exc_type, exc_value, traceback):
         Solver.current = None
+
+    def setMinisat(self):
+        return _lib.vc_setMinisat(self.vc)
+
+    def usingMinisat(self):
+        return _lib.vc_usingMinisat(self.vc)
+
+    def setSimplifyingMinisat(self):
+        return _lib.vc_setSimplifyingMinisat(self.vc)
+
+    def usingSimplifyingMinisat(self):
+        return _lib.vc_usingSimplifyingMinisat(self.vc)
+
+    def supportsCryptoMinisat(self):
+        return _lib.vc_supportsCryptoMinisat(self.vc)
+
+    def setCryptoMinisat(self):
+        return _lib.vc_setCryptoMinisat(self.vc)
+
+    def usingCryptoMinisat(self):
+        return _lib.vc_usingCryptoMinisat(self.vc)
+
+    def supportsRiss(self):
+        return _lib.vc_supportsRiss(self.vc)
+
+    def setRiss(self):
+        return _lib.vc_setRiss(self.vc)
+
+    def usingRiss(self):
+        return _lib.vc_usingRiss(self.vc)
 
     def bitvec(self, name, width=32):
         """Creates a new BitVector variable."""

--- a/bindings/python/stp/stp.py.in
+++ b/bindings/python/stp/stp.py.in
@@ -27,7 +27,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import ast
 from ctypes import cdll, POINTER, CFUNCTYPE
-from ctypes import c_char_p, c_void_p, c_int32, c_uint32, c_uint64, c_ulong, c_ubyte
+from ctypes import c_char_p, c_void_p, c_int32, c_uint32, c_uint64, c_ulong, c_bool
 import inspect
 import os.path
 import sys
@@ -63,18 +63,18 @@ _Type = c_void_p
 _WholeCounterExample = c_void_p
 
 _set_func('vc_createValidityChecker', _VC)
-_set_func('vc_supportsMinisat', c_ubyte, _VC)
-_set_func('vc_useMinisat', c_ubyte, _VC)
-_set_func('vc_isUsingMinisat', c_ubyte, _VC)
-_set_func('vc_supportsSimplifyingMinisat', c_ubyte, _VC)
-_set_func('vc_useSimplifyingMinisat', c_ubyte, _VC)
-_set_func('vc_isUsingSimplifyingMinisat', c_ubyte, _VC)
-_set_func('vc_supportsCryptominisat', c_ubyte, _VC)
-_set_func('vc_useCryptominisat', c_ubyte, _VC)
-_set_func('vc_isUsingCryptominisat', c_ubyte, _VC)
-_set_func('vc_supportsRiss', c_ubyte, _VC)
-_set_func('vc_useRiss', c_ubyte, _VC)
-_set_func('vc_isUsingRiss', c_ubyte, _VC)
+_set_func('vc_supportsMinisat', c_bool, _VC)
+_set_func('vc_useMinisat', c_bool, _VC)
+_set_func('vc_isUsingMinisat', c_bool, _VC)
+_set_func('vc_supportsSimplifyingMinisat', c_bool, _VC)
+_set_func('vc_useSimplifyingMinisat', c_bool, _VC)
+_set_func('vc_isUsingSimplifyingMinisat', c_bool, _VC)
+_set_func('vc_supportsCryptominisat', c_bool, _VC)
+_set_func('vc_useCryptominisat', c_bool, _VC)
+_set_func('vc_isUsingCryptominisat', c_bool, _VC)
+_set_func('vc_supportsRiss', c_bool, _VC)
+_set_func('vc_useRiss', c_bool, _VC)
+_set_func('vc_isUsingRiss', c_bool, _VC)
 _set_func('vc_boolType', _Type, _VC)
 _set_func('vc_arrayType', _Type, _VC, _Type, _Type)
 _set_func('vc_varExpr', _Expr, _VC, c_char_p, _Type)

--- a/bindings/python/stp/stp.py.in
+++ b/bindings/python/stp/stp.py.in
@@ -63,16 +63,18 @@ _Type = c_void_p
 _WholeCounterExample = c_void_p
 
 _set_func('vc_createValidityChecker', _VC)
-_set_func('vc_setMinisat', c_ubyte, _VC)
-_set_func('vc_usingMinisat', c_ubyte, _VC)
-_set_func('vc_setSimplifyingMinisat', c_ubyte, _VC)
-_set_func('vc_usingSimplifyingMinisat', c_ubyte, _VC)
-_set_func('vc_supportsCryptoMinisat', c_ubyte, _VC)
-_set_func('vc_setCryptoMinisat', c_ubyte, _VC)
-_set_func('vc_usingCryptoMinisat', c_ubyte, _VC)
+_set_func('vc_supportsMinisat', c_ubyte, _VC)
+_set_func('vc_useMinisat', c_ubyte, _VC)
+_set_func('vc_isUsingMinisat', c_ubyte, _VC)
+_set_func('vc_supportsSimplifyingMinisat', c_ubyte, _VC)
+_set_func('vc_useSimplifyingMinisat', c_ubyte, _VC)
+_set_func('vc_isUsingSimplifyingMinisat', c_ubyte, _VC)
+_set_func('vc_supportsCryptominisat', c_ubyte, _VC)
+_set_func('vc_useCryptominisat', c_ubyte, _VC)
+_set_func('vc_isUsingCryptominisat', c_ubyte, _VC)
 _set_func('vc_supportsRiss', c_ubyte, _VC)
-_set_func('vc_setRiss', c_ubyte, _VC)
-_set_func('vc_usingRiss', c_ubyte, _VC)
+_set_func('vc_useRiss', c_ubyte, _VC)
+_set_func('vc_isUsingRiss', c_ubyte, _VC)
 _set_func('vc_boolType', _Type, _VC)
 _set_func('vc_arrayType', _Type, _VC, _Type, _Type)
 _set_func('vc_varExpr', _Expr, _VC, c_char_p, _Type)
@@ -213,35 +215,41 @@ class Solver(object):
     def __exit__(self, exc_type, exc_value, traceback):
         Solver.current = None
 
-    def setMinisat(self):
-        return _lib.vc_setMinisat(self.vc)
+    def supportsMinisat(self):
+        return _lib.vc_supportsMinisat(self.vc)
 
-    def usingMinisat(self):
-        return _lib.vc_usingMinisat(self.vc)
+    def useMinisat(self):
+        return _lib.vc_useMinisat(self.vc)
 
-    def setSimplifyingMinisat(self):
-        return _lib.vc_setSimplifyingMinisat(self.vc)
+    def isUsingMinisat(self):
+        return _lib.vc_isUsingMinisat(self.vc)
 
-    def usingSimplifyingMinisat(self):
-        return _lib.vc_usingSimplifyingMinisat(self.vc)
+    def supportsSimplifyingMinisat(self):
+        return _lib.vc_supportsSimplifyingMinisat(self.vc)
 
-    def supportsCryptoMinisat(self):
-        return _lib.vc_supportsCryptoMinisat(self.vc)
+    def useSimplifyingMinisat(self):
+        return _lib.vc_useSimplifyingMinisat(self.vc)
 
-    def setCryptoMinisat(self):
-        return _lib.vc_setCryptoMinisat(self.vc)
+    def isUsingSimplifyingMinisat(self):
+        return _lib.vc_isUsingSimplifyingMinisat(self.vc)
 
-    def usingCryptoMinisat(self):
-        return _lib.vc_usingCryptoMinisat(self.vc)
+    def supportsCryptominisat(self):
+        return _lib.vc_supportsCryptominisat(self.vc)
+
+    def useCryptominisat(self):
+        return _lib.vc_useCryptominisat(self.vc)
+
+    def isUsingCryptominisat(self):
+        return _lib.vc_isUsingCryptominisat(self.vc)
 
     def supportsRiss(self):
         return _lib.vc_supportsRiss(self.vc)
 
-    def setRiss(self):
-        return _lib.vc_setRiss(self.vc)
+    def useRiss(self):
+        return _lib.vc_useRiss(self.vc)
 
-    def usingRiss(self):
-        return _lib.vc_usingRiss(self.vc)
+    def isUsingRiss(self):
+        return _lib.vc_isUsingRiss(self.vc)
 
     def bitvec(self, name, width=32):
         """Creates a new BitVector variable."""

--- a/include/stp/c_interface.h
+++ b/include/stp/c_interface.h
@@ -35,6 +35,8 @@ THE SOFTWARE.
 extern "C" {
 #endif
 
+#include <stdbool.h>
+
 /////////////////////////////////////////////////////////////////////////////
 /// STP API INTERNAL MACROS FOR LINKING
 ///
@@ -1141,54 +1143,54 @@ DLL_PUBLIC int vc_parseMemExpr(VC vc, const char* s, Expr* outQuery,
 //!  Note: always returns true (future support for minisat being the
 //!  non-default)
 //!
-DLL_PUBLIC unsigned char vc_supportsMinisat(VC vc);
+DLL_PUBLIC bool vc_supportsMinisat(VC vc);
 
 //! \brief Sets underlying SAT solver to minisat
 //!
-DLL_PUBLIC unsigned char vc_useMinisat(VC vc);
+DLL_PUBLIC bool vc_useMinisat(VC vc);
 
 //! \brief Checks if underlying SAT solver is minisat
 //!
-DLL_PUBLIC unsigned char vc_isUsingMinisat(VC vc);
+DLL_PUBLIC bool vc_isUsingMinisat(VC vc);
 
 //! \brief Checks if STP was compiled with support for simplifying minisat
 //!
 //!  Note: always returns true (future support for simplifying minisat being
 //!  the non-default)
 //!
-DLL_PUBLIC unsigned char vc_supportsSimplifyingMinisat(VC vc);
+DLL_PUBLIC bool vc_supportsSimplifyingMinisat(VC vc);
 
 //! \brief Sets underlying SAT solver to simplifying minisat
 //!
-DLL_PUBLIC unsigned char vc_useSimplifyingMinisat(VC vc);
+DLL_PUBLIC bool vc_useSimplifyingMinisat(VC vc);
 
 //! \brief Checks if underlying SAT solver is simplifying minisat
 //!
-DLL_PUBLIC unsigned char vc_isUsingSimplifyingMinisat(VC vc);
+DLL_PUBLIC bool vc_isUsingSimplifyingMinisat(VC vc);
 
 //! \brief Checks if STP was compiled with support for cryptominisat
 //!
-DLL_PUBLIC unsigned char vc_supportsCryptominisat(VC vc);
+DLL_PUBLIC bool vc_supportsCryptominisat(VC vc);
 
 //! \brief Sets underlying SAT solver to cryptominisat
 //!
-DLL_PUBLIC unsigned char vc_useCryptominisat(VC vc);
+DLL_PUBLIC bool vc_useCryptominisat(VC vc);
 
 //! \brief Checks if underlying SAT solver is cryptominisat
 //!
-DLL_PUBLIC unsigned char vc_isUsingCryptominisat(VC vc);
+DLL_PUBLIC bool vc_isUsingCryptominisat(VC vc);
 
 //! \brief Checks if STP was compiled with support for riss
 //!
-DLL_PUBLIC unsigned char vc_supportsRiss(VC vc);
+DLL_PUBLIC bool vc_supportsRiss(VC vc);
 
 //! \brief Sets underlying SAT solver to riss
 //!
-DLL_PUBLIC unsigned char vc_useRiss(VC vc);
+DLL_PUBLIC bool vc_useRiss(VC vc);
 
 //! \brief Checks if underlying SAT solver is riss
 //!
-DLL_PUBLIC unsigned char vc_isUsingRiss(VC vc);
+DLL_PUBLIC bool vc_isUsingRiss(VC vc);
 
 
 #ifdef __cplusplus

--- a/include/stp/c_interface.h
+++ b/include/stp/c_interface.h
@@ -1136,33 +1136,47 @@ DLL_PUBLIC int getExprID(Expr ex);
 DLL_PUBLIC int vc_parseMemExpr(VC vc, const char* s, Expr* outQuery,
                                Expr* outAsserts);
 
+//! \brief Checks if STP was compiled with support for minisat
+//!
+//!  Note: always returns true (future support for minisat being the
+//!  non-default)
+//!
+DLL_PUBLIC unsigned char vc_supportsMinisat(VC vc);
+
 //! \brief Sets underlying SAT solver to minisat
 //!
-DLL_PUBLIC unsigned char vc_setMinisat(VC vc);
+DLL_PUBLIC unsigned char vc_useMinisat(VC vc);
 
 //! \brief Checks if underlying SAT solver is minisat
 //!
-DLL_PUBLIC unsigned char vc_usingMinisat(VC vc);
+DLL_PUBLIC unsigned char vc_isUsingMinisat(VC vc);
+
+//! \brief Checks if STP was compiled with support for simplifying minisat
+//!
+//!  Note: always returns true (future support for simplifying minisat being
+//!  the non-default)
+//!
+DLL_PUBLIC unsigned char vc_supportsSimplifyingMinisat(VC vc);
 
 //! \brief Sets underlying SAT solver to simplifying minisat
 //!
-DLL_PUBLIC unsigned char vc_setSimplifyingMinisat(VC vc);
+DLL_PUBLIC unsigned char vc_useSimplifyingMinisat(VC vc);
 
 //! \brief Checks if underlying SAT solver is simplifying minisat
 //!
-DLL_PUBLIC unsigned char vc_usingSimplifyingMinisat(VC vc);
+DLL_PUBLIC unsigned char vc_isUsingSimplifyingMinisat(VC vc);
 
 //! \brief Checks if STP was compiled with support for cryptominisat
 //!
-DLL_PUBLIC unsigned char vc_supportsCryptoMinisat(VC vc);
+DLL_PUBLIC unsigned char vc_supportsCryptominisat(VC vc);
 
 //! \brief Sets underlying SAT solver to cryptominisat
 //!
-DLL_PUBLIC unsigned char vc_setCryptoMinisat(VC vc);
+DLL_PUBLIC unsigned char vc_useCryptominisat(VC vc);
 
 //! \brief Checks if underlying SAT solver is cryptominisat
 //!
-DLL_PUBLIC unsigned char vc_usingCryptoMinisat(VC vc);
+DLL_PUBLIC unsigned char vc_isUsingCryptominisat(VC vc);
 
 //! \brief Checks if STP was compiled with support for riss
 //!
@@ -1170,11 +1184,11 @@ DLL_PUBLIC unsigned char vc_supportsRiss(VC vc);
 
 //! \brief Sets underlying SAT solver to riss
 //!
-DLL_PUBLIC unsigned char vc_setRiss(VC vc);
+DLL_PUBLIC unsigned char vc_useRiss(VC vc);
 
 //! \brief Checks if underlying SAT solver is riss
 //!
-DLL_PUBLIC unsigned char vc_usingRiss(VC vc);
+DLL_PUBLIC unsigned char vc_isUsingRiss(VC vc);
 
 
 #ifdef __cplusplus

--- a/include/stp/c_interface.h
+++ b/include/stp/c_interface.h
@@ -1,5 +1,5 @@
 /********************************************************************
- * AUTHORS: Michael Katelman, Vijay Ganesh, Trevor Hansen
+ * AUTHORS: Michael Katelman, Vijay Ganesh, Trevor Hansen, Andrew V. Jones
  *
  * BEGIN DATE: Apr, 2008
  *
@@ -1135,6 +1135,47 @@ DLL_PUBLIC int getExprID(Expr ex);
 //!
 DLL_PUBLIC int vc_parseMemExpr(VC vc, const char* s, Expr* outQuery,
                                Expr* outAsserts);
+
+//! \brief Sets underlying SAT solver to minisat
+//!
+DLL_PUBLIC unsigned char vc_setMinisat(VC vc);
+
+//! \brief Checks if underlying SAT solver is minisat
+//!
+DLL_PUBLIC unsigned char vc_usingMinisat(VC vc);
+
+//! \brief Sets underlying SAT solver to simplifying minisat
+//!
+DLL_PUBLIC unsigned char vc_setSimplifyingMinisat(VC vc);
+
+//! \brief Checks if underlying SAT solver is simplifying minisat
+//!
+DLL_PUBLIC unsigned char vc_usingSimplifyingMinisat(VC vc);
+
+//! \brief Checks if STP was compiled with support for cryptominisat
+//!
+DLL_PUBLIC unsigned char vc_supportsCryptoMinisat(VC vc);
+
+//! \brief Sets underlying SAT solver to cryptominisat
+//!
+DLL_PUBLIC unsigned char vc_setCryptoMinisat(VC vc);
+
+//! \brief Checks if underlying SAT solver is cryptominisat
+//!
+DLL_PUBLIC unsigned char vc_usingCryptoMinisat(VC vc);
+
+//! \brief Checks if STP was compiled with support for riss
+//!
+DLL_PUBLIC unsigned char vc_supportsRiss(VC vc);
+
+//! \brief Sets underlying SAT solver to riss
+//!
+DLL_PUBLIC unsigned char vc_setRiss(VC vc);
+
+//! \brief Checks if underlying SAT solver is riss
+//!
+DLL_PUBLIC unsigned char vc_usingRiss(VC vc);
+
 
 #ifdef __cplusplus
 }

--- a/lib/Interface/c_interface.cpp
+++ b/lib/Interface/c_interface.cpp
@@ -2130,7 +2130,7 @@ bool _vc_isUsingSolver(VC vc, stp::UserDefinedFlags::SATSolvers solver)
   return b->UserFlags.solver_to_use == solver;
 }
 
-bool vc_supportsMinisat(__attribute__((unused)) VC vc)
+bool vc_supportsMinisat(VC vc __attribute__((unused)))
 {
   return true;
 }
@@ -2146,7 +2146,7 @@ bool vc_isUsingMinisat(VC vc)
   return _vc_isUsingSolver(vc, stp::UserDefinedFlags::MINISAT_SOLVER);
 }
 
-bool vc_supportsSimplifyingMinisat(__attribute__((unused)) VC vc)
+bool vc_supportsSimplifyingMinisat(VC vc __attribute__((unused)))
 {
   return true;
 }
@@ -2162,7 +2162,7 @@ bool vc_isUsingSimplifyingMinisat(VC vc)
   return _vc_isUsingSolver(vc, stp::UserDefinedFlags::SIMPLIFYING_MINISAT_SOLVER);
 }
 
-bool vc_supportsCryptominisat(__attribute__((unused)) VC vc)
+bool vc_supportsCryptominisat(VC vc __attribute__((unused)))
 {
 #ifdef USE_CRYPTOMINISAT
   return true;
@@ -2171,11 +2171,11 @@ bool vc_supportsCryptominisat(__attribute__((unused)) VC vc)
 #endif
 }
 
-bool vc_useCryptominisat(
+bool vc_useCryptominisat(VC vc
 #ifndef USE_CRYPTOMINISAT
-        __attribute__((unused))
+  __attribute__((unused))
 #endif
-        VC vc)
+)
 {
 #ifdef USE_CRYPTOMINISAT
   _vc_useSolver(vc, stp::UserDefinedFlags::CRYPTOMINISAT5_SOLVER);
@@ -2185,11 +2185,11 @@ bool vc_useCryptominisat(
 #endif
 }
 
-bool vc_isUsingCryptominisat(
+bool vc_isUsingCryptominisat(VC vc
 #ifndef USE_CRYPTOMINISAT
-        __attribute__((unused))
+  __attribute__((unused))
 #endif
-        VC vc)
+)
 {
 #ifdef USE_CRYPTOMINISAT
   return _vc_isUsingSolver(vc, stp::UserDefinedFlags::CRYPTOMINISAT5_SOLVER);
@@ -2198,7 +2198,7 @@ bool vc_isUsingCryptominisat(
 #endif
 }
 
-bool vc_supportsRiss(__attribute__((unused)) VC vc)
+bool vc_supportsRiss(VC vc __attribute__((unused)))
 {
 #ifdef USE_RISS
   return true;
@@ -2207,11 +2207,11 @@ bool vc_supportsRiss(__attribute__((unused)) VC vc)
 #endif
 }
 
-bool vc_useRiss(
+bool vc_useRiss(VC vc
 #ifndef USE_RISS
-        __attribute__((unused))
+  __attribute__((unused))
 #endif
-        VC vc)
+)
 {
 #ifdef USE_RISS
   _vc_useSolver(vc, stp::UserDefinedFlags::RISS_SOLVER);
@@ -2221,11 +2221,11 @@ bool vc_useRiss(
 #endif
 }
 
-bool vc_isUsingRiss(
+bool vc_isUsingRiss(VC vc
 #ifndef USE_RISS
-        __attribute__((unused))
+  __attribute__((unused))
 #endif
-        VC vc)
+)
 {
 #ifdef USE_RISS
   return _vc_isUsingSolver(vc, stp::UserDefinedFlags::RISS_SOLVER);

--- a/lib/Interface/c_interface.cpp
+++ b/lib/Interface/c_interface.cpp
@@ -2132,13 +2132,13 @@ bool _vc_isUsingSolver(VC vc, stp::UserDefinedFlags::SATSolvers solver)
 
 bool vc_supportsMinisat(__attribute__((unused)) VC vc)
 {
-  return 1;
+  return true;
 }
 
 bool vc_useMinisat(VC vc)
 {
   _vc_useSolver(vc, stp::UserDefinedFlags::MINISAT_SOLVER);
-  return 1;
+  return true;
 }
 
 bool vc_isUsingMinisat(VC vc)
@@ -2148,13 +2148,13 @@ bool vc_isUsingMinisat(VC vc)
 
 bool vc_supportsSimplifyingMinisat(__attribute__((unused)) VC vc)
 {
-  return 1;
+  return true;
 }
 
 bool vc_useSimplifyingMinisat(VC vc)
 {
   _vc_useSolver(vc, stp::UserDefinedFlags::SIMPLIFYING_MINISAT_SOLVER);
-  return 1;
+  return true;
 }
 
 bool vc_isUsingSimplifyingMinisat(VC vc)
@@ -2165,9 +2165,9 @@ bool vc_isUsingSimplifyingMinisat(VC vc)
 bool vc_supportsCryptominisat(__attribute__((unused)) VC vc)
 {
 #ifdef USE_CRYPTOMINISAT
-  return 1;
+  return true;
 #else
-  return 0;
+  return false;
 #endif
 }
 
@@ -2179,9 +2179,9 @@ bool vc_useCryptominisat(
 {
 #ifdef USE_CRYPTOMINISAT
   _vc_useSolver(vc, stp::UserDefinedFlags::CRYPTOMINISAT5_SOLVER);
-  return 1;
+  return true;
 #else
-  return 0;
+  return false;
 #endif
 }
 
@@ -2194,16 +2194,16 @@ bool vc_isUsingCryptominisat(
 #ifdef USE_CRYPTOMINISAT
   return _vc_isUsingSolver(vc, stp::UserDefinedFlags::CRYPTOMINISAT5_SOLVER);
 #else
-  return 0;
+  return false;
 #endif
 }
 
 bool vc_supportsRiss(__attribute__((unused)) VC vc)
 {
 #ifdef USE_RISS
-  return 1;
+  return true;
 #else
-  return 0;
+  return false;
 #endif
 }
 
@@ -2215,9 +2215,9 @@ bool vc_useRiss(
 {
 #ifdef USE_RISS
   _vc_useSolver(vc, stp::UserDefinedFlags::RISS_SOLVER);
-  return 1;
+  return true;
 #else
-  return 0;
+  return false;
 #endif
 }
 
@@ -2230,7 +2230,7 @@ bool vc_isUsingRiss(
 #ifdef USE_RISS
   return _vc_isUsingSolver(vc, stp::UserDefinedFlags::RISS_SOLVER);
 #else
-  return 0;
+  return false;
 #endif
 }
 

--- a/lib/Interface/c_interface.cpp
+++ b/lib/Interface/c_interface.cpp
@@ -1,5 +1,5 @@
 /********************************************************************
- * AUTHORS: Vijay Ganesh
+ * AUTHORS: Vijay Ganesh, Andrew V. Jones
  *
  * BEGIN DATE: November, 2005
  *
@@ -2094,3 +2094,96 @@ int vc_parseMemExpr(VC vc, const char* s, Expr* oquery, Expr* oasserts)
   }
   return 1;
 }
+
+void _vc_setSolver(VC vc, stp::UserDefinedFlags::SATSolvers solver)
+{
+  /* Helper method to encapsulate setting a solver */
+  stp::STP* stp_i = (stp::STP*)vc;
+  stp::STPMgr* b = stp_i->bm;
+  b->UserFlags.solver_to_use = solver;
+}
+
+unsigned char _vc_usingSolver(VC vc, stp::UserDefinedFlags::SATSolvers solver)
+{
+  /* Helper method to encapsulate getting a solver */
+  stp::STP* stp_i = (stp::STP*)vc;
+  stp::STPMgr* b = stp_i->bm;
+  return b->UserFlags.solver_to_use == solver;
+}
+
+unsigned char vc_setMinisat(VC vc)
+{
+  _vc_setSolver(vc, stp::UserDefinedFlags::MINISAT_SOLVER);
+  unsigned char success = 1;
+  return success;
+}
+
+unsigned char vc_usingMinisat(VC vc)
+{
+  return _vc_usingSolver(vc, stp::UserDefinedFlags::MINISAT_SOLVER);
+}
+
+unsigned char vc_setSimplifyingMinisat(VC vc)
+{
+  _vc_setSolver(vc, stp::UserDefinedFlags::SIMPLIFYING_MINISAT_SOLVER);
+  unsigned char success = 1;
+  return success;
+}
+
+unsigned char vc_usingSimplifyingMinisat(VC vc)
+{
+  return _vc_usingSolver(vc, stp::UserDefinedFlags::SIMPLIFYING_MINISAT_SOLVER);
+}
+
+unsigned char vc_supportsCryptoMinisat(VC /* vc */)
+{
+#ifdef USE_CRYPTOMINISAT
+  unsigned char success = 1;
+#else
+  unsigned char success = 0;
+#endif
+  return success;
+}
+
+unsigned char vc_setCryptoMinisat(VC vc)
+{
+#ifdef USE_CRYPTOMINISAT
+  _vc_setSolver(vc, stp::UserDefinedFlags::CRYPTOMINISAT5_SOLVER);
+  unsigned char success = 1;
+#else
+  unsigned char success = 0;
+#endif
+  return success;
+}
+
+unsigned char vc_usingCryptoMinisat(VC vc)
+{
+  return _vc_usingSolver(vc, stp::UserDefinedFlags::CRYPTOMINISAT5_SOLVER);
+}
+
+unsigned char vc_supportsRiss(VC /* vc */)
+{
+#ifdef USE_RISS
+  unsigned char success = 1;
+#else
+  unsigned char success = 0;
+#endif
+  return success;
+}
+
+unsigned char vc_setRiss(VC vc)
+{
+#ifdef USE_RISS
+  _vc_setSolver(vc, stp::UserDefinedFlags::RISS_SOLVER);
+  unsigned char success = 1;
+#else
+  unsigned char success = 0;
+#endif
+  return success;
+}
+
+unsigned char vc_usingRiss(VC vc)
+{
+  return _vc_usingSolver(vc, stp::UserDefinedFlags::RISS_SOLVER);
+}
+

--- a/lib/Interface/c_interface.cpp
+++ b/lib/Interface/c_interface.cpp
@@ -2095,7 +2095,7 @@ int vc_parseMemExpr(VC vc, const char* s, Expr* oquery, Expr* oasserts)
   return 1;
 }
 
-void _vc_setSolver(VC vc, stp::UserDefinedFlags::SATSolvers solver)
+void _vc_useSolver(VC vc, stp::UserDefinedFlags::SATSolvers solver)
 {
   /* Helper method to encapsulate setting a solver */
   stp::STP* stp_i = (stp::STP*)vc;
@@ -2103,7 +2103,7 @@ void _vc_setSolver(VC vc, stp::UserDefinedFlags::SATSolvers solver)
   b->UserFlags.solver_to_use = solver;
 }
 
-unsigned char _vc_usingSolver(VC vc, stp::UserDefinedFlags::SATSolvers solver)
+unsigned char _vc_isUsingSolver(VC vc, stp::UserDefinedFlags::SATSolvers solver)
 {
   /* Helper method to encapsulate getting a solver */
   stp::STP* stp_i = (stp::STP*)vc;
@@ -2111,79 +2111,107 @@ unsigned char _vc_usingSolver(VC vc, stp::UserDefinedFlags::SATSolvers solver)
   return b->UserFlags.solver_to_use == solver;
 }
 
-unsigned char vc_setMinisat(VC vc)
+unsigned char vc_supportsMinisat(__attribute__((unused)) VC vc)
 {
-  _vc_setSolver(vc, stp::UserDefinedFlags::MINISAT_SOLVER);
-  unsigned char success = 1;
-  return success;
+  return 1;
 }
 
-unsigned char vc_usingMinisat(VC vc)
+unsigned char vc_useMinisat(VC vc)
 {
-  return _vc_usingSolver(vc, stp::UserDefinedFlags::MINISAT_SOLVER);
+  _vc_useSolver(vc, stp::UserDefinedFlags::MINISAT_SOLVER);
+  return 1;
 }
 
-unsigned char vc_setSimplifyingMinisat(VC vc)
+unsigned char vc_isUsingMinisat(VC vc)
 {
-  _vc_setSolver(vc, stp::UserDefinedFlags::SIMPLIFYING_MINISAT_SOLVER);
-  unsigned char success = 1;
-  return success;
+  return _vc_isUsingSolver(vc, stp::UserDefinedFlags::MINISAT_SOLVER);
 }
 
-unsigned char vc_usingSimplifyingMinisat(VC vc)
+unsigned char vc_supportsSimplifyingMinisat(__attribute__((unused)) VC vc)
 {
-  return _vc_usingSolver(vc, stp::UserDefinedFlags::SIMPLIFYING_MINISAT_SOLVER);
+  return 1;
 }
 
-unsigned char vc_supportsCryptoMinisat(VC /* vc */)
+unsigned char vc_useSimplifyingMinisat(VC vc)
+{
+  _vc_useSolver(vc, stp::UserDefinedFlags::SIMPLIFYING_MINISAT_SOLVER);
+  return 1;
+}
+
+unsigned char vc_isUsingSimplifyingMinisat(VC vc)
+{
+  return _vc_isUsingSolver(vc, stp::UserDefinedFlags::SIMPLIFYING_MINISAT_SOLVER);
+}
+
+unsigned char vc_supportsCryptominisat(__attribute__((unused)) VC vc)
 {
 #ifdef USE_CRYPTOMINISAT
-  unsigned char success = 1;
+  return 1;
 #else
-  unsigned char success = 0;
+  return 0;
 #endif
-  return success;
 }
 
-unsigned char vc_setCryptoMinisat(VC vc)
+unsigned char vc_useCryptominisat(
+#ifndef USE_CRYPTOMINISAT
+        __attribute__((unused))
+#endif
+        VC vc)
 {
 #ifdef USE_CRYPTOMINISAT
-  _vc_setSolver(vc, stp::UserDefinedFlags::CRYPTOMINISAT5_SOLVER);
-  unsigned char success = 1;
+  _vc_useSolver(vc, stp::UserDefinedFlags::CRYPTOMINISAT5_SOLVER);
+  return 1;
 #else
-  unsigned char success = 0;
+  return 0;
 #endif
-  return success;
 }
 
-unsigned char vc_usingCryptoMinisat(VC vc)
+unsigned char vc_isUsingCryptominisat(
+#ifndef USE_CRYPTOMINISAT
+        __attribute__((unused))
+#endif
+        VC vc)
 {
-  return _vc_usingSolver(vc, stp::UserDefinedFlags::CRYPTOMINISAT5_SOLVER);
+#ifdef USE_CRYPTOMINISAT
+  return _vc_isUsingSolver(vc, stp::UserDefinedFlags::CRYPTOMINISAT5_SOLVER);
+#else
+  return 0;
+#endif
 }
 
-unsigned char vc_supportsRiss(VC /* vc */)
+unsigned char vc_supportsRiss(__attribute__((unused)) VC vc)
 {
 #ifdef USE_RISS
-  unsigned char success = 1;
+  return 1;
 #else
-  unsigned char success = 0;
+  return 0;
 #endif
-  return success;
 }
 
-unsigned char vc_setRiss(VC vc)
+unsigned char vc_useRiss(
+#ifndef USE_RISS
+        __attribute__((unused))
+#endif
+        VC vc)
 {
 #ifdef USE_RISS
-  _vc_setSolver(vc, stp::UserDefinedFlags::RISS_SOLVER);
-  unsigned char success = 1;
+  _vc_useSolver(vc, stp::UserDefinedFlags::RISS_SOLVER);
+  return 1;
 #else
-  unsigned char success = 0;
+  return 0;
 #endif
-  return success;
 }
 
-unsigned char vc_usingRiss(VC vc)
+unsigned char vc_isUsingRiss(
+#ifndef USE_RISS
+        __attribute__((unused))
+#endif
+        VC vc)
 {
-  return _vc_usingSolver(vc, stp::UserDefinedFlags::RISS_SOLVER);
+#ifdef USE_RISS
+  return _vc_isUsingSolver(vc, stp::UserDefinedFlags::RISS_SOLVER);
+#else
+  return 0;
+#endif
 }
 

--- a/lib/Interface/c_interface.cpp
+++ b/lib/Interface/c_interface.cpp
@@ -2103,7 +2103,7 @@ void _vc_useSolver(VC vc, stp::UserDefinedFlags::SATSolvers solver)
   b->UserFlags.solver_to_use = solver;
 }
 
-unsigned char _vc_isUsingSolver(VC vc, stp::UserDefinedFlags::SATSolvers solver)
+bool _vc_isUsingSolver(VC vc, stp::UserDefinedFlags::SATSolvers solver)
 {
   /* Helper method to encapsulate getting a solver */
   stp::STP* stp_i = (stp::STP*)vc;
@@ -2111,39 +2111,39 @@ unsigned char _vc_isUsingSolver(VC vc, stp::UserDefinedFlags::SATSolvers solver)
   return b->UserFlags.solver_to_use == solver;
 }
 
-unsigned char vc_supportsMinisat(__attribute__((unused)) VC vc)
+bool vc_supportsMinisat(__attribute__((unused)) VC vc)
 {
   return 1;
 }
 
-unsigned char vc_useMinisat(VC vc)
+bool vc_useMinisat(VC vc)
 {
   _vc_useSolver(vc, stp::UserDefinedFlags::MINISAT_SOLVER);
   return 1;
 }
 
-unsigned char vc_isUsingMinisat(VC vc)
+bool vc_isUsingMinisat(VC vc)
 {
   return _vc_isUsingSolver(vc, stp::UserDefinedFlags::MINISAT_SOLVER);
 }
 
-unsigned char vc_supportsSimplifyingMinisat(__attribute__((unused)) VC vc)
+bool vc_supportsSimplifyingMinisat(__attribute__((unused)) VC vc)
 {
   return 1;
 }
 
-unsigned char vc_useSimplifyingMinisat(VC vc)
+bool vc_useSimplifyingMinisat(VC vc)
 {
   _vc_useSolver(vc, stp::UserDefinedFlags::SIMPLIFYING_MINISAT_SOLVER);
   return 1;
 }
 
-unsigned char vc_isUsingSimplifyingMinisat(VC vc)
+bool vc_isUsingSimplifyingMinisat(VC vc)
 {
   return _vc_isUsingSolver(vc, stp::UserDefinedFlags::SIMPLIFYING_MINISAT_SOLVER);
 }
 
-unsigned char vc_supportsCryptominisat(__attribute__((unused)) VC vc)
+bool vc_supportsCryptominisat(__attribute__((unused)) VC vc)
 {
 #ifdef USE_CRYPTOMINISAT
   return 1;
@@ -2152,7 +2152,7 @@ unsigned char vc_supportsCryptominisat(__attribute__((unused)) VC vc)
 #endif
 }
 
-unsigned char vc_useCryptominisat(
+bool vc_useCryptominisat(
 #ifndef USE_CRYPTOMINISAT
         __attribute__((unused))
 #endif
@@ -2166,7 +2166,7 @@ unsigned char vc_useCryptominisat(
 #endif
 }
 
-unsigned char vc_isUsingCryptominisat(
+bool vc_isUsingCryptominisat(
 #ifndef USE_CRYPTOMINISAT
         __attribute__((unused))
 #endif
@@ -2179,7 +2179,7 @@ unsigned char vc_isUsingCryptominisat(
 #endif
 }
 
-unsigned char vc_supportsRiss(__attribute__((unused)) VC vc)
+bool vc_supportsRiss(__attribute__((unused)) VC vc)
 {
 #ifdef USE_RISS
   return 1;
@@ -2188,7 +2188,7 @@ unsigned char vc_supportsRiss(__attribute__((unused)) VC vc)
 #endif
 }
 
-unsigned char vc_useRiss(
+bool vc_useRiss(
 #ifndef USE_RISS
         __attribute__((unused))
 #endif
@@ -2202,7 +2202,7 @@ unsigned char vc_useRiss(
 #endif
 }
 
-unsigned char vc_isUsingRiss(
+bool vc_isUsingRiss(
 #ifndef USE_RISS
         __attribute__((unused))
 #endif

--- a/tests/api/python/tests.py.in
+++ b/tests/api/python/tests.py.in
@@ -4,6 +4,7 @@ The MIT License
 
 Copyright (c) 2008 Vijay Ganesh
               2014 Jurriaan Bremer, jurriaanbremer@gmail.com
+              2018 Andrew V. Jones, andrewvaughanj@gmail.com
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
@@ -29,24 +30,24 @@ import sys
 # Make sure we can find the STP python package
 sys.path.insert(0, "@PYTHON_INTERFACE_DIR@/stp")
 
-from stp import stp, Solver
+import stp
 import unittest
 
 
-@stp
+@stp.stp
 def test0_foo(a, b):
     assert b != 0
     return (a + 42) % b
 
 
-@stp
+@stp.stp
 def test0_bar(a, b):
     return a * b == 12345
 
 
 class TestSTP(unittest.TestCase):
     def setUp(self):
-        self.s = Solver()
+        self.s = stp.Solver()
 
     def test_simple(self):
         s = self.s
@@ -124,7 +125,7 @@ class TestSTP(unittest.TestCase):
             {'y': 489153109, 'x': 489153109},
         ]
 
-        with Solver() as s:
+        with stp.Solver() as s:
             x, y = s.bitvecs('x y')
             count = 0
             while s.check(test0_foo(x, y) == test0_foo(y, x),
@@ -263,6 +264,77 @@ class TestSTP(unittest.TestCase):
             s.check(c == op(a))
             self.assertEqual(s.model()['c'], op(A) % 2**32)
 
+    def test_minisat(self):
+        """
+        Checks that the underlying solver can be set to be minisat
+        """
+
+        #
+        # Setting minisat should never fail
+        #
+        self.assertTrue(self.s.setMinisat())
+
+        #
+        # After calling set, the solver should be minisat
+        #
+        self.assertTrue(self.s.usingMinisat())
+
+    def test_simplifying_minisat(self):
+        """
+        Checks that the underlying solver can be set to be simplifying minisat
+        """
+
+        #
+        # Setting simplifying minisat should never fail
+        #
+        self.assertTrue(self.s.setSimplifyingMinisat())
+
+        #
+        # After calling set, the solver should be simplifying minisat
+        #
+        self.assertTrue(self.s.usingSimplifyingMinisat())
+
+    def test_cryptominisat(self):
+        """
+        Checks that the underlying solver can be set to be cryptominisat
+        """
+
+        if self.s.supportsCryptoMinisat():
+            #
+            # Setting cryptominisat should never fail, if STP is built to support it
+            #
+            self.assertTrue(self.s.setCryptoMinisat())
+
+            #
+            # After calling set, the solver should be cryptominisat
+            #
+            self.assertTrue(self.s.usingCryptoMinisat())
+        else:
+            #
+            # If STP doesn't support cryptominisat, then setting should rerturn false
+            #
+            self.assertFalse(self.s.setCryptoMinisat())
+
+    def test_riss(self):
+        """
+        Checks that the underlying solver can be set to be riss
+        """
+
+        if self.s.supportsRiss():
+            #
+            # Setting riss should never fail, if STP is built to support it
+            #
+            self.assertTrue(self.s.setRiss())
+
+            #
+            # After calling set, the solver should be riss
+            #
+            self.assertTrue(self.s.usingRiss())
+        else:
+            #
+            # If STP doesn't support riss, then setting should rerturn false
+            #
+            self.assertFalse(self.s.setRiss())
 
 if __name__ == '__main__':
     suite = unittest.TestLoader().loadTestsFromTestCase(TestSTP)

--- a/tests/api/python/tests.py.in
+++ b/tests/api/python/tests.py.in
@@ -48,6 +48,9 @@ def test0_bar(a, b):
 class TestSTP(unittest.TestCase):
     def setUp(self):
         self.s = stp.Solver()
+        self.stp_solvers = set(
+            ["Minisat", "SimplifyingMinisat", "Cryptominisat", "Riss"]
+        )
 
     def test_simple(self):
         s = self.s
@@ -285,8 +288,19 @@ class TestSTP(unittest.TestCase):
         #
         # We can use that as the condition for the assertion
         #
-        self.assertTrue(use_method() == supported)
-        self.assertTrue(is_using_method() == supported)
+        self.assertEqual(use_method(), supported)
+        self.assertEqual(is_using_method(), supported)
+
+        #
+        # When we're using a supported solver, then after calling `use_method`,
+        # all other solvers should not be in use
+        #
+        if supported:
+            for other_solver in self.stp_solvers - solver:
+                other_is_using_method = getattr(
+                    self.s, "isUsing{:s}".format(other_solver)
+                )
+                self.assertFalse(other_is_using_method())
 
     def test_minisat(self):
         """

--- a/tests/api/python/tests.py.in
+++ b/tests/api/python/tests.py.in
@@ -264,78 +264,56 @@ class TestSTP(unittest.TestCase):
             s.check(c == op(a))
             self.assertEqual(s.model()['c'], op(A) % 2**32)
 
+    def _test_solver(self, solver, is_default_solver=False):
+        """
+        Helper method to validate that the passed in "solver" can be set and
+        used
+        """
+        supports_method = getattr(self.s, "supports{:s}".format(solver))
+        use_method = getattr(self.s, "use{:s}".format(solver))
+        is_using_method = getattr(self.s, "isUsing{:s}".format(solver))
+
+        supported = supports_method()
+
+        if is_default_solver:
+            self.assertTrue(supported)
+
+        #
+        # If the solver is supported, the "use" and "isUsing" methods should
+        # return true -- similarly, if the solver is not supported, then they
+        # both return false.
+        #
+        # We can use that as the condition for the assertion
+        #
+        self.assertTrue(use_method() == supported)
+        self.assertTrue(is_using_method() == supported)
+
     def test_minisat(self):
         """
         Checks that the underlying solver can be set to be minisat
         """
+        self._test_solver("Minisat", is_default_solver=True)
 
-        #
-        # Setting minisat should never fail
-        #
-        self.assertTrue(self.s.setMinisat())
-
-        #
-        # After calling set, the solver should be minisat
-        #
-        self.assertTrue(self.s.usingMinisat())
-
-    def test_simplifying_minisat(self):
+    def test_simplifyingminisat(self):
         """
-        Checks that the underlying solver can be set to be simplifying minisat
+        Checks that the underlying solver can be set to be simplifyingminisat
         """
-
-        #
-        # Setting simplifying minisat should never fail
-        #
-        self.assertTrue(self.s.setSimplifyingMinisat())
-
-        #
-        # After calling set, the solver should be simplifying minisat
-        #
-        self.assertTrue(self.s.usingSimplifyingMinisat())
+        self._test_solver("SimplifyingMinisat", is_default_solver=True)
 
     def test_cryptominisat(self):
         """
         Checks that the underlying solver can be set to be cryptominisat
         """
-
-        if self.s.supportsCryptoMinisat():
-            #
-            # Setting cryptominisat should never fail, if STP is built to support it
-            #
-            self.assertTrue(self.s.setCryptoMinisat())
-
-            #
-            # After calling set, the solver should be cryptominisat
-            #
-            self.assertTrue(self.s.usingCryptoMinisat())
-        else:
-            #
-            # If STP doesn't support cryptominisat, then setting should rerturn false
-            #
-            self.assertFalse(self.s.setCryptoMinisat())
+        self._test_solver("Cryptominisat", is_default_solver=False)
 
     def test_riss(self):
         """
         Checks that the underlying solver can be set to be riss
         """
-
-        if self.s.supportsRiss():
-            #
-            # Setting riss should never fail, if STP is built to support it
-            #
-            self.assertTrue(self.s.setRiss())
-
-            #
-            # After calling set, the solver should be riss
-            #
-            self.assertTrue(self.s.usingRiss())
-        else:
-            #
-            # If STP doesn't support riss, then setting should rerturn false
-            #
-            self.assertFalse(self.s.setRiss())
+        self._test_solver("Riss", is_default_solver=False)
 
 if __name__ == '__main__':
     suite = unittest.TestLoader().loadTestsFromTestCase(TestSTP)
     unittest.TextTestRunner(verbosity=2).run(suite)
+
+# EOF


### PR DESCRIPTION
This PR provide capability inside of the Python and C API to dynamically get and set the underlying SAT solver.

These changes are, regrettably, more verbose than I would have liked. STP uses the enum `stp::UserDefinedFlags::SATSolvers` to capture the current SAT solver. However, because we need validation of which SAT solvers were enabled at build time, it isn't possible to have a generic method to expose setting via the enum.

The most straightforward way here was to have a setter/getter per SAT solver that STP can support.
