### PR TITLE
StrengthReduction: cancel a shared multiplication factor across an equality

### DIFF
--- a/lib/Simplifier/StrengthReduction.cpp
+++ b/lib/Simplifier/StrengthReduction.cpp
@@ -132,6 +132,35 @@ namespace stp
     return result;
   }
 
+  // True unless the product of the operands' interval maxima provably
+  // fits in `width` bits, i.e. the multiplication can't wrap. Both
+  // maxima are zero-extended into 2w+1 bits so the signed
+  // BitVector_Multiply computes the unsigned product.
+  static bool multMayOverflow(const UnsignedInterval* a,
+                              const UnsignedInterval* b, unsigned width)
+  {
+    if (a == nullptr || b == nullptr)
+      return true;
+
+    const unsigned ew = 2 * width + 1;
+    CBV a2 = CONSTANTBV::BitVector_Create(ew, true);
+    CBV b2 = CONSTANTBV::BitVector_Create(ew, true);
+    CBV product = CONSTANTBV::BitVector_Create(ew, true);
+    CONSTANTBV::BitVector_Interval_Copy(a2, a->maxV, 0, 0, width);
+    CONSTANTBV::BitVector_Interval_Copy(b2, b->maxV, 0, 0, width);
+    CONSTANTBV::BitVector_Multiply(product, a2, b2);
+
+    bool overflow = false;
+    for (unsigned i = width; i < ew && !overflow; i++)
+      if (CONSTANTBV::BitVector_bit_test(product, i))
+        overflow = true;
+
+    CONSTANTBV::BitVector_Destroy(a2);
+    CONSTANTBV::BitVector_Destroy(b2);
+    CONSTANTBV::BitVector_Destroy(product);
+    return overflow;
+  }
+
   // Lots of these rules are more nicely addressed by the fixedbits.
   // When information is transferred properly between domains, lots can be removed.
   ASTNode StrengthReduction::strengthReduction(const ASTNode& n, const NodeToUnsignedIntervalMap& visited)
@@ -301,6 +330,35 @@ namespace stp
           replaceWithSimpler++;
         }
       }
+
+      // (a * b) = (a * c) --> b = c, when a is provably non-zero and
+      // neither multiplication can wrap: without wrapping the products
+      // are integer products, and a non-zero common factor cancels.
+      if (newN == n && n[0].GetKind() == BVMULT && n[0].Degree() == 2 &&
+          n[1].GetKind() == BVMULT && n[1].Degree() == 2)
+      {
+        const auto get = [&visited](const ASTNode& m) -> const UnsignedInterval* {
+          const auto it = visited.find(m);
+          return it == visited.end() ? nullptr : it->second;
+        };
+
+        const unsigned width = n[0].GetValueWidth();
+
+        for (unsigned i = 0; i < 2 && newN == n; i++)
+          for (unsigned j = 0; j < 2 && newN == n; j++)
+            if (n[0][i] == n[1][j])
+            {
+              const UnsignedInterval* shared = get(n[0][i]);
+              if (shared != nullptr &&
+                  !CONSTANTBV::BitVector_is_empty(shared->minV) &&
+                  !multMayOverflow(get(n[0][0]), get(n[0][1]), width) &&
+                  !multMayOverflow(get(n[1][0]), get(n[1][1]), width))
+              {
+                newN = nf->CreateNode(EQ, n[0][1 - i], n[1][1 - j]);
+                replaceWithSimpler++;
+              }
+            }
+      }
     }
     return newN;
   }
@@ -428,6 +486,28 @@ namespace stp
             }
           }
         }
+    }
+    else if (kind == EQ)
+    {
+      // (a * x) = (a * y) --> x = y, when a's lowest bit is fixed to
+      // one: multiplication by an odd factor is a bijection mod 2^w,
+      // so the factor cancels with no overflow condition.
+      if (n[0].GetKind() == BVMULT && n[0].Degree() == 2 &&
+          n[1].GetKind() == BVMULT && n[1].Degree() == 2)
+      {
+        for (unsigned i = 0; i < 2 && newN == n; i++)
+          for (unsigned j = 0; j < 2 && newN == n; j++)
+            if (n[0][i] == n[1][j])
+            {
+              const auto it = visited.find(n[0][i]);
+              if (it != visited.end() && it->second != nullptr &&
+                  it->second->isFixed(0) && it->second->getValue(0))
+              {
+                newN = nf->CreateNode(EQ, n[0][1 - i], n[1][1 - j]);
+                replaceWithSimpler++;
+              }
+            }
+      }
     }
     else if (kind == BVPLUS || kind == BVXOR)
     {

--- a/tests/unit-tests/StrengthReduction_Exhaustive_Test.cpp
+++ b/tests/unit-tests/StrengthReduction_Exhaustive_Test.cpp
@@ -1072,3 +1072,149 @@ TEST(StrengthReduction_Exhaustive_Test, plus_to_concat_via_fixedbits)
       n, result, x, y, width, [](unsigned v) { return (v & 7) == 0; },
       [](unsigned v) { return v < 8; });
 }
