### PR TITLE
Don't reschedule the just-processed node in constant bit propagation

### DIFF
--- a/lib/Simplifier/constantBitP/ConstantBitPropagation.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitPropagation.cpp
@@ -558,9 +558,13 @@ void ConstantBitPropagation::propagate()
 
           assert(!n[i].isConstant());
 
-          // All the immediate parents of this child need to be rescheduled.
-          // Shouldn't reschuedule 'n' but it does.
-          scheduleUp(n[i]);
+          // All the immediate parents of this child need to be
+          // rescheduled - except 'n' itself: the transfer function that
+          // just ran left 'n' at its fixed point for exactly these child
+          // values, so an immediate revisit derives nothing.
+          for (const auto& parent : *dependents->getDependents(n[i]))
+            if (!(parent == n))
+              workList->push(parent);
 
           // Scheduling the child updates all the values that feed into it.
           workList->push(n[i]);


### PR DESCRIPTION
When a propagation visit changes a child's bits, `scheduleUp(child)` re-adds every parent of that child - including the node that was just processed (the old comment admitted it: *"Shouldn't reschedule 'n' but it does"*). The transfer function that just ran left that node at its per-operation fixed point for exactly these child values, so the immediate revisit derives nothing.

**Change**: iterate the child's dependents and skip `n`. The child itself is still pushed (downward flow to grandchildren), and `scheduleUp(n)` on output changes is untouched (a node is never its own parent).

**Measurements** (fifteen most CBITP-heavy QF_BV benchmarks, single binary with the behavior env-toggled so the comparison is exactly isolated, interleaved, three rounds):
- Worklist visits: 4.58M -> 3.80M summed (**-17%** - the redundant re-adds fire heavily in the top-assumption and bit-blasting phases)
- Constant bit propagation time: -3.3%
- Answers unchanged; fixed point unchanged (verified by re-running every node's transfer function against the final state on assert-enabled builds, via `checkAtFixedPoint`); 2501-file differential corpus: 0 mismatches; full test suite passes.

The same experiment matrix also re-evaluated the worklist's cheap/expensive split, since both were questioned together: removing the split costs +27% visits and +7% CBITP time (the arithmetic-heavy catchconv family nearly triples its visits), so it clearly stays. Interestingly the two interact - without the self re-add, losing the split only costs ~2.5%, i.e. part of the split's historical value was containing the re-add cascade.