### PR TITLE
[gcc 13] include cstdint for *int*_t

### DIFF
--- a/include/stp/AST/ASTNode.h
+++ b/include/stp/AST/ASTNode.h
@@ -24,6 +24,8 @@ THE SOFTWARE.
 #ifndef ASTNODE_H
 #define ASTNODE_H
 
+#include <cstdint>
+
 #include "stp/NodeFactory/HashingNodeFactory.h"
 #include "stp/Util/Attributes.h"
 #include "ASTInternal.h"


### PR DESCRIPTION
Otherwise we see errors like this with gcc13:
```
include/stp/AST/ASTNode.h:77:3: error: 'uint8_t' does not name a type
```