### PR TITLE
Fix compiler warnings in Simplifier and unit tests

### DIFF
--- a/include/stp/Simplifier/constantBitP/Dependencies.h
+++ b/include/stp/Simplifier/constantBitP/Dependencies.h
@@ -110,7 +110,7 @@ public:
 
   ~Dependencies()
   {
-    for (const auto it : dependents)
+    for (const auto& it : dependents)
       delete it.second;
   }
 

--- a/lib/Simplifier/PropagateEqualities.cpp
+++ b/lib/Simplifier/PropagateEqualities.cpp
@@ -29,7 +29,7 @@ THE SOFTWARE.
 namespace stp
 {
 
-void log(std::string s)
+void log([[maybe_unused]] std::string s)
 {
 #if 0
   std::cerr << ">>" << s;
@@ -527,7 +527,7 @@ void PropagateEqualities::buildCandidateList(const ASTNode& a)
 
     if (!added && bm->UserFlags.stats_flag)
     {
-      const auto old = todo;
+      [[maybe_unused]] const auto old = todo;
       countToDo(c[0]);
       countToDo(c[1]);
       //if (todo != old)

--- a/lib/Simplifier/Rewriting.cpp
+++ b/lib/Simplifier/Rewriting.cpp
@@ -230,11 +230,11 @@ namespace stp
        )
        {
 
-        for (int matching =0 ; matching < c[1][0].Degree(); matching++)
+        for (size_t matching =0 ; matching < c[1][0].Degree(); matching++)
           if (c[1][0][matching] == c[0])
           {
             ASTVec others;
-            for (int i =0 ; i < c[1][0].Degree(); i++)
+            for (size_t i =0 ; i < c[1][0].Degree(); i++)
               if (i != matching)
                 others.push_back(c[1][0][i]);
 

--- a/lib/Simplifier/Simplifier.cpp
+++ b/lib/Simplifier/Simplifier.cpp
@@ -248,7 +248,7 @@ ASTNodeMap Simplifier::FindConsts_TopLevel(const ASTNode& b, bool pushNeg,ASTNod
 
   ASTNodeMap constants;
   
-  for (const auto e: *SimplifyMap)
+  for (const auto& e: *SimplifyMap)
   {
     if (e.second.isConstant())
     {

--- a/lib/Simplifier/UnsignedIntervalAnalysis.cpp
+++ b/lib/Simplifier/UnsignedIntervalAnalysis.cpp
@@ -779,7 +779,7 @@ namespace stp
 
 #ifdef __SIZEOF_INT128__
     // A type wide enough to hold the product of two word-path values.
-    typedef unsigned __int128 uwide;
+    __extension__ typedef unsigned __int128 uwide;
     static const unsigned wordPathMaxWidth = 64;
 #else
     // No 128-bit type (e.g. 32-bit targets), so the word-level path

--- a/tests/unit-tests/NodeDomainAnalysis_Test.cpp
+++ b/tests/unit-tests/NodeDomainAnalysis_Test.cpp
@@ -284,7 +284,9 @@ static void checkIdempotent(Context& c, stp::FixedBits*& bits,
 
   ASSERT_EQ(bitsAfterFirst == nullptr, bits == nullptr) << msg;
   if (bits != nullptr)
+  {
     ASSERT_TRUE(stp::FixedBits::equals(*bitsAfterFirst, *bits)) << msg;
+  }
 
   ASSERT_EQ(minAfterFirst == nullptr, interval == nullptr) << msg;
   if (interval != nullptr)
@@ -434,8 +436,10 @@ TEST(NodeDomainAnalysis_Test, harmonise_tightens_maximally_exhaustive)
             const bool fixed = bits != nullptr && bits->isFixed(i);
             ASSERT_EQ(agree[i], fixed) << "bit " << i << " " << msg;
             if (fixed)
+            {
               ASSERT_EQ(agreedValue[i], bits->getValue(i))
                   << "bit " << i << " " << msg;
+            }
           }
 
           delete bits;

--- a/tests/unit-tests/SimplifyingNodeFactory_Exhaustive_Test.cpp
+++ b/tests/unit-tests/SimplifyingNodeFactory_Exhaustive_Test.cpp
@@ -150,7 +150,9 @@ struct Context
     ASTNode plain = hf->CreateTerm(k, width, children);
     ASTNode simplified = nf->CreateTerm(k, width, children);
     if (expectFired)
+    {
       EXPECT_NE(plain, simplified);
+    }
     checkEquivalent(plain, simplified);
   }
 
@@ -159,7 +161,9 @@ struct Context
     ASTNode plain = hf->CreateNode(k, children);
     ASTNode simplified = nf->CreateNode(k, children);
     if (expectFired)
+    {
       EXPECT_NE(plain, simplified);
+    }
     checkEquivalent(plain, simplified);
   }
 };

--- a/tests/unit-tests/ValueSet_Test.cpp
+++ b/tests/unit-tests/ValueSet_Test.cpp
@@ -569,7 +569,9 @@ TEST(ValueSet_Test, harmonise_threeway_exhaustive)
                   bits != nullptr && bits->isFixed(i);
               ASSERT_EQ(fixed, !(anyZero && anyOne));
               if (fixed)
+              {
                 ASSERT_EQ(bits->getValue(i), anyOne);
+              }
             }
 
             // Idempotent: a second call changes nothing.
@@ -590,7 +592,9 @@ TEST(ValueSet_Test, harmonise_threeway_exhaustive)
             ASSERT_EQ(members(set), setBefore);
             ASSERT_EQ(bits == nullptr, bitsWereNull);
             if (bits != nullptr)
+            {
               ASSERT_TRUE(FixedBits::equals(*bits, bitsBefore));
+            }
             ASSERT_EQ(interval == nullptr, intervalWasNull);
             if (interval != nullptr)
             {


### PR DESCRIPTION
Cleans up every `-Wall`/`-Wextra` warning GCC emits for STP's own sources. Warnings originating in third-party code under `deps/` (gtest) are out of scope and untouched.

## Changes

| Warning | File(s) | Fix |
|---------|---------|-----|
| `-Wrange-loop-construct` | `Dependencies.h`, `Simplifier.cpp` | Iterate the maps by `const auto&` to avoid copying each pair |
| `-Wunused-parameter` / `-Wunused-variable` | `PropagateEqualities.cpp` | Mark the `#if 0`-only `log()` parameter and the stats-only `old` variable `[[maybe_unused]]` |
| `-Wsign-compare` | `Rewriting.cpp` | Use `size_t` loop counters when comparing against `Degree()` |
| `-Wpedantic` (`__int128`) | `UnsignedIntervalAnalysis.cpp` | Prefix the `unsigned __int128` typedef with `__extension__` |
| `-Wdangling-else` | `NodeDomainAnalysis_Test.cpp`, `SimplifyingNodeFactory_Exhaustive_Test.cpp`, `ValueSet_Test.cpp` | Brace single-statement `if` bodies wrapping gtest `ASSERT`/`EXPECT` macros |

All changes are behavior-preserving. A full rebuild afterwards compiles STP's sources with no remaining warnings.