### PR TITLE
Add derived simplification rules that collapse to constants

### DIFF
--- a/lib/NodeFactory/SimplifyingNodeFactory.cpp
+++ b/lib/NodeFactory/SimplifyingNodeFactory.cpp
@@ -137,6 +137,37 @@ ASTNode SimplifyingNodeFactory::create_gt_node(const ASTVec& children)
     return ASTFalse;
   }
 
+  // (x umod s) > x is false: the remainder never exceeds the dividend,
+  // including s == 0, where SMT-LIB defines the result as x itself.
+  if (children[0].GetKind() == BVMOD && children[0][0] == children[1])
+  {
+    return ASTFalse;
+  }
+
+  // (x udiv ~x) > x is false: a nonzero divisor keeps the quotient <= x,
+  // and ~x == 0 forces x == ones, where dividing by zero gives ones == x.
+  if (children[0].GetKind() == BVDIV && children[0][0] == children[1] &&
+      children[0][1].GetKind() == BVNOT && children[0][1][0] == children[1])
+  {
+    return ASTFalse;
+  }
+
+  // (t << s) > ~s and (t >> s) > ~s are false: shifting by s >= 1 clears
+  // s low (high) bits, capping the result at 2^w - 2^s <= 2^w - 1 - s = ~s,
+  // and s == 0 leaves t <= ones = ~s. The same holds with s = ~u, giving
+  // the forms (t << ~u) > u and (t >> ~u) > u.
+  if (children[0].GetKind() == stp::BVLEFTSHIFT ||
+      children[0].GetKind() == BVRIGHTSHIFT)
+  {
+    const ASTNode& s = children[0][1];
+    const ASTNode& u = children[1];
+    if ((s.GetKind() == BVNOT && s[0] == u) ||
+        (u.GetKind() == BVNOT && u[0] == s))
+    {
+      return ASTFalse;
+    }
+  }
+
   // A 1-bit unsigned comparison has a single satisfying assignment: 1 > 0.
   if (children[0].GetValueWidth() == 1)
   {
@@ -347,6 +378,39 @@ ASTNode SimplifyingNodeFactory::CreateNode(Kind kind, const ASTVec& children)
         const ASTNode b = NodeFactory::CreateNode(
             EQ, children[1], bm.CreateOneConst(1));
         result = NodeFactory::CreateNode(stp::AND, a, b);
+      }
+
+      // x >s (x umod ~x) is false: x never signed-exceeds that remainder.
+      // The BVMOD rules rewrite (x umod ~x) to (ones umod ~x), so match the
+      // dividend as either x or the ones constant.
+      if (result.IsNull() && children[1].GetKind() == BVMOD &&
+          children[1][1].GetKind() == BVNOT &&
+          children[1][1][0] == children[0] &&
+          (children[1][0] == children[0] ||
+           children[1][0] ==
+               bm.CreateMaxConst(children[0].GetValueWidth())))
+      {
+        result = ASTFalse;
+      }
+
+      // x >s (x srem ~x) is false. The SBVREM rules normalise the remainder
+      // to -(1 smod ~x), so match both that and the raw form.
+      if (result.IsNull() && children[1].GetKind() == BVUMINUS &&
+          children[1][0].GetKind() == SBVMOD &&
+          children[1][0][1].GetKind() == BVNOT &&
+          children[1][0][1][0] == children[0] &&
+          children[1][0][0] ==
+              bm.CreateOneConst(children[0].GetValueWidth()))
+      {
+        result = ASTFalse;
+      }
+
+      if (result.IsNull() && children[1].GetKind() == SBVREM &&
+          children[1][0] == children[0] &&
+          children[1][1].GetKind() == BVNOT &&
+          children[1][1][0] == children[0])
+      {
+        result = ASTFalse;
       }
 
       //2nd part is the same -> only care about 1st part
@@ -738,6 +802,18 @@ ASTNode SimplifyingNodeFactory::CreateSimpleEQ(const ASTVec& children)
 
   if ((k1 == BVNOT && in1[0] == in2) || (k2 == BVNOT && in2[0] == in1))
     return ASTFalse;
