### PR TITLE
Add --cnf-generation-effort to trade CNF size against generation time

### DIFF
--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -134,6 +134,26 @@ public:
   bool traditional_cnf = false;
   bool simple_cnf = false; // don't use the good AIG based CNF conversion.
 
+  // How much work to spend turning the AIG into CNF. Higher levels take longer
+  // to generate but produce a smaller CNF, so the best setting depends on
+  // whether a problem's cost is dominated by CNF generation or by solving.
+  //
+  // MEDIUM is ABC's Cnf_Derive(), a cut-enumeration and technology-mapping
+  // pass. VERY_LOW is Cnf_DeriveFast(), which skips cut enumeration entirely.
+  // LOW, HIGH and VERY_HIGH use ABC's newer Mf_ManGenerateCnf() at LUT sizes
+  // 3, 6 and 8; its cost grows steeply with LUT size for little further gain
+  // past 6.
+  enum CNFEffort
+  {
+    CNF_EFFORT_VERY_LOW = 0,
+    CNF_EFFORT_LOW,
+    CNF_EFFORT_MEDIUM,
+    CNF_EFFORT_HIGH,
+    CNF_EFFORT_VERY_HIGH
+  };
+
+  enum CNFEffort cnf_effort = CNF_EFFORT_MEDIUM;
+
   bool exit_after_CNF = false;
 
   // Stop after parsing the input, skipping any check-sat commands.

--- a/include/stp/ToSat/ToCNFAIG.h
+++ b/include/stp/ToSat/ToCNFAIG.h
@@ -27,6 +27,8 @@ THE SOFTWARE.
 
 // From ABC
 #include "aig/aig/aig.h"
+#include "aig/gia/gia.h"
+#include "aig/gia/giaAig.h"
 #include "sat/cnf/cnf.h"
 #include "opt/dar/dar.h"
 
@@ -42,6 +44,10 @@ class ToCNFAIG // not copyable
   UserDefinedFlags& uf;
 
   void dag_aware_aig_rewrite(const bool needAbsRef, BBNodeManagerAIG& mgr);
