### PR TITLE
Fix the extra tools' build and warnings, and exercise them in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        ${{ matrix.env }} cmake -DNOCRYPTOMINISAT:BOOL=OFF -DENABLE_TESTING:BOOL=ON -DWERROR:BOOL=ON -DPYTHON_EXECUTABLE:PATH="$(which python3)" -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -G Ninja ..
+        ${{ matrix.env }} cmake -DNOCRYPTOMINISAT:BOOL=OFF -DENABLE_TESTING:BOOL=ON -DWERROR:BOOL=ON -DBUILD_EXTRA_TOOLS:BOOL=ON -DPYTHON_EXECUTABLE:PATH="$(which python3)" -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -G Ninja ..
 
     - name: Build
       run: |
@@ -106,6 +106,35 @@ jobs:
 
     - name: Test
       run: ctest --parallel "$(nproc)" -VV --output-on-failure
+      working-directory: build
+
+    # BUILD_EXTRA_TOOLS is off by default and nothing else compiles these five
+    # tools, so all of them had quietly stopped building: headers that were
+    # never self-contained, and calls into APIs that had changed shape. Getting
+    # them compiled again is most of the value here, which is why this job now
+    # configures them -- it already enables CryptoMiniSat, which
+    # rewrite_rule_gen requires.
+    #
+    # On top of that, four rewrite_rule_gen invocations. unit-test and test check
+    # themselves and need no input; assertions are live because CI leaves
+    # CMAKE_BUILD_TYPE unset, giving RelWithDebInfo with NDEBUG filtered out, so
+    # they really do assert. verify SAT-checks a small committed rule set, and
+    # fails if the file cannot be read or yields no rules -- without that guard a
+    # mistyped path falls back to stdin and "verifies" nothing. generate is a
+    # bounded rule search, here purely as a regression test against the stack
+    # overflow an unbounded one hits; it is not expected to find rules.
+    #
+    # The tool's remaining modes are unsuitable: expand, rewrite and write-out
+    # want a rules_new.smt2 that is not in the tree and exit 0 immediately
+    # without one, and the default no-argument mode is an interactive, unbounded
+    # search that recurses until the stack is exhausted.
+    - name: Extra tools smoke test
+      run: |
+        ./tools/rewrite_rule_gen/rewrite_rule_gen unit-test
+        ./tools/rewrite_rule_gen/rewrite_rule_gen test
+        ./tools/rewrite_rule_gen/rewrite_rule_gen verify \
+          ../tools/rewrite_rule_gen/test-rules.smt2
+        ./tools/rewrite_rule_gen/rewrite_rule_gen generate 5 3
       working-directory: build
 
   build-cadical:

--- a/include/stp/Util/BBAsProp.h
+++ b/include/stp/Util/BBAsProp.h
@@ -47,7 +47,7 @@ public:
 
   //input1, input2, result
   ASTNode i0, i1, r;
-  stp::ToSAT::ASTNodeToSATVar node_to_satvar_map;
+  stp::ToSATBase::ASTNodeToSATVar node_to_satvar_map;
 
   Cnf_Dat_t* cnf;
   ~BBAsProp() 
@@ -116,7 +116,7 @@ public:
     assumptions.clear();
 
 
-    for (int i = 0; i < a.getWidth(); i++)
+    for (unsigned i = 0; i < a.getWidth(); i++)
     {
       if (a[i] == '1')
       {
@@ -141,7 +141,7 @@ public:
       }
     }
 
