### PR TITLE
Support time-based timeout when calling Cryptominisat

### DIFF
--- a/bindings/python/stp/stp.py.in
+++ b/bindings/python/stp/stp.py.in
@@ -3,7 +3,7 @@ The MIT License
 
 Copyright (c) 2008 Vijay Ganesh
               2014 Jurriaan Bremer, jurriaanbremer@gmail.com
-              2018 Andrew V. Jones, andrewvaughanj@gmail.com
+              2018-2019 Andrew V. Jones, andrewvaughanj@gmail.com
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
@@ -116,7 +116,7 @@ _set_func('vc_printCounterExampleToBuffer', None, _VC, POINTER(c_char_p), POINTE
 _set_func('vc_printQuery', None, _VC)
 _set_func('vc_assertFormula', None, _VC, _Expr)
 _set_func('vc_simplify', _Expr, _VC, _Expr)
-_set_func('vc_query_with_timeout', c_int32, _VC, _Expr, c_int32)
+_set_func('vc_query_with_timeout', c_int32, _VC, _Expr, c_int32, c_int32)
 _set_func('vc_query', c_int32, _VC, _Expr)
 _set_func('vc_getCounterExample', _Expr, _VC, _Expr)
 _set_func('vc_getCounterExampleArray', None, _VC, _Expr, POINTER(POINTER(_Expr)), POINTER(POINTER(_Expr)), POINTER(c_int32))
@@ -315,7 +315,7 @@ class Solver(object):
         exprs = (_Expr * len(exprs))(*exprs)
         return exprs, len(exprs)
 
-    def check(self, *exprs):
+    def check_with_timeout(self, *exprs, **kwargs):
         """Check whether the various expressions are satisfiable."""
 
         _, length = self._n_exprs(*exprs)
@@ -325,10 +325,16 @@ class Solver(object):
         else:
             expr = self.false().expr
 
-        self.push()
-        ret = _lib.vc_query(self.vc, expr)
-        self.pop()
+        max_conflicts = kwargs.get("max_conflicts", -1)
+        max_time = kwargs.get("max_time", -1)
 
+        self.push()
+        ret = _lib.vc_query_with_timeout(self.vc, expr, max_conflicts, max_time)
+        self.pop()
+        return ret
+
+    def check(self, *exprs):
+        ret = self.check_with_timeout(*exprs, max_conflicts=-1, max_time=-1)
         assert ret == 0 or ret == 1, 'Error querying your input'
         return not ret
 

--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -1,5 +1,5 @@
 /********************************************************************
- * AUTHORS: Vijay Ganesh
+ * AUTHORS: Vijay Ganesh, Andrew V. Jones
  *
  * BEGIN DATE: November, 2005
  *
@@ -53,6 +53,8 @@ public:
   bool cinterface_exprdelete_on_flag;
 
   int64_t timeout_max_conflicts;
+
+  int64_t timeout_max_time;
 
   // print DAG nodes
   bool print_nodes_flag;
@@ -166,6 +168,7 @@ public:
     stats_flag = false;
     cinterface_exprdelete_on_flag = true;
     timeout_max_conflicts = -1;
+    timeout_max_time = -1; // milliseconds
     print_nodes_flag = false;
     optimize_flag = true;
     wordlevel_solve_flag = true;

--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -168,7 +168,7 @@ public:
     stats_flag = false;
     cinterface_exprdelete_on_flag = true;
     timeout_max_conflicts = -1;
-    timeout_max_time = -1; // milliseconds
+    timeout_max_time = -1; // seconds
     print_nodes_flag = false;
     optimize_flag = true;
     wordlevel_solve_flag = true;

--- a/include/stp/Sat/CryptoMinisat5.h
+++ b/include/stp/Sat/CryptoMinisat5.h
@@ -1,5 +1,5 @@
 /********************************************************************
- * AUTHORS: Mate Soos
+ * AUTHORS: Mate Soos, Andrew V. Jones
  *
  * BEGIN DATE: November, 2013
  *
@@ -52,7 +52,9 @@ public:
 
   ~CryptoMiniSat5();
 
-  virtual void setMaxConflicts(int64_t max_confl);
+  virtual void setMaxConflicts(int64_t max_confl); // set max solver conflicts
+
+  virtual void setMaxTime(int64_t max_time); // set max solver time in millis
 
   bool addClause(const vec_literals& ps); // Add a clause to the solver.
 
@@ -86,6 +88,7 @@ public:
 private:
   void* temp_cl;
   int64_t max_confl = 0;
+  int64_t max_time = 0; // milliseconds
 };
 }
 

--- a/include/stp/Sat/CryptoMinisat5.h
+++ b/include/stp/Sat/CryptoMinisat5.h
@@ -54,7 +54,7 @@ public:
 
   virtual void setMaxConflicts(int64_t max_confl); // set max solver conflicts
 
-  virtual void setMaxTime(int64_t max_time); // set max solver time in millis
+  virtual void setMaxTime(int64_t max_time); // set max solver time in seconds
 
   bool addClause(const vec_literals& ps); // Add a clause to the solver.
 
@@ -88,7 +88,7 @@ public:
 private:
   void* temp_cl;
   int64_t max_confl = 0;
-  int64_t max_time = 0; // milliseconds
+  int64_t max_time = 0; // seconds
 };
 }
 

--- a/include/stp/Sat/SATSolver.h
+++ b/include/stp/Sat/SATSolver.h
@@ -1,5 +1,5 @@
 /********************************************************************
- * AUTHORS: Trevor Hansen
+ * AUTHORS: Trevor Hansen, Andrew V. Jones
  *
  * BEGIN DATE: Aug, 2010
  *
@@ -68,6 +68,13 @@ public:
   {
     std::cerr
         << "Warning: Max conflict setting is not supported by this SAT solver"
+        << std::endl;
+  }
+
+  virtual void setMaxTime(int64_t /*max_time*/)
+  {
+    std::cerr
+        << "Warning: Max time setting is not supported by this SAT solver"
         << std::endl;
   }
 

