### PR TITLE
Refresh the Sphinx documentation

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -249,5 +249,5 @@ You will need to install [cmake](https://cmake.org/download/) and follow the ste
 * Mate Soos
 * Dan Liew
 * Ryan Govostes
-* Andrew V. Jones
+* Andrew V. Teylu
 * And many others...

--- a/docs/cnf-output-format.rst
+++ b/docs/cnf-output-format.rst
@@ -1,5 +1,12 @@
+CNF output format
+=================
+
 This page describes the output format that STP uses when passed the
-``--output-cnf`` option. For example:
+``--output-CNF`` option. Each query STP sends to the SAT solver is written
+to ``output_<n>.cnf`` in the current directory, numbered from 0. Note that
+the CNF variables cannot be mapped back to the input problem, and that a
+problem the preprocessing simplifier solves on its own produces no file at
+all, because the SAT solver is never invoked. For example:
 
 ::
 
@@ -24,5 +31,6 @@ Each other line encodes one clause. Clauses are defined as a list of
 literals followed by a ``0``. Positive literals are 1, 2, …, and
 negative literals are -1, -2, ….
 
-The code that generates the output file is in
-extlib-abc/aig/cnf/cnfMan.c.
+STP calls ABC to do the conversion, from ``lib/ToSat/ToSATAIG.cpp``; the
+code that writes the file out is ABC's, in
+``lib/extlib-abc/src/sat/cnf/cnfMan.c``.

--- a/docs/code-guide.rst
+++ b/docs/code-guide.rst
@@ -1,27 +1,66 @@
-The src/ directory is organized into subdirectories for each distinct
-component of STP.
+Source code layout
+==================
 
--  ``absrefine_counterexample``: Functions related to abstraction
+The ``lib/`` directory is organized into subdirectories for each distinct
+component of STP. The headers that go with them live under
+``include/stp/``.
+
+-  ``AbsRefineCounterExample``: Functions related to abstraction
    refinement and counterexample construction.
 -  ``AST``: Implements the abstract syntax tree for parsed solver
    inputs.
--  ``c_interface``: Defines a C interface for parsing input files,
-   constructing expressions, executing queries, etc.
--  ``cpp_interface``: Defines the C++ interface for invoking STP.
--  ``extlib-abc``: The
-   `ABC <http://www.eecs.berkeley.edu/~alanmi/abc/abc.htm>`__ package.
--  ``extlib-constbv``: A library that implements multi-word fixed-length
-   integers, based on Steffen Beyer’s
-   `Bit::Vector <http://guest.engelschall.com/~sb/download/>`__ perl
-   module.
--  ``main``: Implements the executable tool ``stp``
--  ``parser``: Contains the parsers for the CVC, SMT-LIB1, and SMT-LIB2
+-  ``Globals``: The handful of thread-local globals that the parser
+   shares with the rest of STP.
+-  ``Interface``: Defines the C interface (``stp/c_interface.h``) for
+   parsing input files, constructing expressions, executing queries,
+   etc., and the C++ interface (``stp/cpp_interface.h``) for invoking
+   STP.
+-  ``NodeFactory``: Creates AST nodes. Which factory a client asks for
+   decides how much work happens as nodes are built, from hash consing
+   alone up to the rewriting done by ``SimplifyingNodeFactory``.
+-  ``Parser``: Contains the parsers for the CVC, SMT-LIB1, and SMT-LIB2
    input formats.
--  ``printer``: Implements various output formatters.
--  ``Sat``: This is a copy of `MiniSat <http://minisat.se>`__, with
-   `CryptoMiniSat <http://www.msoos.org/cryptominisat2/>`__ and some
-   other files added.
--  ``simplifier``: Simplification algorithms for the AST
--  ``STPManager``: Class that hold all the components together
--  ``to-sat``: Conversion of AST to SAT
--  ``util``: Handy utilities for smaller tasks
+-  ``Printer``: Implements various output formatters.
+-  ``Sat``: Adapters presenting each supported SAT solver --
+   `MiniSat <https://github.com/stp/minisat>`__,
+   `CryptoMiniSat <https://github.com/msoos/cryptominisat>`__,
+   `CaDiCaL <https://github.com/arminbiere/cadical>`__ and
+   `Riss <https://github.com/nmanthey/riss-solver>`__ -- through STP's
+   common ``SATSolver`` interface. The solvers themselves are external;
+   only the wrappers live here.
+-  ``Simplifier``: Simplification algorithms for the AST, including the
+   constant bit propagator under ``constantBitP/``.
+-  ``STPManager``: Class that holds all the components together.
+-  ``ToSat``: Conversion of AST to SAT.
+-  ``Util``: Handy utilities for smaller tasks.
+
+Third-party code that is compiled into STP also lives under ``lib/``:
+
+-  ``extlib-abc``: The `ABC <https://github.com/berkeley-abc/abc>`__
+   package, used to build AIGs and convert them to CNF. A git submodule.
+-  ``extlib-constbv``: A library that implements multi-word fixed-length
+   integers, based on Steffen Beyer's
+   `Bit::Vector <https://metacpan.org/pod/Bit::Vector>`__ perl module.
+-  ``extlib-mimalloc``:
+   `mimalloc <https://github.com/microsoft/mimalloc>`__, the allocator
+   the STP executables link against by default. A git submodule; see
+   ``STP_ALLOCATOR`` in the README for the alternatives.
+-  ``extlib-unordered-dense``:
+   `ankerl::unordered_dense <https://github.com/martinus/unordered_dense>`__,
+   a densely stored hash map and set, used in place of
+   ``std::unordered_map`` where it pays off.
+
+The executables are built from ``tools/``:
+
+-  ``stp``: The main command-line solver.
+-  ``stp_simple``: A cut-down front end that accepts a single SMT-LIB2
+   file (or stdin) and no other options. Setting ``ONLY_SIMPLE`` builds
+   this instead of ``stp``, which drops the dependency on Boost.
+-  The rest are development aids, built only when ``BUILD_EXTRA_TOOLS``
+   is enabled: ``propagator_bench``, ``time_constantbitprop``,
+   ``measure_constantbitprop`` and ``test_constantbitprop`` exercise the
+   propagators, ``rewrite_rule_gen`` searches for rewrite rules, and
+   ``cvc_to_c`` turns a CVC file into a C program.
+
+The Python bindings are in ``bindings/python``, and the tests are in
+``tests/`` (see :doc:`testing`).

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,13 +20,13 @@
 # -- Project information -----------------------------------------------------
 
 project = 'stp'
-copyright = '2018, The STP Project'
+copyright = '2018-2026, The STP Project'
 author = 'The STP Project'
 
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '2.3.1'
+release = '2.3.4'
 
 
 # -- General configuration ---------------------------------------------------
@@ -58,7 +58,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -85,7 +85,7 @@ html_theme = 'alabaster'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,7 +23,8 @@ For Debian-like platforms first install the prerequisites:
 
 .. code-block:: bash
 
-    apt-get install cmake g++ zlib1g-dev libboost-all-dev flex bison
+    apt-get install git build-essential cmake bison flex \
+        libboost-program-options-dev libgmp-dev zlib1g-dev perl
 
 Then install minisat:
 
@@ -36,21 +37,24 @@ Then install minisat:
     sudo make install
     cd ../..
 
-Then install STP:
+Then install STP. Note the submodule step: ABC and mimalloc are built as
+part of STP, and the build will not configure without them.
 
 .. code-block:: bash
 
     git clone https://github.com/stp/stp.git
-    cd stp && mkdir build && cd build
+    cd stp
+    git submodule update --init
+    mkdir build && cd build
     cmake ..
     make
     sudo make install
 
-For windows-like environments: you will need to first install the zlib
-library then install minisat and stp exactly like above, using cmake to
-create Visual Studio project files, e.g.
-``cmake .. -G "Visual Studio 10 Win64"`` and then building with Visual
-Studio.
+The `README <https://github.com/stp/stp/blob/master/README.markdown>`__
+covers the rest: the configuration variables, how to point STP at
+dependencies you have built but not installed, static builds, using
+CryptoMiniSat or CaDiCaL instead of MiniSat, and building on
+Windows/Visual Studio.
 
 
 Languages parsed
@@ -83,7 +87,7 @@ Python usage
     s.check()
     >>> True
     s.model()
-    >>> {'a': 5L, 'b': 6L, 'c': 11L}
+    >>> {'a': 5, 'b': 6, 'c': 11}
 
 SMT-LIB2 Usage
 ===============
@@ -100,7 +104,8 @@ Signed division of -1/-2 = 0, should be satisfiable.
 C library usage
 ===============
 
-When STP is built it generates a ``lib/libstp.a`` static library which
+When STP is built it generates the ``libstp`` library -- shared by
+default, or static if you configured with ``STATICCOMPILE=ON`` -- which
 can be used with one of two header files, depending on the preferred
 language:
 
@@ -151,6 +156,17 @@ STP as an external project. An example can be found in the sources under |exampl
 
 .. |examples| replace:: ``examples/simple``
 .. _examples: https://github.com/stp/stp/tree/master/examples/simple
+
+
+Working on STP
+==============
+
+.. toctree::
+   :maxdepth: 1
+
+   code-guide
+   testing
+   cnf-output-format
 
 
 Awards
@@ -224,10 +240,11 @@ terms, and array reads and writes. The predicates in the language
 include equality and (signed) comparators between bitvector terms.
 
 The basic architecture of STP essentially follows the idea of word-level
-preprocessing followed by translation to SAT (We use MINISAT and
-CRYPTOMINISAT). In particular, we introduce several new heuristics for
-the preprocessing step, including abstraction-refinement in the context
-of arrays, a new bitvector linear arithmetic equation solver, and some
+preprocessing followed by translation to SAT (MiniSat is the default SAT
+solver; CryptoMiniSat and CaDiCaL can be used instead). In particular, we
+introduce several new heuristics for the preprocessing step, including
+abstraction-refinement in the context of arrays, a new bitvector linear
+arithmetic equation solver, and some
 interesting simplifications. These heuristics help us achieve several
 magnitudes of order performance over other tools, and also over
 straight-forward translation to SAT. STP has been heavily tested on

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,1 @@
-Sphinx>=7.0
+Sphinx==8.1.3

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,1 @@
-recommonmark==0.4.0
-Sphinx==1.7.1
+Sphinx>=7.0

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -3,94 +3,79 @@ Introduction
 
 STP currently supports the following types of tests
 
--  Tests that use query files (e.g. ``smt2`` files)
-   to drive the ``stp`` binary and check the tool’s output. These are
-   driven using the `lit <https://pypi.python.org/pypi/lit>`__ and
+-  Tests that use query files (e.g. ``smt2`` files) to drive the ``stp``
+   binary and check the tool's output. These are driven using the
+   `lit <https://pypi.org/project/lit/>`__ and
    `OutputCheck <https://github.com/stp/OutputCheck>`__ tools. We refer
-   to these as query file tests.
--  Tests that use STP’s API and are checked using the GoogleTest
-   framework and driven using lit. We refer to these as unit tests.
+   to these as query file tests. They live in ``tests/query-files``.
+-  Tests that call STP's API and check the results with the
+   `GoogleTest <https://google.github.io/googletest/>`__ framework.
+   Those under ``tests/unit-tests`` exercise STP's internals; those
+   under ``tests/api`` exercise the public C, C++ and Python APIs.
+
+Both kinds are registered with CTest, so ``ctest`` (or ``make test``)
+runs everything.
 
 Getting started
 ===============
 
-We depend on various external tools to do testing. Firstly you should
-install python. Secondly you should initialise STP’s git submodules to
-get the GoogleTest and OutputCheck code.
+We depend on a few external tools for testing. You need python3, and you
+need GoogleTest and OutputCheck, which are downloaded into ``deps/`` by
+the setup scripts (they used to be git submodules, they are not any
+more):
 
 ::
 
-    $ cd /path/stp/src
-    $ git submodule init
-    $ git submodule update
+    $ cd /path/to/stp
+    $ ./scripts/deps/setup-gtest.sh
+    $ ./scripts/deps/setup-outputcheck.sh
 
-Now you need to install the lit tool which is available from
-`PyPi <https://pypi.python.org/pypi>`__. An easy way to install the tool
-is using the ``pip`` tool.
+You also need the lit tool, which is available from
+`PyPI <https://pypi.org/project/lit/>`__:
 
 ::
 
     $ pip install lit
 
-Note that for Ubuntu 14.04 you need install the ``python-stdeb``
-package, fix the URL in ``/usr/bin/pypi-install`` to
-``https://pypi.python.org/pypi`` and then execute
-``sudo pypi-install lit``.
-
 Installing lit without root access
 ----------------------------------
 
-If you don’t have root access to your machine you can use the
-`virtualenv <http://www.virtualenv.org/en/latest/>`__ tool to install
-lit in a local python environment.
+If you don't want to install lit system-wide you can put it in a virtual
+environment:
 
 ::
 
-    $ cd /path/to/put/your/virtual_environment
-    $ virtualenv venv
-    Using base prefix '/usr'
-    New python executable in venv/bin/python3
-    Also creating executable in venv/bin/python
-    Installing setuptools, pip...done.
+    $ python3 -m venv venv
     $ . venv/bin/activate
     (venv) $ pip install lit
-    Downloading/unpacking lit
-      Downloading lit-0.3.0.tar.gz (45kB): 45kB downloaded
-    ...                                                                                                                                  
-    Successfully installed lit                                                                                                                                                                                         
-    Cleaning up...
-    (venv) $
 
 Note how the shell prompt changes when the ``venv/bin/activate`` script
 is executed from your shell. This is a hint that you are now using the
-python virtual environment named ``venv``
+python virtual environment named ``venv``.
 
-Note if you do this you need to make sure CMake is aware that you want
-to use the python executable in your virtual environment and not the
-system python executable.
+If you do this you need to make sure CMake picks up the python executable
+in your virtual environment and not the system python executable. If you
+have never executed CMake previously then configuring from a shell where
+the environment is activated is enough -- CMake will find that python.
 
-If you have never executed CMake previously then if you run it from a
-shell where you have activated your virtual environemt (i.e.
-``venv/bin/activate``) then when CMake is configuring it will detect
-your virtual environment python executable.
+If you have configured previously (e.g. because you built STP with
+testing disabled) then, from a shell with the environment activated, run
+``make edit_cache`` in the build directory (``ninja edit_cache`` for
+ninja) and either
 
-If you have executed CMake previously (e.g. because you have already
-built STP perhaps with testing disabled) then in a shell with your
-python virtual environment enabled you should run ``make edit_cache``
-from the STP build directory root (``ninja edit_cache`` for ninja) and
-then do one of the following
-
--  Delete the ``PYTHON_EXECUTABLE`` cache variable and then configure.
-   If all goes well you will see the ``PYTHON_EXECUTABLE`` reappear set
-   to the full path to your virtual environment python executable. Once
-   you have configured successfully you should regenerate the build
-   system (i.e. press the generate button).
+-  Delete the ``PYTHON_EXECUTABLE`` cache variable and then configure. If
+   all goes well you will see ``PYTHON_EXECUTABLE`` reappear, set to the
+   full path of your virtual environment python. Once you have
+   configured successfully you should regenerate the build system (i.e.
+   press the generate button).
 
 OR
 
--  Set the ``PYTHON_EXECUTABLE`` cache variable manually to the path to
-   your virtual environment python executable and then configure and
-   generate.
+-  Set the ``PYTHON_EXECUTABLE`` cache variable manually to the path of
+   your virtual environment python and then configure and generate.
+
+The same applies to ``LIT_TOOL``, which CMake sets to the first ``lit``
+it finds in ``PATH``.
 
 CMake options
 -------------
@@ -100,7 +85,7 @@ easily configure these by…
 
 -  When configuring for the first time use the ``cmake-gui`` or
    ``ccmake`` tool.
--  If you’ve already configured/built previously by running
+-  If you've already configured/built previously by running
    ``make edit_cache`` or ``ninja edit_cache`` in the build directory
    (this assumes you used the ``cmake-gui`` or ``ccmake`` tool when you
    first built).
@@ -108,77 +93,88 @@ easily configure these by…
 At the time of writing the following options are available
 
 -  ``ENABLE_TESTING`` - If enabled other testing options will be
-   available
--  ``LIT_TOOL`` - Path to the ``lit`` executable (you shouldn’t need to
+   available. Note that testing needs a shared library build, so it is
+   forced off when ``STATICCOMPILE`` is on.
+-  ``LIT_TOOL`` - Path to the ``lit`` executable (you shouldn't need to
    modify this normally)
+-  ``LIT_ARGS`` - Arguments passed to ``lit`` when CTest invokes it,
+   ``-s`` by default. Set it to e.g. ``-v`` to see the output of failing
+   tests.
 -  ``PYTHON_EXECUTABLE`` - Path to the python executable to use for
-   testing programs. If you used ``virtualenv`` to install ``lit`` you
-   should ensure that this CMake variable is set to the path to the
-   ``virtualenv`` python executable. This will happen automatically if
-   you used the virtualenv ``activate`` script before configuring.
--  ``TEST_APIS`` - If enabled the tests available under ``tests/api``
-   will become available.
+   testing programs. If you used a virtual environment to install
+   ``lit`` you should ensure that this CMake variable is set to the
+   virtual environment's python executable. This will happen
+   automatically if you activated the environment before configuring.
+-  ``TEST_QUERY_FILES`` - If enabled the query file tests under
+   ``tests/query-files`` will become available for testing.
+-  ``TEST_UNITS`` - If enabled the unit tests under ``tests/unit-tests``
+   will become available for building/testing.
+-  ``TEST_APIS`` - If enabled the tests under ``tests/api`` will become
+   available.
 -  ``TEST_C_API`` - If enabled the C API unit tests will be available
    for building/testing.
--  ``TEST_QUERY_FILES`` - If enabled the query file tests will be
-   available for testing.
--  ``USE_VALGRIND`` - If enabled Valgrind will be used for unit tests.
+-  ``USE_VALGRIND`` - Checks that Valgrind is in your ``PATH`` so that
+   lit-driven GoogleTest suites can run under it.
 
 Running tests
 -------------
 
-To attempt to run all tests from the build directory (assuming you are
-using the Makefile generated build system) run
+To run all tests, from the build directory run
 
 ::
 
-    $ make check
+    $ make test
 
-Note if any tests fail other test suites will not execute (unless you
-pass the ``-i`` flag to make).
+which is CTest's own target, so ``ctest`` does the same thing and takes
+the more useful flags:
+
+::
+
+    $ ctest -j8              # run the suites in parallel
+    $ ctest -N               # list the tests without running them
+    $ ctest --output-on-failure
+    $ ctest -R Rewriting     # run only tests whose name matches
+
+The query file tests appear as a single CTest test named
+``query-files``, which runs the whole lit suite. Each GoogleTest source
+file becomes its own executable and its own CTest test, named after the
+source file with ``Tests-gtest`` appended -- so
+``tests/unit-tests/SimplifyFormula_Test.cpp`` is run by the CTest test
+``SimplifyFormula_TestTests-gtest``.
 
 Notes for Query file tests
 --------------------------
 
-When using the ``lit`` tool to run query file tests it is possible to
-pass various handy parameters.
+The query file tests can also be driven by running ``lit`` yourself. The
+lit configuration is generated into the build tree and named after the
+build type, so pass that as the config prefix and run lit from the build
+directory:
 
 ::
 
-    $ lit --param=solver=/path/to/solver .
+    $ cd /path/to/stp/build
+    $ lit --config-prefix=Release tests/query-files
 
-This will change the solver from STP to a solver of your choice
+Use the ``CMAKE_BUILD_TYPE`` you configured with (``Debug``,
+``RelWithDebInfo``, …) in place of ``Release``.
 
-::
-
-    $ lit --param=solver_params="-flag1 -flag2 -flag3" .
-
-This will pass additional flags to the solver ## Individual test suites
-
-Query file tests
-~~~~~~~~~~~~~~~~
-
-To run the query file tests run
+When using the ``lit`` tool it is possible to pass various handy
+parameters.
 
 ::
 
-    $ make query-file-tests
+    $ lit --config-prefix=Release --param=solver=/path/to/solver tests/query-files
 
-to run directly using ``lit`` run
-
-::
-
-    $ cd /path/to/stp/build/
-    $ lit tests/query-files
-
-C API tests
-~~~~~~~~~~~
-
-To run and build the C-api tests run
+This will change the solver from the STP you just built to a solver of
+your choice.
 
 ::
 
-    $ make C-api-tests
+    $ lit --config-prefix=Release --param=solver_params="-flag1 -flag2" tests/query-files
+
+This will pass additional flags to the solver. There is also
+``--param=outputcheck_params=...`` for passing extra flags to
+OutputCheck.
 
 Individual tests
 ----------------
@@ -188,25 +184,25 @@ Individual tests
 Query file tests
 ~~~~~~~~~~~~~~~~
 
-When running the query file tests the lit tool gives you the ability to
-easily run a subset of tests. For example say you are in the
-``tests/query-files`` directory. You can do the following
+The lit tool gives you the ability to easily run a subset of tests: pass
+it a subdirectory or an individual query file instead of the whole
+suite.
 
 ::
 
-    $ lit -v misc-tests/ unit_test/alwaysTrue.smt2
-
-This will run all tests under the ``tests/misc-tests`` folder and run
-the ``unit_test/alwaysTrue.smt2`` test.
+    $ cd /path/to/stp/build
+    $ lit -v --config-prefix=Release tests/query-files/misc-tests \
+          tests/query-files/simplification-tests/alwaysTrue.smt2
 
 Unit tests
 ~~~~~~~~~~
 
 The unit tests are built as standalone executables so individual tests
-can be executed by just running their executables.
-
-For example for the C API tests the built tests can be found in
-``tests/api/C`` in the build directory.
+can be executed by just running their executables, which live in the
+build directory under the same path they have in the source tree --
+``tests/unit-tests`` and ``tests/api/C``. Because they are GoogleTest
+binaries they take the usual flags, e.g. ``--gtest_filter=...`` to run a
+subset of the cases in one executable.
 
 Writing tests
 -------------
@@ -214,11 +210,11 @@ Writing tests
 .. _query-file-tests-2:
 
 Query file tests
-----------------
+~~~~~~~~~~~~~~~~
 
-You should take a look the existing tests and at the
-`lit <http://llvm.org/docs/CommandGuide/lit.html>`__, `LLVM
-testing <http://llvm.org/docs/TestingGuide.html#writing-new-regression-tests>`__
+You should take a look at the existing tests and at the
+`lit <https://llvm.org/docs/CommandGuide/lit.html>`__, `LLVM
+testing <https://llvm.org/docs/TestingGuide.html#writing-new-regression-tests>`__
 and
 `OutputCheck <https://github.com/stp/OutputCheck/blob/master/README.md>`__
 documentation.
@@ -226,7 +222,11 @@ documentation.
 .. _unit-tests-1:
 
 Unit tests
-----------
+~~~~~~~~~~
 
-You should take a look at some existing testsand read the `GoogleTest
-documentation <https://code.google.com/p/googletest/wiki/Documentation>`__.
+You should take a look at some existing tests and read the `GoogleTest
+documentation <https://google.github.io/googletest/>`__. A new test is
+added by dropping a source file next to them and adding an
+``AddSTPGTest(MyNew_Test.cpp)`` line to the ``CMakeLists.txt`` in that
+directory; it is compiled, linked against ``libstp`` and GoogleTest, and
+registered with CTest for you.


### PR DESCRIPTION
The docs under `docs/` had drifted far enough that following them fails. Everything below was checked against the tree and, where it is a command, against a configured build.

### The install recipe doesn't work (`index.rst`)

It never initialises the submodules, and ABC and mimalloc are now built as part of STP, so the copy-paste sequence cannot even configure. Added `git submodule update --init`, matched the prerequisite list to the README, and replaced the trailing Windows paragraph (which still suggested `-G "Visual Studio 10 Win64"`) with a pointer to the README, so we stop keeping a second, staler copy of the build instructions. Also fixed: `libstp` is shared by default, not `lib/libstp.a`; the python example printed python2 longs (`5L`); and the architecture section named only MiniSat and CryptoMiniSat.

### Three pages were unreachable

`testing.rst`, `code-guide.rst` and `cnf-output-format.rst` were in no toctree, so nothing in the rendered docs linked to them. They now hang off `index` under "Working on STP". (`cnf-output-format.rst` also had no title, which is why it couldn't be linked; it has one now.)

### The testing guide described a setup we don't have (`testing.rst`)

* It said to get GoogleTest and OutputCheck with `git submodule init/update` — they haven't been submodules for years; they're `scripts/deps/setup-gtest.sh` and `setup-outputcheck.sh`.
* **Every documented make target is gone**: `make check`, `make query-file-tests` and `make C-api-tests` don't exist, because `AddGTestSuite` is only referenced from commented-out lines in `tests/unit-tests/CMakeLists.txt` and `tests/api/C/CMakeLists.txt`. Tests are registered with CTest, so the page now documents `ctest`/`make test`, the real test names (`query-files` for the lit suite, `<Source>Tests-gtest` per GoogleTest file), and where the test executables land.
* Running lit by hand was wrong too. The site config is generated as `<CMAKE_BUILD_TYPE>.site.cfg`, so the documented `lit tests/query-files` discovers nothing:

  ```
  $ lit --show-suites tests/query-files
  warning: unable to find test suite for 'tests/query-files'
  error: did not discover any tests for provided path(s)

  $ lit --config-prefix=Debug --show-suites tests/query-files
  STP query-files - 164 tests
  ```
  Both the full-suite and subset invocations in the new text were run against a configured build tree.
* Added the undocumented `TEST_UNITS` and `LIT_ARGS` options, dropped the Ubuntu 14.04 `pypi-install` advice and the lit 0.3.0 install transcript, and switched the venv section to `python3 -m venv`.

### The code guide described a layout from before the `lib/` move (`code-guide.rst`)

`absrefine_counterexample`, `c_interface`, `cpp_interface`, `main`, `parser`, `to-sat`, `util` — none of those directories exist. Rewritten against `lib/`, including that `Sat` holds thin adapters over external solvers rather than "a copy of MiniSat", plus the components that were missing entirely (`NodeFactory`, `Globals`, mimalloc, unordered_dense) and a section on `tools/`.

### `--output-cnf` is not the flag (`cnf-output-format.rst`)

It's `--output-CNF`, and boost's option parsing is case sensitive, so the documented spelling errors out. Also named the output files and their caveats, and fixed the generator path (`lib/extlib-abc/src/sat/cnf/cnfMan.c`).

### Config (`conf.py`, `requirements.txt`)

`release` said 2.3.1 against `STP_FULL_VERSION` 2.3.4; `language = None` and a non-existent `_static` directory each produced a build warning. `requirements.txt` pinned Sphinx 1.7.1 and recommonmark 0.4.0, both from 2018 — recommonmark is unused (no extensions configured, `source_suffix = '.rst'`), so it's dropped in favour of asking for a current Sphinx.

The docs previously built with 5 warnings; they now build clean under Sphinx 8.1.3 with `-W`.

### One name fix outside `docs/`

The README's author list said "Andrew V. Jones" while `docs/index.rst` said "Andrew V. Teylu". Same person, and the commit history says which way round it goes: the Jones name is on commits from 2018-2021, the Teylu name on commits from 2024 to today, both from the same address domain. So the docs are current and the README was stale; the README now says Teylu. Happy to drop this commit if that's not wanted.

Left alone deliberately: `docs/old/`, which duplicates every page and is referenced by nothing, and the `python2` in `Docker.ubuntu20` (#627 deletes that file, so touching it here would only create a conflict).

