### PR TITLE
Stop building the half of ABC that STP never uses

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -126,8 +126,47 @@ endif()
 set(READLINE_FOUND FALSE CACHE BOOL "Disable readline for ABC" FORCE)
 set(ABC_SKIP_TESTS ON CACHE BOOL "Skip ABC tests" FORCE)
 
-# Add ABC as a subdirectory
-add_subdirectory(extlib-abc)
+# ABC has no CMake cache variables for the options below: its CMakeLists runs
+# ABC's own Makefile to extract the source list and flags, forwarding only the
+# readline and namespace settings. The Makefile gates these on ifndef, and make
+# honours the environment for that, which the inherited environment of ABC's
+# execute_process() reaches. So set them here rather than patching the submodule.
+#
+# CUDD: pulls in nine BDD modules (src/bdd/{cudd,extrab,dsd,epd,mtr,reo,cas,bbr,
+# llb}), 123 files and ~110k lines that STP never uses -- we only touch AIG
+# construction, Dar rewriting and CNF derivation. Safe for our include set:
+# ABC_USE_CUDD guards only Abc_Frame_t's DdManager field in base/main/mainInt.h
+# and three Kit_*ToBdd declarations in bool/kit/kit.h, and neither header is
+# reachable from aig/aig/aig.h, opt/dar/dar.h or sat/cnf/cnf.h.
+set(ENV{ABC_USE_NO_CUDD} 1)
+# pthreads: every ABC file we compile that calls pthread_* guards on
+# ABC_USE_PTHREADS (src/starter.c does not, but is in no module.make and is
+# never built). Dropping it also keeps the macro consistent between ABC's own
+# translation units and STP's, which include ABC headers without ABC's flags --
+# see the note on $<TARGET_FILE:libabc-pic> below.
+set(ENV{ABC_USE_NO_PTHREADS} 1)
+
+# EXCLUDE_FROM_ALL: ABC marks libabc and libabc-pic EXCLUDE_FROM_ALL but not its
+# abc executable, which links libabc (non-PIC) and so compiles all of ABC a
+# second time. STP only ever links libabc-pic, pulled in by the dependency
+# below; the executable is dead weight worth ~50% of ABC's build cost.
+#
+# BUILD_SHARED_LIBS: ABC's add_library() calls name neither STATIC nor SHARED,
+# so they follow BUILD_SHARED_LIBS, which defaults to ON. That made libabc-pic a
+# 17MB shared library which libstp.so recorded as a NEEDED entry even though ABC
+# has no install() rules, so an installed libstp.so named a library that was
+# never installed; only the build-tree RUNPATH kept it working. Building it as an
+# archive links the ABC code into libstp.so instead, which is self-contained and
+# installable. libabc-pic is already POSITION_INDEPENDENT_CODE, which is what
+# linking it into a shared library needs. Note the archive does not shrink the
+# result much: ABC is interconnected enough that our ~30 entry points transitively
+# pull in most of it either way -- what changes is that the symbols stop being
+# public, see --exclude-libs at the bottom of this file.
+# The normal variable shadows the cache entry for this scope only; unset()
+# restores the cached value for the rest of lib/.
+set(BUILD_SHARED_LIBS OFF)
+add_subdirectory(extlib-abc EXCLUDE_FROM_ALL)
+unset(BUILD_SHARED_LIBS)
 
 # ABC is a vendored, upstream submodule (berkeley-abc/abc) whose warnings we
 # don't control, so keep WERROR from turning them into build failures. The
@@ -141,9 +180,25 @@ if (WERROR AND NOT MSVC)
     endforeach()
 endif()
 
+# Give each ABC function and data object its own section so the --gc-sections
+# below can drop the ones we never call. Applied to ABC only: the dead weight is
+# all on this side, and confining it keeps STP's own codegen unchanged.
+if (NOT MSVC)
+    foreach(_abc_target libabc libabc-pic)
+        if (TARGET ${_abc_target})
+            target_compile_options(${_abc_target} PRIVATE
+                -ffunction-sections -fdata-sections)
+        endif()
+    endforeach()
+endif()
+
 # Link to the ABC library target
 add_dependencies(stp libabc-pic)
-# Use the full path to the library instead of the target name for export compatibility
+# Use the full path to the library instead of the target name for export
+# compatibility. Note this bypasses ABC's PUBLIC usage requirements, so the
+# flags ABC sets for its own translation units do not reach STP's: any ABC
+# option that changes a declaration in aig.h, dar.h or cnf.h would have to be
+# defined for STP's sources too.
 set(stp_link_libs ${MINISAT_LIBRARIES} $<TARGET_FILE:libabc-pic>)
 
 if (USE_CRYPTOMINISAT)
@@ -167,6 +222,26 @@ endif()
 target_link_libraries(stp
     LINK_PUBLIC ${stp_link_libs}
 )
