### PR TITLE
Run the shift constant-bit propagators on packed words (5-10x faster at 64 bits)

### DIFF
--- a/lib/Simplifier/constantBitP/ConstantBitP_Shifting.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_Shifting.cpp
@@ -470,45 +470,70 @@ static Result ashrCore(const unsigned bitWidth, PackedBits& packedOp,
 
     if (shiftOutPossible)
     {
-      // Refine a copy of the shift with (shift >= bitWidth), and union it in.
-      FixedBits bitWidthFB = FixedBits::fromUnsignedInt(bitWidth, bitWidth);
-      FixedBits truth(1, true);
-      truth.setFixed(0, true);
-      truth.setValue(0, true);
-      FixedBits working(bitWidth, false);
-      for (unsigned i = 0; i < bitWidth; i++)
-        if (packedShift.isFixedBit(i))
-        {
-          working.setFixed(i, true);
-          working.setValue(i, packedShift.valueBit(i));
-        }
-
-      vector<FixedBits*> args;
-      args.push_back(&working);
-      args.push_back(&bitWidthFB);
-      Result r = bvGreaterThanEqualsBothWays(args, truth);
-      assert(CONFLICT != r);
-      (void)r;
-
-      for (unsigned i = 0; i < bitWidth; i++)
+      // What "shift >= bitWidth" forces, exactly as the maximally precise
+      // comparison propagator would: possibleShift[bitWidth] was only set
+      // when the maximum admitted shift value is >= bitWidth, so for every
+      // unfixed bit an admitted value >= bitWidth with that bit one exists
+      // (the maximum itself). An unfixed bit is therefore only ever forced
+      // to one, precisely when clearing it drops the maximum admitted
+      // value below bitWidth.
+      uint64_t* wFixed = (uint64_t*)alloca(sizeof(uint64_t) * words);
+      uint64_t* wValue = (uint64_t*)alloca(sizeof(uint64_t) * words);
+      uint64_t* maxAdm = (uint64_t*)alloca(sizeof(uint64_t) * words);
+      unsigned nonZeroHighWords = 0;
+      for (unsigned j = 0; j < words; j++)
       {
-        const unsigned j = i >> 6;
-        const uint64_t bit = (uint64_t)1 << (i & 63);
-        if (nPossible > 0)
+        wFixed[j] = packedShift.fixed[j];
+        wValue[j] = packedShift.value[j];
+        maxAdm[j] = (packedShift.value[j] | ~packedShift.fixed[j]) &
+                    PackedBits::widthMask(j, bitWidth);
+        if (j > 0 && maxAdm[j] != 0)
+          nonZeroHighWords++;
+      }
+
+      for (unsigned j = 0; j < words; j++)
+      {
+        uint64_t pending = ~packedShift.fixed[j] &
+                           PackedBits::widthMask(j, bitWidth);
+        while (pending)
         {
-          // Union: drop bits "working" leaves open or disagrees on.
-          if (!working.isFixed(i) ||
-              ((vFixed[j] & bit) && working.getValue(i) != ((vValue[j] & bit) != 0)))
-            vFixed[j] &= ~bit;
-        }
-        else if (working.isFixed(i))
-        {
-          // Only shifts >= bitWidth are possible.
-          vFixed[j] |= bit;
-          if (working.getValue(i))
-            vValue[j] |= bit;
+          const unsigned b = __builtin_ctzll(pending);
+          pending &= pending - 1;
+          const uint64_t bit = (uint64_t)1 << b;
+
+          // Is (maxAdm with this bit cleared) < bitWidth?
+          bool less;
+          if (j == 0)
+            less = (nonZeroHighWords == 0) &&
+                   ((maxAdm[0] & ~bit) < (uint64_t)bitWidth);
           else
-            vValue[j] &= ~bit;
+            less = (nonZeroHighWords == (maxAdm[j] == bit ? 1u : 0u)) &&
+                   (maxAdm[0] < (uint64_t)bitWidth) &&
+                   ((maxAdm[j] & ~bit) == 0);
+          if (less)
+          {
+            wFixed[j] |= bit;
+            wValue[j] |= bit;
+          }
+        }
+      }
+
+      if (nPossible > 0)
+      {
+        // Union: drop bits the >= case leaves open or disagrees on.
+        for (unsigned j = 0; j < words; j++)
+        {
+          vFixed[j] &= wFixed[j] & ~(vValue[j] ^ wValue[j]);
+          vValue[j] &= vFixed[j];
+        }
+      }
+      else
+      {
+        // Only shifts >= bitWidth are possible.
+        for (unsigned j = 0; j < words; j++)
+        {
+          vFixed[j] = wFixed[j];
+          vValue[j] = wValue[j];
         }
       }
     }

--- a/lib/Simplifier/constantBitP/ConstantBitP_Shifting.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_Shifting.cpp
@@ -175,6 +175,120 @@ void meetInto(PackedBits& a, const PackedBits& b)
   }
 }
 
+// The shift operand must lie in the union of the possible shift amounts:
+// the bit patterns of the possible finite shifts, unioned with whatever
+// "shift >= bitWidth" allows when shifting everything out is possible.
+// Fixes shift bits the union agrees on; CONFLICT if one contradicts a
+// fixed bit.
+Result applyShiftUnion(const unsigned bitWidth, PackedBits& packedShift,
+                       const unsigned* possibleList, const unsigned nPossible,
+                       const bool shiftOutPossible)
+{
+  const unsigned words = packedShift.words;
+
+  // The union of the finite patterns: bits where they all agree are
+  // fixed. (Patterns are < bitWidth, so any bits above word zero of the
+  // union are fixed to zero.)
+  uint64_t* vFixed = (uint64_t*)alloca(sizeof(uint64_t) * words);
+  uint64_t* vValue = (uint64_t*)alloca(sizeof(uint64_t) * words);
+  if (nPossible > 0)
+  {
+    const uint64_t ref = possibleList[0];
+    uint64_t diff = 0;
+    for (unsigned k = 1; k < nPossible; k++)
+      diff |= ref ^ (uint64_t)possibleList[k];
+    vFixed[0] = ~diff & PackedBits::widthMask(0, bitWidth);
+    vValue[0] = ref & vFixed[0];
+    for (unsigned j = 1; j < words; j++)
+    {
+      vFixed[j] = PackedBits::widthMask(j, bitWidth);
+      vValue[j] = 0;
+    }
+  }
+  else
+    for (unsigned j = 0; j < words; j++)
+      vFixed[j] = vValue[j] = 0;
+
+  if (shiftOutPossible)
+  {
+    // What "shift >= bitWidth" forces, exactly as the maximally precise
+    // comparison propagator would: possibleShift[bitWidth] was only set
+    // when the maximum admitted shift value is >= bitWidth, so for every
+    // unfixed bit an admitted value >= bitWidth with that bit one exists
+    // (the maximum itself). An unfixed bit is therefore only ever forced
+    // to one, precisely when clearing it drops the maximum admitted
+    // value below bitWidth.
+    uint64_t* wFixed = (uint64_t*)alloca(sizeof(uint64_t) * words);
+    uint64_t* wValue = (uint64_t*)alloca(sizeof(uint64_t) * words);
+    uint64_t* maxAdm = (uint64_t*)alloca(sizeof(uint64_t) * words);
+    unsigned nonZeroHighWords = 0;
+    for (unsigned j = 0; j < words; j++)
+    {
+      wFixed[j] = packedShift.fixed[j];
+      wValue[j] = packedShift.value[j];
+      maxAdm[j] = (packedShift.value[j] | ~packedShift.fixed[j]) &
+                  PackedBits::widthMask(j, bitWidth);
+      if (j > 0 && maxAdm[j] != 0)
+        nonZeroHighWords++;
+    }
+
+    for (unsigned j = 0; j < words; j++)
+    {
+      uint64_t pending = ~packedShift.fixed[j] &
+                         PackedBits::widthMask(j, bitWidth);
+      while (pending)
+      {
+        const unsigned b = __builtin_ctzll(pending);
+        pending &= pending - 1;
+        const uint64_t bit = (uint64_t)1 << b;
+
+        // Is (maxAdm with this bit cleared) < bitWidth?
+        bool less;
+        if (j == 0)
+          less = (nonZeroHighWords == 0) &&
+                 ((maxAdm[0] & ~bit) < (uint64_t)bitWidth);
+        else
+          less = (nonZeroHighWords == (maxAdm[j] == bit ? 1u : 0u)) &&
+                 (maxAdm[0] < (uint64_t)bitWidth) &&
+                 ((maxAdm[j] & ~bit) == 0);
+        if (less)
+        {
+          wFixed[j] |= bit;
+          wValue[j] |= bit;
+        }
+      }
+    }
+
+    if (nPossible > 0)
+    {
+      // Union: drop bits the >= case leaves open or disagrees on.
+      for (unsigned j = 0; j < words; j++)
+      {
+        vFixed[j] &= wFixed[j] & ~(vValue[j] ^ wValue[j]);
+        vValue[j] &= vFixed[j];
+      }
+    }
+    else
+    {
+      // Only shifts >= bitWidth are possible.
+      for (unsigned j = 0; j < words; j++)
+      {
+        vFixed[j] = wFixed[j];
+        vValue[j] = wValue[j];
+      }
+    }
+  }
+
+  // Write the union into the shift.
+  for (unsigned j = 0; j < words; j++)
+  {
+    if (vFixed[j] & packedShift.fixed[j] & (packedShift.value[j] ^ vValue[j]))
+      return CONFLICT;
+    packedShift.fixBits(j, vFixed[j], vValue[j]);
+  }
+  return NOT_IMPLEMENTED;
+}
+
 // Whether the concrete shift amount i is admitted by the fixed bits of the
 // shift operand. Equivalent to FixedBits::unsignedHolds(i) for i < 2^64,
 // given anyHighFixedOne = "some bit above word zero is fixed to one".
