### PR TITLE
Move the shift propagators' FixedBits boundary to word operations

### DIFF
--- a/lib/Simplifier/constantBitP/ConstantBitP_Shifting.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_Shifting.cpp
@@ -63,17 +63,7 @@ struct PackedBits
   explicit PackedBits(const FixedBits& b) : words((b.getWidth() + 63) / 64)
   {
     allocate();
-    for (unsigned j = 0; j < 2 * words; j++)
-      fixed[j] = 0; // zeroes both halves; value follows fixed.
-
-    const unsigned width = b.getWidth();
-    for (unsigned i = 0; i < width; i++)
-      if (b.isFixed(i))
-      {
-        fixed[i >> 6] |= (uint64_t)1 << (i & 63);
-        if (b.getValue(i))
-          value[i >> 6] |= (uint64_t)1 << (i & 63);
-      }
+    b.fillPackedWords(fixed, value);
   }
 
   PackedBits(const PackedBits& o) : words(o.words)
@@ -338,9 +328,68 @@ inline bool rightShiftDisagrees(const PackedBits& op, const PackedBits& out,
 }
 }
 
+namespace
+{
+inline uint64_t bitReverse64(uint64_t x)
+{
+  x = __builtin_bswap64(x);
+  x = ((x & 0x0F0F0F0F0F0F0F0FULL) << 4) | ((x >> 4) & 0x0F0F0F0F0F0F0F0FULL);
+  x = ((x & 0x3333333333333333ULL) << 2) | ((x >> 2) & 0x3333333333333333ULL);
+  x = ((x & 0x5555555555555555ULL) << 1) | ((x >> 1) & 0x5555555555555555ULL);
+  return x;
+}
+
+// The packed words of `src` with the bit order reversed over its width:
+// reverse the word order and each word, giving the reverse of the padded
+// words*64-bit value, then shift out the padding. Each output array needs
+// `words` words.
+void packReversed(const FixedBits& src, uint64_t* rf, uint64_t* rv)
+{
+  const unsigned width = src.getWidth();
+  const unsigned words = (width + 63) / 64;
+  const unsigned pad = words * 64 - width;
+
+  uint64_t* f = (uint64_t*)alloca(sizeof(uint64_t) * words);
+  uint64_t* v = (uint64_t*)alloca(sizeof(uint64_t) * words);
+  src.fillPackedWords(f, v);
+
+  for (unsigned j = 0; j < words; j++)
+  {
+    uint64_t lowF = bitReverse64(f[words - 1 - j]);
+    uint64_t lowV = bitReverse64(v[words - 1 - j]);
+    if (pad != 0)
+    {
+      const uint64_t highF = (j + 1 < words) ? bitReverse64(f[words - 2 - j]) : 0;
+      const uint64_t highV = (j + 1 < words) ? bitReverse64(v[words - 2 - j]) : 0;
+      lowF = (lowF >> pad) | (highF << (64 - pad));
+      lowV = (lowV >> pad) | (highV << (64 - pad));
+    }
+    rf[j] = lowF;
+    rv[j] = lowV;
+  }
+}
+
+// Fix in `dst` the reversed bits of `revSrc` that `dst` does not have yet.
+void mergeReversed(const FixedBits& revSrc, FixedBits& dst)
+{
+  const unsigned words = (dst.getWidth() + 63) / 64;
+  uint64_t* rf = (uint64_t*)alloca(sizeof(uint64_t) * words);
+  uint64_t* rv = (uint64_t*)alloca(sizeof(uint64_t) * words);
+  packReversed(revSrc, rf, rv);
+
+  for (unsigned j = 0; j < words; j++)
+  {
+    uint64_t df, dv;
+    dst.fillPackedWord(j, df, dv);
+    const uint64_t add = rf[j] & ~df;
+    if (add != 0)
+      dst.fixWordBits(j, add, rv[j]);
+  }
+}
+}
+
 Result bvRightShiftBothWays(vector<FixedBits*>& children, FixedBits& output)
 {
-  Result result = NO_CHANGE;
   const unsigned bitWidth = output.getWidth();
 
   assert(2 == children.size());
@@ -348,49 +397,35 @@ Result bvRightShiftBothWays(vector<FixedBits*>& children, FixedBits& output)
   FixedBits& op = *children[0];
   FixedBits& shift = *children[1];
 
-  FixedBits outputReverse(bitWidth, false);
+  // Reversing the operand and the output turns the right shift into a
+  // left shift.
+  const unsigned words = (bitWidth + 63) / 64;
+  uint64_t* rf = (uint64_t*)alloca(sizeof(uint64_t) * words);
+  uint64_t* rv = (uint64_t*)alloca(sizeof(uint64_t) * words);
+
   FixedBits opReverse(bitWidth, false);
+  packReversed(op, rf, rv);
+  for (unsigned j = 0; j < words; j++)
+    if (rf[j] != 0)
+      opReverse.fixWordBits(j, rf[j], rv[j]);
 
-  // Reverse the output and the input.
-  for (unsigned i = 0; i < bitWidth; i++)
-  {
-    if (op.isFixed(i))
-    {
-      opReverse.setFixed(bitWidth - 1 - i, true);
-      opReverse.setValue(bitWidth - 1 - i, op.getValue(i));
-    }
-
-    if (output.isFixed(i))
-    {
-      outputReverse.setFixed(bitWidth - 1 - i, true);
-      outputReverse.setValue(bitWidth - 1 - i, output.getValue(i));
-    }
-  }
+  FixedBits outputReverse(bitWidth, false);
+  packReversed(output, rf, rv);
+  for (unsigned j = 0; j < words; j++)
+    if (rf[j] != 0)
+      outputReverse.fixWordBits(j, rf[j], rv[j]);
 
   vector<FixedBits*> args;
   args.push_back(&opReverse);
   args.push_back(&shift); // shift is unmodified.
-  result = bvLeftShiftBothWays(args, outputReverse);
+  const Result result = bvLeftShiftBothWays(args, outputReverse);
 
   if (CONFLICT == result)
     return CONFLICT;
 
-  // Now write the reversed values back.
-  // Reverse the output and the input.
-  for (unsigned i = 0; i < bitWidth; i++)
-  {
-    if (opReverse.isFixed(i) && !op.isFixed(bitWidth - 1 - i))
-    {
-      op.setFixed(bitWidth - 1 - i, true);
-      op.setValue(bitWidth - 1 - i, opReverse.getValue(i));
-    }
-
-    if (outputReverse.isFixed(i) && !output.isFixed(bitWidth - 1 - i))
-    {
-      output.setFixed(bitWidth - 1 - i, true);
-      output.setValue(bitWidth - 1 - i, outputReverse.getValue(i));
-    }
-  }
+  // Write the reversed deductions back.
+  mergeReversed(opReverse, op);
+  mergeReversed(outputReverse, output);
 
   return result;
 }
