### PR TITLE
Let's not use macros instead of "const"-s

### DIFF
--- a/lib/Sat/MinisatCore.cpp
+++ b/lib/Sat/MinisatCore.cpp
@@ -23,7 +23,6 @@ THE SOFTWARE.
 ********************************************************************/
 
 #define __STDC_FORMAT_MACROS
-#define MINISAT_CONSTANTS_AS_MACROS
 #include "stp/Sat/MinisatCore.h"
 #include "minisat/core/Solver.h"
 //#include "utils/System.h"
@@ -79,7 +78,7 @@ bool MinisatCore::propagateWithAssumptions(
   setMaxConflicts(0);
   Minisat::lbool ret = s->solveLimited(assumps);
   assert(s->conflicts ==0);
-  return ret != (Minisat::lbool)l_False;
+  return ret != (Minisat::lbool)Minisat::l_False;
 }
 
 bool MinisatCore::solve(bool& timeout_expired) // Search without assumptions.
@@ -89,12 +88,12 @@ bool MinisatCore::solve(bool& timeout_expired) // Search without assumptions.
 
   Minisat::vec<Minisat::Lit> assumps;
   Minisat::lbool ret = s->solveLimited(assumps);
-  if (ret == (Minisat::lbool)l_Undef)
+  if (ret == (Minisat::lbool)Minisat::l_Undef)
   {
     timeout_expired = true;
   }
 
-  return ret == (Minisat::lbool)l_True;
+  return ret == (Minisat::lbool)Minisat::l_True;
 }
 
 uint8_t MinisatCore::modelValue(uint32_t x) const

--- a/lib/Sat/RissCore.cpp
+++ b/lib/Sat/RissCore.cpp
@@ -23,7 +23,6 @@ THE SOFTWARE.
 ********************************************************************/
 
 #define __STDC_FORMAT_MACROS
-#define MINISAT_CONSTANTS_AS_MACROS
 #include "stp/Sat/Riss.h"
 #include "riss/core/Solver.h"
 //#include "utils/System.h"

--- a/lib/Sat/SimplifyingMinisat.cpp
+++ b/lib/Sat/SimplifyingMinisat.cpp
@@ -23,7 +23,6 @@ THE SOFTWARE.
 ********************************************************************/
 
 #define __STDC_FORMAT_MACROS
-#define MINISAT_CONSTANTS_AS_MACROS
 #include "stp/Sat/SimplifyingMinisat.h"
 #include "minisat/simp/SimpSolver.h"
 
@@ -72,7 +71,7 @@ bool SimplifyingMinisat::solve(
 
   Minisat::vec<Minisat::Lit> assumps;
   Minisat::lbool ret = s->solveLimited(assumps);
-  if (ret == (Minisat::lbool)l_Undef)
+  if (ret == (Minisat::lbool)Minisat::l_Undef)
   {
     timeout_expired = true;
   }


### PR DESCRIPTION
It messed with namespaces, and in particular, messes with CryptoMiniSat's new constexpr setup. STP will not compile with the newest (MPI) cryptominisat with this inside.

Note that there **MAY** be a **SLOWDOWN**. We'd need to test. So let's not merge this before some performance testing. In my understanding, modern compilers (less than 5-7 years old) should not create any slowdown with this code. Also, it's clearly the right way to do it, separating namespaces :)