### PR TITLE
Store FixedBits as packed 64-bit words

### DIFF
--- a/include/stp/Simplifier/constantBitP/FixedBits.h
+++ b/include/stp/Simplifier/constantBitP/FixedBits.h
@@ -61,10 +61,44 @@ static THREAD_LOCAL int staticUniqueId = 1;
 class FixedBits
 {
 private:
-  bool* fixed;
-  bool* values;
+  // Packed LSB-first: bit i of fixedW_[i/64] says whether bit i is fixed;
+  // the same bit of valueW_ is its value. Value bits are only meaningful
+  // where the fixed bit is set (they go stale when a bit is unfixed), so
+  // every multi-bit reader masks the value words with the fixedness words.
+  // Bits at or above the width in the fixedness words are always zero.
+  // Widths of 64 or less live inside the object; wider ones in one heap
+  // block holding the fixedness words followed by the value words.
+  uint64_t* fixedW_;
+  uint64_t* valueW_;
+  uint64_t inlineStorage[2];
   unsigned width;
   bool representsBoolean;
+
+  unsigned numWords() const { return (width + 63) / 64; }
+
+  bool onHeap() const { return width > 64; }
+
+  // Set in the final fixedness word: the bits below the width.
+  uint64_t topMask() const
+  {
+    return (width % 64 == 0) ? ~0ULL : ((1ULL << (width % 64)) - 1);
+  }
+
+  // Points fixedW_/valueW_ at storage for the current width. The contents
+  // are uninitialised.
+  void allocate()
+  {
+    if (width <= 64)
+    {
+      fixedW_ = &inlineStorage[0];
+      valueW_ = &inlineStorage[1];
+    }
+    else
+    {
+      fixedW_ = new uint64_t[2 * numWords()];
+      valueW_ = fixedW_ + numWords();
+    }
+  }
 
   DLL_PUBLIC void init(const FixedBits& copy);
   int uniqueId;
@@ -86,8 +120,8 @@ public:
 
   ~FixedBits()
   {
-    delete[] fixed;
-    delete[] values;
+    if (onHeap())
+      delete[] fixedW_;
   }
 
   bool operator<=(const FixedBits& copy) const
@@ -114,8 +148,8 @@ public:
     if (this == &copy)
       return *this;
 
-    delete[] fixed;
-    delete[] values;
+    if (onHeap())
+      delete[] fixedW_;
     init(copy);
     return *this;
   }
@@ -130,15 +164,7 @@ public:
   {
     assert(isTotallyFixed());
     assert(getWidth() <= 32);
-    unsigned result = 0;
-
-    for (unsigned i = 0; i < width; i++)
-    {
-      if (getValue(i))
-        result += (1u << i);
-    }
-
-    return result;
+    return (unsigned)(valueW_[0] & topMask());
   }
 
   // True if all bits are fixed (irrespective of what value they are fixed to).
@@ -149,93 +175,93 @@ public:
   void setValue(unsigned n, bool value)
   {
     assert(((char)value) == 0 || (char)value == 1);
-    assert(n < width && fixed[n]);
-    values[n] = value;
+    assert(n < width && isFixed(n));
+    const uint64_t bit = 1ULL << (n & 63);
+    if (value)
+      valueW_[n >> 6] |= bit;
+    else
+      valueW_[n >> 6] &= ~bit;
   }
 
   bool getValue(unsigned n) const
   {
-    assert(n < width && fixed[n]);
-    return values[n];
+    assert(n < width && isFixed(n));
+    return (valueW_[n >> 6] >> (n & 63)) & 1;
   }
 
