### PR TITLE
Value sets: say something when a child is unknown

### DIFF
--- a/include/stp/Simplifier/ValueSetAnalysis.h
+++ b/include/stp/Simplifier/ValueSetAnalysis.h
@@ -50,9 +50,39 @@ class ValueSetAnalysis
   static const size_t PRODUCT_CAP =
       ValueSet::MAX_ELEMENTS * ValueSet::MAX_ELEMENTS;
 
+  // An unknown child of at most this many bits is cheap enough to stand in
+  // for by listing every value it could take.
+  static const unsigned SMALL_WIDTH = 6;
+
+  // What an unknown operand does to the result after the fact. The bitwise
+  // operations are handled by running the known children through the
+  // operation's identity and then expanding: anding against an unknown can
+  // clear any subset of the bits that are set, oring can set any subset of
+  // the bits that are clear.
+  enum class Expand
+  {
+    None,
+    Submask,
+    Supermask
+  };
+
   ValueSet* fresh(const ASTNode& n) const;
   ASTNode toNode(const ASTNode& child, const CBV member);
   static CBV toCBV(const ASTNode& evaluated);
+
+  // Values that stand in for an unknown child: evaluating over them gives
+  // exactly the results the child's whole width would give. False when
+  // there are too many of them, or the operation says nothing anyway.
+  bool standIns(const ASTNode& n, size_t index,
+                const vector<const ValueSet*>& children, vector<CBV>& out,
+                Expand& expand);
+  bool shiftStandIns(const ASTNode& n, size_t index,
+                     const vector<const ValueSet*>& children,
+                     vector<CBV>& out);
+
+  // Takes ownership of "set", returning the expanded set, or nullptr when
+  // the expansion is bigger than a set can hold.
+  ValueSet* expand(ValueSet* set, Expand how);
 
 public:
   ValueSetAnalysis(STPMgr& _bm) : bm(_bm) {}

--- a/lib/Simplifier/ValueSetAnalysis.cpp
+++ b/lib/Simplifier/ValueSetAnalysis.cpp
@@ -63,6 +63,64 @@ namespace stp
     return CONSTANTBV::BitVector_Clone(evaluated.GetBVConst());
   }
 
+  namespace
+  {
+    CBV valueOf(unsigned width, uint64_t value)
+    {
+      CBV result = CONSTANTBV::BitVector_Create(width, true);
+      for (unsigned i = 0; i < width && i < 64; i++)
+        if ((value >> i) & 1)
+          CONSTANTBV::BitVector_Bit_On(result, i);
+      return result;
+    }
+
+    CBV allOnes(unsigned width)
+    {
+      CBV result = CONSTANTBV::BitVector_Create(width, true);
+      CONSTANTBV::BitVector_Fill(result);
+      return result;
+    }
+
+    // The shift amount, saturated at the width: shifting by the width or
+    // more always gives the same answer.
+    unsigned shiftAmount(const CBV v, unsigned width)
+    {
+      uint64_t result = 0;
+      for (unsigned i = 0; i < bits_(v); i++)
+        if (CONSTANTBV::BitVector_bit_test(v, i))
+        {
+          if (i >= 63)
+            return width;
+          result |= (1ull << i);
+          if (result >= width)
+            return width;
+        }
+      return (unsigned)result;
+    }
+
+    // Operations that are one-to-one in each argument (or, for equality,
+    // reach both answers whatever the other side is): once an operand is
+    // unknown the result can be anything, so there is nothing to say.
+    bool anythingWhenUnknown(Kind k)
+    {
+      switch (k)
+      {
+        case EQ:
+        case IFF:
+        case XOR:
+        case NOT:
+        case BVXOR:
+        case BVNOT:
+        case BVPLUS:
+        case BVSUB:
+        case BVUMINUS:
+          return true;
+        default:
+          return false;
+      }
+    }
+  }
+
   bool ValueSetAnalysis::constEvaluable(Kind k)
   {
     // The kinds the switch in NonMemberBVConstEvaluator handles; it
@@ -113,6 +171,189 @@ namespace stp
       default:
         return false;
     }