+
+  // x = (~x << x) and x = (~x sdiv x) have no solution (checked exhaustively
+  // over small widths): for the shift, x == 0 gives ones on the right, and
+  // x != 0 has a set bit below position x that the shift has cleared.
+  for (int i = 0; i < 2; i++)
+  {
+    const ASTNode& a = (i == 0) ? in1 : in2;
+    const ASTNode& b = (i == 0) ? in2 : in1;
+    if ((b.GetKind() == stp::BVLEFTSHIFT || b.GetKind() == SBVDIV) &&
+        b[1] == a && b[0].GetKind() == BVNOT && b[0][0] == a)
+      return ASTFalse;
+  }
 
   // Normalise 1-bit equalities so both polarities of a test hash to the
   // same node: (x = 1) becomes NOT(x = 0).
@@ -1261,6 +1337,12 @@ ASTNode SimplifyingNodeFactory::plusRules(const ASTNode& n0, const ASTNode& n1)
   else if (n1.GetKind() == BVUMINUS && n0.GetKind() == BVPLUS &&
            n0.Degree() == 2 && n1[0] == n0[0])
     result = n0[1];
+  else if (n1.GetKind() == BVUMINUS && n1[0].GetKind() == BVPLUS &&
+           n1[0].Degree() == 2 && (n1[0][0] == n0 || n1[0][1] == n0))
+    // a + -(a + b) = -b. This is BVSUB(a, BVPLUS(a, b)) after the
+    // subtraction has been rewritten to plus/uminus form.
+    result = NodeFactory::CreateTerm(BVUMINUS, width,
+                                     n1[0][(n1[0][0] == n0) ? 1 : 0]);
   else if (n1.GetKind() == BVNOT && n1[0] == n0)
     result = bm.CreateMaxConst(width);
   else if (n0.GetKind() == stp::BVCONST && n1.GetKind() == BVPLUS &&
@@ -1290,8 +1372,42 @@ ASTNode SimplifyingNodeFactory::plusRules(const ASTNode& n0, const ASTNode& n1)
   return result;
 }
 
-ASTNode SimplifyingNodeFactory::handle_bvxor(unsigned int width, const ASTVec& input_children) 
+ASTNode SimplifyingNodeFactory::handle_bvxor(unsigned int width, const ASTVec& input_children)
 {
+  // a ^ (a ^ b ^ ...) -> (b ^ ...): cancel an operand shared with a nested
+  // xor. Children aren't flattened, so the duplicate-removal below can't see
+  // this. Restricted to the binary case to keep the scan cheap.
+  if (input_children.size() == 2)
+  {
+    for (int side = 0; side < 2; side++)
+    {
+      ASTNode inner = input_children[side];
+      const ASTNode& other = input_children[1 - side];
+      bool negated = false;
+      if (inner.GetKind() == BVNOT)
+      {
+        negated = true;
+        inner = inner[0];
+      }
+      if (inner.GetKind() != BVXOR)
+        continue;
+      for (unsigned i = 0; i < inner.Degree(); i++)
+      {
+        if (inner[i] != other)
+          continue;
+        ASTVec rest;
+        rest.reserve(inner.Degree() - 1);
+        for (unsigned j = 0; j < inner.Degree(); j++)
+          if (j != i)
+            rest.push_back(inner[j]);
+        const ASTNode r =
+            (rest.size() == 1) ? rest[0]
+                               : NodeFactory::CreateTerm(BVXOR, width, rest);
+        return negated ? NodeFactory::CreateTerm(BVNOT, width, r) : r;
+      }
+    }
+  }
+
   bool accum = false;
 
   const ASTNode zero = bm.CreateZeroConst(width);
@@ -1386,6 +1502,18 @@ ASTNode SimplifyingNodeFactory::handle_bvand(unsigned int width, const ASTVec& n
   SortByExprNum(flat_children); // We want duplicates to be adjacent.
 
   const ASTNode annihilator = bm.CreateZeroConst(width);
+
+  // x & (t << x) == 0 for any t: the shift clears the bits below position x,
+  // while every set bit of x is below position x (x < 2^x). Only scan when a
+  // left shift is actually present.
+  for (size_t i = 0; i < flat_children.size(); i++)
+  {
+    if (flat_children[i].GetKind() != stp::BVLEFTSHIFT)
+      continue;
+    for (size_t j = 0; j < flat_children.size(); j++)
+      if (j != i && flat_children[j] == flat_children[i][1])
+        return annihilator;
+  }
   const ASTNode identity = bm.CreateMaxConst(width);
   ASTNode accumulator = bm.CreateMaxConst(width);
 
@@ -1998,6 +2126,18 @@ ASTNode SimplifyingNodeFactory::CreateTerm(Kind kind, unsigned int width,
                 NodeFactory::CreateTerm(BVUMINUS, width, children[0]),
                 children[1]));
       }
