### PR TITLE
Convert decimal numerals word-at-a-time in BitVector_from_Dec

### DIFF
--- a/lib/extlib-constbv/constantbv.cpp
+++ b/lib/extlib-constbv/constantbv.cpp
@@ -1676,8 +1676,87 @@ namespace CONSTANTBV {
     return(result);
   }
 
+  /* Fast path for BitVector_from_Dec: Horner evaluation with a word-level
+     multiply-accumulate. The digits are processed most-significant-first in
+     chunks of up to LOG10 digits: value = value * 10^chunklen + chunk. Each
+     step costs one pass over the words, instead of the shift-and-add
+     multiplies of the general path. Requires word * chunkbase + carry to fit
+     into an unsigned long long, i.e. 2 * BITS bits (the caller checks).
+     Reports ErrCode_Ovfl as soon as the accumulated value no longer fits in
+     the vector, and ErrCode_Pars on the first non-digit. */
+  static ErrCode BitVector_from_Dec_wordwise(unsigned int *  addr,
+                                             unsigned char * string)
+  {
+    unsigned int  bits = bits_(addr);
+    unsigned int  mask = mask_(addr);
+    unsigned int  size = size_(addr);
+    unsigned int  length;
+    unsigned int  chunk;
+    unsigned int  chunkbase;
+    unsigned int  count;
+    unsigned int  i;
+    unsigned long long product;
+    unsigned long long carry;
+    boolean minus;
+    int     digit;
+
+    if (bits == 0) return(ErrCode_Ok);
+    length = strlen((char *) string);
+    if (length == 0) return(ErrCode_Pars);
+    digit = (int) *string;
+    if ((minus = (digit == (int) '-')) ||
+        (digit == (int) '+'))
+      {
+        string++;
+        if (--length == 0) return(ErrCode_Pars);
+      }
+    BitVector_Empty(addr);
+    while (length > 0)
+      {
+        count = length % LOG10;
+        if (count == 0) count = LOG10;
+        chunk = 0;
+        chunkbase = 1;
+        while (count-- > 0)
+          {
+            digit = (int) *string++; length--;
+            /* separate because isdigit() is likely a macro! */
+            if (isdigit(digit) != 0)
+              {
+                chunk = (chunk * 10) +
+                        ((unsigned int) digit - (unsigned int) '0');
+                chunkbase *= 10;
+              }
+            else return(ErrCode_Pars);
+          }
+        /* addr = addr * chunkbase + chunk; carry stays below chunkbase,
+           so product < 2^BITS * chunkbase + chunkbase <= 2^(2*BITS). */
+        carry = (unsigned long long) chunk;
+        for ( i = 0; i < size; i++ )
+          {
+            product = ((unsigned long long) *(addr+i)) * chunkbase + carry;
+            *(addr+i) = (unsigned int) product;
+            carry = product >> BITS;
+          }
+        if ((carry != 0) || ((*(addr+size-1) & ~ mask) != 0))
+          return(ErrCode_Ovfl);
+      }
+    if (minus)
+      {
+        BitVector_Negate(addr,addr);
+        if ((*(addr + size - 1) & mask & ~ (mask >> 1)) == 0)
+          return(ErrCode_Ovfl);
+      }
+    return(ErrCode_Ok);
+  }
+
   ErrCode BitVector_from_Dec(unsigned int *  addr, unsigned char * string)
   {
+    if ((BITS << 1) <= (unsigned int) (sizeof(unsigned long long) << 3))
+      {
+        return(BitVector_from_Dec_wordwise(addr,string));
+      }
+
     ErrCode error = ErrCode_Ok;
     unsigned int  bits = bits_(addr);
     unsigned int  mask = mask_(addr);

--- a/tests/unit-tests/BitVector_from_Dec_Test.cpp
+++ b/tests/unit-tests/BitVector_from_Dec_Test.cpp
@@ -1,0 +1,149 @@
+/***********
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+**********************/
+
+/*
+ * Tests for BitVector_from_Dec's word-level fast path, cross-checked
+ * against BitVector_from_Hex and BitVector_to_Dec, which use unrelated
+ * code paths.
+ */
+
+#include "extlib-constbv/constantbv.h"
+#include <gtest/gtest.h>
+#include <string>
+
+using namespace CONSTANTBV;
+
+namespace
+{
+
+struct Boot
+{
+  Boot() { BitVector_Boot(); }
+};
+
+// Convert through from_Hex, print with to_Dec, read back with from_Dec:
+// the result must match the original vector.
+void roundTrip(unsigned width, const std::string& hex)
+{
+  unsigned int* fromHex = BitVector_Create(width, true);
+  ASSERT_EQ(ErrCode_Ok,
+            BitVector_from_Hex(fromHex, (unsigned char*)hex.c_str()));
+
+  unsigned char* dec = BitVector_to_Dec(fromHex);
+  ASSERT_NE(dec, nullptr);
+
+  unsigned int* fromDec = BitVector_Create(width, true);
+  EXPECT_EQ(ErrCode_Ok, BitVector_from_Dec(fromDec, dec))
+      << "width " << width << " dec " << dec;
+  EXPECT_TRUE(BitVector_equal(fromHex, fromDec))
+      << "width " << width << " dec " << dec;
+
+  BitVector_Dispose(dec);
+  BitVector_Destroy(fromHex);
+  BitVector_Destroy(fromDec);
+}
+
+// A deterministic hex string of the full width.
+std::string pseudoRandomHex(unsigned width, unsigned seed)
+{
+  const unsigned digits = (width + 3) / 4;
+  std::string s;
+  unsigned state = seed * 2654435761u + 1;
+  for (unsigned i = 0; i < digits; i++)
+  {
+    state = state * 1103515245 + 12345;
+    unsigned d = (state >> 16) & 0xf;
+    if (i == 0 && (width % 4) != 0)
+      d &= (1u << (width % 4)) - 1; // keep the leading digit in range
+    s += "0123456789abcdef"[d];
+  }
+  return s;
+}
+
+TEST(BitVector_from_Dec, round_trips)
+{
+  Boot boot;
+  for (unsigned width : {1u,  2u,  7u,  8u,   31u,  32u,  33u,
+                         64u, 65u, 127u, 128u, 512u, 1056u})
+  {
+    const unsigned digits = (width + 3) / 4;
+    roundTrip(width, std::string(digits, '0'));           // zero
+    roundTrip(width, std::string(digits - 1, '0') + "1"); // one
+    roundTrip(width, pseudoRandomHex(width, width));
+    roundTrip(width, pseudoRandomHex(width, width + 1000));
+  }
+}
+
+TEST(BitVector_from_Dec, all_ones_and_negative)
+{
+  Boot boot;
+  for (unsigned width : {1u, 8u, 33u, 64u, 1056u})
+  {
+    // -1 must give the all-ones vector.
+    unsigned int* v = BitVector_Create(width, true);
+    ASSERT_EQ(ErrCode_Ok, BitVector_from_Dec(v, (unsigned char*)"-1"));
+    unsigned int* ones = BitVector_Create(width, false);
+    BitVector_Fill(ones);
+    EXPECT_TRUE(BitVector_equal(v, ones)) << "width " << width;
+    BitVector_Destroy(ones);
+    BitVector_Destroy(v);
+  }
+}
+
+TEST(BitVector_from_Dec, overflow_and_parse_errors)
+{
+  Boot boot;
+  for (unsigned width : {1u, 8u, 32u, 33u, 512u})
+  {
+    // Print 2^width from a wider vector, then read it back into a
+    // width-bit vector: it is one past the maximum.
+    unsigned int* wide = BitVector_Create(width + 1, true);
+    BitVector_Bit_On(wide, width);
+    unsigned char* dec = BitVector_to_Dec(wide);
+    ASSERT_NE(dec, nullptr);
+
+    unsigned int* v = BitVector_Create(width, true);
+    EXPECT_EQ(ErrCode_Ovfl, BitVector_from_Dec(v, dec)) << "width " << width;
+
+    // The maximum itself must fit: 2^width - 1.
+    unsigned int* wideMax = BitVector_Create(width + 1, true);
+    for (unsigned i = 0; i < width; i++)
+      BitVector_Bit_On(wideMax, i);
+    unsigned char* decMax = BitVector_to_Dec(wideMax);
+    ASSERT_NE(decMax, nullptr);
+    EXPECT_EQ(ErrCode_Ok, BitVector_from_Dec(v, decMax)) << "width " << width;
+
+    BitVector_Dispose(dec);
+    BitVector_Dispose(decMax);
+    BitVector_Destroy(wide);
+    BitVector_Destroy(wideMax);
+    BitVector_Destroy(v);
+  }
+
+  unsigned int* v = BitVector_Create(64, true);
+  EXPECT_EQ(ErrCode_Pars, BitVector_from_Dec(v, (unsigned char*)""));
+  EXPECT_EQ(ErrCode_Pars, BitVector_from_Dec(v, (unsigned char*)"+"));
+  EXPECT_EQ(ErrCode_Pars, BitVector_from_Dec(v, (unsigned char*)"-"));
+  EXPECT_EQ(ErrCode_Pars, BitVector_from_Dec(v, (unsigned char*)"12x3"));
+  EXPECT_EQ(ErrCode_Ok, BitVector_from_Dec(v, (unsigned char*)"+42"));
+  BitVector_Destroy(v);
+}
+
+} // namespace

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -42,5 +42,6 @@ AddSTPGTest(ConstantBitP_TransferFunctions_Test.cpp)
 AddSTPGTest(ConstantBitP_Wide_Test.cpp)
 AddSTPGTest(UnsignedIntervalAnalysis_Test.cpp)
 AddSTPGTest(ConstantBitPropagation_Test.cpp)
+AddSTPGTest(BitVector_from_Dec_Test.cpp)
 AddSTPGTest(ValueSet_Test.cpp)
 


### PR DESCRIPTION
Parsing the 60MB `dualexecution.t1.i28.4c3d51fa.smt2` benchmark (147k decimal constants of width 1056) spent nearly all its preprocessing time inside `BitVector_from_Dec`, which built each value with `BitVector_Mul_Pos` — a shift-and-add multiply that moves the full-width vector left one bit at a time, i.e. O(digits × width² / word-size) per constant.

This replaces the loop with Horner evaluation, processing the digits most-significant-first in LOG10-digit chunks; each chunk is a single multiply-accumulate pass over the words with `unsigned long long` intermediates (`value = value * 10^chunklen + chunk`), so conversion is O(digits × width / word-size) and the five per-call scratch vectors disappear. The old code remains as a fallback for the theoretical platform where two words don't fit in an `unsigned long long`.

**Effect**: interleaved A/B against master under identical machine load: parsing the dualexecution file drops 20.8s → 1.7s (~12x; the whole run to CNF goes from ~21s to 2.0s). All 38 `dualexecution`/`dualexecution_affine` benchmarks, which took ~20s of preprocessing each, get roughly this speedup — their preprocessing was almost entirely decimal-constant conversion.

**Semantics**: overflow behaviour preserved — the value must fit the width (checked per chunk via the multiply carry and top-word mask), negative numerals keep the same magnitude bound and post-negation sign test, non-digits still give `ErrCode_Pars`. One deliberate difference: the old code could spuriously report overflow for a fitting value written with ~20+ leading zeros (its 10^(9k) rank vector overflowed even when the remaining digits were zero); the Horner form accepts those.

**Validation**:
- Cross-checked against `BitVector_from_Hex` on 3717 generated cases: boundaries (0, 1, 2^w−1, 2^w, ±2^(w−1), ±2^(w−1)+1), random values, leading zeros, `+` signs, widths 1–2000.
- A temporary build running both implementations on every constant compared values and error codes over the full dualexecution benchmark: zero differences.
- Generated CNF is byte-identical on ponylink and vlsat3 benchmarks (on dualexecution the CNF differs by a single benign variable-number swap, traced to a pre-existing allocation-order sensitivity in CNF variable numbering, not to values).
- Differential sat/unsat sweep over 2500 fuzzed QF_BV files vs master: no mismatches. All 59 test suites pass.
- New unit test round-trips `from_Hex`/`to_Dec`/`from_Dec` and pins overflow and parse-error cases.