### PR TITLE
Speed up the multiplication propagator's column machinery

### DIFF
--- a/include/stp/Simplifier/constantBitP/multiplication/ColumnCounts.h
+++ b/include/stp/Simplifier/constantBitP/multiplication/ColumnCounts.h
@@ -25,6 +25,7 @@ THE SOFTWARE.
 #ifndef COLUMNCOUNTS_H_
 #define COLUMNCOUNTS_H_
 
+#include <cstdint>
 #include <iostream>
 
 namespace simplifier
@@ -33,13 +34,6 @@ namespace constantBitP
 {
 
 extern std::ostream& log;
-
-struct Interval
-{
-  int& low;
-  int& high;
-  Interval(int& _low, int& _high) : low(_low), high(_high) {}
-};
 
 struct ColumnCounts
 {
@@ -50,36 +44,69 @@ struct ColumnCounts
   unsigned int bitWidth;
   const FixedBits& output;
 
+  // With initialise false the caller provides already-set-up column arrays
+  // (e.g. restored from a saved copy).
   ColumnCounts(signed _columnH[], signed _columnL[], signed _sumH[],
-               signed _sumL[], unsigned _bitWidth, FixedBits& output_)
+               signed _sumL[], unsigned _bitWidth, FixedBits& output_,
+               bool initialise = true)
       : columnH(_columnH), columnL(_columnL), sumH(_sumH), sumL(_sumL),
         output(output_)
   {
     // setup the low and highs.
     bitWidth = _bitWidth;
-    // initialise 'em.
-    for (unsigned i = 0; i < bitWidth; i++)
-    {
-      columnL[i] = 0;
-      columnH[i] = i + 1;
-    }
+    if (initialise)
+      for (unsigned i = 0; i < bitWidth; i++)
+      {
+        columnL[i] = 0;
+        columnH[i] = i + 1;
+      }
   }
 
-  void rebuildSums()
+  // Halve a sum bound. They are always non-negative, so this is /2 without
+  // the negative-rounding correction a signed divide pays for.
+  static int half(int x)
   {
+    assert(x >= 0);
+    return (int)((unsigned)x >> 1);
+  }
+
+  // Returns CONFLICT if a column's counts are crossed (e.g. adjustColumns
+  // found more necessary ones than the column can hold) or a snap emptied a
+  // sum interval; the sums are unusable then.
+  Result rebuildSums()
+  {
+    if (columnH[0] < columnL[0] || columnL[0] < 0)
+      return CONFLICT;
     // Initialise sums.
     sumL[0] = columnL[0];
     sumH[0] = columnH[0];
-    snapTo(0);
+    if (snapTo(0) == CONFLICT)
+      return CONFLICT;
 
+    uint64_t fixed = 0, value = 0;
+    output.fillPackedWord(0, fixed, value);
     for (unsigned i = /**/ 1 /**/; i < bitWidth; i++)
     {
-      assert((columnH[i] >= columnL[i]) && (columnL[i] >= 0));
-      sumH[i] = columnH[i] + (sumH[i - 1] / 2);
-      sumL[i] = columnL[i] + (sumL[i - 1] / 2);
-      if (output.isFixed(i))
-        snapTo(i);
+      if (columnH[i] < columnL[i] || columnL[i] < 0)
+        return CONFLICT;
+      sumH[i] = columnH[i] + half(sumH[i - 1]);
+      sumL[i] = columnL[i] + half(sumL[i - 1]);
+
+      const unsigned b = i & 63;
+      if (b == 0)
+        output.fillPackedWord(i >> 6, fixed, value);
+      if ((fixed >> b) & 1)
+      {
+        const int expected = (int)((value >> b) & 1);
+        if ((sumH[i] & 1) != expected)
+          sumH[i]--;
+        if ((sumL[i] & 1) != expected)
+          sumL[i]++;
+        if ((sumH[i] < sumL[i]) || (sumL[i] < 0))
+          return CONFLICT;
+      }
     }
+    return NO_CHANGE;
   }
 
   void print(std::string message)
@@ -144,16 +171,42 @@ struct ColumnCounts
   {
     Result r = NO_CHANGE;
 
-    // Make sure each column's sum is consistent with the output.
-    for (unsigned i = 0; i < bitWidth; i++)
+    // Make sure each fixed column's sum is consistent with the output;
+    // snapTo(i) is a no-op on unfixed columns, so visit only the fixed
+    // bits, straight off the packed words.
+    const unsigned words = (bitWidth + 63) / 64;
+    for (unsigned w = 0; w < words; w++)
     {
-      const Result ri = snapTo(i);
-      if (ri == CONFLICT)
-        return CONFLICT;
-      if (ri == CHANGED)
-        r = CHANGED;
+      uint64_t fixed, value;
+      output.fillPackedWord(w, fixed, value);
+      while (fixed != 0)
+      {
+        const unsigned b = ctz64(fixed);
+        fixed &= fixed - 1;
+        const unsigned i = w * 64 + b;
+
+        const int expected = (int)((value >> b) & 1);
+        if ((sumH[i] & 1) != expected)
+        {
+          sumH[i]--;
+          r = CHANGED;
+        }
+        if ((sumL[i] & 1) != expected)
+        {
+          sumL[i]++;
+          r = CHANGED;
+        }
+        if ((sumH[i] < sumL[i]) || (sumL[i] < 0))
+          return CONFLICT;
+      }
     }
     return r;
+  }
+
+  static unsigned ctz64(uint64_t v)
+  {
+    assert(v != 0);
+    return (unsigned)__builtin_ctzll(v);
   }
 
   bool inConflict()
@@ -164,11 +217,10 @@ struct ColumnCounts
     return false;
   }
 
