### PR TITLE
Inline ASTNode's ref-counting special members

### DIFF
--- a/include/stp/AST/ASTNode.h
+++ b/include/stp/AST/ASTNode.h
@@ -54,7 +54,14 @@ class ASTNode
   // Ptr to the read data
   ASTInternal* _int_node_ptr;
 
-  DLL_PUBLIC explicit ASTNode(ASTInternal* in);
+  // Creates a new pointer, increments refcount of pointed-to object.
+  DLL_PUBLIC explicit ASTNode(ASTInternal* in) : _int_node_ptr(in)
+  {
+    if (in)
+    {
+      in->IncRef();
+    }
+  }
 
   // Equal iff ASTIntNode pointers are the same.
   friend bool operator==(const ASTNode& node1, const ASTNode& node2)
@@ -78,10 +85,32 @@ public:
   uint8_t getIteration() const;
   void setIteration(uint8_t v) const;
 
+  // Inlined for the same reason as the accessors below: these are among the
+  // hottest calls in STP, and the refcount arithmetic is smaller than the
+  // call sequence needed to reach it.
   DLL_PUBLIC ASTNode() : _int_node_ptr(NULL){};
-  DLL_PUBLIC ASTNode(const ASTNode& n);
-  DLL_PUBLIC ~ASTNode();
-  DLL_PUBLIC ASTNode(ASTNode&& other) noexcept;
+
+  DLL_PUBLIC ASTNode(const ASTNode& n) : _int_node_ptr(n._int_node_ptr)
+  {
+    if (n._int_node_ptr)
+    {
+      n._int_node_ptr->IncRef();
+    }
+  }
+
+  DLL_PUBLIC ~ASTNode()
+  {
+    if (_int_node_ptr)
+    {
+      _int_node_ptr->DecRef();
+    }
+  }
+
+  DLL_PUBLIC ASTNode(ASTNode&& other) noexcept
+      : _int_node_ptr(other._int_node_ptr)
+  {
+    other._int_node_ptr = 0;
+  }
 
   // Print the arguments in lisp format
   friend ostream& LispPrintVec(ostream& os, const ASTVec& v, int indentation);
@@ -122,9 +151,30 @@ public:
   // delegates to the ASTInternal node.
   void nodeprint(ostream& os, bool c_friendly = false) const;
 
-  // Assignment (for ref counting)
-  DLL_PUBLIC ASTNode& operator=(const ASTNode& n);
-  DLL_PUBLIC ASTNode& operator=(ASTNode&& n);
+  // Assignment (for ref counting). The IncRef happens before the DecRef so
+  // that self-assignment is safe.
+  DLL_PUBLIC ASTNode& operator=(const ASTNode& n)
+  {
+    if (n._int_node_ptr)
+      n._int_node_ptr->IncRef();
+
+    if (_int_node_ptr)
+      _int_node_ptr->DecRef();
+
+    _int_node_ptr = n._int_node_ptr;
+    return *this;
+  }
+
+  DLL_PUBLIC ASTNode& operator=(ASTNode&& n)
+  {
+    if (_int_node_ptr)
+      _int_node_ptr->DecRef();
+
+    _int_node_ptr = n._int_node_ptr;
+
+    n._int_node_ptr = 0;
+    return *this;
+  }
 
   // Access node number. Inlined: ASTInternal is complete here (its header no
   // longer includes this one), so these fold to direct field reads at the

--- a/lib/AST/ASTNode.cpp
+++ b/lib/AST/ASTNode.cpp
@@ -44,69 +44,9 @@ STPMgr* ASTNode::GetSTPMgr() const
   return _int_node_ptr->nodeManager;
 }
 