+  }
+
+  // An unknown child stands for every value of its width. Rather than give
+  // up, list values that produce exactly the same results -- there are
+  // usually few or none of them, and the caller stops as soon as too many
+  // results pile up.
+  bool ValueSetAnalysis::standIns(const ASTNode& n, size_t index,
+                                  const vector<const ValueSet*>& children,
+                                  vector<CBV>& out, Expand& expandWith)
+  {
+    const Kind k = n.GetKind();
+    const unsigned width = std::max(1u, n[index].GetValueWidth());
+
+    if (anythingWhenUnknown(k))
+      return false;
+
+    switch (k)
+    {
+      // Multiplication, division and modulus are left out on purpose:
+      // they are the expensive ones to evaluate, and an unknown operand
+      // rarely pins their result down.
+      case BVMULT:
+      case BVDIV:
+      case BVMOD:
+      case SBVDIV:
+      case SBVREM:
+      case SBVMOD:
+        return false;
+
+      case BVAND:
+        expandWith = Expand::Submask;
+        out.push_back(allOnes(width));
+        return true;
+
+      case BVOR:
+        expandWith = Expand::Supermask;
+        out.push_back(CONSTANTBV::BitVector_Create(width, true));
+        return true;
+
+      // The comparisons are monotone in each side, so whatever they can
+      // answer they already answer at the extremes of the unknown one.
+      case BVLT:
+      case BVLE:
+      case BVGT:
+      case BVGE:
+        out.push_back(CONSTANTBV::BitVector_Create(width, true));
+        out.push_back(allOnes(width));
+        return true;
+
+      case BVSLT:
+      case BVSLE:
+      case BVSGT:
+      case BVSGE:
+      {
+        CBV signedMin = CONSTANTBV::BitVector_Create(width, true);
+        CONSTANTBV::BitVector_Bit_On(signedMin, width - 1);
+        CBV signedMax = allOnes(width);
+        CONSTANTBV::BitVector_Bit_Off(signedMax, width - 1);
+        out.push_back(signedMin);
+        out.push_back(signedMax);
+        return true;
+      }
+
+      case BVLEFTSHIFT:
+      case BVRIGHTSHIFT:
+      case BVSRSHIFT:
+        return shiftStandIns(n, index, children, out);
+
+      default:
+        break;
+    }
+
+    // Anything else: every value of the width, when there are few enough
+    // of them. A wider child would push the result past what a set holds.
+    if (width > SMALL_WIDTH)
+      return false;
+    for (uint64_t v = 0; v < (1ull << width); v++)
+      out.push_back(valueOf(width, v));
+    return true;
+  }
+
+  bool ValueSetAnalysis::shiftStandIns(const ASTNode& n, size_t index,
+                                       const vector<const ValueSet*>& children,
+                                       vector<CBV>& out)
+  {
+    const Kind k = n.GetKind();
+    const unsigned width = n.GetValueWidth();
+
+    if (index == 1)
+    {
+      // The amount. Shifting by the width or more always gives the same
+      // answer, so the amounts to try stop there.
+      if (children[0] == nullptr)
+        return false;
+      if ((width + 1) * children[0]->size() > PRODUCT_CAP)
+        return false;
+      for (unsigned s = 0; s <= width; s++)
+        out.push_back(valueOf(width, s));
+      return true;
+    }
+
+    // The value being shifted. Only the bits that survive the smallest of
+    // the amounts can reach the result, so only those are worth varying.
+    if (children[1] == nullptr)
+      return false;
+
+    unsigned smallest = width;
+    for (const CBV s : children[1]->values)
+      smallest = std::min(smallest, shiftAmount(s, width));
+
+    // Shifted all the way out, an arithmetic shift still copies the sign
+    // bit, so that bit always has to be varied.
+    if (BVSRSHIFT == k && smallest == width)
+      smallest = width - 1;
+
+    const unsigned survivors = width - smallest;
+    if (survivors > SMALL_WIDTH)
+      return false;
+
+    for (uint64_t v = 0; v < (1ull << survivors); v++)
+    {
+      CBV value = CONSTANTBV::BitVector_Create(width, true);
+      for (unsigned i = 0; i < survivors; i++)
+        if ((v >> i) & 1)
+          CONSTANTBV::BitVector_Bit_On(value,
+                                       BVLEFTSHIFT == k ? i : i + smallest);
+      out.push_back(value);
+    }
+    return true;
+  }
+
+  // Takes ownership of "set".
+  ValueSet* ValueSetAnalysis::expand(ValueSet* set, Expand how)
+  {
+    const unsigned width = set->getWidth();
+    ValueSet* result = new ValueSet(width, set->isBoolean());
+
+    for (const CBV member : set->values)
+    {
+      // The bits the unknown operand is free to change.
+      vector<unsigned> free;
+      for (unsigned i = 0; i < width; i++)
+      {
+        const bool one = CONSTANTBV::BitVector_bit_test(member, i);
+        if (Expand::Submask == how ? one : !one)
+          free.push_back(i);
+      }
+
+      // Two to the power of that many members: past three bits it can't
+      // fit in a set anyway.
+      if (free.size() > 31 || (1ull << free.size()) > ValueSet::MAX_ELEMENTS)
+      {
+        delete result;
+        delete set;
+        return nullptr;
+      }
+
+      for (uint64_t v = 0; v < (1ull << free.size()); v++)
+      {
+        CBV variant = CONSTANTBV::BitVector_Clone(member);
+        for (unsigned b = 0; b < free.size(); b++)
+        {
+          const bool set_bit = ((v >> b) & 1) != 0;
+          if (Expand::Submask == how)
+          {
+            if (!set_bit)
+              CONSTANTBV::BitVector_Bit_Off(variant, free[b]);
+          }
+          else if (set_bit)
+            CONSTANTBV::BitVector_Bit_On(variant, free[b]);
+        }
+
+        if (!result->insert(variant))
+        {
+          delete result;
+          delete set;
+          return nullptr;
+        }
+      }
+    }
+
+    delete set;
+    return result;
   }
 
   ValueSet* ValueSetAnalysis::dispatchToTransferFunctions(
@@ -183,20 +424,47 @@ namespace stp
     if (!constEvaluable(k) || n.Degree() == 0)
       return nullptr;
 
-    size_t combinations = 1;
-    for (const ValueSet* c : children)
+    // Values standing in for the children nothing is known about.
+    struct Owned
     {
-      if (c == nullptr)
+      vector<vector<CBV>> values;
+      ~Owned()
+      {
+        for (const vector<CBV>& v : values)
+          for (const CBV c : v)
+            CONSTANTBV::BitVector_Destroy(c);
+      }
+    } standIn;
+    standIn.values.resize(children.size());
+
+    Expand expandWith = Expand::None;
+    for (size_t i = 0; i < children.size(); i++)
+      if (children[i] == nullptr &&
+          !standIns(n, i, children, standIn.values[i], expandWith))
+      {
+        widened++;
         return nullptr;
-      combinations *= c->size();
+      }
+
+    // What each child ranges over.
+    vector<const vector<CBV>*> members(children.size());
+    size_t combinations = 1;
+    for (size_t i = 0; i < children.size(); i++)
+    {
+      members[i] = (children[i] != nullptr) ? &children[i]->values
+                                            : &standIn.values[i];
+      combinations *= members[i]->size();
       if (combinations > PRODUCT_CAP)
+      {
+        widened++;
         return nullptr;
+      }
     }
 
     // Constant nodes for every child's member, built once.
     vector<vector<ASTNode>> constants(children.size());
     for (size_t i = 0; i < children.size(); i++)
-      for (const CBV m : children[i]->values)
+      for (const CBV m : *members[i])
         constants[i].push_back(toNode(n[i], m));
 
     // Evaluate the node over each combination of the children's values.
@@ -221,10 +489,22 @@ namespace stp
 
       for (size_t i = 0; i < odometer.size(); i++)
       {
-        if (++odometer[i] < children[i]->size())
+        if (++odometer[i] < members[i]->size())
           break;
         odometer[i] = 0;
       }
+    }
+
+    if (Expand::None != expandWith)
+      result = expand(result, expandWith);
+
+    // A set holding every value of its width says exactly what a null
+    // pointer says.
+    if (result == nullptr || result->isComplete())
+    {
+      delete result;
+      widened++;
+      return nullptr;
     }
 
     propagated++;

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -46,4 +46,5 @@ AddSTPGTest(UnsignedIntervalAnalysis_Test.cpp)
 AddSTPGTest(ConstantBitPropagation_Test.cpp)
 AddSTPGTest(BitVector_from_Dec_Test.cpp)
 AddSTPGTest(ValueSet_Test.cpp)
