### PR TITLE
Make the CNF reproducible across compilers and allocators

### DIFF
--- a/include/stp/ToSat/BBNodeManagerAIG.h
+++ b/include/stp/ToSat/BBNodeManagerAIG.h
@@ -45,6 +45,46 @@ class STPMgr; // we ignore this anyway.
 
 extern vector<BBNodeAIG> _empty_BBNodeAIGVec;
 
+/* ABC's Aig_Exor() and Aig_Mux2() both build their result with two Aig_And()
+ * calls sitting in a single Aig_Or() argument list. The order that function
+ * arguments are evaluated in is unspecified, so GCC (right to left) and Clang
+ * (left to right) create those two AIG nodes in opposite orders. The nodes get
+ * different Ids, and because Ids are what everything downstream sorts on, the
+ * CNF we emit isn't the same from one compiler to the next.
+ *
+ * These build the same nodes in a fixed order. Aside from the sequencing they
+ * match aigOper.c exactly, so use them in preference to ABC's versions.
+ */
+inline Aig_Obj_t* orderedAigExor(Aig_Man_t* p, Aig_Obj_t* p0, Aig_Obj_t* p1)
+{
+  // Aig_Exor()'s fCatchExor branch isn't reproduced here. Nothing in STP turns
+  // that on, and Aig_ManStart() leaves it off.
+  assert(!p->fCatchExor);
+
+  if (p0 == p1)
+    return Aig_ManConst0(p);
+  if (p0 == Aig_Not(p1))
+    return Aig_ManConst1(p);
+  if (Aig_Regular(p0) == Aig_ManConst1(p))
+    return Aig_NotCond(p1, p0 == Aig_ManConst1(p));
+  if (Aig_Regular(p1) == Aig_ManConst1(p))
+    return Aig_NotCond(p0, p1 == Aig_ManConst1(p));
+
+  Aig_Obj_t* const positive = Aig_And(p, p0, Aig_Not(p1));
+  Aig_Obj_t* const negative = Aig_And(p, Aig_Not(p0), p1);
+  return Aig_Or(p, positive, negative);
+}
+
+// Aig_Mux() hard-codes fUseMuxCanon to zero, so it always just hands over to
+// Aig_Mux2(). This is Aig_Mux2().
+inline Aig_Obj_t* orderedAigMux(Aig_Man_t* p, Aig_Obj_t* pC, Aig_Obj_t* p1,
+                                Aig_Obj_t* p0)
+{
+  Aig_Obj_t* const thn = Aig_And(p, pC, p1);
+  Aig_Obj_t* const els = Aig_And(p, Aig_Not(pC), p0);
+  return Aig_Or(p, thn, els);
+}
+
 // Creates AIG nodes with ABC and wraps them in BBNodeAIG's.
 class BBNodeManagerAIG
 {
@@ -199,14 +239,14 @@ public:
 
       case XOR:
         if (children.size() == 2)
-          pNode = Aig_Exor(aigMgr, children[0].n, children[1].n);
+          pNode = orderedAigExor(aigMgr, children[0].n, children[1].n);
         else
-          pNode = makeTower(Aig_Exor, children);
+          pNode = makeTower(orderedAigExor, children);
         break;
 
       case IFF:
         assert(children.size() == 2);
-        pNode = Aig_Exor(aigMgr, children[0].n, children[1].n);
+        pNode = orderedAigExor(aigMgr, children[0].n, children[1].n);
         pNode = Aig_Not(pNode);
         break;
 
@@ -217,7 +257,8 @@ public:
 
       case ITE:
         assert(children.size() == 3);
-        pNode = Aig_Mux(aigMgr, children[0].n, children[1].n, children[2].n);
+        pNode =
+            orderedAigMux(aigMgr, children[0].n, children[1].n, children[2].n);
         break;
 
       default:

--- a/lib/NodeFactory/SimplifyingNodeFactory.cpp
+++ b/lib/NodeFactory/SimplifyingNodeFactory.cpp
@@ -205,11 +205,17 @@ ASTNode SimplifyingNodeFactory::create_gt_node(const ASTVec& children)
     const auto width = children[0].GetValueWidth();
     const auto zero =NodeFactory::CreateZeroConst(width);
 
+    // Named variables, so that the nodes aren't built in whatever order the
+    // compiler picks to evaluate the arguments in.
+    const ASTNode isZero = NodeFactory::CreateNode(EQ, children[1], zero);
+    const ASTNode isPositive =
+        NodeFactory::CreateNode(stp::BVGT, children[0][0], zero);
+
     return NodeFactory::CreateNode
     (
         stp::AND,
-        NodeFactory::CreateNode(EQ, children[1], zero ),
-        NodeFactory::CreateNode(stp::BVGT, children[0][0], zero)
+        isZero,
+        isPositive
     );
   }
 
