### PR TITLE
Install libabc-pic.so, now needed by libstp.so

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -801,6 +801,12 @@ install(FILES
   DESTINATION "${STP_INSTALL_CMAKE_DIR}"
 )
 
+# Install libabc-pic.so from the build/lib directory
+install(
+    FILES "${CMAKE_BINARY_DIR}/lib/libabc-pic.so"
+    DESTINATION lib
+)
+
 # Install the export set for use with the install-tree
 install(EXPORT ${STP_EXPORT_NAME} DESTINATION
   "${STP_INSTALL_CMAKE_DIR}"


### PR DESCRIPTION
This PR aims to install `libabc-pic.so`.

The issue arises when one tries to install STP in a different directory than the one where it was built.  More concretely, it follows the instructions from the README file, but instead of:
 `cmake ..` 
it runs:
`cmake .. -DCMAKE_INSTALL_PREFIX=`pwd`/install`

In this case, the install step does NOT copy the needed `libabc-pic.so`.
