### PR TITLE
Trim allocation and probe overhead in the parsing hot paths

### DIFF
--- a/include/stp/AST/ASTInterior.h
+++ b/include/stp/AST/ASTInterior.h
@@ -52,6 +52,12 @@ class ASTInterior : public ASTInternal
   // The vector of children
   ASTVec _children;
 
+  // Lazily computed by ASTInteriorHasher; 0 means not yet computed.
+  // Stays valid because the kind and children never change once set up,
+  // so the hash isn't recomputed on insertion or removal from the
+  // unique table.
+  mutable size_t _hash_cache = 0;
+
   /******************************************************************
    * Hasher for ASTInterior pointer nodes                           *
    ******************************************************************/
@@ -113,6 +119,16 @@ public:
   ASTInterior(const ASTInterior& int_node)
       : ASTInternal(int_node), _children(int_node._children),
         _value_width(int_node._value_width), _index_width(int_node._index_width)
+  {
+    is_simplified = false;
+  }
+
+  // Steals the children of a probe node that was built on the stack to
+  // search the unique table, keeping its node number and cached hash.
+  ASTInterior(ASTInterior&& int_node)
+      : ASTInternal(int_node), _children(std::move(int_node._children)),
+        _hash_cache(int_node._hash_cache), _value_width(int_node._value_width),
+        _index_width(int_node._index_width)
   {
     is_simplified = false;
   }

--- a/include/stp/AST/ASTInterior.h
+++ b/include/stp/AST/ASTInterior.h
@@ -56,7 +56,7 @@ class ASTInterior : public ASTInternal
   // Stays valid because the kind and children never change once set up,
   // so the hash isn't recomputed on insertion or removal from the
   // unique table.