@@ -713,9 +719,9 @@ ASTNode SimplifyingNodeFactory::CreateSimpleEQ(const ASTVec& children)
       in2[2].GetKind() == stp::BVCONST)
   {
 
-    ASTNode result = NodeFactory::CreateNode(
-        ITE, in2[0], NodeFactory::CreateNode(EQ, in1, in2[1]),
-        NodeFactory::CreateNode(EQ, in1, in2[2]));
+    const ASTNode thn = NodeFactory::CreateNode(EQ, in1, in2[1]);
+    const ASTNode els = NodeFactory::CreateNode(EQ, in1, in2[2]);
+    ASTNode result = NodeFactory::CreateNode(ITE, in2[0], thn, els);
 
     return result;
   }
@@ -2343,18 +2349,19 @@ ASTNode SimplifyingNodeFactory::CreateTerm(Kind kind, unsigned int width,
         }
         if (!t.IsNull())
         {
-          const ASTNode cond = NodeFactory::CreateNode(
-              stp::AND,
-              NodeFactory::CreateNode(
-                  EQ, NodeFactory::CreateTerm(stp::BVAND, width, s, t), s),
-              NodeFactory::CreateNode(stp::BVLT, s, t));
-          result = NodeFactory::CreateTerm(
-              ITE, width,
-              NodeFactory::CreateNode(EQ, s, bm.CreateZeroConst(width)),
-              bm.CreateMaxConst(width),
-              NodeFactory::CreateTerm(ITE, width, cond,
-                                      bm.CreateOneConst(width),
-                                      bm.CreateZeroConst(width)));
+          const ASTNode subsumes = NodeFactory::CreateNode(
+              EQ, NodeFactory::CreateTerm(stp::BVAND, width, s, t), s);
+          const ASTNode smaller = NodeFactory::CreateNode(stp::BVLT, s, t);
+          const ASTNode cond =
+              NodeFactory::CreateNode(stp::AND, subsumes, smaller);
+          const ASTNode sIsZero =
+              NodeFactory::CreateNode(EQ, s, bm.CreateZeroConst(width));
+          const ASTNode oneOrZero = NodeFactory::CreateTerm(
+              ITE, width, cond, bm.CreateOneConst(width),
+              bm.CreateZeroConst(width));
+          result =
+              NodeFactory::CreateTerm(ITE, width, sIsZero,
+                                      bm.CreateMaxConst(width), oneOrZero);
         }
       }
 

