### PR TITLE
Correcting timeout-based tests to avoid failures on Travis

### DIFF
--- a/tests/api/C/timeout.cpp
+++ b/tests/api/C/timeout.cpp
@@ -106,7 +106,6 @@ TEST(timeout_conflicts_minisat, one)
 }
 
 #ifdef USE_CRYPTOMINISAT
-#if 0
 /*
  * Timeout tests only with with CMS
  */
@@ -117,8 +116,8 @@ TEST(timeout_time, one)
    * choose a value lower than it for the next time
    */
   bool is_time_timeout = true;
-  uint32_t max_value = 10;
-  test_timeout(is_time_timeout, max_value);
+  uint32_t max_value = 3; // purposefully very low to ensure we hit a timeout
+  bool use_cms = true;
+  test_timeout(is_time_timeout, max_value, use_cms);
 }
-#endif
 #endif

--- a/tests/api/C/timeout.cpp
+++ b/tests/api/C/timeout.cpp
@@ -101,7 +101,7 @@ TEST(timeout_conflicts_cms, one)
 
 TEST(timeout_conflicts_minisat, one)
 {
-  bool use_cms = true;
+  bool use_cms = false;
   test_conflicts(use_cms);
 }
 

--- a/tests/api/python/tests.py.in
+++ b/tests/api/python/tests.py.in
@@ -365,18 +365,18 @@ class TestSTP(unittest.TestCase):
         self._test_timeout_conflicts(use_cms)
 
     def test_timeout_conflicts_cms(self):
-        use_cms = True
-        self._test_timeout_conflicts(use_cms)
+        if self.s.supportsCryptominisat():
+            use_cms = True
+            self._test_timeout_conflicts(use_cms)
 
     def test_timeout_time(self):
-        is_time_timeout = True
-        max_value = 10
-        use_cms = True
-
         #
         # Time-based timeout is only supported by CMS
         #
         if self.s.supportsCryptominisat():
+            is_time_timeout = True
+            max_value = 10
+            use_cms = True
             self._test_timeout(is_time_timeout, max_value, use_cms)
 
     def _test_solver(self, solver, is_default_solver=False):

--- a/tests/api/python/tests.py.in
+++ b/tests/api/python/tests.py.in
@@ -277,15 +277,17 @@ class TestSTP(unittest.TestCase):
             s.check(c == op(a))
             self.assertEqual(s.model()['c'], op(A) % 2**32)
 
-    def _test_timeout(self, test_with_time, max_value):
+    def _test_timeout(self, test_with_time, max_value, use_cms):
         solver = self.s
 
-        #
-        # If we support CMS, then we should always use it
-        #
-        if solver.supportsCryptominisat():
+        if use_cms:
+            self.assertTrue(solver.supportsCryptominisat())
             solver.useCryptominisat()
             self.assertTrue(solver.isUsingCryptominisat())
+        else:
+            self.assertTrue(solver.supportsMinisat())
+            solver.useMinisat()
+            self.assertTrue(solver.isUsingMinisat())
 
         #
         # Calculate our maximum values
@@ -298,49 +300,54 @@ class TestSTP(unittest.TestCase):
         else:
             max_conflicts = max_value
 
-        #######################################################################
-        #                                                                     #
-        # In `tests/api/C/example.smt`, STP is validated using the 'integer   #
-        # cube root algorithm' (icbrt) -- the below is a Python implmentation #
-        # of this, using STP's API                                            #
-        #                                                                     #
-        #######################################################################
+        #
+        # In `tests/api/C/example.smt`, STP is validated using the
+        # 'integer cube root algorithm' (icbrt).
+        #
+        # We take inspiration from this make an "extremely hard"
+        # instance of this problem (by chaining icbrt calls together
+        # for a desired end result.
+        #
+        # We can scale this problem in the number of bits for each
+        # variable, and the number of times we chain together icbrt.
+        #
+        # The timeout values were found experimentally to be at least
+        # 10x the values we use in the tests
+        #
 
-        #
-        # Use a large width to make the problem "hard" -- note: a lot of time
-        # is spent bit-blasting (because of the size) rather than time spent in
-        # the SAT solver. Still, it is "good enough".
-        #
-        width = 1024
+        width = 64
+        number_of_icbrt = 300
 
-        #
-        # Parameter to 'icbrt'
-        #
-        x = solver.bitvec("x", width)
+        total = solver.bitvecval(width, 0)
 
-        #
-        # Implementation of 'icbrt'
-        #
-        s = 30
-        y = solver.bitvecval(width, 0)
-        while s >= 0:
-            y = y.mul(2)
-            b = (y.mul(3).mul(y.add(1)).add(1)).shl(s)
-            x = solver.ite(x.ge(b), x.sub(b), x)
-            y = solver.ite(x.ge(b), y.add(1), y)
-            s -= 3
+        for i in range(number_of_icbrt):
+            #
+            # Parameter to 'icbrt'
+            #
+            x = solver.bitvec("x_{:d}".format(i), width)
+            solver.add(x > 10)
 
-        #
-        # We're just choosing a random return value and asking STP to find it
-        #
-        return_val = solver.bitvec("return", width)
-        exprs = [return_val.eq(655), return_val.eq(y)]
+            #
+            # Implementation of 'icbrt'
+            #
+            s = 30
+            y = solver.bitvecval(width, 0)
+            while s >= 0:
+                y = y.mul(2)
+                b = (y.mul(3).mul(y.add(1)).add(1)).shl(s)
+                x = solver.ite(x.ge(b), x.sub(b), x)
+                y = solver.ite(x.ge(b), y.add(1), y)
+                s -= 3
+
+            total += y
+
+        solver.add(total == 0)
 
         #
         # Check using a timeout
         #
         result = solver.check_with_timeout(
-            *exprs, max_conflicts=max_conflicts, max_time=max_time
+            max_conflicts=max_conflicts, max_time=max_time
         )
 
         #
@@ -348,20 +355,29 @@ class TestSTP(unittest.TestCase):
         #
         self.assertEqual(result, 3, "Solver did not return 'unknown'")
 
-    def test_timeout_conflicts(self):
+    def _test_timeout_conflicts(self, use_cms):
         is_time_timeout = False
-        max_value = 2
-        self._test_timeout(is_time_timeout, max_value)
+        max_value = 1000
+        self._test_timeout(is_time_timeout, max_value, use_cms)
 
-    def IGNORE_test_timeout_time(self):
+    def test_timeout_conflicts_minisat(self):
+        use_cms = False
+        self._test_timeout_conflicts(use_cms)
+
+    def test_timeout_conflicts_cms(self):
+        use_cms = True
+        self._test_timeout_conflicts(use_cms)
+
+    def test_timeout_time(self):
         is_time_timeout = True
-        max_value = 2
+        max_value = 10
+        use_cms = True
 
         #
         # Time-based timeout is only supported by CMS
         #
         if self.s.supportsCryptominisat():
-            self._test_timeout(is_time_timeout, max_value)
+            self._test_timeout(is_time_timeout, max_value, use_cms)
 
     def _test_solver(self, solver, is_default_solver=False):
         """


### PR DESCRIPTION
Three changes:

- Conflict-based timeout tests are now performed with both CMS and Minisat (both Python and C)

- Python timeout tests are now much more intensive to ensure we hit a timeout (and avoid false negatives during testing)

- C timeout tests have a significantly reduced timeout to ensure we hit a timeout (and avoid false negatives during testing)

Tested locally on my machine, but unclear how the performance of my machine matches Travis. Hopefully my machine is more powerful, and therefore if I hit a timeout, Travis should do as well.