### PR TITLE
Fix operand reordering of non-commutative overflow predicates

### DIFF
--- a/lib/AST/ASTmisc.cpp
+++ b/lib/AST/ASTmisc.cpp
@@ -208,7 +208,9 @@ bool isAtomic(Kind kind)
 {
   if (TRUE == kind || FALSE == kind || EQ == kind || BVLT == kind ||
       BVLE == kind || BVGT == kind || BVGE == kind || BVSLT == kind ||
-      BVSLE == kind || BVSGT == kind || BVSGE == kind || SYMBOL == kind ||
+      BVSLE == kind || BVSGT == kind || BVSGE == kind || BVUADDO == kind ||
+      BVSADDO == kind || BVUMULO == kind || BVSMULO == kind ||
+      BVUSUBO == kind || BVSSUBO == kind || SYMBOL == kind ||
       BOOLEXTRACT == kind)
     return true;
   return false;

--- a/tests/query-files/overflow-tests/bvssubo_operand_order.smt2
+++ b/tests/query-files/overflow-tests/bvssubo_operand_order.smt2
@@ -1,0 +1,13 @@
+; RUN: %solver --difficulty-reversion=0 %s | %OutputCheck %s
+(set-logic QF_BV)
+(declare-fun x () (_ BitVec 1))
+; bvssubo(x, 1) is true iff x = 0 (0 - (-1) = 1 overflows the 1-bit signed
+; range), so this is satisfiable. The swapped bvssubo(1, x) is false for
+; both values of x, so a simplifier that reorders the operands (e.g. via
+; SortByArith, which puts constants first) turns this into unsat.
+; Difficulty reversion is disabled because it happens to undo the reordering
+; on a formula this small, masking the bug.
+(assert (bvssubo x (_ bv1 1)))
+; CHECK-NEXT: ^sat
+(check-sat)
+(exit)


### PR DESCRIPTION
## Problem

Fuzzing against bitwuzla (QF_ABV, fuzzsmt with the SMT-LIB 2.7 overflow predicates) hit `Assertion 'arrayops' failed` at `STP.cpp:690`, and with assertions disabled STP silently answers **unsat** on satisfiable formulas such as:

```smt2
(declare-fun x () (_ BitVec 1))
(assert (bvssubo x (_ bv1 1)))  ; sat: x = 0 gives 0 - (-1) = 1, which overflows
(check-sat)
```

## Cause

The six overflow predicate kinds (`BVUADDO`, `BVSADDO`, `BVUMULO`, `BVSMULO`, `BVUSUBO`, `BVSSUBO`) added in #538/#539 were missing from `isAtomic()` in `lib/AST/ASTmisc.cpp`. `Simplifier::SimplifyFormula` sorts the children of any formula node that isn't `IMPLIES`/`ITE`/`PARAMBOOL`/atomic with `SortByArith`, which moves constants to the front. That's fine for boolean connectives, but for the non-commutative subtraction predicates it changes the meaning: `(bvssubo x #b1)` was rewritten to `(bvssubo #b1 x)`.

The visible symptom depends on the build: the SAT solver finds a model of the reordered formula, the model check against the original formula fails ('bogus counterexample'), `CallSAT_ResultCheck` returns `SOLVER_UNDECIDED`, and since the formula has no array reads to refine, debug builds trip `assert(arrayops)` while release builds go on to give a wrong answer.

## Fix

Add the six overflow kinds to `isAtomic()` so they take the same path as the comparison predicates. The addition/multiplication predicates are commutative so sorting happened to be harmless for them, but they are atomic formulas and shouldn't reach the sorting path either.

The regression test passes `--difficulty-reversion=0` because on a formula this small the difficulty reversion happens to restore the original operand order, masking the bug.

Verified: the fuzzer's failing 2500-problem bulk file now completes with results matching bitwuzla everywhere bitwuzla finished, and all existing overflow-tests still pass.