### PR TITLE
Add USE_TCMALLOC option: ~15% faster time-to-CNF via a faster allocator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -521,6 +521,27 @@ if (USE_CADICAL)
 endif()
 
 # -----------------------------------------------------------------------------
+# Optionally link a faster allocator (tcmalloc)
+# -----------------------------------------------------------------------------
+# STP is allocation-heavy during bit-blasting and CNF generation (the AIG and
+# CNF data structures churn a lot of memory). Replacing the C library allocator
+# with tcmalloc measurably speeds up the pre-SAT stages with no change to
+# results. Opt-in so we don't add a hard runtime dependency.
+option(USE_TCMALLOC "Link against tcmalloc for faster memory allocation" OFF)
+add_feature_info(TCMalloc USE_TCMALLOC "Links tcmalloc for faster allocation")
+
+if (USE_TCMALLOC)
+    find_library(TCMALLOC_LIBRARY NAMES tcmalloc_minimal tcmalloc)
+    if (NOT TCMALLOC_LIBRARY)
+        message(FATAL_ERROR "USE_TCMALLOC is set but tcmalloc was not found. "
+                "Install gperftools (e.g. libtcmalloc-minimal4 / gperftools-libs) "
+                "or unset USE_TCMALLOC.")
+    endif()
+    message(STATUS "Found tcmalloc: ${TCMALLOC_LIBRARY}")
+    link_libraries(${TCMALLOC_LIBRARY})
+endif()
+
+# -----------------------------------------------------------------------------
 # Find CryptoMiniSat
 # -----------------------------------------------------------------------------
 option(NOCRYPTOMINISAT "Don't try to use cryptominisat" OFF)


### PR DESCRIPTION
## What

Add an opt-in `USE_TCMALLOC` CMake option that links `tcmalloc_minimal` (gperftools) as a drop-in replacement for the C library allocator.

## Why

STP is allocation-heavy in the pre-SAT stages: bit-blasting builds a large AIG and CNF generation churns a lot of memory. Profiling `stp --exit-after-CNF` on hard QF_BV benchmarks shows **~12% of time in the glibc allocator** — `_int_malloc`, `_int_free`, `malloc_consolidate`, and page faults from large AIG/CNF allocations. tcmalloc handles this workload far better (thread-caching, better large-allocation/page handling, less fragmentation).

## Result

- **~15% faster time-to-CNF** (`stp --exit-after-CNF`), measured with interleaved A/B on a 60-file, 24-family hard set on a quiet machine (2 rounds: B/A = 0.850, 0.852; total 14.9%).
- **Results unchanged**: CNF output verified **byte-identical** vs the glibc build (`--output-CNF` byte comparison across the test set) — an allocator swap doesn't change what STP computes.
- **All 62 tests pass** (`ctest`) with tcmalloc.

## Notes

- Off by default, so no new hard dependency. Enable with `-DUSE_TCMALLOC=ON` (needs gperftools installed — `libtcmalloc-minimal4` + its `-dev` package on Debian/Ubuntu, `gperftools-libs`/`gperftools-devel` on Fedora).
- Independent of / stacks with #606 (`-O3 -fno-tree-vectorize`); together they give ~20% on the pre-SAT pipeline.
- The win is a drop-in allocator effect, so `jemalloc`/`mimalloc` would give similar gains; `tcmalloc_minimal` is the most widely packaged. The option could reasonably be defaulted on where gperftools is present — left off here for a conservative first cut.