### PR TITLE
Add an --interactive flag controlling character-at-a-time reading

### DIFF
--- a/include/stp/Parser/parser.h
+++ b/include/stp/Parser/parser.h
@@ -47,6 +47,10 @@ DLL_PUBLIC void setCVCIn(FILE* file);
 DLL_PUBLIC void setSMTIn(FILE* file);
 DLL_PUBLIC void setSMT2In(FILE* file);
 
+// Whether the SMT-LIB2 lexer reads a character at a time. Needed when stp
+// is driven interactively over a pipe, where block reads would deadlock.
+DLL_PUBLIC void setSMT2Interactive(bool enable);
+
 DLL_PUBLIC int SMTParse(void* AssertsQuery);
 DLL_PUBLIC int SMT2Parse();
 DLL_PUBLIC int CVCParse(void* AssertsQuery);

--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -139,6 +139,12 @@ public:
   // Stop after parsing the input, skipping any check-sat commands.
   bool parse_only = false;
 
+  // Whether the SMT-LIB2 lexer reads a character at a time, as needed when
+  // stp is driven interactively over a pipe, rather than in blocks.
+  // -1: character at a time for stdin, blocks for files. 0: blocks. 1:
+  // character at a time.
+  int64_t interactive_read = -1;
+
   /* SAT solving options */
 
   int64_t timeout_max_conflicts = -1;

--- a/lib/Parser/smt2.lex
+++ b/lib/Parser/smt2.lex
@@ -307,4 +307,10 @@ namespace stp {
   void setSMT2In(FILE* file) {
     smt2in = file;
   }
+
+  void setSMT2Interactive(bool enable) {
+    if (smt2in == NULL)
+      smt2in = stdin;
+    yy_set_interactive(enable ? 1 : 0);
+  }
 }

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -358,6 +358,12 @@ void ExtraMain::create_options()
       ("parse-only", po::bool_switch(&(bm->UserFlags.parse_only)),
        "exit after parsing the input, without solving")
 
+      ("interactive", po::value<bool>(),
+       "read the input a character at a time, as needed when driving stp "
+       "interactively over a pipe. Off reads in blocks, which is faster. "
+       "Default: on when reading from stdin, off when reading from a file. "
+       "SMT-LIB2 only.")
+
       ("max-num-confl,max_num_confl,g", 
       INT64_ARG(bm->UserFlags.timeout_max_conflicts),
       "Number of conflicts after which the SAT solver gives up. "
@@ -420,6 +426,11 @@ int ExtraMain::parse_options(int argc, char** argv)
   if (vm.count("disable-cbitp"))
   {
     bm->UserFlags.bitConstantProp_flag = false;
+  }
+
+  if (vm.count("interactive"))
+  {
+    bm->UserFlags.interactive_read = vm["interactive"].as<bool>() ? 1 : 0;
   }
 
   int selected_type = 0;

--- a/tools/stp/main_common.cpp
+++ b/tools/stp/main_common.cpp
@@ -122,6 +122,11 @@ void Main::parse_file(ASTVec* AssertsQuery)
   }
   else if (bm->UserFlags.smtlib2_parser_flag)
   {
+    bool interactive = infile.empty(); // reading from stdin.
+    if (bm->UserFlags.interactive_read != -1)
+      interactive = bm->UserFlags.interactive_read != 0;
+    setSMT2Interactive(interactive);
+
     SMT2Parse();
     smt2lex_destroy();
   }


### PR DESCRIPTION
Follow-up to #557, which dropped `always-interactive` and inferred interactivity from `isatty` — meaning a process driving stp over a pipe (send a command, wait for the answer) would deadlock on flex's block reads. Make it explicit instead:

- By default stdin is read a character at a time — so interactive driving over a pipe works exactly as it did before #557 — and files are read in blocks, keeping the speedup.
- `--interactive on/off` overrides the default in either direction. SMT-LIB2 only.

Verified with a coprocess that sends `(check-sat)` and waits for the answer before sending more input: the default responds (sat, then unsat after a further assert), and `--interactive 0` blocks as expected. File parse speed is unchanged (85MB AND-NESTED in 6.5s). All 59 ctest suites pass.