### PR TITLE
Skip rebuilding the domain map when strength reduction changed nothing

### DIFF
--- a/lib/Simplifier/StrengthReduction.cpp
+++ b/lib/Simplifier/StrengthReduction.cpp
@@ -110,13 +110,23 @@ namespace stp
     else
       newN = nf->CreateArrayTerm(n.GetKind(), n.GetIndexWidth(),n.GetValueWidth(), children);
    
+    // buildMap memoises on the node, so it only needs redoing when the
+    // preceding reduction actually replaced the node.
     nda.buildMap(newN);
-    newN = strengthReduction(newN, *nda.getCbitMap());
+    ASTNode reduced = strengthReduction(newN, *nda.getCbitMap());
 
-    nda.buildMap(newN);
-    newN = strengthReduction(newN, *nda.getIntervalMap());
+    if (reduced != newN)
+    {
+      newN = reduced;
+      nda.buildMap(newN);
+    }
+    reduced = strengthReduction(newN, *nda.getIntervalMap());
 
-    nda.buildMap(newN);
+    if (reduced != newN)
+    {
+      newN = reduced;
+      nda.buildMap(newN);
+    }
     newN = strengthReduction(newN, *nda.getValueSetMap());
 
     cache.insert({n,newN});


### PR DESCRIPTION
`StrengthReduction::visit()` called `nda.buildMap(newN)` three times per node, once ahead of each of the three domain-guided reduction passes (fixed bits, intervals, value sets).

`NodeDomainAnalysis::buildMap()` **memoises per node**: its first act is to look the node up in `toFixedBits` and, on a hit, return the already-computed `{bits, interval, set}` triple immediately. It also populates all three maps in a single traversal. So when a reduction pass leaves the node unchanged, the following `buildMap` call on that same node finds it already present and returns straight away — the call is pure overhead on the memo lookup path.

This keeps each reduction's result in a temporary and only rebuilds the map when the reduction actually replaced the node.

### Why the map cannot go stale

This is the one thing that could be wrong, so to be explicit: the map is only left alone when `reduced == newN`, i.e. the node the next pass will consult is *the very node the previous `buildMap` call already inserted*. Its entries in `toFixedBits`/`toIntervals`/`toValueSets` are already there and are the same entries a repeat call would have returned. When the node does change, `buildMap` is called on the new node exactly as before. The skipped calls are precisely the ones that would have hit the memo and done nothing — this is redundant-call elimination, not a change to when analysis happens.

Since `buildMap` fills all three domain maps in one pass, there is also no case where the cbit map is populated but the interval or value-set map is not.

### Measurements

Retired user instructions over the pre-CNF pipeline (`--output-CNF --exit-after-CNF -r`), 40-file QF_BV corpus, Release + CaDiCaL + mimalloc, base = current master (3b766a97):

| | |
|---|---|
| total instructions | 881,671,837,823 -> 880,928,681,390 |
| **total delta** | **-0.08%** |
| per-file median | -0.11% |
| per-file best | -0.88% (`ext_con_056_128_0512.smt2`) |
| per-file worst | +0.00% (`catchconv-15803.smt2`, i.e. noise-level) |

The headline total is smaller than the median because three very large `rw_rule_candidate_*` files dominate the instruction sum and are essentially unaffected (-0.00%); the typical file improves by about 0.1%. This is a small, broad win rather than a large one. Wall clock is not quoted — it is inside this box's ±4% noise floor.

### Neutrality and tests

Against the same base binary:

- CNF byte-identity, 40-file pre-CNF corpus: **39 identical, 0 mismatched**, 1 skipped (baseline emits no CNF).
- CNF byte-identity, 600 fuzzer files: **391 identical, 0 mismatched**, 209 skipped (no CNF emitted).
- sat/unsat differential, 2501 fuzzer files: **2501 agree, 0 disagree, 0 skipped**.
- `ctest` (Debug, assertions on): **67/67 passed**.
