### PR TITLE
Find the interpreter with FindPython3 rather than FindPythonInterp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
+# 3.12 is the floor for FindPython3, which is used to locate the interpreter.
+cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 
 if(POLICY CMP0048)
     #policy for VERSION in cmake 3.0
@@ -815,11 +816,22 @@ set(STP_EXPORT_NAME "STPTargets")
 
 option(ENABLE_TESTING "Enable testing" OFF)
 
+# FindPython3 replaces the deprecated FindPythonInterp, which was happy to
+# select a python2 interpreter and leave the build to fail later on: both the
+# bindings and the test suite need python3. PYTHON_EXECUTABLE is the historical
+# way to point STP at an interpreter, so keep honouring it as a hint, and keep
+# setting it afterwards because the bindings, the test suites and lit all read
+# it.
+if(PYTHON_EXECUTABLE AND NOT Python3_EXECUTABLE)
+    set(Python3_EXECUTABLE "${PYTHON_EXECUTABLE}")
+endif()
+find_package(Python3 COMPONENTS Interpreter)
+set(PYTHON_EXECUTABLE "${Python3_EXECUTABLE}")
+
 # try finding python if the user did not explicitly said that
 # he/she does not want python bindings
 if((NOT DEFINED ENABLE_PYTHON_INTERFACE) OR ENABLE_PYTHON_INTERFACE)
-    find_package (PythonInterp)
-    if(PYTHON_EXECUTABLE AND BUILD_SHARED_LIBS)
+    if(Python3_Interpreter_FOUND AND BUILD_SHARED_LIBS)
         set(ENABLE_PYTHON_INTERFACE ON)
     else()
         set(ENABLE_PYTHON_INTERFACE OFF)

--- a/README.markdown
+++ b/README.markdown
@@ -86,7 +86,7 @@ The system performs word-level preprocessing followed by translation to SAT whic
 
 ## Detailed Building and Installation
 
-STP is built with [CMake](https://cmake.org/), version 3.10 or newer. CMake is a
+STP is built with [CMake](https://cmake.org/), version 3.12 or newer. CMake is a
 meta build system that generates build files for other tools such as
 make(1), Visual Studio, Xcode, etc.
 


### PR DESCRIPTION
Following the README's build steps on a machine that still has python2 installed fails at configure time:

```
AttributeError: 'module' object has no attribute 'base_prefix'
CMake Error at bindings/python/stp/CMakeLists.txt:69 (message):
  Failed to determine python site package directory
```

`find_package(PythonInterp)` selects `/usr/bin/python2`, and the bindings then ask that interpreter for `sys.base_prefix`, which is python3-only. Every CI job passes `-DPYTHON_EXECUTABLE:PATH=$(which python3)`, so CI has never seen it — the documented `mkdir build && cd build && cmake ..` is the path that breaks.

### Change

`FindPythonInterp` has been deprecated since CMake 3.12, and CMP0148 (3.27) makes using it an error under NEW policy settings, so this moves to `FindPython3`:

- `PYTHON_EXECUTABLE` is still honoured, as a hint to the search — that's what CI, `scripts/ci-32bit.sh` and the README all pass.
- It is still *set* from `Python3_EXECUTABLE` afterwards, because `bindings/python/stp/CMakeLists.txt`, both test suites, `lit.site.cfg.in` and the `GitSHA1` provenance string all read it. No consumer needed touching.
- The bindings decision now keys off `Python3_Interpreter_FOUND` instead of "some interpreter was found".
- Asking for python3 explicitly means a bad hint degrades instead of exploding: `-DPYTHON_EXECUTABLE=$(which python2)` now reports `Could NOT find Python3: Found unsuitable major version "2"` and configures with the interface disabled.

`FindPython3` requires CMake 3.12 (June 2018), so `cmake_minimum_required` goes 3.10 → 3.12 and the README is updated to match. For reference, Ubuntu 20.04 shipped 3.16 and Debian bullseye 3.18, so nothing supported is excluded.

### Verification

All three configurations built and tested with `-DENABLE_TESTING=ON -DNOCRYPTOMINISAT=ON`:

| Configuration | Result |
| --- | --- |
| no `PYTHON_EXECUTABLE` (fails on master) | `Found Python3: /usr/bin/python3.10`, 1278 targets built, **65/65 tests pass** |
| `-DPYTHON_EXECUTABLE=$(which python3)` (what CI passes) | unchanged, configures and builds as before |
| `-DPYTHON_EXECUTABLE=$(which python2)` | `Could NOT find Python3: Found unsuitable major version "2"`, configure succeeds, interface off |

One cosmetic note for reviewers: configure still prints `Found PythonInterp` once. That comes from vendored googletest (`deps/gtest/cmake/internal_utils.cmake:205`), not from STP, and it now resolves to python3 because `PYTHON_EXECUTABLE` is set by the time it runs.

The `-DPYTHON_EXECUTABLE` flags in CI are left in place: they are no longer needed to make the build work, but pinning the interpreter explicitly in CI is still worth keeping.