### PR TITLE
Ensuring that we do not create double frames when creating a new frame (closes #385)

### DIFF
--- a/include/stp/cpp_interface.h
+++ b/include/stp/cpp_interface.h
@@ -104,7 +104,7 @@ class Cpp_interface
   };
 
   // The vector of all frames that have been created by calling push
-  std::vector<SolverFrame> frames;
+  std::vector< SolverFrame* > frames;
 
   // Obtain the symbols/functions for the current frame
   ASTVec& getCurrentSymbols();
@@ -112,6 +112,8 @@ class Cpp_interface
 
   void checkInvariant();
   void init();
+  void addFrame();
+  void removeFrame();
 
   bool produce_models;
   bool changed_model_status;

--- a/tests/query-files/unit_test/func_decl_zeroth_scope.smt2
+++ b/tests/query-files/unit_test/func_decl_zeroth_scope.smt2
@@ -1,0 +1,9 @@
+; RUN: %solver %s | %OutputCheck %s
+(set-logic QF_ABV)
+(define-fun |a| () Bool true)
+(assert |a|)
+(push 1)
+; CHECK-NEXT: ^sat
+(check-sat)
+(pop 1)
+(exit)


### PR DESCRIPTION
When I implemented scopes, there was a bug where the copy constructor would get called twice when creating and then adding a scope to the vector of all scopes.

This "double creation" meant that functions were cleaned-up at the wrong time.

This PR changes it such that frames are only created once. An option here would have been to define a move constructor and use `emplace_back` (rather than frames being a vector of pointers) -- @msoos do you have a preference here?

Signed-off-by: Andrew V. Jones <andrew.jones@vector.com>