### PR TITLE
Speed up SMT-LIB2 parsing of hard inputs (4 changes)

### DIFF
--- a/include/stp/AST/AST.h
+++ b/include/stp/AST/AST.h
@@ -38,6 +38,20 @@ void SortByExprNum(ASTVec& c);
 void SortByArith(ASTVec& c);
 bool exprless(const ASTNode& n1, const ASTNode& n2);
 bool arithless(const ASTNode& n1, const ASTNode& n2);
+
+// Functor form of exprless. Passing a free function to std::sort/is_sorted
+// hands it a function pointer, which the algorithm cannot inline, so every
+// comparison is an indirect call. This functor's operator() inlines (and
+// GetNodeNum is itself inline), folding the comparison into the sort's inner
+// loop. Ordering is identical to exprless. Used on the node-creation hot
+// path, where sorting commutative children dominates parse time.
+struct ExprLess
+{
+  bool operator()(const ASTNode& n1, const ASTNode& n2) const
+  {
+    return n1.GetNodeNum() < n2.GetNodeNum();
+  }
+};
 bool isAtomic(Kind k);
 bool isCommutative(const Kind k);
 bool containsArrayOps(const ASTNode& n, STPMgr* stp);

--- a/include/stp/cpp_interface.h
+++ b/include/stp/cpp_interface.h
@@ -174,6 +174,11 @@ public:
 
   DLL_PUBLIC bool isBitVectorFunction(const std::string& name);
   DLL_PUBLIC bool isBooleanFunction(const std::string& name);
+  // Classify a name in a single map probe: returns the function's return
+  // type (BITVECTOR_TYPE or BOOLEAN_TYPE), or UNKNOWN_TYPE when the name
+  // is not a stored function. Lets the lexer avoid a second probe that
+  // calling both isBitVectorFunction and isBooleanFunction would cost.
+  DLL_PUBLIC types functionReturnType(const std::string& name);
   bool hasFunctions() const { return !functions.empty(); }
 
   DLL_PUBLIC ASTNode LookupOrCreateSymbol(std::string name);

--- a/lib/AST/ASTmisc.cpp
+++ b/lib/AST/ASTmisc.cpp
@@ -196,7 +196,7 @@ ATTR_NORETURN void FatalError(const char* str)
 
 void SortByExprNum(ASTVec& v)
 {
-  sort(v.begin(), v.end(), exprless);
+  sort(v.begin(), v.end(), ExprLess{});
 }
 
 void SortByArith(ASTVec& v)

--- a/lib/Interface/cpp_interface.cpp
+++ b/lib/Interface/cpp_interface.cpp
@@ -284,6 +284,15 @@ bool Cpp_interface::isBooleanFunction(const string& name)
   return found->second.function.GetType() == BOOLEAN_TYPE;
 }
 
