### PR TITLE
Ensuring that STP's Travis scripts match the lingeling test repo

### DIFF
--- a/scripts/travis-cmake.sh
+++ b/scripts/travis-cmake.sh
@@ -274,6 +274,7 @@ if [ "$STP_CONFIG" != "NO_BOOST" ] && [ "$STP_CONFIG" != "INTREE_BUILD" ] ; then
     cd build
     cmake ..
     make
+    cp liblgl.a .. # so that Boolector can find it
     sudo cp lingeling /usr/bin/
     cd ..
 

--- a/scripts/travis-cmake.sh
+++ b/scripts/travis-cmake.sh
@@ -270,7 +270,9 @@ if [ "$STP_CONFIG" != "NO_BOOST" ] && [ "$STP_CONFIG" != "INTREE_BUILD" ] ; then
     #lingeling
     git clone https://github.com/msoos/lingeling-ala lingeling
     cd lingeling
-    ./configure
+    mkdir build
+    cd build
+    cmake ..
     make
     sudo cp lingeling /usr/bin/
     cd ..


### PR DESCRIPTION
## Issue

The build scripts that Travis runs point to @msoos's personal copy of Lingeling -- this repo recently got changed to not have a `./configure` script and to use CMake instead.

See: https://github.com/msoos/lingeling-ala/commit/6848f4e105193fd923ce4daf761c85168d6aa32f

## Resolution

This PR fixes Travis's steps to use CMake rather than calling `./configure` for Lingeling.

## Questions

@msoos do you think it is worthwhile adding `msoos/minisat`, `msoos/cryptominisat`, `conp-solutions/riss`, `klee/klee-uclibc`, `msoos/fuzzsmt`, `msoos/lingeling-ala` and `msoos/boolector-1.5.118` as submodules to STP? This would avoid these breakages.

These list of repos are those which come from `scripts/travis-cmake.sh`.

Signed-off-by: Andrew V. Jones <andrew.jones@vector.com>