### PR TITLE
Exposing the underling `_lib` object from STP's Python API

### DIFF
--- a/bindings/python/stp/__init__.py.in
+++ b/bindings/python/stp/__init__.py.in
@@ -35,4 +35,5 @@ from .stp import (
     get_git_version_sha,
     get_git_version_tag,
     get_compilation_env,
+    get_lib,
 )

--- a/bindings/python/stp/stp.py.in
+++ b/bindings/python/stp/stp.py.in
@@ -34,7 +34,7 @@ import sys
 
 __all__ = [
     'Expr', 'Solver', 'stp', 'add', 'bitvec', 'bitvecs', 'check', 'model',
-    'get_git_version_sha', 'get_git_version_tag', 'get_compilation_env'
+    'get_git_version_sha', 'get_git_version_tag', 'get_compilation_env', 'get_lib'
 ]
 
 Py3 = sys.version_info >= (3, 0, 0)
@@ -770,5 +770,17 @@ def get_git_version_tag():
 
 def get_compilation_env():
     return _lib.get_compilation_env()
+
+def get_lib():
+    #
+    # Helper function to expose STP's CDLL object -- this allows for API-based
+    # access to STP's API without going via the `Solver` class.
+    #
+    # There are some calls (e.g., vc_bvConcatExpr) that exist inside of the
+    # `_lib` object, but which do not exist inside of `Solver`.
+    #
+    # Directly exposing `_lib_ allows for access to these routines in the API.
+    #
+    return _lib
 
 # EOF

--- a/tests/api/python/tests.py.in
+++ b/tests/api/python/tests.py.in
@@ -32,6 +32,7 @@ sys.path.insert(0, "@PYTHON_INTERFACE_DIR@/stp")
 
 import stp
 import unittest
+import ctypes
 
 
 @stp.stp
@@ -374,6 +375,20 @@ class TestSTP(unittest.TestCase):
         Test verifies that the returned compilation env is of non-zero length
         """
         self.assertNotEqual(len(stp.get_compilation_env()), 0)
+
+    def test_lib(self):
+        """
+        Test verifies that the returned CDLL object is "well-formed"
+        """
+        stp_cdll = stp.get_lib()
+        self.assertIsNotNone(stp_cdll, "get_lib should never return None")
+        self.assertTrue(
+            isinstance(stp_cdll, ctypes.CDLL), "get_lib should return a CDLL type"
+        )
+        self.assertTrue(
+            callable(stp_cdll.vc_bvConcatExpr),
+            "STP's CDLL object should have a method called 'vc_bvConcatExpr'",
+        )
 
 if __name__ == '__main__':
     suite = unittest.TestLoader().loadTestsFromTestCase(TestSTP)


### PR DESCRIPTION
STP's `Solver` Python class only has wrappers for _some_ of STP's C-based API (e.g., it does not expose `vc_bvConcatExpr` or `vc_isBool`).

In some instances, it there is therefor beneficial to be able to work directly with the `ctypes.CDLL` object, rather than the "proxy" `Solver` class.

In the longer term, it is probably worthwhile identifying all of the calls that are missing, and then exposing these via the `Solver` class.

However, in the interim, this PR does resolve that some of these calls are currently inaccessible, and therefore makes STP's Python API "productive".