### PR TITLE
Read each width once in GetType, and skip the children fetch for symbols

### DIFF
--- a/include/stp/AST/ASTNode.h
+++ b/include/stp/AST/ASTNode.h
@@ -220,11 +220,29 @@ public:
    *                                                                 *
    * Both indexwidth and valuewidth should never be less than 0      *
    *******************************************************************/
-  unsigned int GetIndexWidth() const;
-  DLL_PUBLIC unsigned int GetValueWidth() const;
+  // Inlined for the same reason as the ref-counting members: ASTInternal is
+  // complete here, so these fold to a single virtual dispatch at the call site
+  // instead of a call into the library that then dispatches.
+  unsigned int GetIndexWidth() const { return _int_node_ptr->getIndexWidth(); }
+  DLL_PUBLIC unsigned int GetValueWidth() const
+  {
+    return _int_node_ptr->getValueWidth();
+  }
   void SetIndexWidth(unsigned int iw) const;
   void SetValueWidth(unsigned int vw) const;
-  types GetType(void) const;
+
+  // Reads each width once. The previous form re-read them per branch, which
+  // cost up to six dispatches for what is two pieces of information.
+  types GetType(void) const
+  {
+    const unsigned int iw = GetIndexWidth();
+    const unsigned int vw = GetValueWidth();
+
+    if (0 == iw)
+      return (0 == vw) ? BOOLEAN_TYPE : BITVECTOR_TYPE;
+
+    return (vw > 0) ? ARRAY_TYPE : UNKNOWN_TYPE;
+  }
 
   // Hash is the node's unique id. Inlined: used by every ==/</hash lookup.
   size_t Hash() const { return _int_node_ptr ? _int_node_ptr->node_uid : 0; }

--- a/lib/AST/ASTNode.cpp
+++ b/lib/AST/ASTNode.cpp
@@ -48,19 +48,9 @@ STPMgr* ASTNode::GetSTPMgr() const
 // since ASTInternal.h no longer includes ASTNode.h, breaking the old cycle).
 // The ref-counting special members are inlined there too.
 
-unsigned int ASTNode::GetIndexWidth() const
-{
-  return _int_node_ptr->getIndexWidth();
-}
-
 void ASTNode::SetIndexWidth(unsigned int _iw) const
 {
   _int_node_ptr->setIndexWidth(_iw);
-}
-
-unsigned int ASTNode::GetValueWidth() const
-{
-  return _int_node_ptr->getValueWidth();
 }
 
 void ASTNode::SetValueWidth(unsigned int vw) const
@@ -71,20 +61,6 @@ void ASTNode::SetValueWidth(unsigned int vw) const
 // return the type of the ASTNode:
 //
 // 0 iff BOOLEAN; 1 iff BITVECTOR; 2 iff ARRAY; 3 iff UNKNOWN;
-types ASTNode::GetType() const
-{
-  if ((GetIndexWidth() == 0) && (GetValueWidth() == 0))
-    return BOOLEAN_TYPE;
-
-  if ((GetIndexWidth() == 0) && (GetValueWidth() > 0))
-    return BITVECTOR_TYPE;
-
-  if ((GetIndexWidth() > 0) && (GetValueWidth() > 0))
-    return ARRAY_TYPE;
-
-  return UNKNOWN_TYPE;
-}
-
 // Print the node
 void ASTNode::nodeprint(ostream& os, bool c_friendly) const
 {

--- a/lib/AST/ASTmisc.cpp
+++ b/lib/AST/ASTmisc.cpp
@@ -340,6 +340,11 @@ ASTVec FlattenKind(Kind k, const ASTChildren& children, int maxDepth)
 
 bool BVTypeCheck_term_kind(const ASTNode& n, const Kind& k)
 {
+  // Symbols are a large share of the nodes built while parsing and have no
+  // children, so return before paying the virtual call that fetches them.
+  if (SYMBOL == k)
+    return true;
+
   // The children of bitvector terms are in turn bitvectors.
   const ASTChildren v = n.GetChildren();
 
@@ -350,9 +355,6 @@ bool BVTypeCheck_term_kind(const ASTNode& n, const Kind& k)
         FatalError("BVTypeCheck: The term t does not typecheck, where t = \n",
                    n);
       break;
-
-    case SYMBOL:
-      return true;
 
     case ITE:
       if (n.Degree() != 3)


### PR DESCRIPTION
Two changes on the node-creation path, both mechanical.

### `GetType()` re-read the widths per branch

`ASTNode::GetType()` was out of line in `lib/AST/ASTNode.cpp` and written as

```cpp
if ((GetIndexWidth() == 0) && (GetValueWidth() == 0)) return BOOLEAN_TYPE;
if ((GetIndexWidth() == 0) && (GetValueWidth() > 0))  return BITVECTOR_TYPE;
if ((GetIndexWidth() > 0)  && (GetValueWidth() > 0))  return ARRAY_TYPE;
return UNKNOWN_TYPE;
```

`ASTInternal::getIndexWidth()` and `getValueWidth()` are pure virtual, and
`ASTNode`'s accessors wrapping them were themselves out of line, so each read
was a call into the library that then dispatched. Worst case that is six of
them for what is two pieces of information.

This reads each width once and moves `GetType()`, `GetIndexWidth()` and
`GetValueWidth()` into the header, where `ASTInternal` is already complete --
the same reasoning as the ref-counting members in #660 and the unique-table
hashers in #668. `GetType()` is used well beyond the type checker, throughout
the simplifier and bit-blaster, so this is not confined to parsing.

### `BVTypeCheck_term_kind` fetched children it did not need

The function opened with `const ASTChildren v = n.GetChildren();` before the
switch. `GetChildren()` is virtual, and `SYMBOL` returned immediately without
ever using `v`. Symbols are a large share of the nodes built while parsing.
This returns for `SYMBOL` first and drops the now-unreachable case from the
switch.

### Measurements

Retired user-space instructions. Instruction counts rather than wall clock: the
measuring machine has a wall-clock noise floor near +-4%, while retired
instructions reproduce to about 0.001%.

| | |
|---|---|
| `--parse-only`, `QF_BV/Sage2/bench_4329.smt2` | **-1.26%** |
| 40 QF_BV benchmarks, `--exit-after-CNF` | **-0.18%** |
| fixed startup (`--version`) | unchanged, as expected |

### Correctness

| check | corpus | result |
|---|---|---|
| CNF byte-identical | 40 QF_BV benchmarks | 0 mismatched |
| CNF byte-identical | 600 fuzzer queries | 391 identical, 0 mismatched, 209 emit no CNF |
| sat/unsat agreement | 2501 fuzzer queries | 2501 agree, 0 disagree |

### Not in this PR

Most of what `BVTypeCheck` costs is not either of these. `TypeChecker` wraps
every node the parser creates, and the per-child checks it then runs -- notably
`checkChildrenAreBV()` and its four call sites, the `BITVECTOR_TYPE !=
it->GetType()` guard in the n-ary loop, and the five child-type checks in READ
and WRITE -- re-verify a property of each child that was already established
when that child was itself created and checked, since validation happens bottom
up. Removing those rests on that invariant, which deserves its own review and
its own byte-compare rather than riding along here.
