### PR TITLE
Initial work on improving scopes such that symbols are correctly removed

### DIFF
--- a/lib/Interface/cpp_interface.cpp
+++ b/lib/Interface/cpp_interface.cpp
@@ -1,5 +1,5 @@
 /********************************************************************
- * AUTHORS: Trevor Hansen
+ * AUTHORS: Trevor Hansen, Andrew V. Jones
  *
  * BEGIN DATE: Apr, 2010
  *
@@ -39,7 +39,7 @@ namespace stp
 void Cpp_interface::checkInvariant()
 {
   assert(bm.getAssertLevel() == cache.size());
-  assert(bm.getAssertLevel() == symbols.size());
+  assert(bm.getAssertLevel() == frames.size());
 }
 
 void Cpp_interface::init()
@@ -48,7 +48,9 @@ void Cpp_interface::init()
   alreadyWarned = false;
 
   cache.push_back(Entry(SOLVER_UNDECIDED));
-  symbols.push_back(ASTVec());
+
+  // create an initial, empty frame
+  frames.push_back(SolverFrame(&functions));
 
   if (bm.getVectorOfAsserts().size() == 0)
     bm.Push();
@@ -63,6 +65,16 @@ Cpp_interface::Cpp_interface(STPMgr& bm_, NodeFactory* factory)
     : bm(bm_), letMgr(new LETMgr(bm.ASTUndefined)), nf(factory)
 {
   init();
+}
+
+ASTVec& Cpp_interface::getCurrentSymbols()
+{
+  return frames.back().getSymbols();
+}
+
+vector<std::string>& Cpp_interface::getCurrentFunctions()
+{
+  return frames.back().getFunctions();
 }
 
 void Cpp_interface::startup()
@@ -158,16 +170,23 @@ ASTNode Cpp_interface::LookupOrCreateSymbol(const char* const name)
   return bm.LookupOrCreateSymbol(name);
 }
 
-void Cpp_interface::removeSymbol(ASTNode s)
+void Cpp_interface::removeSymbol(ASTNode to_remove)
 {
   bool removed = false;
 
-  for (size_t i = 0; i < symbols.back().size(); i++)
-    if (symbols.back()[i] == s)
+  // Get the symbols for the current frame
+  ASTVec& curr_symbols = getCurrentSymbols();
+
+  for (ASTVec::iterator iter = curr_symbols.begin(); iter != curr_symbols.end();
+       ++iter)
+  {
+    if ((*iter) == to_remove)
     {
-      symbols.back().erase(symbols.back().begin() + i);
+      curr_symbols.erase(iter);
       removed = true;
+      break;
     }
+  }
 
   if (!removed)
     FatalError("Should have been removed...");
@@ -191,7 +210,13 @@ void Cpp_interface::storeFunction(const string name, const ASTVec& params,
 
   ASTNodeMap cache;
   f.function = SubstitutionMap::replace(function, fromTo, cache, nf);
+
+  // store the function in the global function store
   functions.insert(std::make_pair(f.name, f));
+
+  // record which frame this function was created in, such that it can be
+  // removed later (e.g., via pop)
+  getCurrentFunctions().push_back(f.name);
 }
 
 ASTNode Cpp_interface::applyFunction(const string name, const ASTVec& params)
@@ -286,7 +311,7 @@ void Cpp_interface::deleteNode(ASTNode* n)
 
 void Cpp_interface::addSymbol(ASTNode& s)
 {
-  symbols.back().push_back(s);
+  getCurrentSymbols().push_back(s);
 }
 
 void Cpp_interface::success()
@@ -322,15 +347,15 @@ void Cpp_interface::reset()
 {
   popToFirstLevel();
 
-  if (symbols.size() > 0)
+  if (frames.size() > 0)
   {
     // used just by cvc parser.
     assert(letMgr->_parser_symbol_table.size() == 0);
 
-    symbols.erase(symbols.end() - 1);
+    frames.erase(frames.end() - 1);
   }
 
-  assert(symbols.size() == 0);
+  assert(frames.size() == 0);
 
   // These tables might hold references to symbols that have been
   // removed.
@@ -345,7 +370,7 @@ void Cpp_interface::reset()
 
 void Cpp_interface::popToFirstLevel()
 {
-  while (symbols.size() > 1)
+  while (frames.size() > 1)
     pop();
 
   // I don't understand why this is required.
@@ -355,9 +380,9 @@ void Cpp_interface::popToFirstLevel()
 
 void Cpp_interface::pop()
 {
-  if (symbols.size() == 0)
+  if (frames.size() == 0)
     FatalError("Popping from an empty stack.");
-  if (symbols.size() == 1)
+  if (frames.size() == 1)
     FatalError("Can't pop away the default base element.");
 
   bm.Pop();
@@ -370,7 +395,7 @@ void Cpp_interface::pop()
 
   assert(letMgr->_parser_symbol_table.size() == 0);
 
-  symbols.erase(symbols.end() - 1);
+  frames.erase(frames.end() - 1);
   checkInvariant();
 }
 
@@ -383,7 +408,9 @@ void Cpp_interface::push()
     cache.push_back(Entry(SOLVER_UNDECIDED));
 
   bm.Push();
-  symbols.push_back(ASTVec());
+
+  // on push, create a new solver frame
+  frames.push_back(SolverFrame(&functions));
 
   checkInvariant();
 }
@@ -510,7 +537,7 @@ void Cpp_interface::cleanUp()
 {
   letMgr->cleanupParserSymbolTable();
   cache.clear();
-  symbols.clear();
+  frames.clear();
 }
 
 void Cpp_interface::setOption(std::string option, std::string value)
@@ -612,5 +639,48 @@ void Cpp_interface::getModel()
 void CNFClearMemory()
 {
   Cnf_ClearMemory();
+}
+
+Cpp_interface::SolverFrame::SolverFrame(
+    std::unordered_map<std::string, Function>* global_function_context)
+    : _global_function_context(global_function_context)
+{
+}
+
+// When we destroy a solver frame, we need to make sure that all of the scoped
+// functions in the global function context are also correctly removed.
+//
+// This ensures that the reference counting for any symbols used in the
+// function declarations are correctly decremented.
+Cpp_interface::SolverFrame::~SolverFrame()
+{
+  // Iterate on the function names in our current scope
+  for (vector<std::string>::const_iterator scoped_function_name =
+           getFunctions().begin();
+       scoped_function_name != getFunctions().end(); ++scoped_function_name)
+  {
+    // Find this function in the global context
+    std::unordered_map<std::string, Function>::iterator function_to_erase =
+        _global_function_context->find((*scoped_function_name));
+
+    // Hard-error if we cannot find it!
+    if (function_to_erase == _global_function_context->end())
+    {
+      FatalError("Trying to apply function which has not been defined.");
+    }
+
+    // Remove our scope function from the global function context
+    _global_function_context->erase(function_to_erase);
+  }
+}
+
+vector<std::string>& Cpp_interface::SolverFrame::getFunctions()
+{
+  return _scoped_functions;
+}
+
+ASTVec& Cpp_interface::SolverFrame::getSymbols()
+{
+  return _scoped_symbols;
 }
 }

--- a/lib/Interface/cpp_interface.cpp
+++ b/lib/Interface/cpp_interface.cpp
@@ -655,13 +655,11 @@ Cpp_interface::SolverFrame::SolverFrame(
 Cpp_interface::SolverFrame::~SolverFrame()
 {
   // Iterate on the function names in our current scope
-  for (vector<std::string>::const_iterator scoped_function_name =
-           getFunctions().begin();
-       scoped_function_name != getFunctions().end(); ++scoped_function_name)
+  for (const auto& scoped_function_name : getFunctions())
   {
     // Find this function in the global context
-    std::unordered_map<std::string, Function>::iterator function_to_erase =
-        _global_function_context->find((*scoped_function_name));
+    const auto& function_to_erase =
+        _global_function_context->find(scoped_function_name);
 
     // Hard-error if we cannot find it!
     if (function_to_erase == _global_function_context->end())

--- a/tests/query-files/unit_test/function_pop.smt2
+++ b/tests/query-files/unit_test/function_pop.smt2
@@ -1,0 +1,9 @@
+; RUN: %solver %s | %OutputCheck %s
+; Checks that popping a frame containing a function invalidates all symbols correctly
+(push 1)
+(declare-fun x!2 () Bool)
+(define-fun x!3 () Bool (not x!2))
+(pop 1)
+(assert (not x!2))
+; CHECK: (error "syntax error: line 7 syntax error, unexpected STRING_TOK  token: x!2")
+(check-sat)


### PR DESCRIPTION
## Issue

As identified in https://github.com/stp/stp/issues/365,  the creation of functions can allow for symbols to escape having their reference count decreased to zero, and therefore their lifetimes are longer than we would expect.

### Example

```
(push 1)
(declare-fun x!2 () Bool)
(define-fun x!3 () Bool (not x!2))
(pop 1)
(assert (not x!2))
(check-sat)
```

After popping `x!2` and `x!3`, it should not be possible to refer to `x!2`, but STP allows this.

## Solution

This PR reworks the symbol/function scopes inside of STP such that popping a frame *also* removes the functions declared in that scope.

### Discussion

I opted to keep a pointer to the "global" function context and then remove the popped functions during destruction of a frame.

An alternative would be change `Cpp_interface::applyFunction` to search through all of the frames (starting from the deepest) to find which to apply.

I have initially opted to tweaking how the scopes were stored, as this seemed like the less-invasive approach. Now that we have a `SolverFrame` class, we can improve `Cpp_interface::applyFunction` in the future to also use a "frame" of functions (rather than a global map).


