### PR TITLE
Add a value-set domain to NodeDomainAnalysis

### DIFF
--- a/include/stp/Simplifier/NodeDomainAnalysis.h
+++ b/include/stp/Simplifier/NodeDomainAnalysis.h
@@ -33,6 +33,7 @@ THE SOFTWARE.
 #include "stp/Simplifier/Simplifier.h"
 #include "stp/Simplifier/constantBitP/FixedBits.h"
 #include "stp/Simplifier/UnsignedIntervalAnalysis.h"
+#include "stp/Simplifier/ValueSetAnalysis.h"
 #include <iostream>
 #include <unordered_map>
 
@@ -42,6 +43,7 @@ using simplifier::constantBitP::FixedBits;
 
 using NodeToUnsignedIntervalMap = std::unordered_map<const ASTNode, UnsignedInterval*, ASTNode::ASTNodeHasher, ASTNode::ASTNodeEqual>;
 using NodeToFixedBitsMap = std::unordered_map<const ASTNode, FixedBits*, ASTNode::ASTNodeHasher, ASTNode::ASTNodeEqual>;
+using NodeToValueSetMap = std::unordered_map<const ASTNode, ValueSet*, ASTNode::ASTNodeHasher, ASTNode::ASTNodeEqual>;
 
 class NodeDomainAnalysis
 {
@@ -60,18 +62,29 @@ class NodeDomainAnalysis
   // When we call the transfer functions, we can't send nulls, send unfixed instead.
   FixedBits* getEmptyFixedBits(const ASTNode& n);
   
-  using AnalysisPair = std::pair<FixedBits*, UnsignedInterval*>;
   NodeToFixedBitsMap toFixedBits;
   NodeToUnsignedIntervalMap toIntervals;
+  NodeToValueSetMap toValueSets;
 
   UnsignedIntervalAnalysis intervalAnalysis;
+  ValueSetAnalysis valueSetAnalysis;
 
   unsigned tighten = 0;
+  unsigned setTightened = 0;
+  unsigned setEnumerated = 0;
 
   void stats();
 public:
 
-  NodeDomainAnalysis(STPMgr* _bm) : bm(*_bm), intervalAnalysis(*_bm)
+  struct DomainInfo
+  {
+    FixedBits* bits;
+    UnsignedInterval* interval;
+    ValueSet* set;
+  };
+
+  NodeDomainAnalysis(STPMgr* _bm)
+      : bm(*_bm), intervalAnalysis(*_bm), valueSetAnalysis(*_bm)
   {
     emptyBoolean = new FixedBits(1, true);
   }
@@ -96,6 +109,10 @@ public:
       if (it.second != NULL)
         delete it.second;
 
+    for (auto it : toValueSets)
+      if (it.second != NULL)
+        delete it.second;
+
     stats();
   }
 
@@ -109,7 +126,12 @@ public:
       return &toFixedBits;
    }
 
-  AnalysisPair buildMap(const ASTNode& n);
+   NodeToValueSetMap* getValueSetMap()
+   {
+      return &toValueSets;
+   }
+
+  DomainInfo buildMap(const ASTNode& n);
 
   void topLevel(const ASTNode& top)
   {
@@ -117,9 +139,12 @@ public:
     buildMap(top);
     bm.GetRunTimes()->stop(RunTimes::NodeDomainAnalysis);
     assert(toIntervals.size() == toFixedBits.size());
+    assert(toValueSets.size() == toFixedBits.size());
   }
 
   void harmonise(FixedBits * &bits, UnsignedInterval * &interval);
+  void harmonise(FixedBits * &bits, UnsignedInterval * &interval,
+                 ValueSet * &set, unsigned width, bool isBoolean);
 
 };
 }

--- a/include/stp/Simplifier/StrengthReduction.h
+++ b/include/stp/Simplifier/StrengthReduction.h
@@ -61,9 +61,14 @@ class StrengthReduction
   ASTNode replace(const ASTNode& n, ASTNodeMap& fromTo, ASTNodeMap& cache);
 
   ASTNode visit(const ASTNode& n, stp::NodeDomainAnalysis& nda, ASTNodeMap& fromTo);
-  
+
   ASTNode strengthReduction(const ASTNode& n, const NodeToFixedBitsMap& visited);
   ASTNode strengthReduction(const ASTNode& n, const NodeToUnsignedIntervalMap& visited);
+  ASTNode strengthReduction(const ASTNode& n, const NodeToValueSetMap& visited);
+
+  static bool isIteConstTree(const ASTNode& n);
+  ASTNode replaceIteConst(const ASTNode& n, const ASTNode& newVal,
+                          ASTNodeMap& cache);
 
 public:
 
@@ -77,10 +82,11 @@ public:
   
   ~StrengthReduction();
 
-  //TODO merge these two toplevel funtions, they do the same thing..
+  //TODO merge these toplevel funtions, they do the same thing..
   //Replace nodes with simpler nodes.
   ASTNode topLevel(const ASTNode& top, const NodeToFixedBitsMap& visited);
   ASTNode topLevel(const ASTNode& top, const NodeToUnsignedIntervalMap& visited);
+  ASTNode topLevel(const ASTNode& top, const NodeToValueSetMap& visited);
 
   // New style invocation.
   ASTNode topLevel(const ASTNode& top, NodeDomainAnalysis& nda);

--- a/include/stp/Simplifier/StrengthReduction.h
+++ b/include/stp/Simplifier/StrengthReduction.h
@@ -66,10 +66,6 @@ class StrengthReduction
   ASTNode strengthReduction(const ASTNode& n, const NodeToUnsignedIntervalMap& visited);
   ASTNode strengthReduction(const ASTNode& n, const NodeToValueSetMap& visited);
 
-  static bool isIteConstTree(const ASTNode& n);
-  ASTNode replaceIteConst(const ASTNode& n, const ASTNode& newVal,
-                          ASTNodeMap& cache);
-
 public:
 
   using NodeToUnsignedIntervalMap = std::unordered_map<const ASTNode, UnsignedInterval*, ASTNode::ASTNodeHasher, ASTNode::ASTNodeEqual>;

--- a/include/stp/Simplifier/ValueSet.h
+++ b/include/stp/Simplifier/ValueSet.h
@@ -1,0 +1,146 @@
+/********************************************************************
+ * AUTHORS: Trevor Hansen
+ *
+ * BEGIN DATE: July, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+/*
+ * Holds a small set of the values a node can take. Sets that would
+ * exceed MAX_ELEMENTS are widened away to "unknown" (a null pointer)
+ * by the code that builds them.
+ */
+
+#ifndef VALUESET_H_
+#define VALUESET_H_
+
+#include "stp/AST/AST.h"
+#include <algorithm>
+#include <iostream>
+#include <vector>
+
+namespace stp
+{
+
+struct ValueSet
+{
+  static const size_t MAX_ELEMENTS = 12;
+
+  // Sorted ascending by unsigned comparison, no duplicates. Owned.
+  std::vector<CBV> values;
+
+  unsigned width; // 1 for booleans.
+  bool representsBoolean;
+
+  ValueSet(unsigned _width, bool isBoolean)
+      : width(_width), representsBoolean(isBoolean)
+  {
+    assert(!isBoolean || _width == 1);
+  }
+
+  ~ValueSet()
+  {
+    for (CBV v : values)
+      CONSTANTBV::BitVector_Destroy(v);
+  }
+
+  ValueSet(ValueSet const&) = delete;
+  ValueSet& operator=(ValueSet const&) = delete;
+
+  // Takes ownership of v, which is destroyed if it's already a member.
+  // Returns false without changing the set if adding would exceed
+  // MAX_ELEMENTS; the caller then discards the whole set, widening to
+  // "unknown".
+  bool insert(CBV v)
+  {
+    assert(bits_(v) == width);
+
+    const auto it = lowerBound(v);
+    if (it != values.end() && !CONSTANTBV::BitVector_Lexicompare(*it, v))
+    {
+      CONSTANTBV::BitVector_Destroy(v);
+      return true;
+    }
+    if (values.size() >= MAX_ELEMENTS)
+    {
+      CONSTANTBV::BitVector_Destroy(v);
+      return false;
+    }
+    values.insert(it, v);
+    return true;
+  }
+
+  bool in(const CBV c) const
+  {
+    assert(bits_(c) == width);
+    const auto it = lowerBound(c);
+    return it != values.end() && !CONSTANTBV::BitVector_Lexicompare(*it, c);
+  }
+
+  size_t size() const { return values.size(); }
+
+  bool isConstant() const { return values.size() == 1; }
+
+  // Whether the set holds every value of the width, i.e. no information.
+  bool isComplete() const
+  {
+    return width < 4 && values.size() == ((size_t)1 << width);
+  }
+
+  unsigned getWidth() const { return width; }
+
+  bool isBoolean() const { return representsBoolean; }
+
+  // The extreme members. Still owned by the set.
+  CBV smallest() const
+  {
+    assert(!values.empty());
+    return values.front();
+  }
+
+  CBV largest() const
+  {
+    assert(!values.empty());
+    return values.back();
+  }
+
+  void print() const
+  {
+    for (CBV v : values)
+    {
+      unsigned char* s = CONSTANTBV::BitVector_to_Bin(v);
+      std::cerr << s << " ";
+      free(s);
+    }
+    std::cerr << std::endl;
+  }
+
+private:
+  std::vector<CBV>::const_iterator lowerBound(const CBV v) const
+  {
+    return std::lower_bound(values.begin(), values.end(), v,
+                            [](const CBV a, const CBV b) {
+                              return CONSTANTBV::BitVector_Lexicompare(a, b) <
+                                     0;
+                            });
+  }
+};
+}
+#endif

