### PR TITLE
Exact BVPLUS interval propagation: compare the totals, not step carries

### DIFF
--- a/lib/Simplifier/UnsignedIntervalAnalysis.cpp
+++ b/lib/Simplifier/UnsignedIntervalAnalysis.cpp
@@ -1549,35 +1549,65 @@ namespace stp
       case BVPLUS:
         if (knownC0 && knownC1)
         {
-          //  >=2 arity.
-          result = freshUnsignedInterval(width);
-          CONSTANTBV::BitVector_Flip(result->maxV); // make the max zero too.
+          //  >=2 arity. The sum of intervals takes every value between
+          // the total of the minimums and the total of the maximums, so
+          // when the totals lie in the same 2^width block the exact hull
+          // is their low bits, and otherwise the sums cross a block
+          // boundary and reach both zero and all ones. Comparing the
+          // totals (rather than the carries of each partial addition)
+          // keeps cases where a prefix crosses a boundary but the
+          // remaining children pull the bounds back into one block.
+          bool anyComplete = false;
+          for (unsigned i = 0; i < children.size() && !anyComplete; i++)
+            anyComplete = children[i]->isComplete();
+          if (anyComplete)
+            break; // the sums cover a whole block's worth of values
 
-          bool min_carry;
-          bool max_carry;
-
-          for (size_t i = 0; i < children.size(); i++)
+          const unsigned K = chunksOf(width);
+          uint64_t stackBuf[32];
+          std::vector<uint64_t> heapBuf;
+          uint64_t* buf = stackBuf;
+          if (2 * K > 32)
           {
-            if (children[i]->isComplete())
-            {
-              delete result;
-              result = nullptr;
-              break;
-            }
+            heapBuf.resize(2 * K);
+            buf = heapBuf.data();
+          }
+          uint64_t* mnSum = buf;
+          uint64_t* mxSum = buf + K;
 
-            max_carry = false;
-            min_carry = false;
-
-            CONSTANTBV::BitVector_add(result->maxV, result->maxV,
-                                      children[i]->maxV, &max_carry);
-            CONSTANTBV::BitVector_add(result->minV, result->minV,
-                                      children[i]->minV, &min_carry);
-            if (min_carry != max_carry)
+          uint128 mnCarry = 0, mxCarry = 0;
+          for (unsigned k = 0; k < K; k++)
+          {
+            uint128 mns = mnCarry, mxs = mxCarry;
+            for (unsigned i = 0; i < children.size(); i++)
             {
-              delete result;
-              result = nullptr;
-              break;
+              mns += chunk64(children[i]->minV, k);
+              mxs += chunk64(children[i]->maxV, k);
             }
+            mnSum[k] = (uint64_t)mns;
+            mxSum[k] = (uint64_t)mxs;
+            mnCarry = mns >> 64;
+            mxCarry = mxs >> 64;
+          }
+
+          // The totals share a block exactly when they agree above the
+          // width: in the carry out of the top chunk and in the top
+          // chunk's bits at and above the width.
+          const unsigned topBits = width - 64 * (K - 1);
+          const uint64_t excessMask =
+              (topBits >= 64) ? 0 : ~(((uint64_t)1 << topBits) - 1);
+          if (mnCarry == mxCarry &&
+              (mnSum[K - 1] & excessMask) == (mxSum[K - 1] & excessMask))
+          {
+            CBV mn = CONSTANTBV::BitVector_Create(width, true);
+            CBV mx = CONSTANTBV::BitVector_Create(width, true);
+            for (unsigned k = 0; k < K; k++)
+            {
+              setChunk64(mn, k, mnSum[k]);
+              setChunk64(mx, k, mxSum[k]);
+            }
+            // The interval takes ownership of the fresh bitvectors.
+            result = new UnsignedInterval(mn, mx);
           }
         }
         break;


### PR DESCRIPTION
The BVPLUS transfer function folded children in pairwise and returned nothing as soon as one partial addition's min-carry and max-carry differed. But carries can diverge at a prefix and re-converge in the total. Width 4:

```
[7,8] + [8,8] + [15,15]
```

The sums run over 30..31 — exactly `[14,15]` mod 16 — but the prefix `[7,8]+[8,8] = [15,16]` straddles a block boundary, so the old code returned nothing. Exhaustively at width 3 with three children, **7.7% of all cases were loose like this** (two children were already exact).

**Why totals are the right test.** The n-ary sum of intervals takes *every* integer value between Σmin and Σmax (consecutive shifts of an interval overlap), so the set of sums mod 2^width is: the totals' low bits when Σmin and Σmax lie in the same 2^width block, and the complete range otherwise. Comparing the totals therefore gives the exact hull — there is no tighter sound interval. For two children the block test coincides with the old single-step carry test, so arity-2 results are unchanged by construction.

**Implementation.** Chunk-wise carry-propagating totals of the minimums and maximums (128-bit accumulator per 64-bit chunk, stack buffers, one implementation for every width and arity, same style as #527/#528), informative exactly when the totals agree above the width. The result interval is only allocated on success — the old code allocated, bit-flipped and often immediately deleted.

### Validation

- Exhaustive vs brute force: width 4 × two children (18,496 cases) and width 3 × three children (46,656 cases) both **100% exact, 0 unsound** (was 92.26% exact for the 3-child sweep).
- 150,000 fixed random cases (widths {64, 100, 256, 1000} × arities {2, 3, 5}, mixed interval shapes): 134,988 results identical, **15,012 strictly tighter**, 0 regressions, 0 contradictions; 8 in-range witnesses per informative 64-bit result, 0 violations. Five-child informative rate roughly doubles (14.9% → 33.2% at w=64).
- Timing through `dispatchToTransferFunctions` is level or better: w=64 arity-2 4,136 → 3,245 ns; the worst cell is +2.4% (w=1000 arity-5), where twice as many cases now produce results.
- All 54 ctest suites pass on top of current master.
