### PR TITLE
Bound rewrite_rule_gen's search and give CI some rules to verify

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,9 @@ jobs:
       run: |
         ./tools/rewrite_rule_gen/rewrite_rule_gen unit-test
         ./tools/rewrite_rule_gen/rewrite_rule_gen test
+        ./tools/rewrite_rule_gen/rewrite_rule_gen verify \
+          ../tools/rewrite_rule_gen/test-rules.smt2
+        ./tools/rewrite_rule_gen/rewrite_rule_gen generate 5 3
       working-directory: build
 
   build-cadical:

--- a/tools/rewrite_rule_gen/rewrite_rule_gen.cpp
+++ b/tools/rewrite_rule_gen/rewrite_rule_gen.cpp
@@ -82,6 +82,13 @@ int highestLevel = 0;
 int discarded = 0;
 
 //////////////////////////////////
+// Search bounds for the rule-finding modes. findRewrites() recurses once per
+// expression it separates out, so on a full function list it goes tens of
+// thousands of frames deep and exhausts the stack before finishing. These cap
+// it. Both default to "no limit", which is the historical behaviour.
+int max_search_depth = -1;   // -1: unbounded
+int max_rules_wanted = -1;   // -1: unbounded
+
 const int bits = 6;
 const int widen_to = 10;
 const int values_in_hash = 64 / bits;