+AddSTPGTest(ValueSet_Exhaustive_Test.cpp)
 

--- a/tests/unit-tests/ValueSet_Exhaustive_Test.cpp
+++ b/tests/unit-tests/ValueSet_Exhaustive_Test.cpp
@@ -45,6 +45,7 @@ THE SOFTWARE.
 #include "stp/Simplifier/ValueSet.h"
 #include "stp/Simplifier/ValueSetAnalysis.h"
 #include <algorithm>
+#include <functional>
 #include <gtest/gtest.h>
 #include <string>
 #include <vector>
@@ -254,20 +255,30 @@ std::vector<unsigned> masksFor(const Child& c, unsigned maxSetSize)
   std::vector<unsigned> masks;
   if (c.isConstant)
   {
-    masks.push_back(1u << c.value);
+    masks.push_back(0); // unused: a constant child is always its own value
     return masks;
   }
 
   const unsigned values = 1u << c.width;
-  for (unsigned mask = 1; mask < (1u << values); mask++)
-  {
-    unsigned size = 0;
-    for (unsigned v = 0; v < values; v++)
-      size += (mask >> v) & 1;
-    if (size <= maxSetSize)
-      masks.push_back(mask);
-  }
-  masks.push_back((1u << values) - 1); // unknown: every value, no set
+  const unsigned wanted = std::min(maxSetSize, values);
+
+  // Built up a value at a time. Walking every mask instead would need
+  // 2^32 of them once a child has 32 values.
+  std::function<void(unsigned, unsigned, unsigned)> add =
+      [&](unsigned from, unsigned size, unsigned mask) {
+        if (size == 0)
+        {
+          masks.push_back(mask);
+          return;
+        }
+        for (unsigned v = from; v < values; v++)
+          add(v + 1, size - 1, mask | (1u << v));
+      };
+  for (unsigned size = 1; size <= wanted; size++)
+    add(0, size, 0);
+
+  // Unknown: every value, and no set at all to say so.
+  masks.push_back(values >= 32 ? ~0u : ((1u << values) - 1));
   return masks;
 }
 

