### PR TITLE
Allow bitvecs of length >64

### DIFF
--- a/lib/STPManager/STPManager.cpp
+++ b/lib/STPManager/STPManager.cpp
@@ -184,7 +184,7 @@ bool STPMgr::LookupSymbol(const char* const name, ASTNode& output)
 ASTNode STPMgr::CreateBVConst(unsigned int width,
                               unsigned long long int bvconst)
 {
-  if (width > (sizeof(unsigned long long int) * 8) || width <= 0)
+  if (width == 0)
     FatalError("CreateBVConst: "
                "trying to create bvconst using "
                "unsigned long long of width: ",


### PR DESCRIPTION
PR #304 enables this, but this check prevents it from working. Not sure why the tests aren't catching it.
Also, `width <= 0` is equivalent to `width == 0` as `width` is unsigned.

@TrevorHansen 