### PR TITLE
Rewrite Dockerfile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# AUTHORS: Dan Liew, Ryan Gvostes, Mate Soos
+# AUTHORS: Dan Liew, Ryan Govostes, Mate Soos
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -152,7 +152,7 @@ if (STATICCOMPILE)
 endif()
 add_feature_info(Static STATICCOMPILE "Compiles static library and executable")
 
-if ((${CMAKE_SYSTEM_NAME} MATCHES "Windows") AND (NOT BUILD_SHARED_LIBS))
+if ((${CMAKE_SYSTEM_NAME} MATCHES "Windows") OR (NOT BUILD_SHARED_LIBS))
     set(Boost_USE_STATIC_LIBS ON)
     set(Minisat_USE_STATIC_LIBS ON)
 endif()

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,68 +1,61 @@
-FROM ubuntu:16.04 as builder
+# This Dockerfile builds a statically-compiled instance of STP with MiniSat and
+# CryptoMiniSat that evaluates SMTLIB2 inputs provided on standard input:
+#
+#     docker build --tag stp/stp .
+#     cat example.smt2 | docker run --rm -i stp/stp
 
-LABEL maintainer="Mate Soos"
-LABEL version="5.0"
-LABEL Description="An advanced SAT solver"
 
-# get curl, etc
-RUN apt-get update && apt-get install --no-install-recommends -y software-properties-common && rm -rf /var/lib/apt/lists/*
-RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test && rm -rf /var/lib/apt/lists/*
-RUN apt-get update && apt-get install --no-install-recommends -y libboost-program-options-dev gcc g++ make cmake zlib1g-dev wget && rm -rf /var/lib/apt/lists/*
-RUN apt-get update && apt-get install --no-install-recommends -y bison flex \
-    && rm -rf /var/lib/apt/lists/*
+FROM ubuntu:22.04 as builder
 
-# get M4RI
-RUN mkdir /m4ri-20140914
-WORKDIR /m4ri-20140914
-RUN wget https://bitbucket.org/malb/m4ri/downloads/m4ri-20140914.tar.gz \
-    && tar -xvf m4ri-20140914.tar.gz
-WORKDIR /m4ri-20140914/m4ri-20140914
-RUN ./configure
-RUN make -j6
-RUN make install
-RUN make clean
+# Install dependencies
+RUN apt-get update \
+ && apt-get install --no-install-recommends -y \
+        bison \
+        ca-certificates \
+        cmake \
+        flex \
+        g++ \
+        gcc \
+        libboost-program-options-dev \
+        libm4ri-dev \
+        make \
+        wget \
+        zlib1g-dev \
+ && rm -rf /var/lib/apt/lists/*
 
-# build CMS
-RUN mkdir /cms
+# Build CMS
 WORKDIR /cms
-RUN wget -O cryptominisat.tgz https://github.com/msoos/cryptominisat/archive/5.8.0.tar.gz
-RUN tar xvf cryptominisat.tgz --strip-components 1
-RUN mkdir build
-WORKDIR /cms/build
-RUN cmake -DENABLE_ASSERTIONS=OFF -DCMAKE_BUILD_TYPE=Release -DSTATICCOMPILE=ON ..
-RUN make -j6
-RUN make install
+RUN wget -O cryptominisat.tgz https://github.com/msoos/cryptominisat/archive/5.8.0.tar.gz \
+ && tar xvf cryptominisat.tgz --strip-components 1 \
+ && mkdir build && cd build \
+ && cmake .. \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DENABLE_ASSERTIONS=OFF \
+        -DSTATICCOMPILE=ON \
+ && cmake --build . \
+ && cmake --install .
 
-RUN mkdir /minisat
+# Build MiniSat
 WORKDIR /minisat
-RUN wget -O minisat.tgz https://github.com/stp/minisat/archive/releases/2.2.1.tar.gz
-RUN tar xvf minisat.tgz --strip-components 1
-RUN mkdir build
-WORKDIR /minisat/build
-RUN cmake ..
-RUN make -j6
-RUN make install
+RUN wget -O minisat.tgz https://github.com/stp/minisat/archive/releases/2.2.1.tar.gz \
+ && tar xvf minisat.tgz --strip-components 1 \
+ && mkdir build && cd build \
+ && cmake .. \
+        -DCMAKE_BUILD_TYPE=Release \
+ && cmake --build . \
+ && cmake --install .
 
-# build stp
-RUN mkdir /stp
-WORKDIR /stp
-COPY . /stp
-RUN mkdir build
+# Build STP
 WORKDIR /stp/build
-RUN cmake -DENABLE_ASSERTIONS=OFF -DSTATICCOMPILE=ON -DCMAKE_BUILD_TYPE=Release  ..
-RUN make -j6
-RUN make install
+COPY . /stp
+RUN cmake .. \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DENABLE_ASSERTIONS=OFF \
+        -DSTATICCOMPILE=ON \
+ && cmake --build . \
+ && cmake --install .
 
-# set up for running
-# set up for running
-FROM alpine:latest
-COPY --from=builder /usr/local/bin/stp /usr/local/bin/stp
-ENTRYPOINT ["/usr/local/bin/stp", "--SMTLIB2"]
-
-# --------------------
-# HOW TO USE
-# --------------------
-# on file through STDIN:
-#    cat myfile.smt | docker run --rm -i -a stdin -a stdout stp
-
-
+# Set up to run in a minimal container
+FROM scratch
+COPY --from=builder /usr/local/bin/stp /stp
+ENTRYPOINT ["/stp", "--SMTLIB2"]


### PR DESCRIPTION
I rewrote the Dockerfile to address a few perceived deficiencies, though possibly the right thing is to do (in the future) is to use the `./scripts/deps/` scripts so that the logic is not duplicated.

1. I upgraded the builder image to Ubuntu 22.04 from Ubuntu 16.04.
2. I removed the `LABELS` since these were copied over from CryptoMiniSat and not appropriate for STP.
3. I moved away from building M4RI to installing it from the repository, as CMS instructs in its README.
4. I restructured the `apt-get install` to follow recommended Dockerfile best practices, e.g., with each dependency on its own line, sorted alphabetically, for cleaner diffs. I also reduced the number of times we have to run `apt-get update`.
5. I removed the use of experimental compiler toolchains (`ppa:ubuntu-toolchain-r/test`).
6. I switched from `make && make install` to using `cmake --build` and `cmake --install`.
7. I reduced the number of separate layers that are created during a build, combining some and removing others that are redundant (no effect on the final image).
8. I switched the produced image from `alpine:latest` to a completely blank image (since we are statically linked) which reduces the final image size from 10 MB to 5 MB.