### PR TITLE
Type check both operands of comparison and overflow predicates

### DIFF
--- a/lib/AST/ASTmisc.cpp
+++ b/lib/AST/ASTmisc.cpp
@@ -584,7 +584,7 @@ bool BVTypeCheck_nonterm_kind(const ASTNode& n, const Kind& k)
     case BVSSUBO:
       if (n.Degree() != 2)
         FatalError("BVTypeCheck: should have exactly 2 args\n", n);
-      if (BITVECTOR_TYPE != n[0].GetType() && BITVECTOR_TYPE != n[1].GetType())
+      if (BITVECTOR_TYPE != n[0].GetType() || BITVECTOR_TYPE != n[1].GetType())
       {
         FatalError("BVTypeCheck: terms in atomic formulas must be bitvectors",
                    n);


### PR DESCRIPTION
## The bug

`BVTypeCheck_nonterm_kind` (`lib/AST/ASTmisc.cpp:587`) guards the comparison
and overflow predicates with:

```c
if (BITVECTOR_TYPE != n[0].GetType() && BITVECTOR_TYPE != n[1].GetType())
{
  FatalError("BVTypeCheck: terms in atomic formulas must be bitvectors", n);
}
```

The message says both operands must be bitvectors, but `&&` only fires when
*neither* is one. A comparison where exactly one operand is a bitvector and the
other is an array (or a boolean) passes this check. The condition should be a
disjunction, which is the one-character change here.

## Kinds affected

The case list covers fourteen kinds: `BVLT`, `BVLE`, `BVGT`, `BVGE`, `BVSLT`,
`BVSLE`, `BVSGT`, `BVSGE`, `BVUADDO`, `BVSADDO`, `BVUMULO`, `BVSMULO`,
`BVUSUBO`, `BVSSUBO`.

## Is anything actually let through?

No — and it is worth being precise, because the guard's laxness is masked by an
invariant rather than by a second check aimed at it.

`ASTNode::GetType()` (`lib/AST/ASTNode.cpp:74`) is a pure function of
`(indexWidth, valueWidth)`: `(0,0)` is boolean, `(0,>0)` bitvector, `(>0,>0)`
array, `(>0,0)` unknown. The two checks immediately below the guard require
`n[0]` and `n[1]` to agree on *both* widths, so once they pass, the two operands
necessarily have the same type. A mixed pair is therefore still rejected — but
by the width check, and with the misleading message "terms in atomic formulas
must be of equal length".

So this is a diagnostic fix, not a soundness fix. It makes the guard test what
it claims to test instead of depending on `GetType()` staying width-derived.

## Reachability

* **SMT-LIB2 and CVC parsers** — a boolean operand is impossible: both grammars
  put boolean identifiers in the formula nonterminal (the CVC lexer returns
  `FORMID_TOK` for any symbol whose `GetType()` is `BOOLEAN_TYPE`), so
  `(bvult b x)` and `BVLT(b, x)` are syntax errors. An **array** operand does
  parse and does reach the type checker, via the `TypeChecker` node factory that
  `Main::parse_file` installs — and that runs unconditionally, not under
  `assert`. Before this change `BVLT(arr, x)` died with "must be of equal
  length"; now it dies with "must be bitvectors".
* **C API** — `createBinaryNode` (`lib/Interface/c_interface.cpp:1265`) wraps its
  check in `assert(BVTypeCheck(o))`, so in an `NDEBUG` build there is no type
  check at all and `vc_bvLtExpr(vc, bool_var, bv8_var)` builds the malformed node
  and crashes later during solving. That hole is orthogonal to this patch — the
  guard is not reached there in release builds either way — but it is the only
  route by which such a node can be constructed at all.

## Strictness

This makes the type checker stricter, so it is a behaviour change in principle:
input previously accepted could now abort. Per the analysis above the set of
rejected nodes is unchanged (only the message differs), and that was checked
rather than assumed:

* **ctest** (`-DENABLE_TESTING=ON -DENABLE_ASSERTIONS=ON -DCMAKE_BUILD_TYPE=Debug`):
  68/68 passed, 0 failed.
* **Answer agreement** against a baseline built from `faf9755`: 2501 fuzz
  queries, **2501 agree, 0 disagree, 0 skipped**. Zero skips matters here — a
  file that newly aborted would have failed to produce an answer and been
  counted as a skip.
* **CNF neutrality**: 39 identical / 0 mismatched / 1 skipped on the pre-CNF
  corpus, and 391 identical / 0 mismatched / 209 skipped on 600 fuzz files at
  `TIMEOUT=20`. Every skip is a *baseline* `NOCNF`/`TIMEOUT`; a candidate-only
  failure would have been reported as a mismatch, and there were none.

No performance claim — the emitted CNF is byte-identical and the check costs the
same either way.

## Other instances of the same shape

I scanned the rest of `lib/AST/ASTmisc.cpp` for guards whose message asserts a
property of all operands while the condition is a conjunction of negatives (or
the reverse). There are none — this was the only one. The nearby guards are all
correct: the `EQ` case and the `is_Form_kind` check at the top of the function
negate a conjunction as a whole (`!(a && b)`), `ITE` already uses `||`, and
`checkChildrenAreBV` tests each child in a loop.

I also considered adding an explicit check of the two operands against each
other, and did not: the `GetValueWidth`/`GetIndexWidth` comparisons on the lines
below already do exactly that, and given that `GetType()` is derived from those
two widths, any further type check would be redundant.