+
+// (a * x) = (a * y) --> x = y once a's lowest bit is fixed to one:
+// multiplication by an odd factor is a bijection mod 2^w, so the factor
+// cancels with no overflow condition. Equivalent for every odd a.
+TEST(StrengthReduction_Exhaustive_Test, eq_mult_cancelled_via_odd_fixedbit)
+{
+  const unsigned width = 3;
+
+  Context c;
+  ASTNode a = c.symbol("a", width);
+  ASTNode x = c.symbol("x", width);
+  ASTNode y = c.symbol("y", width);
+  ASTNode m0 = c.nf->CreateTerm(stp::BVMULT, width, a, x);
+  ASTNode m1 = c.nf->CreateTerm(stp::BVMULT, width, a, y);
+  ASTNode n = c.nf->CreateNode(stp::EQ, m0, m1);
+  ASSERT_EQ(n.GetKind(), stp::EQ);
+
+  FixedBits aBits(width, false);
+  aBits.setFixed(0, true);
+  aBits.setValue(0, true);
+
+  stp::NodeToFixedBitsMap map;
+  map.insert({n, nullptr});
+  map.insert({m0, nullptr});
+  map.insert({m1, nullptr});
+  map.insert({a, &aBits});
+
+  ASTNode result = c.sr.topLevel(n, map);
+  ASSERT_FALSE(c.present(stp::BVMULT, result));
+
+  for (unsigned av = 1; av < (1u << width); av += 2)
+    for (unsigned xv = 0; xv < (1u << width); xv++)
+      for (unsigned yv = 0; yv < (1u << width); yv++)
+      {
+        stp::ASTNodeMap assignment;
+        assignment.insert({a, c.constant(width, av)});
+        assignment.insert({x, c.constant(width, xv)});
+        assignment.insert({y, c.constant(width, yv)});
+        ASSERT_EQ(c.eval(n, assignment), c.eval(result, assignment))
+            << "differ on a=" << av << " x=" << xv << " y=" << yv;
+      }
+}
+
+// (a * x) = (a * y) --> x = y when a's interval excludes zero and the
+// operands' interval maxima prove neither product can wrap: overflow-free
+// products are integer products, and a non-zero common factor cancels.
+// Equivalent for every assignment inside the intervals.
+TEST(StrengthReduction_Exhaustive_Test, eq_mult_cancelled_via_intervals)
+{
+  const unsigned width = 4;
+
+  Context c;
+  ASTNode a = c.symbol("a", width);
+  ASTNode x = c.symbol("x", width);
+  ASTNode y = c.symbol("y", width);
+  ASTNode m0 = c.nf->CreateTerm(stp::BVMULT, width, a, x);
+  ASTNode m1 = c.nf->CreateTerm(stp::BVMULT, width, a, y);
+  ASTNode n = c.nf->CreateNode(stp::EQ, m0, m1);
+  ASSERT_EQ(n.GetKind(), stp::EQ);
+
+  stp::UnsignedInterval aInterval(makeCBV(width, 1), makeCBV(width, 2));
+  stp::UnsignedInterval xInterval(makeCBV(width, 0), makeCBV(width, 3));
+  stp::UnsignedInterval yInterval(makeCBV(width, 0), makeCBV(width, 3));
+
+  stp::NodeToUnsignedIntervalMap map;
+  map.insert({n, nullptr});
+  map.insert({m0, nullptr});
+  map.insert({m1, nullptr});
+  map.insert({a, &aInterval});
+  map.insert({x, &xInterval});
+  map.insert({y, &yInterval});
+
+  ASTNode result = c.sr.topLevel(n, map);
+  ASSERT_FALSE(c.present(stp::BVMULT, result));
+
+  for (unsigned av = 1; av <= 2; av++)
+    for (unsigned xv = 0; xv <= 3; xv++)
+      for (unsigned yv = 0; yv <= 3; yv++)
+      {
+        stp::ASTNodeMap assignment;
+        assignment.insert({a, c.constant(width, av)});
+        assignment.insert({x, c.constant(width, xv)});
+        assignment.insert({y, c.constant(width, yv)});
+        ASSERT_EQ(c.eval(n, assignment), c.eval(result, assignment))
+            << "differ on a=" << av << " x=" << xv << " y=" << yv;
+      }
+}
+
+// The interval cancellation must NOT fire when the shared factor may be
+// zero, or when a product may wrap.
+TEST(StrengthReduction_Exhaustive_Test, eq_mult_not_cancelled_without_proof)
+{
+  const unsigned width = 4;
+
+  // Shared factor may be zero.
+  {
+    Context c;
+    ASTNode a = c.symbol("a", width);
+    ASTNode x = c.symbol("x", width);
+    ASTNode y = c.symbol("y", width);
+    ASTNode m0 = c.nf->CreateTerm(stp::BVMULT, width, a, x);
+    ASTNode m1 = c.nf->CreateTerm(stp::BVMULT, width, a, y);
+    ASTNode n = c.nf->CreateNode(stp::EQ, m0, m1);
+
+    stp::UnsignedInterval aInterval(makeCBV(width, 0), makeCBV(width, 2));
+    stp::UnsignedInterval xInterval(makeCBV(width, 0), makeCBV(width, 3));
+    stp::UnsignedInterval yInterval(makeCBV(width, 0), makeCBV(width, 3));
+
+    stp::NodeToUnsignedIntervalMap map;
+    map.insert({n, nullptr});
+    map.insert({m0, nullptr});
+    map.insert({m1, nullptr});
+    map.insert({a, &aInterval});
+    map.insert({x, &xInterval});
+    map.insert({y, &yInterval});
+
+    ASTNode result = c.sr.topLevel(n, map);
+    ASSERT_EQ(result, n);
+  }
+
+  // Products may wrap: 6 * 3 exceeds 4 bits.
+  {
+    Context c;
+    ASTNode a = c.symbol("a", width);
+    ASTNode x = c.symbol("x", width);
+    ASTNode y = c.symbol("y", width);
+    ASTNode m0 = c.nf->CreateTerm(stp::BVMULT, width, a, x);
+    ASTNode m1 = c.nf->CreateTerm(stp::BVMULT, width, a, y);
+    ASTNode n = c.nf->CreateNode(stp::EQ, m0, m1);
+
+    stp::UnsignedInterval aInterval(makeCBV(width, 1), makeCBV(width, 6));
+    stp::UnsignedInterval xInterval(makeCBV(width, 0), makeCBV(width, 3));
+    stp::UnsignedInterval yInterval(makeCBV(width, 0), makeCBV(width, 3));
+
+    stp::NodeToUnsignedIntervalMap map;
+    map.insert({n, nullptr});
+    map.insert({m0, nullptr});
+    map.insert({m1, nullptr});
+    map.insert({a, &aInterval});
+    map.insert({x, &xInterval});
+    map.insert({y, &yInterval});
+
+    ASTNode result = c.sr.topLevel(n, map);
+    ASSERT_EQ(result, n);
+  }
+}


