### PR TITLE
Name introduced variables in SMT-LIB's reserved '@' namespace

### DIFF
--- a/include/stp/STPManager/STPManager.h
+++ b/include/stp/STPManager/STPManager.h
@@ -382,8 +382,11 @@ public:
   ASTNode CreateFreshVariable(int indexWidth, int valueWidth,
                               std::string prefix)
   {
+    // The '@' prefix puts the name in the namespace SMT-LIB 2 reserves for
+    // solver use: symbols beginning with '@' (or '.') may not be declared by
+    // the user, so an introduced variable can never collide with an input one.
     char* d = (char*)alloca(sizeof(char) * (32 + prefix.length()));
-    sprintf(d, "%s_%d", prefix.c_str(), _symbol_count++);
+    sprintf(d, "@%s_%d", prefix.c_str(), _symbol_count++);
     assert(!LookupSymbol(d));
 
     ASTNode CurrentSymbol = CreateSymbol(d, indexWidth, valueWidth);


### PR DESCRIPTION
## Summary

`STPMgr::CreateFreshVariable` generated names like `unconstrained_42`, `lhs_padding_7`, `STP_INTERNAL_comparison_3` — all in the **user's** symbol namespace. The only protection against a clash with an input-declared symbol was `assert(!LookupSymbol(d))`, which is compiled out under `NDEBUG`. In a release build, an input that declared a colliding name would silently make `CreateSymbol` return the user's existing symbol, aliasing an "unconstrained"/introduced variable onto a real, constrained one.

SMT-LIB 2 reserves symbols beginning with `@` (and `.`) for solver use — the user is not permitted to declare them. Prefixing introduced names with `@` therefore makes collisions impossible for conformant input.

## Change

One line in `CreateFreshVariable`: `"%s_%d"` → `"@%s_%d"`. This is the single site that mints introduced variables, so it covers every caller at once: unconstrained-variable elimination, extract splitting, the array transformer, `BVSolver`, the AIG propositional core, and interface-created parameters.

## Impact

- Introduced symbols are already tracked in `Introduced_SymbolsSet` and excluded from counter-example / model output, so models are unchanged (verified: `(get-model)` shows only user variables).
- No test or output path matches these names by string (checked the query-file `CHECK` directives and the unit tests).

## Validation

- Full unit suite: 56/56 pass.
- All `simplification-tests` query files match expected sat/unsat.