### PR TITLE
Make USE_VALGRIND run the tests under valgrind again

### DIFF
--- a/cmake/modules/AddSTPGTest.cmake
+++ b/cmake/modules/AddSTPGTest.cmake
@@ -52,9 +52,20 @@ function(AddSTPGTest sourcefile)
     # Add dependency so that building the testsuite
     # will cause this test (testname) to be built
     #add_dependencies(${TESTSUITE} ${testname})
-    add_test(
-      NAME ${testname}-gtest
-      COMMAND ${testname}
-      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    )
+    if(USE_VALGRIND)
+        add_test(
+          NAME ${testname}-gtest
+          COMMAND ${VALGRIND_TOOL} ${VALGRIND_ARGS} $<TARGET_FILE:${testname}>
+          WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        )
+        # Valgrind costs roughly an order of magnitude in run time, which the
+        # exhaustive tests in particular do not fit into the default timeout.
+        set_tests_properties(${testname}-gtest PROPERTIES TIMEOUT ${VALGRIND_TEST_TIMEOUT})
+    else()
+        add_test(
+          NAME ${testname}-gtest
+          COMMAND ${testname}
+          WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        )
+    endif()
 endfunction()

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -113,8 +113,14 @@ At the time of writing the following options are available
    available.
 -  ``TEST_C_API`` - If enabled the C API unit tests will be available
    for building/testing.
--  ``USE_VALGRIND`` - Checks that Valgrind is in your ``PATH`` so that
-   lit-driven GoogleTest suites can run under it.
+-  ``USE_VALGRIND`` - If enabled, every GoogleTest executable is run under
+   valgrind's memcheck rather than directly, and memory errors fail the
+   test. See :ref:`valgrind` below.
+-  ``VALGRIND_ARGS`` - The flags CTest passes to valgrind. See
+   :ref:`valgrind`.
+-  ``VALGRIND_TEST_TIMEOUT`` - Per-test CTest timeout in seconds when
+   ``USE_VALGRIND`` is on, three hours by default. The default timeout is
+   not enough for the exhaustive tests once valgrind's slowdown is applied.
 
 Running tests
 -------------
@@ -141,6 +147,51 @@ file becomes its own executable and its own CTest test, named after the
 source file with ``Tests-gtest`` appended -- so
 ``tests/unit-tests/SimplifyFormula_Test.cpp`` is run by the CTest test
 ``SimplifyFormula_TestTests-gtest``.
+
+.. _valgrind:
+
+Running the tests under valgrind
+--------------------------------
+
+Configure with ``USE_VALGRIND`` and every GoogleTest executable is run
+through valgrind's memcheck rather than being run directly, so ``ctest``
+covers them as usual. Valgrind has to be in your ``PATH`` or configuration
+fails.
+
+::
+
+    $ cmake -DENABLE_TESTING=ON -DUSE_VALGRIND=ON ..
+    $ make
+    $ ctest -j8
+
+The flags come from ``VALGRIND_ARGS``, which defaults to
+``--error-exitcode=1 --leak-check=full --errors-for-leak-kinds=none
+--track-origins=yes``. Memory errors -- invalid accesses, uninitialised
+values -- therefore fail a test, while leaks are reported in the output
+without failing it. That split is deliberate: the tests under
+``tests/api/C`` build ``Expr`` handles through the C API and mostly never
+call ``vc_DeleteExpr``, so about thirty of them leak a few bytes each by
+construction, and two of the unit tests drop what
+``NodeDomainAnalysis::harmonise`` and ``FixedBits::GetMinBVConst`` hand
+back. To make leaks fail as well, override the list -- remembering that
+CMake lists are semicolon separated:
+
+::
+
+    $ cmake -DVALGRIND_ARGS="--error-exitcode=1;--leak-check=full;--errors-for-leak-kinds=definite" ..
+
+Expect the suite to take well over an order of magnitude longer: 243
+seconds versus 8 seconds at ``-j6`` on the machine this was measured on.
+That is why the per-test CTest timeout is raised to
+``VALGRIND_TEST_TIMEOUT`` (three hours by default) -- the exhaustive tests
+do not fit in CTest's usual allowance once valgrind is in the way.
+
+The query file tests are deliberately left out of this. They drive the
+``stp`` binary, which links mimalloc by default, and mimalloc takes its
+memory from ``mmap`` rather than ``malloc``, so memcheck cannot see the
+individual allocations. Configure with ``-DSTP_ALLOCATOR=system`` if you
+want to run the binary itself under valgrind, and use lit's own ``--vg``
+flag for that.
 
 Notes for Query file tests
 --------------------------

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -92,6 +92,23 @@ include(AddGTestSuite)
 # -----------------------------------------------------------------------------
 option(USE_VALGRIND "Use Valgrind when running unit tests" OFF)
 
