### PR TITLE
Pass ASTNode by const reference in sort comparators

### DIFF
--- a/include/stp/AST/AST.h
+++ b/include/stp/AST/AST.h
@@ -36,8 +36,8 @@ DLL_PUBLIC ATTR_NORETURN void FatalError(const char* str, const ASTNode& a,
 DLL_PUBLIC ATTR_NORETURN void FatalError(const char* str);
 void SortByExprNum(ASTVec& c);
 void SortByArith(ASTVec& c);
-bool exprless(const ASTNode n1, const ASTNode n2);
-bool arithless(const ASTNode n1, const ASTNode n2);
+bool exprless(const ASTNode& n1, const ASTNode& n2);
+bool arithless(const ASTNode& n1, const ASTNode& n2);
 bool isAtomic(Kind k);
 bool isCommutative(const Kind k);
 bool containsArrayOps(const ASTNode& n, STPMgr* stp);

--- a/include/stp/AST/ASTNode.h
+++ b/include/stp/AST/ASTNode.h
@@ -49,8 +49,8 @@ class ASTNode
   friend class vector<ASTNode>;
   friend ASTNode HashingNodeFactory::CreateNode(const stp::Kind kind,
                                                 const ASTVec& back_children);
-  friend bool exprless(const ASTNode n1, const ASTNode n2);
-  friend bool arithless(const ASTNode n1, const ASTNode n2);
+  friend bool exprless(const ASTNode& n1, const ASTNode& n2);
+  friend bool arithless(const ASTNode& n1, const ASTNode& n2);
 
   // Ptr to the read data
   ASTInternal* _int_node_ptr;

--- a/lib/AST/ASTmisc.cpp
+++ b/lib/AST/ASTmisc.cpp
@@ -46,14 +46,14 @@ THREAD_LOCAL uint64_t ASTInternal::node_uid_cntr = 0;
  ****************************************************************/
 
 // Sort ASTNodes by expression numbers
-bool exprless(const ASTNode n1, const ASTNode n2)
+bool exprless(const ASTNode& n1, const ASTNode& n2)
 {
   return (n1.GetNodeNum() < n2.GetNodeNum());
 }
 
 // This is for sorting by arithmetic expressions (for
 // combining like terms, etc.)
-bool arithless(const ASTNode n1, const ASTNode n2)
+bool arithless(const ASTNode& n1, const ASTNode& n2)
 {
   Kind k1 = n1.GetKind();
   Kind k2 = n2.GetKind();


### PR DESCRIPTION
The sort comparators `exprless()` and `arithless()` took their `ASTNode`
arguments by value (`const ASTNode`, not `const ASTNode&`), so every
comparison in `SortByArith` copy-constructed and destroyed two handles —
each a refcount inc/dec pair.

`std::sort` invokes the comparator O(N log N) times, and the simplifier
sorts wide AND/OR child vectors constantly, so on nested-boolean
benchmarks this churn dominated the profile: ~20% self-time in
`ASTNode::ASTNode`/`~ASTNode` plus the comparator itself (perf on the
`20230221-oisc-gurtner` family).

This change passes both comparators by `const` reference. The comparator
logic is unchanged, so the sort order — and therefore all results — are
byte-identical; verified 60/60 on a QF_BV sample against declared
`:status`.

**Measured effect** (Simplifying stage, `--exit-after-CNF`):

| benchmark | before | after | Δ |
|---|---|---|---|
| `SRAI-SAFE-64-1024` | 10.5 s | 8.4 s | −20% |
| `AND-NESTED-8-32` | 7.75 s | 6.7 s | −13% |

Every `SortByArith`/`exprless` caller in STP benefits, not just these
inputs.