### PR TITLE
Fold signed overflow predicates via fixed sign bits

### DIFF
--- a/lib/Simplifier/StrengthReduction.cpp
+++ b/lib/Simplifier/StrengthReduction.cpp
@@ -314,7 +314,8 @@ namespace stp
       replaceWithConstant++;
     }
     else if (kind == BVSGT || kind == BVSGE || kind == SBVDIV ||
-             kind == SBVMOD || kind == SBVREM)
+             kind == SBVMOD || kind == SBVREM || kind == BVSADDO ||
+             kind == BVSSUBO)
     {
       if (visited.find(n[0]) != visited.end() &&
           visited.find(n[1]) != visited.end())
@@ -331,6 +332,22 @@ namespace stp
             {
               // replace with unsigned comparison.
               newN = nf->CreateNode(kind == BVSGT ? BVGT : BVGE, n[0], n[1]);
+              replaceWithSimpler++;
+            }
+            else if (kind == BVSADDO &&
+                     (l->getValue(bw - 1) != r->getValue(bw - 1)))
+            {
+              // Signed add overflow requires the operands to share a sign,
+              // so opposite sign bits prove no overflow.
+              newN = nf->getFalse();
+              replaceWithSimpler++;
+            }
+            else if (kind == BVSSUBO &&
+                     (l->getValue(bw - 1) == r->getValue(bw - 1)))
+            {
+              // Signed sub overflow requires the operands to differ in sign,
+              // so equal sign bits prove no overflow.
+              newN = nf->getFalse();
               replaceWithSimpler++;
             }
             else if (kind == SBVDIV || kind == SBVREM)

--- a/tests/unit-tests/StrengthReduction_Exhaustive_Test.cpp
+++ b/tests/unit-tests/StrengthReduction_Exhaustive_Test.cpp
@@ -499,6 +499,161 @@ TEST(StrengthReduction_Exhaustive_Test, smod_to_urem_via_intervals)
       [](unsigned v) { return v <= 3; });
 }
 