--- a/include/stp/c_interface.h
+++ b/include/stp/c_interface.h
@@ -474,7 +474,8 @@ DLL_PUBLIC Expr vc_simplify(VC vc, Expr e);
 
 //! \brief Checks the validity of the given expression 'e' in the given context.
 //!
-//! The timeout is represented and expected in milliseconds.
+//! 'timeout_max_conflicts' is represented and expected as the number of conflicts
+//! 'timeout_max_time' is represented and expected in milliseconds.
 //! The given expression 'e' must be of type boolean.
 //!
 //! Returns ...
@@ -483,13 +484,9 @@ DLL_PUBLIC Expr vc_simplify(VC vc, Expr e);
 //!   2: if errors occured
 //!   3: if the timeout was reached
 //!
-//! Note: The given timeout is a soft timeout. Use the flag '-g' for a hard timeout
-//!       that will abort automatically. Soft timeouts are only checked sparingly,
-//!       so the actual timeout may be larger.
+//! Note: Only the cryptominisat solver supports timeout_max_time
 //!
-//! Note: The cryptominisat solver does not check the timeout, yet!
-//!
-DLL_PUBLIC int vc_query_with_timeout(VC vc, Expr e, int timeout_ms);
+DLL_PUBLIC int vc_query_with_timeout(VC vc, Expr e, int timeout_max_conflicts, int timeout_max_time);
 
 //! \brief Checks the validity of the given expression 'e' in the given context
 //!        with an unlimited timeout.

--- a/include/stp/c_interface.h
+++ b/include/stp/c_interface.h
@@ -475,7 +475,7 @@ DLL_PUBLIC Expr vc_simplify(VC vc, Expr e);
 //! \brief Checks the validity of the given expression 'e' in the given context.
 //!
 //! 'timeout_max_conflicts' is represented and expected as the number of conflicts
-//! 'timeout_max_time' is represented and expected in milliseconds.
+//! 'timeout_max_time' is represented and expected in seconds.
 //! The given expression 'e' must be of type boolean.
 //!
 //! Returns ...

--- a/lib/Interface/c_interface.cpp
+++ b/lib/Interface/c_interface.cpp
@@ -495,10 +495,10 @@ void vc_assertFormula(VC vc, Expr e)
  * type. */
 int vc_query(VC vc, Expr e)
 {
-  return vc_query_with_timeout(vc, e, -1);
+  return vc_query_with_timeout(vc, e, -1, -1);
 }
 
