### PR TITLE
Move division narrowing and below-divisor reasoning into strength reduction

### DIFF
--- a/lib/Simplifier/Simplifier.cpp
+++ b/lib/Simplifier/Simplifier.cpp
@@ -2341,19 +2341,8 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
         break;
       }
 
-      // If the msb is known. Then puts 0's or the 1's infront.
-      if (mostSignificantConstants(a0) > 0)
-      {
-        if (getConstantBit(a0, 0) == 0)
-          output = nf->CreateTerm(
-              BVCONCAT, inputValueWidth,
-              nf->CreateZeroConst(inputValueWidth - a0.GetValueWidth()), a0);
-        else
-          output = nf->CreateTerm(
-              BVCONCAT, inputValueWidth,
-              nf->CreateMaxConst(inputValueWidth - a0.GetValueWidth()), a0);
-        break;
-      }
+      // nb. A BVSX whose argument's most significant bit is known is
+      // replaced by a concat by strength reduction.
 
       assert(a0.GetKind() != BVCONST);
 
@@ -2686,114 +2675,6 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
       break;
     }
 
-    case BVDIV:
-    {
-      if (inputterm[1] == nf->CreateOneConst(inputValueWidth))
-      {
-        output = inputterm[0];
-        break;
-      }
-      unsigned int nlz = numberOfLeadingZeroes(inputterm[0]);
-      nlz = std::min(inputValueWidth - 1, nlz);
-
-      // We can't do this if the second operand might be zero.
-      ASTNode eq = nf->CreateNode(EQ, inputterm[1],
-                                  nf->CreateZeroConst(inputValueWidth));
-      if (nlz > 0 && eq == ASTFalse)
-      {
-        int rest = inputValueWidth - nlz;
-        ASTNode low = nf->CreateBVConst(32, rest);
-        ASTNode high = nf->CreateBVConst(32, inputValueWidth - 1);
-
-        ASTNode cond = nf->CreateNode(
-            EQ, nf->CreateZeroConst(nlz),
-            nf->CreateTerm(BVEXTRACT, nlz, inputterm[1], high, low));
-
-        ASTNode top = nf->CreateTerm(BVEXTRACT, rest, inputterm[0],
-                                     nf->CreateBVConst(32, rest - 1),
-                                     nf->CreateZeroConst(32));
-        ASTNode bottom = nf->CreateTerm(BVEXTRACT, rest, inputterm[1],
-                                        nf->CreateBVConst(32, rest - 1),
-                                        nf->CreateZeroConst(32));
-
-        ASTNode div = nf->CreateTerm(BVDIV, rest, top, bottom);
-        div = nf->CreateTerm(BVCONCAT, inputValueWidth,
-                             nf->CreateZeroConst(inputValueWidth - rest), div);
-
-        output = nf->CreateTerm(ITE, inputValueWidth, cond, div,
-                                nf->CreateZeroConst(inputValueWidth));
-        break;
-      }
-
-      ASTNode lessThan = SimplifyFormula(
-          nf->CreateNode(BVLT, inputterm[0], inputterm[1]), false, NULL);
-      if (lessThan == ASTTrue)
-      {
-        output = nf->CreateZeroConst(inputValueWidth);
-      }
-      else
-      {
-        output = inputterm;
-      }
-      break;
-    }
-
-    case BVMOD:
-    {
-      if (inputterm[0] == inputterm[1])
-      {
-        output = nf->CreateZeroConst(inputValueWidth);
-        break;
-      }
-      if (inputterm[1] == nf->CreateOneConst(inputValueWidth))
-      {
-        output = nf->CreateZeroConst(inputValueWidth);
-        break;
-      }
-
-      unsigned int nlz = numberOfLeadingZeroes(inputterm[0]);
-      if (nlz > 0)
-      {
-        nlz = std::min(inputValueWidth - 1, nlz);
-        int rest = inputValueWidth - nlz;
-        ASTNode low = nf->CreateBVConst(32, rest);
-        ASTNode high = nf->CreateBVConst(32, inputValueWidth - 1);
-
-        ASTNode cond = nf->CreateNode(
-            EQ, nf->CreateZeroConst(nlz),
-            nf->CreateTerm(BVEXTRACT, nlz, inputterm[1], high, low));
-
-        ASTNode top = nf->CreateTerm(BVEXTRACT, rest, inputterm[0],
-                                     nf->CreateBVConst(32, rest - 1),
-                                     nf->CreateZeroConst(32));
-        ASTNode bottom = nf->CreateTerm(BVEXTRACT, rest, inputterm[1],
-                                        nf->CreateBVConst(32, rest - 1),
-                                        nf->CreateZeroConst(32));
-
-        // nb. This differs from the bvdiv case.
-        ASTNode div = nf->CreateTerm(BVMOD, rest, top, bottom);
-        div = nf->CreateTerm(BVCONCAT, inputValueWidth,
-                             nf->CreateZeroConst(inputValueWidth - rest), div);
-
-        // nb. This differs from the bvdiv case.
-        output = nf->CreateTerm(ITE, inputValueWidth, cond, div, inputterm[0]);
-        break;
-      }
-
-      ASTNode lessThan = SimplifyFormula(
-          nf->CreateNode(BVLT, inputterm[0], inputterm[1]), false, NULL);
-
-      if (lessThan == ASTTrue)
-      {
-        output = inputterm[0];
-      }
-      else
-      {
-        output = inputterm;
-      }
-      break;
-    }
-
     case BVXOR:
     {
       if (inputterm.Degree() == 2 && inputterm[0] == inputterm[1])
@@ -2828,6 +2709,11 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
     case BVNAND:
     case BVNOR:
     case BVSRSHIFT:
+    // nb. Divisions and remainders with leading-zero dividends are
+    // narrowed, and those whose dividend is below the divisor are
+    // resolved, by strength reduction.
+    case BVDIV:
+    case BVMOD:
     {
       output = inputterm;
       break;

--- a/lib/Simplifier/StrengthReduction.cpp
+++ b/lib/Simplifier/StrengthReduction.cpp
@@ -235,6 +235,23 @@ namespace stp
           FatalError("Never here");
       }
     }
