### PR TITLE
Stop copying every let-binding frame on each lexed symbol

### DIFF
--- a/include/stp/Parser/LetMgr.h
+++ b/include/stp/Parser/LetMgr.h
@@ -49,6 +49,9 @@ private:
   std::vector<MapType> stack;
   MapType interim;
 
+  // The expression the innermost binding of s maps to, or nullptr.
+  const ASTNode* lookupLet(const string& s) const;
+
 public:
   
   bool frameMode = true;
@@ -71,9 +74,9 @@ public:
   void CleanupLetIDMap(void);
 
   // Has a let with this name has already been declared.
-  bool isLetDeclared(string s);
+  bool isLetDeclared(const string& s) const;
 
-  ASTNode resolveLet(const string s);
+  ASTNode resolveLet(const string& s) const;
   ASTNode ResolveID(const ASTNode& var);
 
   // Functions that are used to create LET expressions

--- a/lib/Parser/LetMgr.cpp
+++ b/lib/Parser/LetMgr.cpp
@@ -103,31 +103,36 @@ ASTNode LetMgr::ResolveID(const ASTNode& v)
   }
 
   //Lets shadow other symbols, so check them first.
-  if (isLetDeclared(v.GetName()))
-    return resolveLet(v.GetName());
-  
+  const ASTNode* found = lookupLet(v.GetName());
+  if (found != nullptr)
+    return *found;
+
   return v;
 }
 
-ASTNode LetMgr::resolveLet(const string s)
+const ASTNode* LetMgr::lookupLet(const string& s) const
 {
-  assert(isLetDeclared(s));
-
   // Searches backwards because they could be shadowed.
-  for (auto i = stack.rbegin(); i != stack.rend(); ++i ) 
-      if ((*i).find(s) != (*i).end())
-        return (*i).find(s)->second;
-  FatalError("never here...");
+  for (auto i = stack.rbegin(); i != stack.rend(); ++i)
+  {
+    const auto found = i->find(s);
+    if (found != i->end())
+      return &found->second;
+  }
+  return nullptr;
 }
 
-bool LetMgr::isLetDeclared(const string s)
+ASTNode LetMgr::resolveLet(const string& s) const
 {
-  for (auto frame : stack )
-    if (frame.find(s) != frame.end())
-      return true;
+  const ASTNode* found = lookupLet(s);
+  if (found == nullptr)
+    FatalError("never here...");
+  return *found;
+}
 
-  return false;
-
+bool LetMgr::isLetDeclared(const string& s) const
+{
+  return lookupLet(s) != nullptr;
 }
 
 void LetMgr::cleanupParserSymbolTable() 


### PR DESCRIPTION
## Problem

Parsing `QF_BV/Sage2/bench_13989.smt2` (7 MB) took 50 seconds (static debug build). Profiling showed nearly all of it inside the copy constructor of `unordered_map<string, ASTNode>`, called from `LetMgr::isLetDeclared` via the lexer.

`isLetDeclared` iterated the let-frame stack with a **by-value** loop variable (`for (auto frame : stack)`), copying every frame's entire binding map on every call — and the SMT2/SMT1/CVC lexers call it for each symbol token to decide whether a let binding shadows it. Let-heavy files make that quadratic. `resolveLet` then repeated the scan (twice more with assertions on).

## Fix

The lookups now share one backward scan over the frames by reference (`lookupLet`), `ResolveID` uses it directly instead of scanning twice, and the names are passed by const reference.

## Results

Parsing bench_13989.smt2 drops from 50.4 s to 2.0 s; every STP preprocessing phase on the file now completes in ~2.3 s total (the remaining solve time is ordinary SAT search on a hard sat instance).

## Validation

- Differential sat/unsat sweep of 500 corpus files against master: no mismatches, no new timeouts.
- Spot-checked CVC- and SMT1-format query files against the master binary: identical outputs. (Two crypto-tests print a different — equally valid — counterexample model, but plain master built in the same build configuration prints that same model, so the difference is build-config-related, not from this change.)