### PR TITLE
Improve unsigned interval propagators, fix leak and dead code

### DIFF
--- a/include/stp/Simplifier/UnsignedIntervalAnalysis.h
+++ b/include/stp/Simplifier/UnsignedIntervalAnalysis.h
@@ -43,8 +43,6 @@ using std::make_pair;
 
 class UnsignedIntervalAnalysis
 {
-  vector<UnsignedInterval*> toDeleteLater;
-  vector<CBV> likeAutoPtr;
   STPMgr& bm;
   CBV littleOne;
   CBV littleZero;
@@ -55,7 +53,7 @@ class UnsignedIntervalAnalysis
   UnsignedInterval* freshUnsignedInterval(unsigned width);
   UnsignedInterval* getEmptyInterval(const ASTNode& n);
 
-  // We create all intervals through here. Handles collection
+  // The caller owns the returned interval.
   UnsignedInterval* createInterval(CBV min, CBV max);
 
   CBV getEmptyCBV(unsigned width);

--- a/lib/Simplifier/UnsignedIntervalAnalysis.cpp
+++ b/lib/Simplifier/UnsignedIntervalAnalysis.cpp
@@ -666,7 +666,7 @@ namespace stp
         }
         break;
 
-      case BVLEFTSHIFT:
+      case BVLEFTSHIFT: // OVER-APPROXIMATION
         if (knownC0 || knownC1)
         {
           const UnsignedInterval* c0 = children[0];

--- a/lib/Simplifier/UnsignedIntervalAnalysis.cpp
+++ b/lib/Simplifier/UnsignedIntervalAnalysis.cpp
@@ -899,10 +899,12 @@ namespace stp
         break;
       }
 
-      case BVEXTRACT: // OVER-APPROXIMATION
+      case BVEXTRACT:
       {
-        // The index children are always constants, so they're always known.
-        if (knownC0 && knownC2)
+        // The value is (child >> low) mod 2^width. This transfer function
+        // is exact. The index children are always constants; the guard
+        // matters because the shift amount must be the real one.
+        if (knownC2)
         {
           // The lowest bit of the extract is how far the child shifts right.
           unsigned shift_amount = *(children[2]->minV);
@@ -915,9 +917,18 @@ namespace stp
             CONSTANTBV::BitVector_shift_right(max, 0);
           }
 
-          // Sound only if the extract discards no set bits from the top of
-          // the maximum, i.e. the shifted maximum fits into the new width.
-          if (CONSTANTBV::Set_Max(max) < (signed long)width)
+          // The shifted child takes every value between the shifted bounds,
+          // so if the bounds agree above the extract's width, the low bits
+          // run from the minimum's to the maximum's without wrapping.
+          // Otherwise the result wraps: it reaches both zero and all ones,
+          // and only the complete interval contains it.
+          bool sameBlock = true;
+          for (unsigned i = width; i < n[0].GetValueWidth() && sameBlock; i++)
+            if (CONSTANTBV::BitVector_bit_test(min, i) !=
+                CONSTANTBV::BitVector_bit_test(max, i))
+              sameBlock = false;
+
+          if (sameBlock)
           {
             CBV newMin = CONSTANTBV::BitVector_Create(width, true);
             CBV newMax = CONSTANTBV::BitVector_Create(width, true);

--- a/lib/Simplifier/UnsignedIntervalAnalysis.cpp
+++ b/lib/Simplifier/UnsignedIntervalAnalysis.cpp
@@ -974,40 +974,91 @@ namespace stp
         }
         break;
 
-      case BVLEFTSHIFT: // OVER-APPROXIMATION
-        if (knownC0 || knownC1)
+      case BVLEFTSHIFT:
+      {
+        // The value is (x << s) mod 2^width, which keeps the low
+        // (width - s) bits of x and shifts them up. This transfer function
+        // is exact: for each of the at most width+1 effective shift
+        // amounts, x's surviving low bits run contiguously (the same
+        // reasoning as BVEXTRACT), giving an exact hull per shift, and the
+        // result is the union over the reachable shifts.
+        const UnsignedInterval* c0 = children[0];
+        const UnsignedInterval* c1 = children[1];
+
+        const unsigned minShift = cappedShiftAmount(c1->minV, width);
+        const unsigned maxShift = cappedShiftAmount(c1->maxV, width);
+
+        CBV bestMin = nullptr;
+        CBV bestMax = nullptr;
+
+        for (unsigned s = minShift; s <= maxShift; s++)
         {
-          const UnsignedInterval* c0 = children[0];
-          const UnsignedInterval* c1 = children[1];
+          // The hull for this shift amount. Shifting by the width or more
+          // gives zero, so the capped amount stands in for all of those.
+          CBV sMin = CONSTANTBV::BitVector_Create(width, true);
+          CBV sMax = CONSTANTBV::BitVector_Create(width, true);
 
-          const unsigned minShift = cappedShiftAmount(c1->minV, width);
-          const unsigned maxShift = cappedShiftAmount(c1->maxV, width);
-
-          // The index of the highest bit that could be set in the result.
-          const signed long highestBit = CONSTANTBV::Set_Max(c0->maxV);
-
-          if (highestBit < 0 || minShift >= width)
+          if (s < width)
           {
-            // The value is zero, or every set bit is discarded.
-            result = createInterval(getEmptyCBV(width), getEmptyCBV(width));
+            const unsigned surviving = width - s;
+
+            // If the bounds agree above the surviving bits, the low bits
+            // run from the minimum's to the maximum's without wrapping.
+            bool sameBlock = true;
+            for (unsigned i = surviving; i < width && sameBlock; i++)
+              if (CONSTANTBV::BitVector_bit_test(c0->minV, i) !=
+                  CONSTANTBV::BitVector_bit_test(c0->maxV, i))
+                sameBlock = false;
+
+            if (sameBlock)
+            {
+              for (unsigned i = 0; i < surviving; i++)
+              {
+                if (CONSTANTBV::BitVector_bit_test(c0->minV, i))
+                  CONSTANTBV::BitVector_Bit_On(sMin, i + s);
+                if (CONSTANTBV::BitVector_bit_test(c0->maxV, i))
+                  CONSTANTBV::BitVector_Bit_On(sMax, i + s);
+              }
+            }
+            else
+            {
+              // The surviving bits wrap: they reach both zero and all
+              // ones, so this shift contributes [0, 11..1 << s].
+              for (unsigned i = s; i < width; i++)
+                CONSTANTBV::BitVector_Bit_On(sMax, i);
+            }
           }
-          else if (highestBit + (signed long)maxShift < (signed long)width)
+
+          if (bestMin == nullptr)
           {
-            // No shift can discard a set bit, so shifting further only
-            // makes the value bigger.
-            result = freshUnsignedInterval(width);
-
-            CONSTANTBV::BitVector_Copy(result->minV, c0->minV);
-            for (unsigned i = 0; i < minShift; i++)
-              CONSTANTBV::BitVector_shift_left(result->minV, 0);
-
-            CONSTANTBV::BitVector_Copy(result->maxV, c0->maxV);
-            for (unsigned i = 0; i < maxShift; i++)
-              CONSTANTBV::BitVector_shift_left(result->maxV, 0);
+            bestMin = sMin;
+            bestMax = sMax;
           }
-          // Otherwise bits may be shifted out and the value can wrap.
+          else
+          {
+            if (CONSTANTBV::BitVector_Lexicompare(sMin, bestMin) < 0)
+            {
+              CONSTANTBV::BitVector_Destroy(bestMin);
+              bestMin = sMin;
+            }
+            else
+              CONSTANTBV::BitVector_Destroy(sMin);
+
+            if (CONSTANTBV::BitVector_Lexicompare(sMax, bestMax) > 0)
+            {
+              CONSTANTBV::BitVector_Destroy(bestMax);
+              bestMax = sMax;
+            }
+            else
+              CONSTANTBV::BitVector_Destroy(sMax);
+          }
         }
+
+        result = createInterval(bestMin, bestMax);
+        CONSTANTBV::BitVector_Destroy(bestMin);
+        CONSTANTBV::BitVector_Destroy(bestMax);
         break;
+      }
 
       case BVSRSHIFT:
         if (knownC0 || knownC1)

--- a/lib/Simplifier/UnsignedIntervalAnalysis.cpp
+++ b/lib/Simplifier/UnsignedIntervalAnalysis.cpp
@@ -36,7 +36,6 @@ THE SOFTWARE.
 #include "stp/Simplifier/StrengthReduction.h"
 #include <iostream>
 #include <map>
-#include <cmath>
 
 using std::map;
 
@@ -54,6 +53,22 @@ namespace stp
   }
 
   using std::make_pair;
+
+  namespace
+  {
+    // Reads a shift amount, capped at the width. Shifting by the width or
+    // more discards (or sign-fills) everything, so larger amounts behave the
+    // same as shifting by the width.
+    unsigned cappedShiftAmount(const CBV shift, unsigned width)
+    {
+      // Set_Max is the index of the highest set bit (negative if none).
+      if (CONSTANTBV::Set_Max(shift) >= (signed long)(8 * sizeof(unsigned)))
+        return width; // Too big to read out, so certainly >= the width.
+
+      const unsigned amount = *shift; // The value fits into the first word.
+      return std::min(amount, width);
+    }
+  }
 
   UnsignedInterval* UnsignedIntervalAnalysis::freshUnsignedInterval(unsigned width)
   {
@@ -636,36 +651,86 @@ namespace stp
           const UnsignedInterval* c0 = children[0];
           const UnsignedInterval* c1 = children[1];
 
+          const unsigned minShift = cappedShiftAmount(c1->minV, width);
+          const unsigned maxShift = cappedShiftAmount(c1->maxV, width);
+
           // The maximum result is the maximum >> (minimum shift).
-          if (CONSTANTBV::Set_Max(c1->minV) > 1 + std::log2(width) ||
-              *(c1->minV) > width)
-          {
-            // The maximum is zero.
-            CONSTANTBV::BitVector_Flip(result->maxV);
-          }
-          else
-          {
-            unsigned shift_amount = *(c1->minV);
-            CONSTANTBV::BitVector_Copy(result->maxV, c0->maxV);
-            while (shift_amount-- > 0)
-            {
-              CONSTANTBV::BitVector_shift_right(result->maxV, 0);
-            }
-          }
+          CONSTANTBV::BitVector_Copy(result->maxV, c0->maxV);
+          for (unsigned i = 0; i < minShift; i++)
+            CONSTANTBV::BitVector_shift_right(result->maxV, 0);
 
           // The minimum result is the minimum >> (maximum shift).
-          if (CONSTANTBV::Set_Max(c1->maxV) > 1 + std::log2(width) ||
-              *(c1->maxV) > width)
+          CONSTANTBV::BitVector_Copy(result->minV, c0->minV);
+          for (unsigned i = 0; i < maxShift; i++)
+            CONSTANTBV::BitVector_shift_right(result->minV, 0);
+        }
+        break;
+
+      case BVLEFTSHIFT:
+        if (knownC0 || knownC1)
+        {
+          const UnsignedInterval* c0 = children[0];
+          const UnsignedInterval* c1 = children[1];
+
+          const unsigned minShift = cappedShiftAmount(c1->minV, width);
+          const unsigned maxShift = cappedShiftAmount(c1->maxV, width);
+
+          // The index of the highest bit that could be set in the result.
+          const signed long highestBit = CONSTANTBV::Set_Max(c0->maxV);
+
+          if (highestBit < 0 || minShift >= width)
           {
-            // The mimimum is zero. (which it's set to by default.).
+            // The value is zero, or every set bit is discarded.
+            result = createInterval(getEmptyCBV(width), getEmptyCBV(width));
           }
-          else
+          else if (highestBit + (signed long)maxShift < (signed long)width)
           {
-            unsigned shift_amount = *(c1->maxV);
+            // No shift can discard a set bit, so shifting further only
+            // makes the value bigger.
+            result = freshUnsignedInterval(width);
+
             CONSTANTBV::BitVector_Copy(result->minV, c0->minV);
-            while (shift_amount-- > 0)
-              CONSTANTBV::BitVector_shift_right(result->minV, 0);
+            for (unsigned i = 0; i < minShift; i++)
+              CONSTANTBV::BitVector_shift_left(result->minV, 0);
+
+            CONSTANTBV::BitVector_Copy(result->maxV, c0->maxV);
+            for (unsigned i = 0; i < maxShift; i++)
+              CONSTANTBV::BitVector_shift_left(result->maxV, 0);
           }
+          // Otherwise bits may be shifted out and the value can wrap.
+        }
+        break;
+
+      case BVSRSHIFT:
+        if (knownC0 || knownC1)
+        {
+          const UnsignedInterval* c0 = children[0];
+          const UnsignedInterval* c1 = children[1];
+
+          const unsigned minShift = cappedShiftAmount(c1->minV, width);
+          const unsigned maxShift = cappedShiftAmount(c1->maxV, width);
+
+          // An arithmetic shift keeps the sign, and is monotone in the
+          // value, so the result's extremes come from shifting the bounds.
+          // Shifting moves values towards zero if the sign bit is clear
+          // (bigger shift, smaller result), and towards all ones if it is
+          // set (bigger shift, bigger result).
+          const bool minNegative =
+              CONSTANTBV::BitVector_bit_test(c0->minV, width - 1);
+          const bool maxNegative =
+              CONSTANTBV::BitVector_bit_test(c0->maxV, width - 1);
+
+          result = freshUnsignedInterval(width);
+
+          CONSTANTBV::BitVector_Copy(result->minV, c0->minV);
+          const unsigned minShifts = minNegative ? minShift : maxShift;
+          for (unsigned i = 0; i < minShifts; i++)
+            CONSTANTBV::BitVector_shift_right(result->minV, minNegative);
+
+          CONSTANTBV::BitVector_Copy(result->maxV, c0->maxV);
+          const unsigned maxShifts = maxNegative ? maxShift : minShift;
+          for (unsigned i = 0; i < maxShifts; i++)
+            CONSTANTBV::BitVector_shift_right(result->maxV, maxNegative);
         }
         break;
 
@@ -770,8 +835,6 @@ namespace stp
       // TODO
       case SBVDIV:
       case SBVREM:
-      case BVLEFTSHIFT:
-      case BVSRSHIFT:
       case SBVMOD:
       default:
         propagatorNotImplemented++;

--- a/lib/Simplifier/UnsignedIntervalAnalysis.cpp
+++ b/lib/Simplifier/UnsignedIntervalAnalysis.cpp
@@ -119,6 +119,10 @@ namespace stp
     StrengthReduction sr(bm.defaultNodeFactory, &bm.UserFlags);
     ASTNode result = sr.topLevel(top, visited);
 
+    // The intervals are only read during strength reduction, delete them now.
+    for (const auto& pair : visited)
+      delete pair.second;
+
     bm.GetRunTimes()->stop(RunTimes::IntervalPropagation);
 
     return result;
@@ -126,13 +130,14 @@ namespace stp
 
   UnsignedInterval* UnsignedIntervalAnalysis::dispatchToTransferFunctions(const ASTNode&n, const vector<const UnsignedInterval*>& _children)
   {
-    const auto number_children = n.Degree();    
+    const auto number_children = n.Degree();
     const auto width = n.GetValueWidth();
+
+    assert(number_children == _children.size());
+
     const bool knownC0 = number_children < 1 ? false : (_children[0] != NULL);
     const bool knownC1 = number_children < 2 ? false : (_children[1] != NULL);
     const bool knownC2 = number_children < 3 ? false : (_children[2] != NULL);
-
-    assert(number_children == _children.size());
 
     // Put in temporary null ones for any we're missing.
     auto children = _children;
@@ -246,60 +251,41 @@ namespace stp
 
       case BVDIV:
       {
-        const UnsignedInterval* c1 =  children[1];
+        const UnsignedInterval* top = children[0];
+        const UnsignedInterval* c1 = children[1];
 
         result = freshUnsignedInterval(width);
 
-        CBV c1Min = CONSTANTBV::BitVector_Clone(c1->minV);
-        bool bottomChanged = false;
-        if (CONSTANTBV::BitVector_is_empty(c1->minV))
+        if (CONSTANTBV::BitVector_is_empty(c1->maxV))
         {
-          if (CONSTANTBV::BitVector_is_empty(c1->maxV))
-          {
-            CONSTANTBV::BitVector_Fill(result->minV);
-            CONSTANTBV::BitVector_Fill(result->maxV);
-            CONSTANTBV::BitVector_Destroy(c1Min);
-            break; // result is [1111..111, 11...11111]
-          }
-
-          bottomChanged = true;
-          CONSTANTBV::BitVector_Destroy(c1Min);
-          break; // TODO fix so that it can run-on.
+          // Dividing by the constant zero gives all ones.
+          CONSTANTBV::BitVector_Fill(result->minV);
+          break; // result is [1111..111, 11...11111]
         }
-
-        const UnsignedInterval* top = children[0];
-        result->resetToComplete();
 
         CBV remainder = CONSTANTBV::BitVector_Create(width, true);
 
-        CBV tmp0 = CONSTANTBV::BitVector_Clone(top->minV);
+        // The minimum is the smallest dividend divided by the largest
+        // divisor. Division by zero gives all ones, so this lower bound
+        // holds even if the divisor might be zero.
+        CBV dividend = CONSTANTBV::BitVector_Clone(top->minV);
         CONSTANTBV::ErrCode e = CONSTANTBV::BitVector_Div_Pos(
-            result->minV, tmp0, c1->maxV, remainder);
+            result->minV, dividend, c1->maxV, remainder);
         assert(0 == e);
-        CONSTANTBV::BitVector_Destroy(tmp0);
+        CONSTANTBV::BitVector_Destroy(dividend);
 
-        tmp0 = CONSTANTBV::BitVector_Clone(top->maxV);
-        e = CONSTANTBV::BitVector_Div_Pos(result->maxV, tmp0, c1Min, remainder);
-        assert(0 == e);
-
-        CONSTANTBV::BitVector_Destroy(tmp0);
-        CONSTANTBV::BitVector_Destroy(remainder);
-
-        if (bottomChanged) // might have been zero.
+        if (!CONSTANTBV::BitVector_is_empty(c1->minV))
         {
-          if (CONSTANTBV::BitVector_Lexicompare(result->minV, c1Min) > 0)
-          {
-            CONSTANTBV::BitVector_Copy(result->minV,
-                                       c1Min); //c1 should still be 1
-          }
-
-          if (CONSTANTBV::BitVector_Lexicompare(result->maxV, c1Min) < 0)
-          {
-            CONSTANTBV::BitVector_Copy(result->maxV,
-                                       c1Min); //c1 should still be 1
-          }
+          // The divisor can't be zero, so the maximum is the largest
+          // dividend divided by the smallest divisor.
+          dividend = CONSTANTBV::BitVector_Clone(top->maxV);
+          e = CONSTANTBV::BitVector_Div_Pos(result->maxV, dividend, c1->minV,
+                                            remainder);
+          assert(0 == e);
+          CONSTANTBV::BitVector_Destroy(dividend);
         }
-        CONSTANTBV::BitVector_Destroy(c1Min);
+
+        CONSTANTBV::BitVector_Destroy(remainder);
 
         break;
       }
@@ -307,17 +293,48 @@ namespace stp
       case BVMOD: //OVER-APPROXIMATION
         if (knownC1)
         {
-          // When we're dividing by zero, we know nothing.
-          if (!CONSTANTBV::BitVector_is_empty(children[1]->minV))
+          if (CONSTANTBV::BitVector_is_empty(children[1]->maxV))
           {
-            result = freshUnsignedInterval(n.GetValueWidth());
+            // Remainder by the constant zero is the identity.
+            if (knownC0)
+              result = createInterval(children[0]->minV, children[0]->maxV);
+          }
+          else if (!CONSTANTBV::BitVector_is_empty(children[1]->minV))
+          {
+            // The divisor can't be zero.
+            if (knownC0 &&
+                CONSTANTBV::BitVector_Lexicompare(children[0]->maxV,
+                                                  children[1]->minV) < 0)
+            {
+              // The dividend is always below the divisor, so the remainder
+              // is the dividend.
+              result = createInterval(children[0]->minV, children[0]->maxV);
+            }
+            else
+            {
+              // The remainder is less than the largest divisor.
+              result = freshUnsignedInterval(width);
+              CONSTANTBV::BitVector_Copy(result->maxV, children[1]->maxV);
+              CONSTANTBV::BitVector_decrement(result->maxV);
+
+              // If the top is known, and it's maximum is less, use that.
+              if (knownC0 &&
+                  CONSTANTBV::BitVector_Lexicompare(children[0]->maxV,
+                                                    result->maxV) < 0)
+                CONSTANTBV::BitVector_Copy(result->maxV, children[0]->maxV);
+            }
+          }
+          else if (knownC0)
+          {
+            // The divisor might be zero. If it is, the remainder is the
+            // dividend; if it isn't, the remainder is below the divisor's
+            // maximum. Take the larger of the two upper bounds.
+            result = freshUnsignedInterval(width);
             CONSTANTBV::BitVector_Copy(result->maxV, children[1]->maxV);
             CONSTANTBV::BitVector_decrement(result->maxV);
 
-            // If the top is known, and it's maximum is less, use that.
-            if (knownC0 &&
-                CONSTANTBV::BitVector_Lexicompare(children[0]->maxV,
-                                                  result->maxV) < 0)
+            if (CONSTANTBV::BitVector_Lexicompare(children[0]->maxV,
+                                                  result->maxV) > 0)
               CONSTANTBV::BitVector_Copy(result->maxV, children[0]->maxV);
           }
         }