-int vc_query_with_timeout(VC vc, Expr e, int timeout_ms)
+int vc_query_with_timeout(VC vc, Expr e, int timeout_max_conflicts, int timeout_max_time)
 {
   stp::STP* stp_i = (stp::STP*)vc;
   stp::ASTNode* a = (stp::ASTNode*)e;
@@ -518,7 +518,8 @@ int vc_query_with_timeout(VC vc, Expr e, int timeout_ms)
   const stp::ASTVec v = b->GetAsserts();
   stp::ASTNode o;
   int output;
-  stp_i->bm->UserFlags.timeout_max_conflicts = timeout_ms;
+  stp_i->bm->UserFlags.timeout_max_conflicts = timeout_max_conflicts;
+  stp_i->bm->UserFlags.timeout_max_time = timeout_max_time;
   if (!v.empty())
   {
     if (v.size() == 1)

--- a/lib/STPManager/STP.cpp
+++ b/lib/STPManager/STP.cpp
@@ -75,6 +75,9 @@ SOLVER_RETURN_TYPE STP::solve_by_sat_solver(SATSolver* newS,
   if (bm->UserFlags.timeout_max_time >= 0)
     newS->setMaxTime(bm->UserFlags.timeout_max_time);
 
+  // reset the timeout expired flag for the new check
+  bm->soft_timeout_expired = false;
+
   SOLVER_RETURN_TYPE result = TopLevelSTPAux(NewSolver, original_input);
   return result;
 }

--- a/lib/STPManager/STP.cpp
+++ b/lib/STPManager/STP.cpp
@@ -1,5 +1,5 @@
 /********************************************************************
- * AUTHORS: Vijay Ganesh, Trevor Hansen
+ * AUTHORS: Vijay Ganesh, Trevor Hansen, Andrew V. Jones
  *
  * BEGIN DATE: November, 2005
  *
@@ -71,6 +71,9 @@ SOLVER_RETURN_TYPE STP::solve_by_sat_solver(SATSolver* newS,
 
   if (bm->UserFlags.timeout_max_conflicts >= 0)
     newS->setMaxConflicts(bm->UserFlags.timeout_max_conflicts);
+
+  if (bm->UserFlags.timeout_max_time >= 0)
+    newS->setMaxTime(bm->UserFlags.timeout_max_time);
 
   SOLVER_RETURN_TYPE result = TopLevelSTPAux(NewSolver, original_input);
   return result;

--- a/lib/Sat/CryptoMinisat5.cpp
+++ b/lib/Sat/CryptoMinisat5.cpp
@@ -103,7 +103,7 @@ bool CryptoMiniSat5::solve(bool& timeout_expired) // Search without assumptions.
   if (ret == CMSat::l_Undef)
   {
     timeout_expired = true;
-    // TODO: do we want an assertion on the cause of the timeout
+    // TODO: do we want an assertion on the case of a timeout
   }
   return ret == CMSat::l_True;
 }

--- a/lib/Sat/CryptoMinisat5.cpp
+++ b/lib/Sat/CryptoMinisat5.cpp
@@ -95,6 +95,11 @@ bool CryptoMiniSat5::solve(bool& timeout_expired) // Search without assumptions.
      s->set_max_confl(std::max(max_confl - s->get_sum_conflicts(), (uint64_t)1));
   }
 
+  /*
+   * STP uses -1 for a value of "no timeout" -- this means that we only set the
+   * timeout _in the SAT solver_ if the value is >= 0. This avoids us
+   * accidentally setting a large limit (or one in the past).
+   */
   if (max_time > 0) {
      s->set_max_time(max_time);
   }
@@ -103,7 +108,7 @@ bool CryptoMiniSat5::solve(bool& timeout_expired) // Search without assumptions.
   if (ret == CMSat::l_Undef)
   {
     timeout_expired = true;
-    // TODO: do we want an assertion on the case of a timeout
+    // TODO: do we want an assertion on the case of a timeout?
   }
   return ret == CMSat::l_True;
 }

--- a/lib/Sat/CryptoMinisat5.cpp
+++ b/lib/Sat/CryptoMinisat5.cpp
@@ -1,5 +1,5 @@
 /********************************************************************
- * AUTHORS: Mate Soos
+ * AUTHORS: Mate Soos, Andrew V. Jones
  *
  * BEGIN DATE: November, 2013
  *
@@ -62,6 +62,11 @@ void CryptoMiniSat5::setMaxConflicts(int64_t _max_confl)
   max_confl = _max_confl;
 }
 
+void CryptoMiniSat5::setMaxTime(int64_t _max_time)
+{
+  max_time = _max_time;
+}
+
 bool CryptoMiniSat5::addClause(
     const vec_literals& ps) // Add a clause to the solver.
 {
@@ -90,11 +95,15 @@ bool CryptoMiniSat5::solve(bool& timeout_expired) // Search without assumptions.
      s->set_max_confl(std::max(max_confl - s->get_sum_conflicts(), (uint64_t)1));
   }
 
+  if (max_time > 0) {
+     s->set_max_time(max_time);
+  }
+
   CMSat::lbool ret = s->solve();
   if (ret == CMSat::l_Undef)
   {
     timeout_expired = true;
-    assert(s->get_sum_conflicts() >= max_confl);
+    // TODO: do we want an assertion on the cause of the timeout
   }
   return ret == CMSat::l_True;
 }

--- a/lib/Sat/CryptoMinisat5.cpp
+++ b/lib/Sat/CryptoMinisat5.cpp
@@ -108,7 +108,6 @@ bool CryptoMiniSat5::solve(bool& timeout_expired) // Search without assumptions.
   if (ret == CMSat::l_Undef)
   {
     timeout_expired = true;
-    // TODO: do we want an assertion on the case of a timeout?
   }
   return ret == CMSat::l_True;
 }

--- a/tests/api/C/timeout.cpp
+++ b/tests/api/C/timeout.cpp
@@ -46,7 +46,7 @@ void test_timeout(bool test_with_time, uint32_t max_value)
     // SMT_FILE is a macro that expands to a file path
     Expr c = vc_parseExpr(vc, SMT_FILE);
 
-    int limit = // time is in millis
+    int limit = // time is in seconds
         rand() %
         max_value; // FIXME: non-determinsitc behaviour in a test case is BAD!!!
     std::string timeout_type;

--- a/tests/api/C/timeout.cpp
+++ b/tests/api/C/timeout.cpp
@@ -1,5 +1,5 @@
 /***********
-AUTHORS:  Trevor Hansen, Dan Liew
+AUTHORS:  Trevor Hansen, Dan Liew, Andrew V. Jones
 
 BEGIN DATE: Jan, 2012
 
@@ -28,27 +28,76 @@ THE SOFTWARE.
 #include <stdio.h>
 #include <stdlib.h>
 
-TEST(timeout, one)
+void test_timeout(bool test_with_time, uint32_t max_value)
 {
-  VC vc = vc_createValidityChecker();
-  vc_setFlags(vc, 'm');
-
-  srand(time(NULL)); // FIXME: We should not be introducing non-deterministic
-                     // behaviour in a test case!
-
-  // SMT_FILE is a macro that expands to a file path
-  Expr c = vc_parseExpr(vc, SMT_FILE);
-
   for (int i = 0; i < 10; i++)
   {
-    int time =
+    // need to create VCs for every loop, otherwise the timeouts are not used
+    // correctly
+    VC vc = vc_createValidityChecker();
+    vc_setFlags(vc, 'm');
+#ifdef USE_CRYPTOMINISAT
+    vc_useCryptominisat(vc);
+#endif
+
+    srand(time(NULL)); // FIXME: We should not be introducing non-deterministic
+                       // behaviour in a test case!
+
+    // SMT_FILE is a macro that expands to a file path
+    Expr c = vc_parseExpr(vc, SMT_FILE);
+
+    int limit = // time is in millis
         rand() %
-        7000; // FIXME: non-determinsitc behaviour in a test case is BAD!!!
-    std::cout << "Timeout : " << time << " : result " << std::flush;
-    std::cout << vc_query_with_timeout(vc, vc_falseExpr(vc), time) << std::endl;
+        max_value; // FIXME: non-determinsitc behaviour in a test case is BAD!!!
+    std::string timeout_type;
+    uint32_t max_conflicts = -1;
+    uint32_t max_time = -1;
+    if (test_with_time)
+    {
+      timeout_type = "Time ";
+      limit = std::max(limit, 1); // we do not want a 0 timeout
+      max_time = limit;
+    }
+    else
+    {
+      timeout_type = "Conflicts";
+      max_conflicts = limit;
+    }
+    std::cout << timeout_type << " : " << limit << " : result " << std::flush;
+
+    // returns 3 on timeout
+    int query = vc_query_with_timeout(vc, vc_falseExpr(vc), max_conflicts, max_time);
+    ASSERT_TRUE(query == 3);
+
+    std::cout << query << std::endl;
+
+    // FIXME: Actually test something
+    // ASSERT_TRUE(false && "FIXME: Actually test something");
+
+    vc_DeleteExpr(c);
+    vc_Destroy(vc);
   }
-  vc_DeleteExpr(c);
-  vc_Destroy(vc);
-  // FIXME: Actually test something
-  // ASSERT_TRUE(false && "FIXME: Actually test something");
 }
+
+TEST(timeout_conflicts, one)
+{
+  bool is_time_timeout = false;
+  uint32_t max_value = 7000;
+  test_timeout(is_time_timeout, max_value);
+}
+
+#ifdef USE_CRYPTOMINISAT
+/*
+ * Timeout tests only with with CMS
+ */
+TEST(timeout_time, one)
+{
+  /*
+   * this test should probably test the instance without a timeout and then
+   * choose a value lower than it for the next time
+   */
+  bool is_time_timeout = true;
+  uint32_t max_value = 10;
+  test_timeout(is_time_timeout, max_value);
+}
+#endif

--- a/tests/api/python/tests.py.in
+++ b/tests/api/python/tests.py.in
@@ -4,7 +4,7 @@ The MIT License
 
 Copyright (c) 2008 Vijay Ganesh
               2014 Jurriaan Bremer, jurriaanbremer@gmail.com
-              2018 Andrew V. Jones, andrewvaughanj@gmail.com
+              2018, 2019 Andrew V. Jones, andrewvaughanj@gmail.com
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
@@ -276,6 +276,93 @@ class TestSTP(unittest.TestCase):
 
             s.check(c == op(a))
             self.assertEqual(s.model()['c'], op(A) % 2**32)
+
+    def _test_timeout(self, test_with_time, max_value):
+        solver = self.s
+
+        #
+        # Time-based timeout is only supported by CMS
+        #
+        if test_with_time and not solver.supportsCryptominisat():
+            return
+
+        #
+        # If we support CMS, then we should always use it for this test
+        #
+        if solver.supportsCryptominisat():
+            solver.useCryptominisat()
+            self.assertTrue(solver.isUsingCryptominisat())
+
+        #
+        # Calculate our maximum values
+        #
+        max_conflicts = -1
+        max_time = -1
+
+        if test_with_time:
+            max_time = max_value
+        else:
+            max_conflicts = max_value
+
+        #######################################################################
+        #                                                                     #
+        # In `tests/api/C/example.smt`, STP is validated using the 'integer   #
+        # cube root algorithm' (icbrt) -- the below is a Python implmentation #
+        # of this, using STP's API                                            #
+        #                                                                     #
+        #######################################################################
+
+        #
+        # Use a large width to make the problem "hard" -- note: a lot of time
+        # is spent bit-blasting (because of the size) rather than time spent in
+        # the SAT solver. Still, it is "good enough".
+        #
+        width = 1024
+
+        #
+        # Parameter to 'icbrt'
+        #
+        x = solver.bitvec("x", width)
+
+        #
+        # Implementation of 'icbrt'
+        #
+        s = 30
+        y = solver.bitvecval(width, 0)
+        while s >= 0:
+            y = y.mul(2)
+            b = (y.mul(3).mul(y.add(1)).add(1)).shl(s)
+            x = solver.ite(x.ge(b), x.sub(b), x)
+            y = solver.ite(x.ge(b), y.add(1), y)
+            s -= 3
+
+        #
+        # We're just choosing a random return value and asking STP to find it
+        #
+        return_val = solver.bitvec("return", width)
+        exprs = [return_val.eq(655), return_val.eq(y)]
+
+        #
+        # Check using a timeout
+        #
+        result = solver.check_with_timeout(
+            *exprs, max_conflicts=max_conflicts, max_time=max_time
+        )
+
+        #
+        # We should get an unknown result
+        #
+        self.assertEqual(result, 3, "Solver did not return 'unknown'")
+
+    def test_timeout_conflicts(self):
+        is_time_timeout = False
+        max_value = 2
+        self._test_timeout(is_time_timeout, max_value)
+
+    def test_timeout_time(self):
+        is_time_timeout = True
+        max_value = 2
+        self._test_timeout(is_time_timeout, max_value)
 
     def _test_solver(self, solver, is_default_solver=False):
         """

--- a/tests/api/python/tests.py.in
+++ b/tests/api/python/tests.py.in
@@ -281,13 +281,7 @@ class TestSTP(unittest.TestCase):
         solver = self.s
 
         #
-        # Time-based timeout is only supported by CMS
-        #
-        if test_with_time and not solver.supportsCryptominisat():
-            return
-
-        #
-        # If we support CMS, then we should always use it for this test
+        # If we support CMS, then we should always use it
         #
         if solver.supportsCryptominisat():
             solver.useCryptominisat()
@@ -362,7 +356,12 @@ class TestSTP(unittest.TestCase):
     def test_timeout_time(self):
         is_time_timeout = True
         max_value = 2
-        self._test_timeout(is_time_timeout, max_value)
+
+        #
+        # Time-based timeout is only supported by CMS
+        #
+        if self.s.supportsCryptominisat():
+            self._test_timeout(is_time_timeout, max_value)
 
     def _test_solver(self, solver, is_default_solver=False):
         """

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -256,9 +256,9 @@ void ExtraMain::create_options()
       "Number of conflicts after which the SAT solver gives up. "
       "-1 means never (default)")
 
