### PR TITLE
Python unit test fixes

### DIFF
--- a/tests/api/python/tests.py.in
+++ b/tests/api/python/tests.py.in
@@ -322,7 +322,7 @@ class TestSTP(unittest.TestCase):
         # all other solvers should not be in use
         #
         if supported:
-            for other_solver in self.stp_solvers - solver:
+            for other_solver in self.stp_solvers - set([solver]):
                 other_is_using_method = getattr(
                     self.s, "isUsing{:s}".format(other_solver)
                 )

--- a/tests/api/python/tests.py.in
+++ b/tests/api/python/tests.py.in
@@ -377,6 +377,7 @@ class TestSTP(unittest.TestCase):
 
 if __name__ == '__main__':
     suite = unittest.TestLoader().loadTestsFromTestCase(TestSTP)
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    sys.exit(not result.wasSuccessful())
 
 # EOF

--- a/tests/api/python/tests.py.in
+++ b/tests/api/python/tests.py.in
@@ -288,7 +288,12 @@ class TestSTP(unittest.TestCase):
         supported = supports_method()
 
         if is_default_solver:
-            self.assertTrue(supported)
+            self.assertTrue(
+                supported,
+                "{solver:s} is a default solver, which is reporting as disabled".format(
+                    solver=solver
+                ),
+            )
 
         #
         # If the solver is supported, the "use" and "isUsing" methods should
@@ -297,8 +302,20 @@ class TestSTP(unittest.TestCase):
         #
         # We can use that as the condition for the assertion
         #
-        self.assertEqual(use_method(), supported)
-        self.assertEqual(is_using_method(), supported)
+        self.assertEqual(
+            use_method(),
+            supported,
+            "Enabling {solver:s} did not match its 'supported' status".format(
+                solver=solver
+            ),
+        )
+        self.assertEqual(
+            is_using_method(),
+            supported,
+            "Checking if {solver:s} is in use did not match its 'supported' status".format(
+                solver=solver
+            ),
+        )
 
         #
         # When we're using a supported solver, then after calling `use_method`,
@@ -309,7 +326,12 @@ class TestSTP(unittest.TestCase):
                 other_is_using_method = getattr(
                     self.s, "isUsing{:s}".format(other_solver)
                 )
-                self.assertFalse(other_is_using_method())
+                self.assertFalse(
+                    other_is_using_method(),
+                    "{other_solver:s} reported to be in use, while {solver:s} was previously selected".format(
+                        solver=solver, other_solver=other_solver
+                    ),
+                )
 
     def test_minisat(self):
         """


### PR DESCRIPTION
This branch fixes three issues with the Python tests:

1. In the "solver" tests, there were no assertion messages, meaning that failures were hard to debug;
2. Also in the "solver" tests, the calculation of the "other solvers" was actually incorrect and raised a Python exception -- it seems these **never** worked (see below);
3. It actually seems that any failures in the Python tests did not record a test failure (`add_test` in CMake only records a failure on a non-zero error code; with the code as it was, `python` would return `0` irrespective as to what happened during test execution!).