### PR TITLE
Vendor mimalloc and make a fast allocator the default

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "lib/extlib-abc"]
 	path = lib/extlib-abc
 	url = https://github.com/berkeley-abc/abc.git
+[submodule "lib/extlib-mimalloc"]
+	path = lib/extlib-mimalloc
+	url = https://github.com/microsoft/mimalloc.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -564,9 +564,12 @@ if (STP_ALLOCATOR STREQUAL "mimalloc")
             "Run: git submodule update --init lib/extlib-mimalloc "
             "(or configure with -DSTP_ALLOCATOR=system).")
     endif()
-    # Only the static library, with the malloc/free/new/delete overrides on.
-    # Static keeps it self-contained: nothing extra to install or ship.
-    set(MI_BUILD_SHARED OFF CACHE BOOL "" FORCE)
+    # The static library is what the executables link: it keeps them
+    # self-contained, with nothing extra to install or ship. The shared one is
+    # built too but not installed - it is there to be LD_PRELOADed by processes
+    # that embed libstp rather than run the stp binary, the Python (ctypes)
+    # interface being the one in tree. See tests/api/python/allocator_tests.py.
+    set(MI_BUILD_SHARED ON  CACHE BOOL "" FORCE)
     set(MI_BUILD_OBJECT OFF CACHE BOOL "" FORCE)
     set(MI_BUILD_TESTS  OFF CACHE BOOL "" FORCE)
     set(MI_BUILD_STATIC ON  CACHE BOOL "" FORCE)
@@ -575,8 +578,14 @@ if (STP_ALLOCATOR STREQUAL "mimalloc")
     # Vendored upstream code whose warnings we do not control.
     if (WERROR AND NOT MSVC)
         target_compile_options(mimalloc-static PRIVATE -Wno-error)
+        target_compile_options(mimalloc PRIVATE -Wno-error)
     endif()
     set(STP_ALLOCATOR_LIBRARY mimalloc-static)
+    # EXCLUDE_FROM_ALL above keeps mimalloc's other targets out of the build;
+    # the shared library is small and wanted by anyone preloading it, so opt it
+    # back in.
+    set_target_properties(mimalloc PROPERTIES EXCLUDE_FROM_ALL FALSE)
+    set(STP_ALLOCATOR_PRELOADABLE mimalloc)
     message(STATUS "Allocator: vendored mimalloc (lib/extlib-mimalloc)")
 
 elseif (STP_ALLOCATOR STREQUAL "tcmalloc")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -526,25 +526,88 @@ if (USE_CADICAL)
 endif()
 
 # -----------------------------------------------------------------------------
-# Optionally link a faster allocator (tcmalloc)
+# Allocator selection
 # -----------------------------------------------------------------------------
-# STP is allocation-heavy during bit-blasting and CNF generation (the AIG and
-# CNF data structures churn a lot of memory). Replacing the C library allocator
-# with tcmalloc measurably speeds up the pre-SAT stages with no change to
-# results. Opt-in so we don't add a hard runtime dependency.
-option(USE_TCMALLOC "Link against tcmalloc for faster memory allocation" OFF)
-add_feature_info(TCMalloc USE_TCMALLOC "Links tcmalloc for faster allocation")
+# STP is allocation-heavy at every stage: bit-blasting and CNF generation churn
+# the AIG and CNF data structures, and the SAT solvers churn clause memory.
+# The C library allocator is the bottleneck; any of the modern replacements is
+# ~15% faster to CNF, ~14% faster for CaDiCaL solving and ~7% for CryptoMiniSat,
+# with identical results. mimalloc is vendored as a submodule so that a fast
+# allocator is always available and is what you get unless you ask otherwise.
+#
+#   mimalloc  (default) build and link the vendored lib/extlib-mimalloc
+#   tcmalloc            link the system gperftools tcmalloc, if it can be found
+#   system              plain malloc from the C library
+set(STP_ALLOCATOR "mimalloc" CACHE STRING
+    "Memory allocator to link against (mimalloc/tcmalloc/system)")
+set_property(CACHE STP_ALLOCATOR PROPERTY STRINGS mimalloc tcmalloc system)
 
