### PR TITLE
Reach a fixed point when a cbitp node repeats a child

### DIFF
--- a/include/stp/Simplifier/constantBitP/ConstantBitP_Utility.h
+++ b/include/stp/Simplifier/constantBitP/ConstantBitP_Utility.h
@@ -57,6 +57,20 @@ struct stats
 Result merge(Result r1, Result r2);
 
 stats getStats(const vector<FixedBits*>& operands, const unsigned position);
+
+// True when one FixedBits feeds more than one operand slot. The propagator
+// holds one FixedBits per node, so a node that repeats a child hands the
+// transfer function the same pointer twice: ((_ repeat 2) x) is
+// BVCONCAT(x, x), and the hashing node factory builds BVPLUS(x, x) and
+// friends. A write through one slot is then already visible through the
+// others, which a single left-to-right pass does not expect.
+bool operandsAlias(const vector<FixedBits*>& operands);
+
+// Fixed bits over the operands and the output. Aliased operands are counted
+// once per slot; that is fine, because this only ever detects that something
+// became fixed, and fixing is monotone.
+unsigned totalFixedBits(const vector<FixedBits*>& operands,
+                        const FixedBits& output);
 }
 }
 

--- a/lib/Simplifier/constantBitP/ConstantBitP_Shifting.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_Shifting.cpp
@@ -1008,7 +1008,7 @@ static Result shlCore(const unsigned bitWidth, PackedBits& packedOp,
   return NOT_IMPLEMENTED;
 }
 
-Result bvLeftShiftBothWays(vector<FixedBits*>& children, FixedBits& output)
+static Result leftShiftOnePass(vector<FixedBits*>& children, FixedBits& output)
 {
   const unsigned bitWidth = output.getWidth();
   assert(2 == children.size());
@@ -1041,6 +1041,42 @@ Result bvLeftShiftBothWays(vector<FixedBits*>& children, FixedBits& output)
   writeBack(shift, packedShift, origShift);
   writeBack(output, packedOut, origOut);
   return result;
+}
+
+Result bvLeftShiftBothWays(vector<FixedBits*>& children, FixedBits& output)
+{
+  Result r = leftShiftOnePass(children, output);
+
+  // Same shape as bvConcatBothWays: nothing derived or a conflict means a
+  // second pass would see exactly what this one did, and distinct operands
+  // never need one. NB the NO_CHANGE arm is inert here - shlCore ends in an
+  // unconditional `return NOT_IMPLEMENTED`, so this function never reports
+  // NO_CHANGE and the alias check runs on every call. It is two pointer
+  // compares, and the arm starts working the moment shlCore reports honestly.
+  if (NO_CHANGE == r || CONFLICT == r || !operandsAlias(children))
+    return r;
+
+  // x << x. shlCore snapshots the value and the amount into separate
+  // PackedBits and writes both back into the one FixedBits, so a bit it
+  // derives for the amount is not read as part of the value until the next
+  // call - and narrowing either one narrows the other again. Unlike concat
+  // there is no two-pass argument to lean on: random sweeps reach six passes
+  // by width 31, so iterate until nothing new is fixed.
+  unsigned fixed = totalFixedBits(children, output);
+  while (true)
+  {
+    const Result pass = leftShiftOnePass(children, output);
+
+    r = merge(r, pass);
+    if (NO_CHANGE == pass || CONFLICT == pass)
+      return r;
+
+    const unsigned now = totalFixedBits(children, output);
+    assert(now >= fixed); // Bits are only ever fixed, never unfixed.
+    if (now == fixed)
+      return r;
+    fixed = now;
+  }
 }
 }
 }

--- a/lib/Simplifier/constantBitP/ConstantBitP_TransferFunctions.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_TransferFunctions.cpp
@@ -555,7 +555,8 @@ Result bvUnaryMinusBothWays(vector<FixedBits*>& children, FixedBits& output)
   return changed ? CHANGED : NO_CHANGE;
 }
 
-Result bvConcatBothWays(vector<FixedBits*>& children, FixedBits& output)
+// One sweep, least significant operand first.
+static Result concatOnePass(vector<FixedBits*>& children, FixedBits& output)
 {
   Result r = NO_CHANGE;
   const size_t numberOfChildren = children.size();
@@ -589,6 +590,23 @@ Result bvConcatBothWays(vector<FixedBits*>& children, FixedBits& output)
     }
   }
   return r;
+}
+
+Result bvConcatBothWays(vector<FixedBits*>& children, FixedBits& output)
+{
+  const Result first = concatOnePass(children, output);
+
+  // When operands alias, one sweep is not enough: a bit written into the
+  // shared FixedBits through a low operand is not read back out through a
+  // high one until the next sweep. Two sweeps are always enough, though.
+  //
+  if (NO_CHANGE == first || CONFLICT == first || !operandsAlias(children))
+    return first;
+
+  // Merged, not just returned: the second sweep reports NO_CHANGE whenever it
+  // adds nothing, and returning that would tell propagate() nothing happened
+  // when the first sweep had already moved bits.
+  return merge(first, concatOnePass(children, output));
 }
 
 // If the guard is fixed, make equal the appropriate input and output.

--- a/lib/Simplifier/constantBitP/ConstantBitP_Utility.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_Utility.cpp
@@ -237,6 +237,24 @@ Result merge(Result r1, Result r2)
   return NOT_IMPLEMENTED;
 }
 
