### PR TITLE
Add six size-reducing rules to the SimplifyingNodeFactory

### DIFF
--- a/lib/NodeFactory/SimplifyingNodeFactory.cpp
+++ b/lib/NodeFactory/SimplifyingNodeFactory.cpp
@@ -286,6 +286,35 @@ ASTNode SimplifyingNodeFactory::CreateNode(Kind kind, const ASTVec& children)
             NodeFactory::CreateNode(stp::BVSGT, children[0][0], children[1][0]);
       }
 
+      //1st part is the same -> it decides the sign, so the 2nd parts
+      // compare unsigned.
+      if (result.IsNull() && children[0].GetKind() == BVCONCAT &&
+          children[1].GetKind() == BVCONCAT && children[0][0] == children[1][0])
+      {
+        result =
+            NodeFactory::CreateNode(stp::BVGT, children[0][1], children[1][1]);
+      }
+
+      // Sign extension keeps the signed value, so the comparison only
+      // needs the wider of the two originals' widths: drop the extension
+      // of the wider side, and extend the narrower side just up to it.
+      // At least one BVSX always goes away.
+      if (result.IsNull() && children[0].GetKind() == stp::BVSX &&
+          children[1].GetKind() == stp::BVSX)
+      {
+        const unsigned w0 = children[0][0].GetValueWidth();
+        const unsigned w1 = children[1][0].GetValueWidth();
+        ASTNode a = children[0][0];
+        ASTNode b = children[1][0];
+        if (w0 < w1)
+          a = NodeFactory::CreateTerm(stp::BVSX, w1, a,
+                                      bm.CreateBVConst(32, w1));
+        else if (w1 < w0)
+          b = NodeFactory::CreateTerm(stp::BVSX, w0, b,
+                                      bm.CreateBVConst(32, w0));
+        result = NodeFactory::CreateNode(stp::BVSGT, a, b);
+      }
+
       break;
 
     case stp::BVGT:
@@ -624,6 +653,31 @@ ASTNode SimplifyingNodeFactory::CreateSimpleEQ(const ASTVec& children)
     ASTNode a = NodeFactory::CreateNode(EQ, in2[1], c0);
     ASTNode b = NodeFactory::CreateNode(EQ, in2[0], c1);
     return NodeFactory::CreateNode(stp::AND, a, b);
+  }
+
+  // (a ++ b) = (a ++ c) <=> b = c, and (a ++ c) = (b ++ c) <=> a = b.
+  // Sharing a side pins the widths of the other sides to match.
+  if (BVCONCAT == k1 && BVCONCAT == k2 && in1[0] == in2[0])
+    return NodeFactory::CreateNode(EQ, in1[1], in2[1]);
+
+  if (BVCONCAT == k1 && BVCONCAT == k2 && in1[1] == in2[1])
+    return NodeFactory::CreateNode(EQ, in1[0], in2[0]);
+
+  // Sign extension keeps the value, so the equality only needs the wider
+  // of the two originals' widths: drop the extension of the wider side,
+  // and extend the narrower side just up to it. At least one BVSX always
+  // goes away.
+  if (stp::BVSX == k1 && stp::BVSX == k2)
+  {
+    const unsigned w1 = in1[0].GetValueWidth();
+    const unsigned w2 = in2[0].GetValueWidth();
+    ASTNode a = in1[0];
+    ASTNode b = in2[0];
+    if (w1 < w2)
+      a = NodeFactory::CreateTerm(stp::BVSX, w2, a, bm.CreateBVConst(32, w2));
+    else if (w2 < w1)
+      b = NodeFactory::CreateTerm(stp::BVSX, w1, b, bm.CreateBVConst(32, w1));
+    return NodeFactory::CreateNode(EQ, a, b);
   }
 
   // This increases the number of nodes. So disable for now.
@@ -1638,6 +1692,32 @@ ASTNode SimplifyingNodeFactory::CreateTerm(Kind kind, unsigned int width,
                children[0][0].GetKind() != stp::BVCONST)
         result = NodeFactory::CreateTerm(ITE, width, children[0],
                                          children[0][1], children[2]);
