### PR TITLE
Fix worst-case blowup in the multiply interval propagator's minlin

### DIFF
--- a/lib/Simplifier/UnsignedIntervalAnalysis.cpp
+++ b/lib/Simplifier/UnsignedIntervalAnalysis.cpp
@@ -797,7 +797,9 @@ namespace stp
     // Between wraps the values only grow, so the minimum is b or a
     // post-wrap residue; the residues just after each wrap follow the
     // progression b1 + j*((-m) mod a) inside [0, a), which the loop
-    // chases Euclid-style: O(log m) iterations.
+    // chases Euclid-style. A step above m/2 first flips to the same
+    // progression walked backwards, so the modulus at least halves
+    // every level: O(log m) iterations.
     uint128 minlin(uint128 n, uint128 m, uint128 a, uint128 b)
     {
       uint128 best = b;
@@ -807,6 +809,14 @@ namespace stp
           best = b; // the value at i = 0 of this level
         if (a == 0 || n == 1)
           return best;
+        if (a > m / 2)
+        {
+          // The same value set, traversed from its last element with
+          // the complementary step.
+          b = (b + (n - 1) * a) % m;
+          a = m - a;
+          continue;
+        }
         const uint128 firstWrap = (m - b + a - 1) / a;
         if (firstWrap >= n)
           return best; // never wraps, so the values only grow from b

--- a/tests/unit-tests/UnsignedIntervalPropagators_Test.cpp
+++ b/tests/unit-tests/UnsignedIntervalPropagators_Test.cpp
@@ -26,6 +26,7 @@ THE SOFTWARE.
 #include "stp/NodeFactory/SimplifyingNodeFactory.h"
 #include "stp/Simplifier/UnsignedIntervalAnalysis.h"
 #include "stp/Simplifier/UnsignedInterval.h"
+#include <cstdint>
 #include <gtest/gtest.h>
 #include <vector>
 
@@ -51,22 +52,22 @@ struct Context
   }
 };
 
-stp::CBV makeCBV(unsigned width, unsigned value)
+stp::CBV makeCBV(unsigned width, uint64_t value)
 {
   stp::CBV r = CONSTANTBV::BitVector_Create(width, true);
-  for (unsigned i = 0; i < width && i < 8 * sizeof(unsigned); i++)
+  for (unsigned i = 0; i < width && i < 64; i++)
     if ((value >> i) & 1)
       CONSTANTBV::BitVector_Bit_On(r, i);
   return r;
 }
 
-stp::UnsignedInterval* makeInterval(unsigned width, unsigned min, unsigned max)
+stp::UnsignedInterval* makeInterval(unsigned width, uint64_t min, uint64_t max)
 {
   return new stp::UnsignedInterval(makeCBV(width, min), makeCBV(width, max));
 }
 
 void expectInterval(const stp::UnsignedInterval* result, unsigned width,
-                    unsigned min, unsigned max)
+                    uint64_t min, uint64_t max)
 {
   ASSERT_NE(result, nullptr);
   stp::CBV expectedMin = makeCBV(width, min);
@@ -429,6 +430,29 @@ TEST(UnsignedIntervalPropagators, MultExactForWrappingConstantMultiplier)
       c.analysis.dispatchToTransferFunctions(n, children);
 
   expectInterval(result, width, 1, 255);
+  cleanup(children, result);
+}
+
+// Multiplying [1, 2^64-3] by the all-ones constant: the products form the
+// progression with step 2^64-1, whose minimum minlin() chases level by
+// level. A step above half the modulus once degenerated into a subtractive
+// walk of ~2^64 iterations, so this test hung; walked backwards the answer
+// is immediate. The products are the negations -1*x, exactly [3, 2^64-1].
+TEST(UnsignedIntervalPropagators, MultByAllOnesConstantTerminates)
+{
+  const unsigned w = 64;
+  const uint64_t allOnes = ~(uint64_t)0;
+  Context c;
+  stp::ASTNode x = c.mgr.CreateSymbol("x", 0, w);
+  stp::ASTNode y = c.mgr.CreateSymbol("y", 0, w);
+  stp::ASTNode n = makeTerm(c, stp::BVMULT, w, x, y);
+
+  std::vector<const stp::UnsignedInterval*> children = {
+      makeInterval(w, allOnes, allOnes), makeInterval(w, 1, allOnes - 2)};
+  stp::UnsignedInterval* result =
+      c.analysis.dispatchToTransferFunctions(n, children);
+
+  expectInterval(result, w, 3, allOnes);
   cleanup(children, result);
 }
 


### PR DESCRIPTION
## Problem

`stp` effectively hangs on `QF_BV/20210219-Sydr/master/cjpeg/predicate_1999.smt2` (any SAT backend): perf shows ~70% of the time in 128-bit division inside the interval analysis, called from the second StrengthReduction pass.

`minlin()` in `UnsignedIntervalAnalysis.cpp` chases the minimum of `(a*i + b) mod m` level by level and claims Euclid-style O(log m) convergence. But its level step replaces `a` with `(-m) mod a`, which is subtractive rather than a remainder: whenever the step stays above `m/2`, the modulus shrinks by only `m mod a` per level and the walk degenerates to ~m iterations. Multiplying by an all-ones-like constant at width 64 hits exactly that — ~2^64 iterations of 128-bit division.

## Fix

When the step exceeds `m/2`, walk the same progression backwards from its last element with the complementary step `m - a`. The value set is unchanged, so the result stays exact, and the modulus now at least halves every level: genuinely O(log m).

## Validation

- The reversal was checked against brute force: exhaustively for all `m <= 40` with every `a`, `b` and a range of counts, plus 200k random larger instances — always exact. The worst iteration count over random 64-bit inputs (including the formerly hanging one) is 62.
- The benchmark above now solves (`unsat`, matching its `:status`) in ~2s in a debug build, on both MiniSat and CaDiCaL backends.
- Differential sat/unsat sweep of 500 corpus files against master: no mismatches, no new timeouts.
- All interval/StrengthReduction/NodeDomainAnalysis unit-test suites pass.

## Regression test

`UnsignedIntervalPropagators.MultByAllOnesConstantTerminates` multiplies `[1, 2^64-3]` by the all-ones constant and checks the exact hull `[3, 2^64-1]`. With the reversal reverted, the test hangs (verified: killed by a 20s timeout); with it, it completes in under a millisecond.