### PR TITLE
build: fix linking riss

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -126,7 +126,7 @@ endif()
 
 if (USE_RISS)
     set(stp_link_libs
-        ${stp_link_libs} -lcoprocessor -lriss)
+        ${stp_link_libs} -lriss-coprocessor)
 endif()
 
 target_link_libraries(stp


### PR DESCRIPTION
Riss builds its artifacts into separate archive files. When linking
with Riss, both artifacts have to be used, but they have cyclic
dependencies. This can be solved by using linking groups, or by
using the libriss-coprocessor.a archive that is generated by riss.