### PR TITLE
Provide an implementation of 'vc_bvRemExpr' to allow for API consistency

### DIFF
--- a/include/stp/c_interface.h
+++ b/include/stp/c_interface.h
@@ -688,6 +688,14 @@ DLL_PUBLIC Expr vc_bvDivExpr(VC vc, int bitWidth, Expr dividend, Expr divisor);
 //!
 DLL_PUBLIC Expr vc_bvModExpr(VC vc, int bitWidth, Expr dividend, Expr divisor);
 
+//! \brief Returns a bitvector expression with a bit-width of 'bitWidth'
+//!        representing the modulo '(dividend % divisor)' of the two
+//!        given bitvector expressions.
+//!
+//! The given bitvector expressions must have the same bit-width as 'bitWidth'
+//!
+DLL_PUBLIC Expr vc_bvRemExpr(VC vc, int bitWidth, Expr dividend, Expr divisor);
+
 //! \brief Returns a (signed) bitvector expression with a bit-width of 'bitWidth'
 //!        representing the signed division '(dividend / divisor)' of the two
 //!        given bitvector expressions.

--- a/lib/Interface/c_interface.cpp
+++ b/lib/Interface/c_interface.cpp
@@ -1176,6 +1176,15 @@ Expr vc_bvModExpr(VC vc, int n_bits, Expr left, Expr right)
   return createBinaryTerm(vc, n_bits, stp::BVMOD, left, right);
 }
 
+Expr vc_bvRemExpr(VC vc, int n_bits, Expr left, Expr right)
+{
+  /*
+   * bvurem gets mapped to BVMOD -- this is a wrapper to
+   * allow for API consistency
+   */
+  return createBinaryTerm(vc, n_bits, stp::BVMOD, left, right);
+}
+
 Expr vc_sbvDivExpr(VC vc, int n_bits, Expr left, Expr right)
 {
   return createBinaryTerm(vc, n_bits, stp::SBVDIV, left, right);

--- a/tests/api/python/tests.py.in
+++ b/tests/api/python/tests.py.in
@@ -379,6 +379,25 @@ class TestSTP(unittest.TestCase):
             #use_cms = True
             #self._test_timeout(is_time_timeout, max_value, use_cms)
 
+    def test_urem(self):
+        #
+        # Validate the `urem` capability in STP -- note: `urem` == `mod`!
+        #
+        solver = self.s
+        width = 32
+        needle = 0xDEADBEEF
+        x = solver.bitvec("x", width)
+        y = solver.bitvec("y", width)
+        expr = x.rem(y)
+        solver.add(expr == needle)
+        solver.add(y != 0) # avoid divide by zero
+        self.assertTrue(solver.check(), "instance should be satisfiable")
+        model = solver.model()
+        val_for_x = model["x"]
+        val_for_y = model["y"]
+        concrete_value = val_for_x % val_for_y
+        self.assertEqual(concrete_value, needle, "Concrete value did not match expected value")
+
     def _test_solver(self, solver, is_default_solver=False):
         """
         Helper method to validate that the passed in "solver" can be set and


### PR DESCRIPTION
Inside of STP's Python API there was a call to a (non-existent) function of `vc_bvRemExpr`. If using the SMT front-end, the operation `bvurem` gets directly mapped to `BVMOD`.

Given that someone had "already made the mistake" of presuming that `vc_bvRemExpr` existed (e.g., `vc_sbvRemExpr` *does* exist), I provided an implementation that maps (at the API-level) from `vc_bvRemExpr` to `BVMOD`.

An alternative would have been to fix the Python API such that `rem` and `rrem` called `vc_bvModExpr` -- however, adding `vc_bvRemExpr` facilitate API consistency seemed like the better approach.

Tests have been added that would fail on older versions of STP, but give a correct value after this PR.

Signed-off-by: Andrew V. Jones <andrew.jones@vector.com>