### PR TITLE
Accurate NO_CHANGE results and stack-safety fixes for constant bit propagation

### DIFF
--- a/include/stp/Simplifier/constantBitP/ConstantBitPropagation.h
+++ b/include/stp/Simplifier/constantBitP/ConstantBitPropagation.h
@@ -91,6 +91,10 @@ public:
   DLL_PUBLIC ConstantBitPropagation(stp::STPMgr* mgr, stp::Simplifier* _sm,
                          NodeFactory* _nf, const ASTNode& top);
 
+  // The destructor deletes the owned tables, so copying would double-delete.
+  ConstantBitPropagation(const ConstantBitPropagation&) = delete;
+  ConstantBitPropagation& operator=(const ConstantBitPropagation&) = delete;
+
   ~ConstantBitPropagation() { clearTables(); };
 
   // Returns the node after writing in simplifications from constant Bit

--- a/include/stp/Simplifier/constantBitP/FixedBits.h
+++ b/include/stp/Simplifier/constantBitP/FixedBits.h
@@ -133,7 +133,7 @@ public:
     for (unsigned i = 0; i < width; i++)
     {
       if (getValue(i))
-        result += (1 << i);
+        result += (1u << i);
     }
 
     return result;

--- a/lib/Simplifier/constantBitP/ConstantBitP_Arithmetic.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_Arithmetic.cpp
@@ -45,6 +45,9 @@ Result bvSubtractBothWays(vector<FixedBits*>& children, FixedBits& output)
 
   const int bitWidth = a.getWidth();
 
+  const unsigned initialFixedCount =
+      a.countFixed() + b.countFixed() + output.countFixed();
+
   FixedBits one(bitWidth, false);
   one.fixToZero();
   one.setFixed(0, true);
@@ -77,7 +80,10 @@ Result bvSubtractBothWays(vector<FixedBits*>& children, FixedBits& output)
       break;
   }
 
-  return NOT_IMPLEMENTED;
+  return (a.countFixed() + b.countFixed() + output.countFixed() ==
+          initialFixedCount)
+             ? NO_CHANGE
+             : CHANGED;
 }
 
 /////////////// ADDITION>
@@ -255,6 +261,10 @@ void setValue(FixedBits& a, const int i, bool v)
 Result bvAddBothWays(FixedBits& x, FixedBits& y, FixedBits& output)
 {
   const int bitWidth = output.getWidth();
+
+  const unsigned initialFixedCount =
+      x.countFixed() + y.countFixed() + output.countFixed();
+
   FixedBits carry(bitWidth + 1, false);
   carry.setFixed(0, true);
   carry.setValue(0, false);
@@ -336,7 +346,10 @@ Result bvAddBothWays(FixedBits& x, FixedBits& y, FixedBits& output)
     // cerr << i << "[" << ub << ":" << lb << "]" << endl;
   }
 
-  return NOT_IMPLEMENTED;
+  return (x.countFixed() + y.countFixed() + output.countFixed() ==
+          initialFixedCount)
+             ? NO_CHANGE
+             : CHANGED;
 }
 
 Result bvAddBothWays(vector<FixedBits*>& children, FixedBits& output)
@@ -354,15 +367,24 @@ Result bvAddBothWays(vector<FixedBits*>& children, FixedBits& output)
     assert(children[i]->getWidth() == bitWidth);
   }
 
-  int* columnL = (int*)alloca(sizeof(int) * bitWidth); // minimum  "" ""
-  int* columnH = (int*)alloca(
-      sizeof(int) * bitWidth); // maximum number of true partial products.
+  unsigned initialFixedCount = output.countFixed();
+  for (size_t i = 0; i < numberOfChildren; i++)
+    initialFixedCount += children[i]->countFixed();
+
+  // On the heap: bitWidth is unbounded, so these don't belong on the stack.
+  std::vector<int> columnL_store(bitWidth); // minimum  "" ""
+  std::vector<int> columnH_store(
+      bitWidth); // maximum number of true partial products.
+  int* columnL = columnL_store.data();
+  int* columnH = columnH_store.data();
 
   initialiseColumnCounts(columnL, columnH, bitWidth, numberOfChildren,
                          children);
 
