### PR TITLE
Narrow multiplications and additions with leading-zero operands

### DIFF
--- a/lib/Simplifier/StrengthReduction.cpp
+++ b/lib/Simplifier/StrengthReduction.cpp
@@ -435,7 +435,123 @@ namespace stp
           newN =
               nf->CreateTerm(BVOR, n.GetValueWidth(), n.GetChildren());
           replaceWithSimpler++;
+
+          // When the disjointness is a contiguous split, the OR is just
+          // wiring: the high part concatenated onto the low part.
+          if (n.Degree() == 2)
+          {
+            const unsigned width = n.GetValueWidth();
+            for (unsigned i = 0; i < 2; i++)
+            {
+              const FixedBits* high = children[i];
+              const FixedBits* low = children[1 - i];
+
+              // The lowest bit of "high" that might be one.
+              unsigned k = 0;
+              while (k < width && high->isFixed(k) && !high->getValue(k))
+                k++;
+
+              // All of "low"'s possibly-one bits must sit below k.
+              bool lowFits = true;
+              for (unsigned j = k; j < width && lowFits; j++)
+                if (!(low->isFixed(j) && !low->getValue(j)))
+                  lowFits = false;
+
+              if (lowFits && k > 0 && k < width)
+              {
+                newN = nf->CreateTerm(
+                    BVCONCAT, width,
+                    nf->CreateTerm(BVEXTRACT, width - k, n[i],
+                                   nf->CreateBVConst(32, width - 1),
+                                   nf->CreateBVConst(32, k)),
+                    nf->CreateTerm(BVEXTRACT, k, n[1 - i],
+                                   nf->CreateBVConst(32, k - 1),
+                                   nf->CreateBVConst(32, 0)));
+                break;
+              }
+            }
+          }
         }
+        else if (kind == BVPLUS)
+        {
+          // Leading zeros on every operand bound the sum, so the
+          // addition narrows to the width that can carry.
+          const unsigned width = n.GetValueWidth();
+
+          unsigned maxEffective = 0;
+          for (unsigned i = 0; i < children.size(); i++)
+          {
+            unsigned nlz = 0;
+            while (nlz < width && children[i]->isFixed(width - 1 - nlz) &&
+                   !children[i]->getValue(width - 1 - nlz))
+              nlz++;
+            if (width - nlz > maxEffective)
+              maxEffective = width - nlz;
+          }
+
+          // Adding m terms can carry ceil(log2(m)) bits upwards.
+          unsigned carry = 0;
+          while ((1u << carry) < children.size())
+            carry++;
+
+          const unsigned rest = maxEffective + carry;
+          if (maxEffective > 0 && rest < width)
+          {
+            ASTVec narrowed;
+            narrowed.reserve(n.Degree());
+            for (const auto& c : n.GetChildren())
+              narrowed.push_back(
+                  nf->CreateTerm(BVEXTRACT, rest, c,
+                                 nf->CreateBVConst(32, rest - 1),
+                                 nf->CreateBVConst(32, 0)));
+
+            newN = nf->CreateTerm(
+                BVCONCAT, width, nf->CreateZeroConst(width - rest),
+                nf->CreateTerm(BVPLUS, rest, narrowed));
+            replaceWithSimpler++;
+          }
+        }
+      }
+    }
+    else if (kind == BVMULT)
+    {
+      // Leading zeros on the operands bound the product, so the
+      // multiplication narrows to the width the product can occupy.
+      const unsigned width = n.GetValueWidth();
+
+      bool bad = false;
+      unsigned totalEffective = 0;
+      for (const auto& c : n.GetChildren())
+      {
+        const auto it = visited.find(c);
+        if (it == visited.end() || it->second == nullptr)
+        {
+          bad = true;
+          break;
+        }
+
+        unsigned nlz = 0;
+        while (nlz < width - 1 && it->second->isFixed(width - 1 - nlz) &&
+               !it->second->getValue(width - 1 - nlz))
+          nlz++;
+        totalEffective += width - nlz;
+      }
+
+      if (!bad && totalEffective < width)
+      {
+        const unsigned rest = totalEffective;
+
+        ASTVec narrowed;
+        narrowed.reserve(n.Degree());
+        for (const auto& c : n.GetChildren())
+          narrowed.push_back(nf->CreateTerm(BVEXTRACT, rest, c,
+                                            nf->CreateBVConst(32, rest - 1),
+                                            nf->CreateBVConst(32, 0)));
+
+        newN = nf->CreateTerm(
+            BVCONCAT, width, nf->CreateZeroConst(width - rest),
+            nf->CreateTerm(BVMULT, rest, narrowed));
+        replaceWithSimpler++;
       }
     }
     else if (kind == BVDIV || kind == BVMOD)

