### PR TITLE
Emit the POPCNT instruction instead of calling libgcc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -352,6 +352,26 @@ if(TUNE_NATIVE)
   add_cxx_flag_if_supported("-mtune=native")
 endif()
 
+# Let the compiler emit the POPCNT instruction.  Without this, popCount64() in
+# include/stp/Util/BitOps.h counts in software, because gcc's default x86-64
+# target has no POPCNT and __builtin_popcountll would otherwise become an
+# out-of-line call into libgcc.  Note TUNE_NATIVE does not imply this: -mtune
+# only changes scheduling, not the instructions the compiler may emit.
+#
+# On by default -- POPCNT is on every x86-64 CPU since Nehalem (2008) and AMD
+# Barcelona (2007).  Turn it off when building for hardware older than that,
+# such as a distribution package targeting the baseline x86-64 ISA; the
+# software fallback in BitOps.h is then used and remains correct everywhere.
+option(USE_POPCNT "Use the POPCNT instruction (requires Nehalem/2008 or later)" ON)
+if(USE_POPCNT)
+  add_cxx_flag_if_supported("-mpopcnt")
+  # The vendored ABC sources are C.  There is no add_c_flag_if_supported, so
+  # reuse the check above and set CMAKE_C_FLAGS directly, as WERROR does.
+  if(HAVE_FLAG_-mpopcnt)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mpopcnt")
+  endif()
+endif()
+
 option(COVERAGE "Build with coverage check" OFF)
 if (COVERAGE)
     add_cxx_flag("--coverage")

--- a/include/stp/Util/BitOps.h
+++ b/include/stp/Util/BitOps.h
@@ -69,17 +69,19 @@ inline unsigned countLeadingZeroes64(uint64_t v)
 #endif
 }
 
-// MSVC's __popcnt64 is not used: it is emitted unconditionally, so it
-// faults on CPUs without POPCNT. Count in software instead.
 inline unsigned popCount64(uint64_t v)
 {
-#ifdef _MSC_VER
+#if defined(__POPCNT__)
+  return static_cast<unsigned>(__builtin_popcountll(v));
+#else
+  // Without POPCNT in the target ISA, __builtin_popcountll becomes an
+  // out-of-line call into libgcc; counting in software here is cheaper.
+  // MSVC's __popcnt64 is not used: it is emitted unconditionally, so it
+  // faults on CPUs without POPCNT.
   v = v - ((v >> 1) & 0x5555555555555555ULL);
   v = (v & 0x3333333333333333ULL) + ((v >> 2) & 0x3333333333333333ULL);
   v = (v + (v >> 4)) & 0x0f0f0f0f0f0f0f0fULL;
   return static_cast<unsigned>((v * 0x0101010101010101ULL) >> 56);
-#else
-  return static_cast<unsigned>(__builtin_popcountll(v));
 #endif
 }
 

--- a/lib/Simplifier/constantBitP/ConstantBitP_Multiplication.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_Multiplication.cpp
@@ -48,18 +48,6 @@ using std::set;
 const bool debug_multiply = false;
 std::ostream& log = std::cerr;
 
-// The convolution loops below are popcount-bound. The library builds for
-// generic targets, so resolve a POPCNT-instruction clone at load time where
-// the toolchain and platform support it; elsewhere (and on CPUs without
-// POPCNT) the portable SWAR popcount below is used.
-#if (defined(__x86_64__) || defined(__i386__)) && defined(__ELF__) &&          \
-    (defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 6 ||              \
-     defined(__clang__) && __clang_major__ >= 14)
-#define MULT_TARGET_CLONES __attribute__((target_clones("popcnt", "default")))
-#else
-#define MULT_TARGET_CLONES
-#endif
-
 #if 0
 // The maximum size of the carry into a column for MULTIPLICATION
     int
@@ -152,7 +140,6 @@ struct PairMasks
   unsigned widthCached;
 };
 
-MULT_TARGET_CLONES
 Result fixIfCanForMultiplication(vector<FixedBits*>& children,
                                  const unsigned index,
                                  const int aspirationalSum, PairMasks* pm)
@@ -256,9 +243,12 @@ Result fixIfCanForMultiplication(vector<FixedBits*>& children,
   return result;
 }
 