--- a/tests/unit-tests/ValueSet_Exhaustive_Test.cpp
+++ b/tests/unit-tests/ValueSet_Exhaustive_Test.cpp
@@ -1,0 +1,462 @@
+/********************************************************************
+ * AUTHORS: Trevor Hansen
+ *
+ * BEGIN DATE: July, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+/*
+ * The value set transfer functions, exhaustively at small widths.
+ *
+ * Every combination of input sets is tried -- every subset of the values a
+ * child could take, and "nothing is known" as well -- and compared against
+ * the values the operation can actually produce. The analysis is allowed to
+ * widen completely and say nothing; what it may not do is return a set that
+ * is missing a value the operation can produce, or one that is looser than
+ * it needs to be.
+ *
+ * Everything but multiplication, division and modulus is also required to
+ * be exact whenever the answer would fit in a set: those are the operations
+ * that are cheap enough to be worth reasoning about with an unknown operand
+ * (x & 0 is zero however little is known about x).
+ */
+
+#include "stp/AST/AST.h"
+#include "stp/NodeFactory/NodeFactory.h"
+#include "stp/STPManager/STPManager.h"
+#include "stp/Simplifier/Simplifier.h"
+#include "stp/Simplifier/ValueSet.h"
+#include "stp/Simplifier/ValueSetAnalysis.h"
+#include <algorithm>
+#include <gtest/gtest.h>
+#include <string>
+#include <vector>
+
+using stp::ASTNode;
+using stp::ASTVec;
+using stp::Kind;
+using stp::ValueSet;
+using stp::ValueSetAnalysis;
+
+namespace
+{
+
+void boot()
+{
+  static bool booted = false;
+  if (!booted)
+  {
+    CONSTANTBV::BitVector_Boot();
+    booted = true;
+  }
+}
+
+stp::CBV makeCBV(unsigned width, unsigned value)
+{
+  stp::CBV result = CONSTANTBV::BitVector_Create(width, true);
+  for (unsigned i = 0; i < width; i++)
+    if ((value >> i) & 1)
+      CONSTANTBV::BitVector_Bit_On(result, i);
+  return result;
+}
+
+unsigned fromCBV(const stp::CBV v, unsigned width)
+{
+  unsigned result = 0;
+  for (unsigned i = 0; i < width; i++)
+    if (CONSTANTBV::BitVector_bit_test(v, i))
+      result |= 1u << i;
+  return result;
+}
+
+std::vector<unsigned> members(const ValueSet* set)
+{
+  std::vector<unsigned> result;
+  if (set != nullptr)
+    for (const stp::CBV m : set->values)
+      result.push_back(fromCBV(m, set->getWidth()));
+  return result;
+}
+
+// One child of the node under test.
+struct Child
+{
+  unsigned width;      // 1 for booleans
+  bool isBoolean;
+  bool isConstant;     // an extract's bounds, an extend's width
+  unsigned value;      // when isConstant
+};
+
+Child value(unsigned width) { return {width, false, false, 0}; }
+Child boolean() { return {1, true, false, 0}; }
+Child constant(unsigned v) { return {32, false, true, v}; }
+
+struct OpUnderTest
+{
+  Kind kind;
+  std::string name;
+  std::vector<Child> children;
+  unsigned resultWidth; // 1 for booleans
+  bool resultIsBoolean;
+  // Multiplication, division and modulus aren't required to say anything
+  // when an operand is unknown.
+  bool mustBeExact;
+};
+
+// The operations, shaped for the given width.
+std::vector<OpUnderTest> operationsAt(unsigned w)
+{
+  std::vector<OpUnderTest> ops;
+  const std::vector<Kind> binary = {
+      stp::BVAND,   stp::BVOR,   stp::BVXOR,        stp::BVPLUS,
+      stp::BVSUB,   stp::BVMULT, stp::BVDIV,        stp::BVMOD,
+      stp::SBVDIV,  stp::SBVREM, stp::SBVMOD,       stp::BVLEFTSHIFT,
+      stp::BVRIGHTSHIFT, stp::BVSRSHIFT};
+  const std::vector<std::string> binaryNames = {
+      "bvand",  "bvor",  "bvxor",  "bvadd", "bvsub", "bvmul", "bvudiv",
+      "bvurem", "bvsdiv", "bvsrem", "bvsmod", "bvshl", "bvlshr", "bvashr"};
+
+  for (size_t i = 0; i < binary.size(); i++)
+  {
+    const Kind k = binary[i];
+    const bool exact =
+        !(k == stp::BVMULT || k == stp::BVDIV || k == stp::BVMOD ||
+          k == stp::SBVDIV || k == stp::SBVREM || k == stp::SBVMOD);
+    ops.push_back({k, binaryNames[i], {value(w), value(w)}, w, false, exact});
+  }
+
+  const std::vector<Kind> predicates = {stp::EQ,    stp::BVLT,  stp::BVLE,
+                                        stp::BVGT,  stp::BVGE,  stp::BVSLT,
+                                        stp::BVSLE, stp::BVSGT, stp::BVSGE};
+  const std::vector<std::string> predicateNames = {
+      "eq", "bvult", "bvule", "bvugt", "bvuge", "bvslt", "bvsle", "bvsgt",
+      "bvsge"};
+  for (size_t i = 0; i < predicates.size(); i++)
+    ops.push_back({predicates[i], predicateNames[i], {value(w), value(w)}, 1,
+                   true, true});
+
+  ops.push_back({stp::BVNOT, "bvnot", {value(w)}, w, false, true});
+  ops.push_back({stp::BVUMINUS, "bvneg", {value(w)}, w, false, true});
+  ops.push_back(
+      {stp::ITE, "ite", {boolean(), value(w), value(w)}, w, false, true});
+  ops.push_back(
+      {stp::BVCONCAT, "concat", {value(w), value(w)}, 2 * w, false, true});
+  // The top bit of the child.
+  ops.push_back({stp::BVEXTRACT,
+                 "extract",
+                 {value(w), constant(w - 1), constant(w - 1)},
+                 1,
+                 false,
+                 true});
+  ops.push_back({stp::BVZX,
+                 "zero_extend",
+                 {value(w), constant(2 * w)},
+                 2 * w,
+                 false,
+                 true});
+  ops.push_back({stp::BVSX,
+                 "sign_extend",
+                 {value(w), constant(2 * w)},
+                 2 * w,
+                 false,
+                 true});
+
+  // The boolean operations don't have a width.
+  if (w == 1)
+  {
+    ops.push_back({stp::AND, "and", {boolean(), boolean()}, 1, true, true});
+    ops.push_back({stp::OR, "or", {boolean(), boolean()}, 1, true, true});
+    ops.push_back({stp::XOR, "xor", {boolean(), boolean()}, 1, true, true});
+    ops.push_back({stp::IFF, "iff", {boolean(), boolean()}, 1, true, true});
+    ops.push_back(
+        {stp::IMPLIES, "implies", {boolean(), boolean()}, 1, true, true});
+    ops.push_back({stp::NOT, "not", {boolean()}, 1, true, true});
+  }
+
+  return ops;
+}
+
+struct Context
+{
+  stp::STPMgr mgr;
+  NodeFactory* factory() { return mgr.hashingNodeFactory; }
+
+  ASTNode build(const OpUnderTest& op)
+  {
+    ASTVec children;
+    for (size_t i = 0; i < op.children.size(); i++)
+    {
+      const Child& c = op.children[i];
+      if (c.isConstant)
+      {
+        children.push_back(mgr.CreateBVConst(c.width, c.value));
+        continue;
+      }
+      const std::string name =
+          "s_" + op.name + "_" + std::to_string(op.resultWidth) + "_" +
+          std::to_string(i);
+      children.push_back(
+          mgr.CreateSymbol(name.c_str(), 0, c.isBoolean ? 0 : c.width));
+    }
+
+    ASTNode n = op.resultIsBoolean
+                    ? factory()->CreateNode(op.kind, children)
+                    : factory()->CreateTerm(op.kind, op.resultWidth, children);
+    BVTypeCheck(n);
+    return n;
+  }
+
+  // The operation applied to one concrete assignment.
+  unsigned evaluate(const OpUnderTest& op, const std::vector<unsigned>& values)
+  {
+    ASTVec children;
+    for (size_t i = 0; i < op.children.size(); i++)
+    {
+      const Child& c = op.children[i];
+      const unsigned v = c.isConstant ? c.value : values[i];
+      if (c.isBoolean)
+        children.push_back(v ? mgr.ASTTrue : mgr.ASTFalse);
+      else
+        children.push_back(mgr.CreateBVConst(c.width, v));
+    }
+
+    const ASTNode result = stp::NonMemberBVConstEvaluator(
+        &mgr, op.kind, children, op.resultIsBoolean ? 0 : op.resultWidth);
+    if (op.resultIsBoolean)
+      return result == mgr.ASTTrue ? 1 : 0;
+    return fromCBV(result.GetBVConst(), op.resultWidth);
+  }
+};
+
+// A child either ranges over a subset of the values of its width, or over
+// all of them because nothing is known about it. The options are the
+// non-empty subsets whose size is within "maxSetSize", and then one more
+// standing for "unknown", which is the last one.
+std::vector<unsigned> masksFor(const Child& c, unsigned maxSetSize)
+{
+  std::vector<unsigned> masks;
+  if (c.isConstant)
+  {
+    masks.push_back(1u << c.value);
+    return masks;
+  }
+
+  const unsigned values = 1u << c.width;
+  for (unsigned mask = 1; mask < (1u << values); mask++)
+  {
+    unsigned size = 0;
+    for (unsigned v = 0; v < values; v++)
+      size += (mask >> v) & 1;
+    if (size <= maxSetSize)
+      masks.push_back(mask);
+  }
+  masks.push_back((1u << values) - 1); // unknown: every value, no set
+  return masks;
+}
+
+std::string describe(const OpUnderTest& op, const std::vector<unsigned>& masks,
+                     const std::vector<bool>& unknown)
+{
+  std::string result = op.name + "(";
+  for (size_t i = 0; i < masks.size(); i++)
+  {
+    if (i > 0)
+      result += ", ";
+    if (unknown[i])
+    {
+      result += "?";
+      continue;
+    }
+    result += "{";
+    bool first = true;
+    for (unsigned v = 0; v < 32; v++)
+      if ((masks[i] >> v) & 1)
+      {
+        if (!first)
+          result += ",";
+        result += std::to_string(v);
+        first = false;
+      }
+    result += "}";
+  }
+  return result + ")";
+}
+
+void checkExhaustively(unsigned width, unsigned maxSetSize)
+{
+  boot();
+  Context c;
+  ValueSetAnalysis analysis(c.mgr);
+
+  for (const OpUnderTest& op : operationsAt(width))
+  {
+    const ASTNode n = c.build(op);
+    const size_t degree = op.children.size();
+
+    // What the operation produces for every concrete assignment, indexed by
+    // the children's values packed together. Built once: the evaluator is
+    // far slower than the sweep it feeds.
+    std::vector<unsigned> shift(degree, 0);
+    unsigned packedBits = 0;
+    for (size_t i = 0; i < degree; i++)
+    {
+      shift[i] = packedBits;
+      if (!op.children[i].isConstant)
+        packedBits += op.children[i].width;
+    }
+
+    std::vector<unsigned> table(1u << packedBits, 0);
+    for (unsigned packed = 0; packed < table.size(); packed++)
+    {
+      std::vector<unsigned> values(degree, 0);
+      for (size_t i = 0; i < degree; i++)
+        if (!op.children[i].isConstant)
+          values[i] =
+              (packed >> shift[i]) & ((1u << op.children[i].width) - 1);
+      table[packed] = c.evaluate(op, values);
+    }
+
+    std::vector<std::vector<unsigned>> options(degree);
+    std::vector<size_t> option(degree, 0);
+    for (size_t i = 0; i < degree; i++)
+      options[i] = masksFor(op.children[i], maxSetSize);
+
+    bool done = false;
+    while (!done)
+    {
+      std::vector<unsigned> masks(degree, 0);
+      std::vector<bool> unknown(degree, false);
+      for (size_t i = 0; i < degree; i++)
+      {
+        masks[i] = options[i][option[i]];
+        unknown[i] = !op.children[i].isConstant &&
+                     option[i] + 1 == options[i].size();
+      }
+
+      // The sets handed to the analysis. Unknown children are null, which
+      // is how a symbol's value set is stored.
+      std::vector<ValueSet*> owned(degree, nullptr);
+      std::vector<const ValueSet*> children(degree, nullptr);
+      for (size_t i = 0; i < degree; i++)
+      {
+        if (unknown[i])
+          continue;
+        const Child& child = op.children[i];
+        owned[i] = new ValueSet(child.width, child.isBoolean);
+        if (child.isConstant)
+          EXPECT_TRUE(owned[i]->insert(makeCBV(child.width, child.value)));
+        else
+          for (unsigned v = 0; v < (1u << child.width); v++)
+            if ((masks[i] >> v) & 1)
+              EXPECT_TRUE(owned[i]->insert(makeCBV(child.width, v)));
+        children[i] = owned[i];
+      }
+
+      // Every value the operation can produce from those inputs. An
+      // unknown child ranges over its whole width.
+      std::vector<unsigned> ideal;
+      for (unsigned packed = 0; packed < table.size(); packed++)
+      {
+        bool admitted = true;
+        for (size_t i = 0; i < degree && admitted; i++)
+        {
+          if (op.children[i].isConstant || unknown[i])
+            continue;
+          const unsigned v =
+              (packed >> shift[i]) & ((1u << op.children[i].width) - 1);
+          admitted = ((masks[i] >> v) & 1) != 0;
+        }
+        if (admitted &&
+            std::find(ideal.begin(), ideal.end(), table[packed]) == ideal.end())
+          ideal.push_back(table[packed]);
+      }
+      std::sort(ideal.begin(), ideal.end());
+
+      ValueSet* result = analysis.dispatchToTransferFunctions(n, children);
+      const std::string context = describe(op, masks, unknown) + " at width " +
+                                  std::to_string(width);
+
+      // Either the analysis widened completely, or it is exactly right.
+      if (result != nullptr)
+        EXPECT_EQ(members(result), ideal) << context;
+
+      // The cheap operations have to be exact whenever the answer is
+      // something a set can hold and is worth holding.
+      const bool representable = ideal.size() <= ValueSet::MAX_ELEMENTS &&
+                                 ideal.size() < (1u << op.resultWidth);
+      if (op.mustBeExact && representable)
+      {
+        EXPECT_NE(result, nullptr) << context;
+        if (result != nullptr)
+          EXPECT_EQ(members(result), ideal) << context;
+      }
+
+      delete result;
+      for (ValueSet* set : owned)
+        delete set;
+
+      done = true;
+      for (size_t i = 0; i < degree; i++)
+      {
+        if (++option[i] < options[i].size())
+        {
+          done = false;
+          break;
+        }
+        option[i] = 0;
+      }
+    }
+  }
+}
+
+} // namespace
+
+// Every subset of every child, at the widths where running them all is
+// quick. (Width three with every subset passes too, but takes over a
+// minute, which is longer than the rest of the suite put together.)
+TEST(ValueSet_Exhaustive_Test, all_sets_width_one)
+{
+  checkExhaustively(1, 2);
+}
+
+TEST(ValueSet_Exhaustive_Test, all_sets_width_two)
+{
+  checkExhaustively(2, 4);
+}
+
+TEST(ValueSet_Exhaustive_Test, sets_of_three_width_three)
+{
+  checkExhaustively(3, 3);
+}
+
+// Wider, where enumerating every subset is out of reach: single values and
+// the unknown child, which is where the reasoning about unknown operands
+// lives. Width four is also where a bitwise operation's answer first stops
+// fitting in a set -- x & 15 with x unknown has sixteen answers -- so the
+// giving-up path is covered here too.
+TEST(ValueSet_Exhaustive_Test, single_values_width_four)
+{
+  checkExhaustively(4, 1);
+}
+
+TEST(ValueSet_Exhaustive_Test, single_values_width_five)
+{
+  checkExhaustively(5, 1);
+}