--- a/lib/Simplifier/AIGSimplifyPropositionalCore.cpp
+++ b/lib/Simplifier/AIGSimplifyPropositionalCore.cpp
@@ -140,9 +140,12 @@ ASTNode AIGSimplifyPropositionalCore::convert(BBNodeManagerAIG& mgr,
     return nf->CreateNode(NOT, convert(mgr, Aig_Regular(obj), cache));
   else if (Aig_ObjIsAnd(obj))
   {
-    ASTNode result =
-        nf->CreateNode(AND, convert(mgr, Aig_ObjChild0(obj), cache),
-                       convert(mgr, Aig_ObjChild1(obj), cache));
+    // Argument evaluation order is unspecified, so convert each child into a
+    // named variable first, otherwise the nodes are built in a
+    // compiler-dependent order.
+    const ASTNode child0 = convert(mgr, Aig_ObjChild0(obj), cache);
+    const ASTNode child1 = convert(mgr, Aig_ObjChild1(obj), cache);
+    ASTNode result = nf->CreateNode(AND, child0, child1);
     cache.insert(make_pair(obj, result));
     return result;
   }

--- a/lib/Simplifier/RemoveUnconstrained.cpp
+++ b/lib/Simplifier/RemoveUnconstrained.cpp
@@ -33,6 +33,7 @@ THE SOFTWARE.
 #include "stp/Simplifier/RemoveUnconstrained.h"
 #include "stp/AST/MutableASTNode.h"
 #include "stp/Simplifier/constantBitP/Dependencies.h"
+#include <algorithm>
 
 namespace stp
 {
@@ -136,6 +137,15 @@ void RemoveUnconstrained::splitExtractOnly(vector<MutableASTNode*> extracts)
     vector<MutableASTNode*> mut;
     mut.insert(mut.end(), extracts[i]->parents.begin(),
                extracts[i]->parents.end());
+
+    // 'parents' is hashed on the pointer, so it enumerates in an order that
+    // depends on where the allocator happened to put the nodes. We create a
+    // fresh variable per parent below, so that order ends up in the CNF. Sort
+    // on the node number to keep the output the same from run to run.
+    std::sort(mut.begin(), mut.end(),
+              [](const MutableASTNode* a, const MutableASTNode* b) {
+                return a->n.GetNodeNum() < b->n.GetNodeNum();
+              });
 
     for (vector<MutableASTNode*>::iterator it = mut.begin(); it != mut.end();
          it++)

--- a/lib/Simplifier/Simplifier.cpp
+++ b/lib/Simplifier/Simplifier.cpp
@@ -799,8 +799,11 @@ ASTNode Simplifier::CreateSimplifiedEQ(const ASTNode& in1, const ASTNode& in2)
   if (k1 == BVCONCAT && k2 == BVCONCAT &&
       in1[0].GetValueWidth() == in2[0].GetValueWidth())
   {
-    return nf->CreateNode(AND, nf->CreateNode(EQ, in1[0], in2[0]),
-                          nf->CreateNode(EQ, in1[1], in2[1]));
+    // Named variables, so that the nodes aren't built in whatever order the
+    // compiler picks to evaluate the arguments in.
+    const ASTNode topEq = nf->CreateNode(EQ, in1[0], in2[0]);
+    const ASTNode bottomEq = nf->CreateNode(EQ, in1[1], in2[1]);
+    return nf->CreateNode(AND, topEq, bottomEq);
   }
 
   // If the rhs is a concat, and the lhs is a constant. Split.
@@ -819,8 +822,9 @@ ASTNode Simplifier::CreateSimplifiedEQ(const ASTNode& in1, const ASTNode& in2)
     assert(BVTypeCheck(top));
     assert(BVTypeCheck(bottom));
 
-    ASTNode r = nf->CreateNode(AND, nf->CreateNode(EQ, top, in2[0]),
-                               nf->CreateNode(EQ, bottom, in2[1]));
+    const ASTNode topEq = nf->CreateNode(EQ, top, in2[0]);
+    const ASTNode bottomEq = nf->CreateNode(EQ, bottom, in2[1]);
+    ASTNode r = nf->CreateNode(AND, topEq, bottomEq);
 
     return r;
   }
@@ -2156,12 +2160,14 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
           inputterm[1].GetKind() == BVCONCAT &&
           inputterm[0][0].GetValueWidth() == inputterm[1][0].GetValueWidth())
       {
-        output =
-            nf->CreateTerm(BVCONCAT, inputterm.GetValueWidth(),
-                           nf->CreateTerm(k, inputterm[0][0].GetValueWidth(),
-                                          inputterm[0][0], inputterm[1][0]),
-                           nf->CreateTerm(k, inputterm[0][1].GetValueWidth(),
-                                          inputterm[0][1], inputterm[1][1]));
+        const ASTNode top =
+            nf->CreateTerm(k, inputterm[0][0].GetValueWidth(),
+                           inputterm[0][0], inputterm[1][0]);
+        const ASTNode bottom =
+            nf->CreateTerm(k, inputterm[0][1].GetValueWidth(),
+                           inputterm[0][1], inputterm[1][1]);
+        output = nf->CreateTerm(BVCONCAT, inputterm.GetValueWidth(), top,
+                                bottom);
         break;
       }
 