+bool operandsAlias(const vector<FixedBits*>& operands)
+{
+  for (size_t i = 1; i < operands.size(); i++)
+    for (size_t j = 0; j < i; j++)
+      if (operands[i] == operands[j])
+        return true;
+  return false;
+}
+
+unsigned totalFixedBits(const vector<FixedBits*>& operands,
+                        const FixedBits& output)
+{
+  unsigned count = output.countFixed();
+  for (const FixedBits* o : operands)
+    count += o->countFixed();
+  return count;
+}
+
 int toInt(const stp::CBV value)
 {
   return *((unsigned int*)value);

--- a/tests/unit-tests/ConstantBitP_TransferFunctions_Test.cpp
+++ b/tests/unit-tests/ConstantBitP_TransferFunctions_Test.cpp
@@ -20,15 +20,17 @@ THE SOFTWARE.
 
 // Exhaustive tests of the constant bit propagation transfer functions.
 // Every function is checked, at small widths, over every combination of
-// fixed/unfixed bits for four properties:
+// fixed/unfixed bits for five properties:
 //
 // 1) Soundness: propagation must never exclude a concrete assignment of the
 //    children and output that was consistent with the bits before
 //    propagation ran, and CONFLICT is only reported when no assignment
 //    remains.
-// 2) The NO_CHANGE contract: ConstantBitPropagation::propagate() trusts a
-//    NO_CHANGE result and skips rescheduling, so a transfer function that
-//    returns NO_CHANGE must not have altered any bits.
+// 2) The Result contract: NO_CHANGE must mean no bit moved (propagate()
+//    trusts it and skips rescheduling), and CHANGED must mean one did.
+//    Neither has an exception. NOT_IMPLEMENTED says nothing either way and is
+//    rejected unless the call site is marked RESULT_IS_VAGUE - see the note
+//    on that constant for who still does it and why it matters.
 // 3) The lattice rules: propagation may fix bits, but never unfix them or
 //    flip a bit that was already fixed.
 // 4) Maximal precision, for the functions the header documents as
@@ -37,10 +39,29 @@ THE SOFTWARE.
 //    exists at all. The brute-forced join of the solutions provides the
 //    reference, so a propagator that soundly does nothing fails here
 //    rather than passing silently.
+// 5) Local fixed point: calling the function again on the bits the previous
+//    call produced must derive nothing further. ConstantBitPropagation
+//    ::propagate() gives each node exactly one call - when a child moves it
+//    reschedules that child's other parents, but not the node it just ran -
+//    so a function that needs a second call leaves the propagation short of
+//    a fixed point and the solver never sees what the later call would have
+//    found. A call site that passes a bound above SETTLES_IN_ONE_CALL is
+//    recording a measured shortfall, not granting permission; the comment
+//    there says what is lost.
 //
 // The functions checked only for soundness (OVERAPPROXIMATES rather than
 // MAX_PRECISE below) are multiplication and the five division operations.
 // Everything else is confirmed maximally precise here.
+//
+// Every operator is checked twice: once with a distinct FixedBits per
+// operand, and once ALIASED, with one FixedBits shared between several
+// operand slots. Aliasing is not hypothetical - the propagator looks up one
+// FixedBits per *node*, so BVCONCAT(x,x) from ((_ repeat 2) x), BVPLUS(x,x)
+// and BVAND(x,x) all reach the transfer functions with children[0] ==
+// children[1], and a write through one operand is visible through the other.
+// Properties 1, 2, 3 and 5 are required in both modes. Property 4 is checked
+// only unaliased: an aliased call has no way to know that its two reads must
+// take the same value, so the unaliased join is the wrong reference for it.
 
 #include "extlib-constbv/constantbv.h"
 #include "stp/STPManager/STPManager.h"
@@ -140,58 +161,121 @@ struct Slot
 const bool MAX_PRECISE = true;
 const bool OVERAPPROXIMATES = false;
 
-// Run the propagator on one case and check soundness, the NO_CHANGE
-// contract, the lattice rules, and (for the maximally precise functions)
-// that every bit all the solutions agree on gets fixed. Returns a
-// description of the first problem found, or the empty string.
-std::string checkCase(const std::string& opName, const Propagator& propagate,
-                      const Semantics& op, const std::vector<FixedBits>& in0,
-                      const FixedBits& out0, bool expectPrecise)
+// Which FixedBits object each operand position reads. The identity vector is
+// the ordinary case. A repeated entry means one node feeds several operand
+// positions, so the propagator sees the same pointer twice - what it gets for
+// BVCONCAT(x,x), BVPLUS(x,x) and so on.
+typedef std::vector<unsigned> Aliasing;
+
+Aliasing distinctOperands(unsigned arity)
 {
-  std::vector<FixedBits> in(in0);
+  Aliasing a(arity);
+  for (unsigned i = 0; i < arity; i++)
+    a[i] = i;
+  return a;
+}
+
+// How many distinct FixedBits objects an aliasing uses.
+unsigned objectCount(const Aliasing& readsObject)
+{
+  unsigned n = 0;
+  for (unsigned o : readsObject)
+    n = std::max(n, o + 1);
+  return n;
+}
+
+bool isAliased(const Aliasing& readsObject)
+{
+  return objectCount(readsObject) != readsObject.size();
+}
+
+// How many calls a transfer function is allowed to take before it stops
+// deriving anything. propagate() gives it one, so anything above this is a
+// known shortfall rather than a licence: the bound is what the function
+// measurably needs today, and the call sites that pass more than one name
+// what is lost.
+const unsigned SETTLES_IN_ONE_CALL = 1;
+
+// Whether the Result a function returns describes what it did. Returning
+// CHANGED without moving a bit is never allowed and has no exception. What
+// some functions still do is return NOT_IMPLEMENTED unconditionally, which
+// says nothing either way; propagate() reads that as "assume it changed" and
+// re-derives the truth from countFixed(), so it costs work rather than
+// correctness. It is a trap for anything that tries to loop on the Result -
+// `while (r == CHANGED)` exits immediately on a shifter that is still
+// deriving bits. RESULT_IS_VAGUE marks the functions that do it.
+enum class ResultAccuracy
+{
+  Exact,
+  Vague
+};
+const ResultAccuracy RESULT_IS_EXACT = ResultAccuracy::Exact;
+const ResultAccuracy RESULT_IS_VAGUE = ResultAccuracy::Vague;
+
+// Run the propagator on one case and check soundness, the NO_CHANGE
+// contract, the lattice rules, that a second call derives nothing further,
+// and (for the maximally precise functions) that every bit all the solutions
+// agree on gets fixed. Returns a description of the first problem found, or
+// the empty string.
+//
+// obj0 holds one starting value per distinct FixedBits object;
+// readsObject[i] says which of them operand i reads.
+std::string checkCase(const std::string& opName, const Propagator& propagate,
+                      const Semantics& op, const std::vector<FixedBits>& obj0,
+                      const Aliasing& readsObject, const FixedBits& out0,
+                      bool expectPrecise,
+                      unsigned callsAllowed = SETTLES_IN_ONE_CALL,
+                      ResultAccuracy resultIsExact = RESULT_IS_EXACT,
+                      bool* sawNotImplemented = NULL)
+{
+  const unsigned objects = obj0.size();
+  const unsigned slots = readsObject.size();
+
+  std::vector<FixedBits> obj(obj0);
   FixedBits out(out0);
   std::vector<FixedBits*> children;
-  for (auto& c : in)
-    children.push_back(&c);
+  for (unsigned i = 0; i < slots; i++)
+    children.push_back(&obj[readsObject[i]]);
 
   const Result result = propagate(children, out);
 
   std::ostringstream error;
   error << opName << "(";
-  for (unsigned i = 0; i < in0.size(); i++)
-    error << (i ? ", " : "") << str(in0[i]);
+  for (unsigned i = 0; i < slots; i++)
+    error << (i ? ", " : "") << str(obj0[readsObject[i]]);
   error << ") = " << str(out0) << " became (";
-  for (unsigned i = 0; i < in.size(); i++)
-    error << (i ? ", " : "") << str(in[i]);
+  for (unsigned i = 0; i < slots; i++)
+    error << (i ? ", " : "") << str(obj[readsObject[i]]);
   error << ") = " << str(out) << ": ";
 
-  // Enumerate every concrete assignment of the children.
-  const unsigned slots = in0.size();
-  std::vector<unsigned> limit(slots);
+  // Enumerate every concrete assignment of the distinct objects. Aliased
+  // operands necessarily take the same value as each other.
+  std::vector<unsigned> limit(objects);
   unsigned total = 1;
-  for (unsigned i = 0; i < slots; i++)
+  for (unsigned o = 0; o < objects; o++)
   {
-    limit[i] = 1u << in0[i].getWidth();
-    total *= limit[i];
+    limit[o] = 1u << obj0[o].getWidth();
+    total *= limit[o];
   }
 
-  // The join of the solutions: for each operand position, which bits are
-  // zero in some solution and which are one in some solution. A bit every
-  // solution agrees on is the precision target.
+  // The join of the solutions: for each object, which bits are zero in some
+  // solution and which are one in some solution. A bit every solution agrees
+  // on is the precision target.
   bool anySolution = false;
-  std::vector<unsigned> seenZero(slots + 1, 0);
-  std::vector<unsigned> seenOne(slots + 1, 0);
+  std::vector<unsigned> seenZero(objects + 1, 0);
+  std::vector<unsigned> seenOne(objects + 1, 0);
 
+  std::vector<unsigned> objVal(objects);
   std::vector<unsigned> val(slots);
   for (unsigned code = 0; code < total; code++)
   {
     unsigned c = code;
     bool consistent = true;
-    for (unsigned i = 0; i < slots; i++)
+    for (unsigned o = 0; o < objects; o++)
     {
-      val[i] = c % limit[i];
-      c /= limit[i];
-      if (!admits(in0[i], val[i]))
+      objVal[o] = c % limit[o];
+      c /= limit[o];
+      if (!admits(obj0[o], objVal[o]))
       {
         consistent = false;
         break;
@@ -199,18 +283,20 @@ std::string checkCase(const std::string& opName, const Propagator& propagate,
     }
     if (!consistent)
       continue;
+    for (unsigned i = 0; i < slots; i++)
+      val[i] = objVal[readsObject[i]];
     const unsigned ov = op(val);
     if (!admits(out0, ov))
       continue;
 
     anySolution = true;
-    for (unsigned i = 0; i < slots; i++)
+    for (unsigned o = 0; o < objects; o++)
     {
-      seenZero[i] |= ~val[i];
-      seenOne[i] |= val[i];
+      seenZero[o] |= ~objVal[o];
+      seenOne[o] |= objVal[o];
     }
-    seenZero[slots] |= ~ov;
-    seenOne[slots] |= ov;
+    seenZero[objects] |= ~ov;
+    seenOne[objects] |= ov;
 
     // This assignment was consistent before propagation ran.
     if (result == CONFLICT)
@@ -222,8 +308,8 @@ std::string checkCase(const std::string& opName, const Propagator& propagate,
       return error.str();
     }
     bool excluded = !admits(out, ov);
-    for (unsigned i = 0; i < slots && !excluded; i++)
-      excluded = !admits(in[i], val[i]);
+    for (unsigned o = 0; o < objects && !excluded; o++)
+      excluded = !admits(obj[o], objVal[o]);
     if (excluded)
     {
       error << "unsoundly excluded the solution (";
@@ -234,25 +320,85 @@ std::string checkCase(const std::string& opName, const Propagator& propagate,
     }
   }
 
-  if (result == NO_CHANGE)
+  bool movedBits = !FixedBits::equals(out, out0);
+  for (unsigned o = 0; o < objects && !movedBits; o++)
+    movedBits = !FixedBits::equals(obj[o], obj0[o]);
+
+  if (result == NO_CHANGE && movedBits)
   {
-    bool changed = !FixedBits::equals(out, out0);
-    for (unsigned i = 0; i < slots && !changed; i++)
-      changed = !FixedBits::equals(in[i], in0[i]);
-    if (changed)
-    {
-      error << "returned NO_CHANGE but altered bits";
-      return error.str();
-    }
+    error << "returned NO_CHANGE but altered bits";
+    return error.str();
+  }
+
+  if (result == CHANGED && !movedBits)
+  {
+    error << "returned CHANGED but altered nothing";
+    return error.str();
+  }
+
+  if (result == NOT_IMPLEMENTED && sawNotImplemented != NULL)
+    *sawNotImplemented = true;
+
+  if (resultIsExact == RESULT_IS_EXACT && result == NOT_IMPLEMENTED)
+  {
+    error << "returned NOT_IMPLEMENTED, which says nothing about whether it "
+          << (movedBits ? "changed anything (it did)"
+                        : "changed anything (it did not)");
+    return error.str();
   }
 
   bool latticeOK = FixedBits::updateOK(out0, out);
-  for (unsigned i = 0; i < slots && latticeOK; i++)
-    latticeOK = FixedBits::updateOK(in0[i], in[i]);
+  for (unsigned o = 0; o < objects && latticeOK; o++)
+    latticeOK = FixedBits::updateOK(obj0[o], obj[o]);
   if (!latticeOK)
   {
     error << "unfixed or flipped already-fixed bits";
     return error.str();
+  }
+
+  // Keep calling until nothing more is derived. propagate() reschedules the
+  // other parents of a child that moved, but not the node it just ran, so
+  // whatever a later call would have found is simply lost in the solver.
+  // Runs on copies so the precision check below still sees what one call
+  // produces, which is all the solver gets.
+  if (result != CONFLICT)
+  {
+    std::vector<FixedBits> again(obj);
+    FixedBits againOut(out);
+    unsigned calls = 1;
+    while (true)
+    {
+      std::vector<FixedBits> before(again);
+      const FixedBits beforeOut(againOut);
+
+      std::vector<FixedBits*> againChildren;
+      for (unsigned i = 0; i < slots; i++)
+        againChildren.push_back(&again[readsObject[i]]);
+      const Result r = propagate(againChildren, againOut);
+
+      bool moved = !FixedBits::equals(againOut, beforeOut);
+      for (unsigned o = 0; o < objects && !moved; o++)
+        moved = !FixedBits::equals(again[o], before[o]);
+
+      if (!moved && r != CONFLICT)
+        break; // Settled.
+
+      calls++;
+      if (calls > callsAllowed)
+      {
+        error << "not settled after " << callsAllowed << " call"
+              << (callsAllowed == 1 ? "" : "s") << ": call " << calls
+              << " gives (";
+        for (unsigned i = 0; i < slots; i++)
+          error << (i ? ", " : "") << str(again[readsObject[i]]);
+        error << ") = " << str(againOut);
+        if (r == CONFLICT)
+          error << " CONFLICT";
+        return error.str();
+      }
+      if (r == CONFLICT)
+        break;
+    }
   }
 
   if (expectPrecise)
@@ -270,20 +416,20 @@ std::string checkCase(const std::string& opName, const Propagator& propagate,
     // Solutions exist, so CONFLICT was ruled out above. Every bit the
     // solutions all agree on must have come out fixed. (A bit fixed to
     // the wrong value is unsoundness, caught above.)
-    for (unsigned i = 0; i <= slots; i++)
+    for (unsigned o = 0; o <= objects; o++)
     {
-      const FixedBits& bits = (i == slots) ? out : in[i];
+      const FixedBits& bits = (o == objects) ? out : obj[o];
       for (unsigned j = 0; j < bits.getWidth(); j++)
       {
-        const bool zeroSeen = (seenZero[i] >> j) & 1;
-        const bool oneSeen = (seenOne[i] >> j) & 1;
+        const bool zeroSeen = (seenZero[o] >> j) & 1;
+        const bool oneSeen = (seenOne[o] >> j) & 1;
         if (zeroSeen && oneSeen)
           continue; // The solutions disagree, so the bit can't be fixed.
         if (!bits.isFixed(j))
         {
           error << "not maximally precise: every solution has "
-                << (i == slots ? "the output" : "child ")
-                << (i == slots ? std::string() : std::to_string(i))
+                << (o == objects ? "the output" : "child ")
+                << (o == objects ? std::string() : std::to_string(o))
                 << " bit " << j << " as " << (oneSeen ? '1' : '0')
                 << ", but it was left unfixed";
           return error.str();
@@ -296,20 +442,27 @@ std::string checkCase(const std::string& opName, const Propagator& propagate,
 }
 
 // Check every combination of fixed/zero/one bits over the given operand
-// shape. Reports at most the first five problems.
-void exhaustiveCheck(const std::string& opName, const Propagator& propagate,
-                     const Semantics& op, const std::vector<Slot>& ins,
-                     const Slot& outSlot, bool expectPrecise)
+// shape. objs describes the distinct FixedBits the call is given and
+// readsObject which of them each operand position reads. Reports at most the
+// first five problems.
+void exhaustiveCheckAliased(const std::string& opName,
+                            const Propagator& propagate, const Semantics& op,
+                            const std::vector<Slot>& objs,
+                            const Aliasing& readsObject, const Slot& outSlot,
+                            bool expectPrecise,
+                            unsigned callsAllowed = SETTLES_IN_ONE_CALL,
+                            ResultAccuracy resultIsExact = RESULT_IS_EXACT)
 {
-  const unsigned slots = ins.size();
-  std::vector<unsigned> patterns(slots);
+  bool sawNotImplemented = false;
+  const unsigned objects = objs.size();
+  std::vector<unsigned> patterns(objects);
   unsigned total = 1;
-  for (unsigned i = 0; i < slots; i++)
+  for (unsigned o = 0; o < objects; o++)
   {
-    patterns[i] = 1;
-    for (unsigned j = 0; j < ins[i].width; j++)
-      patterns[i] *= 3;
-    total *= patterns[i];
+    patterns[o] = 1;
+    for (unsigned j = 0; j < objs[o].width; j++)
+      patterns[o] *= 3;
+    total *= patterns[o];
   }
   unsigned outPatterns = 1;
   for (unsigned j = 0; j < outSlot.width; j++)
@@ -320,17 +473,19 @@ void exhaustiveCheck(const std::string& opName, const Propagator& propagate,
   for (unsigned code = 0; code < total && errors.size() < 5; code++)
   {
     unsigned c = code;
-    std::vector<FixedBits> in;
-    in.reserve(slots);
-    for (unsigned i = 0; i < slots; i++)
+    std::vector<FixedBits> obj;
+    obj.reserve(objects);
+    for (unsigned o = 0; o < objects; o++)
     {
-      in.push_back(fromTernary(ins[i].width, c % patterns[i], ins[i].isBoolean));
-      c /= patterns[i];
+      obj.push_back(fromTernary(objs[o].width, c % patterns[o],
+                                objs[o].isBoolean));
+      c /= patterns[o];
     }
     const FixedBits out = fromTernary(outSlot.width, c, outSlot.isBoolean);
 
-    const std::string e = checkCase(opName, propagate, op, in, out,
-                                    expectPrecise);
+    const std::string e = checkCase(opName, propagate, op, obj, readsObject,
+                                    out, expectPrecise, callsAllowed,
+                                    resultIsExact, &sawNotImplemented);
     if (!e.empty())
       errors.push_back(e);
   }
@@ -338,7 +493,28 @@ void exhaustiveCheck(const std::string& opName, const Propagator& propagate,
   std::ostringstream all;
   for (const auto& e : errors)
     all << e << "\n";
-  EXPECT_TRUE(errors.empty()) << all.str();
+  EXPECT_TRUE(errors.empty())
+      << (isAliased(readsObject) ? "aliased operands\n" : "") << all.str();
+
+  // Keep the exception list honest: a function marked RESULT_IS_VAGUE that
+  // never actually returns NOT_IMPLEMENTED has been fixed, and the marking
+  // should come off rather than sit there hiding a regression.
+  EXPECT_TRUE(resultIsExact == RESULT_IS_EXACT || sawNotImplemented ||
+              !errors.empty())
+      << opName << " is marked RESULT_IS_VAGUE but never returned "
+                   "NOT_IMPLEMENTED - drop the marking";
+}
+
+// The ordinary case: one distinct FixedBits per operand.
+void exhaustiveCheck(const std::string& opName, const Propagator& propagate,
+                     const Semantics& op, const std::vector<Slot>& ins,
+                     const Slot& outSlot, bool expectPrecise,
+                     unsigned callsAllowed = SETTLES_IN_ONE_CALL,
+                     ResultAccuracy resultIsExact = RESULT_IS_EXACT)
+{
+  exhaustiveCheckAliased(opName, propagate, op, ins,
+                         distinctOperands(ins.size()), outSlot, expectPrecise,
+                         callsAllowed, resultIsExact);
 }
 
 // Interpret an unsigned value of the given width as two's complement.
@@ -435,7 +611,7 @@ TEST_F(ConstantBitP_TransferFunctions, unsignedModulusExhaustiveWidth3)
       [](const std::vector<unsigned>& v) {
         return v[1] == 0 ? v[0] : v[0] % v[1];
       },
-      bv3(2), out3(), OVERAPPROXIMATES);
+      bv3(2), out3(), OVERAPPROXIMATES, SETTLES_IN_ONE_CALL, RESULT_IS_VAGUE);
 }
 
 // The three signed division operations were previously untested. None of
@@ -448,7 +624,7 @@ TEST_F(ConstantBitP_TransferFunctions, signedDivisionExhaustiveWidth3)
         return bvSignedDivisionBothWays(children, out, &mgr);
       },
       evaluatorSemantics(&mgr, stp::SBVDIV, 3), bv3(2), out3(),
-      OVERAPPROXIMATES);
+      OVERAPPROXIMATES, SETTLES_IN_ONE_CALL, RESULT_IS_VAGUE);
 }
 
 TEST_F(ConstantBitP_TransferFunctions, signedRemainderExhaustiveWidth3)
@@ -459,18 +635,24 @@ TEST_F(ConstantBitP_TransferFunctions, signedRemainderExhaustiveWidth3)
         return bvSignedRemainderBothWays(children, out, &mgr);
       },
       evaluatorSemantics(&mgr, stp::SBVREM, 3), bv3(2), out3(),
-      OVERAPPROXIMATES);
+      OVERAPPROXIMATES, SETTLES_IN_ONE_CALL, RESULT_IS_VAGUE);
 }
 