+      else if (children[0].GetKind() == stp::BVSX &&
+               children[0][0].GetKind() == BVEXTRACT &&
+               children[0][0][0] == children[1] &&
+               children[0][0][1] == bm.CreateBVConst(32, width - 1) &&
+               children[0][0][2] == bm.CreateBVConst(32, width - 1))
+      {
+        // (sx(x[msb:msb]) << x) == 0: the base is 0 or ones, and a base of
+        // ones means x's top bit is set, so x >= 2^(w-1) >= w and the shift
+        // clears everything either way. This is (x ashr x) << x, after the
+        // arithmetic shift has been rewritten to the sign-spread form.
+        result = bm.CreateZeroConst(width);
+      }
     }
     break;
 
@@ -2037,6 +2177,43 @@ ASTNode SimplifyingNodeFactory::CreateTerm(Kind kind, unsigned int width,
                                 EQ, bm.CreateZeroConst(width), children[0][0]),
                 bm.CreateOneConst(width),
                 bm.CreateZeroConst(width))); // 391 -> 70
+
+      if (result.IsNull())
+      {
+        // (t >> s) == 0 when t <=u s is structurally guaranteed: t <=u s
+        // implies t <u 2^s, so every bit of t is shifted out. Generalises
+        // the t == s rule above. t <=u s holds when t is an AND containing
+        // s, or t umod-by/ushifts-down s. It also holds for (s ashr u):
+        // a non-negative s bounds its own arithmetic shift, and a negative
+        // s is at least 2^(w-1) >= w as a shift amount.
+        const ASTNode& t = children[0];
+        const ASTNode& s = children[1];
+        bool zero = false;
+        if (t.GetKind() == stp::BVAND)
+        {
+          for (const ASTNode& c : t)
+            if (c == s)
+              zero = true;
+        }
+        else if ((t.GetKind() == BVMOD || t.GetKind() == BVRIGHTSHIFT ||
+                  t.GetKind() == BVSRSHIFT) &&
+                 t[0] == s)
+        {
+          zero = true;
+        }
+
+        // (t >> (t | rest)) == 0: the shift amount is at least t. The OR
+        // arrives as ~(~t & ...), so look for ~t among the AND's operands.
+        if (!zero && s.GetKind() == BVNOT && s[0].GetKind() == stp::BVAND)
+        {
+          for (const ASTNode& c : s[0])
+            if (c.GetKind() == BVNOT && c[0] == t)
+              zero = true;
+        }
+
+        if (zero)
+          result = bm.CreateZeroConst(width);
+      }
     }
     break;
 

--- a/tests/unit-tests/SimplifyingNodeFactory_Exhaustive_Test.cpp
+++ b/tests/unit-tests/SimplifyingNodeFactory_Exhaustive_Test.cpp
@@ -726,4 +726,213 @@ TEST(SimplifyingNodeFactory_Exhaustive, nested_complementary_literals)
   c.checkNode(OR, {p, innerAnd}, false);
 }
 