--- a/include/stp/Simplifier/ValueSetAnalysis.h
+++ b/include/stp/Simplifier/ValueSetAnalysis.h
@@ -1,0 +1,74 @@
+/********************************************************************
+ * AUTHORS: Trevor Hansen
+ *
+ * BEGIN DATE: July, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+/*
+ * Computes the set of values a node can take, when that set is small.
+ * The analysis is only bottom up (without assuming the root is true).
+ * Most operations are handled by evaluating over the cartesian product
+ * of the children's sets.
+ */
+
+#ifndef VALUESETANALYSIS_H_
+#define VALUESETANALYSIS_H_
+
+#include "stp/AST/AST.h"
+#include "stp/STPManager/STPManager.h"
+#include "stp/Simplifier/ValueSet.h"
+
+namespace stp
+{
+
+class ValueSetAnalysis
+{
+  STPMgr& bm;
+
+  unsigned propagated = 0;
+  unsigned widened = 0;
+
+  // The most combinations of children's values that we'll evaluate.
+  static const size_t PRODUCT_CAP =
+      ValueSet::MAX_ELEMENTS * ValueSet::MAX_ELEMENTS;
+
+  ValueSet* fresh(const ASTNode& n) const;
+  ASTNode toNode(const ASTNode& child, const CBV member);
+  static CBV toCBV(const ASTNode& evaluated);
+
+public:
+  ValueSetAnalysis(STPMgr& _bm) : bm(_bm) {}
+
+  ValueSetAnalysis(const ValueSetAnalysis&) = delete;
+  ValueSetAnalysis& operator=(const ValueSetAnalysis&) = delete;
+
+  // The caller owns the result, which is nullptr when nothing is known.
+  ValueSet* dispatchToTransferFunctions(const ASTNode& n,
+                                        const vector<const ValueSet*>& children);
+
+  // Whether the constant evaluator handles the kind.
+  static bool constEvaluable(Kind k);
+
+  void stats();
+};
+}
+
+#endif

--- a/lib/Simplifier/CMakeLists.txt
+++ b/lib/Simplifier/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(simplifier OBJECT
     StrengthReduction.cpp
     AIGSimplifyPropositionalCore.cpp
     UnsignedIntervalAnalysis.cpp
+    ValueSetAnalysis.cpp
     Flatten.cpp
     NodeDomainAnalysis.cpp
     SplitExtracts.cpp

--- a/lib/Simplifier/NodeDomainAnalysis.cpp
+++ b/lib/Simplifier/NodeDomainAnalysis.cpp
@@ -52,6 +52,32 @@ namespace stp
     return result;
   }
 
+  // True if some member of the set matches the fixed bits.
+  bool intersects(FixedBits * bits, const ValueSet * set)
+  {
+    if (bits == nullptr || set == nullptr)
+      return true; // nothing to do.
+
+    assert(((unsigned)bits->getWidth()) == set->getWidth());
+    for (const CBV m : set->values)
+      if (bits->in(m))
+        return true;
+    return false;
+  }
+
+  // True if some member of the set is inside the interval.
+  bool intersects(const UnsignedInterval * interval, const ValueSet * set)
+  {
+    if (interval == nullptr || set == nullptr)
+      return true; // nothing to do.
+
+    assert(interval->getWidth() == set->getWidth());
+    for (const CBV m : set->values)
+      if (interval->in(m))
+        return true;
+    return false;
+  }
+
   // The largest value that matches the fixed bits and is <= bound,
   // or nullptr if there is no such value. Caller destroys the result.
   static CBV maxBelow(const FixedBits& bits, const CBV bound)
@@ -263,14 +289,149 @@ namespace stp
       assert(intersects(bits, interval));
   }
 
-  std::pair<FixedBits*, UnsignedInterval*> NodeDomainAnalysis::buildMap(const ASTNode& n)
+  // Trim all three domains to exactly the values they share. When the
+  // set is missing but the other domains admit few enough values, the
+  // set is created by enumerating them. Idempotent.
+  void NodeDomainAnalysis::harmonise(FixedBits * &bits, UnsignedInterval * &interval,
+                                     ValueSet * &set, unsigned width, bool isBoolean)
+  {
+    harmonise(bits, interval);
+
+    if (set != nullptr)
+    {
+      // Drop the members the other domains exclude.
+      auto& values = set->values;
+      for (size_t i = 0; i < values.size();)
+      {
+        if ((bits != nullptr && !bits->in(values[i])) ||
+            (interval != nullptr && !interval->in(values[i])))
+        {
+          CONSTANTBV::BitVector_Destroy(values[i]);
+          values.erase(values.begin() + i);
+          setTightened++;
+        }
+        else
+          i++;
+      }
+
+      // The domains all contain the node's real values.
+      assert(set->size() > 0);
+
+      if (interval == nullptr)
+        interval = new UnsignedInterval(width);
+      if (interval->replaceMinIfTightens(set->smallest()))
+        tighten++;
+      if (interval->replaceMaxIfTightens(set->largest()))
+        tighten++;
+
+      if (bits == nullptr)
+        bits = new FixedBits(width, isBoolean);
+
+      // Fix each bit that all the members agree on.
+      for (unsigned i = 0; i < width; i++)
+      {
+        if (bits->isFixed(i))
+          continue;
+
+        const bool value = CONSTANTBV::BitVector_bit_test(set->smallest(), i);
+        bool agree = true;
+        for (const CBV m : set->values)
+          if (CONSTANTBV::BitVector_bit_test(m, i) != value)
+          {
+            agree = false;
+            break;
+          }
+
+        if (agree)
+        {
+          bits->setFixed(i, true);
+          bits->setValue(i, value);
+          tighten++;
+        }
+      }
+
+      // Make the bits and interval mutually exact again.
+      harmonise(bits, interval);
+    }
+    else if (interval != nullptr)
+    {
+      // Enumerate the values the bits and interval share, smallest
+      // first, giving up once there are too many for a set.
+      ValueSet* candidate = new ValueSet(width, isBoolean);
+
+      CBV v = (bits != nullptr) ? minAbove(*bits, interval->minV)
+                                : CONSTANTBV::BitVector_Clone(interval->minV);
+      while (v != nullptr)
+      {
+        if (CONSTANTBV::BitVector_Lexicompare(v, interval->maxV) > 0)
+        {
+          CONSTANTBV::BitVector_Destroy(v);
+          break;
+        }
+
+        const bool last =
+            CONSTANTBV::BitVector_Lexicompare(v, interval->maxV) == 0;
+
+        if (!candidate->insert(CONSTANTBV::BitVector_Clone(v)))
+        {
+          CONSTANTBV::BitVector_Destroy(v);
+          delete candidate;
+          candidate = nullptr;
+          break;
+        }
+
+        if (last) // stepping past the maximum could wrap around.
+        {
+          CONSTANTBV::BitVector_Destroy(v);
+          break;
+        }
+
+        CONSTANTBV::BitVector_increment(v);
+        if (bits != nullptr)
+        {
+          CBV next = minAbove(*bits, v);
+          CONSTANTBV::BitVector_Destroy(v);
+          v = next;
+        }
+      }
+
+      if (candidate != nullptr)
+      {
+        // The domains share a value, so the enumeration found >=1.
+        assert(candidate->size() > 0);
+        set = candidate;
+        setEnumerated++;
+      }
+    }
+
+    // Domains that admit every value carry no information; the rest of
+    // the analysis relies on those being null (e.g. a known boolean
+    // interval is always constant).
+    if (set != nullptr && set->isComplete())
+    {
+      delete set;
+      set = nullptr;
+    }
+    if (interval != nullptr && interval->isComplete())
+    {
+      delete interval;
+      interval = nullptr;
+    }
+
+    assert(intersects(bits, interval));
+    assert(intersects(bits, set));
+    assert(intersects(interval, set));
+  }
+
+  NodeDomainAnalysis::DomainInfo NodeDomainAnalysis::buildMap(const ASTNode& n)
   {
     {
       auto it = toFixedBits.find(n);
       if (it != toFixedBits.end())
       {
         auto it0 = toIntervals.find(n);
-        return {it->second, it0->second};
+        auto it1 = toValueSets.find(n);
+        return {it->second, it0->second, it1->second};
       }
     }
 
@@ -282,19 +443,21 @@ namespace stp
     vector<const UnsignedInterval*> children_intervals;
     children_intervals.reserve(number_children);
 
+    vector<const ValueSet*> children_sets;
+    children_sets.reserve(number_children);
+
     bool nothingKnown = true;
 
     for (unsigned i = 0; i < number_children; i++)
     {
       auto ret = buildMap(n[i]);
-      auto op0 = ret.first;
-      auto op1 = ret.second;
 
-      if (op0 != nullptr || op1 != nullptr)
+      if (ret.bits != nullptr || ret.interval != nullptr || ret.set != nullptr)
         nothingKnown = false;
-      
-      children_bits.push_back(op0);
-      children_intervals.push_back(op1);
+
+      children_bits.push_back(ret.bits);
+      children_intervals.push_back(ret.interval);
+      children_sets.push_back(ret.set);
     }
 
     const bool nullChildZero = (number_children > 0) && (children_bits[0] == nullptr && children_intervals[0] == nullptr);
@@ -311,8 +474,9 @@ namespace stp
     {
       toFixedBits.insert({n, nullptr});
       toIntervals.insert({n, nullptr});
+      toValueSets.insert({n, nullptr});
 
-      return {nullptr, nullptr};
+      return {nullptr, nullptr, nullptr};
     }
 
     FixedBits* result_bits = fresh(n);
@@ -377,20 +541,29 @@ namespace stp
       result_interval = nullptr;
     }
 
