### PR TITLE
Remove the unsound x smod x = 0 constant-bit shortcut

### DIFF
--- a/lib/Simplifier/constantBitP/ConstantBitP_Division.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_Division.cpp
@@ -1666,21 +1666,13 @@ Result bvSignedModulusBothWays(vector<FixedBits*>& children, FixedBits& output,
   assert(output.getWidth() == children[0]->getWidth());
   assert(output.getWidth() == children[1]->getWidth());
 
-  if (children[0] == children[1]) // same pointer: x smod x = 0.
+  // Same pointer. This doesn't imply the operands are the same node:
+  // NodeDomainAnalysis hands every unknown operand of a width the same
+  // placeholder object. So nothing can be concluded (not even
+  // x smod x = 0); skip rather than propagate through aliased operands.
+  if (children[0] == children[1])
   {
-    Result r = NO_CHANGE;
-    for (unsigned i = 0; i < output.getWidth(); i++)
-    {
-      if (output.isFixedToOne(i))
-        return CONFLICT;
-      if (!output.isFixed(i))
-      {
-        output.setFixed(i, true);
-        output.setValue(i, false);
-        r = CHANGED;
-      }
-    }
-    return r;
+    return NO_CHANGE;
   }
 
   const Result r0 = bvSignedModulusStructural(children, output, bm);

--- a/tests/query-files/sample-smt-tests/bvsmod-distinct-unknown-operands.smt2
+++ b/tests/query-files/sample-smt-tests/bvsmod-distinct-unknown-operands.smt2
@@ -1,0 +1,18 @@
+; RUN: %solver %s | %OutputCheck %s
+; CHECK-NEXT: ^sat
+(set-logic QF_BV)
+(set-info :source |
+	Regression test for an unsound bvsmod constant-bit propagation rule.
+	The propagator concluded x smod x = 0 from pointer-equal operand
+	FixedBits, but NodeDomainAnalysis hands every unknown operand of a
+	width the same placeholder object, so the two distinct operands here
+	were folded to zero and the formula wrongly reported unsat.
+	Satisfiable, e.g. v = 3: bvsmod(3, 8) = 3 >=s 1.
+|)
+(set-info :smt-lib-version 2.0)
+(set-info :category "check")
+(set-info :status sat)
+(declare-fun v () (_ BitVec 16))
+(assert (not (bvslt (bvsmod v (bvshl (_ bv1 16) v)) (_ bv1 16))))
+(check-sat)
+(exit)


### PR DESCRIPTION
## Summary

Fuzzing found a soundness bug: STP answers `unsat` on this satisfiable formula (e.g. `v = 3`: `bvsmod(3, 8) = 3`), and debug builds abort at `assert(arrayops)` in `STP.cpp:690` when the bogus model is detected:

```smt2
(set-logic QF_BV)
(declare-fun v () (_ BitVec 16))
(assert (not (bvslt (bvsmod v (bvshl (_ bv1 16) v)) (_ bv1 16))))
(check-sat)
```

## Cause

The signed modulus constant-bit propagator reimplemented in #522 fixed its output to all-zeros when the two operand `FixedBits` were the same pointer, reading pointer equality as "both operands are the same node" (`x smod x = 0`).

That inference is valid inside the iterative `ConstantBitPropagation` pass, where each node owns its `FixedBits` in a map — but not in `NodeDomainAnalysis::buildMap`, which hands every unknown operand of a given width the same shared placeholder object (`getEmptyFixedBits`). So any `bvsmod` whose two operands were both completely unknown was constant-folded to zero by StrengthReduction. Here `bvsmod(v, bvshl(1, v))` folded to 0, the surrounding constraint folded to a constant, and the formula came out unsat.

The neighbouring `bvsrem`/`bvsdiv` propagators have the same pointer check but only `return NO_CHANGE`, which is sound under aliasing.

## Fix

Drop the rule: on pointer-equal operands, skip the propagator like `bvsrem`/`bvsdiv` do, and document why nothing may be concluded from pointer equality. `x smod x` is simplified elsewhere anyway.

Adds a lit regression test with the formula above (minimised with ddSMT from the fuzzer-generated original).