### PR TITLE
Exit gracefully on bad command-line options instead of aborting

### DIFF
--- a/tests/query-files/misc-tests/bad-cli-options.smt2
+++ b/tests/query-files/misc-tests/bad-cli-options.smt2
@@ -1,0 +1,81 @@
+; Bad command-line arguments must be diagnosed and exited on, never crash.
+;
+; lit runs RUN lines with 'set -o pipefail', so wrapping stp in 'not' checks
+; the exit status even though the output is piped onwards: 'not' inverts a
+; positive exit status to 0, but leaves the negative status of a process killed
+; by a signal as a failure. A crash therefore fails the RUN line on its own,
+; and the -NOT directives catch it a second time via the C++ runtime's message.
+
+; --- errors detected by boost::program_options ---------------------------
+
+; An unrecognised option.
+; RUN: not %solver --this-option-does-not-exist %s 2>&1 | %OutputCheck %s --check-prefix=UNKNOWN
+; RUN: not %solver -Z %s 2>&1 | %OutputCheck %s --check-prefix=UNKNOWN
+; UNKNOWN-NOT: terminate called
+; UNKNOWN: Unknown option
+
+; An option given without the argument it requires.
+; RUN: not %solver %s --max-time 2>&1 | %OutputCheck %s --check-prefix=MISSINGARG
+; MISSINGARG-NOT: terminate called
+; MISSINGARG: the required argument for option .--max-time. is missing
+
+; An abbreviation matching more than one option.
+; RUN: not %solver --print-back %s 2>&1 | %OutputCheck %s --check-prefix=AMBIGUOUS
+; AMBIGUOUS-NOT: terminate called
+; AMBIGUOUS: is ambiguous
+
+; More than one input file. Only one positional argument is accepted.
+; RUN: not %solver %s %s 2>&1 | %OutputCheck %s --check-prefix=TOOMANY
+; TOOMANY-NOT: terminate called
+; TOOMANY: too many positional options
+
+; A non-boolean argument to a boolean option.
+; RUN: not %solver --flattening=maybe %s 2>&1 | %OutputCheck %s --check-prefix=BADBOOL
+; BADBOOL-NOT: terminate called
+; BADBOOL: Invalid value
+
+; --- errors detected by stp's own validation -----------------------------
+
+; RUN: not %solver --cnf-generation-effort=bogus %s 2>&1 | %OutputCheck %s --check-prefix=BADEFFORT
+; BADEFFORT-NOT: terminate called
+; BADEFFORT: Unknown --cnf-generation-effort value
+
+; RUN: not %solver --search-bias=bogus %s 2>&1 | %OutputCheck %s --check-prefix=BADBIAS
+; BADBIAS-NOT: terminate called
+; BADBIAS: --search-bias must be one of
+
+; RUN: not %solver --max-time=-5 %s 2>&1 | %OutputCheck %s --check-prefix=BADTIME
+; BADTIME-NOT: terminate called
+; BADTIME: --max-time must be -1
+
+; RUN: not %solver --max-num-confl=-5 %s 2>&1 | %OutputCheck %s --check-prefix=BADCONFL
+; BADCONFL-NOT: terminate called
+; BADCONFL: --max-num-confl must be -1
+
+; RUN: not %solver --CVC --SMTLIB2 %s 2>&1 | %OutputCheck %s --check-prefix=BADPARSER
+; BADPARSER-NOT: terminate called
+; BADPARSER: more than one parsing option
+
+; --- the diagnostics above go to stderr, not stdout ----------------------
+;
+; A caller that pipes stdout to a result parser should see nothing on a usage
+; error. Checked with one representative from each of the two paths.
+
+; RUN: not %solver --this-option-does-not-exist %s 2>/dev/null | %OutputCheck %s --check-prefix=NOSTDOUT
+; RUN: not %solver --search-bias=bogus %s 2>/dev/null | %OutputCheck %s --check-prefix=NOSTDOUT
+; NOSTDOUT-NOT: Unknown option
+; NOSTDOUT-NOT: search-bias
+
+; --- a well-formed command line is unaffected ----------------------------
+
+; RUN: %solver --help 2>&1 | %OutputCheck %s --check-prefix=HELP
+; HELP: USAGE: stp
+
+; RUN: %solver %s 2>&1 | %OutputCheck %s --check-prefix=SOLVE
+; SOLVE: ^sat$
+
+(set-logic QF_BV)
+(declare-fun x () (_ BitVec 8))
+(assert (= x (_ bv1 8)))
+(check-sat)
+(exit)

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -96,45 +96,57 @@ void ExtraMain::try_parsing_options(
 
     po::notify(vm);
   }
