### PR TITLE
Cut per-application define-fun lookups and let the lexer block-read

### DIFF
--- a/include/stp/cpp_interface.h
+++ b/include/stp/cpp_interface.h
@@ -81,6 +81,13 @@ class Cpp_interface
   };
   std::unordered_map<std::string, Function> functions;
 
+  // The function most recently found by isBitVectorFunction or
+  // isBooleanFunction, letting applyFunction skip a second hash probe when
+  // the parser applies the function the lexer just identified. Pointers
+  // into the map are stable except across erase, so this is cleared
+  // whenever a frame is removed.
+  const Function* last_found_function = nullptr;
+
   // Nested helper class to encapsulate a frame (i.e., between push a pop)
   class SolverFrame
   {
@@ -164,14 +171,14 @@ public:
 
   // Declare a function. We can't keep references to the declared variables
   // though. So rename them..
-  DLL_PUBLIC void storeFunction(const std::string name, const ASTVec& params,
+  DLL_PUBLIC void storeFunction(const std::string& name, const ASTVec& params,
                                 const ASTNode& function);
 
-  DLL_PUBLIC ASTNode applyFunction(const std::string name,
+  DLL_PUBLIC ASTNode applyFunction(const std::string& name,
                                    const ASTVec& params);
 
-  DLL_PUBLIC bool isBitVectorFunction(const std::string name);
-  DLL_PUBLIC bool isBooleanFunction(const std::string name);
+  DLL_PUBLIC bool isBitVectorFunction(const std::string& name);
+  DLL_PUBLIC bool isBooleanFunction(const std::string& name);
 
   DLL_PUBLIC ASTNode LookupOrCreateSymbol(std::string name);
   DLL_PUBLIC bool LookupSymbol(const char* const name, ASTNode& output);

--- a/lib/Interface/cpp_interface.cpp
+++ b/lib/Interface/cpp_interface.cpp
@@ -71,6 +71,9 @@ void Cpp_interface::addFrame()
 
 void Cpp_interface::removeFrame()
 {
+    // Deleting the frame erases its functions from the map.
+    last_found_function = nullptr;
+
     // obtain the last frame
     SolverFrame* last = frames.back();
 
@@ -212,7 +215,7 @@ void Cpp_interface::removeSymbol(ASTNode to_remove)
     FatalError("Should have been removed...");
 }
 
-void Cpp_interface::storeFunction(const string name, const ASTVec& params,
+void Cpp_interface::storeFunction(const string& name, const ASTVec& params,
                                   const ASTNode& function)
 {
   Function f;
@@ -239,13 +242,21 @@ void Cpp_interface::storeFunction(const string name, const ASTVec& params,
   getCurrentFunctions().push_back(f.name);
 }
 
-ASTNode Cpp_interface::applyFunction(const string name, const ASTVec& params)
+ASTNode Cpp_interface::applyFunction(const string& name, const ASTVec& params)
 {
-  if (functions.find(name) == functions.end())
-    FatalError("Trying to apply function which has not been defined.");
+  const Function* fp = last_found_function;
+  if (fp == NULL || fp->name != name)
+  {
+    const auto found = functions.find(name);
+    if (found == functions.end())
+      FatalError("Trying to apply function which has not been defined.");
+    fp = &found->second;
+  }
 
-  Function f;
-  f = functions[string(name)];
+  const Function& f = *fp;
+
+  if (f.params.size() != params.size())
+    FatalError("Actual parameters differ in number from formal");
 
   ASTNodeMap fromTo;
   for (size_t i = 0, size = f.params.size(); i < size; ++i)
@@ -263,16 +274,28 @@ ASTNode Cpp_interface::applyFunction(const string name, const ASTVec& params)
   return SubstitutionMap::replace(f.function, fromTo, cache, nf);
 }
 
-bool Cpp_interface::isBitVectorFunction(const string name)
+bool Cpp_interface::isBitVectorFunction(const string& name)
 {
-  return ((functions.find(name) != functions.end()) &&
-          functions.find(name)->second.function.GetType() == BITVECTOR_TYPE);
+  const auto found = functions.find(name);
+  if (found == functions.end())
+    return false;
+
+  last_found_function = &found->second;
+  return found->second.function.GetType() == BITVECTOR_TYPE;
 }
 
-bool Cpp_interface::isBooleanFunction(const string name)
+bool Cpp_interface::isBooleanFunction(const string& name)
 {
-  return ((functions.find(name) != functions.end()) &&
-          functions.find(name)->second.function.GetType() == BOOLEAN_TYPE);
+  // Usually called straight after isBitVectorFunction on the same name.
+  if (last_found_function != NULL && last_found_function->name == name)
+    return last_found_function->function.GetType() == BOOLEAN_TYPE;
+
+  const auto found = functions.find(name);
+  if (found == functions.end())
+    return false;
+
+  last_found_function = &found->second;
+  return found->second.function.GetType() == BOOLEAN_TYPE;
 }
 
 ASTNode Cpp_interface::LookupOrCreateSymbol(string name)

--- a/lib/Parser/smt2.lex
+++ b/lib/Parser/smt2.lex
@@ -1,6 +1,5 @@
 /*%option reentrant
 %option bison-bridge*/
-%option always-interactive
 %option noyywrap
 %option nounput
 %option noreject


### PR DESCRIPTION
Files that lean on `define-fun` (e.g. `QF_BV/20230221-oisc-gurtner`, with 1.2M definitions) spent ~22% of parse time probing the function map, because each application probed it up to six times: `isBitVectorFunction`/`isBooleanFunction` each called `find()` twice on a by-value string, and `applyFunction` did `find()` + `operator[]` and then copied the whole `Function` struct.

This PR:
- passes the names by const reference and probes once per predicate
- adds a one-entry memo carrying the hit from the lexer's type query through to `applyFunction`, which then uses the map entry in place (no `Function` copy). The memo stays valid because inserts never displace entries; it is cleared whenever a frame is removed (the only erase path).
- makes `applyFunction` reject applications whose actual parameter count differs from the formals — previously fewer actuals than formals read `params[i]` out of bounds; extras were silently ignored.
- drops `%option always-interactive` from the SMT-LIB2 lexer, so flex block-reads from files and pipes and only uses per-character reads on a terminal (auto-detected via `isatty`).

**Caveat worth reviewing:** with `always-interactive` gone, a process driving stp *interactively over a pipe* (sending a command, waiting for the answer before sending more) would deadlock, since flex may block filling its buffer. Plain piped input (`cat file | stp --SMTLIB2`) is unaffected and tested. If pipe-interactive use matters, I can drop that hunk.

Parse time (`--parse-only`, release build):

| file | size | before | after |
|---|---|---|---|
| AND-NESTED-32-32.smt2 | 85MB | 7.4s | 6.5s |
| laby_18_18_13.lp.smt2 | 36MB | 4.5s | 4.2s |

Checked: all 59 ctest suites pass; sat/unsat matches the `:status` annotation on 80 Sydr/float/Sage2 benchmarks; `define-fun` with parameters works; wrong arity now errors cleanly; stdin input works.