### PR TITLE
Allow CI to be started by hand from the Actions tab

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,7 @@
-on: [push, pull_request]
+# workflow_dispatch adds a "Run workflow" button on the Actions tab, so a run
+# can be started by hand against any branch — useful for re-running against a
+# branch whose last push predates a fix elsewhere.
+on: [push, pull_request, workflow_dispatch]
 name: CI
 
 # A newer commit makes the runs still going for the previous one pointless.


### PR DESCRIPTION
CodeQL already has workflow_dispatch; CI did not, so there was no way to re-run it against a branch without pushing a new commit. Add the trigger so the Actions tab offers a "Run workflow" button with a ref picker.