### PR TITLE
Fixed operator in STPConfig.cmake.in

### DIFF
--- a/STPConfig.cmake.in
+++ b/STPConfig.cmake.in
@@ -12,7 +12,7 @@ get_filename_component(STP_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 set(STP_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@")
 
 
-if ("@USE_CRYPTOMINISAT@" == "ON")
+if ("@USE_CRYPTOMINISAT@" STREQUAL "ON")
     include(CMakeFindDependencyMacro)
     find_dependency(cryptominisat5)
 endif()


### PR DESCRIPTION
@msoos many thanks for the quick fix!  You just got the string comparison operator wrong, and we get this error in KLEE:
```
CMake Error at /Users/cristic/stp/stp.git/build/STPConfig.cmake:15 (if):
  if given arguments:

    "" "==" "ON"
```
This trivial patch fixes it.
