### PR TITLE
Add --search-bias to tune the SAT search towards sat or unsat

### DIFF
--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -24,6 +24,8 @@ THE SOFTWARE.
 #ifndef UDEFFLAGS_H
 #define UDEFFLAGS_H
 
+#include "stp/Sat/SearchBias.h"
+
 namespace stp
 {
 
@@ -187,6 +189,10 @@ public:
   };
 
   enum SATSolvers solver_to_use;
+
+  // Which answer to tune the SAT search towards. NONE, the default, leaves
+  // every backend at its own settings, so the option is opt-in.
+  SearchBias search_bias = SearchBias::NONE;
 
   bool get_print_output_at_all() const
   {

--- a/include/stp/Sat/Cadical.h
+++ b/include/stp/Sat/Cadical.h
@@ -77,6 +77,8 @@ public:
 
   uint32_t newVar() override;
 
+  bool setSearchBias(SearchBias bias) override;
+
   void setVerbosity(int v) override;
 
   unsigned long nVars() const override;

--- a/include/stp/Sat/CryptoMinisat5.h
+++ b/include/stp/Sat/CryptoMinisat5.h
@@ -62,6 +62,8 @@ public:
 
   uint32_t newVar() override;
 
+  bool setSearchBias(SearchBias bias) override;
+
   void setVerbosity(int v) override;
 
   unsigned long nVars() const override;

--- a/include/stp/Sat/SATSolver.h
+++ b/include/stp/Sat/SATSolver.h
@@ -25,6 +25,7 @@ THE SOFTWARE.
 #ifndef SATSOLVER_H_
 #define SATSOLVER_H_
 
+#include "SearchBias.h"
 #include "minisat/core/SolverTypes.h"
 #include "minisat/mtl/Vec.h"
 #include <cassert>
@@ -85,6 +86,15 @@ public:
     p.x = var + var + (int)sign;
     return p;
   }
+
+  // Ask the backend to tune its search towards satisfiable or unsatisfiable
+  // instances. Only ever called before the first clause is added, because a
+  // backend may only accept configuration while it is still empty.
+  //
+  // FALSE means this backend has nothing corresponding to the requested bias.
+  // That isn't an error: the bias is a hint about the workload, and a backend
+  // that ignores it is slower rather than wrong.
+  virtual bool setSearchBias(SearchBias /*bias*/) { return false; }
 
   // ---------------------------------------------------------------------
   // Resource budgets.