+  // The caller must have run rebuildSums (and stopped on CONFLICT from it)
+  // first: it guarantees the entry state has no crossed intervals.
   Result fixedPoint()
   {
-    if (inConflict())
-      return CONFLICT;
-
     bool changed = true;
     bool totalChanged = false;
 
@@ -176,13 +228,17 @@ struct ColumnCounts
     {
       changed = false;
 
-      Result r = snapTo();
+      // propagate before snapTo: the caller runs rebuildSums first, which
+      // already snaps each fixed column as it builds, so an initial snapTo
+      // sweep would find nothing. The fixpoint reached is the same in
+      // either order.
+      Result r = propagate();
       if (r == CHANGED)
         changed = true;
       if (r == CONFLICT)
         return CONFLICT;
 
-      r = propagate();
+      r = snapTo();
       if (r == CHANGED)
         changed = true;
       if (r == CONFLICT)
@@ -192,9 +248,9 @@ struct ColumnCounts
         totalChanged = true;
     }
 
-    if (inConflict())
-      return CONFLICT;
-
+    // No closing conflict scan: rebuildSums guarantees a clean entry state,
+    // and propagate/snapTo report any interval they empty themselves.
+    assert(!inConflict());
     assert(propagate() == NO_CHANGE);
     assert(snapTo() == NO_CHANGE);
 
@@ -204,88 +260,100 @@ struct ColumnCounts
       return NO_CHANGE;
   }
 
