### PR TITLE
Build deps CryptoMiniSat static so installed stp is self-contained

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -713,6 +713,12 @@ if (NOT NOCRYPTOMINISAT)
   message(STATUS "GMP libraries: ${GMP_LIBRARIES}")
   include_directories(SYSTEM ${GMP_INCLUDE_DIRS})
   set(LIBS ${LIBS} ${GMP_LIBRARIES})
+  # A static CryptoMiniSat references cadical/cadiback imported targets but its
+  # config file does not find them itself; a shared CryptoMiniSat has no such
+  # packages, hence QUIET. cadical's export in turn references Threads::Threads.
+  find_package(Threads QUIET)
+  find_package(cadical CONFIG QUIET)
+  find_package(cadiback CONFIG QUIET)
   find_package(cryptominisat5 CONFIG)
   if (cryptominisat5_FOUND AND HAVE_FLAG_STD_CPP11 AND (NOT NOCRYPTOMINISAT))
     message(STATUS "CryptoMiniSat5 dynamic lib: ${CRYPTOMINISAT5_LIBRARIES}")

--- a/scripts/deps/setup-cms.sh
+++ b/scripts/deps/setup-cms.sh
@@ -19,7 +19,12 @@ cd "${dep}"
 # We specify the tags/commits for the other repositories, so do for this too
 git checkout release/v5.14.7
 mkdir build && cd build
-cmake -DENABLE_ASSERTIONS=OFF -DCMAKE_INSTALL_PREFIX:PATH="${install_dir}" ..
+# Build a static (PIC) library. It gets linked into libstp, so the installed
+# stp/libstp do not depend on a libcryptominisat5.so that this script only
+# installs inside the source checkout. STATIC_BINARY=OFF because the fully
+# static cryptominisat5 executable needs static gmp/zlib, which we don't need.
+cmake -DENABLE_ASSERTIONS=OFF -DBUILD_SHARED_LIBS=OFF -DSTATIC_BINARY=OFF \
+      -DCMAKE_INSTALL_PREFIX:PATH="${install_dir}" ..
 cmake --build . --parallel "$(nproc)"
 cmake --install .
 cd ..


### PR DESCRIPTION
## Problem

Anyone following the README quick install on Linux ends up with a broken install:

```
$ stp --version
error while loading shared libraries: libcryptominisat5.so.5.14:
cannot open shared object file: No such file or directory
```

`scripts/deps/setup-cms.sh` installs CryptoMiniSat only into `deps/install` inside the checkout, and the default shared build links libstp against its shared library. The installed `stp`, `libstp.so` and the Python bindings all carry a `libcryptominisat5.so.5.14` DT_NEEDED entry, with `RUNPATH /usr/local/lib` only — so everything fails at load time after `cmake --install`. The build tree works (its RPATH covers `deps/install`), which is why CI never notices: nothing exercises the installed artifacts.

This is long-standing, not new with 5.14: the 5.11-era setup script also installed only to `deps/install`. Machines with an older cms in `/usr/local/lib` from past installs masked it until the 5.14 bump changed the soname.

## Fix

Build the deps CryptoMiniSat static. cms sets `CMAKE_POSITION_INDEPENDENT_CODE` globally, so the archives fold into the shared `libstp.so`, and the existing `--exclude-libs,ALL --gc-sections` handling (added for ABC) keeps its symbols private — only STP's own `vc_*Cadical` API is exported. libstp text grows 3.4MB → 4.8MB. `STATIC_BINARY=OFF` because the fully static cryptominisat5 *executable* would need static gmp/zlib, which nothing needs here.

Two find_package quirks surfaced: the static cms export references `cadical`/`cadiback` imported targets that `cryptominisat5Config.cmake` does not resolve itself, and cadical's export references `Threads::Threads` (without `find_package(Threads)` the literal `-lThreads::Threads` reaches the linker). Both are handled with QUIET find_package calls before finding cryptominisat5.

A system-installed **shared** CryptoMiniSat is found and linked dynamically exactly as before; only a deps-built cms becomes static. The README quickstart needs no changes — the same commands now produce a working install.

## Verification

- `ldd` shows no libcryptominisat5 dependency in the installed `stp` or `libstp.so`
- `--cryptominisat` vs `--minisat` answers agree over 40 `tests/query-files` benchmarks
- The Python bindings import and solve against the new libstp (previously `import stp` raised `OSError`)