+// bvsaddo folds to false when the fixed sign bits differ: signed add
+// overflow requires the operands to share a sign. Equivalent for every
+// assignment with those opposite signs.
+TEST(StrengthReduction_Exhaustive_Test, saddo_false_via_opposite_signs)
+{
+  const unsigned width = 3;
+
+  for (unsigned xSign = 0; xSign <= 1; xSign++)
+  {
+    const unsigned ySign = 1 - xSign;
+
+    Context c;
+    ASTNode x = c.symbol("x", width);
+    ASTNode y = c.symbol("y", width);
+    ASTNode n = c.nf->CreateNode(stp::BVSADDO, x, y);
+    ASSERT_EQ(n.GetKind(), stp::BVSADDO);
+
+    FixedBits xBits = msbFixed(width, xSign == 1);
+    FixedBits yBits = msbFixed(width, ySign == 1);
+
+    stp::NodeToFixedBitsMap map;
+    map.insert({n, nullptr});
+    map.insert({x, &xBits});
+    map.insert({y, &yBits});
+
+    ASTNode result = c.sr.topLevel(n, map);
+    ASSERT_EQ(result, c.mgr.ASTFalse);
+
+    c.checkEquivalent(
+        n, result, x, y, width,
+        [xSign, width](unsigned v) {
+          return ((v >> (width - 1)) & 1) == xSign;
+        },
+        [ySign, width](unsigned v) {
+          return ((v >> (width - 1)) & 1) == ySign;
+        });
+  }
+}
+
+// bvsaddo is left alone when the signs agree: overflow is possible there,
+// so no reduction is justified.
+TEST(StrengthReduction_Exhaustive_Test, saddo_unchanged_when_signs_agree)
+{
+  const unsigned width = 3;
+
+  for (unsigned sign = 0; sign <= 1; sign++)
+  {
+    Context c;
+    ASTNode x = c.symbol("x", width);
+    ASTNode y = c.symbol("y", width);
+    ASTNode n = c.nf->CreateNode(stp::BVSADDO, x, y);
+    ASSERT_EQ(n.GetKind(), stp::BVSADDO);
+
+    FixedBits xBits = msbFixed(width, sign == 1);
+    FixedBits yBits = msbFixed(width, sign == 1);
+
+    stp::NodeToFixedBitsMap map;
+    map.insert({n, nullptr});
+    map.insert({x, &xBits});
+    map.insert({y, &yBits});
+
+    ASTNode result = c.sr.topLevel(n, map);
+    ASSERT_EQ(result, n);
+  }
+}
+
+// bvssubo folds to false when the fixed sign bits agree: signed sub
+// overflow requires the operands to differ in sign. Equivalent for every
+// assignment with those equal signs.
+TEST(StrengthReduction_Exhaustive_Test, ssubo_false_via_equal_signs)
+{
+  const unsigned width = 3;
+
+  for (unsigned sign = 0; sign <= 1; sign++)
+  {
+    Context c;
+    ASTNode x = c.symbol("x", width);
+    ASTNode y = c.symbol("y", width);
+    ASTNode n = c.nf->CreateNode(stp::BVSSUBO, x, y);
+    ASSERT_EQ(n.GetKind(), stp::BVSSUBO);
+
+    FixedBits xBits = msbFixed(width, sign == 1);
+    FixedBits yBits = msbFixed(width, sign == 1);
+
+    stp::NodeToFixedBitsMap map;
+    map.insert({n, nullptr});
+    map.insert({x, &xBits});
+    map.insert({y, &yBits});
+
+    ASTNode result = c.sr.topLevel(n, map);
+    ASSERT_EQ(result, c.mgr.ASTFalse);
+
+    auto consistent = [sign, width](unsigned v) {
+      return ((v >> (width - 1)) & 1) == sign;
+    };
+    c.checkEquivalent(n, result, x, y, width, consistent, consistent);
+  }
+}
+
+// bvssubo is left alone when the signs differ: overflow is possible there,
+// so no reduction is justified.
+TEST(StrengthReduction_Exhaustive_Test, ssubo_unchanged_when_signs_differ)
+{
+  const unsigned width = 3;
+
+  for (unsigned xSign = 0; xSign <= 1; xSign++)
+  {
+    const unsigned ySign = 1 - xSign;
+
+    Context c;
+    ASTNode x = c.symbol("x", width);
+    ASTNode y = c.symbol("y", width);
+    ASTNode n = c.nf->CreateNode(stp::BVSSUBO, x, y);
+    ASSERT_EQ(n.GetKind(), stp::BVSSUBO);
+
+    FixedBits xBits = msbFixed(width, xSign == 1);
+    FixedBits yBits = msbFixed(width, ySign == 1);
+
+    stp::NodeToFixedBitsMap map;
+    map.insert({n, nullptr});
+    map.insert({x, &xBits});
+    map.insert({y, &yBits});
+
+    ASTNode result = c.sr.topLevel(n, map);
+    ASSERT_EQ(result, n);
+  }
+}
+
+// Neither overflow predicate reduces when a sign bit is unknown.
+TEST(StrengthReduction_Exhaustive_Test, signed_overflow_unchanged_when_sign_unknown)
+{
+  const unsigned width = 3;
+
+  for (const stp::Kind kind : {stp::BVSADDO, stp::BVSSUBO})
+  {
+    Context c;
+    ASTNode x = c.symbol("x", width);
+    ASTNode y = c.symbol("y", width);
+    ASTNode n = c.nf->CreateNode(kind, x, y);
+    ASSERT_EQ(n.GetKind(), kind);
+
+    // x's sign bit is fixed, y's is not.
+    FixedBits xBits = msbFixed(width, true);
+    FixedBits yBits(width, false);
+
+    stp::NodeToFixedBitsMap map;
+    map.insert({n, nullptr});
+    map.insert({x, &xBits});
+    map.insert({y, &yBits});
+
+    ASTNode result = c.sr.topLevel(n, map);
+    ASSERT_EQ(result, n);
+  }
+}
+
 // bvadd reduces to bvor when the fixed bits show the operands can't both
 // have a one in any position (no carries are possible).
 TEST(StrengthReduction_Exhaustive_Test, plus_to_or_via_fixedbits)

