### PR TITLE
Make let-binding lookup O(1) instead of scanning every open frame

### DIFF
--- a/include/stp/Parser/LetMgr.h
+++ b/include/stp/Parser/LetMgr.h
@@ -44,13 +44,21 @@ private:
   // with the corresponding expressions.
   // It's complicated because bindings can be shadowed by later bindings.
   // As soon as the brackets that close a let expression is reached it should be popped.
-  
+
+  // Each name maps to the stack of bindings that shadow each other,
+  // innermost last, tagged with the index of the frame they belong to.
+  // A single hash lookup resolves a name however deeply lets are nested.
+  std::unordered_map<string, std::vector<std::pair<size_t, ASTNode>>> bindings;
+
+  // The names bound in each open frame, so pop() can undo them.
   // Initally empty because we expect push() to be called before any bindings are added.
-  std::vector<MapType> stack;
+  std::vector<std::vector<string>> frames;
+
   MapType interim;
 
-  // The expression the innermost binding of s maps to, or nullptr.
-  const ASTNode* lookupLet(const string& s) const;
+  // Adds to the current frame. Returns false if the name is already
+  // bound in the current frame (leaving the existing binding in place).
+  bool insertIntoFrame(const string& name, const ASTNode& letExpr);
 
 public:
   
@@ -75,6 +83,10 @@ public:
 
   // Has a let with this name has already been declared.
   bool isLetDeclared(const string& s) const;
+
+  // The expression the innermost binding of s maps to, or nullptr.
+  // The pointer is invalidated by any change to the bindings.
+  const ASTNode* lookupLet(const string& s) const;
 
   ASTNode resolveLet(const string& s) const;
   ASTNode ResolveID(const ASTNode& var);

--- a/lib/Parser/LetMgr.cpp
+++ b/lib/Parser/LetMgr.cpp
@@ -39,10 +39,10 @@ void LetMgr::LetExprMgr(const ASTNode& var, const ASTNode& letExpr)
   LetExprMgr(var.GetName(), letExpr);
 }
 
-//Creates a new binding.  
+//Creates a new binding.
 void LetMgr::LetExprMgr(string name, const ASTNode& letExpr)
 {
-  assert(stack.size() > 0);
+  assert(frames.size() > 0);
 
   // In CVC lets are available immediately. In SMTLIB2 it's only when the list of them has all been done.
   if (frameMode)
@@ -56,24 +56,33 @@ void LetMgr::LetExprMgr(string name, const ASTNode& letExpr)
   }
   else
   {
-    if (stack.back().find(name) != stack.back().end())
+    if (!insertIntoFrame(name, letExpr))
       {
         string msg = "Let already created:" + name;
         FatalError(msg.c_str());
       }
-
-    stack.back().insert(make_pair(name,letExpr));
   }
 }
 
-// We're ready for these bindings to participate. 
+bool LetMgr::insertIntoFrame(const string& name, const ASTNode& letExpr)
+{
+  auto& shadows = bindings[name];
+  if (!shadows.empty() && shadows.back().first == frames.size() - 1)
+    return false;
+
+  shadows.emplace_back(frames.size() - 1, letExpr);
+  frames.back().push_back(name);
+  return true;
+}
+
+// We're ready for these bindings to participate.
 void LetMgr::commit()
 {
   if (interim.size() == 0)
     return;
 
   for (const auto& k : interim)
-    stack.back().insert(k);
+    insertIntoFrame(k.first, k.second);
   interim.clear();
 }
 
@@ -81,15 +90,23 @@ void LetMgr::commit()
 void LetMgr::push()
 {
   commit();
-  stack.push_back(MapType());
+  frames.push_back(std::vector<string>());
 }
 
 void LetMgr::pop()
 {
-  if (stack.size() == 0)
+  if (frames.size() == 0)
     FatalError("Popping from empty let stack");
 
-  stack.erase(stack.end() - 1);
+  for (const string& name : frames.back())
+  {
+    auto it = bindings.find(name);
+    assert(it != bindings.end());
+    it->second.pop_back();
+    if (it->second.empty())
+      bindings.erase(it);
+  }
+  frames.erase(frames.end() - 1);
 }
 
 // this function looks up the symbols let-binding and returns the
@@ -112,14 +129,12 @@ ASTNode LetMgr::ResolveID(const ASTNode& v)
 
 const ASTNode* LetMgr::lookupLet(const string& s) const
 {
-  // Searches backwards because they could be shadowed.
-  for (auto i = stack.rbegin(); i != stack.rend(); ++i)
-  {
-    const auto found = i->find(s);
-    if (found != i->end())
-      return &found->second;
-  }
-  return nullptr;
+  const auto found = bindings.find(s);
+  if (found == bindings.end())
+    return nullptr;
+
+  // The innermost binding shadows the others.
+  return &found->second.back().second;
 }
 
 ASTNode LetMgr::resolveLet(const string& s) const
