### PR TITLE
Fixed the broken link on SMT-LIBv2 documentation.

### DIFF
--- a/docs/smt-input-language.rst
+++ b/docs/smt-input-language.rst
@@ -5,8 +5,8 @@ SMT-LIBv2 Input Language Reference
 .. highlight:: lisp
 
 This page contains a short description for the SMTLibv2 input language
-that STP can parse. For a longer description please read `this
-PDF <http://www.grammatech.com/resource/smt/SMTLIBTutorial.pdf>`__.
+that STP can parse. For more information related to SMTLIB, please refer to `this
+page <https://smtlib.cs.uiowa.edu/>`__.
 
 Header
 ======

--- a/docs/smt-input-language.rst
+++ b/docs/smt-input-language.rst
@@ -4,8 +4,8 @@ SMT-LIBv2 Input Language Reference
 
 .. highlight:: lisp
 
-This page contains a short description for the SMTLibv2 input language
-that STP can parse. For more information related to SMTLIB, please refer to `this
+This page contains a short description for the SMT-LIB v2 input language
+that STP can parse. For more information related to SMT-LIB, please refer to `this
 page <https://smtlib.cs.uiowa.edu/>`__.
 
 Header


### PR DESCRIPTION
Page: https://stp.readthedocs.io/en/latest/smt-input-language.html. "For a longer description please read [this PDF]". Here the link is broken. After discussion with @aytey changed the link to https://smtlib.cs.uiowa.edu/. 