+  // Make column i consistent with sum i and sum i-1 (i >= 1), tightening
+  // any of the three intervals. Most columns are already consistent, so
+  // the guards are cheap well-predicted branches; the conflict test only
+  // runs when something fired.
+  // Returns changed (bit 0) and conflict — an interval emptied — (bit 1).
+  int propagateAt(unsigned i)
+  {
+    const int cl = half(sumL[i - 1]); // snapshots: the writes below
+    const int ch = half(sumH[i - 1]); // deliberately don't rebuild them.
+    bool changed = false;
+
+    if (sumL[i] < columnL[i] + cl)
+    {
+      sumL[i] = columnL[i] + cl;
+      changed = true;
+    }
+
+    if (sumH[i] > columnH[i] + ch)
+    {
+      sumH[i] = columnH[i] + ch;
+      changed = true;
+    }
+
+    if (sumL[i] - columnH[i] > cl)
+    {
+      sumL[i - 1] = (sumL[i] - columnH[i]) * 2;
+      changed = true;
+    }
+
+    if (sumH[i] - columnL[i] < ch)
+    {
+      sumH[i - 1] = (sumH[i] - columnL[i]) * 2 + 1;
+      changed = true;
+    }
+
+    if (sumL[i] - ch > columnL[i])
+    {
+      columnL[i] = sumL[i] - ch;
+      changed = true;
+    }
+
+    if (sumH[i] - cl < columnH[i])
+    {
+      columnH[i] = sumH[i] - cl;
+      changed = true;
+    }
+
+    if (!changed)
+      return 0;
+    const bool conflict = (sumL[i] > sumH[i]) | (columnL[i] > columnH[i]) |
+                          (sumL[i - 1] > sumH[i - 1]);
+    return 1 | ((int)conflict << 1);
+  }
+
+  // Returns changed (bit 0) and conflict (bit 1), like propagateAt.
+  int syncColumnZero()
+  {
+    bool changed = false;
+    if (sumL[0] > columnL[0])
+    {
+      columnL[0] = sumL[0];
+      changed = true;
+    }
+    if (sumL[0] < columnL[0])
+    {
+      sumL[0] = columnL[0];
+      changed = true;
+    }
+    if (sumH[0] < columnH[0])
+    {
+      columnH[0] = sumH[0];
+      changed = true;
+    }
+    if (sumH[0] > columnH[0])
+    {
+      sumH[0] = columnH[0];
+      changed = true;
+    }
+    return (int)changed | ((sumL[0] > sumH[0]) ? 2 : 0);
+  }
+
   // Assert that all the counts are consistent.
   Result propagate()
   {
-    bool changed = false;
-
-    int i = 0;
-
-    //
-    if (sumL[i] > columnL[i])
-    {
-      columnL[i] = sumL[i];
-      changed = true;
-    }
-    if (sumL[i] < columnL[i])
-    {
-      sumL[i] = columnL[i];
-      changed = true;
-    }
-    if (sumH[i] < columnH[i])
-    {
-      columnH[i] = sumH[i];
-      changed = true;
-    }
-    if (sumH[i] > columnH[i])
-    {
-      sumH[i] = columnH[i];
-      changed = true;
-    }
+    int flags = syncColumnZero();
 
     for (unsigned i = 1; i < bitWidth; i++)
-    {
-      Interval a(sumL[i], sumH[i]);
-      Interval b(columnL[i], columnH[i]);
+      flags |= propagateAt(i);
 
-      int low = sumL[i - 1] / 2; // interval takes references.
-      int high = sumH[i - 1] / 2;
-      Interval c(low, high);
-
-      if (a.low < b.low + c.low)
-      {
-        a.low = b.low + c.low;
-        changed = true;
-      }
-
-      if (a.high > b.high + c.high)
-      {
-        changed = true;
-        a.high = b.high + c.high;
-      }
-
-      if (a.low - b.high > c.low)
-      {
-        int toAssign = ((a.low - b.high) * 2);
-        assert(toAssign > sumL[i - 1]);
-        sumL[i - 1] = toAssign;
-        changed = true;
-      }
-
-      if (a.high - b.low < c.high)
-      {
-        int toAssign = ((a.high - b.low) * 2) + 1;
-        assert(toAssign < sumH[i - 1]);
-        sumH[i - 1] = toAssign;
-        changed = true;
-      }
-
-      if (a.low - c.high > b.low)
-      {
-        b.low = a.low - c.high;
-        changed = true;
-      }
-
-      if (a.high - c.low < b.high)
-      {
-        b.high = a.high - c.low;
-        changed = true;
-      }
-    }
-    if (changed)
+    if (flags & 2)
+      return CONFLICT;
+    if (flags & 1)
       return CHANGED;
-    else
-      return NO_CHANGE;
+    return NO_CHANGE;
   }
 };
 }

--- a/include/stp/Simplifier/constantBitP/multiplication/ColumnStats.h
+++ b/include/stp/Simplifier/constantBitP/multiplication/ColumnStats.h
@@ -82,7 +82,7 @@ struct ColumnStats
   }
 };
 