+// bvsmod is the only transfer function that fails to settle on a single call
+// with *distinct* children: 795 of the 19683 width-3 starting states derive
+// more on a later call, and 671 of those end in a CONFLICT the first call
+// missed. propagate() only ever gives it one call, so that reasoning is
+// currently unreachable in the solver.
 TEST_F(ConstantBitP_TransferFunctions, signedModulusExhaustiveWidth3)
 {
+  const unsigned bvsmodNeedsThreeCalls = 3;
   exhaustiveCheck(
       "bvsmod",
       [this](std::vector<FixedBits*>& children, FixedBits& out) {
         return bvSignedModulusBothWays(children, out, &mgr);
       },
       evaluatorSemantics(&mgr, stp::SBVMOD, 3), bv3(2), out3(),
-      OVERAPPROXIMATES);
+      OVERAPPROXIMATES, bvsmodNeedsThreeCalls);
 }
 
 TEST_F(ConstantBitP_TransferFunctions, multiplicationExhaustiveWidth3)
@@ -481,7 +663,7 @@ TEST_F(ConstantBitP_TransferFunctions, multiplicationExhaustiveWidth3)
         return bvMultiplyBothWays(children, out, &mgr, NULL);
       },
       [](const std::vector<unsigned>& v) { return (v[0] * v[1]) & 7; },
