### PR TITLE
Support SMT-LIB 2.7 bit-vector overflow predicates

### DIFF
--- a/include/stp/AST/ASTNode.h
+++ b/include/stp/AST/ASTNode.h
@@ -115,7 +115,8 @@ public:
   {
     const Kind k = GetKind();
     return k == BVLT || k == BVLE || k == BVGT || k == BVGE || k == BVSLT ||
-           k == BVSLE || k == BVSGT || k == BVSGE || k == EQ;
+           k == BVSLE || k == BVSGT || k == BVSGE || k == BVUADDO ||
+           k == BVSADDO || k == BVUMULO || k == BVSMULO || k == EQ;
   }
 
   // delegates to the ASTInternal node.

--- a/include/stp/ToSat/BitBlaster.h
+++ b/include/stp/ToSat/BitBlaster.h
@@ -188,6 +188,10 @@ class BitBlaster
   // Return bit-blasted form for BVLE, BVGE, BVGT, SBLE, etc.
   BBNode BBcompare(const ASTNode& form, BBNodeSet& support);
 
+  // Return bit-blasted form for the overflow predicates BVUADDO, BVSADDO,
+  // BVUMULO, BVSMULO.
+  BBNode BBOverflow(const ASTNode& form, BBNodeSet& support);
+
   void BBLShift(BBNodeVec& x, unsigned int shift);
   void BBRShift(BBNodeVec& x, unsigned int shift);
 

--- a/include/stp/c_interface.h
+++ b/include/stp/c_interface.h
@@ -1086,6 +1086,10 @@ enum exprkind_t
   BVSLE,        //!< Signed bitvector less-equals
   BVSGT,        //!< Signed bitvector greater-than
   BVSGE,        //!< Signed bitvector greater-equals
+  BVUADDO,      //!< Unsigned addition overflow predicate
+  BVSADDO,      //!< Signed addition overflow predicate
+  BVUMULO,      //!< Unsigned multiplication overflow predicate
+  BVSMULO,      //!< Signed multiplication overflow predicate
   EQ,           //!< Equality comparator
   FALSE,        //!< Constant false boolean expression
   TRUE,         //!< Constant true boolean expression

--- a/lib/AST/ASTKind.kinds
+++ b/lib/AST/ASTKind.kinds
@@ -64,6 +64,10 @@ BVSLT		2	2	Form
 BVSLE		2	2	Form
 BVSGT		2	2	Form
 BVSGE		2	2	Form
+BVUADDO		2	2	Form
+BVSADDO		2	2	Form
+BVUMULO		2	2	Form
+BVSMULO		2	2	Form
 EQ		2	2	Form
 FALSE		0	0	Form
 TRUE		0	0	Form

--- a/lib/AST/ASTmisc.cpp
+++ b/lib/AST/ASTmisc.cpp
@@ -569,6 +569,10 @@ bool BVTypeCheck_nonterm_kind(const ASTNode& n, const Kind& k)
     case BVSLE:
     case BVSGT:
     case BVSGE:
+    case BVUADDO:
+    case BVSADDO:
+    case BVUMULO:
+    case BVSMULO:
       if (n.Degree() != 2)
         FatalError("BVTypeCheck: should have exactly 2 args\n", n);
       if (BITVECTOR_TYPE != n[0].GetType() && BITVECTOR_TYPE != n[1].GetType())

--- a/lib/AbsRefineCounterExample/ArrayTransformer.cpp
+++ b/lib/AbsRefineCounterExample/ArrayTransformer.cpp
@@ -334,6 +334,10 @@ ASTNode ArrayTransformer::TransformFormula(const ASTNode& simpleForm)
     case BVSLE:
     case BVSGT:
     case BVSGE:
+    case BVUADDO:
+    case BVSADDO:
+    case BVUMULO:
+    case BVSMULO:
     {
       ASTVec c;
       c.push_back(TransformTerm(simpleForm[0]));

--- a/lib/AbsRefineCounterExample/CounterExample.cpp
+++ b/lib/AbsRefineCounterExample/CounterExample.cpp
@@ -500,6 +500,10 @@ ASTNode AbsRefine_CounterExample::ComputeFormulaUsingModel(const ASTNode& form)
     case BVSLE:
     case BVSGT:
     case BVSGE:
+    case BVUADDO:
+    case BVSADDO:
+    case BVUMULO:
+    case BVSMULO:
     {
       ASTVec children;
       children.reserve(form.Degree());

--- a/lib/Parser/smt2.lex
+++ b/lib/Parser/smt2.lex
@@ -277,6 +277,11 @@ bv{DIGIT}+             { smt2lval.str = new std::string(smt2text+2); return BVCO
 "repeat"        { return BVREPEAT_TOK;}
 "rotate_left"   { return BVROTATE_LEFT_TOK;}
 "rotate_right"  { return BVROTATE_RIGHT_TOK;}
+"bvnego"        { return BVNEGO_TOK;}
+"bvuaddo"       { return BVUADDO_TOK;}
+"bvsaddo"       { return BVSADDO_TOK;}
+"bvumulo"       { return BVUMULO_TOK;}
+"bvsmulo"       { return BVSMULO_TOK;}
 
  /* Functions for QF_AUFBV. */
 "select"        { return SELECT_TOK; }

--- a/lib/Parser/smt2.y
+++ b/lib/Parser/smt2.y
@@ -93,6 +93,10 @@
   using stp::BVSLE;        //!< Signed bitvector less-equals
   using stp::BVSGT;        //!< Signed bitvector greater-than
   using stp::BVSGE;        //!< Signed bitvector greater-equals
+  using stp::BVUADDO;      //!< Unsigned addition overflow predicate
+  using stp::BVSADDO;      //!< Signed addition overflow predicate
+  using stp::BVUMULO;      //!< Unsigned multiplication overflow predicate
+  using stp::BVSMULO;      //!< Signed multiplication overflow predicate
   using stp::EQ;           //!< Equality comparator
   using stp::FALSE;        //!< Constant false boolean expression
   using stp::TRUE;         //!< Constant true boolean expression
@@ -147,6 +151,10 @@
   using stp::BVSLE;        //!< Signed bitvector less-equals
   using stp::BVSGT;        //!< Signed bitvector greater-than
   using stp::BVSGE;        //!< Signed bitvector greater-equals
+  using stp::BVUADDO;      //!< Unsigned addition overflow predicate
+  using stp::BVSADDO;      //!< Signed addition overflow predicate
+  using stp::BVUMULO;      //!< Unsigned multiplication overflow predicate
+  using stp::BVSMULO;      //!< Signed multiplication overflow predicate
   using stp::EQ;           //!< Equality comparator
   using stp::FALSE;        //!< Constant false boolean expression
   using stp::TRUE;         //!< Constant true boolean expression
@@ -240,6 +248,23 @@
     ASTNode * n = stp::GlobalParserInterface->newNode(stp::GlobalParserInterface->nf->CreateTerm(k, width, *c0, *c1));
     delete c0;
     delete c1;
+    return n;
+  }
+
+  // (bvnego s) is true iff negating s overflows, i.e. iff s is the signed
+  // minimum value INT_MIN (100...0). Desugar it to (= s INT_MIN).
+  ASTNode* createNegOverflow(ASTNode* c0)
+  {
+    auto gi = stp::GlobalParserInterface;
+    const unsigned int width = c0->GetValueWidth();
+    ASTNode intMin;
+    if (width == 1)
+      intMin = gi->CreateOneConst(1);
+    else
+      intMin = gi->nf->CreateTerm(BVCONCAT, width, gi->CreateOneConst(1),
+                                  gi->CreateZeroConst(width - 1));
+    ASTNode* n = gi->newNode(gi->nf->CreateNode(EQ, *c0, intMin));
+    delete c0;
     return n;
   }
 
@@ -337,6 +362,12 @@
 %token BVROTATE_LEFT_TOK
 %token BVREPEAT_TOK
 %token BVCOMP_TOK
+
+%token BVNEGO_TOK
+%token BVUADDO_TOK
+%token BVSADDO_TOK
+%token BVUMULO_TOK
+%token BVSMULO_TOK
 
  /* Types for QF_BV and QF_AUFBV. */
 %token BITVEC_TOK
@@ -965,6 +996,26 @@ TRUE_TOK
 | LPAREN_TOK BVGE_TOK an_term an_term RPAREN_TOK
 {
   $$ = createNode(BVGE, $3, $4);
+}
+| LPAREN_TOK BVUADDO_TOK an_term an_term RPAREN_TOK
+{
+  $$ = createNode(BVUADDO, $3, $4);
+}
+| LPAREN_TOK BVSADDO_TOK an_term an_term RPAREN_TOK
+{
+  $$ = createNode(BVSADDO, $3, $4);
+}
+| LPAREN_TOK BVUMULO_TOK an_term an_term RPAREN_TOK
+{
+  $$ = createNode(BVUMULO, $3, $4);
+}
+| LPAREN_TOK BVSMULO_TOK an_term an_term RPAREN_TOK
+{
+  $$ = createNode(BVSMULO, $3, $4);
+}
+| LPAREN_TOK BVNEGO_TOK an_term RPAREN_TOK
+{
+  $$ = createNegOverflow($3);
 }
 | LPAREN_TOK an_formula RPAREN_TOK
 {

--- a/lib/Printer/PLPrinter.cpp
+++ b/lib/Printer/PLPrinter.cpp
@@ -59,6 +59,10 @@ string functionToCVCName(const Kind k)
     case SBVMOD:
     case BVDIV:
     case BVMOD:
+    case BVUADDO:
+    case BVSADDO:
+    case BVUMULO:
+    case BVSMULO:
       return _kind_names[k];
       break;
     case BVSLT:
@@ -281,6 +285,10 @@ void PL_Print1(ostream& os, const ASTNode& n, int indentation, bool letize,
     case BVSLE:
     case BVSGT:
     case BVSGE:
+    case BVUADDO:
+    case BVSADDO:
+    case BVUMULO:
+    case BVSMULO:
       assert(2 == c.size());
       os << functionToCVCName(kind) << "(";
       PL_Print1(os, c[0], indentation, letize, bm);

--- a/lib/Printer/SMTLIBPrinter.cpp
+++ b/lib/Printer/SMTLIBPrinter.cpp
@@ -211,6 +211,10 @@ string functionToSMTLIBName(const Kind k, bool smtlib1)
     case BVSLE:
     case BVSLT:
     case BVSUB:
+    case BVUADDO:
+    case BVSADDO:
+    case BVUMULO:
+    case BVSMULO:
     case BVXOR:
     case ITE:
     case NAND:

--- a/lib/Simplifier/Simplifier.cpp
+++ b/lib/Simplifier/Simplifier.cpp
@@ -501,6 +501,18 @@ ASTNode Simplifier::SimplifyAtomicFormula(const ASTNode& a, bool pushNeg,
       output = CreateSimplifiedINEQ(kind, left, right, pushNeg);
       break;
     }
+    case BVUADDO:
+    case BVSADDO:
+    case BVUMULO:
+    case BVSMULO:
+    {
+      // Overflow predicates are not inequalities; just rebuild with the
+      // simplified children (constant children are folded by the node
+      // factory) and honour pushNeg.
+      output = nf->CreateNode(kind, left, right);
+      output = pushNeg ? nf->CreateNode(NOT, output) : output;
+      break;
+    }
     default:
       FatalError("SimplifyAtomicFormula: "
                  "NO atomic formula of the kind: ",

--- a/lib/Simplifier/consteval.cpp
+++ b/lib/Simplifier/consteval.cpp
@@ -661,6 +661,79 @@ ASTNode NonMemberBVConstEvaluator(STPMgr* _bm, const Kind k,
       break;
     }
 
+    // Overflow predicates. These are Form nodes, so 'inputwidth' is 0; the
+    // operand width comes from the children.
+    case BVUADDO:
+    {
+      assert(2 == number_of_children);
+      const unsigned w = children[0].GetValueWidth();
+      CBV sum = CONSTANTBV::BitVector_Create(w, true);
+      bool carry = false;
+      CONSTANTBV::BitVector_add(sum, tmp0, tmp1, &carry);
+      CONSTANTBV::BitVector_Destroy(sum);
+      OutputNode = carry ? ASTTrue : ASTFalse;
+      break;
+    }
+    case BVSADDO:
+    {
+      assert(2 == number_of_children);
+      const unsigned w = children[0].GetValueWidth();
+      CBV sum = CONSTANTBV::BitVector_Create(w, true);
+      bool carry = false;
+      CONSTANTBV::BitVector_add(sum, tmp0, tmp1, &carry);
+      // Signed add overflows iff both operands share a sign that differs
+      // from the sign of the result.
+      const bool s0 = CONSTANTBV::BitVector_msb_(tmp0);
+      const bool s1 = CONSTANTBV::BitVector_msb_(tmp1);
+      const bool ss = CONSTANTBV::BitVector_msb_(sum);
+      CONSTANTBV::BitVector_Destroy(sum);
+      OutputNode = ((s0 == s1) && (s0 != ss)) ? ASTTrue : ASTFalse;
+      break;
+    }
+    case BVUMULO:
+    case BVSMULO:
+    {
+      assert(2 == number_of_children);
+      const unsigned w = children[0].GetValueWidth();
+      const bool isSigned = (k == BVSMULO);
+      // Extend both operands to 2w (zero- or sign-extend), multiply exactly,
+      // then inspect the high bits. The 2w product always fits, so the signed
+      // BitVector_Multiply never reports a spurious overflow.
+      CBV y2 = CONSTANTBV::BitVector_Create(2 * w, true);
+      CBV z2 = CONSTANTBV::BitVector_Create(2 * w, true);
+      CBV prod = CONSTANTBV::BitVector_Create(2 * w, true);
+      if (isSigned && CONSTANTBV::BitVector_Sign(tmp0) < 0)
+        CONSTANTBV::BitVector_Fill(y2);
+      if (isSigned && CONSTANTBV::BitVector_Sign(tmp1) < 0)
+        CONSTANTBV::BitVector_Fill(z2);
+      CONSTANTBV::BitVector_Interval_Copy(y2, tmp0, 0, 0, w);
+      CONSTANTBV::BitVector_Interval_Copy(z2, tmp1, 0, 0, w);
+      CONSTANTBV::ErrCode e = CONSTANTBV::BitVector_Multiply(prod, y2, z2);
+      if (0 != e)
+        BVConstEvaluatorError(e);
+      bool overflow = false;
+      if (isSigned)
+      {
+        // Overflow iff the product is not the sign-extension of its low w bits.
+        const bool sign = CONSTANTBV::BitVector_bit_test(prod, w - 1);
+        for (unsigned i = w; i < 2 * w; i++)
+          if (CONSTANTBV::BitVector_bit_test(prod, i) != sign)
+            overflow = true;
+      }
+      else
+      {
+        // Overflow iff any high bit is set.
+        for (unsigned i = w; i < 2 * w; i++)
+          if (CONSTANTBV::BitVector_bit_test(prod, i))
+            overflow = true;
+      }
+      CONSTANTBV::BitVector_Destroy(y2);
+      CONSTANTBV::BitVector_Destroy(z2);
+      CONSTANTBV::BitVector_Destroy(prod);
+      OutputNode = overflow ? ASTTrue : ASTFalse;
+      break;
+    }
+
     case TRUE:
       OutputNode = ASTTrue;
       break;

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -1157,6 +1157,15 @@ const BBNode BitBlaster<BBNode, BBNodeManagerT>::BBForm(const ASTNode& form,
       result = BBcompare(form, support);
       break;
     }
+
+    case BVUADDO:
+    case BVSADDO:
+    case BVUMULO:
+    case BVSMULO:
+    {
+      result = BBOverflow(form, support);
+      break;
+    }
     default:
       FatalError("BBForm: Illegal kind: ", form);
       break;
@@ -2882,6 +2891,76 @@ BBNode BitBlaster<BBNode, BBNodeManagerT>::BBcompare(const ASTNode& form,
     }
     default:
       cerr << "BBCompare: Illegal kind" << form << endl;
+      FatalError("", form);
+      exit(-1);
+  }
+}
+
+// Return bit-blasted form for the overflow predicates BVUADDO, BVSADDO,
+// BVUMULO, BVSMULO. Each returns a single boolean.
+template <class BBNode, class BBNodeManagerT>
+BBNode BitBlaster<BBNode, BBNodeManagerT>::BBOverflow(const ASTNode& form,
+                                                      BBNodeSet& support)
+{
+  const Kind k = form.GetKind();
+  const unsigned w = form[0].GetValueWidth();
+  assert(w > 0);
+
+  switch (k)
+  {
+    case BVUADDO:
+    {
+      // Overflow == carry-out of the unsigned addition. Zero-extend both
+      // operands by one bit, add, and return the top bit of the sum.
+      BBNodeVec l = BBTerm(form[0], support);
+      BBNodeVec r = BBTerm(form[1], support);
+      l.push_back(nf->getFalse());
+      r.push_back(nf->getFalse());
+      BBPlus2(l, r, nf->getFalse());
+      return l[w];
+    }
+    case BVSADDO:
+    {
+      // Sign-extend both operands by one bit, add, and check whether the two
+      // top bits of the (w+1)-bit sum disagree.
+      BBNodeVec l = BBTerm(form[0], support);
+      BBNodeVec r = BBTerm(form[1], support);
+      l.push_back(l[w - 1]);
+      r.push_back(r[w - 1]);
+      BBPlus2(l, r, nf->getFalse());
+      return nf->CreateNode(XOR, l[w], l[w - 1]);
+    }
+    case BVUMULO:
+    case BVSMULO:
+    {
+      // Build the exact 2w-bit product (via zero/sign-extended operands) and
+      // reuse the existing multiplier, then inspect the high bits.
+      const Kind ext = (k == BVUMULO) ? BVZX : BVSX;
+      const ASTNode widthConst = ASTNF->CreateBVConst(32, 2 * w);
+      const ASTNode xE = ASTNF->CreateTerm(ext, 2 * w, form[0], widthConst);
+      const ASTNode yE = ASTNF->CreateTerm(ext, 2 * w, form[1], widthConst);
+      const ASTNode prod = ASTNF->CreateTerm(BVMULT, 2 * w, xE, yE);
+      const BBNodeVec p = BBTerm(prod, support);
+
+      if (k == BVUMULO)
+      {
+        // Overflow iff any high bit is set.
+        BBNodeVec high(p.begin() + w, p.end());
+        return nf->CreateNode(OR, high);
+      }
+      else
+      {
+        // Overflow iff the product is not the sign-extension of its low w bits,
+        // i.e. some bit above w-1 differs from the sign bit p[w-1].
+        BBNodeVec diffs;
+        diffs.reserve(w);
+        for (unsigned i = w; i < 2 * w; i++)
+          diffs.push_back(nf->CreateNode(XOR, p[i], p[w - 1]));
+        return nf->CreateNode(OR, diffs);
+      }
+    }
+    default:
+      cerr << "BBOverflow: Illegal kind" << form << endl;
       FatalError("", form);
       exit(-1);
   }

--- a/tests/query-files/overflow-tests/bvnego_equiv.smt2
+++ b/tests/query-files/overflow-tests/bvnego_equiv.smt2
@@ -1,0 +1,9 @@
+; RUN: %solver %s | %OutputCheck %s
+(set-logic QF_BV)
+(declare-fun x () (_ BitVec 8))
+; bvnego(x) iff x is the signed minimum (0x80), and independently iff -x==x and x!=0.
+(assert (not (= (bvnego x) (= x #x80))))
+(assert (not (= (bvnego x) (and (= x (bvneg x)) (distinct x #x00)))))
+; CHECK-NEXT: ^unsat
+(check-sat)
+(exit)

--- a/tests/query-files/overflow-tests/bvsaddo_equiv.smt2
+++ b/tests/query-files/overflow-tests/bvsaddo_equiv.smt2
@@ -1,0 +1,11 @@
+; RUN: %solver %s | %OutputCheck %s
+(set-logic QF_BV)
+(declare-fun x () (_ BitVec 8))
+(declare-fun y () (_ BitVec 8))
+; bvsaddo(x,y) iff operands share a sign that differs from the sum's sign.
+(assert (not (= (bvsaddo x y)
+  (and (= ((_ extract 7 7) x) ((_ extract 7 7) y))
+       (distinct ((_ extract 7 7) x) ((_ extract 7 7) (bvadd x y)))))))
+; CHECK-NEXT: ^unsat
+(check-sat)
+(exit)

--- a/tests/query-files/overflow-tests/bvsmulo_equiv.smt2
+++ b/tests/query-files/overflow-tests/bvsmulo_equiv.smt2
@@ -1,0 +1,11 @@
+; RUN: %solver %s | %OutputCheck %s
+(set-logic QF_BV)
+(declare-fun x () (_ BitVec 8))
+(declare-fun y () (_ BitVec 8))
+; bvsmulo(x,y) iff the widened product isn't the sign-extension of its low 8 bits.
+(assert (not (= (bvsmulo x y)
+  (let ((p (bvmul ((_ sign_extend 8) x) ((_ sign_extend 8) y))))
+    (distinct p ((_ sign_extend 8) ((_ extract 7 0) p)))))))
+; CHECK-NEXT: ^unsat
+(check-sat)
+(exit)

--- a/tests/query-files/overflow-tests/bvuaddo_equiv.smt2
+++ b/tests/query-files/overflow-tests/bvuaddo_equiv.smt2
@@ -1,0 +1,9 @@
+; RUN: %solver %s | %OutputCheck %s
+(set-logic QF_BV)
+(declare-fun x () (_ BitVec 8))
+(declare-fun y () (_ BitVec 8))
+; bvuaddo(x,y) iff the unsigned sum wraps below x.
+(assert (not (= (bvuaddo x y) (bvult (bvadd x y) x))))
+; CHECK-NEXT: ^unsat
+(check-sat)
+(exit)

--- a/tests/query-files/overflow-tests/bvumulo_equiv.smt2
+++ b/tests/query-files/overflow-tests/bvumulo_equiv.smt2
@@ -1,0 +1,10 @@
+; RUN: %solver %s | %OutputCheck %s
+(set-logic QF_BV)
+(declare-fun x () (_ BitVec 8))
+(declare-fun y () (_ BitVec 8))
+; bvumulo(x,y) iff the high half of the widened product is nonzero.
+(assert (not (= (bvumulo x y)
+  (distinct ((_ extract 15 8) (bvmul ((_ zero_extend 8) x) ((_ zero_extend 8) y))) #x00))))
+; CHECK-NEXT: ^unsat
+(check-sat)
+(exit)

--- a/tests/query-files/overflow-tests/overflow_constants.smt2
+++ b/tests/query-files/overflow-tests/overflow_constants.smt2
@@ -1,0 +1,15 @@
+; RUN: %solver %s | %OutputCheck %s
+(set-logic QF_BV)
+(assert (bvuaddo #xFF #x01))
+(assert (not (bvuaddo #x7F #x01)))
+(assert (bvsaddo #x7F #x01))
+(assert (not (bvsaddo #xFF #x01)))
+(assert (bvumulo #x10 #x10))
+(assert (not (bvumulo #x0F #x10)))
+(assert (bvsmulo #x40 #x02))
+(assert (not (bvsmulo #xFF #x02)))
+(assert (bvnego #x80))
+(assert (not (bvnego #x7F)))
+; CHECK-NEXT: ^sat
+(check-sat)
+(exit)

--- a/tests/query-files/overflow-tests/overflow_sat.smt2
+++ b/tests/query-files/overflow-tests/overflow_sat.smt2
@@ -1,0 +1,9 @@
+; RUN: %solver %s | %OutputCheck %s
+(set-logic QF_BV)
+(declare-fun x () (_ BitVec 8))
+(declare-fun y () (_ BitVec 8))
+(assert (bvsmulo x y))
+(assert (bvuaddo x y))
+; CHECK-NEXT: ^sat
+(check-sat)
+(exit)

--- a/tests/query-files/overflow-tests/overflow_width1.smt2
+++ b/tests/query-files/overflow-tests/overflow_width1.smt2
@@ -1,0 +1,12 @@
+; RUN: %solver %s | %OutputCheck %s
+(set-logic QF_BV)
+(declare-fun a () (_ BitVec 1))
+(declare-fun b () (_ BitVec 1))
+(assert (not (= (bvnego a) (= a #b1))))
+(assert (not (= (bvuaddo a b) (bvult (bvadd a b) a))))
+(assert (not (= (bvsmulo a b)
+  (let ((p (bvmul ((_ sign_extend 1) a) ((_ sign_extend 1) b))))
+    (distinct p ((_ sign_extend 1) ((_ extract 0 0) p)))))))
+; CHECK-NEXT: ^unsat
+(check-sat)
+(exit)


### PR DESCRIPTION
Adds the five overflow-detection predicates that SMT-LIB's `FixedSizeBitVectors` theory (v2.7, 2024-07-21) added to `QF_BV`: `bvnego`, `bvuaddo`, `bvsaddo`, `bvumulo`, `bvsmulo`. These are the only new *QF_BV* language feature STP was missing (the other 2.7 additions — `ubv_to_int`/`sbv_to_int`/`int_to_bv` — need an integer theory STP doesn't have, so they're out of scope).

## Approach

| Operator | Representation |
|---|---|
| `bvnego s` | parse-time desugar to `(= s INT_MIN)` — its expansion is a single equality against a constant, so a dedicated kind buys nothing |
| `bvuaddo` `bvsaddo` `bvumulo` `bvsmulo` | first-class node kinds (`BVUADDO`/`BVSADDO`/`BVUMULO`/`BVSMULO`) |

The four binary kinds are threaded through type-checking (`ASTmisc.cpp`), constant folding (`consteval.cpp`), the array transformer, `SimplifyAtomicFormula`, the counterexample/model path, bit-blasting, and the SMTLIB/PL printers. They're also inserted into the parallel `exprkind_t` enum in `c_interface.h` to keep `getExprKind`'s cast in sync.

**Bit-blasting reuses existing machinery** rather than hand-writing circuits:
- add-overflow = carry-out of a one-bit-wider `BBPlus2`;
- mul-overflow builds a real `2w`-wide `BVMULT` node (zero/sign-extended operands) and inspects the high bits, reusing the full multiplier (Booth recoding, addition networks, etc.).

**Constant folding** uses CONSTANTBV `add`/`msb_`/`Multiply`, extending operands to `2w` so the signed multiply never spuriously reports overflow.

## Semantics (width `w`)

- `bvnego s` — `-s` overflows ⇔ `s = INT_MIN` (`100…0`)
- `bvuaddo s t` — `uint(s)+uint(t) ≥ 2^w`
- `bvsaddo s t` — `int(s)+int(t)` outside `[−2^(w−1), 2^(w−1)−1]`
- `bvumulo s t` — `uint(s)·uint(t) ≥ 2^w`
- `bvsmulo s t` — `int(s)·int(t)` outside the signed range

## Testing

New lit tests under `tests/query-files/overflow-tests/` check each operator against an **independent reference expansion** (equivalence probes, must be UNSAT), plus constant-folding, width-1 edge cases, and a satisfiable-with-model case. Full `ctest` passes (56/56; query-files 152/152). Reference expansions were independently confirmed with z3.

Note: the four binary kinds round-trip as themselves via the SMTLIB printer name table; `bvnego` prints as its desugared form. `CPrinter` (a partial printer that already `FatalError`s on many kinds) is left as-is.