### PR TITLE
Return children as a Span view from GetChildren()

### DIFF
--- a/include/stp/AST/AST.h
+++ b/include/stp/AST/AST.h
@@ -72,7 +72,7 @@ bool BVTypeCheck(const ASTNode& n);
 
 long getCurrentTime();
 
-ASTVec FlattenKind(Kind k, const ASTVec& children, int maxDepth = INT_MAX);
+ASTVec FlattenKind(Kind k, const ASTChildren& children, int maxDepth = INT_MAX);
 
 // Checks recursively all the way down.
 bool BVTypeCheckRecursive(const ASTNode& n);
@@ -100,7 +100,7 @@ typedef std::unordered_map<ASTNode, ASTVec, ASTNode::ASTNodeHasher,
                            ASTNode::ASTNodeEqual>
     ASTNodeToVecMap;
 
-void FlattenKindNoDuplicates(const Kind k, const ASTVec& children,
+void FlattenKindNoDuplicates(const Kind k, const ASTChildren& children,
                              ASTVec& flat_children,
                              ASTNodeSet& alreadyFlattened);
 

--- a/include/stp/AST/ASTBVConst.h
+++ b/include/stp/AST/ASTBVConst.h
@@ -102,7 +102,7 @@ private:
   uint32_t getValueWidth() const { return bits_(_bvconst); }
 
 public:
-  virtual ASTVec const& GetChildren() const { return astbv_empty_children; }
+  virtual ASTChildren GetChildren() const { return astbv_empty_children; }
 
   virtual ~ASTBVConst()
   {

--- a/include/stp/AST/ASTInterior.h
+++ b/include/stp/AST/ASTInterior.h
@@ -149,7 +149,7 @@ public:
 
   virtual ~ASTInterior();
 
-  virtual ASTVec const& GetChildren() const { return _children; }
+  virtual ASTChildren GetChildren() const { return _children; }
 
   bool isSimplified() const { return is_simplified; }
 

--- a/include/stp/AST/ASTInternal.h
+++ b/include/stp/AST/ASTInternal.h
@@ -135,7 +135,7 @@ protected:
   Kind GetKind() const { return _kind; }
 
   // Get the child nodes of this node
-  virtual ASTVec const& GetChildren() const = 0;
+  virtual ASTChildren GetChildren() const = 0;
 
 public:
   // Constructor (kind only, empty children, int nodenum)

--- a/include/stp/AST/ASTNode.h
+++ b/include/stp/AST/ASTNode.h
@@ -136,7 +136,7 @@ public:
   Kind GetKind() const { return _int_node_ptr->GetKind(); }
 
   // Access Children of this Node
-  const ASTVec& GetChildren() const { return _int_node_ptr->GetChildren(); }
+  ASTChildren GetChildren() const { return _int_node_ptr->GetChildren(); }
 
   // Return the number of child nodes
   size_t Degree() const { return GetChildren().size(); };
@@ -148,10 +148,10 @@ public:
   };
 
   // Get begin() iterator for child nodes
-  ASTVec::const_iterator begin() const { return GetChildren().begin(); };
+  const ASTNode* begin() const { return GetChildren().begin(); };
 
   // Get end() iterator for child nodes
-  ASTVec::const_iterator end() const { return GetChildren().end(); };
+  const ASTNode* end() const { return GetChildren().end(); };
 
   // Get back() element for child nodes
   const ASTNode back() const { return GetChildren().back(); };

--- a/include/stp/AST/ASTSymbol.h
+++ b/include/stp/AST/ASTSymbol.h
@@ -96,7 +96,7 @@ private:
   virtual uint32_t getValueWidth() const { return _value_width; }
 
 public:
-  virtual ASTVec const& GetChildren() const { return empty_children; }
+  virtual ASTChildren GetChildren() const { return empty_children; }
 
   // Constructor.  This does NOT copy its argument.
   ASTSymbol(STPMgr* mgr, const char* const name)

--- a/include/stp/AST/UsefulDefs.h
+++ b/include/stp/AST/UsefulDefs.h
@@ -77,6 +77,52 @@ typedef vector<ASTNode> ASTVec;
 typedef unsigned int* CBV;
 DLL_PUBLIC extern ASTVec _empty_ASTVec;
 
+/******************************************************************
+ * A non-owning view over a contiguous run of elements — like     *
+ * std::span, but available under C++17. Returned by GetChildren()*
+ * so a node's children need not be stored in a std::vector.      *
+ * A template so its element-touching members are only checked on *
+ * instantiation, where ASTNode is complete.                      *
+ ******************************************************************/
+template <class T> class Span
+{
+  T* _data;
+  size_t _size;
+
+public:
+  Span() : _data(nullptr), _size(0) {}
+  Span(T* data, size_t size) : _data(data), _size(size) {}
+  // Implicit view over a std::vector<ASTNode> (the historical storage).
+  Span(const ASTVec& v) : _data(v.data()), _size(v.size()) {}
+
+  T* begin() const { return _data; }
+  T* end() const { return _data + _size; }
+  size_t size() const { return _size; }
+  bool empty() const { return _size == 0; }
+  T& operator[](size_t i) const { return _data[i]; }
+  T& front() const { return _data[0]; }
+  T& back() const { return _data[_size - 1]; }
+  T* data() const { return _data; }
+
+  bool operator==(const Span& o) const
+  {
+    if (_size != o._size)
+      return false;
+    for (size_t i = 0; i < _size; i++)
+      if (!(_data[i] == o._data[i]))
+        return false;
+    return true;
+  }
+  bool operator!=(const Span& o) const { return !(*this == o); }
+};
+
+// The children of an interior node, as a read-only view.
+typedef Span<const ASTNode> ASTChildren;
+
+// Materialise a children view into an owned vector (only where a mutable or
+// std::vector-typed copy is genuinely needed).
+DLL_PUBLIC ASTVec toASTVec(const ASTChildren& c);
+
 // Error handling function
 DLL_PUBLIC extern void (*vc_error_hdlr)(const char* err_msg);
 

--- a/include/stp/Simplifier/AlwaysTrue.h
+++ b/include/stp/Simplifier/AlwaysTrue.h
@@ -73,7 +73,7 @@ class AlwaysTrue
     }
 
     ASTNode result = n;
