### PR TITLE
Partially fix Appveyor (windows) automated build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ endif()
 project(STP)
 
 set(CMAKE_C_STANDARD 99)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 include(GenerateExportHeader)
 include(GNUInstallDirs)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,8 +46,7 @@ configuration:
   #- C:\projects\stp\llvm.build -> appveyor.yml
 
 before_build:
-  - IF "%PLATFORM%" == "x86" ( SET CMAKE_GENERATOR="Visual Studio 17 2022")
-  - IF "%PLATFORM%" == "x64" ( SET CMAKE_GENERATOR="Visual Studio 17 2022 Win64")
+  - SET CMAKE_GENERATOR="Visual Studio 17 2022"
 
   - echo %PLATFORM%
   - echo %CMAKE_GENERATOR%
@@ -65,7 +64,7 @@ before_build:
   # - if not exist llvm git clone --depth=1 --branch release_40 https://github.com/llvm-mirror/llvm
   # - if not exist llvm.build mkdir llvm.build
   # - cd llvm.build
-  # - if not exist Release\bin\not.exe cmake -G %CMAKE_GENERATOR% -DPYTHON_EXECUTABLE=%PYTHON%\python.exe ..\llvm
+  # - if not exist Release\bin\not.exe cmake -G %CMAKE_GENERATOR% -A %PLATFORM% -DPYTHON_EXECUTABLE=%PYTHON%\python.exe ..\llvm
   # - if not exist Release\bin\not.exe cmake --build . --config Release --target not
   # - set PATH=%PATH%;%cd%\Release\bin
 
@@ -89,7 +88,7 @@ before_build:
   - mkdir build
   - mkdir myinstall
   - cd build
-  - cmake -G %CMAKE_GENERATOR% -DCMAKE_INSTALL_PREFIX=%ZLIB_ROOT% ..
+  - cmake -G %CMAKE_GENERATOR% -A %PLATFORM% -DCMAKE_INSTALL_PREFIX=%ZLIB_ROOT% ..
   - cmake --build . --config %CONFIGURATION%
   - cmake --build . --config %CONFIGURATION% --target install
   - dir ..\myinstall\
@@ -102,7 +101,7 @@ before_build:
   - mkdir build
   - mkdir myinstall
   - cd build
-  - cmake -DSTATICCOMPILE=ON -G %CMAKE_GENERATOR% -DCMAKE_INSTALL_PREFIX=%MINISAT_ROOT% -DZLIB_ROOT=%ZLIB_ROOT% ..
+  - cmake -DSTATICCOMPILE=ON -G %CMAKE_GENERATOR% -A %PLATFORM% -DCMAKE_INSTALL_PREFIX=%MINISAT_ROOT% -DZLIB_ROOT=%ZLIB_ROOT% ..
   - cmake --build . --config %CONFIGURATION%
   - cmake --build . --config %CONFIGURATION% --target install
   - dir ..\myinstall\
@@ -119,7 +118,7 @@ before_build:
   - mkdir build
   - cd build
   - cmake --version
-  - cmake -G %CMAKE_GENERATOR% -DSTATICCOMPILE=ON -DNOZLIB=ON -DENABLE_PYTHON_INTERFACE=OFF -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DONLY_SIMPLE=ON -DENABLE_TESTING=OFF ..
+  - cmake -G %CMAKE_GENERATOR% -A %PLATFORM% -DSTATICCOMPILE=ON -DNOZLIB=ON -DENABLE_PYTHON_INTERFACE=OFF -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DONLY_SIMPLE=ON -DENABLE_TESTING=OFF ..
   - cmake --build . --config Release
   - cmake --build . --config Release --target install
   - cd ../..
@@ -140,7 +139,7 @@ before_build:
   - mkdir ..\stp.build
   - cd ..\stp.build
   - cmake --version
