### PR TITLE
Added dummy diagnostic-output-channel support

### DIFF
--- a/lib/Interface/cpp_interface.cpp
+++ b/lib/Interface/cpp_interface.cpp
@@ -598,6 +598,13 @@ void Cpp_interface::setOption(std::string option, std::string value)
     else
       unsupported();
   }
+  else if (option == "diagnostic-output-channel")
+  {
+    if (value == "stdout")
+      success();
+    else
+      unsupported();
+  }	  
   else
     unsupported();
 }


### PR DESCRIPTION
Hello, maintainers,

 I added the dummy (not changing any solver behavior) interface for the `diagnostic-output-channel` option support. 
 This is used in PySMT as a minimal requirement for an SMT solver, and this is why I added this.
  https://github.com/pysmt/pysmt/blob/71c35b0b82f7ea63240218777940bed06a18c60c/pysmt/smtlib/solver.py#L47
  
  Because this is a small, harmless change, I hope you will merge this. 