-// Constructor;
-//
-// creates a new pointer, increments refcount of pointed-to object.
-ASTNode::ASTNode(ASTInternal* in) : _int_node_ptr(in)
-{
-  if (in)
-  {
-    in->IncRef();
-  }
-}
-
-//#define ASTNODE_COUNT_OPS
-
-#ifdef ASTNODE_COUNT_OPS
-THREAD_LOCAL_IE int ASTNode::copy = 0;
-THREAD_LOCAL_IE int ASTNode::move = 0;
-THREAD_LOCAL_IE int ASTNode::assign = 0;
-THREAD_LOCAL_IE int ASTNode::destroy = 0;
-THREAD_LOCAL_IE int ASTNode::assign_move = 0;
-#endif
-
-//Maintain _ref_count
-ASTNode::ASTNode(const ASTNode& n) : _int_node_ptr(n._int_node_ptr)
-{
-#ifdef ASTNODE_COUNT_OPS
-  if (++copy % 1000000 == 0)
-    std::cerr << "copy" << copy << std::endl;
-#endif
-
-  if (n._int_node_ptr)
-  {
-    n._int_node_ptr->IncRef();
-  }
-}
-
-ASTNode::ASTNode(ASTNode&& other) noexcept : _int_node_ptr(other._int_node_ptr)
-{
-#ifdef ASTNODE_COUNT_OPS
-  if (++move % 1000000 == 0)
-    std::cerr << "move" << move << std::endl;
-#endif
-
-  other._int_node_ptr = 0;
-}
-
-ASTNode& ASTNode::operator=(ASTNode&& n)
-{
-#ifdef ASTNODE_COUNT_OPS
-  if (++assign_move % 1000000 == 0)
-    std::cerr << "assign_move" << assign_move << std::endl;
-#endif
-
-  if (_int_node_ptr)
-    _int_node_ptr->DecRef();
-
-  _int_node_ptr = n._int_node_ptr;
-
-  n._int_node_ptr = 0;
-  return *this;
-}
-
 // GetKind, GetChildren and GetNodeNum are now inlined in ASTNode.h (possible
 // since ASTInternal.h no longer includes ASTNode.h, breaking the old cycle).
+// The ref-counting special members are inlined there too.
 
 unsigned int ASTNode::GetIndexWidth() const
 {
@@ -143,36 +83,6 @@ types ASTNode::GetType() const
     return ARRAY_TYPE;
 
   return UNKNOWN_TYPE;
-}
-
-ASTNode& ASTNode::operator=(const ASTNode& n)
-{
-#ifdef ASTNODE_COUNT_OPS
-  if (++assign % 1000000 == 0)
-    std::cerr << "assign" << assign << std::endl;
-#endif
-
-  if (n._int_node_ptr)
-    n._int_node_ptr->IncRef();
-
-  if (_int_node_ptr)
-    _int_node_ptr->DecRef();
-
-  _int_node_ptr = n._int_node_ptr;
-  return *this;
-}
-
-ASTNode::~ASTNode()
-{
-#ifdef ASTNODE_COUNT_OPS
-  if (destroy++ % 1000000 == 0)
-    std::cerr << "destroy" << destroy << std::endl;
-#endif
-
-  if (_int_node_ptr)
-  {
-    _int_node_ptr->DecRef();
-  }
 }
 
 // Print the node


### PR DESCRIPTION
`ASTNode`'s copy constructor, move constructor, destructor and both assignment
operators live out of line in `lib/AST/ASTNode.cpp` and are marked
`DLL_PUBLIC`. In a shared-library build every one of them is therefore reached
through the PLT, so a refcount bump -- a null check and an increment -- costs an
indirect call. They are among the most frequently executed functions in STP.

This moves the five bodies into `include/stp/AST/ASTNode.h`.

PLT call sites to those symbols in `libstp.so`:

| symbol | before | after |
|---|---|---|
| `~ASTNode` | 6897 | 40 |
| copy constructor | 1024 | 0 |
| move assignment | 1005 | 0 |
| move constructor | 404 | 0 |
| copy assignment | 278 | 0 |
| `ASTNode(ASTInternal*)` | 13 | 0 |
| **total** | **9621** | **73** |

Copy assignment keeps the increment before the decrement so that self-assignment
stays correct; the comment says so at the call site.

### Measurements

Retired user-space instructions with `--exit-after-CNF`, over 40 QF_BV
benchmarks, one per family. Instruction counts rather than wall clock: the
measuring machine has a wall-clock noise floor near +-4%, while retired
instructions for a fixed binary and input reproduce to about 0.001%.

| | |
|---|---|
| total, 40 files | 877,880,264,658 -> 853,775,001,231 |
| **change** | **-2.75%** |

Per-file it ranges from about 0.00% on the wide-multiply `rw_rule_candidate`
files, which create almost no AST nodes, to -17.75% on `SRAI-SAFE-12-1024`.

### Correctness

The emitted CNF is byte-identical to master:

| check | corpus | result |
|---|---|---|
| CNF byte-identical | 40 QF_BV benchmarks | 39 identical, 0 mismatched, 1 emits no CNF |
| CNF byte-identical | 600 fuzzer queries | 391 identical, 0 mismatched, 209 emit no CNF |
| sat/unsat agreement | 2501 fuzzer queries | 2501 agree, 0 disagree |
| `ctest` | Debug + assertions | 67/67 |

### Relationship to `-Wl,-Bsymbolic-functions`

That linker flag addresses the same PLT indirection for the whole library at
once, and is worth about -1.21% on its own. The two are complementary rather
than alternatives: the flag makes the call direct, whereas inlining removes the
call altogether and lets the compiler see the refcount arithmetic.
