### PR TITLE
Correct the division-by-zero comments in the constant evaluator

### DIFF
--- a/lib/Simplifier/consteval.cpp
+++ b/lib/Simplifier/consteval.cpp
@@ -342,7 +342,9 @@ ASTNode NonMemberBVConstEvaluator(STPMgr* _bm, const Kind k,
 
       if (CONSTANTBV::BitVector_is_empty(tmp1))
       {
-        // Expecting a division by zero. Just return one.
+        // Division by zero, which SMT-LIB defines rather than leaving
+        // undefined: (bvsrem s 0) is s, and (bvsdiv s 0) is 1 when s is
+        // negative and all ones (that is, -1) when it is not.
         if (k == SBVREM)
           OutputNode = children[0];
         else
@@ -528,12 +530,17 @@ ASTNode NonMemberBVConstEvaluator(STPMgr* _bm, const Kind k,
       {
         // a = bq + r, where b!=0 implies r < b. q is quotient, r remainder.
         // i.e. a/b = q.
-        // It doesn't matter what q is when b=0, but r needs to be a.
+        //
+        // Division by zero is defined rather than undefined in SMT-LIB:
+        // (bvurem a 0) is a, which follows from the identity above, while
+        // (bvudiv a 0) is all ones, which does not. That asymmetry is why
+        // the bit-blaster guards BVDIV with an explicit divisor-is-zero
+        // test and needs nothing for BVMOD; see the BVDIV case of BBTerm
+        // in lib/ToSat/BitBlaster.cpp.
         if (k == BVMOD)
           OutputNode = children[0];
         else
           OutputNode = _bm->CreateMaxConst(outputwidth);
-        // Expecting a division by zero. Just return one.
       }
       else
       {


### PR DESCRIPTION
Both division-by-zero branches in `NonMemberBVConstEvaluator` carried the
comment

    // Expecting a division by zero. Just return one.

which does not describe what either branch does.

What the code actually returns, and what SMT-LIB requires:

| operation | divisor is zero | result |
|---|---|---|
| `bvudiv` / `BVDIV` | | all ones |
| `bvurem` / `BVMOD` | | the dividend |
| `bvsdiv` / `SBVDIV` | dividend negative | one |
| `bvsdiv` / `SBVDIV` | dividend non-negative | all ones, i.e. -1 |
| `bvsrem` / `SBVREM` | | the dividend |

The unsigned branch additionally claimed

    // It doesn't matter what q is when b=0, but r needs to be a.

It does matter -- `(bvudiv a 0)` is all ones, not an arbitrary value. The
useful observation buried in that sentence is a different one: the *remainder*
follows from the `a = bq + r` identity quoted just above it, whereas the
quotient does not. That is exactly why `BBTerm` guards `BVDIV` with an explicit
divisor-is-zero test and needs nothing equivalent for `BVMOD`, so the corrected
comment points at that code.

Comments only. No behaviour change, and the emitted CNF is unaffected.