### PR TITLE
Fix quadratic bit-fixing loop in NodeDomainAnalysis::harmonise

### DIFF
--- a/lib/Simplifier/NodeDomainAnalysis.cpp
+++ b/lib/Simplifier/NodeDomainAnalysis.cpp
@@ -186,18 +186,6 @@ namespace stp
     return result;
   }
 
-  // Whether some value matches the fixed bits and lies within [min, max].
-  static bool hasMemberInRange(const FixedBits& bits, const CBV min,
-                               const CBV max)
-  {
-    CBV smallest = minAbove(bits, min);
-    if (smallest == nullptr)
-      return false;
-    const bool result = CONSTANTBV::BitVector_Lexicompare(smallest, max) <= 0;
-    CONSTANTBV::BitVector_Destroy(smallest);
-    return result;
-  }
-
   // Trim each domain to exactly the values the two domains share: the
   // interval becomes [min, max] of the shared values, and a bit is fixed
   // whenever every shared value agrees on it. Assumes the domains share
@@ -250,33 +238,32 @@ namespace stp
           bits = new FixedBits(interval->getWidth(),false); /// TODO do we really need to know if it's boolean??
         }
 
-        // Fix each bit that all the shared values agree on. The interval
-        // is already exactly the range of the shared values, so a bit
-        // can take a polarity iff fixing it that way leaves a value
-        // matching the fixed bits inside the interval.
-        const unsigned width = bits->getWidth();
-        for (unsigned i = 0; i < width; i++)
+        // Fix each bit that all the shared values agree on. The bounds
+        // are now the least and greatest shared values, so above their
+        // highest differing bit every shared value matches their common
+        // prefix. At that bit the bounds themselves witness both
+        // polarities, and below it nothing is forced: the prefix
+        // followed by a zero there and ones at every unfixed bit stays
+        // between the bounds, as does the prefix followed by a one
+        // there and zeroes at every unfixed bit.
+        const int width = bits->getWidth();
+        int split = -1;
+        for (int i = width - 1; i >= 0; i--)
+          if (CONSTANTBV::BitVector_bit_test(interval->minV, i) !=
+              CONSTANTBV::BitVector_bit_test(interval->maxV, i))
+          {
+            split = i;
+            break;
+          }
+
+        for (int i = width - 1; i > split; i--)
         {
           if (bits->isFixed(i))
             continue;
-
           bits->setFixed(i, true);
-          bits->setValue(i, false);
-          const bool canBeZero =
-              hasMemberInRange(*bits, interval->minV, interval->maxV);
-          bits->setValue(i, true);
-          const bool canBeOne =
-              hasMemberInRange(*bits, interval->minV, interval->maxV);
-
-          assert(canBeZero || canBeOne); // the domains share a value.
-
-          if (canBeZero == canBeOne)
-            bits->setFixed(i, false);
-          else
-          {
-            bits->setValue(i, canBeOne);
-            tighten++;
-          }
+          bits->setValue(i,
+                         CONSTANTBV::BitVector_bit_test(interval->minV, i));
+          tighten++;
         }
       }
 

--- a/tests/unit-tests/NodeDomainAnalysis_Test.cpp
+++ b/tests/unit-tests/NodeDomainAnalysis_Test.cpp
@@ -356,6 +356,95 @@ TEST(NodeDomainAnalysis_Test, harmonise_idempotent_exhaustive)
   }
 }
 