@@ -666,14 +701,9 @@ static void writeBack(FixedBits& to, const PackedBits& from,
 {
   for (unsigned j = 0; j < from.words; j++)
   {
-    uint64_t pending = from.fixed[j] & ~originalFixed[j];
-    while (pending)
-    {
-      const unsigned b = __builtin_ctzll(pending);
-      pending &= pending - 1;
-      to.setFixed(j * 64 + b, true);
-      to.setValue(j * 64 + b, (from.value[j] >> b) & 1);
-    }
+    const uint64_t add = from.fixed[j] & ~originalFixed[j];
+    if (add != 0)
+      to.fixWordBits(j, add, from.value[j]);
   }
 }
 


### PR DESCRIPTION
The shift cores already worked on packed words (`PackedBits`), but their FixedBits boundary predated #572's packed storage: the `PackedBits` constructor packed bit-by-bit, `writeBack` fixed bit-by-bit, and `bvRightShiftBothWays` reversed its operand and output bit-by-bit in four O(width) accessor loops before and after delegating to the left shift.

Three boundary changes, no core algorithm changes:
- the constructor is now `fillPackedWords` (a copy on the packed representation),
- `writeBack` lands whole words through `fixWordBits`,
- the right shift's reversal reverses whole words (`bswap` + swap networks, word order reversed, padding shifted out to realign to the width).

**Verification:** the harness's differential phase against the pre-packed original implementations: 600k randomized cases across all three shifts at widths 1–1500, zero mismatches (same `Result` codes and identical final fixings); the exhaustive w=3 contract phase is byte-identical; all 59 ctest suites pass.

**Speed** (interleaved A/B, same binary against previous/new library)

| shape | shl | lshr | ashr |
|---|---|---|---|
| w=64 | 657 → 211ns | 1530 → 359ns | 649 → 300ns |
| w=1024 | 12 → 1.7µs | 24.7 → 2.1µs | 12.2 → 2.3µs |
| w=50000 | 670 → 95µs | 1.39ms → 122µs | 676 → 98µs |

The remaining wide-width cost is the cores' possible-shift union, which is O(feasible shifts × words) when the shift amount is mostly unknown — an algorithmic property of the precision these propagators achieve, not boundary overhead. With this, everything in the catalog except multiplication/division is word-level end to end.