### PR TITLE
Non-install 'library_path.py' now searches 'lib' and 'bin' folders (now consistent with 'library_path.py.in_install')

### DIFF
--- a/bindings/python/stp/CMakeLists.txt
+++ b/bindings/python/stp/CMakeLists.txt
@@ -30,6 +30,18 @@
 
 get_target_property(LIBSTP_BASENAME stp OUTPUT_NAME)
 set(LIBSTP_FILENAME "${CMAKE_SHARED_LIBRARY_PREFIX}${LIBSTP_BASENAME}${CMAKE_SHARED_LIBRARY_SUFFIX}")
+
+#
+# 'library_path.py.in' has some code that is conditional on being on Win32 or
+# not -- rather than have two `.in` files, we leave the non-Win32 code comment
+# out.
+#
+if(WIN32)
+  set(WIN32PYTHONCOMMENT "")
+else()
+  set(WIN32PYTHONCOMMENT "#")
+endif()
+
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/library_path.py.in
                ${CMAKE_CURRENT_BINARY_DIR}/library_path.py @ONLY)
 

--- a/bindings/python/stp/library_path.py.in
+++ b/bindings/python/stp/library_path.py.in
@@ -37,7 +37,9 @@ path_var = (
     else "LD_LIBRARY_PATH"
 )
 
-PATHS = ["@CMAKE_LIBRARY_OUTPUT_DIRECTORY@/@LIBSTP_FILENAME@"] + [
+PATHS = ["@CMAKE_LIBRARY_OUTPUT_DIRECTORY@/@LIBSTP_FILENAME@"
+@WIN32PYTHONCOMMENT@        , "@CMAKE_RUNTIME_OUTPUT_DIRECTORY@/@LIBSTP_FILENAME@"
+        ] + [
     os.path.join(directory, "@LIBSTP_FILENAME@")
     for directory in os.environ.get(path_var, "").split(os.pathsep)
 ]


### PR DESCRIPTION
On Windows, STP's CMake places `libstpwin.dll` inside of the `bin` directory (`CMAKE_RUNTIME_OUTPUT_DIRECTORY`), and not inside of the `lib` directory (`CMAKE_LIBRARY_OUTPUT_DIRECTORY`), which it does on Linux.

This means that the construction of `library_path.py`, which is different to `library_path.py.in_install`, does not work correctly on Windows (as it searches `lib` and not `bin`).

In effect, the file `./bindings/python/stp/library_path.py` gets auto-populated to have Python's search path set to only look in `lib`. This causes the automated Python tests to fail on Windows.

**Note**: I was unsure of the best way to fix this. One thought was to have two `.in` files (one for Windows and one for non-Windows). However, I decided to keep there being one `.in` file, but have some code commented out if `configure_file` is called on non-Windows. This is what `WIN32PYTHONCOMMENT` achieves.