### PR TITLE
Clean up dangling AIG nodes before duplicating after rewriting

### DIFF
--- a/lib/Simplifier/AIGSimplifyPropositionalCore.cpp
+++ b/lib/Simplifier/AIGSimplifyPropositionalCore.cpp
@@ -208,6 +208,10 @@ ASTNode AIGSimplifyPropositionalCore::topLevel(const ASTNode& top)
     Aig_ManStop(pTemp);
     Dar_ManRewrite(mgr.aigMgr, pPars);
 
+    // Rewriting can leave nodes with no fanout behind, and Aig_ManDupDfs()
+    // asserts that it drops none. See the same call in ToCNFAIG.cpp.
+    Aig_ManCleanup(mgr.aigMgr);
+
     mgr.aigMgr = Aig_ManDupDfs(pTemp = mgr.aigMgr);
     Aig_ManStop(pTemp);
 

--- a/lib/ToSat/ToCNFAIG.cpp
+++ b/lib/ToSat/ToCNFAIG.cpp
@@ -82,6 +82,18 @@ void ToCNFAIG::dag_aware_aig_rewrite(const bool needAbsRef,
       Aig_ManStop(pTemp);
       Dar_ManRewrite(mgr.aigMgr, pPars);
 
+      // Rewriting can leave a node with no fanout behind. Dar_LibBuildBest()
+      // builds each replacement subgraph bottom up with Aig_And(), and a
+      // trivial simplification or a structural-hash hit further up can drop
+      // the reference to a node it has just created; nothing deletes it
+      // afterwards, since Dar_ManRewrite() only cleans up on entry.
+      //
+      // Such a node is unreachable from the CO, so Aig_ManDupDfs() does not
+      // copy it -- but it also asserts that it copied everything, and aborts
+      // an assertions build. Delete them here instead. Only unreferenced AND
+      // nodes go, so the CI order the symbol table indexes by is untouched.
+      Aig_ManCleanup(mgr.aigMgr);
+
       mgr.aigMgr = Aig_ManDupDfs(pTemp = mgr.aigMgr);
       Aig_ManStop(pTemp);
 

--- a/tests/query-files/simplification-tests/aigRewriteDanglingNode.smt2
+++ b/tests/query-files/simplification-tests/aigRewriteDanglingNode.smt2
@@ -1,0 +1,31 @@
+; RUN: %solver --aig-rewrite-passes=1 %s | %OutputCheck %s
+(set-logic QF_ABV)
+(set-info :status unsat)
+; Dar_ManRewrite() cleans up dangling nodes on entry but not on exit, so a node
+; that Dar_LibBuildBest() built and then lost the last reference to survives the
+; pass with no fanout. Aig_ManDupDfs() copies from the CO down, so it drops such
+; a node -- and then asserts that it dropped none. This query is a reduction of
+; a fuzzer case that leaves exactly one node behind, which aborted an assertions
+; build before dag_aware_aig_rewrite() cleaned up between the two calls.
+;
+; Reduced from fuzzsmt QF_ABV output, so the term is arbitrary; what matters is
+; that it survives preprocessing intact enough to reach AIG rewriting.
+(declare-fun v () (_ BitVec 13))
+(declare-fun v2 () (_ BitVec 15))
+(declare-fun v24 () (_ BitVec 16))
+(declare-fun a () (Array (_ BitVec 12) (_ BitVec 10)))
+(assert (and
+  (distinct
+    (bvsle v24 (_ bv0 16))
+    (= (bvsmulo v2 ((_ sign_extend 12) (bvsmod (_ bv3 3) ((_ sign_extend 2) (ite (distinct v24 (_ bv0 16)) (_ bv1 1) (_ bv0 1))))))
+       (or (bvumulo (_ bv0 15) (_ bv0 15))
+           (bvsmulo ((_ zero_extend 1) v) ((_ sign_extend 11) (bvneg (bvsmod (_ bv1 3) ((_ sign_extend 2) (ite (distinct v24 (_ bv0 16)) (_ bv1 1) (_ bv0 1)))))))))
+    (= (bvsge ((_ sign_extend 12) (bvneg (bvsmod (_ bv1 3) ((_ sign_extend 2) (ite (distinct v24 (_ bv0 16)) (_ bv1 1) (_ bv0 1)))))) v2)
+       (or (bvuge (_ bv0 14) ((_ zero_extend 13) (ite (distinct v24 (_ bv0 16)) (_ bv1 1) (_ bv0 1))))
+           (bvuge (select a (_ bv1 12)) ((_ zero_extend 7) (bvneg (bvsmod (_ bv1 3) ((_ sign_extend 2) (ite (distinct v24 (_ bv0 16)) (_ bv1 1) (_ bv0 1))))))))))
+  (= (bvnego (_ bv0 1))
+     (bvsle v2 ((_ sign_extend 14) (ite (distinct v24 (_ bv0 16)) (_ bv1 1) (_ bv0 1))))
+     (bvnego (ite (bvsmulo (select a (_ bv1 12)) ((_ sign_extend 7) (bvneg (bvsmod (_ bv1 3) ((_ sign_extend 2) (ite (distinct v24 (_ bv0 16)) (_ bv1 1) (_ bv0 1))))))) (_ bv1 1) (_ bv0 1))))))
+; CHECK-NEXT: ^unsat
+(check-sat)
+(exit)


### PR DESCRIPTION
`--aig-rewrite-passes=1` aborts an assertions build:

```
stp: lib/extlib-abc/src/aig/aig/aigDup.c:602: Aig_ManDupDfs:
  Assertion `p->pEquivs != NULL || Aig_ManBufNum(p) != 0
             || Aig_ManNodeNum(p) == Aig_ManNodeNum(pNew)' failed.
```

Found by the QF_ABV differential fuzzer. It reported the file as a verdict
mismatch, but that was a consequence rather than the bug: the abort truncated
stdout, so every later query in the 2500-query file disagreed with bitwuzla.

## Cause

`Dar_ManRewrite()` calls `Aig_ManCleanup()` on entry and never on exit. During
rewriting, `Dar_LibBuildBest()` builds each replacement subgraph bottom up with
`Aig_And()`, which simplifies and structurally hashes as it goes -- so a call at
an upper level can return a constant or an existing node without ever
referencing the node just built below it. Nothing deletes that node.

`Aig_ManDupDfs()` copies from the CO downwards, so it does not copy such a node.
But it also asserts that it copied every node, which is exactly the assertion
above. Release builds drop the node silently and answer correctly; only
assertions builds abort.

Measured on the query in the new test:

| point | max object id | AND nodes |
| --- | --- | --- |
| before `Dar_ManRewrite()` | 8753 | 8686 |
| after `Dar_ManRewrite()` | 16050 | 4293 |
| after `Aig_ManCleanup()` | 16050 | 4292 |

Exactly one node, id 13424, has `nRefs == 0`. Its id is well past the 8753 that
existed beforehand, so it was created during the pass and never acquired a
fanout.

## Fix

`Aig_ManCleanup()` between `Dar_ManRewrite()` and the following
`Aig_ManDupDfs()`, at both sites that run the sequence:

- `ToCNFAIG::dag_aware_aig_rewrite()` -- `--aig-rewrite-passes`
- `AIGSimplifyPropositionalCore::topLevel()` -- `--aig-core-simplification`

The second was not reported, but runs the identical
`DupDfs / Dar_ManRewrite / DupDfs` sequence and is latently exposed to the same
abort. It is in fact more exposed: it sets `fUseZeros`, so it accepts zero-gain
rewrites and builds more replacement subgraphs.

The change is semantically a no-op. `Aig_ManCleanup()` deletes only AND nodes
with no references, never CIs, so the CI ordering `symbolToBBNode` indexes into
via `Vec_PtrEntry(mgr.aigMgr->vCis, ...)` is untouched. It deletes precisely
the nodes `Aig_ManDupDfs()` was already discarding.

Upstream ABC has the same latent problem -- `Dar_ManRewriteDefault()` in
`darScript.c` and `giaHcd.c` both use the bare
`Dar_ManRewrite(); Aig_ManDupDfs()` sequence. The vendored ABC is left alone.

## Testing

All against bitwuzla on a Debug + assertions build, so the assertion is live.

| check | result |
| --- | --- |
| the new test query, `--aig-rewrite-passes=1` | `unsat`, matches bitwuzla (was: abort) |
| 2500-query fuzz file, `--aig-rewrite-passes=1` | byte-identical to bitwuzla |
| 2500-query fuzz file, `--aig-core-simplification=1` | byte-identical to bitwuzla |
| `lit` query-files suite | 182/182 |
| CNF byte-compare against the unpatched binary | 103 files, 103 identical |

The CNF comparison uses `--output-CNF --exit-after-CNF --aig-rewrite-passes=1`.
97 of the 200 sampled files never reach CNF generation and were skipped. Zero
byte differences confirms the cleanup removes only nodes that were already
being discarded.

Cost, as instruction counts (deterministic, so it avoids the wall-clock noise
floor), interleaved with alternating arm order:

| configuration | files | delta |
| --- | --- | --- |
| `--aig-rewrite-passes=1` | 60 | +0.10% |
| default flags | 30 | -0.15% (control; the code is not reached) |

Both switches default to off, so a default run never executes the new call. The
default-flags row is the measurement floor. `Aig_ManCleanup()` is one linear
scan plus a recursive delete, and the `Aig_ManDupDfs()` immediately after
allocates a whole new manager and copies every live node into it, so the
cleanup is strictly cheaper than the copy it precedes.

The regression test is the failing query reduced with ddSMT from 6666 B / 625
s-expressions to 1209 B / 120. It aborts the pre-fix binary and answers `unsat`
after.