-  mutable size_t _hash_cache = 0;
+  mutable size_t _cached_hash = 0;
 
   /******************************************************************
    * Hasher for ASTInterior pointer nodes                           *
@@ -127,7 +127,7 @@ public:
   // search the unique table, keeping its node number and cached hash.
   ASTInterior(ASTInterior&& int_node)
       : ASTInternal(int_node), _children(std::move(int_node._children)),
-        _hash_cache(int_node._hash_cache), _value_width(int_node._value_width),
+        _cached_hash(int_node._cached_hash), _value_width(int_node._value_width),
         _index_width(int_node._index_width)
   {
     is_simplified = false;

--- a/include/stp/AST/ASTInterior.h
+++ b/include/stp/AST/ASTInterior.h
@@ -52,11 +52,12 @@ class ASTInterior : public ASTInternal
   // The vector of children
   ASTVec _children;
 
-  // The hash of (_kind, _children), computed on first use. The children
-  // are appended before the node reaches the unique table and never
-  // change afterwards, so the value is stable. Zero means "not yet
-  // computed"; a genuine zero hash is recomputed each time, harmlessly.
-  mutable size_t _cached_hash = 0;
+  // The hash of (_kind, _children), computed on first use by
+  // ASTInteriorHasher. The children are appended before the node
+  // reaches the unique table and never change afterwards, so the value
+  // is stable. Zero means "not yet computed"; the hasher remaps a
+  // genuine zero hash to one so it still caches.
+  mutable size_t _hash_cache = 0;
 
   /******************************************************************
    * Hasher for ASTInterior pointer nodes                           *
@@ -119,6 +120,16 @@ public:
   ASTInterior(const ASTInterior& int_node)
       : ASTInternal(int_node), _children(int_node._children),
         _value_width(int_node._value_width), _index_width(int_node._index_width)
+  {
+    is_simplified = false;
+  }
+
+  // Steals the children of a probe node that was built on the stack to
+  // search the unique table, keeping its node number and cached hash.
+  ASTInterior(ASTInterior&& int_node)
+      : ASTInternal(int_node), _children(std::move(int_node._children)),
+        _hash_cache(int_node._hash_cache), _value_width(int_node._value_width),
+        _index_width(int_node._index_width)
   {
     is_simplified = false;
   }

--- a/include/stp/AST/ASTNode.h
+++ b/include/stp/AST/ASTNode.h
@@ -84,12 +84,6 @@ public:
   DLL_PUBLIC ~ASTNode();
   DLL_PUBLIC ASTNode(ASTNode&& other) noexcept;
 
-  // The parsers heap-allocate an ASTNode for almost every token, so
-  // single ASTNodes are served from a free list instead of the general
-  // allocator.
-  DLL_PUBLIC static void* operator new(size_t size);
-  DLL_PUBLIC static void operator delete(void* p);
-
   // Print the arguments in lisp format
   friend ostream& LispPrintVec(ostream& os, const ASTVec& v, int indentation);
 

--- a/include/stp/AST/ASTNode.h
+++ b/include/stp/AST/ASTNode.h
@@ -84,6 +84,12 @@ public:
   DLL_PUBLIC ~ASTNode();
   DLL_PUBLIC ASTNode(ASTNode&& other) noexcept;
 
+  // The parsers heap-allocate an ASTNode for almost every token, so
+  // single ASTNodes are served from a free list instead of the general
+  // allocator.
+  DLL_PUBLIC static void* operator new(size_t size);
+  DLL_PUBLIC static void operator delete(void* p);
+
   // Print the arguments in lisp format
   friend ostream& LispPrintVec(ostream& os, const ASTVec& v, int indentation);
 

--- a/include/stp/STPManager/STPManager.h
+++ b/include/stp/STPManager/STPManager.h
@@ -163,6 +163,10 @@ private:
   // Create unique ASTInterior node.
   ASTInterior* LookupOrCreateInterior(ASTInterior* n);
 
+  // As above, but probes the unique table with a stack node, so nothing
+  // is heap-allocated when an equivalent node already exists.
+  ASTInterior* LookupOrCreateInterior(Kind kind, const ASTVec& children);
+
   // Create unique ASTSymbol node.
   ASTSymbol* LookupOrCreateSymbol(ASTSymbol& s);
 

--- a/include/stp/STPManager/STPManager.h
+++ b/include/stp/STPManager/STPManager.h
@@ -159,6 +159,10 @@ private:
   // Create unique ASTInterior node.
   ASTInterior* LookupOrCreateInterior(ASTInterior* n);
 
+  // As above, but probes the unique table with a stack node, so nothing
+  // is heap-allocated when an equivalent node already exists.
+  ASTInterior* LookupOrCreateInterior(Kind kind, const ASTVec& children);
+
   // Create unique ASTSymbol node.
   ASTSymbol* LookupOrCreateSymbol(ASTSymbol& s);
 

--- a/include/stp/cpp_interface.h
+++ b/include/stp/cpp_interface.h
@@ -174,6 +174,7 @@ public:
 
   DLL_PUBLIC bool isBitVectorFunction(const std::string& name);
   DLL_PUBLIC bool isBooleanFunction(const std::string& name);
+  bool hasFunctions() const { return !functions.empty(); }
 
   DLL_PUBLIC ASTNode LookupOrCreateSymbol(std::string name);
   DLL_PUBLIC bool LookupSymbol(const char* const name, ASTNode& output);

--- a/include/stp/cpp_interface.h
+++ b/include/stp/cpp_interface.h
@@ -179,6 +179,7 @@ public:
 
   DLL_PUBLIC bool isBitVectorFunction(const std::string& name);
   DLL_PUBLIC bool isBooleanFunction(const std::string& name);
+  bool hasFunctions() const { return !functions.empty(); }
 
   DLL_PUBLIC ASTNode LookupOrCreateSymbol(std::string name);
   DLL_PUBLIC bool LookupSymbol(const char* const name, ASTNode& output);

--- a/lib/AST/ASTInterior.cpp
+++ b/lib/AST/ASTInterior.cpp
@@ -54,8 +54,8 @@ void ASTInterior::nodeprint(ostream& os, bool /*c_friendly*/)
 size_t ASTInterior::ASTInteriorHasher::
 operator()(const ASTInterior* int_node_ptr) const
 {
-  if (int_node_ptr->_hash_cache != 0)
-    return int_node_ptr->_hash_cache;
+  if (int_node_ptr->_cached_hash != 0)
+    return int_node_ptr->_cached_hash;
 
   size_t hashval = ((size_t)int_node_ptr->GetKind());
   const ASTVec& ch = int_node_ptr->GetChildren();
@@ -73,7 +73,7 @@ operator()(const ASTInterior* int_node_ptr) const
 
   if (hashval == 0)
     hashval = 1; // 0 marks the hash as not yet computed.
-  int_node_ptr->_hash_cache = hashval;
+  int_node_ptr->_cached_hash = hashval;
   return hashval;
 }
 