-std::ostream& operator<<(std::ostream& o, const ColumnStats& cs)
+inline std::ostream& operator<<(std::ostream& o, const ColumnStats& cs)
 {
   o << "cUnfixed:" << cs.columnUnfixed << endl; // both unfixed.
   o << "cOneFixed:" << cs.columnOneFixed

--- a/lib/Simplifier/constantBitP/ConstantBitP_Multiplication.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_Multiplication.cpp
@@ -30,6 +30,7 @@ THE SOFTWARE.
 #include "stp/Simplifier/constantBitP/multiplication/ColumnCounts.h"
 #include "stp/Simplifier/constantBitP/multiplication/ColumnStats.h"
 #include <cstdint>
+#include <cstring>
 #include <set>
 #include <stdexcept>
 // Multiply.
@@ -46,6 +47,18 @@ using std::set;
 
 const bool debug_multiply = false;
 std::ostream& log = std::cerr;
+
+// The convolution loops below are popcount-bound. The library builds for
+// generic targets, so resolve a POPCNT-instruction clone at load time where
+// the toolchain and platform support it; elsewhere (and on CPUs without
+// POPCNT) the portable SWAR popcount below is used.
+#if (defined(__x86_64__) || defined(__i386__)) && defined(__ELF__) &&          \
+    (defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 6 ||              \
+     defined(__clang__) && __clang_major__ >= 14)
+#define MULT_TARGET_CLONES __attribute__((target_clones("popcnt", "default")))
+#else
+#define MULT_TARGET_CLONES
+#endif
 
 #if 0
 // The maximum size of the carry into a column for MULTIPLICATION
@@ -70,6 +83,8 @@ static inline uint64_t rightShiftedWord(const uint64_t* m, unsigned words,
                                         unsigned s, unsigned j);
 static inline int convolutionAt(const uint64_t* a, const uint64_t* revB,
                                 unsigned words, unsigned width, unsigned j);
+static inline void reverseBitArray(uint64_t* m, unsigned words,
+                                   unsigned width);
 
 // The fixed-to-one and unfixed masks of both operands, packed into words so
 // a column's pair-category counts are shifted-window popcounts rather than
@@ -92,31 +107,30 @@ struct PairMasks
     uint64_t* buf = stackBuf;
     if (words > INLINE_WORDS)
     {
-      heapBuf.assign(4 * words, 0);
+      heapBuf.resize(4 * words);
       buf = heapBuf.data();
     }
-    else
-      for (unsigned t = 0; t < 4 * words; t++)
-        buf[t] = 0;
     xOne = buf;
     xUnfixed = buf + words;
     revYOne = buf + 2 * words;
     revYUnfixed = buf + 3 * words;
 
     widthCached = width;
-    for (unsigned i = 0; i < width; i++)
+    for (unsigned t = 0; t < words; t++)
     {
-      if (!x.isFixed(i))
-        xUnfixed[i >> 6] |= (uint64_t)1 << (i & 63);
-      else if (x.getValue(i))
-        xOne[i >> 6] |= (uint64_t)1 << (i & 63);
-
-      const unsigned r = width - 1 - i;
-      if (!y.isFixed(i))
-        revYUnfixed[r >> 6] |= (uint64_t)1 << (r & 63);
-      else if (y.getValue(i))
-        revYOne[r >> 6] |= (uint64_t)1 << (r & 63);
+      const uint64_t liveMask = (t == words - 1 && (width & 63) != 0)
+                                    ? (((uint64_t)1 << (width & 63)) - 1)
+                                    : ~(uint64_t)0;
+      uint64_t f, one;
+      x.fillPackedWord(t, f, one);
+      xOne[t] = one;
+      xUnfixed[t] = ~f & liveMask;
+      y.fillPackedWord(t, f, one);
+      revYOne[t] = one;
+      revYUnfixed[t] = ~f & liveMask;
     }
+    reverseBitArray(revYOne, words, width);
+    reverseBitArray(revYUnfixed, words, width);
   }
 
   // Bit i of x was just fixed: leave the unfixed set, join the ones if set.
@@ -138,6 +152,7 @@ struct PairMasks
   unsigned widthCached;
 };
 
+MULT_TARGET_CLONES
 Result fixIfCanForMultiplication(vector<FixedBits*>& children,
                                  const unsigned index,
                                  const int aspirationalSum, PairMasks* pm)