-      bv3(2), out3(), OVERAPPROXIMATES);
+      bv3(2), out3(), OVERAPPROXIMATES, SETTLES_IN_ONE_CALL, RESULT_IS_VAGUE);
 }
 
 // BVTypeCheck accepts BVMULT with more than two children, and the hashing
@@ -547,14 +729,14 @@ TEST_F(ConstantBitP_TransferFunctions, shiftsExhaustiveWidth3)
       [](const std::vector<unsigned>& v) {
         return v[1] >= 3 ? 0 : (v[0] << v[1]) & 7;
       },
-      bv3(2), out3(), MAX_PRECISE);
+      bv3(2), out3(), MAX_PRECISE, SETTLES_IN_ONE_CALL, RESULT_IS_VAGUE);
 
   exhaustiveCheck(
       "bvlshr", bvRightShiftBothWays,
       [](const std::vector<unsigned>& v) {
         return v[1] >= 3 ? 0 : v[0] >> v[1];
       },
-      bv3(2), out3(), MAX_PRECISE);
+      bv3(2), out3(), MAX_PRECISE, SETTLES_IN_ONE_CALL, RESULT_IS_VAGUE);
 
   exhaustiveCheck(
       "bvashr", bvArithmeticRightShiftBothWays,
@@ -565,7 +747,7 @@ TEST_F(ConstantBitP_TransferFunctions, shiftsExhaustiveWidth3)
         const unsigned shifted = v[0] >> v[1];
         return sign ? (shifted | (7u & ~(7u >> v[1]))) : shifted;
       },
