### PR TITLE
Use unordered_dense for the constant bit propagator's hash tables

### DIFF
--- a/include/stp/Simplifier/constantBitP/Dependencies.h
+++ b/include/stp/Simplifier/constantBitP/Dependencies.h
@@ -26,6 +26,7 @@ THE SOFTWARE.
 #define DEPENDENCIES_H_
 
 #include "stp/AST/AST.h"
+#include "extlib-unordered-dense/ankerl/unordered_dense.h"
 namespace simplifier
 {
 namespace constantBitP
@@ -33,16 +34,22 @@ namespace constantBitP
 
 using std::cout;
 using std::endl;
-using stp::ASTNodeSet;
+using stp::ASTNode;
 
 // From a child, get the parents of that node.
 class Dependencies
 {
+public:
+  typedef ankerl::unordered_dense::set<ASTNode, ASTNode::ASTNodeHasher,
+                                       ASTNode::ASTNodeEqual>
+      DependentsSet;
+
 private:
-  typedef std::unordered_map<uint64_t, ASTNodeSet*>  NodeToDependentNodeMap;
+  typedef ankerl::unordered_dense::map<uint64_t, DependentsSet*>
+      NodeToDependentNodeMap;
   NodeToDependentNodeMap dependents;
 
-  const ASTNodeSet empty;
+  const DependentsSet empty;
 
   bool checkInvariant() const
   {
@@ -56,13 +63,13 @@ private:
     if (current.isConstant()) // don't care about what depends on constants.
       return;
 
-    ASTNodeSet* vec;
+    DependentsSet* vec;
     bool firstVisit;
     const auto it = dependents.find(current.GetNodeNum());
     if (dependents.end() == it)
     {
       // add it in with a reference to the vector.
-      vec = new ASTNodeSet();
+      vec = new DependentsSet();
       dependents.insert({current.GetNodeNum(), vec});
       firstVisit = true;
     }
@@ -107,7 +114,7 @@ public:
       delete it.second;
   }
 
-  const ASTNodeSet* getDependents(const ASTNode& n) const
+  const DependentsSet* getDependents(const ASTNode& n) const
   {
     if (n.isConstant())
       return &empty;

--- a/include/stp/Simplifier/constantBitP/NodeToFixedBitsMap.h
+++ b/include/stp/Simplifier/constantBitP/NodeToFixedBitsMap.h
@@ -31,6 +31,7 @@ THE SOFTWARE.
 
 #include "stp/AST/AST.h"
 #include "stp/Simplifier/constantBitP/FixedBits.h"
+#include "extlib-unordered-dense/ankerl/unordered_dense.h"
 
 namespace simplifier
 {
@@ -40,9 +41,12 @@ namespace constantBitP
 class NodeToFixedBitsMap
 {
 public:
-  typedef std::unordered_map<stp::ASTNode, FixedBits*,
-                             stp::ASTNode::ASTNodeHasher,
-                             stp::ASTNode::ASTNodeEqual>
+  // A flat hash map: propagation performs several lookups per node
+  // visit, and they dominate its cost on large problems. Note inserting
+  // invalidates iterators (but not the pointed-to FixedBits).
+  typedef ankerl::unordered_dense::map<stp::ASTNode, FixedBits*,
+                                       stp::ASTNode::ASTNodeHasher,
+                                       stp::ASTNode::ASTNodeEqual>
       NodeToFixedBitsMapType;
 
   NodeToFixedBitsMapType* map;

--- a/include/stp/Simplifier/constantBitP/WorkList.h
+++ b/include/stp/Simplifier/constantBitP/WorkList.h
@@ -27,6 +27,7 @@ THE SOFTWARE.
 
 #include "stp/AST/AST.h"
 #include "stp/AST/ASTNode.h"
+#include "extlib-unordered-dense/ankerl/unordered_dense.h"
 
 namespace simplifier
 {
@@ -37,16 +38,14 @@ using std::endl;
 
 class WorkList
 {
-  /* Rough worklist. Constraint Programming people have lovely structures to do
-   * this
-   * The set (on my machine), is implemented by red-black trees. Deleting just
-   * from one end may unbalance the tree??
-   */
-
 private:
+  typedef ankerl::unordered_dense::set<stp::ASTNode, ASTNode::ASTNodeHasher,
+                                       ASTNode::ASTNodeEqual>
+      WorkListSetType;
+
   // select nodes from the cheap_worklist first.
-  std::unordered_set<stp::ASTNode, ASTNode::ASTNodeHasher, ASTNode::ASTNodeEqual> cheap_workList;    
-  std::unordered_set<stp::ASTNode, ASTNode::ASTNodeHasher, ASTNode::ASTNodeEqual> expensive_workList; 
+  WorkListSetType cheap_workList;
+  WorkListSetType expensive_workList;
 
   WorkList(const WorkList&); // Shouldn't needed to copy or assign.
   WorkList& operator=(const WorkList&);
@@ -142,20 +141,10 @@ public:
   void print()
   {
     cerr << "+Worklist" << endl;
-    std::unordered_set<stp::ASTNode, ASTNode::ASTNodeHasher, ASTNode::ASTNodeEqual>::const_iterator it = cheap_workList.begin();
-    while (it != cheap_workList.end())
-    {
-      cerr << *it << " ";
-      it++;
-    }
-
-    it = expensive_workList.begin();
-    while (it != expensive_workList.end())
-    {
-      cerr << *it << " ";
-      it++;
-    }
-
+    for (const auto& n : cheap_workList)
+      cerr << n << " ";
+    for (const auto& n : expensive_workList)
+      cerr << n << " ";
     cerr << "-Worklist" << endl;
   }
 };

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -539,9 +539,10 @@ BitBlaster<BBNode, BBNodeManagerT>::simplify_during_bb(ASTNode& term,
       // Add all the nodes to the worklist that have a constant as a child.
       cb->initWorkList(n_term);
 
-      simplifier::constantBitP::NodeToFixedBitsMap::NodeToFixedBitsMapType::
-          iterator it;
-      it = cb->fixedMap->map->find(n_term);
+      // The FixedBits are held by pointer rather than map iterator:
+      // propagate() inserts into the map, which invalidates iterators,
+      // while the pointed-to FixedBits are stable.
+      auto it = cb->fixedMap->map->find(n_term);
       FixedBits* nBits;
       if (it == cb->fixedMap->map->end())
       {
@@ -561,25 +562,31 @@ BitBlaster<BBNode, BBNodeManagerT>::simplify_during_bb(ASTNode& term,
         *nBits = FixedBits::concreteToAbstract(n_term);
       }
 
-      it = cb->fixedMap->map->find(term);
-      if (it != cb->fixedMap->map->end())
+      FixedBits* termBits = nullptr;
+      {
+        const auto term_it = cb->fixedMap->map->find(term);
+        if (term_it != cb->fixedMap->map->end())
+          termBits = term_it->second;
+      }
+
+      if (termBits != nullptr)
       {
         // Copy over to the (potentially) new node. Everything we know about
         // the old node.
-        nBits->mergeIn(*(it->second));
+        nBits->mergeIn(*termBits);
       }
 
       cb->scheduleUp(n_term);
       cb->scheduleNode(n_term);
       cb->propagate();
 
-      if (it != cb->fixedMap->map->end())
+      if (termBits != nullptr)
       {
         // Copy to the old node, all we know about the new node. This means
         // that
         // all the parents of the old node get the (potentially) updated
         // fixings.
-        it->second->mergeIn(*nBits);
+        termBits->mergeIn(*nBits);
       }
       // Propagate through all the parents of term.
       cb->scheduleUp(term);


### PR DESCRIPTION
The constant bit propagator's node-to-`FixedBits` map is probed several times per node visit - fetching the node's and every child's bits - and those lookups dominate propagation on large problems. The worklist sets see an insert/erase per (re)scheduling, and the dependents index is probed on every upward schedule. All were `std::unordered_*`: node-based buckets, an allocation per element, a pointer chase per probe.

This switches them to `ankerl::unordered_dense` (vendored by #560), following the same reasoning as the parse-path tables: flat bucket array, fingerprint check before an element is touched, dense contiguous storage.

**First commit** fixes a latent bug the swap would otherwise expose: `BitBlaster::simplify_during_bb` held a `fixedMap` iterator across `cb->propagate()`, which inserts into that map - formally invalidated on rehash with `std::unordered_map`, and guaranteed dangling with a dense map. It now holds the pointed-to `FixedBits*`, which is stable (entries are never erased and the payloads are heap-allocated).

**Measurements** (fifteen most CBITP-heavy QF_BV benchmarks: stp/testcase15, bmc-bv, vlsat3, Sydr, catchconv, picorv32 families; interleaved A/B, three rounds, per-file averages):
- Constant bit propagation: 15.1s -> 11.8s summed (-22%), improved on every file
- Total solve time: -4.9%
- Peak RSS: unchanged (largest file 85MB better)

**Soundness**: sat/unsat answers agree on all benchmark runs and on a 2501-file differential corpus; the full test suite passes. Note the tables' iteration order changes, so conjunct ordering (and hence exact CNF) can differ from before; only answer agreement is claimed.