### PR TITLE
Apply carried patches to the ABC submodule at configure time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -449,6 +449,47 @@ include_directories("${CMAKE_CURRENT_BINARY_DIR}/include")
 include_directories(# For extlib-constbv
                     ${PROJECT_SOURCE_DIR}/lib
                    )
+# ABC is a vendored upstream submodule, so local fixes cannot simply be
+# committed to it. Any patch in patches/ that touches ABC is applied here, at
+# configure time, before it is built.
+#
+# Applying is idempotent: a patch that reverse-applies cleanly is already in
+# the tree and is skipped, so re-running cmake, or configuring a second build
+# directory against the same source, does not double-apply. A patch that does
+# neither is a hard error rather than a silent miscompile -- that happens when
+# the submodule is bumped past the code the patch was written against, and the
+# patch then needs rebasing or, if upstream has taken it, deleting.
+file(GLOB STP_ABC_PATCHES "${PROJECT_SOURCE_DIR}/patches/*.patch")
+list(SORT STP_ABC_PATCHES)
+if(STP_ABC_PATCHES AND EXISTS "${PROJECT_SOURCE_DIR}/lib/extlib-abc/src/opt/dar/darCut.c")
+  if(NOT GIT_EXECUTABLE)
+    message(FATAL_ERROR
+            "patches/ contains patches for the vendored ABC but git was not "
+            "found to apply them. Install git, or remove the patches.")
+  endif()
+  foreach(_patch ${STP_ABC_PATCHES})
+    get_filename_component(_patch_name "${_patch}" NAME)
+    execute_process(COMMAND "${GIT_EXECUTABLE}" apply --reverse --check "${_patch}"
+                    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/lib/extlib-abc"
+                    RESULT_VARIABLE _already OUTPUT_QUIET ERROR_QUIET)
+    if(_already EQUAL 0)
+      message(STATUS "ABC patch already applied: ${_patch_name}")
+    else()
+      execute_process(COMMAND "${GIT_EXECUTABLE}" apply "${_patch}"
+                      WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/lib/extlib-abc"
+                      RESULT_VARIABLE _rc ERROR_VARIABLE _err)
+      if(NOT _rc EQUAL 0)
+        message(FATAL_ERROR
+                "Failed to apply ${_patch_name} to lib/extlib-abc:\n${_err}"
+                "It neither applies nor is already applied. If the ABC "
+                "submodule was bumped, rebase the patch onto the new revision, "
+                "or delete it if upstream has taken the change.")
+      endif()
+      message(STATUS "Applied ABC patch: ${_patch_name}")
+    endif()
+  endforeach()
+endif()
+
 # ABC is a vendored upstream submodule (berkeley-abc/abc); mark its headers as
 # SYSTEM so their warnings (e.g. -Wpedantic zero-size arrays, -Wunused-parameter
 # in inline helpers) don't trip -Werror in the STP translation units that

