### PR TITLE
Hash the key once on hot simplifier memo paths

### DIFF
--- a/include/stp/AST/MutableASTNode.h
+++ b/include/stp/AST/MutableASTNode.h
@@ -59,9 +59,10 @@ public:
   static MutableASTNode* build(const ASTNode& n,
                                std::unordered_map<uint64_t, MutableASTNode*>& visited)
   {
-    if (visited.find(n.GetNodeNum()) != visited.end())
     {
-      return visited.find(n.GetNodeNum())->second;
+      const auto it = visited.find(n.GetNodeNum());
+      if (it != visited.end())
+        return it->second;
     }
 
     vector<MutableASTNode*> tempChildren;

--- a/lib/Simplifier/DifficultyScore.cpp
+++ b/lib/Simplifier/DifficultyScore.cpp
@@ -119,8 +119,11 @@ long eval(const ASTNode& b)
 long DifficultyScore::score(const ASTNode& top, STPMgr* mgr)
 {
 
-  if (cache.find(top.GetNodeNum()) != cache.end())
-    return cache.find(top.GetNodeNum())->second;
+  {
+    const auto it = cache.find(top.GetNodeNum());
+    if (it != cache.end())
+      return it->second;
+  }
 
   NonAtomIterator ni(top, mgr->ASTUndefined, *mgr);
   ASTNode current;

--- a/lib/Simplifier/NodeDomainAnalysis.cpp
+++ b/lib/Simplifier/NodeDomainAnalysis.cpp
@@ -566,10 +566,11 @@ namespace stp
       assert(emptyBoolean->isTotallyUnfixed());
       return emptyBoolean;
     }
-    if (emptyBitVector.find(n.GetValueWidth()) == emptyBitVector.end())
-      emptyBitVector[n.GetValueWidth()] = fresh(n);
+    auto it = emptyBitVector.find(n.GetValueWidth());
+    if (it == emptyBitVector.end())
+      it = emptyBitVector.emplace(n.GetValueWidth(), fresh(n)).first;
 
-    FixedBits* r = emptyBitVector[n.GetValueWidth()];
+    FixedBits* r = it->second;
     assert(r->isTotallyUnfixed());
     return r;
   }

--- a/lib/Simplifier/Simplifier.cpp
+++ b/lib/Simplifier/Simplifier.cpp
@@ -311,7 +311,8 @@ ASTNode Simplifier::SimplifyFormula(const ASTNode& b, bool pushNeg)
   }
 
   UpdateSimplifyMap(b, output, pushNeg);
-  UpdateSimplifyMap(a, output, pushNeg);
+  if (a != b) // PullUpITE often returns its input unchanged.
+    UpdateSimplifyMap(a, output, pushNeg);
 
   return output;
 }