+# Leaks are reported but do not fail a test: the tests under tests/api/C
+# create Expr handles through the C API and mostly never call vc_DeleteExpr,
+# so about thirty of them leak a few bytes each by construction. Memory errors
+# -- invalid accesses, uninitialised values -- do fail. Add
+# --errors-for-leak-kinds=definite here if you want to hunt the leaks.
+set(VALGRIND_ARGS
+    --error-exitcode=1
+    --leak-check=full
+    --errors-for-leak-kinds=none
+    --track-origins=yes
+    CACHE STRING "Arguments passed to valgrind when USE_VALGRIND is on"
+   )
+
+set(VALGRIND_TEST_TIMEOUT 10800
+    CACHE STRING "Per-test CTest timeout in seconds when USE_VALGRIND is on"
+   )
+
 if(USE_VALGRIND)
     # Make sure valgrind is currently in PATH
     find_program(VALGRIND_TOOL valgrind
@@ -106,10 +123,11 @@ if(USE_VALGRIND)
         message(STATUS "Found valgrind : ${VALGRIND_TOOL}")
     endif()
 
-    # Note we don't use the VALGRIND_TOOL variable, we just
-    # want to make sure it in the user's PATH so that when
-    # lit tries to use it later it doesn't exit with an unhelpful
-    # error message
+    # AddSTPGTest runs each GoogleTest executable through this. Only those: the
+    # query-file tests drive the stp binary, which links mimalloc by default,
+    # and mimalloc gets its memory from mmap rather than malloc, so memcheck
+    # cannot see individual allocations there. Build with
+    # -DSTP_ALLOCATOR=system if you want to valgrind the binary itself.
 endif()
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to the `USE_VALGRIND` finding in #631's review of the testing docs: the option had no effect beyond a configure-time check that valgrind is on the `PATH`.

### Why it stopped working

The part that did the work was in `AddGTestSuite`, which turned `USE_VALGRIND` into lit's `--vg --vg-leak`. Both calls to that macro were commented out in `a5d4927d` (2022-08-07, *"Lit 15 is trying to run the test suites which I think is causing a CI failure"*), and the GoogleTest executables have been registered directly with CTest by `AddSTPGTest` ever since — which never looked at the flags. So nothing has run under valgrind for four years, while `-DUSE_VALGRIND=ON` kept reporting "Found valgrind" as if it had.

### What this does

Wires it into `AddSTPGTest`: with the option on, each GoogleTest executable is run through valgrind instead of directly, so plain `ctest` / `make test` covers them.

Two new cache variables:

* **`VALGRIND_ARGS`** — the flags, defaulting to `--error-exitcode=1 --leak-check=full --errors-for-leak-kinds=none --track-origins=yes`.
* **`VALGRIND_TEST_TIMEOUT`** — per-test CTest timeout, 3 hours. The exhaustive tests don't fit CTest's default allowance once valgrind is in the way.

### Why leaks are reported but don't fail

Measured, not assumed. With leaks fatal (`--errors-for-leak-kinds=definite`) **33 of 68 tests fail**, and every one of them is a test-side leak — there were no invalid accesses or uninitialised values anywhere in the suite:

* ~31 tests under `tests/api/C` leak the `Expr` handles they create (`vc_andExpr`, `vc_bvConstExprFromStr`, …) and never pass to `vc_DeleteExpr`. Worth noting that the tracking which would have cleaned these up is commented out in the C API itself — `// if(cinterface_exprdelete_on) created_exprs.push_back(output);` at `lib/Interface/c_interface.cpp:1133` and friends.
* `NodeDomainAnalysis_Test` cases 0, 1 and 3 drop the `UnsignedInterval`/`FixedBits` that `harmonise()` allocates into its by-reference arguments; case 2 and the exhaustive cases do delete them. Nothing leaks inside `libstp` — `~NodeDomainAnalysis` frees what the analysis owns.
* `UnsignedIntervalAnalysis_Test` leaks the CBVs returned by `FixedBits::GetMinBVConst()`/`GetMaxBVConst()`, which allocate a fresh `BitVector_Create` per call.

Failing on those would make the option useless out of the box, so the default fails on memory errors only and prints leaks for inspection. Restoring `--errors-for-leak-kinds=definite` in `VALGRIND_ARGS` is one configure flag away.

### Verification

Full suite, both ways, on this branch:

| Configuration | Result | Wall clock (`-j6`) |
| --- | --- | --- |
| `USE_VALGRIND=ON` (new default args) | **68/68 pass** | 243 s |
| `USE_VALGRIND=ON`, leaks fatal | 35/68 pass | 284 s |
| `USE_VALGRIND=OFF` | **68/68 pass** | 8.4 s |

The last row is the regression check that the ordinary path is untouched.

`docs/testing.rst` gets the option's real behaviour plus a section on using it, replacing the description of the inert version that #631 documented.

### Not done here

* The ~33 test-side leaks. Fixing the two unit tests is small and I'm happy to do it; the `tests/api/C` ones are a bigger question about whether the C API's `created_exprs` tracking should come back rather than each test calling `vc_DeleteExpr`.
* `AddGTestSuite` and `tests/lit-unit-tests-common.site.cfg.in` are still there, now with no live consumer. Left alone in case reviving the lit-driven suites is preferred to deleting them.
* No CI job runs this — 4 minutes of valgrind per push is a judgement call I didn't want to make unilaterally.