+/* (x umod s) >u x --> false, so (x umod s) <=u x --> true. */
+TEST(SimplifyingNodeFactory_Exhaustive, gt_urem_dividend)
+{
+  Context c;
+  for (unsigned w : {1u, 2u, 4u})
+  {
+    ASTNode x = c.bv(w);
+    ASTNode y = c.bv(w);
+    ASTNode rem = c.hf->CreateTerm(BVMOD, w, x, y);
+    c.checkNode(BVGT, {rem, x});
+    c.checkNode(BVLE, {rem, x});
+    ASTNode negRem =
+        c.hf->CreateTerm(BVMOD, w, x, c.hf->CreateTerm(BVUMINUS, w, y));
+    c.checkNode(BVLE, {negRem, x});
+    // The divisor's remainder is NOT bounded by the divisor this way.
+    c.checkNode(BVGT, {rem, y}, false);
+  }
+}
+
+/* (x udiv ~x) >u x --> false. */
+TEST(SimplifyingNodeFactory_Exhaustive, gt_udiv_by_not)
+{
+  Context c;
+  for (unsigned w : {1u, 2u, 4u})
+  {
+    ASTNode x = c.bv(w);
+    ASTNode div =
+        c.hf->CreateTerm(BVDIV, w, x, c.hf->CreateTerm(BVNOT, w, x));
+    c.checkNode(BVGT, {div, x});
+  }
+}
+
+/* Shifts never exceed the complement of the shift amount:
+   (t << s) >u ~s and (t >> s) >u ~s --> false, also with s = ~u. */
+TEST(SimplifyingNodeFactory_Exhaustive, gt_shift_vs_not_amount)
+{
+  Context c;
+  for (unsigned w : {2u, 4u})
+  {
+    ASTNode x = c.bv(w);
+    ASTNode y = c.bv(w);
+    ASTNode noty = c.hf->CreateTerm(BVNOT, w, y);
+    for (Kind k : {BVLEFTSHIFT, BVRIGHTSHIFT})
+    {
+      c.checkNode(BVGT, {c.hf->CreateTerm(k, w, x, y), noty});
+      c.checkNode(BVGT, {c.hf->CreateTerm(k, w, x, noty), y});
+      // The shifted value is not bounded by an unrelated term.
+      c.checkNode(BVGT, {c.hf->CreateTerm(k, w, x, y), x}, false);
+    }
+  }
+}
+
+/* x <=s (x umod ~x) --> true, both for the raw form and for the
+   (ones umod ~x) shape the BVMOD rules normalise it to. */
+TEST(SimplifyingNodeFactory_Exhaustive, sgt_urem_by_not)
+{
+  Context c;
+  for (unsigned w : {1u, 2u, 4u})
+  {
+    ASTNode x = c.bv(w);
+    ASTNode nt = c.hf->CreateTerm(BVNOT, w, x);
+    c.checkNode(BVSLE, {x, c.hf->CreateTerm(BVMOD, w, x, nt)});
+    c.checkNode(BVSLE, {x, c.nf->CreateTerm(BVMOD, w, x, nt)});
+  }
+}
+
+/* x <=s (x srem ~x) --> true, raw form and the -(1 smod ~x) normal form. */
+TEST(SimplifyingNodeFactory_Exhaustive, sgt_srem_by_not)
+{
+  Context c;
+  for (unsigned w : {1u, 2u, 4u})
+  {
+    ASTNode x = c.bv(w);
+    ASTNode nt = c.hf->CreateTerm(BVNOT, w, x);
+    c.checkNode(BVSLE, {x, c.hf->CreateTerm(SBVREM, w, x, nt)});
+    c.checkNode(BVSLE, {x, c.nf->CreateTerm(SBVREM, w, x, nt)});
+  }
+}
+
+/* x = (~x << x) and x = (~x sdiv x) --> false, in both argument orders. */
+TEST(SimplifyingNodeFactory_Exhaustive, eq_impossible_not_forms)
+{
+  Context c;
+  for (unsigned w : {1u, 2u, 4u})
+  {
+    ASTNode x = c.bv(w);
+    ASTNode nt = c.hf->CreateTerm(BVNOT, w, x);
+    for (Kind k : {BVLEFTSHIFT, SBVDIV})
+    {
+      ASTNode t = c.hf->CreateTerm(k, w, nt, x);
+      c.checkNode(EQ, {x, t});
+      c.checkNode(EQ, {t, x});
+    }
+  }
+}
+
+/* (t >> s) --> 0 when t is structurally <=u s: an AND containing s, or
+   s umod/lshr/ashr something. */
+TEST(SimplifyingNodeFactory_Exhaustive, rightshift_dominated_numerator)
+{
+  Context c;
+  for (unsigned w : {1u, 2u, 4u})
+  {
+    ASTNode x = c.bv(w);
+    ASTNode y = c.bv(w);
+    c.checkTerm(BVRIGHTSHIFT, w, {c.hf->CreateTerm(BVAND, w, x, y), x});
+    c.checkTerm(BVRIGHTSHIFT, w, {c.hf->CreateTerm(BVMOD, w, x, y), x});
+    c.checkTerm(BVRIGHTSHIFT, w, {c.hf->CreateTerm(BVRIGHTSHIFT, w, x, y), x});
+    c.checkTerm(BVRIGHTSHIFT, w, {c.hf->CreateTerm(BVSRSHIFT, w, x, y), x});
+    // Dominance runs the other way for the divisor: no rule.
+    c.checkTerm(BVRIGHTSHIFT, w, {c.hf->CreateTerm(BVMOD, w, x, y), y}, false);
+  }
+}
+
+/* (x >> (x | y)) --> 0. The OR arrives as ~(~x & ~y). */
+TEST(SimplifyingNodeFactory_Exhaustive, rightshift_by_or_containing_numerator)
+{
+  Context c;
+  for (unsigned w : {2u, 4u})
+  {
+    ASTNode x = c.bv(w);
+    ASTNode y = c.bv(w);
+    ASTNode amount = c.nf->CreateTerm(BVOR, w, x, y);
+    c.checkTerm(BVRIGHTSHIFT, w, {x, amount});
+    // An OR not containing the numerator must not fire.
+    ASTNode z = c.bv(w);
+    ASTNode other = c.nf->CreateTerm(BVOR, w, y, z);
+    c.checkTerm(BVRIGHTSHIFT, w, {x, other}, false);
+  }
+}
+
+/* ((x ashr x) << x) --> 0. The arithmetic shift arrives as the sign-spread
+   sx(x[msb:msb]). */
+TEST(SimplifyingNodeFactory_Exhaustive, leftshift_of_sign_spread)
+{
+  Context c;
+  for (unsigned w : {2u, 4u})
+  {
+    ASTNode x = c.bv(w);
+    ASTNode spread = c.nf->CreateTerm(BVSRSHIFT, w, x, x);
+    c.checkTerm(BVLEFTSHIFT, w, {spread, x});
+  }
+}
+
+/* x & (t << x) --> 0, in any operand order and with extra operands. */
+TEST(SimplifyingNodeFactory_Exhaustive, and_with_shift_by_operand)
+{
+  Context c;
+  for (unsigned w : {1u, 2u, 4u})
+  {
+    ASTNode x = c.bv(w);
+    ASTNode y = c.bv(w);
+    ASTNode shift = c.hf->CreateTerm(BVLEFTSHIFT, w, y, x);
+    c.checkTerm(BVAND, w, {x, shift});
+    c.checkTerm(BVAND, w, {shift, x});
+    ASTNode z = c.bv(w);
+    c.checkTerm(BVAND, w, {z, x, shift});
+    // Shift by an amount that isn't an operand: no rule.
+    c.checkTerm(BVAND, w, {z, shift}, false);
+  }
+}
+
+/* a ^ (a ^ b) --> b, including through a negated nested xor. */
+TEST(SimplifyingNodeFactory_Exhaustive, xor_nested_cancel)
+{
+  Context c;
+  for (unsigned w : {1u, 2u, 4u})
+  {
+    ASTNode x = c.bv(w);
+    ASTNode y = c.bv(w);
+    ASTNode inner = c.hf->CreateTerm(BVXOR, w, x, y);
+    EXPECT_EQ(c.nf->CreateTerm(BVXOR, w, x, inner), y);
+    EXPECT_EQ(c.nf->CreateTerm(BVXOR, w, inner, x), y);
+    c.checkTerm(BVXOR, w, {x, inner});
+    ASTNode notInner = c.hf->CreateTerm(BVNOT, w, inner);
+    c.checkTerm(BVXOR, w, {x, notInner});
+  }
+}
+
+/* a + -(a + b) --> -b; b - (a + b) and a - (a - b) reach it through the
+   plus/uminus rewrite of subtraction, and x - ~(-x) --> 1 falls out. */
+TEST(SimplifyingNodeFactory_Exhaustive, plus_cancels_negated_sum)
+{
+  Context c;
+  for (unsigned w : {1u, 2u, 4u})
+  {
+    ASTNode x = c.bv(w);
+    ASTNode y = c.bv(w);
+    ASTNode sum = c.hf->CreateTerm(BVPLUS, w, x, y);
+    ASTNode negSum = c.hf->CreateTerm(BVUMINUS, w, sum);
+    c.checkTerm(BVPLUS, w, {x, negSum});
+    c.checkTerm(BVPLUS, w, {negSum, y});
+    c.checkTerm(BVSUB, w, {x, sum});
+    c.checkTerm(BVSUB, w, {x, c.hf->CreateTerm(BVSUB, w, x, y)});
+    ASTNode notNeg =
+        c.hf->CreateTerm(BVNOT, w, c.hf->CreateTerm(BVUMINUS, w, x));
+    c.checkTerm(BVSUB, w, {x, notNeg});
+    if (w >= 2)
+    {
+      // At width 1 BVPLUS routes through the xor handler and the chain to
+      // these exact forms doesn't apply (the results are still equivalent).
+      EXPECT_EQ(c.nf->CreateTerm(BVSUB, w, x,
+                                 c.nf->CreateTerm(BVSUB, w, x, y)),
+                y);
+      EXPECT_EQ(c.nf->CreateTerm(BVSUB, w, x, notNeg), c.konst(1, w));
+    }
+  }
+}
+
 } // namespace


