### PR TITLE
Add a --parse-only flag that exits after parsing the input

### DIFF
--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -136,6 +136,9 @@ public:
 
   bool exit_after_CNF = false;
 
+  // Stop after parsing the input, skipping any check-sat commands.
+  bool parse_only = false;
+
   /* SAT solving options */
 
   int64_t timeout_max_conflicts = -1;

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -355,6 +355,9 @@ void ExtraMain::create_options()
       ("exit-after-CNF", po::bool_switch(&(bm->UserFlags.exit_after_CNF)),
        "exit after the CNF has been generated")
 
+      ("parse-only", po::bool_switch(&(bm->UserFlags.parse_only)),
+       "exit after parsing the input, without solving")
+
       ("max-num-confl,max_num_confl,g", 
       INT64_ARG(bm->UserFlags.timeout_max_conflicts),
       "Number of conflicts after which the SAT solver gives up. "

--- a/tools/stp/main_common.cpp
+++ b/tools/stp/main_common.cpp
@@ -98,6 +98,12 @@ void Main::parse_file(ASTVec* AssertsQuery)
 
   GlobalParserInterface->startup();
 
+  if (bm->UserFlags.parse_only)
+  {
+    // The SMT2 parser runs commands (including check-sat) as it parses.
+    GlobalParserInterface->ignoreCheckSat();
+  }
+
   if (onePrintBack)
   {
     if (bm->UserFlags.smtlib2_parser_flag)
@@ -283,7 +289,14 @@ int Main::main(int argc, char** argv)
    *  language is smt2 then all the work has already been done, and all we need
    *  to do is cleanup...
    *    */
-  if (!bm->UserFlags.smtlib2_parser_flag)
+  if (bm->UserFlags.parse_only)
+  {
+    if (bm->UserFlags.quick_statistics_flag)
+    {
+      bm->GetRunTimes()->print();
+    }
+  }
+  else if (!bm->UserFlags.smtlib2_parser_flag)
   {
     if (AssertsQuery->empty())
       FatalError("Input is Empty. Please enter some asserts and query\n");


### PR DESCRIPTION
Adds a `--parse-only` switch that stops after the input has been parsed, without solving. Useful for benchmarking and profiling the parsers in isolation.

- For SMT-LIB2 input the parser executes commands (including `check-sat`) as it reads them, so the flag uses the existing `Cpp_interface::ignoreCheckSat()` mechanism to skip them.
- For CVC and SMT-LIB1 inputs the solve step after parsing is skipped, as are the checks requiring a query, so assert-only files parse cleanly.
- With `-t` the runtime statistics (including parse time) are still printed.