-      bv3(2), out3(), MAX_PRECISE);
+      bv3(2), out3(), MAX_PRECISE, SETTLES_IN_ONE_CALL, RESULT_IS_VAGUE);
 }
 
 TEST_F(ConstantBitP_TransferFunctions, unsignedComparisonsExhaustiveWidth3)
@@ -745,7 +927,8 @@ TEST_F(ConstantBitP_TransferFunctions, zeroExtendExhaustiveWidth3To5)
       const std::string e =
           checkCase("zero_extend", bvZeroExtendBothWays,
                     [](const std::vector<unsigned>& v) { return v[0]; }, in,
-                    fromTernary(5, op), MAX_PRECISE);
+                    distinctOperands(in.size()), fromTernary(5, op),
+                    MAX_PRECISE);
       if (!e.empty())
         errors.push_back(e);
     }
@@ -769,7 +952,7 @@ TEST_F(ConstantBitP_TransferFunctions, signExtendExhaustiveWidth3To5)
           [](const std::vector<unsigned>& v) {
             return ((v[0] >> 2) & 1) ? (v[0] | 0x18u) : v[0];
           },
-          in, fromTernary(5, op), MAX_PRECISE);
+          in, distinctOperands(in.size()), fromTernary(5, op), MAX_PRECISE);
       if (!e.empty())
         errors.push_back(e);
     }
@@ -803,7 +986,8 @@ TEST_F(ConstantBitP_TransferFunctions, extractExhaustiveWidth3)
               [bottom, outWidth](const std::vector<unsigned>& v) {
                 return (v[0] >> bottom) & ((1u << outWidth) - 1);
               },
-              in, fromTernary(outWidth, op), MAX_PRECISE);
+              in, distinctOperands(in.size()), fromTernary(outWidth, op),
+              MAX_PRECISE);
           if (!e.empty())
             errors.push_back(e);
         }
@@ -856,6 +1040,472 @@ TEST_F(ConstantBitP_TransferFunctions, trailingOneReasoningSubsumesOld)
         ASSERT_TRUE(FixedBits::equals(x, x2))
             << "old reasoning mutated " << str(x) << " to " << str(x2);
       }
