### PR TITLE
Add a 32-bit (i386) build-and-test job to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,4 +62,19 @@ jobs:
       run: ctest --parallel "$(nproc)" -VV --output-on-failure
       working-directory: build
 
+  build-32bit:
+    name: gcc (i386)
+    runs-on: [ubuntu-latest]
+
+    steps:
+
+    - uses: actions/checkout@v4
+      with:
+          submodules: 'true'
+
+    - name: Build and test in a 32-bit container
+      run: |
+        docker run --rm -v "$GITHUB_WORKSPACE":/stp -w /stp \
+          i386/debian:bookworm linux32 ./scripts/ci-32bit.sh
+
 # EOF

--- a/lib/Simplifier/UnsignedIntervalAnalysis.cpp
+++ b/lib/Simplifier/UnsignedIntervalAnalysis.cpp
@@ -776,7 +776,17 @@ namespace stp
       return r;
     }
 
-    typedef unsigned __int128 uint128;
+#ifdef __SIZEOF_INT128__
+    // A type wide enough to hold the product of two word-path values.
+    typedef unsigned __int128 uwide;
+    static const unsigned wordPathMaxWidth = 64;
+#else
+    // No 128-bit type (e.g. 32-bit targets), so the word-level path
+    // runs at half scale; wider multiplications use the bignum
+    // fallback instead.
+    typedef uint64_t uwide;
+    static const unsigned wordPathMaxWidth = 32;
+#endif
 
     // The low (up to 64) bits of x as a machine word.
     uint64_t low64(const CBV x)
@@ -793,16 +803,17 @@ namespace stp
     }
 
     // The minimum of (a*i + b) mod m over 0 <= i < n; requires n >= 1,
-    // a < m and b < m, with m <= 2^64 so nothing here can overflow.
+    // a < m and b < m, with m <= 2^wordPathMaxWidth so nothing here can
+    // overflow.
     // Between wraps the values only grow, so the minimum is b or a
     // post-wrap residue; the residues just after each wrap follow the
     // progression b1 + j*((-m) mod a) inside [0, a), which the loop
     // chases Euclid-style. A step above m/2 first flips to the same
     // progression walked backwards, so the modulus at least halves
     // every level: O(log m) iterations.
-    uint128 minlin(uint128 n, uint128 m, uint128 a, uint128 b)
+    uwide minlin(uwide n, uwide m, uwide a, uwide b)
     {
-      uint128 best = b;
+      uwide best = b;
       while (true)
       {
         if (b < best)
@@ -817,14 +828,14 @@ namespace stp
           a = m - a;
           continue;
         }
-        const uint128 firstWrap = (m - b + a - 1) / a;
+        const uwide firstWrap = (m - b + a - 1) / a;
         if (firstWrap >= n)
           return best; // never wraps, so the values only grow from b
-        const uint128 wraps = (b + (n - 1) * a) / m;
-        const uint128 afterWrap = b + firstWrap * a - m; // in [0, a)
+        const uwide wraps = (b + (n - 1) * a) / m;
+        const uwide afterWrap = b + firstWrap * a - m; // in [0, a)
         n = wraps;
         b = afterWrap;
-        const uint128 step = (a - m % a) % a;
+        const uwide step = (a - m % a) % a;
         m = a;
         a = step;
       }
@@ -832,7 +843,7 @@ namespace stp
 
     // The maximum, by reflection: max(v) = m-1 - min(m-1-v), and
     // m-1-(a*i+b) mod m is the progression ((m-a)*i + (m-1-b)) mod m.
-    uint128 maxlin(uint128 n, uint128 m, uint128 a, uint128 b)
+    uwide maxlin(uwide n, uwide m, uwide a, uwide b)
     {
       return m - 1 - minlin(n, m, (m - a) % m, m - 1 - b);
     }
@@ -840,8 +851,8 @@ namespace stp
     // The exact bounds of the progression start, start + step, ...
     // (count terms, mod m), where m is a power of two, step < m and
     // start < m.