+private:
+  // Bits of word w that could possibly be one: unfixed, or fixed to one.
+  uint64_t possibleOnes(unsigned w) const
+  {
+    const uint64_t mask = (w == numWords() - 1) ? topMask() : ~0ULL;
+    return (~fixedW_[w] & mask) | (fixedW_[w] & valueW_[w]);
+  }
+
+  // Position of the lowest set bit at or above the width if none is set.
+  unsigned lowestSet(uint64_t (FixedBits::*wordFn)(unsigned) const) const
+  {
+    for (unsigned w = 0; w < numWords(); w++)
+    {
+      const uint64_t t = (this->*wordFn)(w);
+      if (t != 0)
+        return w * 64 + __builtin_ctzll(t);
+    }
+    return width;
+  }
+
+  uint64_t fixedOnes(unsigned w) const { return fixedW_[w] & valueW_[w]; }
+
+  uint64_t unfixedBits(unsigned w) const
+  {
+    const uint64_t mask = (w == numWords() - 1) ? topMask() : ~0ULL;
+    return ~fixedW_[w] & mask;
+  }
+
+public:
   // returns -1 if it's zero.
   int topmostPossibleLeadingOne()
   {
-    int i;
-    for (i = (int)getWidth() - 1; i >= 0; i--)
+    for (int w = (int)numWords() - 1; w >= 0; w--)
     {
-      if (!isFixed(i) || getValue(i))
-        break;
+      const uint64_t t = possibleOnes(w);
+      if (t != 0)
+        return w * 64 + 63 - __builtin_clzll(t);
     }
-    return i;
+    return -1;
   }
 
   unsigned minimum_trailingOne()
   {
-    unsigned i = 0;
-    for (; i < getWidth(); i++)
-    {
-      if (!isFixed(i) || getValue(i))
-        break;
-    }
-    return i;
+    return lowestSet(&FixedBits::possibleOnes);
   }
 
-  unsigned maximum_trailingOne()
-  {
-    unsigned i = 0;
-    for (; i < getWidth(); i++)
-    {
-      if (isFixed(i) && getValue(i))
-        break;
-    }
-    return i;
-  }
+  unsigned maximum_trailingOne() { return lowestSet(&FixedBits::fixedOnes); }
 
   unsigned minimum_numberOfTrailingZeroes()
   {
-    unsigned i = 0;
-    for (; i < getWidth(); i++)
-    {
-      if (!isFixed(i) || getValue(i))
-        break;
-    }
-    return i;
+    return lowestSet(&FixedBits::possibleOnes);
   }
 
   unsigned maximum_numberOfTrailingZeroes()
   {
-    unsigned i = 0;
-    for (; i < getWidth(); i++)
-    {
-      if (isFixed(i) && getValue(i))
-        break;
-    }
-    return i;
+    return lowestSet(&FixedBits::fixedOnes);
   }
 
   // Returns the position of the first non-fixed value.
   unsigned leastUnfixed() const
   {
-    unsigned i = 0;
-    for (; i < getWidth(); i++)
-    {
-      if (!isFixed(i))
-        break;
-    }
-    return i;
+    return lowestSet(&FixedBits::unfixedBits);
   }
 
   int mostUnfixed() const
   {
-    int i = (int)getWidth() - 1;
-    for (; i >= 0; i--)
+    for (int w = (int)numWords() - 1; w >= 0; w--)
     {
-      if (!isFixed(i))
-        break;
+      const uint64_t t = unfixedBits(w);
+      if (t != 0)
+        return w * 64 + 63 - __builtin_clzll(t);
     }
-    return i;
+    return -1;
   }
 
   // is this bit fixed to zero?
@@ -248,14 +274,18 @@ public:
   bool isFixed(unsigned n) const
   {
     assert(n < width);
-    return fixed[n];
+    return (fixedW_[n >> 6] >> (n & 63)) & 1;
   }
 
   // set bit n to either fixed or unfixed.
   void setFixed(unsigned n, bool value)
   {
     assert(n < width);
-    fixed[n] = value;
+    const uint64_t bit = 1ULL << (n & 63);
+    if (value)
+      fixedW_[n >> 6] |= bit;
+    else
+      fixedW_[n >> 6] &= ~bit;
   }
 
   // Whether the set of values contains this one.