--- a/tests/unit-tests/ValueSet_Exhaustive_Test.cpp
+++ b/tests/unit-tests/ValueSet_Exhaustive_Test.cpp
@@ -361,11 +361,17 @@ void checkExhaustively(unsigned width, unsigned maxSetSize)
         const Child& child = op.children[i];
         owned[i] = new ValueSet(child.width, child.isBoolean);
         if (child.isConstant)
+        {
           EXPECT_TRUE(owned[i]->insert(makeCBV(child.width, child.value)));
+        }
         else
+        {
           for (unsigned v = 0; v < (1u << child.width); v++)
             if ((masks[i] >> v) & 1)
+            {
               EXPECT_TRUE(owned[i]->insert(makeCBV(child.width, v)));
+            }
+        }
         children[i] = owned[i];
       }
 
@@ -395,7 +401,9 @@ void checkExhaustively(unsigned width, unsigned maxSetSize)
 
       // Either the analysis widened completely, or it is exactly right.
       if (result != nullptr)
+      {
         EXPECT_EQ(members(result), ideal) << context;
+      }
 
       // The cheap operations have to be exact whenever the answer is
       // something a set can hold and is worth holding.
@@ -405,7 +413,9 @@ void checkExhaustively(unsigned width, unsigned maxSetSize)
       {
         EXPECT_NE(result, nullptr) << context;
         if (result != nullptr)
+        {
           EXPECT_EQ(members(result), ideal) << context;
+        }
       }
 
       delete result;