### PR DESCRIPTION
Systematically enumerated all small bitvector terms and predicates over {x, y} (up to 5 AST nodes, all ops) at width 4, keeping the ones that evaluate to the same constant under **every** assignment but that no existing stage simplifies — not the SimplifyingNodeFactory, not constant bit propagation, and not AIG construction. Survivors were verified exhaustively at widths 1–7, cross-checked against `NonMemberBVConstEvaluator`, and solver-verified at widths 8/16/32/64 (negation → unsat).

This lands the 22 pattern-matchable survivors as factory rules, written against the factory's normalized forms (e.g. the `bvule` facts arrive as `BVGT` via `BVLE → BVGE → NOT(BVGT)`, subtraction as plus/uminus, `bvor` as `~(~a & ~b)`):

**Predicates**
- `(x umod s) >u x → false` — the remainder never exceeds the dividend. This is the most valuable of the set: re-deriving it costs the SAT solver ~8s at width 64 through the blasted remainder circuit.
- `(x udiv ~x) >u x → false`
- `(t << s) >u ~s → false` and `(t >> s) >u ~s → false`, also with `s = ~u`
- `x >s (x umod ~x) → false` and `x >s (x srem ~x) → false`, matching both raw and normalized divisor forms
- `x = (~x << x) → false`, `x = (~x sdiv x) → false`