@@ -395,13 +412,13 @@ namespace stp
         {
           result = freshUnsignedInterval(width);
           if (CONSTANTBV::BitVector_bit_test(children[0]->minV, 0) &&
-              children[1] != NULL)
+              knownC1)
           {
             CONSTANTBV::BitVector_Copy(result->minV, children[1]->minV);
             CONSTANTBV::BitVector_Copy(result->maxV, children[1]->maxV);
           }
           else if (!CONSTANTBV::BitVector_bit_test(children[0]->minV, 0) &&
-                   children[2] != NULL)
+                   knownC2)
           {
             CONSTANTBV::BitVector_Copy(result->minV, children[2]->minV);
             CONSTANTBV::BitVector_Copy(result->maxV, children[2]->maxV);
@@ -446,11 +463,6 @@ namespace stp
           bool bad = false;
           for (size_t i = 0; i < children.size(); i++)
           {
-            if (children[i] == NULL)
-            {
-              bad = true;
-              break;
-            }
             CONSTANTBV::ErrCode e = CONSTANTBV::BitVector_Multiply(
                 min, result->minV, children[i]->minV);
             assert(0 == e);
@@ -576,30 +588,42 @@ namespace stp
       }
 
       case BVEXTRACT: // OVER-APPROXIMATION
-      break;
       {
-        if (knownC0) // others are always known..
+        // The index children are always constants, so they're always known.
+        if (knownC0 && knownC2)
         {
+          // The lowest bit of the extract is how far the child shifts right.
           unsigned shift_amount = *(children[2]->minV);
 
-          CBV clone = CONSTANTBV::BitVector_Clone(children[0]->maxV);
+          CBV min = CONSTANTBV::BitVector_Clone(children[0]->minV);
+          CBV max = CONSTANTBV::BitVector_Clone(children[0]->maxV);
           while (shift_amount-- > 0)
           {
-            CONSTANTBV::BitVector_shift_right(clone, 0);
+            CONSTANTBV::BitVector_shift_right(min, 0);
+            CONSTANTBV::BitVector_shift_right(max, 0);
           }
 
-          //  If the max bit of clone is greater than the width, ok to continue.
-          if (CONSTANTBV::Set_Max(clone) < width)
+          // Sound only if the extract discards no set bits from the top of
+          // the maximum, i.e. the shifted maximum fits into the new width.
+          if (CONSTANTBV::Set_Max(max) < (signed long)width)
           {
-            CBV max = getEmptyCBV(width); // new width.
+            CBV newMin = CONSTANTBV::BitVector_Create(width, true);
+            CBV newMax = CONSTANTBV::BitVector_Create(width, true);
             for (unsigned i = 0; i < width; i++)
-              if (CONSTANTBV::BitVector_bit_test(clone, i))
-                CONSTANTBV::BitVector_Bit_On(max, i);
+            {
+              if (CONSTANTBV::BitVector_bit_test(min, i))
+                CONSTANTBV::BitVector_Bit_On(newMin, i);
+              if (CONSTANTBV::BitVector_bit_test(max, i))
+                CONSTANTBV::BitVector_Bit_On(newMax, i);
+            }
 
-            result = createInterval(getEmptyCBV(width), max);
+            result = createInterval(newMin, newMax);
+            CONSTANTBV::BitVector_Destroy(newMin);
+            CONSTANTBV::BitVector_Destroy(newMax);
           }
 
-          CONSTANTBV::BitVector_Destroy(clone);
+          CONSTANTBV::BitVector_Destroy(min);
+          CONSTANTBV::BitVector_Destroy(max);
         }
         break;
       }
@@ -697,9 +721,53 @@ namespace stp
         }
         break;
 
+      case BVOR: // OVER-APPROXIMATION
+      {
+        // OR is at least as big as each operand, so the minimum is the
+        // largest of the children's minimums. No bit of the result can be
+        // higher than the highest possible bit of any child.
+        result = freshUnsignedInterval(width);
+
+        signed long highestBit = -1;
+        for (unsigned i = 0; i < children.size(); i++)
+        {
+          if (CONSTANTBV::BitVector_Lexicompare(children[i]->minV,
+                                                result->minV) > 0)
+            CONSTANTBV::BitVector_Copy(result->minV, children[i]->minV);
+
+          highestBit =
+              std::max(highestBit, CONSTANTBV::Set_Max(children[i]->maxV));
+        }
+
+        if (highestBit + 1 < (signed long)width)
+        {
+          CONSTANTBV::BitVector_Empty(result->maxV);
+          for (signed long i = 0; i <= highestBit; i++)
+            CONSTANTBV::BitVector_Bit_On(result->maxV, i);
+        }
+        break;
+      }
+
+      case BVXOR: // OVER-APPROXIMATION
+      {
+        // No bit of the result can be higher than the highest possible bit
+        // of any child.
+        signed long highestBit = -1;
+        for (unsigned i = 0; i < children.size(); i++)
+          highestBit =
+              std::max(highestBit, CONSTANTBV::Set_Max(children[i]->maxV));
+
+        if (highestBit + 1 < (signed long)width)
+        {
+          result = freshUnsignedInterval(width);
+          CONSTANTBV::BitVector_Empty(result->maxV);
+          for (signed long i = 0; i <= highestBit; i++)
+            CONSTANTBV::BitVector_Bit_On(result->maxV, i);
+        }
+        break;
+      }
+
       // TODO
-      case BVXOR:
-      case BVOR:
       case SBVDIV:
       case SBVREM:
       case BVLEFTSHIFT:
@@ -734,7 +802,11 @@ namespace stp
     }
 
     if (n.GetKind() == SYMBOL || n.GetKind() == WRITE || n.GetKind() == READ)
-      return NULL; // Never know anything about these.
+    {
+      // Never know anything about these.
+      visited.insert({n, NULL});
+      return NULL;
+    }
 
     const auto number_children = n.Degree();
     vector<const UnsignedInterval*> children;

--- a/lib/Simplifier/UnsignedIntervalAnalysis.cpp
+++ b/lib/Simplifier/UnsignedIntervalAnalysis.cpp
@@ -68,6 +68,288 @@ namespace stp
       const unsigned amount = *shift; // The value fits into the first word.
       return std::min(amount, width);
     }
+
+    // Sets bit i and clears the bits below it: (x | 2^i) & -(2^i).
+    void setBitClearBelow(CBV x, unsigned i)
+    {
+      CONSTANTBV::BitVector_Bit_On(x, i);
+      for (unsigned j = 0; j < i; j++)
+        CONSTANTBV::BitVector_Bit_Off(x, j);
+    }
+
+    // Clears bit i and sets the bits below it: (x - 2^i) | (2^i - 1).
+    void clearBitSetBelow(CBV x, unsigned i)
+    {
+      CONSTANTBV::BitVector_Bit_Off(x, i);
+      for (unsigned j = 0; j < i; j++)
+        CONSTANTBV::BitVector_Bit_On(x, j);
+    }
+
+    // The six functions below are from section 4-3 of Hacker's Delight.
+    // Each gives the exact bound of a bitwise operation over the intervals
+    // x in [a, b] and y in [c, d]. The caller owns the returned bitvector.
+
+    // The smallest x | y.
+    CBV minOR(const CBV a0, const CBV b, const CBV c0, const CBV d)
+    {
+      CBV a = CONSTANTBV::BitVector_Clone(a0);
+      CBV c = CONSTANTBV::BitVector_Clone(c0);
+
+      for (unsigned i = bits_(a); i-- > 0;)
+      {
+        const bool aBit = CONSTANTBV::BitVector_bit_test(a, i);
+        const bool cBit = CONSTANTBV::BitVector_bit_test(c, i);
+
+        if (!aBit && cBit)
+        {
+          // Raising a to supply this bit lets everything below it be zero.
+          CBV temp = CONSTANTBV::BitVector_Clone(a);
+          setBitClearBelow(temp, i);
+          if (CONSTANTBV::BitVector_Lexicompare(temp, b) <= 0)
+          {
+            CONSTANTBV::BitVector_Destroy(a);
+            a = temp;
+            break;
+          }
+          CONSTANTBV::BitVector_Destroy(temp);
+        }
+        else if (aBit && !cBit)
+        {
+          CBV temp = CONSTANTBV::BitVector_Clone(c);
+          setBitClearBelow(temp, i);
+          if (CONSTANTBV::BitVector_Lexicompare(temp, d) <= 0)
+          {
+            CONSTANTBV::BitVector_Destroy(c);
+            c = temp;
+            break;
+          }
+          CONSTANTBV::BitVector_Destroy(temp);
+        }
+      }
+
+      CBV result = CONSTANTBV::BitVector_Create(bits_(a), true);
+      CONSTANTBV::Set_Union(result, a, c);
+      CONSTANTBV::BitVector_Destroy(a);
+      CONSTANTBV::BitVector_Destroy(c);
+      return result;
+    }
+
+    // The biggest x | y.
+    CBV maxOR(const CBV a, const CBV b0, const CBV c, const CBV d0)
+    {
+      CBV b = CONSTANTBV::BitVector_Clone(b0);
+      CBV d = CONSTANTBV::BitVector_Clone(d0);
+
+      for (unsigned i = bits_(b); i-- > 0;)
+      {
+        if (CONSTANTBV::BitVector_bit_test(b, i) &&
+            CONSTANTBV::BitVector_bit_test(d, i))
+        {
+          // One operand can donate this bit; lowering the other one sets
+          // every bit below it.
+          CBV temp = CONSTANTBV::BitVector_Clone(b);
+          clearBitSetBelow(temp, i);
+          if (CONSTANTBV::BitVector_Lexicompare(temp, a) >= 0)
+          {
+            CONSTANTBV::BitVector_Destroy(b);
+            b = temp;
+            break;
+          }
+          CONSTANTBV::BitVector_Destroy(temp);
+
+          temp = CONSTANTBV::BitVector_Clone(d);
+          clearBitSetBelow(temp, i);
+          if (CONSTANTBV::BitVector_Lexicompare(temp, c) >= 0)
+          {
+            CONSTANTBV::BitVector_Destroy(d);
+            d = temp;
+            break;
+          }
+          CONSTANTBV::BitVector_Destroy(temp);
+        }
+      }
+
+      CBV result = CONSTANTBV::BitVector_Create(bits_(b), true);
+      CONSTANTBV::Set_Union(result, b, d);
+      CONSTANTBV::BitVector_Destroy(b);
+      CONSTANTBV::BitVector_Destroy(d);
+      return result;
+    }
+
+    // The smallest x & y.
+    CBV minAND(const CBV a0, const CBV b, const CBV c0, const CBV d)
+    {
+      CBV a = CONSTANTBV::BitVector_Clone(a0);
+      CBV c = CONSTANTBV::BitVector_Clone(c0);
+
+      for (unsigned i = bits_(a); i-- > 0;)
+      {
+        if (!CONSTANTBV::BitVector_bit_test(a, i) &&
+            !CONSTANTBV::BitVector_bit_test(c, i))
+        {
+          // The bit is zero in both minimums, so it is zero in the result;
+          // raising one minimum past it lets everything below be zero.
+          CBV temp = CONSTANTBV::BitVector_Clone(a);
+          setBitClearBelow(temp, i);
+          if (CONSTANTBV::BitVector_Lexicompare(temp, b) <= 0)
+          {
+            CONSTANTBV::BitVector_Destroy(a);
+            a = temp;
+            break;
+          }
+          CONSTANTBV::BitVector_Destroy(temp);
+
+          temp = CONSTANTBV::BitVector_Clone(c);
+          setBitClearBelow(temp, i);
+          if (CONSTANTBV::BitVector_Lexicompare(temp, d) <= 0)
+          {
+            CONSTANTBV::BitVector_Destroy(c);
+            c = temp;
+            break;
+          }
+          CONSTANTBV::BitVector_Destroy(temp);
+        }
+      }
+
+      CBV result = CONSTANTBV::BitVector_Create(bits_(a), true);
+      CONSTANTBV::Set_Intersection(result, a, c);
+      CONSTANTBV::BitVector_Destroy(a);
+      CONSTANTBV::BitVector_Destroy(c);
+      return result;
+    }
+
+    // The biggest x & y.
+    CBV maxAND(const CBV a, const CBV b0, const CBV c, const CBV d0)
+    {
+      CBV b = CONSTANTBV::BitVector_Clone(b0);
+      CBV d = CONSTANTBV::BitVector_Clone(d0);
+
+      for (unsigned i = bits_(b); i-- > 0;)
+      {
+        const bool bBit = CONSTANTBV::BitVector_bit_test(b, i);
+        const bool dBit = CONSTANTBV::BitVector_bit_test(d, i);
+
+        if (bBit && !dBit)
+        {
+          // The bit can't survive the AND; giving it up sets every bit
+          // below it.
+          CBV temp = CONSTANTBV::BitVector_Clone(b);
+          clearBitSetBelow(temp, i);
+          if (CONSTANTBV::BitVector_Lexicompare(temp, a) >= 0)
+          {
+            CONSTANTBV::BitVector_Destroy(b);
+            b = temp;
+            break;
+          }
+          CONSTANTBV::BitVector_Destroy(temp);
+        }
+        else if (!bBit && dBit)
+        {
+          CBV temp = CONSTANTBV::BitVector_Clone(d);
+          clearBitSetBelow(temp, i);
+          if (CONSTANTBV::BitVector_Lexicompare(temp, c) >= 0)
+          {
+            CONSTANTBV::BitVector_Destroy(d);
+            d = temp;
+            break;
+          }
+          CONSTANTBV::BitVector_Destroy(temp);
+        }
+      }
+
+      CBV result = CONSTANTBV::BitVector_Create(bits_(b), true);
+      CONSTANTBV::Set_Intersection(result, b, d);
+      CONSTANTBV::BitVector_Destroy(b);
+      CONSTANTBV::BitVector_Destroy(d);
+      return result;
+    }
+
+    // The smallest x ^ y. Like minOR, but a bit supplied to cancel one in
+    // the other operand keeps helping at the lower bits, so keep scanning.
+    CBV minXOR(const CBV a0, const CBV b, const CBV c0, const CBV d)
+    {
+      CBV a = CONSTANTBV::BitVector_Clone(a0);
+      CBV c = CONSTANTBV::BitVector_Clone(c0);
+
+      for (unsigned i = bits_(a); i-- > 0;)
+      {
+        const bool aBit = CONSTANTBV::BitVector_bit_test(a, i);
+        const bool cBit = CONSTANTBV::BitVector_bit_test(c, i);
+
+        if (!aBit && cBit)
+        {
+          CBV temp = CONSTANTBV::BitVector_Clone(a);
+          setBitClearBelow(temp, i);
+          if (CONSTANTBV::BitVector_Lexicompare(temp, b) <= 0)
+          {
+            CONSTANTBV::BitVector_Destroy(a);
+            a = temp;
+          }
+          else
+            CONSTANTBV::BitVector_Destroy(temp);
+        }
+        else if (aBit && !cBit)
+        {
+          CBV temp = CONSTANTBV::BitVector_Clone(c);
+          setBitClearBelow(temp, i);
+          if (CONSTANTBV::BitVector_Lexicompare(temp, d) <= 0)
+          {
+            CONSTANTBV::BitVector_Destroy(c);
+            c = temp;
+          }
+          else
+            CONSTANTBV::BitVector_Destroy(temp);
+        }
+      }
+
+      CBV result = CONSTANTBV::BitVector_Create(bits_(a), true);
+      CONSTANTBV::Set_ExclusiveOr(result, a, c);
+      CONSTANTBV::BitVector_Destroy(a);
+      CONSTANTBV::BitVector_Destroy(c);
+      return result;
+    }
+
+    // The biggest x ^ y. Like maxOR, but a shared bit cancels out, so
+    // giving it up in one operand keeps helping at the lower bits.
+    CBV maxXOR(const CBV a, const CBV b0, const CBV c, const CBV d0)
+    {
+      CBV b = CONSTANTBV::BitVector_Clone(b0);
+      CBV d = CONSTANTBV::BitVector_Clone(d0);
+
+      for (unsigned i = bits_(b); i-- > 0;)
+      {
+        if (CONSTANTBV::BitVector_bit_test(b, i) &&
+            CONSTANTBV::BitVector_bit_test(d, i))
+        {
+          CBV temp = CONSTANTBV::BitVector_Clone(b);
+          clearBitSetBelow(temp, i);
+          if (CONSTANTBV::BitVector_Lexicompare(temp, a) >= 0)
+          {
+            CONSTANTBV::BitVector_Destroy(b);
+            b = temp;
+          }
+          else
+          {
+            CONSTANTBV::BitVector_Destroy(temp);
+            temp = CONSTANTBV::BitVector_Clone(d);
+            clearBitSetBelow(temp, i);
+            if (CONSTANTBV::BitVector_Lexicompare(temp, c) >= 0)
+            {
+              CONSTANTBV::BitVector_Destroy(d);
+              d = temp;
+            }
+            else
+              CONSTANTBV::BitVector_Destroy(temp);
+          }
+        }
+      }
+
+      CBV result = CONSTANTBV::BitVector_Create(bits_(b), true);
+      CONSTANTBV::Set_ExclusiveOr(result, b, d);
+      CONSTANTBV::BitVector_Destroy(b);
+      CONSTANTBV::BitVector_Destroy(d);
+      return result;
+    }
   }
 
   UnsignedInterval* UnsignedIntervalAnalysis::freshUnsignedInterval(unsigned width)
@@ -576,29 +858,44 @@ namespace stp
         break;
       }
 
-      case BVAND: // OVER-APPROXIMATION
+      case BVAND:
+      case BVOR:
+      case BVXOR:
       {
-        if (knownC0 || knownC1)
+        // Hacker's Delight gives the exact bounds of the bitwise operations
+        // over intervals. Exact for two children; more children are folded
+        // in pairwise, which is sound but may over-approximate.
+        CBV min = CONSTANTBV::BitVector_Clone(children[0]->minV);
+        CBV max = CONSTANTBV::BitVector_Clone(children[0]->maxV);
+
+        for (unsigned i = 1; i < children.size(); i++)
         {
-          if (!knownC1)
+          CBV newMin, newMax;
+          if (n.GetKind() == BVAND)
           {
-            result = createInterval(getEmptyCBV(width), children[0]->maxV);
+            newMin = minAND(min, max, children[i]->minV, children[i]->maxV);
+            newMax = maxAND(min, max, children[i]->minV, children[i]->maxV);
           }
-          else if (!knownC0)
+          else if (n.GetKind() == BVOR)
           {
-            result = createInterval(getEmptyCBV(width), children[1]->maxV);
+            newMin = minOR(min, max, children[i]->minV, children[i]->maxV);
+            newMax = maxOR(min, max, children[i]->minV, children[i]->maxV);
           }
           else
           {
-            if (CONSTANTBV::BitVector_Lexicompare(children[0]->maxV,
-                                                  children[1]->maxV) > 0)
-            {
-              result = createInterval(getEmptyCBV(width), children[1]->maxV);
-            }
-            else
-              result = createInterval(getEmptyCBV(width), children[0]->maxV);
+            newMin = minXOR(min, max, children[i]->minV, children[i]->maxV);
+            newMax = maxXOR(min, max, children[i]->minV, children[i]->maxV);
           }
+
+          CONSTANTBV::BitVector_Destroy(min);
+          CONSTANTBV::BitVector_Destroy(max);
+          min = newMin;
+          max = newMax;
         }
+
+        result = createInterval(min, max);
+        CONSTANTBV::BitVector_Destroy(min);
+        CONSTANTBV::BitVector_Destroy(max);
         break;
       }
 
@@ -785,52 +1082,6 @@ namespace stp
           CONSTANTBV::BitVector_Destroy(max);
         }
         break;
