### PR TITLE
Fix the README quick install on a fresh clone

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -20,8 +20,6 @@ sudo apt-get install git build-essential cmake bison flex libboost-program-optio
 git clone https://github.com/stp/stp
 cd stp
 git submodule init && git submodule update
-./scripts/deps/setup-gtest.sh
-./scripts/deps/setup-outputcheck.sh
 ./scripts/deps/setup-cms.sh
 ./scripts/deps/setup-minisat.sh
 mkdir build

--- a/scripts/deps/setup-gtest.sh
+++ b/scripts/deps/setup-gtest.sh
@@ -16,6 +16,8 @@ dep="gtest"
 # whole job.
 gtest_tag="v1.17.0"
 
+[ ! -d "${dep_dir}" ] && mkdir -p "${dep_dir}"
+
 cd "${dep_dir}"
 git clone --depth 1 --branch "${gtest_tag}" \
     https://github.com/google/googletest "${dep}"


### PR DESCRIPTION
Two small fixes to the quick-install path:

- **`scripts/deps/setup-gtest.sh`**: create `deps/` before `cd`-ing into it, matching the other setup scripts. It was the only deps script that didn't create the directory itself, so on a fresh clone the README quick install failed at its very first step with `cd: deps: No such file or directory`. (The README's testing section never hit this because it runs `setup-minisat.sh` first, which creates `deps/` as a side effect of making `deps/install`.)
- **`README.markdown`**: drop `setup-gtest.sh` and `setup-outputcheck.sh` from the quick install. GTest and OutputCheck are test-suite-only dependencies, and the quick install configures with `ENABLE_TESTING` off (the default), so they were cloned and never used. `setup-cms.sh` and `setup-minisat.sh` stay because the default build picks both solvers up via `deps/install` on `CMAKE_PREFIX_PATH`.

Verified the fixed script by running it from a directory with no `deps/`: it now creates the directory and clones GTest cleanly.