### PR TITLE
HashingNodeFactory: inlinable comparator and an already-sorted fast path

### DIFF
--- a/include/stp/AST/AST.h
+++ b/include/stp/AST/AST.h
@@ -52,6 +52,16 @@ struct ExprLess
     return n1.GetNodeNum() < n2.GetNodeNum();
   }
 };
+
+// Functor form of arithless, for the same reason as ExprLess above. Ordering
+// is identical to arithless.
+struct ArithLess
+{
+  bool operator()(const ASTNode& n1, const ASTNode& n2) const
+  {
+    return arithless(n1, n2);
+  }
+};
 bool isAtomic(Kind k);
 bool isCommutative(const Kind k);
 bool containsArrayOps(const ASTNode& n, STPMgr* stp);

--- a/lib/AST/ASTmisc.cpp
+++ b/lib/AST/ASTmisc.cpp
@@ -201,7 +201,7 @@ void SortByExprNum(ASTVec& v)
 
 void SortByArith(ASTVec& v)
 {
-  sort(v.begin(), v.end(), arithless);
+  sort(v.begin(), v.end(), ArithLess{});
 }
 
 bool isAtomic(Kind kind)

--- a/lib/NodeFactory/HashingNodeFactory.cpp
+++ b/lib/NodeFactory/HashingNodeFactory.cpp
@@ -63,6 +63,13 @@ ASTNode HashingNodeFactory::CreateNode(const Kind kind,
   }
   else
   {
+    if (std::is_sorted(back_children.begin(), back_children.end(),
+                       stp::ArithLess{}))
+    {
+      // Don't create a new vector if it's already sorted.
+      return ASTNode(bm.LookupOrCreateInterior(kind, back_children));
+    }
+
     ASTVec children(back_children);
     // The Bitvector solver seems to expect constants on the RHS, variables on the
     // LHS.


### PR DESCRIPTION
Two small, related changes on the commutative path of `HashingNodeFactory::CreateNode`. Both are pure overhead removal — the constructed node, and therefore the emitted CNF, is unchanged.

## What

**1. `SortByArith` used a function pointer as its comparator.**

```cpp
sort(v.begin(), v.end(), arithless);   // before
sort(v.begin(), v.end(), ArithLess{}); // after
```

`arithless` is a free function, so `std::sort` was instantiated on `bool(*)(const ASTNode&, const ASTNode&)` and every single comparison was an indirect call that could not be inlined. `ExprLess` already exists in `include/stp/AST/AST.h` for exactly this reason — this adds the matching `ArithLess` functor next to it and finishes the job. `arithless` itself is untouched; it has other callers.

**2. The commutative-*term* branch copied its children unconditionally.**

The commutative-*formula* branch immediately above it already had this shape:

```cpp
const bool isSorted = std::is_sorted(back_children.begin(), back_children.end(), stp::ExprLess{});
if (isSorted)
  return ASTNode(bm.LookupOrCreateInterior(kind, back_children));
```

The term branch below it did not — it always did `ASTVec children(back_children); SortByArith(children);`, i.e. allocated a vector and copied every child, even when the sort was a no-op. It now mirrors the formula branch with `std::is_sorted(..., ArithLess{})` and hands the original span straight to `LookupOrCreateInterior`.

## Why the result is identical

The concern with any change here is operand ordering: the order of a commutative node's children feeds the unique table, so a different order is a different interned node and ultimately a different CNF.

* `ArithLess::operator()` is a direct call to `arithless`. It computes the same predicate; only the way it is passed to `std::sort` differs. `arithless` opens with `if (n1 == n2) return false;`, then puts `BVCONST` first, `SYMBOL` next, and breaks all remaining ties on the unique `GetNodeNum()`. That is a strict total order on distinct nodes, so `std::sort` has exactly one valid output permutation regardless of how the comparator is spelled — there is no room for a tie to be broken differently.
* The fast path skips a sort whose output provably equals its input (`std::is_sorted` under the same comparator that `SortByArith` uses), so `LookupOrCreateInterior` receives the same sequence either way and returns the same interned node.
* No node creation is added or removed on either path — `LookupOrCreateInterior` builds its probe in both cases — so `node_uid` allocation order is untouched. That is what makes this safe where a folding-style change would not be.

Byte-comparing the CNF is what actually proves it; see below.

## Measurements

Release + shared libs + assertions off + CaDiCaL + mimalloc, baseline is current `master` (3b766a97) built with the identical cmake line. Cost is retired user-space instructions up to CNF generation (`--exit-after-CNF`), which is reproducible to ~0.001% on this box; wall clock here has a ±4% noise floor and cannot resolve an effect this size, so it is not quoted.

**Total over the 40-file pre-CNF corpus: 881.68G → 880.78G instructions, -0.10%.**

Three `rw_rule_candidate_vmcai_2022_bw512_*` files are 288G of that 882G and create almost no commutative terms, so they dilute the figure; excluding them it is 593.1G → 592.2G, **-0.15%**. This is well below what a first pass on an older base suggested, and the honest number is that this is a small win.

The largest movers:

| file | base | cand | delta |
|---|---|---|---|
| smulov4bw0640 | 50728674394 | 50251891465 | **-0.94%** |
| arbiter_data_integrity_n4q8w8d8b30 | 3020947755 | 3005455716 | -0.51% |
| vlsat3_a80 | 7009116396 | 6983159865 | -0.37% |
| umulov1bw192 | 5353957221 | 5336947805 | -0.32% |
| predicate_593 | 9510483166 | 9486015807 | -0.26% |
| picorv32-check-unrolled-nomem | 13889122292 | 13852363667 | -0.26% |
| VexRiscv-regch0-30-unrolled-nomem | 12204750044 | 12179079411 | -0.21% |
| vlsat3_g20 | 25852254790 | 25816603377 | -0.14% |

`smulov4bw0640` is a 640-bit multiplier-overflow query that creates a very large number of commutative bitvector terms, and is the best case.

The obvious worry about (2) is that `arithless` sorts constants *first*, so natural input like `(bvadd x #x05)` arrives unsorted and the added `is_sorted` scan would be wasted work. That does not show up: no file in the corpus regressed by more than +0.00%, and the two that are nominally positive (`rw_rule_candidate_..._18` at +0.00%, `bvsub_22943` at +0.00%, `15-puzzle.init10` at +0.00%) are inside the noise of the metric. The scan is cheap next to the allocation and copy it usually avoids.

## Neutrality and tests

* `cnf_neutral.sh` (byte-compare of every emitted CNF) on the pre-CNF corpus: **identical 39, mismatched 0, skipped 1** (the skip emits no CNF on the baseline either).
* `cnf_neutral.sh` on 600 fuzzer-generated files, 20s timeout: **identical 391, mismatched 0, skipped 209** (skips are baseline no-CNF/timeout).
* `answer_diff.sh` over the full 2501-file fuzz corpus — full solve, so this also covers array refinement and counterexample construction: **agree 2501, disagree 0, skipped 0**.
* `ctest` with `-DENABLE_TESTING=ON -DENABLE_ASSERTIONS=ON -DCMAKE_BUILD_TYPE=Debug`: **67/67 passed**.
