### PR TITLE
Define NT64 for ABC on 64-bit Windows (fixes SAT-backend crash)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -407,5 +407,14 @@ jobs:
         # one (crash statuses like 0xC0000005 show up as large negatives).
         "solver exit code: $LASTEXITCODE"
         if ($out.Trim() -ne "sat") { exit 1 }
+        # The query above is answered by the substitution solver during
+        # simplification, so it never reaches the SAT backend. This one
+        # cannot be simplified away: it is the only line here that
+        # exercises bitblasting, ABC's CNF generation and minisat.
+        "(set-logic QF_BV)(declare-fun a () (_ BitVec 8))(declare-fun b () (_ BitVec 8))(assert (= (bvmul a b) #x21))(assert (bvult a b))(check-sat)" | Out-File -Encoding ascii testsat.smt2
+        $out = & $stp testsat.smt2 2>&1 | Out-String
+        "sat-backend output: '$($out.Trim())'"
+        "sat-backend exit code: $LASTEXITCODE"
+        if ($out.Trim() -ne "sat") { exit 1 }
 
 # EOF

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -458,8 +458,13 @@ include_directories(SYSTEM ${PROJECT_SOURCE_DIR}/lib/extlib-abc/src)
 include(CheckTypeSize)
 # Check size of void pointer (void*)
 CHECK_TYPE_SIZE("void*" SIZEOF_VOID_P)
-# LIN/LIN64 select ABC's Linux code paths; on Windows abc_global.h
-# detects NT/NT64 by itself, and defining LIN* there breaks the build.
+# LIN/LIN64 select ABC's Linux code paths, and NT64 the 64-bit Windows
+# ones. (abc_global.h only detects the platform by itself when
+# ABC_USE_STDINT_H is set; without NT64 its fallback ladder sees MSVC's
+# WIN32 and picks a 32-bit ABC_PTRUINT_T, whose tagged AIG pointers
+# (Aig_Not/Aig_Regular) truncate 64-bit heap pointers -- the first query
+# to reach ABC's CNF generation then dies with an access violation.
+# 32-bit Windows is already correct via the WIN32 fallback.)
 if(NOT WIN32)
     if(SIZEOF_VOID_P EQUAL 8)
         add_definitions(-DLIN64)
@@ -467,6 +472,9 @@ if(NOT WIN32)
         add_definitions(-DLIN)
     endif()
 else()
+    if(SIZEOF_VOID_P EQUAL 8)
+        add_definitions(-DNT64)
+    endif()
     # ABC is linked statically; without this its headers declare the
     # ABC API __declspec(dllimport), producing unresolved __imp_ symbols.
     add_definitions(-DWIN32_NO_DLL)


### PR DESCRIPTION
On 64-bit Windows, any query that reaches the SAT backend crashes with an access violation (0xC0000005). CI never noticed because the Windows smoke query `(= x #x2a)` is answered by the substitution solver during simplification, so bitblasting, ABC's CNF generation and minisat had never executed on Windows at all — the job was validating a binary whose decision procedure was unreachable.

The cause is a typedef: nothing defined `NT64`, so `abc_global.h`'s platform ladder fell through to its `WIN32` branch and typedef'd `ABC_PTRUINT_T` as 32-bit `unsigned int` on x64. ABC stores AIG edge polarity in the low pointer bit, so every edge traversal goes through casts like `Aig_Not: (Aig_Obj_t *)((ABC_PTRUINT_T)p ^ 1)`, which then zero the top half of 64-bit heap pointers. MSVC was flagging every instance with `C4311`/`C4312` pointer-truncation warnings (~1200 of them in a master build log). The comment in CMakeLists.txt claimed abc_global.h detects `NT`/`NT64` by itself on Windows, but that self-detection only exists under `ABC_USE_STDINT_H`.

The first commit adds a second Windows smoke query that the simplifier cannot discharge, so the SAT path actually runs in CI. On master's code, that commit alone fails:

```
solver output: 'sat'          <- existing smoke, substitution solver only
sat-backend output: ''
sat-backend exit code: -1073741819   (0xC0000005)
```

The second commit is the fix: define `NT64` for 64-bit Windows, mirroring the `LIN64`/`LIN` definitions the same block already supplies on Linux. With it, the new smoke prints `sat` and the whole matrix is green (demonstrated on a fork mirror: red run on the first commit, green on the second; the truncation-warning count drops from ~1200 to 66, and the remainder are hardcoded `(long)` casts inside ABC modules STP never executes, e.g. pointer hashing in `st.c`/`stmm.c` and sequential-verification code in `fraLcr.c`).

The fix cannot affect other platforms: the define sits in the Windows-only branch, and outside abc_global.h's typedefs `NT64` is consulted exactly once in the whole vendored ABC tree (`extraUtilUtil.c:380`, OR'd with `WIN32`, which MSVC defines anyway). `NT64` is ABC's own macro for this configuration — ABC's Makefile and MSVC project files define it on Win64; STP's CMake just never passed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
