### PR TITLE
SimplifyingNodeFactory: copy-on-write in CreateSimpleAndOr

### DIFF
--- a/lib/NodeFactory/SimplifyingNodeFactory.cpp
+++ b/lib/NodeFactory/SimplifyingNodeFactory.cpp
@@ -603,43 +603,53 @@ ASTNode SimplifyingNodeFactory::CreateSimpleAndOr(bool IsAnd,
     SortByExprNum(sorted_children);  
   }
 
-  //TODO this would be better as copy on write.
+  // Copy on write. Usually nothing is dropped, so we only build up
+  // "new_children" once the first element is actually discarded; until then
+  // "children" itself is the answer.
   ASTVec new_children;
-  new_children.reserve(children.size());
+  bool materialised = false;
 
   const Kind node_kind = IsAnd ? stp::AND : stp::OR;
   bool nested_same_kind = false;
 
-  for (ASTVec::const_iterator it = children.begin(), it_end = children.end();
-       it != it_end; it++)
+  const size_t num_children = children.size();
+  for (size_t i = 0; i < num_children; i++)
   {
-    ASTVec::const_iterator next_it;
-
-    const bool nextexists = (it + 1 < it_end);
-    if (nextexists)
-      next_it = it + 1;
-    else
-      next_it = it_end;
+    const ASTNode& curr = children[i];
+    const bool nextexists = (i + 1 < num_children);
 
     if (nextexists)
-      if (next_it->GetKind() == stp::NOT && (*next_it)[0] == *it)
+    {
+      const ASTNode& next = children[i + 1];
+      if (next.GetKind() == stp::NOT && next[0] == curr)
         return annihilator;
+    }
 
-    if (*it == annihilator)
+    if (curr == annihilator)
     {
       return annihilator;
     }
-    else if (*it == identity || (nextexists && (*next_it == *it)))
+    else if (curr == identity || (nextexists && (children[i + 1] == curr)))
     {
-      // just drop it
+      // just drop it, copying across everything kept so far.
+      if (!materialised)
+      {
+        materialised = true;
+        new_children.reserve(num_children);
+        new_children.insert(new_children.end(), children.begin(),
+                            children.begin() + i);
+      }
     }
     else
     {
-      new_children.push_back(*it);
-      if (it->GetKind() == node_kind)
+      if (materialised)
+        new_children.push_back(curr);
+      if (curr.GetKind() == node_kind)
         nested_same_kind = true;
     }
   }
+
+  const ASTVec& out = materialised ? new_children : children;
 
   // A child of the same kind contributes its own children conjunctively
   // (resp. disjunctively), so a literal here and its negation one level