@@ -435,117 +549,16 @@ static Result ashrCore(const unsigned bitWidth, PackedBits& packedOp,
   // Collect the possible finite shift amounts once.
   const unsigned words = packedOut.words;
   unsigned* possibleList = (unsigned*)alloca(sizeof(unsigned) * bitWidth);
+  possibleList[0] = 0; // quieten -Wmaybe-uninitialized; only read when nPossible > 0.
   unsigned nPossible = 0;
   for (unsigned s = 0; s < bitWidth; s++)
     if (possibleShift[s])
       possibleList[nPossible++] = s;
   const bool shiftOutPossible = possibleShift[bitWidth];
 
-  // The shift operand must lie in the union of the possible shift amounts:
-  // the bit patterns of the possible finite shifts, unioned with whatever
-  // "shift >= bitWidth" allows when shifting everything out is possible.
-  {
-    // The union of the finite patterns: bits where they all agree are
-    // fixed. (Patterns are < bitWidth, so any bits above word zero of the
-    // union are fixed to zero.)
-    uint64_t* vFixed = (uint64_t*)alloca(sizeof(uint64_t) * words);
-    uint64_t* vValue = (uint64_t*)alloca(sizeof(uint64_t) * words);
-    if (nPossible > 0)
-    {
-      const uint64_t ref = possibleList[0];
-      uint64_t diff = 0;
-      for (unsigned k = 1; k < nPossible; k++)
-        diff |= ref ^ (uint64_t)possibleList[k];
-      vFixed[0] = ~diff & PackedBits::widthMask(0, bitWidth);
-      vValue[0] = ref & vFixed[0];
-      for (unsigned j = 1; j < words; j++)
-      {
-        vFixed[j] = PackedBits::widthMask(j, bitWidth);
-        vValue[j] = 0;
-      }
-    }
-    else
-      for (unsigned j = 0; j < words; j++)
-        vFixed[j] = vValue[j] = 0;
-
-    if (shiftOutPossible)
-    {
-      // What "shift >= bitWidth" forces, exactly as the maximally precise
-      // comparison propagator would: possibleShift[bitWidth] was only set
-      // when the maximum admitted shift value is >= bitWidth, so for every
-      // unfixed bit an admitted value >= bitWidth with that bit one exists
-      // (the maximum itself). An unfixed bit is therefore only ever forced
-      // to one, precisely when clearing it drops the maximum admitted
-      // value below bitWidth.
-      uint64_t* wFixed = (uint64_t*)alloca(sizeof(uint64_t) * words);
-      uint64_t* wValue = (uint64_t*)alloca(sizeof(uint64_t) * words);
-      uint64_t* maxAdm = (uint64_t*)alloca(sizeof(uint64_t) * words);
-      unsigned nonZeroHighWords = 0;
-      for (unsigned j = 0; j < words; j++)
-      {
-        wFixed[j] = packedShift.fixed[j];
-        wValue[j] = packedShift.value[j];
-        maxAdm[j] = (packedShift.value[j] | ~packedShift.fixed[j]) &
-                    PackedBits::widthMask(j, bitWidth);
-        if (j > 0 && maxAdm[j] != 0)
-          nonZeroHighWords++;
-      }
-
-      for (unsigned j = 0; j < words; j++)
-      {
-        uint64_t pending = ~packedShift.fixed[j] &
-                           PackedBits::widthMask(j, bitWidth);
-        while (pending)
-        {
-          const unsigned b = __builtin_ctzll(pending);
-          pending &= pending - 1;
-          const uint64_t bit = (uint64_t)1 << b;
-
-          // Is (maxAdm with this bit cleared) < bitWidth?
-          bool less;
-          if (j == 0)
-            less = (nonZeroHighWords == 0) &&
-                   ((maxAdm[0] & ~bit) < (uint64_t)bitWidth);
-          else
-            less = (nonZeroHighWords == (maxAdm[j] == bit ? 1u : 0u)) &&
-                   (maxAdm[0] < (uint64_t)bitWidth) &&
-                   ((maxAdm[j] & ~bit) == 0);
-          if (less)
-          {
-            wFixed[j] |= bit;
-            wValue[j] |= bit;
-          }
-        }
-      }
-
-      if (nPossible > 0)
-      {
-        // Union: drop bits the >= case leaves open or disagrees on.
-        for (unsigned j = 0; j < words; j++)
-        {
-          vFixed[j] &= wFixed[j] & ~(vValue[j] ^ wValue[j]);
-          vValue[j] &= vFixed[j];
-        }
-      }
-      else
-      {
-        // Only shifts >= bitWidth are possible.
-        for (unsigned j = 0; j < words; j++)
-        {
-          vFixed[j] = wFixed[j];
-          vValue[j] = wValue[j];
-        }
-      }
-    }
-
-    // Write the union into the shift.
-    for (unsigned j = 0; j < words; j++)
-    {
-      if (vFixed[j] & packedShift.fixed[j] & (packedShift.value[j] ^ vValue[j]))
-        return CONFLICT;
-      packedShift.fixBits(j, vFixed[j], vValue[j]);
-    }
-  }
+  if (CONFLICT == applyShiftUnion(bitWidth, packedShift, possibleList,
+                                  nPossible, shiftOutPossible))
+    return CONFLICT;
 
   // If a particular input bit appears in every possible shifting,
   // and if that bit is unfixed,
@@ -754,6 +767,216 @@ Result bvArithmeticRightShiftBothWays(vector<FixedBits*>& children,
   return result;
 }
 
+
+// The core of the left-shift transfer, on packed state. Deductions are
+// written into the packed arguments; the wrapper transfers them back to
+// the FixedBits.
+static Result shlCore(const unsigned bitWidth, PackedBits& packedOp,
+                      PackedBits& packedShift, PackedBits& packedOut)
+{
+  const unsigned words = packedOp.words;
+
+  // The topmost entry of possibleShift is the set of all the values of
+  // shift that shift out everything (>= bitWidth), making the output zero.
+  const unsigned numberOfPossibleShifts = bitWidth + 1;
+  bool* possibleShift = (bool*)alloca(sizeof(bool) * numberOfPossibleShifts);
+  for (unsigned i = 0; i < numberOfPossibleShifts; i++)
+    possibleShift[i] = false;
+
+  unsigned minShift, maxShift;
+  packedUnsignedMinMax(packedShift, bitWidth, minShift, maxShift);
+
+  // The shift must be at most the position of the lowest one in the
+  // output: zeroes are shifted in below it.
+  int positionOfFirstOne = -1;
+  for (unsigned j = 0; j < words && positionOfFirstOne < 0; j++)
+  {
+    const uint64_t ones = packedOut.fixed[j] & packedOut.value[j];
+    if (ones != 0)
+      positionOfFirstOne = j * 64 + __builtin_ctzll(ones);
+  }
+
+  if (positionOfFirstOne >= 0)
+  {
+    if ((unsigned)positionOfFirstOne < minShift)
+      return CONFLICT;
+    maxShift = std::min(maxShift, (unsigned)positionOfFirstOne);
+  }
+
+  {
+    const bool highFixedOne = anyFixedOneAboveWordZero(packedShift);
+    for (unsigned i = minShift; i <= std::min(bitWidth, maxShift); i++)
+    {
+      // if the bit-pattern of 'i' is in the set represented by the 'shift'.
+      if (shiftHolds(packedShift, highFixedOne, i))
+        possibleShift[i] = true;
+    }
+  }
+
+  // Given a shift like [-1], possibleShift[2] is false, but a shift of
+  // three is possible: possibleShift[bitWidth] stands for every shift
+  // >= bitWidth.
+  if (maxShift >= bitWidth)
+    possibleShift[bitWidth] = true;
+
+  // Filter the shifts that contradict the fixed bits: a one in the output
+  // below the shift amount, or a disagreement between output[c] and
+  // op[c - shift].
+  for (unsigned s = 0; s < bitWidth; s++)
+  {
+    if (!possibleShift[s])
+      continue;
+    bool disagrees = false;
+    for (unsigned j = 0; j < words && !disagrees; j++)
+    {
+      if (packedOut.fixed[j] & packedOut.value[j] & ~bitsAtOrAbove(j, s))
+        disagrees = true; // a one below the shift amount.
+      else
+      {
+        const uint64_t opF = packedOp.leftShiftedWord(packedOp.fixed, s, j);
+        const uint64_t opV = packedOp.leftShiftedWord(packedOp.value, s, j);
+        if (opF & packedOut.fixed[j] & (opV ^ packedOut.value[j]))
+          disagrees = true;
+      }
+    }
+    if (disagrees)
+      possibleShift[s] = false;
+  }
+  // A shift of >= bitWidth makes the output entirely zero.
+  if (possibleShift[bitWidth])
+    for (unsigned j = 0; j < words; j++)
+      if (packedOut.fixed[j] & packedOut.value[j])
+      {
+        possibleShift[bitWidth] = false;
+        break;
+      }
+
+  int nOfPossibleShifts = 0;
+  for (unsigned i = 0; i < numberOfPossibleShifts; i++)
+    if (possibleShift[i])
+      nOfPossibleShifts++;
+
+  // If it's empty. It's a conflict.
+  if (0 == nOfPossibleShifts)
+    return CONFLICT;
+
+  // Collect the possible finite shift amounts once.
+  unsigned* possibleList = (unsigned*)alloca(sizeof(unsigned) * bitWidth);
+  possibleList[0] = 0; // quieten -Wmaybe-uninitialized; only read when nPossible > 0.
+  unsigned nPossible = 0;
+  for (unsigned s = 0; s < bitWidth; s++)
+    if (possibleShift[s])
+      possibleList[nPossible++] = s;
+  const bool shiftOutPossible = possibleShift[bitWidth];
+
+  if (CONFLICT == applyShiftUnion(bitWidth, packedShift, possibleList,
+                                  nPossible, shiftOutPossible))
+    return CONFLICT;
+
+  // If a particular input bit appears in every possible shifting,
+  // and if that bit is unfixed,
+  // and if the result is fixed to the same value in every position,
+  // then that bit must be fixed. E.g.  [--] << [0-] == [00]
+  //
+  // The top bits are shifted out by the largest possible shift (all of
+  // them, if shifting everything out is possible), so the candidates are
+  // the unfixed operand bits below bitWidth - maxShift. For those, every
+  // possible shift contributes the output bit `shift` positions higher,
+  // i.e. word-wise, (output >> s).
+  if (!shiftOutPossible && nPossible > 0)
+  {
+    const unsigned maxS = possibleList[nPossible - 1];
+    const unsigned s0 = possibleList[0];
+    uint64_t* agree = (uint64_t*)alloca(sizeof(uint64_t) * words);
+    uint64_t* ref = (uint64_t*)alloca(sizeof(uint64_t) * words);
+
+    for (unsigned j = 0; j < words; j++)
+    {
+      agree[j] = packedOut.shiftedWord(packedOut.fixed, s0, j);
+      ref[j] = packedOut.shiftedWord(packedOut.value, s0, j);
+    }
+    for (unsigned k = 1; k < nPossible; k++)
+    {
+      const unsigned s = possibleList[k];
+      for (unsigned j = 0; j < words; j++)
+      {
+        const uint64_t f = packedOut.shiftedWord(packedOut.fixed, s, j);
+        const uint64_t v = packedOut.shiftedWord(packedOut.value, s, j);
+        agree[j] &= f & ~(v ^ ref[j]);
+      }
+    }
+
+    for (unsigned j = 0; j < words; j++)
+    {
+      const uint64_t fixable = agree[j] & ~packedOp.fixed[j] &
+                               ~bitsAtOrAbove(j, bitWidth - maxS) &
+                               PackedBits::widthMask(j, bitWidth);
+      if (fixable != 0)
+        packedOp.fixBits(j, fixable, ref[j]);
+    }
+  }
+
+  // Go through each of the possible shifts. If the same value is fixed
+  // at every location, then it's fixed too in the result. The contribution
+  // of shift s at column c is op[c-s] for c >= s and a shifted-in zero
+  // below; a shift of >= bitWidth contributes zero everywhere.
+  if (nPossible > 0 || shiftOutPossible)
+  {
+    uint64_t* agree = (uint64_t*)alloca(sizeof(uint64_t) * words);
+    uint64_t* ref = (uint64_t*)alloca(sizeof(uint64_t) * words);
+    bool first = true;
+
+    for (unsigned k = 0; k <= nPossible; k++)
+    {
+      unsigned s = 0;
+      bool everythingOut = false;
+      if (k < nPossible)
+        s = possibleList[k];
+      else if (shiftOutPossible)
+        everythingOut = true;
+      else
+        break;
+
+      for (unsigned j = 0; j < words; j++)
+      {
+        uint64_t f, v;
+        if (everythingOut)
+        {
+          f = ~(uint64_t)0;
+          v = 0;
+        }
+        else
+        {
+          // Bits below the shift amount are (fixed) shifted-in zeroes;
+          // leftShiftedWord already leaves the value zero there.
+          f = packedOp.leftShiftedWord(packedOp.fixed, s, j) |
+              ~bitsAtOrAbove(j, s);
+          v = packedOp.leftShiftedWord(packedOp.value, s, j);
+        }
+        if (first)
+        {
+          agree[j] = f;
+          ref[j] = v;
+        }
+        else
+          agree[j] &= f & ~(v ^ ref[j]);
+      }
+      first = false;
+    }
+
+    for (unsigned j = 0; j < words; j++)
+    {
+      const uint64_t agreed = agree[j] & PackedBits::widthMask(j, bitWidth);
+      if (agreed & packedOut.fixed[j] & (packedOut.value[j] ^ ref[j]))
+        return CONFLICT;
+      const uint64_t newFix = agreed & ~packedOut.fixed[j];
+      if (newFix != 0)
+        packedOut.fixBits(j, newFix, ref[j]);
+    }
+  }
+  return NOT_IMPLEMENTED;
+}
+
 Result bvLeftShiftBothWays(vector<FixedBits*>& children, FixedBits& output)
 {
   const unsigned bitWidth = output.getWidth();
@@ -763,365 +986,30 @@ Result bvLeftShiftBothWays(vector<FixedBits*>& children, FixedBits& output)
   FixedBits& op = *children[0];
   FixedBits& shift = *children[1];
 
-  if (debug_shift)
+  PackedBits packedOp(op);
+  PackedBits packedShift(shift);
+  PackedBits packedOut(output);
+  const unsigned words = packedOp.words;
+
+  // Snapshot what was fixed on entry, for the write-back.
+  uint64_t* origOp = (uint64_t*)alloca(sizeof(uint64_t) * words);
+  uint64_t* origShift = (uint64_t*)alloca(sizeof(uint64_t) * words);
+  uint64_t* origOut = (uint64_t*)alloca(sizeof(uint64_t) * words);
+  for (unsigned j = 0; j < words; j++)
   {
-    cerr << "op:" << op << endl;
-    cerr << "shift:" << shift << endl;
-    cerr << "output:" << output << endl;
+    origOp[j] = packedOp.fixed[j];
+    origShift[j] = packedShift.fixed[j];
+    origOut[j] = packedOut.fixed[j];
   }
 
-  // The topmost number of possible shifts corresponds to all
-  // the values of shift that shift out everything.
-  // i.e. possibleShift[bitWidth+1] is the SET of all operations that shift past
-  // the end.
-  const unsigned numberOfPossibleShifts = bitWidth + 1;
-  bool* possibleShift = (bool*)alloca(sizeof(bool) * numberOfPossibleShifts);
-  for (unsigned i = 0; i < numberOfPossibleShifts; i++)
-    possibleShift[i] = false;
-
-  unsigned minShift, maxShift;
-  shift.getUnsignedMinMax(minShift, maxShift);
-
-  // The shift must be less than the position of the first one in the output
-  int positionOfFirstOne = -1;
-  for (unsigned i = 0; i < bitWidth; i++)
-  {
-    if (output.isFixed(i) && output.getValue(i))
-    {
-      positionOfFirstOne = i;
-      break;
-    }
-  }
-
-  if (positionOfFirstOne >= 0)
-  {
-    if ((unsigned)positionOfFirstOne < minShift)
-      return CONFLICT;
-
-    maxShift = std::min(maxShift, (unsigned)positionOfFirstOne);
-  }
-
-  for (unsigned i = minShift; i <= std::min(bitWidth, maxShift); i++)
-  {
-    // if the bit-pattern of 'i' is in the set represented by the 'shift'.
-    if (shift.unsignedHolds(i))
-      possibleShift[i] = true;
-  }
-
-  // Complication. Given a shift like [-1]. possibleShift[2] is now false.
-  // A shift of 2 isn't possible. But one of three is.
-  // possibleShift[2] means any shift >=2 is possible. So it needs to be set
-  // to true.
-  {
-    if (maxShift >= bitWidth)
-      possibleShift[bitWidth] = true;
-  }
-
-  // Now check one-by-one each shifting.
-  // If we are shifting a zero to where a one is (say), then that shifting isn't
-  // possible.
-  for (unsigned shiftIt = 0; shiftIt < numberOfPossibleShifts; shiftIt++)
-  {
-    if (possibleShift[shiftIt])
-    {
-      for (unsigned column = 0; column < bitWidth; column++)
-      {
-        if (column < shiftIt)
-        {
-          if (output.isFixed(column) &&
-              output.getValue(
-                  column)) // output is one in the column. That's wrong.
-          {
-            possibleShift[shiftIt] = false;
-            break;
-          }
-        }
-        else
-        {
-          // if they are fixed to different values. That's wrong.
-          if (output.isFixed(column) && op.isFixed(column - shiftIt) &&
-              (output.getValue(column) != op.getValue(column - shiftIt)))
-          {
-            possibleShift[shiftIt] = false;
-            break;
-          }
-        }
-      }
-    }
-  }
-
-  int nOfPossibleShifts = 0;
-  for (unsigned i = 0; i < numberOfPossibleShifts; i++)
-  {
-    if (possibleShift[i])
-    {
-      nOfPossibleShifts++;
-      if (debug_shift)
-      {
-        std::cerr << "Possible:" << i << std::endl;
-      }
-    }
-  }
-
-  if (debug_shift)
-  {
-    std::cerr << "Number of possible shifts:" << nOfPossibleShifts << endl;
-  }
-
-  // If it's empty. It's a conflict.
-  if (0 == nOfPossibleShifts)
+  const Result result = shlCore(bitWidth, packedOp, packedShift, packedOut);
+  if (result == CONFLICT)
     return CONFLICT;
 
-  // We have a list of all the possible shift amounts.
-  // We take the union of all the bits that are possible.
-
-  FixedBits v(bitWidth, false);
-  bool first = true;
-  for (unsigned i = 0; i < numberOfPossibleShifts - 1; i++)
-  {
-    if (possibleShift[i])
-    {
-      if (first)
-      {
-        first = false;
-        for (unsigned j = 0; j < (unsigned)v.getWidth(); j++)
-        {
-          v.setFixed(j, true);
-          if (j < sizeof(unsigned) * 8)
-            v.setValue(j, 0 != (i & (1u << j)));
-          else
-            v.setValue(j, false);
-        }
-      }
-      else
-      {
-        // join.
-        for (unsigned j = 0;
-             j < (unsigned)v.getWidth() && j < sizeof(unsigned) * 8; j++)
-        {
-          if (v.isFixed(j))
-          {
-            // union.
-            if (v.getValue(j) != (0 != (i & (1u << j))))
-              v.setFixed(j, false);
-          }
-        }
-      }
-    }
-  }
-
-  // The top most entry of the shift table is special. It means all values of
-  // shift
-  // that fill it completely with zeroes. We take the union of all of the values
-  // >bitWidth
-  // in this function.
-  if (possibleShift[numberOfPossibleShifts - 1])
-  {
-    FixedBits bitWidthFB = FixedBits::fromUnsignedInt(bitWidth, bitWidth);
-    FixedBits output(1, true);
-    output.setFixed(0, true);
-    output.setValue(0, true);
-    FixedBits working(shift);
-
-    vector<FixedBits*> args;
-    args.push_back(&working);
-    args.push_back(&bitWidthFB);
-
-    // Write into working anything that can be determined given it's >=bitWidth.
-    Result r = bvGreaterThanEqualsBothWays(args, output);
-    assert(CONFLICT != r);
-
-    // Get the union of "working" with the prior union.
-    for (unsigned i = 0; i < bitWidth; i++)
-    {
-      if (!working.isFixed(i) && v.isFixed(i))
-        v.setFixed(i, false);
-      if (working.isFixed(i) && v.isFixed(i) &&
-          (working.getValue(i) != v.getValue(i)))
-        v.setFixed(i, false);
-      if (first) // no less shifts possible.
-      {
-        if (working.isFixed(i))
-        {
-          v.setFixed(i, true);
-          v.setValue(i, working.getValue(i));
-        }
-      }
-    }
-  }
-
-  if (debug_shift)
-  {
-    std::cerr << "Shift Amount:" << v << std::endl;
-  }
-
-  for (unsigned i = 0; i < bitWidth; i++)
-  {
-    if (v.isFixed(i))
-    {
-      if (!shift.isFixed(i))
-      {
-        shift.setFixed(i, true);
-        shift.setValue(i, v.getValue(i));
-      }
-      else if (shift.isFixed(i) && shift.getValue(i) != v.getValue(i))
-        return CONFLICT;
-    }
-  }
-
-  // If a particular input bit appears in every possible shifting,
-  // and if that bit is unfixed,
-  // and if the result it is fixed to the same value in every position.
-  // Then, that bit must be fixed.
-  // E.g.  [--] << [0-] == [00]
-
-  bool* candidates = (bool*)alloca(sizeof(bool) * bitWidth);
-  for (unsigned i = 0; i < bitWidth; i++)
-  {
-    candidates[i] = !op.isFixed(i);
-  }
-
-  // candidates: So far: the bits that are unfixed.
-
-  for (unsigned i = 0; i < numberOfPossibleShifts; i++)
-  {
-    if (possibleShift[i])
-    {
-      // If this shift is possible, then some bits will be shifted out.
-      for (unsigned j = 0; j < i; j++)
-        candidates[bitWidth - 1 - j] = false;
-    }
-  }
-
-  // candidates: So far: + the input bits that are unfixed.
-  //                     + the input bits that are in every possible fixing.
-
-  // Check all candidates have the same output values.
-  for (unsigned candidate = 0; candidate < bitWidth; candidate++)
-  {
-    bool first = true;
-    bool setTo = false; // value that's never read. To quieten gcc.
-
-    if (candidates[candidate])
-    {
-      for (unsigned shiftIT = 0; shiftIT < bitWidth; shiftIT++)
-      {
-        // If the shift isn't possible continue.
-        if (!possibleShift[shiftIT])
-          continue;
-
-        unsigned idx = candidate + shiftIT;
-
-        if (!output.isFixed(idx))
-        {
-          candidates[candidate] = false;
-          break;
-        }
-        else
-        {
-          if (first)
-          {
-            first = false;
-            setTo = output.getValue(idx);
-          }
-          else
-          {
-            if (setTo != output.getValue(idx))
-            {
-              candidates[candidate] = false;
-              break;
-            }
-          }
-        }
-      }
-    }
-
-    if (candidates[candidate])
-    {
-      assert(!op.isFixed(candidate));
-      op.setFixed(candidate, true);
-      op.setValue(candidate, setTo);
-    }
-  }
-
-  // done.
-
-  // Go through each of the possible shifts. If the same value is fixed
-  // at every location. Then it's fixed too in the result.
-  for (unsigned column = 0; column < bitWidth; column++)
-  {
-    bool allFixedToSame = true;
-    bool allFixedTo = false; // value that's never read. To quieten gcc.
-    bool first = true;
-
-    for (unsigned shiftIt = minShift;
-         (shiftIt < numberOfPossibleShifts) && allFixedToSame; shiftIt++)
-    {
-      if (possibleShift[shiftIt])
-      {
-        // Will have shifted in zeroes.
-        if (shiftIt > column)
-        {
-          if (first)
-          {
-            allFixedTo = false;
-            first = false;
-          }
-          else
-          {
-            if (allFixedTo)
-            {
-              allFixedToSame = false;
-            }
-          }
-        }
-        else
-        {
-          unsigned index = column - shiftIt;
-          if (!op.isFixed(index))
-            allFixedToSame = false;
-          else if (first && op.isFixed(index))
-          {
-            first = false;
-            allFixedTo = op.getValue(index);
-          }
-          if (op.isFixed(index) && allFixedTo != op.getValue(index))
-            allFixedToSame = false;
-        }
-      }
-    }
-
-    // If it can be just one possible value. Then we can fix 'em.
-    if (allFixedToSame)
-    {
-      if (output.isFixed(column) && (output.getValue(column) != allFixedTo))
-        return CONFLICT;
-      if (!output.isFixed(column))
-      {
-        output.setFixed(column, true);
-        output.setValue(column, allFixedTo);
-      }
-    }
-  }
-
-  /*
-  // If there is only one possible shift value. Then, we can push from the
-  output back.
-  if (1 == nOfPossibleShifts)
-  {
-    for (unsigned i = shiftIndex; i < bitWidth; i++)
-    {
-      if (!op.isFixed(i - shiftIndex) && output.isFixed(i))
-      {
-        op.setFixed(i - shiftIndex, true);
-        op.setValue(i - shiftIndex, output.getValue(i));
-        result = CHANGED;
-      }
-    }
-  }
-*/
-
-  return NOT_IMPLEMENTED;
+  writeBack(op, packedOp, origOp);
+  writeBack(shift, packedShift, origShift);
+  writeBack(output, packedOut, origOut);
+  return result;
 }
 }
 }