-  catch (boost::exception_detail::clone_impl<
-         boost::exception_detail::error_info_injector<po::unknown_option>>& c)
+  /*
+   * Catch the program_options types themselves, not the wrapper that
+   * boost::throw_exception happens to build around them. That wrapper used to
+   * be clone_impl<error_info_injector<E>> and is wrapexcept<E> as of Boost
+   * 1.73, so naming it here silently stops catching anything when Boost is
+   * upgraded. Every one of these derives from po::error, and the final handler
+   * catches the ones we have no specific advice for -- missing arguments,
+   * ambiguous abbreviations, too many input files, and whatever future Boost
+   * versions add. Most-derived first.
+   */
+  catch (po::unknown_option& c)
   {
-    cout << "Some option you gave was wrong. Please give '--help' to get help"
+    cerr << "Some option you gave was wrong. Please give '--help' to get help"
          << endl;
-    cout << "Unknown option: " << c.what() << endl;
+    cerr << "Unknown option: " << c.what() << endl;
     exit(-1);
   }
   catch (boost::bad_any_cast& e)
   {
-    std::cerr << "ERROR! You probably gave a wrong argument type (Bad cast): "
-              << e.what() << endl;
+    cerr << "ERROR! You probably gave a wrong argument type (Bad cast): "
+         << e.what() << endl;
 
     exit(-1);
   }
-  catch (boost::exception_detail::clone_impl<
-         boost::exception_detail::error_info_injector<
-             po::invalid_option_value>>& what)
+  // The base of invalid_option_value and invalid_bool_value, which are
+  // siblings rather than one deriving from the other.
+  catch (po::validation_error& what)
   {
-    cerr << "Invalid value '" << what.what() << "'"
-         << " given to option '" << what.get_option_name() << "'" << endl;
+    cerr << "Invalid value given to option '" << what.get_option_name()
+         << "': " << what.what() << endl;
 
     exit(-1);
   }
-  catch (boost::exception_detail::clone_impl<
-         boost::exception_detail::error_info_injector<
-             po::multiple_occurrences>>& what)
+  catch (po::multiple_occurrences& what)
   {
     cerr << "Error: " << what.what() << " of option '" << what.get_option_name()
          << "'" << endl;
 
     exit(-1);
   }
-  catch (boost::exception_detail::clone_impl<
-         boost::exception_detail::error_info_injector<po::required_option>>&
-             what)
+  catch (po::required_option& what)
   {
     cerr << "You forgot to give a required option '" << what.get_option_name()
          << "'" << endl;
+
+    exit(-1);
+  }
+  catch (po::error& what)
+  {
+    cerr << "Error: " << what.what() << endl;
+    cerr << "Please give '--help' to get help" << endl;
 
     exit(-1);
   }
