### PR TITLE
Expose the new C API constructors in Python, and stop building vestigial node kinds

### DIFF
--- a/bindings/python/stp/stp.py.in
+++ b/bindings/python/stp/stp.py.in
@@ -96,6 +96,8 @@ _set_func('vc_andExpr', _Expr, _VC, _Expr, _Expr)
 _set_func('vc_andExprN', _Expr, _VC, POINTER(_Expr), c_int32)
 _set_func('vc_orExpr', _Expr, _VC, _Expr, _Expr)
 _set_func('vc_xorExpr', _Expr, _VC, _Expr, _Expr)
+_set_func('vc_nandExpr', _Expr, _VC, _Expr, _Expr)
+_set_func('vc_norExpr', _Expr, _VC, _Expr, _Expr)
 _set_func('vc_orExprN', _Expr, _VC, POINTER(_Expr), c_int32)
 _set_func('vc_impliesExpr', _Expr, _VC, _Expr, _Expr)
 _set_func('vc_iffExpr', _Expr, _VC, _Expr, _Expr)
@@ -160,10 +162,19 @@ _set_func('vc_sbvLtExpr', _Expr, _VC, _Expr, _Expr)
 _set_func('vc_sbvLeExpr', _Expr, _VC, _Expr, _Expr)
 _set_func('vc_sbvGtExpr', _Expr, _VC, _Expr, _Expr)
 _set_func('vc_sbvGeExpr', _Expr, _VC, _Expr, _Expr)
+_set_func('vc_bvUnsignedAddOverflowExpr', _Expr, _VC, _Expr, _Expr)
+_set_func('vc_bvSignedAddOverflowExpr', _Expr, _VC, _Expr, _Expr)
+_set_func('vc_bvUnsignedSubOverflowExpr', _Expr, _VC, _Expr, _Expr)
+_set_func('vc_bvSignedSubOverflowExpr', _Expr, _VC, _Expr, _Expr)
+_set_func('vc_bvUnsignedMulOverflowExpr', _Expr, _VC, _Expr, _Expr)
+_set_func('vc_bvSignedMulOverflowExpr', _Expr, _VC, _Expr, _Expr)
 _set_func('vc_bvUMinusExpr', _Expr, _VC, _Expr)
 _set_func('vc_bvAndExpr', _Expr, _VC, _Expr, _Expr)
 _set_func('vc_bvOrExpr', _Expr, _VC, _Expr, _Expr)
 _set_func('vc_bvXorExpr', _Expr, _VC, _Expr, _Expr)
+_set_func('vc_bvNandExpr', _Expr, _VC, _Expr, _Expr)
+_set_func('vc_bvNorExpr', _Expr, _VC, _Expr, _Expr)
+_set_func('vc_bvXnorExpr', _Expr, _VC, _Expr, _Expr)
 _set_func('vc_bvNotExpr', _Expr, _VC, _Expr)
 _set_func('vc_bvLeftShiftExprExpr', _Expr, _VC, c_int32, _Expr, _Expr)
 _set_func('vc_bvRightShiftExprExpr', _Expr, _VC, c_int32,  _Expr, _Expr)
@@ -180,6 +191,7 @@ _set_func('vc_bvBoolExtract', _Expr, _VC, _Expr, c_int32)
 _set_func('vc_bvBoolExtract_Zero', _Expr, _VC, _Expr, c_int32)
 _set_func('vc_bvBoolExtract_One', _Expr, _VC, _Expr, c_int32)
 _set_func('vc_bvSignExtend', _Expr, _VC, _Expr, c_int32)
+_set_func('vc_bvZeroExtend', _Expr, _VC, _Expr, c_int32)
 _set_func('vc_bvCreateMemoryArray', _Expr, _VC, c_char_p)
 _set_func('vc_bvReadMemoryArray', _Expr, _VC, _Expr, _Expr, c_int32)
 _set_func('vc_bvWriteToMemoryArray', _Expr, _VC, _Expr, _Expr, _Expr, c_int32)
@@ -441,7 +453,21 @@ class Solver(object):
         assert isinstance(b, Expr), 'Object must be an Expression'
         expr = _lib.vc_xorExpr(self.vc, a.expr, b.expr)
         return Expr(self, None, expr)