@@ -296,24 +326,17 @@ public:
   // todo merger with unsignedHolds()
   bool containsZero() const
   {
-    for (unsigned i = 0; i < getWidth(); i++)
-    {
-      if (isFixed(i) && getValue(i))
+    for (unsigned w = 0; w < numWords(); w++)
+      if (fixedOnes(w) != 0)
         return false;
-    }
-
     return true;
   }
 
   unsigned countFixed() const
   {
     unsigned result = 0;
-    for (unsigned i = 0; i < width; i++)
-    {
-      if (isFixed(i))
-        result++;
-    }
-
+    for (unsigned w = 0; w < numWords(); w++)
+      result += __builtin_popcountll(fixedW_[w]);
     return result;
   }
 
@@ -334,64 +357,37 @@ public:
   void fillUnsignedMinMaxBuffers(unsigned char* minBuf,
                                  unsigned char* maxBuf) const
   {
-    static_assert(sizeof(bool) == 1, "bools are loaded eight at a time");
     const unsigned bytes = (width + 7) / 8;
     for (unsigned byte = 0; byte < bytes; byte++)
     {
-      const unsigned base = byte * 8;
-      const unsigned n = width - base >= 8 ? 8 : width - base;
-      uint64_t f = 0, v = 0;
-      memcpy(&f, fixed + base, n);
-      memcpy(&v, values + base, n);
-      // The bools are 0x00/0x01 bytes; gather each byte's low bit.
-      const uint64_t ones = 0x0101010101010101ULL;
-      const uint64_t gather = 0x0102040810204080ULL;
-      const uint64_t mn = f & v;
-      const uint64_t mx = (f ^ ones) | mn; // unfixed or fixed one.
-      minBuf[byte] = (unsigned char)((mn * gather) >> 56);
-      maxBuf[byte] = (unsigned char)((mx * gather) >> 56);
+      const unsigned w = byte / 8;
+      const unsigned shift = (byte % 8) * 8;
+      const uint64_t mn = fixedW_[w] & valueW_[w];
+      const uint64_t mx = mn | ~fixedW_[w]; // unfixed or fixed one.
+      minBuf[byte] = (unsigned char)(mn >> shift);
+      maxBuf[byte] = (unsigned char)(mx >> shift);
     }
   }
 
-  // True if some bit is fixed in both, but to different values. Reads the
-  // bool arrays as 64-bit lanes; no packing, so an early hit is nearly
-  // free. Branching once per 64 bools rather than per lane lets the
-  // compiler vectorise the block.
+  // True if some bit is fixed in both, but to different values.
   bool disagrees(const FixedBits& other) const
   {
-    static_assert(sizeof(bool) == 1, "bools are loaded eight at a time");
     assert(other.width == width);
-    unsigned i = 0;
-    for (; i + 64 <= width; i += 64)
-    {
-      uint64_t acc = 0;
-      for (unsigned b = 0; b < 64; b += 8)
-      {
-        uint64_t f0, v0, f1, v1;
-        memcpy(&f0, fixed + i + b, 8);
-        memcpy(&v0, values + i + b, 8);
-        memcpy(&f1, other.fixed + i + b, 8);
-        memcpy(&v1, other.values + i + b, 8);
-        // The bools are 0x00/0x01 bytes.
-        acc |= f0 & f1 & (v0 ^ v1);
-      }
-      if (acc != 0)
-        return true;
-    }
-    for (; i + 8 <= width; i += 8)
-    {
-      uint64_t f0, v0, f1, v1;
-      memcpy(&f0, fixed + i, 8);
-      memcpy(&v0, values + i, 8);
-      memcpy(&f1, other.fixed + i, 8);
-      memcpy(&v1, other.values + i, 8);
-      if ((f0 & f1 & (v0 ^ v1)) != 0)
-        return true;
-    }
-    for (; i < width; i++)
-      if (fixed[i] && other.fixed[i] && values[i] != other.values[i])
+    for (unsigned w = 0; w < numWords(); w++)
+      if ((fixedW_[w] & other.fixedW_[w] & (valueW_[w] ^ other.valueW_[w])) !=
+          0)
         return true;
     return false;
+  }
+
+  // Fix the bits of `add` in word w, each to the corresponding bit of
+  // `vals`. Other bits are untouched.
+  void fixWordBits(unsigned w, uint64_t add, uint64_t vals)
+  {
+    assert(w < numWords());
+    assert((add & ~((w == numWords() - 1) ? topMask() : ~0ULL)) == 0);
+    fixedW_[w] |= add;
+    valueW_[w] = (valueW_[w] & ~add) | (vals & add);
   }
 
   // Packs one 64-bit chunk — bits [w*64, min(width, (w+1)*64)) — of the