--- a/lib/Simplifier/constantBitP/ConstantBitP_Shifting.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_Shifting.cpp
@@ -62,17 +62,7 @@ struct PackedBits
 
   explicit PackedBits(const FixedBits& b) : words((b.getWidth() + 63) / 64)
   {
-    if (words <= INLINE_WORDS)
-    {
-      fixed = inlineStore;
-      value = inlineStore + words;
-    }
-    else
-    {
-      heapStore.resize(2 * words);
-      fixed = heapStore.data();
-      value = heapStore.data() + words;
-    }
+    allocate();
     for (unsigned j = 0; j < 2 * words; j++)
       fixed[j] = 0; // zeroes both halves; value follows fixed.
 
@@ -84,6 +74,32 @@ struct PackedBits
         if (b.getValue(i))
           value[i >> 6] |= (uint64_t)1 << (i & 63);
       }
+  }
+
+  PackedBits(const PackedBits& o) : words(o.words)
+  {
+    allocate();
+    copyFrom(o);
+  }
+
+  void copyFrom(const PackedBits& o)
+  {
+    assert(words == o.words);
+    for (unsigned j = 0; j < words; j++)
+    {
+      fixed[j] = o.fixed[j];
+      value[j] = o.value[j];
+    }
+  }
+
+  bool isFixedBit(unsigned i) const
+  {
+    return (fixed[i >> 6] >> (i & 63)) & 1;
+  }
+
+  bool valueBit(unsigned i) const
+  {
+    return (value[i >> 6] >> (i & 63)) & 1;
   }
 
   // Word j of (m >> s). Bits above the width are zero because only bits