### PR DESCRIPTION
Two domain-guarded cancellation rules for `StrengthReduction`, using the fixed-bits and interval maps it already consumes:

- **Fixed bits:** `(a * x) = (a * y) --> x = y` when `a`'s lowest bit is fixed to one. Multiplication by an odd factor is a bijection mod 2^w, so the factor cancels outright — no overflow condition needed. This generalises constant-inverse cancellation (#657) to any factor whose oddness is provable.
- **Intervals:** `(a * b) = (a * c) --> b = c` when `a`'s interval excludes zero and multiplying the operands' interval maxima proves neither product can wrap. Overflow-free products are integer products, and a non-zero common factor cancels there. The overflow check zero-extends the maxima into 2w+1 bits before multiplying, since `BitVector_Multiply` is signed (same approach as the existing exact overflow test in `UnsignedIntervalAnalysis`).

The shared factor matches in any operand position of either 2-arity multiplication.

An `SBVDIV(x,x)` rule was considered here but belongs in the `SimplifyingNodeFactory` instead: `sdiv(0,0)` is all-ones, exactly like `udiv(0,0)`, so `SBVDIV(x,x) --> ITE(x = 0, all-ones, 1)` holds unconditionally — that's being added to #656 beside its `BVDIV` twin. When the domains later prove `x` non-zero, the ITE's condition folds constant-false through the existing replacement machinery, so nothing is lost by not having an interval rule.

**Testing**
- New exhaustive cases in `StrengthReduction_Exhaustive_Test.cpp`: each rule fires under its guard, stays put when the shared factor may be zero or a product may wrap, and agrees with the original on every assignment consistent with the domains (32 tests pass).
- Full `ctest` suite passes (67/67).
- Differential sat/unsat sweep vs the previous build over a 2501-file corpus, new side with assertions on: no mismatches, no assertion failures.