### PR TITLE
Fix two format specifiers.

### DIFF
--- a/tools/rewrite_rule_gen/rewrite_rule_gen.cpp
+++ b/tools/rewrite_rule_gen/rewrite_rule_gen.cpp
@@ -1223,7 +1223,7 @@ void rule_to_string(const ASTNode& n, ASTNodeString& names, string& current,
   for (size_t i = 0; i < n.Degree(); i++)
   {
     char t[1000];
-    sprintf(t, "%s[%d]", current.c_str(), i);
+    sprintf(t, "%s[%zu]", current.c_str(), i);
     string s(t);
     rule_to_string(n[i], names, s, sofar);
   }
@@ -1242,7 +1242,7 @@ string containsNode(const ASTNode& n, const ASTNode& hunting, string& current)
   for (size_t i = 0; i < n.Degree(); i++)
   {
     char t[1000];
-    sprintf(t, "%s[%d]", current.c_str(), i);
+    sprintf(t, "%s[%zu]", current.c_str(), i);
     string s(t);
     string r = containsNode(n[i], hunting, s);
     if (r != "")


### PR DESCRIPTION
The loop variables have type size_t.  On a big endian 64-bit architecture, such as s390x, the %d specifier instructs sprintf to examine only the higher-order 32 bits, which are probably all zero.