### PR TITLE
Default the Docker build to Ubuntu 24.04

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -24,3 +24,5 @@ todo*
 utils
 windows
 Dockerfile
+Docker.ubuntu20
+Docker.ubuntu22

--- a/Docker.ubuntu22
+++ b/Docker.ubuntu22
@@ -1,11 +1,11 @@
 # This Dockerfile builds a statically-compiled instance of STP with MiniSat and
 # CryptoMiniSat that evaluates SMTLIB2 inputs provided on standard input:
 #
-#     docker build --tag stp/stp .
+#     docker build --tag stp/stp --file Docker.ubuntu22 .
 #     cat example.smt2 | docker run --rm -i stp/stp
 
 
-FROM ubuntu:24.04 AS builder
+FROM ubuntu:22.04 AS builder
 
 # Install dependencies
 RUN apt-get update \
@@ -19,7 +19,7 @@ RUN apt-get update \
         libboost-program-options-dev \
         libgmp-dev \
         libm4ri-dev \
-        libncurses-dev \
+        libtinfo-dev \
         make \
         wget \
         zlib1g-dev \


### PR DESCRIPTION
Moves the existing 22.04 `Dockerfile` to `Docker.ubuntu22`, sitting alongside the `Docker.ubuntu20` variant, and makes the default `Dockerfile` build on Ubuntu 24.04.

The 24.04 file is otherwise byte-identical to the 22.04 one — same CryptoMiniSat 5.11.21 and MiniSat 2.2.1 pins, same static release build, same `FROM scratch` final stage — except for one required package change:

* `libtinfo-dev` → `libncurses-dev`. `libtinfo-dev` was last published in Ubuntu 23.04 (lunar) and is absent from noble, so a bare `FROM` bump would fail in the `apt-get install` layer. Its development files were folded into `libncurses-dev`.

`.dockerignore` now also lists the `Docker.ubuntu20`/`Docker.ubuntu22` variants next to the existing `Dockerfile` entry, so editing one does not invalidate the `COPY . /stp` layer of the default build.

`README.markdown`'s `docker build -t stp .` still resolves to the default file, so it is unchanged.

### Testing

One thing to watch if that build trips: the CMS pin here (5.11.21) is well behind `scripts/deps/setup-cms.sh`, which uses `release/v5.14.7`. CMS 5.11.21's `constants.h` does include `<cstdint>` explicitly, so the usual GCC 13 transitive-include breakage should not bite, but bumping the pin is the fix if it does.