-    if (newChildren != n.GetChildren())
+    if (ASTChildren(newChildren) != n.GetChildren())
     {
       if (n.GetType() == BOOLEAN_TYPE)
         result = nf->CreateNode(n.GetKind(), newChildren);

--- a/include/stp/Util/NodeIterator.h
+++ b/include/stp/Util/NodeIterator.h
@@ -72,9 +72,9 @@ public:
 
     result.setIteration(iteration);
 
-    const ASTVec& c = result.GetChildren();
-    ASTVec::const_iterator itC = c.begin();
-    ASTVec::const_iterator itendC = c.end();
+    const ASTChildren c = result.GetChildren();
+    auto itC = c.begin();
+    auto itendC = c.end();
     for (; itC != itendC; itC++)
     {
       if (itC->getIteration() == iteration)

--- a/lib/AST/ASTInterior.cpp
+++ b/lib/AST/ASTInterior.cpp
@@ -58,9 +58,9 @@ operator()(const ASTInterior* int_node_ptr) const
     return int_node_ptr->_cached_hash;
 
   size_t hashval = ((size_t)int_node_ptr->GetKind());
-  const ASTVec& ch = int_node_ptr->GetChildren();
-  ASTVec::const_iterator iend = ch.end();
-  for (ASTVec::const_iterator i = ch.begin(); i != iend; i++)
+  const ASTChildren ch = int_node_ptr->GetChildren();
+  auto iend = ch.end();
+  for (auto i = ch.begin(); i != iend; i++)
   {
     hashval += i->Hash();
     hashval += (hashval << 10);

--- a/lib/AST/ASTNode.cpp
+++ b/lib/AST/ASTNode.cpp
@@ -251,8 +251,8 @@ void ASTNode::NFASTPrint(int l, int max, int prefix) const
   // recurse
   //****************************************
 
-  const ASTVec& children = GetChildren();
-  ASTVec::const_iterator it = children.begin();
+  const ASTChildren children = GetChildren();
+  auto it = children.begin();
   for (; it != children.end(); it++)
   {
     it->NFASTPrint(l + 1, max, prefix + 1);
@@ -276,8 +276,8 @@ void ASTNode::LetizeNode(STPMgr* bm) const
   if (isAtom())
     return;
 
-  const ASTVec& c = this->GetChildren();
-  for (ASTVec::const_iterator it = c.begin(), itend = c.end(); it != itend;
+  const ASTChildren c = this->GetChildren();
+  for (auto it = c.begin(), itend = c.end(); it != itend;
        it++)
   {
     ASTNode ccc = *it;

--- a/lib/AST/ASTmisc.cpp
+++ b/lib/AST/ASTmisc.cpp
@@ -221,14 +221,14 @@ bool isAtomic(Kind kind)
 // typechecked.
 bool BVTypeCheckRecursive(const ASTNode& n)
 {
-  const ASTVec& c = n.GetChildren();
+  const ASTChildren c = n.GetChildren();
 
   if (!BVTypeCheck(n))
   {
     return false;
   }
 
-  for (ASTVec::const_iterator it = c.begin(), itend = c.end(); it != itend;
+  for (auto it = c.begin(), itend = c.end(); it != itend;
        it++)
   {
     if (!BVTypeCheckRecursive(*it))
@@ -257,9 +257,9 @@ void buildListOfSymbols(const ASTNode& n, ASTNodeSet& visited,
     buildListOfSymbols(n[i], visited, symbols);
 }
 
-void checkChildrenAreBV(const ASTVec& v, const ASTNode& n)
+void checkChildrenAreBV(const ASTChildren& v, const ASTNode& n)
 {
-  for (ASTVec::const_iterator it = v.begin(), itend = v.end(); it != itend;
+  for (auto it = v.begin(), itend = v.end(); it != itend;
        it++)
   {
     if (BITVECTOR_TYPE != it->GetType())
@@ -275,12 +275,17 @@ void checkChildrenAreBV(const ASTVec& v, const ASTNode& n)
  * AND,OR operations are not
  * flattened multiple times.
  */
-void FlattenKindNoDuplicates(const Kind k, const ASTVec& children,
+ASTVec toASTVec(const ASTChildren& c)
+{
+  return ASTVec(c.begin(), c.end());
+}
+
+void FlattenKindNoDuplicates(const Kind k, const ASTChildren& children,
                              ASTVec& flat_children,
                              ASTNodeSet& alreadyFlattened)
 {
-  const ASTVec::const_iterator ch_end = children.end();
-  for (ASTVec::const_iterator it = children.begin(); it != ch_end; it++)
+  const auto ch_end = children.end();
+  for (auto it = children.begin(); it != ch_end; it++)
   {
     const Kind ck = it->GetKind();
     if (k == ck)
@@ -299,10 +304,10 @@ void FlattenKindNoDuplicates(const Kind k, const ASTVec& children,
   }
 }
 
-void FlattenKind(const Kind k, const ASTVec& children, ASTVec& flat_children, int depth)
+void FlattenKind(const Kind k, const ASTChildren& children, ASTVec& flat_children, int depth)
 {
-  ASTVec::const_iterator ch_end = children.end();
-  for (ASTVec::const_iterator it = children.begin(); it != ch_end; it++)
+  auto ch_end = children.end();
+  for (auto it = children.begin(); it != ch_end; it++)
   {
     const Kind ck = it->GetKind();
     if (k == ck && depth >= 0 )
@@ -317,7 +322,7 @@ void FlattenKind(const Kind k, const ASTVec& children, ASTVec& flat_children, in
 }
 
 // Flatten (k ... (k ci cj) ...) to (k ... ci cj ...)
-ASTVec FlattenKind(Kind k, const ASTVec& children, int maxDepth)
+ASTVec FlattenKind(Kind k, const ASTChildren& children, int maxDepth)
 {
   ASTVec flat_children;
   if (k == OR || k == BVOR || k == BVAND || k == AND)
@@ -336,7 +341,7 @@ ASTVec FlattenKind(Kind k, const ASTVec& children, int maxDepth)
 bool BVTypeCheck_term_kind(const ASTNode& n, const Kind& k)
 {
   // The children of bitvector terms are in turn bitvectors.
-  const ASTVec& v = n.GetChildren();
+  const ASTChildren v = n.GetChildren();
 
   switch (k)
   {
@@ -434,7 +439,7 @@ bool BVTypeCheck_term_kind(const ASTNode& n, const Kind& k)
                    n);
 
       unsigned int width = n.GetValueWidth();
-      for (ASTVec::const_iterator it = v.begin(), itend = v.end(); it != itend;
+      for (auto it = v.begin(), itend = v.end(); it != itend;
            it++)
       {
         if (width != it->GetValueWidth())
@@ -512,7 +517,7 @@ bool BVTypeCheck_term_kind(const ASTNode& n, const Kind& k)
 bool BVTypeCheck_nonterm_kind(const ASTNode& n, const Kind& k)
 {
   // The children of bitvector terms are in turn bitvectors.
-  const ASTVec& v = n.GetChildren();
+  const ASTChildren v = n.GetChildren();
 
   if (!(is_Form_kind(k) && BOOLEAN_TYPE == n.GetType()))
     FatalError("BVTypeCheck: not a formula:", n);

--- a/lib/AbsRefineCounterExample/ArrayTransformer.cpp
+++ b/lib/AbsRefineCounterExample/ArrayTransformer.cpp
@@ -270,9 +270,9 @@ void ArrayTransformer::assertTransformPostConditions(const ASTNode& term,
   // There should be no nodes left of type array.
   assert(0 == term.GetIndexWidth());
 
-  const ASTVec& c = term.GetChildren();
-  ASTVec::const_iterator it = c.begin();
-  const ASTVec::const_iterator itend = c.end();
+  const ASTChildren c = term.GetChildren();
+  auto it = c.begin();
+  const auto itend = c.end();
   for (; it != itend; it++)
   {
     assertTransformPostConditions(*it, visited);
@@ -370,7 +370,7 @@ ASTNode ArrayTransformer::TransformFormula(const ASTNode& simpleForm)
       ASTVec vec;
       vec.reserve(simpleForm.Degree());
 
-      for (ASTVec::const_iterator it = simpleForm.begin(),
+      for (auto it = simpleForm.begin(),
                                   itend = simpleForm.end();
            it != itend; it++)
       {
@@ -467,9 +467,9 @@ ASTNode ArrayTransformer::TransformTerm(const ASTNode& term)
     }
     default:
     {
-      const ASTVec& c = term.GetChildren();
-      ASTVec::const_iterator it = c.begin();
-      ASTVec::const_iterator itend = c.end();
+      const ASTChildren c = term.GetChildren();
+      auto it = c.begin();
+      auto itend = c.end();
       const unsigned width = term.GetValueWidth();
       const unsigned indexwidth = term.GetIndexWidth();
       ASTVec o;

--- a/lib/AbsRefineCounterExample/CounterExample.cpp
+++ b/lib/AbsRefineCounterExample/CounterExample.cpp
@@ -330,10 +330,10 @@ ASTNode AbsRefine_CounterExample::TermToConstTermUsingModel(const ASTNode& term,
     }
     default:
     {
-      const ASTVec& c = term.GetChildren();
+      const ASTChildren c = term.GetChildren();
       ASTVec o;
       o.reserve(c.size());
-      for (ASTVec::const_iterator it = c.begin(), itend = c.end(); it != itend;
+      for (auto it = c.begin(), itend = c.end(); it != itend;
            it++)
       {
         ASTNode ff = TermToConstTermUsingModel(*it, ArrayReadFlag);
@@ -510,7 +510,7 @@ ASTNode AbsRefine_CounterExample::ComputeFormulaUsingModel(const ASTNode& form)
       ASTVec children;
       children.reserve(form.Degree());
 
-      for (ASTVec::const_iterator it = form.begin(), itend = form.end();
+      for (auto it = form.begin(), itend = form.end();
            it != itend; it++)
       {
         children.push_back(TermToConstTermUsingModel(*it, false));
@@ -532,7 +532,7 @@ ASTNode AbsRefine_CounterExample::ComputeFormulaUsingModel(const ASTNode& form)
       ASTVec children;
       children.reserve(form.Degree());
 
-      for (ASTVec::const_iterator it = form.begin(), itend = form.end();
+      for (auto it = form.begin(), itend = form.end();
            it != itend; it++)
       {
         children.push_back(ComputeFormulaUsingModel(*it));

--- a/lib/Interface/c_interface.cpp
+++ b/lib/Interface/c_interface.cpp
@@ -1885,7 +1885,7 @@ Expr getChild(Expr e, int i)
 {
   stp::ASTNode* a = (stp::ASTNode*)e;
 
-  stp::ASTVec c = a->GetChildren();
+  const stp::ASTChildren c = a->GetChildren();
   if (0 <= i && (unsigned)i < c.size())
   {
     stp::ASTNode o = c[i];

--- a/lib/NodeFactory/SimplifyingNodeFactory.cpp
+++ b/lib/NodeFactory/SimplifyingNodeFactory.cpp
@@ -706,8 +706,8 @@ ASTNode SimplifyingNodeFactory::CreateSimpleEQ(const ASTVec& children)
   if ((k1 == BVPLUS && in1.Degree() <= 2) ||
       (k2 == BVPLUS && in2.Degree() <= 2))
   {
-    const ASTVec& c1 = (k1 == BVPLUS) ? in1.GetChildren() : ASTVec(1, in1);
-    const ASTVec& c2 = (k2 == BVPLUS) ? in2.GetChildren() : ASTVec(1, in2);
+    const ASTVec c1 = (k1 == BVPLUS) ? toASTVec(in1.GetChildren()) : ASTVec(1, in1);
+    const ASTVec c2 = (k2 == BVPLUS) ? toASTVec(in2.GetChildren()) : ASTVec(1, in2);
 
     if (c1.size() <= 2 && c2.size() <= 2)
     {

--- a/lib/Printer/CPrinter.cpp
+++ b/lib/Printer/CPrinter.cpp
@@ -72,7 +72,7 @@ void C_Print1(ostream& os, const ASTNode n, int indentation, bool letize,
 
   // otherwise print it normally
   Kind kind = n.GetKind();
-  const ASTVec& c = n.GetChildren();
+  const ASTChildren c = n.GetChildren();
   switch (kind)
   {
     case BOOLEXTRACT:
@@ -191,7 +191,7 @@ void C_Print1(ostream& os, const ASTNode n, int indentation, bool letize,
     case BVMOD:
       os << kind << "(";
       os << n.GetValueWidth();
-      for (ASTVec::const_iterator it = c.begin(), itend = c.end(); it != itend;
+      for (auto it = c.begin(), itend = c.end(); it != itend;
            it++)
       {
         os << ", " << endl;
@@ -343,8 +343,8 @@ void C_Print1(ostream& os, const ASTNode n, int indentation, bool letize,
     {
       os << "(";
       C_Print1(os, c[0], indentation, letize, bm);
-      ASTVec::const_iterator it = c.begin();
-      ASTVec::const_iterator itend = c.end();
+      auto it = c.begin();
+      auto itend = c.end();
 
       it++;
       for (; it != itend; it++)

--- a/lib/Printer/GDLPrinter.cpp
+++ b/lib/Printer/GDLPrinter.cpp
@@ -70,14 +70,14 @@ void GDL_Print1(ostream& os, const ASTNode& n,
   os << "\"}" << endl;
 
   // print the edges to each child.
-  const ASTVec ch = n.GetChildren();
-  const ASTVec::const_iterator itend = ch.end();
+  const ASTChildren ch = n.GetChildren();
+  const auto itend = ch.end();
 
   // If a node has the child 'TRUE' twice, we only want to output one TRUE node.
   ASTNodeSet constantOutput;
 
   int i = 0;
-  for (ASTVec::const_iterator it = ch.begin(); it < itend; it++)
+  for (auto it = ch.begin(); it < itend; it++)
   {
     std::stringstream label;
 
@@ -112,7 +112,7 @@ void GDL_Print1(ostream& os, const ASTNode& n,
   }
 
   // print each of the children.
-  for (ASTVec::const_iterator it = ch.begin(); it < itend; it++)
+  for (auto it = ch.begin(); it < itend; it++)
   {
     if (!it->isConstant())
       GDL_Print1(os, *it, alreadyOutput, annotate);

--- a/lib/Printer/LispPrinter.cpp
+++ b/lib/Printer/LispPrinter.cpp
@@ -46,13 +46,13 @@ ostream& Lisp_Print1(ostream& os, const ASTNode& n, int indentation)
   Kind kind = n.GetKind();
   // FIXME: figure out how to avoid symbols with same names as kinds.
   //    if (kind == READ) {
-  //      const ASTVec &children = GetChildren();
+  //      const ASTChildren children = GetChildren();
   //      children[0].LispPrint1(os, indentation);
   //  os << "[" << children[1] << "]";
   //    } else
   if (kind == BOOLEXTRACT)
   {
-    const ASTVec& children = n.GetChildren();
+    const ASTChildren children = n.GetChildren();
     // child 0 is a symbol.  Print without the NodeNum.
     os << n.GetNodeNum() << ":";
 
@@ -63,7 +63,7 @@ ostream& Lisp_Print1(ostream& os, const ASTNode& n, int indentation)
   }
   else if (kind == NOT)
   {
-    const ASTVec& children = n.GetChildren();
+    const ASTChildren children = n.GetChildren();
     os << n.GetNodeNum() << ":";
     os << "(NOT ";
     Lisp_Print1(os, children[0], indentation);
@@ -87,13 +87,13 @@ ostream& Lisp_Print1(ostream& os, const ASTNode& n, int indentation)
   else
   {
     Lisp_AlreadyPrintedSet.insert(n);
-    const ASTVec& children = n.GetChildren();
+    const ASTChildren children = n.GetChildren();
     os << n.GetNodeNum() << ":"
        //<< "(" << _int_node_ptr->_ref_count << ")"
        << "(" << kind << " ";
     // os << "{" << GetValueWidth() << "}";
-    ASTVec::const_iterator iend = children.end();
-    for (ASTVec::const_iterator i = children.begin(); i != iend; i++)
+    auto iend = children.end();
+    for (auto i = children.begin(); i != iend; i++)
     {
       Lisp_Print_indent(os, *i, indentation + 2);
     }

--- a/lib/Printer/PLPrinter.cpp
+++ b/lib/Printer/PLPrinter.cpp
@@ -127,7 +127,7 @@ void PL_Print1(ostream& os, const ASTNode& n, int indentation, bool letize,
 
   // otherwise print it normally
   const Kind kind = n.GetKind();
-  const ASTVec& c = n.GetChildren();
+  const ASTChildren c = n.GetChildren();
   switch (kind)
   {
     case BOOLEXTRACT:
@@ -250,7 +250,7 @@ void PL_Print1(ostream& os, const ASTNode& n, int indentation, bool letize,
     case BVMOD:
       os << functionToCVCName(kind) << "(";
       os << n.GetValueWidth();
-      for (ASTVec::const_iterator it = c.begin(), itend = c.end(); it != itend;
+      for (auto it = c.begin(), itend = c.end(); it != itend;
            it++)
       {
         os << ", " << endl;
@@ -317,8 +317,8 @@ void PL_Print1(ostream& os, const ASTNode& n, int indentation, bool letize,
     {
       os << "(";
       PL_Print1(os, c[0], indentation, letize, bm);
-      ASTVec::const_iterator it = c.begin();
-      ASTVec::const_iterator itend = c.end();
+      auto it = c.begin();
+      auto itend = c.end();
 
       it++;
       for (; it != itend; it++)

--- a/lib/Printer/SMTLIB1Printer.cpp
+++ b/lib/Printer/SMTLIB1Printer.cpp
@@ -115,7 +115,7 @@ void printSMTLIB1VarDeclsToStream(ASTNodeSet& symbols, ostream& os)
 void outputBitVec(const ASTNode n, ostream& os)
 {
   const Kind k = n.GetKind();
-  const ASTVec& c = n.GetChildren();
+  const ASTChildren c = n.GetChildren();
   ASTNode op;
 
   if (BITVECTOR == k)
@@ -171,7 +171,7 @@ void SMTLIB1_Print1(ostream& os, const ASTNode n, int indentation, bool letize)
 
   // otherwise print it normally
   const Kind kind = n.GetKind();
-  const ASTVec& c = n.GetChildren();
+  const ASTChildren c = n.GetChildren();
   switch (kind)
   {
     case BITVECTOR:
@@ -256,8 +256,8 @@ void SMTLIB1_Print1(ostream& os, const ASTNode n, int indentation, bool letize)
       {
         os << "(" << functionToSMTLIBName(kind, true);
 
-        ASTVec::const_iterator iend = c.end();
-        for (ASTVec::const_iterator i = c.begin(); i != iend; i++)
+        auto iend = c.end();
+        for (auto i = c.begin(); i != iend; i++)
         {
           os << " ";
           SMTLIB1_Print1(os, *i, 0, letize);

--- a/lib/Printer/SMTLIB2Printer.cpp
+++ b/lib/Printer/SMTLIB2Printer.cpp
@@ -112,7 +112,7 @@ void printVarDeclsToStream(ASTNodeSet& symbols, ostream& os)
 void outputBitVecSMTLIB2(const ASTNode n, ostream& os)
 {
   const Kind k = n.GetKind();
-  const ASTVec& c = n.GetChildren();
+  const ASTChildren c = n.GetChildren();
   ASTNode op;
 
   if (BITVECTOR == k)
@@ -173,7 +173,7 @@ void SMTLIB2_Print1(ostream& os, const ASTNode n, int indentation, bool letize)
 
   // otherwise print it normally
   const Kind kind = n.GetKind();
-  const ASTVec& c = n.GetChildren();
+  const ASTChildren c = n.GetChildren();
   switch (kind)
   {
     case BITVECTOR:
@@ -260,8 +260,8 @@ void SMTLIB2_Print1(ostream& os, const ASTNode n, int indentation, bool letize)
       {
         os << "(" << functionToSMTLIBName(kind, false);
 
-        ASTVec::const_iterator iend = c.end();
-        for (ASTVec::const_iterator i = c.begin(); i != iend; i++)
+        auto iend = c.end();
+        for (auto i = c.begin(); i != iend; i++)
         {
           os << " ";
           SMTLIB2_Print1(os, *i, 0, letize);

--- a/lib/Printer/SMTLIBPrinter.cpp
+++ b/lib/Printer/SMTLIBPrinter.cpp
@@ -135,8 +135,8 @@ void LetizeNode(const ASTNode& n, ASTNodeSet& PLPrintNodeSet, bool smtlib1,
   if (n.isAtom())
     return;
 
-  const ASTVec& c = n.GetChildren();
-  for (ASTVec::const_iterator it = c.begin(), itend = c.end(); it != itend;
+  const ASTChildren c = n.GetChildren();
+  for (auto it = c.begin(), itend = c.end(); it != itend;
        it++)
   {
     const ASTNode& ccc = *it;

--- a/lib/Printer/dotPrinter.cpp
+++ b/lib/Printer/dotPrinter.cpp
@@ -66,17 +66,17 @@ void Dot_Print1(ostream& os, const ASTNode n,
   os << "\"];" << endl;
 
   // print the edges to each child.
-  ASTVec ch = n.GetChildren();
-  ASTVec::iterator itend = ch.end();
+  const ASTChildren ch = n.GetChildren();
+  auto itend = ch.end();
   int i = 0;
-  for (ASTVec::iterator it = ch.begin(); it < itend; it++)
+  for (auto it = ch.begin(); it < itend; it++)
   {
     os << "n" << n.GetNodeNum() << " -> "
        << "n" << it->GetNodeNum() << "[label=" << i++ << "];" << endl;
   }
 
   // print each of the children.
-  for (ASTVec::iterator it = ch.begin(); it < itend; it++)
+  for (auto it = ch.begin(); it < itend; it++)
   {
     Dot_Print1(os, *it, alreadyOutput);
   }

--- a/lib/STPManager/STPManager.cpp
+++ b/lib/STPManager/STPManager.cpp
@@ -599,7 +599,7 @@ bool STPMgr::VarSeenInTerm(const ASTNode& var, const ASTNode& term)
     return true;
   }
 
-  for (ASTVec::const_iterator it = term.begin(), itend = term.end();
+  for (auto it = term.begin(), itend = term.end();
        it != itend; it++)
   {
     if (VarSeenInTerm(var, *it))

--- a/lib/Simplifier/AIGSimplifyPropositionalCore.cpp
+++ b/lib/Simplifier/AIGSimplifyPropositionalCore.cpp
@@ -87,11 +87,11 @@ ASTNode AIGSimplifyPropositionalCore::theoryToFresh(const ASTNode& n,
     return fresh;
   }
 
-  const ASTVec& children = n.GetChildren();
+  const ASTChildren children = n.GetChildren();
   ASTVec new_children;
   new_children.reserve(children.size());
 
-  for (ASTVec::const_iterator it = children.begin(); it != children.end(); it++)
+  for (auto it = children.begin(); it != children.end(); it++)
     new_children.push_back(theoryToFresh(*it, fromTo));
 
   ASTNode result;

--- a/lib/Simplifier/BVSolver.cpp
+++ b/lib/Simplifier/BVSolver.cpp
@@ -527,7 +527,7 @@ ASTNode BVSolver::TopLevelBVSolve(const ASTNode& _input,
   if (EQ == k)
     c.push_back(input);
   else
-    c = input.GetChildren();
+    c = toASTVec(input.GetChildren());
 
   ASTVec eveneqns;
   bool any_solved = false;
@@ -648,9 +648,9 @@ ASTNode BVSolver::CheckEvenEqn(const ASTNode& input, bool& evenflag)
   }
   //Now, LHS is BVPLUS and RHS is ZERO
 
-  const ASTVec& lhs_c = lhs.GetChildren();
+  const ASTChildren lhs_c = lhs.GetChildren();
   ASTNode savetheconst = rhs;
-  for (ASTVec::const_iterator it = lhs_c.begin(), itend = lhs_c.end();
+  for (auto it = lhs_c.begin(), itend = lhs_c.end();
        it != itend; it++)
   {
     const ASTNode aaa = *it;
@@ -718,7 +718,7 @@ ASTNode BVSolver::BVSolve_Even(const ASTNode& input)
   }
   else
   {
-    input_c = input.GetChildren();
+    input_c = toASTVec(input.GetChildren());
   }
 
   // power_of_2 holds the exponent of 2 in the coeff
@@ -744,8 +744,8 @@ ASTNode BVSolver::BVSolve_Even(const ASTNode& input)
       return input;
     }
 
-    const ASTVec& lhs_c = lhs.GetChildren();
-    for (ASTVec::const_iterator it = lhs_c.begin(), itend = lhs_c.end();
+    const ASTChildren lhs_c = lhs.GetChildren();
+    for (auto it = lhs_c.begin(), itend = lhs_c.end();
          it != itend; it++)
     {
       const ASTNode aaa = *it;
@@ -811,9 +811,9 @@ ASTNode BVSolver::BVSolve_Even(const ASTNode& input)
       two =
           _simp->BVConstEvaluator(_bm->CreateTerm(BVMULT, len, two_const, two));
     }
-    const ASTVec& lhs_c = lhs.GetChildren();
+    const ASTChildren lhs_c = lhs.GetChildren();
     ASTVec lhs_out;
-    for (ASTVec::const_iterator it = lhs_c.begin(), itend = lhs_c.end();
+    for (auto it = lhs_c.begin(), itend = lhs_c.end();
          it != itend; it++)
     {
       ASTNode aaa = *it;

--- a/lib/Simplifier/Flatten.cpp
+++ b/lib/Simplifier/Flatten.cpp
@@ -87,7 +87,7 @@ namespace stp
 
     ASTVec newChildren;
 
-    const ASTVec& children = n.GetChildren();
+    const ASTChildren children = n.GetChildren();
     auto it0 = children.begin();
 
     ASTVec nextChildren;

--- a/lib/Simplifier/PropagateEqualities.cpp
+++ b/lib/Simplifier/PropagateEqualities.cpp
@@ -476,7 +476,7 @@ void PropagateEqualities::buildCandidateList(const ASTNode& a)
   }
   else if (IFF == k || EQ == k)
   {
-    const ASTVec& c = a.GetChildren();
+    const ASTChildren c = a.GetChildren();
     const auto width = c[0].GetValueWidth();
     bool added = false;
 

--- a/lib/Simplifier/PropagateEqualitiesOld.cpp
+++ b/lib/Simplifier/PropagateEqualitiesOld.cpp
@@ -209,7 +209,7 @@ ASTNode PropagateEqualities::propagate(const ASTNode& a, ArrayTransformer* at)
   }
   else if (IFF == k || EQ == k)
   {
-    const ASTVec& c = a.GetChildren();
+    const ASTChildren c = a.GetChildren();
 
     if (c[0] == c[1])
       return ASTTrue;
@@ -341,7 +341,7 @@ ASTNode PropagateEqualities::propagate(const ASTNode& a, ArrayTransformer* at)
   }
   else if (AND == k)
   {
-    const ASTVec& c = a.GetChildren();
+    const ASTChildren c = a.GetChildren();
     ASTVec o;
     o.reserve(c.size());
 

--- a/lib/Simplifier/Rewriting.cpp
+++ b/lib/Simplifier/Rewriting.cpp
@@ -92,7 +92,7 @@ namespace stp
 
     ASTNode result =n;
 
-    const ASTVec& children = n.GetChildren();
+    const ASTChildren children = n.GetChildren();
     ASTVec newChildren;
 
     // Copy on write.

--- a/lib/Simplifier/Simplifier.cpp
+++ b/lib/Simplifier/Simplifier.cpp
@@ -313,11 +313,11 @@ ASTNode Simplifier::SimplifyFormula(const ASTNode& b, bool pushNeg,
   Kind kind = b.GetKind();
 
   ASTNode a = b;
-  ASTVec ca = a.GetChildren();
+  ASTVec ca = toASTVec(a.GetChildren());
   if (!(IMPLIES == kind || ITE == kind || PARAMBOOL == kind || isAtomic(kind)))
   {
     SortByArith(ca);
-    if (ca != a.GetChildren())
+    if (ASTChildren(ca) != a.GetChildren())
       a = nf->CreateNode(kind, ca);
   }
 
@@ -1508,7 +1508,7 @@ ASTNode Simplifier::SimplifyTerm(const ASTNode& actualInputterm,
     if (k != SYMBOL) // const and symbols need to be created specially.
     {
       ASTVec v;
-      ASTVec toProcess = actualInputterm.GetChildren();
+      ASTVec toProcess = toASTVec(actualInputterm.GetChildren());
       if (actualInputterm.GetKind() == BVAND ||
           actualInputterm.GetKind() == BVOR ||
           actualInputterm.GetKind() == BVPLUS)
@@ -1532,7 +1532,7 @@ ASTNode Simplifier::SimplifyTerm(const ASTNode& actualInputterm,
       }
 
       assert(v.size() > 0);
-      if (v != actualInputterm.GetChildren()) // short-cut.
+      if (ASTChildren(v) != actualInputterm.GetChildren()) // short-cut.
       {
         output = nf->CreateArrayTerm(k, actualInputterm.GetIndexWidth(),
                                      inputValueWidth, v);
@@ -1547,7 +1547,7 @@ ASTNode Simplifier::SimplifyTerm(const ASTNode& actualInputterm,
       }
     }
 
-    const ASTVec& children = inputterm.GetChildren();
+    const ASTChildren children = inputterm.GetChildren();
     k = inputterm.GetKind();
 
     // Perform constant propagation if possible.
@@ -1685,7 +1685,7 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
     {
       if (BVPLUS == k && inputterm.Degree() == 2 && inputterm[1].GetKind() == BVLEFTSHIFT && inputterm[0] == inputterm[1][1])
       {
-        ASTNode replacement = nf->CreateTerm(BVOR, inputValueWidth, inputterm.GetChildren());
+        ASTNode replacement = nf->CreateTerm(BVOR, inputValueWidth, toASTVec(inputterm.GetChildren()));
         return SimplifyTerm(replacement, VarConstMap);
       }
 
@@ -1798,7 +1798,7 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
       // propagate bvuminus upwards through multiplies.
       if (BVMULT == output.GetKind())
       {
-        ASTVec d = output.GetChildren();
+        ASTVec d = toASTVec(output.GetChildren());
         int uminus = 0;
         for (unsigned i = 0; i < d.size(); i++)
         {
@@ -1828,11 +1828,11 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
       }
       else if (BVMULT == output.GetKind())
       {
-        output = makeTower(BVMULT, output.GetChildren());
+        output = makeTower(BVMULT, toASTVec(output.GetChildren()));
       }
       else if (BVPLUS == output.GetKind())
       {
-        ASTVec d = output.GetChildren();
+        ASTVec d = toASTVec(output.GetChildren());
         SortByArith(d);
         output = nf->CreateTerm(output.GetKind(), output.GetValueWidth(), d);
       }
@@ -1917,9 +1917,9 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
           //
           // BVUMINUS(a1x1 + a2x2 + ...) <=> BVPLUS(BVUMINUS(a1x1) +
           // BVUMINUS(a2x2) + ...
-          const ASTVec& c = a0.GetChildren();
+          const ASTChildren c = a0.GetChildren();
           ASTVec o;
-          for (ASTVec::const_iterator it = c.begin(), itend = c.end();
+          for (auto it = c.begin(), itend = c.end();
                it != itend; it++)
           {
             // Simplify(BVUMINUS(a1x1))
@@ -2068,9 +2068,9 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
         {
           // (BVMULT(n,t,u))[i:j] <==> BVMULT(i+1,t[i:0],u[i:0])[i:j]
           // similar rule for BVPLUS
-          ASTVec c = a0.GetChildren();
+          const ASTChildren c = a0.GetChildren();
           ASTVec o;
-          for (ASTVec::iterator jt = c.begin(), jtend = c.end(); jt != jtend;
+          for (auto jt = c.begin(), jtend = c.end(); jt != jtend;
                jt++)
           {
             ASTNode aaa = *jt;
@@ -2235,10 +2235,10 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
         case BVAND:
         case BVOR:
         {
-          const ASTVec& c = a0.GetChildren();
+          const ASTChildren c = a0.GetChildren();
           ASTVec newChildren;
           newChildren.reserve(c.size());
-          for (ASTVec::const_iterator it = c.begin(), itend = c.end();
+          for (auto it = c.begin(), itend = c.end();
                it != itend; it++)
           {
             newChildren.push_back(
@@ -2251,9 +2251,9 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
         {
           // BVSX(m,BVPLUS(n,BVSX(t1),BVSX(t2))) <==>
           // BVPLUS(m,BVSX(m,t1),BVSX(m,t2))
-          const ASTVec& c = a0.GetChildren();
+          const ASTChildren c = a0.GetChildren();
           bool returnflag = false;
-          for (ASTVec::const_iterator it = c.begin(), itend = c.end();
+          for (auto it = c.begin(), itend = c.end();
                it != itend; it++)
           {
             if (BVSX != it->GetKind())
@@ -2266,7 +2266,7 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
           {
             ASTVec o;
             o.reserve(c.size());
-            for (ASTVec::const_iterator it = c.begin(), itend = c.end();
+            for (auto it = c.begin(), itend = c.end();
                  it != itend; it++)
             {
               ASTNode aaa = SimplifyTerm(
@@ -2410,7 +2410,7 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
       {
         assert(output.Degree() != 0);
         bool allconv = true;
-        for (ASTVec::const_iterator it = output.begin(), itend = output.end();
+        for (auto it = output.begin(), itend = output.end();
              it != itend; it++)
         {
           if (!isPropositionToTerm(*it))
@@ -2423,7 +2423,7 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
         {
           const ASTNode zero = nf->CreateZeroConst(1);
           ASTVec children;
-          for (ASTVec::const_iterator it = output.begin(), itend = output.end();
+          for (auto it = output.begin(), itend = output.end();
                it != itend; it++)
           {
             const ASTNode& n = *it;
@@ -2541,7 +2541,7 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
       const unsigned int width = a.GetValueWidth();
       if (BVCONST == b.GetKind()) // known shift amount.
       {
-        output = SimplifyingNodeFactory::convertKnownShiftAmount(k, inputterm.GetChildren(), *_bm, nf);
+        output = SimplifyingNodeFactory::convertKnownShiftAmount(k, toASTVec(inputterm.GetChildren()), *_bm, nf);
       }
       else if (a == nf->CreateZeroConst(width))
       {
@@ -2717,7 +2717,7 @@ ASTNode Simplifier::CombineLikeTerms(const ASTNode& a)
     return output;
   }
 
-  return CombineLikeTerms(a.GetChildren());
+  return CombineLikeTerms(toASTVec(a.GetChildren()));
 }
 
 ASTNode Simplifier::CombineLikeTerms(const ASTVec& c)
@@ -2769,7 +2769,7 @@ ASTNode Simplifier::CombineLikeTerms(const ASTVec& c)
     {
       //(-1*x)*(y) <==> -1*(xy)
       ASTNode cccc = nf->CreateTerm(BVMULT, len, aaa[0][0], aaa[1]);
-      ASTVec cNodes = cccc.GetChildren();
+      ASTVec cNodes = toASTVec(cccc.GetChildren());
       SortByArith(cNodes);
       vars_to_consts[cccc].push_back(max);
     }
@@ -2777,7 +2777,7 @@ ASTNode Simplifier::CombineLikeTerms(const ASTVec& c)
     {
       // x*(-1*y) <==> -1*(xy)
       ASTNode cccc = nf->CreateTerm(BVMULT, len, aaa[0], aaa[1][0]);
-      ASTVec cNodes = cccc.GetChildren();
+      ASTVec cNodes = toASTVec(cccc.GetChildren());
       SortByArith(cNodes);
       vars_to_consts[cccc].push_back(max);
     }
@@ -2908,8 +2908,8 @@ ASTNode Simplifier::LhsMinusRhs(const ASTNode& eq)
   // right is -1*(rhs): Simplify(-1*rhs)
   rhs = SimplifyTerm(nf->CreateTerm(BVUMINUS, len, rhs));
 
-  ASTVec lvec = lhs.GetChildren();
-  ASTVec rvec = rhs.GetChildren();
+  ASTVec lvec = toASTVec(lhs.GetChildren());
+  const ASTChildren rvec = rhs.GetChildren();
   ASTNode lhsplusrhs;
   if (BVPLUS != lhs.GetKind() && BVPLUS != rhs.GetKind())
   {
@@ -2940,7 +2940,7 @@ ASTNode Simplifier::LhsMinusRhs(const ASTNode& eq)
   // sort if BVPLUS
   if (BVPLUS == output.GetKind())
   {
-    ASTVec outv = output.GetChildren();
+    ASTVec outv = toASTVec(output.GetChildren());
     SortByArith(outv);
     output = nf->CreateTerm(BVPLUS, len, outv);
   }
@@ -3022,7 +3022,7 @@ ASTNode Simplifier::DistributeMultOverPlus(const ASTNode& a,
 
   // by this point we are gauranteed that right is a BVPLUS, but left
   // may not be
-  ASTVec rightnodes = right.GetChildren();
+  const ASTChildren rightnodes = right.GetChildren();
   ASTVec outputvec;
   unsigned len = a.GetValueWidth();
   ASTNode zero = nf->CreateZeroConst(len);
@@ -3041,7 +3041,7 @@ ASTNode Simplifier::DistributeMultOverPlus(const ASTNode& a,
     }
     else
     {
-      for (ASTVec::iterator j = rightnodes.begin(), jend = rightnodes.end();
+      for (auto j = rightnodes.begin(), jend = rightnodes.end();
            j != jend; j++)
       {
         ASTNode out = SimplifyTerm(nf->CreateTerm(BVMULT, len, left, *j));
@@ -3051,14 +3051,14 @@ ASTNode Simplifier::DistributeMultOverPlus(const ASTNode& a,
   }
   else
   {
-    ASTVec leftnodes = left.GetChildren();
+    const ASTChildren leftnodes = left.GetChildren();
     // (x1 + x2 + ... + xm)*(y1 + y2 + ...+ yn) <==> x1*y1 + x1*y2 +
     // ... + x2*y1 + ... + xm*yn
-    for (ASTVec::iterator i = leftnodes.begin(), iend = leftnodes.end();
+    for (auto i = leftnodes.begin(), iend = leftnodes.end();
          i != iend; i++)
     {
       ASTNode multiplier = *i;
-      for (ASTVec::iterator j = rightnodes.begin(), jend = rightnodes.end();
+      for (auto j = rightnodes.begin(), jend = rightnodes.end();
            j != jend; j++)
       {
         ASTNode out = SimplifyTerm(nf->CreateTerm(BVMULT, len, multiplier, *j));

--- a/lib/Simplifier/StrengthReduction.cpp
+++ b/lib/Simplifier/StrengthReduction.cpp
@@ -56,7 +56,7 @@ namespace stp
     for (size_t i = 0; i < result.Degree(); i++)
       new_children.push_back(replace(result[i], fromTo, cache));
 
-    if (new_children == result.GetChildren())
+    if (ASTChildren(new_children) == result.GetChildren())
     {
       cache.insert(make_pair(n, result));
       return result;
@@ -433,7 +433,7 @@ namespace stp
         if (nonZero <= 1) // OK can reduce.
         {
           newN =
-              nf->CreateTerm(BVOR, n.GetValueWidth(), n.GetChildren());
+              nf->CreateTerm(BVOR, n.GetValueWidth(), toASTVec(n.GetChildren()));
           replaceWithSimpler++;
 
           // When the disjointness is a contiguous split, the OR is just

--- a/lib/Simplifier/SubstitutionMap.cpp
+++ b/lib/Simplifier/SubstitutionMap.cpp
@@ -175,14 +175,14 @@ ASTNode SubstitutionMap::replace(const ASTNode& n, ASTNodeMap& fromTo,
     return n;
   }
 
-  const ASTVec& children = n.GetChildren();
+  const ASTChildren children = n.GetChildren();
   assert(children.size() > 0);
   // Should have no leaves left here.
 
   ASTVec newChildren;
   bool changed = false;
 
-  for (ASTVec::const_iterator it = children.begin(); it != children.end(); it++)
+  for (auto it = children.begin(); it != children.end(); it++)
   {
     ASTNode newNode = replace(*it, fromTo, cache, nf, stopAtArrays, preventInfinite);
     if (!changed && newNode!=*it)

--- a/lib/Simplifier/UseITEContext.cpp
+++ b/lib/Simplifier/UseITEContext.cpp
@@ -108,7 +108,7 @@ ASTNode UseITEContext::visit(const ASTNode& n, std::map<ASTNode, int>& visited,
   }
 
   ASTNode result;
-  if (new_children != n.GetChildren())
+  if (ASTChildren(new_children) != n.GetChildren())
     if (n.GetType() == BOOLEAN_TYPE)
       result = nf->CreateNode(n.GetKind(), new_children);
     else

--- a/lib/Simplifier/consteval.cpp
+++ b/lib/Simplifier/consteval.cpp
@@ -910,7 +910,7 @@ ASTNode NonMemberBVConstEvaluator(STPMgr* mgr, const ASTNode& t)
   if (t.isConstant())
     return t;
 
-  return NonMemberBVConstEvaluator(mgr, t.GetKind(), t.GetChildren(),
+  return NonMemberBVConstEvaluator(mgr, t.GetKind(), toASTVec(t.GetChildren()),
                                    t.GetValueWidth());
 }
 

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -638,7 +638,7 @@ const BBNodeVec BitBlaster<BBNode, BBNodeManagerT>::BBTerm(const ASTNode& _term,
   if (!is_Term_kind(k))
     FatalError("BBTerm: Illegal kind to BBTerm", term);
 
-  const ASTVec::const_iterator kids_end = term.end();
+  const auto kids_end = term.end();
   const unsigned int num_bits = term.GetValueWidth();
   switch (k)
   {
@@ -820,7 +820,7 @@ const BBNodeVec BitBlaster<BBNode, BBNodeManagerT>::BBTerm(const ASTNode& _term,
       {
         // Add children pairwise and accumulate in BBsum
 
-        ASTVec::const_iterator it = term.begin();
+        auto it = term.begin();
         BBNodeVec tmp_res = BBTerm(*it, support);
         for (++it; it < kids_end; it++)
         {
@@ -929,7 +929,7 @@ const BBNodeVec BitBlaster<BBNode, BBNodeManagerT>::BBTerm(const ASTNode& _term,
     case BVNAND:
     {
       // Add children pairwise and accumulate in BBsum
-      ASTVec::const_iterator it = term.begin();
+      auto it = term.begin();
       Kind bk = UNDEFINED; // Kind of individual bit op.
       switch (k)
       {
@@ -1133,8 +1133,8 @@ const BBNode BitBlaster<BBNode, BBNodeManagerT>::BBForm(const ASTNode& form,
     {
       BBNodeVec bbkids; // bit-blasted children (formulas)
 
-      ASTVec::const_iterator kids_end = form.end();
-      for (ASTVec::const_iterator it = form.begin(); it != kids_end; it++)
+      auto kids_end = form.end();
+      for (auto it = form.begin(); it != kids_end; it++)
       {
         bbkids.push_back(BBForm(*it, support));
       }


### PR DESCRIPTION
`GetChildren()` returned `const ASTVec&` (a `const std::vector<ASTNode>&`),
which forces every node to store its children in a `std::vector` so a
reference can be handed back. That return type is the single obstacle to
storing children any other way — e.g. tail-allocated inline with the node,
which would drop the interior node's second heap allocation, remove an
indirection on every traversal, and shrink every node.

**This PR is the enabling refactor** — it changes only the interface, not
the storage.

- Adds a minimal C++17 `Span<T>` view (pointer + length, with the
  vector-like surface the call sites use) and `typedef ASTChildren =
  Span<const ASTNode>`.
- `GetChildren()` on `ASTInternal`, the three concrete node types, and the
  `ASTNode` handle now return `ASTChildren` by value. `Span` has an implicit
  constructor from `ASTVec`, so the still-`std::vector` storage converts
  transparently and existing vector callers keep working.
- Call-site updates are mechanical: read-only `const ASTVec&` binds become
  `const ASTChildren`; the few sites that genuinely need an owned/mutable
  vector materialise one via a new `toASTVec()` helper;
  `ASTVec::const_iterator` over a children view becomes `auto` (the span
  iterator is `const ASTNode*`); `FlattenKind` / `checkChildrenAreBV` take
  `ASTChildren`.

**No storage change yet** — children are still a `std::vector`, so there is
no functional or (intended) performance change here; it purely unblocks a
later switch to tail-allocated children behind this interface.

Behaviour-preserving, verified:

- **byte-identical CNF** vs master (`SRAI-SAFE-8-1024` 194,583 lines;
  `square` 57,279 lines);
- 120/120 on a QF_BV sample against declared `:status`;
- clean valgrind (0 errors, 0 bytes definitely lost).