### PR TITLE
Compare ASTNodes by pointer rather than by node number

### DIFF
--- a/include/stp/AST/ASTNode.h
+++ b/include/stp/AST/ASTNode.h
@@ -59,7 +59,9 @@ class ASTNode
   // Equal iff ASTIntNode pointers are the same.
   friend bool operator==(const ASTNode& node1, const ASTNode& node2)
   {
-    return (node1.Hash() == node2.Hash());
+    // Nodes are hash-consed, so the pointer and the node number are in
+    // bijection; comparing pointers avoids dereferencing both nodes.
+    return (node1._int_node_ptr == node2._int_node_ptr);
   }
 
   friend bool operator!=(const ASTNode& node1, const ASTNode& node2)
@@ -234,7 +236,7 @@ public:
   public:
     bool operator()(const ASTNode& n1, const ASTNode& n2) const
     {
-      return (n1.Hash() == n2.Hash());
+      return (n1._int_node_ptr == n2._int_node_ptr);
     }
   };
 };


### PR DESCRIPTION
`operator==` and the `ASTNodeEqual` functor compared `node1.Hash() ==
node2.Hash()`. `Hash()` is not a content hash -- it returns
`_int_node_ptr->node_uid` -- so the comparison was already an identity test,
but one that dereferences both operands to read a field. This compares the
pointers instead.

### Why the pointers are as good as the node numbers

Nodes are hash-consed, so for any two live `ASTNode`s the pointer and the node
number are in bijection:

* `node_uid` is handed out by `node_uid_cntr += 2` when an `ASTInternal` is
  constructed (NOT nodes take `child.uid + 1`), so distinct live nodes have
  distinct uids.
* The only constructor that copies a uid rather than allocating one is
  `ASTInternal`'s copy constructor, which has no callers.
* Unique-table probes in `STPMgr::insertOrReuseProbe` are stack objects and are
  never wrapped in an `ASTNode`, so they never reach this comparison.
* A live `ASTNode` holds `_ref_count > 0`, so its `ASTInternal` cannot be freed
  and its address cannot be recycled while a node still refers to it.

### What is deliberately left alone

`operator<` still compares `Hash()`. Pointer *ordering* is not reproducible
across runs, and the order of `ASTNode`s feeds operand sorting and therefore the
emitted CNF, so switching that too would make builds non-deterministic. Only
equality is changed.

### Measurements

Retired user-space instructions with `--exit-after-CNF`, over 40 QF_BV
benchmarks. Instruction counts rather than wall clock: the measuring machine has
a wall-clock noise floor near +-4%, while retired instructions reproduce to
about 0.001%.

| | |
|---|---|
| total, 40 files | 877,895,035,945 -> 871,684,552,082 |
| **change** | **-0.71%** |

### Correctness

| check | corpus | result |
|---|---|---|
| CNF byte-identical | 40 QF_BV benchmarks | 39 identical, 0 mismatched, 1 emits no CNF |
| CNF byte-identical | 600 fuzzer queries | 391 identical, 0 mismatched, 209 emit no CNF |
| sat/unsat agreement | 2501 fuzzer queries | 2501 agree, 0 disagree |
| `ctest` | Debug + assertions | 67/67 |

The answer comparison matters here beyond the CNF check: it exercises the whole
solve, including abstraction refinement and counterexample construction, which
is where a broken equality would show up even if the first CNF happened to
match.

Independent of #660, which inlines the ref-counting members; either can merge
first.
