### PR TITLE
Cut STP's fixed startup cost: inline the unique-table hashers, enable -fvisibility=hidden and -Bsymbolic-functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -295,6 +295,7 @@ endif()
 # Set the appropriate build flags
 # -----------------------------------------------------------------------------
 include(CheckCXXCompilerFlag)
+include(CheckLinkerFlag)
 
 macro(add_cxx_flag_if_supported flagname)
   check_cxx_compiler_flag("${flagname}" HAVE_FLAG_${flagname})
@@ -335,10 +336,43 @@ if(NOT MSVC)
     if (NOT CMAKE_BUILD_TYPE STREQUAL "Release")
         add_cxx_flag_if_supported("-fno-omit-frame-pointer")
     endif()
-    #if(NOT ENABLE_TESTING AND ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-        # almost working
-        # add_cxx_flag_if_supported("-fvisibility=hidden")
+        # Cut the cost of dynamic symbol resolution, which is ~79% of STP's
+        # fixed 4.15M-instruction startup and so dominates easy queries.
+        #
+        # -fvisibility=hidden exports only what is explicitly annotated
+        # DLL_PUBLIC (see include/stp/Util/Attributes.h), which is the whole
+        # public C and C++ API.  Everything else becomes local, so the loader
+        # has far fewer symbols to look up.
+        #
+        # -Wl,-Bsymbolic-functions binds libstp's calls to its own exported
+        # functions at link time instead of going through the PLT.  The one
+        # consequence is that LD_PRELOAD can no longer interpose STP's own
+        # functions on calls made from inside libstp; that is not a use case
+        # for a solver library, and the flag is in Debian's default hardening
+        # set.  Neither flag changes behaviour: the emitted CNF is unchanged.
+        #
+        # -fvisibility=hidden is skipped for ENABLE_TESTING builds.  The unit
+        # tests link libstp and call directly into entry points that are not
+        # part of the public API (the simplifier passes, STPMgr internals,
+        # SMT2ScanString), so they need the full export set.  This is why the
+        # flag was carried commented-out here.
+        if(NOT ENABLE_TESTING)
+            add_cxx_flag_if_supported("-fvisibility=hidden")
+            # The vendored ABC sources are C.  There is no
+            # add_c_flag_if_supported, so reuse the check above and set
+            # CMAKE_C_FLAGS directly, as WERROR does.
+            if(HAVE_FLAG_-fvisibility=hidden)
+                set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fvisibility=hidden")
+            endif()
+        endif()
+
+        check_linker_flag(CXX "-Wl,-Bsymbolic-functions" HAVE_LINKER_FLAG_BSYMBOLIC_FUNCTIONS)
+        if(HAVE_LINKER_FLAG_BSYMBOLIC_FUNCTIONS)
+            set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-Bsymbolic-functions")
+            set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-Bsymbolic-functions")
+        endif()
+
         set(CMAKE_EXE_LINKER_FLAGS " ${CMAKE_EXE_LINKER_FLAGS} -Wl,--discard-all -Wl,--build-id=sha1")
     endif()
     # add_cxx_flag_if_supported("-flto") # slow compile and not enough benefits

--- a/include/stp/AST/ASTBVConst.h
+++ b/include/stp/AST/ASTBVConst.h
@@ -114,5 +114,26 @@ public:
   CBV GetBVConst() const;
 };
 
+// Defined out of line because they dereference ASTBVConst, which is still
+// incomplete inside the nested class bodies above.  They must stay in the
+// header: they key STPMgr's bvconst unique table, so they run on every
+// hash-cons probe, and being inline keeps that path free of a call.
+inline size_t
+ASTBVConst::ASTBVConstHasher::operator()(const ASTBVConst* bvc) const
+{
+  return CONSTANTBV::BitVector_Hash(bvc->_bvconst);
+}
+
+inline bool
+ASTBVConst::ASTBVConstEqual::operator()(const ASTBVConst* bvc1,
+                                        const ASTBVConst* bvc2) const
+{
+  if (bvc1->getValueWidth() != bvc2->getValueWidth())
+  {
+    return false;
+  }
+  return (0 == CONSTANTBV::BitVector_Compare(bvc1->_bvconst, bvc2->_bvconst));
+}
+
 } // end of namespace
 #endif

