### PR TITLE
Fix unsound multiplication constant-bit propagation for squares (bvmul t t)

### DIFF
--- a/lib/Simplifier/constantBitP/ConstantBitP_Multiplication.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_Multiplication.cpp
@@ -837,6 +837,14 @@ Result bvMultiplyBothWays(vector<FixedBits*>& children, FixedBits& output,
 
   const unsigned bitWidth = x.getWidth();
 
+  // For a square (bvmul t t) both operands are the *same* FixedBits object, so
+  // fixing a bit through one view silently changes the other. The packed pm
+  // masks below cache each operand separately and update only the side they
+  // were told about, so they desync under aliasing. The always-live
+  // ColumnStats path (pm == NULL) re-reads x and y each call and is immune, so
+  // fall back to it here.
+  const bool aliased = (children[0] == children[1]);
+
   if (debug_multiply)
     cerr << "======================" << endl;
 
@@ -941,7 +949,7 @@ Result bvMultiplyBothWays(vector<FixedBits*>& children, FixedBits& output,
     {
       if (cc.columnL[column] == cc.columnH[column])
       {
-        if (!masksValid)
+        if (!aliased && !masksValid)
         {
           pm.build(x, y);
           masksValid = true;
@@ -949,7 +957,7 @@ Result bvMultiplyBothWays(vector<FixedBits*>& children, FixedBits& output,
 
         //(2) Knowledge of the sum may fix the operands.
         Result tempResult = fixIfCanForMultiplication(
-            children, column, cc.columnH[column], &pm);
+            children, column, cc.columnH[column], aliased ? NULL : &pm);
 
         if (CONFLICT == tempResult)
           return CONFLICT;


### PR DESCRIPTION
## Problem

Differential fuzzing (`fuzzsmt 0.32`) found QF_ABV inputs where STP either aborted on

```
ConstantBitP_Multiplication.cpp:219: Assertion `result == CHANGED' failed.
```

or returned a wrong SAT/UNSAT answer. All reproducers are squares — `(bvmul t t)` — including n-ary multiplies with a repeated operand that reduce to `t * t`.

## Root cause

The packed-mask (`PairMasks`) column machinery added in #580 caches each multiplication operand's fixed-to-one and unfixed bits **separately** and updates them **incrementally** as bits are fixed. For a square the dispatcher passes the *same* `FixedBits` object as both operands (`children[0] == children[1]`). Fixing a bit through one operand's view also changes the other via the shared storage, but only the masks for the side that was told about get updated — the other side's masks go stale, so the column pair-counts are wrong on the next read.

- **Assertions build:** the "set every unfixed bit in the column to one" branch is entered off a stale total, then finds nothing to fix, tripping `assert(result == CHANGED)`.
- **Release build:** the stale counts can fix an operand bit to the *wrong value* — an unsound propagation, which is the wrong answer fuzzing flagged.

The classification math itself is exact; the pre-#580 `ColumnStats` path was immune because it re-reads `x`/`y` live on every call.

## Fix

Detect the aliased case once and fall back to the always-live `ColumnStats` path (`pm == NULL`) for that multiply. Squares are a small fraction of multiplies and the fallback is the original per-column scan, so there is no cost on the common (non-aliased) path.

## Verification

- All reproducers (2-, 11-, 16-bit squares) now solve without asserting; answers agree with `--disable-simplifications`.
- Full 2500-file fuzz corpus swept with an assertions build: **0 crashes**.
- `ConstantBitP_TransferFunctions` (25), `ConstantBitP_Wide` (16), and `ConstantBitPropagation` (1) unit tests pass.