### PR DESCRIPTION
The value set analysis gave up as soon as any child had no value set --
which is every symbol -- so it couldn't tell that `x & 0` is zero, that
`x >=u 0` is true, or that `0 << x` is zero.

An unknown child stands for every value of its width. Rather than give up,
it is now replaced by values that produce exactly the results the whole
width would produce:

| | stand-in |
| --- | --- |
| and / or | the operation's identity, and the result is expanded afterwards over the submasks (and) or supermasks (or) that the unknown operand can reach |
| comparisons | the extremes of the order, since a comparison is monotone in each side |
| shifts | the amounts up to the width, or the bits of the value that survive the smallest amount |
| the rest | every value, when the child is narrow enough to list |

Operations that are one-to-one in the unknown operand -- add, subtract, xor,
not, negate, equality -- can't say anything whatever the other side is, and
return early. Multiplication, division and modulus are left out on purpose:
they are the expensive ones to evaluate, and an unknown operand rarely pins
their result down.

A set holding every value of its width is now normalised to no set at all,
which is what it means everywhere else.

Every other operation is now exactly as precise as the domain allows.

## The exhaustive test

`tests/unit-tests/ValueSet_Exhaustive_Test.cpp` runs every combination of
input sets -- every subset of the values a child can take, and "nothing is
known" as well -- against the values the operation can actually produce.

