### PR TITLE
Reduce signed greater-than against boundary constants to (dis)equality

### DIFF
--- a/lib/NodeFactory/SimplifyingNodeFactory.cpp
+++ b/lib/NodeFactory/SimplifyingNodeFactory.cpp
@@ -278,6 +278,26 @@ ASTNode SimplifyingNodeFactory::CreateNode(Kind kind, const ASTVec& children)
           result = ASTFalse;
       }
 
+      // x >s smallest -> NOT(x == smallest). Nothing is below the most-negative
+      // value, so the comparison holds for every x except smallest itself.
+      // (Signed dual of the "x > 0 -> NOT(x == 0)" rule in create_gt_node.)
+      if (result.IsNull() && children[1].GetKind() == stp::BVCONST &&
+          children[1] == get_smallest_number(children[0].GetValueWidth()))
+      {
+        result = NodeFactory::CreateNode(
+            stp::NOT, NodeFactory::CreateNode(EQ, children[0], children[1]));
+      }
+
+      // largest >s x -> NOT(largest == x). Nothing is above the most-positive
+      // value, so the comparison holds for every x except largest itself.
+      // (Signed dual of the "max > x -> NOT(max == x)" rule in create_gt_node.)
+      if (result.IsNull() && children[0].GetKind() == stp::BVCONST &&
+          children[0] == get_largest_number(children[0].GetValueWidth()))
+      {
+        result = NodeFactory::CreateNode(
+            stp::NOT, NodeFactory::CreateNode(EQ, children[0], children[1]));
+      }
+
       //2nd part is the same -> only care about 1st part
       if (children[0].GetKind() == BVCONCAT &&
           children[1].GetKind() == BVCONCAT && children[0][1] == children[1][1])

--- a/tests/unit-tests/SimplifyingNodeFactory_Exhaustive_Test.cpp
+++ b/tests/unit-tests/SimplifyingNodeFactory_Exhaustive_Test.cpp
@@ -501,6 +501,27 @@ TEST(SimplifyingNodeFactory_Exhaustive, sgt_concat_shared_head)
   EXPECT_EQ(c.nf->CreateNode(BVSGT, l, r), c.nf->CreateNode(BVGT, x, y));
 }
 
+/* x sgt smallest --> NOT(x == smallest) and largest sgt x --> NOT(largest == x):
+   nothing is below the most-negative value or above the most-positive value */
+TEST(SimplifyingNodeFactory_Exhaustive, sgt_signed_boundaries)
+{
+  Context c;
+  for (unsigned w : {1u, 2u, 4u})
+  {
+    ASTNode x = c.bv(w);
+    ASTNode smallest = c.konst(1u << (w - 1), w);       // 100...0
+    ASTNode largest = c.konst((1u << (w - 1)) - 1, w);  // 011...1
+
+    c.checkNode(BVSGT, {x, smallest});
+    EXPECT_EQ(c.nf->CreateNode(BVSGT, x, smallest),
+              c.nf->CreateNode(NOT, c.nf->CreateNode(EQ, x, smallest)));
+
+    c.checkNode(BVSGT, {largest, x});
+    EXPECT_EQ(c.nf->CreateNode(BVSGT, largest, x),
+              c.nf->CreateNode(NOT, c.nf->CreateNode(EQ, largest, x)));
+  }
+}
+
 /* a 1-bit ITE choosing between 0 and 1 on a 1-bit equality collapses to
    the tested term or its complement */
 TEST(SimplifyingNodeFactory_Exhaustive, ite_width1_boolean_to_term)

--- a/tests/unit-tests/SimplifyingNodeFactory_Test.cpp
+++ b/tests/unit-tests/SimplifyingNodeFactory_Test.cpp
@@ -399,6 +399,55 @@ TEST(SimplifyingNodeFactory_Test, bvgt)
 
 
 
+// x >s smallest  ->  NOT(x == smallest)   (#x80000 is the most-negative 20-bit value)
+TEST(SimplifyingNodeFactory_Test, bvsgt_smallest)
+{
+  const std::string input = R"(
+    (assert ( = (bvsgt v0 #x80000) (not (= v0 #x80000)))  )
+    )";
+
+   Context c;
+   ASTNode n = c.process(input);
+   ASSERT_EQ(n, c.mgr.ASTTrue);
+}
+
+// largest >s x  ->  NOT(largest == x)      (#x7ffff is the most-positive 20-bit value)
+TEST(SimplifyingNodeFactory_Test, bvsgt_largest)
+{
+  const std::string input = R"(
+    (assert ( = (bvsgt #x7ffff v0) (not (= #x7ffff v0)))  )
+    )";
+
+   Context c;
+   ASTNode n = c.process(input);
+   ASSERT_EQ(n, c.mgr.ASTTrue);
+}
+
+// The signed duals still fold the "always false" corners.
+TEST(SimplifyingNodeFactory_Test, bvsgt_false_corners)
+{
+  const std::string input = R"(
+    (assert (not (bvsgt v0 #x7ffff)) )
+    (assert (not (bvsgt #x80000 v0)) )
+    )";
+
+   Context c;
+   ASTNode n = c.process(input);
+   ASSERT_EQ(n, c.mgr.ASTTrue);
+}
+
+// And BVSGE inherits the reduction: smallest >=s x  ->  x == smallest.
+TEST(SimplifyingNodeFactory_Test, bvsge_smallest)
+{
+  const std::string input = R"(
+    (assert ( = (bvsge #x80000 v0) (= v0 #x80000))  )
+    )";
+
+   Context c;
+   ASTNode n = c.process(input);
+   ASSERT_EQ(n, c.mgr.ASTTrue);
+}
+
 TEST(SimplifyingNodeFactory_Test, bvplus0)
 {
   const std::string input = R"(


### PR DESCRIPTION
## What

`BVSGT` in `SimplifyingNodeFactory` already folds the two *always-false* signed corners (`x >s SMAX → false`, `SMIN >s x → false`), but — unlike unsigned `BVGT` in `create_gt_node` — it never reduced the other two boundaries to a (dis)equality:

```
x >s SMIN   ->  NOT(x == SMIN)   // nothing is below the most-negative value
SMAX >s x   ->  NOT(SMAX == x)   // nothing is above the most-positive value
```

These are the exact signed duals of `BVGT`'s existing `x > 0 → NOT(x == 0)` and `max > x → NOT(max == x)` rules. The asymmetry was found while auditing the simplification rules for missing signed/unsigned counterparts.

## Why it's complete with one edit

- `BVSGE`, `BVSLT`, `BVSLE` all route through `BVSGT`, so they inherit the reduction (e.g. `SMIN >=s x → x == SMIN`).
- `Simplifier::CreateSimplifiedINEQ` rebuilds signed comparisons via this factory (`nf->CreateNode(BVSGT, …)`), so the simplifier picks up the folds without a separate change.

## Confirmation before the fix

Verified through the `SimplifyingNodeFactory` (via the parser) that `bvsgt v0 #x80000` and `bvsgt #x7ffff v0` were emitted as raw `BVSGT` nodes and were not reduced by any other pass, while the two false corners already folded correctly.

## Tests

- `SimplifyingNodeFactory_Test`: `bvsgt_smallest`, `bvsgt_largest`, `bvsgt_false_corners`, `bvsge_smallest`.
- `SimplifyingNodeFactory_Exhaustive`: `sgt_signed_boundaries` brute-forces all assignments at widths 1, 2, 4 and checks the factory output matches `NOT(EQ(...))` — a full soundness check.

All existing SNF and exhaustive tests continue to pass.