### PR TITLE
Add three node-reducing rules to the sharing-aware Rewriting pass

### DIFF
--- a/lib/Simplifier/Rewriting.cpp
+++ b/lib/Simplifier/Rewriting.cpp
@@ -43,6 +43,8 @@ THE SOFTWARE.
 
 
 #include "stp/Simplifier/Rewriting.h"
+#include "stp/Simplifier/Simplifier.h"
+#include "stp/Simplifier/SubstitutionMap.h"
 #include <list>
 
 namespace stp
@@ -550,15 +552,136 @@ namespace stp
         }
 
 /*
-(EQ 
-  62:(BVMULT 
+  (c1 * x) = c0        -->  x = (c1^-1 * c0),        for odd c1.
+  (c1 * x) = (c2 * y)  -->  x = ((c1^-1 * c2) * y),  for odd c1.
+
+  Multiplication by an odd constant is a bijection mod 2^w, so multiplying
+  both sides by the inverse preserves the equality. The multiplication on
+  the c1 side disappears outright.
+*/
+    if (c.GetKind() == EQ)
+      for (unsigned i = 0; i < 2; i++)
+      {
+        const ASTNode& mult = c[i];
+        const ASTNode& other = c[1 - i];
+
+        if (mult.GetKind() != BVMULT || mult.Degree() != 2 ||
+            mult[0].GetKind() != BVCONST ||
+            !CONSTANTBV::BitVector_bit_test(mult[0].GetBVConst(), 0) ||
+            shareCount[mult.GetNodeNum()] > 1)
+          continue;
+
+        const bool otherIsConst = other.GetKind() == BVCONST;
+        // The other side's multiplication dies too (it's rebuilt with a
+        // different constant), so it must also be unshared.
+        const bool otherIsMult =
+            other.GetKind() == BVMULT && other.Degree() == 2 &&
+            other[0].GetKind() == BVCONST &&
+            shareCount[other.GetNodeNum()] <= 1;
+
+        if (!otherIsConst && !otherIsMult)
+          continue;
+
+        const auto width = mult.GetValueWidth();
+        SubstitutionMap subMap(stpMgr);
+        Simplifier simplifier(stpMgr, &subMap);
+        const ASTNode inverse = simplifier.MultiplicativeInverse(mult[0]);
+
+        ASTNode rhs;
+        if (otherIsConst)
+          rhs = nf->CreateTerm(BVMULT, width, inverse, other);
+        else
+          rhs = nf->CreateTerm(
+              BVMULT, width,
+              nf->CreateTerm(BVMULT, width, inverse, other[0]), other[1]);
+
+        c = nf->CreateNode(EQ, mult[1], rhs);
+        break;
+      }
+
+/*
+  (a + x + y) = (a + z)  -->  (x + y) = z
+
+  Addition is cancellative mod 2^w, so addends common to both sides drop
+  with no overflow condition. Each match cancels one occurrence per side.
+*/
+    if (c.GetKind() == EQ
+        && c[0].GetKind() == BVPLUS
+        && c[1].GetKind() == BVPLUS
+        && shareCount[c[0].GetNodeNum()] <= 1
+        && shareCount[c[1].GetNodeNum()] <= 1)
+    {
+      const ASTChildren ch0 = c[0].GetChildren();
+      const ASTChildren ch1 = c[1].GetChildren();
+      ASTVec v0(ch0.begin(), ch0.end());
+      ASTVec v1(ch1.begin(), ch1.end());
+      bool cancelled = false;
+
+      for (auto it = v0.begin(); it != v0.end();)
+      {
+        const auto match = std::find(v1.begin(), v1.end(), *it);
+        if (match != v1.end())
+        {
+          v1.erase(match);
+          it = v0.erase(it);
+          cancelled = true;
+        }
+        else
+          ++it;
+      }
+
+      if (cancelled)
+      {
+        const auto width = c[0].GetValueWidth();
+        auto rebuild = [&](const ASTVec& v) {
+          if (v.empty())
+            return nf->CreateZeroConst(width);
+          if (v.size() == 1)
+            return v[0];
+          return nf->CreateTerm(BVPLUS, width, v);
+        };
+        c = nf->CreateNode(EQ, rebuild(v0), rebuild(v1));
+      }
+    }
+
+/*
+  (a * b) + (a * d)  -->  a * (b + d)
+
+  Multiplication distributes over addition, so a shared factor pulls out
+  and two multiplications become one.
+*/
+    if (c.GetKind() == BVPLUS
+        && c.Degree() == 2
+        && c[0].GetKind() == BVMULT
+        && c[0].Degree() == 2
+        && c[1].GetKind() == BVMULT
+        && c[1].Degree() == 2
+        && shareCount[c[0].GetNodeNum()] <= 1
+        && shareCount[c[1].GetNodeNum()] <= 1)
+    {
+      bool fired = false;
+      for (unsigned i = 0; i < 2 && !fired; i++)
+        for (unsigned j = 0; j < 2 && !fired; j++)
+          if (c[0][i] == c[1][j])
+          {
+            const auto width = c.GetValueWidth();
+            const auto sum =
+                nf->CreateTerm(BVPLUS, width, c[0][1 - i], c[1][1 - j]);
+            c = nf->CreateTerm(BVMULT, width, c[0][i], sum);
+            fired = true;
+          }
+    }
+
+/*
+(EQ
+  62:(BVMULT
     48:t
-    60:(BVPLUS 
+    60:(BVPLUS
       42:s
       58:...)
-  76:(BVMULT 
+  76:(BVMULT
     42:s
-    74:(BVPLUS 
+    74:(BVPLUS
       48:t
       72:...))
   */

