### PR TITLE
Make NodeDomainAnalysis::harmonise optimally tight, with exhaustive tests

### DIFF
--- a/include/stp/Simplifier/NodeDomainAnalysis.h
+++ b/include/stp/Simplifier/NodeDomainAnalysis.h
@@ -66,7 +66,6 @@ class NodeDomainAnalysis
 
   UnsignedIntervalAnalysis intervalAnalysis;
 
-  unsigned todo = 0;
   unsigned tighten = 0;
 
   void stats();

--- a/lib/Simplifier/NodeDomainAnalysis.cpp
+++ b/lib/Simplifier/NodeDomainAnalysis.cpp
@@ -26,14 +26,6 @@ THE SOFTWARE.
 #include "stp/Simplifier/NodeDomainAnalysis.h"
 #include "stp/Simplifier/constantBitP/ConstantBitPropagation.h"
 
-namespace simplifier
-{
-  namespace constantBitP
-  {
-    Result fix(FixedBits& b, stp::CBV low, stp::CBV high);
-  }
-}
-
 namespace stp
 {
 
@@ -60,7 +52,130 @@ namespace stp
     return result;
   }
 
-  // Trim so the min/max of both domains are consistent with each other.
+  // The largest value that matches the fixed bits and is <= bound,
+  // or nullptr if there is no such value. Caller destroys the result.
+  static CBV maxBelow(const FixedBits& bits, const CBV bound)
+  {
+    const int width = bits.getWidth();
+
+    // The highest bit where the fixed bits differ from the bound.
+    int mismatch = -1;
+    for (int i = width - 1; i >= 0; i--)
+      if (bits.isFixed(i) &&
+          bits.getValue(i) != CONSTANTBV::BitVector_bit_test(bound, i))
+      {
+        mismatch = i;
+        break;
+      }
+
+    if (mismatch == -1)
+      return CONSTANTBV::BitVector_Clone(bound);
+
+    // The result equals the bound above "diverge", goes below the bound
+    // at "diverge", and is maximised underneath.
+    int diverge;
+    if (!bits.getValue(mismatch))
+      diverge = mismatch; // the fixed zero takes it below the bound.
+    else
+    {
+      // The fixed one takes it above the bound, so an unfixed bit
+      // higher up must go below instead. The lowest such bit loses the
+      // least.
+      diverge = -1;
+      for (int j = mismatch + 1; j < width; j++)
+        if (!bits.isFixed(j) && CONSTANTBV::BitVector_bit_test(bound, j))
+        {
+          diverge = j;
+          break;
+        }
+      if (diverge == -1)
+        return nullptr;
+    }
+
+    CBV result = CONSTANTBV::BitVector_Create(width, true);
+    for (int i = 0; i < width; i++)
+    {
+      bool bit;
+      if (i > diverge)
+        bit = CONSTANTBV::BitVector_bit_test(bound, i);
+      else if (i == diverge)
+        bit = false;
+      else
+        bit = bits.isFixed(i) ? bits.getValue(i) : true;
+      if (bit)
+        CONSTANTBV::BitVector_Bit_On(result, i);
+    }
+    return result;
+  }
+
+  // The smallest value that matches the fixed bits and is >= bound,
+  // or nullptr if there is no such value. Caller destroys the result.
+  static CBV minAbove(const FixedBits& bits, const CBV bound)
+  {
+    const int width = bits.getWidth();
+
+    int mismatch = -1;
+    for (int i = width - 1; i >= 0; i--)
+      if (bits.isFixed(i) &&
+          bits.getValue(i) != CONSTANTBV::BitVector_bit_test(bound, i))
+      {
+        mismatch = i;
+        break;
+      }
+
+    if (mismatch == -1)
+      return CONSTANTBV::BitVector_Clone(bound);
+
+    // The result equals the bound above "diverge", goes above the bound
+    // at "diverge", and is minimised underneath.
+    int diverge;
+    if (bits.getValue(mismatch))
+      diverge = mismatch; // the fixed one takes it above the bound.
+    else
+    {
+      diverge = -1;
+      for (int j = mismatch + 1; j < width; j++)
+        if (!bits.isFixed(j) && !CONSTANTBV::BitVector_bit_test(bound, j))
+        {
+          diverge = j;
+          break;
+        }
+      if (diverge == -1)
+        return nullptr;
+    }
+
+    CBV result = CONSTANTBV::BitVector_Create(width, true);
+    for (int i = 0; i < width; i++)
+    {
+      bool bit;
+      if (i > diverge)
+        bit = CONSTANTBV::BitVector_bit_test(bound, i);
+      else if (i == diverge)
+        bit = true;
+      else
+        bit = bits.isFixed(i) ? bits.getValue(i) : false;
+      if (bit)
+        CONSTANTBV::BitVector_Bit_On(result, i);
+    }
+    return result;
+  }
+
+  // Whether some value matches the fixed bits and lies within [min, max].
+  static bool hasMemberInRange(const FixedBits& bits, const CBV min,
+                               const CBV max)
+  {
+    CBV smallest = minAbove(bits, min);
+    if (smallest == nullptr)
+      return false;
+    const bool result = CONSTANTBV::BitVector_Lexicompare(smallest, max) <= 0;
+    CONSTANTBV::BitVector_Destroy(smallest);
+    return result;
+  }
+
+  // Trim each domain to exactly the values the two domains share: the
+  // interval becomes [min, max] of the shared values, and a bit is fixed
+  // whenever every shared value agrees on it. Assumes the domains share
+  // at least one value. Idempotent.
   void NodeDomainAnalysis::harmonise(FixedBits * &bits, UnsignedInterval * &interval)
   {
       if (bits == nullptr && interval == nullptr)
@@ -74,117 +189,78 @@ namespace stp
           return; // full information already.
       }
 