-
-      case BVOR: // OVER-APPROXIMATION
-      {
-        // OR is at least as big as each operand, so the minimum is the
-        // largest of the children's minimums. No bit of the result can be
-        // higher than the highest possible bit of any child.
-        result = freshUnsignedInterval(width);
-
-        signed long highestBit = -1;
-        for (unsigned i = 0; i < children.size(); i++)
-        {
-          if (CONSTANTBV::BitVector_Lexicompare(children[i]->minV,
-                                                result->minV) > 0)
-            CONSTANTBV::BitVector_Copy(result->minV, children[i]->minV);
-
-          highestBit =
-              std::max(highestBit, CONSTANTBV::Set_Max(children[i]->maxV));
-        }
-
-        if (highestBit + 1 < (signed long)width)
-        {
-          CONSTANTBV::BitVector_Empty(result->maxV);
-          for (signed long i = 0; i <= highestBit; i++)
-            CONSTANTBV::BitVector_Bit_On(result->maxV, i);
-        }
-        break;
-      }
-
-      case BVXOR: // OVER-APPROXIMATION
-      {
-        // No bit of the result can be higher than the highest possible bit
-        // of any child.
-        signed long highestBit = -1;
-        for (unsigned i = 0; i < children.size(); i++)
-          highestBit =
-              std::max(highestBit, CONSTANTBV::Set_Max(children[i]->maxV));
-
-        if (highestBit + 1 < (signed long)width)
-        {
-          result = freshUnsignedInterval(width);
-          CONSTANTBV::BitVector_Empty(result->maxV);
-          for (signed long i = 0; i <= highestBit; i++)
-            CONSTANTBV::BitVector_Bit_On(result->maxV, i);
-        }
-        break;
-      }
 
       // TODO
       case SBVDIV:

--- a/lib/Simplifier/UnsignedIntervalAnalysis.cpp
+++ b/lib/Simplifier/UnsignedIntervalAnalysis.cpp
@@ -596,6 +596,49 @@ namespace stp
             if (knownC0)
               result = createInterval(children[0]->minV, children[0]->maxV);
           }
+          else if (children[1]->isConstant())
+          {
+            // A constant non-zero divisor is exact: the dividend runs over
+            // every value between its bounds, so if the bounds have the
+            // same quotient the remainders run from one bound's to the
+            // other's, and otherwise a multiple of the divisor is crossed
+            // and every remainder is reachable.
+            const CBV divisor = children[1]->minV;
+            CBV remainderMin = CONSTANTBV::BitVector_Create(width, true);
+            CBV remainderMax = CONSTANTBV::BitVector_Create(width, true);
+            CBV quotientMin = CONSTANTBV::BitVector_Create(width, true);
+            CBV quotientMax = CONSTANTBV::BitVector_Create(width, true);
+
+            CBV dividend = CONSTANTBV::BitVector_Clone(children[0]->minV);
+            CONSTANTBV::ErrCode e = CONSTANTBV::BitVector_Div_Pos(
+                quotientMin, dividend, divisor, remainderMin);
+            assert(0 == e);
+            CONSTANTBV::BitVector_Destroy(dividend);
+
+            dividend = CONSTANTBV::BitVector_Clone(children[0]->maxV);
+            e = CONSTANTBV::BitVector_Div_Pos(quotientMax, dividend, divisor,
+                                              remainderMax);
+            assert(0 == e);
+            CONSTANTBV::BitVector_Destroy(dividend);
+
+            if (CONSTANTBV::BitVector_Lexicompare(quotientMin, quotientMax) ==
+                0)
+            {
+              result = createInterval(remainderMin, remainderMax);
+            }
+            else
+            {
+              CBV divisorLess1 = CONSTANTBV::BitVector_Clone(divisor);
+              CONSTANTBV::BitVector_decrement(divisorLess1);
+              result = createInterval(getEmptyCBV(width), divisorLess1);
+              CONSTANTBV::BitVector_Destroy(divisorLess1);
+            }
+
+            CONSTANTBV::BitVector_Destroy(remainderMin);
+            CONSTANTBV::BitVector_Destroy(remainderMax);
+            CONSTANTBV::BitVector_Destroy(quotientMin);
+            CONSTANTBV::BitVector_Destroy(quotientMax);
+          }
           else if (!CONSTANTBV::BitVector_is_empty(children[1]->minV))
           {
             // The divisor can't be zero.
@@ -614,7 +657,7 @@ namespace stp
               CONSTANTBV::BitVector_Copy(result->maxV, children[1]->maxV);
               CONSTANTBV::BitVector_decrement(result->maxV);
 
-              // If the top is known, and it's maximum is less, use that.
+              // The remainder never exceeds the dividend.
               if (knownC0 &&
                   CONSTANTBV::BitVector_Lexicompare(children[0]->maxV,
                                                     result->maxV) < 0)
@@ -623,16 +666,11 @@ namespace stp
           }
           else if (knownC0)
           {
-            // The divisor might be zero. If it is, the remainder is the
-            // dividend; if it isn't, the remainder is below the divisor's
-            // maximum. Take the larger of the two upper bounds.
+            // The divisor might be zero. The remainder never exceeds the
+            // dividend, and dividing the biggest dividend by zero reaches
+            // that bound, so the maximum is the dividend's maximum.
             result = freshUnsignedInterval(width);
-            CONSTANTBV::BitVector_Copy(result->maxV, children[1]->maxV);
-            CONSTANTBV::BitVector_decrement(result->maxV);
-
-            if (CONSTANTBV::BitVector_Lexicompare(children[0]->maxV,
-                                                  result->maxV) > 0)
-              CONSTANTBV::BitVector_Copy(result->maxV, children[0]->maxV);
+            CONSTANTBV::BitVector_Copy(result->maxV, children[0]->maxV);
           }
         }
         break;

--- a/lib/Simplifier/UnsignedIntervalAnalysis.cpp
+++ b/lib/Simplifier/UnsignedIntervalAnalysis.cpp
@@ -264,6 +264,301 @@ namespace stp
       return result;
     }
 
+    // ---- Helpers for the multiplication bounds. The bitvectors in this
+    // group share one width, chosen wide enough that nothing overflows. ----
+
+    CBV zeroOf(unsigned width)
+    {
+      return CONSTANTBV::BitVector_Create(width, true);
+    }
+
+    // A fresh copy of x at a bigger width.
+    CBV widenTo(const CBV x, unsigned width)
+    {
+      assert(width >= bits_(x));
+      CBV r = zeroOf(width);
+      CONSTANTBV::BitVector_Interval_Copy(r, x, 0, 0, bits_(x));
+      return r;
+    }
+
+    void replaceCBV(CBV& x, CBV fresh)
+    {
+      CONSTANTBV::BitVector_Destroy(x);
+      x = fresh;
+    }
+
+    CBV addFresh(const CBV x, const CBV y)
+    {
+      CBV r = zeroOf(bits_(x));
+      bool carry = false;
+      CONSTANTBV::BitVector_add(r, x, y, &carry);
+      assert(!carry);
+      return r;
+    }
+
+    // x - y, requiring x >= y.
+    CBV subFresh(const CBV x, const CBV y)
+    {
+      assert(CONSTANTBV::BitVector_Lexicompare(x, y) >= 0);
+      CBV r = zeroOf(bits_(x));
+      bool carry = false;
+      CONSTANTBV::BitVector_sub(r, x, y, &carry);
+      return r;
+    }
+
+    CBV mulFresh(const CBV x, const CBV y)
+    {
+      CBV r = zeroOf(bits_(x));
+      CBV tmp = CONSTANTBV::BitVector_Clone(x); // Mul_Pos destroys this one.
+      CONSTANTBV::ErrCode e = CONSTANTBV::BitVector_Mul_Pos(r, tmp, y, true);
+      assert(0 == e);
+      CONSTANTBV::BitVector_Destroy(tmp);
+      return r;
+    }
+
+    // Fresh quotient and remainder of x / y; y >= 1.
+    void divmodFresh(const CBV x, const CBV y, CBV& quotient, CBV& remainder)
+    {
+      quotient = zeroOf(bits_(x));
+      remainder = zeroOf(bits_(x));
+      CBV tmp = CONSTANTBV::BitVector_Clone(x); // Div_Pos destroys this one.
+      CONSTANTBV::ErrCode e =
+          CONSTANTBV::BitVector_Div_Pos(quotient, tmp, y, remainder);
+      assert(0 == e);
+      CONSTANTBV::BitVector_Destroy(tmp);
+    }
+
+    // The sum over 0 <= i < n of floor((a*i + b) / m); m >= 1. This is the
+    // AtCoder Library's floor_sum. The shared width must be big enough
+    // that a*n + b and the sum can't overflow.
+    CBV floorSum(const CBV n0, const CBV m0, const CBV a0, const CBV b0)
+    {
+      const unsigned width = bits_(n0);
+      CBV n = CONSTANTBV::BitVector_Clone(n0);
+      CBV m = CONSTANTBV::BitVector_Clone(m0);
+      CBV a = CONSTANTBV::BitVector_Clone(a0);
+      CBV b = CONSTANTBV::BitVector_Clone(b0);
+      CBV ans = zeroOf(width);
+      CBV one = zeroOf(width);
+      CONSTANTBV::BitVector_increment(one);
+
+      while (true)
+      {
+        if (CONSTANTBV::BitVector_Lexicompare(a, m) >= 0)
+        {
+          CBV q, r;
+          divmodFresh(a, m, q, r);
+          // ans += n * (n - 1) / 2 * q
+          CBV t = subFresh(n, one);
+          replaceCBV(t, mulFresh(n, t));
+          CONSTANTBV::BitVector_shift_right(t, 0); // n*(n-1) is even.
+          replaceCBV(t, mulFresh(t, q));
+          replaceCBV(ans, addFresh(ans, t));
+          CONSTANTBV::BitVector_Destroy(t);
+          CONSTANTBV::BitVector_Destroy(q);
+          replaceCBV(a, r);
+        }
+
+        if (CONSTANTBV::BitVector_Lexicompare(b, m) >= 0)
+        {
+          CBV q, r;
+          divmodFresh(b, m, q, r);
+          CBV t = mulFresh(n, q);
+          replaceCBV(ans, addFresh(ans, t));
+          CONSTANTBV::BitVector_Destroy(t);
+          CONSTANTBV::BitVector_Destroy(q);
+          replaceCBV(b, r);
+        }
+
+        CBV y = mulFresh(a, n);
+        replaceCBV(y, addFresh(y, b));
+        if (CONSTANTBV::BitVector_Lexicompare(y, m) < 0)
+        {
+          CONSTANTBV::BitVector_Destroy(y);
+          break;
+        }
+
+        CBV q, r;
+        divmodFresh(y, m, q, r);
+        CONSTANTBV::BitVector_Destroy(y);
+        replaceCBV(n, q);
+        replaceCBV(b, r);
+        std::swap(m, a);
+      }
+
+      CONSTANTBV::BitVector_Destroy(n);
+      CONSTANTBV::BitVector_Destroy(m);
+      CONSTANTBV::BitVector_Destroy(a);
+      CONSTANTBV::BitVector_Destroy(b);
+      CONSTANTBV::BitVector_Destroy(one);
+      return ans;
+    }
+
+    // How many i in [0, n) have (a*i + b) mod m <= x. floor(t/m) minus
+    // floor((t - x - 1)/m) is one exactly when t mod m <= x; when the
+    // shifted offset would be negative, a multiple of m is added and the
+    // total corrected by n. 'total' is floorSum(n, m, a, b), precomputed
+    // because it doesn't change across a binary search.
+    CBV countAtMost(const CBV x, const CBV total, const CBV n, const CBV m,
+                    const CBV a, const CBV b)
+    {
+      CBV count = CONSTANTBV::BitVector_Clone(total);
+
+      CBV xPlus1 = CONSTANTBV::BitVector_Clone(x);
+      CONSTANTBV::BitVector_increment(xPlus1);
+
+      CBV shifted;
+      if (CONSTANTBV::BitVector_Lexicompare(b, xPlus1) >= 0)
+        shifted = subFresh(b, xPlus1);
+      else
+      {
+        shifted = addFresh(b, m);
+        replaceCBV(shifted, subFresh(shifted, xPlus1));
+        replaceCBV(count, addFresh(count, n));
+      }
+
+      CBV fewer = floorSum(n, m, a, shifted);
+      replaceCBV(count, subFresh(count, fewer));
+
+      CONSTANTBV::BitVector_Destroy(fewer);
+      CONSTANTBV::BitVector_Destroy(shifted);
+      CONSTANTBV::BitVector_Destroy(xPlus1);
+      return count;
+    }
+
+    // The minimum (or maximum) of (a*i + b) mod m over 0 <= i < n: the
+    // smallest x whose count reaches one (or reaches n), found by binary
+    // search on the counting function.
+    CBV progressionBound(bool wantMaximum, const CBV n, const CBV m,
+                         const CBV a, const CBV b)
+    {
+      const unsigned width = bits_(n);
+      CBV total = floorSum(n, m, a, b);
+
+      CBV lo = zeroOf(width);
+      CBV hi = CONSTANTBV::BitVector_Clone(m);
+      CONSTANTBV::BitVector_decrement(hi);
+
+      while (CONSTANTBV::BitVector_Lexicompare(lo, hi) < 0)
+      {
+        CBV mid = addFresh(lo, hi);
+        CONSTANTBV::BitVector_shift_right(mid, 0);
+
+        CBV count = countAtMost(mid, total, n, m, a, b);
+        const bool enough =
+            wantMaximum ? (CONSTANTBV::BitVector_Lexicompare(count, n) >= 0)
+                        : !CONSTANTBV::BitVector_is_empty(count);
+        CONSTANTBV::BitVector_Destroy(count);
+
+        if (enough)
+          replaceCBV(hi, mid);
+        else
+        {
+          CONSTANTBV::BitVector_increment(mid);
+          replaceCBV(lo, mid);
+        }
+      }
+
+      CONSTANTBV::BitVector_Destroy(hi);
+      CONSTANTBV::BitVector_Destroy(total);
+      return lo;
+    }
+
+    // The progression search runs a binary search full of divisions, so
+    // it's only worth it at the widths solvers commonly use.
+    const unsigned progressionWidthLimit = 64;
+
+    // The bounds of x*y (mod 2^width) with x in [a, b] and y in [c, d],
+    // written into resultMin/resultMax; both stay null if nothing is
+    // known. Exact when the bound products land in the same 2^width block,
+    // and when one operand is constant (below the width limit).
+    void multiplyPair(const CBV a, const CBV b, const CBV c, const CBV d,
+                      unsigned width, CBV& resultMin, CBV& resultMax)
+    {
+      resultMin = nullptr;
+      resultMax = nullptr;
+
+      // Wide enough for the products and everything inside floorSum.
+      const unsigned wide = 3 * width + 4;
+
+      CBV aW = widenTo(a, wide);
+      CBV bW = widenTo(b, wide);
+      CBV cW = widenTo(c, wide);
+      CBV dW = widenTo(d, wide);
+
+      CBV lowProduct = mulFresh(aW, cW);
+      CBV highProduct = mulFresh(bW, dW);
+
+      bool sameBlock = true;
+      for (unsigned i = width; i < wide && sameBlock; i++)
+        if (CONSTANTBV::BitVector_bit_test(lowProduct, i) !=
+            CONSTANTBV::BitVector_bit_test(highProduct, i))
+          sameBlock = false;
+
+      if (sameBlock)
+      {
+        // Every product sits between the bound products, which agree above
+        // the width, so the low bits run between the bounds' low bits
+        // without wrapping: exact.
+        resultMin = zeroOf(width);
+        resultMax = zeroOf(width);
+        for (unsigned i = 0; i < width; i++)
+        {
+          if (CONSTANTBV::BitVector_bit_test(lowProduct, i))
+            CONSTANTBV::BitVector_Bit_On(resultMin, i);
+          if (CONSTANTBV::BitVector_bit_test(highProduct, i))
+            CONSTANTBV::BitVector_Bit_On(resultMax, i);
+        }
+      }
+      else
+      {
+        const bool constantY = (CONSTANTBV::BitVector_Lexicompare(c, d) == 0);
+        const bool constantX = (CONSTANTBV::BitVector_Lexicompare(a, b) == 0);
+
+        if ((constantX || constantY) && width <= progressionWidthLimit)
+        {
+          // With one operand constant the products are the arithmetic
+          // progression a*c, a*c + step, ... mod 2^width, whose extremes
+          // the progression search finds: exact.
+          CBV modulus = zeroOf(wide);
+          CONSTANTBV::BitVector_Bit_On(modulus, width);
+
+          CBV count = constantY ? subFresh(bW, aW) : subFresh(dW, cW);
+          CONSTANTBV::BitVector_increment(count);
+
+          const CBV step = constantY ? cW : aW;
+
+          CBV apMin = progressionBound(false, count, modulus, step,
+                                       lowProduct);
+          CBV apMax = progressionBound(true, count, modulus, step,
+                                       lowProduct);
+
+          resultMin = zeroOf(width);
+          resultMax = zeroOf(width);
+          for (unsigned i = 0; i < width; i++)
+          {
+            if (CONSTANTBV::BitVector_bit_test(apMin, i))
+              CONSTANTBV::BitVector_Bit_On(resultMin, i);
+            if (CONSTANTBV::BitVector_bit_test(apMax, i))
+              CONSTANTBV::BitVector_Bit_On(resultMax, i);
+          }
+
+          CONSTANTBV::BitVector_Destroy(apMin);
+          CONSTANTBV::BitVector_Destroy(apMax);
+          CONSTANTBV::BitVector_Destroy(count);
+          CONSTANTBV::BitVector_Destroy(modulus);
+        }
+        // Otherwise the products can wrap in ways intervals can't follow.
+      }
+
+      CONSTANTBV::BitVector_Destroy(aW);
+      CONSTANTBV::BitVector_Destroy(bW);
+      CONSTANTBV::BitVector_Destroy(cW);
+      CONSTANTBV::BitVector_Destroy(dW);
+      CONSTANTBV::BitVector_Destroy(lowProduct);
+      CONSTANTBV::BitVector_Destroy(highProduct);
+    }
+
     // The smallest x ^ y. Like minOR, but a bit supplied to cancel one in
     // the other operand keeps helping at the lower bits, so keep scanning.
     CBV minXOR(const CBV a0, const CBV b, const CBV c0, const CBV d)
@@ -781,52 +1076,31 @@ namespace stp
         }
         break;
 
