### PR TITLE
Treat warnings as errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -373,6 +373,18 @@ if (COVERAGE)
     add_cxx_flag("--coverage")
 endif()
 
+option(WERROR "Build with warnings as errors" OFF)
+if (WERROR)
+    if (NOT MSVC)
+        message(STATUS "Enabling treating warnings as errors")
+        # Let's make things be errors -- we can't test for this
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
+    else()
+        message(STATUS "Warnings as errors is not enabled under MSVC")
+    endif()
+endif()
+
 option(USE_THREAD_LOCAL "Use thread-local storage when available" ON)
 add_feature_info(ThreadLocal USE_THREAD_LOCAL "Enables use of thread-local storage when available")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -546,7 +546,7 @@ else()
     endif()
 endif()
 
-include_directories(${MINISAT_INCLUDE_DIRS})
+include_directories(SYSTEM ${MINISAT_INCLUDE_DIRS})
 set(LIBS ${LIBS} ${MINISAT_LIBRARIES})
 
 # -----------------------------------------------------------------------------

--- a/lib/NodeFactory/CMakeLists.txt
+++ b/lib/NodeFactory/CMakeLists.txt
@@ -28,3 +28,8 @@ add_library(nodefactories OBJECT
 )
 
 add_dependencies(nodefactories ASTKind_header)
+
+if (NOT MSVC)
+  set_source_files_properties(NodeFactory.cpp
+    PROPERTIES COMPILE_FLAGS "-Wno-infinite-recursion")
+endif()

--- a/lib/Parser/CMakeLists.txt
+++ b/lib/Parser/CMakeLists.txt
@@ -51,6 +51,11 @@ foreach(_file ${TOLEX})
         ${CMAKE_CURRENT_BINARY_DIR}/lex${_file}.cpp
         ${CMAKE_CURRENT_BINARY_DIR}/parse${_file}.tab.cpp
     )
