### PR TITLE
Record the Mersenne Twister header in the licence inventory

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -37,5 +37,7 @@ Also includes copyrighted software from:
     * ABC -- Copyright (c) The Regents of the University of California.
     * mimalloc -- Copyright (c) 2018-2025 Microsoft Corporation, Daan Leijen
     * ankerl::unordered_dense -- Copyright (c) 2022-2024 Martin Leitner-Ankerl
+    * Mersenne Twister -- Copyright (C) 1997 - 2002 Makoto Matsumoto and
+        Takuji Nishimura, Copyright (C) 2000 - 2003 Richard J. Wagner
 
 For licenses of these SW packages, please see LICENSE_COMPONENTS

--- a/LICENSE_COMPONENTS
+++ b/LICENSE_COMPONENTS
@@ -5,6 +5,8 @@ STP imports code from the following libraries:
 	* ABC Copyright (c) The Regents of the University of California.
 	* mimalloc Copyright (c) 2018-2025 Microsoft Corporation, Daan Leijen.
 	* ankerl::unordered_dense Copyright (c) 2022-2024 Martin Leitner-Ankerl.
+	* Mersenne Twister Copyright (C) 1997 - 2002 Makoto Matsumoto and Takuji
+		Nishimura, Copyright (C) 2000 - 2003 Richard J. Wagner.
 
 Our build system includes third-party CMake modules (these are not compiled
 into STP, but they are distributed with it):
@@ -129,6 +131,51 @@ ankerl::unordered_dense
 	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 	SOFTWARE.
+
+Mersenne Twister
+	MersenneTwister.h
+	Mersenne Twister random number generator -- a C++ class MTRand
+	Based on code by Makoto Matsumoto, Takuji Nishimura, and Shawn Cokus
+	Richard J. Wagner  v1.0  15 May 2003  rjwagner@writeme.com
+
+	Copyright (C) 1997 - 2002, Makoto Matsumoto and Takuji Nishimura,
+	Copyright (C) 2000 - 2003, Richard J. Wagner
+	All rights reserved.
+
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions
+	are met:
+
+		1. Redistributions of source code must retain the above copyright
+			notice, this list of conditions and the following disclaimer.
+
+		2. Redistributions in binary form must reproduce the above copyright
+			notice, this list of conditions and the following disclaimer in the
+			documentation and/or other materials provided with the distribution.
+
+		3. The names of its contributors may not be used to endorse or promote
+			products derived from this software without specific prior written
+			permission.
+
+	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+	"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+	LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+	A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER
+	OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+	EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+	PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+	PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+	LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+	NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+	SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+	The original code included the following notice:
+
+		When you use this, send an email to: matumoto@math.keio.ac.jp
+		with an appropriate reference to your work.
+
+	It would be nice to CC: rjwagner@writeme.com and Cokus@math.washington.edu
+	when you write.
 
 GetGitRevisionDescription.cmake (cmake/modules)
 	Original Author:


### PR DESCRIPTION
Follow-up to #630, which landed a few minutes before this commit was pushed and so didn't include it.

`include/stp/Simplifier/constantBitP/MersenneTwister.h` is Matsumoto and Nishimura's generator in Richard Wagner's C++ wrapping, under a 3-clause BSD licence (© 1997-2002 Makoto Matsumoto and Takuji Nishimura, © 2000-2003 Richard J. Wagner). It was missing from `LICENSE` and `LICENSE_COMPONENTS`.

It is not test-only, which is what makes it easy to overlook: the conspicuous users are `tools/propagator_bench`, `tools/test_constantbitprop`, `tools/time_constantbitprop` and several unit tests, but `include/stp/Util/Relations.h` and `lib/Simplifier/constantBitP/FixedBits.cpp` also include it, and `FixedBits.cpp` is part of `libstp` (`lib/Simplifier/CMakeLists.txt:51`).

Documentation-only; no code changes.