### PR TITLE
Fix `library_path` import

### DIFF
--- a/bindings/python/stp/stp.py.in
+++ b/bindings/python/stp/stp.py.in
@@ -31,6 +31,7 @@ from ctypes import c_char_p, c_void_p, c_int32, c_uint32, c_uint64, c_ulong, c_b
 import inspect
 import os.path
 import sys
+from stp.library_path import PATHS
 
 __all__ = [
     'Expr', 'Solver', 'stp', 'add', 'bitvec', 'bitvecs', 'check', 'model',
@@ -41,8 +42,6 @@ Py3 = sys.version_info >= (3, 0, 0)
 
 if Py3:
     long = int
-
-from library_path import PATHS
 
 for path in PATHS:
     if not os.path.exists(path):


### PR DESCRIPTION
This is needed (at least) when one customises the Python bindings
installation directory using `PYTHON_LIB_INSTALL_DIR`.

Since the `library_path` module will also be installed into the same
directory as `stp.py`, this change should be safe to make even when one
uses the default `PYTHON_LIB_INSTALL_DIR`.

I moved this line up with the other imports because my linter was
complaining about its location, but I don't mind moving it back to where
it was originally.

See #353 and #400.