--- a/tests/unit-tests/StrengthReduction_Test.cpp
+++ b/tests/unit-tests/StrengthReduction_Test.cpp
@@ -313,6 +313,63 @@ TEST(StrengthReduction_Test , __LINE__)
   ASSERT_EQ(n, c.mgr.ASTTrue);
 }
 
+// Signed add overflow with operands of known-opposite sign folds to false:
+// overflow requires the operands to share a sign.
+TEST(StrengthReduction_Test , __LINE__)
+{
+  const std::string input = R"(
+    (
+      assert
+            (bvsaddo
+              (concat (_ bv0 1) v0)
+              (concat (_ bv1 1) v1)
+            )
+    )
+    )";
+
+  Context c;
+  ASTNode n = c.process(input);
+  ASSERT_EQ(n, c.mgr.ASTFalse);
+}
+
+// Signed sub overflow with operands of known-equal sign folds to false:
+// overflow requires the operands to differ in sign.
+TEST(StrengthReduction_Test , __LINE__)
+{
+  const std::string input = R"(
+    (
+      assert
+            (bvssubo
+              (concat (_ bv1 1) v0)
+              (concat (_ bv1 1) v1)
+            )
+    )
+    )";
+
+  Context c;
+  ASTNode n = c.process(input);
+  ASSERT_EQ(n, c.mgr.ASTFalse);
+}
+
+// Signed add overflow with matching sign bits is not decided: the node
+// still contains the overflow predicate.
+TEST(StrengthReduction_Test , __LINE__)
+{
+  const std::string input = R"(
+    (
+      assert
+            (bvsaddo
+              (concat (_ bv1 1) v0)
+              (concat (_ bv1 1) v1)
+            )
+    )
+    )";
+
+  Context c;
+  ASTNode n = c.process(input);
+  ASSERT_TRUE(c.present(stp::BVSADDO, n));
+}
+
 static bool presentWithWidth(const stp::Kind k, const ASTNode& n,
                              const unsigned width)
 {


### PR DESCRIPTION
## What

Adds two sound fixed-bits strength reductions for the **signed** bitvector
overflow predicates, in `StrengthReduction::strengthReduction`
(`lib/Simplifier/StrengthReduction.cpp`) — the same `else if` chain that
already lowers signed comparisons and divisions to unsigned ones once the
operands' sign bits are known.

## The two rules

Both fire only when *both* operands' sign bits (`bw-1`, `bw = n[0].GetValueWidth()`)
are fixed.

- **BVSADDO(a,b)** — signed add overflow iff `(sign(a)==sign(b)) && (sign(a)!=sign(a+b))`
  (`consteval.cpp` ~677-691). Overflow requires the operands to **share** a sign,
  so if the two known sign bits **differ**, overflow is impossible: fold to `false`.
- **BVSSUBO(a,b)** — signed sub overflow iff `(sign(a)!=sign(b)) && (sign(a)!=sign(a-b))`
  (`consteval.cpp` ~749-763). Overflow requires the operands to **differ** in sign,
  so if the two known sign bits are **equal**, overflow is impossible: fold to `false`.

The overflow node is boolean (width 0), so the operand width is read from `n[0]`,
exactly as the neighbouring signed-comparison branch does. A fully-determined
overflow node was already covered by the totally-fixed constant fold at the top
of the function; these rules add the partial case where only the sign bits are known.

## Why not the others

- **BVSMULO** is excluded: the sign bits alone don't determine multiplication
  overflow (magnitudes matter) — that needs signed-range/interval reasoning.
- Magnitude-based no-overflow cases for add/sub are likewise deferred to a
  signed-interval approach.
- The unsigned overflow predicates are untouched.

## Tests

- `StrengthReduction_Exhaustive_Test.cpp`: five new tests. Sign bits are forced
  with the existing `msbFixed` helper; soundness is checked by the existing
  `checkEquivalent` harness, which enumerates every assignment consistent with
  the fixed signs and asserts the original predicate and the reduced `false`
  evaluate identically. Covers both firing directions, the two non-firing
  sign configurations (left unchanged), and an unknown-sign-bit negative case.
- `StrengthReduction_Test.cpp`: three parser-driven tests that force sign bits
  via `concat` with a constant high bit.

Full `ctest` passes (62/62), no regressions.