### PR TITLE
Move signed div/mod/rem translation into the bitblaster

### DIFF
--- a/include/stp/AbsRefineCounterExample/ArrayTransformer.h
+++ b/include/stp/AbsRefineCounterExample/ArrayTransformer.h
@@ -105,8 +105,6 @@ private:
   ASTNode TransformFormula(const ASTNode& form);
 
 public:
-  static ASTNode TranslateSignedDivModRem(const ASTNode& in, NodeFactory* nf);
-
   // fill the arrayname_readindices vector if e0 is a READ(Arr,index)
   // and index is a BVCONST
   void FillUp_ArrReadIndex_Vec(const ASTNode& e0, const ASTNode& e1);

--- a/lib/AbsRefineCounterExample/ArrayTransformer.cpp
+++ b/lib/AbsRefineCounterExample/ArrayTransformer.cpp
@@ -24,9 +24,8 @@ THE SOFTWARE.
 
 /* Transform:
  *
- * Converts signed Div/signed remainder/signed modulus into their
- * unsigned counterparts. Removes array selects and stores from
- * formula. Arrays are replaced by equivalent bit-vector variables
+ * Removes array selects and stores from the formula. Arrays are
+ * replaced by equivalent bit-vector variables
  */
 #include "stp/AbsRefineCounterExample/ArrayTransformer.h"
 #include "stp/Simplifier/Simplifier.h"
@@ -118,139 +117,6 @@ ASTNode ArrayTransformer::TransformFormula_TopLevel(const ASTNode& form)
   }
 }
 