+    else if (k == BVMOD)
+    {
+      // A remainder whose dividend is always below the divisor is the
+      // dividend. (The quotient analogue needs no rule here: the
+      // interval transfer for BVDIV computes a constant zero interval,
+      // which is replaced above.)
+      const auto l = visited.find(n[0]);
+      const auto r = visited.find(n[1]);
+      if (l != visited.end() && r != visited.end() && l->second != nullptr &&
+          r->second != nullptr &&
+          CONSTANTBV::BitVector_Lexicompare(l->second->maxV,
+                                            r->second->minV) < 0)
+      {
+        newN = n[0];
+        replaceWithSimpler++;
+      }
+    }
     else if (k == EQ)
     {
       // An equality whose sides' intervals meet at exactly one point
@@ -417,6 +434,66 @@ namespace stp
         {
           newN =
               nf->CreateTerm(BVOR, n.GetValueWidth(), n.GetChildren());
+          replaceWithSimpler++;
+        }
+      }
+    }
+    else if (kind == BVDIV || kind == BVMOD)
+    {
+      // If the dividend's leading bits are zero, the interesting part
+      // fits into the remaining width, so narrow the operation, guarded
+      // on the divisor's leading bits being zero too. When they aren't,
+      // the divisor exceeds the dividend, making the quotient zero and
+      // the remainder the dividend. Division additionally needs the
+      // divisor to be provably non-zero, because the narrowed form
+      // wouldn't recreate the all-ones result at full width.
+      const auto l = visited.find(n[0]);
+      const auto r = visited.find(n[1]);
+      if (l != visited.end() && r != visited.end() && l->second != nullptr &&
+          r->second != nullptr)
+      {
+        const FixedBits* dividend = l->second;
+        const FixedBits* divisor = r->second;
+        const unsigned width = n.GetValueWidth();
+
+        unsigned nlz = 0;
+        while (nlz < width - 1 && dividend->isFixed(width - 1 - nlz) &&
+               !dividend->getValue(width - 1 - nlz))
+          nlz++;
+
+        bool divisorNonZero = false;
+        for (unsigned i = 0; i < width; i++)
+          if (divisor->isFixed(i) && divisor->getValue(i))
+          {
+            divisorNonZero = true;
+            break;
+          }
+
+        if (nlz > 0 && (kind == BVMOD || divisorNonZero))
+        {
+          const unsigned rest = width - nlz;
+
+          const ASTNode cond = nf->CreateNode(
+              EQ, nf->CreateZeroConst(nlz),
+              nf->CreateTerm(BVEXTRACT, nlz, n[1],
+                             nf->CreateBVConst(32, width - 1),
+                             nf->CreateBVConst(32, rest)));
+
+          const ASTNode narrowed = nf->CreateTerm(
+              BVCONCAT, width, nf->CreateZeroConst(nlz),
+              nf->CreateTerm(
+                  kind, rest,
+                  nf->CreateTerm(BVEXTRACT, rest, n[0],
+                                 nf->CreateBVConst(32, rest - 1),
+                                 nf->CreateBVConst(32, 0)),
+                  nf->CreateTerm(BVEXTRACT, rest, n[1],
+                                 nf->CreateBVConst(32, rest - 1),
+                                 nf->CreateBVConst(32, 0))));
+
+          const ASTNode otherwise =
+              (kind == BVDIV) ? nf->CreateZeroConst(width) : n[0];
+
+          newN = nf->CreateTerm(ITE, width, cond, narrowed, otherwise);
           replaceWithSimpler++;
         }
       }

--- a/tests/unit-tests/StrengthReduction_Exhaustive_Test.cpp
+++ b/tests/unit-tests/StrengthReduction_Exhaustive_Test.cpp
@@ -693,3 +693,125 @@ TEST(StrengthReduction_Exhaustive_Test, bvsx_to_ones_concat_via_fixedbits)
     ASSERT_EQ(c.eval(n, assignment), c.eval(result, copy));
   }
 }
