### PR TITLE
Fix bison warning "rule useless in parser due to conflicts"

### DIFF
--- a/lib/Parser/cvc.y
+++ b/lib/Parser/cvc.y
@@ -1021,13 +1021,13 @@ Expr            :      TERMID_TOK { $$ = new ASTNode(GlobalParserInterface->letM
 ;
 
 /*Grammar for Array Update Expr*/
-ArrayUpdateExpr : Expr WITH_TOK Updates
+ArrayUpdateExpr : Expr Updates
 {
   ASTNode * result;
   unsigned int width = $1->GetValueWidth();
 
-  ASTNodeMap::iterator it = $3->begin();
-  ASTNodeMap::iterator itend = $3->end();
+  ASTNodeMap::iterator it = $2->begin();
+  ASTNodeMap::iterator itend = $2->end();
   result = new ASTNode(GlobalParserInterface->nf->CreateArrayTerm(WRITE,
                                             $1->GetIndexWidth(),
                                             width,
@@ -1046,20 +1046,20 @@ ArrayUpdateExpr : Expr WITH_TOK Updates
   }
   BVTypeCheck(*result);
   $$ = result;
-  delete $3;
+  delete $2;
   delete $1;
 }
 ;
 
-Updates         : '[' Expr ']' ASSIGN_TOK Expr 
+Updates         : '[' Expr ']' ASSIGN_TOK Expr
 {
   $$ = new ASTNodeMap();
-  (*$$)[*$2] = *$5;         
+  (*$$)[*$2] = *$5;
   delete $2;
-  delete $5;        
+  delete $5;
 }
-| Updates WITH_TOK '[' Expr ']' ASSIGN_TOK Expr 
-{                   
+| Updates WITH_TOK '[' Expr ']' ASSIGN_TOK Expr
+{
   (*$1)[*$4] = *$7;
   delete $4;
   delete $7;


### PR DESCRIPTION
The following rules were conflicting:

ArrayUpdateExpr : Expr WITH_TOK Updates
Updates : '[' Expr ']' ASSIGN_TOK Expr
        | Updates WITH_TOK '[' Expr ']' ASSIGN_TOK Expr

I think it was intended to allow

a [ e1 ] := val
OR
a WITH [ e1 ] := val