### PR TITLE
Fix compilation error on libstdc++-7-dev

### DIFF
--- a/include/stp/ToSat/BitBlaster.h
+++ b/include/stp/ToSat/BitBlaster.h
@@ -230,7 +230,7 @@ public:
   // representing the boolean formula.
   const BBNodeVec BBTerm(const ASTNode& term, BBNodeSet& support);
   
-  typename std::unordered_map<ASTNode, BBNodeVec>::iterator
+  typename std::unordered_map<ASTNode, BBNodeVec, ASTNode::ASTNodeHasher, ASTNode::ASTNodeEqual>::iterator
   simplify_during_bb(ASTNode& term, BBNodeSet& support);
 
   BitBlaster(BBNodeManagerT* bnm, Simplifier* _simp, NodeFactory* astNodeF,

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -473,7 +473,7 @@ ASTNode BitBlaster<BBNode, BBNodeManagerT>::getConstant(const BBNodeVec& v,
 // simplification.
 // Then the term that we bitblast will by "y".
 template <class BBNode, class BBNodeManagerT>
-typename std::unordered_map<ASTNode, vector<BBNode>>::iterator
+typename std::unordered_map<ASTNode, vector<BBNode>, ASTNode::ASTNodeHasher, ASTNode::ASTNodeEqual>::iterator
 BitBlaster<BBNode, BBNodeManagerT>::simplify_during_bb(ASTNode& term,
                                                        BBNodeSet& support)
 {


### PR DESCRIPTION
There were [compilation errors](https://github.com/misonijnik/klee/actions/runs/2954874974/jobs/4918669387) during the build of the master branch of stp on KLEE 2.3 CI. This commit fixes them.