### PR TITLE
Fix unsound n-ary BVMULT constant-bit propagation; refresh the worklist's expensive set

### DIFF
--- a/include/stp/Simplifier/constantBitP/WorkList.h
+++ b/include/stp/Simplifier/constantBitP/WorkList.h
@@ -94,11 +94,26 @@ public:
       return;
 
     // cerr << "WorkList Inserting:" << n.GetNodeNum() << endl;
-    if (n.GetKind() == stp::BVMULT || n.GetKind() == stp::BVPLUS ||
-        n.GetKind() == stp::BVDIV)
-      expensive_workList.insert(n);
-    else
-      cheap_workList.insert(n);
+    // The division family costs hundreds of microseconds per visit at wide
+    // bit-widths, one to three orders of magnitude more than the other
+    // transfer functions, so process those only once the cheap worklist has
+    // quietened down. BVPLUS is kept here for its n-ary forms: the column
+    // algorithm's cost grows with the number of children.
+    switch (n.GetKind())
+    {
+      case stp::BVMULT:
+      case stp::BVPLUS:
+      case stp::BVDIV:
+      case stp::BVMOD:
+      case stp::SBVDIV:
+      case stp::SBVREM:
+      case stp::SBVMOD:
+        expensive_workList.insert(n);
+        break;
+      default:
+        cheap_workList.insert(n);
+        break;
+    }
   }
 
   stp::ASTNode pop()

--- a/lib/Simplifier/constantBitP/ConstantBitP_Multiplication.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_Multiplication.cpp
@@ -581,6 +581,13 @@ void printColumns(signed* sumL, signed* sumH, int bitWidth)
 Result bvMultiplyBothWays(vector<FixedBits*>& children, FixedBits& output,
                           stp::STPMgr* bm, MultiplicationStats* ms)
 {
+  // BVTypeCheck allows BVMULT nodes with more than two children, and the
+  // hashing node factory builds them (the simplifying factory binarises).
+  // The reasoning below is about exactly two operands; running it on the
+  // first two children of a wider multiply fixes bits unsoundly.
+  if (children.size() != 2)
+    return NO_CHANGE;
+
   FixedBits& x = *children[0];
   FixedBits& y = *children[1];
 

--- a/tests/unit-tests/ConstantBitP_TransferFunctions_Test.cpp
+++ b/tests/unit-tests/ConstantBitP_TransferFunctions_Test.cpp
@@ -484,6 +484,29 @@ TEST_F(ConstantBitP_TransferFunctions, multiplicationExhaustiveWidth3)
       bv3(2), out3(), OVERAPPROXIMATES);
 }
 
+// BVTypeCheck accepts BVMULT with more than two children, and the hashing
+// node factory builds such nodes (only the simplifying factory binarises
+// them). The multiply transfer function reasons about exactly two operands,
+// so on a wider multiply it must do nothing: propagating on the first two
+// children fixed the output's low bit to one for <-1> * <-1> * <-->,
+// excluding solutions like 1 * 1 * 2 = 2.
+TEST_F(ConstantBitP_TransferFunctions, multiplicationThreeChildrenDoesNothing)
+{
+  FixedBits a = fromString("**1");
+  FixedBits b = fromString("**1");
+  FixedBits c = fromString("***");
+  FixedBits out = fromString("***");
+
+  std::vector<FixedBits*> children;
+  children.push_back(&a);
+  children.push_back(&b);
+  children.push_back(&c);
+
+  EXPECT_EQ(NO_CHANGE, bvMultiplyBothWays(children, out, &mgr, NULL));
+  EXPECT_TRUE(FixedBits::equals(out, fromString("***")));
+  EXPECT_TRUE(FixedBits::equals(a, fromString("**1")));
+}
+
 TEST_F(ConstantBitP_TransferFunctions, additionExhaustiveWidth3)
 {
   exhaustiveCheck(


### PR DESCRIPTION
Two independent fixes found while auditing the constant bit propagators.

## Unsound n-ary multiplication (first commit)

`BVTypeCheck` accepts BVMULT with more than two children, and the hashing node factory builds such nodes — only `SimplifyingNodeFactory` binarises them ("Never create multiplications with arity > 2"). The stp binary installs the simplifying factory, but library/API users get the hashing factory by default, and the SMT2 parser hands the full operand list to whatever factory is installed.

`bvMultiplyBothWays` read `children[0]` and `children[1]` with no arity check, so on a wider multiply it propagated as if the remaining operands didn't exist. Exhaustively at width 2 this excludes surviving solutions in **1,362 of 6,561** fixed-bit patterns (e.g. `<-1> * <-1> * <-->` fixes the output's low bit to one, excluding 1·1·2 = 2). Now it returns NO_CHANGE for arity above two, with a regression test.

The other transfer functions whose kinds allow extra children were audited the same way and are fine: `bvAddBothWays` and the bitwise and/or/xor measure **0 unsound and 100% maximally precise** at three and four children.

## Worklist expensive set (second commit)

The constant-bit worklist defers "expensive" nodes until the cheap list drains, but the expensive set — `{BVMULT, BVPLUS, BVDIV}` — doesn't match where the time actually goes. Per-call at width 64 on random partially-fixed inputs:

| op | worst measured cost |
|---|---|
| SBVREM | ~540 µs |
| SBVMOD | ~310 µs (reimplemented, #522) |
| BVMOD | ~155 µs |
| SBVDIV | ~160 µs |
| BVDIV | ~43 µs |
| BVMULT | ~8 µs |
| everything else | ≤ ~16 µs (bvsub/bvashr worst) |

The four missing division ops are now on the expensive list. BVMULT/BVDIV stay, and BVPLUS stays because the column algorithm's cost scales with arity and n-ary BVPLUS is common.

## Testing

All 54 ctest suites pass. The n-ary soundness/precision numbers come from an exhaustive width-2/3 audit harness (all 3^k fixed-bit patterns per operand shape, brute-force reference).