@@ -131,9 +147,33 @@ struct PackedBits
   }
 
 private:
-  PackedBits(const PackedBits&);
-  PackedBits& operator=(const PackedBits&);
+  void allocate()
+  {
+    if (words <= INLINE_WORDS)
+    {
+      fixed = inlineStore;
+      value = inlineStore + words;
+    }
+    else
+    {
+      heapStore.resize(2 * words);
+      fixed = heapStore.data();
+      value = heapStore.data() + words;
+    }
+  }
+
+  PackedBits& operator=(const PackedBits&); // use copyFrom.
 };
+
+// Meet (the union of what the two states admit), written into a.
+void meetInto(PackedBits& a, const PackedBits& b)
+{
+  for (unsigned j = 0; j < a.words; j++)
+  {
+    a.fixed[j] &= b.fixed[j] & ~(a.value[j] ^ b.value[j]);
+    a.value[j] &= a.fixed[j];
+  }
+}
 
 // Whether the concrete shift amount i is admitted by the fixed bits of the
 // shift operand. Equivalent to FixedBits::unsignedHolds(i) for i < 2^64,
@@ -241,31 +281,33 @@ Result bvRightShiftBothWays(vector<FixedBits*>& children, FixedBits& output)
   return result;
 }
 
-unsigned getMaxShiftFromValueViaAlternation(const unsigned bitWidth,
-                                            const FixedBits& output)
+// The shift must be less than the position of the first alternation in the
+// (fixed bits of the) output.
+static unsigned getMaxShiftFromValueViaAlternation(const unsigned bitWidth,
+                                                   const PackedBits& output)
 {
   unsigned maxShiftFromValue = UINT_MAX;
 
-  // The shift must be less than the position of the first alternation.
   bool foundTrue = false;
   bool foundFalse = false;
   for (int i = bitWidth - 1; i >= 0; i--)
   {
-    if (output.isFixed(i))
+    if (output.isFixedBit(i))
     {
-      if (output.getValue(i) && foundFalse)
+      const bool v = output.valueBit(i);
+      if (v && foundFalse)
       {
         maxShiftFromValue = i;
         break;
       }
-      if (!output.getValue(i) && foundTrue)
+      if (!v && foundTrue)
       {
         maxShiftFromValue = i;
         break;
       }
-      if (output.getValue(i))
+      if (v)
         foundTrue = true;
-      else if (!output.getValue(i))
+      else
         foundFalse = true;
     }
   }
@@ -276,86 +318,37 @@ unsigned getMaxShiftFromValueViaAlternation(const unsigned bitWidth,
   return maxShiftFromValue;
 }
 
-Result bvArithmeticRightShiftBothWays(vector<FixedBits*>& children,
-                                      FixedBits& output)
+// The range of the values the fixed bits admit, clamped as the original
+// FixedBits::getUnsignedMinMax: anything reaching past the low 32 bits
+// saturates to UINT_MAX.
+static void packedUnsignedMinMax(const PackedBits& b, unsigned bitWidth,
+                                 unsigned& min, unsigned& max)
 {
-  const unsigned bitWidth = output.getWidth();
-  assert(2 == children.size());
-  assert(bitWidth > 0);
-  assert(children[0]->getWidth() == children[1]->getWidth());
+  bool bigMin = false, bigMax = false;
+  for (unsigned j = 0; j < b.words; j++)
+  {
+    const uint64_t high = bitsAtOrAbove(j, 32) & PackedBits::widthMask(j, bitWidth);
+    if (b.fixed[j] & b.value[j] & high)
+      bigMin = true;
+    if ((b.value[j] | ~b.fixed[j]) & high)
+      bigMax = true;
+  }
+  const uint64_t low = ~bitsAtOrAbove(0, 32) & PackedBits::widthMask(0, bitWidth);
+  min = bigMin ? UINT_MAX : (unsigned)(b.fixed[0] & b.value[0] & low);
+  max = bigMax ? UINT_MAX : (unsigned)((b.value[0] | ~b.fixed[0]) & low);
+}
+
+// The core of the arithmetic right-shift transfer, on packed state. The
+// operand's MSB must be fixed on entry. Deductions are written into the
+// packed arguments; the wrapper transfers them back to the FixedBits.
+static Result ashrCore(const unsigned bitWidth, PackedBits& packedOp,
+                       PackedBits& packedShift, PackedBits& packedOut)
+{
   const unsigned MSBIndex = bitWidth - 1;
+  const unsigned msbWord = MSBIndex >> 6;
+  const uint64_t msbBit = (uint64_t)1 << (MSBIndex & 63);
 
-  FixedBits& op = *children[0];
-  FixedBits& shift = *children[1];
-
-  // The output's MSB always equals the operand's (whatever the shift is),
-  // so copy it over before considering the case split below: the branch
-  // with the opposite MSB would only conflict.
-  if (!op.isFixed(MSBIndex) && output.isFixed(MSBIndex))
-  {
-    op.setFixed(MSBIndex, true);
-    op.setValue(MSBIndex, output.getValue(MSBIndex));
-  }
-
-  // If the MSB isn't set, create a copy with it set each way and take the meet.
-  if (!op.isFixed(MSBIndex))
-  {
-    vector<FixedBits*> children1;
-    vector<FixedBits*> children2;
-    FixedBits op1(op);
-    FixedBits op2(op);
-    FixedBits shift1(shift);
-    FixedBits shift2(shift);
-    FixedBits output1(output);
-    FixedBits output2(output);
-
-    children1.push_back(&op1);
-    children1.push_back(&shift1);
-    op1.setFixed(MSBIndex, true);
-    op1.setValue(MSBIndex, true);
-
-    children2.push_back(&op2);
-    children2.push_back(&shift2);
-    op2.setFixed(MSBIndex, true);
-    op2.setValue(MSBIndex, false);
-
-    Result r1 = bvArithmeticRightShiftBothWays(children1, output1);
-    Result r2 = bvArithmeticRightShiftBothWays(children2, output2);
-
-    if (r1 == CONFLICT && r2 == CONFLICT)
-      return CONFLICT;
-
-    if (r1 == CONFLICT)
-    {
-      op = op2;
-      shift = shift2;
-      output = output2;
-      return r2;
-    }
-
-    if (r2 == CONFLICT)
-    {
-      op = op1;
-      shift = shift1;
-      output = output1;
-      return r1;
-    }
-
-    op = FixedBits::meet(op1, op2);
-    shift = FixedBits::meet(shift1, shift2);
-    output = FixedBits::meet(output1, output2);
-    return r1;
-  }
-
-  assert(op.isFixed(MSBIndex));
-
-  if (debug_shift)
-  {
-    cerr << "=========" << endl;
-    cerr << op << " >a> ";
-    cerr << shift;
-    cerr << " = " << output << endl;
-  }
+  assert(packedOp.fixed[msbWord] & msbBit);
 
   // The topmost number of possible shifts corresponds to all
   // the values of shift that shift out everything.
@@ -366,48 +359,24 @@ Result bvArithmeticRightShiftBothWays(vector<FixedBits*>& children,
   for (unsigned i = 0; i < numberOfPossibleShifts; i++)
     possibleShift[i] = false;
 
-  // If either of the top two bits are fixed they should be equal.
-  if (op.isFixed(MSBIndex) ^ output.isFixed(MSBIndex))
-  {
-    if (op.isFixed(MSBIndex))
-    {
-      output.setFixed(MSBIndex, true);
-      output.setValue(MSBIndex, op.getValue(MSBIndex));
-    }
-
-    if (output.isFixed(MSBIndex))
-    {
-      op.setFixed(MSBIndex, true);
-      op.setValue(MSBIndex, output.getValue(MSBIndex));
-    }
-  }
-
-  // Both the MSB of the operand and the output should be fixed now..
-  assert(output.isFixed(MSBIndex));
+  // The output's MSB always equals the operand's.
+  if (!(packedOut.fixed[msbWord] & msbBit))
+    packedOut.fixBits(msbWord, msbBit, packedOp.value[msbWord]);
 
   unsigned minShiftFromShift,
       maxShiftFromShift; // The range of the "shift" value.
-  shift.getUnsignedMinMax(minShiftFromShift, maxShiftFromShift);
+  packedUnsignedMinMax(packedShift, bitWidth, minShiftFromShift,
+                       maxShiftFromShift);
 
   // The shift can't be any bigger than the topmost alternation in the output.
   // For example if the output is 0.01000, then the shift can not be bigger than
   // 3.
   unsigned maxShiftFromOutput =
-      getMaxShiftFromValueViaAlternation(bitWidth, output);
+      getMaxShiftFromValueViaAlternation(bitWidth, packedOut);
 
   maxShiftFromShift = std::min(maxShiftFromShift, (unsigned)maxShiftFromOutput);
 
-  if (debug_shift)
   {
-    cerr << "minshift:" << minShiftFromShift << endl;
-    cerr << "maxshift:" << maxShiftFromShift << endl;
-    cerr << "total:" << maxShiftFromShift << endl;
-  }
-
-  PackedBits packedOp(op);
-  PackedBits packedOut(output);
-  {
-    const PackedBits packedShift(shift);
     const bool highFixedOne = anyFixedOneAboveWordZero(packedShift);
 
     for (unsigned i = minShiftFromShift;
@@ -506,7 +475,13 @@ Result bvArithmeticRightShiftBothWays(vector<FixedBits*>& children,
       FixedBits truth(1, true);
       truth.setFixed(0, true);
       truth.setValue(0, true);
-      FixedBits working(shift);
+      FixedBits working(bitWidth, false);
+      for (unsigned i = 0; i < bitWidth; i++)
+        if (packedShift.isFixedBit(i))
+        {
+          working.setFixed(i, true);
+          working.setValue(i, packedShift.valueBit(i));
+        }
 
       vector<FixedBits*> args;
       args.push_back(&working);
@@ -541,21 +516,9 @@ Result bvArithmeticRightShiftBothWays(vector<FixedBits*>& children,
     // Write the union into the shift.
     for (unsigned j = 0; j < words; j++)
     {
-      uint64_t pending = vFixed[j];
-      while (pending)
-      {
-        const unsigned b = __builtin_ctzll(pending);
-        pending &= pending - 1;
-        const unsigned i = j * 64 + b;
-        const bool value = (vValue[j] >> b) & 1;
-        if (!shift.isFixed(i))
-        {
-          shift.setFixed(i, true);
-          shift.setValue(i, value);
-        }
-        else if (shift.getValue(i) != value)
-          return CONFLICT;
-      }
+      if (vFixed[j] & packedShift.fixed[j] & (packedShift.value[j] ^ vValue[j]))
+        return CONFLICT;
+      packedShift.fixBits(j, vFixed[j], vValue[j]);
     }
   }
 
@@ -596,24 +559,10 @@ Result bvArithmeticRightShiftBothWays(vector<FixedBits*>& children,
     {
       const uint64_t fixable = agree[j] & ~packedOp.fixed[j] &
                                bitsAtOrAbove(j, maxS) &
-                               packedOut.widthMask(j, bitWidth);
-      if (fixable == 0)
-        continue;
-      for (unsigned b = 0; b < 64; b++)
-        if ((fixable >> b) & 1)
-        {
-          op.setFixed(j * 64 + b, true);
-          op.setValue(j * 64 + b, (ref[j] >> b) & 1);
-        }
-      packedOp.fixBits(j, fixable, ref[j]);
+                               PackedBits::widthMask(j, bitWidth);
+      if (fixable != 0)
+        packedOp.fixBits(j, fixable, ref[j]);
     }
-  }
-
-  if (debug_shift)
-  {
-    cerr << op << " >a> ";
-    cerr << shift;
-    cerr << " = " << output << endl;
   }
 
   // Go through each of the possible shifts. If the same value is fixed
@@ -621,7 +570,7 @@ Result bvArithmeticRightShiftBothWays(vector<FixedBits*>& children,
   // of shift s at column c is op[c+s] for c <= bitWidth-1-s, and the
   // (fixed) MSB for higher columns; a shift of >= bitWidth contributes the
   // MSB everywhere.
-  const bool MSBValue = op.getValue(MSBIndex);
+  const bool MSBValue = (packedOp.value[msbWord] & msbBit) != 0;
   if (nPossible > 0 || shiftOutPossible)
   {
     uint64_t* agree = (uint64_t*)alloca(sizeof(uint64_t) * words);
@@ -662,21 +611,122 @@ Result bvArithmeticRightShiftBothWays(vector<FixedBits*>& children,
 
     for (unsigned j = 0; j < words; j++)
     {
-      const uint64_t agreed = agree[j] & packedOut.widthMask(j, bitWidth);
+      const uint64_t agreed = agree[j] & PackedBits::widthMask(j, bitWidth);
       if (agreed & packedOut.fixed[j] & (packedOut.value[j] ^ ref[j]))
         return CONFLICT;
       const uint64_t newFix = agreed & ~packedOut.fixed[j];
-      if (newFix == 0)
-        continue;
-      for (unsigned b = 0; b < 64; b++)
-        if ((newFix >> b) & 1)
-        {
-          output.setFixed(j * 64 + b, true);
-          output.setValue(j * 64 + b, (ref[j] >> b) & 1);
-        }
+      if (newFix != 0)
+        packedOut.fixBits(j, newFix, ref[j]);
     }
   }
   return NOT_IMPLEMENTED;
+}
+
+// Transfer newly fixed bits from the packed state back into the FixedBits.
+static void writeBack(FixedBits& to, const PackedBits& from,
+                      const uint64_t* originalFixed)
+{
+  for (unsigned j = 0; j < from.words; j++)
+  {
+    uint64_t pending = from.fixed[j] & ~originalFixed[j];
+    while (pending)
+    {
+      const unsigned b = __builtin_ctzll(pending);
+      pending &= pending - 1;
+      to.setFixed(j * 64 + b, true);
+      to.setValue(j * 64 + b, (from.value[j] >> b) & 1);
+    }
+  }
+}
+
+Result bvArithmeticRightShiftBothWays(vector<FixedBits*>& children,
+                                      FixedBits& output)
+{
+  const unsigned bitWidth = output.getWidth();
+  assert(2 == children.size());
+  assert(bitWidth > 0);
+  assert(children[0]->getWidth() == children[1]->getWidth());
+  const unsigned MSBIndex = bitWidth - 1;
+  const unsigned msbWord = MSBIndex >> 6;
+  const uint64_t msbBit = (uint64_t)1 << (MSBIndex & 63);
+
+  FixedBits& op = *children[0];
+  FixedBits& shift = *children[1];
+
+  PackedBits packedOp(op);
+  PackedBits packedShift(shift);
+  PackedBits packedOut(output);
+  const unsigned words = packedOp.words;
+
+  // Snapshot what was fixed on entry, for the write-back.
+  uint64_t* origOp = (uint64_t*)alloca(sizeof(uint64_t) * words);
+  uint64_t* origShift = (uint64_t*)alloca(sizeof(uint64_t) * words);
+  uint64_t* origOut = (uint64_t*)alloca(sizeof(uint64_t) * words);
+  for (unsigned j = 0; j < words; j++)
+  {
+    origOp[j] = packedOp.fixed[j];
+    origShift[j] = packedShift.fixed[j];
+    origOut[j] = packedOut.fixed[j];
+  }
+
+  // The output's MSB always equals the operand's (whatever the shift is),
+  // so copy it over before considering the case split below: the branch
+  // with the opposite MSB would only conflict.
+  if (!(packedOp.fixed[msbWord] & msbBit) && (packedOut.fixed[msbWord] & msbBit))
+    packedOp.fixBits(msbWord, msbBit, packedOut.value[msbWord]);
+
+  Result result;
+  if (!(packedOp.fixed[msbWord] & msbBit))
+  {
+    // The MSB isn't fixed: run the core with it set each way and take the
+    // union (meet in the fixed-bits lattice) of the survivors.
+    PackedBits op1(packedOp), shift1(packedShift), out1(packedOut);
+    PackedBits op2(packedOp), shift2(packedShift), out2(packedOut);
+    op1.fixBits(msbWord, msbBit, msbBit);
+    op2.fixBits(msbWord, msbBit, 0);
+
+    const Result r1 = ashrCore(bitWidth, op1, shift1, out1);
+    const Result r2 = ashrCore(bitWidth, op2, shift2, out2);
+
+    if (r1 == CONFLICT && r2 == CONFLICT)
+      return CONFLICT;
+
+    if (r1 == CONFLICT)
+    {
+      packedOp.copyFrom(op2);
+      packedShift.copyFrom(shift2);
+      packedOut.copyFrom(out2);
+      result = r2;
+    }
+    else if (r2 == CONFLICT)
+    {
+      packedOp.copyFrom(op1);
+      packedShift.copyFrom(shift1);
+      packedOut.copyFrom(out1);
+      result = r1;
+    }
+    else
+    {
+      meetInto(op1, op2);
+      meetInto(shift1, shift2);
+      meetInto(out1, out2);
+      packedOp.copyFrom(op1);
+      packedShift.copyFrom(shift1);
+      packedOut.copyFrom(out1);
+      result = r1;
+    }
+  }
+  else
+  {
+    result = ashrCore(bitWidth, packedOp, packedShift, packedOut);
+    if (result == CONFLICT)
+      return CONFLICT;
+  }
+
+  writeBack(op, packedOp, origOp);
+  writeBack(shift, packedShift, origShift);
+  writeBack(output, packedOut, origOut);
+  return result;
 }
 
 Result bvLeftShiftBothWays(vector<FixedBits*>& children, FixedBits& output)

--- a/lib/Simplifier/constantBitP/ConstantBitP_Shifting.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_Shifting.cpp
@@ -27,6 +27,9 @@ THE SOFTWARE.
 // FIXME: External library
 #include "extlib-constbv/constantbv.h"
 
+#include <cstdint>
+#include <vector>
+
 // Left shift, right shift.
 // Trevor Hansen. BSD License.
 
@@ -42,6 +45,103 @@ namespace constantBitP
 {
 
 const bool debug_shift = false;
+
+namespace
+{
+// The fixed/value bits packed into words, so the possible-shift set can be
+// computed with word operations rather than bit-at-a-time probing. Widths
+// up to 256 bits (the overwhelmingly common case) live on the stack.
+struct PackedBits
+{
+  static const unsigned INLINE_WORDS = 4;
+  uint64_t inlineStore[2 * INLINE_WORDS];
+  uint64_t* fixed;
+  uint64_t* value; // only meaningful where fixed.
+  unsigned words;
+  std::vector<uint64_t> heapStore;
+
+  explicit PackedBits(const FixedBits& b) : words((b.getWidth() + 63) / 64)
+  {
+    if (words <= INLINE_WORDS)
+    {
+      fixed = inlineStore;
+      value = inlineStore + words;
+    }
+    else
+    {
+      heapStore.resize(2 * words);
+      fixed = heapStore.data();
+      value = heapStore.data() + words;
+    }
+    for (unsigned j = 0; j < 2 * words; j++)
+      fixed[j] = 0; // zeroes both halves; value follows fixed.
+
+    const unsigned width = b.getWidth();
+    for (unsigned i = 0; i < width; i++)
+      if (b.isFixed(i))
+      {
+        fixed[i >> 6] |= (uint64_t)1 << (i & 63);
+        if (b.getValue(i))
+          value[i >> 6] |= (uint64_t)1 << (i & 63);
+      }
+  }
+
+  // Word j of (m >> s). Bits above the width are zero because only bits
+  // below the width are ever set.
+  uint64_t shiftedWord(const uint64_t* m, unsigned s, unsigned j) const
+  {
+    const unsigned word = j + (s >> 6);
+    const unsigned bit = s & 63;
+    if (word >= words)
+      return 0;
+    uint64_t r = m[word] >> bit;
+    if (bit != 0 && word + 1 < words)
+      r |= m[word + 1] << (64 - bit);
+    return r;
+  }
+
+private:
+  PackedBits(const PackedBits&);
+  PackedBits& operator=(const PackedBits&);
+};
+
+// Whether the concrete shift amount i is admitted by the fixed bits of the
+// shift operand. Equivalent to FixedBits::unsignedHolds(i) for i < 2^64,
+// given anyHighFixedOne = "some bit above word zero is fixed to one".
+inline bool shiftHolds(const PackedBits& shift, bool anyHighFixedOne,
+                       uint64_t i)
+{
+  if (anyHighFixedOne)
+    return false;
+  return (i & shift.fixed[0]) == (shift.value[0] & shift.fixed[0]);
+}
+
+bool anyFixedOneAboveWordZero(const PackedBits& shift)
+{
+  for (unsigned j = 1; j < shift.words; j++)
+    if (shift.fixed[j] & shift.value[j])
+      return true;
+  return false;
+}
+
+// Whether shifting the operand right by s contradicts the fixed output
+// bits: some column c <= width-1-s has both output[c] and op[c+s] fixed,
+// to different values.
+inline bool rightShiftDisagrees(const PackedBits& op, const PackedBits& out,
+                                unsigned s)
+{
+  for (unsigned j = 0; j < out.words; j++)
+  {
+    const uint64_t opF = op.shiftedWord(op.fixed, s, j);
+    if (opF == 0)
+      continue;
+    const uint64_t opV = op.shiftedWord(op.value, s, j);
+    if (opF & out.fixed[j] & (opV ^ out.value[j]))
+      return true;
+  }
+  return false;
+}
+}
 
 Result bvRightShiftBothWays(vector<FixedBits*>& children, FixedBits& output)
 {
@@ -237,6 +337,15 @@ Result bvArithmeticRightShiftBothWays(vector<FixedBits*>& children,
   FixedBits& op = *children[0];
   FixedBits& shift = *children[1];
 
+  // The output's MSB always equals the operand's (whatever the shift is),
+  // so copy it over before considering the case split below: the branch
+  // with the opposite MSB would only conflict.
+  if (!op.isFixed(MSBIndex) && output.isFixed(MSBIndex))
+  {
+    op.setFixed(MSBIndex, true);
+    op.setValue(MSBIndex, output.getValue(MSBIndex));
+  }
+
   // If the MSB isn't set, create a copy with it set each way and take the meet.
   if (!op.isFixed(MSBIndex))
   {
@@ -344,44 +453,37 @@ Result bvArithmeticRightShiftBothWays(vector<FixedBits*>& children,
     cerr << "total:" << maxShiftFromShift << endl;
   }
 
-  for (unsigned i = minShiftFromShift;
-       i <= std::min(bitWidth, maxShiftFromShift); i++)
   {
-    // if the bit-pattern of 'i' is in the set represented by the 'shift'.
-    if (shift.unsignedHolds(i))
-      possibleShift[i] = true;
-  }
+    const PackedBits packedOp(op);
+    const PackedBits packedShift(shift);
+    const PackedBits packedOut(output);
+    const bool highFixedOne = anyFixedOneAboveWordZero(packedShift);
 
-  // Complication. Given a shift like [.1] possibleShift[2] is now false.
-  // A shift of 2 isn't possible. But one of three is.
-  // possibleShift[2] means any shift >=2 is possible. So it needs to be set
-  // to true.
-  {
+    for (unsigned i = minShiftFromShift;
+         i <= std::min(bitWidth, maxShiftFromShift); i++)
+    {
+      // if the bit-pattern of 'i' is in the set represented by the 'shift'.
+      if (shiftHolds(packedShift, highFixedOne, i))
+        possibleShift[i] = true;
+    }
+
+    // Complication. Given a shift like [.1] possibleShift[2] is now false.
+    // A shift of 2 isn't possible. But one of three is.
+    // possibleShift[2] means any shift >=2 is possible. So it needs to be set
+    // to true.
     if (maxShiftFromShift >= bitWidth)
       possibleShift[bitWidth] = true;
-  }
 
-  // Now check one-by-one each shifting.
-  // If we are shifting a zero to where a one is (say), then that shifting isn't
-  // possible.
-  for (unsigned shiftIt = minShiftFromShift; shiftIt < numberOfPossibleShifts;
-       shiftIt++)
-  {
-    if (possibleShift[shiftIt])
+    // Now check one-by-one each shifting.
+    // If we are shifting a zero to where a one is (say), then that shifting
+    // isn't possible. (A shift of bitWidth has no overlapping columns, so
+    // it is never filtered here, as before.)
+    for (unsigned shiftIt = minShiftFromShift; shiftIt < numberOfPossibleShifts;
+         shiftIt++)
     {
-      for (unsigned column = 0; column < bitWidth; column++)
-      {
-        // if they are fixed to different values. That's wrong.
-        if (column + shiftIt <= bitWidth - 1)
-        {
-          if (output.isFixed(column) && op.isFixed(column + shiftIt) &&
-              (output.getValue(column) != op.getValue(column + shiftIt)))
-          {
-            possibleShift[shiftIt] = false;
-            break;
-          }
-        }
-      }
+      if (possibleShift[shiftIt] && shiftIt < bitWidth &&
+          rightShiftDisagrees(packedOp, packedOut, shiftIt))
+        possibleShift[shiftIt] = false;
     }
   }
 

--- a/lib/Simplifier/constantBitP/ConstantBitP_Shifting.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_Shifting.cpp
@@ -100,6 +100,36 @@ struct PackedBits
     return r;
   }
 
+  // Word j of (m << s). May carry set bits above the width; callers mask.
+  uint64_t leftShiftedWord(const uint64_t* m, unsigned s, unsigned j) const
+  {
+    const int word = (int)j - (int)(s >> 6);
+    const unsigned bit = s & 63;
+    if (word < 0)
+      return 0;
+    uint64_t r = m[word] << bit;
+    if (bit != 0 && word >= 1)
+      r |= m[word - 1] >> (64 - bit);
+    return r;
+  }
+
+  void fixBits(unsigned j, uint64_t mask, uint64_t values)
+  {
+    fixed[j] |= mask;
+    value[j] = (value[j] & ~mask) | (values & mask);
+  }
+
+  // Bits of word j that lie below the width.
+  static uint64_t widthMask(unsigned j, unsigned width)
+  {
+    const uint64_t base = (uint64_t)j * 64;
+    if (base + 64 <= width)
+      return ~(uint64_t)0;
+    if (base >= width)
+      return 0;
+    return (((uint64_t)1 << (width - base)) - 1);
+  }
+
 private:
   PackedBits(const PackedBits&);
   PackedBits& operator=(const PackedBits&);
@@ -122,6 +152,17 @@ bool anyFixedOneAboveWordZero(const PackedBits& shift)
     if (shift.fixed[j] & shift.value[j])
       return true;
   return false;
+}
+
+// Bits of word j whose global index is >= threshold.
+inline uint64_t bitsAtOrAbove(unsigned j, unsigned threshold)
+{
+  const uint64_t base = (uint64_t)j * 64;
+  if (base >= threshold)
+    return ~(uint64_t)0;
+  if (base + 64 <= threshold)
+    return 0;
+  return ~(((uint64_t)1 << (threshold - base)) - 1);
 }
 
 // Whether shifting the operand right by s contradicts the fixed output
@@ -453,10 +494,10 @@ Result bvArithmeticRightShiftBothWays(vector<FixedBits*>& children,
     cerr << "total:" << maxShiftFromShift << endl;
   }
 
+  PackedBits packedOp(op);
+  PackedBits packedOut(output);
   {
-    const PackedBits packedOp(op);
     const PackedBits packedShift(shift);
-    const PackedBits packedOut(output);
     const bool highFixedOne = anyFixedOneAboveWordZero(packedShift);
 
     for (unsigned i = minShiftFromShift;
@@ -535,81 +576,62 @@ Result bvArithmeticRightShiftBothWays(vector<FixedBits*>& children,
     }
   }
 
+  // Collect the possible finite shift amounts once.
+  const unsigned words = packedOut.words;
+  unsigned* possibleList = (unsigned*)alloca(sizeof(unsigned) * bitWidth);
+  unsigned nPossible = 0;
+  for (unsigned s = 0; s < bitWidth; s++)
+    if (possibleShift[s])
+      possibleList[nPossible++] = s;
+  const bool shiftOutPossible = possibleShift[bitWidth];
+
   // If a particular input bit appears in every possible shifting,
   // and if that bit is unfixed,
-  // and if the result it is fixed to the same value in every position.
-  // Then, that bit must be fixed.
-  // E.g.  [--] << [0-] == [00]
-
-  bool* candidates = (bool*)alloca(sizeof(bool) * bitWidth);
-  for (unsigned i = 0; i < bitWidth; i++)
+  // and if the result is fixed to the same value in every position,
+  // then that bit must be fixed. E.g.  [--] << [0-] == [00]
+  //
+  // A bit below the largest possible shift amount is shifted out in some
+  // scenario (and everything is if a shift of >= bitWidth is possible), so
+  // the candidates are the unfixed operand bits at or above every possible
+  // shift amount. For those, every possible shift contributes the output
+  // bit that is `shift` positions lower, i.e. word-wise, (output << s).
+  if (!shiftOutPossible && nPossible > 0)
   {
-    candidates[i] = !op.isFixed(i);
-  }
+    const unsigned maxS = possibleList[nPossible - 1];
+    const unsigned s0 = possibleList[0];
+    uint64_t* agree = (uint64_t*)alloca(sizeof(uint64_t) * words);
+    uint64_t* ref = (uint64_t*)alloca(sizeof(uint64_t) * words);
 
-  // candidates: So far: the bits that are unfixed in the operand.
-
-  for (unsigned i = 0; i < numberOfPossibleShifts; i++)
-  {
-    if (possibleShift[i])
+    for (unsigned j = 0; j < words; j++)
     {
-      // If this shift is possible, then some bits will be shifted out.
-      for (unsigned j = 0; j < i; j++)
-        candidates[j] = false;
+      agree[j] = packedOut.leftShiftedWord(packedOut.fixed, s0, j);
+      ref[j] = packedOut.leftShiftedWord(packedOut.value, s0, j);
     }
-  }
-
-  // candidates: So far: + the input bits that are unfixed.
-  //                     + the input bits that are in every possible fixing.
-
-  // Check all candidates have the same output values.
-  for (unsigned candidate = 0; candidate < bitWidth; candidate++)
-  {
-    bool setTo = false; // value that's never read. To quieten gcc.
-
-    if (candidates[candidate])
+    for (unsigned k = 1; k < nPossible; k++)
     {
-      bool first = true;
-      for (unsigned shiftIT = 0; shiftIT < bitWidth; shiftIT++)
+      const unsigned s = possibleList[k];
+      for (unsigned j = 0; j < words; j++)
       {
-        // If the shift isn't possible continue.
-        if (!possibleShift[shiftIT])
-          continue;
-
-        if (shiftIT > candidate)
-          continue;
-
-        unsigned idx = candidate - shiftIT;
-
-        if (!output.isFixed(idx))
-        {
-          candidates[candidate] = false;
-          break;
-        }
-        else
-        {
-          if (first)
-          {
-            first = false;
-            setTo = output.getValue(idx);
-          }
-          else
-          {
-            if (setTo != output.getValue(idx))
-            {
-              candidates[candidate] = false;
-              break;
-            }
-          }
-        }
+        const uint64_t f = packedOut.leftShiftedWord(packedOut.fixed, s, j);
+        const uint64_t v = packedOut.leftShiftedWord(packedOut.value, s, j);
+        agree[j] &= f & ~(v ^ ref[j]);
       }
     }
 
-    if (candidates[candidate])
+    for (unsigned j = 0; j < words; j++)
     {
-      assert(!op.isFixed(candidate));
-      op.setFixed(candidate, true);
-      op.setValue(candidate, setTo);
+      const uint64_t fixable = agree[j] & ~packedOp.fixed[j] &
+                               bitsAtOrAbove(j, maxS) &
+                               packedOut.widthMask(j, bitWidth);
+      if (fixable == 0)
+        continue;
+      for (unsigned b = 0; b < 64; b++)
+        if ((fixable >> b) & 1)
+        {
+          op.setFixed(j * 64 + b, true);
+          op.setValue(j * 64 + b, (ref[j] >> b) & 1);
+        }
+      packedOp.fixBits(j, fixable, ref[j]);
     }
   }
 
@@ -621,65 +643,63 @@ Result bvArithmeticRightShiftBothWays(vector<FixedBits*>& children,
   }
 
   // Go through each of the possible shifts. If the same value is fixed
-  // at every location. Then it's fixed too in the result.
-  // Looping over the output columns.
-  bool MSBValue = op.getValue(MSBIndex);
-
-  for (unsigned column = 0; column < bitWidth; column++)
+  // at every location, then it's fixed too in the result. The contribution
+  // of shift s at column c is op[c+s] for c <= bitWidth-1-s, and the
+  // (fixed) MSB for higher columns; a shift of >= bitWidth contributes the
+  // MSB everywhere.
+  const bool MSBValue = op.getValue(MSBIndex);
+  if (nPossible > 0 || shiftOutPossible)
   {
-    bool allFixedToSame = true;
-    bool allFixedTo = false; // value that's never read. To quieten gcc.
+    uint64_t* agree = (uint64_t*)alloca(sizeof(uint64_t) * words);
+    uint64_t* ref = (uint64_t*)alloca(sizeof(uint64_t) * words);
     bool first = true;
 
-    for (unsigned shiftIt = 0;
-         (shiftIt < numberOfPossibleShifts) && allFixedToSame; shiftIt++)
+    for (unsigned k = 0; k <= nPossible; k++)
     {
-      if (possibleShift[shiftIt])
+      unsigned boundary; // columns at or above read the MSB.
+      unsigned s = 0;
+      if (k < nPossible)
       {
-        // Will have shifted in something..
-        if (shiftIt > (bitWidth - 1 - column))
+        s = possibleList[k];
+        boundary = bitWidth - s;
+      }
+      else if (shiftOutPossible)
+        boundary = 0;
+      else
+        break;
+
+      for (unsigned j = 0; j < words; j++)
+      {
+        const uint64_t hi = bitsAtOrAbove(j, boundary);
+        const uint64_t f = packedOp.shiftedWord(packedOp.fixed, s, j) | hi;
+        const uint64_t v =
+            (packedOp.shiftedWord(packedOp.value, s, j) & ~hi) |
+            (MSBValue ? hi : 0);
+        if (first)
         {
-          if (first)
-          {
-            allFixedTo = MSBValue;
-            first = false;
-          }
-          else
-          {
-            if (allFixedTo != MSBValue)
-            {
-              allFixedToSame = false;
-            }
-          }
+          agree[j] = f;
+          ref[j] = v;
         }
         else
-        {
-          unsigned index = column + shiftIt;
-          if (!op.isFixed(index))
-            allFixedToSame = false;
-          else if (first && op.isFixed(index))
-          {
-            first = false;
-            allFixedTo = op.getValue(index);
-          }
-          if (op.isFixed(index) && allFixedTo != op.getValue(index))
-            allFixedToSame = false;
-        }
+          agree[j] &= f & ~(v ^ ref[j]);
       }
+      first = false;
     }
 
-    // If it can be just one possible value. Then we can fix 'em.
-    if (allFixedToSame)
+    for (unsigned j = 0; j < words; j++)
     {
-      if (output.isFixed(column) && (output.getValue(column) != allFixedTo))
-      {
+      const uint64_t agreed = agree[j] & packedOut.widthMask(j, bitWidth);
+      if (agreed & packedOut.fixed[j] & (packedOut.value[j] ^ ref[j]))
         return CONFLICT;
-      }
-      if (!output.isFixed(column))
-      {
-        output.setFixed(column, true);
-        output.setValue(column, allFixedTo);
-      }
+      const uint64_t newFix = agreed & ~packedOut.fixed[j];
+      if (newFix == 0)
+        continue;
+      for (unsigned b = 0; b < 64; b++)
+        if ((newFix >> b) & 1)
+        {
+          output.setFixed(j * 64 + b, true);
+          output.setValue(j * 64 + b, (ref[j] >> b) & 1);
+        }
     }
   }
   return NOT_IMPLEMENTED;

--- a/lib/Simplifier/constantBitP/ConstantBitP_Shifting.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_Shifting.cpp
@@ -241,96 +241,6 @@ Result bvRightShiftBothWays(vector<FixedBits*>& children, FixedBits& output)
   return result;
 }
 
-// Converts the array of possible shifts into a set that represents the values.
-FixedBits getPossible(unsigned bitWidth, bool possibleShift[],
-                      unsigned numberOfPossibleShifts, const FixedBits& shift)
-{
-  FixedBits v(bitWidth, false);
-  bool first = true;
-  for (unsigned i = 0; i < numberOfPossibleShifts - 1; i++)
-  {
-    if (possibleShift[i])
-    {
-      if (first)
-      {
-        first = false;
-        for (unsigned j = 0; j < (unsigned)v.getWidth(); j++)
-        {
-          v.setFixed(j, true);
-          if (j < sizeof(unsigned) * 8)
-            v.setValue(j, 0 != (i & (1u << j)));
-          else
-            v.setValue(j, false);
-        }
-      }
-      else
-      {
-        // join.
-        for (unsigned j = 0;
-             j < (unsigned)v.getWidth() && j < sizeof(unsigned) * 8; j++)
-        {
-          if (v.isFixed(j))
-          {
-            // union.
-            if (v.getValue(j) != (0 != (i & (1u << j))))
-              v.setFixed(j, false);
-          }
-        }
-      }
-    }
-  }
-
-  unsigned firstShift;
-  for (firstShift = 0; firstShift < numberOfPossibleShifts; firstShift++)
-    if (possibleShift[firstShift])
-      break;
-
-  // The top most entry of the shift table is special. It means all values of
-  // shift
-  // that fill it completely with zeroes /ones. We take the union of all of the
-  // values >bitWidth
-  // in this function.
-  if (possibleShift[numberOfPossibleShifts - 1])
-  {
-    FixedBits bitWidthFB = FixedBits::fromUnsignedInt(bitWidth, bitWidth);
-    FixedBits output(1, true);
-    output.setFixed(0, true);
-    output.setValue(0, true);
-    FixedBits working(shift);
-
-    vector<FixedBits*> args;
-    args.push_back(&working);
-    args.push_back(&bitWidthFB);
-
-    // Write into working anything that can be determined given it's >=bitWidth.
-    Result r = bvGreaterThanEqualsBothWays(args, output);
-    assert(CONFLICT != r);
-
-    // Get the union of "working" with the prior union.
-    for (unsigned i = 0; i < bitWidth; i++)
-    {
-      if (!working.isFixed(i) && v.isFixed(i))
-        v.setFixed(i, false);
-      if (working.isFixed(i) && v.isFixed(i) &&
-          (working.getValue(i) != v.getValue(i)))
-        v.setFixed(i, false);
-      if (firstShift == numberOfPossibleShifts - 1) // no less shifts possible.
-      {
-        if (working.isFixed(i))
-        {
-          v.setFixed(i, true);
-          v.setValue(i, working.getValue(i));
-        }
-      }
-    }
-  }
-
-  if (debug_shift)
-    cerr << "Set of possible shifts:" << v << endl;
-
-  return v;
-}
-
 unsigned getMaxShiftFromValueViaAlternation(const unsigned bitWidth,
                                             const FixedBits& output)
 {
@@ -553,29 +463,6 @@ Result bvArithmeticRightShiftBothWays(vector<FixedBits*>& children,
     return CONFLICT;
   }
 
-  // We have a list of all the possible shift amounts.
-  // We take the union of all the bits that are possible.
-  FixedBits setOfPossibleShifts =
-      getPossible(bitWidth, possibleShift, numberOfPossibleShifts, shift);
-
-  // Write in any fixed values to the shift.
-  for (unsigned i = 0; i < bitWidth; i++)
-  {
-    if (setOfPossibleShifts.isFixed(i))
-    {
-      if (!shift.isFixed(i))
-      {
-        shift.setFixed(i, true);
-        shift.setValue(i, setOfPossibleShifts.getValue(i));
-      }
-      else if (shift.isFixed(i) &&
-               shift.getValue(i) != setOfPossibleShifts.getValue(i))
-      {
-        return CONFLICT;
-      }
-    }
-  }
-
   // Collect the possible finite shift amounts once.
   const unsigned words = packedOut.words;
   unsigned* possibleList = (unsigned*)alloca(sizeof(unsigned) * bitWidth);
@@ -584,6 +471,93 @@ Result bvArithmeticRightShiftBothWays(vector<FixedBits*>& children,
     if (possibleShift[s])
       possibleList[nPossible++] = s;
   const bool shiftOutPossible = possibleShift[bitWidth];
+
+  // The shift operand must lie in the union of the possible shift amounts:
+  // the bit patterns of the possible finite shifts, unioned with whatever
+  // "shift >= bitWidth" allows when shifting everything out is possible.
+  {
+    // The union of the finite patterns: bits where they all agree are
+    // fixed. (Patterns are < bitWidth, so any bits above word zero of the
+    // union are fixed to zero.)
+    uint64_t* vFixed = (uint64_t*)alloca(sizeof(uint64_t) * words);
+    uint64_t* vValue = (uint64_t*)alloca(sizeof(uint64_t) * words);
+    if (nPossible > 0)
+    {
+      const uint64_t ref = possibleList[0];
+      uint64_t diff = 0;
+      for (unsigned k = 1; k < nPossible; k++)
+        diff |= ref ^ (uint64_t)possibleList[k];
+      vFixed[0] = ~diff & PackedBits::widthMask(0, bitWidth);
+      vValue[0] = ref & vFixed[0];
+      for (unsigned j = 1; j < words; j++)
+      {
+        vFixed[j] = PackedBits::widthMask(j, bitWidth);
+        vValue[j] = 0;
+      }
+    }
+    else
+      for (unsigned j = 0; j < words; j++)
+        vFixed[j] = vValue[j] = 0;
+
+    if (shiftOutPossible)
+    {
+      // Refine a copy of the shift with (shift >= bitWidth), and union it in.
+      FixedBits bitWidthFB = FixedBits::fromUnsignedInt(bitWidth, bitWidth);
+      FixedBits truth(1, true);
+      truth.setFixed(0, true);
+      truth.setValue(0, true);
+      FixedBits working(shift);
+
+      vector<FixedBits*> args;
+      args.push_back(&working);
+      args.push_back(&bitWidthFB);
+      Result r = bvGreaterThanEqualsBothWays(args, truth);
+      assert(CONFLICT != r);
+      (void)r;
+
+      for (unsigned i = 0; i < bitWidth; i++)
+      {
+        const unsigned j = i >> 6;
+        const uint64_t bit = (uint64_t)1 << (i & 63);
+        if (nPossible > 0)
+        {
+          // Union: drop bits "working" leaves open or disagrees on.
+          if (!working.isFixed(i) ||
+              ((vFixed[j] & bit) && working.getValue(i) != ((vValue[j] & bit) != 0)))
+            vFixed[j] &= ~bit;
+        }
+        else if (working.isFixed(i))
+        {
+          // Only shifts >= bitWidth are possible.
+          vFixed[j] |= bit;
+          if (working.getValue(i))
+            vValue[j] |= bit;
+          else
+            vValue[j] &= ~bit;
+        }
+      }
+    }
+
+    // Write the union into the shift.
+    for (unsigned j = 0; j < words; j++)
+    {
+      uint64_t pending = vFixed[j];
+      while (pending)
+      {
+        const unsigned b = __builtin_ctzll(pending);
+        pending &= pending - 1;
+        const unsigned i = j * 64 + b;
+        const bool value = (vValue[j] >> b) & 1;
+        if (!shift.isFixed(i))
+        {
+          shift.setFixed(i, true);
+          shift.setValue(i, value);
+        }
+        else if (shift.getValue(i) != value)
+          return CONFLICT;
+      }
+    }
+  }
 
   // If a particular input bit appears in every possible shifting,
   // and if that bit is unfixed,


### PR DESCRIPTION
The three shift transfer functions were among the slowest maximally-precise constant-bit propagators at 64 bits. Six incremental changes move them entirely onto a packed-word representation while keeping their deductions bit-for-bit identical (the exhaustive width-3 tests pin maximal precision, the 100-bit wide tests cover the multi-word paths, and an exhaustive result-contract audit produces identical counters to the old code over all 19,683 width-3 fixed-bit patterns per op):

1. Pack operand/shift/output once per call; compute the possible-shift set with word ops (replaces per-amount `unsignedHolds` probing and per-shift column scans); copy a fixed output MSB onto the operand before the sign case-split.
2. Word-parallel column scans for fixing operand bits from the output and output bits from the operand/sign bit.
3. The union of possible shift amounts via one XOR-accumulate over the patterns (deletes `getPossible` and its FixedBits/bitvector churn).
4. Run the whole arithmetic right-shift core on packed state: the sign case-split copies and meets four-word stack arrays instead of heap FixedBits, with one write-back at the end (on CONFLICT nothing is written back; callers discard the state anyway).
5. Derive the shift-past-the-end refinement directly: that case is only reachable when the maximum admitted shift is >= bitWidth, so an unfixed bit is forced (to one) exactly when clearing it drops the maximum below bitWidth — replacing the comparison-propagator call and the last FixedBits temporaries.
6. Port the same structure to `bvLeftShiftBothWays` (which also serves bvlshr through the reversal wrapper), sharing the shift-union code via `applyShiftUnion`.

## Measurements

64-bit operands, 10k random satisfiable cases per configuration, ns/call at 1%/5%/50% of bits initially fixed (Ryzen 3900X, Release):

| | prob=1 | prob=5 | prob=50 |
|---|---|---|---|
| bvashr before | 14602 | 8192 | 7900 |
| bvashr after | **1483** | **940** | **1484** |
| bvshl before | 8278 | 3765 | 3103 |
| bvshl after | **911** | **726** | **1237** |
| bvlshr before | 8834 | 4218 | 4285 |
| bvlshr after | **1258** | **1169** | **2344** |

## Testing

All 54 ctest suites pass, including the exhaustive width-3 checks that every deduction of the maximally-precise reference is still made (so no precision was traded for speed), the NO_CHANGE-contract checks, and the 100-bit wide tests. Witness-based soundness checks over 90k random 64-bit cases per op report zero violations, and the exhaustive result-contract audit (CONFLICT/CHANGED/NO_CHANGE/NOT_IMPLEMENTED classification per case) is identical to the old code for all three ops.