-        
+
+    def nand(self, a, b):
+        """Boolean nand, i.e. not (a and b)."""
+        assert isinstance(a, Expr), 'Object must be an Expression'
+        assert isinstance(b, Expr), 'Object must be an Expression'
+        expr = _lib.vc_nandExpr(self.vc, a.expr, b.expr)
+        return Expr(self, None, expr)
+
+    def nor(self, a, b):
+        """Boolean nor, i.e. not (a or b)."""
+        assert isinstance(a, Expr), 'Object must be an Expression'
+        assert isinstance(b, Expr), 'Object must be an Expression'
+        expr = _lib.vc_norExpr(self.vc, a.expr, b.expr)
+        return Expr(self, None, expr)
+
     def ite(self, a, b, c):
         assert isinstance(a, Expr), 'Object must be an Expression'
         assert isinstance(b, Expr), 'Object must be an Expression'
@@ -493,6 +519,17 @@ class Expr(object):
         assert isinstance(other, Expr), 'Other object must be an Expr instance'
         expr = cb(self.s.vc, self.expr, other.expr)
         return Expr(self.s, self.width, expr)
+
+    def _2b(self, cb, other):
+        """Wrapper around double-expression STP functions returning a boolean.
+
+        Unlike _2 the result is not a bitvector, so it carries no width --
+        matching what Solver.true()/and_()/xor() produce.
+        """
+        other = self._toexpr(other)
+        assert isinstance(other, Expr), 'Other object must be an Expr instance'
+        expr = cb(self.s.vc, self.expr, other.expr)
+        return Expr(self.s, None, expr)
 
     def _2w(self, cb, a, b):
         """Wrapper around double-expression with width STP functions."""
@@ -632,6 +669,42 @@ class Expr(object):
     __xor__ = xor
     __rxor__ = xor
 
+    def nand(self, other):
+        """Bitwise nand, i.e. ~(self & other)."""
+        return self._2(_lib.vc_bvNandExpr, other)
+
+    def nor(self, other):
+        """Bitwise nor, i.e. ~(self | other)."""
+        return self._2(_lib.vc_bvNorExpr, other)
+
+    def xnor(self, other):
+        """Bitwise xnor, i.e. ~(self ^ other)."""
+        return self._2(_lib.vc_bvXnorExpr, other)
+
+    def uaddo(self, other):
+        """True when the unsigned addition self + other overflows."""
+        return self._2b(_lib.vc_bvUnsignedAddOverflowExpr, other)
+
+    def saddo(self, other):
+        """True when the signed addition self + other overflows."""
+        return self._2b(_lib.vc_bvSignedAddOverflowExpr, other)
+
+    def usubo(self, other):
+        """True when the unsigned subtraction self - other overflows."""
+        return self._2b(_lib.vc_bvUnsignedSubOverflowExpr, other)
+
+    def ssubo(self, other):
+        """True when the signed subtraction self - other overflows."""
+        return self._2b(_lib.vc_bvSignedSubOverflowExpr, other)
+
+    def umulo(self, other):
+        """True when the unsigned multiplication self * other overflows."""
+        return self._2b(_lib.vc_bvUnsignedMulOverflowExpr, other)
+
+    def smulo(self, other):
+        """True when the signed multiplication self * other overflows."""
+        return self._2b(_lib.vc_bvSignedMulOverflowExpr, other)
+
     def neg(self):
         return self._1(_lib.vc_bvUMinusExpr)
 
@@ -674,6 +747,24 @@ class Expr(object):
     def extract(self, high, low):
         expr = _lib.vc_bvExtract(self.s.vc, self.expr, high, low)
         return Expr(self.s, self.width, expr)
+
+    def zero_extend(self, width):
+        """Widen to 'width' by padding with zeroes.
+
+        A 'width' at or below the current one truncates instead, which is what
+        the underlying vc_bvZeroExtend does.
+        """
+        expr = _lib.vc_bvZeroExtend(self.s.vc, self.expr, width)
+        return Expr(self.s, width, expr)
+
+    def sign_extend(self, width):
+        """Widen to 'width' by replicating the sign bit.
+
+        A 'width' at or below the current one truncates instead, which is what
+        the underlying vc_bvSignExtend does.
+        """
+        expr = _lib.vc_bvSignExtend(self.s.vc, self.expr, width)
+        return Expr(self.s, width, expr)
 
     def simplify(self):
         """Simplify an expression."""

