### PR TITLE
Update GitHub Actions to current versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7
       with:
           submodules: 'true'
 
@@ -68,7 +68,7 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
           submodules: 'true'
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,10 +29,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v7
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v4
       with:
          languages: ${{ matrix.language }}
 
@@ -49,4 +49,4 @@ jobs:
        make
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
Bumps the workflow actions to their current major versions:

- `actions/checkout` v2 (CI clang job, CodeQL) and v4 (i386 job) -> **v7**
- `github/codeql-action` v1 -> **v4**

codeql-action v1/v2 were deprecated and are no longer accepted by GitHub, so the weekly scheduled CodeQL run has been failing; this should bring it back to life. checkout v7 is a drop-in replacement for how it's used here (only the `submodules` option, which is unchanged).