--- a/include/stp/Sat/SearchBias.h
+++ b/include/stp/Sat/SearchBias.h
@@ -1,0 +1,64 @@
+/********************************************************************
+ * AUTHORS: Trevor Hansen
+ *
+ * BEGIN DATE: July, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#ifndef SEARCHBIAS_H_
+#define SEARCHBIAS_H_
+
+namespace stp
+{
+
+// Which answer to tune the SAT search towards.
+//
+// Modern CDCL solvers alternate between a mode that is good at finding models
+// and one that is good at closing off the search space, and several of them
+// let a caller pin one of the two. On a workload that is known to lean one way
+// -- verification conditions are usually unsatisfiable -- the time spent in the
+// other mode is wasted.
+//
+// This selects heuristics only. A correct SAT solver returns the same verdict
+// whatever bias it is given, so getting the bias wrong costs time, not
+// soundness. Each backend maps this onto whatever it happens to offer, and
+// backends with nothing to offer ignore it.
+enum class SearchBias
+{
+  NONE = 0, // leave the solver at its own defaults
+  SAT,      // tune for finding a model
+  UNSAT     // tune for proving that there isn't one
+};
+
+inline const char* searchBiasName(SearchBias bias)
+{
+  switch (bias)
+  {
+    case SearchBias::SAT:
+      return "sat";
+    case SearchBias::UNSAT:
+      return "unsat";
+    default:
+      return "none";
+  }
+}
+}
+
+#endif

--- a/lib/STPManager/STP.cpp
+++ b/lib/STPManager/STP.cpp
@@ -146,6 +146,17 @@ SATSolver* STP::get_new_sat_solver()
       break;
   };
 
+  // Before any clause reaches it, which is the only point some backends will
+  // accept a configuration at.
+  if (bm->UserFlags.search_bias != SearchBias::NONE &&
+      !newS->setSearchBias(bm->UserFlags.search_bias))
+  {
+    std::cerr << "Warning: the SAT solver in use has no '"
+              << searchBiasName(bm->UserFlags.search_bias)
+              << "' search bias to select; using its own settings instead."
+              << std::endl;
+  }
+
   return newS;
 }
 

--- a/lib/Sat/Cadical.cpp
+++ b/lib/Sat/Cadical.cpp
@@ -100,6 +100,34 @@ uint32_t Cadical::newVar()
   return ++next_variable;
 }
 
+bool Cadical::setSearchBias(SearchBias bias)
+{
+  // Cadical has named configurations of its own, so this is a straight
+  // translation. "unsat" turns off stabilising search and the local-search
+  // walker, keeping Cadical in focused, restart-heavy search; "sat" leaves it
+  // stabilising and spends more effort on elimination and subsumption.
+  //
+  // Cadical only accepts a configuration "right after initialization", which
+  // is why this is applied here rather than at solve time. Setting "quiet" in
+  // the constructor doesn't spoil that: quiet and verbose are exempt from
+  // Cadical's state check, and only adding a clause leaves the configuring
+  // state.
+  const char* config = nullptr;
+  switch (bias)
+  {
+    case SearchBias::SAT:
+      config = "sat";
+      break;
+    case SearchBias::UNSAT:
+      config = "unsat";
+      break;
+    case SearchBias::NONE:
+      return true; // nothing to do, which counts as honouring the request.
+  }
+
+  return s->configure(config);
+}
+
 void Cadical::setVerbosity(int v)
 {
   if (v ==0)

--- a/lib/Sat/CryptoMinisat5.cpp
+++ b/lib/Sat/CryptoMinisat5.cpp
@@ -143,6 +143,37 @@ uint32_t CryptoMiniSat5::newVar()
   return s->nVars() - 1;
 }
 
+bool CryptoMiniSat5::setSearchBias(SearchBias bias)
+{
+  // CryptoMiniSat has no named configurations, so what it offers has to be
+  // picked out by hand. Turning off SLS is the piece that carries over: it is
+  // the local-search phase, it looks for models, and it is wasted work when
+  // there isn't one. On the QF_BV/20230221-oisc-gurtner family it came out
+  // ahead on all 18 interleaved A/B pairs measured, by 12% of wall clock at
+  // the median.
+  //
+  // Its other half-analogue was measured and rejected. CryptoMiniSat rotates
+  // its polarity strategy over {best, stable, best_inv, saved} as the search
+  // restarts, which looks like the stabilising mode that other solvers turn
+  // off for unsatisfiable instances -- but pinning the rotation to plain
+  // phase saving was *slower* on 8 of 9 of the same pairs, by 10-49%, so the
+  // rotation is evidently earning its keep here whatever the answer turns out
+  // to be. Its restart strategy is not reachable through the public API, so
+  // the stabilising side of the bias is simply left alone.
+  //
+  // Nothing is done for SAT: the defaults are already the satisfiable-leaning
+  // end of what is on offer, so say so rather than pretend to have applied
+  // something.
+  if (bias == SearchBias::NONE)
+    return true;
+
+  if (bias == SearchBias::SAT)
+    return false;
+
+  s->set_sls(0);
+  return true;
+}
+
 void CryptoMiniSat5::setVerbosity(int v)
 {
   s->set_verbosity(v);

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -47,4 +47,5 @@ AddSTPGTest(ConstantBitPropagation_Test.cpp)
 AddSTPGTest(BitVector_from_Dec_Test.cpp)
 AddSTPGTest(ValueSet_Test.cpp)
 AddSTPGTest(ValueSet_Exhaustive_Test.cpp)
+AddSTPGTest(SearchBias_Test.cpp)
 

--- a/tests/unit-tests/SearchBias_Test.cpp
+++ b/tests/unit-tests/SearchBias_Test.cpp
@@ -1,0 +1,154 @@
+// Guards --search-bias. A bias only selects heuristics, so whichever one is
+// asked for, the sat/unsat verdict has to come out the same: that is the only
+// way this feature could do damage. Every backend compiled into this build is
+// checked, including one that doesn't implement the bias at all, since
+// reporting that honestly is what drives the warning STP prints.
+#include "stp/Sat/MinisatCore.h"
+#include "stp/Sat/SATSolver.h"
+#include "stp/Sat/SearchBias.h"
+#include <cstdlib>
+#include <functional>
+#include <gtest/gtest.h>
+#include <memory>
+
+#ifdef USE_CADICAL
+#include "stp/Sat/Cadical.h"
+#endif
+#ifdef USE_CRYPTOMINISAT
+#include "stp/Sat/CryptoMinisat5.h"
+#endif
+
+using stp::SATSolver;
+using stp::SearchBias;
+
+namespace
+{
+
+using SolverFactory = std::function<std::unique_ptr<SATSolver>()>;
+
+const SearchBias all_biases[] = {SearchBias::NONE, SearchBias::SAT,
+                                 SearchBias::UNSAT};
+
+void addUnit(SATSolver& s, uint32_t var, bool negated)
+{
+  SATSolver::vec_literals c;
+  c.push(SATSolver::mkLit(var, negated));
+  s.addClause(c);
+}
+
+void addBinary(SATSolver& s, uint32_t a, bool a_neg, uint32_t b, bool b_neg)
+{
+  SATSolver::vec_literals c;
+  c.push(SATSolver::mkLit(a, a_neg));
+  c.push(SATSolver::mkLit(b, b_neg));
+  s.addClause(c);
+}
+
+// (x) & (~x) is unsatisfiable under every bias.
+void checkUnsatVerdict(const SolverFactory& make, const char* name)
+{
+  for (const SearchBias bias : all_biases)
+  {
+    std::unique_ptr<SATSolver> s = make();
+    s->setSearchBias(bias);
+
+    const uint32_t x = s->newVar();
+    addUnit(*s, x, false);
+    addUnit(*s, x, true);
+
+    bool timed_out = false;
+    EXPECT_FALSE(s->solve(timed_out))
+        << name << " bias=" << stp::searchBiasName(bias);
+    EXPECT_FALSE(timed_out) << name << " bias=" << stp::searchBiasName(bias);
+  }
+}
+
+// (x | y) & (~x) is satisfiable under every bias, and only with y true.
+void checkSatVerdict(const SolverFactory& make, const char* name)
+{
+  for (const SearchBias bias : all_biases)
+  {
+    std::unique_ptr<SATSolver> s = make();
+    s->setSearchBias(bias);
+
+    const uint32_t x = s->newVar();
+    const uint32_t y = s->newVar();
+    addBinary(*s, x, false, y, false);
+    addUnit(*s, x, true);
+
+    bool timed_out = false;
+    ASSERT_TRUE(s->solve(timed_out))
+        << name << " bias=" << stp::searchBiasName(bias);
+    EXPECT_EQ(s->modelValue(y), s->true_literal())
+        << name << " bias=" << stp::searchBiasName(bias);
+  }
+}
+
+} // namespace
+
+TEST(SearchBias, MinisatVerdictsAreStable)
+{
+  const SolverFactory make = [] {
+    return std::unique_ptr<SATSolver>(new stp::MinisatCore);
+  };
+  checkUnsatVerdict(make, "minisat");
+  checkSatVerdict(make, "minisat");
+}
+
+// Minisat has nothing to bias, and has to say so rather than silently drop
+// the request: STP warns on the back of this.
+TEST(SearchBias, MinisatReportsNoSupport)
+{
+  stp::MinisatCore s;
+  EXPECT_FALSE(s.setSearchBias(SearchBias::SAT));
+  EXPECT_FALSE(s.setSearchBias(SearchBias::UNSAT));
+}
+
+#ifdef USE_CADICAL
+TEST(SearchBias, CadicalVerdictsAreStable)
+{
+  const SolverFactory make = [] {
+    return std::unique_ptr<SATSolver>(new stp::Cadical);
+  };
+  checkUnsatVerdict(make, "cadical");
+  checkSatVerdict(make, "cadical");
+}
+
+// Cadical has a named configuration for each direction.
+TEST(SearchBias, CadicalAcceptsBothDirections)
+{
+  {
+    stp::Cadical s;
+    EXPECT_TRUE(s.setSearchBias(SearchBias::SAT));
+  }
+  {
+    stp::Cadical s;
+    EXPECT_TRUE(s.setSearchBias(SearchBias::UNSAT));
+  }
+}
+#endif
+
+#ifdef USE_CRYPTOMINISAT
+TEST(SearchBias, CryptoMiniSatVerdictsAreStable)
+{
+  const SolverFactory make = [] {
+    return std::unique_ptr<SATSolver>(new stp::CryptoMiniSat5(1));
+  };
+  checkUnsatVerdict(make, "cryptominisat");
+  checkSatVerdict(make, "cryptominisat");
+}
+
+// CryptoMiniSat can be pushed towards unsatisfiable instances, but its
+// defaults are already the satisfiable-leaning end of what it offers.
+TEST(SearchBias, CryptoMiniSatOnlyBiasesTowardsUnsat)
+{
+  {
+    stp::CryptoMiniSat5 s(1);
+    EXPECT_TRUE(s.setSearchBias(SearchBias::UNSAT));
+  }
+  {
+    stp::CryptoMiniSat5 s(1);
+    EXPECT_FALSE(s.setSearchBias(SearchBias::SAT));
+  }
+}
+#endif

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -55,6 +55,9 @@ public:
   po::options_description cmdline_options;
   po::options_description visible_options;
   po::positional_options_description pos_options;
+
+  // Held as text until parse_options() turns it into UserFlags.search_bias.
+  std::string search_bias;
 };
 
 int ExtraMain::create_and_parse_options(int argc, char** argv)
@@ -247,7 +250,12 @@ void ExtraMain::create_options()
               "minisat", "use installed minisat version as the solver "
 #ifndef USE_CRYPTOMINISAT
 #endif
-              );
+              )
+      ("search-bias", po::value<std::string>(&search_bias),
+       "tune the SAT search towards one answer: 'unsat' (best for "
+       "unsatisfiable / verification workloads), 'sat', or 'none' (the "
+       "default, leaving the solver at its own settings). Solvers with no "
+       "such setting ignore it");
 
   po::options_description refinement_options("Refinement options");
   refinement_options.add_options()(
@@ -513,6 +521,22 @@ int ExtraMain::parse_options(int argc, char** argv)
   if (vm.count("cadical"))
   {
     bm->UserFlags.solver_to_use = UserDefinedFlags::CADICAL_SOLVER;
+  }
+
+  if (vm.count("search-bias"))
+  {
+    if (search_bias == "sat")
+      bm->UserFlags.search_bias = SearchBias::SAT;
+    else if (search_bias == "unsat")
+      bm->UserFlags.search_bias = SearchBias::UNSAT;
+    else if (search_bias == "none")
+      bm->UserFlags.search_bias = SearchBias::NONE;
+    else
+    {
+      cout << "ERROR: --search-bias must be one of 'sat', 'unsat' or 'none'"
+           << endl;
+      std::exit(-1);
+    }
   }
 
 


### PR DESCRIPTION
## What

Adds an opt-in `--search-bias {sat,unsat,none}` option that tunes the SAT search
towards one answer. It is a property of the query rather than of one solver:
`SATSolver::setSearchBias()` takes a `SearchBias`, `STP::get_new_sat_solver()`
applies it to whichever back end is in use before the first clause is added, and
each back end maps it onto whatever it happens to offer.

| back end | `unsat` | `sat` |
|---|---|---|
| cadical | `configure("unsat")` — `stabilize=0`, `walk=0` | `configure("sat")` |
| cryptominisat | `set_sls(0)` | unsupported, reported as such |
| minisat / simplifying-minisat / riss | nothing to offer, reported as such | same |

A back end that cannot honour a bias returns `false` rather than silently
dropping the request, and STP warns. `none` is the default, so every back end is
left at its own settings unless the option is passed.

## Why

Modern CDCL solvers alternate between a mode that is good at finding models and
one that is good at closing off the search space. On a workload known to lean one
way — verification conditions are usually unsatisfiable — the effort spent in the
other mode is wasted.

Measured on the `QF_BV/20230221-oisc-gurtner` family (RISC-V OISC correctness
proofs, all UNSAT), where SAT solving is ~99% of wall-clock.

**cadical**, isolated serial, `--cadical` vs `--cadical --search-bias unsat`:

| file              | default | unsat | speedup |
|-------------------|--------:|------:|--------:|
| SRLI-SAFE-48-48   |   76.2s |  5.9s | 12.9x |
| SRAI-SAFE-48-48   |  127.1s | 11.7s | 10.9x |
| SRL-SAFE-128-128  |  114.6s | 48.2s |  2.4x |
| SRL-SAFE-64-64    |   26.0s | 17.4s |  1.5x |
| (8-file frontier) |  503.2s |190.2s | **2.65x** |

It also solves instances that otherwise time out, e.g. SRAI-SAFE-128-128
(timeout → 43s) and SRAI-SAFE-256-256 (timeout → 246s).

**cryptominisat**, interleaved A/B over SRAI-SAFE-{16,20,24,28}: ahead on all 18
pairs, by 12% of wall clock at the median (0.9%–19.4%). Those figures include
STP's own preprocessing, so they understate the effect on the solve itself.

## What was tried and rejected

CryptoMiniSat has no named configurations — `set_up_for_scalmc()` and friends are
model-counting presets, not a sat/unsat bias — so the pieces had to be picked out
by hand, and only one of the two candidates survived measurement.

It rotates its polarity strategy over `{best, stable, best_inv, saved}` as the
search restarts, switching to geometric restarts in the `best` phase. That looks
like the stabilising mode cadical's `unsat` profile turns off. It isn't: pinning
the rotation to `polarmode_saved` was **slower** on 8 of 9 of the same pairs, by
10–49%, and `polarmode_stable` / `polarmode_neg` were worse still. The rotation
earns its keep whatever the answer turns out to be, so the stabilising side of
the bias is left alone for cryptominisat. Its restart strategy is not reachable
through the public API in any case.

## Soundness

A bias only selects heuristics, so it cannot change a correct SAT solver's
verdict. `tests/unit-tests/SearchBias_Test.cpp` holds every back end compiled
into the build to that — verdict stability across `none`/`sat`/`unsat` on both a
satisfiable and an unsatisfiable instance — and checks that a back end which
cannot honour a bias reports it rather than silently dropping it.

A 2501-file differential over the local fuzz corpus (mixed sat/unsat) produced 0
verdict mismatches for the cadical `unsat` path, which is the same
`configure("unsat")` call this PR now reaches through `--search-bias`. The
cryptominisat path has not had that sweep.

## Notes

- Opt-in; default behaviour unchanged for every back end.
- Supersedes the earlier CaDiCaL-only `--cadical-config <name>` on this branch.
  Free-form profile names (`plain`, and anything CaDiCaL adds later) are no
  longer reachable; the option now carries the portable concept only.
- `SearchBias` lives in its own dependency-free header so both
  `UserDefinedFlags.h` and `SATSolver.h` can include it.
- No constructor plumbing was needed for CaDiCaL. `configure()` requires the
  configuring state, but `set("quiet", …)` is exempt from that check
  (`solver.cpp:452-458`) and only `add()` leaves the state, so applying the bias
  after construction is safe.