-    assert(intersects(result_bits, result_interval));
+    ValueSet* result_set =
+        valueSetAnalysis.dispatchToTransferFunctions(n, children_sets);
 
-    harmonise(result_bits, result_interval);
+    assert(intersects(result_bits, result_interval));
+    assert(intersects(result_bits, result_set));
+    assert(intersects(result_interval, result_set));
+
+    harmonise(result_bits, result_interval, result_set,
+              n.GetValueWidth() > 0 ? n.GetValueWidth() : 1,
+              BOOLEAN_TYPE == n.GetType());
 
     toFixedBits.insert({n, result_bits});
     toIntervals.insert({n, result_interval});
+    toValueSets.insert({n, result_set});
 
     if (n.isConstant())
     {
       assert(result_bits->isTotallyFixed());
       assert(result_interval->isConstant());
+      assert(result_set != nullptr && result_set->isConstant());
     }
 
-    return {result_bits, result_interval};
+    return {result_bits, result_interval, result_set};
   }
 
   // When we call the transfer functions, we can't send nulls, send unfixed instead.
@@ -414,8 +587,13 @@ namespace stp
     if (bm.UserFlags.stats_flag)
     {
       std::cerr << "{NodeDomainAnalysis} Tightened:" << tighten << std::endl;
+      std::cerr << "{NodeDomainAnalysis} Set members removed:" << setTightened
+                << std::endl;
+      std::cerr << "{NodeDomainAnalysis} Sets enumerated:" << setEnumerated
+                << std::endl;
 
       intervalAnalysis.stats();
+      valueSetAnalysis.stats();
     }
   }
 }

--- a/lib/Simplifier/Simplifier.cpp
+++ b/lib/Simplifier/Simplifier.cpp
@@ -540,55 +540,6 @@ unsigned getConstantBit(const ASTNode& n, const int i)
   abort();
 }
 
-ASTNode replaceIteConst(const ASTNode& n, const ASTNode& newVal,
-                        NodeFactory* nf)
-{
-  assert(!n.IsNull());
-  assert(!newVal.IsNull());
-  if (n.GetKind() == BVCONST)
-  {
-    return nf->CreateNode(EQ, newVal, n);
-  }
-  else if (n.GetKind() == ITE)
-  {
-    return nf->CreateNode(ITE, n[0], replaceIteConst(n[1], newVal, nf),
-                          replaceIteConst(n[2], newVal, nf));
-  }
-  FatalError("never here", n);
-}
-
-bool getPossibleValues(const ASTNode& n, ASTNodeSet& visited,
-                       vector<ASTNode>& found, int maxCount = 5)
-{
-  if (maxCount <= 0)
-    return false;
-
-  ASTNodeSet::iterator it = visited.find(n);
-  if (it != visited.end())
-    return true;
-  visited.insert(n);
-
-  if (n.GetKind() == BVCONST)
-  {
-    found.push_back(n);
-    return true;
-  }
-
-  if (n.GetKind() == ITE)
-  {
-    bool a = getPossibleValues(n[1], visited, found, maxCount - 1);
-    if (!a)
-      return a;
-
-    bool b = getPossibleValues(n[2], visited, found, maxCount - 1);
-    if (!b)
-      return b;
-    return true;
-  }
-
-  return false;
-}
-
 unsigned numberOfLeadingZeroes(const ASTNode& n)
 {
   unsigned c = mostSignificantConstants(n);
@@ -599,27 +550,6 @@ unsigned numberOfLeadingZeroes(const ASTNode& n)
     if (getConstantBit(n, i) != 0)
       return i;
   return c;
-}
-
-bool unsignedGreaterThan(const ASTNode& n1, const ASTNode& n2)
-{
-  assert(n1.isConstant());
-  assert(n2.isConstant());
-  assert(n1.GetValueWidth() == n2.GetValueWidth());
-
-  int comp =
-      CONSTANTBV::BitVector_Lexicompare(n1.GetBVConst(), n2.GetBVConst());
-  return comp == 1;
-}
-
-bool signedGreaterThan(const ASTNode& n1, const ASTNode& n2)
-{
-  assert(n1.isConstant());
-  assert(n2.isConstant());
-  assert(n1.GetValueWidth() == n2.GetValueWidth());
-
-  int comp = CONSTANTBV::BitVector_Compare(n1.GetBVConst(), n2.GetBVConst());
-  return comp == 1;
 }
 
 ASTNode Simplifier::CreateSimplifiedINEQ(const Kind k_i, const ASTNode& left_i,
@@ -718,37 +648,6 @@ ASTNode Simplifier::CreateSimplifiedINEQ(const Kind k_i, const ASTNode& left_i,
       return pushNeg ? nf->CreateNode(NOT, status) : status;
     }
 
-    {
-      ASTNodeSet visited0, visited1;
-      vector<ASTNode> l0, l1;
-
-      // Sound overapproximation. Doesn't consider the equalities.
-      if (getPossibleValues(left, visited0, l0) &&
-          getPossibleValues(right, visited1, l1))
-      {
-        {
-          bool (*comp)(const ASTNode&, const ASTNode&);
-          if (k == BVSGT || k == BVSGE)
-            comp = signedGreaterThan;
-          else
-            comp = unsignedGreaterThan;
-          {
-            ASTNode minLHS = *max_element(l0.begin(), l0.end(), comp);
-            ASTNode maxRHS = *min_element(l1.begin(), l1.end(), comp);
-
-            if (comp(minLHS, maxRHS))
-              return pushNeg ? ASTFalse : ASTTrue;
-          }
-          {
-            ASTNode maxLHS = *min_element(l0.begin(), l0.end(), comp);
-            ASTNode minRHS = *max_element(l1.begin(), l1.end(), comp);
-
-            if (comp(minRHS, maxLHS))
-              return pushNeg ? ASTTrue : ASTFalse;
-          }
-        }
-      }
-    }
   }
 
   const ASTNode unsigned_min = nf->CreateZeroConst(len);
@@ -1032,37 +931,6 @@ ASTNode Simplifier::CreateSimplifiedEQ(const ASTNode& in1, const ASTNode& in2)
     return r;
   }
 
-  if ((k1 == ITE || k1 == BVCONST) && (k2 == ITE || k2 == BVCONST))
-  {
-    // If it can only evaluate to constants on the LHS and the RHS, and those
-    // constants are never equal,
-    // then it must be false. e.g.   ite( f, 10 , 20 ) = ite (g, 30 ,12)
-    ASTNodeSet visited0, visited1;
-    vector<ASTNode> l0, l1;
-
-    if (getPossibleValues(in1, visited0, l0) &&
-        getPossibleValues(in2, visited1, l1))
-    {
-      sort(l0.begin(), l0.end());
-      sort(l1.begin(), l1.end());
-      vector<ASTNode> result(l0.size() + l1.size());
-      vector<ASTNode>::iterator it = set_intersection(
-          l0.begin(), l0.end(), l1.begin(), l1.end(), result.begin());
-      if (it == result.begin())
-        return ASTFalse;
-
-      if (it == result.begin() + 1)
-      {
-        // If there is just one value in common, then, set it to true whenever
-        // it equals that value.
-        ASTNode lhs = replaceIteConst(in1, *result.begin(), nf);
-        ASTNode rhs = replaceIteConst(in2, *result.begin(), nf);
-
-        ASTNode result = nf->CreateNode(AND, lhs, rhs);
-        return result;
-      }
-    }
-  }
   if (k2 == ITE && (in2[1] == in1) && in1.GetType() == BITVECTOR_TYPE)
   {
     ASTNode eq = nf->CreateNode(EQ, in1, in2[2]);

--- a/lib/Simplifier/StrengthReduction.cpp
+++ b/lib/Simplifier/StrengthReduction.cpp
@@ -106,7 +106,10 @@ namespace stp
 
     nda.buildMap(newN);
     newN = strengthReduction(newN, *nda.getIntervalMap());
-    
+
+    nda.buildMap(newN);
+    newN = strengthReduction(newN, *nda.getValueSetMap());
+
     cache.insert({n,newN});
     return newN;
   }
@@ -410,6 +413,115 @@ namespace stp
     return newN;
   }
 