-  int* sumH = (int*)alloca(sizeof(int) * bitWidth);
-  int* sumL = (int*)alloca(sizeof(int) * bitWidth);
+  std::vector<int> sumH_store(bitWidth);
+  std::vector<int> sumL_store(bitWidth);
+  int* sumH = sumH_store.data();
+  int* sumL = sumL_store.data();
   sumL[0] = columnL[0];
   sumH[0] = columnH[0];
 
@@ -518,7 +540,11 @@ Result bvAddBothWays(vector<FixedBits*>& children, FixedBits& output)
       }
     }
   }
-  return NOT_IMPLEMENTED;
+
+  unsigned finalFixedCount = output.countFixed();
+  for (size_t i = 0; i < numberOfChildren; i++)
+    finalFixedCount += children[i]->countFixed();
+  return (finalFixedCount == initialFixedCount) ? NO_CHANGE : CHANGED;
 }
 }
 }

--- a/lib/Simplifier/constantBitP/ConstantBitP_Comparison.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_Comparison.cpp
@@ -174,6 +174,18 @@ bool fast_exit(FixedBits& c0, FixedBits& c1)
   return false;
 }
 
+// Convert the before/after count of fixed bits into a Result. Transfer
+// functions only ever fix extra bits, so an unchanged count means nothing
+// was altered. The propagation loop trusts NO_CHANGE and skips rescheduling,
+// so it must only be returned when that is really so.
+Result fixedCountToResult(const unsigned before, const FixedBits& c0,
+                          const FixedBits& c1, const FixedBits& output)
+{
+  const unsigned now = c0.countFixed() + c1.countFixed() + output.countFixed();
+  assert(now >= before);
+  return (now == before) ? NO_CHANGE : CHANGED;
+}
+
 ///////// Signed operations.
 
 Result bvSignedLessThanBothWays(FixedBits& c0, FixedBits& c1, FixedBits& output)
@@ -182,6 +194,9 @@ Result bvSignedLessThanBothWays(FixedBits& c0, FixedBits& c1, FixedBits& output)
 
   if (!output.isFixed(0) && fast_exit(c0, c1))
     return NO_CHANGE;
+
+  const unsigned initialFixedCount =
+      c0.countFixed() + c1.countFixed() + output.countFixed();
 
   CBV c0_min = CONSTANTBV::BitVector_Create(c0.getWidth(), true);
   CBV c0_max = CONSTANTBV::BitVector_Create(c0.getWidth(), true);
@@ -230,7 +245,8 @@ Result bvSignedLessThanBothWays(FixedBits& c0, FixedBits& c1, FixedBits& output)
     t.setFixed(0, true);
     t.setValue(0, true);
     destroy(c0_min, c0_max, c1_min, c1_max);
-    return bvSignedGreaterThanEqualsBothWays(c0, c1, t);
+    return merge(bvSignedGreaterThanEqualsBothWays(c0, c1, t),
+                 fixedCountToResult(initialFixedCount, c0, c1, output));
   }
 
   const int msb = c0.getWidth() - 1;
@@ -317,7 +333,7 @@ Result bvSignedLessThanBothWays(FixedBits& c0, FixedBits& c1, FixedBits& output)
     }
   }
   destroy(c0_min, c0_max, c1_min, c1_max);