+// Every fixed-bits pattern crossed with every interval that shares at
+// least one value with it. Checks that harmonise tightens fully: the
+// interval's bounds become the least and greatest shared values, and a
+// bit ends up fixed exactly when every shared value agrees on it.
+TEST(NodeDomainAnalysis_Test, harmonise_tightens_maximally_exhaustive)
+{
+  boot();
+  Context c;
+
+  for (unsigned width = 1; width <= 5; width++)
+  {
+    unsigned configs = 1;
+    for (unsigned i = 0; i < width; i++)
+      configs *= 3;
+    const unsigned values = 1u << width;
+
+    for (unsigned config = 0; config < configs; config++)
+    {
+      const stp::FixedBits pattern = bitsFromTernary(width, config);
+
+      for (unsigned lo = 0; lo < values; lo++)
+        for (unsigned hi = lo; hi < values; hi++)
+        {
+          // The shared values, and per bit whether they all agree.
+          unsigned smallest = 0, largest = 0;
+          bool any = false;
+          std::vector<bool> agree(width), agreedValue(width);
+          for (unsigned v = lo; v <= hi; v++)
+          {
+            if (!bitsContain(pattern, v))
+              continue;
+            if (!any)
+            {
+              smallest = v;
+              for (unsigned i = 0; i < width; i++)
+              {
+                agree[i] = true;
+                agreedValue[i] = ((v >> i) & 1) != 0;
+              }
+            }
+            else
+              for (unsigned i = 0; i < width; i++)
+                if (agree[i] && agreedValue[i] != (((v >> i) & 1) != 0))
+                  agree[i] = false;
+            largest = v;
+            any = true;
+          }
+          if (!any)
+            continue; // harmonise requires the domains to intersect.
+
+          stp::FixedBits* bits = new stp::FixedBits(pattern);
+          stp::UnsignedInterval* interval = new stp::UnsignedInterval(
+              cbvFromUnsigned(width, lo), cbvFromUnsigned(width, hi));
+
+          const std::string input = describe(bits, interval);
+
+          c.domain.harmonise(bits, interval);
+
+          const std::string msg =
+              "input: " + input + ", output: " + describe(bits, interval);
+
+          ASSERT_NE(interval, nullptr) << msg;
+          stp::CBV expectedMin = cbvFromUnsigned(width, smallest);
+          stp::CBV expectedMax = cbvFromUnsigned(width, largest);
+          ASSERT_EQ(
+              0, CONSTANTBV::BitVector_Lexicompare(interval->minV, expectedMin))
+              << msg;
+          ASSERT_EQ(
+              0, CONSTANTBV::BitVector_Lexicompare(interval->maxV, expectedMax))
+              << msg;
+          CONSTANTBV::BitVector_Destroy(expectedMin);
+          CONSTANTBV::BitVector_Destroy(expectedMax);
+
+          for (unsigned i = 0; i < width; i++)
+          {
+            const bool fixed = bits != nullptr && bits->isFixed(i);
+            ASSERT_EQ(agree[i], fixed) << "bit " << i << " " << msg;
+            if (fixed)
+              ASSERT_EQ(agreedValue[i], bits->getValue(i))
+                  << "bit " << i << " " << msg;
+          }
+
+          delete bits;
+          delete interval;
+        }
+    }
+  }
+}
+
 // Fixed bits with no interval: harmonise builds the interval, and must
 // still be idempotent.
 TEST(NodeDomainAnalysis_Test, harmonise_idempotent_bits_only)


### PR DESCRIPTION
## Problem

On wide formulas the Domain Analysis pass inside StrengthReduction dominates solving: `QF_BV/brummayerbiere/bitrev4096.smt2` spends 16 of its 38 seconds there, and `bitrev8192.smt2` takes 234 seconds in total (static debug build).

`harmonise()` fixed each bit that all the values shared by the fixed bits and the interval agree on by probing, per unfixed bit, whether either polarity leaves a member inside the interval. Each probe scans every bit (`minAbove`), making the pass O(width²) per node — with 4096-bit vectors that's tens of millions of per-bit calls per node.

## Fix

The probing is unnecessary. By this point the interval's bounds are the least and greatest shared values, so:

- **Above the bounds' highest differing bit**, every shared value matches their common prefix (anything else leaves the range) — those bits get fixed.
- **At that bit**, the bounds themselves witness both polarities.
- **Below it**, nothing is forced: the prefix followed by a zero there and ones at every unfixed bit stays between the bounds, as does the prefix followed by a one there and zeroes at every unfixed bit.

So harmonise now just fixes the unfixed bits above the bounds' highest differing bit, in one O(width) pass. `hasMemberInRange` had no other callers and is removed.

## Results

| benchmark | before | after |
|---|---|---|
| bitrev4096.smt2 | ~38 s | 1.1 s |
| bitrev8192.smt2 | 234 s | 3.0 s |

Identical simplification traces (phase-by-phase node sizes) and the same `unsat` answers on all nine bitrev instances.

## Validation

- New `harmonise_tightens_maximally_exhaustive` test: for every fixed-bits pattern crossed with every intersecting interval at widths 1..5, the bounds must become exactly the least and greatest shared values, and a bit must end up fixed exactly when every shared value agrees on it. It passes on **both** the old and new implementations, pinning the equivalence.
- The pre-existing exhaustive harmonise tests (idempotence, intersection preservation) still pass, as do the StrengthReduction, UnsignedInterval*, ConstantBitPropagation, and NodeDomainAnalysis suites.
- Differential sat/unsat sweep of 500 corpus files against master: no mismatches, no new timeouts.