+  // Whether every node of the term is an ITE or a constant, so it takes
+  // one of the constants' values. Bounded so huge trees aren't walked.
+  bool StrengthReduction::isIteConstTree(const ASTNode& n)
+  {
+    ASTNodeSet visited;
+    vector<ASTNode> toVisit = {n};
+
+    while (!toVisit.empty())
+    {
+      const ASTNode current = toVisit.back();
+      toVisit.pop_back();
+
+      if (!visited.insert(current).second)
+        continue;
+
+      if (visited.size() > 64)
+        return false;
+
+      if (current.GetKind() == BVCONST)
+        continue;
+
+      if (current.GetKind() != ITE)
+        return false;
+
+      toVisit.push_back(current[1]);
+      toVisit.push_back(current[2]);
+    }
+    return true;
+  }
+
+  // Replaces each constant leaf of an ITE tree with a test that the
+  // leaf equals the given value, keeping the ITE structure. The cache
+  // stops shared subtrees being rebuilt repeatedly.
+  ASTNode StrengthReduction::replaceIteConst(const ASTNode& n,
+                                             const ASTNode& newVal,
+                                             ASTNodeMap& cache)
+  {
+    const auto it = cache.find(n);
+    if (it != cache.end())
+      return it->second;
+
+    ASTNode result;
+    if (n.GetKind() == BVCONST)
+      result = nf->CreateNode(EQ, newVal, n);
+    else
+    {
+      assert(n.GetKind() == ITE);
+      result = nf->CreateNode(ITE, n[0], replaceIteConst(n[1], newVal, cache),
+                              replaceIteConst(n[2], newVal, cache));
+    }
+
+    cache.insert({n, result});
+    return result;
+  }
+
+  ASTNode StrengthReduction::strengthReduction(const ASTNode& n, const NodeToValueSetMap& visited)
+  {
+    // An equality where each side is an ITE tree over constants, and
+    // exactly one constant is shared: the equality holds just when both
+    // sides select the shared value. Disjoint sides don't need handling
+    // here; the equality's own domain is then a constant false, which
+    // the other passes replace.
+    if (n.GetKind() != EQ)
+      return n;
+
+    const auto l = visited.find(n[0]);
+    const auto r = visited.find(n[1]);
+    if (l == visited.end() || r == visited.end() || l->second == nullptr ||
+        r->second == nullptr)
+      return n;
+
+    const std::vector<CBV>& left = l->second->values;
+    const std::vector<CBV>& right = r->second->values;
+
+    // Both are sorted, so the intersection is a merge walk.
+    CBV common = nullptr;
+    size_t commonCount = 0;
+    for (size_t i = 0, j = 0; i < left.size() && j < right.size();)
+    {
+      const int compare = CONSTANTBV::BitVector_Lexicompare(left[i], right[j]);
+      if (compare < 0)
+        i++;
+      else if (compare > 0)
+        j++;
+      else
+      {
+        common = left[i];
+        commonCount++;
+        i++;
+        j++;
+      }
+    }
+
+    if (commonCount != 1)
+      return n;
+
+    if (!isIteConstTree(n[0]) || !isIteConstTree(n[1]))
+      return n;
+
+    const ASTNode commonNode = nf->CreateConstant(
+        CONSTANTBV::BitVector_Clone(common), n[0].GetValueWidth());
+
+    ASTNodeMap cacheL, cacheR;
+    ASTNode newN = nf->CreateNode(AND, replaceIteConst(n[0], commonNode, cacheL),
+                                  replaceIteConst(n[1], commonNode, cacheR));
+    replaceWithSimpler++;
+    return newN;
+  }
+
   //TODO merge these two toplevel funtions, they do the same thing..
   ASTNode StrengthReduction::topLevel(const ASTNode& top,   const NodeToFixedBitsMap& visited)
   {
@@ -471,7 +583,36 @@ namespace stp
     return result;
   }
 
-  StrengthReduction::StrengthReduction(NodeFactory* _nf, UserDefinedFlags * _uf) 
+  ASTNode StrengthReduction::topLevel(const ASTNode& top,  const NodeToValueSetMap& visited)
+  {
+    ASTNodeMap fromTo;
+    for (auto it = visited.begin(); it != visited.end(); ++it)
+    {
+      const ASTNode& n = it->first;
+
+      if (n.isConstant())
+        continue;
+
+      ASTNode newN = strengthReduction(n,visited);
+      if (n != newN)
+        fromTo.insert({n,newN});
+    }
+
+    ASTNode result = top;
+
+    if (uf->stats_flag)
+      stats();
+
+    if (fromTo.size() > 0)
+    {
+      ASTNodeMap cache;
+      result = SubstitutionMap::replace(result, fromTo, cache, nf);
+    }
+
+    return result;
+  }
+
+  StrengthReduction::StrengthReduction(NodeFactory* _nf, UserDefinedFlags * _uf)
   {
     littleOne = CONSTANTBV::BitVector_Create(1, true);
     littleZero = CONSTANTBV::BitVector_Create(1, true);

--- a/lib/Simplifier/StrengthReduction.cpp
+++ b/lib/Simplifier/StrengthReduction.cpp
@@ -413,69 +413,21 @@ namespace stp
     return newN;
   }
 
-  // Whether every node of the term is an ITE or a constant, so it takes
-  // one of the constants' values. Bounded so huge trees aren't walked.
-  bool StrengthReduction::isIteConstTree(const ASTNode& n)
-  {
-    ASTNodeSet visited;
-    vector<ASTNode> toVisit = {n};
-
-    while (!toVisit.empty())
-    {
-      const ASTNode current = toVisit.back();
-      toVisit.pop_back();
-
-      if (!visited.insert(current).second)
-        continue;
-
-      if (visited.size() > 64)
-        return false;
-
-      if (current.GetKind() == BVCONST)
-        continue;
-
-      if (current.GetKind() != ITE)
-        return false;
-
-      toVisit.push_back(current[1]);
-      toVisit.push_back(current[2]);
-    }
-    return true;
-  }
-
-  // Replaces each constant leaf of an ITE tree with a test that the
-  // leaf equals the given value, keeping the ITE structure. The cache
-  // stops shared subtrees being rebuilt repeatedly.
-  ASTNode StrengthReduction::replaceIteConst(const ASTNode& n,
-                                             const ASTNode& newVal,
-                                             ASTNodeMap& cache)
-  {
-    const auto it = cache.find(n);
-    if (it != cache.end())
-      return it->second;
-
-    ASTNode result;
-    if (n.GetKind() == BVCONST)
-      result = nf->CreateNode(EQ, newVal, n);
-    else
-    {
-      assert(n.GetKind() == ITE);
-      result = nf->CreateNode(ITE, n[0], replaceIteConst(n[1], newVal, cache),
-                              replaceIteConst(n[2], newVal, cache));
-    }
-
-    cache.insert({n, result});
-    return result;
-  }
-
   ASTNode StrengthReduction::strengthReduction(const ASTNode& n, const NodeToValueSetMap& visited)
   {
-    // An equality where each side is an ITE tree over constants, and
-    // exactly one constant is shared: the equality holds just when both
-    // sides select the shared value. Disjoint sides don't need handling
-    // here; the equality's own domain is then a constant false, which
-    // the other passes replace.
+    // An equality whose sides share exactly one possible value holds
+    // just when both sides take that value, so it splits into a
+    // conjunction of equalities against a constant - which simplify
+    // further (an ITE over constants folds towards its condition, for
+    // instance). Disjoint sides don't need handling here; the
+    // equality's own domain is then a constant false, which the other
+    // passes replace.
     if (n.GetKind() != EQ)
+      return n;
+
+    // With a constant on either side the equality already is a
+    // comparison against a constant; the split would rebuild it.
+    if (n[0].isConstant() || n[1].isConstant())
       return n;
 
     const auto l = visited.find(n[0]);
@@ -509,15 +461,12 @@ namespace stp
     if (commonCount != 1)
       return n;
 
-    if (!isIteConstTree(n[0]) || !isIteConstTree(n[1]))
-      return n;
-
     const ASTNode commonNode = nf->CreateConstant(
         CONSTANTBV::BitVector_Clone(common), n[0].GetValueWidth());
 
-    ASTNodeMap cacheL, cacheR;
-    ASTNode newN = nf->CreateNode(AND, replaceIteConst(n[0], commonNode, cacheL),
-                                  replaceIteConst(n[1], commonNode, cacheR));
+    ASTNode newN =
+        nf->CreateNode(AND, nf->CreateNode(EQ, commonNode, n[0]),
+                       nf->CreateNode(EQ, commonNode, n[1]));
     replaceWithSimpler++;
     return newN;
   }