@@ -399,44 +395,26 @@ public:
   // is isFixed(w*64+i), bit i of valueW is a fixed one there.
   void fillPackedWord(unsigned w, uint64_t& fixedW, uint64_t& valueW) const
   {
-    static_assert(sizeof(bool) == 1, "bools are loaded eight at a time");
-    const uint64_t gather = 0x0102040810204080ULL;
-    uint64_t fw = 0, vw = 0;
-    const unsigned base = w * 64;
-    const unsigned limit = width - base >= 64 ? 64 : width - base;
-    for (unsigned b = 0; b < limit; b += 8)
-    {
-      const unsigned n = limit - b >= 8 ? 8 : limit - b;
-      uint64_t f = 0, v = 0;
-      memcpy(&f, fixed + base + b, n);
-      memcpy(&v, values + base + b, n);
-      // The bools are 0x00/0x01 bytes; gather each byte's low bit.
-      fw |= ((f * gather) >> 56) << b;
-      vw |= (((f & v) * gather) >> 56) << b;
-    }
-    fixedW = fw;
-    valueW = vw;
+    fixedW = fixedW_[w];
+    valueW = fixedW_[w] & valueW_[w];
   }
 
   // As above over the whole width. Each array needs ceil(width/64) words.
   void fillPackedWords(uint64_t* fixedW,
                        uint64_t* valueW) const
   {
-    const unsigned words = (width + 63) / 64;
-    for (unsigned w = 0; w < words; w++)
+    for (unsigned w = 0; w < numWords(); w++)
       fillPackedWord(w, fixedW[w], valueW[w]);
   }
 
   void mergeIn(const FixedBits& a)
   {
     assert(a.getWidth() == getWidth());
-    for (unsigned i = 0; i < width; i++)
+    for (unsigned w = 0; w < numWords(); w++)
     {
-      if (a.isFixed(i) && !isFixed(i))
-      {
-        setFixed(i, true);
-        setValue(i, a.getValue(i));
-      }
+      const uint64_t add = a.fixedW_[w] & ~fixedW_[w];
+      fixedW_[w] |= add;
+      valueW_[w] = (valueW_[w] & ~add) | (a.valueW_[w] & add);
     }
   }
 

--- a/lib/Simplifier/constantBitP/ConstantBitP_Boolean.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_Boolean.cpp
@@ -311,32 +311,45 @@ Result bvImpliesBothWays(vector<FixedBits*>& children, FixedBits& result)
 Result bvNotBothWays(FixedBits& a, FixedBits& output)
 {
   assert(a.getWidth() == output.getWidth());
-  const int bitWidth = a.getWidth();
+  const unsigned width = a.getWidth();
+  const unsigned words = (width + 63) / 64;
 
   Result result = NO_CHANGE;
 
-  for (int i = 0; i < bitWidth; i++)
+  for (unsigned w = 0; w < words; w++)
   {
-    // error if they are the same.
-    if (a.isFixed(i) && output.isFixed(i) &&
-        (a.getValue(i) == output.getValue(i)))
+    uint64_t fa, va, fo, vo;
+    a.fillPackedWord(w, fa, va);
+    output.fillPackedWord(w, fo, vo);
+
+    // Error where both are fixed to the same value.
+    const uint64_t conflict = fa & fo & ~(va ^ vo);
+
+    uint64_t addOut = fa & ~fo;
+    uint64_t addA = fo & ~fa;
+
+    if (conflict != 0)
     {
+      // Match the bit-at-a-time original: bits below the first conflicting
+      // one are still fixed before the conflict is reported.
+      const uint64_t below = (1ULL << __builtin_ctzll(conflict)) - 1;
+      addOut &= below;
+      addA &= below;
+    }
+
+    if (addOut != 0)
+    {
+      output.fixWordBits(w, addOut, ~va);
+      result = CHANGED;
+    }
+    if (addA != 0)
+    {
+      a.fixWordBits(w, addA, ~vo);
+      result = CHANGED;
+    }
+
+    if (conflict != 0)
       return CONFLICT;
-    }
-
-    if (a.isFixed(i) && !output.isFixed(i))
-    {
-      output.setFixed(i, true);
-      output.setValue(i, !a.getValue(i));
-      result = CHANGED;
-    }
-
-    if (output.isFixed(i) && !a.isFixed(i))
-    {
-      a.setFixed(i, true);
-      a.setValue(i, !output.getValue(i));
-      result = CHANGED;
-    }
   }
   return result;
 }

