### PR TITLE
Build Release at -O3 (minus auto-vectorization): ~5% faster time-to-CNF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,7 +208,8 @@ if (NOT MSVC)
 
     add_compile_options("$<$<CONFIG:RELWITHDEBINFO>:-O2>")
 
-    add_compile_options("$<$<CONFIG:RELEASE>:-O2>")
+    add_compile_options("$<$<CONFIG:RELEASE>:-O3>")
+    add_compile_options("$<$<CONFIG:RELEASE>:-fno-tree-vectorize>")
     add_compile_options("$<$<CONFIG:RELEASE>:-g0>")
 
     add_compile_options("$<$<CONFIG:DEBUG>:-O0>")


### PR DESCRIPTION
## What

Compile the Release build at `-O3 -fno-tree-vectorize` instead of the current effective `-O2`.

The `if (NOT MSVC)` block appended `add_compile_options($<CONFIG:RELEASE>:-O2>)` *after* CMake's default Release flags (`-O3 -DNDEBUG`). Since the last `-O` on the GCC command line wins, the whole binary — including the ABC AIG/CNF code that dominates bit-blasting and CNF generation — was actually built at **-O2**, not -O3.

## Why `-fno-tree-vectorize`

- Plain `-O3` is ~3% faster to CNF, but GCC's auto-vectorizer reorders a traversal so a few large instances (e.g. `asp/EdgeMatching`) emit their clauses in a different *order*. The formula is logically identical (same variable count, same clause multiset — verified), but the CNF is no longer byte-identical to the -O2 build.
- Disabling auto-vectorization removes that reordering **and** is itself faster here: STP's hot paths are scalar, pointer-chasing AIG cut enumeration / structural hashing (`Dar_ObjComputeCuts`, `Aig_Table*`), which the vectorizer pessimizes rather than helps.

## Result

- **~5.0% faster** time-to-CNF (`stp --exit-after-CNF`), measured with interleaved A/B timing over a 60-file, 24-family hard QF_BV set (2 rounds: B/A = 0.9456, 0.9496).
- **Byte-identical CNF** vs the -O2 build, verified on 265 files across 84 families (`--output-CNF` byte comparison).

For reference, the two candidates measured:

| Build | speedup vs -O2 | byte-identical CNF |
|---|---|---|
| `-O3` | ~3.0% | no (benign clause reorder on ~0.7% of files) |
| `-O3 -fno-tree-vectorize` | **~5.0%** | yes |