-    for (int i = 0; i < output.getWidth(); i++)
+    for (unsigned i = 0; i < output.getWidth(); i++)
     {
       if (output[i] == '1')
       {

--- a/include/stp/Util/Relations.h
+++ b/include/stp/Util/Relations.h
@@ -76,14 +76,14 @@ struct Relations
       ASTNode result = stp::NonMemberBVConstEvaluator(beev, k, c, bitWidth);
       FixedBits output = FixedBits::concreteToAbstract(result);
 
-      for (int i = 0; i < a.getWidth(); i++)
+      for (unsigned i = 0; i < a.getWidth(); i++)
       {
         if (rand.randInt() % 100 >= probabilityOfFixing)
           a.setFixed(i, false);
         if (rand.randInt() % 100 >= probabilityOfFixing)
           b.setFixed(i, false);
       }
-      for (int i = 0; i < output.getWidth(); i++)
+      for (unsigned i = 0; i < output.getWidth(); i++)
         if (rand.randInt() % 100 >= probabilityOfFixing)
           output.setFixed(i, false);
 

--- a/tools/cvc_to_c/cvc-to-c.cpp
+++ b/tools/cvc_to_c/cvc-to-c.cpp
@@ -30,7 +30,7 @@ g++ -I$HOME/stp/c_interface cvc-to-c.cpp -L$HOME/stp/lib -lstp -o cvc-to-c
 #include "stp/c_interface.h"
 #include <iostream>
 
-int main(int argc, char** argv)
+int main(int /*argc*/, char** argv)
 {
   VC vc = vc_createValidityChecker();
 

--- a/tools/measure_constantbitprop/Functions.cpp
+++ b/tools/measure_constantbitprop/Functions.cpp
@@ -77,7 +77,7 @@ int bvAndF(int a, int b)
 
 int rightSF(int a, int b)
 {
-  if (b >= sizeof(int) * 8)
+  if (b >= (int)(sizeof(int) * 8))
     return 0;
 
   return a >> b;
@@ -85,7 +85,7 @@ int rightSF(int a, int b)
 
 int leftSF(int a, int b)
 {
-  if (b >= sizeof(int) * 8)
+  if (b >= (int)(sizeof(int) * 8))
     return 0;
 
   return a << b;

--- a/tools/rewrite_rule_gen/Functionlist.h
+++ b/tools/rewrite_rule_gen/Functionlist.h
@@ -126,7 +126,7 @@ private:
     for (size_t i = 0; i < functions.size(); i++)
     {
       assert(functions[i].GetType() == stp::BITVECTOR_TYPE);
-      assert(functions[i].GetValueWidth() == bits);
+      assert(functions[i].GetValueWidth() == (unsigned)bits);
       assert(BVTypeCheckRecursive(functions[i]));
     }
   }

--- a/tools/rewrite_rule_gen/VariableAssignment.h
+++ b/tools/rewrite_rule_gen/VariableAssignment.h
@@ -25,6 +25,8 @@ THE SOFTWARE.
 #ifndef VARIABLEASSIGNMENT_H_
 #define VARIABLEASSIGNMENT_H_
 
+#include "stp/AST/AST.h"
+
 // A pair of constants of the same bit-width assigned to v and w..
 
 struct VariableAssignment

--- a/tools/rewrite_rule_gen/misc.h
+++ b/tools/rewrite_rule_gen/misc.h
@@ -25,6 +25,7 @@ THE SOFTWARE.
 #ifndef MISC_H
 #define MISC_H
 
+#include "VariableAssignment.h"
 #include "stp/AST/AST.h"
 
 extern const int bits;

--- a/tools/rewrite_rule_gen/rewrite_rule.h
+++ b/tools/rewrite_rule_gen/rewrite_rule.h
@@ -100,7 +100,9 @@ public:
 
   // The "from" and "to" should be ordered with the orderEquivalence function.
   Rewrite_rule(stp::STPMgr* bm, const stp::ASTNode& from_,
-               const stp::ASTNode& to_, const int t, int _id = -1)
+               // _id is only used by the #if 0 block below, but callers
+               // still pass it.
+               const stp::ASTNode& to_, const int t, int /*_id*/ = -1)
       : from(from_), to(to_)
   {
 #if 0

--- a/tools/rewrite_rule_gen/rewrite_rule_gen.cpp
+++ b/tools/rewrite_rule_gen/rewrite_rule_gen.cpp
@@ -82,6 +82,13 @@ int highestLevel = 0;
 int discarded = 0;
 
 //////////////////////////////////
+// Search bounds for the rule-finding modes. findRewrites() recurses once per
+// expression it separates out, so on a full function list it goes tens of
+// thousands of frames deep and exhausts the stack before finishing. These cap
+// it. Both default to "no limit", which is the historical behaviour.
+int max_search_depth = -1;   // -1: unbounded
+int max_rules_wanted = -1;   // -1: unbounded
+
 const int bits = 6;
 const int widen_to = 10;
 const int values_in_hash = 64 / bits;
@@ -269,7 +276,7 @@ ASTNode eval(const ASTNode& n, ASTNodeMap& map, int count = 0)
 
   // We have an array of arrays already created to store the children.
   // This reduces the number of objects created/destroyed.
-  if (count >= saved_array.size())
+  if ((size_t)count >= saved_array.size())
     saved_array.push_back(new ASTVec());
 
   ASTVec& new_children = *saved_array[count];
@@ -298,7 +305,7 @@ bool checkProp(const ASTNode& n)
   for (int i = 0; i < pow(2, symbols.size()); i++)
   {
     ASTNodeMap mapToVal;
-    for (int j = 0; j < symbols.size(); j++)
+    for (size_t j = 0; j < symbols.size(); j++)
       mapToVal.insert(make_pair(symbols[j],
                                 (0x1 & (i >> (j * bits))) == 0 ? mgr->ASTFalse
                                                                : mgr->ASTTrue));
@@ -319,7 +326,7 @@ bool checkProp(const ASTNode& n)
         if (value != (mgr->ASTFalse == nd ? 0 : 1))
           return false;
       }
-      else if (value != nd.GetUnsignedConst())
+      else if (value != (int)nd.GetUnsignedConst())
         return false;
     }
   }
@@ -348,7 +355,7 @@ bool isConstant(const ASTNode& n, VariableAssignment& different,
 
     for (size_t i = 0; i < symbols.size(); i++)
     {
-      assert(symbols[i].GetValueWidth() == bit_width);
+      assert(symbols[i].GetValueWidth() == (unsigned)bit_width);
 
       if (strncmp(symbols[i].GetName(), "v", 1) == 0)
         vN = GlobalSTP->Ctr_Example->GetCounterExample(symbols[i]);
@@ -426,7 +433,7 @@ ASTNode widen(const ASTNode& w, int width)
   }
 
   if (w.GetKind() == BVCONCAT &&
-      ((ch[0].GetValueWidth() + ch[1].GetValueWidth()) != width))
+      ((int)(ch[0].GetValueWidth() + ch[1].GetValueWidth()) != width))
     return mgr->ASTUndefined; // Didn't widen properly.
 
   // We got to the trouble below because sometimes we get 1-bit wide expressions
@@ -548,7 +555,8 @@ bool orderEquivalence_not_yet(ASTNode& from, ASTNode& to)
       s_from.begin(), s_from.end(), s_to.begin(), s_to.end(), result.begin());
   int intersection = it - result.begin();
 
-  if (intersection != s_from.size() && intersection != s_to.size())
+  if ((size_t)intersection != s_from.size() &&
+      (size_t)intersection != s_to.size())
     return false;
 
   if (to.isAtom() && from.isAtom())
@@ -728,7 +736,7 @@ void doIte(ASTNode a)
   }
 }
 