**Terms**
- `(t >> s) → 0` when `t ≤u s` structurally: `t` an AND containing `s`, or `s umod/lshr/ashr` anything
- `(x >> (x | rest)) → 0`, with the OR matched in its NAND normal form
- `x & (t << x) → 0` for any `t` (every set bit of `x` is below position `x`)
- `a ^ (a ^ b) → b` — nested xor cancellation (children aren't flattened, so the existing dedup can't see it)
- `a + -(a + b) → -b`, which also collapses `x-(x+y)`, `x-(x-y)`, and `x - ~(-x) → 1`
- `((x ashr x) << x) → 0`, via its sign-spread normal form

Two discovered rules are documented but not implemented: `smod(x, udiv(y,y)) → 0` and `x ≤u -(udiv(x,x))` dissolve into ITE forms (`udiv(y,y) → ITE(y=0, ones, 1)`) and need ITE branch-lifting rather than pattern rules.

**Verification**
- 12 new exhaustive unit tests: all-assignment equivalence against the hashing factory at widths 1/2/4, rule-fired assertions, and no-overmatch negative cases. Full suite 67/67.
- Differential sat/unsat sweep vs master over the 2501-file fuzz corpus: no mismatches.
- Re-running the discovery enumerator against the patched factory reports zero remaining instances of the implemented schemas and no evaluator disagreements.

Full derivation details in `bench-hard/reports/2026-07-27-const-collapse-rules-not-in-snf.md`.