### PR TITLE
Flatten AND/OR on output; drop the pushNeg re-simplification pass

### DIFF
--- a/lib/Simplifier/Simplifier.cpp
+++ b/lib/Simplifier/Simplifier.cpp
@@ -295,39 +295,17 @@ ASTNode Simplifier::SimplifyFormula(const ASTNode& b, bool pushNeg,
 
   if (b.isConstant())
   {
-    if (!pushNeg)
-      return b;
-    else
-    {
-      if (ASTTrue == b)
-        return ASTFalse;
-      else
-        return ASTTrue;
-    }
+    return pushNeg ? nf->CreateNode(NOT, b) : b;
   }
 
   ASTNode output;
   if (CheckSimplifyMap(b, output, pushNeg, VarConstMap))
     return output;
 
-  Kind kind = b.GetKind();
+  // pullUpITE can change the Kind of the node.
+  ASTNode a = PullUpITE(b);
 
-  ASTNode a = b;
-  ASTVec ca = toASTVec(a.GetChildren());
-  // AND/OR are excluded: SimplifyAndOrFormula flattens and re-sorts their
-  // children itself, so sorting (and rebuilding the node) here is wasted work.
-  if (!(IMPLIES == kind || ITE == kind || PARAMBOOL == kind || AND == kind ||
-        OR == kind || isAtomic(kind)))
-  {
-    SortByArith(ca);
-    if (ASTChildren(ca) != a.GetChildren())
-      a = nf->CreateNode(kind, ca);
-  }
-
-  a = PullUpITE(a);
-  kind = a.GetKind(); // pullUpITE can change the Kind of the node.
-
-  switch (kind)
+  switch (a.GetKind())
   {
     case AND:
     case OR:
@@ -363,20 +341,12 @@ ASTNode Simplifier::SimplifyFormula(const ASTNode& b, bool pushNeg,
   UpdateSimplifyMap(b, output, pushNeg, VarConstMap);
   UpdateSimplifyMap(a, output, pushNeg, VarConstMap);
 
-  ASTNode input_with_not = pushNeg ? nf->CreateNode(NOT, a) : a;
-  if (input_with_not != output)
-  {
-    return SimplifyFormula(output, false, VarConstMap);
-  }
   return output;
 }
 
 ASTNode Simplifier::SimplifyAtomicFormula(const ASTNode& a, bool pushNeg,
                                           ASTNodeMap* VarConstMap)
 {
-  //     if (!optimize_flag)
-  //       return a;
-
   ASTNode output;
   if (CheckSimplifyMap(a, output, pushNeg, VarConstMap))
   {
@@ -950,15 +920,15 @@ ASTNode Simplifier::SimplifyAndOrFormula(const ASTNode& a, bool pushNeg,
   // and a child that simplifies to the annihilator collapses the whole node.
   const ASTNode annihilator =
       isAnd ? (pushNeg ? ASTTrue : ASTFalse) : (pushNeg ? ASTFalse : ASTTrue);
+  const Kind outKind = (isAnd == !pushNeg) ? AND : OR;
 
-  // Flatten nested same-kind operands (the factory does not do this) and
-  // recursively simplify each child. Short-circuit as soon as a child is the
-  // annihilator, without simplifying the rest.
-  ASTVec c = FlattenKind(k, a.GetChildren());
-
+  // Recursively simplify each child; short-circuit as soon as one is the
+  // annihilator. We do NOT pre-flatten nested same-kind operands: simplifying
+  // such a child yields an outKind node, which the splice below flattens
+  // anyway, so a separate FlattenKind pass would be redundant work.
   ASTVec outvec;
-  outvec.reserve(c.size());
-  for (const ASTNode& child : c)
+  outvec.reserve(a.Degree());
+  for (const ASTNode& child : a.GetChildren())
   {
     const ASTNode aaa = SimplifyFormula(child, pushNeg, VarConstMap);
     if (aaa == annihilator)
@@ -966,13 +936,19 @@ ASTNode Simplifier::SimplifyAndOrFormula(const ASTNode& a, bool pushNeg,
       UpdateSimplifyMap(a, annihilator, pushNeg, VarConstMap);
       return annihilator;
     }
-    outvec.push_back(aaa);
+    // A child that simplified to the output connective (typically via De
+    // Morgan) would otherwise leave a nested same-kind node, which the factory
+    // does not flatten. Splice its already-simplified operands in so the
+    // result stays flat -- without this SimplifyFormula is not idempotent.
+    if (aaa.GetKind() == outKind)
+      outvec.insert(outvec.end(), aaa.begin(), aaa.end());
+    else
+      outvec.push_back(aaa);
   }
 
   // Hand the simplified children to the node factory. CreateSimpleAndOr
   // sorts them, drops identities, removes duplicates, detects complements
   // and unwraps singletons -- so none of that is repeated here.
-  const Kind outKind = (isAnd == !pushNeg) ? AND : OR;
   output = nf->CreateNode(outKind, outvec);
 
   UpdateSimplifyMap(a, output, pushNeg, VarConstMap);

--- a/tests/unit-tests/SimplifyFormula_Test.cpp
+++ b/tests/unit-tests/SimplifyFormula_Test.cpp
@@ -471,4 +471,90 @@ TEST(SimplifyAndOr, fuzz_sound_and_idempotent)
   }
 }
 
+
+// A deeply nested all-AND DAG with billions of root->leaf paths but only a
+// handful of distinct nodes. Each level has one AND per node of the previous
+// level, omitting that node, so every node is heavily shared. Built with the
+// hashing factory (no flattening), this is a compact DAG whose tree expansion
+// is enormous -- it checks that SimplifyAndOrFormula flattens DAG-aware (once
+// per distinct node) rather than tree-expanding (which would never finish).
+// Logically the whole thing is just the conjunction of all the variables.
+TEST(SimplifyAndOr, deep_omit_one_and_dag)
+{
+  Context c;
+  const int numVars = 20;
+  const int numLevels = 7; // ~ 20 * 19^7 ~= 1.8e10 root->leaf paths
+
+  std::vector<ASTNode> vars;
+  for (int i = 0; i < numVars; i++)
+    vars.push_back(c.boolean());
+
+  std::vector<ASTNode> level = vars;
+  for (int L = 0; L < numLevels; L++)
+  {
+    std::vector<ASTNode> next;
+    for (size_t omit = 0; omit < level.size(); omit++)
+    {
+      ASTVec children;
+      for (size_t j = 0; j < level.size(); j++)
+        if (j != omit)
+          children.push_back(level[j]);
+      next.push_back(c.hf->CreateNode(AND, children));
+    }
+    level = next;
+  }
+  ASTNode top = c.hf->CreateNode(AND, ASTVec(level.begin(), level.end()));
+
+  ASTNode out = c.run(top);
+  // Flattening + dedup collapses the whole structure to AND(all variables).
+  ASSERT_EQ(out.GetKind(), AND);
+  EXPECT_EQ(out.Degree(), static_cast<size_t>(numVars));
+}
+
+
+// As above, but every conjunction is expressed as NOT(OR(negated children)),
+// so simplification must apply De Morgan (and eliminate double negations) at
+// every one of the shared nodes to recover it. A billions-of-paths DAG that
+// hammers the pushNeg path -- it must stay DAG-aware there too. Logically it
+// is still just AND(all variables).
+TEST(SimplifyAndOr, deep_omit_one_demorgan)
+{
+  Context c;
+  const int numVars = 20;
+  const int numLevels = 7; // ~ 20 * 19^7 ~= 1.8e10 root->leaf paths
+
+  // AND(children) written as NOT(OR(!children)).
+  auto andAsNotOr = [&](const ASTVec& children) {
+    ASTVec negs;
+    negs.reserve(children.size());
+    for (const auto& ch : children)
+      negs.push_back(c.hf->CreateNode(NOT, ch));
+    return c.hf->CreateNode(NOT, c.hf->CreateNode(OR, negs));
+  };
+
+  std::vector<ASTNode> vars;
+  for (int i = 0; i < numVars; i++)
+    vars.push_back(c.boolean());
+
+  std::vector<ASTNode> level = vars;
+  for (int L = 0; L < numLevels; L++)
+  {
+    std::vector<ASTNode> next;
+    for (size_t omit = 0; omit < level.size(); omit++)
+    {
+      ASTVec children;
+      for (size_t j = 0; j < level.size(); j++)
+        if (j != omit)
+          children.push_back(level[j]);
+      next.push_back(andAsNotOr(children));
+    }
+    level = next;
+  }
+  ASTNode top = andAsNotOr(ASTVec(level.begin(), level.end()));
+
+  ASTNode out = c.run(top);
+  ASSERT_EQ(out.GetKind(), AND);
+  EXPECT_EQ(out.Degree(), static_cast<size_t>(numVars));
+}
+
 } // namespace


### PR DESCRIPTION
Follow-up to #592 (now merged).

## What

`SimplifyFormula` reached a fixpoint by re-simplifying its **whole output** on every negated node — the `input_with_not != output` re-pass. Its real job was to flatten the nested same-kind nodes that De Morgan pushdown creates under `pushNeg`, but it did so by re-running the entire simplifier, firing on essentially every negated node.

This replaces it with **local flatten-on-output** in `SimplifyAndOrFormula`: when a simplified child comes back as the output connective, its operands are spliced into the result instead of nesting. The fixpoint is reached in place, so the re-pass is dropped.

With flatten-on-output present, the up-front `FlattenKind` pass is **redundant**: simplifying a nested same-kind input child yields an `outKind` node the splice flattens anyway, and the factory (`CreateSimpleAndOr`) handles dedup / identity / complement / annihilator. So the children are iterated directly and the separate `FlattenKind` traversal — plus its per-call `ASTVec` + `ASTNodeSet` allocation — is removed. The `SimplifyMap` memo (not `FlattenKind`'s visited-set) keeps this DAG-aware.

Also folds the pre-dispatch `SortByArith` (dead for the remaining switch kinds) into the constant / `PullUpITE` handling.

## Verification

- **Byte-identical CNF** on `SRAI-SAFE-8-1024`, `square`, and `AND-NESTED-8-32` (`--output-CNF --exit-after-CNF`).
- **120/120** sound on the differential status corpus.
- **23/23** unit tests.

## New tests

Two stress tests build a compact all-shared DAG (20 vars, 7 levels of omit-one ANDs: ~161 distinct nodes but ~1.8e10 root->leaf paths):

- `deep_omit_one_and_dag` — plain AND.
- `deep_omit_one_demorgan` — every AND written as `NOT(OR(!children))`, hammering the `pushNeg`/De-Morgan path.

Both collapse in a few ms, confirming the pass stays **DAG-aware** (linear in distinct nodes, not path count) and guarding against any future regression back to tree-exponential behaviour.