### PR TITLE
Rewrite ((s & t) mod t) / s and (t & (s mod t)) / s to an ITE chain

### DIFF
--- a/lib/NodeFactory/SimplifyingNodeFactory.cpp
+++ b/lib/NodeFactory/SimplifyingNodeFactory.cpp
@@ -2123,6 +2123,52 @@ ASTNode SimplifyingNodeFactory::CreateTerm(Kind kind, unsigned int width,
             NodeFactory::CreateNode(EQ, children[1], bm.CreateZeroConst(width)),
             bm.CreateMaxConst(width), bm.CreateZeroConst(width));
 
+      // ((s & t) mod t) / s  and  (t & (s mod t)) / s  both equal
+      // ite(s = 0, max, ite((s & t) = s AND s < t, 1, 0)):
+      // each numerator is at most s, so the quotient is 0 or 1, and it is 1
+      // exactly when the numerator equals a non-zero s, which for both forms
+      // requires s's bits to be a subset of t's and s < t. Replaces a
+      // division and a modulus with comparisons.
+      if (result.IsNull())
+      {
+        const ASTNode& s = children[1];
+        ASTNode t;
+        const ASTNode& n = children[0];
+        if (n.GetKind() == BVMOD && n[0].GetKind() == stp::BVAND &&
+            n[0].Degree() == 2 &&
+            ((n[0][0] == s && n[0][1] == n[1]) ||
+             (n[0][1] == s && n[0][0] == n[1])))
+        {
+          // ((s & t) mod t) / s
+          t = n[1];
+        }
+        else if (n.GetKind() == stp::BVAND && n.Degree() == 2)
+        {
+          // (t & (s mod t)) / s, with the BVAND's children in either order.
+          for (unsigned i = 0; i < 2; i++)
+            if (n[i].GetKind() == BVMOD && n[i][0] == s && n[i][1] == n[1 - i])
+            {
+              t = n[1 - i];
+              break;
+            }
+        }
+        if (!t.IsNull())
+        {
+          const ASTNode cond = NodeFactory::CreateNode(
+              stp::AND,
+              NodeFactory::CreateNode(
+                  EQ, NodeFactory::CreateTerm(stp::BVAND, width, s, t), s),
+              NodeFactory::CreateNode(stp::BVLT, s, t));
+          result = NodeFactory::CreateTerm(
+              ITE, width,
+              NodeFactory::CreateNode(EQ, s, bm.CreateZeroConst(width)),
+              bm.CreateMaxConst(width),
+              NodeFactory::CreateTerm(ITE, width, cond,
+                                      bm.CreateOneConst(width),
+                                      bm.CreateZeroConst(width)));
+        }
+      }
+
       break;
 
     case SBVDIV:

--- a/tests/unit-tests/SimplifyingNodeFactory_Exhaustive_Test.cpp
+++ b/tests/unit-tests/SimplifyingNodeFactory_Exhaustive_Test.cpp
@@ -331,4 +331,43 @@ TEST(SimplifyingNodeFactory_Exhaustive, bvor_zero)
   c.checkTerm(stp::BVOR, 3, {c.konst(0, 3), x, y});
 }
 
+/* ((s & t) mod t) / s and (t & (s mod t)) / s: both become
+   ite(s = 0, max, ite((s & t) = s AND s < t, 1, 0)), removing the
+   division and the modulus. The original expressions:
+     873:(NOT 872:(EQ
+       842:(BVDIV
+         838:(BVMOD
+           576:(BVAND 42:s 48:t)
+           48:t)
+         42:s)
+       870:(BVDIV
+         866:(BVAND
+           48:t
+           854:(BVMOD 42:s 48:t))
+         42:s)))  */
+TEST(SimplifyingNodeFactory_Exhaustive, div_of_mod_of_and)
+{
+  Context c;
+  for (unsigned w : {1u, 2u, 4u})
+  {
+    ASTNode s = c.bv(w);
+    ASTNode t = c.bv(w);
+
+    ASTNode modOfAnd =
+        c.hf->CreateTerm(BVMOD, w, c.hf->CreateTerm(stp::BVAND, w, s, t), t);
+    c.checkTerm(BVDIV, w, {modOfAnd, s});
+
+    ASTNode andOfMod =
+        c.hf->CreateTerm(stp::BVAND, w, t, c.hf->CreateTerm(BVMOD, w, s, t));
+    c.checkTerm(BVDIV, w, {andOfMod, s});
+
+    // Both forms must produce the identical node, so an equality between
+    // them folds to true.
+    ASTNode lhs = c.nf->CreateTerm(BVDIV, w, modOfAnd, s);
+    ASTNode rhs = c.nf->CreateTerm(BVDIV, w, andOfMod, s);
+    EXPECT_EQ(lhs, rhs);
+    EXPECT_EQ(lhs.GetKind(), ITE);
+  }
+}
+
 } // namespace


### PR DESCRIPTION
Rewrite-rule discovery turned up this valid identity:

```
(NOT (EQ
  (BVDIV (BVMOD (BVAND s t) t) s)
  (BVDIV (BVAND t (BVMOD s t)) s)))
```

is unsatisfiable at every width. Both sides equal `ite(s = 0, max, ite((s & t) = s AND s < t, 1, 0))`: each numerator is at most `s`, so the quotient is 0 or 1, and it is 1 exactly when the numerator equals a non-zero `s`, which for both forms requires `s`'s bits to be a subset of `t`'s together with `s < t`.

Rather than canonicalising one side into the other, the SimplifyingNodeFactory rewrites both `BVDIV` patterns to the ITE form. That removes a division and a modulus from the bit-blasted encoding, and the two forms hash-cons to the identical node, so an equality between them folds to true — the negated 64-bit identity goes from 2.5s of SAT solving to being discharged during node creation.

Verification:
- Exhaustive enumeration of the identity and the ITE form at widths 1–8 (SMT-LIB div/mod-by-zero semantics).
- New exhaustive unit test at widths 1, 2 and 4, creating both shapes through both factories, checking equivalence on every assignment and that the two shapes simplify to the identical node.
- Differential sat/unsat sweep over 2500 fuzzed QF_BV files against master: no mismatches.
- Full ctest suite passes.