### PR TITLE
Consolidate local rewrite rules into the SimplifyingNodeFactory

### DIFF
--- a/lib/NodeFactory/SimplifyingNodeFactory.cpp
+++ b/lib/NodeFactory/SimplifyingNodeFactory.cpp
@@ -1764,6 +1764,25 @@ ASTNode SimplifyingNodeFactory::CreateTerm(Kind kind, unsigned int width,
                                            children[0]);
           result = NodeFactory::CreateTerm(BVUMINUS, width, result);
         }
+        // (t * (u << s)) == ((t * u) << s), for either operand order. A
+        // constant shift amount is already lowered to a concat, so this only
+        // fires for variable shift amounts.
+        else if (children[1].GetKind() == stp::BVLEFTSHIFT)
+        {
+          result = NodeFactory::CreateTerm(
+              stp::BVLEFTSHIFT, width,
+              NodeFactory::CreateTerm(stp::BVMULT, width, children[0],
+                                      children[1][0]),
+              children[1][1]);
+        }
+        else if (children[0].GetKind() == stp::BVLEFTSHIFT)
+        {
+          result = NodeFactory::CreateTerm(
+              stp::BVLEFTSHIFT, width,
+              NodeFactory::CreateTerm(stp::BVMULT, width, children[1],
+                                      children[0][0]),
+              children[0][1]);
+        }
         else
         {
           // (2^p * (k ++ y)) is a left shift by p; when p is the width of k,
@@ -2030,6 +2049,19 @@ ASTNode SimplifyingNodeFactory::CreateTerm(Kind kind, unsigned int width,
       else if (children[0].GetKind() == BVMULT && children[0].Degree() == 2 &&
                children[0][0] == bm.CreateMaxConst(width))
         result = children[0][1];
+      else if (children[0].GetKind() == stp::BVAND && children[0].Degree() == 2)
+      {
+        // -(x & -x) == x | -x. (The dual -(x | -x) == x & -x never fires:
+        // BVOR is lowered to ~(~x & ~y) at creation, so no BVOR node survives
+        // as a BVUMINUS child.)
+        const ASTNode& inner = children[0];
+        if (inner[1].GetKind() == BVUMINUS && inner[1][0] == inner[0])
+          result =
+              NodeFactory::CreateTerm(stp::BVOR, width, inner[0], inner[1]);
+        else if (inner[0].GetKind() == BVUMINUS && inner[0][0] == inner[1])
+          result =
+              NodeFactory::CreateTerm(stp::BVOR, width, inner[1], inner[0]);
+      }
       break;
 
     case BVEXTRACT:

--- a/lib/Simplifier/Simplifier.cpp
+++ b/lib/Simplifier/Simplifier.cpp
@@ -1310,6 +1310,12 @@ ASTNode Simplifier::SimplifyIteFormula(const ASTNode& b, bool pushNeg,
     t2 = SimplifyFormula(a[2], false, VarConstMap);
   }
 
+  // Every structural fold below - constant condition, equal branches, a
+  // constant branch collapsing to AND/OR - is done by the simplifying node
+  // factory when the ITE node is (re)created, so we just hand it the
+  // simplified children. The one exception is ITE(c, false, true): the factory
+  // would only give a shallow NOT(c), whereas pushing the negation into c
+  // exposes more simplifications.
   if (ASTTrue == t0)
   {
     output = t1;
@@ -1318,33 +1324,9 @@ ASTNode Simplifier::SimplifyIteFormula(const ASTNode& b, bool pushNeg,
   {
     output = t2;
   }
-  else if (t1 == t2)
-  {
-    output = t1;
-  }
-  else if (ASTTrue == t1 && ASTFalse == t2)
-  {
-    output = t0;
-  }
   else if (ASTFalse == t1 && ASTTrue == t2)
   {
     output = SimplifyFormula(t0, true, VarConstMap);
-  }
-  else if (ASTTrue == t1)
-  {
-    output = nf->CreateNode(OR, t0, t2);
-  }
-  else if (ASTFalse == t1)
-  {
-    output = nf->CreateNode(AND, nf->CreateNode(NOT, t0), t2);
-  }
-  else if (ASTTrue == t2)
-  {
-    output = nf->CreateNode(OR, nf->CreateNode(NOT, t0), t1);
-  }
-  else if (ASTFalse == t2)
-  {
-    output = nf->CreateNode(AND, t0, t1);
   }
   else
   {
@@ -1668,20 +1650,8 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
       break;
 
     case BVMULT:
-    if (inputterm.Degree() == 2 && inputterm[1].GetKind() == BVLEFTSHIFT)
-    {
-      ASTNode replacement = nf->CreateTerm(BVMULT, inputValueWidth, {inputterm[0], inputterm[1][0]});
-      replacement = nf->CreateTerm(BVLEFTSHIFT, inputValueWidth, {replacement, inputterm[1][1]});
-      return SimplifyTerm(replacement, VarConstMap);
-    }
-
-    if (inputterm.Degree() == 2 && inputterm[0].GetKind() == BVLEFTSHIFT)
-    {
-      ASTNode replacement = nf->CreateTerm(BVMULT, inputValueWidth, {inputterm[1], inputterm[0][0]});
-      replacement = nf->CreateTerm(BVLEFTSHIFT, inputValueWidth, {replacement, inputterm[0][1]});
-      return SimplifyTerm(replacement, VarConstMap);
-    }
-
+    // nb. (t * (u << s)) == ((t * u) << s) is done by the simplifying node
+    // factory.
 
     // fall-through
     case BVPLUS:
@@ -1843,24 +1813,10 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
     }
 
     case BVSUB:
-    {
-      assert(inputterm.Degree() == 2);
-
-      const ASTNode& a0 = inputterm[0];
-      const ASTNode& a1 = inputterm[1];
-
-      if (a0 == a1)
-        output = nf->CreateZeroConst(inputValueWidth);
-      else
-      {
-        // covert x-y into x+(-y) and simplify. this transformation
-        // triggers more simplifications
-        //
-        output = nf->CreateTerm(BVPLUS, inputValueWidth, a0,
-                                nf->CreateTerm(BVUMINUS, inputValueWidth, a1));
-      }
+      // nb. (x - x) == 0, (x - 0) == x, and (x - y) == x + (-y) are done by
+      // the simplifying node factory.
+      output = inputterm;
       break;
-    }
 
     case BVUMINUS:
     {
@@ -1940,20 +1896,9 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
           output = nf->CreateTerm(BVSUB, inputValueWidth, a0[1], a0[0]);
           break;
         }
-        case BVAND:
-          if (a0.Degree() == 2 && (a0[1].GetKind() == BVUMINUS) &&
-              a0[1][0] == a0[0])
-          {
-            output = nf->CreateTerm(BVOR, inputValueWidth, a0[0], a0[1]);
-          }
-          break;
-        case BVOR:
-          if (a0.Degree() == 2 && (a0[1].GetKind() == BVUMINUS) &&
-              a0[1][0] == a0[0])
-          {
-            output = nf->CreateTerm(BVAND, inputValueWidth, a0[0], a0[1]);
-          }
-          break;
+        // nb. -(x & -x) == x | -x is done by the simplifying node factory.
+        // (The -(x | -x) case here was dead: BVOR is lowered to ~(~x & ~y) at
+        // creation, so no BVOR node ever reaches this switch.)
         case BVLEFTSHIFT:
           if (a0[0].GetKind() == BVCONST)
             output = nf->CreateTerm(
@@ -2011,18 +1956,8 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
 
       switch (k1)
       {
-        case BVEXTRACT:
-        {
-          const unsigned innerLow = a0[2].GetUnsignedConst();
-          // const unsigned innerHigh = a0[1].GetUnsignedConst();
-
-          output = nf->CreateTerm(BVEXTRACT, inputValueWidth, a0[0],
-                                  nf->CreateBVConst(32, i_val + innerLow),
-                                  nf->CreateBVConst(32, j_val + innerLow));
-          assert(BVTypeCheck(output));
-          break;
-        }
-
+        // nb. an extract over an extract is merged by the simplifying node
+        // factory.
         case BVCONCAT:
         {
           // assumes concatenation is binary
@@ -2123,15 +2058,7 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
               break;
             }
 #endif
-        case BVNOT:
-        {
-          // (~t)[i:j] <==> ~(t[i:j])
-          ASTNode t = a0[0];
-          t = SimplifyTerm(nf->CreateTerm(BVEXTRACT, inputValueWidth, t, i, j),
-                           VarConstMap);
-          output = nf->CreateTerm(BVNOT, inputValueWidth, t);
-          break;
-        }
+        // nb. (~t)[i:j] == ~(t[i:j]) is done by the simplifying node factory.
         // case BVSX:{ //(BVSX(t,n)[i:j] <==> BVSX(t,i+1), if n
         //        >= i+1 and j=0 ASTNode t = a0[0]; unsigned int
         //        bvsx_len = a0.GetValueWidth(); if(bvsx_len <
@@ -2537,33 +2464,15 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
 
     case BVLEFTSHIFT:
     case BVRIGHTSHIFT:
-    { // If the shift amount is known. Then replace it by an extract.
-      const ASTNode a = inputterm[0];
-      const ASTNode b = inputterm[1];
-
-      const unsigned int width = a.GetValueWidth();
-      if (BVCONST == b.GetKind()) // known shift amount.
-      {
-        output = SimplifyingNodeFactory::convertKnownShiftAmount(k, toASTVec(inputterm.GetChildren()), *_bm, nf);
-      }
-      else if (a == nf->CreateZeroConst(width))
-      {
-        output = nf->CreateZeroConst(width);
-      }
-      else
-      {
-        output = inputterm;
-      }
+      // nb. A known shift amount is lowered to an extract, and a zero shiftee
+      // is folded to zero, by the simplifying node factory.
+      output = inputterm;
       break;
-    }
 
     case BVXOR:
     {
-      if (inputterm.Degree() == 2 && inputterm[0] == inputterm[1])
-      {
-        output = nf->CreateZeroConst(inputterm.GetValueWidth());
-        break;
-      }
+      // nb. (x ^ x) == 0 and (0 ^ x) == x are done by the simplifying node
+      // factory.
       if (inputterm.Degree() == 2 && inputterm[0].GetKind() == BVCONCAT &&
           inputterm[1].GetKind() == BVCONCAT &&
           inputterm[0][0].GetValueWidth() == inputterm[1][0].GetValueWidth())
@@ -2574,12 +2483,6 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
                                           inputterm[0][0], inputterm[1][0]),
                            nf->CreateTerm(k, inputterm[0][1].GetValueWidth(),
                                           inputterm[0][1], inputterm[1][1]));
-        break;
-      }
-      if (inputterm.Degree() == 2 &&
-          inputterm[0] == nf->CreateZeroConst(inputterm.GetValueWidth()))
-      {
-        output = inputterm[1];
         break;
       }
     }

--- a/tests/unit-tests/SimplifyingNodeFactory_Test.cpp
+++ b/tests/unit-tests/SimplifyingNodeFactory_Test.cpp
@@ -489,11 +489,243 @@ TEST(SimplifyingNodeFactory_Test, bvplus5)
 TEST(SimplifyingNodeFactory_Test, bvplus6)
 {
   const std::string input = R"(
-      (assert (= 
-                (bvadd (bvnot (bvnot (bvnot v1) ))  v1   )   
+      (assert (=
+                (bvadd (bvnot (bvnot (bvnot v1) ))  v1   )
                  (bvnot (_ bv0 20)  )
                )
       )
+    )";
+
+   Context c;
+   ASTNode n = c.process(input);
+   ASSERT_EQ(n, c.mgr.ASTTrue);
+}
+
+// The following confirm rewrites that used to live in Simplifier.cpp are done
+// by the simplifying node factory (these queries are not run through the
+// Simplifier pass, only the factory).
+
+TEST(SimplifyingNodeFactory_Test, bvsub_self)
+{
+  // (x - x) == 0
+  const std::string input = R"(
+    (assert (= (bvsub v0 v0) (_ bv0 20) )  )
+    )";
+
+   Context c;
+   ASTNode n = c.process(input);
+   ASSERT_EQ(n, c.mgr.ASTTrue);
+}
+
+TEST(SimplifyingNodeFactory_Test, bvsub_zero)
+{
+  // (x - 0) == x
+  const std::string input = R"(
+    (assert (= (bvsub v0 (_ bv0 20)) v0 )  )
+    )";
+
+   Context c;
+   ASTNode n = c.process(input);
+   ASSERT_EQ(n, c.mgr.ASTTrue);
+}
+
+TEST(SimplifyingNodeFactory_Test, bvsub_to_plus)
+{
+  // (x - y) == x + (-y)
+  const std::string input = R"(
+    (assert (= (bvsub v0 v1) (bvadd v0 (bvneg v1)) )  )
+    )";
+
+   Context c;
+   ASTNode n = c.process(input);
+   ASSERT_EQ(n, c.mgr.ASTTrue);
+}
+
+TEST(SimplifyingNodeFactory_Test, shift_by_zero)
+{
+  // (x << 0) == x
+  const std::string input = R"(
+    (assert (= (bvshl v0 (_ bv0 20)) v0 )  )
+    )";
+
+   Context c;
+   ASTNode n = c.process(input);
+   ASSERT_EQ(n, c.mgr.ASTTrue);
+}
+
+TEST(SimplifyingNodeFactory_Test, shift_left_past_width)
+{
+  // (x << width) == 0
+  const std::string input = R"(
+    (assert (= (bvshl v0 (_ bv20 20)) (_ bv0 20) )  )
+    )";
+
+   Context c;
+   ASTNode n = c.process(input);
+   ASSERT_EQ(n, c.mgr.ASTTrue);
+}
+
+TEST(SimplifyingNodeFactory_Test, shift_right_past_width)
+{
+  // (x >> width) == 0
+  const std::string input = R"(
+    (assert (= (bvlshr v0 (_ bv20 20)) (_ bv0 20) )  )
+    )";
+
+   Context c;
+   ASTNode n = c.process(input);
+   ASSERT_EQ(n, c.mgr.ASTTrue);
+}
+
+TEST(SimplifyingNodeFactory_Test, shift_left_const_to_concat)
+{
+  // (x << 4) == (x[15:0] ++ 0000)
+  const std::string input = R"(
+    (assert (= (bvshl v0 (_ bv4 20)) (concat ((_ extract 15 0) v0) (_ bv0 4)) )  )
+    )";
+
+   Context c;
+   ASTNode n = c.process(input);
+   ASSERT_EQ(n, c.mgr.ASTTrue);
+}
+
+TEST(SimplifyingNodeFactory_Test, extract_over_extract)
+{
+  // ((x[10:1])[5:2]) == x[6:3]
+  const std::string input = R"(
+    (assert (= ((_ extract 5 2) ((_ extract 10 1) v0)) ((_ extract 6 3) v0) )  )
+    )";
+
+   Context c;
+   ASTNode n = c.process(input);
+   ASSERT_EQ(n, c.mgr.ASTTrue);
+}
+
+TEST(SimplifyingNodeFactory_Test, extract_over_bvnot)
+{
+  // (~x)[5:2] == ~(x[5:2])
+  const std::string input = R"(
+    (assert (= ((_ extract 5 2) (bvnot v0)) (bvnot ((_ extract 5 2) v0)) )  )
+    )";
+
+   Context c;
+   ASTNode n = c.process(input);
+   ASSERT_EQ(n, c.mgr.ASTTrue);
+}
+
+TEST(SimplifyingNodeFactory_Test, bvxor_self)
+{
+  // (x ^ x) == 0
+  const std::string input = R"(
+    (assert (= (bvxor v0 v0) (_ bv0 20) )  )
+    )";
+
+   Context c;
+   ASTNode n = c.process(input);
+   ASSERT_EQ(n, c.mgr.ASTTrue);
+}
+
+TEST(SimplifyingNodeFactory_Test, bvxor_zero)
+{
+  // (0 ^ x) == x
+  const std::string input = R"(
+    (assert (= (bvxor (_ bv0 20) v0) v0 )  )
+    )";
+
+   Context c;
+   ASTNode n = c.process(input);
+   ASSERT_EQ(n, c.mgr.ASTTrue);
+}
+
+TEST(SimplifyingNodeFactory_Test, bvneg_and_self)
+{
+  // -(x & -x) == x | -x
+  const std::string input = R"(
+    (assert (= (bvneg (bvand v0 (bvneg v0))) (bvor v0 (bvneg v0)) )  )
+    )";
+
+   Context c;
+   ASTNode n = c.process(input);
+   ASSERT_EQ(n, c.mgr.ASTTrue);
+}
+
+TEST(SimplifyingNodeFactory_Test, mult_over_leftshift)
+{
+  // (x * (y << s)) == ((x * y) << s), for a variable shift amount.
+  const std::string input = R"(
+    (assert (= (bvmul v0 (bvshl v1 v2)) (bvshl (bvmul v0 v1) v2) )  )
+    )";
+
+   Context c;
+   ASTNode n = c.process(input);
+   ASSERT_EQ(n, c.mgr.ASTTrue);
+}
+
+TEST(SimplifyingNodeFactory_Test, ite_equal_branches)
+{
+  // ITE(c, x, x) == x
+  const std::string input = R"(
+    (assert (= (ite a b b) b )  )
+    )";
+
+   Context c;
+   ASTNode n = c.process(input);
+   ASSERT_EQ(n, c.mgr.ASTTrue);
+}
+
+TEST(SimplifyingNodeFactory_Test, ite_then_true)
+{
+  // ITE(c, true, x) == (c or x)
+  const std::string input = R"(
+    (assert (= (ite a true b) (or a b) )  )
+    )";
+
+   Context c;
+   ASTNode n = c.process(input);
+   ASSERT_EQ(n, c.mgr.ASTTrue);
+}
+
+TEST(SimplifyingNodeFactory_Test, ite_then_false)
+{
+  // ITE(c, false, x) == ((not c) and x)
+  const std::string input = R"(
+    (assert (= (ite a false b) (and (not a) b) )  )
+    )";
+
+   Context c;
+   ASTNode n = c.process(input);
+   ASSERT_EQ(n, c.mgr.ASTTrue);
+}
+
+TEST(SimplifyingNodeFactory_Test, ite_else_true)
+{
+  // ITE(c, x, true) == ((not c) or x)
+  const std::string input = R"(
+    (assert (= (ite a b true) (or (not a) b) )  )
+    )";
+
+   Context c;
+   ASTNode n = c.process(input);
+   ASSERT_EQ(n, c.mgr.ASTTrue);
+}
+
+TEST(SimplifyingNodeFactory_Test, ite_else_false)
+{
+  // ITE(c, x, false) == (c and x)
+  const std::string input = R"(
+    (assert (= (ite a b false) (and a b) )  )
+    )";
+
+   Context c;
+   ASTNode n = c.process(input);
+   ASSERT_EQ(n, c.mgr.ASTTrue);
+}
+
+TEST(SimplifyingNodeFactory_Test, ite_true_false)
+{
+  // ITE(c, true, false) == c
+  const std::string input = R"(
+    (assert (= (ite a true false) a )  )
     )";
 
    Context c;