The property it holds the analysis to is that it either widens completely
and says nothing, or is exactly right: it never returns a set that is
missing a value the operation can produce, and never one that is looser than
it needs to be. Everything but multiplication, division and modulus must
additionally be exact whenever the answer fits in a set.

Widths one and two run every subset; the wider sweeps cover the single
values and the unknown child, which is where the reasoning about unknown
operands lives. Width four is also where a bitwise operation's answer first
stops fitting in a set -- `x & 15` with `x` unknown has sixteen answers --
so the giving-up path is covered too. About 15 seconds.

It caught a real bug while this was being written: an arithmetic shift by at
least the width still copies the sign bit, which the first version of the
stand-ins dropped. Reverting that one line makes the test fail with
`bvashr(?, {1}) at width 1`, so it isn't passing vacuously.

## Testing

* `ctest`: 63/63 pass.
* 2500 file fuzz corpus: every answer identical to a binary built without
  the change.
* Interleaved A/B over the constant-bit-heavy benchmarks: 93.07s before,
  93.40s after -- well inside the drift between rounds, so no measurable
  cost.

The gap was found with the propagator benchmark in #617, which is
independent of this and can land in either order. With this change its value
set tables go from 273 imprecise / 105 precise rows to 72 / 306, and the 72
are exactly the multiplication and division ones.