### PR TITLE
Keep discovered variable-to-constant assignments when difficulty reversion runs

### DIFF
--- a/lib/STPManager/STP.cpp
+++ b/lib/STPManager/STP.cpp
@@ -604,6 +604,17 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input)
 
     if (bm->UserFlags.stats_flag)
       cerr << "simplification made the problem harder, reverting." << endl;
+
+    // Variable-to-constant assignments discovered during the discarded
+    // simplification can't make the problem harder, so they are re-applied
+    // to the reverted formula.
+    ASTNodeMap keptConstants;
+    for (const auto& e : *simp->Return_SolverMap())
+      if (e.first.GetKind() == SYMBOL && e.second.isConstant() &&
+          revert->initialSolverMap.find(e.first) ==
+              revert->initialSolverMap.end())
+        keptConstants.insert(e);
+
     inputToSat = revert->toRevertTo;
 
     // I do this to clear the substitution/solver map.
@@ -614,6 +625,19 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input)
     simp->Return_SolverMap()->insert(revert->initialSolverMap.begin(),
                                      revert->initialSolverMap.end());
     revert->initialSolverMap.clear();
+
+    if (keptConstants.size() > 0)
+    {
+      if (bm->UserFlags.stats_flag)
+        cerr << "Re-applying " << keptConstants.size()
+             << " discovered constants." << endl;
+      ASTNodeMap cache;
+      inputToSat = SubstitutionMap::replace(inputToSat, keptConstants, cache,
+                                            bm->defaultNodeFactory);
+      simp->Return_SolverMap()->insert(keptConstants.begin(),
+                                       keptConstants.end());
+      bm->ASTNodeStats("after reverting: ", inputToSat);
+    }
 
     // Copy back what we knew about arrays at the start..
     arrayTransformer->arrayToIndexToRead.clear();


### PR DESCRIPTION
When the difficulty reversion decides that speculative simplification made the problem harder, it discards everything the main simplification phase learned — including variable-to-constant assignments. Replacing a variable by a constant can't make the problem harder (each one strictly removes a variable), so those discoveries are worth keeping even when the rest of the simplification is reverted.

This change harvests solver-map entries mapping a `SYMBOL` to a constant before the map is cleared (skipping keys already present in the pre-snapshot map, which are already baked into the reverted formula), then applies them to the reverted formula with `SubstitutionMap::replace` and inserts them into the restored solver map so counterexample construction still assigns the eliminated variables. With `-s`, `Re-applying N discovered constants.` is printed when the path fires.

This is sound also for constants recorded by satisfiability-preserving passes (pure literals, unconstrained elimination): the solver-map model-reconstruction invariant guarantees a model of the snapshot formula exists in which those variables take exactly the recorded constant values.

Testing:
- Full ctest suite passes (debug build, assertions on).
- The path is rarely taken in practice (the pre-snapshot pipeline runs size-reducing simplification to a fixed point, and a main-phase constant usually reduces difficulty enough to avoid reverting). To stress it, I built a temporary binary with `worse = true` forced so every problem reverts: the query-files lit results were identical with and without this change, and a differential sat/unsat comparison against an unmodified build over ~2500 fuzzed QF_BV files produced no mismatches, with the re-application path firing on 5 of them.
- On `tests/query-files/simplification-tests/mod.smt2` (forced reversion), the kept constant reduces the reverted formula to 4 nodes and `-p -d` produces a verified model.