### PR TITLE
Harden the fuzzing scripts and use z3 as the reference solver

### DIFF
--- a/scripts/fuzz/fuzz.sh
+++ b/scripts/fuzz/fuzz.sh
@@ -6,10 +6,12 @@
 # Usage: fuzz.sh [jobs]
 #
 # Environment:
-#   JOBS      Number of workers. Default: the [jobs] argument, else half the
-#             cores, so a worker and its reference solver each get one.
+#   JOBS      Number of workers. Default: the [jobs] argument, else 1/8th
+#             the number of cores.
 #   FUZZ_DIR  Parent of the per-worker working directories. Default:
-#             /dev/shm/stp-fuzz where tmpfs exists, else $TMPDIR/stp-fuzz.
+#             /dev/shm/stp-fuzz-$$ where tmpfs exists, else $TMPDIR/stp-fuzz-$$.
+#             A directory we generate ourselves is removed on exit; one given
+#             here is left alone beyond rmdir'ing the empty worker directories.
 #
 # Everything fuzz_single.sh reads (STP, CHECKER, FUZZSMT_JAR, FAIL_DIR, ...) is
 # passed straight through, so e.g.
@@ -19,26 +21,59 @@
 script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 fuzzer="$script_dir/fuzz_single.sh"
 
+# moreutils ships a different "parallel" with an incompatible command line
+# (no --ungroup, no {}), so check which one is on PATH rather than just that
+# something by that name exists.
+if ! command -v parallel > /dev/null; then
+  echo "GNU parallel not found; install it, or run $fuzzer directly." >&2
+  exit 1
+fi
+if ! parallel --version 2> /dev/null | grep -q '^GNU parallel'; then
+  echo "$(command -v parallel) is not GNU parallel (moreutils ships another" >&2
+  echo "program by that name). Install GNU parallel, or run $fuzzer directly." >&2
+  exit 1
+fi
+
 if command -v nproc > /dev/null; then
   cores=$(nproc)
 else
   cores=$(getconf _NPROCESSORS_ONLN 2> /dev/null || echo 2)
 fi
-jobs=${1:-${JOBS:-$(( cores / 4 ))}}
+jobs=${1:-${JOBS:-$(( cores / 8 ))}}
 [ "$jobs" -ge 1 ] 2> /dev/null || jobs=1
 
-export PARALLEL_PID=$$
+export OUR_PID=$$
 
 if [ -z "${FUZZ_DIR:-}" ]; then
   if [ -d /dev/shm ] && [ -w /dev/shm ]; then
-    FUZZ_DIR=/dev/shm/stp-fuzz-${PARALLEL_PID}
+    FUZZ_DIR=/dev/shm/stp-fuzz-${OUR_PID}
   else
-    FUZZ_DIR=${TMPDIR:-/tmp}/stp-fuzz-${PARALLEL_PID}
+    FUZZ_DIR=${TMPDIR:-/tmp}/stp-fuzz-${OUR_PID}
   fi
+  generated_fuzz_dir=1
 fi
