### PR TITLE
Modernize Boost usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-cmake_minimum_required(VERSION 3.3 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 
 if(POLICY CMP0048)
     #policy for VERSION in cmake 3.0
@@ -441,10 +441,6 @@ endif()
 
 if(NOT Boost_FOUND)
     set(ONLY_SIMPLE ON)
-else()
-    message(STATUS "Boost -- found at library: ${Boost_LIBRARIES}")
-    message(STATUS "Boost -- adding '${Boost_LIBRARY_DIRS}' to link directories")
-    link_directories(${Boost_LIBRARY_DIRS})
 endif()
 add_feature_info(SimpleOptions ONLY_SIMPLE "Simplifies command-line interface, only a few command-line options will be available")
 

--- a/tools/stp/CMakeLists.txt
+++ b/tools/stp/CMakeLists.txt
@@ -22,7 +22,6 @@
 # Create binary
 # -----------------------------------------------------------------------------
 if(BUILD_EXECUTABLES AND NOT ONLY_SIMPLE)
-    include_directories(${Boost_INCLUDE_DIR})
     add_executable(stp-bin
         main.cpp
         main_common.cpp
@@ -36,7 +35,7 @@ if(BUILD_EXECUTABLES AND NOT ONLY_SIMPLE)
 
     target_link_libraries(stp-bin
         stp
-        "${Boost_LIBRARIES}"
+        Boost::program_options
     )
 
     install(TARGETS stp-bin


### PR DESCRIPTION
In this PR I modernized Boost usage by using [imported targets](https://cmake.org/cmake/help/latest/module/FindBoost.html#imported-targets). But the feature was introduced in CMake 3.5, so I bumped the version. But KLEE uses [the same version](https://github.com/klee/klee/blob/0ba95edbad26fe70c8132f0731778d94f9609874/CMakeLists.txt#L13), so I hope it's okay :)

Made the same PR for [cryptominisat](https://github.com/msoos/cryptominisat/pull/666).