-      // max_time -- TODO: check units here! Is it is 'ms' or 's'?
+      // max_time
       ("max_time,g", po::value<int64_t>(&max_time),
-      "Number of milliseconds after which the SAT solver gives up. "
+      "Number of seconds after which the SAT solver gives up. "
       "-1 means never (default)")
 
       // check-sanity

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -1,5 +1,5 @@
 /********************************************************************
- * AUTHORS: Vijay Ganesh, Trevor Hansen
+ * AUTHORS: Vijay Ganesh, Trevor Hansen, Andrew V. Jones
  *
  * BEGIN DATE: November, 2005
  *
@@ -245,12 +245,24 @@ void ExtraMain::create_options()
       "save in ABC's bench format to output.bench");
 
   po::options_description misc_options("Output options");
-  misc_options.add_options()("exit-after-CNF",
-                             po::bool_switch(&(bm->UserFlags.exit_after_CNF)),
-                             "exit after the CNF has been generated")(
-      "timeout,g", po::value<int64_t>(&max_num_confl),
-      "Number of conflicts after which the SAT solver gives up. -1 means never "
-      "(default)")("check-sanity,d", "construct counterexample and check it");
+  misc_options.add_options()
+      // exit-after-CNF
+      ("exit-after-CNF",
+       po::bool_switch(&(bm->UserFlags.exit_after_CNF)),
+       "exit after the CNF has been generated")
+
+      // max_confl
+      ("max_num_confl,g", po::value<int64_t>(&max_num_confl),
+      "Number of conflicts after which the SAT solver gives up. "
+      "-1 means never (default)")
+
+      // max_time -- TODO: check units here! Is it is 'ms' or 's'?
+      ("max_time,g", po::value<int64_t>(&max_time),
+      "Number of milliseconds after which the SAT solver gives up. "
+      "-1 means never (default)")
+
+      // check-sanity
+      ("check-sanity,d", "construct counterexample and check it");
 
   cmdline_options.add(general_options)
       .add(simplification_options)
@@ -363,9 +375,14 @@ int ExtraMain::parse_options(int argc, char** argv)
     bm->UserFlags.propagate_equalities = false;
   }
 
-  if (vm.count("timeout"))
+  if (vm.count("max_num_confl"))
   {
     bm->UserFlags.timeout_max_conflicts = max_num_confl;
+  }
+
+  if (vm.count("max_time"))
+  {
+    bm->UserFlags.timeout_max_time = max_time;
   }
 
   if (vm.count("check-sanity"))


### PR DESCRIPTION
This PR introduces functionality to utilise Cryptominisat's time-based timeout functionality, to allow checking assertions with a given timeout.

To work entirely correctly, this PR depends on [CMS PR 555](https://github.com/msoos/cryptominisat/pull/555). Without this PR, STP's solver timeouts are based on the starting age of the underlying process and not the age of the solver.

Given this change in CMS, I think it would be best to add more tests to STP that have timeouts across multiple checks/solvers, and where the timeout is shorter than the process age, but still a valid timeout (e.g., a 1 second timeout on a 10 second old process).

I am opening this PR now to allow for early review/comments.