-if (USE_TCMALLOC)
-    find_library(TCMALLOC_LIBRARY NAMES tcmalloc_minimal tcmalloc)
-    if (NOT TCMALLOC_LIBRARY)
-        message(FATAL_ERROR "USE_TCMALLOC is set but tcmalloc was not found. "
-                "Install gperftools (e.g. libtcmalloc-minimal4 / gperftools-libs) "
-                "or unset USE_TCMALLOC.")
+# Back-compat: -DUSE_TCMALLOC=ON/OFF predates STP_ALLOCATOR and still works.
+if (DEFINED USE_TCMALLOC AND NOT DEFINED _STP_ALLOCATOR_FROM_USE_TCMALLOC)
+    if (USE_TCMALLOC)
+        message(WARNING "USE_TCMALLOC is deprecated, use -DSTP_ALLOCATOR=tcmalloc")
+        set(STP_ALLOCATOR "tcmalloc" CACHE STRING "" FORCE)
+    else()
+        message(WARNING "USE_TCMALLOC=OFF is deprecated, use -DSTP_ALLOCATOR=system")
+        set(STP_ALLOCATOR "system" CACHE STRING "" FORCE)
     endif()
-    message(STATUS "Found tcmalloc: ${TCMALLOC_LIBRARY}")
-    link_libraries(${TCMALLOC_LIBRARY})
+    set(_STP_ALLOCATOR_FROM_USE_TCMALLOC ON CACHE INTERNAL "")
 endif()
