### PR TITLE
Remove nonsensical sbrk usage

### DIFF
--- a/tools/stp/main_common.cpp
+++ b/tools/stp/main_common.cpp
@@ -30,15 +30,7 @@ THE SOFTWARE.
 #include <memory>
 
 
-//for srbk() function
-#if !defined(__MINGW32__) && !defined(__MINGW64__) && !defined(_MSC_VER)
-#include <unistd.h>
-#endif
-
 extern void errorHandler(const char* error_msg);
-
-// Amount of memory to ask for at beginning of main.
-extern const intptr_t INITIAL_MEMORY_PREALLOCATION_SIZE;
 
 using namespace stp;
 using std::unique_ptr;
@@ -52,9 +44,6 @@ void errorHandler(const char* error_msg)
   exit(-1);
 }
 
-// Amount of memory to ask for at beginning of main.
-const intptr_t INITIAL_MEMORY_PREALLOCATION_SIZE = 4000000;
-
 Main::Main() : onePrintBack(false)
 {
   bm = NULL;
@@ -65,15 +54,6 @@ Main::Main() : onePrintBack(false)
 
   // Register the error handler
   vc_error_hdlr = errorHandler;
-
-#if !defined(__MINGW32__) && !defined(__MINGW64__) && !defined(_MSC_VER)
-  // Grab some memory from the OS upfront to reduce system time when
-  // individual hash tables are being allocated
-  if (sbrk(INITIAL_MEMORY_PREALLOCATION_SIZE) == ((void*)-1))
-  {
-    FatalError("Initial allocation of memory failed.");
-  }
-#endif
 
   bm = new STPMgr();
   GlobalParserBM = bm;


### PR DESCRIPTION
This code called sbrk(4000000) and beyond error checking ignored the result meaning the 4MB of address space allocated could never be used without another call to sbrk and reference to INITIAL_MEMORY_PREALLOCATION_SIZE, but nothing in the repo does either.