+
+  // Turn the AIG into CNF, choosing the generator from uf.cnf_effort.
+  Cnf_Dat_t* derive_cnf(BBNodeManagerAIG& mgr);
+  Cnf_Dat_t* derive_cnf_mf(BBNodeManagerAIG& mgr, int nLutSize);
 
   void fill_node_to_var(Cnf_Dat_t* cnfData,
                         ToSATBase::ASTNodeToSATVar& nodeToVars,

--- a/lib/ToSat/ToCNFAIG.cpp
+++ b/lib/ToSat/ToCNFAIG.cpp
@@ -125,7 +125,7 @@ void ToCNFAIG::toCNF(const BBNodeAIG& top, Cnf_Dat_t*& cnfData,
 
   if (!uf.simple_cnf)
   {
-    cnfData = Cnf_Derive(mgr.aigMgr, 0);
+    cnfData = derive_cnf(mgr);
     if (uf.stats_flag)
       cerr << "advanced CNF" << endl;
   }
@@ -138,6 +138,86 @@ void ToCNFAIG::toCNF(const BBNodeAIG& top, Cnf_Dat_t*& cnfData,
   assert(cnfData != NULL);
 
   fill_node_to_var(cnfData, nodeToVars, mgr);
+}
+
+// ABC's newer CNF generator. It works on a Gia_Man_t, so the AIG is converted
+// first. nLutSize bounds the cuts it considers: larger means a smaller CNF for
+// steeply more work.
+Cnf_Dat_t* ToCNFAIG::derive_cnf_mf(BBNodeManagerAIG& mgr, int nLutSize)
+{
+  Gia_Man_t* pGia = Gia_ManFromAig(mgr.aigMgr);
+
+  // fAddOrCla must be set. Cnf_Derive(pAig, 0) emits the clauses asserting the
+  // COs itself, but this generator only does so on request: it adds a single
+  // clause OR-ing all COs, and toCNF() has already established there is exactly
+  // one, so that clause is the unit which asserts the top-level formula.
+  // Without it the CNF is trivially satisfiable.
+  Cnf_Dat_t* cnfData =
+      (Cnf_Dat_t*)Mf_ManGenerateCnf(pGia, nLutSize, 0, 1, 0, 0);
+
+  // pVarNums comes back indexed by Gia object id, but addVariables() and
+  // fill_node_to_var() index it by Aig CI object id. Rebuild it over the Aig id
+  // space so those callers need no special case; only CIs are ever looked up,
+  // so everything else stays -1.
+  //
+  // Aig_ManObjNumMax(), not Aig_ManObjNum(): the latter subtracts nDeleted, and
+  // the Aig_ManCleanup() in toCNF() deletes nodes, so ids run past the count of
+  // live objects. Sizing by the count under-allocates by exactly nDeleted, and
+  // fill_node_to_var() then reads off the end of the array.
+  //
+  // Reading Gia CI ids is safe even though this generator may derive the CNF
+  // over a coarsened copy of the Gia (Gia_ManDupMuxes, when fCnfObjIds is 0):
+  // both managers append CIs before any AND node, so CI ids are 1..nCi in each,
+  // and pVarNums is sized by an object count that includes them.
+  const int nAigObjs = Aig_ManObjNumMax(mgr.aigMgr);
+  int* pRemap = ABC_ALLOC(int, nAigObjs);
+  for (int i = 0; i < nAigObjs; i++)
+    pRemap[i] = -1;
+
+  Aig_Obj_t* pCi;
+  int ci;
+  Aig_ManForEachCi(mgr.aigMgr, pCi, ci)
+    pRemap[pCi->Id] = cnfData->pVarNums[Gia_ObjId(pGia, Gia_ManCi(pGia, ci))];
+
+  ABC_FREE(cnfData->pVarNums);
+  cnfData->pVarNums = pRemap;
+
+  // Mf_ManGenerateCnf leaves pMan pointing at the Gia, cast to Aig_Man_t*.
+  // Nothing in STP reads pMan and Cnf_DataFree() does not touch it, so the Gia
+  // can be released here; null the pointer so it cannot be followed.
+  cnfData->pMan = NULL;
+  Gia_ManStop(pGia);
+
+  return cnfData;
+}
+
+Cnf_Dat_t* ToCNFAIG::derive_cnf(BBNodeManagerAIG& mgr)
+{
+  switch (uf.cnf_effort)
+  {
+    case UserDefinedFlags::CNF_EFFORT_VERY_LOW:
+      // No cut enumeration at all: a marking pass, then clause generation.
+      // This is the floor of the scale rather than Cnf_DeriveSimple() (the
+      // plain Tseitin encoding the simple_cnf path above uses), because
+      // Cnf_DeriveSimple buys about 12% off generation time for roughly 1.9x
+      // the clauses -- measured on one input at 51.7M clauses against 27.6M
+      // here. That trade is not worth a level.
+      return Cnf_DeriveFast(mgr.aigMgr, 0);
+
+    case UserDefinedFlags::CNF_EFFORT_LOW:
+      return derive_cnf_mf(mgr, 3);
+
+    case UserDefinedFlags::CNF_EFFORT_HIGH:
+      return derive_cnf_mf(mgr, 6);
+
+    case UserDefinedFlags::CNF_EFFORT_VERY_HIGH:
+      return derive_cnf_mf(mgr, 8);
+
+    case UserDefinedFlags::CNF_EFFORT_MEDIUM:
+    default:
+      // Cut enumeration and technology mapping, ABC's Cnf_Derive().
+      return Cnf_Derive(mgr.aigMgr, 0);
+  }
 }
 
 void ToCNFAIG::fill_node_to_var(Cnf_Dat_t* cnfData,

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -351,6 +351,10 @@ void ExtraMain::create_options()
   po::options_description misc_options("Output options");
   misc_options.add_options()
 
+      ("cnf-generation-effort", po::value<string>()->default_value("medium"),
+       "effort spent minimising the CNF: very-low, low, medium, high, "
+       "very-high. Higher is slower to generate but yields a smaller CNF")
+
       // exit-after-CNF
       ("exit-after-CNF", po::bool_switch(&(bm->UserFlags.exit_after_CNF)),
        "exit after the CNF has been generated")
@@ -432,6 +436,28 @@ int ExtraMain::parse_options(int argc, char** argv)
   if (vm.count("interactive"))
   {
     bm->UserFlags.interactive_read = vm["interactive"].as<bool>() ? 1 : 0;
+  }
+
+  if (vm.count("cnf-generation-effort"))
+  {
+    const string effort = vm["cnf-generation-effort"].as<string>();
+    if (effort == "very-low")
+      bm->UserFlags.cnf_effort = UserDefinedFlags::CNF_EFFORT_VERY_LOW;
+    else if (effort == "low")
+      bm->UserFlags.cnf_effort = UserDefinedFlags::CNF_EFFORT_LOW;
+    else if (effort == "medium")
+      bm->UserFlags.cnf_effort = UserDefinedFlags::CNF_EFFORT_MEDIUM;
+    else if (effort == "high")
+      bm->UserFlags.cnf_effort = UserDefinedFlags::CNF_EFFORT_HIGH;
+    else if (effort == "very-high")
+      bm->UserFlags.cnf_effort = UserDefinedFlags::CNF_EFFORT_VERY_HIGH;
+    else
+    {
+      std::cerr << "Unknown --cnf-generation-effort value '" << effort
+                << "'. Expected one of: very-low, low, medium, high, very-high."
+                << std::endl;
+      return -1;
+    }
   }
 
   int selected_type = 0;


### PR DESCRIPTION
## Why

CNF conversion is the largest pre-SAT cost on the hard set — **22% of total time (3,887 s)**, about 3× the next stage. Inside it, **74–82% is the cut enumeration** in `Dar_ManComputeCuts`, whose parameters `Cnf_Derive` hardcodes:

| file | cuts | map | save | cuts as % of ABC CNF |
|---|---|---|---|---|
| `mcm/186.smt2` | 44.9 s | 4.0 | 6.1 | 82% |
| `mcm/185.smt2` | 43.2 s | 4.1 | 5.8 | 81% |
| `float/sin.c.175.smt2` | 35.2 s | 3.6 | 4.2 | 82% |
| `oisc/AND-NESTED-12-32.smt2` | 17.0 s | 1.9 | 3.9 | 74% |

On `mcm/186.smt2` that is 44.9 s of a 101.3 s run. Whether the effort is worthwhile is problem-dependent — a smaller CNF can pay for itself in solving, or generation can dominate — and there was no way to choose. `Cnf_DeriveSimple` was reachable only as a side effect of `--disable-simplifications`, which changes ~15 other settings at once.

(These phase numbers come from `Cnf_Man_t::time{Cuts,Map,Save}`, which ABC fills in but only prints from commented-out `ABC_PRT` lines. `Cnf_Man_t` is public in `cnf.h` and `Cnf_ManRead()` is exported, so they are readable without touching the submodule.)

## What

`--cnf-generation-effort {very-low,low,medium,high,very-high}`, measured on `20220315-ecrw/rw_rule_candidate_vmcai_2022_bw512_12.smt2`:

| level | generator | derive | vars | clauses |
|---|---|---|---|---|
| `very-low` | `Cnf_DeriveFast` | 3.3 s | 7,055,392 | 27,563,385 |
| `low` | `Mf_ManGenerateCnf`, LUT 3 | 15.4 s | 5,468,475 | 23,757,984 |
| **`medium`** (default) | `Cnf_Derive` | 20.3 s | 3,816,256 | 21,708,410 |
| `high` | `Mf_ManGenerateCnf`, LUT 6 | 32.5 s | 2,664,270 | 19,682,981 |
| `very-high` | `Mf_ManGenerateCnf`, LUT 8 | 68.5 s | 2,597,687 | 19,511,319 |

`medium` is `Cnf_Derive`, so **the default is unchanged** — byte-identical CNF to the previous code on all 29 test inputs that generate one.

`Mf_ManGenerateCnf` (`src/aig/gia/giaMf.c:1877`) is ABC's newer generator, already in our pinned submodule and used by ABC's own CEC and BMC. It works on `Gia_Man_t`, so the AIG is converted with `Gia_ManFromAig()` first. Worth stating plainly since the name invites the opposite assumption: **it is not a faster `Cnf_Derive`** — at ABC's own default LUT size 8 it is 3.4× slower for 10% fewer clauses, and past LUT 6 the returns are negligible.

## Options the measurements ruled out

Recorded so they are not retried:

* **`Cnf_Man_t::nMergeLimit`** — byte-identical CNF at 4, 6, 8, 10 and 12 (8,999,996 vars / 45,853,244 clauses / 142,898,869 literals at every setting). It gates `Cnf_CutCompose` (`cnfCut.c:312`), which `Cnf_DeriveWithMan`'s flow never reaches.
* **`fSkipTtMin`** — 20.6 s vs 20.3 s, CNF essentially unchanged. Within noise.
* **`Dar_ManComputeCuts` `nCutsMax`** — at 4 it halves derivation (10.0 s) but adds 47% clauses (31.8 M). `Cnf_DeriveFast` is both faster *and* smaller, so this is dominated on both axes.
* **`Cnf_DeriveSimple`** — 12% off generation for **1.9× the clauses** (51.7 M vs 27.6 M) and 2.4× the variables. Plain Tseitin does not earn a level, which is why `very-low` is `Cnf_DeriveFast`.

## Two integration details

Both non-obvious from the headers, so they are commented in the source:

1. **`fAddOrCla` must be 1.** `Cnf_Derive(pAig, 0)` emits the clauses asserting the COs itself; `Mf_ManGenerateCnf` only does so on request. It adds one clause OR-ing all COs, and `toCNF` has already asserted there is exactly one, so that clause is the unit asserting the top-level formula. Without it the CNF is trivially satisfiable.
2. **The `pVarNums` remap is sized with `Aig_ManObjNumMax()`, not `Aig_ManObjNum()`.** The latter subtracts `nDeleted`, and the `Aig_ManCleanup()` in `toCNF` deletes nodes, so object ids run past the count of live objects. `Mf_ManGenerateCnf` returns `pVarNums` indexed by Gia object id while `addVariables`/`fill_node_to_var` index by Aig CI object id, so it is rebuilt over the Aig id space and downstream callers are untouched.

## Testing

* Every level agrees with the default on **all 96 `tests/query-files`** under `--check-sanity`, which constructs *and checks* the counterexample. That is the necessary check here: these paths differ in variable numbering, so verdict agreement alone would not catch a bad mapping.
* `--disable-simplifications` (the `simple_cnf` path) verified unchanged against master, 96/96.
* `ctest` 63/63, including the 164-case `query-files` lit suite.
* `medium` CNF byte-identical to pre-change master on all 29 inputs that produce one (22 of 96 query-files, 7 of 25 real QF_BV benchmarks; the rest are solved during simplification and never reach CNF generation).

## Scope

Only `medium` has end-to-end solve-time evidence. The other levels are backed by CNF-generation measurements; establishing which wins on total time needs a benchmark set selected from runs timed to completion, which is separate work. The flag is what makes that measurable.

`simple_cnf` still short-circuits ahead of the scale, so `--disable-simplifications` behaviour is untouched. Folding it in — deleting `simple_cnf` and having `disableSimplifications()` set `very-low` — would remove a redundant mechanism and halve that path's clause count, but it changes what that flag means, so it is left for a separate discussion. Likewise `traditional_cnf` appears to be dead (read at `STP.cpp:702`, never written) and is left alone here.