+
+# STP_ALLOCATOR_LIBRARY is what the executables link; empty means system malloc.
+set(STP_ALLOCATOR_LIBRARY "")
+
+if (STP_ALLOCATOR STREQUAL "mimalloc")
+    if (NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/lib/extlib-mimalloc/CMakeLists.txt")
+        message(FATAL_ERROR
+            "STP_ALLOCATOR=mimalloc but lib/extlib-mimalloc is empty. "
+            "Run: git submodule update --init lib/extlib-mimalloc "
+            "(or configure with -DSTP_ALLOCATOR=system).")
+    endif()
+    # Only the static library, with the malloc/free/new/delete overrides on.
+    # Static keeps it self-contained: nothing extra to install or ship.
+    set(MI_BUILD_SHARED OFF CACHE BOOL "" FORCE)
+    set(MI_BUILD_OBJECT OFF CACHE BOOL "" FORCE)
+    set(MI_BUILD_TESTS  OFF CACHE BOOL "" FORCE)
+    set(MI_BUILD_STATIC ON  CACHE BOOL "" FORCE)
+    set(MI_OVERRIDE     ON  CACHE BOOL "" FORCE)
+    add_subdirectory(lib/extlib-mimalloc EXCLUDE_FROM_ALL)
+    # Vendored upstream code whose warnings we do not control.
+    if (WERROR AND NOT MSVC)
+        target_compile_options(mimalloc-static PRIVATE -Wno-error)
+    endif()
+    set(STP_ALLOCATOR_LIBRARY mimalloc-static)
+    message(STATUS "Allocator: vendored mimalloc (lib/extlib-mimalloc)")
+
+elseif (STP_ALLOCATOR STREQUAL "tcmalloc")
+    if (NOT BUILD_SHARED_LIBS)
+        # A -static link needs the archive; a versioned .so is useless here.
+        find_library(TCMALLOC_LIBRARY NAMES tcmalloc_minimal tcmalloc)
+    else()
+        # Distributions ship the unversioned symlink only in the -dev package,
+        # so also accept the runtime soname that everyone actually has.
+        find_library(TCMALLOC_LIBRARY
+                     NAMES tcmalloc_minimal tcmalloc
+                           libtcmalloc_minimal.so.4 libtcmalloc.so.4)
+    endif()
+    if (NOT TCMALLOC_LIBRARY)
+        message(FATAL_ERROR "STP_ALLOCATOR=tcmalloc but tcmalloc was not found. "
+                "Install gperftools (e.g. libtcmalloc-minimal-dev / gperftools-devel), "
+                "point -DTCMALLOC_LIBRARY at it, or use -DSTP_ALLOCATOR=mimalloc.")
+    endif()
+    set(STP_ALLOCATOR_LIBRARY ${TCMALLOC_LIBRARY})
+    message(STATUS "Allocator: tcmalloc (${TCMALLOC_LIBRARY})")
+
+elseif (STP_ALLOCATOR STREQUAL "system")
+    message(STATUS "Allocator: system malloc (slower; -DSTP_ALLOCATOR=mimalloc is the default)")
+
+else()
+    message(FATAL_ERROR "STP_ALLOCATOR must be mimalloc, tcmalloc or system, "
+            "not '${STP_ALLOCATOR}'")
+endif()
+
+add_feature_info(Allocator "NOT STP_ALLOCATOR STREQUAL system"
+                 "Links ${STP_ALLOCATOR} for faster allocation")
 
 # -----------------------------------------------------------------------------
 # Find CryptoMiniSat

--- a/README.markdown
+++ b/README.markdown
@@ -99,6 +99,13 @@ generators.
 - `PYTHON_EXECUTABLE` - Set python executable in case you have more than one python installed
 - `SANITIZE` - Use Clang's sanitization checks
 - `STATICCOMPILE` - Build static libraries and binaries instead of dynamic
+- `STP_ALLOCATOR` - Which memory allocator the `stp` binary uses. STP is
+  allocation-heavy, and the C library allocator is a significant bottleneck, so
+  this defaults to `mimalloc`, which is vendored as a submodule and built as
+  part of STP. Set to `tcmalloc` to link a system gperftools instead, or to
+  `system` for plain `malloc` (roughly 14% slower, but the lowest peak memory).
+  Only the executables link the allocator; `libstp` leaves the choice to
+  whatever application embeds it.
 
 ### Dependencies
 STP relies on : boost, flex, bison and minisat. You can install these by:

--- a/tests/api/python/CMakeLists.txt
+++ b/tests/api/python/CMakeLists.txt
@@ -37,3 +37,25 @@ add_test (
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
+# Allocator behaviour of the ctypes interface. Unlike the stp binaries, which
+# link an allocator statically, a process embedding libstp picks the allocator
+# itself - so libstp must not carry one, and preloading one must reach it.
+if (STP_ALLOCATOR_PRELOADABLE AND TARGET ${STP_ALLOCATOR_PRELOADABLE})
+    set(STP_PRELOADABLE_ALLOCATOR "$<TARGET_FILE:${STP_ALLOCATOR_PRELOADABLE}>")
+else()
+    set(STP_PRELOADABLE_ALLOCATOR "")
+endif()
+
+configure_file(allocator_tests.py.in allocator_tests.py.in.g @ONLY)
+# file(GENERATE) rather than a second configure_file: the allocator path is a
+# generator expression and is only known at generate time.
+file(GENERATE
+     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/allocator_tests.py
+     INPUT ${CMAKE_CURRENT_BINARY_DIR}/allocator_tests.py.in.g)
+
+add_test (
+  NAME python-allocator-tests
+  COMMAND ${PYTHON_EXECUTABLE} allocator_tests.py
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+)
+

--- a/tests/api/python/allocator_tests.py.in
+++ b/tests/api/python/allocator_tests.py.in
@@ -1,0 +1,169 @@
+"""
+AUTHORS: Trevor Hansen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+Allocator behaviour of the Python (ctypes) interface.
+
+The stp executables link a fast allocator statically, which interposes malloc
+for the whole process. The Python interface is different: it dlopen()s libstp
+into an interpreter that has already been allocating with the C library, so the
+allocator has to be chosen for the process rather than baked into the library.
+
+These tests pin both halves of that contract:
+
+  * libstp must not embed an allocator of its own. If it did, memory could be
+    allocated by libstp's allocator and freed by the interpreter's (or the
+    reverse) and the mixed heaps would eventually corrupt.
+  * When an allocator *is* preloaded into the interpreter, libstp's allocations
+    must actually go through it, and results must be unchanged.
+"""
+
+import os
+import re
+import subprocess
+import sys
+import unittest
+
+sys.path.insert(0, "@PYTHON_INTERFACE_DIR@/stp")
+
+import stp
+# The package already knows where it loaded libstp from; reuse that rather than
+# second-guessing the library name and layout.
+from library_path import PATHS
+
+LIBSTP = next((p for p in PATHS if os.path.exists(p)), None)
+PRELOADABLE_ALLOCATOR = "@STP_PRELOADABLE_ALLOCATOR@"
+ALLOCATOR_NAME = "@STP_ALLOCATOR@"
+
+# Symbols an allocator would define if one were linked into libstp:
+# malloc/free/realloc/calloc plus operator new / operator delete.
+ALLOCATOR_SYMBOLS = {
+    "malloc", "free", "realloc", "calloc",
+    "_Znwm", "_Znam", "_ZdlPv", "_ZdaPv",
+}
+
+# A tiny query with a known unique answer, used to prove the solver still
+# produces correct results under whichever allocator is in play.
+SOLVE_SNIPPET = """
+import sys
+sys.path.insert(0, {interface!r})
+import stp
+s = stp.Solver()
+a = s.bitvec('a', 8)
+b = s.bitvec('b', 8)
+s.add(a + b == 10)
+s.add(a == 3)
+assert s.check(), "expected sat"
+print("RESULT", s.model()['b'])
+"""
+
+
+def _solve_in_child(env):
+    """Run a solve in a fresh interpreter and return (stdout, stderr)."""
+    code = SOLVE_SNIPPET.format(interface="@PYTHON_INTERFACE_DIR@/stp")
+    child = subprocess.run(
+        [sys.executable, "-c", code],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        env=dict(os.environ, **env), universal_newlines=True,
+    )
+    return child
+
+
+class TestPythonAllocator(unittest.TestCase):
+    def test_bindings_solve_correctly(self):
+        """The in-process ctypes interface works under the configured build."""
+        s = stp.Solver()
+        a = s.bitvec('a', 8)
+        b = s.bitvec('b', 8)
+        s.add(a + b == 10)
+        s.add(a == 3)
+        self.assertTrue(s.check())
+        self.assertEqual(s.model()['b'], 7)
+
+    def test_libstp_does_not_embed_an_allocator(self):
+        """libstp must leave the allocator to the process that loads it.
+
+        The allocator is linked into the stp executables, never into the
+        library. Linking it here instead would give a ctypes user two heaps in
+        one process.
+        """
+        if not sys.platform.startswith("linux"):
+            self.skipTest("symbol inspection is Linux-specific")
+        if not LIBSTP:
+            self.skipTest("could not locate libstp on any of %s" % PATHS)
+        try:
+            out = subprocess.check_output(
+                ["nm", "-D", "--defined-only", LIBSTP], universal_newlines=True)
+        except (OSError, subprocess.CalledProcessError):
+            self.skipTest("nm unavailable")
+
+        defined = set()
+        for line in out.splitlines():
+            parts = line.split()
+            # "<addr> <type> <name>", or "<type> <name>" for undefined-address
+            if len(parts) >= 2 and parts[-2] in ("T", "W", "i"):
+                defined.add(parts[-1])
+
+        clash = defined & ALLOCATOR_SYMBOLS
+        self.assertEqual(
+            clash, set(),
+            "libstp defines allocator symbols %s. The allocator belongs on the "
+            "executables (STP_ALLOCATOR_LIBRARY), not on the library: a ctypes "
+            "process would end up allocating with one heap and freeing with "
+            "another." % sorted(clash))
+
+    def test_preloaded_allocator_serves_libstp(self):
+        """With an allocator preloaded, libstp's allocations go through it.
+
+        This is what a Python user does to get the same allocator the stp
+        binary uses: LD_PRELOAD it into the interpreter.
+        """
+        if not sys.platform.startswith("linux"):
+            self.skipTest("LD_PRELOAD is Linux-specific")
+        if not PRELOADABLE_ALLOCATOR or not os.path.exists(PRELOADABLE_ALLOCATOR):
+            self.skipTest("no preloadable allocator was built (STP_ALLOCATOR=%s)"
+                          % ALLOCATOR_NAME)
+
+        # Correct answer under the preloaded allocator.
+        child = _solve_in_child({"LD_PRELOAD": PRELOADABLE_ALLOCATOR})
+        self.assertEqual(child.returncode, 0,
+                         "solve failed under LD_PRELOAD:\n%s" % child.stderr)
+        self.assertIn("RESULT 7", child.stdout)
+
+        # ...and it really was that allocator serving libstp, not the C library.
+        child = _solve_in_child({"LD_PRELOAD": PRELOADABLE_ALLOCATOR,
+                                 "LD_DEBUG": "bindings"})
+        if "symbol=" not in child.stderr and "binding file" not in child.stderr:
+            self.skipTest("loader diagnostics unavailable")
+
+        allocator = os.path.basename(PRELOADABLE_ALLOCATOR)
+        pattern = re.compile(
+            r"binding file \S*libstp\S* \[0\] to \S*" + re.escape(allocator)
+            + r"\S* \[0\]: normal symbol `(?:malloc|free|_Znwm)'")
+        self.assertTrue(
+            pattern.search(child.stderr),
+            "libstp did not bind malloc to the preloaded %s; something in the "
+            "build is defeating symbol interposition" % allocator)
+
+
+if __name__ == '__main__':
+    suite = unittest.TestLoader().loadTestsFromTestCase(TestPythonAllocator)
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    sys.exit(0 if result.wasSuccessful() else 1)

--- a/tools/stp/CMakeLists.txt
+++ b/tools/stp/CMakeLists.txt
@@ -33,7 +33,12 @@ if(BUILD_EXECUTABLES AND NOT ONLY_SIMPLE)
         INSTALL_RPATH_USE_LINK_PATH TRUE
     )
 
+    # The allocator goes on the executable, not on libstp: it must interpose
+    # malloc for the whole process, and an embedder of libstp gets to keep
+    # whatever allocator it chose. Listing it first keeps its definitions ahead
+    # of libc for static archives.
     target_link_libraries(stp-bin
+        ${STP_ALLOCATOR_LIBRARY}
         stp
         Boost::program_options
     )

--- a/tools/stp_simple/CMakeLists.txt
+++ b/tools/stp_simple/CMakeLists.txt
@@ -34,6 +34,7 @@ if(BUILD_EXECUTABLES)
     )
 
     target_link_libraries(stp_simple-bin
+        ${STP_ALLOCATOR_LIBRARY}
         stp
     )
 