@@ -2286,18 +2292,20 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
         {
           // i contains the number of leading zeroes.
           if (i < output.GetValueWidth())
-            output = nf->CreateTerm(
-                BVCONCAT, output.GetValueWidth(), nf->CreateZeroConst(i),
-                nf->CreateTerm(
-                    BVAND, output.GetValueWidth() - i,
-                    nf->CreateTerm(
-                        BVEXTRACT, output.GetValueWidth() - i, output[0],
-                        nf->CreateBVConst(32, output.GetValueWidth() - i - 1),
-                        nf->CreateBVConst(32, 0)),
-                    nf->CreateTerm(
-                        BVEXTRACT, output.GetValueWidth() - i, output[1],
-                        nf->CreateBVConst(32, output.GetValueWidth() - i - 1),
-                        nf->CreateBVConst(32, 0))));
+          {
+            const unsigned rest = output.GetValueWidth() - i;
+            const ASTNode lhs =
+                nf->CreateTerm(BVEXTRACT, rest, output[0],
+                               nf->CreateBVConst(32, rest - 1),
+                               nf->CreateBVConst(32, 0));
+            const ASTNode rhs =
+                nf->CreateTerm(BVEXTRACT, rest, output[1],
+                               nf->CreateBVConst(32, rest - 1),
+                               nf->CreateBVConst(32, 0));
+            output = nf->CreateTerm(BVCONCAT, output.GetValueWidth(),
+                                    nf->CreateZeroConst(i),
+                                    nf->CreateTerm(BVAND, rest, lhs, rhs));
+          }
 
           assert(BVTypeCheck(output));
         }
@@ -2386,12 +2394,14 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
           inputterm[1].GetKind() == BVCONCAT &&
           inputterm[0][0].GetValueWidth() == inputterm[1][0].GetValueWidth())
       {
-        output =
-            nf->CreateTerm(BVCONCAT, inputterm.GetValueWidth(),
-                           nf->CreateTerm(k, inputterm[0][0].GetValueWidth(),
-                                          inputterm[0][0], inputterm[1][0]),
-                           nf->CreateTerm(k, inputterm[0][1].GetValueWidth(),
-                                          inputterm[0][1], inputterm[1][1]));
+        const ASTNode top =
+            nf->CreateTerm(k, inputterm[0][0].GetValueWidth(),
+                           inputterm[0][0], inputterm[1][0]);
+        const ASTNode bottom =
+            nf->CreateTerm(k, inputterm[0][1].GetValueWidth(),
+                           inputterm[0][1], inputterm[1][1]);
+        output = nf->CreateTerm(BVCONCAT, inputterm.GetValueWidth(), top,
+                                bottom);
         break;
       }
     }

--- a/lib/Simplifier/StrengthReduction.cpp
+++ b/lib/Simplifier/StrengthReduction.cpp
@@ -284,8 +284,11 @@ namespace stp
         {
           const ASTNode touch = nf->CreateConstant(
               CONSTANTBV::BitVector_Clone(lo), n[0].GetValueWidth());
-          newN = nf->CreateNode(AND, nf->CreateNode(EQ, touch, n[0]),
-                                nf->CreateNode(EQ, touch, n[1]));
+          // Named variables, so that the nodes aren't built in whatever order
+          // the compiler picks to evaluate the arguments in.
+          const ASTNode eq0 = nf->CreateNode(EQ, touch, n[0]);
+          const ASTNode eq1 = nf->CreateNode(EQ, touch, n[1]);
+          newN = nf->CreateNode(AND, eq0, eq1);
           replaceWithSimpler++;
         }
       }
@@ -476,14 +479,14 @@ namespace stp
 
               if (lowFits && k > 0 && k < width)
               {
-                newN = nf->CreateTerm(
-                    BVCONCAT, width,
-                    nf->CreateTerm(BVEXTRACT, width - k, n[i],
-                                   nf->CreateBVConst(32, width - 1),
-                                   nf->CreateBVConst(32, k)),
-                    nf->CreateTerm(BVEXTRACT, k, n[1 - i],
-                                   nf->CreateBVConst(32, k - 1),
-                                   nf->CreateBVConst(32, 0)));
+                const ASTNode top = nf->CreateTerm(
+                    BVEXTRACT, width - k, n[i],
+                    nf->CreateBVConst(32, width - 1),
+                    nf->CreateBVConst(32, k));
+                const ASTNode bottom = nf->CreateTerm(
+                    BVEXTRACT, k, n[1 - i], nf->CreateBVConst(32, k - 1),
+                    nf->CreateBVConst(32, 0));
+                newN = nf->CreateTerm(BVCONCAT, width, top, bottom);
                 break;
               }
             }
@@ -612,16 +615,17 @@ namespace stp
                              nf->CreateBVConst(32, width - 1),
                              nf->CreateBVConst(32, rest)));
 
