### PR TITLE
Speed up the division-family constant-bit propagators ~2x at 64 bits

### DIFF
--- a/include/stp/Simplifier/constantBitP/multiplication/ColumnCounts.h
+++ b/include/stp/Simplifier/constantBitP/multiplication/ColumnCounts.h
@@ -147,7 +147,11 @@ struct ColumnCounts
     // Make sure each column's sum is consistent with the output.
     for (unsigned i = 0; i < bitWidth; i++)
     {
-      r = merge(r, snapTo(i));
+      const Result ri = snapTo(i);
+      if (ri == CONFLICT)
+        return CONFLICT;
+      if (ri == CHANGED)
+        r = CHANGED;
     }
     return r;
   }

--- a/lib/Simplifier/constantBitP/ConstantBitP_Division.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_Division.cpp
@@ -605,10 +605,9 @@ Result bvUnsignedQuotientAndRemainder2(vector<FixedBits*>& children,
   else
     throw std::runtime_error("sdjjfas");
 
-  FixedBits aCopy(newWidth, false);
-  FixedBits bCopy(newWidth, false);
-  FixedBits rCopy(newWidth, false);
-  FixedBits qCopy(newWidth, false);
+  // Bits are only ever fixed, so a changed count means changed bits: cheap
+  // change detection for the dependency-driven loop below.
+  unsigned bCount, rCount, timesCount;
 
   // Times and plus must not overflow.
   for (unsigned i = (unsigned)output.getWidth(); i < newWidth; i++)
@@ -645,32 +644,64 @@ Result bvUnsignedQuotientAndRemainder2(vector<FixedBits*>& children,
   multiplicationChildren.push_back(&q);
   multiplicationChildren.push_back(&b);
 
-  do
+  // Run the three transfer functions to a joint fixed point, but only
+  // re-run one when an operand it reads has changed since it last ran:
+  // each is deterministic and reaches its own fixed point, so re-running
+  // it on unchanged inputs cannot add anything, and the loop still ends
+  // at the same joint fixed point as re-running everything every time.
+  // The multiplication at double width dominates the cost, so the skipped
+  // runs (including the final all-quiet confirmation pass) matter.
+  bool ltDirty = true, multDirty = true, addDirty = true;
+  while (ltDirty || multDirty || addDirty)
   {
-    aCopy = a;
-    bCopy = b;
-    rCopy = r;
-    qCopy = q;
-
     if (debug_division)
     {
       log << "p1:" << a << "/" << b << "=" << q << "rem(" << r << ")" << endl;
       log << "times" << times << endl;
     }
 
-    result = bvLessThanBothWays(r, b, trueBit); // (r < b)
-    if (result == CONFLICT)
-      return CONFLICT;
+    if (ltDirty)
+    {
+      ltDirty = false;
+      rCount = r.countFixed();
+      bCount = b.countFixed();
+      result = bvLessThanBothWays(r, b, trueBit); // (r < b)
+      if (result == CONFLICT)
+        return CONFLICT;
+      if (r.countFixed() != rCount)
+        addDirty = true; // r feeds the addition.
+      if (b.countFixed() != bCount)
+        multDirty = true; // b feeds the multiplication.
+    }
 
-    result = bvMultiplyBothWays(multiplicationChildren, times, bm);
-    if (result == CONFLICT)
-      return CONFLICT;
+    if (multDirty)
+    {
+      multDirty = false;
+      bCount = b.countFixed();
+      timesCount = times.countFixed();
+      result = bvMultiplyBothWays(multiplicationChildren, times, bm); // q*b
+      if (result == CONFLICT)
+        return CONFLICT;
+      if (b.countFixed() != bCount)
+        ltDirty = true; // b feeds the less-than.
+      if (times.countFixed() != timesCount)
+        addDirty = true; // times feeds the addition.
+    }
 
-    result = bvAddBothWays(addChildren, a);
-    if (result == CONFLICT)
-      return CONFLICT;
-  } while (!(FixedBits::equals(aCopy, a) && FixedBits::equals(bCopy, b) &&
-             FixedBits::equals(rCopy, r) && FixedBits::equals(qCopy, q)));
+    if (addDirty)
+    {
+      addDirty = false;
+      rCount = r.countFixed();
+      timesCount = times.countFixed();
+      result = bvAddBothWays(addChildren, a); // times + r = a
+      if (result == CONFLICT)
+        return CONFLICT;
+      if (r.countFixed() != rCount)
+        ltDirty = true; // r feeds the less-than.
+      if (times.countFixed() != timesCount)
+        multDirty = true; // times feeds the multiplication.
+    }
+  }
 
   bool conflict = false;
   for (unsigned i = 0; i < output.getWidth(); i++)

--- a/lib/Simplifier/constantBitP/ConstantBitP_Multiplication.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_Multiplication.cpp
@@ -65,20 +65,112 @@ std::ostream& log = std::cerr;
       }
 #endif
 