-// Branch-free SWAR popcount: the library builds for generic targets, where
-// __builtin_popcountll lowers to a libgcc call — too slow for the
-// convolution inner loop.
+// Branch-free SWAR popcount for the convolution inner loop.  With USE_POPCNT
+// the compiler recognises this as a popcount and emits the instruction; with
+// USE_POPCNT off it is what runs, and it stays correct on a CPU that has no
+// POPCNT.  Counting in software here rather than calling __builtin_popcountll
+// avoids the out-of-line libgcc call that the builtin becomes when the target
+// ISA has no POPCNT.
 static inline int popcount64(uint64_t v)
 {
   v -= (v >> 1) & 0x5555555555555555ULL;
@@ -339,7 +329,6 @@ static inline int convolutionAt(const uint64_t* a, const uint64_t* revB,
 //   columnL[j] += #{i + k == j : x[i] and y[k] both fixed to one}
 // The counts come from running prefix sums and two boolean convolutions
 // evaluated as shifted-window popcounts over packed words.
-MULT_TARGET_CLONES
 Result adjustColumns(const FixedBits& x, const FixedBits& y, int* columnL,
                      int* columnH)
 {

--- a/lib/Simplifier/constantBitP/ConstantBitP_Multiplication.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_Multiplication.cpp
@@ -29,6 +29,7 @@ THE SOFTWARE.
 #include "stp/Simplifier/constantBitP/MultiplicationStats.h"
 #include "stp/Simplifier/constantBitP/multiplication/ColumnCounts.h"
 #include "stp/Simplifier/constantBitP/multiplication/ColumnStats.h"
+#include "stp/Util/BitOps.h"
 #include <cstdint>
 #include <cstring>
 #include <set>
@@ -66,7 +67,6 @@ std::ostream& log = std::cerr;
       }
 #endif
 
-static inline int popcount64(uint64_t v);
 static inline uint64_t rightShiftedWord(const uint64_t* m, unsigned words,
                                         unsigned s, unsigned j);
 static inline int convolutionAt(const uint64_t* a, const uint64_t* revB,
@@ -243,20 +243,6 @@ Result fixIfCanForMultiplication(vector<FixedBits*>& children,
   return result;
 }
 
-// Branch-free SWAR popcount for the convolution inner loop.  With USE_POPCNT
-// the compiler recognises this as a popcount and emits the instruction; with
-// USE_POPCNT off it is what runs, and it stays correct on a CPU that has no
-// POPCNT.  Counting in software here rather than calling __builtin_popcountll
-// avoids the out-of-line libgcc call that the builtin becomes when the target
-// ISA has no POPCNT.
-static inline int popcount64(uint64_t v)
-{
-  v -= (v >> 1) & 0x5555555555555555ULL;
-  v = (v & 0x3333333333333333ULL) + ((v >> 2) & 0x3333333333333333ULL);
-  v = (v + (v >> 4)) & 0x0F0F0F0F0F0F0F0FULL;
-  return (int)((v * 0x0101010101010101ULL) >> 56);
-}
-
 static inline uint64_t reverseBits64(uint64_t v)
 {
   v = ((v >> 1) & 0x5555555555555555ULL) | ((v & 0x5555555555555555ULL) << 1);
@@ -318,7 +304,7 @@ static inline int convolutionAt(const uint64_t* a, const uint64_t* revB,
   {
     const uint64_t aw = a[t];
     if (aw != 0)
-      count += popcount64(aw & rightShiftedWord(revB, words, s, t));
+      count += ::stp::popCount64(aw & rightShiftedWord(revB, words, s, t));
   }
   return count;
 }
@@ -401,14 +387,14 @@ Result adjustColumns(const FixedBits& x, const FixedBits& y, int* columnL,
         uint64_t win = revYFF[word] >> bit;
         if (bit != 0 && word + 1 < words)
           win |= revYFF[word + 1] << (64 - bit);
-        ffPairs += popcount64(xFF[t] & win);
+        ffPairs += ::stp::popCount64(xFF[t] & win);
       }
       if (onePairsPossible && xOne[t] != 0)
       {
         uint64_t win = revYOne[word] >> bit;
         if (bit != 0 && word + 1 < words)
           win |= revYOne[word + 1] << (64 - bit);
-        onePairs += popcount64(xOne[t] & win);
+        onePairs += ::stp::popCount64(xOne[t] & win);
       }
     }
 


### PR DESCRIPTION
`popCount64` has called `__builtin_popcountll` for years, so it looks as though
hardware popcount is already in use. It is not: gcc's default x86-64 target does
not include POPCNT, so the builtin is lowered to an out-of-line call into
libgcc.

```
gcc -O3                 ->  call __popcountdi2@PLT
gcc -O3 -mpopcnt        ->  popcntq %rdi, %rax
gcc -O3 -mtune=native   ->  call __popcountdi2@PLT
```

The third line matters: the existing `TUNE_NATIVE` option adds `-mtune=native`,
but `-mtune` only affects instruction scheduling, not the instructions the
compiler may emit. So as shipped, STP has never emitted a `popcnt`, and every
`popCount64` call has been a function call. There were 52 such call sites in
`libstp`, all in constant-bit propagation: `bvUnsignedQuotientAndRemainder2`
(12), `bvAddBothWays` (10), `bvSignedModulusBothWays` (9), `bvSubtractBothWays`
(6), `propagate` (4), and others.

## What this does

**`include/stp/Util/BitOps.h`** — use the builtin only when `__POPCNT__` says
the instruction is in the target ISA, and otherwise count in software inline.
Previously the non-MSVC path always used the builtin, which is where the libgcc
call came from. This removes the call on every target, whatever the build
settings.

**`CMakeLists.txt`** — add `USE_POPCNT`, **on by default**, which adds
`-mpopcnt`. POPCNT is on every x86-64 CPU since Nehalem (2008) and AMD
Barcelona (2007). Builds that must run on older hardware -- a distribution
package targeting the baseline x86-64 ISA, say -- can set `-DUSE_POPCNT=OFF`
and get the software fallback above, which is correct everywhere.

The flag also reaches `CMAKE_C_FLAGS`, since the vendored ABC sources are C.
There is no `add_c_flag_if_supported` in this project, so it reuses the C++
feature check and sets the variable directly, as `WERROR` does.

## Measurements

Retired user-space instructions, `--exit-after-CNF`, over 40 QF_BV benchmarks
spanning 3 G to 138 G instructions of pre-SAT work, one file per family.

Instruction counts rather than wall clock: wall clock on the measuring machine
has a noise floor of about +-4%, wider than this change, while retired
instructions for a fixed binary and input reproduce to about 0.001%.

| configuration | vs master |
|---|---|
| software fallback only (`USE_POPCNT=OFF`) | **-0.14%** |
| **`USE_POPCNT=ON`, the new default** | **-0.75%** |

In `libstp`: calls to `__popcountdi2` 52 -> 0, `popcnt` instructions 13 -> 223.

The 13 `popcnt` already present on master are not from `popCount64`; they are
clones produced by gcc's own popcount idiom recognition, and are identical in
both builds.

`__builtin_clzll` was checked too. It already compiles to a bare `bsrq` on the
default target, so `countLeadingZeroes64` has no equivalent problem and is
unchanged.

## Correctness

The emitted CNF is byte-identical to master, checked with
`--output-CNF --exit-after-CNF` and a hash comparison:

| check | corpus | result |
|---|---|---|
| CNF byte-identical | 40 QF_BV benchmarks | 39 identical, 0 mismatched, 1 emits no CNF |
| CNF byte-identical | 600 fuzzer queries | 392 identical, 0 mismatched, 208 emit no CNF |
| sat/unsat agreement | 2501 fuzzer queries | 2501 agree, 0 disagree |
| `ctest` | Debug + assertions | 67/67 |

Queries that emit no CNF are answered during preprocessing; the answer
comparison covers those.

**`lib/Simplifier/constantBitP/ConstantBitP_Multiplication.cpp`** — remove the
`target_clones("popcnt", "default")` multiversioning on the two convolution
functions. It existed to reach POPCNT without a build flag; `USE_POPCNT` now
does that directly and for the whole library, so the clones are redundant.
Measured over the same 40 benchmarks, removing them is **+0.00%**
(876,787,802,555 against 876,800,934,374 retired instructions, inside the
counter's ~0.001% reproducibility) with the CNF byte-identical on every file.
The clone was better *codegen* -- 155 more `popcnt` instructions in the binary
-- but not better *execution*. Removing it also drops an IFUNC resolver and a
duplicate copy of both functions. The software popcount in that file stays: it
is what runs when `USE_POPCNT` is off, and the compiler recognises it and emits
the instruction when it is on.

## An approach that was tried and rejected

An earlier version of this PR used `__attribute__((target_clones("popcnt",
"default")))` on the hot constant-bit-propagation functions, so that a capable
CPU would select a POPCNT clone at load time with no build flag at all,
following the existing `MULT_TARGET_CLONES` precedent in
`ConstantBitP_Multiplication.cpp`. It worked, and was measured at **-0.43%** --
but that is only 57% of what the flag gives, because with POPCNT in the ISA the
compiler also inlines `countFixed()` freely, whereas cloning decides inlining
against the bulky software body first.

It was dropped for a second reason as well, which also motivated removing the
pre-existing multiversioning described above. Forcing that attribute onto the
`DLL_PUBLIC` and member-function shapes and building with clang 14 shows two
failure modes, and only one is loud: `ConstantBitPropagation.cpp` fails with
"function declaration cannot become a multiversioned function after first
usage", while `ConstantBitP_Arithmetic.cpp`, `_Utility.cpp` and `_Division.cpp`
compile with no diagnostic at all and emit POPCNT into the plain, un-suffixed
bodies of `bvAddBothWays` and `bvSubtractBothWays` -- 175 instructions with no
clone in sight, which would fault on a CPU without the instruction. A build
flag has none of that subtlety.

## Follow-up, not in this PR

The larger remaining popcount win is in the vendored ABC sources.
`Dar_WordCountOnes` (`lib/extlib-abc/src/opt/dar/darCut.c:86`) is a hand-written
twelve-operation SWAR popcount called once per cut pair from
`Dar_ObjComputeCuts` (`:761`), which is 30-50% of pre-SAT time on CNF-heavy
inputs. gcc does not recognise that idiom, so it needs a source change guarded
on `__POPCNT__` -- which this PR now makes effective by default. Because
`lib/extlib-abc` is a submodule tracking berkeley-abc/abc, that needs either an
upstream pull request or a carried patch, so it is left for separate
discussion.