@@ -151,11 +166,10 @@ Result fixIfCanForMultiplication(vector<FixedBits*>& children,
   // packed masks: a pair contributes "ones" when both operands are fixed
   // to one, "one fixed" when one is fixed to one and the other unfixed,
   // and "unfixed" when both are unfixed. (Pairs with a fixed zero are the
-  // remainder, and aren't needed here.) Short columns are cheaper to scan
-  // directly.
+  // remainder, and aren't needed here.)
   const unsigned width = x.getWidth();
   int columnOnes, columnUnfixed, columnOneFixed;
-  if (pm == NULL || index < 16)
+  if (pm == NULL)
   {
     ColumnStats cs(x, y, index);
     columnOnes = cs.columnOnes;
@@ -242,13 +256,48 @@ Result fixIfCanForMultiplication(vector<FixedBits*>& children,
   return result;
 }
 
+// Branch-free SWAR popcount: the library builds for generic targets, where
+// __builtin_popcountll lowers to a libgcc call — too slow for the
+// convolution inner loop.
 static inline int popcount64(uint64_t v)
 {
-#ifdef _MSC_VER
-  return (int)__popcnt64(v);
-#else
-  return __builtin_popcountll(v);
-#endif
+  v -= (v >> 1) & 0x5555555555555555ULL;
+  v = (v & 0x3333333333333333ULL) + ((v >> 2) & 0x3333333333333333ULL);
+  v = (v + (v >> 4)) & 0x0F0F0F0F0F0F0F0FULL;
+  return (int)((v * 0x0101010101010101ULL) >> 56);
+}
+
+static inline uint64_t reverseBits64(uint64_t v)
+{
+  v = ((v >> 1) & 0x5555555555555555ULL) | ((v & 0x5555555555555555ULL) << 1);
+  v = ((v >> 2) & 0x3333333333333333ULL) | ((v & 0x3333333333333333ULL) << 2);
+  v = ((v >> 4) & 0x0F0F0F0F0F0F0F0FULL) | ((v & 0x0F0F0F0F0F0F0F0FULL) << 4);
+  v = ((v >> 8) & 0x00FF00FF00FF00FFULL) | ((v & 0x00FF00FF00FF00FFULL) << 8);
+  v = ((v >> 16) & 0x0000FFFF0000FFFFULL) |
+      ((v & 0x0000FFFF0000FFFFULL) << 16);
+  return (v >> 32) | (v << 32);
+}
+
+// Reverse the low `width` bits of m in place; bits at or above the width
+// must be zero on entry and are zero on exit.
+static inline void reverseBitArray(uint64_t* m, unsigned words, unsigned width)
+{
+  for (unsigned i = 0, j = words - 1; i < j; i++, j--)
+  {
+    const uint64_t t = reverseBits64(m[i]);
+    m[i] = reverseBits64(m[j]);
+    m[j] = t;
+  }
+  if (words & 1)
+    m[words / 2] = reverseBits64(m[words / 2]);
+  const unsigned s = words * 64 - width;
+  if (s != 0)
+    for (unsigned t = 0; t < words; t++)
+    {
+      m[t] >>= s;
+      if (t + 1 < words)
+        m[t] |= m[t + 1] << (64 - s);
+    }
 }
 
 // Word `j` of (m >> s), for a `words`-long array.
@@ -272,7 +321,10 @@ static inline int convolutionAt(const uint64_t* a, const uint64_t* revB,
 {
   int count = 0;
   const unsigned s = width - 1 - j;
-  for (unsigned t = 0; t < words; t++)
+  // Only pairs with i <= j exist, so a's words above bit j can't contribute
+  // (the matching window of revB is all zero there).
+  const unsigned tEnd = (words > j / 64 + 1) ? j / 64 + 1 : words;
+  for (unsigned t = 0; t < tEnd; t++)
   {
     const uint64_t aw = a[t];
     if (aw != 0)
@@ -287,6 +339,7 @@ static inline int convolutionAt(const uint64_t* a, const uint64_t* revB,
 //   columnL[j] += #{i + k == j : x[i] and y[k] both fixed to one}
 // The counts come from running prefix sums and two boolean convolutions
 // evaluated as shifted-window popcounts over packed words.
+MULT_TARGET_CLONES
 Result adjustColumns(const FixedBits& x, const FixedBits& y, int* columnL,
                      int* columnH)
 {
@@ -306,27 +359,19 @@ Result adjustColumns(const FixedBits& x, const FixedBits& y, int* columnL,
   uint64_t* xOne = buf + words;       // x fixed to one.
   uint64_t* revYFF = buf + 2 * words; // y fixed to zero, bit-reversed.
   uint64_t* revYOne = buf + 3 * words;
-  for (unsigned t = 0; t < 4 * words; t++)
-    buf[t] = 0;
 
-  for (unsigned i = 0; i < bitWidth; i++)
+  for (unsigned t = 0; t < words; t++)
   {
-    if (x.isFixed(i))
-    {
-      if (x.getValue(i))
-        xOne[i >> 6] |= (uint64_t)1 << (i & 63);
-      else
-        xFF[i >> 6] |= (uint64_t)1 << (i & 63);
-    }
-    if (y.isFixed(i))
-    {
-      const unsigned r = bitWidth - 1 - i;
-      if (y.getValue(i))
-        revYOne[r >> 6] |= (uint64_t)1 << (r & 63);
-      else
-        revYFF[r >> 6] |= (uint64_t)1 << (r & 63);
-    }
+    uint64_t f, one;
+    x.fillPackedWord(t, f, one);
+    xOne[t] = one;
+    xFF[t] = f ^ one; // fixed and not one.
+    y.fillPackedWord(t, f, one);
+    revYOne[t] = one;
+    revYFF[t] = f ^ one;
   }
+  reverseBitArray(revYOne, words, bitWidth);
+  reverseBitArray(revYFF, words, bitWidth);
 
   bool anyXFF = false, anyYFF = false, anyXOne = false, anyYOne = false;
   for (unsigned t = 0; t < words; t++)
@@ -351,17 +396,38 @@ Result adjustColumns(const FixedBits& x, const FixedBits& y, int* columnL,
     if ((xFF[j >> 6] >> (j & 63)) & 1)
       xZeroes++;
 
-    int decrement = yZeroes + xZeroes;
-    if (ffPairsPossible)
-      decrement -= convolutionAt(xFF, revYFF, words, bitWidth, j);
+    // The two convolutions at column j, with the shifted-window address
+    // arithmetic computed once for both.
+    int ffPairs = 0, onePairs = 0;
+    const unsigned s = bitWidth - 1 - j;
+    const unsigned tEnd = (words > j / 64 + 1) ? j / 64 + 1 : words;
+    for (unsigned t = 0; t < tEnd; t++)
+    {
+      const unsigned word = t + (s >> 6);
+      if (word >= words)
+        break;
+      const unsigned bit = s & 63;
+      if (ffPairsPossible && xFF[t] != 0)
+      {
+        uint64_t win = revYFF[word] >> bit;
+        if (bit != 0 && word + 1 < words)
+          win |= revYFF[word + 1] << (64 - bit);
+        ffPairs += popcount64(xFF[t] & win);
+      }
+      if (onePairsPossible && xOne[t] != 0)
+      {
+        uint64_t win = revYOne[word] >> bit;
+        if (bit != 0 && word + 1 < words)
+          win |= revYOne[word + 1] << (64 - bit);
+        onePairs += popcount64(xOne[t] & win);
+      }
+    }
+
+    const int decrement = yZeroes + xZeroes - ffPairs;
     if (decrement != 0)
       columnH[j] -= decrement;
-    if (onePairsPossible)
-    {
-      const int onePairs = convolutionAt(xOne, revYOne, words, bitWidth, j);
-      if (onePairs != 0)
-        columnL[j] += onePairs;
-    }
+    if (onePairs != 0)
+      columnL[j] += onePairs;
   }
   return NO_CHANGE;
 }
@@ -786,35 +852,72 @@ Result bvMultiplyBothWays(vector<FixedBits*>& children, FixedBits& output,
   if (CONFLICT == r)
     return r;
 
-  // On the heap: bitWidth is unbounded, and this used to alloca inside the
-  // loop, which only returns the stack space when the function exits. The
-  // ColumnCounts constructor re-initialises the arrays each iteration.
-  std::vector<signed> columnH_store(bitWidth); // max. no of true partial products.
-  std::vector<signed> columnL_store(bitWidth); // minimum ""  ""
-  std::vector<signed> sumH_store(bitWidth);
-  std::vector<signed> sumL_store(bitWidth);
+  // bitWidth is unbounded, so wide instances go to the heap (this used to
+  // alloca inside the loop, which only returns the stack space when the
+  // function exits). Uninitialised: the ColumnCounts constructor writes
+  // columnL/columnH and rebuildSums writes sumL/sumH each iteration.
+  const unsigned INLINE_COLUMNS = 256; // 6KB of stack.
+  signed stackCols[6 * INLINE_COLUMNS];
+  std::vector<signed> heapCols;
+  signed* cols = stackCols;
+  if (bitWidth > INLINE_COLUMNS)
+  {
+    heapCols.resize(6 * bitWidth);
+    cols = heapCols.data();
+  }
+  signed* columnH = cols;
+  signed* columnL = cols + bitWidth;
+  signed* sumH = cols + 2 * bitWidth;
+  signed* sumL = cols + 3 * bitWidth;
+  signed* baseH = cols + 4 * bitWidth; // adjustColumns' result, cached
+  signed* baseL = cols + 5 * bitWidth; // while x and y are unchanged.
 
+  // Packed column stats for fixIfCanForMultiplication. Built lazily: many
+  // calls trigger no column. Once built the masks persist across passes
+  // and stay in sync: fixIfCanForMultiplication updates them as it fixes
+  // bits; anything else that touches x or y invalidates them.
+  PairMasks pm;
+  bool masksValid = false;
+
+  bool columnsDirty = true;
   bool changed = true;
   while (changed)
   {
     changed = false;
-    signed* columnH = columnH_store.data();
-    signed* columnL = columnL_store.data();
-    signed* sumH = sumH_store.data();
-    signed* sumL = sumL_store.data();
-    ColumnCounts cc(columnH, columnL, sumH, sumL, bitWidth, output);
+    ColumnCounts cc(columnH, columnL, sumH, sumL, bitWidth, output,
+                    /*initialise*/ false);
 
-    // Use the number of zeroes and ones in a column to update the possible
-    // counts.
-    adjustColumns(x, y, columnL, columnH);
+    if (columnsDirty)
+    {
+      for (unsigned i = 0; i < bitWidth; i++)
+      {
+        columnL[i] = 0;
+        columnH[i] = i + 1;
+      }
+      // Use the number of zeroes and ones in a column to update the possible
+      // counts.
+      adjustColumns(x, y, columnL, columnH);
+      memcpy(baseH, columnH, bitWidth * sizeof(signed));
+      memcpy(baseL, columnL, bitWidth * sizeof(signed));
+      columnsDirty = false;
+    }
+    else
+    {
+      // Neither operand changed in the last pass (only the output did), so
+      // adjustColumns would recompute exactly the cached columns.
+      memcpy(columnH, baseH, bitWidth * sizeof(signed));
+      memcpy(columnL, baseL, bitWidth * sizeof(signed));
+    }
 
-    cc.rebuildSums();
+    if (cc.rebuildSums() == CONFLICT)
+      return CONFLICT;
     Result r = cc.fixedPoint();
 
     if (r == CONFLICT)
       return CONFLICT;
 
     r = NO_CHANGE;
+    Result rOperands = NO_CHANGE;
 
     // If any of the sums have a cardinality of 1. Set the result.
     for (unsigned column = 0; column < bitWidth; column++)
@@ -834,21 +937,11 @@ Result bvMultiplyBothWays(vector<FixedBits*>& children, FixedBits& output,
       }
     }
 
-    if (CHANGED == r)
-      changed = true;
-
-    // The packed column stats only pay off past one word; at 64 bits and
-    // below the direct scan is cheaper, so bvmul at common widths keeps
-    // the original path while the division machinery (double width)
-    // benefits.
-    PairMasks pm;
-    bool masksValid = false; // built lazily: many passes trigger no column.
-    const bool usePacked = bitWidth > 64;
     for (unsigned column = 0; column < bitWidth; column++)
     {
       if (cc.columnL[column] == cc.columnH[column])
       {
-        if (usePacked && !masksValid)
+        if (!masksValid)
         {
           pm.build(x, y);
           masksValid = true;
@@ -856,13 +949,17 @@ Result bvMultiplyBothWays(vector<FixedBits*>& children, FixedBits& output,
 
         //(2) Knowledge of the sum may fix the operands.
         Result tempResult = fixIfCanForMultiplication(
-            children, column, cc.columnH[column], usePacked ? &pm : NULL);
+            children, column, cc.columnH[column], &pm);
 
         if (CONFLICT == tempResult)
           return CONFLICT;
 
         if (CHANGED == tempResult)
+        {
           r = CHANGED; // the masks were updated incrementally.
+          rOperands = CHANGED;
+          columnsDirty = true;
+        }
       }
     }
 
@@ -876,9 +973,6 @@ Result bvMultiplyBothWays(vector<FixedBits*>& children, FixedBits& output,
 
     assert(CONFLICT != r);
 
-    if (CHANGED == r)
-      changed = true;
-
     if (ms != NULL)
     {
       *ms = MultiplicationStats(bitWidth, cc.columnL, cc.columnH, cc.sumL,
@@ -888,12 +982,23 @@ Result bvMultiplyBothWays(vector<FixedBits*>& children, FixedBits& output,
       ms->r = output;
     }
 
-    if (changed)
+    if (CHANGED == r)
     {
-      useTrailingZeroesToFix(x, y, output);
-      //  if (r == NO_CHANGE)
-      //    changed= false;
+      if (CHANGED == useTrailingZeroesToFix(x, y, output))
+      {
+        // May have fixed operand bits behind the caches' backs.
+        columnsDirty = true;
+        masksValid = false;
+        rOperands = CHANGED;
+      }
     }
+
+    // Another pass can only discover something if an operand changed:
+    // output bits fixed above take exactly the parity the sums already
+    // carry, so with x and y untouched the next pass would rebuild an
+    // identical state and fix nothing further.
+    if (CHANGED == rOperands)
+      changed = true;
   }
 
   if (children[0]->isTotallyFixed() && children[1]->isTotallyFixed())


### PR DESCRIPTION
The constant-bit multiplication propagator spent most of its time rebuilding per-column state bit by bit. This reworks that machinery; measured at 65 bits with an interleaved same-process A/B harness it is 2.3x faster with half the bits fixed (5.9us -> 2.5us per call) and 1.4-1.7x faster with few bits fixed, with every width from 3 to 300 improving. The bits fixed are identical: exhaustive width-3/4 tables, randomized differential sweeps at widths 3-300 (three fixing densities), and the division family's differential set (division runs this fixpoint at double width) all report zero delta against the previous implementation.

The changes:

- Build `adjustColumns`' and `PairMasks`' packed masks a word at a time with `fillPackedWord` plus a SWAR bit-reversal of y, instead of per-bit `isFixed`/`getValue` loops.
- Popcount with an inline SWAR sequence instead of `__builtin_popcountll`, which lowers to a libgcc call on generic builds; additionally clone the two convolution-heavy functions with `target_clones("popcnt")` on ELF x86, so CPUs with POPCNT resolve to a hardware-popcount clone at load time (GCC recognises the SWAR idiom and folds it to the instruction).
- Limit each column's convolution to the words that can contribute (only pairs with i <= j exist), and fuse the fixed-zero/fixed-one convolutions into one loop sharing the window address arithmetic.
- Keep the four column/sum arrays in one stack block below 256 bits (previously four heap vectors per call), cache `adjustColumns`' result across passes while the operands are unchanged, and keep the `PairMasks` alive across passes: `fixIfCanForMultiplication` maintains them incrementally, so they now also serve columns below 16 bits and widths of 64 and less, which the old thresholds excluded (and which now measure faster packed too).
- `rebuildSums` reads the output from packed words, halves with an unsigned shift (sums are non-negative), and reports crossed columns itself; `propagate`/`snapTo` report intervals they empty. Together that replaces `fixedPoint`'s entry and exit `inConflict` scans, and `snapTo` visits only the output's fixed bits via ctz.
- Run `propagate` before `snapTo` in the fixpoint: `rebuildSums` has just snapped every fixed column, so the leading `snapTo` sweep always found nothing.
- Skip the trailing rerun pass when only output bits were fixed: those take exactly the parity the sums already carry, so with the operands untouched the next pass rebuilds an identical state and can discover nothing.
- Mark `ColumnStats`' `operator<<` inline (it is defined in a header) and drop the now-unused `Interval` struct.

Verification: exhaustive accuracy at widths 3/4 (unsound=0, precision unchanged to the case count); old-vs-new differential fixed-bit equality at widths 3-300 x fixing probabilities 1/5/30/50; the division differential (bvudiv/bvurem/bvsdiv/bvsrem/bvsmod embed the multiplication fixpoint at 2x width) with zero deltas; the Debug+assertions build runs the same sweeps with the internal subsumption asserts live, and ctest passes 59/59.