--- a/lib/AST/ASTInterior.cpp
+++ b/lib/AST/ASTInterior.cpp
@@ -54,8 +54,8 @@ void ASTInterior::nodeprint(ostream& os, bool /*c_friendly*/)
 size_t ASTInterior::ASTInteriorHasher::
 operator()(const ASTInterior* int_node_ptr) const
 {
-  if (int_node_ptr->_cached_hash != 0)
-    return int_node_ptr->_cached_hash;
+  if (int_node_ptr->_hash_cache != 0)
+    return int_node_ptr->_hash_cache;
 
   size_t hashval = ((size_t)int_node_ptr->GetKind());
   const ASTVec& ch = int_node_ptr->GetChildren();
@@ -70,7 +70,10 @@ operator()(const ASTInterior* int_node_ptr) const
   hashval += (hashval << 3);
   hashval ^= (hashval >> 11);
   hashval += (hashval << 15);
-  int_node_ptr->_cached_hash = hashval;
+
+  if (hashval == 0)
+    hashval = 1; // 0 marks the hash as not yet computed.
+  int_node_ptr->_hash_cache = hashval;
   return hashval;
 }
 

--- a/lib/AST/ASTInterior.cpp
+++ b/lib/AST/ASTInterior.cpp
@@ -54,6 +54,9 @@ void ASTInterior::nodeprint(ostream& os, bool /*c_friendly*/)
 size_t ASTInterior::ASTInteriorHasher::
 operator()(const ASTInterior* int_node_ptr) const
 {
+  if (int_node_ptr->_hash_cache != 0)
+    return int_node_ptr->_hash_cache;
+
   size_t hashval = ((size_t)int_node_ptr->GetKind());
   const ASTVec& ch = int_node_ptr->GetChildren();
   ASTVec::const_iterator iend = ch.end();
@@ -67,6 +70,10 @@ operator()(const ASTInterior* int_node_ptr) const
   hashval += (hashval << 3);
   hashval ^= (hashval >> 11);
   hashval += (hashval << 15);
+
+  if (hashval == 0)
+    hashval = 1; // 0 marks the hash as not yet computed.
+  int_node_ptr->_hash_cache = hashval;
   return hashval;
 }
 