-      bool changed=false;
-
-      // Tighten the intervals using the fixed bit information.
       if (bits != nullptr)
       {
         const auto width = bits->getWidth();
 
-        if (interval == nullptr) 
+        if (interval == nullptr)
             interval = new UnsignedInterval(width);
 
-        // (1) Cheap attempt to tighten intervals.
-        CBV max = bits->GetMaxBVConst();
-        CBV min = bits->GetMinBVConst();
-        if (interval->replaceMaxIfTightens(max))
-          tighten++;
-        if (interval->replaceMinIfTightens(min))
-          tighten++;
-        CONSTANTBV::BitVector_Destroy(min);
-        CONSTANTBV::BitVector_Destroy(max);
+        // The least and greatest values the domains share.
+        CBV max = maxBelow(*bits, interval->maxV);
+        CBV min = minAbove(*bits, interval->minV);
 
-        // (2) More comprehensive is required because cheap (1) isn't enough.
-        if(!bits->in(interval->maxV))
+        // The domains share a value, so both exist.
+        assert(max != nullptr && min != nullptr);
+
+        if (max != nullptr)
         {
-          const stp::CBV max = bits->GetMaxBVConst();
-          assert( width > 1 ); // i don't think can come in here otherwise.
-          
-          stp::CBV result = CONSTANTBV::BitVector_Create(width, true);
-          bool reduced = false;
-          for (int i = width-1; i >=0 ; i--)
-          {
-            const bool bit = CONSTANTBV::BitVector_bit_test(interval->maxV, i);
-            if (bits->isFixed(i))
-            {
-              if (bits->getValue(i))
-              {
-                  CONSTANTBV::BitVector_Bit_On(result,i);
-                  if (!bit && !reduced)
-                  {
-                     // We are increasing the result. So we need to reduce above.
-                    for (unsigned j = i+1 ; j <= width-1 ; j++)
-                    {
-                      if (bits->isFixed(j))   
-                        continue;
-                      const bool bv = CONSTANTBV::BitVector_bit_test(interval->maxV, j);
-                      if (bv)
-                      {
-                        CONSTANTBV::BitVector_Bit_Off(result,j);
-                        reduced = true;
-                        break;
-                      }
-                      else
-                        CONSTANTBV::BitVector_Bit_On(result,j);
-                    }
-                    assert(reduced);
-                  }
-              }
-              else
-              {
-                  CONSTANTBV::BitVector_Bit_Off(result,i);
-                  if (bit)
-                    reduced=true;
-              }
-            }
-            else
-            {
-              if (reduced || bit)
-                 CONSTANTBV::BitVector_Bit_On(result,i);
-              else
-                CONSTANTBV::BitVector_Bit_Off(result,i);
-            }
-          }
-
-          // The old max must be greater or equal to the new max.
-          assert (CONSTANTBV::BitVector_Lexicompare(max, result) > 0); 
-          assert (bits->in(result)); 
-
-          interval->replaceMaxIfTightens(result);
-          CONSTANTBV::BitVector_Destroy(result);
+          if (interval->replaceMaxIfTightens(max))
+            tighten++;
           CONSTANTBV::BitVector_Destroy(max);
-          tighten++;
         }
-        if(!bits->in(interval->minV))
+        if (min != nullptr)
         {
-            //TODO - still need to do it on the minimimum.
-            todo++;
+          if (interval->replaceMinIfTightens(min))
+            tighten++;
+          CONSTANTBV::BitVector_Destroy(min);
         }
       }
