### PR TITLE
Add BUILD_EXECUTABLES option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -658,9 +658,12 @@ add_feature_info(PythonInterface ENABLE_PYTHON_INTERFACE "Enables Python interfa
 # -----------------------------------------------------------------------------
 
 message(STATUS "Final CXX flags ${CMAKE_CXX_FLAGS}")
+
+option(BUILD_EXECUTABLES "Build executables" ON)
 add_subdirectory(lib)
 add_subdirectory(tools)
 add_subdirectory(bindings)
+add_feature_info(Executables BUILD_EXECUTABLES "Enables executables compilation")
 
 # -----------------------------------------------------------------------------
 # Add uninstall target for makefiles

--- a/tools/stp/CMakeLists.txt
+++ b/tools/stp/CMakeLists.txt
@@ -21,7 +21,7 @@
 # -----------------------------------------------------------------------------
 # Create binary
 # -----------------------------------------------------------------------------
-if (NOT ONLY_SIMPLE)
+if(BUILD_EXECUTABLES AND NOT ONLY_SIMPLE)
     include_directories(${Boost_INCLUDE_DIR})
     add_executable(stp-bin
         main.cpp

--- a/tools/stp_simple/CMakeLists.txt
+++ b/tools/stp_simple/CMakeLists.txt
@@ -21,21 +21,23 @@
 # -----------------------------------------------------------------------------
 # Create binary
 # -----------------------------------------------------------------------------
-add_executable(stp_simple-bin
-    main_simple.cpp
-    ../stp/main_common.cpp
-)
+if(BUILD_EXECUTABLES)
+    add_executable(stp_simple-bin
+        main_simple.cpp
+        ../stp/main_common.cpp
+    )
 
-set_target_properties(stp_simple-bin PROPERTIES
-    OUTPUT_NAME stp_simple
-    RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}
-    INSTALL_RPATH_USE_LINK_PATH TRUE
-)
+    set_target_properties(stp_simple-bin PROPERTIES
+        OUTPUT_NAME stp_simple
+        RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}
+        INSTALL_RPATH_USE_LINK_PATH TRUE
+    )
 
-target_link_libraries(stp_simple-bin
-    stp
-)
+    target_link_libraries(stp_simple-bin
+        stp
+    )
 
-install(TARGETS stp_simple-bin
-        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-)
+    install(TARGETS stp_simple-bin
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    )
+endif()


### PR DESCRIPTION
Adds an option that disables the build of executable files. This is useful if `stp` is being used as a library. Otherwise, when using the `install` rule, the `stp` application is installed with the product.