### PR TITLE
Remove the unnecessary use of a SCARY iterator that may break on older compilers

### DIFF
--- a/lib/Simplifier/StrengthReduction.cpp
+++ b/lib/Simplifier/StrengthReduction.cpp
@@ -405,8 +405,7 @@ namespace stp
   ASTNode StrengthReduction::topLevel(const ASTNode& top,  const NodeToUnsignedIntervalMap& visited)
   {
     ASTNodeMap fromTo;
-    for (std::unordered_map<const ASTNode, UnsignedInterval*>::const_iterator it = visited.begin();
-         it != visited.end(); it++)
+    for (auto it = visited.begin(); it != visited.end(); ++it)
     {
       const ASTNode& n = it->first;
 


### PR DESCRIPTION
Older compilers (see #430) currently fail building STP master due to the unnecessary use of a SCARY iterator. This PR simply replaces the written out type with an `auto` use, which will deduce the correct iterator type.