### PR TITLE
Use initial-exec TLS model for hot parse-path thread-locals

### DIFF
--- a/include/stp/AST/ASTInternal.h
+++ b/include/stp/AST/ASTInternal.h
@@ -77,7 +77,7 @@ protected:
   // the are NOTs of.
   //
   uint64_t node_uid;
-  static THREAD_LOCAL uint64_t node_uid_cntr;
+  static THREAD_LOCAL_IE uint64_t node_uid_cntr;
 
   // reference counting for garbage collection
   uint32_t _ref_count;

--- a/include/stp/Globals/Globals.h
+++ b/include/stp/Globals/Globals.h
@@ -87,8 +87,8 @@ extern THREAD_LOCAL enum inputStatus
 
 // Useful global variables. Use for parsing only
 DLL_PUBLIC extern THREAD_LOCAL STP* GlobalSTP;
-DLL_PUBLIC extern THREAD_LOCAL STPMgr* GlobalParserBM;
-DLL_PUBLIC extern THREAD_LOCAL Cpp_interface* GlobalParserInterface;
+DLL_PUBLIC extern THREAD_LOCAL_IE STPMgr* GlobalParserBM;
+DLL_PUBLIC extern THREAD_LOCAL_IE Cpp_interface* GlobalParserInterface;
 
 // Function that computes various kinds of statistics for the phases
 // of STP

--- a/include/stp/Util/Attributes.h
+++ b/include/stp/Util/Attributes.h
@@ -81,4 +81,17 @@ THE SOFTWARE.
 #error "Cannot define THREAD_LOCAL"
 #endif
 
+// THREAD_LOCAL_IE: a thread-local requesting the initial-exec TLS model,
+// which is accessed by a fixed offset instead of a __tls_get_addr call.
+// Use only for hot thread-locals that libstp itself defines and that are
+// touched on the parse/node-creation fast path. Safe when libstp is in
+// the initial load set or dlopen'd before the using thread is created
+// (the normal cases: the stp binary and the Python bindings). glibc's
+// static-TLS surplus covers typical dlopen use too.
+#if USE_THREAD_LOCAL && (defined(__GNUC__) || defined(__clang__))
+#define THREAD_LOCAL_IE THREAD_LOCAL __attribute__((tls_model("initial-exec")))
+#else
+#define THREAD_LOCAL_IE THREAD_LOCAL
+#endif
+
 #endif //ATTRIBUTES_H_

--- a/lib/AST/ASTmisc.cpp
+++ b/lib/AST/ASTmisc.cpp
@@ -39,7 +39,7 @@ using std::cout;
 using std::cerr;
 using std::endl;
 
-THREAD_LOCAL uint64_t ASTInternal::node_uid_cntr = 0;
+THREAD_LOCAL_IE uint64_t ASTInternal::node_uid_cntr = 0;
 
 /****************************************************************
  * Universal Helper Functions                                   *

--- a/lib/Globals/Globals.cpp
+++ b/lib/Globals/Globals.cpp
@@ -38,10 +38,10 @@ THREAD_LOCAL enum inputStatus input_status = NOT_DECLARED;
 
 // Originally just used by the parser, now used elesewhere.
 THREAD_LOCAL STP* GlobalSTP;
-THREAD_LOCAL STPMgr* GlobalParserBM;
+THREAD_LOCAL_IE STPMgr* GlobalParserBM;
 
 // Used exclusively for parsing.
-THREAD_LOCAL Cpp_interface* GlobalParserInterface;
+THREAD_LOCAL_IE Cpp_interface* GlobalParserInterface;
 
 // FIXME: This isn't in Globals.h so how can anyone use this?
 void (*vc_error_hdlr)(const char* err_msg) = 0;


### PR DESCRIPTION
`GlobalParserInterface`/`GlobalParserBM` (read once per parser action and per lexer token) and `ASTInternal::node_uid_cntr` (read+written on **every** node construction) are `extern` thread-locals defined in `libstp.so`. In a shared library that means the general-dynamic TLS model, so each access is a `__tls_get_addr` call. Profiling `--parse-only` on the 50 largest QF_BV benchmarks put `__tls_get_addr` at ~3–4% of parse self-time.

This adds a `THREAD_LOCAL_IE` macro that requests the **initial-exec** TLS model (`__attribute__((tls_model("initial-exec")))`) — a fixed-offset access with no call — and applies it to those three hot thread-locals. Semantics are identical; only the access sequence changes.

### Results
Parse-only, interleaved A/B vs master:
- `asp/Labyrinth` **−4.4%** (min), −5.9% (mean)
- `AND-NESTED-32-32` **−2.1%**
- neutral on small inputs (little node creation)

Behavior-neutral: 0 sat/unsat differences across 25 define-fun files; `libstp` loads cleanly.

### Safety note
initial-exec requires the thread-local's storage to be reachable at a fixed offset, i.e. the library must be in the initial load set or `dlopen`'d before the using thread exists. That holds for the normal deployments: the `stp` binary links `libstp` directly, and the Python bindings `dlopen` it at import time (before any worker thread). glibc also keeps a static-TLS surplus that covers `dlopen` for a handful of small variables like these. The only unsupported case is an application that `dlopen`s `libstp` from an already-running thread after the static-TLS surplus is exhausted.