--- a/tests/unit-tests/Rewriting_Exhaustive_Test.cpp
+++ b/tests/unit-tests/Rewriting_Exhaustive_Test.cpp
@@ -354,4 +354,91 @@ TEST(Rewriting_Exhaustive, bvand_ite_from_bvor_shape)
   c.checkEquivalent(top, c.run(top));
 }
 
+/* (c1 * x) = c0 with odd c1: multiply through by the inverse; the
+   multiplication disappears. 5^-1 mod 8 is 5, so x = 5*3 mod 8 = 7. */
+TEST(Rewriting_Exhaustive, eq_mult_constant_inverse)
+{
+  Context c;
+  ASTNode x = c.bv(3);
+  ASTNode mult = c.hf->CreateTerm(BVMULT, 3, c.konst(5, 3), x);
+  ASTNode top = c.hf->CreateNode(NOT, c.hf->CreateNode(EQ, mult, c.konst(3, 3)));
+  EXPECT_NE(c.run(top), top);
+  c.checkEquivalent(top, c.run(top));
+}
+
+/* (c1 * x) = (c2 * y) with odd c1 --> x = ((c1^-1 * c2) * y) */
+TEST(Rewriting_Exhaustive, eq_mult_mult_inverse)
+{
+  Context c;
+  ASTNode x = c.bv(3), y = c.bv(3);
+  ASTNode m1 = c.hf->CreateTerm(BVMULT, 3, c.konst(3, 3), x);
+  ASTNode m2 = c.hf->CreateTerm(BVMULT, 3, c.konst(2, 3), y);
+  ASTNode top = c.hf->CreateNode(NOT, c.hf->CreateNode(EQ, m1, m2));
+  EXPECT_NE(c.run(top), top);
+  c.checkEquivalent(top, c.run(top));
+}
+
+/* the mult is shared, so multiplying through would strand it: no fire */
+TEST(Rewriting_Exhaustive, eq_mult_inverse_respects_sharing)
+{
+  Context c;
+  ASTNode x = c.bv(3), y = c.bv(3);
+  ASTNode mult = c.hf->CreateTerm(BVMULT, 3, c.konst(5, 3), x);
+  ASTNode eq1 = c.hf->CreateNode(EQ, mult, c.konst(3, 3));
+  ASTNode eq2 = c.hf->CreateNode(EQ, mult, y);
+  ASTNode top = c.hf->CreateNode(AND, eq1, eq2);
+  EXPECT_EQ(c.run(top), top);
+  c.checkEquivalent(top, c.run(top));
+}
+
+/* addends common to both sides of an equality cancel, one occurrence per
+   side per match */
+TEST(Rewriting_Exhaustive, eq_plus_plus_cancel)
+{
+  Context c;
+  ASTNode a = c.bv(2), x = c.bv(2), y = c.bv(2), z = c.bv(2);
+
+  ASTNode lhs = c.hf->CreateTerm(BVPLUS, 2, a, x, y);
+  ASTNode rhs = c.hf->CreateTerm(BVPLUS, 2, a, z);
+  ASTNode top = c.hf->CreateNode(NOT, c.hf->CreateNode(EQ, lhs, rhs));
+  EXPECT_NE(c.run(top), top);
+  c.checkEquivalent(top, c.run(top));
+
+  // x + x = x + y cancels only one occurrence of x.
+  ASTNode lhs2 = c.hf->CreateTerm(BVPLUS, 2, x, x);
+  ASTNode rhs2 = c.hf->CreateTerm(BVPLUS, 2, x, y);
+  ASTNode top2 = c.hf->CreateNode(NOT, c.hf->CreateNode(EQ, lhs2, rhs2));
+  EXPECT_NE(c.run(top2), top2);
+  c.checkEquivalent(top2, c.run(top2));
+
+  // Identical sums cancel completely, to 0 = 0.
+  ASTNode top3 = c.hf->CreateNode(
+      NOT, c.hf->CreateNode(EQ, c.hf->CreateTerm(BVPLUS, 2, x, y),
+                            c.hf->CreateTerm(BVPLUS, 2, y, x)));
+  c.checkEquivalent(top3, c.run(top3));
+}
+
+/* (a * b) + (a * d) --> a * (b + d), including when the summed constants
+   fold to zero */
+TEST(Rewriting_Exhaustive, plus_of_shared_factor_mults)
+{
+  Context c;
+  ASTNode a = c.bv(3), b = c.bv(3), d = c.bv(3);
+  ASTNode m1 = c.hf->CreateTerm(BVMULT, 3, a, b);
+  ASTNode m2 = c.hf->CreateTerm(BVMULT, 3, a, d);
+  ASTNode plus = c.hf->CreateTerm(BVPLUS, 3, m1, m2);
+  ASTNode top = c.hf->CreateNode(EQ, plus, c.bv(3));
+  EXPECT_NE(c.run(top), top);
+  c.checkEquivalent(top, c.run(top));
+
+  // 3x + 5x at width 3 is 8x = 0.
+  ASTNode x = c.bv(3);
+  ASTNode k1 = c.hf->CreateTerm(BVMULT, 3, c.konst(3, 3), x);
+  ASTNode k2 = c.hf->CreateTerm(BVMULT, 3, c.konst(5, 3), x);
+  ASTNode plus2 = c.hf->CreateTerm(BVPLUS, 3, k1, k2);
+  ASTNode top2 = c.hf->CreateNode(EQ, plus2, c.bv(3));
+  EXPECT_NE(c.run(top2), top2);
+  c.checkEquivalent(top2, c.run(top2));
+}
+
 } // namespace