+    if (NOT MSVC)
+        set_source_files_properties(lex${_file}.cpp
+            PROPERTIES COMPILE_FLAGS
+            "-Wno-unneeded-internal-declaration -Wno-unreachable-code")
+    endif()
 endforeach()
 
 add_library(parser OBJECT

--- a/lib/STPManager/CMakeLists.txt
+++ b/lib/STPManager/CMakeLists.txt
@@ -24,3 +24,8 @@ add_library(stpmgr OBJECT
 )
 
 add_dependencies(stpmgr ASTKind_header)
+
+if (NOT MSVC)
+    set_source_files_properties(STPManager.cpp
+        PROPERTIES COMPILE_FLAGS "-Wno-shift-count-overflow")
+endif()

--- a/lib/Sat/CryptoMinisat5.cpp
+++ b/lib/Sat/CryptoMinisat5.cpp
@@ -182,7 +182,8 @@ uint32_t CryptoMiniSat5::getFixedCountWithAssumptions(const stp::SATSolver::vec_
   //std::cerr << assigned << " assignments at end" <<std::endl;
 
   // The assumptions are each single literals (corresponding to bits) that are true/false. 
-  // so in the result they should be all be set 
+  // so in the result they should be all be set
+  assert(assumps.size() >= 0);
   assert(assigned >= static_cast<uint32_t>(assumps.size()));
   assert(s->get_sum_conflicts() == conf ); // no searching, so no conflicts.
   assert(CMSat::l_False != r); // always satisfiable.

--- a/lib/Simplifier/CMakeLists.txt
+++ b/lib/Simplifier/CMakeLists.txt
@@ -46,3 +46,9 @@ add_library(simplifier OBJECT
     constantBitP/FixedBits.cpp
 )
 add_dependencies(simplifier ASTKind_header)
+if (NOT MSVC)
+    set_source_files_properties(constantBitP/ConstantBitP_Division.cpp
+        PROPERTIES COMPILE_FLAGS "-Wno-unreachable-code")
+    set_source_files_properties(StrengthReduction.cpp
+        PROPERTIES COMPILE_FLAGS "-Wno-unreachable-code")
+endif()

--- a/lib/Simplifier/DifficultyScore.cpp
+++ b/lib/Simplifier/DifficultyScore.cpp
@@ -54,7 +54,7 @@ long eval(const ASTNode& b)
     const auto cbv = b[0].GetBVConst(); // cleanup?
     bool last = CONSTANTBV::BitVector_bit_test(cbv,0);
     int changes = 0;
-    for (unsigned int i =1; i < b.GetValueWidth();i++)
+    for (unsigned int i = 1; i < b.GetValueWidth(); i++)
     {
         if (last != CONSTANTBV::BitVector_bit_test(cbv,i))
           changes++;

--- a/lib/Simplifier/Simplifier.cpp
+++ b/lib/Simplifier/Simplifier.cpp
@@ -2037,7 +2037,7 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
     }
 
 
-    // follow on.
+    // fall-through
     case BVPLUS:
     {
       if (BVPLUS == k && inputterm.Degree() == 2 && inputterm[1].GetKind() == BVLEFTSHIFT && inputterm[0] == inputterm[1][1])

--- a/lib/extlib-abc/CMakeLists.txt
+++ b/lib/extlib-abc/CMakeLists.txt
@@ -86,3 +86,10 @@ add_library(abc OBJECT
     aig/kit/kitSop.c
     aig/kit/kitTruth.c
 )
+
+if (NOT MSVC)
+    set_source_files_properties(aig/aig/aigDfs.c
+        PROPERTIES COMPILE_FLAGS "-Wno-dangling-else")
+    set_source_files_properties(aig/cnf/cnfData.c
+        PROPERTIES COMPILE_FLAGS "-Wno-pointer-sign")
+endif()

--- a/lib/extlib-abc/aig.h
+++ b/lib/extlib-abc/aig.h
@@ -177,8 +177,11 @@ struct Aig_Man_t_
 #define PRT(a,t)  printf("%s = ", (a)); printf("%6.2f sec\n", (float)(t)/(float)(CLOCKS_PER_SEC))
 #endif
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wempty-body"
 static inline int          Aig_Base2Log( unsigned n )             { int r; if ( n < 2 ) return n; for ( r = 0, n--; n; n >>= 1, r++ ); return r; }
 static inline int          Aig_Base10Log( unsigned n )            { int r; if ( n < 2 ) return n; for ( r = 0, n--; n; n /= 10, r++ ); return r; }
+#pragma GCC diagnostic pop
 static inline char *       Aig_UtilStrsav( char * s )             { return s ? strcpy(ALLOC(char, strlen(s)+1), s) : NULL; }
 static inline int          Aig_BitWordNum( int nBits )            { return (nBits>>5) + ((nBits&31) > 0);                  }
 static inline int          Aig_TruthWordNum( int nVars )          { return nVars <= 5 ? 1 : (1 << (nVars - 5));            }

--- a/lib/extlib-abc/cnf_short.h
+++ b/lib/extlib-abc/cnf_short.h
@@ -80,6 +80,8 @@ struct Cnf_Dat_t_
     int *           pVarNums;        // the number of CNF variable for each node ID (-1 if unused)
 };
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 // the cut used to represent node in the AIG
 struct Cnf_Cut_t_
 {
@@ -89,6 +91,7 @@ struct Cnf_Cut_t_
     Vec_Int_t *     vIsop[2];        // neg/pos ISOPs
     int             pFanins[0];      // the fanins (followed by the truth table)
 };
+#pragma GCC diagnostic pop
 
 // the CNF computation manager
 struct Cnf_Man_t_

--- a/lib/extlib-abc/vecPtr.h
+++ b/lib/extlib-abc/vecPtr.h
@@ -739,6 +739,10 @@ static inline void Vec_PtrReorder( Vec_Ptr_t * p, int nItems )
   SeeAlso     []
 
 ***********************************************************************/
+#pragma GCC diagnostic push
+#if !defined(__clang__) && __GNUC__ > 7
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+#endif /* !defined(__clang__) || __GNUC__ > 7 */
 static inline void Vec_PtrSort( Vec_Ptr_t * p, int (*Vec_PtrSortCompare)() )
 {
     if ( p->nSize < 2 )
@@ -746,6 +750,7 @@ static inline void Vec_PtrSort( Vec_Ptr_t * p, int (*Vec_PtrSortCompare)() )
     qsort( (void *)p->pArray, p->nSize, sizeof(void *), 
             (int (*)(const void *, const void *)) Vec_PtrSortCompare );
 }
+#pragma GCC diagnostic pop
 
 /**Function*************************************************************
 
@@ -758,6 +763,10 @@ static inline void Vec_PtrSort( Vec_Ptr_t * p, int (*Vec_PtrSortCompare)() )
   SeeAlso     []
 
 ***********************************************************************/
+#pragma GCC diagnostic push
+#if !defined(__clang__) && __GNUC__ > 7
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+#endif /* !defined(__clang__) || __GNUC__ > 7 */
 static inline void Vec_PtrUniqify( Vec_Ptr_t * p, int (*Vec_PtrSortCompare)() )
 {
     int i, k;
@@ -770,6 +779,7 @@ static inline void Vec_PtrUniqify( Vec_Ptr_t * p, int (*Vec_PtrSortCompare)() )
             p->pArray[k++] = p->pArray[i];
     p->nSize = k;
 }
+#pragma GCC diagnostic pop
 
 #endif
 

--- a/lib/extlib-abc/vecStr.h
+++ b/lib/extlib-abc/vecStr.h
@@ -430,6 +430,8 @@ static inline void Vec_StrPush( Vec_Str_t * p, char Entry )
   SeeAlso     []
 
 ******************************************************************************/
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wempty-body"
 static inline int Vec_StrBase10Log( unsigned Num )
 {
     int Res;
@@ -438,6 +440,7 @@ static inline int Vec_StrBase10Log( unsigned Num )
 	for ( Res = 0, Num--;  Num;  Num /= 10,  Res++ );
     return Res;
 } /* end of Extra_Base2Log */
+#pragma GCC diagnostic pop
 
 /**Function*************************************************************
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -66,7 +66,10 @@ if (MSVC)
   set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 endif()
 
+set(PREV_CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-format-nonliteral -Wno-missing-field-initializers")
 add_subdirectory(${GTEST_PREFIX} gtest)
+set(CMAKE_CXX_FLAGS "${PREV_CMAKE_CXX_FLAGS}")
 set(GTEST_BOTH_LIBRARIES gtest gtest_main)
 
 include_directories(${GTEST_PREFIX}/include)

--- a/tests/api/C/array-cvcl-02.cpp
+++ b/tests/api/C/array-cvcl-02.cpp
@@ -57,7 +57,7 @@ TEST(array_cvcl02, one)
     Expr index = vc_bvConcatExpr(vc, pre, exprj);
     index = vc_simplify(vc, index);
     Expr a_of_j = vc_readExpr(vc, cvcl_array, index);
-    Expr ce = vc_getCounterExample(vc, a_of_j);
+    (void)vc_getCounterExample(vc, a_of_j);
   }
   vc_Destroy(vc);
   // vc_printCounterExample(vc);

--- a/tests/api/C/b4-c2.cpp
+++ b/tests/api/C/b4-c2.cpp
@@ -2550,7 +2550,8 @@ TEST(b4_c2, one)
   vc_assertFormula(vc, e5286030);
   vc_push(vc);
   Expr e5286031 = vc_falseExpr(vc);
-  if (false)
+  bool print_debug = false;
+  if (print_debug)
   {
     char* cc;
     unsigned long len;

--- a/tests/api/C/b4-c2.cpp
+++ b/tests/api/C/b4-c2.cpp
@@ -2550,14 +2550,14 @@ TEST(b4_c2, one)
   vc_assertFormula(vc, e5286030);
   vc_push(vc);
   Expr e5286031 = vc_falseExpr(vc);
-  bool print_debug = false;
-  if (print_debug)
+#if 0
   {
     char* cc;
     unsigned long len;
     vc_printQueryStateToBuffer(vc, e5286031, &cc, &len, 1);
     std::cout << cc << std::endl;
   }
+#endif
   int ret = vc_query(vc, e5286031);
   ASSERT_FALSE(ret);
   vc_pop(vc);

--- a/tests/api/C/example_broken.cpp
+++ b/tests/api/C/example_broken.cpp
@@ -14,7 +14,6 @@ TEST(examplebroken, one)
 {
   int width = 8;
   VC handle = vc_createValidityChecker();
-  VC handle2 = vc_createValidityChecker();
 
   // Create variable "x"
   Expr x = vc_varExpr(handle, "x", vc_bvType(handle, width));

--- a/tests/api/C/getbv.cpp
+++ b/tests/api/C/getbv.cpp
@@ -33,7 +33,7 @@ THE SOFTWARE.
 
 TEST(getbv, INT64)
 {
-  ASSERT_EQ(64, sizeof(uint64_t) * 8);
+  ASSERT_EQ(64ul, sizeof(uint64_t) * 8);
 
   for (uint64_t j = 1; j < UINT64_MAX; j |= (j << 1))
   {
@@ -61,7 +61,7 @@ TEST(getbv, INT64)
 
 TEST(getbv, INT32)
 {
-  ASSERT_EQ(32, sizeof(int32_t) * 8);
+  ASSERT_EQ(32ul, sizeof(int32_t) * 8);
 
   for (uint32_t j = 1; j < UINT32_MAX; j |= (j << 1))
   {

--- a/tests/api/C/mdempsky.cpp
+++ b/tests/api/C/mdempsky.cpp
@@ -28,7 +28,6 @@ THE SOFTWARE.
 TEST(mdempsky, one)
 {
   VC vc = vc_createValidityChecker();
-  Expr trueExpr = vc_trueExpr(vc);
 
   Expr A = vc_varExpr(vc, "A", vc_bv32Type(vc));
   Expr B = vc_varExpr(vc, "B", vc_bv32Type(vc));

--- a/tests/api/C/parsefile-using-cinterface.cpp
+++ b/tests/api/C/parsefile-using-cinterface.cpp
@@ -45,7 +45,7 @@ TEST(parsefile, CVC)
   vc_DeleteExpr(c);
   printf("\n");
   vc_Destroy(vc);
-  ASSERT_EQ(errorCount, 0);
+  ASSERT_EQ(errorCount, 0u);
 }
 
 void errorHandler(const char* err_msg)

--- a/tests/api/C/stp-bool.cpp
+++ b/tests/api/C/stp-bool.cpp
@@ -29,7 +29,7 @@ THE SOFTWARE.
 TEST(stp_bool, one)
 {
   VC vc = vc_createValidityChecker();
-  Type type64 = vc_boolType(vc);
+  (void)vc_boolType(vc);
 
   vc_Destroy(vc);
   // FIXME: Actually test something

--- a/tests/api/C/stp-counterex.cpp
+++ b/tests/api/C/stp-counterex.cpp
@@ -37,8 +37,6 @@ TEST(stp_counterex, one)
   vc_setFlags(vc, 'd');
   // vc_setFlags(vc,'p');
 
-  Type bv8 = vc_bvType(vc, 8);
-
   Expr a = vc_bvCreateMemoryArray(vc, "a");
 
   Expr index_1 = vc_bvConstExprFromInt(vc, 32, 1);

--- a/tests/api/C/stp-div-001.cpp
+++ b/tests/api/C/stp-div-001.cpp
@@ -36,8 +36,6 @@ TEST(stp_div, one)
   vc_setFlags(vc, 'd');
   // vc_setFlags(vc,'p');
 
-  Type bv8 = vc_bvType(vc, 8);
-
   Expr a = vc_bvCreateMemoryArray(vc, "a");
 
   Expr index_3 = vc_bvConstExprFromInt(vc, 32, 3);

--- a/tests/api/C/stp-even-eqn-assert.cpp
+++ b/tests/api/C/stp-even-eqn-assert.cpp
@@ -24,17 +24,15 @@ THE SOFTWARE.
 
 #include "stp/c_interface.h"
 #include <gtest/gtest.h>
+#include <string>
 
-void test(void)
+TEST(even_eqn_assert, one)
 {
   VC vc = vc_createValidityChecker();
   vc_setInterfaceFlags(vc, (ifaceflag_t)0, 0);
   vc_push(vc);
-  Type ty_bv8 = vc_bvType(vc, 8);
   Type ty_bv16 = vc_bvType(vc, 16);
   Type ty_bv32 = vc_bvType(vc, 32);
-
-  Expr var_i00 = vc_varExpr(vc, "i00", ty_bv8);
 
   Expr var_is4a = vc_varExpr(vc, "is4a", ty_bv16);
   Expr var_is48 = vc_varExpr(vc, "is48", ty_bv16);
@@ -42,7 +40,6 @@ void test(void)
 
   Expr var_t343 = vc_varExpr(vc, "t343", ty_bv32);
 
-  Expr const_0_8 = vc_bvConstExprFromInt(vc, 8, 0);
   Expr const_0_16 = vc_bvConstExprFromInt(vc, 16, 0);
   Expr const_0_32 = vc_bvConstExprFromInt(vc, 32, 0);
 
@@ -96,8 +93,3 @@ void test(void)
   ASSERT_TRUE(ret);
 }
 
-int main(int argc, char** argv)
-{
-  test();
-  return 0;
-}


### PR DESCRIPTION
Enable warnings as errors (`-Werror`) while building with GCC/clang, and
fix code (and associated tests) such that STP builds across: gcc-7,
gcc-9, gcc-10, clang-7, clang-8, clang-9, clang-10, clang-11 on Linux.

Errors from external libraries (e.g., MiniSat) are marked as `SYSTEM`
(via CMake) and errors in 'internal' libraries (e.g., extlib-abc) are
suppressed via `pragmas`, which work with both GCC and clang. Selective
files in STP have explicit warnings disabled via CMake.

Treating warnings as errors is not enabled when compling with MSVC.

Signed-off-by: Andrew V. Jones <andrewvaughanj@gmail.com>