+
+// A division whose dividend has fixed leading zero bits narrows to the
+// remaining width, guarded on the divisor's leading bits. The divisor
+// must be provably non-zero.
+TEST(StrengthReduction_Exhaustive_Test, div_narrowed_via_fixedbits)
+{
+  const unsigned width = 4;
+
+  Context c;
+  ASTNode x = c.symbol("x", width);
+  ASTNode y = c.symbol("y", width);
+  ASTNode n = c.nf->CreateTerm(stp::BVDIV, width, x, y);
+  ASSERT_EQ(n.GetKind(), stp::BVDIV);
+
+  // x: the top two bits are fixed zero. y: the lowest bit is fixed one.
+  FixedBits xBits(width, false);
+  xBits.setFixed(3, true);
+  xBits.setValue(3, false);
+  xBits.setFixed(2, true);
+  xBits.setValue(2, false);
+  FixedBits yBits(width, false);
+  yBits.setFixed(0, true);
+  yBits.setValue(0, true);
+
+  stp::NodeToFixedBitsMap map;
+  map.insert({n, nullptr});
+  map.insert({x, &xBits});
+  map.insert({y, &yBits});
+
+  ASTNode result = c.sr.topLevel(n, map);
+  ASSERT_EQ(result.GetKind(), stp::ITE);
+  ASSERT_FALSE(c.present(stp::BVDIV, result[2]));
+
+  c.checkEquivalent(
+      n, result, x, y, width, [](unsigned v) { return v < 4; },
+      [](unsigned v) { return (v & 1) == 1; });
+}
+
+// The remainder version narrows without needing a non-zero divisor: a
+// remainder by zero is the dividend, which the untaken branch recreates.
+TEST(StrengthReduction_Exhaustive_Test, mod_narrowed_via_fixedbits)
+{
+  const unsigned width = 4;
+
+  Context c;
+  ASTNode x = c.symbol("x", width);
+  ASTNode y = c.symbol("y", width);
+  ASTNode n = c.nf->CreateTerm(stp::BVMOD, width, x, y);
+  ASSERT_EQ(n.GetKind(), stp::BVMOD);
+
+  FixedBits xBits(width, false);
+  xBits.setFixed(3, true);
+  xBits.setValue(3, false);
+  xBits.setFixed(2, true);
+  xBits.setValue(2, false);
+  FixedBits yBits(width, false);
+
+  stp::NodeToFixedBitsMap map;
+  map.insert({n, nullptr});
+  map.insert({x, &xBits});
+  map.insert({y, &yBits});
+
+  ASTNode result = c.sr.topLevel(n, map);
+  ASSERT_EQ(result.GetKind(), stp::ITE);
+  ASSERT_EQ(result[2], x);
+
+  c.checkEquivalent(
+      n, result, x, y, width, [](unsigned v) { return v < 4; },
+      [](unsigned) { return true; });
+}
+
+// Division is left alone when the divisor might be zero.
+TEST(StrengthReduction_Exhaustive_Test, div_not_narrowed_when_divisor_may_be_zero)
+{
+  const unsigned width = 4;
+
+  Context c;
+  ASTNode x = c.symbol("x", width);
+  ASTNode y = c.symbol("y", width);
+  ASTNode n = c.nf->CreateTerm(stp::BVDIV, width, x, y);
+
+  FixedBits xBits(width, false);
+  xBits.setFixed(3, true);
+  xBits.setValue(3, false);
+  FixedBits yBits(width, false);
+
+  stp::NodeToFixedBitsMap map;
+  map.insert({n, nullptr});
+  map.insert({x, &xBits});
+  map.insert({y, &yBits});
+
+  ASTNode result = c.sr.topLevel(n, map);
+  ASSERT_EQ(result, n);
+}
+
+// A remainder whose dividend's interval sits below the divisor's is the
+// dividend.
+TEST(StrengthReduction_Exhaustive_Test, mod_below_divisor_via_intervals)
+{
+  const unsigned width = 4;
+
+  Context c;
+  ASTNode x = c.symbol("x", width);
+  ASTNode y = c.symbol("y", width);
+  ASTNode n = c.nf->CreateTerm(stp::BVMOD, width, x, y);
+  ASSERT_EQ(n.GetKind(), stp::BVMOD);
+
+  stp::UnsignedInterval xInterval(makeCBV(width, 0), makeCBV(width, 4));
+  stp::UnsignedInterval yInterval(makeCBV(width, 5), makeCBV(width, 15));
+
+  stp::NodeToUnsignedIntervalMap map;
+  map.insert({n, nullptr});
+  map.insert({x, &xInterval});
+  map.insert({y, &yInterval});
+
+  ASTNode result = c.sr.topLevel(n, map);
+  ASSERT_EQ(result, x);
+
+  c.checkEquivalent(
+      n, result, x, y, width, [](unsigned v) { return v <= 4; },
+      [](unsigned v) { return v >= 5; });
+}

