### PR TITLE
Ensuring that all CMake targets are correct to support no-op builds

### DIFF
--- a/lib/Interface/CMakeLists.txt
+++ b/lib/Interface/CMakeLists.txt
@@ -34,13 +34,22 @@ add_dependencies(cppinterface ASTKind_header)
 # FIXME: Remove this
 # For legacy reasons make the interface header files available in include/stp/ in the build directory
 if (NOT ("${PROJECT_BINARY_DIR}" STREQUAL "${PROJECT_SOURCE_DIR}"))
-    add_custom_target(CopyPublicHeaders ALL)
     set(HEADER_DEST "${PROJECT_BINARY_DIR}/include/stp")
     foreach(public_header c_interface.h cpp_interface.h)
-        add_custom_command(TARGET CopyPublicHeaders PRE_BUILD
+        # Name of the current legacy header
+        set(LEGACY_HEADER "${HEADER_DEST}/${public_header}")
+
+        # List of all legacy headers
+        list(APPEND LEGACY_HEADERS ${LEGACY_HEADER})
+
+        # Custom command to generate this one legacy header
+        add_custom_command(OUTPUT ${LEGACY_HEADER} PRE_BUILD
                            COMMAND ${CMAKE_COMMAND} -E make_directory ${HEADER_DEST}
                            COMMAND ${CMAKE_COMMAND} -E echo "LEGACY: Copying ${public_header} to ${HEADER_DEST}"
-                           COMMAND ${CMAKE_COMMAND} -E copy_if_different "${PROJECT_SOURCE_DIR}/include/stp/${public_header}" "${HEADER_DEST}/${public_header}"
+                           COMMAND ${CMAKE_COMMAND} -E copy_if_different "${PROJECT_SOURCE_DIR}/include/stp/${public_header}" ${LEGACY_HEADER}
                           )
     endforeach()
+
+    # Target needs to depend on all legacy headers
+    add_custom_target(CopyPublicHeaders ALL DEPENDS ${LEGACY_HEADERS})
 endif()


### PR DESCRIPTION
## Issue

If you use the `ninja` generator with STP, then it becomes clear that STP's build system does work even when there are no changes:

```
[avj@tempvm build]$ ninja
[1/1] Running utility command for CopyPublicHeaders
LEGACY: Copying c_interface.h to /home/avj/clones/stp/master/build/include/stp
LEGACY: Copying cpp_interface.h to /home/avj/clones/stp/master/build/include/stp
[avj@tempvm build]$ ninja
[1/1] Running utility command for CopyPublicHeaders
LEGACY: Copying c_interface.h to /home/avj/clones/stp/master/build/include/stp
LEGACY: Copying cpp_interface.h to /home/avj/clones/stp/master/build/include/stp
[avj@tempvm build]$ ninja
[1/1] Running utility command for CopyPublicHeaders
LEGACY: Copying c_interface.h to /home/avj/clones/stp/master/build/include/stp
LEGACY: Copying cpp_interface.h to /home/avj/clones/stp/master/build/include/stp
```

This means that STP's builds aren't called "no-op" (i.e., they do work even when the build is up-to-date).

## Resolution

This PR fixes it such that these "legacy" rules do not fire every time:

```
[avj@tempvm build]$ git rev-parse --abbrev-ref HEAD
noop_builds
[avj@tempvm build]$ ninja
ninja: no work to do.
[avj@tempvm build]$ ninja
ninja: no work to do.
[avj@tempvm build]$ ninja
ninja: no work to do.
```

### Note

This occurred because we had a target attached to a custom command that did not specify its output.

The correction here is to a have a custom command `OUTPUT` a file, and then have the target depend on all generated `OUTPUT`s (this is what this PR does).



Signed-off-by: Andrew V. Jones <andrew.jones@vector.com>