### PR TITLE
Strength-reduce bvsmod and bvsge when the sign bits are fixed

### DIFF
--- a/include/stp/Simplifier/StrengthReduction.h
+++ b/include/stp/Simplifier/StrengthReduction.h
@@ -50,7 +50,6 @@ class StrengthReduction
 {
   unsigned replaceWithConstant =0;
   unsigned replaceWithSimpler =0;
-  unsigned unimplementedReduction =0;
 
   CBV littleOne;
   CBV littleZero;

--- a/lib/Simplifier/StrengthReduction.cpp
+++ b/lib/Simplifier/StrengthReduction.cpp
@@ -145,7 +145,7 @@ namespace stp
         newN = nf->CreateConstant(clone, n.GetValueWidth());
       }
     }
-    else if (k == BVSGT || k == BVSGE || k == SBVDIV || k == BVSRSHIFT || k == SBVREM || k == BVSX)
+    else if (k == BVSGT || k == BVSGE || k == SBVDIV || k == BVSRSHIFT || k == SBVREM || k == SBVMOD || k == BVSX)
     {
       // If the leading bits are false then we can reduce from signed to
       // unsigned comparison. This is all expressed more naturally using the 
@@ -201,8 +201,12 @@ namespace stp
           break;
 
         case SBVREM:
+        case SBVMOD:
           if (lhs && rhs)
           {
+            // With both operands non-negative these agree with the
+            // unsigned remainder, including remainder by zero, which all
+            // three define as the dividend.
             newN = nf->CreateTerm(BVMOD, n.GetValueWidth(), n[0], n[1]);
           }
           break;
@@ -251,8 +255,8 @@ namespace stp
 
       replaceWithConstant++;
     }
-    else if (kind == BVSGT || kind == SBVDIV || kind == SBVMOD ||
-             kind == SBVREM)
+    else if (kind == BVSGT || kind == BVSGE || kind == SBVDIV ||
+             kind == SBVMOD || kind == SBVREM)
     {
       if (visited.find(n[0]) != visited.end() &&
           visited.find(n[1]) != visited.end())
@@ -264,10 +268,11 @@ namespace stp
           const unsigned bw = n[0].GetValueWidth();
           if (l->isFixed(bw - 1) && r->isFixed(bw - 1))
           {
-            if (kind == BVSGT && (l->getValue(bw - 1) == r->getValue(bw - 1)))
+            if ((kind == BVSGT || kind == BVSGE) &&
+                (l->getValue(bw - 1) == r->getValue(bw - 1)))
             {
               // replace with unsigned comparison.
-              newN = nf->CreateNode(BVGT, n[0], n[1]);
+              newN = nf->CreateNode(kind == BVSGT ? BVGT : BVGE, n[0], n[1]);
               replaceWithSimpler++;
             }
             else if (kind == SBVDIV || kind == SBVREM)
@@ -297,7 +302,42 @@ namespace stp
             }
             else if (kind == SBVMOD)
             {
-              unimplementedReduction++;
+              // The result of bvsmod takes the divisor's sign, so with
+              // both signs fixed it's the unsigned remainder of the
+              // magnitudes, moved onto the divisor's side of zero.
+              const auto width = n.GetValueWidth();
+              const bool sNegative = l->getValue(bw - 1);
+              const bool tNegative = r->getValue(bw - 1);
+
+              ASTNode absS = n[0];
+              ASTNode absT = n[1];
+
+              if (sNegative)
+                absS = nf->CreateTerm(BVUMINUS, width, absS);
+              if (tNegative)
+                absT = nf->CreateTerm(BVUMINUS, width, absT);
+
+              ASTNode u = nf->CreateTerm(BVMOD, width, absS, absT);
+
+              if (sNegative == tNegative)
+              {
+                // Same signs: already on the divisor's side. This also
+                // covers remainder by zero (only possible with both
+                // non-negative), where both operations give the dividend.
+                newN = sNegative ? nf->CreateTerm(BVUMINUS, width, u) : u;
+              }
+              else
+              {
+                // Different signs: a non-zero remainder is off the
+                // divisor's side by exactly one divisor.
+                const ASTNode zero = nf->CreateZeroConst(width);
+                ASTNode shifted = nf->CreateTerm(
+                    BVPLUS, width,
+                    sNegative ? nf->CreateTerm(BVUMINUS, width, u) : u, n[1]);
+                newN = nf->CreateTerm(ITE, width, nf->CreateNode(EQ, u, zero),
+                                      zero, shifted);
+              }
+              replaceWithSimpler++;
             }
           }
         }
@@ -441,7 +481,6 @@ namespace stp
 
     replaceWithConstant = 0;
     replaceWithSimpler = 0;
-    unimplementedReduction = 0;
   }
 
   StrengthReduction::~StrengthReduction()
@@ -458,7 +497,5 @@ namespace stp
     std::cerr << "{" << name
               << "} replace with simpler operation: " << replaceWithSimpler
               << std::endl;
-    std::cerr << "{" << name << "} TODO replace with simpler operation: "
-              << unimplementedReduction << std::endl;
   }
 }

--- a/tests/unit-tests/StrengthReduction_Exhaustive_Test.cpp
+++ b/tests/unit-tests/StrengthReduction_Exhaustive_Test.cpp
@@ -393,6 +393,112 @@ TEST(StrengthReduction_Exhaustive_Test, srem_to_urem_via_fixedbits)
     }
 }
 
