### PR TITLE
Keep the full export set when building the extra tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -352,12 +352,14 @@ if(NOT MSVC)
         # for a solver library, and the flag is in Debian's default hardening
         # set.  Neither flag changes behaviour: the emitted CNF is unchanged.
         #
-        # -fvisibility=hidden is skipped for ENABLE_TESTING builds.  The unit
-        # tests link libstp and call directly into entry points that are not
-        # part of the public API (the simplifier passes, STPMgr internals,
-        # SMT2ScanString), so they need the full export set.  This is why the
-        # flag was carried commented-out here.
-        if(NOT ENABLE_TESTING)
+        # -fvisibility=hidden is skipped for ENABLE_TESTING and
+        # BUILD_EXTRA_TOOLS builds.  The unit tests and the extra tools
+        # (propagator_bench and friends) link libstp and call directly into
+        # entry points that are not part of the public API (the simplifier
+        # passes, the domain analyses, STPMgr internals, SMT2ScanString), so
+        # they need the full export set.  This is why the flag was carried
+        # commented-out here.
+        if(NOT ENABLE_TESTING AND NOT BUILD_EXTRA_TOOLS)
             add_cxx_flag_if_supported("-fvisibility=hidden")
             # The vendored ABC sources are C.  There is no
             # add_c_flag_if_supported, so reuse the check above and set


### PR DESCRIPTION
`-fvisibility=hidden` strips every symbol not annotated `DLL_PUBLIC` from `libstp.so`. The extra tools (`propagator_bench` and friends) call internal entry points — the domain analyses' `dispatchToTransferFunctions`, `constantBitP::maxPrecision`, `BVTypeCheck`, and non-public `STPMgr`/`ASTNode` members — so a `BUILD_EXTRA_TOOLS=ON` + `BUILD_SHARED_LIBS=ON` release build failed to link `propagator_bench` with undefined references, even though the symbols were present (local) in the library.

CI never sees this combination: the only job with `BUILD_EXTRA_TOOLS=ON` also sets `ENABLE_TESTING=ON`, which already skips the visibility flag, and every other job leaves the extra tools off.

Fix: extend the existing `ENABLE_TESTING` exemption so `BUILD_EXTRA_TOOLS` builds also keep the full export set. The extra tools are internal dev harnesses in the same position as the unit tests, so this matches the rationale already documented at the guard. A plain build (both options off) still gets the startup-time visibility optimization.

Verified locally: `BUILD_EXTRA_TOOLS=ON`, `ENABLE_TESTING=OFF`, shared Release build now links, and `propagator_bench --help` runs.