-          const ASTNode narrowed = nf->CreateTerm(
-              BVCONCAT, width, nf->CreateZeroConst(nlz),
-              nf->CreateTerm(
-                  kind, rest,
-                  nf->CreateTerm(BVEXTRACT, rest, n[0],
-                                 nf->CreateBVConst(32, rest - 1),
-                                 nf->CreateBVConst(32, 0)),
-                  nf->CreateTerm(BVEXTRACT, rest, n[1],
-                                 nf->CreateBVConst(32, rest - 1),
-                                 nf->CreateBVConst(32, 0))));
+          const ASTNode lhs =
+              nf->CreateTerm(BVEXTRACT, rest, n[0],
+                             nf->CreateBVConst(32, rest - 1),
+                             nf->CreateBVConst(32, 0));
+          const ASTNode rhs =
+              nf->CreateTerm(BVEXTRACT, rest, n[1],
+                             nf->CreateBVConst(32, rest - 1),
+                             nf->CreateBVConst(32, 0));
+          const ASTNode narrowed =
+              nf->CreateTerm(BVCONCAT, width, nf->CreateZeroConst(nlz),
+                             nf->CreateTerm(kind, rest, lhs, rhs));
 
           const ASTNode otherwise =
               (kind == BVDIV) ? nf->CreateZeroConst(width) : n[0];
@@ -712,9 +716,9 @@ namespace stp
     const ASTNode commonNode = nf->CreateConstant(
         CONSTANTBV::BitVector_Clone(common), n[0].GetValueWidth());
 
