### PR TITLE
Use the initial-exec TLS model for every STP thread-local

### DIFF
--- a/include/stp/AST/MutableASTNode.h
+++ b/include/stp/AST/MutableASTNode.h
@@ -37,7 +37,7 @@ namespace stp
 {
 class MutableASTNode
 {
-  static THREAD_LOCAL vector<MutableASTNode*> all;
+  static THREAD_LOCAL_IE vector<MutableASTNode*> all;
 
 public:
   typedef std::unordered_set<MutableASTNode*> ParentsType;

--- a/include/stp/Globals/Globals.h
+++ b/include/stp/Globals/Globals.h
@@ -82,11 +82,11 @@ enum SOLVER_RETURN_TYPE
 // Empty vector. Useful commonly used ASTNodes
 DLL_PUBLIC extern std::vector<ASTNode> _empty_ASTVec;
 
-extern THREAD_LOCAL enum inputStatus
+extern THREAD_LOCAL_IE enum inputStatus
     input_status; // Needed by the SMTLIB printer
 
 // Useful global variables. Use for parsing only
-DLL_PUBLIC extern THREAD_LOCAL STP* GlobalSTP;
+DLL_PUBLIC extern THREAD_LOCAL_IE STP* GlobalSTP;
 DLL_PUBLIC extern THREAD_LOCAL_IE STPMgr* GlobalParserBM;
 DLL_PUBLIC extern THREAD_LOCAL_IE Cpp_interface* GlobalParserInterface;
 

--- a/include/stp/Printer/SMTLIBPrinter.h
+++ b/include/stp/Printer/SMTLIBPrinter.h
@@ -31,15 +31,15 @@ namespace printer
 {
 
 // Map from ASTNodes to LetVars
-extern THREAD_LOCAL stp::ASTNodeMap NodeLetVarMap;
+extern THREAD_LOCAL_IE stp::ASTNodeMap NodeLetVarMap;
 
 // This is a vector which stores the Node to LetVars pairs. It
 // allows for sorted printing, as opposed to NodeLetVarMap
-extern THREAD_LOCAL vector<std::pair<ASTNode, ASTNode>> NodeLetVarVec;
+extern THREAD_LOCAL_IE vector<std::pair<ASTNode, ASTNode>> NodeLetVarVec;
 
 // a partial Map from ASTNodes to LetVars. Needed in order to
 // correctly print shared subterms inside the LET itself
-extern THREAD_LOCAL stp::ASTNodeMap NodeLetVarMap1;
+extern THREAD_LOCAL_IE stp::ASTNodeMap NodeLetVarMap1;
 
 std::string functionToSMTLIBName(const Kind k, bool smtlib1);
 

--- a/include/stp/Printer/printers.h
+++ b/include/stp/Printer/printers.h
@@ -45,7 +45,7 @@ DLL_PUBLIC void PL_Print1(ostream& os, const ASTNode& n, int indentation,
                           bool letize, STPMgr* bm);
 
 ostream& Lisp_Print(ostream& os, const stp::ASTNode& n, int indentation = 0);
-extern THREAD_LOCAL stp::ASTNodeSet Lisp_AlreadyPrintedSet;
+extern THREAD_LOCAL_IE stp::ASTNodeSet Lisp_AlreadyPrintedSet;
 ostream& Lisp_Print_indent(ostream& os, const stp::ASTNode& n,
                            int indentation = 0);
 

--- a/include/stp/Simplifier/constantBitP/FixedBits.h
+++ b/include/stp/Simplifier/constantBitP/FixedBits.h
@@ -55,7 +55,7 @@ namespace constantBitP
 #define CONSTANTBITP_UTILITY_XSTR(s) CONSTANTBITP_UTILITY_STR(s)
 #define LOCATION __FILE__ ":" CONSTANTBITP_UTILITY_XSTR(__LINE__) ": "
 
-static THREAD_LOCAL int staticUniqueId = 1;
+static THREAD_LOCAL_IE int staticUniqueId = 1;
 
 // Bits can be fixed, or unfixed. Fixed bits are fixed to either zero or one.
 // Unfixed bits are marked as '*' when using operator[]

--- a/include/stp/Simplifier/constantBitP/MersenneTwister.h
+++ b/include/stp/Simplifier/constantBitP/MersenneTwister.h
@@ -359,7 +359,7 @@ inline MTRand::uint32 MTRand::hash(time_t t, clock_t c)
   // Better than uint32(x) in case x is floating point in [0,1]
   // Based on code by Lawrence Kirby (fred@genesis.demon.co.uk)
 
-  static THREAD_LOCAL uint32 differ =
+  static THREAD_LOCAL_IE uint32 differ =
       0; // guarantee time-based seeds will change
 
   uint32 h1 = 0;

--- a/include/stp/ToSat/ToSATAIG.h
+++ b/include/stp/ToSat/ToSATAIG.h
@@ -71,7 +71,7 @@ private:
     first = true;
   }
 
-  static THREAD_LOCAL int cnf_calls;
+  static THREAD_LOCAL_IE int cnf_calls;
 
 public:
   void add_cnf_to_solver(SATSolver& satSolver, Cnf_Dat_t* cnfData);

--- a/include/stp/Util/Attributes.h
+++ b/include/stp/Util/Attributes.h
@@ -60,38 +60,43 @@ THE SOFTWARE.
 #define DLL_LOCAL
 #endif
 
-//Defining THREAD_LOCAL
+// Defining THREAD_LOCAL_IE, the storage class STP uses for every one of its
+// mutable globals. "IE" is the initial-exec TLS model: the variable lives at a
+// fixed offset from the thread pointer instead of being reached through a
+// __tls_get_addr call into the dynamic loader on every access. Thread-safety
+// is identical either way -- one copy per thread -- only the addressing
+// differs, so this is the right default for all of them, not just the hot
+// ones. The cost is that initial-exec variables are allocated out of the
+// process's static TLS surplus; that is fine for the stp binary and for
+// libstp when it is in the initial load set or dlopen'd early, which are the
+// normal cases. Configure with -DUSE_THREAD_LOCAL=OFF for plain globals.
 #if !USE_THREAD_LOCAL
-#define THREAD_LOCAL
+#define STP_THREAD_LOCAL
 #elif __cplusplus >= 201103L
-#define THREAD_LOCAL thread_local
+#define STP_THREAD_LOCAL thread_local
 #elif defined _WIN32 && (defined _MSC_VER || defined __ICL ||                  \
                          defined __DMC__ || defined __BORLANDC__)
 
 //********************
-// For windows, this does not work, DLL_PUBLIC and THREAD_LOCAL together die
+// For windows, this does not work, DLL_PUBLIC and thread-local together die
 //********************
-//#define THREAD_LOCAL __declspec(thread)
-#define THREAD_LOCAL
+//#define STP_THREAD_LOCAL __declspec(thread)
+#define STP_THREAD_LOCAL
 
 /* note that ICC (linux) and Clang are covered by __GNUC__ */
 #elif defined __GNUC__ || defined __SUNPRO_C || defined __xlC__
-#define THREAD_LOCAL __thread
+#define STP_THREAD_LOCAL __thread
 #else
-#error "Cannot define THREAD_LOCAL"
+#error "Cannot define STP_THREAD_LOCAL"
 #endif
 
-// THREAD_LOCAL_IE: a thread-local requesting the initial-exec TLS model,
-// which is accessed by a fixed offset instead of a __tls_get_addr call.
-// Use only for hot thread-locals that libstp itself defines and that are
-// touched on the parse/node-creation fast path. Safe when libstp is in
-// the initial load set or dlopen'd before the using thread is created
-// (the normal cases: the stp binary and the Python bindings). glibc's
-// static-TLS surplus covers typical dlopen use too.
+// The initial-exec attribute is a GCC/Clang spelling; everywhere else the
+// macro degrades to a plain thread-local (or to nothing).
 #if USE_THREAD_LOCAL && (defined(__GNUC__) || defined(__clang__))
-#define THREAD_LOCAL_IE THREAD_LOCAL __attribute__((tls_model("initial-exec")))
+#define THREAD_LOCAL_IE                                                        \
+  STP_THREAD_LOCAL __attribute__((tls_model("initial-exec")))
 #else
-#define THREAD_LOCAL_IE THREAD_LOCAL
+#define THREAD_LOCAL_IE STP_THREAD_LOCAL
 #endif
 
 #endif //ATTRIBUTES_H_

--- a/lib/AST/ASTNode.cpp
+++ b/lib/AST/ASTNode.cpp
@@ -58,11 +58,11 @@ ASTNode::ASTNode(ASTInternal* in) : _int_node_ptr(in)
 //#define ASTNODE_COUNT_OPS
 
 #ifdef ASTNODE_COUNT_OPS
-THREAD_LOCAL int ASTNode::copy = 0;
-THREAD_LOCAL int ASTNode::move = 0;
-THREAD_LOCAL int ASTNode::assign = 0;
-THREAD_LOCAL int ASTNode::destroy = 0;
-THREAD_LOCAL int ASTNode::assign_move = 0;
+THREAD_LOCAL_IE int ASTNode::copy = 0;
+THREAD_LOCAL_IE int ASTNode::move = 0;
+THREAD_LOCAL_IE int ASTNode::assign = 0;
+THREAD_LOCAL_IE int ASTNode::destroy = 0;
+THREAD_LOCAL_IE int ASTNode::assign_move = 0;
 #endif
 
 //Maintain _ref_count

--- a/lib/AST/ASTUtil.cpp
+++ b/lib/AST/ASTUtil.cpp
@@ -51,7 +51,7 @@ ostream& operator<<(ostream& os, const Spacer& sp)
 // the function will then print the stats that it has collected.
 void CountersAndStats(const char* functionname, STPMgr* bm)
 {
-  static THREAD_LOCAL function_counters s;
+  static THREAD_LOCAL_IE function_counters s;
   if (bm->UserFlags.stats_flag)
   {
 

--- a/lib/AST/MutableASTNode.cpp
+++ b/lib/AST/MutableASTNode.cpp
@@ -26,5 +26,5 @@ THE SOFTWARE.
 namespace stp
 {
 
-THREAD_LOCAL vector<MutableASTNode*> MutableASTNode::all;
+THREAD_LOCAL_IE vector<MutableASTNode*> MutableASTNode::all;
 }

--- a/lib/Globals/Globals.cpp
+++ b/lib/Globals/Globals.cpp
@@ -34,10 +34,10 @@ THE SOFTWARE.
 
 namespace stp
 {
-THREAD_LOCAL enum inputStatus input_status = NOT_DECLARED;
+THREAD_LOCAL_IE enum inputStatus input_status = NOT_DECLARED;
 
 // Originally just used by the parser, now used elesewhere.
-THREAD_LOCAL STP* GlobalSTP;
+THREAD_LOCAL_IE STP* GlobalSTP;
 THREAD_LOCAL_IE STPMgr* GlobalParserBM;
 
 // Used exclusively for parsing.

--- a/lib/Parser/smt.lex
+++ b/lib/Parser/smt.lex
@@ -44,7 +44,7 @@
   extern int smterror (const char *msg);
 
   // File-static (local to this file) variables and functions
-  static THREAD_LOCAL std::string _string_lit;
+  static THREAD_LOCAL_IE std::string _string_lit;
   static char escapeChar(char c) {
     switch(c) {
     case 'n': return '\n';

--- a/lib/Parser/smt2.lex
+++ b/lib/Parser/smt2.lex
@@ -52,11 +52,11 @@
 #endif
 
   // File-static (local to this file) variables and functions
-  static thread_local std::string _string_lit;
+  static THREAD_LOCAL_IE std::string _string_lit;
 
   // Nesting depth while skipping the arguments of a command we don't
   // interpret. Zero means the next ')' closes the command itself.
-  static thread_local int skippedDepth = 0;
+  static THREAD_LOCAL_IE int skippedDepth = 0;
 
   static int lookup(char* s)
   {

--- a/lib/Printer/LispPrinter.cpp
+++ b/lib/Printer/LispPrinter.cpp
@@ -30,7 +30,7 @@ namespace printer
 using std::string;
 using namespace stp;
 
-THREAD_LOCAL ASTNodeSet Lisp_AlreadyPrintedSet;
+THREAD_LOCAL_IE ASTNodeSet Lisp_AlreadyPrintedSet;
 ostream& Lisp_Print_indent(ostream& os, const ASTNode& n, int indentation);
 
 /** Internal function to print in lisp format.  Assume newline

--- a/lib/Printer/SMTLIBPrinter.cpp
+++ b/lib/Printer/SMTLIBPrinter.cpp
@@ -42,15 +42,15 @@ static string tolower(const char* name)
 }
 
 // Map from ASTNodes to LetVars
-THREAD_LOCAL stp::ASTNodeMap NodeLetVarMap;
+THREAD_LOCAL_IE stp::ASTNodeMap NodeLetVarMap;
 
 // This is a vector which stores the Node to LetVars pairs. It
 // allows for sorted printing, as opposed to NodeLetVarMap
-THREAD_LOCAL vector<pair<ASTNode, ASTNode>> NodeLetVarVec;
+THREAD_LOCAL_IE vector<pair<ASTNode, ASTNode>> NodeLetVarVec;
 
 // a partial Map from ASTNodes to LetVars. Needed in order to
 // correctly print shared subterms inside the LET itself
-THREAD_LOCAL stp::ASTNodeMap NodeLetVarMap1;
+THREAD_LOCAL_IE stp::ASTNodeMap NodeLetVarMap1;
 
 // copied from Presentation Langauge printer.
 ostream&

--- a/lib/Simplifier/constantBitP/ConstantBitPropagation.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitPropagation.cpp
@@ -57,7 +57,7 @@ namespace simplifier
 {
 namespace constantBitP
 {
-THREAD_LOCAL NodeToFixedBitsMap* PrintingHackfixedMap; // Used when debugging.
+THREAD_LOCAL_IE NodeToFixedBitsMap* PrintingHackfixedMap; // Used when debugging.
 
 const bool debug_cBitProp_messages = false;
 const bool output_mult_like = false;

--- a/lib/ToSat/ToSATAIG.cpp
+++ b/lib/ToSat/ToSATAIG.cpp
@@ -29,7 +29,7 @@ THE SOFTWARE.
 namespace stp
 {
 
-THREAD_LOCAL int ToSATAIG::cnf_calls = 0;
+THREAD_LOCAL_IE int ToSATAIG::cnf_calls = 0;
 
 bool ToSATAIG::CallSAT(SATSolver& satSolver, const ASTNode& input,
                        bool needAbsRef)

--- a/lib/extlib-constbv/constantbv.cpp
+++ b/lib/extlib-constbv/constantbv.cpp
@@ -69,24 +69,24 @@ namespace CONSTANTBV {
 
   /* FIXME: use a thread-safe Singleton pattern instead */
 
-  static THREAD_LOCAL unsigned int BITS; /* = # of bits in machine word (must be power of 2) */
-  static THREAD_LOCAL unsigned int MODMASK; /* = BITS - 1 (mask for calculating modulo BITS) */
-  static THREAD_LOCAL unsigned int LOGBITS; /* = ld(BITS) (logarithmus dualis) */
-  static THREAD_LOCAL unsigned int FACTOR; /* = ld(BITS / 8) (ld of # of bytes) */
+  static THREAD_LOCAL_IE unsigned int BITS; /* = # of bits in machine word (must be power of 2) */
+  static THREAD_LOCAL_IE unsigned int MODMASK; /* = BITS - 1 (mask for calculating modulo BITS) */
+  static THREAD_LOCAL_IE unsigned int LOGBITS; /* = ld(BITS) (logarithmus dualis) */
+  static THREAD_LOCAL_IE unsigned int FACTOR; /* = ld(BITS / 8) (ld of # of bytes) */
 
-  static THREAD_LOCAL unsigned int LSB = 1; /* = mask for least significant bit */
-  static THREAD_LOCAL unsigned int MSB; /* = mask for most significant bit */
+  static THREAD_LOCAL_IE unsigned int LSB = 1; /* = mask for least significant bit */
+  static THREAD_LOCAL_IE unsigned int MSB; /* = mask for most significant bit */
 
-  static THREAD_LOCAL unsigned int LONGBITS; /* = # of bits in unsigned long */
+  static THREAD_LOCAL_IE unsigned int LONGBITS; /* = # of bits in unsigned long */
 
-  static THREAD_LOCAL unsigned int LOG10; /* = logarithm to base 10 of BITS - 1 */
-  static THREAD_LOCAL unsigned int EXP10; /* = largest possible power of 10 in signed int */
+  static THREAD_LOCAL_IE unsigned int LOG10; /* = logarithm to base 10 of BITS - 1 */
+  static THREAD_LOCAL_IE unsigned int EXP10; /* = largest possible power of 10 in signed int */
 
   /********************************************************************/
   /* global bit mask table for fast access (set by "BitVector_Boot"): */
   /********************************************************************/
 
-  static THREAD_LOCAL unsigned int BITMASKTAB[sizeof(unsigned int) << 3];
+  static THREAD_LOCAL_IE unsigned int BITMASKTAB[sizeof(unsigned int) << 3];
 
   /*****************************/
   /* global macro definitions: */


### PR DESCRIPTION
## What

`include/stp/Util/Attributes.h` had two macros: `THREAD_LOCAL` (plain `thread_local`) and `THREAD_LOCAL_IE` (the same thing plus `__attribute__((tls_model("initial-exec")))`). This collapses them into one public macro, `THREAD_LOCAL_IE`, and uses it for every one of STP's mutable globals. The `THREAD_LOCAL` name is gone.

The platform matrix behind the macro is unchanged: `USE_THREAD_LOCAL=OFF` still expands to nothing, the MSVC branch is still deliberately empty (`DLL_PUBLIC` and thread-local together break there), and `__thread` is still used for pre-C++11 GCC/SunPro/xlC. The initial-exec attribute is still only applied under `#if USE_THREAD_LOCAL && (defined(__GNUC__) || defined(__clang__))`. The internal spelling of the plain form is now `STP_THREAD_LOCAL`, a private implementation detail of that one header.

Two `static thread_local`s in `lib/Parser/smt2.lex` (`_string_lit`, `skippedDepth`) were written as raw `thread_local` rather than the macro. They are converted for uniformity so that they obey `USE_THREAD_LOCAL` like everything else — not for speed; they sit on cold paths (string literals, skipped-command nesting) and measure as no change. `lib/extlib-abc` uses raw `__thread` in three files; that is upstream code and is left alone.

## Why STP has thread-locals at all

`d0b3eb30` (2017-10-02, Andrew Chi, "Provide thread-safety (if C++11)") applied `thread_local` to all non-constant global and static variables across 32 files. The `stp` binary itself is single-threaded, so this is not for its benefit: `libstp` is an installed shared library, it keeps solver state in globals (`GlobalSTP`, `GlobalParserBM`, `GlobalParserInterface`, `input_status`, the printer's letization maps, `MutableASTNode::all`, the node UID counter, the constantbv word-size constants), and an API user may solve on more than one thread. The thread-locals are what make that safe.

## Why it is slow

In a shared library a `thread_local` with no explicit model gets the **general-dynamic** TLS model, because the compiler must assume the library could be `dlopen`'d at any point. Under that model the variable's address is not known at link time, so every access compiles to a call into the dynamic loader's `__tls_get_addr`. Under **initial-exec** the offset is resolved at load time and the access is a plain load off `%fs`.

Nothing about the semantics changes. Both models give one copy per thread; only the addressing differs. Which is the point of doing this uniformly rather than hand-picking hot variables: there is no thread-safety trade-off to weigh per variable.

## Evidence

Two binaries from the same source tree, identical options (Release, `BUILD_SHARED_LIBS=ON`, cadical, mimalloc), differing only by this branch.

**`__tls_get_addr` call sites in `libstp.so.2.3`:**

| | call sites |
|---|---:|
| master | 237 |
| this branch | 17 |

**TLS relocations in `libstp.so.2.3`:**

| | `DTPMOD64` | `DTPOFF64` | `TPOFF64` |
|---|---:|---:|---:|
| master | 10 | 9 | 3 |
| this branch | 1 | 0 | 31 |

The 17 residual call sites are: 2 in ABC's `Gia_ManRandom` (upstream `__thread`), 3 in compiler-generated "TLS init function" thunks, and 12 in `smtlex()`/`smt2lex()`. The last group is the compiler's own `__tls_guard` for dynamically-initialised thread-locals — a variable GCC synthesises, which does not inherit our attribute. Reaching those would need `-ftls-model=initial-exec` as a compile flag, which is a bigger hammer and not proposed here.

**Speed.** Retired user instructions on the pre-SAT pipeline over the 40-file QF_BV corpus. Instruction counts rather than wall clock: they reproduce to about 0.001% on this box, where wall clock has a ±4% noise floor. Selected rows plus the total:

| benchmark | master insn | this branch | delta |
|---|---:|---:|---:|
| predicate_593.smt2 | 9,944,462,114 | 9,523,028,382 | −4.24% |
| SRAI-SAFE-80-1024.smt2 | 31,326,440,575 | 30,430,023,888 | −2.86% |
| SRL-SAFE-16-1024.smt2 | 8,315,010,408 | 8,189,641,289 | −1.51% |
| test_v5_r15_vr10_c1_s11127.smt2 | 9,792,619,480 | 9,651,484,611 | −1.44% |
| bvsub_22943.smt2 | 7,955,846,093 | 7,849,154,089 | −1.34% |
| SRAI-SAFE-12-1024.smt2 | 17,882,568,875 | 17,703,506,949 | −1.00% |
| testcase15.stp.smt2 | 22,032,664,407 | 21,854,971,452 | −0.81% |
| newton.4.2.i.smt2 | 4,619,969,006 | 4,583,275,732 | −0.79% |
| catchconv-15803.smt2 | 4,317,068,539 | 4,289,625,310 | −0.64% |
| picorv32_mutBX_QF_BV_NONINCR.smt2 | 11,135,443,873 | 11,065,082,683 | −0.63% |
| arbiter_data_integrity_n4q8w8d8b30.smt2 | 3,042,531,429 | 3,026,692,965 | −0.52% |
| VexRiscv-regch0-30-unrolled-nomem.smt2 | 11,898,298,687 | 11,844,097,785 | −0.46% |
| picorv32-check-unrolled-nomem.smt2 | 13,246,968,436 | 13,202,715,494 | −0.33% |
| rw_rule_candidate_vmcai_2022_bw512_14.smt2 | 138,560,208,752 | 138,560,208,823 | +0.00% |
| **TOTAL (40 files)** | **883,446,881,753** | **880,590,797,784** | **−0.32%** |

38 of 40 files improved; the two flat rows are `rw_rule_candidate_*` benchmarks that spend essentially all of their pre-SAT budget elsewhere. Nothing regressed beyond noise.

**Neutrality.** Zero mismatches everywhere:

| check | corpus | result |
|---|---|---|
| CNF byte-identity | 40-file QF_BV pre-CNF corpus | 39 identical, 0 mismatched, 1 skipped (emits no CNF) |
| CNF byte-identity | 600 fuzzer queries, 20s timeout | 392 identical, 0 mismatched, 208 skipped (emit no CNF) |
| sat/unsat agreement | 2501 fuzzer queries | 2501 agree, 0 disagree, 0 skipped |

The skipped files are answered by preprocessing before any CNF is written; the sat/unsat run covers them, and also exercises abstraction refinement and counterexample construction.

**Build configurations checked:** default Release shared; `-DUSE_THREAD_LOCAL=OFF` (builds, solves, `PT_TLS` `MemSiz` falls to 8 bytes and `__tls_get_addr` sites to the 2 residual ABC ones — the macro really does vanish); `-DSTATICCOMPILE=ON` (builds and solves; initial-exec is trivially correct in a static binary). `ctest` on a Debug build with assertions: **67/67 passed**.

## Risk

The one thing worth a reviewer's attention. Initial-exec variables must live in the process's **static TLS block**, which is sized at program start with a fixed surplus for late-loaded modules (glibc 2.35 here). A `dlopen` of a module needing more static TLS than remains fails with `cannot allocate memory in static TLS block`. Extending the model from ten `unsigned int`s to ~30 variables including `std::string`, `std::vector`, `ASTNodeSet` and `ASTNodeMap` objects is the thing to check, so I measured it:

```
readelf -lW libstp.so.2.3 | grep -A1 TLS
```

| | `PT_TLS` `FileSiz` | `PT_TLS` `MemSiz` |
|---|---:|---:|
| master | 0x1c | **0x278 (632 bytes)** |
| this branch | 0x1c | **0x278 (632 bytes)** |

**Unchanged.** Two reasons. First, the container types are small handles — a `std::vector` is 24 bytes, a hash map header is a few dozen; their storage is on the heap, not in TLS. Second and more importantly, the TLS model is a property of the **whole module's TLS block**, not of individual variables: master already marks `ASTInternal::node_uid_cntr`, `GlobalParserBM` and `GlobalParserInterface` as initial-exec, so `libstp` already had to be allocated out of static TLS. This PR does not change that, and does not enlarge the block by a single byte. 632 bytes is comfortably inside glibc's surplus (historically 1664 bytes, larger and tunable via `glibc.rtld.optional_static_tls` in modern versions).

So: safe for the `stp` binary, safe for `libstp` in the initial load set, safe for `libstp` `dlopen`'d before threads are created (the Python bindings). The theoretical failure mode is a process that `dlopen`s `libstp` very late, after other modules have exhausted the surplus — an exposure the tree already had before this PR. `-DUSE_THREAD_LOCAL=OFF` remains available and now yields genuinely plain globals.

## API note

`THREAD_LOCAL` appears in installed headers — `Globals.h`, `printers.h`, `SMTLIBPrinter.h`, `FixedBits.h`, `MutableASTNode.h`, `ToSATAIG.h`, `MersenneTwister.h` — so deleting the name is visible to anything that includes them. It is an STP-internal implementation macro and not documented API, and no in-tree or bundled consumer uses it, but flagging it explicitly in case anyone wants it kept as a deprecated alias of `THREAD_LOCAL_IE`. That is a one-line addition if preferred.