--- a/tests/unit-tests/StrengthReduction_Exhaustive_Test.cpp
+++ b/tests/unit-tests/StrengthReduction_Exhaustive_Test.cpp
@@ -815,3 +815,109 @@ TEST(StrengthReduction_Exhaustive_Test, mod_below_divisor_via_intervals)
       n, result, x, y, width, [](unsigned v) { return v <= 4; },
       [](unsigned v) { return v >= 5; });
 }
+
+// Fix the bit range [from, to] of "bits" to zero.
+static void fixZero(FixedBits& bits, unsigned from, unsigned to)
+{
+  for (unsigned i = from; i <= to; i++)
+  {
+    bits.setFixed(i, true);
+    bits.setValue(i, false);
+  }
+}
+
+// A multiplication whose operands have fixed leading zeros narrows to
+// the width the product can occupy.
+TEST(StrengthReduction_Exhaustive_Test, mult_narrowed_via_fixedbits)
+{
+  const unsigned width = 6;
+
+  Context c;
+  ASTNode x = c.symbol("x", width);
+  ASTNode y = c.symbol("y", width);
+  ASTNode n = c.nf->CreateTerm(stp::BVMULT, width, x, y);
+  ASSERT_EQ(n.GetKind(), stp::BVMULT);
+
+  FixedBits xBits(width, false);
+  fixZero(xBits, 2, 5); // x < 4
+  FixedBits yBits(width, false);
+  fixZero(yBits, 3, 5); // y < 8
+
+  stp::NodeToFixedBitsMap map;
+  map.insert({n, nullptr});
+  map.insert({x, &xBits});
+  map.insert({y, &yBits});
+
+  ASTNode result = c.sr.topLevel(n, map);
+  ASSERT_EQ(result.GetKind(), stp::BVCONCAT);
+  ASSERT_EQ(result[1].GetKind(), stp::BVMULT);
+  ASSERT_EQ(result[1].GetValueWidth(), 5u);
+
+  c.checkEquivalent(
+      n, result, x, y, width, [](unsigned v) { return v < 4; },
+      [](unsigned v) { return v < 8; });
+}
+
+// An addition whose operands have fixed leading zeros narrows to the
+// width the sum can occupy.
+TEST(StrengthReduction_Exhaustive_Test, plus_narrowed_via_fixedbits)
+{
+  const unsigned width = 6;
+
+  Context c;
+  ASTNode x = c.symbol("x", width);
+  ASTNode y = c.symbol("y", width);
+  ASTNode n = c.nf->CreateTerm(stp::BVPLUS, width, x, y);
+  ASSERT_EQ(n.GetKind(), stp::BVPLUS);
+
+  FixedBits xBits(width, false);
+  fixZero(xBits, 3, 5); // x < 8
+  FixedBits yBits(width, false);
+  fixZero(yBits, 3, 5); // y < 8
+
+  stp::NodeToFixedBitsMap map;
+  map.insert({n, nullptr});
+  map.insert({x, &xBits});
+  map.insert({y, &yBits});
+
+  ASTNode result = c.sr.topLevel(n, map);
+  ASSERT_EQ(result.GetKind(), stp::BVCONCAT);
+  ASSERT_EQ(result[1].GetKind(), stp::BVPLUS);
+  ASSERT_EQ(result[1].GetValueWidth(), 4u);
+
+  c.checkEquivalent(
+      n, result, x, y, width, [](unsigned v) { return v < 8; },
+      [](unsigned v) { return v < 8; });
+}
+
+// When an addition's operands split at a bit boundary, the adder is
+// just wiring: the high part concatenated onto the low part.
+TEST(StrengthReduction_Exhaustive_Test, plus_to_concat_via_fixedbits)
+{
+  const unsigned width = 6;
+
+  Context c;
+  ASTNode x = c.symbol("x", width);
+  ASTNode y = c.symbol("y", width);
+  ASTNode n = c.nf->CreateTerm(stp::BVPLUS, width, x, y);
+  ASSERT_EQ(n.GetKind(), stp::BVPLUS);
+
+  FixedBits xBits(width, false);
+  fixZero(xBits, 0, 2); // x's low three bits are zero.
+  FixedBits yBits(width, false);
+  fixZero(yBits, 3, 5); // y < 8
+
+  stp::NodeToFixedBitsMap map;
+  map.insert({n, nullptr});
+  map.insert({x, &xBits});
+  map.insert({y, &yBits});
+
+  ASTNode result = c.sr.topLevel(n, map);
+  ASSERT_EQ(result.GetKind(), stp::BVCONCAT);
+  ASSERT_FALSE(c.present(stp::BVPLUS, result));
+  ASSERT_FALSE(c.present(stp::BVNOT, result));
+
+  c.checkEquivalent(
+      n, result, x, y, width, [](unsigned v) { return (v & 7) == 0; },
+      [](unsigned v) { return v < 8; });
+}

