### PR TITLE
Cut redundant hash-map work in constant bit propagation

### DIFF
--- a/include/stp/Simplifier/constantBitP/ConstantBitPropagation.h
+++ b/include/stp/Simplifier/constantBitP/ConstantBitPropagation.h
@@ -70,8 +70,9 @@ class ConstantBitPropagation
 
   bool topFixed;
 
-  // A vector that's reused.
+  // Vectors that are reused.
   vector<unsigned> previousChildrenFixedCount;
+  vector<FixedBits*> childrenBits;
 
   void printNodeWithFixings();
 

--- a/include/stp/Simplifier/constantBitP/Dependencies.h
+++ b/include/stp/Simplifier/constantBitP/Dependencies.h
@@ -57,25 +57,32 @@ private:
       return;
 
     ASTNodeSet* vec;
+    bool firstVisit;
     const auto it = dependents.find(current.GetNodeNum());
     if (dependents.end() == it)
     {
       // add it in with a reference to the vector.
       vec = new ASTNodeSet();
       dependents.insert({current.GetNodeNum(), vec});
+      firstVisit = true;
     }
     else
     {
       vec = it->second;
+      firstVisit = false;
     }
 
     if (prior != current) // initially called with both the same.
     {
-      if (vec->count(prior) == 0)
-        vec->insert(prior);
-      else
+      if (!vec->insert(prior).second)
         return; // already been added in.
     }
+
+    // On a repeat visit through a new parent, the edges to the children
+    // are already recorded; descending again would redo a hash find per
+    // child for every extra parent.
+    if (!firstVisit)
+      return;
 
     for (const auto &child: current)
     {

--- a/lib/Simplifier/constantBitP/ConstantBitPropagation.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitPropagation.cpp
@@ -503,21 +503,34 @@ void ConstantBitPropagation::propagate()
            << endl;
     }
 
-    // get a copy of the current fixing from the cache.
-    int previousTop = getCurrentFixedBits(n)->countFixed();
+    // Fetch each FixedBits from the map once per visit; the map lookups
+    // dominate the cost of propagation on large problems.
+    FixedBits* nBits = getCurrentFixedBits(n);
+    int previousTop = nBits->countFixed();
 
-    // get the current for the children.
+    const unsigned degree = n.GetChildren().size();
+    childrenBits.clear();
     previousChildrenFixedCount.clear();
 
     // get a copy of the current fixing from the cache.
-    for (unsigned i = 0; i < n.GetChildren().size(); i++)
+    for (unsigned i = 0; i < degree; i++)
     {
-      previousChildrenFixedCount.push_back(
-          getCurrentFixedBits(n[i])->countFixed());
+      FixedBits* cb = getCurrentFixedBits(n[i]);
+      childrenBits.push_back(cb);
+      previousChildrenFixedCount.push_back(cb->countFixed());
     }
 
-    // derive the new ones.
-    int newCount = getUpdatedFixedBits(n)->countFixed();
+    // derive the new ones. (As getUpdatedFixedBits, but reusing the
+    // already-fetched FixedBits.)
+    if (SYMBOL != n.GetKind())
+    {
+      assert(status != CONFLICT);
+      status = dispatchToTransferFunctions(mgr, n.GetKind(), childrenBits,
+                                           *nBits, n, msm);
+      assert(((unsigned)nBits->getWidth()) == n.GetValueWidth() ||
+             nBits->getWidth() == 1);
+    }
+    int newCount = nBits->countFixed();
 
     if (CONFLICT == status)
       return;
@@ -532,16 +545,15 @@ void ConstantBitPropagation::propagate()
         scheduleUp(n); // schedule everything that depends on n.
       }
 
-      for (unsigned i = 0; i < n.GetChildren().size(); i++)
+      for (unsigned i = 0; i < degree; i++)
       {
-        if (getCurrentFixedBits(n[i])->countFixed() !=
-            previousChildrenFixedCount[i])
+        if (childrenBits[i]->countFixed() != previousChildrenFixedCount[i])
         {
           if (debug_cBitProp_messages)
           {
             cerr << "Changed: " << n[i].GetNodeNum()
                  << " from:" << previousChildrenFixedCount[i]
-                 << "to:" << *getCurrentFixedBits(n[i]) << endl;
+                 << "to:" << *childrenBits[i] << endl;
           }
 
           assert(!n[i].isConstant());


### PR DESCRIPTION
On big benchmarks the constant-bit-propagation pass is dominated not by its transfer functions but by hash-map bookkeeping: on `ponylink-slaveTXlen-unsat-unrolled-nomem.smt2` the `fixedMap` find alone was 8% of the whole run in perf, ahead of every transfer function, and `Dependencies::build` another few percent on the vlsat3 family.

Two commits:

1. **Fetch each FixedBits once per visit in propagate()**. Each worklist iteration looked up the node's and every child's `FixedBits` three times: for the before-counts, again inside `getUpdatedFixedBits`, and a third time for the change check. Now the pointers are fetched once per visit into a reused vector and the dispatch is done directly. Worklist scheduling decisions are unchanged, so propagation reaches the identical fixed point in the identical order.

2. **Build the parent map once per node**. `Dependencies::build` memoised per (parent, child) edge: reaching an already-visited node through a new parent re-descended into every child, paying a hash find per child per extra parent — Σ(parents × children) wasted finds on shared-heavy DAGs. A first-visit flag skips the re-descent; the resulting map and even its insertion order are identical.

**Effect**: interleaved A/B runs against master under identical machine load (Release, `-t --exit-after-CNF`, two rounds each):
- ponylink: Constant Bit Propagation 16.7s/16.5s → 15.4s/15.6s (~7%)
- vlsat3_a67: Constant Bit Propagation 5.8s/5.7s → 5.2s/5.4s (~7%)

(An earlier measurement suggested a much larger win, but that turned out to be machine-load drift between the baseline and patched runs; the numbers above are from alternating runs minutes apart.)

**Validation**: generated CNF is byte-for-byte identical to master on ponylink (135MB) and vlsat3_g92 (691MB); differential sat/unsat sweep over 2500 fuzzed QF_BV files: no mismatches; all 59 test suites pass.