--- a/lib/Interface/c_interface.cpp
+++ b/lib/Interface/c_interface.cpp
@@ -1391,22 +1391,46 @@ Expr vc_bvXorExpr(VC vc, Expr left, Expr right)
                           stp::BVXOR, left, right);
 }
 
+/*
+ * The bitwise nand/nor/xnor below are built as a negated and/or/xor rather
+ * than as the BVNAND/BVNOR/BVXNOR kinds their names suggest. Those kinds are
+ * vestigial: no parser produces them -- the SMT-LIB2 grammar expands bvnand,
+ * bvnor and bvxnor exactly this way, see lib/Parser/smt2.y -- so while the
+ * bit-blaster handles them, constant folding (BVConstEvaluator) and printing
+ * (functionToSMTLIBName has no BVXNOR) do not. Building them here would make
+ * those kinds reachable for the first time and abort on a constant operand.
+ */
+static Expr createNegatedBinaryTerm(VC vc, Kind k, Expr left, Expr right)
+{
+  stp::STP* stp_i = (stp::STP*)vc;
+  stp::STPMgr* b = stp_i->bm;
+  stp::ASTNode* l = (stp::ASTNode*)left;
+  stp::ASTNode* r = (stp::ASTNode*)right;
+
+  assert(BVTypeCheck(*l));
+  assert(BVTypeCheck(*r));
+
+  const unsigned int width = l->GetValueWidth();
+  stp::ASTNode o =
+      b->CreateTerm(stp::BVNOT, width, b->CreateTerm(k, width, *l, *r));
+  assert(BVTypeCheck(o));
+  stp::ASTNode* output = new stp::ASTNode(o);
+  return output;
+}
+
 Expr vc_bvNandExpr(VC vc, Expr left, Expr right)
 {
-  return createBinaryTerm(vc, (*((stp::ASTNode*)left)).GetValueWidth(),
-                          stp::BVNAND, left, right);
+  return createNegatedBinaryTerm(vc, stp::BVAND, left, right);
 }
 
 Expr vc_bvNorExpr(VC vc, Expr left, Expr right)
 {
-  return createBinaryTerm(vc, (*((stp::ASTNode*)left)).GetValueWidth(),
-                          stp::BVNOR, left, right);
+  return createNegatedBinaryTerm(vc, stp::BVOR, left, right);
 }
 
 Expr vc_bvXnorExpr(VC vc, Expr left, Expr right)
 {
-  return createBinaryTerm(vc, (*((stp::ASTNode*)left)).GetValueWidth(),
-                          stp::BVXNOR, left, right);
+  return createNegatedBinaryTerm(vc, stp::BVXOR, left, right);
 }
 
 Expr vc_bvNotExpr(VC vc, Expr ccc)

--- a/tests/api/C/new-expr-kinds.cpp
+++ b/tests/api/C/new-expr-kinds.cpp
@@ -420,28 +420,72 @@ TEST(new_expr_kinds, kinds_are_reported_correctly)
   EXPECT_EQ(getExprKind(vc_bvSignedSubOverflowExpr(f.vc, a, b)), BVSSUBO);
   EXPECT_EQ(getExprKind(vc_bvUnsignedMulOverflowExpr(f.vc, a, b)), BVUMULO);
   EXPECT_EQ(getExprKind(vc_bvSignedMulOverflowExpr(f.vc, a, b)), BVSMULO);