+}
+
+// ---------------------------------------------------------------------------
+// Aliased operands.
+//
+// ConstantBitPropagation::propagate() looks up one FixedBits per node, so a
+// node whose child list repeats a node hands the transfer function the same
+// pointer twice. These runs pass one shared FixedBits into several operand
+// slots and require soundness, the NO_CHANGE contract, the lattice rules and
+// the local fixed point - everything except maximal precision, which an
+// aliased call has no way to reach.
+// ---------------------------------------------------------------------------
+
+// n operand positions, all reading object 0.
+Aliasing allSame(unsigned arity)
+{
+  return Aliasing(arity, 0);
+}
+
+// Bounds for the functions that do not settle on one call when their
+// operands alias. These are measurements, not targets: propagate() calls the
+// function once, so every call past the first is reasoning the solver never
+// gets. See the aliased tests below for what each one loses.
+const unsigned TWO_CALLS = 2;
+const unsigned THREE_CALLS = 3;
+const unsigned FOUR_CALLS = 4;
+
+const std::vector<Slot> ONE_BV3(1, Slot{3, false});
+const std::vector<Slot> ONE_BOOL(1, Slot{1, true});
+
+// Only bvurem falls short here. x % x is 0 for every non-zero x and x for
+// x = 0, so an output with a one bit forces x = 0 and then contradicts
+// itself - but only on the second call. 6 of the 729 width-3 states are
+// UNSAT that the solver does not see.
+TEST_F(ConstantBitP_TransferFunctions, aliasedDivisionsWidth3)
+{
+  const unsigned mask = 7;
+  exhaustiveCheckAliased(
+      "bvudiv(x,x)",
+      [this](std::vector<FixedBits*>& children, FixedBits& out) {
+        return bvUnsignedDivisionBothWays(children, out, &mgr);
+      },
+      [](const std::vector<unsigned>& v) {
+        return v[1] == 0 ? mask : v[0] / v[1];
+      },
+      ONE_BV3, allSame(2), out3(), OVERAPPROXIMATES);
+
+  exhaustiveCheckAliased(
+      "bvurem(x,x)",
+      [this](std::vector<FixedBits*>& children, FixedBits& out) {
+        return bvUnsignedModulusBothWays(children, out, &mgr);
+      },
+      [](const std::vector<unsigned>& v) {
+        return v[1] == 0 ? v[0] : v[0] % v[1];
+      },
+      ONE_BV3, allSame(2), out3(), OVERAPPROXIMATES, TWO_CALLS, RESULT_IS_VAGUE);
+
+  exhaustiveCheckAliased(
+      "bvsdiv(x,x)",
+      [this](std::vector<FixedBits*>& children, FixedBits& out) {
+        return bvSignedDivisionBothWays(children, out, &mgr);
+      },
+      evaluatorSemantics(&mgr, stp::SBVDIV, 3), ONE_BV3, allSame(2), out3(),
+      OVERAPPROXIMATES);
+
+  exhaustiveCheckAliased(
+      "bvsrem(x,x)",
+      [this](std::vector<FixedBits*>& children, FixedBits& out) {
+        return bvSignedRemainderBothWays(children, out, &mgr);
+      },
+      evaluatorSemantics(&mgr, stp::SBVREM, 3), ONE_BV3, allSame(2), out3(),
+      OVERAPPROXIMATES);
+
+  exhaustiveCheckAliased(
+      "bvsmod(x,x)",
+      [this](std::vector<FixedBits*>& children, FixedBits& out) {
+        return bvSignedModulusBothWays(children, out, &mgr);
+      },
+      evaluatorSemantics(&mgr, stp::SBVMOD, 3), ONE_BV3, allSame(2), out3(),
+      OVERAPPROXIMATES);
+}
+
+TEST_F(ConstantBitP_TransferFunctions, aliasedMultiplicationWidth3)
+{
+  exhaustiveCheckAliased(
+      "bvmul(x,x)",
+      [this](std::vector<FixedBits*>& children, FixedBits& out) {
+        return bvMultiplyBothWays(children, out, &mgr, NULL);
+      },
+      [](const std::vector<unsigned>& v) { return (v[0] * v[1]) & 7; },
+      ONE_BV3, allSame(2), out3(), OVERAPPROXIMATES, SETTLES_IN_ONE_CALL, RESULT_IS_VAGUE);
+}
+
+TEST_F(ConstantBitP_TransferFunctions, aliasedArithmeticWidth3)
+{
+  exhaustiveCheckAliased(
+      "bvadd(x,x)", bvAddBothWays,
+      [](const std::vector<unsigned>& v) { return (v[0] + v[1]) & 7; },
+      ONE_BV3, allSame(2), out3(), OVERAPPROXIMATES);
+
+  exhaustiveCheckAliased(
+      "bvadd(x,x,x)", bvAddBothWays,
+      [](const std::vector<unsigned>& v) { return (v[0] + v[1] + v[2]) & 3; },
+      std::vector<Slot>(1, Slot{2, false}), allSame(3), Slot{2, false},
+      OVERAPPROXIMATES);
+
+  exhaustiveCheckAliased(
+      "bvsub(x,x)", bvSubtractBothWays,
+      [](const std::vector<unsigned>& v) { return (v[0] - v[1]) & 7; },
+      ONE_BV3, allSame(2), out3(), OVERAPPROXIMATES);
+}
+
+// x shifted by x: narrowing the shift amount from the output narrows the
+// value being shifted, which narrows the amount again. bvLeftShiftBothWays
+// iterates when its operands alias, so bvshl settles in one call; before that
+// it took two here and, because shlCore snapshots the value and the amount
+// separately and writes both back to the one object, up to six by width 31 -
+// which is why it iterates rather than running a fixed number of times. See
+// aliasedSettlesAtWideWidths, since width 3 badly understates this one.
+//
+// The two right shifts are unfixed. Both are unreachable in the solver: the
+// simplifying node factory rewrites bvlshr(x,x) to zero and bvashr(x,x) to a
+// sign extension of x's top bit, so neither shape survives node creation.
+// Their bounds below are width-3 measurements. Every state needing an extra
+// call is an UNSAT that would be missed: 95/729 for bvlshr, 62/729 for
+// bvashr.
+TEST_F(ConstantBitP_TransferFunctions, aliasedShiftsWidth3)
+{
+  exhaustiveCheckAliased(
+      "bvshl(x,x)", bvLeftShiftBothWays,
+      [](const std::vector<unsigned>& v) {
+        return v[1] >= 3 ? 0 : (v[0] << v[1]) & 7;
+      },
+      ONE_BV3, allSame(2), out3(), OVERAPPROXIMATES, SETTLES_IN_ONE_CALL,
+      RESULT_IS_VAGUE);
+
+  exhaustiveCheckAliased(
+      "bvlshr(x,x)", bvRightShiftBothWays,
+      [](const std::vector<unsigned>& v) {
+        return v[1] >= 3 ? 0 : v[0] >> v[1];
+      },
+      ONE_BV3, allSame(2), out3(), OVERAPPROXIMATES, FOUR_CALLS, RESULT_IS_VAGUE);
+
+  exhaustiveCheckAliased(
+      "bvashr(x,x)", bvArithmeticRightShiftBothWays,
+      [](const std::vector<unsigned>& v) {
+        const unsigned sign = (v[0] >> 2) & 1;
+        if (v[1] >= 3)
+          return sign ? 7u : 0u;
+        const unsigned shifted = v[0] >> v[1];
+        return sign ? (shifted | (7u & ~(7u >> v[1]))) : shifted;
+      },
+      ONE_BV3, allSame(2), out3(), OVERAPPROXIMATES, THREE_CALLS, RESULT_IS_VAGUE);
+}
+
+// x < x and x <= x are constants, so an output fixed the wrong way is UNSAT.
+// The transfer functions get there, but only on the second call: the first
+// narrows x against itself until it is fully fixed, and the contradiction is
+// visible only once it is. 12 of the 81 width-3 states per operator.
+TEST_F(ConstantBitP_TransferFunctions, aliasedComparisonsWidth3)
+{
+  const struct
+  {
+    const char* name;
+    Propagator prop;
+    std::function<bool(unsigned, unsigned)> cmp;
+  } unsignedOps[] = {
+      {"bvult(x,x)",
+       [](std::vector<FixedBits*>& c, FixedBits& o) {
+         return bvLessThanBothWays(c, o);
+       },
+       [](unsigned a, unsigned b) { return a < b; }},
+      {"bvule(x,x)", bvLessThanEqualsBothWays,
+       [](unsigned a, unsigned b) { return a <= b; }},
+      {"bvugt(x,x)", bvGreaterThanBothWays,
+       [](unsigned a, unsigned b) { return a > b; }},
+      {"bvuge(x,x)", bvGreaterThanEqualsBothWays,
+       [](unsigned a, unsigned b) { return a >= b; }},
+  };
+  for (const auto& o : unsignedOps)
+  {
+    const auto cmp = o.cmp;
+    exhaustiveCheckAliased(o.name, o.prop,
+                           [cmp](const std::vector<unsigned>& v) {
+                             return cmp(v[0], v[1]) ? 1u : 0u;
+                           },
+                           ONE_BV3, allSame(2), boolSlot(), OVERAPPROXIMATES,
+                           TWO_CALLS);
+  }
+
+  const struct
+  {
+    const char* name;
+    Propagator prop;
+    std::function<bool(int, int)> cmp;
+  } signedOps[] = {
+      {"bvslt(x,x)", bvSignedLessThanBothWays,
+       [](int a, int b) { return a < b; }},
+      {"bvsle(x,x)", bvSignedLessThanEqualsBothWays,
+       [](int a, int b) { return a <= b; }},
+      {"bvsgt(x,x)", bvSignedGreaterThanBothWays,
+       [](int a, int b) { return a > b; }},
+      {"bvsge(x,x)", bvSignedGreaterThanEqualsBothWays,
+       [](int a, int b) { return a >= b; }},
+  };
+  for (const auto& o : signedOps)
+  {
+    const auto cmp = o.cmp;
+    exhaustiveCheckAliased(
+        o.name, o.prop,
+        [cmp](const std::vector<unsigned>& v) {
+          return cmp(asSigned(v[0], 3), asSigned(v[1], 3)) ? 1u : 0u;
+        },
+        ONE_BV3, allSame(2), boolSlot(), OVERAPPROXIMATES, TWO_CALLS);
+  }
+}
+
+TEST_F(ConstantBitP_TransferFunctions, aliasedBitwiseWidth3)
+{
+  exhaustiveCheckAliased(
+      "bvand(x,x)", bvAndBothWays,
+      [](const std::vector<unsigned>& v) { return v[0] & v[1]; }, ONE_BV3,
+      allSame(2), out3(), OVERAPPROXIMATES);
+  exhaustiveCheckAliased(
+      "bvor(x,x)", bvOrBothWays,
+      [](const std::vector<unsigned>& v) { return v[0] | v[1]; }, ONE_BV3,
+      allSame(2), out3(), OVERAPPROXIMATES);
+  exhaustiveCheckAliased(
+      "bvxor(x,x)", bvXorBothWays,
+      [](const std::vector<unsigned>& v) { return v[0] ^ v[1]; }, ONE_BV3,
+      allSame(2), out3(), OVERAPPROXIMATES);
+  exhaustiveCheckAliased(
+      "=(x,x)", bvEqualsBothWays,
+      [](const std::vector<unsigned>& v) { return v[0] == v[1] ? 1u : 0u; },
+      ONE_BV3, allSame(2), boolSlot(), OVERAPPROXIMATES);
+}
+
+// and/or/xor/iff all settle on one call even aliased. implies(x,x) is the
+// exception: it is a tautology, so a false output is UNSAT, and that takes a
+// second call to see.
+TEST_F(ConstantBitP_TransferFunctions, aliasedBooleanLogic)
+{
+  exhaustiveCheckAliased(
+      "and(x,x)", bvAndBothWays,
+      [](const std::vector<unsigned>& v) { return v[0] & v[1]; }, ONE_BOOL,
+      allSame(2), boolSlot(), OVERAPPROXIMATES);
+  exhaustiveCheckAliased(
+      "and(x,x,x)", bvAndBothWays,
+      [](const std::vector<unsigned>& v) { return v[0] & v[1] & v[2]; },
+      ONE_BOOL, allSame(3), boolSlot(), OVERAPPROXIMATES);
+  exhaustiveCheckAliased(
+      "or(x,x)", bvOrBothWays,
+      [](const std::vector<unsigned>& v) { return v[0] | v[1]; }, ONE_BOOL,
+      allSame(2), boolSlot(), OVERAPPROXIMATES);
+  exhaustiveCheckAliased(
+      "or(x,x,x)", bvOrBothWays,
+      [](const std::vector<unsigned>& v) { return v[0] | v[1] | v[2]; },
+      ONE_BOOL, allSame(3), boolSlot(), OVERAPPROXIMATES);
+  exhaustiveCheckAliased(
+      "xor(x,x)", bvXorBothWays,
+      [](const std::vector<unsigned>& v) { return v[0] ^ v[1]; }, ONE_BOOL,
+      allSame(2), boolSlot(), OVERAPPROXIMATES);
+  exhaustiveCheckAliased(
+      "xor(x,x,x)", bvXorBothWays,
+      [](const std::vector<unsigned>& v) { return v[0] ^ v[1] ^ v[2]; },
+      ONE_BOOL, allSame(3), boolSlot(), OVERAPPROXIMATES);
+  exhaustiveCheckAliased(
+      "implies(x,x)", bvImpliesBothWays,
+      [](const std::vector<unsigned>& v) {
+        return (v[0] == 0 || v[1]) ? 1u : 0u;
+      },
+      ONE_BOOL, allSame(2), boolSlot(), OVERAPPROXIMATES, TWO_CALLS);
+  exhaustiveCheckAliased(
+      "iff(x,x)", bvEqualsBothWays,
+      [](const std::vector<unsigned>& v) { return v[0] == v[1] ? 1u : 0u; },
+      ONE_BOOL, allSame(2), boolSlot(), OVERAPPROXIMATES);
+}
+
+// ((_ repeat n) x) is exactly this shape, and it is what found the problem.
+// A single sweep goes least-significant operand first, so a bit written into
+// the shared child through a low operand is not read back out through a high
+// one until the next sweep - it cost 2 of the 27 two-operand states and 6 of
+// the 81 three-operand ones, as lost precision rather than missed conflicts.
+// bvConcatBothWays now sweeps twice when its operands alias, which is always
+// enough; aliasedSettlesAtWideWidths checks that at wider widths and arities.
+TEST_F(ConstantBitP_TransferFunctions, aliasedConcat)
+{
+  exhaustiveCheckAliased(
+      "concat(x,x)", bvConcatBothWays,
+      [](const std::vector<unsigned>& v) { return (v[0] << 1) | v[1]; },
+      std::vector<Slot>(1, Slot{1, false}), allSame(2), Slot{2, false},
+      OVERAPPROXIMATES);
+
+  exhaustiveCheckAliased(
+      "concat(x,x,x)", bvConcatBothWays,
+      [](const std::vector<unsigned>& v) {
+        return (v[0] << 2) | (v[1] << 1) | v[2];
+      },
+      std::vector<Slot>(1, Slot{1, false}), allSame(3), out3(),
+      OVERAPPROXIMATES);
+}
+
+// The two value operands of an ITE can be the same node; the guard cannot be
+// aliased with them, it has a different type.
+TEST_F(ConstantBitP_TransferFunctions, aliasedITEValuesWidth3)
+{
+  std::vector<Slot> objs;
+  objs.push_back(boolSlot());     // object 0: the guard.
+  objs.push_back(Slot{3, false}); // object 1: both value operands.
+
+  Aliasing readsObject;
+  readsObject.push_back(0);
+  readsObject.push_back(1);
+  readsObject.push_back(1);
+
+  exhaustiveCheckAliased(
+      "ite(c,x,x)", bvITEBothWays,
+      [](const std::vector<unsigned>& v) { return v[0] ? v[1] : v[2]; }, objs,
+      readsObject, out3(), OVERAPPROXIMATES);
+}
+
+// Partial aliasing: an n-ary node where only some operands share a node,
+// which is what the corpus actually shows for BVPLUS. allSame() above covers
+// the all-operands case; these cover the mixed one.
+TEST_F(ConstantBitP_TransferFunctions, partiallyAliasedNary)
+{
+  // Two width-2 objects: operands 0 and 2 read object 0, operand 1 reads
+  // object 1. So bvadd(x, y, x) and concat(x, y, x).
+  std::vector<Slot> objs2(2, Slot{2, false});
+  Aliasing xyx;
+  xyx.push_back(0);
+  xyx.push_back(1);
+  xyx.push_back(0);
+
+  exhaustiveCheckAliased(
+      "bvadd(x,y,x)", bvAddBothWays,
+      [](const std::vector<unsigned>& v) { return (v[0] + v[1] + v[2]) & 3; },
+      objs2, xyx, Slot{2, false}, OVERAPPROXIMATES);
+
+  exhaustiveCheckAliased(
+      "bvadd(x,x,y)", bvAddBothWays,
+      [](const std::vector<unsigned>& v) { return (v[0] + v[1] + v[2]) & 3; },
+      objs2, {0, 0, 1}, Slot{2, false}, OVERAPPROXIMATES);
+
+  const std::vector<Slot> objs1(2, Slot{1, false});
+  exhaustiveCheckAliased(
+      "concat(x,y,x)", bvConcatBothWays,
+      [](const std::vector<unsigned>& v) {
+        return (v[0] << 2) | (v[1] << 1) | v[2];
+      },
+      objs1, xyx, out3(), OVERAPPROXIMATES);
+
+  exhaustiveCheckAliased(
+      "concat(x,x,y)", bvConcatBothWays,
+      [](const std::vector<unsigned>& v) {
+        return (v[0] << 2) | (v[1] << 1) | v[2];
+      },
+      objs1, {0, 0, 1}, out3(), OVERAPPROXIMATES);
+
+  const std::vector<Slot> bools2(2, Slot{1, true});
+  exhaustiveCheckAliased(
+      "and(x,y,x)", bvAndBothWays,
+      [](const std::vector<unsigned>& v) { return v[0] & v[1] & v[2]; },
+      bools2, xyx, boolSlot(), OVERAPPROXIMATES);
+  exhaustiveCheckAliased(
+      "or(x,y,x)", bvOrBothWays,
+      [](const std::vector<unsigned>& v) { return v[0] | v[1] | v[2]; },
+      bools2, xyx, boolSlot(), OVERAPPROXIMATES);
+  exhaustiveCheckAliased(
+      "xor(x,y,x)", bvXorBothWays,
+      [](const std::vector<unsigned>& v) { return v[0] ^ v[1] ^ v[2]; },
+      bools2, xyx, boolSlot(), OVERAPPROXIMATES);
+
+  // bvmul is the other n-ary kind the corpus shows aliased. Above two
+  // operands its transfer function does nothing, so this is a no-op check
+  // that it stays that way.
+  const std::vector<Slot> bv3s(2, Slot{3, false});
+  exhaustiveCheckAliased(
+      "bvmul(x,y,x)",
+      [this](std::vector<FixedBits*>& children, FixedBits& out) {
+        return bvMultiplyBothWays(children, out, &mgr, NULL);
+      },
+      [](const std::vector<unsigned>& v) { return (v[0] * v[1] * v[2]) & 7; },
+      bv3s, xyx, out3(), OVERAPPROXIMATES);
+}
+
+// The exhaustive checks above only reach width 3, and for the shifts that is
+// far too narrow to be representative: before bvLeftShiftBothWays iterated,
+// aliased bvshl needed 2 calls at width 3 but 6 at width 31. This is the
+// same settling property at widths the exhaustive sweep cannot reach,
+// sampled rather than exhaustive.
+TEST_F(ConstantBitP_TransferFunctions, aliasedSettlesAtWideWidths)
+{
+  auto passes = [](const Propagator& prop, std::vector<FixedBits>& obj,
+                   FixedBits& out, const Aliasing& reads) {
+    unsigned productive = 0, guard = 0;
+    while (true)
+    {
+      std::vector<FixedBits> before(obj);
+      const FixedBits beforeOut(out);
+      std::vector<FixedBits*> ch;
+      for (unsigned i = 0; i < reads.size(); i++) ch.push_back(&obj[reads[i]]);
+      const Result r = prop(ch, out);
+      if (r == CONFLICT) { productive++; break; }
+      bool moved = !FixedBits::equals(out, beforeOut);
+      for (unsigned o = 0; o < obj.size() && !moved; o++)
+        moved = !FixedBits::equals(obj[o], before[o]);
+      if (!moved) break;
+      productive++;
+      if (++guard > 200) { productive = 9999; break; }
+    }
+    return productive;
+  };
+  uint64_t st = 0x9E3779B97F4A7C15ull;
+  auto rnd = [&st]() { st ^= st << 13; st ^= st >> 7; st ^= st << 17; return st; };
+  auto randomBits = [&](unsigned w, unsigned d) {
+    FixedBits b(w, false);
+    for (unsigned i = 0; i < w; i++)
+      if (rnd() % 100 < d) { b.setFixed(i, true); b.setValue(i, rnd() & 1); }
+    return b;
+  };
+  for (unsigned w : {1u,2u,3u,4u,5u,8u,16u,31u,32u,33u,64u})
+  {
+    unsigned worst = 0;
+    for (unsigned d = 5; d <= 95; d += 10)
+      for (unsigned t = 0; t < 4000; t++)
+      {
+        std::vector<FixedBits> obj{randomBits(w, d)};
+        FixedBits out = randomBits(w, d);
+        worst = std::max(worst, passes(bvLeftShiftBothWays, obj, out, allSame(2)));
+      }
+    EXPECT_LE(worst, 1u) << "bvshl(x,x) width " << w;
+  }
+  for (unsigned k : {2u,3u,4u,8u})
+    for (unsigned w : {1u,3u,8u,16u})
+    {
+      unsigned worst = 0;
+      for (unsigned d = 5; d <= 95; d += 10)
+        for (unsigned t = 0; t < 2000; t++)
+        {
+          std::vector<FixedBits> obj{randomBits(w, d)};
+          FixedBits out = randomBits(k * w, d);
+          worst = std::max(worst, passes(bvConcatBothWays, obj, out, allSame(k)));
+        }
+      EXPECT_LE(worst, 1u) << "concat x" << k << " width " << w;
+    }
+
+  // bvConcatBothWays runs a fixed two sweeps rather than iterating, which
+  // rests on every operand holding the full join after the first sweep. That
+  // argument does not care whether the aliasing is total or partial, so check
+  // a mixed pattern too: concat(x, y, x, y, x).
+  Aliasing mixed;
+  for (unsigned i = 0; i < 5; i++)
+    mixed.push_back(i % 2);
+  for (unsigned w : {1u, 3u, 8u})
+  {
+    unsigned worst = 0;
+    for (unsigned d = 5; d <= 95; d += 10)
+      for (unsigned t = 0; t < 2000; t++)
+      {
+        std::vector<FixedBits> obj{randomBits(w, d), randomBits(w, d)};
+        FixedBits out = randomBits(5 * w, d);
+        worst = std::max(worst, passes(bvConcatBothWays, obj, out, mixed));
+      }
+    EXPECT_LE(worst, 1u) << "concat(x,y,x,y,x) width " << w;
+  }
 }
 
 } // namespace