-// Translates signed BVDIV,BVMOD and BVREM into unsigned variety
-ASTNode ArrayTransformer::TranslateSignedDivModRem(const ASTNode& in,
-                                                   NodeFactory* nf)
-{
-  assert(in.GetChildren().size() == 2);
-
-  const ASTNode& dividend = in[0];
-  const ASTNode& divisor = in[1];
-  const unsigned len = in.GetValueWidth();
-
-  ASTNode hi1 = nf->CreateBVConst(32, len - 1);
-  ASTNode one = nf->CreateOneConst(1);
-  ASTNode zero = nf->CreateZeroConst(1);
-  // create the condition for the dividend
-  ASTNode cond_dividend =
-      nf->CreateNode(EQ, one, nf->CreateTerm(BVEXTRACT, 1, dividend, hi1, hi1));
-  // create the condition for the divisor
-  ASTNode cond_divisor =
-      nf->CreateNode(EQ, one, nf->CreateTerm(BVEXTRACT, 1, divisor, hi1, hi1));
-
-  if (SBVREM == in.GetKind())
-  {
-    // BVMOD is an expensive operation. So have the fewest bvmods
-    // possible. Just one.
-
-    // Take absolute value.
-    ASTNode pos_dividend =
-        nf->CreateTerm(ITE, len, cond_dividend,
-                       nf->CreateTerm(BVUMINUS, len, dividend), dividend);
-    ASTNode pos_divisor =
-        nf->CreateTerm(ITE, len, cond_divisor,
-                       nf->CreateTerm(BVUMINUS, len, divisor), divisor);
-
-    // create the modulus term
-    ASTNode modnode = nf->CreateTerm(BVMOD, len, pos_dividend, pos_divisor);
-
-    // If the dividend is <0 take the unary minus.
-    ASTNode n = nf->CreateTerm(ITE, len, cond_dividend,
-                               nf->CreateTerm(BVUMINUS, len, modnode), modnode);
-    return n;
-  }
-
-  // This is the modulus of dividing rounding to -infinity.
-  else if (SBVMOD == in.GetKind())
-  {
-
-    /*
-    (bvsmod s t) abbreviates
-        (let ((?msb_s ((_ extract |m-1| |m-1|) s))
-          (?msb_t ((_ extract |m-1| |m-1|) t)))
-        (let ((abs_s (ite (= ?msb_s #b0) s (bvneg s)))
-            (abs_t (ite (= ?msb_t #b0) t (bvneg t))))
-          (let ((u (bvurem abs_s abs_t)))
-          (ite (= u (_ bv0 m))
-             u
-          (ite (and (= ?msb_s #b0) (= ?msb_t #b0))
-             u
-          (ite (and (= ?msb_s #b1) (= ?msb_t #b0))
-             (bvadd (bvneg u) t)
-          (ite (and (= ?msb_s #b0) (= ?msb_t #b1))
-             (bvadd u t)
-             (bvneg u))))))))
-     */
-
-    // Take absolute value.
-    ASTNode pos_dividend =
-        nf->CreateTerm(ITE, len, cond_dividend,
-                       nf->CreateTerm(BVUMINUS, len, dividend), dividend);
-    ASTNode pos_divisor =
-        nf->CreateTerm(ITE, len, cond_divisor,
-                       nf->CreateTerm(BVUMINUS, len, divisor), divisor);
-
-    ASTNode urem_node = nf->CreateTerm(BVMOD, len, pos_dividend, pos_divisor);
-
-    // If the dividend is <0, then we negate the whole thing.
-    ASTNode rev_node =
-        nf->CreateTerm(ITE, len, cond_dividend,
-                       nf->CreateTerm(BVUMINUS, len, urem_node), urem_node);
-
-    // if It's XOR <0, and it doesn't perfectly divide, then add t (not its
-    // absolute value).
-    ASTNode xor_node = nf->CreateNode(XOR, cond_dividend, cond_divisor);
-    ASTNode neZ = nf->CreateNode(
-        NOT,
-        nf->CreateNode(EQ, rev_node,
-                       nf->CreateZeroConst(divisor.GetValueWidth())));
-    ASTNode cond = nf->CreateNode(AND, xor_node, neZ);
-    ASTNode n = nf->CreateTerm(ITE, len, cond,
-                               nf->CreateTerm(BVPLUS, len, rev_node, divisor),
-                               rev_node);
-
-    return n;
-  }
-  else if (SBVDIV == in.GetKind())
-  {
-    // now handle the BVDIV case
-    // if topBit(dividend) is 1 and topBit(divisor) is 0
-    //
-    // then output is -BVDIV(-dividend,divisor)
-    //
-    // elseif topBit(dividend) is 0 and topBit(divisor) is 1
-    //
-    // then output is -BVDIV(dividend,-divisor)
-    //
-    // elseif topBit(dividend) is 1 and topBit(divisor) is 1
-    //
-    // then output is BVDIV(-dividend,-divisor)
-    //
-    // else simply output BVDIV(dividend,divisor)
-
-    // Take absolute value.
-    ASTNode pos_dividend =
-        nf->CreateTerm(ITE, len, cond_dividend,
-                       nf->CreateTerm(BVUMINUS, len, dividend), dividend);
-    ASTNode pos_divisor =
-        nf->CreateTerm(ITE, len, cond_divisor,
-                       nf->CreateTerm(BVUMINUS, len, divisor), divisor);
-
-    ASTNode divnode = nf->CreateTerm(BVDIV, len, pos_dividend, pos_divisor);
-
-    // A little confusing. Only negate the result if they are XOR <0.
-    ASTNode xor_node = nf->CreateNode(XOR, cond_dividend, cond_divisor);
-    ASTNode n = nf->CreateTerm(ITE, len, xor_node,
-                               nf->CreateTerm(BVUMINUS, len, divnode), divnode);
-
-    return n;
-  }
-
-  FatalError("TranslateSignedDivModRem:"
-             "input must be signed DIV/MOD/REM",
-             in);
-}
-
 // Check that the transformations have occurred.
 void ArrayTransformer::assertTransformPostConditions(const ASTNode& term,
                                                      ASTNodeSet& visited)
