### PR TITLE
Smtcomp 2021

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,7 +16,6 @@ LICENSE
 LICENSE_COMPONENTS
 papers
 README.markdown
-scripts
 stp.kdev4
 stuff*
 tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,6 +87,10 @@ RUN apt-get update && \
         unzip
 RUN pip install supervisor awscli
 
+# Enable transparent huge pages, always
+RUN DEBIAN_FRONTEND=noninteractive apt -y install hugepages
+RUN hugeadm --thp-always
+
 # Finally run the tool
 CMD /stp/tools/container-default-command.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,8 @@ RUN make install
 RUN mkdir /stp
 WORKDIR /stp
 COPY . /stp
+# make all starexec tools available
+COPY scripts/starexec/bin/* /usr/local/bin/
 RUN mkdir build
 WORKDIR /stp/build
 RUN cmake -DSTATICCOMPILE=ON ..
@@ -55,14 +57,37 @@ RUN make install
 
 # set up for running
 # set up for running
-FROM alpine:latest
-COPY --from=builder /usr/local/bin/stp /usr/local/bin/stp
-ENTRYPOINT ["/usr/local/bin/stp", "--SMTLIB2"]
+# FROM alpine:latest
+# COPY --from=builder /usr/local/bin/stp /usr/local/bin/stp
 
+# Run the solver from a script
+# COPY --from=builder /stp/tools/container-default-command.sh \
+#     /usr/local/bin/container-default-command.sh
+
+WORKDIR /stp
+
+
+# Finally run the tool
+CMD /stp/tools/container-default-command.sh
+
+# --------------------
+# Example call for solving a local file
+# --------------------
+#
+# docker build -f Dockerfile . && STP_CONTAINER=$(docker build -q -f Dockerfile .) && echo "Container: $STP_CONTAINER"
+# export FILE_DIR=$PWD/tests/query-files/unit_test
+# export INPUT_FILE=bvsgt.smt2;
+# docker run --rm -i -v $FILE_DIR:$FILE_DIR:ro -e INPUT_FILE=$FILE_DIR/$INPUT_FILE "$STP_CONTAINER"
+#
 # --------------------
 # HOW TO USE
 # --------------------
 # on file through STDIN:
 #    cat myfile.smt | docker run --rm -i -a stdin -a stdout stp
-
+#
+# on file $INPUT_FILE with path $FILE_DIR, e.g.: FILE_DIR=$PWD/tests/query-files/unit_test; export INPUT_FILE=bvsgt.smt2
+#    docker run --rm -i -v $FILE_DIR:$FILE_DIR:ro -e INPUT_FILE=$FILE_DIR/myfile.smt -a stdin -a stdout stp
+#
+# on file in S3 located in "${S3_BKT}"/"${COMP_S3_PROBLEM_PATH}"
+#    docker run --rm -i -v -e S3_BKT=${S3_BKT} -e COMP_S3_PROBLEM_PATH=${COMP_S3_PROBLEM_PATH} -a stdin -a stdout stp
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,17 @@ RUN make install
 WORKDIR /stp
 
 
+# Relevant for interaction with aws (might move ths section further up!
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt install -y \
+        cmake \
+        curl \
+        iproute2 \
+        python \
+        python-pip \
+        unzip
+RUN pip install supervisor awscli
+
 # Finally run the tool
 CMD /stp/tools/container-default-command.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,15 @@ RUN cmake ..
 RUN make -j6
 RUN make install
 
+# get mergesat and make available
+RUN mkdir /mergesat
+WORKDIR /mergesat
+RUN wget -O mergesat-v3.0.tar.gz https://github.com/conp-solutions/mergesat/archive/refs/tags/v3.0.tar.gz
+RUN tar xfz mergesat-v3.0.tar.gz --strip-components 1
+RUN make r -j6
+RUN cp build/release/bin/mergesat /usr/local/bin/
+RUN which mergesat
+
 # build stp
 RUN mkdir /stp
 WORKDIR /stp

--- a/scripts/starexec/bin/multi-solver.py
+++ b/scripts/starexec/bin/multi-solver.py
@@ -22,7 +22,7 @@ def setup_solvers(threads):
     # Call strings for solvers
     cmsString = "cryptominisat5 --verb 0 --printsol 0 --threads "  # $(nproc)"
     mergesatString = "mergesat -verb=0 "
-    rissString = "riss -verb=0 -quiet "
+    mergesatUnsatString = "mergesat -verb=0 --no-use-ccnr -no-use-rephasing "
     minisatString = "minisat -verb=0 "
 
     # Set threads
@@ -37,7 +37,7 @@ def setup_solvers(threads):
     if threads > 1:
         solvers["mergesat"] = dir_path+mergesatString
     if threads > 2:
-        solvers["riss"] = dir_path+rissString
+        solvers["mergesatUnsat"] = dir_path+mergesatUnsatString
     if threads > 3:
         solvers["minisat"] = dir_path+minisatString
 

--- a/scripts/starexec/bin/starexec_run_portfolio
+++ b/scripts/starexec/bin/starexec_run_portfolio
@@ -15,7 +15,12 @@ rm -f output_0.cnf
 # In case a file was created, call the SAT solver
 if [ -f output_0.cnf ]
 then
-	result="$("$SOLVERDIR"/multi-solver.py $(nproc) output_0.cnf 2>&1)"
+	# Only use every second CPU, but at least 1
+	CPUS=$(nproc)
+	CPUS=$((CPUS/2))
+	[ "$CPUS" -eq 0 ] && CPUS=1
+
+	result="$("$SOLVERDIR"/multi-solver.py "$CPUS" output_0.cnf 2>&1)"
 	echo "$result" | grep winner 1>&2
 
 	if [[ "$result" == *"s SATISFIABLE"* ]]; then

--- a/tools/container-default-command.sh
+++ b/tools/container-default-command.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# Copyright Norbert Manthey, 2019
+
+# This script is executed as default in the container
+
+set -x
+
+echo "Start container default command"
+echo "Start container default command" 1>&2
+
+# Default location is defined by environment variable INPUT_FILE
+INPUT_FILE=${INPUT_FILE:-}
+
+
+# Get file from S3, copy it to a temporary directory
+trap '[ -d "$STPTMPDIR" ] && rm -rf "$STPTMPDIR"' EXIT
+STPTMPDIR=$(mktemp -d)
+
+SCRIPT=$(readlink -e "$0")
+SCRIPTDIR=$(dirname "$SCRIPT")
+
+
+# In case that variable is not given, we might have a file stored in S3
+if [ -z "$INPUT_FILE" ]
+then
+    if ! command -v aws &> /dev/null
+    then
+        echo "error: cannot find tool 'aws', abort" 1>&2
+        exit 1
+    fi
+    
+    # Get file basename
+    PROBLEM=$(basename ${COMP_S3_PROBLEM_PATH})
+    
+    echo "Trying to obtain the file from S3: ${S3_BKT}/${COMP_S3_PROBLEM_PATH}" 1>&2
+    aws s3 cp s3://"${S3_BKT}"/"${COMP_S3_PROBLEM_PATH}" "$STPTMPDIR/$PROBLEM"
+    
+    INPUT_FILE="$STPTMPDIR/$PROBLEM"
+fi
+
+
+# Final check wrt input file
+if [ ! -r "$INPUT_FILE" ]
+then
+    echo "error: cannot read input file '$INPUT_FILE'" 1>&2
+    exit 1
+fi
+
+# Capture stdin to file, in case we miss an input file
+if [ -z "$INPUT_FILE" ]; then
+    # Get file from stdin, so that we can forward the file
+    INPUT_FILE="$STPTMPDIR"/stdin.smt2
+    echo "Catch file from stdin in $INPUT_FILE (as none was specified) ..." 1>&2
+    cat > "$INPUT_FILE"
+fi
+
+# Run starexec portfolio script on input file
+starexec_run_portfolio "$INPUT_FILE"
+
+# Using native solver, use the next command:
+# echo "Run stp with file $INPUT_FILE" 1>&2
+# exec /usr/local/bin/stp --SMTLIB2 "$INPUT_FILE"

--- a/tools/container-default-command.sh
+++ b/tools/container-default-command.sh
@@ -4,10 +4,11 @@
 
 # This script is executed as default in the container
 
-set -x
-
-echo "Start container default command"
-echo "Start container default command" 1>&2
+# Make debugging more explicit
+DEBUGGING=0
+[ "$DEBUGGING" -ne 0 ] && set -x
+[ "$DEBUGGING" -ne 0 ] && echo "Start container default command"
+[ "$DEBUGGING" -ne 0 ] && echo "Start container default command" 1>&2
 
 # Default location is defined by environment variable INPUT_FILE
 INPUT_FILE=${INPUT_FILE:-}


### PR DESCRIPTION
This branch is a proposal for the parallel track of the SMT Comptition 2021 (See issue #399 )

The Dockerfile now
 * also installs MergeSat
 * uses transparent huge pages by default
 * uses the starexec portfolio configuration
 * only uses every 2nd CPU (to not run into hyperthread sharing)
 * does not support the stdin use case anymore
 * can access input from S3

A few related scripts have been adapted as well.

### Note

This change is not meant to be (fully) merged, but rather to aid the discussion for SMT comp.

### Testing Done

The change has been tested with the following sequence of commands:

```
# build verbose (to see steps), get the container ID
docker build -f Dockerfile . && STP_CONTAINER=$(docker build -q -f Dockerfile .) && echo "Container: $STP_CONTAINER"

# setup example input
export FILE_DIR=$PWD/tests/query-files/unit_test; export INPUT_FILE=bvsgt.smt2

# run the container with the input file
docker run --rm -i -v $FILE_DIR:$FILE_DIR:ro -e INPUT_FILE=$FILE_DIR/$INPUT_FILE "$STP_CONTAINER"
```