+      else if (width == 1 && children[0].GetKind() == EQ &&
+               children[0][0].GetValueWidth() == 1 &&
+               children[1].isConstant() && children[2].isConstant() &&
+               children[1] != children[2])
+      {
+        // A 1-bit ITE choosing between 0 and 1 on a 1-bit equality is the
+        // tested term or its complement, e.g. ITE(t = 1, 1, 0) --> t.
+        ASTNode t;
+        bool condOne = false;
+        if (children[0][0].isConstant())
+        {
+          t = children[0][1];
+          condOne = (children[0][0] == bm.CreateOneConst(1));
+        }
+        else if (children[0][1].isConstant())
+        {
+          t = children[0][0];
+          condOne = (children[0][1] == bm.CreateOneConst(1));
+        }
+        if (!t.IsNull())
+        {
+          const bool thenOne = (children[1] == bm.CreateOneConst(1));
+          result = (thenOne == condOne) ? t
+                                        : NodeFactory::CreateTerm(BVNOT, 1, t);
+        }
+      }
       break;
     }
 
@@ -2121,8 +2201,21 @@ ASTNode SimplifyingNodeFactory::CreateTerm(Kind kind, unsigned int width,
     case stp::BVDIV:
       if (children[1].isConstant() && children[1] == bm.CreateOneConst(width))
         result = children[0];
-      if (children[1].isConstant() &&
-          CONSTANTBV::BitVector_bit_test(children[1].GetBVConst(), width - 1))
+      else if (children[1].isConstant() && hasSingleOneBit(children[1]) &&
+               lowestOneBit(children[1]) > 0)
+      {
+        // (x / 2^n) --> (0^n ++ x[width-1:n]): a division by a power of
+        // two just discards the low bits.
+        const unsigned n = lowestOneBit(children[1]);
+        result = NodeFactory::CreateTerm(
+            BVCONCAT, width, bm.CreateZeroConst(n),
+            NodeFactory::CreateTerm(BVEXTRACT, width - n, children[0],
+                                    bm.CreateBVConst(32, width - 1),
+                                    bm.CreateBVConst(32, n)));
+      }
+      else if (children[1].isConstant() &&
+               CONSTANTBV::BitVector_bit_test(children[1].GetBVConst(),
+                                              width - 1))
       {
         // We are dividing by something that has a one in the MSB. It's either 1
         // or zero.
@@ -2262,6 +2355,19 @@ ASTNode SimplifyingNodeFactory::CreateTerm(Kind kind, unsigned int width,
 
       if (children[1].isConstant() && children[1] == one)
         result = bm.CreateZeroConst(width);
+
+      if (children[1].isConstant() && hasSingleOneBit(children[1]) &&
+          lowestOneBit(children[1]) > 0)
+      {
+        // (x mod 2^n) --> (0^(width-n) ++ x[n-1:0]): a remainder by a
+        // power of two just keeps the low bits.
+        const unsigned n = lowestOneBit(children[1]);
+        result = NodeFactory::CreateTerm(
+            BVCONCAT, width, bm.CreateZeroConst(width - n),
+            NodeFactory::CreateTerm(BVEXTRACT, n, children[0],
+                                    bm.CreateBVConst(32, n - 1),
+                                    bm.CreateBVConst(32, 0)));
+      }
 
       if (children[0].isConstant() && children[0] == one)
         result = NodeFactory::CreateTerm(

--- a/tests/unit-tests/SimplifyingNodeFactory_Exhaustive_Test.cpp
+++ b/tests/unit-tests/SimplifyingNodeFactory_Exhaustive_Test.cpp
@@ -408,4 +408,126 @@ TEST(SimplifyingNodeFactory_Exhaustive, sx_of_sx)
   EXPECT_EQ(collapsed[0], a);
 }
 
+/* x / 2^n --> 0^n ++ x[w-1:n] */
+TEST(SimplifyingNodeFactory_Exhaustive, div_by_power_of_two)
+{
+  Context c;
+  ASTNode x = c.bv(4);
+  for (unsigned d : {2u, 4u, 8u})
+  {
+    c.checkTerm(BVDIV, 4, {x, c.konst(d, 4)});
+    EXPECT_EQ(c.nf->CreateTerm(BVDIV, 4, x, c.konst(d, 4)).GetKind(),
+              BVCONCAT);
+  }
+}
+
+/* x mod 2^n --> 0^(w-n) ++ x[n-1:0] */
+TEST(SimplifyingNodeFactory_Exhaustive, mod_by_power_of_two)
+{
+  Context c;
+  ASTNode x = c.bv(4);
+  for (unsigned d : {2u, 4u, 8u})
+  {
+    c.checkTerm(BVMOD, 4, {x, c.konst(d, 4)});
+    EXPECT_EQ(c.nf->CreateTerm(BVMOD, 4, x, c.konst(d, 4)).GetKind(),
+              BVCONCAT);
+  }
+}
+
+/* (a ++ b) = (a ++ c) --> b = c, and the shared-tail variant */
+TEST(SimplifyingNodeFactory_Exhaustive, eq_concat_shared_half)
+{
+  Context c;
+  ASTNode a = c.bv(2);
+  ASTNode x = c.bv(3);
+  ASTNode y = c.bv(3);
+
+  ASTNode sharedHead1 = c.hf->CreateTerm(BVCONCAT, 5, a, x);
+  ASTNode sharedHead2 = c.hf->CreateTerm(BVCONCAT, 5, a, y);
+  c.checkNode(EQ, {sharedHead1, sharedHead2});
+  EXPECT_EQ(c.nf->CreateNode(EQ, sharedHead1, sharedHead2),
+            c.nf->CreateNode(EQ, x, y));
+
+  ASTNode sharedTail1 = c.hf->CreateTerm(BVCONCAT, 5, x, a);
+  ASTNode sharedTail2 = c.hf->CreateTerm(BVCONCAT, 5, y, a);
+  c.checkNode(EQ, {sharedTail1, sharedTail2});
+  EXPECT_EQ(c.nf->CreateNode(EQ, sharedTail1, sharedTail2),
+            c.nf->CreateNode(EQ, x, y));
+}
+
+/* equality and signed comparison of two sign extensions from the same
+   width reduce to the originals */
+TEST(SimplifyingNodeFactory_Exhaustive, sx_pairs)
+{
+  Context c;
+  ASTNode a = c.bv(3);
+  ASTNode b = c.bv(3);
+  ASTNode len = c.mgr.CreateBVConst(32, 6);
+  ASTNode sxa = c.hf->CreateTerm(BVSX, 6, a, len);
+  ASTNode sxb = c.hf->CreateTerm(BVSX, 6, b, len);
+
+  c.checkNode(EQ, {sxa, sxb});
+  EXPECT_EQ(c.nf->CreateNode(EQ, sxa, sxb), c.nf->CreateNode(EQ, a, b));
+
+  c.checkNode(BVSGT, {sxa, sxb});
+  EXPECT_EQ(c.nf->CreateNode(BVSGT, sxa, sxb),
+            c.nf->CreateNode(BVSGT, a, b));
+
+  // Different source widths: the wider side's extension goes away, and
+  // the narrower side extends just up to the wider side's width.
+  ASTNode n = c.bv(2);
+  ASTNode sxn = c.hf->CreateTerm(BVSX, 6, n, len);
+  ASTNode nTo3 = c.nf->CreateTerm(BVSX, 3, n, c.mgr.CreateBVConst(32, 3));
+
+  c.checkNode(EQ, {sxn, sxb});
+  EXPECT_EQ(c.nf->CreateNode(EQ, sxn, sxb), c.nf->CreateNode(EQ, nTo3, b));
+
+  c.checkNode(BVSGT, {sxb, sxn});
+  EXPECT_EQ(c.nf->CreateNode(BVSGT, sxb, sxn),
+            c.nf->CreateNode(BVSGT, b, nTo3));
+}
+
+/* (a ++ b) sgt (a ++ c): the shared head decides the sign, so the tails
+   compare unsigned */
+TEST(SimplifyingNodeFactory_Exhaustive, sgt_concat_shared_head)
+{
+  Context c;
+  ASTNode a = c.bv(2);
+  ASTNode x = c.bv(3);
+  ASTNode y = c.bv(3);
+  ASTNode l = c.hf->CreateTerm(BVCONCAT, 5, a, x);
+  ASTNode r = c.hf->CreateTerm(BVCONCAT, 5, a, y);
+  c.checkNode(BVSGT, {l, r});
+  EXPECT_EQ(c.nf->CreateNode(BVSGT, l, r), c.nf->CreateNode(BVGT, x, y));
+}
+
+/* a 1-bit ITE choosing between 0 and 1 on a 1-bit equality collapses to
+   the tested term or its complement */
+TEST(SimplifyingNodeFactory_Exhaustive, ite_width1_boolean_to_term)
+{
+  Context c;
+  ASTNode t = c.bv(1);
+  ASTNode one = c.konst(1, 1);
+  ASTNode zero = c.konst(0, 1);
+
+  for (int constFirst = 0; constFirst < 2; constFirst++)
+  {
+    ASTNode eqOne = constFirst ? c.hf->CreateNode(EQ, one, t)
+                               : c.hf->CreateNode(EQ, t, one);
+    ASTNode eqZero = constFirst ? c.hf->CreateNode(EQ, zero, t)
+                                : c.hf->CreateNode(EQ, t, zero);
+
+    c.checkTerm(ITE, 1, {eqOne, one, zero});
+    EXPECT_EQ(c.nf->CreateTerm(ITE, 1, eqOne, one, zero), t);
+
+    c.checkTerm(ITE, 1, {eqZero, zero, one});
+    EXPECT_EQ(c.nf->CreateTerm(ITE, 1, eqZero, zero, one), t);
+
+    c.checkTerm(ITE, 1, {eqOne, zero, one});
+    c.checkTerm(ITE, 1, {eqZero, one, zero});
+    EXPECT_EQ(c.nf->CreateTerm(ITE, 1, eqOne, zero, one),
+              c.nf->CreateTerm(ITE, 1, eqZero, one, zero));
+  }
+}
+
 } // namespace


### PR DESCRIPTION
Six new local, non-size-increasing rules, all applied at node-creation time. Stacked on #561 (shares the test file); retarget to master once that merges.

* **Division by a power of two**: `(x / 2^n) --> (0^n ++ x[w-1:n])` — removes a division circuit entirely. Ordered before the existing divide-by-MSB-set rule so `2^(w-1)` gets the cheaper concat form.
* **Remainder by a power of two**: `(x mod 2^n) --> (0^(w-n) ++ x[n-1:0])`.
* **Equality of concats sharing a half**: `(a ++ b) = (a ++ c) --> b = c` and `(a ++ c) = (b ++ c) --> a = b`. `create_gt_node` and `BVSGT` already had these shapes; `CreateSimpleEQ` only had the (disabled, size-increasing) general split.
* **EQ / BVSGT over two sign extensions**: sign extension keeps the signed value, so the comparison only needs the wider of the two original widths — the wider side's extension is dropped and the narrower side extends just up to it, so at least one `BVSX` is always removed and the comparison narrows.
* **Signed comparison with a shared concat head**: `(a ++ b) sgt (a ++ c) --> b bvugt c` — the head decides the sign, the tails compare unsigned. Complements the existing shared-tail rule.
* **1-bit ITE collapse**: `ITE(t = 1, 1, 0) --> t`, with the flipped and negated forms giving `~t`.

Verification:
* Six new cases in `SimplifyingNodeFactory_Exhaustive_Test`: each asserts the rule fires and checks semantic equivalence over every assignment at small widths (including the mixed-width sign-extend cases).
* Full ctest suite passes (60/60).
* A differential sat/unsat sweep of 2500 fuzzed QF_BV files against master showed no result changes.