### PR TITLE
Make timestamp in generated file use $SOURCE_DATE_EPOCH

### DIFF
--- a/lib/AST/genkinds.pl
+++ b/lib/AST/genkinds.pl
@@ -38,7 +38,7 @@ $maxkids = 0;
 %cat_index = ();
 
 if ($timestamp) {
-  $now = " " . localtime time;
+  $now = " " . localtime ($ENV{SOURCE_DATE_EPOCH} || time)
 } else {
   $now = "";
 }
@@ -125,7 +125,7 @@ sub gen_cpp_file {
   open(CPPFILE, "> ASTKind.cpp") || die "Cannot open .h file: $!\n";
 
   print CPPFILE
-    "// Generated automatically by genkinds.h from ASTKind.kinds$now.\n",
+    "// Generated automatically by genkinds.pl from ASTKind.kinds$now.\n",
     "// Do not edit\n",
     "namespace stp {\n",
     "#if defined(__GNUC__) || defined(__clang__)\n\n",


### PR DESCRIPTION
Currently the generator puts the time of the build in the file, making the results different in each rebuild. Use $SOURCE_DATE_EPOCH to set the timestamp, if the variable is defined.

See https://reproducible-builds.org/docs/source-date-epoch/ for background and the definition of the variable.

The code modification is based on
https://reproducible-builds.org/docs/source-date-epoch/#perl.

Also, fix typo in the header.