--- a/lib/Simplifier/constantBitP/FixedBits.cpp
+++ b/lib/Simplifier/constantBitP/FixedBits.cpp
@@ -57,10 +57,10 @@ std::ostream& operator<<(std::ostream& output, const FixedBits& h)
 
 void FixedBits::fixToZero()
 {
-  for (unsigned i = 0; i < getWidth(); i++)
+  for (unsigned w = 0; w < numWords(); w++)
   {
-    setFixed(i, true);
-    setValue(i, false);
+    fixedW_[w] = (w == numWords() - 1) ? topMask() : ~0ULL;
+    valueW_[w] = 0;
   }
 }
 
@@ -70,7 +70,7 @@ stp::CBV FixedBits::GetMinBVConst() const
 
   for (unsigned i = 0; i < width; i++)
   {
-    if (fixed[i] && values[i])
+    if (isFixedToOne(i))
       CONSTANTBV::BitVector_Bit_On(result, i);
   }
 
@@ -83,7 +83,7 @@ stp::CBV FixedBits::GetMaxBVConst() const
 
   for (unsigned i = 0; i < width; i++)
   {
-    if (!fixed[i] || values[i])
+    if (!isFixed(i) || getValue(i))
       CONSTANTBV::BitVector_Bit_On(result, i);
   }
 
@@ -99,7 +99,7 @@ stp::CBV FixedBits::GetBVConst() const
 
   for (unsigned i = 0; i < width; i++)
   {
-    if (values[i])
+    if (getValue(i))
       CONSTANTBV::BitVector_Bit_On(result, i);
   }
 