-    ASTNode newN =
-        nf->CreateNode(AND, nf->CreateNode(EQ, commonNode, n[0]),
-                       nf->CreateNode(EQ, commonNode, n[1]));
+    const ASTNode eq0 = nf->CreateNode(EQ, commonNode, n[0]);
+    const ASTNode eq1 = nf->CreateNode(EQ, commonNode, n[1]);
+    ASTNode newN = nf->CreateNode(AND, eq0, eq1);
     replaceWithSimpler++;
     return newN;
   }

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -1118,10 +1118,17 @@ const BBNode BitBlaster<BBNode, BBNodeManagerT>::BBForm(const ASTNode& form,
       break;
 
     case ITE:
-      result =
-          nf->CreateNode(ITE, BBForm(form[0], support),
-                         BBForm(form[1], support), BBForm(form[2], support));
+    {
+      // The order that arguments to a function are evaluated in is
+      // unspecified, so bit-blast each child into a named variable first.
+      // Otherwise the nodes are created in a compiler-dependent order, and
+      // the CNF that STP produces isn't the same across compilers.
+      const BBNode cond = BBForm(form[0], support);
+      const BBNode thn = BBForm(form[1], support);
+      const BBNode els = BBForm(form[2], support);
+      result = nf->CreateNode(ITE, cond, thn, els);
       break;
+    }
 
     case AND:
     case OR:
@@ -1284,8 +1291,13 @@ BBNode BitBlaster<BBNode, BBNodeManagerT>::Majority(const BBNode& a,
   // worth doing explicitly (e.g., a = b, a = ~b, etc.)
   else
   {
-    return nf->CreateNode(OR, nf->CreateNode(AND, a, b),
-                          nf->CreateNode(AND, b, c), nf->CreateNode(AND, a, c));
+    // Argument evaluation order is unspecified, so build each conjunction into
+    // a named variable first. Otherwise the AIG nodes are created in a
+    // compiler-dependent order, and the CNF isn't the same across compilers.
+    const BBNode ab = nf->CreateNode(AND, a, b);
+    const BBNode bc = nf->CreateNode(AND, b, c);
+    const BBNode ac = nf->CreateNode(AND, a, c);
+    return nf->CreateNode(OR, ab, bc, ac);
   }
 }
 
@@ -1493,9 +1505,13 @@ void BitBlaster<BBNode, BBNodeManagerT>::buildAdditionNetworkResult(
     }
     else
     {
-      carry =
-          nf->CreateNode(OR, nf->CreateNode(AND, a, b),
-                         nf->CreateNode(AND, b, c), nf->CreateNode(AND, a, c));
+      // As in Majority(), the conjunctions have to be built into named
+      // variables so that the order they're created in doesn't depend on the
+      // compiler's choice of argument evaluation order.
+      const BBNode ab = nf->CreateNode(AND, a, b);
+      const BBNode bc = nf->CreateNode(AND, b, c);
+      const BBNode ac = nf->CreateNode(AND, a, c);
+      carry = nf->CreateNode(OR, ab, bc, ac);
       sum = nf->CreateNode(XOR, nf->CreateNode(XOR, c, b), a);
     }
 


### PR DESCRIPTION
Given the same SMT-LIB2 input, STP did not necessarily produce the same CNF.
Runs of one binary agreed, and so did `-O1`/`-O2`/`-O3` under one compiler, but
**GCC and Clang disagreed on 187 of 244 files, and merely swapping the memory
allocator changed the CNF on 60 of 244.**

Two causes.

### Unspecified argument evaluation order

C++ does not specify the order function arguments are evaluated in. GCC goes
right to left, Clang left to right. Node identity here is a creation counter
(`node_uid`, `Aig_Obj_t::Id`), and that counter is what `ASTNode::operator<`,
`SortByExprNum`, `PropagateEqualities`' priority queue and `ArrayTransformer`'s
`std::map` all order on. So wherever we wrote

```cpp
nf->CreateNode(OR, nf->CreateNode(AND, a, b), nf->CreateNode(AND, b, c), ...)
```

the two compilers built a different formula. Each such site now hoists its
arguments into named locals first.

The two that mattered most are in ABC — `Aig_Exor` and `Aig_Mux2`, hit by
every XOR and every ITE, so by essentially every bitvector operation. Rather
than patch the submodule, `BBNodeManagerAIG.h` grows `orderedAigExor()` and
`orderedAigMux()`. We call those two functions from exactly four places and
nowhere else, and ABC's own callers are all in packages we never touch. The
copies are exact: `Aig_Exor`'s `fCatchExor` branch is unreachable
(`Aig_ManStart()` clears it, we never set it, and the replacement asserts so),
and `Aig_Mux` hard-codes `fUseMuxCanon = 0` so it always delegates to
`Aig_Mux2`. **The submodule pointer is untouched.**

The rest are in the adder's `Majority()`, `BBForm`'s ITE case,
`SimplifyingNodeFactory`, `Simplifier`, `StrengthReduction` and
`AIGSimplifyPropositionalCore`.

### Address-ordered iteration in RemoveUnconstrained

`MutableASTNode::parents` is an `unordered_set` hashed on the **pointer**.
`splitExtractOnly()` creates one fresh variable per parent in enumeration
order, so variable creation followed the allocator's layout. This was the
entire allocator sensitivity — disabling that one pass took the
mimalloc-vs-system-malloc difference from 60/60 to 0/60. Now sorted on
`GetNodeNum()`.

Worth noting it survived ASLR, because ASLR shifts the heap base but leaves the
relative layout intact. Repeat-run equality is not evidence that code is
address-independent.

### Verification

Corpus of 244 CNF-producing files (195 from QF_BV, largest CNF 11 MB, plus 49
fuzz files), hashing `output_0.cnf` from `stp -r --output-CNF --exit-after-CNF`.
Differing files against gcc -O1:

| configuration | before | after |
| --- | --- | --- |
| gcc -O1, rerun (ASLR on) | 0 | 0 |
| gcc -O2 | 0 | 0 |
| gcc -O3 | 0 | 0 |
| clang -O2 | 187 | **0** |
| gcc -O2, `STP_ALLOCATOR=system` | 60 | **0** |

Also byte-identical across compilers under `--bit-blast-simplification -1`,
`--aig-core-simplification 1`, `--aig-rewrite-passes 2`,
`--ite-context-simplifications 1`, `--size-reducing-only` and
`--disable-cbitp`.

- 68/68 ctest pass.
- No sat/unsat disagreements against the pre-change binary over 900 fuzz files.
- CNF size effect: aggregate −0.46%, mean per file +0.05%. GCC now builds in
  what used to be Clang's order, so its output does move, but this is a
  reordering rather than a structural change.

Upstream ABC has not fixed `Aig_Exor`/`Aig_Mux2` — both are unchanged at HEAD
(`c1f9a942c`), and no upstream issue mentions it. Nothing here depends on that
changing. The same pattern exists in `hopOper.c` and in the unreached canonical
branches of `Aig_Mux`/`Aig_Maj`, which would be worth including if anyone
raises a PR there.