-
-  EXPECT_EQ(getExprKind(vc_bvNandExpr(f.vc, a, b)), BVNAND);
-  EXPECT_EQ(getExprKind(vc_bvNorExpr(f.vc, a, b)), BVNOR);
-  EXPECT_EQ(getExprKind(vc_bvXnorExpr(f.vc, a, b)), BVXNOR);
 }
 
 /*
- * A validity checker builds nodes through SimplifyingNodeFactory, so some of
- * these kinds never reach the caller: a zero-extend is canonicalised to a
- * concat with a zero constant, and the boolean nand/nor to a negated and/or.
- * That is the factory's business rather than the API's -- the equivalence
- * proofs above are what pin down what the constructors mean -- but a caller
- * inspecting getExprKind() should not expect to see the kind it asked for.
+ * The rest do not reach the caller as the kind its constructor is named for.
+ *
+ * BVNAND, BVNOR and BVXNOR are vestigial kinds: no parser produces them --
+ * SMT-LIB2 expands bvnand/bvnor/bvxnor into a negated and/or/xor, see
+ * lib/Parser/smt2.y -- so only the bit-blaster is complete for them, and
+ * BVConstEvaluator would abort on one with a constant operand. The
+ * constructors expand them the same way the parser does.
+ *
+ * The remaining three are canonicalised by SimplifyingNodeFactory, which is
+ * the factory a validity checker builds through: a zero-extend becomes a
+ * concat with a zero constant, and the boolean nand/nor a negated and/or.
+ *
+ * Either way the equivalence proofs above are what pin down what the
+ * constructors mean; a caller inspecting getExprKind() should not expect to
+ * see the kind it asked for.
  */
-TEST(new_expr_kinds, some_kinds_are_canonicalised_on_construction)
+TEST(new_expr_kinds, some_kinds_are_rewritten_on_construction)
 {
   Fixture f;
   Expr a = f.bv("a");
+  Expr b = f.bv("b");
   Expr p = f.boolean("p");
   Expr q = f.boolean("q");
+
+  // Which kind the negated form settles on is the simplifier's business -- it
+  // pushes the negation through with De Morgan, for instance -- so what
+  // matters is only that the vestigial kind is not what comes back.
+  EXPECT_NE(getExprKind(vc_bvNandExpr(f.vc, a, b)), BVNAND);
+  EXPECT_NE(getExprKind(vc_bvNorExpr(f.vc, a, b)), BVNOR);
+  EXPECT_NE(getExprKind(vc_bvXnorExpr(f.vc, a, b)), BVXNOR);
 
   EXPECT_EQ(getExprKind(vc_bvZeroExtend(f.vc, a, W + 1)), BVCONCAT);
   EXPECT_EQ(getExprKind(vc_nandExpr(f.vc, p, q)), NOT);
   EXPECT_EQ(getExprKind(vc_norExpr(f.vc, p, q)), NOT);
+}
+
+/*
+ * The point of expanding them: an operand that is constant sends the
+ * expression through BVConstEvaluator, which has no case for the BVNAND,
+ * BVNOR or BVXNOR kinds and calls FatalError on anything it does not know.
+ */
+TEST(new_expr_kinds, bitwise_negated_ops_fold_with_constant_operands)
+{
+  Fixture f;
+  Expr a = f.bv("a");
+
+  // Values chosen to fit in W bits.
+  const unsigned int K = 0x2A, J = 0x35;
+  const unsigned int MASK = (1u << W) - 1;
+  Expr k = vc_bvConstExprFromInt(f.vc, W, K);
+
+  f.expectEqual(vc_bvNandExpr(f.vc, a, k),
+                vc_bvNotExpr(f.vc, vc_bvAndExpr(f.vc, a, k)),
+                "vc_bvNandExpr with a constant operand");
+  f.expectEqual(vc_bvNorExpr(f.vc, a, k),
+                vc_bvNotExpr(f.vc, vc_bvOrExpr(f.vc, a, k)),
+                "vc_bvNorExpr with a constant operand");
+  f.expectEqual(vc_bvXnorExpr(f.vc, a, k),
+                vc_bvNotExpr(f.vc, vc_bvXorExpr(f.vc, a, k)),
+                "vc_bvXnorExpr with a constant operand");
+
+  // Both operands constant: the whole expression has to fold to a value.
+  Expr folded = vc_bvNandExpr(f.vc, vc_bvConstExprFromInt(f.vc, W, J), k);
+  EXPECT_EQ(getExprKind(folded), BVCONST);
+  EXPECT_EQ(getBVUnsigned(folded), (~(J & K)) & MASK);
 }

