### PR TITLE
Inline the hit path of getCurrentFixedBits

### DIFF
--- a/include/stp/Simplifier/constantBitP/ConstantBitPropagation.h
+++ b/include/stp/Simplifier/constantBitP/ConstantBitPropagation.h
@@ -78,7 +78,22 @@ class ConstantBitPropagation
 
   FixedBits* getUpdatedFixedBits(const ASTNode& n);
 
-  FixedBits* getCurrentFixedBits(const ASTNode& n);
+  // get the current value from the map. If no value is in the map. Make a new
+  // value. Almost all calls hit in the map, so that path is inlined here, and
+  // only the cold creation path is out of line.
+  FixedBits* getCurrentFixedBits(const ASTNode& n)
+  {
+    assert(NULL != fixedMap);
+
+    const NodeToFixedBitsMap::NodeToFixedBitsMapType::iterator it =
+        fixedMap->map->find(n);
+    if (it != fixedMap->map->end())
+      return it->second;
+
+    return createFixedBits(n);
+  }
+
+  FixedBits* createFixedBits(const ASTNode& n);
 
   void scheduleDown(const ASTNode& n);
 

--- a/lib/Simplifier/constantBitP/ConstantBitPropagation.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitPropagation.cpp
@@ -574,19 +574,10 @@ void ConstantBitPropagation::propagate()
   }
 }
 
-// get the current value from the map. If no value is in the map. Make a new
-// value.
-FixedBits* ConstantBitPropagation::getCurrentFixedBits(const ASTNode& n)
+// No value is in the map yet, so make a new one. The lookup that discovered
+// the miss is inlined into getCurrentFixedBits.
+FixedBits* ConstantBitPropagation::createFixedBits(const ASTNode& n)
 {
-  assert(NULL != fixedMap);
-
-  NodeToFixedBitsMap::NodeToFixedBitsMapType::iterator it =
-      fixedMap->map->find(n);
-  if (it != fixedMap->map->end())
-  {
-    return it->second;
-  }
-
   int bw;
   if (0 == n.GetValueWidth())
   {


### PR DESCRIPTION
`getCurrentFixedBits(n)` looks a node up in `fixedMap` and, on a miss, creates a fresh `FixedBits` for it. It is one of the hottest entry points in constant-bit propagation, and in practice nearly every call hits in the map — but the entire function lived out of line, so every hit paid a function call on top of the hash lookup.

This moves the lookup and the hit return into the header so they inline at the call sites, and leaves only the cold creation path out of line, renamed `createFixedBits()`.

### Why behaviour is unchanged

Same map, same lookup, same creation code, in the same order. The only change is which side of the translation-unit boundary the hit path lives on. The out-of-line function keeps the `assert(NULL != fixedMap)` semantics (the assert moves into the header alongside the lookup it guards).

### Measurements

Retired user instructions over the pre-CNF pipeline (`--output-CNF --exit-after-CNF -r`), 40-file QF_BV corpus, Release + CaDiCaL + mimalloc, base = current master (3b766a97):

| | |
|---|---|
| total instructions | 881,678,395,269 -> 877,455,357,496 |
| **total delta** | **-0.48%** |
| per-file median | -0.03% |
| per-file best | -7.40% (`smulov4bw0640.smt2`) |
| per-file worst | -0.00% (no file regressed) |

The win is concentrated in cbitp-heavy queries; on files where constant-bit propagation is not the bottleneck it is close to nil, which is what you would expect. Wall clock is not quoted — it sits inside this box's ±4% noise floor. An earlier measurement of this change on an older base suggested a larger gain; -0.48% is what it actually measures against current master.

### Neutrality and tests

Against the same base binary:

- CNF byte-identity, 40-file pre-CNF corpus: **39 identical, 0 mismatched**, 1 skipped (baseline emits no CNF).
- CNF byte-identity, 600 fuzzer files: **391 identical, 0 mismatched**, 209 skipped (no CNF emitted).
- sat/unsat differential, 2501 fuzzer files: **2501 agree, 0 disagree, 0 skipped**.
- `ctest` (Debug, assertions on): **67/67 passed**.