-void do_write_out(int ignore)
+void do_write_out(int /*ignore*/)
 {
   difficulty_cache.clear();
   force_writeout = true;
@@ -737,7 +745,7 @@ void do_write_out(int ignore)
 volatile bool debug_usr2 = false;
 
 // toggle.
-void do_usr2(int ignore)
+void do_usr2(int /*ignore*/)
 {
   debug_usr2 = !debug_usr2;
 }
@@ -942,6 +950,19 @@ void findRewrites(ASTVec& expressions, const vector<VariableAssignment>& values,
     return;
   }
 
+  if (max_search_depth >= 0 && depth >= max_search_depth)
+  {
+    discarded += expressions.size();
+    return;
+  }
+
+  if (max_rules_wanted >= 0 &&
+      (int)rewrite_system.size() >= max_rules_wanted)
+  {
+    discarded += expressions.size();
+    return;
+  }
+
   cout << '\n'
        << "depth:" << depth << ", size:" << expressions.size()
        << " values:" << values.size() << " found: " << rewrite_system.size()
@@ -1003,7 +1024,8 @@ void findRewrites(ASTVec& expressions, const vector<VariableAssignment>& values,
     // nb. I haven't rebuilt the map, it's done by writeOutRules().
     equiv[i] = rewrite_system.rewriteNode(equiv[i]);
 
-    for (int j = i + 1; j < equiv.size(); j++) /// commutative so skip some.
+    for (size_t j = i + 1; j < equiv.size();
+         j++) /// commutative so skip some.
     {
       if (equiv[i].GetKind() == UNDEFINED || equiv[j].GetKind() == UNDEFINED)
         continue;
@@ -1216,6 +1238,8 @@ void rule_to_string(const ASTNode& n, ASTNodeString& names, string& current,
     case BVOR:
     case BVAND:
       sofar += "&& " + current + ".Degree() ==2 ";
+      break;
+    default:
       break;
   }
 
@@ -1669,7 +1693,7 @@ ASTNode rewrite(const ASTNode& n, const Rewrite_rule& original_rule,
   assert(v.size() > 0);
   ASTNode n2;
 
-  if (v != n.GetChildren())
+  if (ASTChildren(v) != n.GetChildren())
   {
     if (n.GetType() != BOOLEAN_TYPE)
       n2 = mgr->CreateArrayTerm(n.GetKind(), n.GetIndexWidth(),
@@ -1829,7 +1853,11 @@ void load_new_rules(const string fileName = "rules_new.smt2")
     bool done = false;
     while (true)
     {
-      fgets(line, sizeof line, in);
+      if (fgets(line, sizeof line, in) == NULL)
+      {
+        done = true;
+        break;
+      }
       if (first)
       {
         int rv = sscanf(line, ";id:%d\tverified_to:%d\ttime:%d\tfrom_"
@@ -2128,16 +2156,64 @@ int main(int argc, const char* argv[])
     rewrite_system.rewriteAll();
     writeOutRules();
   }
+  else if (argc == 4 && !strcmp("generate", argv[1]))
+  {
+    // Bounded, non-interactive form of the argc == 1 mode above, for smoke
+    // testing: "generate <max-depth> <max-rules>". Either bound may be -1 for
+    // no limit, though with both unbounded this is the mode that exhausts the
+    // stack. Rules found are written out as usual.
+    max_search_depth = atoi(argv[2]);
+    max_rules_wanted = atoi(argv[3]);
+    cout << "Bounded search: max depth " << max_search_depth << ", max rules "
+         << max_rules_wanted << endl;
+
+    load_new_rules();
+    createVariables();
+    rewrite_system.buildLookupTable();
+
+    Function_list functionList;
+    functionList.buildAll();
+
+    vector<VariableAssignment> values;
+    findRewrites(functionList.functions, values);
+
+    rewrite_system.rewriteAll();
+    writeOutRules();
+    cout << "Rules found: " << rewrite_system.size() << endl;
+  }
   else if (argc == 2 && !strcmp("unit-test", argv[1]))
   {
     load_new_rules();
     createVariables();
     unit_test();
   }
-  else if (argc == 2 && !strcmp("verify", argv[1]))
+  else if ((argc == 2 || argc == 3) && !strcmp("verify", argv[1]))
   {
-    load_new_rules();
+    // "verify [file]" -- SAT-check every loaded rule. Without a file the rules
+    // come from ./rules_new.smt2, or stdin when that does not exist.
+    if (argc == 3)
+    {
+      // Fail rather than verify nothing. load_new_rules() falls back to stdin
+      // when the file is missing, so a mistyped path would otherwise load zero
+      // rules and report success.
+      if (!ifstream(argv[2]))
+      {
+        cerr << "Cannot read rules file: " << argv[2] << endl;
+        return 1;
+      }
+      load_new_rules(argv[2]);
+      if (rewrite_system.size() == 0)
+      {
+        cerr << "No rules loaded from " << argv[2] << endl;
+        return 1;
+      }
+    }
+    else
+      load_new_rules();
+
+    cout << "Verifying " << rewrite_system.size() << " rules" << endl;
     rewrite_system.verifyAllwithSAT();
+    cout << "Verified " << rewrite_system.size() << " rules" << endl;
   }
   else if ((argc == 4 || argc == 3) && !strcmp("expand", argv[1]))
   {
@@ -2204,7 +2280,7 @@ matchNode(const ASTNode& n0, const ASTNode& n1, ASTNodeMap& fromTo, const int te
     if (n0 == n1)
     return true;
 
-    if (n0.GetKind() == SYMBOL && strlen(n0.GetName()) == term_variable_width)
+    if (n0.GetKind() == SYMBOL && strlen(n0.GetName()) == (size_t)term_variable_width)
       {
         if (fromTo.find(n0) != fromTo.end())
         return matchNode(fromTo.find(n0)->second, n1, fromTo, term_variable_width);
@@ -2255,7 +2331,7 @@ bool commutative_matchNode(const ASTNode& n0, const ASTNode& n1,
   if (n0.GetValueWidth() != n1.GetValueWidth())
     return false;
 
-  if (n0.GetKind() == SYMBOL && strlen(n0.GetName()) == term_variable_width)
+  if (n0.GetKind() == SYMBOL && strlen(n0.GetName()) == (size_t)term_variable_width)
   {
     if (n0.GetName()[0] == 'v')
     {
@@ -2362,8 +2438,9 @@ bool c_matchNode(const ASTNode& n0, const ASTNode& n1,
   pair<ASTNode, ASTNode> p = commutative_to_check.back();
   commutative_to_check.pop_back();
   assert(p.first.GetKind() == p.second.GetKind());
-  const ASTVec& f = p.first.GetChildren();
-  ASTVec s = p.second.GetChildren(); // non-const, needs to be sorted later.
+  const ASTChildren f = p.first.GetChildren();
+  // Materialised, not a view: sorted in place below.
+  ASTVec s = toASTVec(p.second.GetChildren());
 
   if (f.size() != s.size())
   {
@@ -2482,7 +2559,7 @@ bool commutative_matchNode(const ASTNode& n0, const ASTNode& n1,
     it = vars.begin();
     while (it != vars.end())
     {
-      assert(strlen(it->GetName()) == term_variable_width);
+      assert(strlen(it->GetName()) == (size_t)term_variable_width);
       it++;
     }
     assert(vars.size() <= 2);
@@ -2503,7 +2580,7 @@ bool commutative_matchNode(const ASTNode& n0, const ASTNode& n1,
     for (vector<ASTNode>::iterator it = s.begin(); it != s.end(); it++)
     {
       assert(it->GetKind() == SYMBOL);
-      assert(strlen(it->GetName()) == term_variable_width);
+      assert(strlen(it->GetName()) == (size_t)term_variable_width);
       if (it->GetName()[0] == 'v')
       {
         assert(vNode != mgr->ASTUndefined);

--- a/tools/rewrite_rule_gen/rewrite_rule_gen.cpp
+++ b/tools/rewrite_rule_gen/rewrite_rule_gen.cpp
@@ -91,8 +91,6 @@ int max_rules_wanted = -1;   // -1: unbounded
 
 const int bits = 6;
 const int widen_to = 10;
-const int values_in_hash = 64 / bits;
-const int mask = (1 << (bits)) - 1;
 //////////////////////////////////
 
 // Set by the signal handler to write out the rules that have been discovered.

--- a/tools/rewrite_rule_gen/rewrite_system.h
+++ b/tools/rewrite_rule_gen/rewrite_system.h
@@ -25,8 +25,8 @@ THE SOFTWARE.
 #ifndef REWRITESYSTEM_H
 #define REWRITESYSTEM_H
 
-// FIXME: This header might be dead
-//#include "stp/Util/find-rewrites/rewrite_rule.h"
+#include "VariableAssignment.h"
+#include "rewrite_rule.h"
 #include "stp/AST/AST.h"
 #include <list>
 

--- a/tools/rewrite_rule_gen/test-rules.smt2
+++ b/tools/rewrite_rule_gen/test-rules.smt2
@@ -1,0 +1,41 @@
+;id:1	verified_to:0	time:0	from_difficulty:0	to_difficulty:0
+(push 1)
+; Valid rewrite rules, used to smoke test rewrite_rule_gen:
+;   rewrite_rule_gen verify tools/rewrite_rule_gen/test-rules.smt2
+;
+; Format note: load_new_rules() reads the tab-separated ";id:..." line of each
+; block with sscanf and stops parsing the moment a line does not match, so
+; comments cannot appear before a header or between blocks -- only inside one,
+; like this, where the SMT2 parser handles them.
+;
+; These are deliberately rules the SimplifyingNodeFactory does not already
+; know. Anything it can fold collapses to from == to when the loader rebuilds
+; the rule with that factory, and is then dropped as unorderable, so the
+; obvious candidates (De Morgan, bvsub as add-negate, double negation) are
+; unusable here. The absorption and consensus laws below survive.
+(set-logic QF_BV)
+(declare-fun v () (_ BitVec 6))
+(declare-fun w () (_ BitVec 6))
+(assert (= (bvand v (bvor v w)) v))
+(exit)
+;id:2	verified_to:0	time:0	from_difficulty:0	to_difficulty:0
+(push 1)
+(set-logic QF_BV)
+(declare-fun v () (_ BitVec 6))
+(declare-fun w () (_ BitVec 6))
+(assert (= (bvor v (bvand v w)) v))
+(exit)
+;id:3	verified_to:0	time:0	from_difficulty:0	to_difficulty:0
+(push 1)
+(set-logic QF_BV)
+(declare-fun v () (_ BitVec 6))
+(declare-fun w () (_ BitVec 6))
+(assert (= (bvor (bvand v w) (bvand v (bvnot w))) v))
+(exit)
+;id:4	verified_to:0	time:0	from_difficulty:0	to_difficulty:0
+(push 1)
+(set-logic QF_BV)
+(declare-fun v () (_ BitVec 6))
+(declare-fun w () (_ BitVec 6))
+(assert (= (bvand (bvor v w) (bvor v (bvnot w))) v))
+(exit)

--- a/tools/test_constantbitprop/test_cbitp.cpp
+++ b/tools/test_constantbitprop/test_cbitp.cpp
@@ -344,7 +344,7 @@ void exhaustive(Result (*transfer)(vector<FixedBits*>&, FixedBits&),
 
   assert(signature.maxInputWidth > 0);
   if (signature.inputType == BOOL_TYPE)
-    assert(signature.maxInputWidth = 1);
+    assert(signature.maxInputWidth == 1);
 
   for (int length = 1; length <= signature.maxInputWidth; length++)
   {
@@ -687,8 +687,13 @@ void exhaustively_check(const int bitwidth, Kind k,
 
     BBAsProp BBP(k, mgr, bitwidth);
     BBP.fill_assumps_with(*children[0], *children[1], output);
-    bool bb_conflict = !BBP.unit_prop_with_assumps();
-    const int BBFixed = BBP.fixedCount();
+    // fixed_count_unit_prop_with_assumps() replaced the old
+    // unit_prop_with_assumps()/fixedCount() pair. It returns the count
+    // directly and asserts the instance is satisfiable
+    // (CryptoMiniSat5::getFixedCountWithAssumptions), so there is no longer a
+    // conflict for this harness to observe.
+    const int BBFixed = BBP.fixed_count_unit_prop_with_assumps();
+    const bool bb_conflict = false;
 
     bool transfer_conflict = (transfer(children, output) == CONFLICT);
     const int transferFixed = children[0]->countFixed() +

--- a/tools/time_constantbitprop/time_cbitp.cpp
+++ b/tools/time_constantbitprop/time_cbitp.cpp
@@ -83,23 +83,21 @@ void runSimple(Result (*transfer)(vector<FixedBits*>&, FixedBits&),
     children.push_back(&a);
     children.push_back(&b);
 
-    if (false)
-    {
-      std::cerr << a;
-      std::cerr << b;
-      std::cerr << output;
-      std::cerr << std::endl;
-    }
+#if 0
+    std::cerr << a;
+    std::cerr << b;
+    std::cerr << output;
+    std::cerr << std::endl;
+#endif
 
     Result r = transfer(children, output);
 
-    if (false)
-    {
-      std::cerr << "after" << a;
-      std::cerr << b;
-      std::cerr << output;
-      std::cerr << std::endl;
-    }
+#if 0
+    std::cerr << "after" << a;
+    std::cerr << b;
+    std::cerr << output;
+    std::cerr << std::endl;
+#endif
 
     if(r == CONFLICT)
     {


### PR DESCRIPTION
Supersedes #619, which did the same build fix but exempted the tools from `WERROR` instead of fixing their warnings. Also carries the work from #620, which was accidentally merged into #619's branch rather than master and would otherwise have been stranded there. Rebased on current master.

## Why

`BUILD_EXTRA_TOOLS` defaults to OFF and no CI job enabled it, so nothing compiled the five tools it guards. **All of them had stopped building.**

This surfaced while checking whether `STP::tosat` was dead: `rewrite_rule_gen` is its only solving user, and the tool had not compiled in some time — so the question could not be settled by building anything.

## Build failures

**1. Headers that were never self-contained** (153 errors). They worked only by accident of include order from one translation unit:

| header | uses | included |
|---|---|---|
| `VariableAssignment.h` | `ASTNode` | nothing |
| `misc.h` | `VariableAssignment` | no |
| `rewrite_system.h` | `Rewrite_rule`, `VariableAssignment` | commented out, under the stale path `stp/Util/find-rewrites/rewrite_rule.h` |

**2. `GetChildren()` returns a view now** (3 errors) — `ASTChildren` (`Span<const ASTNode>`), not `ASTVec&`. Fixed with the codebase's own idioms: `Span::operator!=` for the comparison, holding the view directly where only `.size()`/`[]` are used, and `toASTVec()` where an owned vector is genuinely needed because it gets sorted.

**3. `BBAsProp.h` named the deleted `stp::ToSAT`** — every "`node_to_satvar_map` was not declared" error cascaded from that one failed member declaration. This broke `measure_constantbitprop` and `test_constantbitprop`. Its consumer also called `unit_prop_with_assumps()`/`fixedCount()`, since merged into `fixed_count_unit_prop_with_assumps()`, which returns the count and **asserts** satisfiability rather than reporting a conflict.

## The 85 warnings, fixed rather than suppressed

| warning | n | fix |
|---|---|---|
| `-Wswitch` | 54 | **One** switch over `Kind` that only adds a `Degree()==2` constraint for flattenable n-ary kinds. Falling through for the rest is the existing intent, so it gets a `default`. |
| `-Wsign-compare` | 25 | Each counter matched to what it is compared against — `unsigned` for `getWidth()`, `size_t` for `.size()`/`strlen` — rather than casting at the comparison. |
| `-Wunused-parameter` | 4 | Two signal handlers that ignore their argument by design, `cvc_to_c`'s `argc`, and `Rewrite_rule::_id` whose only use sits inside an `#if 0`. |
| `-Wunused-result` | 1 | Discarded `fgets` result, now checked, with end-of-input handled the way the `sscanf` check below already implied. |
| `-Wparentheses` | 1 | **A real defect — see below.** |

### `-Wparentheses` found an actual bug

`test_cbitp.cpp:347`, under `if (signature.inputType == BOOL_TYPE)`:

```c
assert(signature.maxInputWidth = 1);   // '=' where '==' was meant
```

It assigned 1 and then asserted `1`, so it never checked anything. Worse, `assert` compiles away under `NDEBUG`, so the assignment disappeared too and `maxInputWidth` kept its original value — changing the bound of the loop immediately below. **Debug and release behaved differently.**

Every `BOOL_TYPE` signature already sets `maxInputWidth = 1` (lines 847, 921, 931, 953), which I checked before changing it, so the corrected assertion holds rather than firing.

This is the case for fixing rather than exempting: suppressing 85 warnings to save effort would have kept this one hidden.

## Making the tool runnable (from #620)

Two further changes were needed before CI could do more than compile these tools.

**Search bounds.** `findRewrites()` recurses once per expression it separates out, so on a full function list it descends tens of thousands of frames and exhausts the stack — unbounded it reaches **depth 20067 and segfaults after ~8.6 s**, having found nothing. `max_search_depth` and `max_rules_wanted` cap it, both defaulting to `-1` for the old behaviour, driven by `generate <max-depth> <max-rules>`.

| depth cap | wall | exit | rules found |
|---|---|---|---|
| 3 | 7.43 s | 0 | 0 |
| 5 | 8.56 s | 0 | 0 |
| 10 | 12.41 s | 0 | 0 |
| 20 | 18.84 s | 0 | 0 |
| 15000 | 300 s (timeout) | — | 0 |

**This makes the search terminate, not productive.** It finds no rules at any bound, and the log shows `Split into 1 pieces` repeatedly — it descends a degenerate path rather than partitioning. Rule discovery looks separately unwell. So `generate 5 3` in CI is a regression test against the stack overflow, not evidence that rules get discovered.

**A rule corpus.** `verify` SAT-checks every loaded rule, but with no `rules_new.smt2` in the tree it had nothing to check and passed in 0.00 s. `test-rules.smt2` supplies four valid rules, and `verify` takes an optional path.

Two constraints shaped that file, both found the hard way:

* **The rules must be ones `SimplifyingNodeFactory` does not already know.** The loader rebuilds each rule with that factory, so anything it folds collapses to `from == to` and is dropped as unorderable. Four of five obvious candidates were rejected that way — De Morgan, `bvsub` as add-negate, double negation, `bvadd v v` as `bvmul v 2`. The absorption and consensus laws survive.
* **Comments cannot precede a `;id:` header.** The loader reads it with `sscanf` and stops at the first non-matching line, so a leading comment block silently yields zero rules. The explanation therefore lives inside the first block.

`verify <file>` now fails when the file is unreadable or yields no rules — `load_new_rules()` falls back to **stdin** for a missing file, so a mistyped path would otherwise verify nothing and exit 0, which is exactly what happened while writing this and looked like a pass.

## CI

`-DBUILD_EXTRA_TOOLS:BOOL=ON` on the existing `gcc`/`clang` matrix job — the job that already enables CryptoMiniSat, which `rewrite_rule_gen` requires (`tools/rewrite_rule_gen/CMakeLists.txt:21`). `WERROR` stays on for these targets, with no exemption.

Plus a step running four `rewrite_rule_gen` invocations: `unit-test` and `test` (self-checking), `verify` against the committed corpus, and a bounded `generate`. Assertions are live because CI leaves `CMAKE_BUILD_TYPE` unset, so `CMakeLists.txt` defaults to `RelWithDebInfo` with `NDEBUG` filtered out — otherwise those modes would pass vacuously.

## Testing

* Full build with `-DWERROR:BOOL=ON` and extra tools on: **0 errors, 0 warnings of ours** (only ABC's, already exempted, and two pre-existing bison notices).
* All five tools produced: `rewrite_rule_gen`, `test_constantbitprop`, `time_constantbitprop`, `measure`, `cvc_to_c`.
* All four CI invocations exit 0, with `verify` reporting `Verified 4 rules`.
* **The verify test is non-vacuous:** falsifying any rule in the corpus aborts with `Bad to, then from` and exit 134; a mistyped path exits 1.
* The `fgets` change is behaviour-preserving: a four-rule corpus still gives `New Style Rules Loaded:4`.

One local note: I build with `-DBUILD_SHARED_LIBS=OFF` because my locally-built CryptoMiniSat exports static GMP, which cannot go into a shared `libstp.so`. That is an environment quirk — this job builds shared with CMS enabled and links fine, as this PR's CI run will show.