-      case BVMULT: //OVER-APPROXIMATION
-        if (knownC0 && knownC1)
+      case BVMULT: // OVER-APPROXIMATION
+      {
+        // Folded pairwise: exact for two children, sound beyond.
+        CBV min = CONSTANTBV::BitVector_Clone(children[0]->minV);
+        CBV max = CONSTANTBV::BitVector_Clone(children[0]->maxV);
+
+        for (unsigned i = 1; i < children.size() && min != nullptr; i++)
         {
-          //  >=2 arity.
-          CBV min, max;
-          min = CONSTANTBV::BitVector_Create(2 * width, true);
-          max = CONSTANTBV::BitVector_Create(2 * width, true);
-
-          // Make the result interval 1.
-          result = freshUnsignedInterval(width);
-          CONSTANTBV::BitVector_increment(result->minV);
-          CONSTANTBV::BitVector_Flip(result->maxV);
-          CONSTANTBV::BitVector_increment(result->maxV);
-
-          bool bad = false;
-          for (size_t i = 0; i < children.size(); i++)
-          {
-            CONSTANTBV::ErrCode e = CONSTANTBV::BitVector_Multiply(
-                min, result->minV, children[i]->minV);
-            assert(0 == e);
-
-            e = CONSTANTBV::BitVector_Multiply(max, result->maxV,
-                                               children[i]->maxV);
-            assert(0 == e);
-
-            if (CONSTANTBV::Set_Max(max) >= width)
-              bad = true;
-
-            for (unsigned j = width; j < 2 * width; j++)
-            {
-              if (CONSTANTBV::BitVector_bit_test(min, j))
-                bad = true;
-            }
-
-            CONSTANTBV::BitVector_Interval_Copy(result->minV, min, 0, 0, width);
-            CONSTANTBV::BitVector_Interval_Copy(result->maxV, max, 0, 0, width);
-          }
+          CBV newMin, newMax;
+          multiplyPair(min, max, children[i]->minV, children[i]->maxV, width,
+                       newMin, newMax);
           CONSTANTBV::BitVector_Destroy(min);
           CONSTANTBV::BitVector_Destroy(max);
-          if (bad)
-            {
-              delete result;
-              result = NULL;
-            }
+          min = newMin;
+          max = newMax;
+        }
+
+        if (min != nullptr)
+        {
+          result = createInterval(min, max);
+          CONSTANTBV::BitVector_Destroy(min);
+          CONSTANTBV::BitVector_Destroy(max);
         }
         break;
+      }
 
       case AND:
       {

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -29,6 +29,7 @@ AddSTPGTest(Flatten_Test.cpp)
 AddSTPGTest(NodeDomainAnalysis_Test.cpp)
 AddSTPGTest(SplitExtracts_Test.cpp)
 AddSTPGTest(StrengthReduction_Test.cpp)
+AddSTPGTest(UnsignedIntervalPropagators_Test.cpp)
 AddSTPGTest(AlwaysTrue_Test.cpp)
 AddSTPGTest(MergeSame_Test.cpp)
 

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -30,6 +30,7 @@ AddSTPGTest(NodeDomainAnalysis_Test.cpp)
 AddSTPGTest(SplitExtracts_Test.cpp)
 AddSTPGTest(StrengthReduction_Test.cpp)
 AddSTPGTest(UnsignedIntervalPropagators_Test.cpp)
+AddSTPGTest(UnsignedIntervalExhaustive_Test.cpp)
 AddSTPGTest(AlwaysTrue_Test.cpp)
 AddSTPGTest(MergeSame_Test.cpp)
 

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -31,6 +31,7 @@ AddSTPGTest(SplitExtracts_Test.cpp)
 AddSTPGTest(StrengthReduction_Test.cpp)
 AddSTPGTest(UnsignedIntervalPropagators_Test.cpp)
 AddSTPGTest(UnsignedIntervalExhaustive_Test.cpp)
+AddSTPGTest(UnsignedIntervalWide_Test.cpp)
 AddSTPGTest(AlwaysTrue_Test.cpp)
 AddSTPGTest(MergeSame_Test.cpp)
 

--- a/tests/unit-tests/UnsignedIntervalExhaustive_Test.cpp
+++ b/tests/unit-tests/UnsignedIntervalExhaustive_Test.cpp
@@ -34,13 +34,13 @@ THE SOFTWARE.
 // The perfect transfer functions are:
 //
 //   NOT, AND, OR, XOR (boolean), EQ, BVGT, BVSGT, ITE, BVNOT, BVUMINUS,
-//   BVSX, BVCONCAT, BVPLUS, BVDIV, BVRIGHTSHIFT, BVSRSHIFT,
+//   BVSX, BVCONCAT, BVEXTRACT, BVPLUS, BVDIV, BVRIGHTSHIFT, BVSRSHIFT,
 //   BVAND, BVOR, BVXOR (exact for two children; folded pairwise beyond)
 //
 // The over-approximating ones (marked OVER-APPROXIMATION in the source) are
 // only checked for soundness:
 //
-//   BVMOD, BVMULT, BVEXTRACT, BVLEFTSHIFT
+//   BVMOD, BVMULT, BVLEFTSHIFT
 
 #include "stp/STPManager/STPManager.h"
 #include "stp/NodeFactory/SimplifyingNodeFactory.h"
@@ -513,9 +513,9 @@ TEST(UnsignedIntervalExhaustive, Extract)
             stp::UnsignedInterval* result =
                 c.analysis.dispatchToTransferFunctions(n, children);
 
-            const bool good =
-                checkAgainstHull(stp::BVEXTRACT, w, result, wOut, bruteMin,
-                                 bruteMax, OVERAPPROXIMATES);
+            const bool good = checkAgainstHull(stp::BVEXTRACT, w, result,
+                                               wOut, bruteMin, bruteMax,
+                                               EXACT);
             cleanup(children, result);
             if (!good)
             {

--- a/tests/unit-tests/UnsignedIntervalExhaustive_Test.cpp
+++ b/tests/unit-tests/UnsignedIntervalExhaustive_Test.cpp
@@ -34,12 +34,13 @@ THE SOFTWARE.
 // The perfect transfer functions are:
 //
 //   NOT, AND, OR, XOR (boolean), EQ, BVGT, BVSGT, ITE, BVNOT, BVUMINUS,
-//   BVSX, BVCONCAT, BVPLUS, BVDIV, BVRIGHTSHIFT, BVSRSHIFT
+//   BVSX, BVCONCAT, BVPLUS, BVDIV, BVRIGHTSHIFT, BVSRSHIFT,
+//   BVAND, BVOR, BVXOR (exact for two children; folded pairwise beyond)
 //
 // The over-approximating ones (marked OVER-APPROXIMATION in the source) are
 // only checked for soundness:
 //
-//   BVMOD, BVMULT, BVAND, BVOR, BVXOR, BVEXTRACT, BVLEFTSHIFT
+//   BVMOD, BVMULT, BVEXTRACT, BVLEFTSHIFT
 
 #include "stp/STPManager/STPManager.h"
 #include "stp/NodeFactory/SimplifyingNodeFactory.h"
@@ -344,19 +345,19 @@ TEST(UnsignedIntervalExhaustive, Mult)
 TEST(UnsignedIntervalExhaustive, Bvand)
 {
   for (unsigned w = 1; w <= 4; w++)
-    checkBinary(stp::BVAND, w, OVERAPPROXIMATES);
+    checkBinary(stp::BVAND, w, EXACT);
 }
 
 TEST(UnsignedIntervalExhaustive, Bvor)
 {
   for (unsigned w = 1; w <= 4; w++)
-    checkBinary(stp::BVOR, w, OVERAPPROXIMATES);
+    checkBinary(stp::BVOR, w, EXACT);
 }
 
 TEST(UnsignedIntervalExhaustive, Bvxor)
 {
   for (unsigned w = 1; w <= 4; w++)
-    checkBinary(stp::BVXOR, w, OVERAPPROXIMATES);
+    checkBinary(stp::BVXOR, w, EXACT);
 }
 
 TEST(UnsignedIntervalExhaustive, RightShift)

--- a/tests/unit-tests/UnsignedIntervalExhaustive_Test.cpp
+++ b/tests/unit-tests/UnsignedIntervalExhaustive_Test.cpp
@@ -1,0 +1,565 @@
+/***********
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+**********************/
+
+// Exhaustively checks that the interval transfer functions in
+// UnsignedIntervalAnalysis are sound at low bitwidths. For every interval
+// (or pair of intervals) of each width, the interval computed for the node
+// must contain the operation's result for every concrete value the children
+// can take. STP's constant evaluator provides the reference semantics, so
+// the tests can't drift from the solver's.
+//
+// A null result claims nothing, so it is always sound; these tests don't
+// check precision.
+
+#include "stp/STPManager/STPManager.h"
+#include "stp/NodeFactory/SimplifyingNodeFactory.h"
+#include "stp/Simplifier/Simplifier.h"
+#include "stp/Simplifier/UnsignedIntervalAnalysis.h"
+#include "stp/Simplifier/UnsignedInterval.h"
+#include <gtest/gtest.h>
+#include <vector>
+
+namespace
+{
+
+// BitVector_Boot must run before anything allocates constant bitvectors.
+struct Boot
+{
+  Boot() { CONSTANTBV::BitVector_Boot(); }
+};
+
+struct Context
+{
+  Boot boot;
+  stp::STPMgr mgr;
+  SimplifyingNodeFactory snf;
+  stp::UnsignedIntervalAnalysis analysis;
+
+  Context() : snf(*(mgr.hashingNodeFactory), mgr), analysis(mgr)
+  {
+    mgr.defaultNodeFactory = &snf;
+  }
+};
+
+stp::CBV makeCBV(unsigned width, uint64_t value)
+{
+  stp::CBV r = CONSTANTBV::BitVector_Create(width, true);
+  for (unsigned i = 0; i < width; i++)
+    if ((value >> i) & 1)
+      CONSTANTBV::BitVector_Bit_On(r, i);
+  return r;
+}
+
+stp::UnsignedInterval* makeInterval(unsigned width, uint64_t min, uint64_t max)
+{
+  return new stp::UnsignedInterval(makeCBV(width, min), makeCBV(width, max));
+}
+
+// The widths used here always fit into the first word of the bitvector.
+uint64_t cbvValue(const stp::CBV c, unsigned width)
+{
+  return *c & ((1ull << width) - 1);
+}
+
+uint64_t constantValue(const stp::ASTNode& n)
+{
+  if (n.GetKind() == stp::TRUE)
+    return 1;
+  if (n.GetKind() == stp::FALSE)
+    return 0;
+  return cbvValue(n.GetBVConst(), n.GetValueWidth());
+}
+
+void cleanup(std::vector<const stp::UnsignedInterval*>& children,
+             stp::UnsignedInterval* result)
+{
+  for (const auto* c : children)
+    delete c;
+  delete result;
+}
+
+// Checks that every value in [rmin, rmax] claimed for the node covers the
+// reference result. Reports and returns false on the first violation.
+bool covered(stp::Kind k, unsigned width, const stp::UnsignedInterval* result,
+             unsigned resultWidth, uint64_t reference, uint64_t a, uint64_t b)
+{
+  const uint64_t rmin = cbvValue(result->minV, resultWidth);
+  const uint64_t rmax = cbvValue(result->maxV, resultWidth);
+
+  if (reference < rmin || reference > rmax)
+  {
+    ADD_FAILURE() << "kind " << k << " at width " << width << ": operands ("
+                  << a << ", " << b << ") give " << reference
+                  << ", outside the computed interval [" << rmin << ", "
+                  << rmax << "]";
+    return false;
+  }
+  return true;
+}
+
+// Exhaustively checks a two-child operation: child widths w0 and w1, result
+// width wOut. Propositions (BVGT and friends) have a one-bit result.
+void checkBinary(stp::Kind k, unsigned w0, unsigned w1, unsigned wOut,
+                 bool isPredicate)
+{
+  Context c;
+  const uint64_t N0 = 1ull << w0;
+  const uint64_t N1 = 1ull << w1;
+
+  stp::ASTVec symbols;
+  symbols.push_back(c.mgr.CreateSymbol("x", 0, w0));
+  symbols.push_back(c.mgr.CreateSymbol("y", 0, w1));
+  const stp::ASTNode n =
+      isPredicate ? c.mgr.hashingNodeFactory->CreateNode(k, symbols)
+                  : c.mgr.hashingNodeFactory->CreateTerm(k, wOut, symbols);
+
+  // Reference results from the solver's constant evaluator.
+  std::vector<uint64_t> table(N0 * N1);
+  for (uint64_t a = 0; a < N0; a++)
+    for (uint64_t b = 0; b < N1; b++)
+    {
+      stp::ASTVec consts;
+      consts.push_back(c.mgr.CreateBVConst(w0, a));
+      consts.push_back(c.mgr.CreateBVConst(w1, b));
+      const stp::ASTNode op =
+          isPredicate ? c.mgr.hashingNodeFactory->CreateNode(k, consts)
+                      : c.mgr.hashingNodeFactory->CreateTerm(k, wOut, consts);
+      table[a * N1 + b] = constantValue(NonMemberBVConstEvaluator(&c.mgr, op));
+    }
+
+  const unsigned resultWidth = isPredicate ? 1 : wOut;
+
+  for (uint64_t lo0 = 0; lo0 < N0; lo0++)
+    for (uint64_t hi0 = lo0; hi0 < N0; hi0++)
+      for (uint64_t lo1 = 0; lo1 < N1; lo1++)
+        for (uint64_t hi1 = lo1; hi1 < N1; hi1++)
+        {
+          std::vector<const stp::UnsignedInterval*> children = {
+              makeInterval(w0, lo0, hi0), makeInterval(w1, lo1, hi1)};
+          stp::UnsignedInterval* result =
+              c.analysis.dispatchToTransferFunctions(n, children);
+
+          if (result != nullptr)
+            for (uint64_t a = lo0; a <= hi0; a++)
+              for (uint64_t b = lo1; b <= hi1; b++)
+                if (!covered(k, w0, result, resultWidth, table[a * N1 + b], a,
+                             b))
+                {
+                  cleanup(children, result);
+                  return;
+                }
+
+          cleanup(children, result);
+        }
+}
+
+void checkBinary(stp::Kind k, unsigned width)
+{
+  checkBinary(k, width, width, width, false);
+}
+
+void checkPredicate(stp::Kind k, unsigned width)
+{
+  checkBinary(k, width, width, 1, true);
+}
+
+void checkUnary(stp::Kind k, unsigned width)
+{
+  Context c;
+  const uint64_t N = 1ull << width;
+
+  stp::ASTVec symbols;
+  symbols.push_back(c.mgr.CreateSymbol("x", 0, width));
+  const stp::ASTNode n =
+      c.mgr.hashingNodeFactory->CreateTerm(k, width, symbols);
+
+  std::vector<uint64_t> table(N);
+  for (uint64_t a = 0; a < N; a++)
+  {
+    stp::ASTVec consts;
+    consts.push_back(c.mgr.CreateBVConst(width, a));
+    const stp::ASTNode op =
+        c.mgr.hashingNodeFactory->CreateTerm(k, width, consts);
+    table[a] = constantValue(NonMemberBVConstEvaluator(&c.mgr, op));
+  }
+
+  for (uint64_t lo = 0; lo < N; lo++)
+    for (uint64_t hi = lo; hi < N; hi++)
+    {
+      std::vector<const stp::UnsignedInterval*> children = {
+          makeInterval(width, lo, hi)};
+      stp::UnsignedInterval* result =
+          c.analysis.dispatchToTransferFunctions(n, children);
+
+      if (result != nullptr)
+        for (uint64_t a = lo; a <= hi; a++)
+          if (!covered(k, width, result, width, table[a], a, 0))
+          {
+            cleanup(children, result);
+            return;
+          }
+
+      cleanup(children, result);
+    }
+}
+
+TEST(UnsignedIntervalExhaustive, Udiv)
+{
+  for (unsigned w = 1; w <= 4; w++)
+    checkBinary(stp::BVDIV, w);
+}
+
+TEST(UnsignedIntervalExhaustive, Urem)
+{
+  for (unsigned w = 1; w <= 4; w++)
+    checkBinary(stp::BVMOD, w);
+}
+
+TEST(UnsignedIntervalExhaustive, SignedDivRemMod)
+{
+  // Not implemented yet (always null), but keeps them covered if they are.
+  for (unsigned w = 1; w <= 4; w++)
+  {
+    checkBinary(stp::SBVDIV, w);
+    checkBinary(stp::SBVREM, w);
+    checkBinary(stp::SBVMOD, w);
+  }
+}
+
+TEST(UnsignedIntervalExhaustive, Plus)
+{
+  for (unsigned w = 1; w <= 4; w++)
+    checkBinary(stp::BVPLUS, w);
+}
+
+TEST(UnsignedIntervalExhaustive, Mult)
+{
+  for (unsigned w = 1; w <= 4; w++)
+    checkBinary(stp::BVMULT, w);
+}
+
+TEST(UnsignedIntervalExhaustive, Bvand)
+{
+  for (unsigned w = 1; w <= 4; w++)
+    checkBinary(stp::BVAND, w);
+}
+
+TEST(UnsignedIntervalExhaustive, Bvor)
+{
+  for (unsigned w = 1; w <= 4; w++)
+    checkBinary(stp::BVOR, w);
+}
+
+TEST(UnsignedIntervalExhaustive, Bvxor)
+{
+  for (unsigned w = 1; w <= 4; w++)
+    checkBinary(stp::BVXOR, w);
+}
+
+TEST(UnsignedIntervalExhaustive, RightShift)
+{
+  for (unsigned w = 1; w <= 4; w++)
+    checkBinary(stp::BVRIGHTSHIFT, w);
+}
+
+TEST(UnsignedIntervalExhaustive, LeftShift)
+{
+  for (unsigned w = 1; w <= 4; w++)
+    checkBinary(stp::BVLEFTSHIFT, w);
+}
+
+TEST(UnsignedIntervalExhaustive, SignedRightShift)
+{
+  for (unsigned w = 1; w <= 4; w++)
+    checkBinary(stp::BVSRSHIFT, w);
+}
+
+TEST(UnsignedIntervalExhaustive, Concat)
+{
+  for (unsigned w0 = 1; w0 <= 3; w0++)
+    for (unsigned w1 = 1; w1 <= 3; w1++)
+      checkBinary(stp::BVCONCAT, w0, w1, w0 + w1, false);
+}
+
+TEST(UnsignedIntervalExhaustive, Bvgt)
+{
+  for (unsigned w = 1; w <= 4; w++)
+    checkPredicate(stp::BVGT, w);
+}
+
+TEST(UnsignedIntervalExhaustive, Bvsgt)
+{
+  for (unsigned w = 1; w <= 4; w++)
+    checkPredicate(stp::BVSGT, w);
+}
+
+TEST(UnsignedIntervalExhaustive, Eq)
+{
+  for (unsigned w = 1; w <= 4; w++)
+    checkPredicate(stp::EQ, w);
+}
+
+TEST(UnsignedIntervalExhaustive, Bvnot)
+{
+  for (unsigned w = 1; w <= 5; w++)
+    checkUnary(stp::BVNOT, w);
+}
+
+TEST(UnsignedIntervalExhaustive, Bvuminus)
+{
+  for (unsigned w = 1; w <= 5; w++)
+    checkUnary(stp::BVUMINUS, w);
+}
+
+TEST(UnsignedIntervalExhaustive, Bvsx)
+{
+  for (unsigned wIn = 1; wIn <= 3; wIn++)
+    for (unsigned wOut = wIn + 1; wOut <= 5; wOut++)
+    {
+      Context c;
+      const uint64_t N = 1ull << wIn;
+
+      stp::ASTVec symbols;
+      symbols.push_back(c.mgr.CreateSymbol("x", 0, wIn));
+      symbols.push_back(c.mgr.CreateBVConst(32, wOut));
+      const stp::ASTNode n =
+          c.mgr.hashingNodeFactory->CreateTerm(stp::BVSX, wOut, symbols);
+
+      std::vector<uint64_t> table(N);
+      for (uint64_t a = 0; a < N; a++)
+      {
+        stp::ASTVec consts;
+        consts.push_back(c.mgr.CreateBVConst(wIn, a));
+        consts.push_back(c.mgr.CreateBVConst(32, wOut));
+        const stp::ASTNode op =
+            c.mgr.hashingNodeFactory->CreateTerm(stp::BVSX, wOut, consts);
+        table[a] = constantValue(NonMemberBVConstEvaluator(&c.mgr, op));
+      }
+
+      for (uint64_t lo = 0; lo < N; lo++)
+        for (uint64_t hi = lo; hi < N; hi++)
+        {
+          std::vector<const stp::UnsignedInterval*> children = {
+              makeInterval(wIn, lo, hi), nullptr};
+          stp::UnsignedInterval* result =
+              c.analysis.dispatchToTransferFunctions(n, children);
+
+          if (result != nullptr)
+            for (uint64_t a = lo; a <= hi; a++)
+              if (!covered(stp::BVSX, wIn, result, wOut, table[a], a, wOut))
+              {
+                cleanup(children, result);
+                return;
+              }
+
+          cleanup(children, result);
+        }
+    }
+}
+
+TEST(UnsignedIntervalExhaustive, Extract)
+{
+  for (unsigned w = 1; w <= 4; w++)
+    for (unsigned lo = 0; lo < w; lo++)
+      for (unsigned hi = lo; hi < w; hi++)
+      {
+        Context c;
+        const uint64_t N = 1ull << w;
+        const unsigned wOut = hi - lo + 1;
+
+        stp::ASTVec symbols;
+        symbols.push_back(c.mgr.CreateSymbol("x", 0, w));
+        symbols.push_back(c.mgr.CreateBVConst(32, hi));
+        symbols.push_back(c.mgr.CreateBVConst(32, lo));
+        const stp::ASTNode n =
+            c.mgr.hashingNodeFactory->CreateTerm(stp::BVEXTRACT, wOut,
+                                                 symbols);
+
+        std::vector<uint64_t> table(N);
+        for (uint64_t a = 0; a < N; a++)
+        {
+          stp::ASTVec consts;
+          consts.push_back(c.mgr.CreateBVConst(w, a));
+          consts.push_back(c.mgr.CreateBVConst(32, hi));
+          consts.push_back(c.mgr.CreateBVConst(32, lo));
+          const stp::ASTNode op = c.mgr.hashingNodeFactory->CreateTerm(
+              stp::BVEXTRACT, wOut, consts);
+          table[a] = constantValue(NonMemberBVConstEvaluator(&c.mgr, op));
+        }
+
+        for (uint64_t lo0 = 0; lo0 < N; lo0++)
+          for (uint64_t hi0 = lo0; hi0 < N; hi0++)
+          {
+            std::vector<const stp::UnsignedInterval*> children = {
+                makeInterval(w, lo0, hi0), makeInterval(32, hi, hi),
+                makeInterval(32, lo, lo)};
+            stp::UnsignedInterval* result =
+                c.analysis.dispatchToTransferFunctions(n, children);
+
+            if (result != nullptr)
+              for (uint64_t a = lo0; a <= hi0; a++)
+                if (!covered(stp::BVEXTRACT, w, result, wOut, table[a], a,
+                             lo))
+                {
+                  cleanup(children, result);
+                  return;
+                }
+
+            cleanup(children, result);
+          }
+      }
+}
+
+TEST(UnsignedIntervalExhaustive, Ite)
+{
+  for (unsigned w = 1; w <= 4; w++)
+  {
+    Context c;
+    const uint64_t N = 1ull << w;
+
+    stp::ASTVec symbols;
+    symbols.push_back(c.mgr.CreateSymbol("c", 0, 0));
+    symbols.push_back(c.mgr.CreateSymbol("x", 0, w));
+    symbols.push_back(c.mgr.CreateSymbol("y", 0, w));
+    const stp::ASTNode n =
+        c.mgr.hashingNodeFactory->CreateTerm(stp::ITE, w, symbols);
+
+    // Condition alternatives: unknown, false, true; with the concrete
+    // condition values each allows.
+    const std::vector<std::vector<uint64_t>> condValues = {{0, 1}, {0}, {1}};
+
+    for (unsigned condChoice = 0; condChoice < 3; condChoice++)
+      for (uint64_t lo1 = 0; lo1 < N; lo1++)
+        for (uint64_t hi1 = lo1; hi1 < N; hi1++)
+          for (uint64_t lo2 = 0; lo2 < N; lo2++)
+            for (uint64_t hi2 = lo2; hi2 < N; hi2++)
+            {
+              const stp::UnsignedInterval* cond = nullptr;
+              if (condChoice == 1)
+                cond = makeInterval(1, 0, 0);
+              else if (condChoice == 2)
+                cond = makeInterval(1, 1, 1);
+
+              std::vector<const stp::UnsignedInterval*> children = {
+                  cond, makeInterval(w, lo1, hi1), makeInterval(w, lo2, hi2)};
+              stp::UnsignedInterval* result =
+                  c.analysis.dispatchToTransferFunctions(n, children);
+
+              if (result != nullptr)
+                for (const uint64_t condV : condValues[condChoice])
+                  for (uint64_t a = lo1; a <= hi1; a++)
+                    for (uint64_t b = lo2; b <= hi2; b++)
+                    {
+                      const uint64_t v = condV ? a : b;
+                      if (!covered(stp::ITE, w, result, w, v, a, b))
+                      {
+                        cleanup(children, result);
+                        return;
+                      }
+                    }
+
+              cleanup(children, result);
+            }
+  }
+}
+
+TEST(UnsignedIntervalExhaustive, BooleanOps)
+{
+  Context c;
+
+  stp::ASTVec symbols;
+  symbols.push_back(c.mgr.CreateSymbol("a", 0, 0));
+  symbols.push_back(c.mgr.CreateSymbol("b", 0, 0));
+
+  struct Op
+  {
+    stp::Kind kind;
+    uint64_t (*eval)(uint64_t, uint64_t);
+  };
+  const std::vector<Op> ops = {
+      {stp::AND, [](uint64_t a, uint64_t b) { return a & b; }},
+      {stp::OR, [](uint64_t a, uint64_t b) { return a | b; }},
+      {stp::XOR, [](uint64_t a, uint64_t b) { return a ^ b; }},
+  };
+
+  // Boolean alternatives: unknown, false, true; with the concrete values
+  // each allows.
+  const std::vector<std::vector<uint64_t>> boolValues = {{0, 1}, {0}, {1}};
+
+  for (const auto& op : ops)
+  {
+    const stp::ASTNode n =
+        c.mgr.hashingNodeFactory->CreateNode(op.kind, symbols);
+
+    for (unsigned choice0 = 0; choice0 < 3; choice0++)
+      for (unsigned choice1 = 0; choice1 < 3; choice1++)
+      {
+        const stp::UnsignedInterval* i0 =
+            choice0 == 0 ? nullptr : makeInterval(1, choice0 - 1, choice0 - 1);
+        const stp::UnsignedInterval* i1 =
+            choice1 == 0 ? nullptr : makeInterval(1, choice1 - 1, choice1 - 1);
+
+        std::vector<const stp::UnsignedInterval*> children = {i0, i1};
+        stp::UnsignedInterval* result =
+            c.analysis.dispatchToTransferFunctions(n, children);
+
+        if (result != nullptr)
+          for (const uint64_t a : boolValues[choice0])
+            for (const uint64_t b : boolValues[choice1])
+              if (!covered(op.kind, 1, result, 1, op.eval(a, b), a, b))
+              {
+                cleanup(children, result);
+                return;
+              }
+
+        cleanup(children, result);
+      }
+  }
+
+  // Boolean NOT.
+  {
+    stp::ASTVec child;
+    child.push_back(symbols[0]);
+    const stp::ASTNode n =
+        c.mgr.hashingNodeFactory->CreateNode(stp::NOT, child);
+
+    for (unsigned choice = 0; choice < 3; choice++)
+    {
+      const stp::UnsignedInterval* i0 =
+          choice == 0 ? nullptr : makeInterval(1, choice - 1, choice - 1);
+
+      std::vector<const stp::UnsignedInterval*> children = {i0};
+      stp::UnsignedInterval* result =
+          c.analysis.dispatchToTransferFunctions(n, children);
+
+      if (result != nullptr)
+        for (const uint64_t a : boolValues[choice])
+          if (!covered(stp::NOT, 1, result, 1, a ^ 1, a, 0))
+          {
+            cleanup(children, result);
+            return;
+          }
+
+      cleanup(children, result);
+    }
+  }
+}
+
+} // namespace

--- a/tests/unit-tests/UnsignedIntervalExhaustive_Test.cpp
+++ b/tests/unit-tests/UnsignedIntervalExhaustive_Test.cpp
@@ -34,13 +34,14 @@ THE SOFTWARE.
 // The perfect transfer functions are:
 //
 //   NOT, AND, OR, XOR (boolean), EQ, BVGT, BVSGT, ITE, BVNOT, BVUMINUS,
-//   BVSX, BVCONCAT, BVEXTRACT, BVPLUS, BVDIV, BVRIGHTSHIFT, BVSRSHIFT,
-//   BVAND, BVOR, BVXOR (exact for two children; folded pairwise beyond)
+//   BVSX, BVCONCAT, BVEXTRACT, BVPLUS, BVDIV, BVRIGHTSHIFT, BVLEFTSHIFT,
+//   BVSRSHIFT, BVAND, BVOR, BVXOR (bitwise ones exact for two children;
+//   folded pairwise beyond)
 //
 // The over-approximating ones (marked OVER-APPROXIMATION in the source) are
 // only checked for soundness:
 //
-//   BVMOD, BVMULT, BVLEFTSHIFT
+//   BVMOD, BVMULT
 
 #include "stp/STPManager/STPManager.h"
 #include "stp/NodeFactory/SimplifyingNodeFactory.h"
@@ -369,7 +370,7 @@ TEST(UnsignedIntervalExhaustive, RightShift)
 TEST(UnsignedIntervalExhaustive, LeftShift)
 {
   for (unsigned w = 1; w <= 4; w++)
-    checkBinary(stp::BVLEFTSHIFT, w, OVERAPPROXIMATES);
+    checkBinary(stp::BVLEFTSHIFT, w, EXACT);
 }
 
 TEST(UnsignedIntervalExhaustive, SignedRightShift)

--- a/tests/unit-tests/UnsignedIntervalExhaustive_Test.cpp
+++ b/tests/unit-tests/UnsignedIntervalExhaustive_Test.cpp
@@ -18,15 +18,28 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 **********************/
 
-// Exhaustively checks that the interval transfer functions in
-// UnsignedIntervalAnalysis are sound at low bitwidths. For every interval
-// (or pair of intervals) of each width, the interval computed for the node
-// must contain the operation's result for every concrete value the children
-// can take. STP's constant evaluator provides the reference semantics, so
+// Exhaustively checks the interval transfer functions in
+// UnsignedIntervalAnalysis at low bitwidths. For every interval (or pair of
+// intervals) of each width, the brute-force hull -- the smallest interval
+// containing the operation's result for every concrete value the children
+// can take -- is compared against the interval the transfer function
+// computes. STP's constant evaluator provides the reference semantics, so
 // the tests can't drift from the solver's.
 //
-// A null result claims nothing, so it is always sound; these tests don't
-// check precision.
+// Every transfer function must be sound: the computed interval must contain
+// the hull (a null result claims nothing, so it is always sound).
+//
+// The perfect transfer functions must also be exact: the computed interval
+// must equal the hull, and must only be null when the hull is complete.
+// The perfect transfer functions are:
+//
+//   NOT, AND, OR, XOR (boolean), EQ, BVGT, BVSGT, ITE, BVNOT, BVUMINUS,
+//   BVSX, BVCONCAT, BVPLUS, BVDIV, BVRIGHTSHIFT, BVSRSHIFT
+//
+// The over-approximating ones (marked OVER-APPROXIMATION in the source) are
+// only checked for soundness:
+//
+//   BVMOD, BVMULT, BVAND, BVOR, BVXOR, BVEXTRACT, BVLEFTSHIFT
 
 #include "stp/STPManager/STPManager.h"
 #include "stp/NodeFactory/SimplifyingNodeFactory.h"
@@ -38,6 +51,9 @@ THE SOFTWARE.
 
 namespace
 {
+
+const bool EXACT = true;
+const bool OVERAPPROXIMATES = false;
 
 // BitVector_Boot must run before anything allocates constant bitvectors.
 struct Boot
@@ -95,29 +111,55 @@ void cleanup(std::vector<const stp::UnsignedInterval*>& children,
   delete result;
 }
 
-// Checks that every value in [rmin, rmax] claimed for the node covers the
-// reference result. Reports and returns false on the first violation.
-bool covered(stp::Kind k, unsigned width, const stp::UnsignedInterval* result,
-             unsigned resultWidth, uint64_t reference, uint64_t a, uint64_t b)
+// Compares the computed interval against the brute-force hull
+// [bruteMin, bruteMax]. Containment of every reachable value is equivalent
+// to containment of the hull, because the hull's ends are reachable.
+// Reports and returns false on a problem.
+bool checkAgainstHull(stp::Kind k, unsigned width,
+                      const stp::UnsignedInterval* result,
+                      unsigned resultWidth, uint64_t bruteMin,
+                      uint64_t bruteMax, bool exact)
 {
+  const uint64_t fullMax = (1ull << resultWidth) - 1;
+
+  if (result == nullptr)
+  {
+    if (exact && !(bruteMin == 0 && bruteMax == fullMax))
+    {
+      ADD_FAILURE() << "kind " << k << " at width " << width
+                    << ": nothing was computed, but the exact result is ["
+                    << bruteMin << ", " << bruteMax << "]";
+      return false;
+    }
+    return true;
+  }
+
   const uint64_t rmin = cbvValue(result->minV, resultWidth);
   const uint64_t rmax = cbvValue(result->maxV, resultWidth);
 
-  if (reference < rmin || reference > rmax)
+  if (bruteMin < rmin || bruteMax > rmax)
   {
-    ADD_FAILURE() << "kind " << k << " at width " << width << ": operands ("
-                  << a << ", " << b << ") give " << reference
-                  << ", outside the computed interval [" << rmin << ", "
-                  << rmax << "]";
+    ADD_FAILURE() << "kind " << k << " at width " << width << ": UNSOUND: ["
+                  << rmin << ", " << rmax << "] was computed, but ["
+                  << bruteMin << ", " << bruteMax << "] is reachable";
     return false;
   }
+
+  if (exact && (bruteMin != rmin || bruteMax != rmax))
+  {
+    ADD_FAILURE() << "kind " << k << " at width " << width << ": [" << rmin
+                  << ", " << rmax << "] was computed, but the exact result is"
+                  << " [" << bruteMin << ", " << bruteMax << "]";
+    return false;
+  }
+
   return true;
 }
 
 // Exhaustively checks a two-child operation: child widths w0 and w1, result
 // width wOut. Propositions (BVGT and friends) have a one-bit result.
 void checkBinary(stp::Kind k, unsigned w0, unsigned w1, unsigned wOut,
-                 bool isPredicate)
+                 bool isPredicate, bool exact)
 {
   Context c;
   const uint64_t N0 = 1ull << w0;
@@ -146,41 +188,67 @@ void checkBinary(stp::Kind k, unsigned w0, unsigned w1, unsigned wOut,
 
   const unsigned resultWidth = isPredicate ? 1 : wOut;
 
-  for (uint64_t lo0 = 0; lo0 < N0; lo0++)
-    for (uint64_t hi0 = lo0; hi0 < N0; hi0++)
-      for (uint64_t lo1 = 0; lo1 < N1; lo1++)
-        for (uint64_t hi1 = lo1; hi1 < N1; hi1++)
+  // Every interval of the width, plus "unknown" (a null child). The
+  // transfer functions treat unknown children specially, so it exercises
+  // different paths than the complete interval does.
+  struct Choice
+  {
+    bool isNull;
+    uint64_t lo, hi;
+  };
+  const auto choicesFor = [](uint64_t N) {
+    std::vector<Choice> choices;
+    choices.push_back({true, 0, N - 1});
+    for (uint64_t lo = 0; lo < N; lo++)
+      for (uint64_t hi = lo; hi < N; hi++)
+        choices.push_back({false, lo, hi});
+    return choices;
+  };
+
+  for (const Choice& c0 : choicesFor(N0))
+    for (const Choice& c1 : choicesFor(N1))
+    {
+      uint64_t bruteMin = UINT64_MAX, bruteMax = 0;
+      for (uint64_t a = c0.lo; a <= c0.hi; a++)
+        for (uint64_t b = c1.lo; b <= c1.hi; b++)
         {
-          std::vector<const stp::UnsignedInterval*> children = {
-              makeInterval(w0, lo0, hi0), makeInterval(w1, lo1, hi1)};
-          stp::UnsignedInterval* result =
-              c.analysis.dispatchToTransferFunctions(n, children);
-
-          if (result != nullptr)
-            for (uint64_t a = lo0; a <= hi0; a++)
-              for (uint64_t b = lo1; b <= hi1; b++)
-                if (!covered(k, w0, result, resultWidth, table[a * N1 + b], a,
-                             b))
-                {
-                  cleanup(children, result);
-                  return;
-                }
-
-          cleanup(children, result);
+          const uint64_t v = table[a * N1 + b];
+          bruteMin = std::min(bruteMin, v);
+          bruteMax = std::max(bruteMax, v);
         }
+
+      std::vector<const stp::UnsignedInterval*> children = {
+          c0.isNull ? nullptr : makeInterval(w0, c0.lo, c0.hi),
+          c1.isNull ? nullptr : makeInterval(w1, c1.lo, c1.hi)};
+      stp::UnsignedInterval* result =
+          c.analysis.dispatchToTransferFunctions(n, children);
+
+      const bool good = checkAgainstHull(k, w0, result, resultWidth, bruteMin,
+                                         bruteMax, exact);
+      cleanup(children, result);
+      if (!good)
+      {
+        ADD_FAILURE() << "children were "
+                      << (c0.isNull ? "unknown" : "known") << " [" << c0.lo
+                      << ", " << c0.hi << "] and "
+                      << (c1.isNull ? "unknown" : "known") << " [" << c1.lo
+                      << ", " << c1.hi << "]";
+        return;
+      }
+    }
 }
 
-void checkBinary(stp::Kind k, unsigned width)
+void checkBinary(stp::Kind k, unsigned width, bool exact)
 {
-  checkBinary(k, width, width, width, false);
+  checkBinary(k, width, width, width, false, exact);
 }
 
-void checkPredicate(stp::Kind k, unsigned width)
+void checkPredicate(stp::Kind k, unsigned width, bool exact)
 {
-  checkBinary(k, width, width, 1, true);
+  checkBinary(k, width, width, 1, true, exact);
 }
 
-void checkUnary(stp::Kind k, unsigned width)
+void checkUnary(stp::Kind k, unsigned width, bool exact)
 {
   Context c;
   const uint64_t N = 1ull << width;
@@ -200,36 +268,54 @@ void checkUnary(stp::Kind k, unsigned width)
     table[a] = constantValue(NonMemberBVConstEvaluator(&c.mgr, op));
   }
 
+  // Every interval of the width, plus "unknown" (a null child).
+  struct Choice
+  {
+    bool isNull;
+    uint64_t lo, hi;
+  };
+  std::vector<Choice> choices;
+  choices.push_back({true, 0, N - 1});
   for (uint64_t lo = 0; lo < N; lo++)
     for (uint64_t hi = lo; hi < N; hi++)
+      choices.push_back({false, lo, hi});
+
+  for (const Choice& c0 : choices)
+  {
+    uint64_t bruteMin = UINT64_MAX, bruteMax = 0;
+    for (uint64_t a = c0.lo; a <= c0.hi; a++)
     {
-      std::vector<const stp::UnsignedInterval*> children = {
-          makeInterval(width, lo, hi)};
-      stp::UnsignedInterval* result =
-          c.analysis.dispatchToTransferFunctions(n, children);
-
-      if (result != nullptr)
-        for (uint64_t a = lo; a <= hi; a++)
-          if (!covered(k, width, result, width, table[a], a, 0))
-          {
-            cleanup(children, result);
-            return;
-          }
-
-      cleanup(children, result);
+      bruteMin = std::min(bruteMin, table[a]);
+      bruteMax = std::max(bruteMax, table[a]);
     }
+
+    std::vector<const stp::UnsignedInterval*> children = {
+        c0.isNull ? nullptr : makeInterval(width, c0.lo, c0.hi)};
+    stp::UnsignedInterval* result =
+        c.analysis.dispatchToTransferFunctions(n, children);
+
+    const bool good =
+        checkAgainstHull(k, width, result, width, bruteMin, bruteMax, exact);
+    cleanup(children, result);
+    if (!good)
+    {
+      ADD_FAILURE() << "child was " << (c0.isNull ? "unknown" : "known")
+                    << " [" << c0.lo << ", " << c0.hi << "]";
+      return;
+    }
+  }
 }
 
 TEST(UnsignedIntervalExhaustive, Udiv)
 {
   for (unsigned w = 1; w <= 4; w++)
-    checkBinary(stp::BVDIV, w);
+    checkBinary(stp::BVDIV, w, EXACT);
 }
 
 TEST(UnsignedIntervalExhaustive, Urem)
 {
   for (unsigned w = 1; w <= 4; w++)
-    checkBinary(stp::BVMOD, w);
+    checkBinary(stp::BVMOD, w, OVERAPPROXIMATES);
 }
 
 TEST(UnsignedIntervalExhaustive, SignedDivRemMod)
@@ -237,95 +323,95 @@ TEST(UnsignedIntervalExhaustive, SignedDivRemMod)
   // Not implemented yet (always null), but keeps them covered if they are.
   for (unsigned w = 1; w <= 4; w++)
   {
-    checkBinary(stp::SBVDIV, w);
-    checkBinary(stp::SBVREM, w);
-    checkBinary(stp::SBVMOD, w);
+    checkBinary(stp::SBVDIV, w, OVERAPPROXIMATES);
+    checkBinary(stp::SBVREM, w, OVERAPPROXIMATES);
+    checkBinary(stp::SBVMOD, w, OVERAPPROXIMATES);
   }
 }
 
 TEST(UnsignedIntervalExhaustive, Plus)
 {
   for (unsigned w = 1; w <= 4; w++)
-    checkBinary(stp::BVPLUS, w);
+    checkBinary(stp::BVPLUS, w, EXACT);
 }
 
 TEST(UnsignedIntervalExhaustive, Mult)
 {
   for (unsigned w = 1; w <= 4; w++)
-    checkBinary(stp::BVMULT, w);
+    checkBinary(stp::BVMULT, w, OVERAPPROXIMATES);
 }
 
 TEST(UnsignedIntervalExhaustive, Bvand)
 {
   for (unsigned w = 1; w <= 4; w++)
-    checkBinary(stp::BVAND, w);
+    checkBinary(stp::BVAND, w, OVERAPPROXIMATES);
 }
 
 TEST(UnsignedIntervalExhaustive, Bvor)
 {
   for (unsigned w = 1; w <= 4; w++)
-    checkBinary(stp::BVOR, w);
+    checkBinary(stp::BVOR, w, OVERAPPROXIMATES);
 }
 
 TEST(UnsignedIntervalExhaustive, Bvxor)
 {
   for (unsigned w = 1; w <= 4; w++)
-    checkBinary(stp::BVXOR, w);
+    checkBinary(stp::BVXOR, w, OVERAPPROXIMATES);
 }
 
 TEST(UnsignedIntervalExhaustive, RightShift)
 {
   for (unsigned w = 1; w <= 4; w++)
-    checkBinary(stp::BVRIGHTSHIFT, w);
+    checkBinary(stp::BVRIGHTSHIFT, w, EXACT);
 }
 
 TEST(UnsignedIntervalExhaustive, LeftShift)
 {
   for (unsigned w = 1; w <= 4; w++)
-    checkBinary(stp::BVLEFTSHIFT, w);
+    checkBinary(stp::BVLEFTSHIFT, w, OVERAPPROXIMATES);
 }
 
 TEST(UnsignedIntervalExhaustive, SignedRightShift)
 {
   for (unsigned w = 1; w <= 4; w++)
-    checkBinary(stp::BVSRSHIFT, w);
+    checkBinary(stp::BVSRSHIFT, w, EXACT);
 }
 
 TEST(UnsignedIntervalExhaustive, Concat)
 {
   for (unsigned w0 = 1; w0 <= 3; w0++)
     for (unsigned w1 = 1; w1 <= 3; w1++)
-      checkBinary(stp::BVCONCAT, w0, w1, w0 + w1, false);
+      checkBinary(stp::BVCONCAT, w0, w1, w0 + w1, false, EXACT);
 }
 
 TEST(UnsignedIntervalExhaustive, Bvgt)
 {
   for (unsigned w = 1; w <= 4; w++)
-    checkPredicate(stp::BVGT, w);
+    checkPredicate(stp::BVGT, w, EXACT);
 }
 
 TEST(UnsignedIntervalExhaustive, Bvsgt)
 {
   for (unsigned w = 1; w <= 4; w++)
-    checkPredicate(stp::BVSGT, w);
+    checkPredicate(stp::BVSGT, w, EXACT);
 }
 
 TEST(UnsignedIntervalExhaustive, Eq)
 {
   for (unsigned w = 1; w <= 4; w++)
-    checkPredicate(stp::EQ, w);
+    checkPredicate(stp::EQ, w, EXACT);
 }
 
 TEST(UnsignedIntervalExhaustive, Bvnot)
 {
   for (unsigned w = 1; w <= 5; w++)
-    checkUnary(stp::BVNOT, w);
+    checkUnary(stp::BVNOT, w, EXACT);
 }
 
 TEST(UnsignedIntervalExhaustive, Bvuminus)
 {
   for (unsigned w = 1; w <= 5; w++)
-    checkUnary(stp::BVUMINUS, w);
+    checkUnary(stp::BVUMINUS, w, EXACT);
 }
 
 TEST(UnsignedIntervalExhaustive, Bvsx)
@@ -356,20 +442,27 @@ TEST(UnsignedIntervalExhaustive, Bvsx)
       for (uint64_t lo = 0; lo < N; lo++)
         for (uint64_t hi = lo; hi < N; hi++)
         {
+          uint64_t bruteMin = UINT64_MAX, bruteMax = 0;
+          for (uint64_t a = lo; a <= hi; a++)
+          {
+            bruteMin = std::min(bruteMin, table[a]);
+            bruteMax = std::max(bruteMax, table[a]);
+          }
+
           std::vector<const stp::UnsignedInterval*> children = {
               makeInterval(wIn, lo, hi), nullptr};
           stp::UnsignedInterval* result =
               c.analysis.dispatchToTransferFunctions(n, children);
 
-          if (result != nullptr)
-            for (uint64_t a = lo; a <= hi; a++)
-              if (!covered(stp::BVSX, wIn, result, wOut, table[a], a, wOut))
-              {
-                cleanup(children, result);
-                return;
-              }
-
+          const bool good = checkAgainstHull(stp::BVSX, wIn, result, wOut,
+                                             bruteMin, bruteMax, EXACT);
           cleanup(children, result);
+          if (!good)
+          {
+            ADD_FAILURE() << "child was [" << lo << ", " << hi
+                          << "], extended to width " << wOut;
+            return;
+          }
         }
     }
 }
