### PR TITLE
Fix two bugs that made --aig-core-simplification unusable

### DIFF
--- a/lib/Simplifier/AIGSimplifyPropositionalCore.cpp
+++ b/lib/Simplifier/AIGSimplifyPropositionalCore.cpp
@@ -49,43 +49,66 @@ namespace stp
 {
 using std::make_pair;
 
-THREAD_LOCAL ASTNodeMap varToNodeMap;
-THREAD_LOCAL STPMgr* bm;
-THREAD_LOCAL NodeFactory* nf;
-
 AIGSimplifyPropositionalCore::AIGSimplifyPropositionalCore(STPMgr* _bm)
 {
   bm = _bm;
   nf = _bm->defaultNodeFactory;
 }
 
+// The propositional skeleton that this pass hands to the AIG rewriter.
+// Anything else of boolean type is a theory atom, and is replaced wholesale by
+// a fresh propositional variable.
+//
+// This is deliberately a structural test rather than a list of atom kinds. A
+// list silently rots as kinds are added, and an atom that isn't recognised as
+// one gets descended into by theoryToFresh, which then walks into bitvector
+// terms that it has no way to handle.
+static bool isPropositionalConnective(const ASTNode& n)
+{
+  switch (n.GetKind())
+  {
+    case NOT:
+    case AND:
+    case OR:
+    case NAND:
+    case NOR:
+    case XOR:
+    case IFF:
+    case IMPLIES:
+      return true;
+
+    // ITE is a connective only when it is a formula. A term-valued ITE is an
+    // atom's argument, so it is never reached.
+    case ITE:
+      return n.GetType() == BOOLEAN_TYPE;
+
+    default:
+      return false;
+  }
+}
+
 // Convert theory nodes to fresh variables.
 ASTNode AIGSimplifyPropositionalCore::theoryToFresh(const ASTNode& n,
                                                     ASTNodeMap& fromTo)
 {
-  if (n.isConstant())
-    return n;
+  assert(n.GetType() == BOOLEAN_TYPE);
 
-  const Kind k = n.GetKind();
-  if (k == SYMBOL)
+  if (n.isConstant() || n.GetKind() == SYMBOL)
     return n;
 
   ASTNodeMap::const_iterator it;
   if ((it = fromTo.find(n)) != fromTo.end())
     return it->second;
 
-  assert(n.GetValueWidth() == 0);
-  assert(n.GetIndexWidth() == 0);
-
-  if (k == BVGT || k == BVGE || k == EQ || k == BVSGE || k == BVSGT ||
-      k == PARAMBOOL) // plus the rest.
+  if (!isPropositionalConnective(n))
   {
-    ASTNode fresh = bm->CreateFreshVariable(n.GetIndexWidth(),
-                                            n.GetValueWidth(), "theoryToFresh");
+    ASTNode fresh = bm->CreateFreshVariable(0, 0, "theoryToFresh");
     varToNodeMap.insert(make_pair(fresh, n));
     fromTo.insert(make_pair(n, fresh));
     return fresh;
   }
+
+  const Kind k = n.GetKind();
 
   const ASTChildren children = n.GetChildren();
   ASTVec new_children;
@@ -131,7 +154,10 @@ ASTNode AIGSimplifyPropositionalCore::convert(BBNodeManagerAIG& mgr,
     return convert(mgr, Aig_ObjChild0(obj), cache);
   else
   {
-    FatalError("Unknown type");
+    // Every combinational input was put into the cache by topLevel(), so
+    // reaching here means the symbol-to-input mapping is incomplete.
+    assert(!Aig_ObjIsCi(obj) && "AIG input missing from the symbol map");
+    FatalError("AIGSimplifyPropositionalCore: unhandled AIG object type");
   }
   assert(false);
   exit(-1);
@@ -213,7 +239,11 @@ ASTNode AIGSimplifyPropositionalCore::topLevel(const ASTNode& top)
     assert((it->second).size() == 1); // should be a propositional variable.
     const int index =
         (it->second)[0].symbol_index; // This is the index of the pi.
-    Aig_Obj_t* pi = Aig_ManLi(mgr.aigMgr, index);
+    // symbol_index indexes vCis (see BBNodeManagerAIG::CreateSymbol), so this
+    // is a combinational input. Not Aig_ManLi, which is the latch-input
+    // accessor and reads past the end of vCos on a combinational AIG.
+    assert(index < Aig_ManCiNum(mgr.aigMgr));
+    Aig_Obj_t* pi = Aig_ManCi(mgr.aigMgr, index);
     ptrToOrig.insert(make_pair(pi, result));
   }
 

--- a/tests/query-files/simplification-tests/aigCoreAtomKinds.smt2
+++ b/tests/query-files/simplification-tests/aigCoreAtomKinds.smt2
@@ -1,0 +1,25 @@
+; RUN: %solver --aig-core-simplification=1 %s | %OutputCheck %s
+(set-logic QF_BV)
+(set-info :status sat)
+; --aig-core-simplification rewrites the propositional skeleton with AIGs,
+; replacing each theory atom by a fresh boolean. Every atom below is boolean
+; valued over bitvector terms, so none of them may be recursed into. The
+; comparison and overflow predicates used to be absent from the list of atom
+; kinds, which sent the recursion down into the bitvector terms underneath.
+(declare-fun x () (_ BitVec 8))
+(declare-fun y () (_ BitVec 8))
+(declare-fun p () Bool)
+(declare-fun q () Bool)
+(assert (or (bvult x y) (bvule y x)))
+(assert (or (bvslt x y) (bvsle y x)))
+(assert (or (bvugt x y) (bvuge y x)))
+(assert (or (bvsgt x y) (bvsge y x)))
+(assert (or (not (bvuaddo x y)) (bvsaddo x y) p))
+(assert (or (not (bvumulo x y)) (bvsmulo x y) q))
+(assert (or (not (bvusubo x y)) (bvssubo x y) (not p)))
+(assert (or (not (bvnego x)) (bvsdivo x y) q))
+(assert (= ((_ extract 0 0) x) #b1))
+(assert (and (or p q) (or (not p) q)))
+; CHECK-NEXT: ^sat
+(check-sat)
+(exit)

--- a/tests/query-files/simplification-tests/aigCoreUnsatCore.smt2
+++ b/tests/query-files/simplification-tests/aigCoreUnsatCore.smt2
@@ -1,0 +1,20 @@
+; RUN: %solver --aig-core-simplification=1 %s | %OutputCheck %s
+(set-logic QF_BV)
+(set-info :status unsat)
+; All four clauses over two theory atoms, so unsatisfiable propositionally
+; whatever the atoms mean. Collapsing that is what the AIG rewrite of the
+; propositional core is for, so this checks the rewritten core is converted
+; back faithfully, not merely that the pass runs without crashing.
+;
+; The atoms are deliberately not asserted as top-level units: that way the
+; earlier simplifications cannot dispatch the contradiction on their own, and
+; the pass really does see a non-constant formula.
+(declare-fun x () (_ BitVec 8))
+(declare-fun y () (_ BitVec 8))
+(assert (or (bvuaddo x y) (bvumulo x y)))
+(assert (or (not (bvuaddo x y)) (bvumulo x y)))
+(assert (or (bvuaddo x y) (not (bvumulo x y))))
+(assert (or (not (bvuaddo x y)) (not (bvumulo x y))))
+; CHECK-NEXT: ^unsat
+(check-sat)
+(exit)


### PR DESCRIPTION
`--aig-core-simplification=1` aborts on almost any input, so it cannot have been exercised in a long time. Two independent bugs.

### The atom-kind list rotted

`theoryToFresh()` decided what a theory atom was with a hand-written list of kinds ending in `// plus the rest.`, and the rest never arrived. `BVLT`, `BVLE`, `BVSLT`, `BVSLE`, `BOOLEXTRACT` and the six overflow predicates were all missing, so they fell through to the recursion meant for propositional structure, which descended into their bitvector term children and tripped `assert(n.GetValueWidth() == 0)`. The overflow predicates postdate the list, which is how a list like this rots.

Decided structurally instead: a node is propositional structure iff its kind is `NOT`, `AND`, `OR`, `NAND`, `NOR`, `XOR`, `IFF` or `IMPLIES`, or it is a boolean-typed `ITE`. Everything else of boolean type is an atom, whatever kinds get added later.

### Symbols were mapped back through the latch-input accessor

Mapping bit-blasted symbols to AIG inputs used `Aig_ManLi`, which is `vCos[Aig_ManCoNum(p) - Aig_ManRegNum(p) + i]`. The AIG here is combinational — one CO, no registers — so every lookup read `vCos[1 + i]`, past the end of a one-element vector. The indices come from `BBNodeManagerAIG::CreateSymbol` and index `vCis`, as `ToCNFAIG` already assumes, so this is `Aig_ManCi`.

With assertions off this presented as the *other* bug's `FatalError("Unknown type")`: the junk pointers meant the real inputs missed the conversion cache and fell to the default arm. That error now names the pass, and asserts a combinational input never reaches it.

### Also

Dropped three dead `THREAD_LOCAL` globals. The header declares `varToNodeMap`, `bm` and `nf` as members, so every use inside a member function resolved to the member and the globals were never read.

### Testing

Two lit tests, covering one bug each — reverting either fix alone fails them, the `Aig_ManLi` revert on ABC's own `Vec_PtrEntry` bounds assertion. The unsat test keeps its atoms out of top-level unit assertions deliberately: assert them directly and the earlier simplifications reduce the formula to a constant, so `topLevel()` returns before the pass ever runs and the test passes even with the bug present.

Beyond that: full `ctest` green; 400 fuzzsmt files differentially compared against the default configuration with no diffs, on both release and assertions-on builds; and 180 QF_ABV queries across 3 instances matching bitwuzla with the option enabled.