-  - cmake -G %CMAKE_GENERATOR% -DENABLE_TESTING=NO -DENABLE_PYTHON_INTERFACE=OFF -DMINISAT_LIBDIR=%MINISAT_ROOT% -DMINISAT_INCLUDE_DIRS=%MINISAT_ROOT%\include -DSTATICCOMPILE=ON -DZLIB_ROOT=%ZLIB_ROOT% -DCMAKE_PREFIX_PATH=C:\cygwin64 -DBOOST_LIBRARYDIR=%BOOST_ROOT%/lib -DBoost_DEBUG=1 -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DBOOST_ROOT=%BOOST_ROOT% ../stp
+  - cmake -G %CMAKE_GENERATOR% -A %PLATFORM% -DENABLE_TESTING=NO -DENABLE_PYTHON_INTERFACE=OFF -DMINISAT_LIBDIR=%MINISAT_ROOT% -DMINISAT_INCLUDE_DIRS=%MINISAT_ROOT%\include -DSTATICCOMPILE=ON -DZLIB_ROOT=%ZLIB_ROOT% -DCMAKE_PREFIX_PATH=C:\cygwin64 -DBOOST_LIBRARYDIR=%BOOST_ROOT%/lib -DBoost_DEBUG=1 -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DBOOST_ROOT=%BOOST_ROOT% ../stp
   - ls
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ environment:
     BOOST_ROOT: C:\projects\stp\boost_1_59_0_install
     MINISAT_ROOT: C:\projects\stp\minisat\myinstall
     ZLIB_ROOT: C:\projects\stp\zlib\myinstall
-    PYTHON: "C:\Python33"
+    PYTHON: "C:\\Python33"
     PYTHON_ARCH: "x86"
     PYTHON_VERSION: "3.3.5"
     BUILD_TYPE: Release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -106,6 +106,8 @@ before_build:
   - cmake --build . --config %CONFIGURATION% --target install
   - dir ..\myinstall\
   - dir ..\myinstall\lib\
+  # To check it's really static.
+  - lib /list ..\myinstall\lib\minisat.lib
   - dir ..\myinstall\bin\
   - dir ..\myinstall\include\
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,9 +25,9 @@ environment:
     BOOST_ROOT: C:\projects\stp\boost_1_59_0_install
     MINISAT_ROOT: C:\projects\stp\minisat\myinstall
     ZLIB_ROOT: C:\projects\stp\zlib\myinstall
-    PYTHON: "C:\Python38-x64"
-    PYTHON_ARCH: "x64"
-    PYTHON_VERSION: "3.8.10"
+    PYTHON: "C:\Python312"
+    PYTHON_ARCH: "x86"
+    PYTHON_VERSION: "3.12.0"
     BUILD_TYPE: Release
     APPVEYOR_SAVE_CACHE_ON_ERROR: false
     BOOST_OPTIONS: link=static runtime-link=static

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -133,6 +133,8 @@ before_build:
 
   # finally STP
   - cd c:\projects\stp
+  #Fixes:  fatal: detected dubious ownership in repository at '/cygdrive/c/projects/stp'
+  - git config --global --add safe.directory /cygdrive/c/projects/stp
   - git submodule update --init --recursive
   # Building in c:\projects\stp\build fails with cmake --build since ASTKind.h
   # cannot be found, so build it in ..\stp.build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,6 @@ branches:
     - appveyor_debug
 
 image:
-  - Visual Studio 2019
   - Visual Studio 2022
 
 # scripts that are called at very beginning, before repo cloning
@@ -22,7 +21,7 @@ platform:
 
 environment:
   global:
-    BOOST_ROOT: C:\projects\stp\boost_1_59_0_install
+    BOOST_ROOT: C:\Libraries\boost_1_83_0
     MINISAT_ROOT: C:\projects\stp\minisat\myinstall
     ZLIB_ROOT: C:\projects\stp\zlib\myinstall
     PYTHON: "C:\\Python39"
@@ -71,14 +70,14 @@ before_build:
   # - set PATH=%PATH%;%cd%\Release\bin
 
   # boost
