### PR TITLE
Make ToSATBase::PrintOutput static; it uses no instance state

### DIFF
--- a/include/stp/AST/ASTNode.h
+++ b/include/stp/AST/ASTNode.h
@@ -44,7 +44,6 @@ class ASTInternal;
 class ASTNode
 {
   friend class STPMgr;
-  friend class ASTtoCNF;
   friend class ASTInterior;
   friend class vector<ASTNode>;
   friend ASTNode HashingNodeFactory::CreateNode(const stp::Kind kind,

--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -131,7 +131,6 @@ public:
 
 
   /* CNF Generation options */
-  bool traditional_cnf = false;
   bool simple_cnf = false; // don't use the good AIG based CNF conversion.
 
   bool exit_after_CNF = false;

--- a/include/stp/ToSat/ToCNFAIG.h
+++ b/include/stp/ToSat/ToCNFAIG.h
@@ -35,8 +35,6 @@ THE SOFTWARE.
 
 namespace stp
 {
-class ASTtoCNF;
-
 class ToCNFAIG // not copyable
 {
   UserDefinedFlags& uf;

--- a/include/stp/ToSat/ToSATBase.h
+++ b/include/stp/ToSat/ToSATBase.h
@@ -52,8 +52,10 @@ public:
 
   virtual ~ToSATBase() {}
 
-  // print the STP solver output
-  void PrintOutput(SOLVER_RETURN_TYPE ret);
+  // Print the STP solver output. Static because it needs no instance state:
+  // everything it touches is either the result passed in, the manager, or
+  // the thread-local input_status.
+  static void PrintOutput(STPMgr* bm, SOLVER_RETURN_TYPE ret);
 
   // Bitblasts, CNF conversion and calls toSATandSolve()
   virtual bool CallSAT(SATSolver& SatSolver, const ASTNode& input,

--- a/lib/Interface/cpp_interface.cpp
+++ b/lib/Interface/cpp_interface.cpp
@@ -540,7 +540,7 @@ void Cpp_interface::checkSat(const ASTVec& assertionsSMT2)
     bm.GetRunTimes()->print();
   }
 
-  (GlobalSTP->tosat)->PrintOutput(last_run.result);
+  ToSATBase::PrintOutput(&bm, last_run.result);
 
   // User has specified -p option to print model.
    if (bm.UserFlags.print_counterexample_flag)

--- a/lib/STPManager/STP.cpp
+++ b/lib/STPManager/STP.cpp
@@ -699,7 +699,7 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input)
   }
 
   ToSATAIG toSATAIG(bm, cb, arrayTransformer);
-  ToSATBase* satBase = bm->UserFlags.traditional_cnf ? tosat : &toSATAIG;
+  ToSATBase* satBase = &toSATAIG;
 
   if (bm->soft_timeout_expired)
     return SOLVER_TIMEOUT;

--- a/lib/ToSat/ToSATBase.cpp
+++ b/lib/ToSat/ToSATBase.cpp
@@ -31,7 +31,7 @@ using std::cout;
 using std::endl;
 
 // This function prints the output of the STP solver
-void ToSATBase::PrintOutput(SOLVER_RETURN_TYPE ret)
+void ToSATBase::PrintOutput(STPMgr* bm, SOLVER_RETURN_TYPE ret)
 {
   if (ret == SOLVER_TIMEOUT || ret == SOLVER_UNDECIDED)
   {

--- a/tools/stp/main_common.cpp
+++ b/tools/stp/main_common.cpp
@@ -326,7 +326,7 @@ int Main::main(int argc, char** argv)
       {
         bm->GetRunTimes()->print();
       }
-      stp->tosat->PrintOutput(ret);
+      ToSATBase::PrintOutput(bm, ret);
     }
 
     asserts = ASTNode();


### PR DESCRIPTION
> **Stacked on #613** — base is `remove-traditional-cnf`, not `master`. Merge #613 first, or retarget this to `master` afterwards. The diff specific to this PR is one commit, `d1be912a`.

## What

`PrintOutput` becomes `static void PrintOutput(STPMgr* bm, SOLVER_RETURN_TYPE ret)`.

It uses no instance state. Reading `ToSATBase::PrintOutput` (`lib/ToSat/ToSATBase.cpp`), everything it touches is:

* the `SOLVER_RETURN_TYPE` passed in,
* `bm->UserFlags` (`print_output_flag`, the parser flags),
* `input_status` — which is a **thread-local global** declared in `Globals.h:86` and defined in `Globals.cpp:37`, shared with the SMTLIB printers, not a member,

and it writes `bm->ValidFlag`. Nothing belongs to the object.

Requiring a receiver was therefore misleading: it implied the output depended on which translator instance you asked, when in fact any instance yields identical output because the receiver is only a route to `bm`. Both call sites made that worse by going through an instance that had *not* done the solving:

```c
(GlobalSTP->tosat)->PrintOutput(last_run.result);   // cpp_interface.cpp:543
stp->tosat->PrintOutput(ret);                       // main_common.cpp:329
```

which naturally prompts "how does that instance know the result?" The answer is that it doesn't need to — but you have to go read the function to find that out. Both now pass the manager directly.

## The `tosat` member stays

Worth stating explicitly, because the obvious next step is to conclude the member is now unused and delete it. **It is not unused.**

* `tools/rewrite_rule_gen/rewrite_rule_gen.cpp:794-797` — `clearSAT()` does `delete GlobalSTP->tosat`, constructs a fresh `ToSATAIG`, and assigns it back.
* `rewrite_rule_gen.cpp:818` — `isConstantToSat()` then passes `GlobalSTP->tosat` to `CallSAT_ResultCheck`, i.e. uses it **for solving**.
* `STP::ClearAllTables` (`STP.h:134`) clears its `nodeToSATVar`, which is meaningful for that tool.

`rewrite_rule_gen` builds only under `BUILD_EXTRA_TOOLS=ON` *and* `USE_CRYPTOMINISAT` (`tools/rewrite_rule_gen/CMakeLists.txt:21`), neither of which CI enables — so removing the member would break a tool no automated job compiles.

## Testing

* `ctest` 63/63 with `-DBUILD_EXTRA_TOOLS=ON`, including the 164-case `query-files` lit suite.
* `rewrite_rule_gen` does not call `PrintOutput`, so it is unaffected by the signature change. I could not compile it here (it needs `USE_CRYPTOMINISAT`); a standalone syntax check of that translation unit produces an identical error count — 135, from my ad-hoc include flags — both with and without this change, confirming the diff makes no difference to it.

No behaviour change: same function body, same inputs, same outputs.