@@ -492,7 +504,7 @@ int ExtraMain::parse_options(int argc, char** argv)
 
   if (selected_type > 1)
   {
-    cout << "ERROR: You have selected more than one parsing option from"
+    cerr << "ERROR: You have selected more than one parsing option from "
             "CVC/SMTLIB1/SMTLIB2"
          << endl;
     std::exit(-1);
@@ -533,7 +545,7 @@ int ExtraMain::parse_options(int argc, char** argv)
       bm->UserFlags.search_bias = SearchBias::NONE;
     else
     {
-      cout << "ERROR: --search-bias must be one of 'sat', 'unsat' or 'none'"
+      cerr << "ERROR: --search-bias must be one of 'sat', 'unsat' or 'none'"
            << endl;
       std::exit(-1);
     }
@@ -547,13 +559,13 @@ int ExtraMain::parse_options(int argc, char** argv)
    */
   if (bm->UserFlags.timeout_max_conflicts < -1)
   {
-    cout << "ERROR: --max-num-confl must be -1 (no limit) or greater" << endl;
+    cerr << "ERROR: --max-num-confl must be -1 (no limit) or greater" << endl;
     std::exit(-1);
   }
 
   if (bm->UserFlags.timeout_max_time < -1)
   {
-    cout << "ERROR: --max-time must be -1 (no limit) or greater" << endl;
+    cerr << "ERROR: --max-time must be -1 (no limit) or greater" << endl;
     std::exit(-1);
   }
 

--- a/tools/stp_simple/main_simple.cpp
+++ b/tools/stp_simple/main_simple.cpp
@@ -38,7 +38,7 @@ int SimpleMain::create_and_parse_options(int argc, char** argv)
   if (argc > 2)
   {
     std::cerr << "Only one option is allowed, the input file" << std::endl;
-    exit(0);
+    exit(-1);
   }
 
   bm->UserFlags.smtlib2_parser_flag = true;


### PR DESCRIPTION
Every command-line error currently aborts `stp` with a core dump — including plain typos:

```
$ stp --bogus-opt
terminate called after throwing an instance of 'boost::wrapexcept<boost::program_options::unknown_option>'
  what():  unrecognised option '--bogus-opt'
Aborted (core dumped)              # exit 134

$ stp a.smt2 b.smt2
terminate called after throwing an instance of 'boost::wrapexcept<boost::program_options::too_many_positional_options_error>'
Aborted (core dumped)
```

## Cause

`ExtraMain::try_parsing_options()` named the *wrapper* that `boost::throw_exception` builds around a program_options error, rather than the error type itself:

```cpp
catch (boost::exception_detail::clone_impl<
       boost::exception_detail::error_info_injector<po::unknown_option>>& c)
```

Boost changed that wrapper to `boost::wrapexcept<E>` in 1.73. `clone_impl` and `error_info_injector` still exist in the headers, so this compiles without a warning — but nothing is thrown as that type any more, so **none of the five handlers could fire**. The exception escaped `main()` and hit `std::terminate`.

## Fix

Catch the program_options types themselves. `wrapexcept<E>` derives from `E`, so this is correct on both old and new Boost, and a final `catch (po::error&)` covers the cases with no specific advice — missing arguments, ambiguous abbreviations, too many input files — so a future wrapper change can't reintroduce this.

Worth noting for reviewers: `po::invalid_bool_value` is a **sibling** of `po::invalid_option_value`, not derived from it. Both are caught via their common base `po::validation_error`. This matters because most of STP's options are booleans, so `--flattening=maybe` is the likeliest typo of all.

Two smaller things folded in:

- The diagnostics went to `cout`, so a caller piping stdout into a result parser saw the error text where it expected `sat`/`unsat`. Moved to `cerr`, along with the four hand-rolled validation messages that were already exiting cleanly.
- `stp_simple` exited **0** on `Only one option is allowed, the input file` — a misuse that reported success. Now non-zero, matching `stp`.

## Before / after

| Command line | Before | After |
|---|---|---|
| `--bogus-opt`, `-Z` | abort 134 | 255, `Unknown option: …` |
| `--max-time` (argument missing) | abort 134 | 255, `the required argument … is missing` |
| `--print-back` (ambiguous prefix) | abort 134 | 255, `… is ambiguous and matches …` |
| `a.smt2 b.smt2` | abort 134 | 255, `too many positional options …` |
| `--flattening=maybe` | abort 134 | 255, `Invalid value given to option '--flattening' …` |
| `--cnf-generation-effort=bogus` | 255 | 255 (now on stderr) |
| `--search-bias=bogus` | 255 | 255 (now on stderr) |
| `--max-time=-5`, `--max-num-confl=-5` | 255 | 255 (now on stderr) |
| `--CVC --SMTLIB2` | 255 | 255 (now on stderr) |
| `--help` | 0 | 0 |

Nothing is printed on stdout for any of these now.

## Test

`tests/query-files/misc-tests/bad-cli-options.smt2`, 15 RUN lines, with two independent guards per case:

1. lit runs RUN lines under `set -o pipefail`, and OutputCheck's `not` helper only inverts a *positive* exit status (`if result > 0`) — a process killed by a signal returns negative from `subprocess.wait()`. So wrapping `stp` in `not` asserts "exited non-zero **and was not killed by a signal**", even though the output is piped onward.
2. A `-NOT: terminate called` directive on each prefix, catching the C++ runtime's abort message directly.

Plus `NOSTDOUT` prefixes asserting the diagnostics stay off stdout, and positive controls (`--help` exits 0, a good command line still prints `sat`) so the file can't pass vacuously.

Verified the test fails against the unfixed binary and passes with the fix. Full `query-files` suite: 165/165.