-    void progressionHull(uint128 start, uint128 step, uint128 count,
-                         uint128 m, uint128& mn, uint128& mx)
+    void progressionHull(uwide start, uwide step, uwide count,
+                         uwide m, uwide& mn, uwide& mx)
     {
       if (step == 0)
       {
@@ -851,7 +862,7 @@ namespace stp
       // The progression repeats with period m / gcd; a count covering a
       // full period hits exactly the residues congruent to start modulo
       // the gcd.
-      const uint128 gcd = (uint128)1 << __builtin_ctzll((uint64_t)step);
+      const uwide gcd = (uwide)1 << __builtin_ctzll((uint64_t)step);
       if (count >= m / gcd)
       {
         mn = start & (gcd - 1);
@@ -872,23 +883,23 @@ namespace stp
     // written into resultMin/resultMax; both stay null if nothing is
     // known. Exact when the bound products land in the same 2^width block,
     // and when either operand has at most smallSideLimit values (at
-    // widths up to 64).
+    // widths up to wordPathMaxWidth).
     void multiplyPair(const CBV a, const CBV b, const CBV c, const CBV d,
                       unsigned width, CBV& resultMin, CBV& resultMax)
     {
       resultMin = nullptr;
       resultMax = nullptr;
 
-      if (width <= 64)
+      if (width <= wordPathMaxWidth)
       {
         const uint64_t aV = low64(a), bV = low64(b);
         const uint64_t cV = low64(c), dV = low64(d);
-        const uint128 m = (uint128)1 << width;
+        const uwide m = (uwide)1 << width;
 
-        const uint128 lowProduct = (uint128)aV * cV;
-        const uint128 highProduct = (uint128)bV * dV;
+        const uwide lowProduct = (uwide)aV * cV;
+        const uwide highProduct = (uwide)bV * dV;
 
-        uint128 apMin, apMax;
+        uwide apMin, apMax;
         bool known = false;
 
         if ((lowProduct >> width) == (highProduct >> width))
@@ -910,8 +921,8 @@ namespace stp
           const uint64_t fixedLo = xSmall ? aV : cV;
           const uint64_t fixedHi = xSmall ? bV : dV;
           const uint64_t movingLo = xSmall ? cV : aV;
-          const uint128 movingCount =
-              (uint128)(xSmall ? dV - cV : bV - aV) + 1;
+          const uwide movingCount =
+              (uwide)(xSmall ? dV - cV : bV - aV) + 1;
 
           if (fixedHi - fixedLo < smallSideLimit)
           {
@@ -919,8 +930,8 @@ namespace stp
             apMax = 0;
             for (uint64_t v = fixedLo;; v++)
             {
-              uint128 pmn, pmx;
-              progressionHull(((uint128)v * movingLo) & (m - 1), v,
+              uwide pmn, pmx;
+              progressionHull(((uwide)v * movingLo) & (m - 1), v,
                               movingCount, m, pmn, pmx);
               if (pmn < apMin)
                 apMin = pmn;
@@ -949,7 +960,7 @@ namespace stp
         return;
       }
 
-      // Bignum fallback for widths over 64: the same-block case only.
+      // Bignum fallback for wider values: the same-block case only.
       // Wide enough for the bound products.
       const unsigned wide = 2 * width + 2;
 
@@ -1888,19 +1899,28 @@ namespace stp
           uint64_t* mnSum = buf;
           uint64_t* mxSum = buf + K;
 
-          uint128 mnCarry = 0, mxCarry = 0;
+          // The carry out of a chunk is the number of times its 64-bit
+          // sum wrapped; counting the wraps keeps the totals exact
+          // without needing an integer type wider than the chunks.
+          uint64_t mnCarry = 0, mxCarry = 0;
           for (unsigned k = 0; k < K; k++)
           {
-            uint128 mns = mnCarry, mxs = mxCarry;
+            uint64_t mns = mnCarry, mxs = mxCarry;
+            mnCarry = 0;
+            mxCarry = 0;
             for (unsigned i = 0; i < children.size(); i++)
             {
-              mns += chunk64(children[i]->minV, k);
-              mxs += chunk64(children[i]->maxV, k);
+              const uint64_t mnc = chunk64(children[i]->minV, k);
+              const uint64_t mxc = chunk64(children[i]->maxV, k);
+              mns += mnc;
+              if (mns < mnc)
+                mnCarry++;
+              mxs += mxc;
+              if (mxs < mxc)
+                mxCarry++;
             }
-            mnSum[k] = (uint64_t)mns;
-            mxSum[k] = (uint64_t)mxs;
-            mnCarry = mns >> 64;
-            mxCarry = mxs >> 64;
+            mnSum[k] = mns;
+            mxSum[k] = mxs;
           }
 
           // The totals share a block exactly when they agree above the

--- a/lib/extlib-constbv/constantbv.cpp
+++ b/lib/extlib-constbv/constantbv.cpp
@@ -317,6 +317,12 @@ namespace CONSTANTBV {
     return(ErrCode_Ok);
   }
 
+  /* Creating a bit vector before "BitVector_Boot" has set the constants
+     above computes an undersized allocation and corrupts the heap, so
+     run it when the library is loaded rather than trusting every caller
+     to get there first. */
+  [[maybe_unused]] static const ErrCode boot_at_load = BitVector_Boot();
+
   unsigned int BitVector_Size(unsigned int bits) {          /* bit vector size (# of words)  */
     unsigned int size;
 

--- a/scripts/ci-32bit.sh
+++ b/scripts/ci-32bit.sh
@@ -45,9 +45,16 @@ cmake \
   -G Ninja ..
 cmake --build . --parallel "$(nproc)"
 
-# Temporary diagnostic: show exactly what the solver prints for the
-# lit test that fails only on i386.
-./stp ../tests/query-files/let-tests/let_009.smt2 2>&1 || echo "let_009 exit code: $?"
+# Temporary diagnostic: replicate the lit pipeline for the test that
+# fails only on i386, keeping the intermediate output visible.
+{ ./stp ../tests/query-files/let-tests/let_009.smt2 2>&1 \
+    || echo "let_009 exit code: $?"; } | tee /tmp/let009.out \
+  | python3 ../deps/OutputCheck/bin/OutputCheck \
+      ../tests/query-files/let-tests/let_009.smt2 \
+  || echo "manual OutputCheck exit code: $?"
+echo "--- captured let_009 output:"
+cat -A /tmp/let009.out
+echo "--- end"
 
 ctest --parallel "$(nproc)" -VV --output-on-failure
 

--- a/scripts/ci-32bit.sh
+++ b/scripts/ci-32bit.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# Build and test STP with a 32-bit (i386) toolchain, to catch code that
+# assumes 64-bit pointers or a 64-bit long. Run from the repository root
+# inside an i386 Debian container:
+#
+#   docker run --rm -v "$(pwd)":/stp -w /stp i386/debian:bookworm \
+#     linux32 ./scripts/ci-32bit.sh
+
+set -e -u -o pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update
+apt-get install -y --no-install-recommends \
+  bison \
+  build-essential \
+  ca-certificates \
+  cmake \
+  flex \
+  git \
+  libboost-program-options-dev \
+  ninja-build \
+  python3 \
+  python3-pip \
+  python3-setuptools \
+  zlib1g-dev
+pip3 install --break-system-packages -U lit
+
+# The workspace is bind-mounted from the host, so it is owned by a
+# different user than the one running in the container.
+git config --global --add safe.directory '*'
+
+./scripts/deps/setup-minisat.sh
+./scripts/deps/setup-gtest.sh
+./scripts/deps/setup-outputcheck.sh
+
+mkdir -p build-32bit
+cd build-32bit
+cmake \
+  -DNOCRYPTOMINISAT:BOOL=ON \
+  -DENABLE_TESTING:BOOL=ON \
+  -DPYTHON_EXECUTABLE:PATH="$(which python3)" \
+  -G Ninja ..
+cmake --build . --parallel "$(nproc)"
+ctest --parallel "$(nproc)" -VV --output-on-failure
+
+# EOF

--- a/scripts/ci-32bit.sh
+++ b/scripts/ci-32bit.sh
@@ -44,6 +44,11 @@ cmake \
   -DPYTHON_EXECUTABLE:PATH="$(which python3)" \
   -G Ninja ..
 cmake --build . --parallel "$(nproc)"
+
+# Temporary diagnostic: show exactly what the solver prints for the
+# lit test that fails only on i386.
+./stp ../tests/query-files/let-tests/let_009.smt2 2>&1 || echo "let_009 exit code: $?"
+
 ctest --parallel "$(nproc)" -VV --output-on-failure
 
 # EOF

--- a/scripts/ci-32bit.sh
+++ b/scripts/ci-32bit.sh
@@ -45,16 +45,29 @@ cmake \
   -G Ninja ..
 cmake --build . --parallel "$(nproc)"
 
-# Temporary diagnostic: replicate the lit pipeline for the test that
-# fails only on i386, keeping the intermediate output visible.
-{ ./stp ../tests/query-files/let-tests/let_009.smt2 2>&1 \
-    || echo "let_009 exit code: $?"; } | tee /tmp/let009.out \
-  | python3 ../deps/OutputCheck/bin/OutputCheck \
-      ../tests/query-files/let-tests/let_009.smt2 \
-  || echo "manual OutputCheck exit code: $?"
-echo "--- captured let_009 output:"
-cat -A /tmp/let009.out
-echo "--- end"
+# Temporary diagnostic: the manual pipeline passes on i386 but the same
+# test fails under lit, so run lit itself on just that test -- once
+# plain, once with the solver wrapped to capture what it prints when
+# lit spawns it.
+(
+  cd tests/query-files
+  LIT_BIN=$(sed -n 's/^add_test(query-files "\([^"]*\)".*/\1/p' CTestTestfile.cmake)
+  PREFIX=$(sed -n 's/.*--config-prefix=\([^" ]*\).*/\1/p' CTestTestfile.cmake)
+  cat > /tmp/stp-tee <<'EOF'
+#!/bin/bash
+/stp/build-32bit/stp "$@" 2>&1 | tee -a /tmp/lit-solver.out
+exit "${PIPESTATUS[0]}"
+EOF
+  chmod +x /tmp/stp-tee
+  echo "--- plain lit run:"
+  "$LIT_BIN" -a ${PREFIX:+--config-prefix=$PREFIX} --filter let_009 . || true
+  echo "--- lit run with tee-wrapped solver:"
+  "$LIT_BIN" -a ${PREFIX:+--config-prefix=$PREFIX} --param solver=/tmp/stp-tee \
+    --filter let_009 . || true
+  echo "--- solver output captured under lit:"
+  cat -A /tmp/lit-solver.out || true
+  echo "--- end"
+)
 
 ctest --parallel "$(nproc)" -VV --output-on-failure
 

--- a/scripts/ci-32bit.sh
+++ b/scripts/ci-32bit.sh
@@ -40,6 +40,7 @@ cd build-32bit
 cmake \
   -DNOCRYPTOMINISAT:BOOL=ON \
   -DENABLE_TESTING:BOOL=ON \
+  -DLIT_ARGS:STRING=-v \
   -DPYTHON_EXECUTABLE:PATH="$(which python3)" \
   -G Ninja ..
 cmake --build . --parallel "$(nproc)"

--- a/scripts/ci-32bit.sh
+++ b/scripts/ci-32bit.sh
@@ -24,7 +24,6 @@ apt-get install -y --no-install-recommends \
   python3 \
   python3-pip \
   python3-setuptools \
-  strace \
   zlib1g-dev
 pip3 install --break-system-packages -U lit
 
@@ -46,28 +45,11 @@ cmake \
   -G Ninja ..
 cmake --build . --parallel "$(nproc)"
 
-# Temporary diagnostic: under lit the solver appears to never run for
-# let_009 (a tee wrapper left no trace). Strace the lit run to see the
-# exec and writes, and try a variant of the test without 'not'.
-(
-  cd tests/query-files
-  LIT_BIN=$(sed -n 's/^add_test(query-files "\([^"]*\)".*/\1/p' CTestTestfile.cmake)
-  PREFIX=$(sed -n 's/.*--config-prefix=\([^" ]*\).*/\1/p' CTestTestfile.cmake)
-
-  sed 's/^; RUN: not %solver/; RUN: %solver/' \
-    ../../tests/query-files/let-tests/let_009.smt2 \
-    > ../../tests/query-files/let-tests/let_009_no_not.smt2
-
-  echo "--- strace'd lit run:"
-  strace -ff -e trace=process -s 300 -o /tmp/lit-strace \
-    "$LIT_BIN" -a ${PREFIX:+--config-prefix=$PREFIX} --filter 'let_009' . || true
-  echo "--- execve calls mentioning stp or OutputCheck or not:"
-  grep -h "execve" /tmp/lit-strace* | grep -E "stp|OutputCheck|/not|bin/not" || true
-  echo "--- exits and signals:"
-  grep -hE "exited with|killed by" /tmp/lit-strace* | sort | uniq -c | sort -rn | head
-  rm -f ../../tests/query-files/let-tests/let_009_no_not.smt2
-  echo "--- end"
-)
+# Tests whose RUN line uses "not" need it as a real executable under
+# lit's default external shell; it comes with LLVM, which the GitHub
+# Ubuntu images happen to ship but this container does not. Have lit
+# use its internal shell, which implements "not" itself.
+export LIT_USE_INTERNAL_SHELL=1
 
 ctest --parallel "$(nproc)" -VV --output-on-failure
 

--- a/scripts/ci-32bit.sh
+++ b/scripts/ci-32bit.sh
@@ -24,6 +24,7 @@ apt-get install -y --no-install-recommends \
   python3 \
   python3-pip \
   python3-setuptools \
+  strace \
   zlib1g-dev
 pip3 install --break-system-packages -U lit
 
@@ -45,27 +46,26 @@ cmake \
   -G Ninja ..
 cmake --build . --parallel "$(nproc)"
 
-# Temporary diagnostic: the manual pipeline passes on i386 but the same
-# test fails under lit, so run lit itself on just that test -- once
-# plain, once with the solver wrapped to capture what it prints when
-# lit spawns it.
+# Temporary diagnostic: under lit the solver appears to never run for
+# let_009 (a tee wrapper left no trace). Strace the lit run to see the
+# exec and writes, and try a variant of the test without 'not'.
 (
   cd tests/query-files
   LIT_BIN=$(sed -n 's/^add_test(query-files "\([^"]*\)".*/\1/p' CTestTestfile.cmake)
   PREFIX=$(sed -n 's/.*--config-prefix=\([^" ]*\).*/\1/p' CTestTestfile.cmake)
-  cat > /tmp/stp-tee <<'EOF'
-#!/bin/bash
-/stp/build-32bit/stp "$@" 2>&1 | tee -a /tmp/lit-solver.out
-exit "${PIPESTATUS[0]}"
-EOF
-  chmod +x /tmp/stp-tee
-  echo "--- plain lit run:"
-  "$LIT_BIN" -a ${PREFIX:+--config-prefix=$PREFIX} --filter let_009 . || true
-  echo "--- lit run with tee-wrapped solver:"
-  "$LIT_BIN" -a ${PREFIX:+--config-prefix=$PREFIX} --param solver=/tmp/stp-tee \
-    --filter let_009 . || true
-  echo "--- solver output captured under lit:"
-  cat -A /tmp/lit-solver.out || true
+
+  sed 's/^; RUN: not %solver/; RUN: %solver/' \
+    ../../tests/query-files/let-tests/let_009.smt2 \
+    > ../../tests/query-files/let-tests/let_009_no_not.smt2
+
+  echo "--- strace'd lit run:"
+  strace -ff -e trace=process -s 300 -o /tmp/lit-strace \
+    "$LIT_BIN" -a ${PREFIX:+--config-prefix=$PREFIX} --filter 'let_009' . || true
+  echo "--- execve calls mentioning stp or OutputCheck or not:"
+  grep -h "execve" /tmp/lit-strace* | grep -E "stp|OutputCheck|/not|bin/not" || true
+  echo "--- exits and signals:"
+  grep -hE "exited with|killed by" /tmp/lit-strace* | sort | uniq -c | sort -rn | head
+  rm -f ../../tests/query-files/let-tests/let_009_no_not.smt2
   echo "--- end"
 )
 

--- a/tests/unit-tests/UnsignedIntervalPropagators_Test.cpp
+++ b/tests/unit-tests/UnsignedIntervalPropagators_Test.cpp
@@ -452,6 +452,33 @@ TEST(UnsignedIntervalPropagators, MultByAllOnesConstantTerminates)
   stp::UnsignedInterval* result =
       c.analysis.dispatchToTransferFunctions(n, children);
 
+#ifdef __SIZEOF_INT128__
+  expectInterval(result, w, 3, allOnes);
+#else
+  // Without a 128-bit type width 64 takes the bignum fallback, which
+  // gives up on wrapping products; termination is still checked.
+  if (result != nullptr)
+    expectInterval(result, w, 3, allOnes);
+#endif
+  cleanup(children, result);
+}
+
+// The same shape at width 32 stays on the word-level path on every
+// target: the products are the negations -1*x, exactly [3, 2^32-1].
+TEST(UnsignedIntervalPropagators, MultByAllOnesConstantWord)
+{
+  const unsigned w = 32;
+  const uint64_t allOnes = 0xffffffffu;
+  Context c;
+  stp::ASTNode x = c.mgr.CreateSymbol("x", 0, w);
+  stp::ASTNode y = c.mgr.CreateSymbol("y", 0, w);
+  stp::ASTNode n = makeTerm(c, stp::BVMULT, w, x, y);
+
+  std::vector<const stp::UnsignedInterval*> children = {
+      makeInterval(w, allOnes, allOnes), makeInterval(w, 1, allOnes - 2)};
+  stp::UnsignedInterval* result =
+      c.analysis.dispatchToTransferFunctions(n, children);
+
   expectInterval(result, w, 3, allOnes);
   cleanup(children, result);
 }


### PR DESCRIPTION
STP does a lot of word-level bit manipulation, which is exactly where hidden assumptions about 64-bit `long`, `size_t`, or pointer width creep in. 32-bit targets are still real (embedded ARM, i686 distro builds, 32-bit Windows, and wasm32 all have 32-bit pointers), so this adds a CI job that builds STP and runs the full test suite with a genuinely 32-bit toolchain — and fixes the three bugs it immediately found.

**The CI job.** Runs on a normal 64-bit runner but does everything inside an `i386/debian:bookworm` container (Debian still ships a complete i386 userland; Ubuntu's last i386 image was 18.04). `linux32` sets the personality so `uname` reports i686. The container script `scripts/ci-32bit.sh` mirrors the existing job: build minisat/gtest from source, configure with testing enabled, build, run ctest. CryptoMiniSat is disabled so the job exercises STP itself. It can be run locally with:

```
docker run --rm -v "$(pwd)":/stp -w /stp i386/debian:bookworm linux32 ./scripts/ci-32bit.sh
```

**Bugs the job caught, fixed here:**

1. *`__int128` does not exist on 32-bit targets.* The interval analysis' multiplication bounds used `unsigned __int128` unconditionally and failed to compile. The word-level path now runs at half scale (64-bit products of 32-bit values) where `__SIZEOF_INT128__` is missing, with wider multiplications taking the existing bignum fallback; the n-ary addition bounds now count 64-bit carry wraps instead of needing a 128-bit accumulator, which is exact on every target.

2. *Heap corruption from pre-boot bitvector creation.* `BitVector_Create` sizes its allocation from constants that `BitVector_Boot` fills in at runtime, and the `StrengthReduction` / `UnsignedIntervalAnalysis` constructors create bitvectors before any existing boot call site runs — a 4-byte allocation gets three header words plus data written into it. On x86-64 the overflow hid in allocator slack (valgrind confirms it there too); on i386 glibc it corrupts the heap and aborts. The library now boots itself from a static initializer.

3. *The lit suite silently depends on LLVM's `not` utility.* Under lit's default external shell, `let_009.smt2`'s `RUN: not %solver ...` needs a real `not` executable, which the GitHub Ubuntu images happen to ship but a bare container does not — bash fed OutputCheck an empty stream and the test failed with a misleading "no match" error. The 32-bit job runs lit with `LIT_USE_INTERNAL_SHELL=1`, whose shell implements `not` itself.

The width-64 multiplication exactness test now only requires the exact hull where `__int128` exists (termination is still checked everywhere), and a width-32 twin keeps the progression machinery covered on every target.