### PR DESCRIPTION
## Summary

Several rewrites in `Simplifier.cpp` are either already performed by the `SimplifyingNodeFactory` (the default `nf` in production and all tests), or are purely local/structural and belong in the factory so they fire on every node creation rather than only during the simplify pass. This PR moves the latter into the factory and trims the former.

## Moved into `SimplifyingNodeFactory`
- `(t * (u << s)) == ((t * u) << s)` (added to the `BVMULT` case). Only fires for variable shift amounts — constant shifts are already lowered to concats.
- `-(x & -x) == x | -x` (added to the `BVUMINUS` case).
  - Note: the dual `-(x | -x) == x & -x` turned out to be **dead code**. `BVOR` is lowered to `~(~x & ~y)` at creation, so no `BVOR` node ever reaches the `BVUMINUS` switch — this was already unreachable in the Simplifier. Only the reachable `BVAND` direction was ported.

## Trimmed from the Simplifier (subsumed by the factory)
The file already uses the `output = inputterm; // factory/strength-reduction handles it` idiom (e.g. `BVDIV`/`BVMOD`), so these follow the existing convention:
- `BVSUB` (`x-x`, `x-0`, `x-y -> x+(-y)`)
- `BVLEFTSHIFT`/`BVRIGHTSHIFT` known-amount lowering and zero shiftee
- `BVEXTRACT` over `BVEXTRACT`, and over `BVNOT`
- `BVXOR` `x^x -> 0` and `0^x -> x` (the concat push-through, which the factory does not do, is kept)
- `SimplifyIteFormula`: every structural fold is done by `CreateSimpleFormITE` (which even has two cases the Simplifier lacked). The switch collapses to a constant-condition check plus the one branch that does real pass-level work — `ITE(c, false, true)`, which deep-pushes the negation via `SimplifyFormula(t0, true)` rather than the factory's shallow `NOT c`.

## Tests
Added 18 unit tests to `SimplifyingNodeFactory_Test.cpp`, one per moved/deleted rule (plus the ITE folds). They exercise each rewrite through the factory alone — no Simplifier pass — so they confirm the factory does the work that was removed.

## Verification
- New factory tests: 54/54 pass
- Exhaustive soundness tests (SimplifyingNodeFactory / Rewriting / StrengthReduction): pass
- Full `ctest`: 60/60 pass (including the end-to-end query-files lit suite)
- 300 fuzz-corpus files under the assertions-on debug build: 0 assertions/crashes