--- a/tests/api/python/tests.py.in
+++ b/tests/api/python/tests.py.in
@@ -517,6 +517,113 @@ class TestSTP(unittest.TestCase):
             "STP's CDLL object should have a method called 'vc_bvConcatExpr'",
         )
 
+    #
+    # Operators that were added to the C API for node kinds it could not
+    # previously build: the bitwise nand/nor/xnor, the boolean nand/nor, the
+    # six overflow predicates and zero-extend.
+    #
+
+    def test_bitwise_nand_nor_xnor(self):
+        s = self.s
+        width = 8
+        mask = 2 ** width - 1
+        A, B = 0xCA, 0x6C
+
+        a = s.bitvec('a', width)
+        b = s.bitvec('b', width)
+        c = s.bitvec('c', width)
+        s.add(a == A, b == B)
+
+        for method, expected in (('nand', ~(A & B) & mask),
+                                 ('nor', ~(A | B) & mask),
+                                 ('xnor', ~(A ^ B) & mask)):
+            self.assertTrue(s.check(c == getattr(a, method)(b)), method)
+            self.assertEqual(s.model()['c'], expected, method)
+
+    def test_boolean_nand_nor(self):
+        s = self.s
+        a, b = s.bitvecs('a b', 8)
+        p = a == 1
+        q = b == 1
+
+        # nand/nor agree with the negated and/or for every a and b, i.e. the
+        # two sides can never disagree.
+        self.assertFalse(s.check(s.xor(s.nand(p, q), s.not_(s.and_(p, q)))))
+        self.assertFalse(s.check(s.xor(s.nor(p, q), s.not_(s.or_(p, q)))))
+
+    def test_overflow_predicates_concrete(self):
+        s = self.s
+        width = 8
+
+        # (method, left, right, overflows?). Negative operands are given in
+        # two's complement: 0x80 is -128 and 0xFF is -1.
+        cases = [
+            ('uaddo', 200, 100, True),
+            ('uaddo', 100, 100, False),
+            ('saddo', 100, 100, True),   # 200 > 127
+            ('saddo', 100, 20, False),   # 120 fits
+            ('usubo', 100, 200, True),   # borrows
+            ('usubo', 200, 100, False),
+            ('ssubo', 0x80, 1, True),    # -128 - 1 does not fit
+            ('ssubo', 100, 100, False),
+            ('umulo', 16, 16, True),     # 256 > 255
+            ('umulo', 15, 15, False),    # 225 fits
+            ('smulo', 64, 2, True),      # 128 > 127
+            ('smulo', 63, 2, False),     # 126 fits
+            ('smulo', 0xFF, 0xFF, False) # -1 * -1 == 1
+        ]
+
+        for method, left, right, overflows in cases:
+            predicate = getattr(s.bitvecval(width, left), method)(
+                s.bitvecval(width, right))
+            label = '%s(%d, %d)' % (method, left, right)
+
+            self.assertEqual(s.check(predicate), overflows, label)
+
+    def test_unsigned_add_overflow_matches_a_wider_sum(self):
+        #
+        # The predicate holds exactly when the sum computed at one extra bit
+        # of width does not fit back into the original width -- for every
+        # input, not just the concrete ones above.
+        #
+        s = self.s
+        width = 4
+
+        a = s.bitvec('a', width)
+        b = s.bitvec('b', width)
+        exact = a.zero_extend(width + 1) + b.zero_extend(width + 1)
+        does_not_fit = exact >= s.bitvecval(width + 1, 2 ** width)
+
+        self.assertFalse(s.check(s.xor(a.uaddo(b), does_not_fit)))
+
+    def test_zero_extend_and_sign_extend(self):
+        s = self.s
+        a = s.bitvec('a', 8)
+        c = s.bitvec('c', 16)
+        s.add(a == 0xF0)
+
+        self.assertTrue(s.check(c == a.zero_extend(16)))
+        self.assertEqual(s.model()['c'], 0x00F0)
+
+        self.assertTrue(s.check(c == a.sign_extend(16)))
+        self.assertEqual(s.model()['c'], 0xFFF0)
+
+    def test_zero_extend_reports_its_new_width(self):
+        s = self.s
+        a = s.bitvec('a', 8)
+        s.add(a == 0xF5)
+
+        self.assertEqual(a.zero_extend(16).width, 16)
+        self.assertEqual(a.sign_extend(16).width, 16)
+
+        # Asking for fewer bits truncates rather than failing.
+        narrowed = a.zero_extend(4)
+        self.assertEqual(narrowed.width, 4)
+
+        c = s.bitvec('c', 4)
+        self.assertTrue(s.check(c == narrowed))
+        self.assertEqual(s.model()['c'], 0x5)
+
     # Check that wide values work.
     def test_wide0(self):
         s = self.s


