### PR TITLE
Remove traditional_cnf, which selects between two of the same thing

### DIFF
--- a/include/stp/AST/ASTNode.h
+++ b/include/stp/AST/ASTNode.h
@@ -44,7 +44,6 @@ class ASTInternal;
 class ASTNode
 {
   friend class STPMgr;
-  friend class ASTtoCNF;
   friend class ASTInterior;
   friend class vector<ASTNode>;
   friend ASTNode HashingNodeFactory::CreateNode(const stp::Kind kind,

--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -131,7 +131,6 @@ public:
 
 
   /* CNF Generation options */
-  bool traditional_cnf = false;
   bool simple_cnf = false; // don't use the good AIG based CNF conversion.
 
   bool exit_after_CNF = false;

--- a/include/stp/ToSat/ToCNFAIG.h
+++ b/include/stp/ToSat/ToCNFAIG.h
@@ -35,8 +35,6 @@ THE SOFTWARE.
 
 namespace stp
 {
-class ASTtoCNF;
-
 class ToCNFAIG // not copyable
 {
   UserDefinedFlags& uf;

--- a/lib/STPManager/STP.cpp
+++ b/lib/STPManager/STP.cpp
@@ -699,7 +699,7 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input)
   }
 
   ToSATAIG toSATAIG(bm, cb, arrayTransformer);
-  ToSATBase* satBase = bm->UserFlags.traditional_cnf ? tosat : &toSATAIG;
+  ToSATBase* satBase = &toSATAIG;
 
   if (bm->soft_timeout_expired)
     return SOLVER_TIMEOUT;


### PR DESCRIPTION
## What

`traditional_cnf` reads as a choice between the AIG-based CNF translator and an older direct AST→CNF one. That second translator no longer exists.

`ToSATBase` has exactly one implementation, `ToSATAIG` (`ToSATAIG.h:40`), and the member this flag switched to is *also* a `ToSATAIG` — `STP.h:87`: `tosat = new ToSATAIG(bm, arrayTransformer)`. So both arms of

```c
ToSATBase* satBase = bm->UserFlags.traditional_cnf ? tosat : &toSATAIG;   // STP.cpp:702
```

are instances of the same class, differing only in lifetime: a long-lived member versus a local built one line earlier.

On top of that, nothing ever writes the flag. It is initialised `false` and has no command-line option, API setter, or binding — the only two references in the tree are its declaration and this ternary. So the expression always evaluated to `&toSATAIG`, and substituting that is **exactly equivalent on every code path**.

## Also removed

Two leftovers from the deleted translator:

* `class ASTtoCNF;` forward declaration in `ToCNFAIG.h:40`
* `friend class ASTtoCNF;` in `ASTNode.h:47`

`ASTtoCNF` has no definition anywhere in the tree, so both declarations are inert — the friend grant in particular names a class that cannot exist.

## Deliberately not changed

The `tosat` member stays: `Cpp_interface` still uses it for `PrintOutput` (`cpp_interface.cpp:543`), and `STP.h` creates, clears and deletes it.

That does leave something odd, which this PR does not address: `tosat` is only
used for printing on the paths built by default, while a separate local
`ToSATAIG` does the solving. Two clarifications, since an earlier version of this
description overstated the concern:

* **There is no correctness issue.** `PrintOutput` is defined on `ToSATBase` and
  reads only the `ret` passed in, `bm->UserFlags`, and `input_status` — which is a
  thread-local global (`Globals.cpp:37`), not instance state. It writes
  `bm->ValidFlag`. So the receiver is merely a way to reach `bm`; any instance
  gives identical output.
* **The member is not removable.** `tools/rewrite_rule_gen` deletes
  `GlobalSTP->tosat`, installs a fresh `ToSATAIG`, and passes it to
  `CallSAT_ResultCheck` for actual solving (`rewrite_rule_gen.cpp:794-818`), and
  `tools/stp/main_common.cpp:329` is a second `PrintOutput` caller. That tool only
  builds under `BUILD_EXTRA_TOOLS=ON`, which CI does not enable.

Making `PrintOutput` static so neither call site needs an instance is a separate
follow-up.

## Testing

`ctest` 63/63, including the 164-case `query-files` lit suite. Since the flag was unreachable, no behaviour can change; the tests confirm the refactor compiles and links cleanly rather than proving equivalence, which the always-`false` initialiser already does.

## Note for merge ordering

This touches `UserDefinedFlags.h` two lines above where #612 adds its `CNFEffort` enum. If both land, one may need a trivial rebase — the edits are adjacent but independent.