+static inline int popcount64(uint64_t v);
+static inline uint64_t rightShiftedWord(const uint64_t* m, unsigned words,
+                                        unsigned s, unsigned j);
+static inline int convolutionAt(const uint64_t* a, const uint64_t* revB,
+                                unsigned words, unsigned width, unsigned j);
+
+// The fixed-to-one and unfixed masks of both operands, packed into words so
+// a column's pair-category counts are shifted-window popcounts rather than
+// a per-column scan. Rebuild after either operand changes.
+struct PairMasks
+{
+  static const unsigned INLINE_WORDS = 8; // up to 512 bits on the stack.
+  uint64_t stackBuf[4 * INLINE_WORDS];
+  std::vector<uint64_t> heapBuf;
+  uint64_t* xOne;
+  uint64_t* xUnfixed;
+  uint64_t* revYOne; // y, bit-reversed.
+  uint64_t* revYUnfixed;
+  unsigned words;
+
+  void build(const FixedBits& x, const FixedBits& y)
+  {
+    const unsigned width = x.getWidth();
+    words = (width + 63) / 64;
+    uint64_t* buf = stackBuf;
+    if (words > INLINE_WORDS)
+    {
+      heapBuf.assign(4 * words, 0);
+      buf = heapBuf.data();
+    }
+    else
+      for (unsigned t = 0; t < 4 * words; t++)
+        buf[t] = 0;
+    xOne = buf;
+    xUnfixed = buf + words;
+    revYOne = buf + 2 * words;
+    revYUnfixed = buf + 3 * words;
+
+    widthCached = width;
+    for (unsigned i = 0; i < width; i++)
+    {
+      if (!x.isFixed(i))
+        xUnfixed[i >> 6] |= (uint64_t)1 << (i & 63);
+      else if (x.getValue(i))
+        xOne[i >> 6] |= (uint64_t)1 << (i & 63);
+
+      const unsigned r = width - 1 - i;
+      if (!y.isFixed(i))
+        revYUnfixed[r >> 6] |= (uint64_t)1 << (r & 63);
+      else if (y.getValue(i))
+        revYOne[r >> 6] |= (uint64_t)1 << (r & 63);
+    }
+  }
+
+  // Bit i of x was just fixed: leave the unfixed set, join the ones if set.
+  void xFixed(unsigned i, bool value)
+  {
+    xUnfixed[i >> 6] &= ~((uint64_t)1 << (i & 63));
+    if (value)
+      xOne[i >> 6] |= (uint64_t)1 << (i & 63);
+  }
+
+  void yFixed(unsigned i, bool value)
+  {
+    const unsigned r = widthCached - 1 - i;
+    revYUnfixed[r >> 6] &= ~((uint64_t)1 << (r & 63));
+    if (value)
+      revYOne[r >> 6] |= (uint64_t)1 << (r & 63);
+  }
+
+  unsigned widthCached;
+};
+
 Result fixIfCanForMultiplication(vector<FixedBits*>& children,
                                  const unsigned index,
-                                 const int aspirationalSum)
+                                 const int aspirationalSum, PairMasks* pm)
 {
   assert(index < children[0]->getWidth());
 
   FixedBits& x = *children[0];
   FixedBits& y = *children[1];
 
-  ColumnStats cs(x, y, index);
-
-  int columnUnfixed = cs.columnUnfixed;   // both unfixed.
-  int columnOneFixed = cs.columnOneFixed; // one of the values is fixed to one.
-  int columnOnes = cs.columnOnes;         // both are ones.
+  // The counts ColumnStats(x, y, index) walks the column for, but from the
+  // packed masks: a pair contributes "ones" when both operands are fixed
+  // to one, "one fixed" when one is fixed to one and the other unfixed,
+  // and "unfixed" when both are unfixed. (Pairs with a fixed zero are the
+  // remainder, and aren't needed here.) Short columns are cheaper to scan
+  // directly.
+  const unsigned width = x.getWidth();
+  int columnOnes, columnUnfixed, columnOneFixed;
+  if (pm == NULL || index < 16)
+  {
+    ColumnStats cs(x, y, index);
+    columnOnes = cs.columnOnes;
+    columnUnfixed = cs.columnUnfixed;
+    columnOneFixed = cs.columnOneFixed;
+  }
+  else
+  {
+    columnOnes = convolutionAt(pm->xOne, pm->revYOne, pm->words, width, index);
+    columnUnfixed =
+        convolutionAt(pm->xUnfixed, pm->revYUnfixed, pm->words, width, index);
+    columnOneFixed =
+        convolutionAt(pm->xOne, pm->revYUnfixed, pm->words, width, index) +
+        convolutionAt(pm->xUnfixed, pm->revYOne, pm->words, width, index);
+  }
 
   Result result = NO_CHANGE;
 
@@ -96,6 +188,8 @@ Result fixIfCanForMultiplication(vector<FixedBits*>& children,
       {
         y.setFixed(i, true);
         y.setValue(i, true);
+        if (pm)
+          pm->yFixed(i, true);
         result = CHANGED;
       }
 
@@ -103,6 +197,8 @@ Result fixIfCanForMultiplication(vector<FixedBits*>& children,
       {
         x.setFixed(index - i, true);
         x.setValue(index - i, true);
+        if (pm)
+          pm->xFixed(index - i, true);
         result = CHANGED;
       }
     }
@@ -124,6 +220,8 @@ Result fixIfCanForMultiplication(vector<FixedBits*>& children,
       {
         y.setFixed(i, true);
         y.setValue(i, false);
+        if (pm)
+          pm->yFixed(i, false);
         result = CHANGED;
       }
 
@@ -132,6 +230,8 @@ Result fixIfCanForMultiplication(vector<FixedBits*>& children,
       {
         x.setFixed(index - i, true);
         x.setValue(index - i, false);
+        if (pm)
+          pm->xFixed(index - i, false);
         result = CHANGED;
       }
     }
@@ -730,19 +830,32 @@ Result bvMultiplyBothWays(vector<FixedBits*>& children, FixedBits& output,
     if (CHANGED == r)
       changed = true;
 
+    // The packed column stats only pay off past one word; at 64 bits and
+    // below the direct scan is cheaper, so bvmul at common widths keeps
+    // the original path while the division machinery (double width)
+    // benefits.
+    PairMasks pm;
+    bool masksValid = false; // built lazily: many passes trigger no column.
+    const bool usePacked = bitWidth > 64;
     for (unsigned column = 0; column < bitWidth; column++)
     {
       if (cc.columnL[column] == cc.columnH[column])
       {
+        if (usePacked && !masksValid)
+        {
+          pm.build(x, y);
+          masksValid = true;
+        }
+
         //(2) Knowledge of the sum may fix the operands.
-        Result tempResult =
-            fixIfCanForMultiplication(children, column, cc.columnH[column]);
+        Result tempResult = fixIfCanForMultiplication(
+            children, column, cc.columnH[column], usePacked ? &pm : NULL);
 
         if (CONFLICT == tempResult)
           return CONFLICT;
 
         if (CHANGED == tempResult)
-          r = CHANGED;
+          r = CHANGED; // the masks were updated incrementally.
       }
     }
 

--- a/lib/Simplifier/constantBitP/ConstantBitP_Multiplication.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_Multiplication.cpp
@@ -29,6 +29,7 @@ THE SOFTWARE.
 #include "stp/Simplifier/constantBitP/MultiplicationStats.h"
 #include "stp/Simplifier/constantBitP/multiplication/ColumnCounts.h"
 #include "stp/Simplifier/constantBitP/multiplication/ColumnStats.h"
+#include <cstdint>
 #include <set>
 #include <stdexcept>
 // Multiply.
@@ -141,52 +142,126 @@ Result fixIfCanForMultiplication(vector<FixedBits*>& children,
   return result;
 }
 
-// Uses the zeroes / ones present adjust the column counts.
+static inline int popcount64(uint64_t v)
+{
+#ifdef _MSC_VER
+  return (int)__popcnt64(v);
+#else
+  return __builtin_popcountll(v);
+#endif
+}
+
+// Word `j` of (m >> s), for a `words`-long array.
+static inline uint64_t rightShiftedWord(const uint64_t* m, unsigned words,
+                                        unsigned s, unsigned j)
+{
+  const unsigned word = j + (s >> 6);
+  const unsigned bit = s & 63;
+  if (word >= words)
+    return 0;
+  uint64_t r = m[word] >> bit;
+  if (bit != 0 && word + 1 < words)
+    r |= m[word + 1] << (64 - bit);
+  return r;
+}
+
+// The number of pairs i + k == j with a[i] and revB[width-1-k] both set,
+// i.e. the boolean convolution of a and (un-reversed) b at column j.
+static inline int convolutionAt(const uint64_t* a, const uint64_t* revB,
+                                unsigned words, unsigned width, unsigned j)
+{
+  int count = 0;
+  const unsigned s = width - 1 - j;
+  for (unsigned t = 0; t < words; t++)
+  {
+    const uint64_t aw = a[t];
+    if (aw != 0)
+      count += popcount64(aw & rightShiftedWord(revB, words, s, t));
+  }
+  return count;
+}
+
+// Uses the zeroes / ones present adjust the column counts:
+//   columnH[j] -= #{i <= j : y[i] fixed to zero}
+//              +  #{i <= j : x[i] fixed to zero and y[j-i] not fixed to zero}
+//   columnL[j] += #{i + k == j : x[i] and y[k] both fixed to one}
+// The counts come from running prefix sums and two boolean convolutions
+// evaluated as shifted-window popcounts over packed words.
 Result adjustColumns(const FixedBits& x, const FixedBits& y, int* columnL,
                      int* columnH)
 {
   const unsigned bitWidth = x.getWidth();
+  const unsigned words = (bitWidth + 63) / 64;
 
-  std::vector<bool> yFixedFalse(bitWidth);
-  std::vector<bool> xFixedFalse(bitWidth);
+  const unsigned INLINE_WORDS = 8; // up to 512 bits on the stack.
+  uint64_t stackBuf[4 * INLINE_WORDS];
+  std::vector<uint64_t> heapBuf;
+  uint64_t* buf = stackBuf;
+  if (words > INLINE_WORDS)
+  {
+    heapBuf.resize(4 * words);
+    buf = heapBuf.data();
+  }
+  uint64_t* xFF = buf;                // x fixed to zero.
+  uint64_t* xOne = buf + words;       // x fixed to one.
+  uint64_t* revYFF = buf + 2 * words; // y fixed to zero, bit-reversed.
+  uint64_t* revYOne = buf + 3 * words;
+  for (unsigned t = 0; t < 4 * words; t++)
+    buf[t] = 0;
+
   for (unsigned i = 0; i < bitWidth; i++)
   {
-    yFixedFalse[i] = y.isFixed(i) && !y.getValue(i);
-    xFixedFalse[i] = x.isFixed(i) && !x.getValue(i);
+    if (x.isFixed(i))
+    {
+      if (x.getValue(i))
+        xOne[i >> 6] |= (uint64_t)1 << (i & 63);
+      else
+        xFF[i >> 6] |= (uint64_t)1 << (i & 63);
+    }
+    if (y.isFixed(i))
+    {
+      const unsigned r = bitWidth - 1 - i;
+      if (y.getValue(i))
+        revYOne[r >> 6] |= (uint64_t)1 << (r & 63);
+      else
+        revYFF[r >> 6] |= (uint64_t)1 << (r & 63);
+    }
   }
 
-  for (unsigned i = 0; i < bitWidth; i++)
+  bool anyXFF = false, anyYFF = false, anyXOne = false, anyYOne = false;
+  for (unsigned t = 0; t < words; t++)
   {
-    // decrease using zeroes.
-    if (yFixedFalse[i])
-    {
-      for (unsigned j = i; j < bitWidth; j++)
-      {
-        columnH[j]--;
-      }
-    }
+    anyXFF |= xFF[t] != 0;
+    anyXOne |= xOne[t] != 0;
+    anyYFF |= revYFF[t] != 0;
+    anyYOne |= revYOne[t] != 0;
+  }
+  const bool ffPairsPossible = anyXFF && anyYFF;
+  const bool onePairsPossible = anyXOne && anyYOne;
+  if (!anyXFF && !anyYFF && !onePairsPossible)
+    return NO_CHANGE; // nothing fixed that could adjust any count.
 
-    if (xFixedFalse[i])
-    {
-      for (unsigned j = i; j < bitWidth; j++)
-      {
-        // if the row hasn't already been zeroed out.
-        if (!yFixedFalse[j - i])
-          columnH[j]--;
-      }
-    }
+  int xZeroes = 0, yZeroes = 0;
+  for (unsigned j = 0; j < bitWidth; j++)
+  {
+    // Running prefix counts of the fixed-to-zero bits at or below j.
+    const unsigned r = bitWidth - 1 - j;
+    if ((revYFF[r >> 6] >> (r & 63)) & 1)
+      yZeroes++;
+    if ((xFF[j >> 6] >> (j & 63)) & 1)
+      xZeroes++;
 
-    // check if there are any pairs of ones.
-    if (x.isFixed(i) && x.getValue(i))
-      for (unsigned j = 0; j < (bitWidth - i); j++)
-      {
-        assert(i + j < bitWidth);
-        if (y.isFixed(j) && y.getValue(j))
-        {
-          // a pair of ones. Increase the lower bound.
-          columnL[i + j]++;
-        }
-      }
+    int decrement = yZeroes + xZeroes;
+    if (ffPairsPossible)
+      decrement -= convolutionAt(xFF, revYFF, words, bitWidth, j);
+    if (decrement != 0)
+      columnH[j] -= decrement;
+    if (onePairsPossible)
+    {
+      const int onePairs = convolutionAt(xOne, revYOne, words, bitWidth, j);
+      if (onePairs != 0)
+        columnL[j] += onePairs;
+    }
   }
   return NO_CHANGE;
 }


### PR DESCRIPTION
Four measured, individually-validated changes to the machinery behind bvsrem/bvsmod/bvurem/bvudiv/bvsdiv (which model a = q*b + r at double width through the multiplication propagator), found by profiling bvsrem — the slowest propagator in the tree. Every change was accepted only as a Pareto improvement on random 64-bit operands: faster with provably no accuracy loss, verified by a differential harness running the pre-change implementations (extracted verbatim from master into a parallel namespace) against the new ones on identical inputs.

## The changes

1. **Dependency-driven fixed point in the remainder core** — the lessThan/multiply/add pipeline re-ran all three propagators every round, including a full final confirmation pass; now each re-runs only when an operand it reads changed. This also *fixed a precision bug*: the old convergence test forgot to compare the intermediate product, so it could exit before quiescence and discard deductions (see below).
2. **Prefix sums + popcount convolutions for the multiplication column adjustments** (`adjustColumns` was O(width²) bit loops).
3. **Packed pair-category counts for the column fixer above 64 bits** — `ColumnStats`'s O(column) scans become shifted-window popcounts; plain bvmul at ≤64 bits keeps the original (cheaper) path.
4. **Conflict-early column snap** — `ColumnCounts::snapTo()` kept scanning and mutating columns after a conflict; every caller discards the state on CONFLICT, and conflicts are extremely common inside the division machinery's feasibility probing.

Two further restructurings (bidirectional narrowing sweeps; in-pass conflict checks in `propagate`) measured slower and were rejected.

## Results (width 64, 10k random satisfiable cases, ns/call at 1%/5%/50% bits initially fixed)

| | prob=1 | prob=5 | prob=50 |
|---|---|---|---|
| bvsrem before | 131,587 | 514,147 | 538,099 |
| bvsrem after | **67,770** | **249,223** | **260,261** |
| bvmul | 1,349/1,649/8,205 → 1,121/1,545/4,553 | | |

bvsdiv/bvurem/bvudiv share the machinery and improve correspondingly.

## Accuracy

Never worse, sometimes better: the old-vs-new differential harness (10k identical cases per op at width 64, 30k each at widths 3 and 4) reports **zero** cases where the old code fixes a bit or finds a conflict the new code misses, for all five operations. At widths 3–4 the new code is strictly *more* precise for bvsrem (+55/+73 bits, 6 extra conflicts over 30k cases) — the deductions the old early-exiting fixed point threw away.

## Testing

Exhaustive width-3 soundness/precision tests, the 100-bit wide tests, and the full 54-suite ctest run pass after every commit.