@@ -937,6 +944,19 @@ void findRewrites(ASTVec& expressions, const vector<VariableAssignment>& values,
                   const int depth = 0)
 {
   if (expressions.size() < 2)
+  {
+    discarded += expressions.size();
+    return;
+  }
+
+  if (max_search_depth >= 0 && depth >= max_search_depth)
+  {
+    discarded += expressions.size();
+    return;
+  }
+
+  if (max_rules_wanted >= 0 &&
+      (int)rewrite_system.size() >= max_rules_wanted)
   {
     discarded += expressions.size();
     return;
@@ -2128,16 +2148,64 @@ int main(int argc, const char* argv[])
     rewrite_system.rewriteAll();
     writeOutRules();
   }
+  else if (argc == 4 && !strcmp("generate", argv[1]))
+  {
+    // Bounded, non-interactive form of the argc == 1 mode above, for smoke
+    // testing: "generate <max-depth> <max-rules>". Either bound may be -1 for
+    // no limit, though with both unbounded this is the mode that exhausts the
+    // stack. Rules found are written out as usual.
+    max_search_depth = atoi(argv[2]);
+    max_rules_wanted = atoi(argv[3]);
+    cout << "Bounded search: max depth " << max_search_depth << ", max rules "
+         << max_rules_wanted << endl;
+
+    load_new_rules();
+    createVariables();
+    rewrite_system.buildLookupTable();
+
+    Function_list functionList;
+    functionList.buildAll();
+
+    vector<VariableAssignment> values;
+    findRewrites(functionList.functions, values);
+
+    rewrite_system.rewriteAll();
+    writeOutRules();
+    cout << "Rules found: " << rewrite_system.size() << endl;
+  }
   else if (argc == 2 && !strcmp("unit-test", argv[1]))
   {
     load_new_rules();
     createVariables();
     unit_test();
   }
-  else if (argc == 2 && !strcmp("verify", argv[1]))
+  else if ((argc == 2 || argc == 3) && !strcmp("verify", argv[1]))
   {
-    load_new_rules();
+    // "verify [file]" -- SAT-check every loaded rule. Without a file the rules
+    // come from ./rules_new.smt2, or stdin when that does not exist.
+    if (argc == 3)
+    {
+      // Fail rather than verify nothing. load_new_rules() falls back to stdin
+      // when the file is missing, so a mistyped path would otherwise load zero
+      // rules and report success.
+      if (!ifstream(argv[2]))
+      {
+        cerr << "Cannot read rules file: " << argv[2] << endl;
+        return 1;
+      }
+      load_new_rules(argv[2]);
+      if (rewrite_system.size() == 0)
+      {
+        cerr << "No rules loaded from " << argv[2] << endl;
+        return 1;
+      }
+    }
+    else
+      load_new_rules();
+
+    cout << "Verifying " << rewrite_system.size() << " rules" << endl;
     rewrite_system.verifyAllwithSAT();
+    cout << "Verified " << rewrite_system.size() << " rules" << endl;
   }
   else if ((argc == 4 || argc == 3) && !strcmp("expand", argv[1]))
   {

--- a/tools/rewrite_rule_gen/test-rules.smt2
+++ b/tools/rewrite_rule_gen/test-rules.smt2
@@ -1,0 +1,41 @@
+;id:1	verified_to:0	time:0	from_difficulty:0	to_difficulty:0
+(push 1)
+; Valid rewrite rules, used to smoke test rewrite_rule_gen:
+;   rewrite_rule_gen verify tools/rewrite_rule_gen/test-rules.smt2
+;
+; Format note: load_new_rules() reads the tab-separated ";id:..." line of each
+; block with sscanf and stops parsing the moment a line does not match, so
+; comments cannot appear before a header or between blocks -- only inside one,
+; like this, where the SMT2 parser handles them.
+;
+; These are deliberately rules the SimplifyingNodeFactory does not already
+; know. Anything it can fold collapses to from == to when the loader rebuilds
+; the rule with that factory, and is then dropped as unorderable, so the
+; obvious candidates (De Morgan, bvsub as add-negate, double negation) are
+; unusable here. The absorption and consensus laws below survive.
+(set-logic QF_BV)
+(declare-fun v () (_ BitVec 6))
+(declare-fun w () (_ BitVec 6))
+(assert (= (bvand v (bvor v w)) v))
+(exit)
+;id:2	verified_to:0	time:0	from_difficulty:0	to_difficulty:0
+(push 1)
+(set-logic QF_BV)
+(declare-fun v () (_ BitVec 6))
+(declare-fun w () (_ BitVec 6))
+(assert (= (bvor v (bvand v w)) v))
+(exit)
+;id:3	verified_to:0	time:0	from_difficulty:0	to_difficulty:0
+(push 1)
+(set-logic QF_BV)
+(declare-fun v () (_ BitVec 6))
+(declare-fun w () (_ BitVec 6))
+(assert (= (bvor (bvand v w) (bvand v (bvnot w))) v))
+(exit)
+;id:4	verified_to:0	time:0	from_difficulty:0	to_difficulty:0
+(push 1)
+(set-logic QF_BV)
+(declare-fun v () (_ BitVec 6))
+(declare-fun w () (_ BitVec 6))
+(assert (= (bvand (bvor v w) (bvor v (bvnot w))) v))
+(exit)


### PR DESCRIPTION
> **Stacked on #619** — base is `fix-rewrite-rule-gen-build`, not `master`, because the tool has to compile before it can be run. Merge #619 first or retarget afterwards. This PR's own change is one commit, `ae77586e`.

## Search bounds

`findRewrites()` recurses once per expression it separates out, so on a full function list it descends tens of thousands of frames and exhausts the stack. Unbounded it reaches **depth 20067 and segfaults after ~8.6 s**, having found nothing.

Two bounds, both defaulting to `-1` (unbounded, the historical behaviour), checked at the head of `findRewrites`:

```c
int max_search_depth = -1;
int max_rules_wanted = -1;
```

driven by a non-interactive mode following the existing `expand <ms>` convention:

```
rewrite_rule_gen generate <max-depth> <max-rules>
```

| depth cap | wall | exit | rules found |
|---|---|---|---|
| 3 | 7.43 s | 0 | 0 |
| 5 | 8.56 s | 0 | 0 |
| 10 | 12.41 s | 0 | 0 |
| 20 | 18.84 s | 0 | 0 |
| 15000 | 300 s (timeout) | — | 0 |

Cost is ~7 s of `buildAll()` plus ~0.6 s per depth level.

**This makes the search terminate, not productive.** It finds no rules at any bound, and none in 300 s capped at 15000 — the log shows `Split into 1 pieces` repeatedly, i.e. it descends a degenerate path rather than partitioning usefully. Rule discovery looks separately unwell. So `generate 5 3` in CI is a **regression test against the stack overflow**, not evidence that rules get discovered. I would rather say that plainly than have a green tick imply more than it does.

## A rule corpus, so `verify` does something

`verify` SAT-checks every loaded rule — but with no `rules_new.smt2` in the tree there was nothing to check, and it passed in 0.00 s. `test-rules.smt2` supplies four valid rules, and `verify` now takes an optional path so CI need not copy the file into the working directory.

Two constraints shaped the file, both discovered the hard way:

* **The rules must be ones `SimplifyingNodeFactory` does not already know.** The loader rebuilds each rule with that factory (`withNF`), so anything it folds collapses to `from == to` and is dropped as unorderable. Of five obvious candidates, four were rejected — De Morgan, `bvsub` as add-negate, double negation, `bvadd v v` as `bvmul v 2`. The absorption and consensus laws survive.
* **Comments cannot precede a `;id:` header.** `load_new_rules()` reads that line with `sscanf` and stops parsing at the first line that does not match, so a leading comment block silently yields zero rules. The explanation therefore lives inside the first block, where the SMT2 parser handles `;`.

## Guard against a vacuous pass

`verify <file>` now fails when the file is unreadable or yields no rules. `load_new_rules()` falls back to **stdin** for a missing file, so a mistyped path would otherwise verify nothing and exit 0 — which is exactly what happened to me while writing this, and it looked like a pass.

## Testing

* Four rules load and verify: `Verifying 4 rules` / `Verified 4 rules`, exit 0, 0.03 s.
* **Non-vacuous:** falsifying any single rule in the corpus aborts with `Bad to, then from` and exit 134.
* Wrong path: `Cannot read rules file: …`, exit 1.
* All four CI commands (`unit-test`, `test`, `verify <file>`, `generate 5 3`) run clean from a build directory.