--- a/patches/0001-darcut-popcount.patch
+++ b/patches/0001-darcut-popcount.patch
@@ -1,0 +1,36 @@
+diff --git a/src/opt/dar/darCut.c b/src/opt/dar/darCut.c
+index da1c9eafa..1e76ae912 100644
+--- a/src/opt/dar/darCut.c
++++ b/src/opt/dar/darCut.c
+@@ -85,11 +85,26 @@ void Dar_ObjCutPrint( Aig_Man_t * p, Aig_Obj_t * pObj )
+ ***********************************************************************/
+ static inline int Dar_WordCountOnes( unsigned uWord )
+ {
+-    uWord = (uWord & 0x55555555) + ((uWord>>1) & 0x55555555);
+-    uWord = (uWord & 0x33333333) + ((uWord>>2) & 0x33333333);
+-    uWord = (uWord & 0x0F0F0F0F) + ((uWord>>4) & 0x0F0F0F0F);
+-    uWord = (uWord & 0x00FF00FF) + ((uWord>>8) & 0x00FF00FF);
+-    return  (uWord & 0x0000FFFF) + (uWord>>16);
++    // Dar_ObjComputeCuts() calls this once per pair of fanin cuts, making it
++    // the most frequently executed line in cut enumeration.
++    //
++    // Guarded on __POPCNT__, the target having the instruction, rather than on
++    // the compiler understanding the builtin: without POPCNT in the target ISA
++    // __builtin_popcount() is lowered to an out-of-line call into libgcc,
++    // which would be slower here than counting in software.
++    //
++    // The fallback is written in the form the optimiser recognises as a
++    // population count, so gcc 10 and later and clang 14 and later emit the
++    // instruction from it as well; it is also a step shorter than the
++    // shift-and-mask sequence it replaces, so no target loses.
++#if defined(__POPCNT__)
++    return __builtin_popcount( uWord );
++#else
++    uWord = uWord - ((uWord >> 1) & 0x55555555);
++    uWord = (uWord & 0x33333333) + ((uWord >> 2) & 0x33333333);
++    uWord = (uWord + (uWord >> 4)) & 0x0F0F0F0F;
++    return (int)((uWord * 0x01010101) >> 24);
++#endif
+ }
+ 
+ /**Function*************************************************************


### PR DESCRIPTION
`lib/extlib-abc` is a submodule tracking berkeley-abc/abc, so a fix to ABC
cannot simply be committed. This adds a `patches/` directory whose contents are
applied to the submodule at configure time, and carries one patch in it.

### The patch

`Dar_WordCountOnes()` (`src/opt/dar/darCut.c`) counts set bits with the naive
shift-and-mask sequence. `Dar_ObjComputeCuts()` calls it once per pair of fanin
cuts, as the rejection test guarding `Dar_CutFindFree()`, `Dar_CutMerge()`,
`Dar_CutFilter()` and the truth-table computation -- so it runs more often than
any of the work it protects, and profiling puts `Dar_ObjComputeCuts()` at
31-51% of a pre-SAT run on CNF-heavy inputs.

No compiler recognises that sequence as a population count: not GCC 7 through
16, nor clang 9 through 22. The patch uses the builtin where `__POPCNT__` says
the target has the instruction, and otherwise the `popcount64c` sequence, which
GCC 10+ and clang 10+ do recognise and which is 8 instructions shorter than
what ABC ships regardless.

The guard is on `__POPCNT__`, the target having POPCNT, rather than on the
compiler understanding `__builtin_popcount()`. Without the instruction in the
target ISA the builtin is lowered to an out-of-line call into libgcc, which
would be slower than counting in software -- so guarding on `__GNUC__` would be
a regression on default builds.

This is `USE_POPCNT`-dependent: with it off, the software path runs and the
patch is merely 8 instructions shorter.

### The mechanism

`patches/*.patch` is globbed in sorted order and each is applied to
`lib/extlib-abc` with `git apply`. Adding a future patch needs no CMake change.

Applying is idempotent. A patch that reverse-applies cleanly is already in the
tree and is skipped, so re-running cmake, or configuring a second build
directory against the same source, does not double-apply. A patch that neither
applies nor is already applied is a **hard error**, not a warning:

```
CMake Error at CMakeLists.txt:482 (message):
  Failed to apply 0001-darcut-popcount.patch to lib/extlib-abc:
  error: patch does not apply
  It neither applies nor is already applied.  If the ABC submodule was
  bumped, rebase the patch onto the new revision, or delete it if
  upstream has taken the change.
```

That case is the one worth failing loudly on: when the ABC submodule is next
bumped, a silently-unpatched build would just quietly lose the speedup.

Verified across all four paths: fresh submodule checkout applies it; a second
build directory against the same source reports "already applied"; re-running
cmake reports "already applied"; and a submodule deliberately drifted past the
patch produces the error above. After applying, `lib/extlib-abc` has exactly
one modified file.

### Upstream

Submitted to ABC as berkeley-abc/abc#533. That version omits the `__POPCNT__`
guard, keeping only the recognised sequence, which is a smaller diff and easier
to accept; this carried version keeps the guard because it also covers GCC 7-9,
which do not recognise either sequence. If upstream takes it, this patch stops
applying on the next submodule bump and should be deleted -- the hard error
above makes that impossible to miss.

Note also berkeley-abc/abc#436, which routes this function through a shared
helper guarded on `__GNUC__`; that would introduce the libgcc call described
above.

### Effect

Measurement against current master is running and will be added here. The
earlier figure for this change, taken on an older base, was -7.48% of pre-SAT
instructions over a 20-file corpus, with per-file values from -9.78% to
-11.56%.

`darCut.c.o` contains one `popcnt` after this change and none before; `libstp`
contains no calls to libgcc's `__popcountdi2` either way.