+types Cpp_interface::functionReturnType(const string& name)
+{
+  const auto found = functions.find(name);
+  if (found == functions.end())
+    return UNKNOWN_TYPE;
+
+  return found->second.function.GetType();
+}
+
 ASTNode Cpp_interface::LookupOrCreateSymbol(string name)
 {
   return bm.LookupOrCreateSymbol(name.c_str());

--- a/lib/Interface/cpp_interface.cpp
+++ b/lib/Interface/cpp_interface.cpp
@@ -250,6 +250,14 @@ ASTNode Cpp_interface::applyFunction(const string& name, const ASTVec& params)
   if (f.params.size() != params.size())
     FatalError("Actual parameters differ in number from formal");
 
+  // A nullary function application is just its body: there is nothing to
+  // substitute, so skip building the (always empty) fromTo and cache maps
+  // and the replace() traversal. Files built from define-funs with no
+  // parameters (e.g. bit-blasted circuits) apply such functions millions
+  // of times, once each, so the per-call map churn dominated.
+  if (f.params.empty())
+    return f.function;
+
   ASTNodeMap fromTo;
   for (size_t i = 0, size = f.params.size(); i < size; ++i)
   {

--- a/lib/NodeFactory/HashingNodeFactory.cpp
+++ b/lib/NodeFactory/HashingNodeFactory.cpp
@@ -51,7 +51,7 @@ ASTNode HashingNodeFactory::CreateNode(const Kind kind,
   }
   else if (is_Form_kind(kind)) // formula and commutative.
   {
-    const bool isSorted =  std::is_sorted(back_children.begin(),back_children.end(),stp::exprless);
+    const bool isSorted =  std::is_sorted(back_children.begin(),back_children.end(),stp::ExprLess{});
     if (isSorted)
     {
       return ASTNode(bm.LookupOrCreateInterior(kind, back_children));

--- a/lib/NodeFactory/SimplifyingNodeFactory.cpp
+++ b/lib/NodeFactory/SimplifyingNodeFactory.cpp
@@ -523,7 +523,7 @@ ASTNode SimplifyingNodeFactory::CreateSimpleAndOr(bool IsAnd,
   const ASTNode& identity = (IsAnd ? ASTTrue : ASTFalse);
 
   // Sorting these can be expensive, so we only sort it if it's not already sorted.
-  bool isSorted =  std::is_sorted(c.begin(),c.end(),stp::exprless);
+  bool isSorted =  std::is_sorted(c.begin(),c.end(),stp::ExprLess{});
   ASTVec sorted_children;
   const ASTVec& children = isSorted ? c: sorted_children;
   if (!isSorted)
@@ -1799,7 +1799,7 @@ ASTNode SimplifyingNodeFactory::CreateTerm(Kind kind, unsigned int width,
         for (unsigned i = 0; i < children.size(); i++)
           names.push_back(children[i]);
 
-        sort(names.begin(), names.end(), stp::exprless);
+        sort(names.begin(), names.end(), stp::ExprLess{});
 
         while (names.size() > 1)
         {

--- a/lib/Parser/smt2.lex
+++ b/lib/Parser/smt2.lex
@@ -89,22 +89,31 @@
     }
     // Checking the functions before the symbols saves a symbol-table
     // probe in files built almost entirely from define-funs. A name can't
-    // legally be both, so the order isn't observable on valid input.
-    else if (stp::GlobalParserInterface->hasFunctions() &&
-             stp::GlobalParserInterface->isBitVectorFunction(s))
+    // legally be both, so the order isn't observable on valid input. A
+    // single functionReturnType probe classifies the name, avoiding the
+    // second map lookup that separate isBitVector/isBooleanFunction calls
+    // would cost on boolean-function references.
+    else if (stp::GlobalParserInterface->hasFunctions())
     {
-      smt2lval.str = new std::string(s);
-      if (cleaned)
-        free (cleaned);
-      return  BITVECTOR_FUNCTIONID_TOK;
-    }
-    else if (stp::GlobalParserInterface->hasFunctions() &&
-             stp::GlobalParserInterface->isBooleanFunction(s))
-    {
-       smt2lval.str = new std::string(s);
-       if (cleaned)
-         free (cleaned);
-       return  BOOLEAN_FUNCTIONID_TOK;
+      const stp::types ft = stp::GlobalParserInterface->functionReturnType(s);
+      if (ft == stp::BITVECTOR_TYPE)
+      {
+        smt2lval.str = new std::string(s);
+        if (cleaned)
+          free (cleaned);
+        return  BITVECTOR_FUNCTIONID_TOK;
+      }
+      else if (ft == stp::BOOLEAN_TYPE)
+      {
+        smt2lval.str = new std::string(s);
+        if (cleaned)
+          free (cleaned);
+        return  BOOLEAN_FUNCTIONID_TOK;
+      }
+      else if (stp::GlobalParserInterface->LookupSymbol(s,nptr)) // it's a symbol.
+      {
+        found = true;
+      }
     }
     else if (stp::GlobalParserInterface->LookupSymbol(s,nptr)) // it's a symbol.
     {

--- a/lib/Parser/smt2.lex
+++ b/lib/Parser/smt2.lex
@@ -5,6 +5,7 @@
 %option noreject
 %option noyymore
 %option yylineno
+%option full
 
 %{
 /********************************************************************


### PR DESCRIPTION
Four independent, behavior-neutral parsing speedups found by profiling `--parse-only` on hard QF_BV inputs (asp/Labyrinth, the oisc-gurtner AND/SLL-NESTED families, Sydr). Each was kept only after an interleaved A/B on this machine and a correctness check.

### Changes
1. **Classify function names in a single map probe** (`functionReturnType`). The SMT-LIB2 lexer called `isBitVectorFunction` then `isBooleanFunction`, doing two `functions`-map finds for every boolean-function reference (and a wasted probe for plain symbols in function-bearing files). One probe now returns the function's return type. *−2 to −3% on function-heavy inputs; provably neutral where there are no functions.*
2. **Short-circuit nullary function applications.** `applyFunction` built an always-empty `fromTo`/`cache` map pair and ran a full `SubstitutionMap::replace` even for parameterless functions, where the result is just the body. Circuit-style inputs (e.g. the bit-blasted oisc-gurtner benchmarks) are built almost entirely from nullary define-funs applied once each. *−2% AND-NESTED-32-32, −6.5% SLL-NESTED.*
3. **Sort commutative children with an inlinable functor** (`ExprLess`), not the free function `exprless`. Passing a function pointer to `std::sort`/`std::is_sorted` blocks inlining, so every comparison was an indirect call; after the accessor-inlining in #583 this comparator was the single largest self-time symbol (~14%) on wide n-ary inputs. *−6.4% Labyrinth, −5.4%/−7.1% (min/mean) Sudoku.*
4. **Generate the scanner with a full (uncompressed) DFA table** (`%option full`). The flex default (`-Cem`) trades scan speed for table size via equivalence-class indirection on every character; `smt2lex` is the largest self-time symbol and all input goes through it. Cost is +119 KB in `libstp.so`. *−5 to −6% across all inputs.*

### Cumulative
Interleaved A/B, `--parse-only`, vs the merge base: **AND-NESTED-32-32 −14.7%, SLL-NESTED −12.0%, Sydr predicate_2208 −7.3%.** Holds at extreme scale: the 2 GB `ridecore` parses ~10% faster.

### Correctness
Behavior-neutral by construction (single-probe classification, empty-substitution short-circuit, identical sort ordering, same DFA). Verified: 0 sat/unsat differences across 25 define-fun files, and byte-identical CNF output (187 MB on `sudoku.in4`) before/after.