### PR DESCRIPTION
Follow-up to #626, which added C API constructors for node kinds STP could not previously build but left the Python binding untouched.

### Python binding

None of the fourteen new functions were declared, so they were unreachable from Python — including via `get_lib()`, where an undeclared function has no `argtypes` and ctypes silently truncates the 64-bit `VC` pointer to `int`.

| Added | |
|---|---|
| `Expr.nand` / `nor` / `xnor` | bitwise |
| `Solver.nand` / `nor` | boolean |
| `Expr.uaddo` / `saddo` / `usubo` / `ssubo` / `umulo` / `smulo` | overflow predicates |
| `Expr.zero_extend` | plus `sign_extend`, which was already declared in the binding but had no method either |

The overflow predicates return a boolean rather than a bitvector, so they use a new `_2b` wrapper that leaves `width` unset — matching what `Solver.true()` and `Solver.and_()` already produce. `zero_extend`/`sign_extend` report the width they were asked for rather than the operand's.

### The crash the Python tests found

Writing those tests turned up a genuine bug in three of #626's constructors.

`BVNAND`, `BVNOR` and `BVXNOR` are **vestigial kinds**. No parser produces them: the SMT-LIB2 grammar expands `bvnand`/`bvnor`/`bvxnor` into a negated and/or/xor at parse time (`lib/Parser/smt2.y:1339`, `:1388`, `:1395`). Consequently only the bit-blaster is complete for them —

- `BVConstEvaluator` (`lib/Simplifier/consteval.cpp`) has no case for any of the three and `FatalError`s on anything it does not know;
- `functionToSMTLIBName` (`lib/Printer/SMTLIBPrinter.cpp:206`) has `BVNAND` and `BVNOR` but no `BVXNOR`, giving "Unknown name when outputting".

The C tests in #626 used free variables throughout, so they never reached constant folding and the hole went unnoticed. A single constant operand aborts the process:

```python
a = solver.bitvec('a', 8)
solver.add(a == 0xCA)
solver.check(c == a.nand(solver.bitvecval(8, 0x6C)))
# Fatal Error: BVConstEvaluator: The input kind is not supported yet:
```

`vc_bvNandExpr`, `vc_bvNorExpr` and `vc_bvXnorExpr` now expand the same way the parser does. That keeps the kinds unreachable rather than adding fold and print support for kinds nothing else in STP produces — the alternative would have meant auditing every kind-switch in the simplifier, the propagators and the printers on behalf of dead kinds.

The C test that asserted `getExprKind()` returns `BVNAND`/`BVNOR`/`BVXNOR` is updated, and gains the constant-operand case that used to abort. It asserts only that the vestigial kind is *not* what comes back, since which form the result settles on is the simplifier's business — De Morgan turns `~(a | b)` into `~a & ~b`, for instance.

The six overflow predicates and `BVZX` are unaffected. Those kinds really are produced by the SMT-LIB2 parser and are handled throughout; `(assert (bvuaddo #xC8 #xC8))` and `(assert (not (bvsmulo #xFF #xFF)))` both fold correctly, and the tests cover the API path with constant and symbolic operands.

### Testing

`ctest` passes 68/68. Seven new Python tests cover the bitwise ops, the boolean ops, the six overflow predicates against concrete cases including the `-1 * -1` signed/unsigned split, a symbolic equivalence proof of `uaddo` against a wider sum, and the extends. I also probed each new kind with mixed symbolic/constant operands through counterexample construction and SMT-LIB printing to check no other pass had a matching hole.

Latent gap left alone, since nothing can now reach it: `BVConstEvaluator` and `functionToSMTLIBName` are still incomplete for these three kinds, which would bite anyone constructing them directly against the hashing node factory.
