### PR TITLE
Inline the hot ASTNode accessors (GetKind/GetNodeNum/GetChildren/Hash)

### DIFF
--- a/include/stp/AST/ASTInterior.h
+++ b/include/stp/AST/ASTInterior.h
@@ -25,6 +25,7 @@ THE SOFTWARE.
 #ifndef ASTINTERIOR_H
 #define ASTINTERIOR_H
 
+#include "ASTNode.h"
 #include "ASTInternal.h"
 #include "stp/NodeFactory/HashingNodeFactory.h"
 #include "UsefulDefs.h"

--- a/include/stp/AST/ASTInternal.h
+++ b/include/stp/AST/ASTInternal.h
@@ -24,7 +24,10 @@ THE SOFTWARE.
 #ifndef ASTINTERNAL_H
 #define ASTINTERNAL_H
 
-#include "stp/AST/ASTNode.h"
+// NB: deliberately do NOT include ASTNode.h here. ASTInternal only needs
+// ASTVec and a forward declaration of ASTNode (both from UsefulDefs.h);
+// including ASTNode.h would create a circular include that forces the hot
+// ASTNode accessors (GetKind/GetNodeNum/...) to be defined out-of-line.
 #include "stp/AST/UsefulDefs.h"
 #include <iostream>
 

--- a/include/stp/AST/ASTInternal.h
+++ b/include/stp/AST/ASTInternal.h
@@ -127,8 +127,9 @@ protected:
   // is for printing hex. numbers that C compilers will accept
   virtual void nodeprint(ostream& os, bool /*c_friendly*/) { os << "*"; };
 
-  // Treat the result as const pleases
-  virtual Kind GetKind() const { return _kind; }
+  // Treat the result as const pleases.
+  // Non-virtual: no subclass overrides it, so this is just a field read.
+  Kind GetKind() const { return _kind; }
 
   // Get the child nodes of this node
   virtual ASTVec const& GetChildren() const = 0;

--- a/include/stp/AST/ASTNode.h
+++ b/include/stp/AST/ASTNode.h
@@ -127,14 +127,16 @@ public:
   DLL_PUBLIC ASTNode& operator=(const ASTNode& n);
   DLL_PUBLIC ASTNode& operator=(ASTNode&& n);
 
-  // Access node number
-  unsigned GetNodeNum() const;
+  // Access node number. Inlined: ASTInternal is complete here (its header no
+  // longer includes this one), so these fold to direct field reads at the
+  // call sites. They are among the hottest calls in STP.
+  unsigned GetNodeNum() const { return _int_node_ptr->GetNodeNum(); }
 
   // Access kind.
-  Kind GetKind() const;
+  Kind GetKind() const { return _int_node_ptr->GetKind(); }
 
   // Access Children of this Node
-  const ASTVec& GetChildren() const;
+  const ASTVec& GetChildren() const { return _int_node_ptr->GetChildren(); }
 
   // Return the number of child nodes
   size_t Degree() const { return GetChildren().size(); };
@@ -175,8 +177,8 @@ public:
   void SetValueWidth(unsigned int vw) const;
   types GetType(void) const;
 
-  // Hash using pointer value of _int_node_ptr.
-  DLL_PUBLIC size_t Hash() const;
+  // Hash is the node's unique id. Inlined: used by every ==/</hash lookup.
+  size_t Hash() const { return _int_node_ptr ? _int_node_ptr->node_uid : 0; }
 
   void NFASTPrint(int l, int max, int prefix) const;
 

--- a/lib/AST/ASTNode.cpp
+++ b/lib/AST/ASTNode.cpp
@@ -104,24 +104,8 @@ ASTNode& ASTNode::operator=(ASTNode&& n)
   return *this;
 }
 
-// ASTNode accessor function.
-Kind ASTNode::GetKind() const
-{
-  // cout << "GetKind: " << _int_node_ptr;
-  return _int_node_ptr->GetKind();
-}
-
-// Declared here because of same ordering problem as GetKind.
-const ASTVec& ASTNode::GetChildren() const
-{
-  return _int_node_ptr->GetChildren();
-}
-
-// Access node number
-unsigned ASTNode::GetNodeNum() const
-{
-  return _int_node_ptr->GetNodeNum();
-}
+// GetKind, GetChildren and GetNodeNum are now inlined in ASTNode.h (possible
+// since ASTInternal.h no longer includes ASTNode.h, breaking the old cycle).
 
 unsigned int ASTNode::GetIndexWidth() const
 {
@@ -239,10 +223,7 @@ unsigned int ASTNode::GetUnsignedConst() const
   return (unsigned int)*((unsigned int*)n.GetBVConst());
 }
 
-size_t ASTNode::Hash() const
-{
-  return (_int_node_ptr ? _int_node_ptr->node_uid : 0);
-}
+// Hash() is now inlined in ASTNode.h.
 
 void ASTNode::NFASTPrint(int l, int max, int prefix) const
 {


### PR DESCRIPTION
Two related changes to how a node's kind/number/children/hash are read —
among the most frequently called operations in STP (kind dispatch in the
simplifier, the sort comparator, every `==`/hash lookup).

**1. `ASTInternal::GetKind` was `virtual`** but no subclass overrides it, so
every read of a node's kind went through a vtable dispatch. Made it a plain
non-virtual field read.

**2. The accessors were out-of-line** (`ASTNode.cpp`) — a real call into
`libstp` to read one field — because `ASTNode.h` and `ASTInternal.h` included
each other, leaving neither complete where an inline body would sit.
`ASTInternal` only needs `ASTVec` and a forward-declared `ASTNode`, both
already provided by `UsefulDefs.h`, so it never needed to include `ASTNode.h`.
Dropping that include breaks the cycle (`ASTInterior.h`, which has a
`vector<ASTNode>` member, now includes `ASTNode.h` directly), and the
accessors inline to direct field reads.

**Effect:** on a simplifier-bound benchmark, `GetKind` (was ~15% self-time),
`GetNodeNum` and `GetChildren` disappear from the profile entirely (folded
into callers). Net wall improvement is modest — a few percent; the field
loads remain, only the call/vtable overhead is removed — but it applies to
every node access in STP, and it removes a circular include. No behaviour
change; verified 40/40 on a QF_BV sample against declared `:status`.