-  return NOT_IMPLEMENTED;
+  return fixedCountToResult(initialFixedCount, c0, c1, output);
 }
 
 Result bvSignedLessThanEqualsBothWays(FixedBits& c0, FixedBits& c1,
@@ -327,6 +343,9 @@ Result bvSignedLessThanEqualsBothWays(FixedBits& c0, FixedBits& c1,
 
   if (!output.isFixed(0) && fast_exit(c0, c1))
     return NO_CHANGE;
+
+  const unsigned initialFixedCount =
+      c0.countFixed() + c1.countFixed() + output.countFixed();
 
   CBV c0_min = CONSTANTBV::BitVector_Create(c0.getWidth(), true);
   CBV c0_max = CONSTANTBV::BitVector_Create(c0.getWidth(), true);
@@ -373,7 +392,8 @@ Result bvSignedLessThanEqualsBothWays(FixedBits& c0, FixedBits& c1,
     t.setFixed(0, true);
     t.setValue(0, true);
     destroy(c0_min, c0_max, c1_min, c1_max);
-    return bvSignedGreaterThanBothWays(c0, c1, t);
+    return merge(bvSignedGreaterThanBothWays(c0, c1, t),
+                 fixedCountToResult(initialFixedCount, c0, c1, output));
   }
 
   const int msb = c0.getWidth() - 1;
@@ -463,7 +483,7 @@ Result bvSignedLessThanEqualsBothWays(FixedBits& c0, FixedBits& c1,
   }
 
   destroy(c0_min, c0_max, c1_min, c1_max);
-  return NOT_IMPLEMENTED;
+  return fixedCountToResult(initialFixedCount, c0, c1, output);
 }
 
 ///////////////////////// UNSIGNED.
@@ -475,6 +495,9 @@ Result bvLessThanBothWays(FixedBits& c0, FixedBits& c1, FixedBits& output)
 
   if (!output.isFixed(0) && fast_exit(c0, c1))
     return NO_CHANGE;
+
+  const unsigned initialFixedCount =
+      c0.countFixed() + c1.countFixed() + output.countFixed();
 
   CBV c0_min = CONSTANTBV::BitVector_Create(c0.getWidth(), true);
   CBV c0_max = CONSTANTBV::BitVector_Create(c0.getWidth(), true);
@@ -524,7 +547,8 @@ Result bvLessThanBothWays(FixedBits& c0, FixedBits& c1, FixedBits& output)
     t.setFixed(0, true);
     t.setValue(0, true);
     destroy(c0_min, c0_max, c1_min, c1_max);
-    return bvGreaterThanEqualsBothWays(c0, c1, t);
+    return merge(bvGreaterThanEqualsBothWays(c0, c1, t),
+                 fixedCountToResult(initialFixedCount, c0, c1, output));
   }
 
   if (output.isFixed(0) && output.getValue(0))
@@ -573,7 +597,7 @@ Result bvLessThanBothWays(FixedBits& c0, FixedBits& c1, FixedBits& output)
   }
 
   destroy(c0_min, c0_max, c1_min, c1_max);
-  return NOT_IMPLEMENTED;
+  return fixedCountToResult(initialFixedCount, c0, c1, output);
 }
 
 Result bvLessThanEqualsBothWays(FixedBits& c0, FixedBits& c1, FixedBits& output)
@@ -582,6 +606,9 @@ Result bvLessThanEqualsBothWays(FixedBits& c0, FixedBits& c1, FixedBits& output)
 
   if (!output.isFixed(0) && fast_exit(c0, c1))
     return NO_CHANGE;
+
+  const unsigned initialFixedCount =
+      c0.countFixed() + c1.countFixed() + output.countFixed();
 
   CBV c0_min = CONSTANTBV::BitVector_Create(c0.getWidth(), true);
   CBV c0_max = CONSTANTBV::BitVector_Create(c0.getWidth(), true);
@@ -630,7 +657,8 @@ Result bvLessThanEqualsBothWays(FixedBits& c0, FixedBits& c1, FixedBits& output)
     t.setFixed(0, true);
     t.setValue(0, true);
     destroy(c0_min, c0_max, c1_min, c1_max);
-    return bvGreaterThanBothWays(c0, c1, t);
+    return merge(bvGreaterThanBothWays(c0, c1, t),
+                 fixedCountToResult(initialFixedCount, c0, c1, output));
   }
 
   // We only deal with the true case in this function.
@@ -684,7 +712,7 @@ Result bvLessThanEqualsBothWays(FixedBits& c0, FixedBits& c1, FixedBits& output)
     }
   }
   destroy(c0_min, c0_max, c1_min, c1_max);
-  return NOT_IMPLEMENTED;
+  return fixedCountToResult(initialFixedCount, c0, c1, output);
 }
 }
 }

--- a/lib/Simplifier/constantBitP/ConstantBitP_MaxPrecision.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_MaxPrecision.cpp
@@ -50,7 +50,7 @@ ASTNode createConstant(int bitWidth, int val, STPMgr* beev)
   CBV cbv = CONSTANTBV::BitVector_Create(bitWidth, true);
   int max = bitWidth > ((int)sizeof(int) * 8) ? sizeof(int) * 8 : bitWidth;
   for (int i = 0; i < max; i++)
