### PR TITLE
`ToSATAIG::runSolver` now returns the value of `SATSolver::solve`

### DIFF
--- a/lib/ToSat/ToSATAIG.cpp
+++ b/lib/ToSat/ToSATAIG.cpp
@@ -202,13 +202,13 @@ void ToSATAIG::mark_variables_as_frozen(SATSolver& satSolver)
 bool ToSATAIG::runSolver(SATSolver& satSolver)
 {
   bm->GetRunTimes()->start(RunTimes::Solving);
-  satSolver.solve(bm->soft_timeout_expired);
+  bool result = satSolver.solve(bm->soft_timeout_expired);
   bm->GetRunTimes()->stop(RunTimes::Solving);
 
   if (bm->UserFlags.stats_flag)
     satSolver.printStats();
 
-  return satSolver.okay();
+  return result;
 }
 
 ToSATAIG::~ToSATAIG()


### PR DESCRIPTION
Issue #396 documented a case where STP was crashing when using a build
of CMS that had 'BreakID' enabled. Such a configuration of CMS can
return `l_False` for a `solve` check, but *also* return `true` on a call
to `okay`.

This led to a crash in `ConstructCounterExample` where STP expected the
underlying SAT solver to have a satisfying model, when actually it had
reported UNSAT.

This commit makes it such that `ToSATAIG::runSolver` results the value
of `SATSolver::solve` and not `SATSolver::okay`.

Signed-off-by: Andrew V. Jones <andrewvaughanj@gmail.com>