### PR DESCRIPTION
Found by a fuzzer: `--bb.conjoin-constant=1` on a QF_ABV file aborted in
`checkAtFixedPoint`.

## The bug

`ConstantBitPropagation` holds one `FixedBits` per *node*, so a node whose
child list repeats a node hands the transfer function the same pointer twice.
`((_ repeat n) x)` is nested `BVCONCAT(x, x)`. A write through one operand is
then already visible through the others, which a single left-to-right sweep
does not expect.

`propagate()` calls each node's transfer function exactly once — when a child
moves it reschedules that child's *other* parents but not the node it just ran
— so whatever a second call would have derived is lost. In the reproducer,
`BVCONCAT(x1, x1)` ended a sweep with its output bit 1 fixed and `x1` fixed,
but its own low bit still free:

```
PARENT kind: BVCONCAT num 60   60:(BVCONCAT 58:(BVCONCAT 42:x1 42:x1) 42:x1)
CHILD  index 0 kind: BVCONCAT num 58
before: <1->   after: <11>
```

Not a soundness bug — the lost fixed point only costs precision, so release
builds silently propagated less. The assertion was the only visible symptom.

## The fix

`bvConcatBothWays` sweeps twice when its operands alias. Two is always enough:
the operand-to-output map is a bijection per slot, so after the first sweep
every operand holds the join of all the output slots that read it, and the
second only broadcasts that back.