@@ -388,9 +481,8 @@ TEST(UnsignedIntervalExhaustive, Extract)
         symbols.push_back(c.mgr.CreateSymbol("x", 0, w));
         symbols.push_back(c.mgr.CreateBVConst(32, hi));
         symbols.push_back(c.mgr.CreateBVConst(32, lo));
-        const stp::ASTNode n =
-            c.mgr.hashingNodeFactory->CreateTerm(stp::BVEXTRACT, wOut,
-                                                 symbols);
+        const stp::ASTNode n = c.mgr.hashingNodeFactory->CreateTerm(
+            stp::BVEXTRACT, wOut, symbols);
 
         std::vector<uint64_t> table(N);
         for (uint64_t a = 0; a < N; a++)
@@ -407,22 +499,29 @@ TEST(UnsignedIntervalExhaustive, Extract)
         for (uint64_t lo0 = 0; lo0 < N; lo0++)
           for (uint64_t hi0 = lo0; hi0 < N; hi0++)
           {
+            uint64_t bruteMin = UINT64_MAX, bruteMax = 0;
+            for (uint64_t a = lo0; a <= hi0; a++)
+            {
+              bruteMin = std::min(bruteMin, table[a]);
+              bruteMax = std::max(bruteMax, table[a]);
+            }
+
             std::vector<const stp::UnsignedInterval*> children = {
                 makeInterval(w, lo0, hi0), makeInterval(32, hi, hi),
                 makeInterval(32, lo, lo)};
             stp::UnsignedInterval* result =
                 c.analysis.dispatchToTransferFunctions(n, children);
 
-            if (result != nullptr)
-              for (uint64_t a = lo0; a <= hi0; a++)
-                if (!covered(stp::BVEXTRACT, w, result, wOut, table[a], a,
-                             lo))
-                {
-                  cleanup(children, result);
-                  return;
-                }
-
+            const bool good =
+                checkAgainstHull(stp::BVEXTRACT, w, result, wOut, bruteMin,
+                                 bruteMax, OVERAPPROXIMATES);
             cleanup(children, result);
+            if (!good)
+            {
+              ADD_FAILURE() << "child was [" << lo0 << ", " << hi0
+                            << "], extracting [" << hi << ":" << lo << "]";
+              return;
+            }
           }
       }
 }