### PR DESCRIPTION
Three new rules for the Rewriting pass, all purely syntactic and all strictly node-reducing under the pass's usual single-use share-count guards (the nodes each rule replaces are proven dead before it fires).

- **Multiply through by a constant's inverse.** `(c1 * x) = c0` with odd `c1` becomes `x = (c1^-1 * c0)`, and `(c1 * x) = (c2 * y)` becomes `x = ((c1^-1 * c2) * y)`. Multiplication by an odd constant is a bijection mod 2^w, so the equality is preserved and a multiplication disappears from the problem. Uses the existing `Simplifier::MultiplicativeInverse`.
- **Cancel common addends across an equality.** `(a + x + y) = (a + z)` becomes `(x + y) = z`. Addition is cancellative mod 2^w, so no overflow side-condition is needed; matching is multiset-style, one occurrence per side per match. Works at any arity of either plus.
- **Pull out a shared multiplication factor.** `(a * b) + (a * d)` becomes `a * (b + d)`, turning two multiplications into one. When the residual sum folds — e.g. `3x + 5x` at width 3, where `3+5 = 0` — the whole product collapses to a constant.

**Testing**
- New cases in `Rewriting_Exhaustive_Test.cpp` prove each rule fires, respects the sharing guard (a shared multiplication is left alone), and agrees with the original formula on every assignment at small widths (15 tests pass).
- Full `ctest` suite passes (67/67).
- Differential sat/unsat sweep vs the previous build over a 2501-file corpus, new side with assertions on: no mismatches, no assertion failures.