`bvLeftShiftBothWays` iterates instead. `shlCore` snapshots the value and the
amount into separate `PackedBits` and writes both back into the one
`FixedBits`, and randomised sweeps reach **six** passes by width 31, so there
is no fixed bound to lean on. (Width 3 shows only two — badly misleading.)

Both skip the extra work when the operands are distinct, so unaliased
behaviour is unchanged and the cost there is a pointer compare.

## Why only these two

The simplifying node factory folds the other aliased shapes away at creation:

| shape | factory result |
| --- | --- |
| `concat(x,x)` | `BVCONCAT` — **survives** |
| `bvshl(x,x)`, width > 1 | `BVLEFTSHIFT` — **survives** |
| `bvshl(x,x)`, width 1 | `0` |
| `bvlshr(x,x)`, `bvurem(x,x)` | `0` |
| `bvashr(x,x)` | `BVSX(x[w-1:w-1])` |
| the eight comparisons | `TRUE`/`FALSE` |
| `implies(b,b)` | `TRUE` |

A tally over ~3050 files agrees: `BVCONCAT` and `BVLEFTSHIFT` are the only
aliased kinds reaching a transfer function that failed to settle. The
overflow predicates reach `default: notHandled` and have no transfer function
at all.

## Tests

`ConstantBitP_TransferFunctions_Test.cpp` grows two properties.

**Aliasing.** Each operator is now checked twice — once with a distinct
`FixedBits` per operand, once with one shared between several operand slots —
for soundness, the `Result` contract, the lattice rules and settling. Maximal
precision stays unaliased-only: an aliased call cannot know its two reads must
agree. Partial aliasing (`bvadd(x,y,x)`, `concat(x,y,x)`) is covered too, since
the corpus shows it for `BVPLUS`.

**Settling.** Calling a function again on the bits the previous call produced
must derive nothing. A call site may declare a higher bound, which records a
measured shortfall rather than granting permission; every declared bound was
checked to be tight. Remaining offenders are the two right shifts (unreachable
in the solver, see the table above) and **`bvsmod`**, which is the one case
with *distinct* children: three calls on 795 of 19683 width-3 states, 671 of
which end in a `CONFLICT` the solver never sees. Not addressed here.

Property 2 also widens from "NO_CHANGE must not have moved bits" to the full
contract, with `CHANGED` required to mean a bit moved — nothing violates that.
`NOT_IMPLEMENTED`, which says nothing either way, is rejected unless the call
site is marked `RESULT_IS_VAGUE`. Seven functions still need it, and a marking
that stops being needed fails rather than lingering. Worth knowing for anyone
writing a loop over a transfer function: `while (r == CHANGED)` exits
immediately on a shifter that is still deriving bits, and `while (r !=
NO_CHANGE)` never exits at all.

`aliasedSettlesAtWideWidths` samples widths to 64 and concat arities to 8,
because width 3 understates the shifts so badly.

## Verification

| check | result |
| --- | --- |
| the reproducer, with and without `--bb.conjoin-constant=1` | `sat`, agrees with z3 |
| `ctest` — 66 targets including 182 lit tests | pass |
| assertions build, `--bb.conjoin-constant=1`, 2501 fuzz files | 0 failures |
| release before vs after, sat/unsat, 2501 files | 0 diffs |
| interleaved A/B to CNF, 60 QF_BV files | 82.8s vs 83.6s — noise |