+// bvsge reduces to bvuge when the fixed bits give both operands the same
+// sign. The node is built with the hashing factory because the
+// simplifying factory rewrites bvsge on creation.
+TEST(StrengthReduction_Exhaustive_Test, sge_to_uge_via_fixedbits)
+{
+  const unsigned width = 3;
+
+  for (unsigned sign = 0; sign <= 1; sign++)
+  {
+    Context c;
+    ASTNode x = c.symbol("x", width);
+    ASTNode y = c.symbol("y", width);
+    ASTNode n =
+        c.mgr.hashingNodeFactory->CreateNode(stp::BVSGE, stp::ASTVec{x, y});
+    ASSERT_EQ(n.GetKind(), stp::BVSGE);
+
+    FixedBits xBits = msbFixed(width, sign == 1);
+    FixedBits yBits = msbFixed(width, sign == 1);
+
+    stp::NodeToFixedBitsMap map;
+    map.insert({n, nullptr});
+    map.insert({x, &xBits});
+    map.insert({y, &yBits});
+
+    // The created BVGE is rewritten to NOT(BVGT ...) by the simplifying
+    // factory, so check for the BVGT.
+    ASTNode result = c.sr.topLevel(n, map);
+    ASSERT_FALSE(c.present(stp::BVSGE, result));
+    ASSERT_FALSE(c.present(stp::BVSGT, result));
+    ASSERT_TRUE(c.present(stp::BVGT, result));
+
+    auto consistent = [sign, width](unsigned v) {
+      return ((v >> (width - 1)) & 1) == sign;
+    };
+    c.checkEquivalent(n, result, x, y, width, consistent, consistent);
+  }
+}
+
+// bvsmod reduces to bvurem (with negations, and an adjustment when the
+// signs differ) once both sign bits are fixed. Equivalent for every
+// consistent assignment, including remainder by zero.
+TEST(StrengthReduction_Exhaustive_Test, smod_to_urem_via_fixedbits)
+{
+  const unsigned width = 3;
+
+  for (unsigned xSign = 0; xSign <= 1; xSign++)
+    for (unsigned ySign = 0; ySign <= 1; ySign++)
+    {
+      Context c;
+      ASTNode x = c.symbol("x", width);
+      ASTNode y = c.symbol("y", width);
+      ASTNode n = c.nf->CreateTerm(stp::SBVMOD, width, x, y);
+      ASSERT_EQ(n.GetKind(), stp::SBVMOD);
+
+      FixedBits xBits = msbFixed(width, xSign == 1);
+      FixedBits yBits = msbFixed(width, ySign == 1);
+
+      stp::NodeToFixedBitsMap map;
+      map.insert({n, nullptr});
+      map.insert({x, &xBits});
+      map.insert({y, &yBits});
+
+      ASTNode result = c.sr.topLevel(n, map);
+      ASSERT_FALSE(c.present(stp::SBVMOD, result));
+      ASSERT_TRUE(c.present(stp::BVMOD, result));
+
+      c.checkEquivalent(
+          n, result, x, y, width,
+          [xSign, width](unsigned v) {
+            return ((v >> (width - 1)) & 1) == xSign;
+          },
+          [ySign, width](unsigned v) {
+            return ((v >> (width - 1)) & 1) == ySign;
+          });
+    }
+}
+
+// bvsmod reduces to bvurem when both intervals exclude the top bit.
+TEST(StrengthReduction_Exhaustive_Test, smod_to_urem_via_intervals)
+{
+  const unsigned width = 3;
+
+  Context c;
+  ASTNode x = c.symbol("x", width);
+  ASTNode y = c.symbol("y", width);
+  ASTNode n = c.nf->CreateTerm(stp::SBVMOD, width, x, y);
+  ASSERT_EQ(n.GetKind(), stp::SBVMOD);
+
+  // y's interval includes zero, checking remainder by zero as well.
+  stp::UnsignedInterval xInterval(makeCBV(width, 0), makeCBV(width, 3));
+  stp::UnsignedInterval yInterval(makeCBV(width, 0), makeCBV(width, 3));
+
+  stp::NodeToUnsignedIntervalMap map;
+  map.insert({n, nullptr});
+  map.insert({x, &xInterval});
+  map.insert({y, &yInterval});
+
+  ASTNode result = c.sr.topLevel(n, map);
+  ASSERT_FALSE(c.present(stp::SBVMOD, result));
+  ASSERT_TRUE(c.present(stp::BVMOD, result));
+
+  c.checkEquivalent(
+      n, result, x, y, width, [](unsigned v) { return v <= 3; },
+      [](unsigned v) { return v <= 3; });
+}
+
 // bvadd reduces to bvor when the fixed bits show the operands can't both
 // have a one in any position (no carries are possible).
 TEST(StrengthReduction_Exhaustive_Test, plus_to_or_via_fixedbits)


### PR DESCRIPTION
Two additions to strength reduction, both driven by the domain analysis:

**bvsmod with both sign bits fixed** (previously just counted as an unimplemented reduction): following the SMT-LIB definition, it becomes an unsigned remainder of the magnitudes -- negated when both operands are negative, and moved onto the divisor's side of zero via `ite(u = 0, 0, ±u + t)` when the signs differ. Remainder by zero stays correct: it is only reachable in the both-non-negative case, where bvsmod and bvurem each return the dividend. The interval domain also now reduces bvsmod to bvurem when both operands are non-negative, mirroring bvsrem.

**bvsge reduces to bvge** when the fixed bits give both operands the same sign. The interval domain already did this; the fixed-bit domain only handled bvsgt.

The dead `unimplementedReduction` counter (bvsmod was its only user) is removed.

Tested by new cases in `StrengthReduction_Exhaustive_Test.cpp`: all four sign combinations for bvsmod, checked equivalent to the original by enumerating every assignment consistent with the domain (including zero divisors), plus the interval-driven bvsmod and fixed-bits bvsge reductions. The bvsge test builds its node with the hashing factory since the simplifying factory rewrites bvsge on creation.

These fire more often now that the signed modulus propagator (#522) fixes sign bits.