-    
-      if (interval != nullptr)
+
+      if (interval != nullptr && !interval->isComplete())
       {
         if (bits == nullptr)
         {
           bits = new FixedBits(interval->getWidth(),false); /// TODO do we really need to know if it's boolean??
         }
-        const auto last = bits->countFixed();
-        simplifier::constantBitP::fix(*bits, interval->minV, interval->maxV);
-        if (bits->countFixed() != last)
+
+        // Fix each bit that all the shared values agree on. The interval
+        // is already exactly the range of the shared values, so a bit
+        // can take a polarity iff fixing it that way leaves a value
+        // matching the fixed bits inside the interval.
+        const unsigned width = bits->getWidth();
+        for (unsigned i = 0; i < width; i++)
         {
-          changed = true;
-          tighten++;
-        }
-        if (bits->countFixed() == 0)
-        {
-          delete bits;
-          bits = nullptr;
+          if (bits->isFixed(i))
+            continue;
+
+          bits->setFixed(i, true);
+          bits->setValue(i, false);
+          const bool canBeZero =
+              hasMemberInRange(*bits, interval->minV, interval->maxV);
+          bits->setValue(i, true);
+          const bool canBeOne =
+              hasMemberInRange(*bits, interval->minV, interval->maxV);
+
+          assert(canBeZero || canBeOne); // the domains share a value.
+
+          if (canBeZero == canBeOne)
+            bits->setFixed(i, false);
+          else
+          {
+            bits->setValue(i, canBeOne);
+            tighten++;
+          }
         }
       }
-    
+
+      if (bits != nullptr && bits->countFixed() == 0)
+      {
+        delete bits;
+        bits = nullptr;
+      }
+
       assert(intersects(bits, interval));
-      if (changed)
-        harmonise(bits, interval);
   }
 
   std::pair<FixedBits*, UnsignedInterval*> NodeDomainAnalysis::buildMap(const ASTNode& n)
