### PR TITLE
Remove parallel flag because does not work on ctest 3.5.1.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -181,7 +181,7 @@ mkdir build
 cd build
 cmake -DENABLE_TESTING=ON ..
 make
-make check
+make test
 ```
 
 ### Installing

--- a/scripts/deps/setup-gtest.sh
+++ b/scripts/deps/setup-gtest.sh
@@ -14,7 +14,7 @@ git clone https://github.com/stp/googletest "${dep}"
 cd "${dep}"
 mkdir build && cd build
 cmake -DCMAKE_INSTALL_PREFIX:PATH="${install_dir}" ..
-cmake --build . --parallel "$(nproc)"
+cmake --build . 
 cmake --install .
 cd ..
 


### PR DESCRIPTION
The --parallel flag doesn't seems to work on ctest 3.5.1.  All our build scripts work on 3.5.1 so it seems a mistake. Building gtest seems fast so I don't think we need parallel on it anyway.
