### PR TITLE
Add propagator_bench: speed and precision tables for the propagators

### DIFF
--- a/tools/propagator_bench/CMakeLists.txt
+++ b/tools/propagator_bench/CMakeLists.txt
@@ -1,4 +1,4 @@
-# AUTHORS: Dan Liew, Ryan Govostes, Mate Soos
+# AUTHORS: Trevor Hansen
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -18,15 +18,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-add_subdirectory(stp)
-add_subdirectory(stp_simple)
+add_executable(propagator_bench
+    main.cpp
+    Ops.cpp
+    Cbitp.cpp
+    Domains.cpp
+    Report.cpp
+)
 
-option(BUILD_EXTRA_TOOLS "Build extra tools" OFF)
-if (BUILD_EXTRA_TOOLS)
-  add_subdirectory(rewrite_rule_gen)
-  add_subdirectory(propagator_bench)
-  add_subdirectory(time_constantbitprop)
-  add_subdirectory(measure_constantbitprop)
-  add_subdirectory(test_constantbitprop)
-  add_subdirectory(cvc_to_c)
-endif()
+target_link_libraries(propagator_bench stp)

--- a/tools/propagator_bench/Cbitp.cpp
+++ b/tools/propagator_bench/Cbitp.cpp
@@ -1,0 +1,581 @@
+/********************************************************************
+ * AUTHORS: Trevor Hansen
+ *
+ * BEGIN DATE: July, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+// The constant-bit propagators: speed on random partially fixed cases,
+// exhaustive precision against a brute-forced ideal at a small width, and a
+// spot check against the SAT-based maxPrecision() at the benchmarked width.
+
+#include "PropagatorBench.h"
+
+#include "stp/Simplifier/constantBitP/ConstantBitP_MaxPrecision.h"
+
+#include <chrono>
+#include <cmath>
+#include <iostream>
+
+using namespace stp;
+using namespace simplifier::constantBitP;
+
+namespace propbench
+{
+namespace
+{
+
+typedef std::chrono::steady_clock Clock;
+
+// One benchmark case: the seeded domains plus the concrete solution they
+// were built from, which every sound propagator must keep admitting.
+struct Case
+{
+  explicit Case(const Layout& l)
+      : output(l.outWidth, l.outIsBoolean),
+        witnessOut(l.outWidth, l.outIsBoolean)
+  {
+  }
+
+  vector<FixedBits> children;
+  FixedBits output;
+  vector<FixedBits> witness;
+  FixedBits witnessOut;
+};
+
+bool admits(const FixedBits& domain, const FixedBits& concrete)
+{
+  for (unsigned i = 0; i < domain.getWidth(); i++)
+    if (domain.isFixed(i) && domain.getValue(i) != concrete.getValue(i))
+      return false;
+  return true;
+}
+
+bool admitsValue(const FixedBits& domain, uint64_t v)
+{
+  for (unsigned i = 0; i < domain.getWidth(); i++)
+    if (domain.isFixed(i) && domain.getValue(i) != (((v >> i) & 1) != 0))
+      return false;
+  return true;
+}
+
+unsigned countFixed(const Case& c)
+{
+  unsigned total = c.output.countFixed();
+  for (const FixedBits& f : c.children)
+    total += f.countFixed();
+  return total;
+}
+
+bool isShift(Kind k)
+{
+  return k == BVLEFTSHIFT || k == BVRIGHTSHIFT || k == BVSRSHIFT;
+}
+
+// ---------------------------------------------------------------------------
+// Case generation. A concrete solution is drawn first and evaluated, then
+// bits are unfixed, so the case is always satisfiable: propagators never
+// short circuit on a conflict, which would make the timings meaningless.
+
+vector<Case> makeCases(STPMgr* mgr, const OpSpec& op, const Layout& l,
+                       Direction dir, unsigned prob, unsigned count,
+                       MTRand& rand, bool shiftBias)
+{
+  vector<Case> cases;
+  cases.reserve(count);
+
+  for (unsigned i = 0; i < count; i++)
+  {
+    Case c(l);
+    ASTVec concrete;
+    for (unsigned j = 0; j < l.children.size(); j++)
+    {
+      const ChildSpec& spec = l.children[j];
+      FixedBits bits(1, false);
+      if (spec.isConstant)
+        bits = concreteOf(spec, spec.value);
+      else if (shiftBias && isShift(op.kind) && j == 1 && (rand.randInt() % 2))
+        // Otherwise a random 64 bit shift amount is out of range almost
+        // every time, and the propagator only ever sees the easy case.
+        bits = concreteOf(spec, rand.randInt() % spec.width);
+      else
+        bits = randomConcrete(spec, rand);
+
+      if (spec.isBoolean)
+        concrete.push_back(bits.getValue(0) ? mgr->ASTTrue : mgr->ASTFalse);
+      else
+        concrete.push_back(mgr->CreateBVConst(bits.GetBVConst(), spec.width));
+
+      c.witness.push_back(bits);
+    }
+
+    c.witnessOut = FixedBits::concreteToAbstract(evaluateNodes(mgr, op, l, concrete));
+
+    // Seed the domains from the solution.
+    for (unsigned j = 0; j < l.children.size(); j++)
+    {
+      FixedBits bits(c.witness[j]);
+      if (!l.children[j].isConstant)
+      {
+        if (dir == Direction::TopDown)
+          bits = FixedBits(bits.getWidth(), bits.isBoolean());
+        else
+          unfixTo(bits, prob, rand);
+      }
+      c.children.push_back(bits);
+    }
+
+    c.output = c.witnessOut;
+    if (dir == Direction::BottomUp)
+      c.output = FixedBits(l.outWidth, l.outIsBoolean);
+    else
+      unfixTo(c.output, prob, rand);
+
+    cases.push_back(c);
+  }
+  return cases;
+}
+
+// ---------------------------------------------------------------------------
+// Timing. The box this normally runs on is busy, so each configuration is
+// timed several times and the median is reported.
+
+Timing timeCases(STPMgr* mgr, const OpSpec& op, const vector<Case>& pristine,
+                 const Config& cfg)
+{
+  Timing t;
+  vector<double> nsPerCall;
+
+  for (unsigned repeat = 0; repeat < cfg.repeats; repeat++)
+  {
+    vector<Case> work(pristine); // untimed: propagators mutate their inputs
+    vector<Result> results(work.size(), NO_CHANGE);
+    vector<FixedBits*> ptrs(work.empty() ? 0 : work[0].children.size());
+
+    size_t done = 0;
+    const auto start = Clock::now();
+    for (size_t i = 0; i < work.size(); i++)
+    {
+      for (size_t j = 0; j < ptrs.size(); j++)
+        ptrs[j] = &work[i].children[j];
+      results[i] = cbitpTransfer(mgr, op.kind, ptrs, work[i].output);
+      done++;
+      if ((done & 63) == 0 &&
+          std::chrono::duration<double>(Clock::now() - start).count() >
+              cfg.budgetSeconds)
+        break;
+    }
+    const double elapsed =
+        std::chrono::duration<double>(Clock::now() - start).count();
+    if (done == 0)
+      continue;
+    nsPerCall.push_back(1e9 * elapsed / done);
+
+    if (repeat == 0)
+    {
+      t.calls = done;
+      uint64_t before = 0, after = 0;
+      for (size_t i = 0; i < done; i++)
+      {
+        before += countFixed(pristine[i]);
+        if (results[i] == CONFLICT)
+        {
+          t.conflicts++; // shouldn't happen: every case is satisfiable
+          after += countFixed(pristine[i]);
+          continue;
+        }
+        after += countFixed(work[i]);
+
+        // The solution the case was built from must survive.
+        bool sound = admits(work[i].output, pristine[i].witnessOut);
+        for (size_t j = 0; j < work[i].children.size(); j++)
+          sound = sound && admits(work[i].children[j], pristine[i].witness[j]);
+        if (!sound)
+          t.unsound++;
+      }
+      t.bitsGained = double(after - before) / done;
+    }
+  }
+
+  t.nsPerCall = median(nsPerCall);
+  return t;
+}
+
+// ---------------------------------------------------------------------------
+// Exhaustive precision at a small width.
+
+FixedBits fromTernary(const ChildSpec& spec, uint64_t pattern)
+{
+  FixedBits bits(spec.width, spec.isBoolean);
+  for (unsigned i = 0; i < spec.width; i++)
+  {
+    const unsigned t = pattern % 3;
+    pattern /= 3;
+    if (t != 2)
+    {
+      bits.setFixed(i, true);
+      bits.setValue(i, t == 1);
+    }
+  }
+  return bits;
+}
+
+uint64_t pow3(unsigned n)
+{
+  uint64_t r = 1;
+  for (unsigned i = 0; i < n; i++)
+    r *= 3;
+  return r;
+}
+
+// The number of (pattern combination, brute force) steps a run would take.
+double exhaustiveWork(const OpSpec& op, const Layout& l, Direction dir)
+{
+  double patterns = 1;
+  if (dir != Direction::TopDown)
+    for (unsigned i : l.varying())
+      patterns *= double(pow3(l.children[i].width));
+  if (dir != Direction::BottomUp)
+    patterns *= double(pow3(l.outWidth));
+  (void)op;
+  return patterns * double(1ull << l.packedBits());
+}
+
+PrecisionResult exhaustive(STPMgr* mgr, const OpSpec& op, Direction dir,
+                           const Config& cfg)
+{
+  PrecisionResult result;
+
+  // Shrink the width until the run is affordable.
+  unsigned width = cfg.precisionWidth;
+  Layout l;
+  while (width >= 1)
+  {
+    l = layoutFor(op, width, cfg.arity);
+    if (l.ok && l.packedBits() <= 24 &&
+        exhaustiveWork(op, l, dir) <= double(cfg.precisionCaseCap) * 64)
+      break;
+    width--;
+  }
+  if (!l.ok)
+    return result;
+
+  result.ran = true;
+  result.width = width;
+
+  const vector<unsigned> varying = l.varying();
+  const vector<uint64_t> table = semanticsTable(mgr, op, l);
+  const uint64_t packedCount = 1ull << l.packedBits();
+
+  // Odometers over the ternary patterns of the children and the result.
+  vector<uint64_t> childPatterns(varying.size(), 0);
+  vector<uint64_t> childLimit(varying.size(), 1);
+  for (size_t i = 0; i < varying.size(); i++)
+    childLimit[i] = (dir == Direction::TopDown)
+                        ? 1 // everything unfixed
+                        : pow3(l.children[varying[i]].width);
+  const uint64_t outLimit =
+      (dir == Direction::BottomUp) ? 1 : pow3(l.outWidth);
+
+  // Where each varying child sits in the packed value.
+  vector<unsigned> shift(varying.size(), 0);
+  {
+    unsigned s = 0;
+    for (size_t i = 0; i < varying.size(); i++)
+    {
+      shift[i] = s;
+      s += l.children[varying[i]].width;
+    }
+  }
+
+  vector<FixedBits> initial;
+  for (const ChildSpec& spec : l.children)
+    initial.push_back(FixedBits(spec.width, spec.isBoolean));
+
+  bool done = false;
+  while (!done)
+  {
+    // Build the children for this pattern combination.
+    for (unsigned i = 0; i < l.children.size(); i++)
+      if (l.children[i].isConstant)
+        initial[i] = concreteOf(l.children[i], l.children[i].value);
+    for (size_t i = 0; i < varying.size(); i++)
+      initial[varying[i]] =
+          fromTernary(l.children[varying[i]],
+                      dir == Direction::TopDown ? pow3(l.children[varying[i]].width) - 1
+                                                : childPatterns[i]);
+
+    for (uint64_t outPattern = 0; outPattern < outLimit; outPattern++)
+    {
+      ChildSpec outSpec;
+      outSpec.width = l.outWidth;
+      outSpec.isBoolean = l.outIsBoolean;
+      const FixedBits initialOut =
+          (dir == Direction::BottomUp)
+              ? FixedBits(l.outWidth, l.outIsBoolean)
+              : fromTernary(outSpec, outPattern);
+
+      result.cases++;
+
+      // Brute force the join of every surviving solution.
+      vector<uint64_t> seenZero(varying.size() + 1, 0);
+      vector<uint64_t> seenOne(varying.size() + 1, 0);
+      bool anySolution = false;
+      for (uint64_t packed = 0; packed < packedCount; packed++)
+      {
+        bool ok = true;
+        for (size_t i = 0; i < varying.size() && ok; i++)
+        {
+          const unsigned w = l.children[varying[i]].width;
+          const uint64_t v = (packed >> shift[i]) & ((1ull << w) - 1);
+          ok = admitsValue(initial[varying[i]], v);
+        }
+        if (!ok)
+          continue;
+        const uint64_t out = table[packed];
+        if (!admitsValue(initialOut, out))
+          continue;
+
+        anySolution = true;
+        for (size_t i = 0; i < varying.size(); i++)
+        {
+          const unsigned w = l.children[varying[i]].width;
+          const uint64_t v = (packed >> shift[i]) & ((1ull << w) - 1);
+          seenZero[i] |= ~v;
+          seenOne[i] |= v;
+        }
+        seenZero[varying.size()] |= ~out;
+        seenOne[varying.size()] |= out;
+      }
+
+      // Run the propagator.
+      vector<FixedBits> children(initial);
+      FixedBits output(initialOut);
+      vector<FixedBits*> ptrs;
+      for (FixedBits& f : children)
+        ptrs.push_back(&f);
+      const Result r = cbitpTransfer(mgr, op.kind, ptrs, output);
+
+      if (!anySolution)
+      {
+        if (r == CONFLICT)
+          result.precise++;
+        else
+          result.missedConflict++;
+        continue;
+      }
+
+      if (r == CONFLICT)
+      {
+        result.unsound++;
+        continue;
+      }
+
+      unsigned derivable = 0, gained = 0;
+      bool unsound = false;
+      for (size_t s = 0; s <= varying.size(); s++)
+      {
+        const bool isOut = (s == varying.size());
+        const FixedBits& was = isOut ? initialOut : initial[varying[s]];
+        const FixedBits& now = isOut ? output : children[varying[s]];
+        for (unsigned i = 0; i < now.getWidth(); i++)
+        {
+          const bool zero = ((seenZero[s] >> i) & 1) != 0;
+          const bool one = ((seenOne[s] >> i) & 1) != 0;
+          if (now.isFixed(i) && !was.isFixed(i))
+            gained++;
+          if (zero != one) // every solution agrees on this bit
+          {
+            if (!was.isFixed(i))
+              derivable++;
+            if (now.isFixed(i) && now.getValue(i) != one)
+              unsound = true;
+          }
+          else if (now.isFixed(i) && !was.isFixed(i))
+            unsound = true; // a solution was thrown away
+        }
+      }
+
+      if (unsound)
+      {
+        result.unsound++;
+        continue;
+      }
+      result.derivable += derivable;
+      result.gained += gained;
+      if (gained == derivable)
+        result.precise++;
+    }
+
+    // Step the children's odometer.
+    done = true;
+    for (size_t i = 0; i < varying.size(); i++)
+    {
+      if (++childPatterns[i] < childLimit[i])
+      {
+        done = false;
+        break;
+      }
+      childPatterns[i] = 0;
+    }
+    if (varying.empty())
+      done = true;
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Spot check against the SAT-based maximally precise propagator, at the
+// width being benchmarked.
+
+SatCheck satSpotCheck(STPMgr* mgr, const OpSpec& op, const vector<Case>& cases,
+                      unsigned howMany, double budgetSeconds)
+{
+  SatCheck check;
+  check.ran = true;
+  const auto start = Clock::now();
+
+  for (size_t i = 0; i < cases.size() && check.cases < howMany; i++)
+  {
+    if (std::chrono::duration<double>(Clock::now() - start).count() >
+        budgetSeconds)
+      break; // a wide multiplier can take minutes per case
+
+    vector<FixedBits> got(cases[i].children);
+    FixedBits gotOut(cases[i].output);
+    vector<FixedBits*> ptrs;
+    for (FixedBits& f : got)
+      ptrs.push_back(&f);
+    const Result r = cbitpTransfer(mgr, op.kind, ptrs, gotOut);
+
+    vector<FixedBits> ideal(cases[i].children);
+    FixedBits idealOut(cases[i].output);
+    vector<FixedBits*> idealPtrs;
+    for (FixedBits& f : ideal)
+      idealPtrs.push_back(&f);
+    const bool noSolution = maxPrecision(idealPtrs, idealOut, op.kind, mgr);
+
+    check.cases++;
+    if (noSolution)
+    {
+      // Can't happen: the cases are built from a solution.
+      if (r != CONFLICT)
+        check.unsound++;
+      continue;
+    }
+    if (r == CONFLICT)
+    {
+      check.unsound++;
+      continue;
+    }
+
+    bool equal = FixedBits::equals(gotOut, idealOut);
+    bool tooStrong = gotOut.countFixed() > idealOut.countFixed();
+    for (size_t j = 0; j < got.size(); j++)
+    {
+      equal = equal && FixedBits::equals(got[j], ideal[j]);
+      tooStrong = tooStrong || got[j].countFixed() > ideal[j].countFixed();
+    }
+    if (tooStrong)
+      check.unsound++;
+    else if (equal)
+      check.precise++;
+  }
+  return check;
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+
+void runCbitp(STPMgr* mgr, const Config& cfg, vector<Row>& out)
+{
+  for (const OpSpec& op : allOps())
+  {
+    if (!cfg.ops.empty() &&
+        std::find(cfg.ops.begin(), cfg.ops.end(), string(op.name)) ==
+            cfg.ops.end())
+      continue;
+
+    const bool isBoolean =
+        op.shape == Shape::BoolNary || op.shape == Shape::BoolUnary;
+    vector<unsigned> widths = isBoolean ? vector<unsigned>{1} : cfg.widths;
+
+    for (Direction dir : cfg.directions)
+    {
+      PrecisionResult precision;
+      if (cfg.precision)
+      {
+        if (cfg.verbose)
+          std::cerr << "cbitp precision " << op.name << " " << name(dir)
+                    << std::endl;
+        precision = exhaustive(mgr, op, dir, cfg);
+      }
+
+      for (unsigned width : widths)
+      {
+        const Layout l = layoutFor(op, width, cfg.arity);
+        if (!l.ok)
+          continue;
+
+        for (unsigned prob : cfg.probs)
+        {
+          if (cfg.verbose)
+            std::cerr << "cbitp speed " << op.name << " " << name(dir) << " w="
+                      << width << " p=" << prob << std::endl;
+
+          MTRand rand(cfg.seed);
+          const vector<Case> cases =
+              makeCases(mgr, op, l, dir, prob, cfg.iterations, rand,
+                        cfg.shiftBias);
+          const Timing t = timeCases(mgr, op, cases, cfg);
+
+          Row row;
+          row.domain = Domain::Cbitp;
+          row.op = op.name;
+          row.direction = dir;
+          row.width = width;
+          row.arity = (unsigned)l.children.size();
+          row.prob = prob;
+          row.input = std::to_string(prob) + "% fixed";
+          row.nsPerCall = t.nsPerCall;
+          row.opsPerSec = t.nsPerCall > 0 ? 1e9 / t.nsPerCall : 0;
+          row.bitsGained = t.bitsGained;
+          row.calls = t.calls;
+          row.conflicts = t.conflicts;
+          row.witnessUnsound = t.unsound;
+          row.precision = precision;
+
+          if (cfg.satCases > 0 && op.satCheckable)
+          {
+            if (cfg.verbose)
+              std::cerr << "  sat check" << std::endl;
+            row.sat =
+                satSpotCheck(mgr, op, cases, cfg.satCases, cfg.satBudgetSeconds);
+          }
+
+          out.push_back(row);
+        }
+      }
+    }
+  }
+}
+} // namespace propbench

--- a/tools/propagator_bench/Domains.cpp
+++ b/tools/propagator_bench/Domains.cpp
@@ -1,0 +1,707 @@
+/********************************************************************
+ * AUTHORS: Trevor Hansen
+ *
+ * BEGIN DATE: July, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+// The two value-analysis domains: unsigned intervals and value sets. Both
+// only ever run bottom up -- they compute a node's domain from its
+// children's -- so there is nothing to seed at the result.
+
+#include "PropagatorBench.h"
+
+#include "stp/Simplifier/UnsignedIntervalAnalysis.h"
+#include "stp/Simplifier/ValueSetAnalysis.h"
+
+#include <algorithm>
+#include <chrono>
+#include <iostream>
+
+using namespace stp;
+
+namespace propbench
+{
+namespace
+{
+
+typedef std::chrono::steady_clock Clock;
+
+CBV cbvOf(unsigned width, uint64_t value)
+{
+  CBV v = CONSTANTBV::BitVector_Create(width, true);
+  for (unsigned i = 0; i < width && i < 64; i++)
+    if ((value >> i) & 1)
+      CONSTANTBV::BitVector_Bit_On(v, i);
+  return v;
+}
+
+uint64_t u64Of(CBV v, unsigned width)
+{
+  uint64_t r = 0;
+  for (unsigned i = 0; i < width && i < 64; i++)
+    if (CONSTANTBV::BitVector_bit_test(v, i))
+      r |= (1ull << i);
+  return r;
+}
+
+// ---------------------------------------------------------------------------
+// Unsigned intervals.
+
+UnsignedInterval* intervalOf(unsigned width, uint64_t lo, uint64_t hi)
+{
+  return new UnsignedInterval(cbvOf(width, lo), cbvOf(width, hi));
+}
+
+// The tightest interval holding everything the fixed bits admit. This is how
+// NodeDomainAnalysis moves between the two domains, and it keeps the
+// "50% fixed" input of the interval tables comparable with cbitp's.
+UnsignedInterval* intervalOf(const FixedBits& bits)
+{
+  const unsigned width = bits.getWidth();
+  CBV min = CONSTANTBV::BitVector_Create(width, true);
+  CBV max = CONSTANTBV::BitVector_Create(width, true);
+  for (unsigned i = 0; i < width; i++)
+  {
+    if (bits.isFixed(i))
+    {
+      if (bits.getValue(i))
+      {
+        CONSTANTBV::BitVector_Bit_On(min, i);
+        CONSTANTBV::BitVector_Bit_On(max, i);
+      }
+    }
+    else
+      CONSTANTBV::BitVector_Bit_On(max, i);
+  }
+  return new UnsignedInterval(min, max);
+}
+
+// How much of the value is pinned down, in bits: the width less the number
+// of bits needed to count the interval's members. Zero for a complete
+// interval, the full width for a constant.
+double knownBits(const UnsignedInterval* iv, unsigned width)
+{
+  if (iv == NULL)
+    return 0;
+  CBV diff = CONSTANTBV::BitVector_Create(width, true);
+  bool carry = false;
+  CONSTANTBV::BitVector_sub(diff, iv->maxV, iv->minV, &carry);
+  int highest = -1;
+  for (int i = (int)width - 1; i >= 0; i--)
+    if (CONSTANTBV::BitVector_bit_test(diff, i))
+    {
+      highest = i;
+      break;
+    }
+  CONSTANTBV::BitVector_Destroy(diff);
+  return width - (highest + 1);
+}
+
+// ---------------------------------------------------------------------------
+// Value sets.
+
+ValueSet* valueSetOf(unsigned width, bool isBoolean,
+                     const vector<uint64_t>& values)
+{
+  ValueSet* set = new ValueSet(width, isBoolean);
+  for (uint64_t v : values)
+    if (!set->insert(cbvOf(width, v)))
+    {
+      delete set;
+      return NULL; // more members than the domain can hold
+    }
+  return set;
+}
+
+double knownBits(const ValueSet* set, unsigned width)
+{
+  if (set == NULL || set->size() == 0)
+    return 0;
+  double bits = 0;
+  while ((1u << (unsigned)bits) < set->size())
+    bits++;
+  return width - bits;
+}
+
+// The subset of {0, ..., 2^width - 1} a mask stands for.
+vector<uint64_t> membersOf(uint32_t mask)
+{
+  vector<uint64_t> members;
+  for (unsigned i = 0; i < 32; i++)
+    if ((mask >> i) & 1)
+      members.push_back(i);
+  return members;
+}
+
+uint32_t maskOf(const ValueSet* set, unsigned width)
+{
+  if (set == NULL)
+    return (width >= 5) ? 0xffffffffu : ((1u << (1u << width)) - 1);
+  uint32_t mask = 0;
+  for (CBV v : set->values)
+    mask |= (1u << u64Of(v, width));
+  return mask;
+}
+
+// ---------------------------------------------------------------------------
+// Shared: enumerate every combination of per-child input domains.
+
+// An odometer over `limits`. Returns false when it wraps.
+bool step(vector<uint64_t>& odometer, const vector<uint64_t>& limits)
+{
+  for (size_t i = 0; i < odometer.size(); i++)
+  {
+    if (++odometer[i] < limits[i])
+      return true;
+    odometer[i] = 0;
+  }
+  return false;
+}
+
+vector<unsigned> shiftsOf(const Layout& l, const vector<unsigned>& varying)
+{
+  vector<unsigned> shift(varying.size(), 0);
+  unsigned s = 0;
+  for (size_t i = 0; i < varying.size(); i++)
+  {
+    shift[i] = s;
+    s += l.children[varying[i]].width;
+  }
+  return shift;
+}
+
+// ---------------------------------------------------------------------------
+// Interval precision: exhaustively, at a small width, against the hull of
+// every value the operation can actually take.
+
+PrecisionResult intervalPrecision(STPMgr* mgr, const OpSpec& op,
+                                  const Config& cfg)
+{
+  PrecisionResult result;
+
+  unsigned width = cfg.precisionWidth;
+  Layout l;
+  while (width >= 1)
+  {
+    l = layoutFor(op, width, cfg.arity);
+    if (l.ok && l.packedBits() <= 20)
+    {
+      double work = 1;
+      for (unsigned i : l.varying())
+      {
+        const uint64_t n = 1ull << l.children[i].width;
+        work *= double(n * (n + 1) / 2);
+      }
+      work *= double(1ull << l.packedBits());
+      if (work <= double(cfg.precisionCaseCap) * 64)
+        break;
+    }
+    width--;
+  }
+  if (!l.ok)
+    return result;
+
+  result.ran = true;
+  result.width = width;
+
+  UnsignedIntervalAnalysis analysis(*mgr);
+  const ASTNode node = buildNode(mgr, op, l);
+  const vector<uint64_t> table = semanticsTable(mgr, op, l);
+  const vector<unsigned> varying = l.varying();
+  const vector<unsigned> shift = shiftsOf(l, varying);
+  const uint64_t packedCount = 1ull << l.packedBits();
+
+  // Every (low, high) pair, per varying child.
+  vector<vector<std::pair<uint64_t, uint64_t>>> options(varying.size());
+  vector<uint64_t> limits(varying.size(), 0);
+  for (size_t i = 0; i < varying.size(); i++)
+  {
+    const uint64_t n = 1ull << l.children[varying[i]].width;
+    for (uint64_t lo = 0; lo < n; lo++)
+      for (uint64_t hi = lo; hi < n; hi++)
+        options[i].push_back({lo, hi});
+    limits[i] = options[i].size();
+  }
+
+  vector<uint64_t> odometer(varying.size(), 0);
+  const uint64_t outMask =
+      (l.outWidth >= 64) ? ~0ull : ((1ull << l.outWidth) - 1);
+
+  do
+  {
+    // The children, in the order the transfer function expects.
+    vector<UnsignedInterval*> owned(l.children.size(), NULL);
+    vector<const UnsignedInterval*> children(l.children.size(), NULL);
+    for (unsigned j = 0; j < l.children.size(); j++)
+      if (l.children[j].isConstant)
+      {
+        owned[j] = intervalOf(l.children[j].width, l.children[j].value,
+                              l.children[j].value);
+        children[j] = owned[j];
+      }
+    for (size_t i = 0; i < varying.size(); i++)
+    {
+      const auto& bounds = options[i][odometer[i]];
+      const unsigned w = l.children[varying[i]].width;
+      // A complete interval carries no information; the analysis passes a
+      // null pointer for those, and some transfer functions check for it.
+      if (bounds.first == 0 && bounds.second == (1ull << w) - 1)
+        continue;
+      owned[varying[i]] = intervalOf(w, bounds.first, bounds.second);
+      children[varying[i]] = owned[varying[i]];
+    }
+
+    // The hull of everything the operation attains.
+    uint64_t idealLo = outMask, idealHi = 0;
+    bool any = false;
+    for (uint64_t packed = 0; packed < packedCount; packed++)
+    {
+      bool ok = true;
+      for (size_t i = 0; i < varying.size() && ok; i++)
+      {
+        const unsigned w = l.children[varying[i]].width;
+        const uint64_t v = (packed >> shift[i]) & ((1ull << w) - 1);
+        ok = v >= options[i][odometer[i]].first &&
+             v <= options[i][odometer[i]].second;
+      }
+      if (!ok)
+        continue;
+      const uint64_t out = table[packed];
+      idealLo = std::min(idealLo, out);
+      idealHi = std::max(idealHi, out);
+      any = true;
+    }
+
+    if (any)
+    {
+      result.cases++;
+      UnsignedInterval* got = analysis.dispatchToTransferFunctions(node, children);
+      const uint64_t gotLo = got ? u64Of(got->minV, l.outWidth) : 0;
+      const uint64_t gotHi = got ? u64Of(got->maxV, l.outWidth) : outMask;
+
+      if (gotLo > idealLo || gotHi < idealHi)
+        result.unsound++;
+      else
+      {
+        if (gotLo == idealLo && gotHi == idealHi)
+          result.precise++;
+        UnsignedInterval ideal(cbvOf(l.outWidth, idealLo),
+                               cbvOf(l.outWidth, idealHi));
+        result.derivable += (uint64_t)knownBits(&ideal, l.outWidth);
+        result.gained += (uint64_t)knownBits(got, l.outWidth);
+      }
+      delete got;
+    }
+
+    for (UnsignedInterval* iv : owned)
+      delete iv;
+  } while (step(odometer, limits) && !varying.empty());
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Value set precision: exhaustively over every subset, at a small width.
+
+PrecisionResult valueSetPrecision(STPMgr* mgr, const OpSpec& op,
+                                  const Config& cfg)
+{
+  PrecisionResult result;
+
+  unsigned width = std::min(cfg.precisionWidth, 4u);
+  Layout l;
+  while (width >= 1)
+  {
+    l = layoutFor(op, width, cfg.arity);
+    if (l.ok && l.packedBits() <= 20)
+    {
+      double work = 1;
+      for (unsigned i : l.varying())
+        work *= double(1ull << (1ull << l.children[i].width));
+      work *= double(1ull << l.packedBits());
+      if (work <= double(cfg.precisionCaseCap) * 64)
+        break;
+    }
+    width--;
+  }
+  if (!l.ok)
+    return result;
+
+  result.ran = true;
+  result.width = width;
+
+  ValueSetAnalysis analysis(*mgr);
+  const ASTNode node = buildNode(mgr, op, l);
+  const vector<uint64_t> table = semanticsTable(mgr, op, l);
+  const vector<unsigned> varying = l.varying();
+  const vector<unsigned> shift = shiftsOf(l, varying);
+  const uint64_t packedCount = 1ull << l.packedBits();
+
+  // Every non-empty subset, plus "nothing is known" -- which the analysis
+  // represents with a null pointer, and which a symbol always has.
+  vector<uint64_t> limits(varying.size(), 0);
+  for (size_t i = 0; i < varying.size(); i++)
+    limits[i] = 1ull << (1ull << l.children[varying[i]].width);
+
+  vector<uint64_t> odometer(varying.size(), 0);
+
+  do
+  {
+    vector<ValueSet*> owned(l.children.size(), NULL);
+    vector<const ValueSet*> children(l.children.size(), NULL);
+    vector<uint32_t> masks(varying.size(), 0);
+    bool buildable = true;
+
+    for (unsigned j = 0; j < l.children.size(); j++)
+      if (l.children[j].isConstant)
+      {
+        owned[j] = valueSetOf(l.children[j].width, false,
+                              {l.children[j].value});
+        children[j] = owned[j];
+      }
+
+    for (size_t i = 0; i < varying.size() && buildable; i++)
+    {
+      const ChildSpec& spec = l.children[varying[i]];
+      const bool unknown = (odometer[i] == limits[i] - 1);
+      masks[i] = unknown ? (uint32_t)(limits[i] - 1)
+                         : (uint32_t)(odometer[i] + 1);
+      if (unknown)
+        continue; // leave the child null
+
+      owned[varying[i]] =
+          valueSetOf(spec.width, spec.isBoolean, membersOf(masks[i]));
+      if (owned[varying[i]] == NULL)
+        buildable = false; // more members than the domain holds
+      children[varying[i]] = owned[varying[i]];
+    }
+
+    if (buildable)
+    {
+      // Exactly the values the operation attains.
+      uint32_t idealMask = 0;
+      for (uint64_t packed = 0; packed < packedCount; packed++)
+      {
+        bool ok = true;
+        for (size_t i = 0; i < varying.size() && ok; i++)
+        {
+          const unsigned w = l.children[varying[i]].width;
+          const uint64_t v = (packed >> shift[i]) & ((1ull << w) - 1);
+          ok = (masks[i] >> v) & 1;
+        }
+        if (ok)
+          idealMask |= (1u << table[packed]);
+      }
+
+      result.cases++;
+      ValueSet* got = analysis.dispatchToTransferFunctions(node, children);
+      const uint32_t gotMask = maskOf(got, l.outWidth);
+
+      if ((gotMask | idealMask) != gotMask)
+        result.unsound++; // a value the operation attains isn't in the set
+      else
+      {
+        if (gotMask == idealMask)
+          result.precise++;
+        vector<uint64_t> idealMembers = membersOf(idealMask);
+        ValueSet* ideal =
+            valueSetOf(l.outWidth, l.outIsBoolean, idealMembers);
+        result.derivable += (uint64_t)knownBits(ideal, l.outWidth);
+        result.gained += (uint64_t)knownBits(got, l.outWidth);
+        delete ideal;
+      }
+      delete got;
+    }
+
+    for (ValueSet* set : owned)
+      delete set;
+  } while (step(odometer, limits) && !varying.empty());
+
+  return result;
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+
+void runInterval(STPMgr* mgr, const Config& cfg, vector<Row>& out)
+{
+  UnsignedIntervalAnalysis analysis(*mgr);
+
+  for (const OpSpec& op : allOps())
+  {
+    if (!cfg.ops.empty() &&
+        std::find(cfg.ops.begin(), cfg.ops.end(), string(op.name)) ==
+            cfg.ops.end())
+      continue;
+    if (!supports(Domain::Interval, op))
+      continue;
+
+    PrecisionResult precision;
+    if (cfg.precision)
+    {
+      if (cfg.verbose)
+        std::cerr << "interval precision " << op.name << std::endl;
+      precision = intervalPrecision(mgr, op, cfg);
+    }
+
+    const bool isBoolean =
+        op.shape == Shape::BoolNary || op.shape == Shape::BoolUnary;
+    const vector<unsigned> widths = isBoolean ? vector<unsigned>{1} : cfg.widths;
+
+    for (unsigned width : widths)
+    {
+      const Layout l = layoutFor(op, width, cfg.arity);
+      if (!l.ok)
+        continue;
+      const ASTNode node = buildNode(mgr, op, l);
+
+      for (unsigned prob : cfg.probs)
+      {
+        if (cfg.verbose)
+          std::cerr << "interval speed " << op.name << " w=" << width
+                    << " p=" << prob << std::endl;
+
+        MTRand rand(cfg.seed);
+        // Inputs are read-only, so one set is reused by every repeat.
+        vector<vector<UnsignedInterval*>> owned(cfg.iterations);
+        vector<vector<const UnsignedInterval*>> cases(cfg.iterations);
+        for (unsigned i = 0; i < cfg.iterations; i++)
+        {
+          for (unsigned j = 0; j < l.children.size(); j++)
+          {
+            const ChildSpec& spec = l.children[j];
+            UnsignedInterval* iv;
+            if (spec.isConstant)
+              iv = intervalOf(spec.width, spec.value, spec.value);
+            else
+            {
+              FixedBits bits = randomConcrete(spec, rand);
+              unfixTo(bits, prob, rand);
+              iv = intervalOf(bits);
+            }
+            owned[i].push_back(iv);
+            cases[i].push_back(iv->isComplete() ? NULL : iv);
+          }
+        }
+
+        vector<double> nsPerCall;
+        vector<UnsignedInterval*> results(cfg.iterations, NULL);
+        double gained = 0;
+        uint64_t calls = 0;
+        for (unsigned repeat = 0; repeat < cfg.repeats; repeat++)
+        {
+          size_t done = 0;
+          const auto start = Clock::now();
+          for (unsigned i = 0; i < cfg.iterations; i++)
+          {
+            results[i] = analysis.dispatchToTransferFunctions(node, cases[i]);
+            done++;
+            if ((done & 63) == 0 &&
+                std::chrono::duration<double>(Clock::now() - start).count() >
+                    cfg.budgetSeconds)
+              break;
+          }
+          const double elapsed =
+              std::chrono::duration<double>(Clock::now() - start).count();
+          if (done > 0)
+            nsPerCall.push_back(1e9 * elapsed / done);
+
+          if (repeat == 0)
+          {
+            calls = done;
+            for (size_t i = 0; i < done; i++)
+              gained += knownBits(results[i], l.outWidth);
+          }
+          for (size_t i = 0; i < done; i++)
+          {
+            delete results[i];
+            results[i] = NULL;
+          }
+        }
+
+        Row row;
+        row.domain = Domain::Interval;
+        row.op = op.name;
+        row.direction = Direction::BottomUp;
+        row.width = width;
+        row.arity = (unsigned)l.children.size();
+        row.prob = prob;
+        row.input = std::to_string(prob) + "% fixed";
+        row.nsPerCall = median(nsPerCall);
+        row.opsPerSec = row.nsPerCall > 0 ? 1e9 / row.nsPerCall : 0;
+        row.bitsGained = calls ? gained / calls : 0;
+        row.calls = calls;
+        row.precision = precision;
+        out.push_back(row);
+
+        for (auto& v : owned)
+          for (UnsignedInterval* iv : v)
+            delete iv;
+      }
+    }
+  }
+}
+
+void runValueSet(STPMgr* mgr, const Config& cfg, vector<Row>& out)
+{
+  ValueSetAnalysis analysis(*mgr);
+
+  for (const OpSpec& op : allOps())
+  {
+    if (!cfg.ops.empty() &&
+        std::find(cfg.ops.begin(), cfg.ops.end(), string(op.name)) ==
+            cfg.ops.end())
+      continue;
+    if (!supports(Domain::ValueSet, op))
+      continue;
+
+    PrecisionResult precision;
+    if (cfg.precision)
+    {
+      if (cfg.verbose)
+        std::cerr << "valueset precision " << op.name << std::endl;
+      precision = valueSetPrecision(mgr, op, cfg);
+    }
+
+    const bool isBoolean =
+        op.shape == Shape::BoolNary || op.shape == Shape::BoolUnary;
+    const vector<unsigned> widths = isBoolean ? vector<unsigned>{1} : cfg.widths;
+
+    for (unsigned width : widths)
+    {
+      const Layout l = layoutFor(op, width, cfg.arity);
+      if (!l.ok)
+        continue;
+      const ASTNode node = buildNode(mgr, op, l);
+
+      for (unsigned setSize : cfg.setSizes)
+      {
+        if (cfg.verbose)
+          std::cerr << "valueset speed " << op.name << " w=" << width
+                    << " n=" << setSize << std::endl;
+
+        MTRand rand(cfg.seed);
+        vector<vector<ValueSet*>> owned(cfg.iterations);
+        vector<vector<const ValueSet*>> cases(cfg.iterations);
+        bool buildable = true;
+        for (unsigned i = 0; i < cfg.iterations && buildable; i++)
+        {
+          for (unsigned j = 0; j < l.children.size(); j++)
+          {
+            const ChildSpec& spec = l.children[j];
+            vector<uint64_t> values;
+            if (spec.isConstant)
+              values.push_back(spec.value);
+            else
+            {
+              // Distinct values, so a row labelled "4 values" really is
+              // four. Small widths can run out; the set is then smaller.
+              const uint64_t limit =
+                  spec.width >= 64 ? ~0ull : (1ull << spec.width);
+              for (unsigned k = 0, tries = 0;
+                   k < setSize && tries < 20 * setSize; tries++)
+              {
+                const uint64_t v =
+                    (((uint64_t)rand.randInt() << 32) | rand.randInt()) %
+                    limit;
+                if (std::find(values.begin(), values.end(), v) == values.end())
+                {
+                  values.push_back(v);
+                  k++;
+                }
+              }
+            }
+            ValueSet* set = valueSetOf(spec.width, spec.isBoolean, values);
+            if (set == NULL)
+            {
+              buildable = false; // asked for more values than fit
+              break;
+            }
+            // Passed as-is even when the set turns out to be every value of
+            // the width: a null child would measure the early bail-out
+            // instead of the transfer function.
+            owned[i].push_back(set);
+            cases[i].push_back(set);
+          }
+        }
+
+        if (buildable)
+        {
+          vector<double> nsPerCall;
+          vector<ValueSet*> results(cfg.iterations, NULL);
+          double gained = 0;
+          uint64_t calls = 0;
+          for (unsigned repeat = 0; repeat < cfg.repeats; repeat++)
+          {
+            size_t done = 0;
+            const auto start = Clock::now();
+            for (unsigned i = 0; i < cfg.iterations; i++)
+            {
+              results[i] = analysis.dispatchToTransferFunctions(node, cases[i]);
+              done++;
+              if ((done & 63) == 0 &&
+                  std::chrono::duration<double>(Clock::now() - start).count() >
+                      cfg.budgetSeconds)
+                break;
+            }
+            const double elapsed =
+                std::chrono::duration<double>(Clock::now() - start).count();
+            if (done > 0)
+              nsPerCall.push_back(1e9 * elapsed / done);
+
+            if (repeat == 0)
+            {
+              calls = done;
+              for (size_t i = 0; i < done; i++)
+                gained += knownBits(results[i], l.outWidth);
+            }
+            for (size_t i = 0; i < done; i++)
+            {
+              delete results[i];
+              results[i] = NULL;
+            }
+          }
+
+          Row row;
+          row.domain = Domain::ValueSet;
+          row.op = op.name;
+          row.direction = Direction::BottomUp;
+          row.width = width;
+          row.arity = (unsigned)l.children.size();
+          row.setSize = setSize;
+          row.input = std::to_string(setSize) + " values";
+          row.nsPerCall = median(nsPerCall);
+          row.opsPerSec = row.nsPerCall > 0 ? 1e9 / row.nsPerCall : 0;
+          row.bitsGained = calls ? gained / calls : 0;
+          row.calls = calls;
+          row.precision = precision;
+          out.push_back(row);
+        }
+
+        for (auto& v : owned)
+          for (ValueSet* set : v)
+            delete set;
+      }
+    }
+  }
+}
+} // namespace propbench

--- a/tools/propagator_bench/Ops.cpp
+++ b/tools/propagator_bench/Ops.cpp
@@ -1,0 +1,500 @@
+/********************************************************************
+ * AUTHORS: Trevor Hansen
+ *
+ * BEGIN DATE: July, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+// The operations under test, how their nodes are shaped, and the reference
+// semantics that the precision phases compare against.
+
+#include "PropagatorBench.h"
+
+#include "stp/Simplifier/Simplifier.h"
+#include "stp/Simplifier/ValueSetAnalysis.h"
+#include "stp/Simplifier/constantBitP/ConstantBitP_TransferFunctions.h"
+
+#include <algorithm>
+#include <sstream>
+
+using namespace stp;
+using namespace simplifier::constantBitP;
+
+namespace propbench
+{
+
+const char* name(Domain d)
+{
+  switch (d)
+  {
+    case Domain::Cbitp: return "cbitp";
+    case Domain::Interval: return "interval";
+    case Domain::ValueSet: return "valueset";
+  }
+  return "?";
+}
+
+const char* name(Direction d)
+{
+  switch (d)
+  {
+    case Direction::BottomUp: return "bottom-up";
+    case Direction::TopDown: return "top-down";
+    case Direction::BothWays: return "both-ways";
+  }
+  return "?";
+}
+
+bool parseDomain(const string& s, Domain& out)
+{
+  if (s == "cbitp") { out = Domain::Cbitp; return true; }
+  if (s == "interval") { out = Domain::Interval; return true; }
+  if (s == "valueset") { out = Domain::ValueSet; return true; }
+  return false;
+}
+
+bool parseDirection(const string& s, Direction& out)
+{
+  if (s == "bottom-up" || s == "bottomup" || s == "up")
+  { out = Direction::BottomUp; return true; }
+  if (s == "top-down" || s == "topdown" || s == "down")
+  { out = Direction::TopDown; return true; }
+  if (s == "both-ways" || s == "bothways" || s == "both")
+  { out = Direction::BothWays; return true; }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+
+const vector<OpSpec>& allOps()
+{
+  static const vector<OpSpec> ops = {
+      // kind, name, shape, n-ary, SAT checkable
+      {BVAND, "bvand", Shape::Nary, true, true},
+      {BVOR, "bvor", Shape::Nary, true, true},
+      {BVXOR, "bvxor", Shape::Nary, true, true},
+      {BVNOT, "bvnot", Shape::Unary, false, true},
+      {BVPLUS, "bvadd", Shape::Nary, true, true},
+      {BVSUB, "bvsub", Shape::Nary, false, true},
+      {BVUMINUS, "bvneg", Shape::Unary, false, true},
+      {BVMULT, "bvmul", Shape::Nary, false, true},
+      {BVDIV, "bvudiv", Shape::Nary, false, true},
+      {BVMOD, "bvurem", Shape::Nary, false, true},
+      {SBVDIV, "bvsdiv", Shape::Nary, false, true},
+      {SBVREM, "bvsrem", Shape::Nary, false, true},
+      {SBVMOD, "bvsmod", Shape::Nary, false, true},
+      {BVLEFTSHIFT, "bvshl", Shape::Nary, false, true},
+      {BVRIGHTSHIFT, "bvlshr", Shape::Nary, false, true},
+      {BVSRSHIFT, "bvashr", Shape::Nary, false, true},
+      {BVLT, "bvult", Shape::Predicate, false, true},
+      {BVLE, "bvule", Shape::Predicate, false, true},
+      {BVGT, "bvugt", Shape::Predicate, false, true},
+      {BVGE, "bvuge", Shape::Predicate, false, true},
+      {BVSLT, "bvslt", Shape::Predicate, false, true},
+      {BVSLE, "bvsle", Shape::Predicate, false, true},
+      {BVSGT, "bvsgt", Shape::Predicate, false, true},
+      {BVSGE, "bvsge", Shape::Predicate, false, true},
+      {EQ, "eq", Shape::Predicate, false, true},
+      {ITE, "ite", Shape::Ite, false, true},
+      {BVCONCAT, "concat", Shape::Concat, false, true},
+      {BVEXTRACT, "extract", Shape::Extract, false, false},
+      {BVZX, "zero_extend", Shape::Extend, false, false},
+      {BVSX, "sign_extend", Shape::Extend, false, false},
+      {AND, "and", Shape::BoolNary, true, true},
+      {OR, "or", Shape::BoolNary, true, true},
+      {XOR, "xor", Shape::BoolNary, false, true},
+      {NOT, "not", Shape::BoolUnary, false, true},
+      {IMPLIES, "implies", Shape::BoolNary, false, true},
+      {IFF, "iff", Shape::BoolNary, false, true},
+  };
+  return ops;
+}
+
+const OpSpec* findOp(const string& n)
+{
+  for (const OpSpec& o : allOps())
+    if (n == o.name)
+      return &o;
+  return NULL;
+}
+
+// The kinds each analysis has a transfer function for. cbitp's list is the
+// switch in ConstantBitPropagation::dispatchToTransferFunctions, the
+// interval list is the switch in
+// UnsignedIntervalAnalysis::dispatchToTransferFunctions, and the value set
+// analysis evaluates over the cartesian product of anything the constant
+// evaluator handles.
+bool supports(Domain d, const OpSpec& op)
+{
+  switch (d)
+  {
+    case Domain::Cbitp:
+      return true; // every operation in the table is dispatched to.
+
+    case Domain::Interval:
+      switch (op.kind)
+      {
+        case NOT:
+        case AND:
+        case OR:
+        case XOR:
+        case EQ:
+        case BVGT:
+        case BVSGT:
+        case BVAND:
+        case BVOR:
+        case BVXOR:
+        case BVNOT:
+        case BVPLUS:
+        case BVMULT:
+        case BVDIV:
+        case BVMOD:
+        case SBVDIV:
+        case SBVREM:
+        case SBVMOD:
+        case BVLEFTSHIFT:
+        case BVRIGHTSHIFT:
+        case BVSRSHIFT:
+        case BVSX:
+        case BVUMINUS:
+        case BVCONCAT:
+        case BVEXTRACT:
+        case ITE:
+          return true;
+        default:
+          return false;
+      }
+
+    case Domain::ValueSet:
+      return ValueSetAnalysis::constEvaluable(op.kind);
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+
+vector<unsigned> Layout::varying() const
+{
+  vector<unsigned> result;
+  for (unsigned i = 0; i < children.size(); i++)
+    if (!children[i].isConstant)
+      result.push_back(i);
+  return result;
+}
+
+unsigned Layout::packedBits() const
+{
+  unsigned total = 0;
+  for (const ChildSpec& c : children)
+    if (!c.isConstant)
+      total += c.width;
+  return total;
+}
+
+static ChildSpec value(unsigned width)
+{
+  ChildSpec c;
+  c.width = width;
+  return c;
+}
+
+static ChildSpec boolean()
+{
+  ChildSpec c;
+  c.width = 1;
+  c.isBoolean = true;
+  return c;
+}
+
+static ChildSpec constant(uint64_t v)
+{
+  ChildSpec c;
+  c.width = 32;
+  c.isConstant = true;
+  c.value = v;
+  return c;
+}
+
+Layout layoutFor(const OpSpec& op, unsigned width, unsigned arity)
+{
+  Layout l;
+  if (width == 0)
+    return l;
+  const unsigned n = op.nary ? std::max(2u, arity) : 2;
+
+  switch (op.shape)
+  {
+    case Shape::Nary:
+      for (unsigned i = 0; i < n; i++)
+        l.children.push_back(value(width));
+      l.outWidth = width;
+      break;
+
+    case Shape::Predicate:
+      l.children.push_back(value(width));
+      l.children.push_back(value(width));
+      l.outIsBoolean = true;
+      l.outWidth = 1;
+      break;
+
+    case Shape::Unary:
+      l.children.push_back(value(width));
+      l.outWidth = width;
+      break;
+
+    case Shape::BoolNary:
+      // The boolean operations don't have a width; they are only run once.
+      if (width != 1)
+        return l;
+      for (unsigned i = 0; i < n; i++)
+        l.children.push_back(boolean());
+      l.outIsBoolean = true;
+      l.outWidth = 1;
+      break;
+
+    case Shape::BoolUnary:
+      if (width != 1)
+        return l;
+      l.children.push_back(boolean());
+      l.outIsBoolean = true;
+      l.outWidth = 1;
+      break;
+
+    case Shape::Ite:
+      l.children.push_back(boolean());
+      l.children.push_back(value(width));
+      l.children.push_back(value(width));
+      l.outWidth = width;
+      break;
+
+    case Shape::Concat:
+      if (width < 2 || width % 2 != 0)
+        return l;
+      l.children.push_back(value(width / 2));
+      l.children.push_back(value(width / 2));
+      l.outWidth = width;
+      break;
+
+    case Shape::Extract:
+      // The bottom half of the input.
+      if (width < 2)
+        return l;
+      l.children.push_back(value(width));
+      l.children.push_back(constant(width / 2 - 1));
+      l.children.push_back(constant(0));
+      l.outWidth = width / 2;
+      break;
+
+    case Shape::Extend:
+      if (width < 2 || width % 2 != 0)
+        return l;
+      l.children.push_back(value(width / 2));
+      l.children.push_back(constant(width));
+      l.outWidth = width;
+      break;
+  }
+
+  l.ok = true;
+  return l;
+}
+
+// ---------------------------------------------------------------------------
+
+ASTNode buildNode(STPMgr* mgr, const OpSpec& op, const Layout& l)
+{
+  ASTVec children;
+  for (unsigned i = 0; i < l.children.size(); i++)
+  {
+    const ChildSpec& c = l.children[i];
+    if (c.isConstant)
+    {
+      children.push_back(mgr->CreateBVConst(c.width, c.value));
+      continue;
+    }
+    std::stringstream n;
+    n << "pb_" << op.name << "_" << l.outWidth << "_" << l.children.size()
+      << "_" << i;
+    children.push_back(
+        mgr->CreateSymbol(n.str().c_str(), 0, c.isBoolean ? 0 : c.width));
+  }
+
+  ASTNode n;
+  if (l.outIsBoolean)
+    n = mgr->CreateNode(op.kind, children);
+  else
+    n = mgr->CreateTerm(op.kind, l.outWidth, children);
+  BVTypeCheck(n);
+  return n;
+}
+
+// ---------------------------------------------------------------------------
+
+ASTNode evaluateNodes(STPMgr* mgr, const OpSpec& op, const Layout& l,
+                      const ASTVec& children)
+{
+  return NonMemberBVConstEvaluator(mgr, op.kind, children,
+                                   l.outIsBoolean ? 0 : l.outWidth);
+}
+
+uint64_t evaluate(STPMgr* mgr, const OpSpec& op, const Layout& l,
+                  const vector<uint64_t>& values)
+{
+  ASTVec children;
+  for (unsigned i = 0; i < l.children.size(); i++)
+  {
+    const ChildSpec& c = l.children[i];
+    const uint64_t v = c.isConstant ? c.value : values[i];
+    if (c.isBoolean)
+      children.push_back(v ? mgr->ASTTrue : mgr->ASTFalse);
+    else
+      children.push_back(mgr->CreateBVConst(c.width, v));
+  }
+
+  const ASTNode result = evaluateNodes(mgr, op, l, children);
+  if (l.outIsBoolean)
+    return result == mgr->ASTTrue ? 1 : 0;
+  return result.GetUnsignedConst();
+}
+
+vector<uint64_t> semanticsTable(STPMgr* mgr, const OpSpec& op, const Layout& l)
+{
+  const vector<unsigned> varying = l.varying();
+  const unsigned bits = l.packedBits();
+  vector<uint64_t> table((size_t)1 << bits);
+
+  vector<uint64_t> values(l.children.size(), 0);
+  for (uint64_t packed = 0; packed < table.size(); packed++)
+  {
+    uint64_t rest = packed;
+    for (unsigned i : varying)
+    {
+      const unsigned w = l.children[i].width;
+      values[i] = rest & ((w == 64) ? ~0ull : ((1ull << w) - 1));
+      rest >>= w;
+    }
+    table[packed] = evaluate(mgr, op, l, values);
+  }
+  return table;
+}
+
+// ---------------------------------------------------------------------------
+
+FixedBits concreteOf(const ChildSpec& spec, uint64_t v)
+{
+  FixedBits bits(spec.width, spec.isBoolean);
+  for (unsigned i = 0; i < spec.width; i++)
+  {
+    bits.setFixed(i, true);
+    bits.setValue(i, ((v >> i) & 1) != 0);
+  }
+  return bits;
+}
+
+FixedBits randomConcrete(const ChildSpec& spec, MTRand& rand)
+{
+  FixedBits bits(spec.width, spec.isBoolean);
+  for (unsigned i = 0; i < spec.width; i++)
+  {
+    bits.setFixed(i, true);
+    bits.setValue(i, (rand.randInt() % 2) == 1);
+  }
+  return bits;
+}
+
+void unfixTo(FixedBits& bits, unsigned percent, MTRand& rand)
+{
+  for (unsigned i = 0; i < bits.getWidth(); i++)
+    if (rand.randInt() % 100 >= percent)
+      bits.setFixed(i, false);
+}
+
+uint64_t unsignedValue(const FixedBits& bits)
+{
+  uint64_t v = 0;
+  for (unsigned i = 0; i < bits.getWidth() && i < 64; i++)
+    if (bits.isFixed(i) && bits.getValue(i))
+      v |= (1ull << i);
+  return v;
+}
+
+double median(vector<double>& v)
+{
+  if (v.empty())
+    return 0;
+  std::sort(v.begin(), v.end());
+  return v[v.size() / 2];
+}
+
+// ---------------------------------------------------------------------------
+// The constant-bit transfer functions, mapped exactly as
+// ConstantBitPropagation::dispatchToTransferFunctions maps them.
+
+Result cbitpTransfer(STPMgr* mgr, Kind k, vector<FixedBits*>& children,
+                     FixedBits& output)
+{
+  switch (k)
+  {
+    case BVLEFTSHIFT: return bvLeftShiftBothWays(children, output);
+    case BVRIGHTSHIFT: return bvRightShiftBothWays(children, output);
+    case BVSRSHIFT: return bvArithmeticRightShiftBothWays(children, output);
+
+    case BVLT: return bvLessThanBothWays(children, output);
+    case BVLE: return bvLessThanEqualsBothWays(children, output);
+    case BVGT: return bvGreaterThanBothWays(children, output);
+    case BVGE: return bvGreaterThanEqualsBothWays(children, output);
+
+    case BVSLT: return bvSignedLessThanBothWays(children, output);
+    case BVSGT: return bvSignedGreaterThanBothWays(children, output);
+    case BVSLE: return bvSignedLessThanEqualsBothWays(children, output);
+    case BVSGE: return bvSignedGreaterThanEqualsBothWays(children, output);
+
+    case XOR:
+    case BVXOR: return bvXorBothWays(children, output);
+    case OR:
+    case BVOR: return bvOrBothWays(children, output);
+    case AND:
+    case BVAND: return bvAndBothWays(children, output);
+    case IFF:
+    case EQ: return bvEqualsBothWays(children, output);
+    case IMPLIES: return bvImpliesBothWays(children, output);
+    case NOT:
+    case BVNOT: return bvNotBothWays(children, output);
+
+    case BVZX: return bvZeroExtendBothWays(children, output);
+    case BVSX: return bvSignExtendBothWays(children, output);
+    case BVUMINUS: return bvUnaryMinusBothWays(children, output);
+    case BVEXTRACT: return bvExtractBothWays(children, output);
+    case BVPLUS: return bvAddBothWays(children, output);
+    case BVSUB: return bvSubtractBothWays(children, output);
+    case ITE: return bvITEBothWays(children, output);
+    case BVCONCAT: return bvConcatBothWays(children, output);
+
+    case BVMULT: return bvMultiplyBothWays(children, output, mgr, NULL);
+    case BVDIV: return bvUnsignedDivisionBothWays(children, output, mgr);
+    case BVMOD: return bvUnsignedModulusBothWays(children, output, mgr);
+    case SBVDIV: return bvSignedDivisionBothWays(children, output, mgr);
+    case SBVREM: return bvSignedRemainderBothWays(children, output, mgr);
+    case SBVMOD: return bvSignedModulusBothWays(children, output, mgr);
+
+    default:
+      return NO_CHANGE;
+  }
+}
+} // namespace propbench

--- a/tools/propagator_bench/PropagatorBench.h
+++ b/tools/propagator_bench/PropagatorBench.h
@@ -1,0 +1,278 @@
+/********************************************************************
+ * AUTHORS: Trevor Hansen
+ *
+ * BEGIN DATE: July, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+// Shared types for the propagator benchmark. See README.md.
+
+#ifndef PROPAGATOR_BENCH_H_
+#define PROPAGATOR_BENCH_H_
+
+#include "stp/AST/AST.h"
+#include "stp/STPManager/STPManager.h"
+#include "stp/Simplifier/constantBitP/ConstantBitPropagation.h"
+#include "stp/Simplifier/constantBitP/FixedBits.h"
+#include "stp/Simplifier/constantBitP/MersenneTwister.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace propbench
+{
+using simplifier::constantBitP::FixedBits;
+using std::string;
+using std::vector;
+
+// ---------------------------------------------------------------------------
+// The abstract domains that STP propagates over.
+
+enum class Domain
+{
+  Cbitp,   // simplifier::constantBitP, the FixedBits transfer functions
+  Interval, // stp::UnsignedIntervalAnalysis
+  ValueSet  // stp::ValueSetAnalysis
+};
+
+// Which way information flows in the cases we hand the propagator. The
+// constant-bit transfer functions are all "both ways" functions, so the
+// direction here describes what is *seeded*, not what the code is able to
+// deduce:
+//   BottomUp  children partially known, result unknown
+//   TopDown   result partially known, children unknown
+//   BothWays  everything partially known
+// The interval and value-set analyses only ever run bottom up.
+enum class Direction
+{
+  BottomUp,
+  TopDown,
+  BothWays
+};
+
+const char* name(Domain d);
+const char* name(Direction d);
+bool parseDomain(const string& s, Domain& out);
+bool parseDirection(const string& s, Direction& out);
+
+// ---------------------------------------------------------------------------
+// Operations.
+
+// The shape of a node as a function of the benchmarked width w.
+enum class Shape
+{
+  Nary,      // (w, w, ...) -> w
+  Predicate, // (w, w) -> bool
+  Unary,     // (w) -> w
+  BoolNary,  // (bool, bool, ...) -> bool
+  BoolUnary, // (bool) -> bool
+  Ite,       // (bool, w, w) -> w
+  Concat,    // (w/2, w/2) -> w
+  Extract,   // (w, const, const) -> w/2
+  Extend     // (w/2, const) -> w
+};
+
+struct ChildSpec
+{
+  unsigned width = 0;      // 1 for booleans
+  bool isBoolean = false;
+  // Structural children -- the bounds of an extract, the width of an
+  // extend. They are always completely known and never propagated over.
+  bool isConstant = false;
+  uint64_t value = 0; // when isConstant
+};
+
+// One instance of an operation: the widths of its children and result.
+struct Layout
+{
+  vector<ChildSpec> children;
+  unsigned outWidth = 0;
+  bool outIsBoolean = false;
+  bool ok = false; // false when the operation can't be built at that width
+
+  // Indices of the children the harness varies (i.e. not structural).
+  vector<unsigned> varying() const;
+  // Total width of the varying children; the semantics table is indexed by
+  // their concatenated values, so this must stay small for the exhaustive
+  // phases.
+  unsigned packedBits() const;
+};
+
+struct OpSpec
+{
+  stp::Kind kind;
+  const char* name; // as in SMT-LIB, e.g. "bvsgt"
+  Shape shape;
+  bool nary;         // whether the transfer function takes more than 2 children
+  bool satCheckable; // maxPrecision() builds its node out of plain symbols,
+                     // so operations with structural children are excluded
+};
+
+const vector<OpSpec>& allOps();
+const OpSpec* findOp(const string& name);
+bool supports(Domain d, const OpSpec& op);
+
+// Builds the layout, expanding n-ary operations to `arity` children.
+Layout layoutFor(const OpSpec& op, unsigned width, unsigned arity);
+
+// A node of the right shape with a fresh symbol for every varying child.
+// The interval and value-set transfer functions dispatch on the node, and
+// the SAT-based precision check needs the same shape.
+stp::ASTNode buildNode(stp::STPMgr* mgr, const OpSpec& op, const Layout& l);
+
+// The reference semantics, from STP's constant evaluator. `values` holds one
+// entry per child, structural children included.
+uint64_t evaluate(stp::STPMgr* mgr, const OpSpec& op, const Layout& l,
+                  const vector<uint64_t>& values);
+
+// The same, for children that are already constant nodes. Widths above 64
+// bits go through here.
+stp::ASTNode evaluateNodes(stp::STPMgr* mgr, const OpSpec& op, const Layout& l,
+                           const stp::ASTVec& children);
+
+// evaluate() for every combination of the varying children's values, indexed
+// by their concatenated values (child 0 in the least significant position).
+// Only usable when packedBits() is small.
+vector<uint64_t> semanticsTable(stp::STPMgr* mgr, const OpSpec& op,
+                                const Layout& l);
+
+// ---------------------------------------------------------------------------
+// Results.
+
+// Exhaustive comparison against a brute-forced maximally precise reference at
+// a small width.
+struct PrecisionResult
+{
+  bool ran = false;
+  unsigned width = 0;
+  uint64_t cases = 0;
+  uint64_t precise = 0;         // cases where nothing more could be deduced
+  uint64_t unsound = 0;         // cases where a real solution was excluded
+  uint64_t missedConflict = 0;  // cases with no solution, not reported
+  uint64_t derivable = 0;       // bits an ideal propagator would have deduced
+  uint64_t gained = 0;          // bits this propagator deduced
+
+  bool maximallyPrecise() const
+  {
+    return ran && cases > 0 && precise == cases && unsound == 0;
+  }
+};
+
+// Spot check against maxPrecision() at the row's own width.
+struct SatCheck
+{
+  bool ran = false;
+  uint64_t cases = 0;
+  uint64_t precise = 0;
+  uint64_t unsound = 0;
+};
+
+struct Row
+{
+  Domain domain = Domain::Cbitp;
+  string op;
+  Direction direction = Direction::BottomUp;
+  unsigned width = 0;
+  unsigned arity = 2;
+  string input;         // how the case was seeded, e.g. "50% fixed"
+  unsigned prob = 0;    // percentage of bits seeded (cbitp, interval)
+  unsigned setSize = 0; // values per input set (value set)
+  bool implemented = true;
+
+  double nsPerCall = 0;
+  double opsPerSec = 0;
+  double bitsGained = 0; // information deduced per call, in bits
+  uint64_t calls = 0;
+  uint64_t conflicts = 0;
+  uint64_t witnessUnsound = 0; // cases whose known solution was excluded
+
+  PrecisionResult precision; // exhaustive, at a small width
+  SatCheck sat;              // at this row's width
+};
+
+struct Config
+{
+  vector<Domain> domains;
+  vector<string> ops; // empty means every operation
+  vector<unsigned> widths{8, 16, 32, 64};
+  vector<unsigned> probs{1, 50, 95};
+  vector<unsigned> setSizes{2, 4, 8};
+  vector<Direction> directions{Direction::BottomUp, Direction::BothWays};
+  unsigned arity = 2;
+  unsigned iterations = 20000;
+  double budgetSeconds = 0.25;
+  unsigned repeats = 3;
+  bool precision = true;
+  unsigned precisionWidth = 4;
+  uint64_t precisionCaseCap = 4000000;
+  unsigned satCases = 0;        // 0 disables the SAT spot check
+  double satBudgetSeconds = 5;  // it is thousands of times slower per case
+  unsigned seed = 42;
+  bool shiftBias = true; // draw half the shift amounts from [0, width)
+  bool verbose = false;
+  string html;
+  string csv;
+};
+
+// The measured cost of one configuration, in the units the runners share.
+struct Timing
+{
+  double nsPerCall = 0;
+  uint64_t calls = 0;
+  uint64_t conflicts = 0;
+  uint64_t unsound = 0;
+  double bitsGained = 0;
+};
+
+// ---------------------------------------------------------------------------
+// Per-domain runners. Each appends its rows to `out`.
+
+void runCbitp(stp::STPMgr* mgr, const Config& c, vector<Row>& out);
+void runInterval(stp::STPMgr* mgr, const Config& c, vector<Row>& out);
+void runValueSet(stp::STPMgr* mgr, const Config& c, vector<Row>& out);
+
+// The constant-bit transfer function for a kind, exactly as
+// ConstantBitPropagation::dispatchToTransferFunctions would call it.
+simplifier::constantBitP::Result cbitpTransfer(stp::STPMgr* mgr, stp::Kind k,
+                                               vector<FixedBits*>& children,
+                                               FixedBits& output);
+
+// ---------------------------------------------------------------------------
+// Reporting.
+
+void printText(const Config& c, const vector<Row>& rows);
+void writeCsv(const Config& c, const vector<Row>& rows, const string& path);
+void writeHtml(const Config& c, const vector<Row>& rows, const string& path);
+
+// ---------------------------------------------------------------------------
+// Small shared helpers.
+
+// A fully fixed FixedBits holding a random value (or the given one).
+FixedBits randomConcrete(const ChildSpec& spec, MTRand& rand);
+FixedBits concreteOf(const ChildSpec& spec, uint64_t value);
+// Unfixes every bit with probability (100 - percent)%.
+void unfixTo(FixedBits& bits, unsigned percent, MTRand& rand);
+uint64_t unsignedValue(const FixedBits& bits);
+
+double median(vector<double>& v);
+} // namespace propbench
+
+#endif

--- a/tools/propagator_bench/README.md
+++ b/tools/propagator_bench/README.md
@@ -1,0 +1,110 @@
+# propagator_bench
+
+How fast are STP's propagators, and how much do they deduce?
+
+The tool times one transfer function at a time, over random cases at a chosen
+bit-width and a chosen density of known input bits, and reports operations per
+second alongside a verdict on whether the propagator is *maximally precise* --
+whether it deduces everything that follows from what it was given.
+
+It covers the three abstract domains STP propagates over:
+
+| domain | code | direction |
+| --- | --- | --- |
+| `cbitp` | `simplifier::constantBitP`, the `bv*BothWays` transfer functions | both ways |
+| `interval` | `stp::UnsignedIntervalAnalysis::dispatchToTransferFunctions` | bottom up |
+| `valueset` | `stp::ValueSetAnalysis::dispatchToTransferFunctions` | bottom up |
+
+## Building and running
+
+It is one of the extra tools:
+
+```sh
+cmake -DBUILD_EXTRA_TOOLS=ON -DCMAKE_BUILD_TYPE=Release ..
+make propagator_bench
+```
+
+Build Release. A Debug build measures the assertions, not the propagators.
+
+```sh
+# Everything, into an HTML report (tens of minutes).
+./propagator_bench --html propagator-bench.html --csv propagator-bench.csv
+
+# One question, quickly.
+./propagator_bench --domains cbitp --ops bvsgt --widths 64 --probs 50 \
+                   --directions bottom-up
+```
+
+`--list` shows the operations and which domains implement them, `--help` the
+rest of the options.
+
+## What a row means
+
+> cbitp, bvsgt, bottom-up, 64 bit, 50% fixed: 40.7M ops/sec, 0.19 bits, precise
+
+* **direction** is what was *seeded*, not what the code can deduce. The
+  constant-bit transfer functions all propagate in both directions; the
+  interval and value-set analyses only ever compute a node's domain from its
+  children's, so they only have bottom-up rows.
+  * `bottom-up` -- children partially known, result unknown.
+  * `top-down` -- result partially known, children unknown.
+  * `both-ways` -- everything partially known.
+* **input** is how much was known going in: for `cbitp` and `interval`, the
+  percentage of bits fixed; for `valueset`, the number of values in each
+  input set.
+* **ops/sec** is the median of `--repeats` timed runs. The propagators mutate
+  their arguments, so every run works on a fresh copy, made outside the timed
+  region.
+* **bits** is what the call deduced, in bits: newly fixed bits for `cbitp`,
+  and the width less the log of the domain's size for `interval` and
+  `valueset`. It is the thing the ops/sec figure buys.
+* **precise** is the precision verdict, described below.
+
+Every case is built by drawing a concrete solution, evaluating it with STP's
+own constant evaluator, and then forgetting bits of it. So no case is
+contradictory, no propagator can short-circuit on a conflict, and the
+solution gives a free soundness check: a propagator that excludes it is
+reported as unsound rather than fast.
+
+## The precision verdict
+
+*Maximally precise* means: given these inputs, no sound propagator could have
+deduced more. It is checked two ways.
+
+**Exhaustively, at a small width** (`--precision-width`, default 4, lowered
+automatically when the enumeration would be too large). Every combination of
+input domains is enumerated -- all ternary patterns for `cbitp`, all
+intervals for `interval`, all subsets for `valueset` -- and for each one the
+ideal answer is brute-forced from the operation's truth table. The row says
+`12/6561 cases` and what share of the deducible bits were found. A propagator
+that is precise at width 4 is not proven precise at width 64, which is why
+the width is printed.
+
+**Against the SAT solver, at the benchmarked width** (`--sat-check N`). The
+existing `maxPrecision()` in `ConstantBitP_MaxPrecision.cpp` computes the join
+of every solution by repeatedly calling the SAT solver, which is exact at any
+width but thousands of times slower than the propagator; `--sat-budget`
+caps how long a row may spend on it. This one is `cbitp` only, and skips
+`extract` and the two extends, whose structural children can't be turned into
+plain SAT variables.
+
+A row is `yes` only when both checks that ran agree, `no` when either found
+something more to deduce, and `unsound` when a real solution was excluded --
+which would be a bug in the propagator, not a precision result.
+
+## Caveats worth knowing before quoting a number
+
+* **The machine matters.** These are absolute timings; on a loaded box they
+  are an upper bound on cost. For an A/B comparison of two implementations,
+  interleave the two in the same process rather than comparing two runs.
+* **Shift amounts are biased.** A uniformly random 64-bit shift amount is out
+  of range almost every time, so half of them are drawn from `[0, width)`
+  instead. `--no-shift-bias` turns that off.
+* **Divisors are not biased**, so a random 64-bit division is usually a
+  division by a huge number.
+* **n-ary operations are timed at `--arity` children** (default 2), which
+  understates `bvand` and `bvadd` as the solver actually sees them.
+* **`valueset` rows go null often.** Two 4-element sets multiply out to 16
+  possible results, past the 12 the domain can hold, so the analysis widens to
+  "unknown" and the deduced bits drop to zero. That is the domain working as
+  designed, not a measurement problem.

--- a/tools/propagator_bench/README.md
+++ b/tools/propagator_bench/README.md
@@ -108,3 +108,9 @@ which would be a bug in the propagator, not a precision result.
   possible results, past the 12 the domain can hold, so the analysis widens to
   "unknown" and the deduced bits drop to zero. That is the domain working as
   designed, not a measurement problem.
+* **`valueset` timings are noisy.** Every call evaluates through the constant
+  evaluator, which interns nodes, so the cost drifts upwards as the node table
+  fills: the same configuration has come out anywhere between 89k and 139k
+  calls a second in the same process. Take a difference of less than about
+  50% there as nothing at all, and compare two implementations by
+  alternating them, not by comparing two runs.

--- a/tools/propagator_bench/Report.cpp
+++ b/tools/propagator_bench/Report.cpp
@@ -1,0 +1,393 @@
+/********************************************************************
+ * AUTHORS: Trevor Hansen
+ *
+ * BEGIN DATE: July, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+// Text, CSV and HTML renderings of the measurements.
+
+#include "PropagatorBench.h"
+
+#include <cmath>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <set>
+#include <sstream>
+
+namespace propbench
+{
+namespace
+{
+
+string rate(double perSecond)
+{
+  std::ostringstream o;
+  o << std::fixed;
+  if (perSecond >= 1e9)
+    o << std::setprecision(2) << perSecond / 1e9 << "G";
+  else if (perSecond >= 1e6)
+    o << std::setprecision(2) << perSecond / 1e6 << "M";
+  else if (perSecond >= 1e3)
+    o << std::setprecision(0) << perSecond / 1e3 << "k";
+  else
+    o << std::setprecision(0) << perSecond;
+  return o.str();
+}
+
+string fixed(double v, int places)
+{
+  std::ostringstream o;
+  o << std::fixed << std::setprecision(places) << v;
+  return o.str();
+}
+
+// yes / no / unknown, from the exhaustive run and the SAT spot check.
+string verdict(const Row& r)
+{
+  if (r.precision.unsound > 0 || r.witnessUnsound > 0 || r.sat.unsound > 0)
+    return "unsound";
+  if (!r.precision.ran || r.precision.cases == 0)
+    return "?";
+  if (!r.precision.maximallyPrecise())
+    return "no";
+  if (r.sat.ran && r.sat.cases > 0 && r.sat.precise < r.sat.cases)
+    return "no";
+  return "yes";
+}
+
+string precisionDetail(const Row& r)
+{
+  std::ostringstream o;
+  if (!r.precision.ran || r.precision.cases == 0)
+    o << "not checked";
+  else
+  {
+    o << "exhaustive w=" << r.precision.width << ": " << r.precision.precise
+      << "/" << r.precision.cases << " cases";
+    if (r.precision.derivable > 0)
+      o << ", " << fixed(100.0 * r.precision.gained / r.precision.derivable, 1)
+        << "% of deducible bits";
+    if (r.precision.missedConflict > 0)
+      o << ", " << r.precision.missedConflict << " missed conflicts";
+    if (r.precision.unsound > 0)
+      o << ", " << r.precision.unsound << " UNSOUND";
+  }
+  if (r.sat.ran && r.sat.cases > 0)
+  {
+    o << "; SAT w=" << r.width << ": " << r.sat.precise << "/" << r.sat.cases;
+    if (r.sat.unsound > 0)
+      o << " (" << r.sat.unsound << " UNSOUND)";
+  }
+  if (r.witnessUnsound > 0)
+    o << "; " << r.witnessUnsound << " timed cases lost their solution";
+  if (r.conflicts > 0)
+    o << "; " << r.conflicts << " unexpected conflicts";
+  return o.str();
+}
+
+string escape(const string& s)
+{
+  string out;
+  for (char c : s)
+  {
+    if (c == '&') out += "&amp;";
+    else if (c == '<') out += "&lt;";
+    else if (c == '>') out += "&gt;";
+    else if (c == '"') out += "&quot;";
+    else out += c;
+  }
+  return out;
+}
+
+string configSummary(const Config& c)
+{
+  std::ostringstream o;
+  o << c.iterations << " cases per configuration, " << c.repeats
+    << " timed repeats (median reported), " << c.budgetSeconds
+    << "s budget each, arity " << c.arity << ", seed " << c.seed;
+  if (c.satCases > 0)
+    o << ", " << c.satCases << " SAT-checked cases per row";
+  return o.str();
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+
+void printText(const Config& cfg, const vector<Row>& rows)
+{
+  for (Domain d : {Domain::Cbitp, Domain::Interval, Domain::ValueSet})
+  {
+    bool any = false;
+    for (const Row& r : rows)
+      any = any || r.domain == d;
+    if (!any)
+      continue;
+
+    std::cout << "\n== " << name(d) << " ==\n";
+    std::cout << std::left << std::setw(14) << "op" << std::setw(12)
+              << "direction" << std::setw(7) << "width" << std::setw(12)
+              << "input" << std::right << std::setw(12) << "ops/sec"
+              << std::setw(12) << "ns/call" << std::setw(10) << "bits"
+              << "  " << std::left << std::setw(8) << "precise"
+              << "detail\n";
+
+    for (const Row& r : rows)
+    {
+      if (r.domain != d)
+        continue;
+      std::cout << std::left << std::setw(14) << r.op << std::setw(12)
+                << name(r.direction) << std::setw(7) << r.width
+                << std::setw(12) << r.input << std::right << std::setw(12)
+                << rate(r.opsPerSec) << std::setw(12) << fixed(r.nsPerCall, 1)
+                << std::setw(10) << fixed(r.bitsGained, 2) << "  " << std::left
+                << std::setw(8) << verdict(r) << precisionDetail(r) << "\n";
+    }
+  }
+  std::cout << "\n" << configSummary(cfg) << std::endl;
+}
+
+// ---------------------------------------------------------------------------
+
+void writeCsv(const Config& cfg, const vector<Row>& rows, const string& path)
+{
+  std::ofstream f(path.c_str());
+  if (!f)
+  {
+    std::cerr << "propagator_bench: cannot write " << path << std::endl;
+    return;
+  }
+  f << "domain,op,direction,width,arity,input,ops_per_second,ns_per_call,"
+       "bits_gained_per_call,calls,conflicts,maximally_precise,"
+       "exhaustive_width,exhaustive_cases,exhaustive_precise,"
+       "exhaustive_unsound,exhaustive_missed_conflicts,deducible_bits,"
+       "gained_bits,sat_cases,sat_precise,sat_unsound\n";
+  for (const Row& r : rows)
+  {
+    f << name(r.domain) << "," << r.op << "," << name(r.direction) << ","
+      << r.width << "," << r.arity << ",\"" << r.input << "\","
+      << fixed(r.opsPerSec, 0) << "," << fixed(r.nsPerCall, 2) << ","
+      << fixed(r.bitsGained, 4) << "," << r.calls << "," << r.conflicts << ","
+      << verdict(r) << "," << r.precision.width << "," << r.precision.cases
+      << "," << r.precision.precise << "," << r.precision.unsound << ","
+      << r.precision.missedConflict << "," << r.precision.derivable << ","
+      << r.precision.gained << "," << r.sat.cases << "," << r.sat.precise
+      << "," << r.sat.unsound << "\n";
+  }
+  (void)cfg;
+  std::cout << "wrote " << path << std::endl;
+}
+
+// ---------------------------------------------------------------------------
+
+void writeHtml(const Config& cfg, const vector<Row>& rows, const string& path)
+{
+  std::ofstream f(path.c_str());
+  if (!f)
+  {
+    std::cerr << "propagator_bench: cannot write " << path << std::endl;
+    return;
+  }
+
+  f << "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n"
+    << "<meta charset=\"utf-8\">\n"
+    << "<meta name=\"viewport\" content=\"width=device-width, "
+       "initial-scale=1\">\n"
+    << "<title>STP propagator benchmark</title>\n<style>\n"
+    << ":root { color-scheme: light dark;\n"
+    << "  --bg: #ffffff; --fg: #1a1a1a; --muted: #666; --line: #d8d8d8;\n"
+    << "  --head: #f4f4f6; --zebra: #fafafa; --good: #0a7a3d; --bad: #a33;\n"
+    << "  --warn: #8a6d00; }\n"
+    << "@media (prefers-color-scheme: dark) {\n"
+    << ":root { --bg: #14161a; --fg: #e6e6e6; --muted: #9aa0a6;\n"
+    << "  --line: #2c3038; --head: #1c1f25; --zebra: #181b20;\n"
+    << "  --good: #4ec97f; --bad: #f08a8a; --warn: #e0c060; } }\n"
+    << "body { background: var(--bg); color: var(--fg); margin: 0 auto;\n"
+    << "  padding: 2rem 1.2rem; max-width: 1200px;\n"
+    << "  font: 15px/1.5 system-ui, -apple-system, 'Segoe UI', sans-serif; }\n"
+    << "h1 { font-size: 1.5rem; margin: 0 0 .3rem; }\n"
+    << "h2 { font-size: 1.15rem; margin: 2.2rem 0 .4rem; }\n"
+    << "p.note, .meta { color: var(--muted); font-size: .87rem; }\n"
+    << ".wrap { overflow-x: auto; border: 1px solid var(--line);\n"
+    << "  border-radius: 6px; }\n"
+    << "table { border-collapse: collapse; width: 100%; font-size: .88rem; }\n"
+    << "th, td { padding: .38rem .6rem; text-align: right;\n"
+    << "  border-bottom: 1px solid var(--line); white-space: nowrap; }\n"
+    << "th:first-child, td:first-child, th.l, td.l { text-align: left; }\n"
+    << "thead th { background: var(--head); position: sticky; top: 0;\n"
+    << "  cursor: pointer; user-select: none; }\n"
+    << "tbody tr:nth-child(even) { background: var(--zebra); }\n"
+    << "td.detail { color: var(--muted); font-size: .8rem;\n"
+    << "  white-space: normal; }\n"
+    << ".yes { color: var(--good); font-weight: 600; }\n"
+    << ".no { color: var(--bad); }\n"
+    << ".unsound { color: var(--bad); font-weight: 700; }\n"
+    << ".unknown { color: var(--muted); }\n"
+    << ".filters { margin: .6rem 0; display: flex; flex-wrap: wrap;\n"
+    << "  gap: .5rem; align-items: center; font-size: .85rem; }\n"
+    << "select, input { font: inherit; padding: .2rem .35rem;\n"
+    << "  background: var(--bg); color: var(--fg);\n"
+    << "  border: 1px solid var(--line); border-radius: 4px; }\n"
+    << "code { font-size: .85em; }\n"
+    << "</style>\n</head>\n<body>\n";
+
+  f << "<h1>STP propagator benchmark</h1>\n";
+  f << "<p class=\"meta\">" << escape(configSummary(cfg)) << ".</p>\n";
+  f << "<p class=\"note\">Every case is built from a concrete solution and "
+       "then partially forgotten, so no case is contradictory and no "
+       "propagator can short-circuit on a conflict. Timings are the median "
+       "of the repeats; on a loaded machine treat them as an upper bound on "
+       "the cost. <em>bits</em> is the information the propagator deduced per "
+       "call: newly fixed bits for cbitp, and the width less the log of the "
+       "domain's size for the interval and value-set analyses. "
+       "<em>precise</em> is whether the propagator deduced everything that "
+       "follows from its inputs, checked exhaustively at the small width "
+       "given in the last column";
+  if (cfg.satCases > 0)
+    f << " and spot-checked at the benchmarked width against the SAT-based "
+         "maximally precise propagator";
+  f << ".</p>\n";
+
+  for (Domain d : {Domain::Cbitp, Domain::Interval, Domain::ValueSet})
+  {
+    bool any = false;
+    for (const Row& r : rows)
+      any = any || r.domain == d;
+    if (!any)
+      continue;
+
+    const string id = name(d);
+    f << "<h2>" << id << "</h2>\n";
+    if (d == Domain::Cbitp)
+      f << "<p class=\"note\">simplifier::constantBitP -- the transfer "
+           "functions in <code>ConstantBitP_*.cpp</code>. They propagate in "
+           "both directions; the direction column says what was known going "
+           "in.</p>\n";
+    else if (d == Domain::Interval)
+      f << "<p class=\"note\">stp::UnsignedIntervalAnalysis -- unsigned "
+           "intervals, bottom up only. Inputs are the tightest interval "
+           "around the same partially fixed bits the cbitp rows use.</p>\n";
+    else
+      f << "<p class=\"note\">stp::ValueSetAnalysis -- sets of up to "
+           "12 values, bottom up only, evaluated over the cartesian product "
+           "of the children's sets.</p>\n";
+
+    // Filters.
+    std::set<string> directions, widths, inputs, ops;
+    for (const Row& r : rows)
+      if (r.domain == d)
+      {
+        directions.insert(name(r.direction));
+        widths.insert(std::to_string(r.width));
+        inputs.insert(r.input);
+        ops.insert(r.op);
+      }
+
+    f << "<div class=\"filters\" data-for=\"" << id << "\">\n";
+    const char* labels[] = {"op", "direction", "width", "input"};
+    const std::set<string>* sets[] = {&ops, &directions, &widths, &inputs};
+    for (int i = 0; i < 4; i++)
+    {
+      f << "<label>" << labels[i] << " <select data-col=\"" << i
+        << "\"><option value=\"\">all</option>";
+      for (const string& v : *sets[i])
+        f << "<option>" << escape(v) << "</option>";
+      f << "</select></label>\n";
+    }
+    f << "</div>\n";
+
+    f << "<div class=\"wrap\"><table id=\"t_" << id << "\">\n<thead><tr>"
+      << "<th class=\"l\">op</th><th class=\"l\">direction</th>"
+      << "<th>width</th><th class=\"l\">input</th><th>ops/sec</th>"
+      << "<th>ns/call</th><th>bits</th><th class=\"l\">precise</th>"
+      << "<th class=\"l\">precision detail</th></tr></thead>\n<tbody>\n";
+
+    for (const Row& r : rows)
+    {
+      if (r.domain != d)
+        continue;
+      const string v = verdict(r);
+      const string cls =
+          v == "yes" ? "yes" : (v == "no" ? "no"
+                                          : (v == "unsound" ? "unsound"
+                                                            : "unknown"));
+      f << "<tr><td class=\"l\">" << escape(r.op) << "</td><td class=\"l\">"
+        << name(r.direction) << "</td><td data-v=\"" << r.width << "\">"
+        << r.width << "</td><td class=\"l\">" << escape(r.input)
+        << "</td><td data-v=\"" << fixed(r.opsPerSec, 0) << "\">"
+        << rate(r.opsPerSec) << "</td><td data-v=\"" << fixed(r.nsPerCall, 2)
+        << "\">" << fixed(r.nsPerCall, 1) << "</td><td data-v=\""
+        << fixed(r.bitsGained, 4) << "\">" << fixed(r.bitsGained, 2)
+        << "</td><td class=\"l " << cls << "\">" << v
+        << "</td><td class=\"detail l\">" << escape(precisionDetail(r))
+        << "</td></tr>\n";
+    }
+    f << "</tbody></table></div>\n";
+  }
+
+  f << "<script>\n"
+    << "function cellValue(row, i) {\n"
+    << "  const c = row.cells[i];\n"
+    << "  const v = c.getAttribute('data-v');\n"
+    << "  return v === null ? c.textContent.trim() : parseFloat(v);\n"
+    << "}\n"
+    << "document.querySelectorAll('table').forEach(function (table) {\n"
+    << "  table.querySelectorAll('thead th').forEach(function (th, i) {\n"
+    << "    let asc = false;\n"
+    << "    th.addEventListener('click', function () {\n"
+    << "      asc = !asc;\n"
+    << "      const body = table.tBodies[0];\n"
+    << "      const rows = Array.from(body.rows);\n"
+    << "      rows.sort(function (a, b) {\n"
+    << "        const x = cellValue(a, i), y = cellValue(b, i);\n"
+    << "        if (x < y) return asc ? -1 : 1;\n"
+    << "        if (x > y) return asc ? 1 : -1;\n"
+    << "        return 0;\n"
+    << "      });\n"
+    << "      rows.forEach(function (r) { body.appendChild(r); });\n"
+    << "    });\n"
+    << "  });\n"
+    << "});\n"
+    << "document.querySelectorAll('.filters').forEach(function (bar) {\n"
+    << "  const table = document.getElementById('t_' + bar.dataset.for);\n"
+    << "  function apply() {\n"
+    << "    const want = {};\n"
+    << "    bar.querySelectorAll('select').forEach(function (s) {\n"
+    << "      if (s.value) want[s.dataset.col] = s.value;\n"
+    << "    });\n"
+    << "    Array.from(table.tBodies[0].rows).forEach(function (row) {\n"
+    << "      let show = true;\n"
+    << "      for (const col in want)\n"
+    << "        if (row.cells[col].textContent.trim() !== want[col])\n"
+    << "          show = false;\n"
+    << "      row.style.display = show ? '' : 'none';\n"
+    << "    });\n"
+    << "  }\n"
+    << "  bar.querySelectorAll('select').forEach(function (s) {\n"
+    << "    s.addEventListener('change', apply);\n"
+    << "  });\n"
+    << "});\n"
+    << "</script>\n</body>\n</html>\n";
+
+  std::cout << "wrote " << path << std::endl;
+}
+} // namespace propbench

--- a/tools/propagator_bench/main.cpp
+++ b/tools/propagator_bench/main.cpp
@@ -1,0 +1,243 @@
+/********************************************************************
+ * AUTHORS: Trevor Hansen
+ *
+ * BEGIN DATE: July, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+// How fast are STP's propagators, and how much do they deduce? See README.md.
+
+#include "PropagatorBench.h"
+
+#include "stp/Parser/LetMgr.h"
+#include "stp/cpp_interface.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <sstream>
+
+using namespace propbench;
+using std::string;
+using std::vector;
+
+namespace
+{
+
+vector<string> split(const string& s)
+{
+  vector<string> parts;
+  std::stringstream ss(s);
+  string item;
+  while (std::getline(ss, item, ','))
+    if (!item.empty())
+      parts.push_back(item);
+  return parts;
+}
+
+vector<unsigned> splitNumbers(const string& s)
+{
+  vector<unsigned> parts;
+  for (const string& item : split(s))
+    parts.push_back((unsigned)strtoul(item.c_str(), NULL, 10));
+  return parts;
+}
+
+void usage()
+{
+  std::cout
+      << "usage: propagator_bench [options]\n\n"
+      << "Measures the speed and the precision of STP's propagators.\n\n"
+      << "  --domains LIST      cbitp,interval,valueset (default: all)\n"
+      << "  --ops LIST          only these operations (default: all)\n"
+      << "  --widths LIST       bit-widths to time at (default 8,16,32,64)\n"
+      << "  --probs LIST        percentage of input bits known, for cbitp\n"
+      << "                      and interval (default 1,50,95)\n"
+      << "  --set-sizes LIST    values per input set, for valueset\n"
+      << "                      (default 2,4,8)\n"
+      << "  --directions LIST   bottom-up,top-down,both-ways -- what is\n"
+      << "                      seeded (default bottom-up,both-ways).\n"
+      << "                      Only cbitp propagates downwards.\n"
+      << "  --arity N           children for the n-ary operations "
+         "(default 2)\n"
+      << "  --iterations N      cases per configuration (default 20000)\n"
+      << "  --budget SECONDS    time limit per timed run (default 0.25)\n"
+      << "  --repeats N         timed runs per configuration, the median is\n"
+      << "                      reported (default 3)\n"
+      << "  --precision-width W exhaustive precision width (default 4);\n"
+      << "                      lowered automatically when too costly\n"
+      << "  --no-precision      skip the exhaustive precision phase\n"
+      << "  --sat-check N       also check N cases per row against the\n"
+      << "                      SAT-based maxPrecision(), at the real width\n"
+      << "  --sat-budget SECS   time limit for that check, per row\n"
+      << "                      (default 5); fewer cases are run if it\n"
+      << "                      doesn't fit\n"
+      << "  --no-shift-bias     draw shift amounts uniformly, instead of\n"
+      << "                      half of them from [0, width)\n"
+      << "  --seed N            random seed (default 42)\n"
+      << "  --html FILE         write an HTML report\n"
+      << "  --csv FILE          write the rows as CSV\n"
+      << "  --list              list the operations and exit\n"
+      << "  --verbose           report progress on stderr\n";
+}
+
+void list()
+{
+  std::cout << "operation      cbitp interval valueset\n";
+  for (const OpSpec& op : allOps())
+  {
+    std::cout.width(15);
+    std::cout << std::left << op.name;
+    std::cout << (supports(Domain::Cbitp, op) ? "yes   " : "-     ")
+              << (supports(Domain::Interval, op) ? "yes      " : "-        ")
+              << (supports(Domain::ValueSet, op) ? "yes" : "-") << "\n";
+  }
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+  Config cfg;
+  cfg.domains = {Domain::Cbitp, Domain::Interval, Domain::ValueSet};
+
+  for (int i = 1; i < argc; i++)
+  {
+    const string arg = argv[i];
+    const bool hasValue = (i + 1 < argc);
+    const string value = hasValue ? argv[i + 1] : "";
+
+    if (arg == "--help" || arg == "-h")
+    {
+      usage();
+      return 0;
+    }
+    else if (arg == "--list")
+    {
+      list();
+      return 0;
+    }
+    else if (arg == "--no-precision")
+      cfg.precision = false;
+    else if (arg == "--no-shift-bias")
+      cfg.shiftBias = false;
+    else if (arg == "--verbose" || arg == "-v")
+      cfg.verbose = true;
+    else if (!hasValue)
+    {
+      std::cerr << "propagator_bench: " << arg << " needs a value\n";
+      return 1;
+    }
+    else if (arg == "--domains")
+    {
+      cfg.domains.clear();
+      for (const string& d : split(value))
+      {
+        Domain parsed;
+        if (!parseDomain(d, parsed))
+        {
+          std::cerr << "propagator_bench: unknown domain " << d << "\n";
+          return 1;
+        }
+        cfg.domains.push_back(parsed);
+      }
+      i++;
+    }
+    else if (arg == "--ops")
+    {
+      cfg.ops = split(value);
+      for (const string& o : cfg.ops)
+        if (findOp(o) == NULL)
+        {
+          std::cerr << "propagator_bench: unknown operation " << o
+                    << " (--list shows them)\n";
+          return 1;
+        }
+      i++;
+    }
+    else if (arg == "--directions")
+    {
+      cfg.directions.clear();
+      for (const string& d : split(value))
+      {
+        Direction parsed;
+        if (!parseDirection(d, parsed))
+        {
+          std::cerr << "propagator_bench: unknown direction " << d << "\n";
+          return 1;
+        }
+        cfg.directions.push_back(parsed);
+      }
+      i++;
+    }
+    else if (arg == "--widths") { cfg.widths = splitNumbers(value); i++; }
+    else if (arg == "--probs") { cfg.probs = splitNumbers(value); i++; }
+    else if (arg == "--set-sizes") { cfg.setSizes = splitNumbers(value); i++; }
+    else if (arg == "--arity") { cfg.arity = atoi(value.c_str()); i++; }
+    else if (arg == "--iterations") { cfg.iterations = atoi(value.c_str()); i++; }
+    else if (arg == "--budget") { cfg.budgetSeconds = atof(value.c_str()); i++; }
+    else if (arg == "--repeats") { cfg.repeats = atoi(value.c_str()); i++; }
+    else if (arg == "--precision-width")
+    { cfg.precisionWidth = atoi(value.c_str()); i++; }
+    else if (arg == "--sat-check") { cfg.satCases = atoi(value.c_str()); i++; }
+    else if (arg == "--sat-budget")
+    { cfg.satBudgetSeconds = atof(value.c_str()); i++; }
+    else if (arg == "--seed") { cfg.seed = atoi(value.c_str()); i++; }
+    else if (arg == "--html") { cfg.html = value; i++; }
+    else if (arg == "--csv") { cfg.csv = value; i++; }
+    else
+    {
+      std::cerr << "propagator_bench: unknown option " << arg << "\n";
+      usage();
+      return 1;
+    }
+  }
+
+  if (cfg.iterations == 0 || cfg.repeats == 0)
+  {
+    std::cerr << "propagator_bench: --iterations and --repeats must be "
+                 "positive\n";
+    return 1;
+  }
+
+  stp::STPMgr* mgr = new stp::STPMgr();
+  stp::Cpp_interface interface(*mgr, mgr->defaultNodeFactory);
+  interface.startup();
+  stp::GlobalParserBM = mgr;
+
+  vector<Row> rows;
+  for (Domain d : cfg.domains)
+  {
+    switch (d)
+    {
+      case Domain::Cbitp: runCbitp(mgr, cfg, rows); break;
+      case Domain::Interval: runInterval(mgr, cfg, rows); break;
+      case Domain::ValueSet: runValueSet(mgr, cfg, rows); break;
+    }
+  }
+
+  printText(cfg, rows);
+  if (!cfg.csv.empty())
+    writeCsv(cfg, rows, cfg.csv);
+  if (!cfg.html.empty())
+    writeHtml(cfg, rows, cfg.html);
+
+  return 0;
+}


### PR DESCRIPTION
A tool that measures what the propagators cost and how much they deduce.

It times one transfer function at a time and reports operations per second
next to a verdict on whether the propagator deduced everything that follows
from its inputs. It covers the three domains STP propagates over: the
constant-bit transfer functions, the unsigned interval analysis and the
value set analysis. Built under the existing `BUILD_EXTRA_TOOLS` option.

A row reads:

```
cbitp  bvsgt  bottom-up  64  50% fixed   68.1M ops/sec   0.20 bits   precise: yes
       exhaustive w=4: 6561/6561 cases, 100.0% of deducible bits; SAT w=64: 3/3
```

The dimensions are domain, operation, direction (what was seeded -- the
constant-bit functions all propagate both ways), width, and how much was
known going in.

Cases are built by drawing a concrete solution, evaluating it with the
constant evaluator and then forgetting bits of it, so no case is
contradictory -- a propagator can't look fast by short-circuiting on a
conflict -- and the solution doubles as a soundness check.

Precision is decided two ways: exhaustively at a small width against a
brute-forced ideal (every ternary pattern, interval or subset), and, for the
constant-bit propagators, spot-checked at the benchmarked width against the
existing SAT-based `maxPrecision()`.

Output is plain text, CSV, and a self-contained HTML report with one
sortable table per domain.

## Does it measure what it claims to?

* Timings agree with the older `tools/time_constantbitprop` to within ~3% at
  65 bits and 50% fixed: addition 2000 vs 1813 ns, multiplication 2400 vs
  2269, unsigned division 14200 vs 14205.
* The constant-bit operations it calls imprecise are exactly the six the
  source already documents as imprecise -- multiplication and the five
  division and remainder ones -- and no others.
* A Debug build with assertions runs the whole sweep clean: no assertion
  fires, and no case loses the solution it was built from.

## What the first full run turned up

* `bvsub` costs about eight times `bvadd` for identical precision -- 14.7 vs
  1.9 us at 64 bits, both maximally precise -- because
  `bvSubtractBothWays` re-runs a ternary `bvAddBothWays(a, ~b, 1)` plus a
  `bvNotBothWays` to a fixed point, copying three `FixedBits` per iteration.
* The value set analysis said nothing whenever any child was unknown, so it
  couldn't do `x & 0`. Fixed separately in #618; the two are independent and
  can land in either order.
* The division and remainder family is both the slowest by three orders of
  magnitude and the least precise: `bvudiv` both ways at 64 bits manages 58%
  of the deducible bits and misses conflicts in 9% of small-width cases.

The three older tools (`time_constantbitprop`, `measure_constantbitprop`,
`test_constantbitprop`) overlap with parts of this and could be retired
later; this leaves them alone.