@@ -144,7 +159,8 @@ void LetMgr::cleanupParserSymbolTable()
 void LetMgr::CleanupLetIDMap(void)
 {
   interim.clear();
-  stack.clear();
+  bindings.clear();
+  frames.clear();
   push();
 }
 

--- a/lib/Parser/cvc.lex
+++ b/lib/Parser/cvc.lex
@@ -140,9 +140,9 @@ ANYTHING  ({LETTER}|{DIGIT}|{OPCHAR})
    // Making 4.4M strings took 1B instructions. So I split out the above case
    // which occurs >90% of the time (so avoiding turning the char* into a string).
    string str(yytext);
-   if (GlobalParserInterface->letMgr->isLetDeclared(str)) // a let.
+   if (const ASTNode* let = GlobalParserInterface->letMgr->lookupLet(str)) // a let.
    {
-     nptr= GlobalParserInterface->letMgr->resolveLet(str);
+     nptr= *let;
      cvclval.node = GlobalParserInterface->newNode(nptr);
 
      if ((cvclval.node)->GetType() == BOOLEAN_TYPE)

--- a/lib/Parser/smt.lex
+++ b/lib/Parser/smt.lex
@@ -229,9 +229,9 @@ bit{DIGIT}+     {
     	nptr= stp::GlobalParserInterface->LookupOrCreateSymbol(str);
     	found = true;
     }
-    else if (stp::GlobalParserInterface->letMgr->isLetDeclared(str)) // a let.
+    else if (const stp::ASTNode* let = stp::GlobalParserInterface->letMgr->lookupLet(str)) // a let.
     {
-    	nptr= stp::GlobalParserInterface->letMgr->resolveLet(str);
+    	nptr= *let;
     	found = true;
     }
 

--- a/lib/Parser/smt2.lex
+++ b/lib/Parser/smt2.lex
@@ -83,9 +83,9 @@
     stp::ASTNode nptr;
     bool found = false;
 
-    if (stp::GlobalParserInterface->letMgr->isLetDeclared(s)) // Lets shadow everything else.
+    if (const stp::ASTNode* let = stp::GlobalParserInterface->letMgr->lookupLet(s)) // Lets shadow everything else.
     {
-      nptr = stp::GlobalParserInterface->letMgr->resolveLet(s);
+      nptr = *let;
       found = true;
     }
     else if (stp::GlobalParserInterface->LookupSymbol(s,nptr)) // it's a symbol.

--- a/tests/query-files/let-tests/let_009.smt2
+++ b/tests/query-files/let-tests/let_009.smt2
@@ -1,8 +1,7 @@
-; RUN: %solver %s 2>&1 | %OutputCheck %s
+; RUN: not %solver %s 2>&1 | %OutputCheck %s
 (set-logic QF_BV)
 
-; CHECK-NOT:"sat"
-; Should fail because binds "a" twice in the same let.
-;(assert (not (let ((a false) (a false)) a)))
-
+; Should fail because "a" is bound twice in the same let.
+(assert (not (let ((a false) (a false)) a)))
+; CHECK: Let already created:a
 (check-sat)

--- a/tests/query-files/let-tests/let_010.smt2
+++ b/tests/query-files/let-tests/let_010.smt2
@@ -1,0 +1,19 @@
+; RUN: %solver %s | %OutputCheck %s
+(set-info :smt-lib-version 2.6)
+(set-logic QF_BV)
+(set-info :category "crafted")
+(set-info :status unsat)
+
+; The same name is rebound at three depths. After each inner let closes,
+; references must resolve to the enclosing binding again.
+(assert (not
+  (let ((x (_ bv1 8)))
+    (= (bvadd
+         (let ((x (bvadd x (_ bv1 8))))          ; x = 2
+           (bvadd (let ((x (bvadd x (_ bv1 8)))) ; x = 3
+                    x)
+                  x))                            ; 3 + 2 = 5
+         x)                                      ; 5 + 1 = 6
+       (_ bv6 8)))))
+; CHECK-NEXT: ^unsat
+(check-sat)

--- a/tests/query-files/let-tests/let_011.smt2
+++ b/tests/query-files/let-tests/let_011.smt2
@@ -1,0 +1,16 @@
+; RUN: %solver %s | %OutputCheck %s
+(set-info :smt-lib-version 2.6)
+(set-logic QF_BV)
+(set-info :category "crafted")
+(set-info :status unsat)
+
+(declare-fun x () (_ BitVec 8))
+(assert (= x (_ bv5 8)))
+
+; The let shadows the declared x; once the let closes the declared x
+; must be visible again.
+(assert (not (=
+  (bvadd (let ((x (_ bv1 8))) x) x)   ; 1 + 5
+  (_ bv6 8))))
+; CHECK-NEXT: ^unsat
+(check-sat)

--- a/tests/query-files/let-tests/let_012.smt2
+++ b/tests/query-files/let-tests/let_012.smt2
@@ -1,0 +1,18 @@
+; RUN: %solver %s | %OutputCheck %s
+(set-info :smt-lib-version 2.6)
+(set-logic QF_BV)
+(set-info :category "crafted")
+(set-info :status sat)
+
+(declare-fun t () (_ BitVec 4))
+
+; Sibling lets reuse the same name after the previous one has closed,
+; including with a different type.
+(assert (let ((s (_ bv3 4))) (= s (_ bv3 4))))
+(assert (let ((s true)) s))
+(assert (and
+  (let ((s true)) s)
+  (let ((s (_ bv0 4))) (= s (_ bv0 4)))
+  (= t t)))
+; CHECK-NEXT: ^sat
+(check-sat)

--- a/tests/query-files/let-tests/let_013.smt2
+++ b/tests/query-files/let-tests/let_013.smt2
@@ -1,0 +1,14 @@
+; RUN: %solver %s | %OutputCheck %s
+(set-info :smt-lib-version 2.6)
+(set-logic QF_BV)
+(set-info :category "crafted")
+(set-info :status unsat)
+
+; In the inner binding list, b is bound in parallel with the rebinding of a,
+; so b must see the outer a, not the new one.
+(assert (not
+  (let ((a (_ bv1 4)))
+    (let ((a (_ bv2 4)) (b a))
+      (and (= a (_ bv2 4)) (= b (_ bv1 4)))))))
+; CHECK-NEXT: ^unsat
+(check-sat)

--- a/tests/query-files/let-tests/let_014.smt2
+++ b/tests/query-files/let-tests/let_014.smt2
@@ -1,0 +1,19 @@
+; RUN: %solver %s | %OutputCheck %s
+(set-info :smt-lib-version 2.6)
+(set-logic QF_BV)
+(set-info :category "crafted")
+(set-info :status unsat)
+
+(declare-fun y () (_ BitVec 8))
+(assert (= y (_ bv10 8)))
+
+; The binding for z opens and closes further lets that shadow y while the
+; outer binding list is still pending. The binding for w and the body must
+; both see the declared y.
+(assert (not
+  (let ((z (let ((y (_ bv1 8)))
+             (bvadd y (let ((y (_ bv2 8))) y))))   ; z = 1 + 2 = 3
+        (w y))                                     ; declared y = 10
+    (= (bvadd z w y) (_ bv23 8)))))                ; 3 + 10 + 10
+; CHECK-NEXT: ^unsat
+(check-sat)


### PR DESCRIPTION
`LetMgr` kept a vector of per-frame hash maps and resolved each identifier by searching the frames innermost-first. On files with deeply nested lets that mostly reference declared variables (e.g. the QF_BV/sage/app7 benchmarks, which keep ~16k frames open at once), every lookup that wasn't a let scanned all open frames — and the lexers did that scan twice per symbol (`isLetDeclared` then `resolveLet`) — making parsing quadratic. `perf` showed 88% of parse time in `LetMgr::lookupLet`.

Now a single hash map maps each name to its stack of shadowing bindings, tagged with the owning frame index; a per-frame undo log restores the map on `pop()`. Lookups are one hash probe regardless of nesting depth, and all three lexers use the now-public `lookupLet()` to resolve in one probe instead of two.

Parse times (`--parse-only`, release build):

| file | size | before | after |
|---|---|---|---|
| sage/app7/bench_503.smt2 | 4.2MB | 7.5s | 0.68s |
| sage/app7/bench_1159.smt2 | 4.2MB | 6.9s | 0.71s |
| sage/app7/bench_5892.smt2 | 3.3MB | 3.2s | 0.60s |
| sage/app7/bench_242.smt2 | 3.2MB | 3.0s | 0.48s |
| Sage2/bench_1010.smt2 | 2.9MB | 0.20s | 0.16s |
| asp/laby_18_18_13.lp.smt2 | 36MB | 4.5s | 4.3s |

Checked:
- unit + query-file tests pass (59/59)
- sat/unsat matches the `:status` annotation on 51 sage/app7 and Sage2 benchmarks (no mismatches)
- shadowed nested lets still resolve to the innermost binding, and duplicate names in one binding list are still rejected