-  - cd C:\projects\stp
-  - mkdir boost_1_59_0_install
-  - ps: . .\scripts\appveyor.ps1
-  - cd boost_1_59_0
-  - echo "Building boost.."
-  - bootstrap.bat --with-libraries=program_options
-  - cat project-config.jam
-  - b2 --with-program_options address-model=64 toolset=msvc-14.0 variant=release %BOOST_OPTIONS% threading=multi  install --prefix=%BOOST_ROOT% > boost_install.out
+  #- cd C:\projects\stp
+  #- mkdir boost_1_59_0_install
+  #- ps: . .\scripts\appveyor.ps1
+  #- cd boost_1_59_0
+  #- echo "Building boost.."
+  #- bootstrap.bat --with-libraries=program_options
+  #- cat project-config.jam
+  #- b2 --with-program_options address-model=64 toolset=msvc-14.0 variant=release %BOOST_OPTIONS% threading=multi  install --prefix=%BOOST_ROOT% > boost_install.out
 
   # zlib
   # TODO check out http://stackoverflow.com/questions/10507893/libzip-with-visual-studio-2010

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,9 +25,9 @@ environment:
     BOOST_ROOT: C:\projects\stp\boost_1_59_0_install
     MINISAT_ROOT: C:\projects\stp\minisat\myinstall
     ZLIB_ROOT: C:\projects\stp\zlib\myinstall
-    PYTHON: "C:\Python38"
-    PYTHON_ARCH: "x64"
-    PYTHON_VERSION: "3.8.0"
+    PYTHON: "C:\Python33"
+    PYTHON_ARCH: "x86"
+    PYTHON_VERSION: "3.3.5"
     BUILD_TYPE: Release
     APPVEYOR_SAVE_CACHE_ON_ERROR: false
     BOOST_OPTIONS: link=static runtime-link=static

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -107,7 +107,7 @@ before_build:
   - dir ..\myinstall\
   - dir ..\myinstall\lib\
   # To check it's really static.
-  - dumpbin /DIRECTIVES  ..\myinstall\lib\minisat.lib
+  - C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.38.33130\bin\Hostx64\x64\dumpbin /DIRECTIVES  ..\myinstall\lib\minisat.lib
   - dir ..\myinstall\bin\
   - dir ..\myinstall\include\
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,8 +6,8 @@ branches:
     - appveyor_debug
 
 image:
-  - Visual Studio 2015
-  - Visual Studio 2017
+  - Visual Studio 2019
+  - Visual Studio 2022
 
 # scripts that are called at very beginning, before repo cloning
 init:
@@ -25,9 +25,9 @@ environment:
     BOOST_ROOT: C:\projects\stp\boost_1_59_0_install
     MINISAT_ROOT: C:\projects\stp\minisat\myinstall
     ZLIB_ROOT: C:\projects\stp\zlib\myinstall
-    PYTHON: "C:\\Python38"
+    PYTHON: "C:\\Python39"
     PYTHON_ARCH: "x86"
-    PYTHON_VERSION: "3.8.0"
+    PYTHON_VERSION: "3.9.13"
     BUILD_TYPE: Release
     APPVEYOR_SAVE_CACHE_ON_ERROR: false
     BOOST_OPTIONS: link=static runtime-link=static

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -95,10 +95,8 @@ before_build:
 
   # minisat
   - cd C:\projects\stp
-  - git clone https://github.com/msoos/minisat
+  - git clone https://github.com/stp/minisat
   - cd minisat
-  # Trying to get it before the "fix" to dynamic/static linking.
-  - git checkout 55d7e7613b94f0369476a0a8ff35969485ed324f
   - echo %cd%
   - mkdir build
   - mkdir myinstall

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -81,7 +81,7 @@ before_build:
   # zlib
   # TODO check out http://stackoverflow.com/questions/10507893/libzip-with-visual-studio-2010
   - cd C:\projects\stp
-  - git clone https://github.com/madler/zlib
+  - git clone https://github.com/madler/zlib 
   - cd zlib
   - git checkout v1.2.8
   - echo %cd%
@@ -97,6 +97,8 @@ before_build:
   - cd C:\projects\stp
   - git clone https://github.com/msoos/minisat
   - cd minisat