--- a/tests/unit-tests/StrengthReduction_Test.cpp
+++ b/tests/unit-tests/StrengthReduction_Test.cpp
@@ -312,3 +312,91 @@ TEST(StrengthReduction_Test , __LINE__)
   ASTNode n = c.process(input);
   ASSERT_EQ(n, c.mgr.ASTTrue);
 }
+
+static bool presentWithWidth(const stp::Kind k, const ASTNode& n,
+                             const unsigned width)
+{
+  if (n.GetKind() == k && n.GetValueWidth() == width)
+    return true;
+
+  for (const auto& c : n)
+    if (presentWithWidth(k, c, width))
+      return true;
+
+  return false;
+}
+
+// A division whose dividend has fixed leading zero bits (here via a
+// mask) narrows to the width that can be non-zero. With a constant
+// divisor that fits, the guard folds away and only the narrow division
+// remains.
+TEST(StrengthReduction_Test , __LINE__)
+{
+  const std::string input = R"(
+    (
+      assert
+            ( = v2
+              (bvudiv (bvand v0 (_ bv1023 20)) (_ bv100 20))
+            )
+    )
+    )";
+
+  Context c;
+  ASTNode n = c.process(input);
+  ASSERT_FALSE(presentWithWidth(stp::BVDIV, n, 20));
+  ASSERT_TRUE(presentWithWidth(stp::BVDIV, n, 10));
+}
+
+// When the constant divisor doesn't fit into the narrowed width it
+// exceeds the dividend, so the quotient folds to zero outright.
+TEST(StrengthReduction_Test , __LINE__)
+{
+  const std::string input = R"(
+    (
+      assert
+            ( = v2
+              (bvudiv (bvand v0 (_ bv15 20)) (_ bv100 20))
+            )
+    )
+    )";
+
+  Context c;
+  ASTNode n = c.process(input);
+  ASSERT_FALSE(c.present(stp::BVDIV, n));
+}
+
+// The remainder version: a dividend below the divisor is returned
+// unchanged, so the remainder disappears.
+TEST(StrengthReduction_Test , __LINE__)
+{
+  const std::string input = R"(
+    (
+      assert
+            ( = v2
+              (bvurem (bvand v0 (_ bv15 20)) (_ bv100 20))
+            )
+    )
+    )";
+
+  Context c;
+  ASTNode n = c.process(input);
+  ASSERT_FALSE(c.present(stp::BVMOD, n));
+  ASSERT_TRUE(c.present(stp::BVAND, n));
+}
+
+// A sign extension whose argument's top bit is fixed becomes a concat.
+TEST(StrengthReduction_Test , __LINE__)
+{
+  const std::string input = R"(
+    (
+      assert
+            ( = v2
+              ((_ sign_extend 4) (bvand ((_ extract 15 0) v0) (_ bv1023 16)))
+            )
+    )
+    )";
+
+  Context c;
+  ASTNode n = c.process(input);
+  ASSERT_FALSE(c.present(stp::BVSX, n));
+}