--- a/include/stp/AST/ASTInterior.h
+++ b/include/stp/AST/ASTInterior.h
@@ -156,5 +156,42 @@ public:
   void hasBeenSimplified() const { is_simplified = true; }
 };
 
+// Defined out of line because they dereference ASTInterior, which is still
+// incomplete inside the nested class bodies above.  They must stay in the
+// header: they key STPMgr's interior unique table, so they run on every
+// hash-cons probe, and being inline keeps that path free of a call.
+inline size_t
+ASTInterior::ASTInteriorHasher::operator()(const ASTInterior* int_node_ptr) const
+{
+  if (int_node_ptr->_cached_hash != 0)
+    return int_node_ptr->_cached_hash;
+
+  size_t hashval = ((size_t)int_node_ptr->GetKind());
+  const ASTChildren ch = int_node_ptr->GetChildren();
+  auto iend = ch.end();
+  for (auto i = ch.begin(); i != iend; i++)
+  {
+    hashval += i->Hash();
+    hashval += (hashval << 10);
+    hashval ^= (hashval >> 6);
+  }
+
+  hashval += (hashval << 3);
+  hashval ^= (hashval >> 11);
+  hashval += (hashval << 15);
+
+  if (hashval == 0)
+    hashval = 1; // 0 marks the hash as not yet computed.
+  int_node_ptr->_cached_hash = hashval;
+  return hashval;
+}
+
+inline bool
+ASTInterior::ASTInteriorEqual::operator()(const ASTInterior* int_node_ptr1,
+                                          const ASTInterior* int_node_ptr2) const
+{
+  return (*int_node_ptr1 == *int_node_ptr2);
+}
+
 } // end of namespace stp
 #endif

--- a/lib/AST/ASTBVConst.cpp
+++ b/lib/AST/ASTBVConst.cpp
@@ -102,19 +102,7 @@ CBV ASTBVConst::GetBVConst() const
   return _bvconst;
 }
 
-size_t ASTBVConst::ASTBVConstHasher::operator()(const ASTBVConst* bvc) const
-{
-  return CONSTANTBV::BitVector_Hash(bvc->_bvconst);
-}
-
-bool ASTBVConst::ASTBVConstEqual::operator()(const ASTBVConst* bvc1,
-                                             const ASTBVConst* bvc2) const
-{
-  if (bvc1->getValueWidth() != bvc2->getValueWidth())
-  {
-    return false;
-  }
-  return (0 == CONSTANTBV::BitVector_Compare(bvc1->_bvconst, bvc2->_bvconst));
-}
+// ASTBVConstHasher::operator() and ASTBVConstEqual::operator() are defined
+// inline in ASTBVConst.h.
 
 } //end of namespace

--- a/lib/AST/ASTInterior.cpp
+++ b/lib/AST/ASTInterior.cpp
@@ -46,44 +46,8 @@ void ASTInterior::nodeprint(ostream& os, bool /*c_friendly*/)
   os << _kind_names[_kind];
 }
 
