### PR TITLE
Build and test with CaDiCaL in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,57 @@ jobs:
       run: ctest --parallel "$(nproc)" -VV --output-on-failure
       working-directory: build
 
+  build-cadical:
+    name: gcc (cadical)
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - uses: actions/checkout@v7
+      with:
+          submodules: 'true'
+
+    - name: Packages
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          bison \
+          build-essential \
+          cmake \
+          flex \
+          gcc \
+          git \
+          libboost-program-options-dev \
+          ninja-build \
+          python3 \
+          python3-pip \
+          python3-setuptools \
+          zlib1g-dev
+        sudo pip3 install -U lit
+
+    # CryptoMiniSat is left out: USE_CADICAL makes CaDiCaL the default
+    # solver, so building CMS as well would only add build time.
+    - name: Dependencies
+      run: |
+        ./scripts/deps/setup-minisat.sh
+        ./scripts/deps/setup-cadical.sh
+        ./scripts/deps/setup-gtest.sh
+        ./scripts/deps/setup-outputcheck.sh
+
+    - name: Configure
+      run: |
+        mkdir build
+        cd build
+        cmake -DUSE_CADICAL:BOOL=ON -DCADICAL_DIR:PATH="$GITHUB_WORKSPACE/deps/cadical" -DNOCRYPTOMINISAT:BOOL=ON -DENABLE_TESTING:BOOL=ON -DPYTHON_EXECUTABLE:PATH="$(which python3)" -G Ninja ..
+
+    - name: Build
+      run: cmake --build . --parallel "$(nproc)"
+      working-directory: build
+
+    - name: Test
+      run: ctest --parallel "$(nproc)" -VV --output-on-failure
+      working-directory: build
+
   build-32bit:
     name: gcc (i386)
     runs-on: ubuntu-latest

--- a/README.markdown
+++ b/README.markdown
@@ -133,6 +133,26 @@ $ command -v ldconfig && sudo ldconfig
 
 Alternatively, these commands are pre-configused in `scripts/deps/setup-minisat.sh` and `scripts/deps/setup-cms.sh` (respectively).
 
+CaDiCaL is also supported, but is opt-in rather than auto-detected. It is
+consumed from a build tree rather than an installation, so point
+`CADICAL_DIR` at the checkout:
+
+```
+$ git clone https://github.com/arminbiere/cadical
+$ cd cadical
+$ ./configure -fPIC
+$ make
+```
+
+then configure STP with `-DUSE_CADICAL:BOOL=ON -DCADICAL_DIR:PATH=<path>`,
+where `<path>` is the checkout containing `src/cadical.hpp` and
+`build/libcadical.a`. `-fPIC` is required because `libcadical.a` is linked
+into STP's shared library. These commands are pre-configured in
+`scripts/deps/setup-cadical.sh`.
+
+When STP is built this way CaDiCaL becomes the *default* solver; `--minisat`
+or `--cryptominisat` select the others at runtime.
+
 #### Building against non-installed libraries
 
 If you wish to build STP's dependencies without installing them, you can tell CMake where to find the non-installed artefacts. For example:

--- a/lib/Sat/CMakeLists.txt
+++ b/lib/Sat/CMakeLists.txt
@@ -29,7 +29,7 @@ if (USE_CRYPTOMINISAT)
 endif()
 
 if (USE_CADICAL)
-    include_directories(${CADICAL_INCLUDE_DIRS})
+    include_directories(${CADICAL_INCLUDE_DIR})
     set(sat_lib_to_add ${sat_lib_to_add} Cadical.cpp)
 endif()
 

--- a/scripts/deps/setup-cadical.sh
+++ b/scripts/deps/setup-cadical.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -e -u -o pipefail
+
+dep_dir="deps"
+
+[ ! -d "${dep_dir}" ] && mkdir -p "${dep_dir}"
+
+dep="cadical"
+
+cd "${dep_dir}"
+
+# CaDiCaL uses its own configure script rather than CMake, and is consumed
+# in place: STP's CADICAL_DIR points at this checkout, which holds the
+# header in src/cadical.hpp and the static library in build/libcadical.a.
+git clone https://github.com/arminbiere/cadical "${dep}"
+cd "${dep}"
+# We specify the tags/commits for the other repositories, so do for this too
+git checkout rel-2.1.3
+# -fPIC: libcadical.a is linked into libstp.so, and CaDiCaL's configure
+# does not build position-independent code by default.
+./configure -fPIC
+make -j"$(nproc)"
+cd ..
+
+# EOF


### PR DESCRIPTION
Based on `modernize-ci` (#513), so the diff here is just the last commit. GitHub will retarget this to `master` once #513 merges.

STP has had a CaDiCaL backend since #547, but nothing ever built it: `USE_CADICAL` defaults to `OFF` and no workflow or dependency script sets it, so `lib/Sat/Cadical.cpp` is never compiled in CI and can bitrot unnoticed. (The CaDiCaL that the Linux job *does* compile is an internal CryptoMiniSat dependency, which STP never talks to directly.)

- **`scripts/deps/setup-cadical.sh`** — follows the existing dependency-script convention and pins `rel-2.1.3`. CaDiCaL is consumed from its build tree rather than an installation, so the script leaves the checkout in place for `CADICAL_DIR` to point at.
  - It configures with `-fPIC`. CaDiCaL does not build position-independent code by default and `libcadical.a` is linked into `libstp.so`, so without it the link fails with ``relocation R_X86_64_PC32 against symbol `stderr' can not be used when making a shared object``.
- **`build-cadical` job** — builds with `-DUSE_CADICAL=ON` and runs the full test suite. CryptoMiniSat is left out because `USE_CADICAL` makes CaDiCaL the default solver (`UserDefinedFlags.h:212`), so building CMS as well would only add build time without adding coverage.
- **`lib/Sat/CMakeLists.txt`** — referred to `CADICAL_INCLUDE_DIRS`, which is never set; the variable is `CADICAL_INCLUDE_DIR`. Harmless only because the top-level `CMakeLists.txt` already adds the directory globally.
- **README** — documents the CaDiCaL option alongside the existing minisat/CryptoMiniSat instructions.

Verified locally: CaDiCaL 2.1.3 builds and links, and a `gdb` breakpoint confirms `stp::Cadical::solve` is what actually runs (via `ToSATAIG::runSolver`) rather than the minisat backend. All 60 gtest suites pass with CaDiCaL as the solver, matching the `modernize-ci` baseline exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)