### PR TITLE
Search for cryptominisat before using its targets in STPConfig.cmake.

### DIFF
--- a/STPConfig.cmake.in
+++ b/STPConfig.cmake.in
@@ -11,6 +11,9 @@
 get_filename_component(STP_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 set(STP_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@")
 
+include(CMakeFindDependencyMacro)
+find_dependency(cryptominisat5)
+
 # Our library dependencies (contains definitions for IMPORTED targets)
 include("${STP_CMAKE_DIR}/@STP_TARGETS_FILENAME@")
 


### PR DESCRIPTION
This fixes build for projects that have dependency on STP, but not on Cryptominisat.