### PR TITLE
MSVC: Fix overriding '/MTd' with '/MT'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,26 +228,8 @@ else()
 
     add_compile_options("$<$<CONFIG:DEBUG>:/Od>")
 
-    if (NOT BUILD_SHARED_LIBS)
-        # We statically link to reduce dependencies
-        foreach(flag_var CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
-            # /MD -- Causes the application to use the multithread-specific
-            #        and DLL-specific version of the run-time library.
-            #        Defines _MT and _DLL and causes the compiler to place
-            #        the library name MSVCRT.lib into the .obj file.
-            if(${flag_var} MATCHES "/MD")
-                string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
-            endif(${flag_var} MATCHES "/MD")
-
-            # /MDd	-- Defines _DEBUG, _MT, and _DLL and causes the application to use the debug multithread-specific and DLL-specific version of the run-time library.
-            #          It also causes the compiler to place the library name MSVCRTD.lib into the .obj file.
-            if(${flag_var} MATCHES "/MDd")
-                string(REGEX REPLACE "/MDd" "/MTd" ${flag_var} "${${flag_var}}")
-            endif(${flag_var} MATCHES "/MDd")
-        endforeach(flag_var)
-
-        # Creates a multithreaded executable (static) file using LIBCMT.lib.
-        add_compile_options(/MT)
+    if(STATICCOMPILE)
+        add_compile_options($<$<CONFIG:>:/MT> $<$<CONFIG:Debug>:/MTd> $<$<CONFIG:Release>:/MT>)
     endif()
 
     # buffers security check
@@ -443,8 +425,6 @@ if(NOT Boost_FOUND)
     set(ONLY_SIMPLE ON)
 else()
     message(STATUS "Boost -- found at library: ${Boost_LIBRARIES}")
-    message(STATUS "Boost -- adding '${Boost_LIBRARY_DIRS}' to link directories")
-    link_directories(${Boost_LIBRARY_DIRS})
 endif()
 add_feature_info(SimpleOptions ONLY_SIMPLE "Simplifies command-line interface, only a few command-line options will be available")
 

--- a/tools/stp/CMakeLists.txt
+++ b/tools/stp/CMakeLists.txt
@@ -22,7 +22,6 @@
 # Create binary
 # -----------------------------------------------------------------------------
 if(BUILD_EXECUTABLES AND NOT ONLY_SIMPLE)
-    include_directories(${Boost_INCLUDE_DIR})
     add_executable(stp-bin
         main.cpp
         main_common.cpp
@@ -36,7 +35,7 @@ if(BUILD_EXECUTABLES AND NOT ONLY_SIMPLE)
 
     target_link_libraries(stp-bin
         stp
-        "${Boost_LIBRARIES}"
+        Boost::program_options
     )
 
     install(TARGETS stp-bin


### PR DESCRIPTION
This PR fixes the following MSVC warning:

```
 Command line warning D9025 : overriding '/MTd' with '/MT'
 ```

 when `STATICCOMPILE` is `ON`.
 
The issue was caused by `add_compile_options(/MT)` that doesn't necessary, since the flag is already replaced in the logic above.
 
I also removed redundant `if(${flag_var} MATCHES "/MDd")` because if it `true` then `if(${flag_var} MATCHES "/MD")` is also `true` because `MATCHES` performs a partial regex match.