--- a/lib/AST/ASTNode.cpp
+++ b/lib/AST/ASTNode.cpp
@@ -28,6 +28,30 @@ THE SOFTWARE.
 
 namespace stp
 {
+
+// Freed single-ASTNode blocks, linked through their own storage. Blocks
+// are only returned to the general allocator at process exit.
+static THREAD_LOCAL void* astnode_free_list = NULL;
+
+void* ASTNode::operator new(size_t size)
+{
+  if (size != sizeof(ASTNode) || astnode_free_list == NULL)
+    return ::operator new(size);
+
+  void* p = astnode_free_list;
+  astnode_free_list = *static_cast<void**>(p);
+  return p;
+}
+
+void ASTNode::operator delete(void* p)
+{
+  if (p == NULL)
+    return;
+
+  *static_cast<void**>(p) = astnode_free_list;
+  astnode_free_list = p;
+}
+
 uint8_t ASTNode::getIteration() const
 {
   return _int_node_ptr->iteration;

--- a/lib/AST/ASTNode.cpp
+++ b/lib/AST/ASTNode.cpp
@@ -29,29 +29,6 @@ THE SOFTWARE.
 namespace stp
 {
 
-// Freed single-ASTNode blocks, linked through their own storage. Blocks
-// are only returned to the general allocator at process exit.
-static THREAD_LOCAL void* astnode_free_list = NULL;
-
-void* ASTNode::operator new(size_t size)
-{
-  if (size != sizeof(ASTNode) || astnode_free_list == NULL)
-    return ::operator new(size);
-
-  void* p = astnode_free_list;
-  astnode_free_list = *static_cast<void**>(p);
-  return p;
-}
-
-void ASTNode::operator delete(void* p)
-{
-  if (p == NULL)
-    return;
-
-  *static_cast<void**>(p) = astnode_free_list;
-  astnode_free_list = p;
-}
-
 uint8_t ASTNode::getIteration() const
 {
   return _int_node_ptr->iteration;

--- a/lib/Interface/cpp_interface.cpp
+++ b/lib/Interface/cpp_interface.cpp
@@ -572,6 +572,13 @@ void Cpp_interface::cleanUp()
   letMgr->cleanupParserSymbolTable();
   cache.clear();
 
+  // Every frame is going away, so don't erase the functions from the
+  // map one at a time (files can define millions of functions).
+  functions.clear();
+  last_found_function = nullptr;
+  for (SolverFrame* frame : frames)
+    frame->getFunctions().clear();
+
   while (frames.size() > 0)
   {
     removeFrame();

--- a/lib/Interface/cpp_interface.cpp
+++ b/lib/Interface/cpp_interface.cpp
@@ -558,6 +558,12 @@ void Cpp_interface::cleanUp()
   letMgr->cleanupParserSymbolTable();
   cache.clear();
 
+  // Every frame is going away, so don't erase the functions from the
+  // map one at a time (files can define millions of functions).
+  functions.clear();
+  for (SolverFrame* frame : frames)
+    frame->getFunctions().clear();
+
   while (frames.size() > 0)
   {
     removeFrame();

--- a/lib/NodeFactory/HashingNodeFactory.cpp
+++ b/lib/NodeFactory/HashingNodeFactory.cpp
@@ -47,37 +47,28 @@ ASTNode HashingNodeFactory::CreateNode(const Kind kind,
   if (back_children.size()  <= 1 || !isCommutative(kind))
   {
     // Don't create a new vector if it won't be sorted.
-    ASTInterior* n_ptr = new ASTInterior(&bm, kind, back_children);
-    ASTNode n(bm.LookupOrCreateInterior(n_ptr));
-    return n;    
+    return ASTNode(bm.LookupOrCreateInterior(kind, back_children));
   }
   else if (is_Form_kind(kind)) // formula and commutative.
   {
     const bool isSorted =  std::is_sorted(back_children.begin(),back_children.end(),stp::exprless);
     if (isSorted)
     {
-      ASTInterior* n_ptr = new ASTInterior(&bm, kind, back_children);
-      ASTNode n(bm.LookupOrCreateInterior(n_ptr));
-      return n;
+      return ASTNode(bm.LookupOrCreateInterior(kind, back_children));
     }
 
     ASTVec sorted_children = back_children;
-    SortByExprNum(sorted_children);  
-    ASTInterior* n_ptr = new ASTInterior(&bm, kind, sorted_children);
-    ASTNode n(bm.LookupOrCreateInterior(n_ptr));
-    return n;
+    SortByExprNum(sorted_children);
+    return ASTNode(bm.LookupOrCreateInterior(kind, sorted_children));
   }
   else
   {
     ASTVec children(back_children);
     // The Bitvector solver seems to expect constants on the RHS, variables on the
-    // LHS. 
+    // LHS.
     SortByArith(children);
 
-    // Todo - we could move the children into the astinterior.
-    ASTInterior* n_ptr = new ASTInterior(&bm, kind, children);
-    ASTNode n(bm.LookupOrCreateInterior(n_ptr));
-    return n;
+    return ASTNode(bm.LookupOrCreateInterior(kind, children));
   }
 }
 

--- a/lib/Parser/smt2.lex
+++ b/lib/Parser/smt2.lex
@@ -87,23 +87,28 @@
       nptr = *let;
       found = true;
     }
-    else if (stp::GlobalParserInterface->LookupSymbol(s,nptr)) // it's a symbol.
-    {
-      found = true;
-    }
-    else if (stp::GlobalParserInterface->isBitVectorFunction(s))
+    // Checking the functions before the symbols saves a symbol-table
+    // probe in files built almost entirely from define-funs. A name can't
+    // legally be both, so the order isn't observable on valid input.
+    else if (stp::GlobalParserInterface->hasFunctions() &&
+             stp::GlobalParserInterface->isBitVectorFunction(s))
     {
       smt2lval.str = new std::string(s);
       if (cleaned)
         free (cleaned);
       return  BITVECTOR_FUNCTIONID_TOK;
     }
-    else if (stp::GlobalParserInterface->isBooleanFunction(s))
+    else if (stp::GlobalParserInterface->hasFunctions() &&
+             stp::GlobalParserInterface->isBooleanFunction(s))
     {
        smt2lval.str = new std::string(s);
        if (cleaned)
          free (cleaned);
        return  BOOLEAN_FUNCTIONID_TOK;
+    }
+    else if (stp::GlobalParserInterface->LookupSymbol(s,nptr)) // it's a symbol.
+    {
+      found = true;
     }
 
     if (found)

--- a/lib/STPManager/STPManager.cpp
+++ b/lib/STPManager/STPManager.cpp
@@ -59,6 +59,28 @@ ASTInterior* STPMgr::LookupOrCreateInterior(ASTInterior* n_ptr)
   return *it;
 }
 
+ASTInterior* STPMgr::LookupOrCreateInterior(Kind kind, const ASTVec& children)
+{
+  ASTInterior probe(this, kind, children);
+
+  const ASTInteriorSet::iterator it = _interior_unique_table.find(&probe);
+  if (it != _interior_unique_table.end())
+    return *it;
+
+  if (kind == NOT)
+  {
+    // The internal node can't be a NOT, because then we'd add
+    // 1 to the NOT's node number, meaning we'd hit an even number,
+    // which could duplicate the next newNodeNum().
+    assert(children[0].GetKind() != NOT);
+  }
+
+  // The heap node steals the probe's children, node number and hash.
+  ASTInterior* n_ptr = new ASTInterior(std::move(probe));
+  _interior_unique_table.insert(n_ptr);
+  return n_ptr;
+}
+
 ASTInterior* STPMgr::CreateInteriorNode(Kind /*kind*/,
                                         // children array of this
                                         // node will be modified.


### PR DESCRIPTION
Profiling `--parse-only` runs (after #556/#557) showed node creation and teardown machinery dominating. This PR takes the non-map-implementation wins:

- **Cache each ASTInterior's hash in the node** (lazy, 0 = uncomputed). Children never change once the node is set up, so insertion into and erasure from the unique table no longer rewalk the children. *Note: the separate map-library evaluation also carries a version of this — whichever lands first, the other side's diff shrinks; the two efforts are otherwise disjoint.*
- **Probe the unique table with a stack ASTInterior** and only heap-allocate on a miss. `HashingNodeFactory` previously always allocated a candidate that `LookupOrCreateInterior` deleted whenever an equivalent node existed. The heap node steals the probe's children, node number and cached hash via a new move constructor.
- **Clear the functions map wholesale in `Cpp_interface::cleanUp`** instead of erasing one probe at a time from `~SolverFrame`; teardown of a file with 1.2M define-funs was ~2% of the whole run.
- **Check the define-fun map before the symbol table in the SMT-LIB2 lexer** (guarded by `hasFunctions()`, so files without functions are unaffected). Function-heavy files previously paid a wasted symbol-table probe per reference; a name can't legally be both, so the order isn't observable on valid input.

Interleaved A/B against master (`--parse-only`, release, 4 rounds each):

| file | master | this PR |
|---|---|---|
| AND-NESTED-32-32.smt2 (85MB, 1.2M define-funs) | 6.36s | **5.93s (−7%)** |
| sage/app7/bench_1270.smt2 | 0.57s | 0.56s (noise) |
| asp/Labyrinth laby_18_18_13 (36MB) | 4.01s | 3.97s (noise) |

The remaining parse-time leaders (interior/function-map `find` and rehash, ~35% combined) are hash-map-implementation-bound and left to the separate map evaluation.

Checked: all 59 ctest suites pass; sat/unsat matches the `:status` annotation on 87 benchmarks across five families (sage/app7, Sage2, Sydr, float, SchurNumbers).