-    if (val & (1 << i))
+    if (val & (1u << i))
       CONSTANTBV::BitVector_Bit_On(cbv, i);
   return beev->CreateBVConst(cbv, bitWidth);
 }

--- a/lib/Simplifier/constantBitP/ConstantBitP_Multiplication.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_Multiplication.cpp
@@ -147,8 +147,8 @@ Result adjustColumns(const FixedBits& x, const FixedBits& y, int* columnL,
 {
   const unsigned bitWidth = x.getWidth();
 
-  bool* yFixedFalse = (bool*)alloca(sizeof(bool) * bitWidth);
-  bool* xFixedFalse = (bool*)alloca(sizeof(bool) * bitWidth);
+  std::vector<bool> yFixedFalse(bitWidth);
+  std::vector<bool> xFixedFalse(bitWidth);
   for (unsigned i = 0; i < bitWidth; i++)
   {
     yFixedFalse[i] = y.isFixed(i) && !y.getValue(i);
@@ -604,16 +604,22 @@ Result bvMultiplyBothWays(vector<FixedBits*>& children, FixedBits& output,
   if (CONFLICT == r)
     return r;
 
+  // On the heap: bitWidth is unbounded, and this used to alloca inside the
+  // loop, which only returns the stack space when the function exits. The
+  // ColumnCounts constructor re-initialises the arrays each iteration.
+  std::vector<signed> columnH_store(bitWidth); // max. no of true partial products.
+  std::vector<signed> columnL_store(bitWidth); // minimum ""  ""
+  std::vector<signed> sumH_store(bitWidth);
+  std::vector<signed> sumL_store(bitWidth);
+
   bool changed = true;
   while (changed)
   {
     changed = false;
-    signed* columnH = (signed*)alloca(
-        sizeof(signed) * bitWidth); // maximum number of true partial products.
-    signed* columnL =
-        (signed*)alloca(sizeof(signed) * bitWidth); // minimum  ""            ""
-    signed* sumH = (signed*)alloca(sizeof(signed) * bitWidth);
-    signed* sumL = (signed*)alloca(sizeof(signed) * bitWidth);
+    signed* columnH = columnH_store.data();
+    signed* columnL = columnL_store.data();
+    signed* sumH = sumH_store.data();
+    signed* sumL = sumL_store.data();
     ColumnCounts cc(columnH, columnL, sumH, sumL, bitWidth, output);
 
     // Use the number of zeroes and ones in a column to update the possible

--- a/lib/Simplifier/constantBitP/ConstantBitP_Shifting.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_Shifting.cpp
@@ -117,7 +117,7 @@ FixedBits getPossible(unsigned bitWidth, bool possibleShift[],
         {
           v.setFixed(j, true);
           if (j < sizeof(unsigned) * 8)
-            v.setValue(j, 0 != (i & (1 << j)));
+            v.setValue(j, 0 != (i & (1u << j)));
           else
             v.setValue(j, false);
         }
@@ -131,7 +131,7 @@ FixedBits getPossible(unsigned bitWidth, bool possibleShift[],
           if (v.isFixed(j))
           {
             // union.
-            if (v.getValue(j) != (0 != (i & (1 << j))))
+            if (v.getValue(j) != (0 != (i & (1u << j))))
               v.setFixed(j, false);
           }
         }
@@ -717,7 +717,7 @@ Result bvLeftShiftBothWays(vector<FixedBits*>& children, FixedBits& output)
         {
           v.setFixed(j, true);
           if (j < sizeof(unsigned) * 8)
-            v.setValue(j, 0 != (i & (1 << j)));
+            v.setValue(j, 0 != (i & (1u << j)));
           else
             v.setValue(j, false);
         }
@@ -731,7 +731,7 @@ Result bvLeftShiftBothWays(vector<FixedBits*>& children, FixedBits& output)
           if (v.isFixed(j))
           {
             // union.
-            if (v.getValue(j) != (0 != (i & (1 << j))))
+            if (v.getValue(j) != (0 != (i & (1u << j))))
               v.setFixed(j, false);
           }
         }

--- a/lib/Simplifier/constantBitP/ConstantBitP_TransferFunctions.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_TransferFunctions.cpp
@@ -312,6 +312,9 @@ Result bvUnaryMinusBothWays(vector<FixedBits*>& children, FixedBits& output)
   assert(children.size() == 1);
   const int bitWidth = children[0]->getWidth();
 
+  const unsigned initialFixedCount =
+      children[0]->countFixed() + output.countFixed();
+
   // If it's only one bit. This will be negative one.
   FixedBits one(bitWidth, false);
   one.fixToZero();
@@ -345,7 +348,10 @@ Result bvUnaryMinusBothWays(vector<FixedBits*>& children, FixedBits& output)
       break;
   }
 
-  return NOT_IMPLEMENTED; // don't set the status properly yet..
+  return (children[0]->countFixed() + output.countFixed() ==
+          initialFixedCount)
+             ? NO_CHANGE
+             : CHANGED;
 }
 
 Result bvConcatBothWays(vector<FixedBits*>& children, FixedBits& output)

--- a/lib/Simplifier/constantBitP/FixedBits.cpp
+++ b/lib/Simplifier/constantBitP/FixedBits.cpp
@@ -281,7 +281,7 @@ bool FixedBits::unsignedHolds_old(unsigned val)
   {
     if (i < (unsigned)width && i < sizeof(unsigned) * 8)
     {
-      if (isFixed(i) && (getValue(i) != (((val & (1 << i))) != 0)))
+      if (isFixed(i) && (getValue(i) != (((val & (1u << i))) != 0)))
         return false;
     }
     else if (i < (unsigned)width)
@@ -291,7 +291,7 @@ bool FixedBits::unsignedHolds_old(unsigned val)
     }
     else // The unsigned value is bigger than the bitwidth of this.
     {
-      if (val & (1 << i))
+      if (val & (1u << i))
         return false;
     }
   }
@@ -406,7 +406,7 @@ FixedBits FixedBits::fromUnsignedInt(unsigned width, unsigned val)
     if (i < width && i < sizeof(unsigned) * 8)
     {
       output.setFixed(i, true);
-      output.setValue(i, (val & (1 << i)));
+      output.setValue(i, (val & (1u << i)));
     }
     else if (i < width)
     {
@@ -415,7 +415,7 @@ FixedBits FixedBits::fromUnsignedInt(unsigned width, unsigned val)
     }
     else // The unsigned value is bigger than the bitwidth of this.
     {    // so it can't be represented.
-      if (val & (1 << i))
+      if (val & (1u << i))
       {
         stp::FatalError(LOCATION "Cant be represented.");
       }
@@ -431,7 +431,7 @@ void FixedBits::fromUnsigned(unsigned val)
     if (i < width && i < sizeof(unsigned) * 8)
     {
       setFixed(i, true);
-      setValue(i, (val & (1 << i)));
+      setValue(i, (val & (1u << i)));
     }
     else if (i < width)
     {
@@ -440,7 +440,7 @@ void FixedBits::fromUnsigned(unsigned val)
     }
     else // The unsigned value is bigger than the bitwidth of this.
     {    // so it can't be represented.
-      if (val & (1 << i))
+      if (val & (1u << i))
       {
         stp::FatalError(LOCATION "Cant be represented.");
       }
@@ -540,12 +540,12 @@ void FixedBits::getUnsignedMinMax(unsigned& minShift, unsigned& maxShift) const
   {
     if ((*this)[i] == '1')
     {
-      minShift |= (1 << i);
-      maxShift |= (1 << i);
+      minShift |= (1u << i);
+      maxShift |= (1u << i);
     }
     else if ((*this)[i] == '*')
     {
-      maxShift |= (1 << i);
+      maxShift |= (1u << i);
     }
   }
 


### PR DESCRIPTION
Re-lands #517 onto master. #517 was accidentally based on `cbitp-exhaustive-tests` (its stack parent) rather than master, so its squash-merge landed on that branch. This cherry-picks the squash commit 8be53b54 onto master; the tree is identical to `cbitp-exhaustive-tests` after the merge.

See #517 for the full description and review.