### PR TITLE
Drop the unneeded width captures that break the clang build

### DIFF
--- a/tests/unit-tests/StrengthReduction_Exhaustive_Test.cpp
+++ b/tests/unit-tests/StrengthReduction_Exhaustive_Test.cpp
@@ -529,12 +529,8 @@ TEST(StrengthReduction_Exhaustive_Test, saddo_false_via_opposite_signs)
 
     c.checkEquivalent(
         n, result, x, y, width,
-        [xSign, width](unsigned v) {
-          return ((v >> (width - 1)) & 1) == xSign;
-        },
-        [ySign, width](unsigned v) {
-          return ((v >> (width - 1)) & 1) == ySign;
-        });
+        [xSign](unsigned v) { return ((v >> (width - 1)) & 1) == xSign; },
+        [ySign](unsigned v) { return ((v >> (width - 1)) & 1) == ySign; });
   }
 }
 
@@ -591,7 +587,7 @@ TEST(StrengthReduction_Exhaustive_Test, ssubo_false_via_equal_signs)
     ASTNode result = c.sr.topLevel(n, map);
     ASSERT_EQ(result, c.mgr.ASTFalse);
 
-    auto consistent = [sign, width](unsigned v) {
+    auto consistent = [sign](unsigned v) {
       return ((v >> (width - 1)) & 1) == sign;
     };
     c.checkEquivalent(n, result, x, y, width, consistent, consistent);


### PR DESCRIPTION
Master's clang job has been failing since #603:

```
tests/unit-tests/StrengthReduction_Exhaustive_Test.cpp:532:17: error: lambda capture 'width' is not required to be captured for this use [-Werror,-Wunused-lambda-capture]
```

`width` is a `const unsigned` initialised with a constant expression, so reading it inside these lambdas is not an odr-use and the capture is redundant. gcc says nothing; clang rejects it under `-Werror`.

Dropping the three captures leaves the lambdas reading the same constant, so the tests are unchanged. Checked with clang using the CI warning flags: compiles clean.