### PR TITLE
Making sure STP's '__init__.py' is consistent with '__all__' in 'stp.py'

### DIFF
--- a/bindings/python/stp/__init__.py.in
+++ b/bindings/python/stp/__init__.py.in
@@ -1,5 +1,8 @@
-#author: Dan Liew
-#date: Sep, 2014
+# author: Dan Liew
+# date: Sep, 2014
+#
+# author: Andrew V. Jones
+# date: Apr, 2019
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,4 +23,16 @@
 # THE SOFTWARE.
 
 
-from .stp import Expr, Solver, stp, add, bitvec, bitvecs, check, model
+from .stp import (
+    Expr,
+    Solver,
+    stp,
+    add,
+    bitvec,
+    bitvecs,
+    check,
+    model,
+    get_git_version_sha,
+    get_git_version_tag,
+    get_compilation_env,
+)


### PR DESCRIPTION
It seems that we do not have consistency between STP's `__init__.py` and the symbols that we try to export via `__all__` in `stp.py`.

STP's Python modules are structured like this:

     buildings/python/stp/stp.py

Therefore, if you set PYTHONPATH path to point to `buildings/python` (i.e., the parent directory of the `stp` **folder**) then you do not get our newly-exported symbols, as `import stp` imports the folder (i.e., `__all__.py`) and not the module (i.e., `stp.py`).

This PR (manually) ensures that what's in `__init__.py` is consistent with `__all__`.