### PR TITLE
Reduce unsigned overflow predicates via the unsigned interval pass

### DIFF
--- a/lib/Simplifier/UnsignedIntervalAnalysis.cpp
+++ b/lib/Simplifier/UnsignedIntervalAnalysis.cpp
@@ -1204,6 +1204,93 @@ namespace stp
         }
         break;
 
+      // Unsigned overflow predicates. These are boolean (Form) nodes, so the
+      // operand width is read from the children, not from 'width' (which is 0
+      // for a boolean node). Only the three UNSIGNED predicates are handled:
+      // the unsigned interval domain carries no signed-range information, so it
+      // cannot soundly decide BVSADDO/BVSMULO/BVSSUBO.
+
+      case BVUSUBO:
+        // Unsigned subtraction overflows (borrows) iff a <u b, mirroring
+        // BVGT(b, a). The comparison of the attained unsigned extremes decides
+        // it for every point in the operand box.
+        if (knownC0 && knownC1)
+        {
+          const UnsignedInterval* a = children[0];
+          const UnsignedInterval* b = children[1];
+
+          if (CONSTANTBV::BitVector_Lexicompare(a->maxV, b->minV) < 0)
+            // even the largest a is below the smallest b: always borrows.
+            result = createInterval(littleOne, littleOne);
+          else if (CONSTANTBV::BitVector_Lexicompare(a->minV, b->maxV) >= 0)
+            // even the smallest a is at least the largest b: never borrows.
+            result = createInterval(littleZero, littleZero);
+        }
+        break;
+
+      case BVUADDO:
+        // Unsigned add overflows iff a + b >= 2^w, i.e. the width-w addition
+        // carries out. The integer sum ranges over [minV+minV, maxV+maxV], so
+        // if the maxes don't carry no point overflows, and if the mins carry
+        // every point overflows.
+        if (knownC0 && knownC1)
+        {
+          const unsigned w = children[0]->getWidth();
+          CBV tmp = CONSTANTBV::BitVector_Create(w, true);
+
+          bool carryMax = false;
+          CONSTANTBV::BitVector_add(tmp, children[0]->maxV, children[1]->maxV,
+                                    &carryMax);
+          bool carryMin = false;
+          CONSTANTBV::BitVector_add(tmp, children[0]->minV, children[1]->minV,
+                                    &carryMin);
+          CONSTANTBV::BitVector_Destroy(tmp);
+
+          if (!carryMax)
+            result = createInterval(littleZero, littleZero);
+          else if (carryMin)
+            result = createInterval(littleOne, littleOne);
+        }
+        break;
+
+      case BVUMULO:
+        // Unsigned multiply overflows iff a * b >= 2^w. The unsigned product is
+        // monotone in both operands, so it ranges over [minV*minV, maxV*maxV].
+        // If the max-product has no bit at index >= w set, no point overflows;
+        // if the min-product has such a bit set, every point overflows. The
+        // products are computed exactly by zero-extending both operands into a
+        // 2w+1 bit buffer (BitVector_Multiply is a signed multiply, but the
+        // zero-extended operands are non-negative in the wider width, so the
+        // product is the exact unsigned product).
+        if (knownC0 && knownC1)
+        {
+          const unsigned w = children[0]->getWidth();
+          const unsigned ew = 2 * w + 1;
+
+          auto productOverflows = [&](CBV a, CBV b) -> bool {
+            CBV a2 = CONSTANTBV::BitVector_Create(ew, true);
+            CBV b2 = CONSTANTBV::BitVector_Create(ew, true);
+            CBV prod = CONSTANTBV::BitVector_Create(ew, true);
+            CONSTANTBV::BitVector_Interval_Copy(a2, a, 0, 0, w);
+            CONSTANTBV::BitVector_Interval_Copy(b2, b, 0, 0, w);
+            CONSTANTBV::BitVector_Multiply(prod, a2, b2);
+            bool of = false;
+            for (unsigned i = w; i < ew && !of; i++)
+              if (CONSTANTBV::BitVector_bit_test(prod, i))
+                of = true;
+            CONSTANTBV::BitVector_Destroy(a2);
+            CONSTANTBV::BitVector_Destroy(b2);
+            CONSTANTBV::BitVector_Destroy(prod);
+            return of;
+          };
+
+          if (!productOverflows(children[0]->maxV, children[1]->maxV))
+            result = createInterval(littleZero, littleZero);
+          else if (productOverflows(children[0]->minV, children[1]->minV))
+            result = createInterval(littleOne, littleOne);
+        }
+        break;
+
       case BVDIV:
       {
         const UnsignedInterval* top = children[0];

--- a/lib/Simplifier/UnsignedIntervalAnalysis.cpp
+++ b/lib/Simplifier/UnsignedIntervalAnalysis.cpp
@@ -1213,8 +1213,9 @@ namespace stp
       case BVUSUBO:
         // Unsigned subtraction overflows (borrows) iff a <u b, mirroring
         // BVGT(b, a). The comparison of the attained unsigned extremes decides
-        // it for every point in the operand box.
-        if (knownC0 && knownC1)
+        // it for every point in the operand box. An unknown operand is the
+        // full range [0, 2^w-1] (substituted above), so this stays exact even
+        // when only one side pins the result (e.g. a - 0 never borrows).
         {
           const UnsignedInterval* a = children[0];
           const UnsignedInterval* b = children[1];
@@ -1232,8 +1233,8 @@ namespace stp
         // Unsigned add overflows iff a + b >= 2^w, i.e. the width-w addition
         // carries out. The integer sum ranges over [minV+minV, maxV+maxV], so
         // if the maxes don't carry no point overflows, and if the mins carry
-        // every point overflows.
-        if (knownC0 && knownC1)
+        // every point overflows. An unknown operand is the full range (see
+        // above), so a + 0 is still resolved to "never overflows".
         {
           const unsigned w = children[0]->getWidth();
           CBV tmp = CONSTANTBV::BitVector_Create(w, true);
@@ -1261,8 +1262,8 @@ namespace stp
         // products are computed exactly by zero-extending both operands into a
         // 2w+1 bit buffer (BitVector_Multiply is a signed multiply, but the
         // zero-extended operands are non-negative in the wider width, so the
-        // product is the exact unsigned product).
-        if (knownC0 && knownC1)
+        // product is the exact unsigned product). An unknown operand is the
+        // full range (see above), so e.g. a * 0 resolves to "never overflows".
         {
           const unsigned w = children[0]->getWidth();
           const unsigned ew = 2 * w + 1;

--- a/lib/Simplifier/UnsignedIntervalAnalysis.cpp
+++ b/lib/Simplifier/UnsignedIntervalAnalysis.cpp
@@ -1255,20 +1255,30 @@ namespace stp
         break;
 
       case BVUMULO:
-        // Unsigned multiply overflows iff a * b >= 2^w. The unsigned product is
-        // monotone in both operands, so it ranges over [minV*minV, maxV*maxV].
-        // If the max-product has no bit at index >= w set, no point overflows;
-        // if the min-product has such a bit set, every point overflows. The
-        // products are computed exactly by zero-extending both operands into a
-        // 2w+1 bit buffer (BitVector_Multiply is a signed multiply, but the
-        // zero-extended operands are non-negative in the wider width, so the
-        // product is the exact unsigned product). An unknown operand is the
-        // full range (see above), so e.g. a * 0 resolves to "never overflows".
+        // Unsigned multiply overflows iff a * b >= 2^w. The product is monotone
+        // in both operands, so it ranges over [minV*minV, maxV*maxV]: if the
+        // max-product doesn't overflow no point does, and if the min-product
+        // overflows every point does. An unknown operand is the full range
+        // (see above), so e.g. a * 0 resolves to "never overflows".
+        //
+        // Whether one product X*Y overflows is decided by a leading-zeros
+        // screen first (Hacker's Delight 2-13). With bit-lengths bx and by
+        // (highest set bit + 1) we have 2^(bx+by-2) <= X*Y < 2^(bx+by), so:
+        //   bx == 0 or by == 0  -> product is 0, no overflow
+        //   bx + by <= w        -> largest possible product < 2^w, no overflow
+        //   bx + by >= w + 2    -> smallest possible product >= 2^w, overflow
+        //   bx + by == w + 1    -> ambiguous; fall back to an exact multiply.
+        // The screen decides every case where the operands aren't both close to
+        // a power-of-two boundary (in particular all the fully-/half-unknown
+        // cases), so the expensive multiply is rarely reached.
         {
           const unsigned w = children[0]->getWidth();
           const unsigned ew = 2 * w + 1;
 
-          auto productOverflows = [&](CBV a, CBV b) -> bool {
+          // Exact fallback: zero-extend both operands into 2w+1 bits (so the
+          // signed BitVector_Multiply computes the unsigned product) and test
+          // for a set bit at index >= w.
+          auto exactOverflows = [&](CBV a, CBV b) -> bool {
             CBV a2 = CONSTANTBV::BitVector_Create(ew, true);
             CBV b2 = CONSTANTBV::BitVector_Create(ew, true);
             CBV prod = CONSTANTBV::BitVector_Create(ew, true);
@@ -1283,6 +1293,25 @@ namespace stp
             CONSTANTBV::BitVector_Destroy(b2);
             CONSTANTBV::BitVector_Destroy(prod);
             return of;
+          };
+
+          auto productOverflows = [&](CBV a, CBV b) -> bool {
+            // Set_Max is the highest set bit's index, or negative if the value
+            // is zero; bit-length is that index + 1.
+            const signed long topA = CONSTANTBV::Set_Max(a);
+            const signed long topB = CONSTANTBV::Set_Max(b);
+            if (topA <= 0 || topB <= 0)
+              // a or b is 0 or 1 (Set_Max < 0 means 0, == 0 means 1), so the
+              // product is 0 or the other operand, which is below 2^w. This
+              // also keeps 1 * (full-width) out of the ambiguous band below.
+              return false;
+            const unsigned long bitsSum =
+                (unsigned long)topA + (unsigned long)topB + 2; // bx + by
+            if (bitsSum <= w)
+              return false;
+            if (bitsSum >= (unsigned long)w + 2)
+              return true;
+            return exactOverflows(a, b); // bx + by == w + 1
           };
 
           if (!productOverflows(children[0]->maxV, children[1]->maxV))

--- a/tests/unit-tests/UnsignedIntervalExhaustive_Test.cpp
+++ b/tests/unit-tests/UnsignedIntervalExhaustive_Test.cpp
@@ -457,6 +457,73 @@ TEST(UnsignedIntervalExhaustive, Eq)
     checkPredicate(stp::EQ, w, EXACT);
 }
 
+// The unsigned overflow predicates only claim true/false when the operand
+// box decides them, so they over-approximate. Only soundness is required.
+TEST(UnsignedIntervalExhaustive, Bvuaddo)
+{
+  for (unsigned w = 1; w <= 4; w++)
+    checkPredicate(stp::BVUADDO, w, OVERAPPROXIMATES);
+}
+
+TEST(UnsignedIntervalExhaustive, Bvumulo)
+{
+  for (unsigned w = 1; w <= 4; w++)
+    checkPredicate(stp::BVUMULO, w, OVERAPPROXIMATES);
+}
+
+TEST(UnsignedIntervalExhaustive, Bvusubo)
+{
+  for (unsigned w = 1; w <= 4; w++)
+    checkPredicate(stp::BVUSUBO, w, OVERAPPROXIMATES);
+}
+
+// Confirms the transfer functions actually fire (produce a constant verdict)
+// at a realistic width where brute force is impossible, in both the "always"
+// and "never" directions.
+TEST(UnsignedIntervalExhaustive, OverflowFires)
+{
+  Context c;
+
+  const auto predicate = [&](stp::Kind k) {
+    stp::ASTVec symbols;
+    symbols.push_back(c.mgr.CreateSymbol("x", 0, 32));
+    symbols.push_back(c.mgr.CreateSymbol("y", 0, 32));
+    return c.mgr.hashingNodeFactory->CreateNode(k, symbols);
+  };
+
+  // Returns 0 (false), 1 (true), or -1 (unknown / no constant computed).
+  const auto run = [&](stp::Kind k, uint64_t aLo, uint64_t aHi, uint64_t bLo,
+                       uint64_t bHi) -> int {
+    const stp::ASTNode n = predicate(k);
+    std::vector<const stp::UnsignedInterval*> children = {
+        makeInterval(32, aLo, aHi), makeInterval(32, bLo, bHi)};
+    stp::UnsignedInterval* result =
+        c.analysis.dispatchToTransferFunctions(n, children);
+    int verdict = -1;
+    if (result != nullptr && result->isConstant())
+      verdict = (int)cbvValue(result->minV, 1);
+    cleanup(children, result);
+    return verdict;
+  };
+
+  // Add: x in [0,100] plus 5 can never carry out of 32 bits -> always false.
+  EXPECT_EQ(run(stp::BVUADDO, 0, 100, 5, 5), 0);
+  // Add: both operands at least 2^31 always carry -> always true.
+  EXPECT_EQ(run(stp::BVUADDO, (1ull << 31), (1ull << 31), (1ull << 31),
+                (1ull << 31) + 10),
+            1);
+  // Mul: small * small can't reach 2^32 -> always false.
+  EXPECT_EQ(run(stp::BVUMULO, 0, 100, 0, 100), 0);
+  // Mul: both operands at least 2^16 reach 2^32 -> always true.
+  EXPECT_EQ(run(stp::BVUMULO, (1ull << 16), (1ull << 20), (1ull << 16),
+                (1ull << 20)),
+            1);
+  // Sub: max(a) < min(b) means a <u b always borrows -> always true.
+  EXPECT_EQ(run(stp::BVUSUBO, 0, 10, 20, 30), 1);
+  // Sub: min(a) >= max(b) never borrows -> always false.
+  EXPECT_EQ(run(stp::BVUSUBO, 20, 30, 0, 10), 0);
+}
+
 TEST(UnsignedIntervalExhaustive, Bvnot)
 {
   for (unsigned w = 1; w <= 5; w++)

--- a/tests/unit-tests/UnsignedIntervalExhaustive_Test.cpp
+++ b/tests/unit-tests/UnsignedIntervalExhaustive_Test.cpp
@@ -457,24 +457,26 @@ TEST(UnsignedIntervalExhaustive, Eq)
     checkPredicate(stp::EQ, w, EXACT);
 }
 
-// The unsigned overflow predicates only claim true/false when the operand
-// box decides them, so they over-approximate. Only soundness is required.
+// The unsigned overflow predicates are exact: the outcome is monotone in the
+// operand box, and an unknown operand is treated as the full range, so the
+// attained extremes decide the hull for every combination (including the cases
+// where only one operand is known, e.g. a * 0 or a + 0).
 TEST(UnsignedIntervalExhaustive, Bvuaddo)
 {
   for (unsigned w = 1; w <= 4; w++)
-    checkPredicate(stp::BVUADDO, w, OVERAPPROXIMATES);
+    checkPredicate(stp::BVUADDO, w, EXACT);
 }
 
 TEST(UnsignedIntervalExhaustive, Bvumulo)
 {
   for (unsigned w = 1; w <= 4; w++)
-    checkPredicate(stp::BVUMULO, w, OVERAPPROXIMATES);
+    checkPredicate(stp::BVUMULO, w, EXACT);
 }
 
 TEST(UnsignedIntervalExhaustive, Bvusubo)
 {
   for (unsigned w = 1; w <= 4; w++)
-    checkPredicate(stp::BVUSUBO, w, OVERAPPROXIMATES);
+    checkPredicate(stp::BVUSUBO, w, EXACT);
 }
 
 // Confirms the transfer functions actually fire (produce a constant verdict)


### PR DESCRIPTION
## Summary

The three UNSIGNED bitvector overflow predicates now reduce to `true`/`false` via the unsigned interval analysis pass when the operands' unsigned intervals prove the outcome. They were previously handled nowhere but whole-constant folding in `consteval`.

No `StrengthReduction` change is needed: that pass already turns any node whose computed interval is a constant into the constant (emitting `true`/`false` for boolean nodes), so assigning a constant 1-bit interval in the transfer function is sufficient for the reduction to fire.

## Transfer functions

Added three `case` branches to the transfer-function switch in `lib/Simplifier/UnsignedIntervalAnalysis.cpp`. The operand width `w` is read from the children (the predicate node itself is boolean, width 0). A `[1,1]` interval means provably true, `[0,0]` provably false, and null (unknown) is always sound.

- **BVUSUBO(a,b)** == `a <u b` (mirrors `BVGT(b,a)`), via `BitVector_Lexicompare`:
  - `max(a) <u min(b)`  -> always true
  - `min(a) >=u max(b)` -> always false
- **BVUADDO(a,b)** == `a+b >= 2^w` (carry out at width w). The integer sum ranges over `[min+min, max+max]`:
  - `max(a)+max(b)` does not carry out of width w -> always false
  - `min(a)+min(b)` does carry out                -> always true
  - Implemented with two width-w `BitVector_add` calls reading the carry-out flag.
- **BVUMULO(a,b)** == `a*b >= 2^w`. The unsigned product is monotone in both operands, so it ranges over `[min*min, max*max]`:
  - `max(a)*max(b) < 2^w`  -> always false
  - `min(a)*min(b) >= 2^w` -> always true
  - Products are computed exactly by zero-extending both operands into a `2w+1` bit buffer before the (signed) `BitVector_Multiply`, then testing for any set bit at index `>= w`.

## Why the signed trio is excluded

`BVSADDO`/`BVSMULO`/`BVSSUBO` are deliberately left unhandled. Deciding signed overflow needs the operands' signed ranges, and the unsigned interval domain carries no signed-range information (an unsigned interval can straddle the sign boundary), so it cannot soundly conclude anything about them.

## Test coverage

In `tests/unit-tests/UnsignedIntervalExhaustive_Test.cpp`:

- Exhaustive soundness tests at widths 1..4 for all three predicates over every pair of operand intervals (including unknown children). The harness brute-forces the hull from the constant evaluator's reference semantics and asserts every concluded verdict holds for every point in the operand box.
- A width-32 firing test exercising both the "always true" and "always false" directions of each predicate, confirming the reductions actually fire where brute force is impossible.

All of `UnsignedIntervalAnalysis_TestTests`, `UnsignedIntervalExhaustive_TestTests`, `UnsignedIntervalWide_TestTests`, `UnsignedIntervalPropagators_TestTests`, and `SimplifyingNodeFactory_Exhaustive_TestTests` pass, and the full `ctest` unit-test suite (62/62) passes with no regressions.