### PR TITLE
Remove the dead AlwaysTrueFormSet machinery from the Simplifier

### DIFF
--- a/include/stp/Simplifier/PropagateEqualities.h
+++ b/include/stp/Simplifier/PropagateEqualities.h
@@ -50,7 +50,6 @@ class PropagateEqualities : public NodeSimplifier
   NodeFactory* nf;
   STPMgr* bm;
   const ASTNode ASTTrue, ASTFalse;
-  const bool always_true;
 
   using IdSet =  std::unordered_set<uint64_t>;
   using MapToNodeSet = std::unordered_map<uint64_t, std::tuple <ASTNode, ASTNode, IdSet, int > > ;
@@ -81,8 +80,7 @@ class PropagateEqualities : public NodeSimplifier
 
 public:
   PropagateEqualities(Simplifier* simp_, NodeFactory* nf_, STPMgr* bm_)
- : ASTTrue(bm_->ASTTrue), ASTFalse(bm_->ASTFalse),
-   always_true(bm_->UserFlags.enable_always_true)
+ : ASTTrue(bm_->ASTTrue), ASTFalse(bm_->ASTFalse)
   {
     simp = simp_;
     nf = nf_;

--- a/include/stp/Simplifier/PropagateEqualitiesOld.h
+++ b/include/stp/Simplifier/PropagateEqualitiesOld.h
@@ -56,16 +56,13 @@ class PropagateEqualitiesOld
   ASTNode propagate(const ASTNode& a, ArrayTransformer* at);
   std::unordered_set<int> alreadyVisited;
 
-  const bool always_true;
-
   bool timedOut();
   bool timeOut = false;
   long startTime;
 
 public:
   PropagateEqualitiesOld(Simplifier* simp_, NodeFactory* nf_, STPMgr* bm_)
-      : ASTTrue(bm_->ASTTrue), ASTFalse(bm_->ASTFalse),
-        always_true(bm_->UserFlags.enable_always_true)
+      : ASTTrue(bm_->ASTTrue), ASTFalse(bm_->ASTFalse)
   {
     simp = simp_;
     nf = nf_;

--- a/include/stp/Simplifier/Simplifier.h
+++ b/include/stp/Simplifier/Simplifier.h
@@ -49,7 +49,6 @@ private:
   // value is simplified node.
   ASTNodeMap* SimplifyMap;
   ASTNodeMap* SimplifyNegMap;
-  std::unordered_set<int> AlwaysTrueHashSet;
   ASTNodeMap MultInverseMap;
 
   NodeFactory* nf;
@@ -87,8 +86,6 @@ public:
                         ASTNodeMap* VarConstMap = NULL);
   void UpdateSimplifyMap(const ASTNode& key, const ASTNode& value, bool pushNeg,
                          ASTNodeMap* VarConstMap = NULL);
-  bool CheckAlwaysTrueFormSet(const ASTNode& key, bool& result);
-  void UpdateAlwaysTrueFormSet(const ASTNode& val);
   bool CheckMultInverseMap(const ASTNode& key, ASTNode& output);
   void UpdateMultInverseMap(const ASTNode& key, const ASTNode& value);
 
@@ -170,7 +167,6 @@ public:
   {
     SimplifyMap->clear();
     SimplifyNegMap->clear();
-    AlwaysTrueHashSet.clear();
     MultInverseMap.clear();
     substitutionMap.clear();
   }
@@ -178,7 +174,6 @@ public:
   // These can be cleared (to save memory) without changing the answer.
   void ClearCaches()
   {
-    AlwaysTrueHashSet.clear();
     MultInverseMap.clear();
     SimplifyMap->clear();
     SimplifyNegMap->clear();

--- a/lib/Simplifier/PropagateEqualities.cpp
+++ b/lib/Simplifier/PropagateEqualities.cpp
@@ -538,12 +538,7 @@ void PropagateEqualities::buildCandidateList(const ASTNode& a)
   else if (AND == k)
   {
     for (const auto& it : a)
-    {
-      if (always_true)
-        simp->UpdateAlwaysTrueFormSet(it);
-      
       buildCandidateList(it);
-    }
   }
 }
 

--- a/lib/Simplifier/PropagateEqualitiesOld.cpp
+++ b/lib/Simplifier/PropagateEqualitiesOld.cpp
@@ -348,8 +348,6 @@ ASTNode PropagateEqualities::propagate(const ASTNode& a, ArrayTransformer* at)
     for (ASTVec::const_iterator it = c.begin(), itend = c.end(); it != itend;
          it++)
     {
-      if (always_true)
-        simp->UpdateAlwaysTrueFormSet(*it);
       ASTNode aaa = propagate(*it, at);
 
       if (ASTTrue != aaa)

--- a/lib/Simplifier/Simplifier.cpp
+++ b/lib/Simplifier/Simplifier.cpp
@@ -208,53 +208,6 @@ void Simplifier::UpdateMultInverseMap(const ASTNode& key, const ASTNode& value)
   MultInverseMap[key] = value;
 }
 
-// Check if key, or NOT(key) is found in the alwaysTrueSet.
-bool Simplifier::CheckAlwaysTrueFormSet(const ASTNode& key, bool& result)
-{
-  std::unordered_set<int>::const_iterator it_end_2 = AlwaysTrueHashSet.end();
-  std::unordered_set<int>::const_iterator it2 =
-      AlwaysTrueHashSet.find(key.GetNodeNum());
-
-  if (it2 != it_end_2)
-  {
-    result = true; // The key should be replaced by TRUE.
-    return true;
-  }
-
-  int toSearch;
-  if (key.GetKind() == NOT)
-    toSearch = key.GetNodeNum() - 1;
-  else
-    toSearch = key.GetNodeNum() + 1;
-
-  it2 = AlwaysTrueHashSet.find(toSearch);
-  if (it2 != it_end_2)
-  {
-    result = false;
-    return true;
-  }
-
-  return false;
-}
-
-void Simplifier::UpdateAlwaysTrueFormSet(const ASTNode& /*key*/)
-{
-  // The always true/ always false relies on the top level constraint not being
-  // removed.
-  // however with bb equivalence checking, AIGs can figure out that the outer
-  // constraint
-  // is unncessary because it's enforced by the implicit constraint---removing
-  // it. That
-  // leaves just one instance of the constraint, so it we replace it with
-  // true/false
-  // the constraint is lost. This is subsumed by constant bit propagation, so I
-  // suspect
-  // it's not a big loss.
-
-  /*if (false)//(!nf->UserFlags.isSet("bb-equiv", "1"))
-    AlwaysTrueHashSet.insert(key.GetNodeNum());*/
-}
-
 ASTNode Simplifier::SimplifyFormula_NoRemoveWrites(const ASTNode& b,
                                                    bool pushNeg,
                                                    ASTNodeMap* VarConstMap)
@@ -952,15 +905,6 @@ ASTNode Simplifier::CreateSimplifiedTermITE(const ASTNode& in0,
   if (t1 == t2)
     return t1;
 
-  bool result;
-  if (CheckAlwaysTrueFormSet(t0, result))
-  {
-    if (result)
-      return t1;
-    else
-      return t2;
-  }
-
   return nf->CreateArrayTerm(ITE, t1.GetIndexWidth(), t1.GetValueWidth(), t0,
                              t1, t2);
 }
@@ -982,15 +926,6 @@ ASTNode Simplifier::CreateSimplifiedFormulaITE(const ASTNode& in0,
       return t2;
     if (t1 == t2)
       return t1;
-
-    bool result;
-    if (CheckAlwaysTrueFormSet(t0, result))
-    {
-      if (result)
-        return t1;
-      else
-        return t2;
-    }
   }
   ASTNode result = nf->CreateNode(ITE, t0, t1, t2);
   assert(BVTypeCheck(result));
@@ -1115,16 +1050,6 @@ ASTNode Simplifier::SimplifyNotFormula(const ASTNode& a, bool pushNeg,
 
   // pushnegation if there are odd number of NOTs
   bool pn = (NotCount % 2 == 0) ? false : true;
-
-  bool alwaysTrue = false;
-  if (CheckAlwaysTrueFormSet(o, alwaysTrue))
-  {
-    if (alwaysTrue)
-      return (pn ? ASTFalse : ASTTrue);
-
-    // We don't do the false case because it is sometimes
-    // called at the top level.
-  }
 
   if (CheckSimplifyMap(o, output, pn))
   {
@@ -1270,7 +1195,6 @@ ASTNode Simplifier::SimplifyImpliesFormula(const ASTNode& a, bool pushNeg,
   {
     c0 = SimplifyFormula(a[0], false, VarConstMap);
     c1 = SimplifyFormula(a[1], false, VarConstMap);
-    bool atResult;
     if (ASTFalse == c0)
     {
       output = ASTTrue;
@@ -1282,26 +1206,6 @@ ASTNode Simplifier::SimplifyImpliesFormula(const ASTNode& a, bool pushNeg,
     else if (c0 == c1)
     {
       output = ASTTrue;
-    }
-    else if (CheckAlwaysTrueFormSet(c0, atResult))
-    {
-      // c0 AND (~c0 OR c1) <==> c1
-      //(~c0 AND (~c0 OR c1)) <==> TRUE
-      //(c0 AND ~c0->c1) <==> TRUE
-      //(~c1 AND c0->c1) <==> (~c1 AND ~c1->~c0) <==> ~c0
-      //(c1 AND c0->~c1) <==> (c1 AND c1->~c0) <==> ~c0
-
-      if (atResult)
-        output = c1;
-      else
-        output = ASTTrue;
-    }
-    else if (CheckAlwaysTrueFormSet(c1, atResult))
-    {
-      if (atResult)
-        output = ASTTrue;
-      else
-        output = nf->CreateNode(NOT, c0);
     }
     else
     {
@@ -1340,8 +1244,6 @@ ASTNode Simplifier::SimplifyIffFormula(const ASTNode& a, bool pushNeg,
   else
     c0 = SimplifyFormula(c0, false, VarConstMap);
 
-  bool alwaysResult;
-
   if (ASTTrue == c0)
   {
     output = c1;
@@ -1366,20 +1268,6 @@ ASTNode Simplifier::SimplifyIffFormula(const ASTNode& a, bool pushNeg,
            (NOT == c1.GetKind() && c0 == c1[0]))
   {
     output = ASTFalse;
-  }
-  else if (CheckAlwaysTrueFormSet(c0, alwaysResult))
-  {
-    if (alwaysResult)
-      output = c1;
-    else
-      output = nf->CreateNode(NOT, c1);
-  }
-  else if (CheckAlwaysTrueFormSet(c1, alwaysResult))
-  {
-    if (alwaysResult)
-      output = c0;
-    else
-      output = nf->CreateNode(NOT, c0);
   }
   else
   {
@@ -1419,8 +1307,6 @@ ASTNode Simplifier::SimplifyIteFormula(const ASTNode& b, bool pushNeg,
     t2 = SimplifyFormula(a[2], false, VarConstMap);
   }
 
-  bool alwaysTrue;
-
   if (ASTTrue == t0)
   {
     output = t1;
@@ -1456,13 +1342,6 @@ ASTNode Simplifier::SimplifyIteFormula(const ASTNode& b, bool pushNeg,
   else if (ASTFalse == t2)
   {
     output = nf->CreateNode(AND, t0, t1);
-  }
-  else if (CheckAlwaysTrueFormSet(t0, alwaysTrue))
-  {
-    if (alwaysTrue)
-      output = t1;
-    else
-      output = t2;
   }
   else
   {
@@ -3503,8 +3382,6 @@ void Simplifier::printCacheStatus()
        << SimplifyMap->bucket_count() << endl;
   cerr << "SimplifyNegMap:" << SimplifyNegMap->size() << ":"
        << SimplifyNegMap->bucket_count() << endl;
-  cerr << "AlwaysTrueFormSet" << AlwaysTrueHashSet.size() << ":"
-       << AlwaysTrueHashSet.bucket_count() << endl;
   cerr << "MultInverseMap" << MultInverseMap.size() << ":"
        << MultInverseMap.bucket_count() << endl;
 


### PR DESCRIPTION
`AlwaysTrueHashSet` has been unpopulated for nearly a decade. History:

* `76d9b067`/`805dd340` (2011): the in-simplifier mechanism was added — nodes asserted at the top level get replaced by TRUE/FALSE at their other occurrences, tracked by node number.
* `725868dc` (2012): bb-equivalence checking exposed a soundness problem — the AIG layer can prove the top-level constraint redundant and remove it, after which replacing the remaining occurrence loses the constraint. The insert was made conditional on bb-equiv being off.
* `772d0c29` (2016): the condition became `if (false)`; the set has never been populated since, so every `CheckAlwaysTrueFormSet` branch in the NOT/IMPLIES/IFF/ITE handlers is unreachable.
* `8cc64370` (2022): the standalone `AlwaysTrue` pass (`enable_always_true`, run from `sizeReducing`) became the live, safe implementation — it tracks whether it is still inside the top-level conjunction before substituting. It is untouched by this PR.

This deletes the set, both accessor functions, all eight unreachable consumer branches, the `printCacheStatus` line, and the `always_true` members of both PropagateEqualities variants (which existed only to gate the no-op update calls). Net −140 lines, no behavioral change.

Verification: full ctest suite passes (60/60); a 2500-file differential sat/unsat sweep against master shows no result changes.