### PR DESCRIPTION
Follow-up to the discussion on #561: several Simplifier rules were dataflow reasoning done syntactically — they only fired when the dividend's leading zeros were literal constants on a concat spine. This moves them to StrengthReduction where the fixed-bit and interval domains supply the trigger, which is strictly more general:

* **BVDIV/BVMOD narrowing** now lives in the fixed-bits overload of `StrengthReduction::strengthReduction`. A dividend whose leading bits are fixed zero narrows the operation to the remaining width, guarded on the divisor's leading bits; division additionally requires the divisor provably non-zero (any bit fixed to one), because the narrowed form can't recreate the full-width all-ones divide-by-zero result. The zeros can now come from masks, shifts, extracts, or zero extensions — not just literal `0 ++ x` dividends. With a constant divisor the guard folds at node creation, leaving either the plain narrowed operation (divisor fits) or a constant (divisor doesn't).
* **BVDIV `dividend < divisor → 0`** is deleted outright: the unsigned interval transfer for BVDIV already computes a constant zero interval in that situation, which StrengthReduction folds. The Simplifier's version asked `SimplifyFormula(BVLT(a,b))` recursively — a weaker oracle at a higher price.
* **BVMOD `dividend < divisor → dividend`** becomes a small new interval rule (the result isn't a constant, so the interval transfer alone couldn't express it).
* **The Simplifier's BVSX known-MSB rule** is deleted: StrengthReduction already replaces a BVSX whose top bit is fixed with a concat, via both domains.

The remaining trivial BVDIV/BVMOD rules the Simplifier had (divide by one, `x mod x`, mod by one) are already applied by the SimplifyingNodeFactory, so both cases reduce to pass-throughs.

Verification:
* New exhaustive unit tests: narrowing fires and is semantically equivalent on every consistent assignment at width 4; division is left alone when the divisor may be zero; the interval below-divisor rule replaces the remainder with the dividend.
* New pipeline tests (`StrengthReduction_Test`): the fixed-bit trigger works through an AND mask; both constant-divisor folds; sign-extend-to-concat through an extract+mask.
* Full ctest suite passes (60/60).
* 2500-file differential sat/unsat sweep against master: no result changes.