### PR TITLE
Move, don't copy, sorted children into the interior-node probe

### DIFF
--- a/include/stp/AST/ASTInterior.h
+++ b/include/stp/AST/ASTInterior.h
@@ -114,6 +114,17 @@ public:
       node_uid = children[0].GetNodeNum() + 1;
   }
 
+  // As above, but takes ownership of an already-owned children vector,
+  // avoiding a copy when the caller has a temporary to give up.
+  ASTInterior(STPMgr* mgr, Kind kind, ASTVec&& children)
+      : ASTInternal(mgr, kind), _children(std::move(children)), _value_width(0),
+        _index_width(0)
+  {
+    is_simplified = false;
+    if (kind == NOT)
+      node_uid = _children[0].GetNodeNum() + 1;
+  }
+
   // This copies the contents of the child nodes
   // array, along with everything else. Assigning the smart pointer,
   // ASTNode, does NOT invoke this.

--- a/include/stp/STPManager/STPManager.h
+++ b/include/stp/STPManager/STPManager.h
@@ -167,6 +167,15 @@ private:
   // is heap-allocated when an equivalent node already exists.
   ASTInterior* LookupOrCreateInterior(Kind kind, const ASTVec& children);
 
+  // As above, but moves an owned children vector into the probe (and, on a
+  // miss, into the heap node), avoiding a copy when the caller has a
+  // temporary to give up — e.g. a freshly sorted vector.
+  ASTInterior* LookupOrCreateInterior(Kind kind, ASTVec&& children);
+
+  // Shared tail of the two overloads above: look the probe up, or move it
+  // onto the heap and insert it.
+  ASTInterior* insertOrReuseProbe(ASTInterior&& probe);
+
   // Create unique ASTSymbol node.
   ASTSymbol* LookupOrCreateSymbol(ASTSymbol& s);
 

--- a/lib/NodeFactory/HashingNodeFactory.cpp
+++ b/lib/NodeFactory/HashingNodeFactory.cpp
@@ -59,7 +59,7 @@ ASTNode HashingNodeFactory::CreateNode(const Kind kind,
 
     ASTVec sorted_children = back_children;
     SortByExprNum(sorted_children);
-    return ASTNode(bm.LookupOrCreateInterior(kind, sorted_children));
+    return ASTNode(bm.LookupOrCreateInterior(kind, std::move(sorted_children)));
   }
   else
   {
@@ -68,7 +68,7 @@ ASTNode HashingNodeFactory::CreateNode(const Kind kind,
     // LHS.
     SortByArith(children);
 
-    return ASTNode(bm.LookupOrCreateInterior(kind, children));
+    return ASTNode(bm.LookupOrCreateInterior(kind, std::move(children)));
   }
 }
 

--- a/lib/STPManager/STPManager.cpp
+++ b/lib/STPManager/STPManager.cpp
@@ -59,26 +59,37 @@ ASTInterior* STPMgr::LookupOrCreateInterior(ASTInterior* n_ptr)
   return *it;
 }
 
-ASTInterior* STPMgr::LookupOrCreateInterior(Kind kind, const ASTVec& children)
+// Probe the unique table with an already-built stack node; on a miss, move
+// it onto the heap (stealing the probe's children, node number and hash).
+ASTInterior* STPMgr::insertOrReuseProbe(ASTInterior&& probe)
 {
-  ASTInterior probe(this, kind, children);
-
   const ASTInteriorSet::iterator it = _interior_unique_table.find(&probe);
   if (it != _interior_unique_table.end())
     return *it;
 
-  if (kind == NOT)
+  if (probe.GetKind() == NOT)
   {
     // The internal node can't be a NOT, because then we'd add
     // 1 to the NOT's node number, meaning we'd hit an even number,
     // which could duplicate the next newNodeNum().
-    assert(children[0].GetKind() != NOT);
+    assert(probe.GetChildren()[0].GetKind() != NOT);
   }
 
-  // The heap node steals the probe's children, node number and hash.
   ASTInterior* n_ptr = new ASTInterior(std::move(probe));
   _interior_unique_table.insert(n_ptr);
   return n_ptr;
+}
+
+ASTInterior* STPMgr::LookupOrCreateInterior(Kind kind, const ASTVec& children)
+{
+  ASTInterior probe(this, kind, children);
+  return insertOrReuseProbe(std::move(probe));
+}
+
+ASTInterior* STPMgr::LookupOrCreateInterior(Kind kind, ASTVec&& children)
+{
+  ASTInterior probe(this, kind, std::move(children));
+  return insertOrReuseProbe(std::move(probe));
 }
 
 ASTInterior* STPMgr::CreateInteriorNode(Kind /*kind*/,


### PR DESCRIPTION
When `CreateNode` handles a commutative kind, it builds a locally-owned
children vector, sorts it, then passes it by `const` reference to
`LookupOrCreateInterior`, which copied it **again** into the stack probe
used to search the unique table. That second copy is avoidable — the
caller has a temporary to give up.

This adds an rvalue overload `LookupOrCreateInterior(Kind, ASTVec&&)` and
a matching move-from-vector `ASTInterior` constructor, and `std::move`s the
sorted vectors at the two call sites. The children now flow
`local → probe → heap node` by move (the heap move already existed via the
move constructor from #559); only the one copy genuinely needed for sorting
remains. The shared find/insert tail of the two overloads is factored into
a small `insertOrReuseProbe` helper.

**Behaviour-neutral** — node contents, ordering and numbering are unchanged.
Verified:

- byte-identical CNF output (`SRAI-SAFE-8-1024`, 194,583 lines) vs master;
- 60/60 on a QF_BV sample against declared `:status`;
- clean valgrind run to completion (0 errors, 0 bytes definitely lost).