### PR TITLE
Make the install RPATH absolute, and check it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,11 +205,18 @@ jobs:
         key: ccache-cadical-${{ github.run_id }}
         restore-keys: ccache-cadical-
 
+    # CMAKE_INSTALL_PREFIX and PYTHON_LIB_INSTALL_DIR are set so that the
+    # install step below lands in the workspace rather than needing root.
+    # Both have to be settled here rather than at install time: the header
+    # and Python destinations are absolute paths baked into the cache, and
+    # so is the install RPATH this job checks. Neither affects what is built
+    # or tested - the Python tests run out of the build tree.
     - name: Configure
       run: |
         mkdir build
+        mkdir -p "$GITHUB_WORKSPACE/install/pylib"
         cd build
-        cmake -DUSE_CADICAL:BOOL=ON -DCADICAL_DIR:PATH="$GITHUB_WORKSPACE/deps/cadical" -DNOCRYPTOMINISAT:BOOL=ON -DENABLE_TESTING:BOOL=ON -DWERROR:BOOL=ON -DPYTHON_EXECUTABLE:PATH="$(which python3)" -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -G Ninja ..
+        cmake -DUSE_CADICAL:BOOL=ON -DCADICAL_DIR:PATH="$GITHUB_WORKSPACE/deps/cadical" -DNOCRYPTOMINISAT:BOOL=ON -DENABLE_TESTING:BOOL=ON -DWERROR:BOOL=ON -DPYTHON_EXECUTABLE:PATH="$(which python3)" -DCMAKE_INSTALL_PREFIX:PATH="$GITHUB_WORKSPACE/install" -DPYTHON_LIB_INSTALL_DIR:PATH="$GITHUB_WORKSPACE/install/pylib" -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -G Ninja ..
 
     - name: Build
       run: |
@@ -221,6 +228,41 @@ jobs:
     - name: Test
       run: ctest --parallel "$(nproc)" -VV --output-on-failure
       working-directory: build
+
+    # An installed binary has to find its own libraries whatever directory it
+    # is run from. The install RPATH used to be CMAKE_INSTALL_LIBDIR, which
+    # GNUInstallDirs leaves relative ("lib", or "lib64" where a distro sets
+    # it), so the loader resolved it against the *caller's* working directory:
+    # stp found libstp only when it happened to be run somewhere with a
+    # matching lib/ alongside, and preferred whatever was in there to its own
+    # install. Nothing caught it because the build tree links against absolute
+    # paths and every test ran from the build directory.
+    #
+    # LD_LIBRARY_PATH supplies the dependencies the install tree genuinely
+    # does not contain - minisat is installed under deps/ - and deliberately
+    # omits install/lib, since finding that is the property under test.
+    - name: Check the installed stp runs from an unrelated directory
+      run: |
+        cmake --install build
+
+        stp="$GITHUB_WORKSPACE/install/bin/stp"
+        deps="$GITHUB_WORKSPACE/deps/install/lib"
+        readelf -d "$stp" | grep -E 'R(UN)?PATH' || echo "(no RPATH/RUNPATH)"
+
+        soname=$(readelf -d "$stp" |
+                 sed -n 's/.*NEEDED.*\[\(libstp\.so[^]]*\)\]/\1/p')
+        test -n "$soname"
+
+        cd "$(mktemp -d)"
+        LD_LIBRARY_PATH="$deps" "$stp" --version > /dev/null
+        echo "ok: runs from $PWD"
+
+        # ...and must not be diverted by a decoy sitting in ./lib. Loading
+        # this one fails outright ("file too short"), so a pass here means the
+        # loader never consulted it rather than that it got away with it.
+        mkdir lib && echo 'not an ELF file' > "lib/$soname"
+        LD_LIBRARY_PATH="$deps" "$stp" --version > /dev/null
+        echo "ok: ignored the decoy ./lib/$soname"
 
   # Until this job existed, the only static build in CI was the Windows one,
   # so a break that only shows up when everything is linked into one

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,16 +181,16 @@ else ()
     # (but later on when installing)
     SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
 
-    SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_LIBDIR}")
+    SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_FULL_LIBDIR}")
 
     # add the automatically determined parts of the RPATH
     # which point to directories outside the build tree to the install RPATH
     SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
     # the RPATH to be used when installing, but only if it's not a system directory
-    LIST(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_LIBDIR}" isSystemDir)
+    LIST(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_FULL_LIBDIR}" isSystemDir)
     IF("${isSystemDir}" STREQUAL "-1")
-        SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_LIBDIR}")
+        SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_FULL_LIBDIR}")
     ENDIF("${isSystemDir}" STREQUAL "-1")
 
     if (APPLE)


### PR DESCRIPTION
The install RPATH is `${CMAKE_INSTALL_LIBDIR}`, which `GNUInstallDirs` documents as *relative to the prefix*. `a26083b6` (2017) introduced it, changing the absolute `${CMAKE_INSTALL_PREFIX}/lib` to the relative form while fixing `lib` vs `lib64`. @jirislaby reported it in #437 and posted the fix in #438 in July 2022; this picks up his commit unchanged and adds a CI check so it cannot come back.