+
+# ABC is interconnected enough that satisfying our ~30 entry points transitively
+# drags in most of the archive, including its vendored zlib and bzlib (gzopen,
+# inflate, deflate, crc32, BZ2_*). Left with default visibility those would be
+# exported from libstp.so, where they can serve requests that belong to the real
+# libz used by minisat and CryptoMiniSat. --exclude-libs makes symbols taken from
+# static archives local to the output, so libstp.so exports only STP's own API
+# and the ABC code it uses stays private. GNU ld and lld only; on Apple and
+# Windows this is skipped, and for a static libstp there is no link step to
+# apply it to.
+#
+# --gc-sections then discards the ABC sections nothing reaches. Linking ABC as an
+# archive puts its code inside libstp.so, and the transitive pull-in is most of
+# ABC, so without this the library grows from ~2MB to ~18MB; with it, ~3.4MB.
+# Hiding the symbols first is what makes the collection effective -- an exported
+# symbol is a GC root.
+if (BUILD_SHARED_LIBS AND NOT APPLE AND NOT WIN32 AND NOT MSVC)
+    set_property(TARGET stp APPEND_STRING PROPERTY
+        LINK_FLAGS " -Wl,--exclude-libs,ALL -Wl,--gc-sections")
+endif()
 
 install(TARGETS stp
     EXPORT ${STP_EXPORT_NAME}


### PR DESCRIPTION
STP touches about thirty ABC entry points: AIG construction, Dar rewriting and
CNF derivation. The build was treating the vendored submodule as if we needed all
of it. Everything here is in `lib/CMakeLists.txt` — the submodule is untouched.

## Build cost

ABC marks `libabc` and `libabc-pic` `EXCLUDE_FROM_ALL` but **not** its `abc`
executable, which links `libabc` (non-PIC). So `lib/extlib-abc/all` reached the
executable and every default build compiled the whole of ABC a second time for a
binary that neither STP nor its tests use. Excluding the subdirectory leaves only
`libabc-pic`, pulled in by the existing `add_dependencies(stp libabc-pic)`.

CUDD is on unless `ABC_USE_NO_CUDD` is set, adding nine BDD modules
(`src/bdd/{cudd,extrab,dsd,epd,mtr,reo,cas,bbr,llb}`, 123 files, ~110k lines) to a
solver that does no BDD work. ABC exposes no cache variable for it — its
CMakeLists runs ABC's Makefile to extract the source list and forwards only the
readline and namespace settings — but the Makefile gates on `ifndef` and make
reads the environment, which the inherited environment of ABC's
`execute_process()` reaches. `ABC_USE_NO_PTHREADS` goes the same way; every ABC
file we compile that calls `pthread_*` guards on `ABC_USE_PTHREADS` (`src/starter.c`
does not, but it is in no `module.make` and is never built).

Dropping CUDD is safe for our include set: `ABC_USE_CUDD` guards only
`Abc_Frame_t`'s `DdManager` field in `base/main/mainInt.h` and three `Kit_*ToBdd`
declarations in `bool/kit/kit.h`, and neither header is reachable from
`aig/aig/aig.h`, `opt/dar/dar.h` or `sat/cnf/cnf.h`.

| | before | after |
|---|---|---|
| default build objects | 2363 | 1104 |
| default build user CPU (`-j20`, Release) | 1416.4 s | 687.4 s (**-51.5%**) |
| default build wall | 149.0 s | 42.4 s |

## Linkage

ABC's `add_library()` calls name neither STATIC nor SHARED, so they followed
`BUILD_SHARED_LIBS` (default ON) and produced a 17 MB `libabc-pic.so` that
`libstp.so` recorded as `NEEDED` — even though ABC has no `install()` rules. An
installed `libstp.so` therefore named a library that was never installed, and only
the build-tree RUNPATH kept it loadable. It also placed ABC's vendored zlib and
bzlib (`gzopen`, `gzread`, `inflate`, `deflate`, `compress`, `crc32`, `adler32`,
`BZ2_*`) in the global namespace beside the real libz that minisat and
CryptoMiniSat use, leaving load order to decide which one served them.

Building it as an archive makes `libstp.so` self-contained, but not smaller on its
own: ABC is interconnected enough that our entry points transitively pull in most
of it (~4675 symbols) either way. `--exclude-libs,ALL` keeps that code private,
which is what actually removes the vendored zlib from the dynamic namespace, and
it makes `--gc-sections` effective since an exported symbol is a GC root. With
`-ffunction-sections` on the ABC targets only:

| | before | after |
|---|---|---|
| `libstp.so` | 2.0 MB + a 17.4 MB `libabc-pic.so` sidecar | 3.4 MB, self-contained |
| symbols exported by `libstp.so` | 1639, plus 14684 in the sidecar | 1639 |
| ABC/zlib symbols in the global namespace | 14684 | 0 |

STP's own API is unaffected (139 `vc_*`/`stp::` symbols still exported). The link
flags are gated to shared, non-Apple, non-Windows builds: `--exclude-libs` is GNU
ld/lld only, and a static `libstp` has no link step to apply them to.

`set(BUILD_SHARED_LIBS OFF)` is a normal variable shadowing the cache entry for
that scope only; `unset()` restores it. Verified the parent scope is unaffected —
`ENABLE_TESTING` still survives its `if (NOT BUILD_SHARED_LIBS)` guard, which
runs after `lib/`.

## Testing

`ctest`: 63/63 pass, including `query-files` at 164/164 lit cases. Separately,
60 `tests/query-files` cases give identical results with and without
`--aig-rewrite-passes 3`, exercising `Dar_ManRewrite` — the path most likely to
reach the BDD/kit machinery that CUDD was providing.

Not done here: `ABC_USE_STDINT_H=1` would retire ABC's compile-and-run
`arch_flags.c` probe (a cross-compilation hazard, and redundant with STP's own
`CheckTypeSize`), but inside its `#ifdef` `abc_global.h` does a bare
`#define LIN64` that conflicts with STP's `-DLIN64` under `WERROR`. Taking it
properly means retiring STP's `LIN`/`LIN64` and `SIZEOF_*` definitions and
defining `ABC_USE_STDINT_H` for STP's own sources too, since it changes
`ABC_PTRDIFF_T`/`ABC_PTRUINT_T`. That touches the Windows `WIN32_NO_DLL` path and
the 32-bit build, so it belongs in its own change.