@@ -126,19 +126,19 @@ stp::CBV FixedBits::GetBVConst(unsigned to, unsigned from) const
 void FixedBits::init(const FixedBits& copy)
 {
   width = copy.width;
-  fixed = new bool[width];
-  values = new bool[width];
   representsBoolean = copy.representsBoolean;
+  allocate();
 
-  memcpy(fixed, copy.fixed, width * sizeof(bool));
-  memcpy(values, copy.values, width * sizeof(bool));
+  memcpy(fixedW_, copy.fixedW_, numWords() * sizeof(uint64_t));
+  memcpy(valueW_, copy.valueW_, numWords() * sizeof(uint64_t));
 }
 
 bool FixedBits::isTotallyFixed() const
 {
-  for (unsigned i = 0; i < width; i++)
+  for (unsigned w = 0; w < numWords(); w++)
   {
-    if (!fixed[i])
+    const uint64_t mask = (w == numWords() - 1) ? topMask() : ~0ULL;
+    if (fixedW_[w] != mask)
       return false;
   }
 
@@ -147,9 +147,9 @@ bool FixedBits::isTotallyFixed() const
 
 bool FixedBits::isTotallyUnfixed() const
 {
-  for (unsigned i = 0; i < width; i++)
+  for (unsigned w = 0; w < numWords(); w++)
   {
-    if (fixed[i])
+    if (fixedW_[w] != 0)
       return false;
   }
 
@@ -160,14 +160,13 @@ FixedBits::FixedBits(unsigned n, bool isbool)
 {
   assert(n > 0);
 
-  fixed = new bool[n];
-  values = new bool[n];
   width = n;
+  allocate();
 
-  for (unsigned i = 0; i < width; i++)
+  for (unsigned w = 0; w < numWords(); w++)
   {
-    fixed[i] = false;  // I don't know if there's a default value??
-    values[i] = false; // stops it printing out junk.
+    fixedW_[w] = 0;
+    valueW_[w] = 0; // stops it printing out junk.
   }
 
   representsBoolean = isbool;


### PR DESCRIPTION
FixedBits held two heap-allocated `bool` arrays, one byte per bit. It now holds packed fixedness/value words, LSB-first: widths of 64 or less live inline in the object (no heap allocations at all), wider ones in a single block. Value bits stay meaningful only where the fixed bit is set — they go stale when a bit is unfixed, exactly like the old bool array — so multi-bit readers mask values with fixedness. Nobody outside the class touched the arrays, so the 500+ per-bit API call sites in the propagators compile unchanged.

The representation collapses the helpers that existed to work around the bool arrays: `fillPackedWords`/`fillUnsignedMinMaxBuffers` lose their byte-gather multiplies, `disagrees` reads true 64-bit lanes, and `countFixed`/`containsZero`/`isTotallyFixed` and the leading/trailing scans become popcount/clz/ctz one-liners. A new `fixWordBits` lets propagators fix a word's worth of bits at once; BVNOT uses it now (its per-bit loop was the one propagator the conversion regressed — same-word read-modify-write chains are the representation's weak spot — and it is now the catalog's largest win instead).

**Verification**
- The differential testers from #569/#570 plus a new exhaustive BVNOT tester: 81M cases bit-identical (results and `Result` codes), against Release and assertions-enabled builds.
- `contract`, `accuracy` and `nary` phases of the local propagator harness: output byte-identical to master for every operation.
- 2,500-file fuzz sweep: sat/unsat answers identical to a master binary; all 59 ctest suites pass on an assertions build.

**Performance, before → after** (interleaved A/B, min of 3, loaded box)

FixedBits micro-ops, w=64: create+destroy 35 → 15ns, copy 34 → 12ns, copy+mergeIn 88 → 13ns, countFixed 31 → 3.7ns, fillPackedWords 31 → 1.3ns; `sizeof` grows 32 → 48 but the two heap allocations disappear for w ≤ 64 (and halve above it).

Transfer-function catalog (w=64, ns/call at 1/5/50% bits fixed): bvnot 94/113/414 → 29/23/22, eq 129/126/63 → 46/46/43, bvadd 554/561/1972 → 299/373/1868, bvsub 2169/3322 → 1636/2682 (50%: neutral), bvneg 183 → 129, bvult/bvule ~1.1–1.7x, bvsge/bvsgt ~1.1–1.2x, bvand/bvor/bvxor/bvashr neutral, bvshl/bvlshr at 50% ~5–10% slower (per-bit copy loops; see below).

End-to-end on a 15-file CBITP-heavy QF_BV set (3 interleaved rounds, min): CBITP time 6360 → 6355ms, wall 94.3 → 93.9s, peak RSS unchanged — neutral. These files spend their propagation time in the n-ary AND and multiplication propagators, which are still per-bit loops; the ops that got faster are small fractions of their totals.

**Weak spot and follow-up.** Per-bit writes are now read-modify-write on a shared word, so tight per-bit store loops (shifts; adversarially, a full-width sweep) run slower than byte stores. The fix that beats both representations is the BVNOT pattern — pack to locals with `fillPackedWord`, operate, write back with `fixWordBits` — which this conversion makes a two-line affair per word. The n-ary bitwise family and the shifts are the natural next candidates, and are what would move the end-to-end numbers.