### PR TITLE
Fix spurious fatal error when constant folding bvumulo/bvsmulo

### DIFF
--- a/lib/Simplifier/consteval.cpp
+++ b/lib/Simplifier/consteval.cpp
@@ -696,12 +696,16 @@ ASTNode NonMemberBVConstEvaluator(STPMgr* _bm, const Kind k,
       assert(2 == number_of_children);
       const unsigned w = children[0].GetValueWidth();
       const bool isSigned = (k == BVSMULO);
-      // Extend both operands to 2w (zero- or sign-extend), multiply exactly,
-      // then inspect the high bits. The 2w product always fits, so the signed
-      // BitVector_Multiply never reports a spurious overflow.
-      CBV y2 = CONSTANTBV::BitVector_Create(2 * w, true);
-      CBV z2 = CONSTANTBV::BitVector_Create(2 * w, true);
-      CBV prod = CONSTANTBV::BitVector_Create(2 * w, true);
+      // Extend both operands (zero- or sign-extend), multiply exactly, then
+      // inspect the high bits. BitVector_Multiply is a signed multiply that
+      // reports overflow once the product's magnitude reaches the
+      // destination's sign bit, so the intermediates need 2w+1 bits: an
+      // unsigned product can be up to (2^w-1)^2, which exceeds the signed
+      // 2w-bit maximum but fits in 2w+1 bits.
+      const unsigned ew = 2 * w + 1;
+      CBV y2 = CONSTANTBV::BitVector_Create(ew, true);
+      CBV z2 = CONSTANTBV::BitVector_Create(ew, true);
+      CBV prod = CONSTANTBV::BitVector_Create(ew, true);
       if (isSigned && CONSTANTBV::BitVector_Sign(tmp0) < 0)
         CONSTANTBV::BitVector_Fill(y2);
       if (isSigned && CONSTANTBV::BitVector_Sign(tmp1) < 0)
@@ -716,14 +720,14 @@ ASTNode NonMemberBVConstEvaluator(STPMgr* _bm, const Kind k,
       {
         // Overflow iff the product is not the sign-extension of its low w bits.
         const bool sign = CONSTANTBV::BitVector_bit_test(prod, w - 1);
-        for (unsigned i = w; i < 2 * w; i++)
+        for (unsigned i = w; i < ew; i++)
           if (CONSTANTBV::BitVector_bit_test(prod, i) != sign)
             overflow = true;
       }
       else
       {
         // Overflow iff any high bit is set.
-        for (unsigned i = w; i < 2 * w; i++)
+        for (unsigned i = w; i < ew; i++)
           if (CONSTANTBV::BitVector_bit_test(prod, i))
             overflow = true;
       }

--- a/tests/query-files/overflow-tests/overflow_constants_large_product.smt2
+++ b/tests/query-files/overflow-tests/overflow_constants_large_product.smt2
@@ -1,0 +1,22 @@
+; RUN: %solver %s | %OutputCheck %s
+; Regression test: constant folding of bvumulo used to abort with
+; "BVConstEvaluator:numeric overflow error" whenever the exact product
+; reached 2^(2w-1), because the 2w-bit intermediate was multiplied with
+; the signed, strict-overflow BitVector_Multiply.
+(set-logic QF_BV)
+; 11585^2 = 134212225 < 2^27: never crashed, overflows 14 bits.
+(assert (bvumulo (_ bv11585 14) (_ bv11585 14)))
+; 11586^2 = 134235396 >= 2^27: smallest square past the old crash boundary.
+(assert (bvumulo (_ bv11586 14) (_ bv11586 14)))
+; Maximal operands.
+(assert (bvumulo (_ bv16383 14) (_ bv16383 14)))
+(assert (bvumulo #xFF #xFF))
+; Small product: no overflow.
+(assert (not (bvumulo (_ bv3 14) (_ bv5 14))))
+; Signed cases with most-negative operands.
+(assert (bvsmulo #x80 #x80))
+(assert (bvsmulo (_ bv8192 14) (_ bv8192 14)))
+(assert (not (bvsmulo #xFF #x02)))
+; CHECK-NEXT: ^sat
+(check-sat)
+(exit)


### PR DESCRIPTION
Constant evaluation of the multiply-overflow predicates (added in #538) extends both operands to 2w bits and multiplies with `BitVector_Multiply`. That routine is a **signed** multiply with strict overflow checking: it reports `ErrCode_Ovfl` as soon as the product's magnitude reaches the destination's sign bit. An unsigned w-bit product can be as large as (2^w − 1)², which exceeds the signed 2w-bit maximum of 2^(2w−1) − 1, so any constant `bvumulo` whose exact product reached 2^(2w−1) aborted at parse time:

```
(assert (bvumulo (_ bv11586 14) (_ bv11586 14)))
; Fatal Error: BVConstEvaluator:numeric overflow error
```

(`bvsmulo` was safe in practice — a signed product's magnitude is at most 2^(2w−2) — but gets the same headroom.)

**Fix:** widen the intermediates to 2w+1 bits so the destination's sign bit is unreachable and the strict multiply can never spuriously overflow.

**Verification:**
- The fuzzsmt-generated QF_ABV file that exposed the bug now solves (`sat`, confirmed against bitwuzla).
- Exhaustive width-4 sweep: all 256 operand pairs for both `bvumulo` and `bvsmulo` constant-fold to ground truth.
- New regression test `overflow_constants_large_product.smt2` covers the old crash boundary (11585² < 2^27 ≤ 11586²), maximal operands, and most-negative signed operands.
- All 12 existing overflow-tests still pass.