@@ -451,6 +550,15 @@ TEST(UnsignedIntervalExhaustive, Ite)
           for (uint64_t lo2 = 0; lo2 < N; lo2++)
             for (uint64_t hi2 = lo2; hi2 < N; hi2++)
             {
+              uint64_t bruteMin = UINT64_MAX, bruteMax = 0;
+              for (const uint64_t condV : condValues[condChoice])
+              {
+                const uint64_t lo = condV ? lo1 : lo2;
+                const uint64_t hi = condV ? hi1 : hi2;
+                bruteMin = std::min(bruteMin, lo);
+                bruteMax = std::max(bruteMax, hi);
+              }
+
               const stp::UnsignedInterval* cond = nullptr;
               if (condChoice == 1)
                 cond = makeInterval(1, 0, 0);
@@ -462,20 +570,16 @@ TEST(UnsignedIntervalExhaustive, Ite)
               stp::UnsignedInterval* result =
                   c.analysis.dispatchToTransferFunctions(n, children);
 
-              if (result != nullptr)
-                for (const uint64_t condV : condValues[condChoice])
-                  for (uint64_t a = lo1; a <= hi1; a++)
-                    for (uint64_t b = lo2; b <= hi2; b++)
-                    {
-                      const uint64_t v = condV ? a : b;
-                      if (!covered(stp::ITE, w, result, w, v, a, b))
-                      {
-                        cleanup(children, result);
-                        return;
-                      }
-                    }
-
+              const bool good = checkAgainstHull(stp::ITE, w, result, w,
+                                                 bruteMin, bruteMax, EXACT);
               cleanup(children, result);
+              if (!good)
+              {
+                ADD_FAILURE() << "condition choice " << condChoice
+                              << ", branches [" << lo1 << ", " << hi1
+                              << "] and [" << lo2 << ", " << hi2 << "]";
+                return;
+              }
             }
   }
 }
@@ -511,6 +615,15 @@ TEST(UnsignedIntervalExhaustive, BooleanOps)
     for (unsigned choice0 = 0; choice0 < 3; choice0++)
       for (unsigned choice1 = 0; choice1 < 3; choice1++)
       {
+        uint64_t bruteMin = UINT64_MAX, bruteMax = 0;
+        for (const uint64_t a : boolValues[choice0])
+          for (const uint64_t b : boolValues[choice1])
+          {
+            const uint64_t v = op.eval(a, b);
+            bruteMin = std::min(bruteMin, v);
+            bruteMax = std::max(bruteMax, v);
+          }
+
         const stp::UnsignedInterval* i0 =
             choice0 == 0 ? nullptr : makeInterval(1, choice0 - 1, choice0 - 1);
         const stp::UnsignedInterval* i1 =
@@ -520,16 +633,14 @@ TEST(UnsignedIntervalExhaustive, BooleanOps)
         stp::UnsignedInterval* result =
             c.analysis.dispatchToTransferFunctions(n, children);
 
-        if (result != nullptr)
-          for (const uint64_t a : boolValues[choice0])
-            for (const uint64_t b : boolValues[choice1])
-              if (!covered(op.kind, 1, result, 1, op.eval(a, b), a, b))
-              {
-                cleanup(children, result);
-                return;
-              }
-
+        const bool good =
+            checkAgainstHull(op.kind, 1, result, 1, bruteMin, bruteMax, EXACT);
         cleanup(children, result);
+        if (!good)
+        {
+          ADD_FAILURE() << "choices were " << choice0 << " and " << choice1;
+          return;
+        }
       }
   }
 
@@ -542,6 +653,13 @@ TEST(UnsignedIntervalExhaustive, BooleanOps)
 
     for (unsigned choice = 0; choice < 3; choice++)
     {
+      uint64_t bruteMin = UINT64_MAX, bruteMax = 0;
+      for (const uint64_t a : boolValues[choice])
+      {
+        bruteMin = std::min(bruteMin, a ^ 1);
+        bruteMax = std::max(bruteMax, a ^ 1);
+      }
+
       const stp::UnsignedInterval* i0 =
           choice == 0 ? nullptr : makeInterval(1, choice - 1, choice - 1);
 
@@ -549,15 +667,14 @@ TEST(UnsignedIntervalExhaustive, BooleanOps)
       stp::UnsignedInterval* result =
           c.analysis.dispatchToTransferFunctions(n, children);
 
-      if (result != nullptr)
-        for (const uint64_t a : boolValues[choice])
-          if (!covered(stp::NOT, 1, result, 1, a ^ 1, a, 0))
-          {
-            cleanup(children, result);
-            return;
-          }
-
+      const bool good =
+          checkAgainstHull(stp::NOT, 1, result, 1, bruteMin, bruteMax, EXACT);
       cleanup(children, result);
+      if (!good)
+      {
+        ADD_FAILURE() << "choice was " << choice;
+        return;
+      }
     }
   }
 }

--- a/tests/unit-tests/UnsignedIntervalExhaustive_Test.cpp
+++ b/tests/unit-tests/UnsignedIntervalExhaustive_Test.cpp
@@ -48,6 +48,7 @@ THE SOFTWARE.
 #include "stp/Simplifier/Simplifier.h"
 #include "stp/Simplifier/UnsignedIntervalAnalysis.h"
 #include "stp/Simplifier/UnsignedInterval.h"
+#include "stp/Simplifier/constantBitP/MersenneTwister.h"
 #include <gtest/gtest.h>
 #include <vector>
 
@@ -341,6 +342,58 @@ TEST(UnsignedIntervalExhaustive, Mult)
 {
   for (unsigned w = 1; w <= 4; w++)
     checkBinary(stp::BVMULT, w, OVERAPPROXIMATES);
+}
+
+// The constant-multiplier multiplication path finds the extremes of an
+// arithmetic progression mod 2^width by a binary search over a Euclidean
+// counting function. The exhaustive widths only reach shallow recursions,
+// so this stresses it with random wide intervals at width 16, where the
+// hull is still brute-forceable.
+TEST(UnsignedIntervalExhaustive, MultConstantOperandRandomised)
+{
+  Context c;
+  MTRand rand(12345U);
+
+  const unsigned w = 16;
+  const uint64_t N = 1ull << w;
+
+  stp::ASTVec symbols;
+  symbols.push_back(c.mgr.CreateSymbol("x", 0, w));
+  symbols.push_back(c.mgr.CreateSymbol("y", 0, w));
+  const stp::ASTNode n =
+      c.mgr.hashingNodeFactory->CreateTerm(stp::BVMULT, w, symbols);
+
+  for (unsigned iteration = 0; iteration < 300; iteration++)
+  {
+    uint64_t lo = rand.randInt() % N;
+    uint64_t hi = rand.randInt() % N;
+    if (lo > hi)
+      std::swap(lo, hi);
+    const uint64_t multiplier = rand.randInt() % N;
+
+    uint64_t bruteMin = UINT64_MAX, bruteMax = 0;
+    for (uint64_t x = lo; x <= hi; x++)
+    {
+      const uint64_t v = (x * multiplier) & (N - 1);
+      bruteMin = std::min(bruteMin, v);
+      bruteMax = std::max(bruteMax, v);
+    }
+
+    std::vector<const stp::UnsignedInterval*> children = {
+        makeInterval(w, lo, hi), makeInterval(w, multiplier, multiplier)};
+    stp::UnsignedInterval* result =
+        c.analysis.dispatchToTransferFunctions(n, children);
+
+    const bool good =
+        checkAgainstHull(stp::BVMULT, w, result, w, bruteMin, bruteMax,
+                         EXACT);
+    cleanup(children, result);
+    if (!good)
+    {
+      ADD_FAILURE() << "[" << lo << ", " << hi << "] * " << multiplier;
+      return;
+    }
+  }
 }
 
 TEST(UnsignedIntervalExhaustive, Bvand)

--- a/tests/unit-tests/UnsignedIntervalPropagators_Test.cpp
+++ b/tests/unit-tests/UnsignedIntervalPropagators_Test.cpp
@@ -1,0 +1,341 @@
+/***********
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+**********************/
+
+// Tests for the interval transfer functions in UnsignedIntervalAnalysis.
+// Each test builds a node, supplies intervals for its children, and checks
+// the interval that dispatchToTransferFunctions() computes for the node.
+
+#include "stp/STPManager/STPManager.h"
+#include "stp/NodeFactory/SimplifyingNodeFactory.h"
+#include "stp/Simplifier/UnsignedIntervalAnalysis.h"
+#include "stp/Simplifier/UnsignedInterval.h"
+#include <gtest/gtest.h>
+#include <vector>
+
+namespace
+{
+
+// BitVector_Boot must run before anything allocates constant bitvectors.
+struct Boot
+{
+  Boot() { CONSTANTBV::BitVector_Boot(); }
+};
+
+struct Context
+{
+  Boot boot;
+  stp::STPMgr mgr;
+  SimplifyingNodeFactory snf;
+  stp::UnsignedIntervalAnalysis analysis;
+
+  Context() : snf(*(mgr.hashingNodeFactory), mgr), analysis(mgr)
+  {
+    mgr.defaultNodeFactory = &snf;
+  }
+};
+
+stp::CBV makeCBV(unsigned width, unsigned value)
+{
+  stp::CBV r = CONSTANTBV::BitVector_Create(width, true);
+  for (unsigned i = 0; i < width && i < 8 * sizeof(unsigned); i++)
+    if ((value >> i) & 1)
+      CONSTANTBV::BitVector_Bit_On(r, i);
+  return r;
+}
+
+stp::UnsignedInterval* makeInterval(unsigned width, unsigned min, unsigned max)
+{
+  return new stp::UnsignedInterval(makeCBV(width, min), makeCBV(width, max));
+}
+
+void expectInterval(const stp::UnsignedInterval* result, unsigned width,
+                    unsigned min, unsigned max)
+{
+  ASSERT_NE(result, nullptr);
+  stp::CBV expectedMin = makeCBV(width, min);
+  stp::CBV expectedMax = makeCBV(width, max);
+  EXPECT_EQ(CONSTANTBV::BitVector_Lexicompare(result->minV, expectedMin), 0)
+      << "minimum differs";
+  EXPECT_EQ(CONSTANTBV::BitVector_Lexicompare(result->maxV, expectedMax), 0)
+      << "maximum differs";
+  CONSTANTBV::BitVector_Destroy(expectedMin);
+  CONSTANTBV::BitVector_Destroy(expectedMax);
+}
+
+void cleanup(std::vector<const stp::UnsignedInterval*>& children,
+             stp::UnsignedInterval* result)
+{
+  for (const auto* c : children)
+    delete c;
+  delete result;
+}
+
+// The hashing node factory builds the node without simplifying it, so the
+// tests exercise exactly the kind they name.
+stp::ASTNode makeTerm(Context& c, stp::Kind kind, unsigned w,
+                      const stp::ASTNode& op0, const stp::ASTNode& op1)
+{
+  stp::ASTVec children;
+  children.push_back(op0);
+  children.push_back(op1);
+  return c.mgr.hashingNodeFactory->CreateTerm(kind, w, children);
+}
+
+const unsigned width = 8;
+
+// [10,20] / [2,4] is [10/4, 20/2] = [2,10].
+TEST(UnsignedIntervalPropagators, UdivBoundsWithNonZeroDivisor)
+{
+  Context c;
+  stp::ASTNode x = c.mgr.CreateSymbol("x", 0, width);
+  stp::ASTNode y = c.mgr.CreateSymbol("y", 0, width);
+  stp::ASTNode n = makeTerm(c, stp::BVDIV, width, x, y);
+
+  std::vector<const stp::UnsignedInterval*> children = {
+      makeInterval(width, 10, 20), makeInterval(width, 2, 4)};
+  stp::UnsignedInterval* result =
+      c.analysis.dispatchToTransferFunctions(n, children);
+
+  expectInterval(result, width, 2, 10);
+  cleanup(children, result);
+}
+
+// Dividing by the constant zero gives all ones.
+TEST(UnsignedIntervalPropagators, UdivByConstantZero)
+{
+  Context c;
+  stp::ASTNode x = c.mgr.CreateSymbol("x", 0, width);
+  stp::ASTNode y = c.mgr.CreateSymbol("y", 0, width);
+  stp::ASTNode n = makeTerm(c, stp::BVDIV, width, x, y);
+
+  std::vector<const stp::UnsignedInterval*> children = {
+      makeInterval(width, 10, 20), makeInterval(width, 0, 0)};
+  stp::UnsignedInterval* result =
+      c.analysis.dispatchToTransferFunctions(n, children);
+
+  expectInterval(result, width, 255, 255);
+  cleanup(children, result);
+}
+
+// [10,20] / [0,5]: division by zero gives all ones, so only the upper bound
+// is lost. The lower bound 10/5 = 2 still holds.
+TEST(UnsignedIntervalPropagators, UdivWhenDivisorMightBeZero)
+{
+  Context c;
+  stp::ASTNode x = c.mgr.CreateSymbol("x", 0, width);
+  stp::ASTNode y = c.mgr.CreateSymbol("y", 0, width);
+  stp::ASTNode n = makeTerm(c, stp::BVDIV, width, x, y);
+
+  std::vector<const stp::UnsignedInterval*> children = {
+      makeInterval(width, 10, 20), makeInterval(width, 0, 5)};
+  stp::UnsignedInterval* result =
+      c.analysis.dispatchToTransferFunctions(n, children);
+
+  expectInterval(result, width, 2, 255);
+  cleanup(children, result);
+}
+
+// x mod [3,7] is less than the divisor's maximum.
+TEST(UnsignedIntervalPropagators, UremBoundsWithNonZeroDivisor)
+{
+  Context c;
+  stp::ASTNode x = c.mgr.CreateSymbol("x", 0, width);
+  stp::ASTNode y = c.mgr.CreateSymbol("y", 0, width);
+  stp::ASTNode n = makeTerm(c, stp::BVMOD, width, x, y);
+
+  std::vector<const stp::UnsignedInterval*> children = {
+      nullptr, makeInterval(width, 3, 7)};
+  stp::UnsignedInterval* result =
+      c.analysis.dispatchToTransferFunctions(n, children);
+
+  expectInterval(result, width, 0, 6);
+  cleanup(children, result);
+}
+
+// x mod 0 = x, so remainder by the constant zero is the identity.
+TEST(UnsignedIntervalPropagators, UremByConstantZeroIsIdentity)
+{
+  Context c;
+  stp::ASTNode x = c.mgr.CreateSymbol("x", 0, width);
+  stp::ASTNode y = c.mgr.CreateSymbol("y", 0, width);
+  stp::ASTNode n = makeTerm(c, stp::BVMOD, width, x, y);
+
+  std::vector<const stp::UnsignedInterval*> children = {
+      makeInterval(width, 5, 10), makeInterval(width, 0, 0)};
+  stp::UnsignedInterval* result =
+      c.analysis.dispatchToTransferFunctions(n, children);
+
+  expectInterval(result, width, 5, 10);
+  cleanup(children, result);
+}
+
+// [1,3] mod [10,20]: the dividend is always below the divisor, so the
+// remainder is the dividend. Both bounds carry over, not just the maximum.
+TEST(UnsignedIntervalPropagators, UremIsIdentityWhenDividendBelowDivisor)
+{
+  Context c;
+  stp::ASTNode x = c.mgr.CreateSymbol("x", 0, width);
+  stp::ASTNode y = c.mgr.CreateSymbol("y", 0, width);
+  stp::ASTNode n = makeTerm(c, stp::BVMOD, width, x, y);
+
+  std::vector<const stp::UnsignedInterval*> children = {
+      makeInterval(width, 1, 3), makeInterval(width, 10, 20)};
+  stp::UnsignedInterval* result =
+      c.analysis.dispatchToTransferFunctions(n, children);
+
+  expectInterval(result, width, 1, 3);
+  cleanup(children, result);
+}
+
+// [0,5] mod [0,3]: if the divisor is zero the result is the dividend (<= 5),
+// otherwise it is below the divisor (<= 2). So the result is at most 5.
+TEST(UnsignedIntervalPropagators, UremWhenDivisorMightBeZero)
+{
+  Context c;
+  stp::ASTNode x = c.mgr.CreateSymbol("x", 0, width);
+  stp::ASTNode y = c.mgr.CreateSymbol("y", 0, width);
+  stp::ASTNode n = makeTerm(c, stp::BVMOD, width, x, y);
+
+  std::vector<const stp::UnsignedInterval*> children = {
+      makeInterval(width, 0, 5), makeInterval(width, 0, 3)};
+  stp::UnsignedInterval* result =
+      c.analysis.dispatchToTransferFunctions(n, children);
+
+  expectInterval(result, width, 0, 5);
+  cleanup(children, result);
+}
+
+stp::ASTNode makeExtract(Context& c, const stp::ASTNode& child, unsigned high,
+                         unsigned low)
+{
+  stp::ASTVec children;
+  children.push_back(child);
+  children.push_back(c.mgr.CreateBVConst(32, high));
+  children.push_back(c.mgr.CreateBVConst(32, low));
+  return c.mgr.hashingNodeFactory->CreateTerm(stp::BVEXTRACT, high - low + 1,
+                                              children);
+}
+
+// Extracting [5:2] from a value that is at most 0x30 gives at most 0x30 >> 2.
+TEST(UnsignedIntervalPropagators, ExtractUpperBound)
+{
+  Context c;
+  stp::ASTNode x = c.mgr.CreateSymbol("x", 0, width);
+  stp::ASTNode n = makeExtract(c, x, 5, 2);
+
+  std::vector<const stp::UnsignedInterval*> children = {
+      makeInterval(width, 0, 0x30), makeInterval(32, 5, 5),
+      makeInterval(32, 2, 2)};
+  stp::UnsignedInterval* result =
+      c.analysis.dispatchToTransferFunctions(n, children);
+
+  expectInterval(result, 4, 0, 12);
+  cleanup(children, result);
+}
+
+// When no bits are discarded from the top, the minimum shifts down too.
+TEST(UnsignedIntervalPropagators, ExtractBothBounds)
+{
+  Context c;
+  stp::ASTNode x = c.mgr.CreateSymbol("x", 0, width);
+  stp::ASTNode n = makeExtract(c, x, 5, 2);
+
+  std::vector<const stp::UnsignedInterval*> children = {
+      makeInterval(width, 0x10, 0x30), makeInterval(32, 5, 5),
+      makeInterval(32, 2, 2)};
+  stp::UnsignedInterval* result =
+      c.analysis.dispatchToTransferFunctions(n, children);
+
+  expectInterval(result, 4, 4, 12);
+  cleanup(children, result);
+}
+
+// Extracting [3:0] from a value that is at most 0xF0 discards set bits from
+// the top, so nothing is known about the result.
+TEST(UnsignedIntervalPropagators, ExtractGivesNothingWhenTopBitsTruncated)
+{
+  Context c;
+  stp::ASTNode x = c.mgr.CreateSymbol("x", 0, width);
+  stp::ASTNode n = makeExtract(c, x, 3, 0);
+
+  std::vector<const stp::UnsignedInterval*> children = {
+      makeInterval(width, 0, 0xF0), makeInterval(32, 3, 3),
+      makeInterval(32, 0, 0)};
+  stp::UnsignedInterval* result =
+      c.analysis.dispatchToTransferFunctions(n, children);
+
+  EXPECT_EQ(result, nullptr);
+  cleanup(children, result);
+}
+
+// [8,15] | [0,7]: OR is at least each operand, so at least 8. Neither
+// operand has a bit above bit 3, so the result is at most 15.
+TEST(UnsignedIntervalPropagators, BvorBounds)
+{
+  Context c;
+  stp::ASTNode x = c.mgr.CreateSymbol("x", 0, width);
+  stp::ASTNode y = c.mgr.CreateSymbol("y", 0, width);
+  stp::ASTNode n = makeTerm(c, stp::BVOR, width, x, y);
+
+  std::vector<const stp::UnsignedInterval*> children = {
+      makeInterval(width, 8, 15), makeInterval(width, 0, 7)};
+  stp::UnsignedInterval* result =
+      c.analysis.dispatchToTransferFunctions(n, children);
+
+  expectInterval(result, width, 8, 15);
+  cleanup(children, result);
+}
+
+// OR with an unknown operand still keeps the other operand's minimum.
+TEST(UnsignedIntervalPropagators, BvorMinimumWithUnknownChild)
+{
+  Context c;
+  stp::ASTNode x = c.mgr.CreateSymbol("x", 0, width);
+  stp::ASTNode y = c.mgr.CreateSymbol("y", 0, width);
+  stp::ASTNode n = makeTerm(c, stp::BVOR, width, x, y);
+
+  std::vector<const stp::UnsignedInterval*> children = {
+      nullptr, makeInterval(width, 4, 7)};
+  stp::UnsignedInterval* result =
+      c.analysis.dispatchToTransferFunctions(n, children);
+
+  expectInterval(result, width, 4, 255);
+  cleanup(children, result);
+}
+
+// [0,5] ^ [0,3]: neither operand has a bit above bit 2, so the XOR is at
+// most 7.
+TEST(UnsignedIntervalPropagators, BvxorUpperBound)
+{
+  Context c;
+  stp::ASTNode x = c.mgr.CreateSymbol("x", 0, width);
+  stp::ASTNode y = c.mgr.CreateSymbol("y", 0, width);
+  stp::ASTNode n = makeTerm(c, stp::BVXOR, width, x, y);
+
+  std::vector<const stp::UnsignedInterval*> children = {
+      makeInterval(width, 0, 5), makeInterval(width, 0, 3)};
+  stp::UnsignedInterval* result =
+      c.analysis.dispatchToTransferFunctions(n, children);
+
+  expectInterval(result, width, 0, 7);
+  cleanup(children, result);
+}
+
+} // namespace