It is not openSUSE-specific. `CMAKE_INSTALL_LIBDIR` is relative by default everywhere — plain `lib` on Ubuntu — so the README's own `cmake .. && sudo cmake --install .` is enough to produce it:

```
$ readelf -d /usr/local/bin/stp | grep RUNPATH
 (RUNPATH)  Library runpath: [lib]
```

## Why it matters

A relative RUNPATH is resolved against the **caller's working directory**, and is searched ahead of `ld.so.cache`. On the installed binary:

```
$ mkdir -p /tmp/x/lib && echo 'not an elf' > /tmp/x/lib/libstp.so.2.3
$ cd /tmp/x && /usr/local/bin/stp --version
/usr/local/bin/stp: error while loading shared libraries: lib/libstp.so.2.3: file too short

$ cd /tmp && /usr/local/bin/stp --version
STP version 2.3.3
```

Replace the truncated file with a valid `.so` and it runs instead of the real one. Anything linking `libstp` inherits this.

The quieter failure is the more likely one. Installing this branch's parent commit into a private prefix and running the result:

```
$ ldd install/bin/stp | grep libstp
libstp.so.2.3 => /usr/local/lib/libstp.so.2.3
```

The freshly installed `stp` resolved `libstp` to an unrelated months-old build elsewhere on the machine rather than to the copy beside it in its own install tree. It only crashed because the ABI had drifted (`undefined symbol: _ZN3stp18setSMT2InteractiveEb`); without drift it would have silently run a different solver.

## Why CI never noticed

The `gcc (cadical)` job did not install at all, and every test runs from the build tree, which links against absolute paths. `cmake --install` has been printing the bogus value all along —

```
-- Set runtime path of ".../bin/stp" to "lib"
```

— but nothing looked at it.

So the second commit installs into the workspace and runs the installed `stp` from a fresh `mktemp -d`, with only the *dependency* prefix on `LD_LIBRARY_PATH`; `install/lib` is deliberately left off, because finding that is the property under test. It then repeats with a corrupt `libstp` in `./lib`, which the loader must not consult. The soname comes from the binary's own `DT_NEEDED` rather than being hardcoded.

`CMAKE_INSTALL_PREFIX` and `PYTHON_LIB_INSTALL_DIR` move to configure time because the header destination, the Python destination and the install RPATH are all absolute paths baked into the cache. Passing `--prefix` at install time would leave the RPATH pointing at the configure-time prefix and defeat the check.

## Verification

Built as the job configures it (CaDiCaL from `libcadical.a`, minisat under `deps/install`), extracting the step's `run:` block from the YAML and executing it verbatim under `bash -e`:

| Tree | RUNPATH | Step exit |
| --- | --- | --- |
| this branch | `<prefix>/lib` | **0** |
| first commit reverted | `lib` | **127** |

Reverting needs only `cmake . && cmake --install .` — CMake applies the install RPATH via `file(RPATH_CHANGE)` at install time, so no relink is involved.

## Two things deliberately left out

**The `isSystemDir` guard is dead, and this does not fix it.**

```cmake
SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_FULL_LIBDIR}")          # unconditional
...
LIST(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_FULL_LIBDIR}" isSystemDir)
IF("${isSystemDir}" STREQUAL "-1")
    SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_FULL_LIBDIR}")      # same value
ENDIF(...)
```

The guard is meant to avoid an RPATH when the libdir is already a system directory, but the unconditional `SET` above has already done it, so the `IF` can only re-set the same value. With this change and a `/usr` prefix the RPATH becomes `/usr/lib64`, which rpmlint flags as `standard-dir-in-rpath` — so for distro packaging this trades one complaint for another. Dropping the unconditional `SET` makes the guard live and yields no RPATH for a system prefix, `/opt/stp/lib64` for a private one. That is a behaviour change beyond what #438 claims, so it is not in here. @jirislaby raised the same question twice in #437 and also filed it against the Kitware wiki this was copied from: https://discourse.cmake.org/t/rpath-handling-in-the-wiki-bug/6155

**`CMAKE_INSTALL_RPATH_USE_LINK_PATH` contributes nothing.** Even with this fix, the generated `NEW_RPATH` is the install libdir alone, while the build-tree binary gets the full set. So `libminisat.so.2`, a `NEEDED` entry of `libstp.so`, is recorded nowhere in the installed artifact. The documented flow survives because the README has you install minisat to `/usr/local` and run `ldconfig`; an install against a private dependency prefix does not. That is why the check puts the dependency prefix on `LD_LIBRARY_PATH` — it isolates "does stp find its own libstp" from that separate, unfixed problem. Worth its own issue.

Closes #437. Supersedes #438 (same commit, retained authorship — that PR can be closed once this lands).

Note for whoever merges: #627 touches the same `Configure` line in this job to add the identical `CMAKE_INSTALL_PREFIX` / `PYTHON_LIB_INSTALL_DIR` flags, so whichever of the two lands second will need a one-line conflict resolution.