@@ -337,7 +413,6 @@ namespace stp
   {
     if (bm.UserFlags.stats_flag)
     {
-      std::cerr << "{NodeDomainAnalysis} TODO:" << todo << std::endl;
       std::cerr << "{NodeDomainAnalysis} Tightened:" << tighten << std::endl;
 
       intervalAnalysis.stats();

--- a/tests/unit-tests/NodeDomainAnalysis_Test.cpp
+++ b/tests/unit-tests/NodeDomainAnalysis_Test.cpp
@@ -97,7 +97,7 @@ TEST(NodeDomainAnalysis_Test, 0)
 }
 
 // fixed bits are null, internval is costant.
-TEST(NodeDomainAnalysis_Test, DISABLED_1)
+TEST(NodeDomainAnalysis_Test, 1)
 {
   Context c;
 
@@ -114,7 +114,7 @@ TEST(NodeDomainAnalysis_Test, DISABLED_1)
 }
 
 
-TEST(NodeDomainAnalysis_Test, DISABLED_2)
+TEST(NodeDomainAnalysis_Test, 2)
 {
   Context c;
   MTRand rand(10U);
@@ -145,7 +145,7 @@ TEST(NodeDomainAnalysis_Test, DISABLED_2)
 }
 
 
-TEST(NodeDomainAnalysis_Test, DISABLED_3)
+TEST(NodeDomainAnalysis_Test, 3)
 {
   Context c;
 
@@ -436,14 +436,9 @@ TEST(NodeDomainAnalysis_Test, harmonise_idempotent_interval_only)
 }
 
 // Checks harmonise produces the tightest possible domains: the interval
-// exactly [min, max] of the shared values, and every bit that agrees
-// across all shared values fixed.
-// Disabled because harmonise is deliberately approximate: the interval
-// minimum isn't comprehensively tightened from the fixed bits (a TODO in
-// NodeDomainAnalysis::harmonise), and fix() only fixes the leading bits
-// that min/max agree on. Roughly 6% of width<=5 cases are not optimally
-// tight. Harmonise is idempotent regardless (tested above).
-TEST(NodeDomainAnalysis_Test, DISABLED_harmonise_perfectly_tight)
+// exactly [min, max] of the shared values, and a bit fixed if and only
+// if all the shared values agree on it.
+TEST(NodeDomainAnalysis_Test, harmonise_perfectly_tight)
 {
   boot();
   Context c;
@@ -493,8 +488,9 @@ TEST(NodeDomainAnalysis_Test, DISABLED_harmonise_perfectly_tight)
             tight = false;
           CONSTANTBV::BitVector_Destroy(best);
 
-          // A bit the shared values all agree on should be fixed.
-          for (unsigned i = 0; i < width && bits != nullptr; i++)
+          // A bit should be fixed exactly when the shared values all
+          // agree on it, and to the value they agree on.
+          for (unsigned i = 0; i < width; i++)
           {
             bool agree = true;
             for (unsigned v : sharedValues)
@@ -503,7 +499,11 @@ TEST(NodeDomainAnalysis_Test, DISABLED_harmonise_perfectly_tight)
                 agree = false;
                 break;
               }
-            if (agree != bits->isFixed(i))
+            const bool isFixed = (bits != nullptr) && bits->isFixed(i);
+            if (agree != isFixed)
+              tight = false;
+            else if (isFixed &&
+                     bits->getValue(i) != (((sharedValues.front() >> i) & 1) != 0))
               tight = false;
           }
 

--- a/tests/unit-tests/NodeDomainAnalysis_Test.cpp
+++ b/tests/unit-tests/NodeDomainAnalysis_Test.cpp
@@ -161,8 +161,425 @@ TEST(NodeDomainAnalysis_Test, DISABLED_3)
   stp::UnsignedInterval* b_ptr = nullptr;
 
   c.domain.harmonise(a_ptr, b_ptr);
-  
+
   ASSERT_EQ(a_ptr->isTotallyFixed(), true);
   ASSERT_EQ(b_ptr->isConstant(), true);
+}
+
+///// Idempotence of harmonise. Tightening should reach a fixpoint in a
+///// single call, so a second call must leave both domains unchanged.
+
+static void boot()
+{
+  static bool booted = false;
+  if (!booted)
+  {
+    CONSTANTBV::BitVector_Boot();
+    booted = true;
+  }
+}
+
+static stp::CBV cbvFromUnsigned(unsigned width, unsigned v)
+{
+  assert(width <= 32);
+  stp::CBV result = CONSTANTBV::BitVector_Create(width, true);
+  for (unsigned i = 0; i < width; i++)
+    if ((v >> i) & 1)
+      CONSTANTBV::BitVector_Bit_On(result, i);
+  return result;
+}
+
+// Build a FixedBits from a base-3 encoding: digit 0 = unfixed,
+// digit 1 = fixed to zero, digit 2 = fixed to one.
+static stp::FixedBits bitsFromTernary(unsigned width, unsigned config)
+{
+  stp::FixedBits b(width, false);
+  for (unsigned i = 0; i < width; i++)
+  {
+    const unsigned digit = config % 3;
+    config /= 3;
+    if (digit == 0)
+      b.setFixed(i, false);
+    else
+    {
+      b.setFixed(i, true);
+      b.setValue(i, digit == 2);
+    }
+  }
+  return b;
+}
+
+static bool bitsContain(const stp::FixedBits& b, unsigned v)
+{
+  for (unsigned i = 0; i < b.getWidth(); i++)
+    if (b.isFixed(i) && b.getValue(i) != (((v >> i) & 1) != 0))
+      return false;
+  return true;
+}
+
+// Whether "v" is in the intersection of the two domains, where nullptr
+// means the domain contains everything.
+static bool contains(const stp::FixedBits* bits,
+                     const stp::UnsignedInterval* interval, unsigned width,
+                     unsigned v)
+{
+  if (bits != nullptr && !bitsContain(*bits, v))
+    return false;
+  if (interval != nullptr)
+  {
+    stp::CBV cbv = cbvFromUnsigned(width, v);
+    const bool in = interval->in(cbv);
+    CONSTANTBV::BitVector_Destroy(cbv);
+    if (!in)
+      return false;
+  }
+  return true;
+}
+
+static std::string describe(const stp::FixedBits* bits,
+                            const stp::UnsignedInterval* interval)
+{
+  std::stringstream s;
+  if (bits == nullptr)
+    s << "bits: null";
+  else
+    s << "bits: " << *bits;
+  s << ", interval: ";
+  if (interval == nullptr)
+    s << "null";
+  else
+  {
+    unsigned char* min = CONSTANTBV::BitVector_to_Bin(interval->minV);
+    unsigned char* max = CONSTANTBV::BitVector_to_Bin(interval->maxV);
+    s << "[" << min << ", " << max << "]";
+    free(min);
+    free(max);
+  }
+  return s.str();
+}
+
+// harmonise, then harmonise again, and check the second call changed
+// nothing. Deletes/replaces the domains via harmonise, so callers must
+// delete what remains afterwards.
+static void checkIdempotent(Context& c, stp::FixedBits*& bits,
+                            stp::UnsignedInterval*& interval,
+                            const std::string& input)
+{
+  c.domain.harmonise(bits, interval);
+
+  // Snapshot the state after the first call.
+  stp::FixedBits* bitsAfterFirst =
+      (bits == nullptr) ? nullptr : new stp::FixedBits(*bits);
+  stp::CBV minAfterFirst =
+      (interval == nullptr) ? nullptr : CONSTANTBV::BitVector_Clone(interval->minV);
+  stp::CBV maxAfterFirst =
+      (interval == nullptr) ? nullptr : CONSTANTBV::BitVector_Clone(interval->maxV);
+  const std::string afterFirst = describe(bits, interval);
+
+  c.domain.harmonise(bits, interval);
+
+  const std::string msg = "input: " + input + ", after first call: " +
+                          afterFirst + ", after second call: " +
+                          describe(bits, interval);
+
+  ASSERT_EQ(bitsAfterFirst == nullptr, bits == nullptr) << msg;
+  if (bits != nullptr)
+    ASSERT_TRUE(stp::FixedBits::equals(*bitsAfterFirst, *bits)) << msg;
+
+  ASSERT_EQ(minAfterFirst == nullptr, interval == nullptr) << msg;
+  if (interval != nullptr)
+  {
+    ASSERT_EQ(0, CONSTANTBV::BitVector_Lexicompare(minAfterFirst, interval->minV)) << msg;
+    ASSERT_EQ(0, CONSTANTBV::BitVector_Lexicompare(maxAfterFirst, interval->maxV)) << msg;
+  }
+
+  delete bitsAfterFirst;
+  if (minAfterFirst != nullptr)
+    CONSTANTBV::BitVector_Destroy(minAfterFirst);
+  if (maxAfterFirst != nullptr)
+    CONSTANTBV::BitVector_Destroy(maxAfterFirst);
+}
+
+// Every fixed-bits pattern crossed with every interval that shares at
+// least one value with it. Checks that harmonise is idempotent and that
+// it neither adds nor removes values from the intersection.
+TEST(NodeDomainAnalysis_Test, harmonise_idempotent_exhaustive)
+{
+  boot();
+  Context c;
+
+  for (unsigned width = 1; width <= 5; width++)
+  {
+    unsigned configs = 1;
+    for (unsigned i = 0; i < width; i++)
+      configs *= 3;
+    const unsigned values = 1u << width;
+
+    for (unsigned config = 0; config < configs; config++)
+    {
+      const stp::FixedBits pattern = bitsFromTernary(width, config);
+
+      for (unsigned lo = 0; lo < values; lo++)
+        for (unsigned hi = lo; hi < values; hi++)
+        {
+          // harmonise requires the domains to intersect.
+          bool shared = false;
+          for (unsigned v = lo; v <= hi && !shared; v++)
+            shared = bitsContain(pattern, v);
+          if (!shared)
+            continue;
+
+          stp::FixedBits* bits = new stp::FixedBits(pattern);
+          stp::UnsignedInterval* interval = new stp::UnsignedInterval(
+              cbvFromUnsigned(width, lo), cbvFromUnsigned(width, hi));
+
+          const std::string input = describe(bits, interval);
+
+          std::vector<bool> memberBefore(values);
+          for (unsigned v = 0; v < values; v++)
+            memberBefore[v] = contains(bits, interval, width, v);
+
+          checkIdempotent(c, bits, interval, input);
+          if (::testing::Test::HasFatalFailure())
+            return;
+
+          // Tightening must preserve the intersection exactly.
+          for (unsigned v = 0; v < values; v++)
+            ASSERT_EQ(memberBefore[v], contains(bits, interval, width, v))
+                << "value " << v << " input: " << input << ", output: "
+                << describe(bits, interval);
+
+          delete bits;
+          delete interval;
+        }
+    }
+  }
+}
+
+// Fixed bits with no interval: harmonise builds the interval, and must
+// still be idempotent.
+TEST(NodeDomainAnalysis_Test, harmonise_idempotent_bits_only)
+{
+  boot();
+  Context c;
+
+  for (unsigned width = 1; width <= 5; width++)
+  {
+    unsigned configs = 1;
+    for (unsigned i = 0; i < width; i++)
+      configs *= 3;
+    const unsigned values = 1u << width;
+
+    for (unsigned config = 0; config < configs; config++)
+    {
+      stp::FixedBits* bits = new stp::FixedBits(bitsFromTernary(width, config));
+      stp::UnsignedInterval* interval = nullptr;
+
+      const std::string input = describe(bits, interval);
+
+      std::vector<bool> memberBefore(values);
+      for (unsigned v = 0; v < values; v++)
+        memberBefore[v] = contains(bits, interval, width, v);
+
+      checkIdempotent(c, bits, interval, input);
+      if (::testing::Test::HasFatalFailure())
+        return;
+
+      for (unsigned v = 0; v < values; v++)
+        ASSERT_EQ(memberBefore[v], contains(bits, interval, width, v))
+            << "value " << v << " input: " << input << ", output: "
+            << describe(bits, interval);
+
+      delete bits;
+      delete interval;
+    }
+  }
+}
+
+// An interval with no fixed bits: harmonise builds the fixed bits, and
+// must still be idempotent.
+TEST(NodeDomainAnalysis_Test, harmonise_idempotent_interval_only)
+{
+  boot();
+  Context c;
+
+  for (unsigned width = 1; width <= 5; width++)
+  {
+    const unsigned values = 1u << width;
+
+    for (unsigned lo = 0; lo < values; lo++)
+      for (unsigned hi = lo; hi < values; hi++)
+      {
+        stp::FixedBits* bits = nullptr;
+        stp::UnsignedInterval* interval = new stp::UnsignedInterval(
+            cbvFromUnsigned(width, lo), cbvFromUnsigned(width, hi));
+
+        const std::string input = describe(bits, interval);
+
+        std::vector<bool> memberBefore(values);
+        for (unsigned v = 0; v < values; v++)
+          memberBefore[v] = contains(bits, interval, width, v);
+
+        checkIdempotent(c, bits, interval, input);
+        if (::testing::Test::HasFatalFailure())
+          return;
+
+        for (unsigned v = 0; v < values; v++)
+          ASSERT_EQ(memberBefore[v], contains(bits, interval, width, v))
+              << "value " << v << " input: " << input << ", output: "
+              << describe(bits, interval);
+
+        delete bits;
+        delete interval;
+      }
+  }
+}
+
+// Checks harmonise produces the tightest possible domains: the interval
+// exactly [min, max] of the shared values, and every bit that agrees
+// across all shared values fixed.
+// Disabled because harmonise is deliberately approximate: the interval
+// minimum isn't comprehensively tightened from the fixed bits (a TODO in
+// NodeDomainAnalysis::harmonise), and fix() only fixes the leading bits
+// that min/max agree on. Roughly 6% of width<=5 cases are not optimally
+// tight. Harmonise is idempotent regardless (tested above).
+TEST(NodeDomainAnalysis_Test, DISABLED_harmonise_perfectly_tight)
+{
+  boot();
+  Context c;
+
+  unsigned imperfect = 0;
+  unsigned total = 0;
+  std::string example;
+
+  for (unsigned width = 1; width <= 5; width++)
+  {
+    unsigned configs = 1;
+    for (unsigned i = 0; i < width; i++)
+      configs *= 3;
+    const unsigned values = 1u << width;
+
+    for (unsigned config = 0; config < configs; config++)
+    {
+      const stp::FixedBits pattern = bitsFromTernary(width, config);
+
+      for (unsigned lo = 0; lo < values; lo++)
+        for (unsigned hi = lo; hi < values; hi++)
+        {
+          std::vector<unsigned> sharedValues;
+          for (unsigned v = lo; v <= hi; v++)
+            if (bitsContain(pattern, v))
+              sharedValues.push_back(v);
+          if (sharedValues.empty())
+            continue;
+
+          stp::FixedBits* bits = new stp::FixedBits(pattern);
+          stp::UnsignedInterval* interval = new stp::UnsignedInterval(
+              cbvFromUnsigned(width, lo), cbvFromUnsigned(width, hi));
+          const std::string input = describe(bits, interval);
+
+          c.domain.harmonise(bits, interval);
+          total++;
+
+          bool tight = true;
+
+          // The tightest interval is [min,max] of the shared values.
+          stp::CBV best = cbvFromUnsigned(width, sharedValues.front());
+          if (CONSTANTBV::BitVector_Lexicompare(best, interval->minV) != 0)
+            tight = false;
+          CONSTANTBV::BitVector_Destroy(best);
+          best = cbvFromUnsigned(width, sharedValues.back());
+          if (CONSTANTBV::BitVector_Lexicompare(best, interval->maxV) != 0)
+            tight = false;
+          CONSTANTBV::BitVector_Destroy(best);
+
+          // A bit the shared values all agree on should be fixed.
+          for (unsigned i = 0; i < width && bits != nullptr; i++)
+          {
+            bool agree = true;
+            for (unsigned v : sharedValues)
+              if (((v >> i) & 1) != ((sharedValues.front() >> i) & 1))
+              {
+                agree = false;
+                break;
+              }
+            if (agree != bits->isFixed(i))
+              tight = false;
+          }
+
+          if (!tight)
+          {
+            imperfect++;
+            if (example.empty())
+              example = "input: " + input + ", output: " + describe(bits, interval);
+          }
+
+          delete bits;
+          delete interval;
+        }
+    }
+  }
+
+  ASSERT_EQ(0u, imperfect) << imperfect << " of " << total
+                           << " harmonised domains are not optimally tight,"
+                           << " e.g. " << example;
+}
+
+static stp::CBV randomCBV(unsigned width, MTRand& rand)
+{
+  stp::CBV result = CONSTANTBV::BitVector_Create(width, true);
+  for (unsigned i = 0; i < width; i++)
+    if (rand.randInt() & 1)
+      CONSTANTBV::BitVector_Bit_On(result, i);
+  return result;
+}
+
+// Random fixed bits and intervals at widths too big to enumerate.
+TEST(NodeDomainAnalysis_Test, harmonise_idempotent_random)
+{
+  boot();
+  Context c;
+  MTRand rand(10U);
+
+  const unsigned widths[] = {8, 20, 33, 64, 100};
+
+  for (unsigned width : widths)
+    for (unsigned iteration = 0; iteration < 500; iteration++)
+    {
+      stp::FixedBits* bits = new stp::FixedBits(
+          stp::FixedBits::createRandom(width, rand.randInt() % 101, rand));
+
+      // A random member of the fixed bits, so the interval built around
+      // it is guaranteed to intersect them.
+      stp::CBV member = CONSTANTBV::BitVector_Create(width, true);
+      for (unsigned i = 0; i < width; i++)
+      {
+        const bool bit =
+            bits->isFixed(i) ? bits->getValue(i) : ((rand.randInt() & 1) != 0);
+        if (bit)
+          CONSTANTBV::BitVector_Bit_On(member, i);
+      }
+
+      stp::UnsignedInterval* interval = nullptr;
+      if (iteration % 4 != 0) // every 4th iteration leaves the interval null.
+      {
+        stp::CBV lo = randomCBV(width, rand);
+        if (CONSTANTBV::BitVector_Lexicompare(lo, member) > 0)
+          CONSTANTBV::BitVector_Copy(lo, member);
+        stp::CBV hi = randomCBV(width, rand);
+        if (CONSTANTBV::BitVector_Lexicompare(hi, member) < 0)
+          CONSTANTBV::BitVector_Copy(hi, member);
+        interval = new stp::UnsignedInterval(lo, hi);
+      }
+      CONSTANTBV::BitVector_Destroy(member);
+
+      const std::string input = describe(bits, interval);
+      checkIdempotent(c, bits, interval, input);
+      if (::testing::Test::HasFatalFailure())
+        return;
+
+      delete bits;
+      delete interval;
+    }
 }
 