--- a/tests/unit-tests/UnsignedIntervalPropagators_Test.cpp
+++ b/tests/unit-tests/UnsignedIntervalPropagators_Test.cpp
@@ -320,6 +320,93 @@ TEST(UnsignedIntervalPropagators, BvorMinimumWithUnknownChild)
   cleanup(children, result);
 }
 
+// [1,3] << [1,2]: no set bit can be shifted out, so the bounds shift too.
+TEST(UnsignedIntervalPropagators, LeftShiftBounds)
+{
+  Context c;
+  stp::ASTNode x = c.mgr.CreateSymbol("x", 0, width);
+  stp::ASTNode y = c.mgr.CreateSymbol("y", 0, width);
+  stp::ASTNode n = makeTerm(c, stp::BVLEFTSHIFT, width, x, y);
+
+  std::vector<const stp::UnsignedInterval*> children = {
+      makeInterval(width, 1, 3), makeInterval(width, 1, 2)};
+  stp::UnsignedInterval* result =
+      c.analysis.dispatchToTransferFunctions(n, children);
+
+  expectInterval(result, width, 2, 12);
+  cleanup(children, result);
+}
+
+// Shifting an unknown value left by at least the width gives zero.
+TEST(UnsignedIntervalPropagators, LeftShiftByWidthOrMoreIsZero)
+{
+  Context c;
+  stp::ASTNode x = c.mgr.CreateSymbol("x", 0, width);
+  stp::ASTNode y = c.mgr.CreateSymbol("y", 0, width);
+  stp::ASTNode n = makeTerm(c, stp::BVLEFTSHIFT, width, x, y);
+
+  std::vector<const stp::UnsignedInterval*> children = {
+      nullptr, makeInterval(width, 8, 255)};
+  stp::UnsignedInterval* result =
+      c.analysis.dispatchToTransferFunctions(n, children);
+
+  expectInterval(result, width, 0, 0);
+  cleanup(children, result);
+}
+
+// [0x10,0x30] >>s [1,2]: the sign bit is clear, so it behaves like a
+// logical shift: [0x10 >> 2, 0x30 >> 1].
+TEST(UnsignedIntervalPropagators, SignedRightShiftOfNonNegative)
+{
+  Context c;
+  stp::ASTNode x = c.mgr.CreateSymbol("x", 0, width);
+  stp::ASTNode y = c.mgr.CreateSymbol("y", 0, width);
+  stp::ASTNode n = makeTerm(c, stp::BVSRSHIFT, width, x, y);
+
+  std::vector<const stp::UnsignedInterval*> children = {
+      makeInterval(width, 0x10, 0x30), makeInterval(width, 1, 2)};
+  stp::UnsignedInterval* result =
+      c.analysis.dispatchToTransferFunctions(n, children);
+
+  expectInterval(result, width, 4, 24);
+  cleanup(children, result);
+}
+
+// [0x80,0xF0] >>s 1: the sign bit is set, so ones are shifted in.
+TEST(UnsignedIntervalPropagators, SignedRightShiftOfNegative)
+{
+  Context c;
+  stp::ASTNode x = c.mgr.CreateSymbol("x", 0, width);
+  stp::ASTNode y = c.mgr.CreateSymbol("y", 0, width);
+  stp::ASTNode n = makeTerm(c, stp::BVSRSHIFT, width, x, y);
+
+  std::vector<const stp::UnsignedInterval*> children = {
+      makeInterval(width, 0x80, 0xF0), makeInterval(width, 1, 1)};
+  stp::UnsignedInterval* result =
+      c.analysis.dispatchToTransferFunctions(n, children);
+
+  expectInterval(result, width, 0xC0, 0xF8);
+  cleanup(children, result);
+}
+
+// [0x70,0x90] >>s 4 crosses the sign boundary: the minimum comes from the
+// non-negative end, the maximum from the negative end.
+TEST(UnsignedIntervalPropagators, SignedRightShiftCrossingSign)
+{
+  Context c;
+  stp::ASTNode x = c.mgr.CreateSymbol("x", 0, width);
+  stp::ASTNode y = c.mgr.CreateSymbol("y", 0, width);
+  stp::ASTNode n = makeTerm(c, stp::BVSRSHIFT, width, x, y);
+
+  std::vector<const stp::UnsignedInterval*> children = {
+      makeInterval(width, 0x70, 0x90), makeInterval(width, 4, 4)};
+  stp::UnsignedInterval* result =
+      c.analysis.dispatchToTransferFunctions(n, children);
+
+  expectInterval(result, width, 0x07, 0xF9);
+  cleanup(children, result);
+}
+
 // [0,5] ^ [0,3]: neither operand has a bit above bit 2, so the XOR is at
 // most 7.
 TEST(UnsignedIntervalPropagators, BvxorUpperBound)

--- a/tests/unit-tests/UnsignedIntervalPropagators_Test.cpp
+++ b/tests/unit-tests/UnsignedIntervalPropagators_Test.cpp
@@ -204,6 +204,60 @@ TEST(UnsignedIntervalPropagators, UremIsIdentityWhenDividendBelowDivisor)
   cleanup(children, result);
 }
 
+// [8,9] mod 5: both bounds have quotient 1, so the remainders run from
+// 8 mod 5 to 9 mod 5 exactly.
+TEST(UnsignedIntervalPropagators, UremExactForConstantDivisor)
+{
+  Context c;
+  stp::ASTNode x = c.mgr.CreateSymbol("x", 0, width);
+  stp::ASTNode y = c.mgr.CreateSymbol("y", 0, width);
+  stp::ASTNode n = makeTerm(c, stp::BVMOD, width, x, y);
+
+  std::vector<const stp::UnsignedInterval*> children = {
+      makeInterval(width, 8, 9), makeInterval(width, 5, 5)};
+  stp::UnsignedInterval* result =
+      c.analysis.dispatchToTransferFunctions(n, children);
+
+  expectInterval(result, width, 3, 4);
+  cleanup(children, result);
+}
+
+// [4,7] mod 3 crosses a multiple of the divisor, so every remainder is
+// reachable: [0, 2].
+TEST(UnsignedIntervalPropagators, UremConstantDivisorCrossingMultiple)
+{
+  Context c;
+  stp::ASTNode x = c.mgr.CreateSymbol("x", 0, width);
+  stp::ASTNode y = c.mgr.CreateSymbol("y", 0, width);
+  stp::ASTNode n = makeTerm(c, stp::BVMOD, width, x, y);
+
+  std::vector<const stp::UnsignedInterval*> children = {
+      makeInterval(width, 4, 7), makeInterval(width, 3, 3)};
+  stp::UnsignedInterval* result =
+      c.analysis.dispatchToTransferFunctions(n, children);
+
+  expectInterval(result, width, 0, 2);
+  cleanup(children, result);
+}
+
+// [0,0] mod [0,5]: zero mod anything is zero. The remainder never exceeds
+// the dividend, even when the divisor might be zero.
+TEST(UnsignedIntervalPropagators, UremCappedByDividendWithMaybeZeroDivisor)
+{
+  Context c;
+  stp::ASTNode x = c.mgr.CreateSymbol("x", 0, width);
+  stp::ASTNode y = c.mgr.CreateSymbol("y", 0, width);
+  stp::ASTNode n = makeTerm(c, stp::BVMOD, width, x, y);
+
+  std::vector<const stp::UnsignedInterval*> children = {
+      makeInterval(width, 0, 0), makeInterval(width, 0, 5)};
+  stp::UnsignedInterval* result =
+      c.analysis.dispatchToTransferFunctions(n, children);
+
+  expectInterval(result, width, 0, 0);
+  cleanup(children, result);
+}
+
 // [0,5] mod [0,3]: if the divisor is zero the result is the dividend (<= 5),
 // otherwise it is below the divisor (<= 2). So the result is at most 5.
 TEST(UnsignedIntervalPropagators, UremWhenDivisorMightBeZero)

--- a/tests/unit-tests/UnsignedIntervalPropagators_Test.cpp
+++ b/tests/unit-tests/UnsignedIntervalPropagators_Test.cpp
@@ -374,6 +374,64 @@ TEST(UnsignedIntervalPropagators, BvorMinimumWithUnknownChild)
   cleanup(children, result);
 }
 
+// [0,1] * [0,8]: no wrap is possible, so the bounds multiply. (This used
+// to propagate nothing: the bounds were multiplied as signed values, and 8
+// has the top bit of its nibble... any bound reaching the upper half of
+// the range looked like an overflow.)
+TEST(UnsignedIntervalPropagators, MultKeepsBoundsWithUpperHalfOperand)
+{
+  Context c;
+  stp::ASTNode x = c.mgr.CreateSymbol("x", 0, width);
+  stp::ASTNode y = c.mgr.CreateSymbol("y", 0, width);
+  stp::ASTNode n = makeTerm(c, stp::BVMULT, width, x, y);
+
+  std::vector<const stp::UnsignedInterval*> children = {
+      makeInterval(width, 0, 129), makeInterval(width, 0, 1)};
+  stp::UnsignedInterval* result =
+      c.analysis.dispatchToTransferFunctions(n, children);
+
+  expectInterval(result, width, 0, 129);
+  cleanup(children, result);
+}
+
+// [32,33] * 8: the products 256 and 264 wrap, but they land in the same
+// 2^8 block, so the result is exactly [0, 8].
+TEST(UnsignedIntervalPropagators, MultExactAcrossWrapInSameBlock)
+{
+  Context c;
+  stp::ASTNode x = c.mgr.CreateSymbol("x", 0, width);
+  stp::ASTNode y = c.mgr.CreateSymbol("y", 0, width);
+  stp::ASTNode n = makeTerm(c, stp::BVMULT, width, x, y);
+
+  std::vector<const stp::UnsignedInterval*> children = {
+      makeInterval(width, 32, 33), makeInterval(width, 8, 8)};
+  stp::UnsignedInterval* result =
+      c.analysis.dispatchToTransferFunctions(n, children);
+
+  expectInterval(result, width, 0, 8);
+  cleanup(children, result);
+}
+
+// [3,200] * 3: the products cross several 2^8 blocks. They form the
+// arithmetic progression 9, 12, ... mod 256; the largest value below the
+// first wrap is 255 (x = 85) and the smallest reachable value is 1
+// (x = 171 gives 513 = 2*256 + 1).
+TEST(UnsignedIntervalPropagators, MultExactForWrappingConstantMultiplier)
+{
+  Context c;
+  stp::ASTNode x = c.mgr.CreateSymbol("x", 0, width);
+  stp::ASTNode y = c.mgr.CreateSymbol("y", 0, width);
+  stp::ASTNode n = makeTerm(c, stp::BVMULT, width, x, y);
+
+  std::vector<const stp::UnsignedInterval*> children = {
+      makeInterval(width, 3, 200), makeInterval(width, 3, 3)};
+  stp::UnsignedInterval* result =
+      c.analysis.dispatchToTransferFunctions(n, children);
+
+  expectInterval(result, width, 1, 255);
+  cleanup(children, result);
+}
+
 // Extracting [2:0] from [0x44, 0x46]: the values agree above bit 2, so the
 // low bits run from the minimum's to the maximum's without wrapping, even
 // though set bits are discarded from the top.

--- a/tests/unit-tests/UnsignedIntervalPropagators_Test.cpp
+++ b/tests/unit-tests/UnsignedIntervalPropagators_Test.cpp
@@ -267,8 +267,8 @@ TEST(UnsignedIntervalPropagators, ExtractBothBounds)
   cleanup(children, result);
 }
 
-// Extracting [3:0] from a value that is at most 0xF0 discards set bits from
-// the top, so nothing is known about the result.
+// Extracting [3:0] from [0x00, 0xF0] wraps through the extract's width
+// several times, so every result is reachable and nothing is known.
 TEST(UnsignedIntervalPropagators, ExtractGivesNothingWhenTopBitsTruncated)
 {
   Context c;
@@ -317,6 +317,25 @@ TEST(UnsignedIntervalPropagators, BvorMinimumWithUnknownChild)
       c.analysis.dispatchToTransferFunctions(n, children);
 
   expectInterval(result, width, 4, 255);
+  cleanup(children, result);
+}
+
+// Extracting [2:0] from [0x44, 0x46]: the values agree above bit 2, so the
+// low bits run from the minimum's to the maximum's without wrapping, even
+// though set bits are discarded from the top.
+TEST(UnsignedIntervalPropagators, ExtractExactWhenHighBitsAgree)
+{
+  Context c;
+  stp::ASTNode x = c.mgr.CreateSymbol("x", 0, width);
+  stp::ASTNode n = makeExtract(c, x, 2, 0);
+
+  std::vector<const stp::UnsignedInterval*> children = {
+      makeInterval(width, 0x44, 0x46), makeInterval(32, 2, 2),
+      makeInterval(32, 0, 0)};
+  stp::UnsignedInterval* result =
+      c.analysis.dispatchToTransferFunctions(n, children);
+
+  expectInterval(result, 3, 4, 6);
   cleanup(children, result);
 }
 

--- a/tests/unit-tests/UnsignedIntervalPropagators_Test.cpp
+++ b/tests/unit-tests/UnsignedIntervalPropagators_Test.cpp
@@ -339,6 +339,24 @@ TEST(UnsignedIntervalPropagators, ExtractExactWhenHighBitsAgree)
   cleanup(children, result);
 }
 