@@ -647,7 +657,7 @@ ASTNode SimplifyingNodeFactory::CreateSimpleAndOr(bool IsAnd,
   if (nested_same_kind)
   {
     stp::ASTNodeSet positive, negated;
-    for (const ASTNode& n : new_children)
+    for (const ASTNode& n : out)
     {
       if (n.GetKind() == node_kind)
       {
@@ -669,19 +679,19 @@ ASTNode SimplifyingNodeFactory::CreateSimpleAndOr(bool IsAnd,
 
   // If we get here, we saw no annihilators, and children should
   // be only the non-True nodes.
-  switch (new_children.size())
+  switch (out.size())
   {
     case 0:
       return identity;
       break;
 
     case 1:
-      return new_children[0];
+      return out[0];
       break;
 
     default:
       // 2 or more children.  Create a new node.
-      return hashing.CreateNode(IsAnd ? stp::AND : stp::OR, new_children);
+      return hashing.CreateNode(IsAnd ? stp::AND : stp::OR, out);
       break;
   }
   assert(false);


### PR DESCRIPTION
`CreateSimpleAndOr` carried this note:

```cpp
//TODO this would be better as copy on write.
```

This is that TODO.

## What

The function walks the (already sorted) children, dropping any that are the identity or a duplicate of their successor, and bailing out early on an annihilator. It built a fresh `new_children` vector up front and `push_back`-ed every child that survived — so the common case, where nothing at all is dropped, paid for an allocation plus a copy of the whole child list, then handed a vector that is element-for-element equal to its input to `hashing.CreateNode`.

Now the vector is only built once an element is actually discarded. At that point everything seen so far was kept (by construction: `materialised` is still false, so nothing before `i` was dropped), so the prefix `[0, i)` is copied across in a single `insert` and the loop continues appending from there. If nothing is ever dropped, no vector is allocated at all and `children` is used directly:

```cpp
const ASTVec& out = materialised ? new_children : children;
```

The iterator arithmetic went with it. The old loop constructed a `next_it` that was set to `it_end` and then never dereferenced in that state — the lookahead is now just `children[i + 1]`, guarded by the same `nextexists`.

## Why the result is identical

This is on the node-construction path, so the thing to be careful about is that the child list handed to `hashing.CreateNode` is the same sequence in the same order, and that the early-outs still fire in the same iterations.

* **Order and membership.** The kept elements are exactly those that fail both drop tests, in index order, in both versions. When `materialised` is false no element was dropped, so `children` *is* what `new_children` would have contained; when it becomes true at index `i`, the prefix that is copied is exactly the elements the old loop had already pushed.
* **Annihilator from a complementary pair.** `next.GetKind() == stp::NOT && next[0] == curr` reads `children[i]` and `children[i + 1]` — the same adjacent pair as the old `*it` / `*next_it`, and it is still evaluated before either drop test, so the `return annihilator` happens on the same iteration.
* **Direct annihilator** (`curr == annihilator`) and **identity/duplicate drop** (`curr == identity || (nextexists && children[i + 1] == curr)`) are the same predicates over the same elements, in the same order, so the `return annihilator` and the set of dropped indices are unchanged.
* `nested_same_kind` is still set for every *kept* child of the same kind — that flag is now set outside the `materialised` branch, so it does not depend on whether the vector exists — and the nested-complement scan and the final `switch` both run over `out`, which is the same sequence the old code would have had in `new_children`.

Since the sequence is identical, `hashing.CreateNode` interns the same node, `node_uid` allocation order is untouched, and the CNF is unchanged. The byte-compare below is what actually establishes that.

## Measurements

Release + shared libs + assertions off + CaDiCaL + mimalloc, baseline is current `master` (3b766a97) built with the identical cmake line. Cost is retired user-space instructions up to CNF generation (`--exit-after-CNF`), reproducible to ~0.001% on this box; wall clock has a ±4% noise floor here and cannot resolve an effect this size, so it is not quoted.

**Total over the 40-file pre-CNF corpus: 881.67G -> 878.36G instructions, -0.38%.**

Three `rw_rule_candidate_vmcai_2022_bw512_*` files are 288G of that 882G and barely reach this code, so they dilute the figure; excluding them it is 593.1G -> 589.8G, **-0.56%**.

The largest movers:

| file | base | cand | delta |
|---|---|---|---|
| SRAI-SAFE-12-1024 | 17422319035 | 16834896786 | **-3.37%** |
| SRAI-SAFE-80-1024 | 30178864368 | 29397419187 | **-2.59%** |
| s3_clnt_3_false.BV.c.cil.c.21 | 30950845874 | 30300712824 | -2.10% |
| s3_srvr_3_true.BV.c.cil.c.17 | 34303643417 | 33615582018 | -2.01% |
| SRL-SAFE-16-1024 | 8108317649 | 7946975685 | -1.99% |
| 15-puzzle.init10 | 11042258899 | 10976915538 | -0.59% |
| edge-matching-width=9-height=9-colours=11 | 34045419313 | 33865170568 | -0.53% |
| solitaire-edge-time=24 | 4255360919 | 4233292750 | -0.52% |
| picorv32-check-unrolled-nomem | 13889804340 | 13848687539 | -0.30% |

The shift-safety and TLS-verification queries at the top are the ones that build very wide AND/OR nodes, which is exactly where the avoided copy is worth the most. Nothing regressed: the two nominally positive entries (`rw_rule_candidate_..._18`, `smulov4bw0640`) are +0.00%, i.e. inside the resolution of the metric.

## Neutrality and tests

* `cnf_neutral.sh` (byte-compare of every emitted CNF) on the 40-file pre-CNF corpus: **identical 39, mismatched 0, skipped 1** (the skip emits no CNF on the baseline either).
* `cnf_neutral.sh` on 600 fuzzer-generated files, 20s timeout: **identical 391, mismatched 0, skipped 209** (skips are baseline no-CNF/timeout).
* `answer_diff.sh` over the full 2501-file fuzz corpus — full solve, so this also covers array refinement and counterexample construction: **agree 2501, disagree 0, skipped 0**.
* `ctest` with `-DENABLE_TESTING=ON -DENABLE_ASSERTIONS=ON -DCMAKE_BUILD_TYPE=Debug`: **67/67 passed**.