+
+# Ctrl-C is the normal way out, so the cleanup has to be a trap: bash dies on
+# the signal rather than running the rest of the script. The INT/TERM traps
+# turn the signal into an exit so the EXIT trap gets its turn.
+#
+# Only a directory we named ourselves is safe to remove outright; a FUZZ_DIR
+# from the environment may be a scratch area holding other things, so there we
+# just rmdir the worker directories and the parent, which fails harmlessly if
+# either is non-empty.
+cleanup() {
+  if [ -n "${generated_fuzz_dir:-}" ]; then
+    rm -rf -- "$FUZZ_DIR"
+  else
+    for n in $(seq 1 "$jobs"); do rmdir -- "$FUZZ_DIR/$n" 2> /dev/null; done
+    rmdir -- "$FUZZ_DIR" 2> /dev/null
+  fi
+  return 0
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 echo "starting $jobs workers under $FUZZ_DIR"
 
 seq 1 "$jobs" | parallel --ungroup -j "$jobs" "$fuzzer" "$FUZZ_DIR/{}"
-
-wait

--- a/scripts/fuzz/fuzz_single.sh
+++ b/scripts/fuzz/fuzz_single.sh
@@ -205,12 +205,18 @@ if [ -z "$supported" ]; then
 fi
 
 declare -a checked=()
+declare -a dropped=()
+offered=${#arr[@]}
 for e in "${arr[@]}"
   do
     keep=1
     for opt in $(echo "$e" | grep -o -- '--[a-zA-Z0-9.][a-zA-Z0-9.-]*'); do
       if ! echo "$supported" | grep -qx -- "$opt"; then
-        echo "dropping unsupported entry: $e ($opt not in this build)" >&2
+        if [ "$e" = "$opt" ]; then
+          dropped+=("$e")
+        else
+          dropped+=("$e  ($opt is the missing one)")
+        fi
         keep=0
         break
       fi
@@ -218,6 +224,18 @@ for e in "${arr[@]}"
     if [ $keep -eq 1 ]; then checked+=("$e"); fi
 done
 arr=("${checked[@]}")
+
+# Worth being loud about: a dropped entry is a code path that silently stops
+# being fuzzed, and the run otherwise looks perfectly healthy for hours.
+if [ "${#dropped[@]}" -gt 0 ]; then
+  echo >&2
+  echo "WARNING: ${#dropped[@]} of $offered option settings dropped, this build" >&2
+  echo "  does not support them:" >&2
+  printf '    %s\n' "${dropped[@]}" >&2
+  echo "  Those code paths are NOT being fuzzed. Rebuild with them enabled if" >&2
+  echo "  that is not deliberate." >&2
+  echo >&2
+fi
 if [ "${#arr[@]}" -eq 0 ]; then
   echo "No usable option settings, every entry was dropped." >&2
   exit 1

--- a/scripts/fuzz/fuzz_single.sh
+++ b/scripts/fuzz/fuzz_single.sh
@@ -111,7 +111,15 @@ rm -f -- *.smt2
 echo "workdir: $path"
 echo "stp:     $STP"
 echo "checker: $CHECKER"
-echo "results: $FAIL_DIR"
+# Deliberately not cleared: it may hold findings from an earlier run that have
+# not been triaged yet, and several workers share it. Say how many are already
+# there so a directory found later is not mistaken for one this run produced.
+existing=$(find "$FAIL_DIR" -mindepth 1 -maxdepth 1 -type d 2> /dev/null | wc -l)
+if [ "$existing" -gt 0 ]; then
+  echo "results: $FAIL_DIR ($existing already there from earlier runs, kept)"
+else
+  echo "results: $FAIL_DIR"
+fi
 
 # FuzzSMT uses the bit-vector overflow predicates, which older solvers do not
 # know. z3 4.8.12 for instance answers the query anyway and prints an extra
@@ -389,6 +397,7 @@ while (true)
        cp -- * "$failure"
        {
          echo "kind:    $kind"
+         echo "when:    $(date '+%Y-%m-%d %H:%M:%S')"
          echo "options: $se"
          echo "stp:     $STP (exit $stp_rc)"
          echo "checker: $CHECKER (exit $checker_rc)"

--- a/scripts/fuzz/fuzz_single.sh
+++ b/scripts/fuzz/fuzz_single.sh
@@ -91,6 +91,21 @@ mkdir -p "$FAIL_DIR" || exit 1
 path=${1:-$(mktemp -d "${TMPDIR:-/tmp}/stp-fuzz.XXXXXX")}
 mkdir -p "$path" || exit 1
 cd "$path" || exit 1
+
+# Everything below deletes *.smt2 from this directory, on startup and after
+# every iteration, so adopting the wrong one destroys its contents: pointed at
+# a corpus or at tests/query-files it would wipe the lot. Only take over a
+# directory that is empty or that a previous run left this marker in.
+marker=.stp-fuzz-workdir
+if [ ! -e "$marker" ] && [ -n "$(ls -A)" ]; then
+  echo "Refusing to use '$path' as a working directory." >&2
+  echo "It is not empty and no previous run of this script claimed it, and" >&2
+  echo "every *.smt2 in it would be deleted. Give the fuzzer a directory of" >&2
+  echo "its own, or pass no argument to get a fresh temporary one." >&2
+  exit 1
+fi
+touch "$marker" || exit 1
+
 rm -f -- *.smt2
 
 echo "workdir: $path"
@@ -296,7 +311,10 @@ done
 echo "$combinations combinations"
 
 #Don't want to fill up SHM.
-trap 'rm -f -- *.smt2 expression.txt first.txt second.txt' EXIT
+# The marker goes too, so a clean exit leaves the directory empty and fuzz.sh
+# can rmdir it. A run killed outright leaves the marker behind, which is what
+# lets the next run recognise the directory as its own and wipe it.
+trap 'rm -f -- *.smt2 expression.txt first.txt second.txt "$marker"' EXIT
 trap 'exit 130' INT
 trap 'exit 143' TERM
 
@@ -360,7 +378,14 @@ while (true)
     fi
 
     if [ -n "$kind" ]; then
-       failure=$(mktemp -d "$FAIL_DIR/XXXXXX")
+       # Without this check a full or unwritable FAIL_DIR would leave $failure
+       # empty, cp would fail, and the evidence for a real bug would be gone
+       # by the next iteration.
+       if ! failure=$(mktemp -d "$FAIL_DIR/XXXXXX"); then
+         echo "Could not create a directory under $FAIL_DIR to save a" >&2
+         echo "$kind in. Stopping rather than discarding it." >&2
+         exit 1
+       fi
        cp -- * "$failure"
        {
          echo "kind:    $kind"

--- a/scripts/fuzz/fuzz_single.sh
+++ b/scripts/fuzz/fuzz_single.sh
@@ -127,15 +127,36 @@ if [ "$probe_rc" -ne 0 ] || [ "$probe_out" != "sat" ]; then
 fi
 rm -f probe.smt2
 
-# One entry is picked at random per iteration. Entries must be non-default,
-# otherwise they just re-run the baseline "" entry and waste a cycle: check
-# against the "arg (=N)" defaults in `stp --help` when adding to this list.
+# Options are grouped by what they affect. Each iteration draws one entry from
+# every group and concatenates the picks, so settings from different groups are
+# exercised together instead of one at a time. Every group carries an empty
+# entry, which is how it sits out an iteration; drawing empty from all of them
+# reproduces the default configuration.
+#
+# Entries within a group are alternatives to each other, so put mutually
+# exclusive options in the same group -- that is what stops --minisat and
+# --cadical being handed over together. Options that combine freely belong in
+# groups of their own.
+#
+# An entry has to be non-default AND has to actually change the output,
+# otherwise it silently re-runs the baseline and wastes the iteration. Check it
+# against the "arg (=N)" defaults in `stp --help`, then confirm the emitted CNF
+# really differs before adding it:
+#
+#   stp --output-CNF --exit-after-CNF f.smt2                  # baseline
+#   stp <entry> --output-CNF --exit-after-CNF f.smt2          # with the entry
+#
+# --bb.mult-v2=1 on its own looked reasonable and failed exactly that test:
+# byte-identical CNF on every one of 49 QF_BV and QF_ABV files, because each
+# site reading upper_multiplication_bound is gated behind constant-bit
+# propagation having produced MultiplicationStats, which does not happen under
+# the default multiplication variant. Paired with variant 5 it does bite, so
+# that is the form kept below.
 
-declare -a arr=(
-# Baseline.
+declare -a OPTION_GROUPS=(simplify mult bitblast cnf solver misc)
+
+declare -a g_simplify=(
 ""
-
-# Simplification.
 "--disable-simplifications"
 "--switch-word"
 "--disable-opt-inc"
@@ -160,16 +181,12 @@ declare -a arr=(
 # here rather than being trusted.
 "--unconstrained-variable-elimination=0"
 "--aig-rewrite-passes=1"
+)
 
-# Bit-blasting.
-"--bb.div-v1=0"
-"--bb.div-v2=0"
-"--bb.div-v3=1"
-"--bb.add-v1=0"
-"--bb.add-v2=0"
-"--bb.vle-v1=0"
-"--bb.conjoin-constant=1"
-"--bb.mult-v2=1"
+# Multiplication: the variants are alternative settings of one option, so they
+# have to share a group.
+declare -a g_mult=(
+""
 "--bb.mult-variant=3"
 "--bb.mult-variant=4"
 "--bb.mult-variant=5"
@@ -180,17 +197,38 @@ declare -a arr=(
 "--bb.mult-variant=13"
 # multWithBounds() is only reachable from variant 5, so pair them.
 "--bb.mult-variant=5 --bb.mult-v2=1"
+)
 
-# CNF generation and solvers.
+# The rest of bit-blasting. These are independent of each other, but keeping
+# them in one group bounds how far a single iteration strays from the default.
+declare -a g_bitblast=(
+""
+"--bb.div-v1=0"
+"--bb.div-v2=0"
+"--bb.div-v3=1"
+"--bb.add-v1=0"
+"--bb.add-v2=0"
+"--bb.vle-v1=0"
+"--bb.conjoin-constant=1"
+)
+
+declare -a g_cnf=(
+""
 "--cnf-generation-effort=very-low"
 "--cnf-generation-effort=very-high"
+)
+
+declare -a g_solver=(
+""
 "--cadical"
 "--cryptominisat"
 "--cryptominisat --threads=4"
 "--simplifying-minisat"
 "--minisat"
+)
 
-# Misc.
+declare -a g_misc=(
+""
 "--ackermanize"
 "--interactive=1"
 )
@@ -204,26 +242,31 @@ if [ -z "$supported" ]; then
   exit 1
 fi
 
-declare -a checked=()
 declare -a dropped=()
-offered=${#arr[@]}
-for e in "${arr[@]}"
-  do
-    keep=1
-    for opt in $(echo "$e" | grep -o -- '--[a-zA-Z0-9.][a-zA-Z0-9.-]*'); do
-      if ! echo "$supported" | grep -qx -- "$opt"; then
-        if [ "$e" = "$opt" ]; then
-          dropped+=("$e")
-        else
-          dropped+=("$e  ($opt is the missing one)")
+offered=0
+for gname in "${OPTION_GROUPS[@]}"; do
+  declare -n group="g_$gname"
+  offered=$(( offered + ${#group[@]} ))
+  declare -a checked=()
+  for e in "${group[@]}"
+    do
+      keep=1
+      for opt in $(echo "$e" | grep -o -- '--[a-zA-Z0-9.][a-zA-Z0-9.-]*'); do
+        if ! echo "$supported" | grep -qx -- "$opt"; then
+          if [ "$e" = "$opt" ]; then
+            dropped+=("$gname: $e")
+          else
+            dropped+=("$gname: $e  ($opt is the missing one)")
+          fi
+          keep=0
+          break
         fi
-        keep=0
-        break
-      fi
-    done
-    if [ $keep -eq 1 ]; then checked+=("$e"); fi
+      done
+      if [ $keep -eq 1 ]; then checked+=("$e"); fi
+  done
+  group=("${checked[@]}")
+  unset -n group
 done
-arr=("${checked[@]}")
 
 # Worth being loud about: a dropped entry is a code path that silently stops
 # being fuzzed, and the run otherwise looks perfectly healthy for hours.
@@ -236,11 +279,21 @@ if [ "${#dropped[@]}" -gt 0 ]; then
   echo "  that is not deliberate." >&2
   echo >&2
 fi
-if [ "${#arr[@]}" -eq 0 ]; then
-  echo "No usable option settings, every entry was dropped." >&2
-  exit 1
-fi
-echo "${#arr[@]} option settings"
+
+# The empty entry never matches the filter, so a group cannot come out of that
+# loop empty unless the group itself was written empty.
+combinations=1
+for gname in "${OPTION_GROUPS[@]}"; do
+  declare -n group="g_$gname"
+  if [ "${#group[@]}" -eq 0 ]; then
+    echo "Option group '$gname' is empty." >&2
+    exit 1
+  fi
+  printf '  %-10s %2d entries\n' "$gname" "${#group[@]}"
+  combinations=$(( combinations * ${#group[@]} ))
+  unset -n group
+done
+echo "$combinations combinations"
 
 #Don't want to fill up SHM.
 trap 'rm -f -- *.smt2 expression.txt first.txt second.txt' EXIT
@@ -255,7 +308,15 @@ timed_out() { [ "$1" -eq 152 ] || [ "$1" -eq 137 ]; }
 
 while (true)
   do
-    se=${arr[ $RANDOM % ${#arr[@]} ]}
+    # One pick per group, concatenated. Empty picks contribute nothing, so an
+    # all-empty draw leaves $se empty and tests the default configuration.
+    se=""
+    for gname in "${OPTION_GROUPS[@]}"; do
+      declare -n group="g_$gname"
+      pick=${group[ $RANDOM % ${#group[@]} ]}
+      if [ -n "$pick" ]; then se="${se:+$se }$pick"; fi
+      unset -n group
+    done
 
     # Without this check a generation failure is silent: big.smt2 ends up
     # holding just the header, both solvers print nothing, the comparison

--- a/scripts/fuzz/fuzz_single.sh
+++ b/scripts/fuzz/fuzz_single.sh
@@ -17,12 +17,20 @@
 # own. Putting it on a tmpfs (/dev/shm) keeps the generated files off disk.
 #
 # Environment:
-#   STP           STP binary. Default: the first of build/stp, build_debug/stp,
-#                 build_static_debug/stp in the source tree, else stp on PATH.
-#                 A build with assertions enabled finds more.
+#   STP           STP binary. Default: the first of build_static_debug/stp,
+#                 build/stp, build_debug/stp in the source tree, else stp on
+#                 PATH. A build with assertions enabled finds more.
 #   CHECKER       Reference solver, invoked as "$CHECKER file.smt2".
-#                 Default: bitwuzla. Anything that prints one sat/unsat line
-#                 per query works, e.g. boolector, cvc5, z3.
+#                 Default: z3. Anything that prints one sat/unsat line per
+#                 query and understands the bit-vector overflow predicates
+#                 works; z3 5.0.0 and bitwuzla 0.9.1 were both checked. This
+#                 is probed at startup, because a solver that gets it wrong
+#                 turns every iteration into a bogus mismatch -- z3 4.8.12 and
+#                 boolector 3.0.1 both fail it, the latter on bvnego.
+#
+#                 On a 2500-query QF_ABV batch, z3 5.0.0 took 6.8s where
+#                 bitwuzla 0.9.1 took 251s, so the checker is no longer the
+#                 bottleneck. Both gave identical answers.
 #   FUZZSMT_JAR   fuzzsmt.jar, from the FuzzSMT release of Brummayer and Biere,
 #                 "Fuzzing and Delta-Debugging SMT Solvers" (SMT'09).
 #                 Default: searched for next to the source tree and in $HOME.
@@ -51,7 +59,7 @@ if [ ! -x "${STP:-}" ]; then
 fi
 
 # Find the reference solver.
-CHECKER=${CHECKER:-bitwuzla}
+CHECKER=${CHECKER:-z3}
 if ! command -v "$CHECKER" > /dev/null && [ ! -x "$CHECKER" ]; then
   echo "Reference solver '$CHECKER' not found. Set CHECKER=/path/to/solver." >&2
   exit 1
@@ -89,6 +97,35 @@ echo "workdir: $path"
 echo "stp:     $STP"
 echo "checker: $CHECKER"
 echo "results: $FAIL_DIR"
+
+# FuzzSMT uses the bit-vector overflow predicates, which older solvers do not
+# know. z3 4.8.12 for instance answers the query anyway and prints an extra
+# (error ...) line, so it neither fails outright nor gives a usable answer --
+# every iteration would land in FAIL_DIR looking like an STP bug. Check the
+# checker before trusting a whole run to it.
+{
+  echo "(set-logic $LOGIC)"
+  echo "(declare-fun x () (_ BitVec 8))"
+  echo "(declare-fun y () (_ BitVec 8))"
+  for p in bvnego bvsaddo bvsdivo bvsmulo bvssubo bvuaddo bvumulo bvusubo; do
+    if [ "$p" = bvnego ]; then
+      echo "(assert (or (bvnego x) true))"
+    else
+      echo "(assert (or ($p x y) true))"
+    fi
+  done
+  echo "(check-sat)"
+} > probe.smt2
+probe_out=$(timeout 60 "$CHECKER" probe.smt2 2>&1)
+probe_rc=$?
+if [ "$probe_rc" -ne 0 ] || [ "$probe_out" != "sat" ]; then
+  echo "Reference solver '$CHECKER' failed the startup probe (exit $probe_rc):" >&2
+  echo "$probe_out" | sed 's/^/  /' >&2
+  echo "It must print exactly 'sat' for a query using the bit-vector overflow" >&2
+  echo "predicates. Upgrade it, or set CHECKER to one that does." >&2
+  exit 1
+fi
+rm -f probe.smt2
 
 # One entry is picked at random per iteration. Entries must be non-default,
 # otherwise they just re-run the baseline "" entry and waste a cycle: check
@@ -181,37 +218,80 @@ for e in "${arr[@]}"
     if [ $keep -eq 1 ]; then checked+=("$e"); fi
 done
 arr=("${checked[@]}")
+if [ "${#arr[@]}" -eq 0 ]; then
+  echo "No usable option settings, every entry was dropped." >&2
+  exit 1
+fi
 echo "${#arr[@]} option settings"
 
 #Don't want to fill up SHM.
 trap 'rm -f -- *.smt2 expression.txt first.txt second.txt' EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+# ulimit -t raises SIGXCPU and then SIGKILL. Running out of CPU is itself worth
+# investigating -- these problems are small -- so a timeout is saved like any
+# other failure, just labelled so triage knows which kind it is without having
+# to re-run it.
+timed_out() { [ "$1" -eq 152 ] || [ "$1" -eq 137 ]; }
 
 while (true)
   do
     se=${arr[ $RANDOM % ${#arr[@]} ]}
 
-    java -jar "$FUZZSMT_JAR" "$LOGIC" -g -bulk-export "$QUERIES" \
-         -seed `od -A n -t d -N 3 /dev/urandom`
+    # Without this check a generation failure is silent: big.smt2 ends up
+    # holding just the header, both solvers print nothing, the comparison
+    # passes, and the loop spins at full speed testing nothing.
+    if ! java -jar "$FUZZSMT_JAR" "$LOGIC" -g -bulk-export "$QUERIES" \
+              -seed `od -A n -t d -N 3 /dev/urandom`; then
+      echo "fuzzsmt failed to generate $LOGIC problems" >&2
+      exit 1
+    fi
+    if ! compgen -G '_file*.smt2' > /dev/null; then
+      echo "fuzzsmt wrote no _file*.smt2, is -bulk-export supported?" >&2
+      exit 1
+    fi
+
     sed -i '1i (push 1)' _file*.smt2
     sed -i -e "\$a (pop 1)" _file*.smt2
 
-    #two spaces so the sed doesn't match it.
-    echo "(set-logic   $LOGIC)" >> big.smt2
+    # fuzzsmt writes (set-logic  LOGIC) with two spaces, once per generated
+    # file; strip those and keep a single header. The header uses three spaces
+    # so the sed below doesn't match it too.
+    echo "(set-logic   $LOGIC)" > big.smt2
     cat _file*.smt2 >> big.smt2
-    sed -i 's/(set-logic  QF_BV)//g' big.smt2
     sed -i "s/(set-logic  $LOGIC)//g" big.smt2
 
     echo "$se" > expression.txt
     (ulimit -t "$CPU_LIMIT"; "$CHECKER" big.smt2 > first.txt) &
+    checker_job=$!
     # $se is deliberately unquoted, some entries are two options.
     (ulimit -t "$CPU_LIMIT"; "$STP" $se -d big.smt2 > second.txt)
+    stp_rc=$?
+    wait "$checker_job"
+    checker_rc=$?
 
-    wait
-    if (! cmp -s first.txt second.txt ); then
-       cp -- * "$(mktemp -d "$FAIL_DIR/XXXXXX")"
-       echo -n "FAIL"
+    kind=""
+    if timed_out "$stp_rc"; then
+       kind="timeout-stp"
+    elif timed_out "$checker_rc"; then
+       kind="timeout-checker"
+    elif (! cmp -s first.txt second.txt ); then
+       kind="mismatch"
     fi
 
+    if [ -n "$kind" ]; then
+       failure=$(mktemp -d "$FAIL_DIR/XXXXXX")
+       cp -- * "$failure"
+       {
+         echo "kind:    $kind"
+         echo "options: $se"
+         echo "stp:     $STP (exit $stp_rc)"
+         echo "checker: $CHECKER (exit $checker_rc)"
+       } > "$failure/what-happened.txt"
+       echo -n "[$kind $failure]"
+    else
+       echo -n "#"
+    fi
     rm -f -- *.smt2 expression.txt first.txt second.txt
-    echo -n "#"
 done


### PR DESCRIPTION
Follow-up to #646, from reviewing those scripts.

## Correctness

- **A fuzzsmt failure was silent.** If generation failed, `big.smt2` held only the `set-logic` header, both solvers printed nothing, `cmp` passed, and the loop spun at full speed testing nothing. Now checked.
- **`big.smt2` was appended to, not truncated**, so it accumulated across iterations whenever the end-of-loop cleanup wasn't reached.
- **Timeouts were indistinguishable from wrong answers.** `ulimit -t` leaves truncated output, which compares unequal. They're still saved — these problems are small, so running out of CPU is worth investigating — but they're labelled now, and each saved directory gets a `what-happened.txt` recording which solver failed, its exit code, and the options in use.
- **An empty option array** made `$RANDOM % 0` fail every iteration.

## Reference solver

`CHECKER` now defaults to `z3`. Measured on a 2500-query QF_ABV batch:

| solver | time | answers |
|---|---|---|
| z3 5.0.0 | 6.8 s | identical to bitwuzla |
| STP `-d` | 79 s | identical to bitwuzla |
| bitwuzla 0.9.1 | 251 s | baseline |

Confirmed on a second batch with a different seed (6.4 s vs 210 s, identical answers). The checker drops from ~76% of an iteration's wall clock to ~8%. bitwuzla's build was already `buildtype=release -O3`, so this isn't a debug-build artifact — though LTO and alternative SAT backends were not tried.

The checker is now **probed at startup**. FuzzSMT emits the bit-vector overflow predicates, and a solver that doesn't know them is worse than one that fails outright: z3 4.8.12 answers anyway *and* prints an `(error ...)` line, and since only stdout is compared, every iteration would land in `FAIL_DIR` looking like an STP soundness bug. The probe caught that boolector 3.0.1 fails on `bvnego`, so it's dropped from the suggested list.

⚠️ On distros shipping an older z3 (Ubuntu 22.04 has 4.8.12) the probe will now refuse to start until a modern z3 is installed, or `CHECKER=bitwuzla` is set.

## fuzz.sh

- **Cleanup moved into a trap.** Ctrl-C is the documented way to stop, and bash dies on the signal rather than running the last line, so `FUZZ_DIR` was never removed in the normal case. Only a directory the script names itself is removed outright; a `FUZZ_DIR` from the environment may be a scratch area holding other things, so it just gets `rmdir`.
- **Check that `parallel` is GNU parallel** — moreutils ships an unrelated program by that name with no `--ungroup` and no `{}`.
- Dropped the no-op trailing `wait`; restored the trailing newline.

## Testing

`bash -n` on both. Live runs against both z3 5.0.0 and bitwuzla as checker (14 and 24+ iterations), zero spurious failures, zero leftover files after SIGINT and SIGTERM. Verified the probe rejects z3 4.8.12 and boolector 3.0.1 and accepts z3 5.0.0 and bitwuzla 0.9.1. Also confirmed workers get independent `$RANDOM` streams, so parallel copies don't test the same option sequence.