--- a/lib/Simplifier/ValueSetAnalysis.cpp
+++ b/lib/Simplifier/ValueSetAnalysis.cpp
@@ -1,0 +1,239 @@
+/********************************************************************
+ * AUTHORS: Trevor Hansen
+ *
+ * BEGIN DATE: July, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#include "stp/Simplifier/ValueSetAnalysis.h"
+#include "stp/Simplifier/Simplifier.h"
+
+namespace stp
+{
+
+  const size_t ValueSet::MAX_ELEMENTS;
+
+  ValueSet* ValueSetAnalysis::fresh(const ASTNode& n) const
+  {
+    return new ValueSet(n.GetValueWidth() > 0 ? n.GetValueWidth() : 1,
+                        BOOLEAN_TYPE == n.GetType());
+  }
+
+  // A constant node with the member's value, suitable as an argument of
+  // the constant evaluator.
+  ASTNode ValueSetAnalysis::toNode(const ASTNode& child, const CBV member)
+  {
+    if (BOOLEAN_TYPE == child.GetType())
+      return CONSTANTBV::BitVector_bit_test(member, 0) ? bm.ASTTrue
+                                                       : bm.ASTFalse;
+    return bm.CreateBVConst(CONSTANTBV::BitVector_Clone(member),
+                            child.GetValueWidth());
+  }
+
+  // The evaluated constant's value as a fresh CBV the caller owns.
+  CBV ValueSetAnalysis::toCBV(const ASTNode& evaluated)
+  {
+    if (TRUE == evaluated.GetKind())
+    {
+      CBV r = CONSTANTBV::BitVector_Create(1, true);
+      CONSTANTBV::BitVector_Bit_On(r, 0);
+      return r;
+    }
+    if (FALSE == evaluated.GetKind())
+      return CONSTANTBV::BitVector_Create(1, true);
+
+    assert(BVCONST == evaluated.GetKind());
+    return CONSTANTBV::BitVector_Clone(evaluated.GetBVConst());
+  }
+
+  bool ValueSetAnalysis::constEvaluable(Kind k)
+  {
+    // The kinds the switch in NonMemberBVConstEvaluator handles; it
+    // exits fatally on anything else. Note BVNAND/BVNOR/BVXNOR are not
+    // implemented there.
+    switch (k)
+    {
+      case BOOLEXTRACT:
+      case BVNOT:
+      case BVSX:
+      case BVZX:
+      case BVLEFTSHIFT:
+      case BVRIGHTSHIFT:
+      case BVSRSHIFT:
+      case BVAND:
+      case BVOR:
+      case BVXOR:
+      case BVSUB:
+      case BVUMINUS:
+      case BVEXTRACT:
+      case BVCONCAT:
+      case BVMULT:
+      case BVPLUS:
+      case SBVDIV:
+      case SBVREM:
+      case SBVMOD:
+      case BVDIV:
+      case BVMOD:
+      case ITE:
+      case EQ:
+      case BVLT:
+      case BVLE:
+      case BVGT:
+      case BVGE:
+      case BVSLT:
+      case BVSLE:
+      case BVSGT:
+      case BVSGE:
+      case NOT:
+      case OR:
+      case NOR:
+      case XOR:
+      case AND:
+      case NAND:
+      case IFF:
+      case IMPLIES:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  ValueSet* ValueSetAnalysis::dispatchToTransferFunctions(
+      const ASTNode& n, const vector<const ValueSet*>& children)
+  {
+    const Kind k = n.GetKind();
+
+    if (BVCONST == k)
+    {
+      ValueSet* result = fresh(n);
+      result->insert(CONSTANTBV::BitVector_Clone(n.GetBVConst()));
+      propagated++;
+      return result;
+    }
+
+    if (TRUE == k || FALSE == k)
+    {
+      ValueSet* result = fresh(n);
+      CBV v = CONSTANTBV::BitVector_Create(1, true);
+      if (TRUE == k)
+        CONSTANTBV::BitVector_Bit_On(v, 0);
+      result->insert(v);
+      propagated++;
+      return result;
+    }
+
+    if (ITE == k)
+    {
+      // The condition selects a branch when it's known; otherwise the
+      // node can take any value from either branch.
+      const ValueSet* condition = children[0];
+      if (condition != nullptr && condition->isConstant())
+      {
+        const ValueSet* branch =
+            CONSTANTBV::BitVector_bit_test(condition->smallest(), 0)
+                ? children[1]
+                : children[2];
+        if (branch == nullptr)
+          return nullptr;
+
+        ValueSet* result = fresh(n);
+        for (const CBV m : branch->values)
+        {
+          bool fitted = result->insert(CONSTANTBV::BitVector_Clone(m));
+          assert(fitted);
+          (void)fitted;
+        }
+        propagated++;
+        return result;
+      }
+
+      if (children[1] == nullptr || children[2] == nullptr)
+        return nullptr;
+
+      ValueSet* result = fresh(n);
+      for (int branch = 1; branch <= 2; branch++)
+        for (const CBV m : children[branch]->values)
+          if (!result->insert(CONSTANTBV::BitVector_Clone(m)))
+          {
+            delete result;
+            widened++;
+            return nullptr;
+          }
+      propagated++;
+      return result;
+    }
+
+    if (!constEvaluable(k) || n.Degree() == 0)
+      return nullptr;
+
+    size_t combinations = 1;
+    for (const ValueSet* c : children)
+    {
+      if (c == nullptr)
+        return nullptr;
+      combinations *= c->size();
+      if (combinations > PRODUCT_CAP)
+        return nullptr;
+    }
+
+    // Constant nodes for every child's member, built once.
+    vector<vector<ASTNode>> constants(children.size());
+    for (size_t i = 0; i < children.size(); i++)
+      for (const CBV m : children[i]->values)
+        constants[i].push_back(toNode(n[i], m));
+
+    // Evaluate the node over each combination of the children's values.
+    ValueSet* result = fresh(n);
+    vector<size_t> odometer(children.size(), 0);
+    for (size_t count = 0; count < combinations; count++)
+    {
+      ASTVec combination;
+      combination.reserve(children.size());
+      for (size_t i = 0; i < children.size(); i++)
+        combination.push_back(constants[i][odometer[i]]);
+
+      const ASTNode evaluated =
+          NonMemberBVConstEvaluator(&bm, k, combination, n.GetValueWidth());
+
+      if (!result->insert(toCBV(evaluated)))
+      {
+        delete result;
+        widened++;
+        return nullptr;
+      }
+
+      for (size_t i = 0; i < odometer.size(); i++)
+      {
+        if (++odometer[i] < children[i]->size())
+          break;
+        odometer[i] = 0;
+      }
+    }
+
+    propagated++;
+    return result;
+  }
+
+  void ValueSetAnalysis::stats()
+  {
+    std::cerr << "{ValueSetAnalysis} Propagated: " << propagated << std::endl;
+    std::cerr << "{ValueSetAnalysis} Widened: " << widened << std::endl;
+  }
+}

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -39,4 +39,5 @@ AddSTPGTest(ConstantBitP_TransferFunctions_Test.cpp)
 AddSTPGTest(ConstantBitP_Wide_Test.cpp)
 AddSTPGTest(UnsignedIntervalAnalysis_Test.cpp)
 AddSTPGTest(ConstantBitPropagation_Test.cpp)
+AddSTPGTest(ValueSet_Test.cpp)
 

--- a/tests/unit-tests/ValueSet_Test.cpp
+++ b/tests/unit-tests/ValueSet_Test.cpp
@@ -715,6 +715,47 @@ TEST(ValueSet_Test, single_common_value_rewrites_to_selection)
     }
 }
 
+// The split doesn't need the sides to be ITE trees over constants: any
+// term with a known value set qualifies. Here the right side is an
+// addition, which only the sets pin down to two values.
+TEST(ValueSet_Test, single_common_value_splits_non_ite_terms)
+{
+  boot();
+  Context c;
+  stp::NodeDomainAnalysis domain(&c.mgr);
+
+  const unsigned width = 8;
+  ASTNode p = c.boolSymbol("p");
+  ASTNode q = c.boolSymbol("q");
+  ASTNode left = c.hashing()->CreateTerm(stp::ITE, width, p,
+                                         c.constant(width, 8),
+                                         c.constant(width, 9));
+  // ite(q, 8, 9) + 1, so {9, 10}: shares just 9 with the left side.
+  ASTNode right = c.hashing()->CreateTerm(
+      stp::BVPLUS, width,
+      c.hashing()->CreateTerm(stp::ITE, width, q, c.constant(width, 8),
+                              c.constant(width, 9)),
+      c.constant(width, 1));
+  ASTNode eq = c.hashing()->CreateNode(stp::EQ, left, right);
+
+  stp::StrengthReduction sr(&c.snf, &c.mgr.UserFlags);
+  ASTNode result = sr.topLevel(eq, domain);
+
+  ASSERT_NE(result, eq);
+  ASSERT_NE(result.GetKind(), stp::EQ);
+
+  // Equivalent under all four assignments.
+  for (unsigned pv = 0; pv <= 1; pv++)
+    for (unsigned qv = 0; qv <= 1; qv++)
+    {
+      stp::ASTNodeMap assignment;
+      assignment.insert({p, pv ? c.mgr.ASTTrue : c.mgr.ASTFalse});
+      assignment.insert({q, qv ? c.mgr.ASTTrue : c.mgr.ASTFalse});
+      ASSERT_EQ(c.eval(eq, assignment), c.eval(result, assignment))
+          << "differ on p=" << pv << " q=" << qv;
+    }
+}
+
 // A node whose interval spans more values than a set can hold gets no
 // set, while the interval information is kept.
 TEST(ValueSet_Test, widens_when_the_interval_is_too_big)

--- a/tests/unit-tests/ValueSet_Test.cpp
+++ b/tests/unit-tests/ValueSet_Test.cpp
@@ -1,0 +1,738 @@
+/***********
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+**********************/
+
+/*
+ * Tests of the ValueSet domain:
+ *
+ * 1) The ValueSet container itself.
+ * 2) The transfer functions, on hand-built child sets.
+ * 3) The three-way harmonise: enumeration from the bits/interval,
+ *    filtering of the set, and (exhaustively at small widths) that the
+ *    triple's shared values are preserved exactly and a second call
+ *    changes nothing.
+ * 4) End to end: equalities of ITE trees over constants are proven
+ *    false when the sets are disjoint, and rewritten to selection
+ *    conditions when exactly one value is shared.
+ */
+
+#include "stp/Simplifier/NodeDomainAnalysis.h"
+#include "stp/Simplifier/Simplifier.h"
+#include "stp/Simplifier/StrengthReduction.h"
+#include "stp/Simplifier/SubstitutionMap.h"
+#include "stp/Simplifier/UnsignedInterval.h"
+#include "stp/Simplifier/ValueSet.h"
+#include "stp/Simplifier/ValueSetAnalysis.h"
+#include "stp/Simplifier/constantBitP/FixedBits.h"
+#include <gtest/gtest.h>
+
+using simplifier::constantBitP::FixedBits;
+
+static void boot()
+{
+  static bool booted = false;
+  if (!booted)
+  {
+    CONSTANTBV::BitVector_Boot();
+    booted = true;
+  }
+}
+
+static stp::CBV makeCBV(unsigned width, unsigned value)
+{
+  stp::CBV result = CONSTANTBV::BitVector_Create(width, true);
+  for (unsigned i = 0; i < width; i++)
+    if ((value >> i) & 1)
+      CONSTANTBV::BitVector_Bit_On(result, i);
+  return result;
+}
+
+static unsigned fromCBV(const stp::CBV v, unsigned width)
+{
+  unsigned result = 0;
+  for (unsigned i = 0; i < width; i++)
+    if (CONSTANTBV::BitVector_bit_test(v, i))
+      result |= 1u << i;
+  return result;
+}
+
+// A set holding the given values.
+static stp::ValueSet* makeSet(unsigned width, bool isBoolean,
+                              const std::vector<unsigned>& values)
+{
+  stp::ValueSet* result = new stp::ValueSet(width, isBoolean);
+  for (unsigned v : values)
+    EXPECT_TRUE(result->insert(makeCBV(width, v)));
+  return result;
+}
+
+// The members as unsigned values, in the stored (ascending) order.
+static std::vector<unsigned> members(const stp::ValueSet* set)
+{
+  std::vector<unsigned> result;
+  if (set != nullptr)
+    for (const stp::CBV m : set->values)
+      result.push_back(fromCBV(m, set->getWidth()));
+  return result;
+}
+
+struct Context
+{
+  stp::STPMgr mgr;
+  SimplifyingNodeFactory snf;
+
+  Context() : snf(*(mgr.hashingNodeFactory), mgr)
+  {
+    mgr.defaultNodeFactory = &snf;
+  }
+
+  NodeFactory* hashing() { return mgr.hashingNodeFactory; }
+
+  ASTNode symbol(const char* name, unsigned width)
+  {
+    return mgr.CreateSymbol(name, 0, width);
+  }
+
+  ASTNode boolSymbol(const char* name) { return mgr.CreateSymbol(name, 0, 0); }
+
+  ASTNode constant(unsigned width, unsigned value)
+  {
+    return mgr.CreateBVConst(width, value);
+  }
+
+  // Evaluate "n" with the symbols replaced by the constants in "assignment".
+  ASTNode eval(const ASTNode& n, stp::ASTNodeMap assignment)
+  {
+    stp::ASTNodeMap cache;
+    ASTNode substituted =
+        stp::SubstitutionMap::replace(n, assignment, cache, &snf);
+    if (substituted.isConstant())
+      return substituted;
+    return stp::NonMemberBVConstEvaluator(&mgr, substituted);
+  }
+};
+
+/////////////////////////////////////////////////////////////////////////////
+// The container.
+/////////////////////////////////////////////////////////////////////////////
+
+TEST(ValueSet_Test, container_basics)
+{
+  boot();
+
+  stp::ValueSet set(8, false);
+
+  // Inserted out of order, stored sorted, duplicates coalesce.
+  ASSERT_TRUE(set.insert(makeCBV(8, 200)));
+  ASSERT_TRUE(set.insert(makeCBV(8, 3)));
+  ASSERT_TRUE(set.insert(makeCBV(8, 90)));
+  ASSERT_TRUE(set.insert(makeCBV(8, 3)));
+
+  ASSERT_EQ(set.size(), 3u);
+  ASSERT_EQ(fromCBV(set.smallest(), 8), 3u);
+  ASSERT_EQ(fromCBV(set.largest(), 8), 200u);
+
+  stp::CBV probe = makeCBV(8, 90);
+  ASSERT_TRUE(set.in(probe));
+  CONSTANTBV::BitVector_Destroy(probe);
+
+  probe = makeCBV(8, 91);
+  ASSERT_FALSE(set.in(probe));
+  CONSTANTBV::BitVector_Destroy(probe);
+
+  // A 13th distinct value doesn't fit.
+  for (unsigned v = 10; v < 19; v++)
+    ASSERT_TRUE(set.insert(makeCBV(8, v)));
+  ASSERT_EQ(set.size(), stp::ValueSet::MAX_ELEMENTS);
+  ASSERT_FALSE(set.insert(makeCBV(8, 19)));
+  ASSERT_EQ(set.size(), stp::ValueSet::MAX_ELEMENTS);
+
+  // Re-inserting an existing value still succeeds at capacity.
+  ASSERT_TRUE(set.insert(makeCBV(8, 200)));
+}
+
+/////////////////////////////////////////////////////////////////////////////
+// Transfer functions.
+/////////////////////////////////////////////////////////////////////////////
+
+TEST(ValueSet_Test, transfer_pointwise_add)
+{
+  boot();
+  Context c;
+  stp::ValueSetAnalysis analysis(c.mgr);
+
+  ASTNode n = c.hashing()->CreateTerm(stp::BVPLUS, 8, c.symbol("x", 8),
+                                      c.symbol("y", 8));
+
+  stp::ValueSet* left = makeSet(8, false, {1, 2, 3});
+  stp::ValueSet* right = makeSet(8, false, {10, 20});
+
+  stp::ValueSet* result = analysis.dispatchToTransferFunctions(n, {left, right});
+
+  ASSERT_NE(result, nullptr);
+  ASSERT_EQ(members(result), std::vector<unsigned>({11, 12, 13, 21, 22, 23}));
+
+  delete left;
+  delete right;
+  delete result;
+}
+
+TEST(ValueSet_Test, transfer_ite)
+{
+  boot();
+  Context c;
+  stp::ValueSetAnalysis analysis(c.mgr);
+
+  ASTNode n = c.hashing()->CreateTerm(stp::ITE, 8, c.boolSymbol("p"),
+                                      c.symbol("x", 8), c.symbol("y", 8));
+
+  stp::ValueSet* thenSet = makeSet(8, false, {1, 2});
+  stp::ValueSet* elseSet = makeSet(8, false, {2, 7});
+
+  // Unknown condition: the union of the branches.
+  stp::ValueSet* result =
+      analysis.dispatchToTransferFunctions(n, {nullptr, thenSet, elseSet});
+  ASSERT_EQ(members(result), std::vector<unsigned>({1, 2, 7}));
+  delete result;
+
+  // A condition fixed to true selects the then-branch, even when
+  // nothing is known about the other branch.
+  stp::ValueSet* trueSet = makeSet(1, true, {1});
+  result = analysis.dispatchToTransferFunctions(n, {trueSet, thenSet, nullptr});
+  ASSERT_EQ(members(result), std::vector<unsigned>({1, 2}));
+  delete result;
+
+  // Unknown condition with an unknown branch: nothing known.
+  result = analysis.dispatchToTransferFunctions(n, {nullptr, thenSet, nullptr});
+  ASSERT_EQ(result, nullptr);
+
+  delete trueSet;
+  delete thenSet;
+  delete elseSet;
+}
+
+TEST(ValueSet_Test, transfer_widens_past_max_elements)
+{
+  boot();
+  Context c;
+  stp::ValueSetAnalysis analysis(c.mgr);
+
+  ASTNode n = c.hashing()->CreateTerm(stp::BVCONCAT, 8, c.symbol("x", 4),
+                                      c.symbol("y", 4));
+
+  // 16 distinct results is more than a set can hold.
+  stp::ValueSet* left = makeSet(4, false, {0, 1, 2, 3});
+  stp::ValueSet* right = makeSet(4, false, {0, 1, 2, 3});
+
+  stp::ValueSet* result = analysis.dispatchToTransferFunctions(n, {left, right});
+  ASSERT_EQ(result, nullptr);
+
+  delete left;
+  delete right;
+}
+
+TEST(ValueSet_Test, transfer_respects_product_cap)
+{
+  boot();
+  Context c;
+  stp::ValueSetAnalysis analysis(c.mgr);
+
+  ASTVec children = {c.symbol("x", 8), c.symbol("y", 8), c.symbol("z", 8)};
+  ASTNode n = c.hashing()->CreateTerm(stp::BVPLUS, 8, children);
+
+  // 6*6*6 = 216 combinations exceeds the evaluation cap, even though
+  // the result would collapse to few values.
+  stp::ValueSet* a = makeSet(8, false, {0, 1, 2, 3, 4, 5});
+  stp::ValueSet* b = makeSet(8, false, {0, 1, 2, 3, 4, 5});
+  stp::ValueSet* d = makeSet(8, false, {0, 1, 2, 3, 4, 5});
+
+  stp::ValueSet* result = analysis.dispatchToTransferFunctions(n, {a, b, d});
+  ASSERT_EQ(result, nullptr);
+
+  delete a;
+  delete b;
+  delete d;
+}
+
+TEST(ValueSet_Test, transfer_skips_kinds_without_an_evaluator)
+{
+  boot();
+  Context c;
+  stp::ValueSetAnalysis analysis(c.mgr);
+
+  ASSERT_FALSE(stp::ValueSetAnalysis::constEvaluable(stp::BVXNOR));
+
+  ASTNode n = c.hashing()->CreateTerm(stp::BVXNOR, 8, c.symbol("x", 8),
+                                      c.symbol("y", 8));
+
+  stp::ValueSet* left = makeSet(8, false, {1});
+  stp::ValueSet* right = makeSet(8, false, {2});
+
+  stp::ValueSet* result = analysis.dispatchToTransferFunctions(n, {left, right});
+  ASSERT_EQ(result, nullptr);
+
+  delete left;
+  delete right;
+}
+
+TEST(ValueSet_Test, transfer_division_by_zero)
+{
+  boot();
+  Context c;
+  stp::ValueSetAnalysis analysis(c.mgr);
+
+  stp::ValueSet* left = makeSet(4, false, {5});
+  stp::ValueSet* right = makeSet(4, false, {0, 2});
+
+  // 5 bvudiv 0 is all ones; 5 bvurem 0 is 5.
+  ASTNode div = c.hashing()->CreateTerm(stp::BVDIV, 4, c.symbol("x", 4),
+                                        c.symbol("y", 4));
+  stp::ValueSet* result = analysis.dispatchToTransferFunctions(div, {left, right});
+  ASSERT_EQ(members(result), std::vector<unsigned>({2, 15}));
+  delete result;
+
+  ASTNode mod = c.hashing()->CreateTerm(stp::BVMOD, 4, c.symbol("x", 4),
+                                        c.symbol("y", 4));
+  result = analysis.dispatchToTransferFunctions(mod, {left, right});
+  ASSERT_EQ(members(result), std::vector<unsigned>({1, 5}));
+  delete result;
+
+  delete left;
+  delete right;
+}
+
+TEST(ValueSet_Test, transfer_comparison_of_disjoint_sets)
+{
+  boot();
+  Context c;
+  stp::ValueSetAnalysis analysis(c.mgr);
+
+  ASTNode n = c.hashing()->CreateNode(stp::EQ, c.symbol("x", 8),
+                                      c.symbol("y", 8));
+
+  stp::ValueSet* left = makeSet(8, false, {8, 9});
+  stp::ValueSet* right = makeSet(8, false, {7, 10});
+
+  stp::ValueSet* result = analysis.dispatchToTransferFunctions(n, {left, right});
+  ASSERT_NE(result, nullptr);
+  ASSERT_TRUE(result->isBoolean());
+  ASSERT_EQ(members(result), std::vector<unsigned>({0}));
+
+  delete left;
+  delete right;
+  delete result;
+}
+
+/////////////////////////////////////////////////////////////////////////////
+// Three-way harmonise.
+/////////////////////////////////////////////////////////////////////////////
+
+TEST(ValueSet_Test, harmonise_enumerates_small_intervals)
+{
+  boot();
+  Context c;
+  stp::NodeDomainAnalysis domain(&c.mgr);
+
+  // [3,5] has three values: they become the set.
+  {
+    FixedBits* bits = nullptr;
+    stp::UnsignedInterval* interval =
+        new stp::UnsignedInterval(makeCBV(8, 3), makeCBV(8, 5));
+    stp::ValueSet* set = nullptr;
+
+    domain.harmonise(bits, interval, set, 8, false);
+    ASSERT_EQ(members(set), std::vector<unsigned>({3, 4, 5}));
+
+    // Idempotent.
+    domain.harmonise(bits, interval, set, 8, false);
+    ASSERT_EQ(members(set), std::vector<unsigned>({3, 4, 5}));
+
+    delete bits;
+    delete interval;
+    delete set;
+  }
+
+  // The full interval has far too many values.
+  {
+    FixedBits* bits = nullptr;
+    stp::UnsignedInterval* interval =
+        new stp::UnsignedInterval(makeCBV(8, 0), makeCBV(8, 255));
+    stp::ValueSet* set = nullptr;
+
+    domain.harmonise(bits, interval, set, 8, false);
+    ASSERT_EQ(set, nullptr);
+
+    delete bits;
+    delete interval;
+  }
+
+  // An interval ending at the maximum value doesn't wrap around.
+  {
+    FixedBits* bits = nullptr;
+    stp::UnsignedInterval* interval =
+        new stp::UnsignedInterval(makeCBV(8, 252), makeCBV(8, 255));
+    stp::ValueSet* set = nullptr;
+
+    domain.harmonise(bits, interval, set, 8, false);
+    ASSERT_EQ(members(set), std::vector<unsigned>({252, 253, 254, 255}));
+
+    delete bits;
+    delete interval;
+    delete set;
+  }
+
+  // Fixed bits cut a wide interval down to few enough values.
+  {
+    FixedBits* bits = new FixedBits(8, false);
+    for (unsigned i = 3; i < 8; i++)
+    {
+      bits->setFixed(i, true);
+      bits->setValue(i, false);
+    }
+    stp::UnsignedInterval* interval =
+        new stp::UnsignedInterval(makeCBV(8, 0), makeCBV(8, 255));
+    stp::ValueSet* set = nullptr;
+
+    domain.harmonise(bits, interval, set, 8, false);
+    ASSERT_EQ(members(set),
+              std::vector<unsigned>({0, 1, 2, 3, 4, 5, 6, 7}));
+
+    delete bits;
+    delete interval;
+    delete set;
+  }
+}
+
+TEST(ValueSet_Test, harmonise_filters_and_tightens)
+{
+  boot();
+  Context c;
+  stp::NodeDomainAnalysis domain(&c.mgr);
+
+  FixedBits* bits = nullptr;
+  stp::UnsignedInterval* interval =
+      new stp::UnsignedInterval(makeCBV(8, 4), makeCBV(8, 10));
+  stp::ValueSet* set = makeSet(8, false, {1, 5, 9});
+
+  domain.harmonise(bits, interval, set, 8, false);
+
+  // 1 is outside the interval; the survivors are {5, 9}.
+  ASSERT_EQ(members(set), std::vector<unsigned>({5, 9}));
+
+  // The interval becomes the set's hull.
+  ASSERT_EQ(fromCBV(interval->minV, 8), 5u);
+  ASSERT_EQ(fromCBV(interval->maxV, 8), 9u);
+
+  // 5 is 0101 and 9 is 1001: bits 0 and 1 agree.
+  ASSERT_NE(bits, nullptr);
+  ASSERT_TRUE(bits->isFixed(0) && bits->getValue(0));
+  ASSERT_TRUE(bits->isFixed(1) && !bits->getValue(1));
+
+  delete bits;
+  delete interval;
+  delete set;
+}
+
+// Base-3 encoding: digit 0=unfixed, 1=fixed-to-zero, 2=fixed-to-one.
+static FixedBits bitsFromTernary(unsigned width, unsigned config)
+{
+  FixedBits b(width, false);
+  for (unsigned i = 0; i < width; i++)
+  {
+    const unsigned digit = config % 3;
+    config /= 3;
+    if (digit == 0)
+      b.setFixed(i, false);
+    else
+    {
+      b.setFixed(i, true);
+      b.setValue(i, digit == 2);
+    }
+  }
+  return b;
+}
+
+static bool bitsContain(const FixedBits& b, unsigned v)
+{
+  for (unsigned i = 0; i < b.getWidth(); i++)
+    if (b.isFixed(i) && b.getValue(i) != (((v >> i) & 1) != 0))
+      return false;
+  return true;
+}
+
+// All three domains trimmed to exactly their shared values, and a
+// second call changes nothing. Exhaustive over every combination of
+// fixed bits, interval and set at small widths.
+TEST(ValueSet_Test, harmonise_threeway_exhaustive)
+{
+  boot();
+  Context c;
+  stp::NodeDomainAnalysis domain(&c.mgr);
+
+  for (unsigned width = 1; width <= 3; width++)
+  {
+    unsigned configs = 1;
+    for (unsigned i = 0; i < width; i++)
+      configs *= 3;
+    const unsigned values = 1u << width;
+
+    for (unsigned config = 0; config < configs; config++)
+    {
+      const FixedBits pattern = bitsFromTernary(width, config);
+
+      for (unsigned lo = 0; lo < values; lo++)
+        for (unsigned hi = lo; hi < values; hi++)
+          for (unsigned mask = 1; mask < (1u << values); mask++)
+          {
+            // The values every domain admits. Sound domains always
+            // share the node's real values, so harmonise requires a
+            // non-empty intersection; skip the impossible inputs.
+            // (The pairwise bits/interval intersection can't be empty
+            // when the triple's isn't.)
+            std::vector<bool> shared(values);
+            bool anyShared = false;
+            for (unsigned v = 0; v < values; v++)
+            {
+              shared[v] = bitsContain(pattern, v) && v >= lo && v <= hi &&
+                          ((mask >> v) & 1);
+              anyShared |= shared[v];
+            }
+            bool pairShared = false;
+            for (unsigned v = 0; v < values; v++)
+              pairShared |= bitsContain(pattern, v) && v >= lo && v <= hi;
+            if (!anyShared || !pairShared)
+              continue;
+
+            FixedBits* bits = new FixedBits(pattern);
+            stp::UnsignedInterval* interval = new stp::UnsignedInterval(
+                makeCBV(width, lo), makeCBV(width, hi));
+            std::vector<unsigned> setValues;
+            for (unsigned v = 0; v < values; v++)
+              if ((mask >> v) & 1)
+                setValues.push_back(v);
+            stp::ValueSet* set = makeSet(width, false, setValues);
+
+            domain.harmonise(bits, interval, set, width, false);
+
+            // The set is exactly the shared values (they always fit at
+            // these widths), except that a set holding every value
+            // carries no information and becomes null.
+            std::vector<unsigned> expected;
+            for (unsigned v = 0; v < values; v++)
+              if (shared[v])
+                expected.push_back(v);
+
+            if (expected.size() == values)
+              ASSERT_EQ(set, nullptr)
+                  << "width " << width << " config " << config << " [" << lo
+                  << "," << hi << "] mask " << mask;
+            else
+              ASSERT_EQ(members(set), expected)
+                  << "width " << width << " config " << config << " [" << lo
+                  << "," << hi << "] mask " << mask;
+
+            // The interval is the shared values' hull, or null when
+            // that spans everything.
+            if (expected.front() == 0 && expected.back() == values - 1)
+              ASSERT_EQ(interval, nullptr);
+            else
+            {
+              ASSERT_NE(interval, nullptr);
+              ASSERT_EQ(fromCBV(interval->minV, width), expected.front());
+              ASSERT_EQ(fromCBV(interval->maxV, width), expected.back());
+            }
+
+            // A bit is fixed exactly when every shared value agrees.
+            for (unsigned i = 0; i < width; i++)
+            {
+              bool anyZero = false, anyOne = false;
+              for (unsigned v : expected)
+                (((v >> i) & 1) ? anyOne : anyZero) = true;
+
+              const bool fixed =
+                  bits != nullptr && bits->isFixed(i);
+              ASSERT_EQ(fixed, !(anyZero && anyOne));
+              if (fixed)
+                ASSERT_EQ(bits->getValue(i), anyOne);
+            }
+
+            // Idempotent: a second call changes nothing.
+            const std::vector<unsigned> setBefore = members(set);
+            const bool setWasNull = set == nullptr;
+            FixedBits bitsBefore =
+                (bits != nullptr) ? *bits : FixedBits(width, false);
+            const bool bitsWereNull = bits == nullptr;
+            const bool intervalWasNull = interval == nullptr;
+            const unsigned minBefore =
+                intervalWasNull ? 0 : fromCBV(interval->minV, width);
+            const unsigned maxBefore =
+                intervalWasNull ? 0 : fromCBV(interval->maxV, width);
+
+            domain.harmonise(bits, interval, set, width, false);
+
+            ASSERT_EQ(set == nullptr, setWasNull);
+            ASSERT_EQ(members(set), setBefore);
+            ASSERT_EQ(bits == nullptr, bitsWereNull);
+            if (bits != nullptr)
+              ASSERT_TRUE(FixedBits::equals(*bits, bitsBefore));
+            ASSERT_EQ(interval == nullptr, intervalWasNull);
+            if (interval != nullptr)
+            {
+              ASSERT_EQ(fromCBV(interval->minV, width), minBefore);
+              ASSERT_EQ(fromCBV(interval->maxV, width), maxBefore);
+            }
+
+            delete bits;
+            delete interval;
+            delete set;
+          }
+    }
+  }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+// End to end.
+/////////////////////////////////////////////////////////////////////////////
+
+// The requested example: (ite p 8 9) = (ite q 7 10). The sets {8,9} and
+// {7,10} are disjoint, so the equality is false.
+TEST(ValueSet_Test, disjoint_ite_equality_is_false)
+{
+  boot();
+  Context c;
+  stp::NodeDomainAnalysis domain(&c.mgr);
+
+  const unsigned width = 20;
+  ASTNode left = c.hashing()->CreateTerm(stp::ITE, width, c.boolSymbol("p"),
+                                         c.constant(width, 8),
+                                         c.constant(width, 9));
+  ASTNode right = c.hashing()->CreateTerm(stp::ITE, width, c.boolSymbol("q"),
+                                          c.constant(width, 7),
+                                          c.constant(width, 10));
+  ASTNode eq = c.hashing()->CreateNode(stp::EQ, left, right);
+
+  domain.buildMap(eq);
+
+  const stp::ValueSet* eqSet = (*domain.getValueSetMap())[eq];
+  ASSERT_EQ(members(eqSet), std::vector<unsigned>({0}));
+
+  FixedBits* eqBits = (*domain.getCbitMap())[eq];
+  ASSERT_NE(eqBits, nullptr);
+  ASSERT_TRUE(eqBits->isFixed(0) && !eqBits->getValue(0));
+
+  stp::StrengthReduction sr(&c.snf, &c.mgr.UserFlags);
+  ASSERT_EQ(sr.topLevel(eq, domain), c.mgr.ASTFalse);
+}
+
+// A disjoint pair that neither the fixed bits nor the interval can
+// prove apart: {1,6} vs {2,5} fix no bits and the hulls overlap. Only
+// the sets show the equality is false.
+TEST(ValueSet_Test, disjoint_equality_only_the_sets_prove)
+{
+  boot();
+  Context c;
+  stp::NodeDomainAnalysis domain(&c.mgr);
+
+  const unsigned width = 8;
+  ASTNode left = c.hashing()->CreateTerm(stp::ITE, width, c.boolSymbol("p"),
+                                         c.constant(width, 1),
+                                         c.constant(width, 6));
+  ASTNode right = c.hashing()->CreateTerm(stp::ITE, width, c.boolSymbol("q"),
+                                          c.constant(width, 2),
+                                          c.constant(width, 5));
+  ASTNode eq = c.hashing()->CreateNode(stp::EQ, left, right);
+
+  domain.buildMap(eq);
+
+  // The low bits carry no information: 1/6 and 2/5 disagree on all of
+  // them (the sets do fix the high bits to zero, identically on both
+  // sides, which cannot separate the terms either).
+  for (unsigned i = 0; i < 3; i++)
+  {
+    ASSERT_FALSE((*domain.getCbitMap())[left]->isFixed(i));
+    ASSERT_FALSE((*domain.getCbitMap())[right]->isFixed(i));
+  }
+
+  ASSERT_EQ(members((*domain.getValueSetMap())[eq]),
+            std::vector<unsigned>({0}));
+
+  stp::StrengthReduction sr(&c.snf, &c.mgr.UserFlags);
+  ASSERT_EQ(sr.topLevel(eq, domain), c.mgr.ASTFalse);
+}
+
+// Exactly one value shared: the equality becomes the conjunction of
+// "each side selects the shared value", checked equivalent on every
+// assignment.
+TEST(ValueSet_Test, single_common_value_rewrites_to_selection)
+{
+  boot();
+  Context c;
+  stp::NodeDomainAnalysis domain(&c.mgr);
+
+  const unsigned width = 8;
+  ASTNode p = c.boolSymbol("p");
+  ASTNode q = c.boolSymbol("q");
+  ASTNode left = c.hashing()->CreateTerm(stp::ITE, width, p,
+                                         c.constant(width, 8),
+                                         c.constant(width, 9));
+  ASTNode right = c.hashing()->CreateTerm(stp::ITE, width, q,
+                                          c.constant(width, 9),
+                                          c.constant(width, 10));
+  ASTNode eq = c.hashing()->CreateNode(stp::EQ, left, right);
+
+  stp::StrengthReduction sr(&c.snf, &c.mgr.UserFlags);
+  ASTNode result = sr.topLevel(eq, domain);
+
+  // Rewritten away from an equality of ITE trees.
+  ASSERT_NE(result, eq);
+  ASSERT_NE(result.GetKind(), stp::EQ);
+
+  // Equivalent under all four assignments.
+  for (unsigned pv = 0; pv <= 1; pv++)
+    for (unsigned qv = 0; qv <= 1; qv++)
+    {
+      stp::ASTNodeMap assignment;
+      assignment.insert({p, pv ? c.mgr.ASTTrue : c.mgr.ASTFalse});
+      assignment.insert({q, qv ? c.mgr.ASTTrue : c.mgr.ASTFalse});
+      ASSERT_EQ(c.eval(eq, assignment), c.eval(result, assignment))
+          << "differ on p=" << pv << " q=" << qv;
+    }
+}
+
+// A node whose interval spans more values than a set can hold gets no
+// set, while the interval information is kept.
+TEST(ValueSet_Test, widens_when_the_interval_is_too_big)
+{
+  boot();
+  Context c;
+  stp::NodeDomainAnalysis domain(&c.mgr);
+
+  const unsigned width = 8;
+  // x bvurem 21 is within [0, 20]: 21 values, too many for a set.
+  ASTNode n = c.hashing()->CreateTerm(stp::BVMOD, width, c.symbol("x", width),
+                                      c.constant(width, 21));
+
+  domain.buildMap(n);
+
+  ASSERT_EQ((*domain.getValueSetMap())[n], nullptr);
+
+  const stp::UnsignedInterval* interval = (*domain.getIntervalMap())[n];
+  ASSERT_NE(interval, nullptr);
+  ASSERT_EQ(fromCBV(interval->maxV, width), 20u);
+}


### PR DESCRIPTION
Tracks the set of values a node can take (up to 12 elements; anything bigger widens to unknown) as a third abstract domain alongside the fixed bits and unsigned intervals.

**Transfer functions** (`ValueSetAnalysis`): most operations are handled generically by evaluating the node over the cartesian product of the children's sets with the existing constant evaluator (capped at 144 combinations, whitelisted to the kinds the evaluator implements). ITE takes the selected branch when the condition is known, and the union of the branches otherwise. Division by zero therefore follows the solver's own semantics for free.

**Harmonise** now moves information between all three domains: set members the bits or interval exclude are dropped; the interval tightens to the set's hull; bits every member agrees on get fixed; and when the bits and interval admit at most 12 values, the set is *created* by enumerating them — so terms like `bvand x 1` or `bvurem x 3` get sets with no ITE structure in sight. Sets holding every value of the width (e.g. a boolean `{0,1}`) carry no information and drop to null, preserving the existing invariant that a known boolean interval is constant.

**Simplifier**: `getPossibleValues` and its two use sites are removed. The disjoint-sets and min/max range checks are subsumed: the equality/inequality's own domain now evaluates to a constant through the generic transfer, and the ordinary strength-reduction constant replacement fires (e.g. `(ite p 8 9) = (ite q 7 10)` becomes `false`). The one rewrite that wasn't subsumed — an equality of ITE trees sharing exactly one constant becomes the conjunction of the two selection conditions — moves to StrengthReduction, driven by the sets and no longer depth-limited.

**Tests** (`ValueSet_Test.cpp`, 15 tests): container behaviour and widening; the transfer functions on hand-built sets including the product cap, non-evaluable kinds and division by zero; harmonise enumeration including the all-ones wrap-around bound; an exhaustive three-way harmonise check at widths 1–3 (every fixed-bits pattern × interval × non-empty set: the shared values are preserved exactly, each domain ends optimally tight, and a second call changes nothing); and end-to-end checks that disjoint ITE equalities fold to false — including a pair `{1,6}` vs `{2,5}` that neither the bits nor the intervals can separate — with the single-common-value rewrite equivalence-checked over all assignments.

Full ctest suite (unit tests + query files) passes in Debug and Release; runtimes on the sample query files are unchanged.