+  # Trying to get it before the "fix" to dynamic/static linking.
+  - git checkout 55d7e7613b94f0369476a0a8ff35969485ed324f
   - echo %cd%
   - mkdir build
   - mkdir myinstall

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,9 +25,9 @@ environment:
     BOOST_ROOT: C:\projects\stp\boost_1_59_0_install
     MINISAT_ROOT: C:\projects\stp\minisat\myinstall
     ZLIB_ROOT: C:\projects\stp\zlib\myinstall
-    PYTHON: "C:\\Python33"
+    PYTHON: "C:\\Python38"
     PYTHON_ARCH: "x86"
-    PYTHON_VERSION: "3.3.5"
+    PYTHON_VERSION: "3.8.0"
     BUILD_TYPE: Release
     APPVEYOR_SAVE_CACHE_ON_ERROR: false
     BOOST_OPTIONS: link=static runtime-link=static

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -107,7 +107,7 @@ before_build:
   - dir ..\myinstall\
   - dir ..\myinstall\lib\
   # To check it's really static.
-  - C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.38.33130\bin\Hostx64\x64\dumpbin /DIRECTIVES  ..\myinstall\lib\minisat.lib
+  - C:\"Program Files"\"Microsoft Visual Studio"\2022\Community\VC\Tools\MSVC\14.38.33130\bin\Hostx64\x64\dumpbin /DIRECTIVES  ..\myinstall\lib\minisat.lib
   - dir ..\myinstall\bin\
   - dir ..\myinstall\include\
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,9 +25,9 @@ environment:
     BOOST_ROOT: C:\projects\stp\boost_1_59_0_install
     MINISAT_ROOT: C:\projects\stp\minisat\myinstall
     ZLIB_ROOT: C:\projects\stp\zlib\myinstall
-    PYTHON: "C:\Python312"
-    PYTHON_ARCH: "x86"
-    PYTHON_VERSION: "3.12.0"
+    PYTHON: "C:\Python38"
+    PYTHON_ARCH: "x64"
+    PYTHON_VERSION: "3.8.0"
     BUILD_TYPE: Release
     APPVEYOR_SAVE_CACHE_ON_ERROR: false
     BOOST_OPTIONS: link=static runtime-link=static

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,8 +46,8 @@ configuration:
   #- C:\projects\stp\llvm.build -> appveyor.yml
 
 before_build:
-  - IF "%PLATFORM%" == "x86" ( SET CMAKE_GENERATOR="Visual Studio 14 2015")
-  - IF "%PLATFORM%" == "x64" ( SET CMAKE_GENERATOR="Visual Studio 14 2015 Win64")
+  - IF "%PLATFORM%" == "x86" ( SET CMAKE_GENERATOR="Visual Studio 17 2022")
+  - IF "%PLATFORM%" == "x64" ( SET CMAKE_GENERATOR="Visual Studio 17 2022 Win64")
 
   - echo %PLATFORM%
   - echo %CMAKE_GENERATOR%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,8 +35,8 @@ environment:
     # https://stackoverflow.com/questions/1023858/how-to-suppress-specific-msbuild-warning
     MSBUILD_FLAGS: /maxcpucount /nologo /property:WarningLevel=1
 
-install:
-    "%PYTHON%\\python.exe -m pip install lit"
+#install:
+    #"%PYTHON%\\python.exe -m pip install lit"
 
 configuration:
   - Release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -107,7 +107,7 @@ before_build:
   - dir ..\myinstall\
   - dir ..\myinstall\lib\
   # To check it's really static.
-  - lib /list ..\myinstall\lib\minisat.lib
+  - dumpbin /DIRECTIVES  ..\myinstall\lib\minisat.lib
   - dir ..\myinstall\bin\
   - dir ..\myinstall\include\
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,9 +25,9 @@ environment:
     BOOST_ROOT: C:\projects\stp\boost_1_59_0_install
     MINISAT_ROOT: C:\projects\stp\minisat\myinstall
     ZLIB_ROOT: C:\projects\stp\zlib\myinstall
-    PYTHON: "C:\\Python27"
-    PYTHON_ARCH: "x86"
-    PYTHON_VERSION: "2.7.13"
+    PYTHON: "C:\Python38-x64"
+    PYTHON_ARCH: "x64"
+    PYTHON_VERSION: "3.8.10"
     BUILD_TYPE: Release
     APPVEYOR_SAVE_CACHE_ON_ERROR: false
     BOOST_OPTIONS: link=static runtime-link=static

