### PR TITLE
CMakeLists: use absolute libdir in rpath handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,16 +181,16 @@ else ()
     # (but later on when installing)
     SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
 
-    SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_LIBDIR}")
+    SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_FULL_LIBDIR}")
 
     # add the automatically determined parts of the RPATH
     # which point to directories outside the build tree to the install RPATH
     SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
     # the RPATH to be used when installing, but only if it's not a system directory
-    LIST(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_LIBDIR}" isSystemDir)
+    LIST(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_FULL_LIBDIR}" isSystemDir)
     IF("${isSystemDir}" STREQUAL "-1")
-        SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_LIBDIR}")
+        SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_FULL_LIBDIR}")
     ENDIF("${isSystemDir}" STREQUAL "-1")
 
     if (APPLE)


### PR DESCRIPTION
Commit a26083b634fe (Fixing libdirs for CMakeLists) switched from
`${CMAKE_INSTALL_PREFIX}/lib` to `${CMAKE_INSTALL_LIBDIR}`. It fixed the
issue with `lib` vs `lib64`. But while the former is absolute, the latter
needs not. That causes troubles as rpath can be set to something like
`lib64` only. That is bogus.

So fix this by using absolute `${CMAKE_INSTALL_FULL_LIBDIR}` from
`GNUInstallDirs` which is already included and handles the paths correctly.

Fixes #437.