@@ -282,7 +148,7 @@ void ArrayTransformer::assertTransformPostConditions(const ASTNode& term,
 /********************************************************
  * TransformFormula()
  *
- * Get rid of DIV/MODs, ARRAY read/writes, FOR constructs
+ * Get rid of ARRAY read/writes
  ********************************************************/
 ASTNode ArrayTransformer::TransformFormula(const ASTNode& simpleForm)
 {

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -22,7 +22,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ********************************************************************/
 #include "stp/ToSat/BitBlaster.h"
-#include "stp/AbsRefineCounterExample/ArrayTransformer.h"
 #include "stp/Simplifier/Simplifier.h"
 #include "stp/Simplifier/constantBitP/ConstantBitPropagation.h"
 #include "stp/Simplifier/constantBitP/FixedBits.h"
@@ -67,6 +66,137 @@ vector<BBNodeAIG> _empty_BBNodeAIGVec;
 // that should have already been applied.
 const bool debug_do_check = false;
 const bool debug_bitblaster = false;
+
+// Translates signed BVDIV,BVMOD and BVREM into unsigned variety
+static ASTNode TranslateSignedDivModRem(const ASTNode& in, NodeFactory* nf)
+{
+  assert(in.GetChildren().size() == 2);
+
+  const ASTNode& dividend = in[0];
+  const ASTNode& divisor = in[1];
+  const unsigned len = in.GetValueWidth();
+
+  ASTNode hi1 = nf->CreateBVConst(32, len - 1);
+  ASTNode one = nf->CreateOneConst(1);
+  // create the condition for the dividend
+  ASTNode cond_dividend =
+      nf->CreateNode(EQ, one, nf->CreateTerm(BVEXTRACT, 1, dividend, hi1, hi1));
+  // create the condition for the divisor
+  ASTNode cond_divisor =
+      nf->CreateNode(EQ, one, nf->CreateTerm(BVEXTRACT, 1, divisor, hi1, hi1));
+
+  if (SBVREM == in.GetKind())
+  {
+    // BVMOD is an expensive operation. So have the fewest bvmods
+    // possible. Just one.
+
+    // Take absolute value.
+    ASTNode pos_dividend =
+        nf->CreateTerm(ITE, len, cond_dividend,
+                       nf->CreateTerm(BVUMINUS, len, dividend), dividend);
+    ASTNode pos_divisor =
+        nf->CreateTerm(ITE, len, cond_divisor,
+                       nf->CreateTerm(BVUMINUS, len, divisor), divisor);
+
+    // create the modulus term
+    ASTNode modnode = nf->CreateTerm(BVMOD, len, pos_dividend, pos_divisor);
+
+    // If the dividend is <0 take the unary minus.
+    ASTNode n = nf->CreateTerm(ITE, len, cond_dividend,
+                               nf->CreateTerm(BVUMINUS, len, modnode), modnode);
+    return n;
+  }
+
+  // This is the modulus of dividing rounding to -infinity.
+  else if (SBVMOD == in.GetKind())
+  {
+
+    /*
+    (bvsmod s t) abbreviates
+        (let ((?msb_s ((_ extract |m-1| |m-1|) s))
+          (?msb_t ((_ extract |m-1| |m-1|) t)))
+        (let ((abs_s (ite (= ?msb_s #b0) s (bvneg s)))
+            (abs_t (ite (= ?msb_t #b0) t (bvneg t))))
+          (let ((u (bvurem abs_s abs_t)))
+          (ite (= u (_ bv0 m))
+             u
+          (ite (and (= ?msb_s #b0) (= ?msb_t #b0))
+             u
+          (ite (and (= ?msb_s #b1) (= ?msb_t #b0))
+             (bvadd (bvneg u) t)
+          (ite (and (= ?msb_s #b0) (= ?msb_t #b1))
+             (bvadd u t)
+             (bvneg u))))))))
+     */
+
+    // Take absolute value.
+    ASTNode pos_dividend =
+        nf->CreateTerm(ITE, len, cond_dividend,
+                       nf->CreateTerm(BVUMINUS, len, dividend), dividend);
+    ASTNode pos_divisor =
+        nf->CreateTerm(ITE, len, cond_divisor,
+                       nf->CreateTerm(BVUMINUS, len, divisor), divisor);
+
+    ASTNode urem_node = nf->CreateTerm(BVMOD, len, pos_dividend, pos_divisor);
+
+    // If the dividend is <0, then we negate the whole thing.
+    ASTNode rev_node =
+        nf->CreateTerm(ITE, len, cond_dividend,
+                       nf->CreateTerm(BVUMINUS, len, urem_node), urem_node);
+
+    // if It's XOR <0, and it doesn't perfectly divide, then add t (not its
+    // absolute value).
+    ASTNode xor_node = nf->CreateNode(XOR, cond_dividend, cond_divisor);
+    ASTNode neZ = nf->CreateNode(
+        NOT,
+        nf->CreateNode(EQ, rev_node,
+                       nf->CreateZeroConst(divisor.GetValueWidth())));
+    ASTNode cond = nf->CreateNode(AND, xor_node, neZ);
+    ASTNode n = nf->CreateTerm(ITE, len, cond,
+                               nf->CreateTerm(BVPLUS, len, rev_node, divisor),
+                               rev_node);
+
+    return n;
+  }
+  else if (SBVDIV == in.GetKind())
+  {
+    // now handle the BVDIV case
+    // if topBit(dividend) is 1 and topBit(divisor) is 0
+    //
+    // then output is -BVDIV(-dividend,divisor)
+    //
+    // elseif topBit(dividend) is 0 and topBit(divisor) is 1
+    //
+    // then output is -BVDIV(dividend,-divisor)
+    //
+    // elseif topBit(dividend) is 1 and topBit(divisor) is 1
+    //
+    // then output is BVDIV(-dividend,-divisor)
+    //
+    // else simply output BVDIV(dividend,divisor)
+
+    // Take absolute value.
+    ASTNode pos_dividend =
+        nf->CreateTerm(ITE, len, cond_dividend,
+                       nf->CreateTerm(BVUMINUS, len, dividend), dividend);
+    ASTNode pos_divisor =
+        nf->CreateTerm(ITE, len, cond_divisor,
+                       nf->CreateTerm(BVUMINUS, len, divisor), divisor);
+
+    ASTNode divnode = nf->CreateTerm(BVDIV, len, pos_dividend, pos_divisor);
+
+    // A little confusing. Only negate the result if they are XOR <0.
+    ASTNode xor_node = nf->CreateNode(XOR, cond_dividend, cond_divisor);
+    ASTNode n = nf->CreateTerm(ITE, len, xor_node,
+                               nf->CreateTerm(BVUMINUS, len, divnode), divnode);
+
+    return n;
+  }
+
+  FatalError("TranslateSignedDivModRem:"
+             "input must be signed DIV/MOD/REM",
+             in);
+}
 
 //"Hash" (=add) first 5 node IDs together
 //TODO pretty bad hash
@@ -885,7 +1015,7 @@ const BBNodeVec BitBlaster<BBNode, BBNodeManagerT>::BBTerm(const ASTNode& _term,
     case SBVMOD:
     case SBVDIV:
     {
-      ASTNode p = ArrayTransformer::TranslateSignedDivModRem(term, ASTNF);
+      ASTNode p = TranslateSignedDivModRem(term, ASTNF);
       result = BBTerm(p, support);
       break;
     }


### PR DESCRIPTION
`ArrayTransformer::TranslateSignedDivModRem` has only one caller: the bitblaster, which uses it to expand `SBVDIV`/`SBVREM`/`SBVMOD` lazily when a signed node is reached during blasting. The ArrayTransformer itself stopped rewriting these kinds long ago — the static helper just never moved out.

This makes the function a file-local helper in `BitBlaster.cpp` and removes it from the ArrayTransformer's header, so the array transformer's interface no longer advertises a function that has nothing to do with arrays. The body is unchanged apart from dropping an unused `zero` local. Comments claiming the transformer converts signed operations are updated to match reality.

Keeping the expansion lazy (rather than doing it in the transformer pass) is deliberate: the signed kinds survive through the word-level pipeline, where the simplifier, constant-bit propagation and value-set analysis all handle them natively and more precisely than the expanded ITE form.

Tested: signed-division lit tests give expected answers; 12-file differential on `bvsdiv`/`bvsrem`/`bvsmod` corpus files agrees with the pre-change binary.