### PR TITLE
Skip the pre-dispatch children sort for AND/OR

### DIFF
--- a/lib/Simplifier/Simplifier.cpp
+++ b/lib/Simplifier/Simplifier.cpp
@@ -314,7 +314,10 @@ ASTNode Simplifier::SimplifyFormula(const ASTNode& b, bool pushNeg,
 
   ASTNode a = b;
   ASTVec ca = toASTVec(a.GetChildren());
-  if (!(IMPLIES == kind || ITE == kind || PARAMBOOL == kind || isAtomic(kind)))
+  // AND/OR are excluded: SimplifyAndOrFormula flattens and re-sorts their
+  // children itself, so sorting (and rebuilding the node) here is wasted work.
+  if (!(IMPLIES == kind || ITE == kind || PARAMBOOL == kind || AND == kind ||
+        OR == kind || isAtomic(kind)))
   {
     SortByArith(ca);
     if (ASTChildren(ca) != a.GetChildren())


### PR DESCRIPTION
`SimplifyFormula` sorts a node's children with `SortByArith` (and rebuilds
the node if the order changed) before dispatching on kind. For `AND` and
`OR` this is wasted work: `SimplifyAndOrFormula` immediately flattens the
children with `FlattenKind` and sorts the flattened result itself, so the
pre-sort's ordering — and the intermediate node it may build — are
discarded.

This adds `AND`/`OR` to the exclusion list alongside
`IMPLIES`/`ITE`/`PARAMBOOL`/atoms, so those kinds skip the redundant sort
and go straight to `SimplifyAndOrFormula`.

**Behaviour-preserving** — the flattened children are re-canonicalised
identically, so the output is unchanged. Verified:

- **byte-identical CNF** (`SRAI-SAFE-8-1024` 194,583 lines; `square`
  57,279 lines);
- 120/120 on a QF_BV sample against declared `:status`.

**Effect:** on the nested-boolean `oisc-gurtner` benchmarks this removes a
full `SortByArith` (and often a node rebuild) per AND/OR simplification.
`SRAI-SAFE-8-1024 --exit-after-CNF` drops from 6.56s to 6.20s user CPU
(min of 3, ~5.5%).