--- a/include/stp/AST/ASTBVConst.h
+++ b/include/stp/AST/ASTBVConst.h
@@ -95,10 +95,10 @@ private:
 
   const static ASTVec astbv_empty_children;
 
-  void setIndexWidth(uint32_t i __attribute__((unused))) { assert(i == 0); }
+  void setIndexWidth( [[maybe_unused]] uint32_t i ) { assert(i == 0); }
   uint32_t getIndexWidth() const { return 0; }
 
-  void setValueWidth(uint32_t v __attribute__((unused))) { assert(v == getValueWidth()); }
+  void setValueWidth([[maybe_unused]] uint32_t v ) { assert(v == getValueWidth()); }
   uint32_t getValueWidth() const { return bits_(_bvconst); }
 
 public:

--- a/include/stp/Simplifier/Simplifier.h
+++ b/include/stp/Simplifier/Simplifier.h
@@ -107,8 +107,16 @@ public:
   ASTNode applySubstitutionMapUntilArrays(const ASTNode& n, ASTNodeMap& cache);
 
   
-  DLL_PUBLIC ASTNode applySubstitutionMapAtTopLevel(const ASTNode& topLevel) __attribute__((warn_unused_result));
+  #ifdef _MSC_VER
+  #include <sal.h>
+  #define WARN_UNUSED_RESULT _Check_return_
+  #else
+  #define WARN_UNUSED_RESULT __attribute__((warn_unused_result))
+  #endif
 
+  DLL_PUBLIC WARN_UNUSED_RESULT ASTNode applySubstitutionMapAtTopLevel(const ASTNode& topLevel) WARN_UNUSED_RESULT;
+    
+  #undef WARN_UNUSED_RESULT
 
   /****************************************************************
    * Simplification functions                                     *

--- a/include/stp/Simplifier/SubstitutionMap.h
+++ b/include/stp/Simplifier/SubstitutionMap.h
@@ -177,7 +177,16 @@ public:
                          ASTNodeMap& cache, NodeFactory* nf, bool stopAtArrays,
                          bool preventInfiniteLoops);
 
-  ASTNode applySubstitutionMapAtTopLevel(const ASTNode& n)  __attribute__((warn_unused_result));
+  #ifdef _MSC_VER
+  #include <sal.h>
+  #define WARN_UNUSED_RESULT _Check_return_
+  #else
+  #define WARN_UNUSED_RESULT __attribute__((warn_unused_result))
+  #endif
+
+  ASTNode applySubstitutionMapAtTopLevel(const ASTNode& n) WARN_UNUSED_RESULT;
+
+  #undef WARN_UNUSED_RESULT
 };
 }
 

--- a/tests/api/C/counter-example-reading.cpp
+++ b/tests/api/C/counter-example-reading.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include <stdio.h>
 #include <stp/c_interface.h>
+#include <cstdint>
 
 TEST(counter_example_reading, one)
 {

--- a/tests/api/C/timeout.cpp
+++ b/tests/api/C/timeout.cpp
@@ -27,6 +27,8 @@ THE SOFTWARE.
 #include <iostream>
 #include <stdio.h>
 #include <stdlib.h>
+#include <cstdint>
+
 
 void test_timeout(bool test_with_time, uint32_t max_value, bool use_cms)
 {

--- a/tools/stp/main_common.cpp
+++ b/tools/stp/main_common.cpp
@@ -29,10 +29,6 @@ THE SOFTWARE.
 #include "stp/ToSat/ToSATAIG.h"
 #include <memory>
 
-#if !defined(__MINGW32__) && !defined(__MINGW64__) && !defined(_MSC_VER)
-#include <cstdint>
-#endif
-
 extern void errorHandler(const char* error_msg);
 
 using namespace stp;


### PR DESCRIPTION
This gets the windows build closer to working.

It also changes the c++ compiler to a minimum of c++-17, which is the same as cryptominisat requires. If this causes problems, it can be changed back and just results in more warnings. 