--- a/tests/unit-tests/StrengthReduction_Test.cpp
+++ b/tests/unit-tests/StrengthReduction_Test.cpp
@@ -400,3 +400,61 @@ TEST(StrengthReduction_Test , __LINE__)
   ASTNode n = c.process(input);
   ASSERT_FALSE(c.present(stp::BVSX, n));
 }
+
+// A multiplication whose operands are masked down narrows to the width
+// the product can occupy: here 2 + 3 bits.
+TEST(StrengthReduction_Test , __LINE__)
+{
+  const std::string input = R"(
+    (
+      assert
+            ( = v2
+              (bvmul (bvand v0 (_ bv3 20)) (bvand v1 (_ bv7 20)))
+            )
+    )
+    )";
+
+  Context c;
+  ASTNode n = c.process(input);
+  ASSERT_FALSE(presentWithWidth(stp::BVMULT, n, 20));
+  ASSERT_TRUE(presentWithWidth(stp::BVMULT, n, 5));
+}
+
+// An addition of two masked operands narrows to the width the sum can
+// occupy: here 4 + 1 carry bits.
+TEST(StrengthReduction_Test , __LINE__)
+{
+  const std::string input = R"(
+    (
+      assert
+            ( = v2
+              (bvadd (bvand v0 (_ bv15 20)) (bvand v1 (_ bv15 20)))
+            )
+    )
+    )";
+
+  Context c;
+  ASTNode n = c.process(input);
+  ASSERT_FALSE(presentWithWidth(stp::BVPLUS, n, 20));
+  ASSERT_TRUE(presentWithWidth(stp::BVPLUS, n, 5));
+}
+
+// An addition whose operands split at a bit boundary becomes a concat:
+// no adder, no bitwise operation at all.
+TEST(StrengthReduction_Test , __LINE__)
+{
+  const std::string input = R"(
+    (
+      assert
+            ( = v2
+              (bvadd (bvand v0 (_ bv240 20)) (bvand v1 (_ bv15 20)))
+            )
+    )
+    )";
+
+  Context c;
+  ASTNode n = c.process(input);
+  ASSERT_FALSE(c.present(stp::BVPLUS, n));
+  ASSERT_FALSE(c.present(stp::BVNOT, n));
+  ASSERT_TRUE(c.present(stp::BVCONCAT, n));
+}


### PR DESCRIPTION
Extends the fixed-bits overload of `StrengthReduction::strengthReduction` with two more narrowings, completing the family #564 started. (#565's stronger zero-extension transfer feeds these rules directly — more fixed leading zeros means more triggers.)

* **Multiplication narrowing**: when the operands' leading bits are fixed zero, `a < 2^p` and `b < 2^q` bound the product below `2^(p+q)`, so a width-w multiply becomes `0^(w-p-q) ++ (a[p+q-1:0] * b[p+q-1:0])` whenever `p+q < w`. Multiplier circuits are quadratic in width, so halving the width quarters the bitblasted size. Works for any arity by summing effective widths; the trigger sees through masks, extracts, shifts and zero extensions.
* **Addition narrowing**: the sum of m operands each below `2^e` fits in `e + ceil(log2(m))` bits, so the addition narrows accordingly. Applies when the existing disjoint-bits→OR rule doesn't.
* **Adder→wiring upgrade**: the existing "disjoint BVPLUS/BVXOR becomes BVOR" rule now recognises the contiguous-split case — one operand's possibly-set bits all above the other's — and emits `high[w-1:k] ++ low[k-1:0]` instead of an OR. The concat is free in bitblasting, while the OR would otherwise De-Morgan into two NOTs and an AND.

Verification:
* New exhaustive unit tests: each rule fires (checked structurally) and is semantically equivalent on every consistent assignment at width 6; the pre-existing `plus_to_or`/`xor_to_or` tests still pass, confirming the OR path remains for non-contiguous disjointness.
* New pipeline tests: narrowing triggers through AND masks end-to-end; the split addition leaves no adder and no bitwise ops at all.
* Full ctest suite passes (60/60) on the rebased tree including #565.
* 2500-file differential sat/unsat sweep against master: no result changes.