### PR DESCRIPTION
STP is allocation-heavy at every stage: bit-blasting and CNF generation churn
the AIG and CNF data structures, and the SAT solvers churn clause memory.
Against the C library allocator, a modern replacement is **~15% faster to CNF,
~14% faster for CaDiCaL solving and ~7% for CryptoMiniSat**, with identical
results.

`USE_TCMALLOC` (#607) made that opt-in, and mostly did not fire:

* `find_library()` only looked for the unversioned `libtcmalloc_minimal.so`
  symlink from the `-dev` package, so a machine with only the runtime package
  failed to configure rather than using the library it already had.
* `STATICCOMPILE=ON` could not be satisfied at all without a static archive.

## What this does

Vendor mimalloc as a submodule the same way ABC is vendored, and select the
allocator with `STP_ALLOCATOR=mimalloc|tcmalloc|system`, defaulting to
`mimalloc`. Because it is in-tree, a fast allocator is always available —
including for static builds — and no detection can silently fail. Opting out is
now the deliberate act (`-DSTP_ALLOCATOR=system`).

`USE_TCMALLOC=ON/OFF` still works, with a deprecation warning.

### The allocator goes on the executables, not on libstp

An allocator has to interpose `malloc` process-wide, and `malloc`/`free` are two
halves of one data structure — whoever frees must be the allocator that
allocated. STP's C API hands buffers to callers who free them themselves
(`c_interface.cpp` uses `strdup`/`malloc`, and the header says *"It is the
caller's responsibility to free the buffer's memory"*), so a library that
quietly switched allocators would corrupt already-compiled callers. It is also
the practice [WG21 N1976](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2006/n1976.html)
warns against.

So `stp` and `stp_simple` link a static mimalloc with `MI_OVERRIDE`; `libstp`
stays allocator-neutral and an application embedding it keeps whatever allocator
it chose. A side benefit is that the exported `STPTargets.cmake` no longer
carries an absolute path to a system allocator.

## Why mimalloc

Benchmarked tcmalloc, mimalloc and jemalloc against each other first. They are
within 1.5% of one another on every workload, so the choice came down to
packaging and memory:

| | tcmalloc | mimalloc | jemalloc |
|---|---|---|---|
| Speed | baseline | ±0% | ±1% |
| Peak RSS, CaDiCaL solve | 172 MB | **155 MB** | 158 MB |
| Vendorable | painful (autotools, ~50k LoC) | **easy (plain CMake)** | painful |
| Windows | no (minimal form) | **yes** | limited |

mimalloc is a plain CMake project that drops into the ABC pattern, and uses ~10%
less peak RSS than tcmalloc during solving.

## Verification

* Every shared object in the process — `libstp`, `libabc-pic`, `libminisat`,
  `libstdc++`, boost and `libc` itself — binds `malloc`/`free`/`operator new` to
  the executable's mimalloc (checked with `LD_DEBUG=bindings`).
* **64/64 tests pass** with assertions on, from a clean build.
* `STATICCOMPILE=ON` produces a fully static binary with mimalloc in it.
* All configurations exercised: default / `system` / `tcmalloc` / an invalid
  value (hard-errors) / `USE_TCMALLOC=ON` / `USE_TCMALLOC=OFF` / static.
* Vendored build measured at **0.861×** the time of the system allocator on a
  19-file interleaved A/B, CI [0.809, 0.914], faster on 17/19 — matching the
  earlier `LD_PRELOAD` study, so vendoring costs nothing.

## New test

`python-allocator-tests` pins the allocator contract of the ctypes interface,
which cannot use the executable's allocator and so has its own rules:

* `libstp` must not embed an allocator (else a ctypes process gets two heaps);
* a preloaded allocator must actually reach `libstp`, i.e. nothing in the build
  defeats symbol interposition;
* plus a plain solve, to catch the allocator change breaking ctypes at all.

Both assertions were checked to be load-bearing: the symbol scan flags the `stp`
binary, which does embed an allocator, and the interposition pattern does not
match when the preload is removed.

The shared `libmimalloc.so` is built so there is something to preload. It is not
installed.

## Notes for review

* **The 32-bit job needs CI to confirm.** `scripts/ci-32bit.sh` builds with
  `WERROR=ON` and will now pull mimalloc in on i386; I have no local i386
  environment. The `-Wno-error` guard mirrors ABC's. If it breaks, the cheap fix
  is defaulting to `system` on 32-bit.
* **Pinned v2.4.1**, the head of mimalloc's v2 line and the version benchmarked.
  v3.4.3 exists and may well be better, but is unevaluated here.
* The shared mimalloc is deliberately not installed, to avoid colliding with a
  system copy. If Python users should be able to preload it after
  `cmake --install`, that is a follow-up worth deciding on.