--- a/lib/Simplifier/StrengthReduction.cpp
+++ b/lib/Simplifier/StrengthReduction.cpp
@@ -329,13 +329,13 @@ namespace stp
              kind == SBVMOD || kind == SBVREM || kind == BVSADDO ||
              kind == BVSSUBO)
     {
-      if (visited.find(n[0]) != visited.end() &&
-          visited.find(n[1]) != visited.end())
-        if (visited.find(n[0])->second != nullptr &&
-            visited.find(n[1])->second != nullptr)
+      const auto lIt = visited.find(n[0]);
+      const auto rIt = visited.find(n[1]);
+      if (lIt != visited.end() && rIt != visited.end())
+        if (lIt->second != nullptr && rIt->second != nullptr)
         {
-          const FixedBits* l = visited.find(n[0])->second;
-          const FixedBits* r = visited.find(n[1])->second;
+          const FixedBits* l = lIt->second;
+          const FixedBits* r = rIt->second;
           const unsigned bw = n[0].GetValueWidth();
           if (l->isFixed(bw - 1) && r->isFixed(bw - 1))
           {

--- a/lib/Simplifier/StrengthReduction.cpp
+++ b/lib/Simplifier/StrengthReduction.cpp
@@ -39,15 +39,21 @@ namespace stp
     if (n.isAtom())
       return n;
 
-    if (cache.find(n) != cache.end())
-      return (*(cache.find(n))).second;
+    {
+      const ASTNodeMap::const_iterator it = cache.find(n);
+      if (it != cache.end())
+        return it->second;
+    }
 
     ASTNode result = n;
 
-    if (fromTo.find(n) != fromTo.end())
     {
-      result = (*fromTo.find(n)).second;
-      fromTo.erase(n); // this is how it differs from the everyday replace.
+      const ASTNodeMap::iterator it = fromTo.find(n);
+      if (it != fromTo.end())
+      {
+        result = it->second;
+        fromTo.erase(it); // this is how it differs from the everyday replace.
+      }
     }
 
     ASTVec new_children;
@@ -84,8 +90,11 @@ namespace stp
     if (n.Degree() == 0 )
       return n;
 
-    if (cache.find(n) != cache.end())
-      return cache[n];
+    {
+      const ASTNodeMap::const_iterator it = cache.find(n);
+      if (it != cache.end())
+        return it->second;
+    }
 
     ASTVec children;
     children.reserve(n.Degree());

--- a/lib/Simplifier/VariablesInExpression.cpp
+++ b/lib/Simplifier/VariablesInExpression.cpp
@@ -50,9 +50,10 @@ void VariablesInExpression::insert(const ASTNode& n, Symbols* s)
 // no new symbols are introduced.
 Symbols* VariablesInExpression::getSymbol(const ASTNode& n)
 {
-  if (symbol_graph.find(n.GetNodeNum()) != symbol_graph.end())
   {
-    return symbol_graph[n.GetNodeNum()];
+    const ASTNodeToNodes::const_iterator it = symbol_graph.find(n.GetNodeNum());
+    if (it != symbol_graph.end())
+      return it->second;
   }
 
   Symbols* node;


### PR DESCRIPTION
## What

Hash each key once on the hot memo paths of the simplifier. No behaviour
change: every one of these sites already computed the right answer, it just
hashed the same key two or three times to get there.

## The pattern

The recurring shape is `map.find(k)` to test for membership, followed by
`map[k]` or a second `map.find(k)` to read the value:

```cpp
if (cache.find(n) != cache.end())
  return cache[n];              // second hash + probe of the same key
```

Each is rewritten to keep the iterator that the one `find()` already returned.
All of these are on per-node recursive walks, so they run once per node of the
expression graph, and the memo-hit branch is the common case.

| Site | Before |
|---|---|
| `StrengthReduction::visit` | `cache.find(n)` then `cache[n]` |
| `StrengthReduction::replace` (cache) | `cache.find(n)` twice |
| `StrengthReduction::replace` (fromTo) | `fromTo.find(n)` twice, then `fromTo.erase(n)` by key |
| `StrengthReduction::strengthReduction(NodeToFixedBitsMap)` | `n[0]` and `n[1]` each looked up three times on the signed-comparison path |
| `NodeDomainAnalysis::getEmptyFixedBits` | `find()` then `operator[]` then `operator[]` |
| `VariablesInExpression::getSymbol` | `find()` then `operator[]` |
| `MutableASTNode::build` | `find()` twice per already-seen node |
| `DifficultyScore::score` | `find()` twice on the memo hit |

One extra, of a slightly different kind: `Simplifier::SimplifyFormula` ends with

```cpp
UpdateSimplifyMap(b, output, pushNeg, VarConstMap);
UpdateSimplifyMap(a, output, pushNeg, VarConstMap);
```

where `a = PullUpITE(b)`. `PullUpITE` usually returns its input unchanged, and
when it does the two calls have identical key, value and `pushNeg`, so the
second is a pure repeat of the first. It is now guarded with `if (a != b)`.
`UpdateSimplifyMap` is a plain map assignment plus a `hasBeenSimplfied()` flag
set, both idempotent, so skipping the exact repeat is equivalent.

## Why it is safe

Semantics are unchanged at every site: the same key is looked up, the same
value is returned, and where an element is created (`getEmptyFixedBits`) it is
created with the same value it had before, by a `fresh()` call that does not
itself touch the map.

The one way a change like this can be silently wrong is iterator invalidation:
caching an iterator across a call that can write to the same map is undefined
behaviour. That was checked at each site, and it does not occur:

* `StrengthReduction::visit`, `StrengthReduction::replace`,
  `VariablesInExpression::getSymbol`, `MutableASTNode::build`,
  `DifficultyScore::score` — the iterator is used in an early `return` on the
  memo hit. The recursion into children is only reached on the memo *miss*
  path, after the iterator is out of scope. (Each lookup is wrapped in its own
  `{ }` block to make that lifetime explicit.)
* `StrengthReduction::replace`'s `fromTo` lookup — `result` is copied out of
  the iterator and the iterator is then passed to `erase`; the recursive
  `replace()` calls come afterwards. `erase(it)` erases exactly the element
  `erase(n)` did.
* `StrengthReduction::strengthReduction` signed-comparison path — `lIt` and
  `rIt` are dereferenced into `const FixedBits*` immediately, before any node
  is created; nothing runs between the `find`s and the dereferences.
* `NodeDomainAnalysis::getEmptyFixedBits` — not recursive; the only mutation is
  the `emplace` whose own return value the iterator is reassigned from.

## Sites considered and rejected

* **`Simplifier::UpdateSimplifyMap`** does `(*SimplifyMap)[key] = value`. That
  is already a single hash plus probe, so there is nothing to save.
  `try_emplace` would be *wrong* here, because it does not overwrite an
  existing entry and this map is legitimately re-assigned.
* **`Simplifier::SimplifyNotFormula`** does `CheckSimplifyMap(o, output, pn)`
  and then calls `SimplifyFormula(o, pn, ...)`, which immediately does the same
  `CheckSimplifyMap(o, ...)` again. Removing that redundant probe requires
  splitting `SimplifyFormula` into a memo-checking wrapper and a body — a
  structural change, not a lookup fix — so it is left alone.

## Measurements

Instruction counts (`perf stat`) over the 40-file pre-CNF corpus, Release,
CaDiCaL, mimalloc, `--output-CNF --exit-after-CNF`. Instruction counts are used
rather than wall clock because they are reproducible to about 0.001% on this
hardware, whereas wall clock has a roughly +-4% noise floor — far too coarse to
resolve a change of this size.

Selected rows (full corpus is 40 files; `cnf` column confirms the emitted CNF
is byte-identical for every one):

| file | base insn | cand insn | delta |
|---|---|---|---|
| SRAI-SAFE-12-1024 | 17,704,590,753 | 17,273,993,297 | **-2.43%** |
| SRL-SAFE-16-1024 | 8,190,166,175 | 8,059,317,217 | -1.60% |
| SRAI-SAFE-80-1024 | 30,427,921,348 | 29,995,374,267 | -1.42% |
| ext_con_056_128_0512 | 4,540,165,901 | 4,522,215,926 | -0.40% |
| edge-matching-width=9-height=9-colours=11 | 33,900,660,988 | 33,796,001,086 | -0.31% |
| solitaire-edge-time=24 | 4,237,774,691 | 4,224,672,664 | -0.31% |
| vlsat3_a80 | 7,007,389,863 | 6,990,911,974 | -0.24% |
| 15-puzzle.init10 | 11,006,464,434 | 10,980,015,912 | -0.24% |
| arbiter_data_integrity_n4q8w8d8b30 | 3,026,698,177 | 3,020,024,688 | -0.22% |
| picorv32_mutBX_QF_BV_NONINCR | 11,065,393,127 | 11,041,092,285 | -0.22% |
| testcase15.stp | 21,869,404,797 | 21,837,460,046 | -0.15% |
| rw_rule_candidate_vmcai_2022_bw512_14 | 138,560,205,746 | 138,559,543,371 | -0.00% |
| **corpus total** | **880,604,962,564** | **879,087,298,595** | **-0.17%** |

Every file improves or is flat; none regresses. CNF mismatches: 0.

The three `rw_rule_candidate_vmcai_2022_bw512_*` files are flat at -0.00%, and
between them they are a third of the corpus's instruction count. Their time is
almost entirely wide-multiply constant-bit propagation, which this change does
not touch. Excluding them, the remaining 37 files move **-0.256%**.

This is a small, free win, not a headline one. It is worth taking because it
costs nothing: no new state, no new branches on the hot path, and the code is
arguably clearer for holding the iterator it already had.

## Verification

Baseline is current `master` (`f18c2f78`), candidate is this branch, both built
with identical options.

Completed and passing:

* `cnf_neutral.sh` over the 40-file pre-CNF corpus: **39 identical, 0
  mismatched, 1 skipped** (the skipped file emits no CNF on the baseline
  either).
* `cnf_neutral.sh` over 600 fuzz files with `TIMEOUT=20`: **392 identical, 0
  mismatched, 208 skipped** (skipped = no CNF emitted by the baseline).
* `answer_diff.sh` over the full 2501-file fuzz corpus: **2501 agree, 0
  disagree, 0 skipped**.
* `ab_precnf.sh` instruction-count A/B: the table above, 0 CNF mismatches.
* `ctest` on a Debug build with assertions enabled: **67/67 passed, 0 failed**.

## Note for whoever merges second

`simplifier-varconstmap-and-end-deref` touches `Simplifier.cpp` and
`StrengthReduction.cpp` as well — it removes the always-NULL `VarConstMap`
parameter and fixes an `end()` dereference in the BVPLUS/BVXOR arm of
`strengthReduction`. This branch is deliberately independent of it and applies
to `master` as it stands, but whichever of the two lands second will need a
trivial rebase.