-/******************************************************************
- * ASTInteriorHasher and ASTInteriorEqual Member Functions        *
- ******************************************************************/
-
-// ASTInteriorHasher operator()
-size_t ASTInterior::ASTInteriorHasher::
-operator()(const ASTInterior* int_node_ptr) const
-{
-  if (int_node_ptr->_cached_hash != 0)
-    return int_node_ptr->_cached_hash;
-
-  size_t hashval = ((size_t)int_node_ptr->GetKind());
-  const ASTChildren ch = int_node_ptr->GetChildren();
-  auto iend = ch.end();
-  for (auto i = ch.begin(); i != iend; i++)
-  {
-    hashval += i->Hash();
-    hashval += (hashval << 10);
-    hashval ^= (hashval >> 6);
-  }
-
-  hashval += (hashval << 3);
-  hashval ^= (hashval >> 11);
-  hashval += (hashval << 15);
-
-  if (hashval == 0)
-    hashval = 1; // 0 marks the hash as not yet computed.
-  int_node_ptr->_cached_hash = hashval;
-  return hashval;
-}
-
-// ASTInteriorEqual operator()
-bool ASTInterior::ASTInteriorEqual::
-operator()(const ASTInterior* int_node_ptr1,
-           const ASTInterior* int_node_ptr2) const
-{
-  return (*int_node_ptr1 == *int_node_ptr2);
-}
+// ASTInteriorHasher::operator() and ASTInteriorEqual::operator() are defined
+// inline in ASTInterior.h.
 
 ASTInterior::~ASTInterior()
 {

--- a/lib/extlib-constbv/constantbv.h
+++ b/lib/extlib-constbv/constantbv.h
@@ -55,6 +55,14 @@
 
 namespace CONSTANTBV {
 
+// STP builds with -fvisibility=hidden, but this API has to stay exported:
+// inline code in STP's public headers calls it -- ASTBVConst's hasher,
+// equality and destructor all do -- so a translation unit outside libstp that
+// emits one of those inlines needs to be able to bind to it.
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC visibility push(default)
+#endif
+
 #ifdef __cplusplus
   extern "C" {
     typedef bool boolean;
@@ -311,6 +319,10 @@ namespace CONSTANTBV {
     };
 #ifdef __cplusplus
   }
+#endif
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC visibility pop
 #endif
 } //end of namespace CONSTANTBV
 #endif


### PR DESCRIPTION
## What

Two commits:

1. Inline the two unique-table hashers (and the matching equality functors) into their headers.
2. Turn on `-fvisibility=hidden` and `-Wl,-Bsymbolic-functions` on Linux.

Together they cut STP's fixed startup by **5.75%** and a trivial query by **10.35%**, with the emitted CNF byte-identical.

## Why startup matters

STP pays a fixed **4.15 M instructions** before it has looked at the input. `stp --version`, which initialises everything and exits before parsing, costs 4,144,461 instructions; an empty C++ `main` on this platform costs 136 K. So ~4 M of that is STP's own startup, and it is paid whatever the query is. On easy problems -- most of SMT-LIB -- that *is* the runtime.

`valgrind --tool=callgrind` on `stp --version` (4,308,189 Ir total) says almost all of it is the dynamic loader:

| function | Ir | share |
|---|---|---|
| `_dl_lookup_symbol_x` | 1,385,305 | 32.2% |
| `do_lookup_x` | 1,078,273 | 25.0% |
| `_dl_relocate_object` (dl-machine.h) | 426,151 | 9.9% |
| `_dl_relocate_object` (do-rel.h) | 193,612 | 4.5% |
| `check_match` | 170,389 | 4.0% |
| `strcmp` (in ld.so) | 150,362 | 3.5% |
| **ld.so total** | | **~79%** |

Corroborating: `LD_BIND_NOW=1` takes `--version` from 4,147,285 to 7,861,646 instructions, which is how much resolution work lazy binding is deferring rather than avoiding.

(Do not measure this with `LD_DEBUG=statistics`. It reports only the resolution done before `main` and badly understates the total.)

## Why these two flags

**`-fvisibility=hidden`** makes everything not annotated `DLL_PUBLIC` local to the library, so the loader has far fewer names to look up. **`-Wl,-Bsymbolic-functions`** binds `libstp`'s references to its own exported functions at link time instead of routing them through the PLT.

| | exported symbols | PLT entries |
|---|---|---|
| master | 1,710 | 1,125 |
| this PR | 637 | 151 |

They compose, and neither changes generated code semantics.

## The hasher change

`-fvisibility=hidden` has been sitting in `CMakeLists.txt` commented out with the note "almost working". Part of what was not working: `ASTInteriorHasher::operator()` and `ASTBVConstHasher::operator()` were declared in the headers but defined out of line in the `.cpp` files, so hiding them made them unavailable to anything outside `libstp` that emits the surrounding inline code.

Moving them into their headers is not just a workaround. Both key `STPMgr`'s unique tables (`_interior_unique_table`, `_bvconst_unique_table`), so they run on **every hash-cons probe** -- the hottest path in node creation; `STPMgr::insertOrReuseProbe` alone is 1.43% of a solve. Every probe was paying an out-of-line call.

Measured on its own, over the 40-file QF_BV corpus, pre-CNF pipeline: **-0.19%**, CNF identical on all 40.

They dereference the enclosing class, which is incomplete inside the nested class body, so they are defined just after the enclosing class closes. `ASTInteriorEqual::operator()` and `ASTBVConstEqual::operator()` moved with them -- same two tables, same path, and both are three lines.

## Measurements

| | master | this PR | delta |
|---|---|---|---|
| `stp --version` | 4,144,461 | 3,906,253 | **-5.75%** |
| trivial 4-line QF_BV query | 4,642,099 | 4,161,474 | **-10.35%** |
| 40-file QF_BV corpus, pre-CNF | 783,006,310,000 | 773,164,750,000 | **-1.26%** |

Retired user instructions (`perf stat -e instructions:u`), reproducible to ~0.001% on this box; wall clock has a ±4% noise floor here and was not used.

The spread between -10.35% and -1.26% is expected and is the point: the saving is a roughly **fixed** instruction count, so it is large where the problem is small and vanishes where the problem is large. Nobody should expect this to speed up a hard instance.

## Correctness

* **CNF byte-identical**: 39/39 of the hard QF_BV corpus (1 skipped -- baseline emits no CNF), and 391/391 of 600 fuzz files (209 skipped for the same reason). 0 mismatches.
* **Same answer**: `sat`/`unsat` compared against master over **2,501** fuzzer-generated QF_BV files -- 2,501 agree, 0 disagree, 0 skipped.
* **ctest**: 67/67 pass (`ENABLE_TESTING=ON`, `ENABLE_ASSERTIONS=ON`, Debug).
* **Static build** (`-DSTATICCOMPILE=ON -DBUILD_SHARED_LIBS=OFF`) configures, builds and solves.
* **clang** (14.0.0): configures, builds and solves; both flag probes succeed.
* **Public API still exported** under `-fvisibility=hidden`: `vc_createValidityChecker`, `vc_assertFormula`, `vc_query`, `vc_Destroy`, `vc_printCounterExample`, `vc_parseExpr`, `vc_getCounterExample`, `vc_bvConstExprFromInt`, `vc_setFlags`, `vc_push`, `vc_pop` all present in `nm -D --defined-only`, as are `stp::STPMgr`, `stp::STP::TopLevelSTP`, `stp::Cpp_interface` and `stp::GlobalParserBM`. The existing `DLL_PUBLIC` annotations are doing their job.

Both flags are guarded (`check_cxx_compiler_flag` / `check_linker_flag`) and applied on Linux only, so a toolchain that rejects either degrades gracefully rather than failing the configure.

## Risk and caveats

* **`-Wl,-Bsymbolic-functions`**: `LD_PRELOAD` can no longer interpose STP's *own* functions on calls made from inside `libstp` (calls from outside still go through the normal path, and interposing libc is unaffected). For a solver library that is not a real use case, and the flag is in Debian's default hardening set.
* **`-fvisibility=hidden` is skipped when `ENABLE_TESTING=ON`.** The unit tests link `libstp` and call straight into ~43 entry points that are not part of the public API (the simplifier passes, `STPMgr::LookupOrCreateSymbol`, `SMT2ScanString`, ...), so a testing build keeps the full export set. Annotating all of those `DLL_PUBLIC` would put STP's internals in the published ABI, which seems worse than the asymmetry. Happy to do it the other way if you disagree. `-Wl,-Bsymbolic-functions` is applied unconditionally, including to testing builds, so ctest does exercise it.
* `lib/extlib-constbv/constantbv.h` now wraps its declarations in `#pragma GCC visibility push(default)`. Inline code in STP's public headers -- `ASTBVConst`'s hasher, equality and destructor -- calls that C API, so a translation unit outside `libstp` (`stp-bin` itself, for one) that emits one of those inlines has to be able to bind to it. This is what puts the exported count at 637 rather than 536.

## Why not just remove PLT call sites

Worth recording, because it is counter-intuitive: **#660 removed 9,581 PLT call sites** (inlining `ASTNode`'s ref-counting members) **and did not move startup at all** -- 4,149,003 before, 4,147,494 after. Lazy binding resolves each *symbol* once on first use; the cost is set by the number of distinct symbols, not by how many places call them. Reducing the exported set and binding intra-library references is the thing that works.