### PR DESCRIPTION
NodeDomainAnalysis::harmonise trims the fixed-bit and unsigned-interval domains of a node against each other. Previously the tightening was approximate: only the interval maximum was comprehensively tightened from the fixed bits (the minimum side was a TODO), and the interval only fixed the leading bits that its endpoints agree on. On exhaustive enumeration at widths <= 5, about 6% of domain pairs came back less tight than the shared values allow.

This makes harmonise exact. Two O(width) helpers, `maxBelow` and `minAbove`, find the largest/smallest value that matches the fixed bits on either side of a bound. The interval becomes exactly [min, max] of the values the two domains share, and each unfixed bit is fixed when only one polarity has a witness inside the tightened interval. Since the result is optimal in one pass, the fixpoint recursion is no longer needed.

Examples (bits msb-first, `-` = unfixed):

| before | after |
|---|---|
| `<-1-0>`, [0101, 1101] | `<-1-0>`, [0110, 1100] — fixed bits move both interval endpoints inward |
| null bits, [1001, 1010] | `<10-->`, [1001, 1010] — interval fixes the common leading bits |
| `<---0>`, [0001, 0100] | `<0--0>`, [0010, 0100] — each domain tightens the other |
| `<--10>`, [0011, 1001] | `<0110>`, [0110, 0110] — together they identify the constant 6 |

Tests added:
- Idempotence: exhaustive over every fixed-bits pattern crossed with every intersecting interval at widths 1-5, one-sided (bits-only / interval-only) variants, and randomized cases up to width 100. A second harmonise call must change nothing, and tightening must preserve the set of shared values exactly.
- Optimal tightness: the interval must be exactly [min, max] of the shared values, and a bit fixed if and only if all shared values agree on it. This test fails before the harmonise change (second commit) and passes after (third commit).
- The three previously disabled tests in NodeDomainAnalysis_Test.cpp now pass and are re-enabled.