### PR TITLE
Skip the transform pass when the problem has no arrays

### DIFF
--- a/include/stp/AST/AST.h
+++ b/include/stp/AST/AST.h
@@ -65,6 +65,7 @@ struct ArithLess
 bool isAtomic(Kind k);
 bool isCommutative(const Kind k);
 bool containsArrayOps(const ASTNode& n, STPMgr* stp);
+bool containsParamBool(const ASTNode& n, STPMgr* stp);
 bool numberOfReadsLessThan(const ASTNode& n, int v);
 
 // If (a > b) in the termorder, then return 1 elseif (a < b) in the

--- a/lib/AST/ASTmisc.cpp
+++ b/lib/AST/ASTmisc.cpp
@@ -135,6 +135,20 @@ bool containsArrayOps(const ASTNode& n, STPMgr* mgr)
   return false;
 }
 
+// True if any descendants are parameterised booleans. Only the CVC
+// parser creates these; the ArrayTransformer converts them to
+// boolean variables.
+bool containsParamBool(const ASTNode& n, STPMgr* mgr)
+{
+  NodeIterator ni(n, mgr->ASTUndefined, *mgr);
+  ASTNode current;
+  while ((current = ni.next()) != ni.end())
+    if (PARAMBOOL == current.GetKind())
+      return true;
+
+  return false;
+}
+
 bool isCommutative(const Kind k)
 {
   switch (k)

--- a/lib/STPManager/STP.cpp
+++ b/lib/STPManager/STP.cpp
@@ -303,6 +303,12 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input)
 
   ASTNode inputToSat = original_input;
 
+  bool arrayops = containsArrayOps(inputToSat, bm);
+
+  // The transformer also converts parameterised booleans (only the CVC
+  // parser creates them), so it can't be skipped while any are present.
+  bool needsTransform = arrayops || containsParamBool(inputToSat, bm);
+
   // If the number of array reads is small. We rewrite them through.
   // The bit-vector simplifications are more thorough than the array
   // simplifications. For example,
@@ -312,9 +318,9 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input)
   // introduced.
   // TODO: I chose the number of reads we perform this operation at randomly.
   bool removed = false;
-  if ((bm->UserFlags.ackermannisation &&
-       numberOfReadsLessThan(inputToSat, 50)) ||
-      numberOfReadsLessThan(inputToSat, 10))
+  if (arrayops && ((bm->UserFlags.ackermannisation &&
+                    numberOfReadsLessThan(inputToSat, 50)) ||
+                   numberOfReadsLessThan(inputToSat, 10)))
   {
     // If the number of axioms that would be added it small. Remove them.
     bm->UserFlags.ackermannisation = true;
@@ -324,12 +330,12 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input)
       cerr << "Have removed array operations" << endl;
     }
     removed = true;
-  }
 
-  const bool arrayops = containsArrayOps(inputToSat, bm);
-  if (removed)
-  {
-    assert(!arrayops);
+    // With ackermannisation on, the transform removes every array
+    // operation, and it converts any parameterised booleans too.
+    arrayops = false;
+    needsTransform = false;
+    assert(!containsArrayOps(inputToSat, bm));
   }
 
   if (bm->UserFlags.check_counterexample_flag ||
@@ -660,8 +666,11 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input)
   }
   revert.reset(NULL);
 
-  inputToSat = arrayTransformer->TransformFormula_TopLevel(inputToSat);
-  bm->ASTNodeStats("after transformation: ", inputToSat);
+  if (needsTransform)
+  {
+    inputToSat = arrayTransformer->TransformFormula_TopLevel(inputToSat);
+    bm->ASTNodeStats("after transformation: ", inputToSat);
+  }
   bm->TermsAlreadySeenMap_Clear();
 
   bm->UserFlags.optimize_flag = optimize_enabled;


### PR DESCRIPTION
The ArrayTransformer's whole-formula rewrite ran **twice** on every array-free problem:

1. The early read-removal block is guarded by `numberOfReadsLessThan(inputToSat, 10)`, which is trivially true when there are zero reads — so every pure bit-vector problem entered it, force-set `ackermannisation`, and walked the whole formula through the transformer.
2. The pre-bitblasting call at the bottom of `TopLevelSTPAux` ran unconditionally.

Both walks are identity rewrites when there is nothing to remove. This computes `containsArrayOps` up front and runs the transform only when the formula contains array operations, or parameterised booleans — the CVC-only construct that the same pass converts to Boolean variables (the bitblaster has no `PARAMBOOL` case, so the walk must stay for those). Signed div/mod/rem, which the pass historically rewrote, are expanded lazily by the bitblaster, so nothing else needs it.

A side effect is that `ackermannisation` is no longer force-enabled on array-free problems; nothing downstream observes the difference (`maybeRefinement` requires `arrayops`).

Verification (candidate vs a binary differing only by this change):
- CNF output byte-identical on 15 array-free QF_BV files.
- sat/unsat differential clean on 235 corpus files (including 40 with arrays) and all 43 sample CVC tests; the smt2 command/incremental tests are output-identical.
- Targeted `PARAMBOOL` tests (`p(0hex1)` etc.) behave identically, and models on the CVC tests pass `--check-sanity`.
- Instruction counts at `--exit-after-CNF` on bench-hard files move by ≤0.01% — this is a pipeline-hygiene change, not a measurable speedup.