+// [0x81,0x82] << 1: the top bit is discarded from both bounds, but the
+// bounds agree above the surviving bits, so the result is still exact.
+TEST(UnsignedIntervalPropagators, LeftShiftExactWhenHighBitsAgree)
+{
+  Context c;
+  stp::ASTNode x = c.mgr.CreateSymbol("x", 0, width);
+  stp::ASTNode y = c.mgr.CreateSymbol("y", 0, width);
+  stp::ASTNode n = makeTerm(c, stp::BVLEFTSHIFT, width, x, y);
+
+  std::vector<const stp::UnsignedInterval*> children = {
+      makeInterval(width, 0x81, 0x82), makeInterval(width, 1, 1)};
+  stp::UnsignedInterval* result =
+      c.analysis.dispatchToTransferFunctions(n, children);
+
+  expectInterval(result, width, 2, 4);
+  cleanup(children, result);
+}
+
 // [1,3] << [1,2]: no set bit can be shifted out, so the bounds shift too.
 TEST(UnsignedIntervalPropagators, LeftShiftBounds)
 {

--- a/tests/unit-tests/UnsignedIntervalWide_Test.cpp
+++ b/tests/unit-tests/UnsignedIntervalWide_Test.cpp
@@ -1,0 +1,538 @@
+/***********
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+**********************/
+
+// Checks the interval transfer functions at 100 bits, where the bitvectors
+// span several machine words. The exhaustive tests cover widths 1 to 4;
+// this covers the multi-word code paths (word boundaries, capped shift
+// amounts, carries across words) that narrow widths can't reach.
+//
+// Each child interval is narrow -- at most four values -- and sits at a
+// boundary: near zero, across the 2^64 word boundary, across the sign bit,
+// or at the top. Narrow intervals keep the brute-force hull computable:
+// every concrete value is enumerated and run through STP's constant
+// evaluator. The transfer functions classified as perfect must return
+// exactly the hull; the over-approximating ones (BVMOD, BVMULT) must
+// contain it.
+
+#include "stp/STPManager/STPManager.h"
+#include "stp/NodeFactory/SimplifyingNodeFactory.h"
+#include "stp/Simplifier/Simplifier.h"
+#include "stp/Simplifier/UnsignedIntervalAnalysis.h"
+#include "stp/Simplifier/UnsignedInterval.h"
+#include <gtest/gtest.h>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace
+{
+
+const bool EXACT = true;
+const bool OVERAPPROXIMATES = false;
+
+const unsigned WIDTH = 100;
+
+// BitVector_Boot must run before anything allocates constant bitvectors.
+struct Boot
+{
+  Boot() { CONSTANTBV::BitVector_Boot(); }
+};
+
+struct Context
+{
+  Boot boot;
+  stp::STPMgr mgr;
+  SimplifyingNodeFactory snf;
+  stp::UnsignedIntervalAnalysis analysis;
+
+  Context() : snf(*(mgr.hashingNodeFactory), mgr), analysis(mgr)
+  {
+    mgr.defaultNodeFactory = &snf;
+  }
+};
+
+// A value near a boundary of the width: 'z' is zero + delta, 'w' is the
+// 2^64 word boundary + delta, 's' is the sign bit 2^(width-1) + delta, and
+// 'm' is the all-ones maximum + delta (delta <= 0).
+stp::CBV boundaryValue(unsigned width, char kind, long delta)
+{
+  stp::CBV r = CONSTANTBV::BitVector_Create(width, true);
+  switch (kind)
+  {
+    case 'z':
+      break;
+    case 'w':
+      assert(width > 64);
+      CONSTANTBV::BitVector_Bit_On(r, 64);
+      break;
+    case 's':
+      CONSTANTBV::BitVector_Bit_On(r, width - 1);
+      break;
+    case 'm':
+      CONSTANTBV::BitVector_Fill(r);
+      break;
+    default:
+      assert(false);
+  }
+  for (; delta > 0; delta--)
+    CONSTANTBV::BitVector_increment(r);
+  for (; delta < 0; delta++)
+    CONSTANTBV::BitVector_decrement(r);
+  return r;
+}
+
+// A narrow interval at a boundary: [kind + lo, kind + hi].
+struct WideInterval
+{
+  char kind;
+  long lo, hi;
+};
+
+std::string describe(const WideInterval& wi)
+{
+  std::ostringstream s;
+  s << wi.kind << "[" << wi.lo << ".." << wi.hi << "]";
+  return s.str();
+}
+
+const std::vector<WideInterval> wideIntervals = {
+    {'z', 0, 3},  // at the bottom, includes zero
+    {'z', 7, 7},  // a small constant
+    {'z', 5, 7},  // small, no zero, not constant
+    {'w', -2, 1}, // crosses the 2^64 word boundary
+    {'s', -2, 1}, // crosses the sign bit
+    {'m', -3, 0}, // at the top
+};
+
+std::vector<stp::CBV> enumerateValues(unsigned width, const WideInterval& wi)
+{
+  std::vector<stp::CBV> values;
+  for (long d = wi.lo; d <= wi.hi; d++)
+    values.push_back(boundaryValue(width, wi.kind, d));
+  return values;
+}
+
+stp::UnsignedInterval* makeInterval(unsigned width, const WideInterval& wi)
+{
+  return new stp::UnsignedInterval(boundaryValue(width, wi.kind, wi.lo),
+                                   boundaryValue(width, wi.kind, wi.hi));
+}
+
+void destroyValues(std::vector<std::vector<stp::CBV>>& childValues)
+{
+  for (auto& values : childValues)
+    for (stp::CBV v : values)
+      CONSTANTBV::BitVector_Destroy(v);
+}
+
+// Runs the transfer function for n on the given child intervals, computes
+// the brute-force hull over the enumerated child values with the constant
+// evaluator, and compares. childValues[i] must list every value that
+// children[i] allows (a null child is fine as long as its values are
+// listed, e.g. an unknown boolean).
+void checkHull(Context& c, const stp::ASTNode& n,
+               const std::vector<std::vector<stp::CBV>>& childValues,
+               std::vector<const stp::UnsignedInterval*>& children,
+               bool exact, const std::string& label)
+{
+  stp::UnsignedInterval* result =
+      c.analysis.dispatchToTransferFunctions(n, children);
+
+  const bool isPredicate = (n.GetType() == stp::BOOLEAN_TYPE);
+
+  stp::CBV bruteMin = nullptr;
+  stp::CBV bruteMax = nullptr;
+
+  // Walk the cartesian product of the child values.
+  std::vector<size_t> idx(childValues.size(), 0);
+  while (true)
+  {
+    stp::ASTVec consts;
+    for (unsigned i = 0; i < childValues.size(); i++)
+    {
+      const stp::CBV v = childValues[i][idx[i]];
+      if (n[i].GetType() == stp::BOOLEAN_TYPE)
+        consts.push_back(CONSTANTBV::BitVector_bit_test(v, 0) ? c.mgr.ASTTrue
+                                                              : c.mgr.ASTFalse);
+      else
+        consts.push_back(c.mgr.CreateBVConst(CONSTANTBV::BitVector_Clone(v),
+                                             n[i].GetValueWidth()));
+    }
+
+    const stp::ASTNode op =
+        isPredicate
+            ? c.mgr.hashingNodeFactory->CreateNode(n.GetKind(), consts)
+            : c.mgr.hashingNodeFactory->CreateTerm(n.GetKind(),
+                                                   n.GetValueWidth(), consts);
+    const stp::ASTNode evaluated = NonMemberBVConstEvaluator(&c.mgr, op);
+
+    stp::CBV value;
+    if (evaluated.GetKind() == stp::TRUE ||
+        evaluated.GetKind() == stp::FALSE)
+    {
+      value = CONSTANTBV::BitVector_Create(1, true);
+      if (evaluated.GetKind() == stp::TRUE)
+        CONSTANTBV::BitVector_Bit_On(value, 0);
+    }
+    else
+      value = CONSTANTBV::BitVector_Clone(evaluated.GetBVConst());
+
+    if (bruteMin == nullptr)
+    {
+      bruteMin = CONSTANTBV::BitVector_Clone(value);
+      bruteMax = CONSTANTBV::BitVector_Clone(value);
+    }
+    else
+    {
+      if (CONSTANTBV::BitVector_Lexicompare(value, bruteMin) < 0)
+        CONSTANTBV::BitVector_Copy(bruteMin, value);
+      if (CONSTANTBV::BitVector_Lexicompare(value, bruteMax) > 0)
+        CONSTANTBV::BitVector_Copy(bruteMax, value);
+    }
+    CONSTANTBV::BitVector_Destroy(value);
+
+    unsigned i = 0;
+    for (; i < idx.size(); i++)
+    {
+      if (++idx[i] < childValues[i].size())
+        break;
+      idx[i] = 0;
+    }
+    if (i == idx.size())
+      break;
+  }
+
+  if (result == nullptr)
+  {
+    const bool hullComplete = CONSTANTBV::BitVector_is_empty(bruteMin) &&
+                              CONSTANTBV::BitVector_is_full(bruteMax);
+    EXPECT_TRUE(!exact || hullComplete)
+        << label << ": nothing was computed, but the hull isn't complete";
+  }
+  else
+  {
+    EXPECT_LE(CONSTANTBV::BitVector_Lexicompare(result->minV, bruteMin), 0)
+        << label << ": UNSOUND minimum";
+    EXPECT_GE(CONSTANTBV::BitVector_Lexicompare(result->maxV, bruteMax), 0)
+        << label << ": UNSOUND maximum";
+
+    if (exact)
+    {
+      EXPECT_EQ(CONSTANTBV::BitVector_Lexicompare(result->minV, bruteMin), 0)
+          << label << ": imprecise minimum";
+      EXPECT_EQ(CONSTANTBV::BitVector_Lexicompare(result->maxV, bruteMax), 0)
+          << label << ": imprecise maximum";
+    }
+  }
+
+  CONSTANTBV::BitVector_Destroy(bruteMin);
+  CONSTANTBV::BitVector_Destroy(bruteMax);
+  delete result;
+}
+
+void checkWideBinary(stp::Kind k, bool isPredicate, bool exact)
+{
+  Context c;
+
+  stp::ASTVec symbols;
+  symbols.push_back(c.mgr.CreateSymbol("x", 0, WIDTH));
+  symbols.push_back(c.mgr.CreateSymbol("y", 0, WIDTH));
+  const stp::ASTNode n =
+      isPredicate ? c.mgr.hashingNodeFactory->CreateNode(k, symbols)
+                  : c.mgr.hashingNodeFactory->CreateTerm(k, WIDTH, symbols);
+
+  for (const WideInterval& i0 : wideIntervals)
+    for (const WideInterval& i1 : wideIntervals)
+    {
+      std::vector<std::vector<stp::CBV>> childValues = {
+          enumerateValues(WIDTH, i0), enumerateValues(WIDTH, i1)};
+      std::vector<const stp::UnsignedInterval*> children = {
+          makeInterval(WIDTH, i0), makeInterval(WIDTH, i1)};
+
+      checkHull(c, n, childValues, children, exact,
+                describe(i0) + " op " + describe(i1));
+
+      destroyValues(childValues);
+      for (const auto* ch : children)
+        delete ch;
+    }
+}
+
+void checkWideUnary(stp::Kind k, bool exact)
+{
+  Context c;
+
+  stp::ASTVec symbols;
+  symbols.push_back(c.mgr.CreateSymbol("x", 0, WIDTH));
+  const stp::ASTNode n =
+      c.mgr.hashingNodeFactory->CreateTerm(k, WIDTH, symbols);
+
+  for (const WideInterval& i0 : wideIntervals)
+  {
+    std::vector<std::vector<stp::CBV>> childValues = {
+        enumerateValues(WIDTH, i0)};
+    std::vector<const stp::UnsignedInterval*> children = {
+        makeInterval(WIDTH, i0)};
+
+    checkHull(c, n, childValues, children, exact, describe(i0));
+
+    destroyValues(childValues);
+    for (const auto* ch : children)
+      delete ch;
+  }
+}
+
+TEST(UnsignedIntervalWide, Udiv)
+{
+  checkWideBinary(stp::BVDIV, false, EXACT);
+}
+
+TEST(UnsignedIntervalWide, Urem)
+{
+  checkWideBinary(stp::BVMOD, false, OVERAPPROXIMATES);
+}
+
+TEST(UnsignedIntervalWide, Plus)
+{
+  checkWideBinary(stp::BVPLUS, false, EXACT);
+}
+
+TEST(UnsignedIntervalWide, Mult)
+{
+  checkWideBinary(stp::BVMULT, false, OVERAPPROXIMATES);
+}
+
+TEST(UnsignedIntervalWide, Bvand)
+{
+  checkWideBinary(stp::BVAND, false, EXACT);
+}
+
+TEST(UnsignedIntervalWide, Bvor)
+{
+  checkWideBinary(stp::BVOR, false, EXACT);
+}
+
+TEST(UnsignedIntervalWide, Bvxor)
+{
+  checkWideBinary(stp::BVXOR, false, EXACT);
+}
+
+TEST(UnsignedIntervalWide, RightShift)
+{
+  checkWideBinary(stp::BVRIGHTSHIFT, false, EXACT);
+}
+
+TEST(UnsignedIntervalWide, LeftShift)
+{
+  checkWideBinary(stp::BVLEFTSHIFT, false, EXACT);
+}
+
+TEST(UnsignedIntervalWide, SignedRightShift)
+{
+  checkWideBinary(stp::BVSRSHIFT, false, EXACT);
+}
+
+TEST(UnsignedIntervalWide, Bvgt)
+{
+  checkWideBinary(stp::BVGT, true, EXACT);
+}
+
+TEST(UnsignedIntervalWide, Bvsgt)
+{
+  checkWideBinary(stp::BVSGT, true, EXACT);
+}
+
+TEST(UnsignedIntervalWide, Eq)
+{
+  checkWideBinary(stp::EQ, true, EXACT);
+}
+
+TEST(UnsignedIntervalWide, Bvnot)
+{
+  checkWideUnary(stp::BVNOT, EXACT);
+}
+
+TEST(UnsignedIntervalWide, Bvuminus)
+{
+  checkWideUnary(stp::BVUMINUS, EXACT);
+}
+
+TEST(UnsignedIntervalWide, Extract)
+{
+  // Positions chosen to land on and straddle the 32-bit word boundaries.
+  const std::vector<std::pair<unsigned, unsigned>> positions = {
+      {99, 68}, {95, 32}, {67, 60}, {63, 32}, {31, 0}, {99, 0}};
+
+  for (const auto& position : positions)
+  {
+    const unsigned hi = position.first;
+    const unsigned lo = position.second;
+    const unsigned wOut = hi - lo + 1;
+
+    Context c;
+    stp::ASTVec symbols;
+    symbols.push_back(c.mgr.CreateSymbol("x", 0, WIDTH));
+    symbols.push_back(c.mgr.CreateBVConst(32, hi));
+    symbols.push_back(c.mgr.CreateBVConst(32, lo));
+    const stp::ASTNode n =
+        c.mgr.hashingNodeFactory->CreateTerm(stp::BVEXTRACT, wOut, symbols);
+
+    for (const WideInterval& i0 : wideIntervals)
+    {
+      std::vector<std::vector<stp::CBV>> childValues = {
+          enumerateValues(WIDTH, i0),
+          {boundaryValue(32, 'z', hi)},
+          {boundaryValue(32, 'z', lo)}};
+      std::vector<const stp::UnsignedInterval*> children = {
+          makeInterval(WIDTH, i0),
+          new stp::UnsignedInterval(boundaryValue(32, 'z', hi),
+                                    boundaryValue(32, 'z', hi)),
+          new stp::UnsignedInterval(boundaryValue(32, 'z', lo),
+                                    boundaryValue(32, 'z', lo))};
+
+      std::ostringstream label;
+      label << describe(i0) << "[" << hi << ":" << lo << "]";
+      checkHull(c, n, childValues, children, EXACT, label.str());
+
+      destroyValues(childValues);
+      for (const auto* ch : children)
+        delete ch;
+    }
+  }
+}
+
+TEST(UnsignedIntervalWide, Bvsx)
+{
+  const unsigned wOut = 128;
+
+  Context c;
+  stp::ASTVec symbols;
+  symbols.push_back(c.mgr.CreateSymbol("x", 0, WIDTH));
+  symbols.push_back(c.mgr.CreateBVConst(32, wOut));
+  const stp::ASTNode n =
+      c.mgr.hashingNodeFactory->CreateTerm(stp::BVSX, wOut, symbols);
+
+  for (const WideInterval& i0 : wideIntervals)
+  {
+    std::vector<std::vector<stp::CBV>> childValues = {
+        enumerateValues(WIDTH, i0), {boundaryValue(32, 'z', wOut)}};
+    std::vector<const stp::UnsignedInterval*> children = {
+        makeInterval(WIDTH, i0),
+        new stp::UnsignedInterval(boundaryValue(32, 'z', wOut),
+                                  boundaryValue(32, 'z', wOut))};
+
+    checkHull(c, n, childValues, children, EXACT, describe(i0) + " sx");
+
+    destroyValues(childValues);
+    for (const auto* ch : children)
+      delete ch;
+  }
+}
+
+TEST(UnsignedIntervalWide, Concat)
+{
+  const unsigned lowWidth = 28;
+
+  Context c;
+  stp::ASTVec symbols;
+  symbols.push_back(c.mgr.CreateSymbol("x", 0, WIDTH));
+  symbols.push_back(c.mgr.CreateSymbol("y", 0, lowWidth));
+  const stp::ASTNode n = c.mgr.hashingNodeFactory->CreateTerm(
+      stp::BVCONCAT, WIDTH + lowWidth, symbols);
+
+  // The 'w' kind needs more than 64 bits, so the low child uses the others.
+  const std::vector<WideInterval> lowIntervals = {
+      {'z', 0, 3}, {'s', -1, 1}, {'m', -2, 0}};
+
+  for (const WideInterval& i0 : wideIntervals)
+    for (const WideInterval& i1 : lowIntervals)
+    {
+      std::vector<std::vector<stp::CBV>> childValues = {
+          enumerateValues(WIDTH, i0), enumerateValues(lowWidth, i1)};
+      std::vector<const stp::UnsignedInterval*> children = {
+          makeInterval(WIDTH, i0), makeInterval(lowWidth, i1)};
+
+      checkHull(c, n, childValues, children, EXACT,
+                describe(i0) + " concat " + describe(i1));
+
+      destroyValues(childValues);
+      for (const auto* ch : children)
+        delete ch;
+    }
+}
+
+TEST(UnsignedIntervalWide, Ite)
+{
+  Context c;
+  stp::ASTVec symbols;
+  symbols.push_back(c.mgr.CreateSymbol("c", 0, 0));
+  symbols.push_back(c.mgr.CreateSymbol("x", 0, WIDTH));
+  symbols.push_back(c.mgr.CreateSymbol("y", 0, WIDTH));
+  const stp::ASTNode n =
+      c.mgr.hashingNodeFactory->CreateTerm(stp::ITE, WIDTH, symbols);
+
+  // Condition alternatives: unknown (null interval, both values), false,
+  // true.
+  for (unsigned condChoice = 0; condChoice < 3; condChoice++)
+    for (const WideInterval& i1 : wideIntervals)
+      for (const WideInterval& i2 : wideIntervals)
+      {
+        std::vector<stp::CBV> condValues;
+        if (condChoice == 0 || condChoice == 1)
+          condValues.push_back(CONSTANTBV::BitVector_Create(1, true));
+        if (condChoice == 0 || condChoice == 2)
+        {
+          stp::CBV one = CONSTANTBV::BitVector_Create(1, true);
+          CONSTANTBV::BitVector_Bit_On(one, 0);
+          condValues.push_back(one);
+        }
+
+        const stp::UnsignedInterval* cond = nullptr;
+        if (condChoice == 1)
+          cond = new stp::UnsignedInterval(
+              CONSTANTBV::BitVector_Create(1, true),
+              CONSTANTBV::BitVector_Create(1, true));
+        else if (condChoice == 2)
+        {
+          stp::CBV lo = CONSTANTBV::BitVector_Create(1, true);
+          stp::CBV hi = CONSTANTBV::BitVector_Create(1, true);
+          CONSTANTBV::BitVector_Bit_On(lo, 0);
+          CONSTANTBV::BitVector_Bit_On(hi, 0);
+          cond = new stp::UnsignedInterval(lo, hi);
+        }
+
+        std::vector<std::vector<stp::CBV>> childValues = {
+            condValues, enumerateValues(WIDTH, i1),
+            enumerateValues(WIDTH, i2)};
+        std::vector<const stp::UnsignedInterval*> children = {
+            cond, makeInterval(WIDTH, i1), makeInterval(WIDTH, i2)};
+
+        std::ostringstream label;
+        label << "ite cond" << condChoice << " " << describe(i1) << " "
+              << describe(i2);
+        checkHull(c, n, childValues, children, EXACT, label.str());
+
+        destroyValues(childValues);
+        for (const auto* ch : children)
+          delete ch;
+      }
+}
+
+} // namespace


### PR DESCRIPTION
A careful pass over the transfer functions in `UnsignedIntervalAnalysis`. The first commit adds unit tests for the transfer functions — nine of the thirteen fail against master. The second commit makes them pass.

## Precision improvements

- **BVEXTRACT**: the transfer function was completely dead — a stray `break;` sat between the case label and its body. The reinstated version bounds both ends (the old code only bounded the maximum): when no set bits are discarded from the top of the shifted maximum, the extract is exactly a right shift, so the minimum shifts down too. It also no longer mutates the shared cached zero bitvector, which would have tripped the cache's emptiness assertion.
- **BVDIV**: when the divisor's interval includes zero, the old code gave up entirely (the `bottomChanged` recovery code after the early `break` was unreachable). Since division by zero gives all ones, the lower bound — smallest dividend over largest divisor — always holds and is now kept.
- **BVMOD**:
  - remainder by the constant zero is the identity, so the dividend's interval carries over;
  - when the dividend is always below the divisor, the remainder *is* the dividend, so the minimum carries over too (previously only the maximum was kept);
  - when the divisor might be zero, the result is bounded by the larger of the dividend's maximum and the divisor's maximum minus one (previously nothing).
- **BVOR** (new): the minimum is the largest of the children's minimums, and no result bit can be above the highest possible bit of any child.
- **BVXOR** (new): same upper bound as BVOR.

## Cleanups

- Every interval computed by `topLevel()` leaked: nothing deleted the values of the `visited` map, and the `toDeleteLater`/`likeAutoPtr` members that presumably once handled collection were unused. The intervals are now deleted after strength reduction reads them, and the vestigial members are gone.
- SYMBOL/READ/WRITE nodes now cache their (null) result instead of being re-examined through every parent.
- ITE: the `children[1] != NULL` guards could never fail because null children are replaced with complete intervals before dispatch; they now test `knownC1`/`knownC2` as intended (same behaviour, but the guard is real).
- BVMULT: removed the equivalent never-null child check.
- The children-size assertion now runs before the accesses it guards.

## Testing

- New `UnsignedIntervalPropagators_Test` suite: 13 tests, 9 failing before the fix commit, all passing after.
- Full ctest suite (unit tests, API tests, query-files lit suite): all 47 pass.