### PR TITLE
Distribute predicates over an ITE on the ground path

### DIFF
--- a/lib/Simplifier/RemoveUnconstrained.cpp
+++ b/lib/Simplifier/RemoveUnconstrained.cpp
@@ -110,6 +110,24 @@ void RemoveUnconstrained::replace(const ASTNode& from, const ASTNode to)
   simplifier->UpdateSubstitutionMapFewChecks(from, to);
 }
 
+// Rebuild one collected step as an ASTNode around `in`. Used when a
+// distributed ITE's other branch gets the suffix steps re-applied.
+static ASTNode applyStepToNode(NodeFactory* nf, STPMgr& bm,
+                               const GroundStep& s, const ASTNode& in)
+{
+  if (s.kind == BVSX || s.kind == BVZX)
+    return nf->CreateTerm(s.kind, s.outWidth, in,
+                          bm.CreateBVConst(32, s.outWidth));
+  if (s.kind == BVEXTRACT)
+    return nf->CreateTerm(BVEXTRACT, s.outWidth, in, s.constants[0],
+                          s.constants[1]);
+  if (s.samePathAllOperands)
+    return nf->CreateTerm(s.kind, s.outWidth, in, in);
+  if (s.pathIndex == 0)
+    return nf->CreateTerm(s.kind, s.outWidth, in, s.constants[0]);
+  return nf->CreateTerm(s.kind, s.outWidth, s.constants[0], in);
+}
+
 /* When none of the per-kind rules fired for `var` (each detaches the
  * variable when it does), generalise: climb from the variable towards the
  * root while every node on the way is single-use and every sibling is a
@@ -121,10 +139,18 @@ void RemoveUnconstrained::replace(const ASTNode& from, const ASTNode to)
  * boolean v with var := ITE(v, w_true, w_false) recorded, exactly like the
  * direct EQ rule.
  *
+ * One term-level ITE may sit on the path with a non-ground condition and
+ * other branch: the predicate distributes over it,
+ *   P(g(ite(c, f(x), t)))  ==>  ite(c, v, P(g(t))),
+ * where the x-branch P(g(f(x))) collapses to the fresh boolean v as
+ * usual. x's definition is sound regardless of c, since x only
+ * influences the formula when c selects its branch.
+ *
  * The interior nodes must be single-use: a second use of any node on the
  * path would survive the rewrite and be forced to the witness values,
  * changing its meaning. The predicate node itself may be shared, since
- * under the recorded definition every occurrence of it evaluates to v.
+ * under the recorded definition every occurrence of it evaluates to v
+ * (or to the distributed ITE, which is a pure equivalence).
  */
 bool RemoveUnconstrained::tryGroundPathCollapse(
     MutableASTNode& muteNode, vector<MutableASTNode*>& variables)
@@ -141,6 +167,13 @@ bool RemoveUnconstrained::tryGroundPathCollapse(
   Kind predKind = UNDEFINED;
   bool pathFirst = false;
   ASTNode predConst;
+
+  // At most one ITE frame on the path (each one doubles the rebuilt else
+  // side). framePos counts the steps below it.
+  MutableASTNode* iteCond = NULL;
+  MutableASTNode* iteOther = NULL;
+  bool itePathThen = false;
+  size_t framePos = 0;
 
   MutableASTNode* cur = &muteNode;
   for (unsigned depth = 0; depth < AchievableImage::MAX_PATH; depth++)
@@ -169,6 +202,26 @@ bool RemoveUnconstrained::tryGroundPathCollapse(
 
     // Term level: one path child, constants everywhere else.
     const Kind kind = p.GetKind();
+
+    if (kind == ITE && p.GetValueWidth() > 0)
+    {
+      // Capture a distribution frame and keep climbing; the ITE
+      // contributes no image step (on x's branch it is the identity).
+      if (iteCond != NULL || p.GetIndexWidth() != 0 || kids.size() != 3)
+        return false;
+      const bool inThen = (kids[1] == cur);
+      if ((!inThen && kids[2] != cur) || kids[1] == kids[2] || kids[0] == cur)
+        return false;
+      iteCond = kids[0];
+      iteOther = inThen ? kids[2] : kids[1];
+      itePathThen = inThen;
+      framePos = steps.size();
+      if (parent.parents.size() != 1)
+        return false;
+      cur = &parent;
+      continue;
+    }
+
     if (!AchievableImage::handledKind(kind))
       return false;
 
@@ -271,9 +324,43 @@ bool RemoveUnconstrained::tryGroundPathCollapse(
   if (!d.collapse)
     return false;
 
-  // The predicate has width 0, so this creates a fresh boolean and prunes
-  // the whole path out of the mutable tree.
-  ASTNode v = replaceParentWithFresh(*predicate, variables);
+  if (iteCond == NULL)
+  {
+    // The predicate has width 0, so this creates a fresh boolean and
+    // prunes the whole path out of the mutable tree.
+    ASTNode v = replaceParentWithFresh(*predicate, variables);
+    replace(var, nf->CreateTerm(ITE, var.GetValueWidth(), v, d.witnessTrue,
+                                d.witnessFalse));
+    return true;
+  }
+
+  // Distribute the predicate over the captured ITE frame:
+  //   P(g(ite(c, f(x), t)))  ==>  ite(c, v, P(g(t))).
+  ASTNode v = bm.CreateFreshVariable(0, 0, "unconstrained_ite");
+  ASTNode gt = iteOther->toASTNode(&bm);
+  for (size_t i = framePos; i < steps.size(); i++)
+    gt = applyStepToNode(nf, bm, steps[i], gt);
+  ASTNode elseP = pathFirst ? nf->CreateNode(predKind, gt, predConst)
+                            : nf->CreateNode(predKind, predConst, gt);
+  ASTNode newP = nf->CreateNode(ITE, iteCond->toASTNode(&bm),
+                                itePathThen ? v : elseP,
+                                itePathThen ? elseP : v);
+
+  // Splice the new formula in, reusing the existing mutable nodes for the
+  // variables it mentions (same mechanics as the comparison rule).
+  vector<MutableASTNode*> vars;
+  std::unordered_set<MutableASTNode*> visited;
+  iteCond->getAllVariablesRecursively(vars, visited);
+  iteOther->getAllVariablesRecursively(vars, visited);
+  visited.clear();
+  std::unordered_map<uint64_t, MutableASTNode*> create;
+  for (MutableASTNode* m : vars)
+    create.insert(std::make_pair(m->n.GetNodeNum(), m));
+  vars.clear();
+
+  MutableASTNode* newN = MutableASTNode::build(newP, create);
+  predicate->replaceWithAnotherNode(newN);
+
   replace(var, nf->CreateTerm(ITE, var.GetValueWidth(), v, d.witnessTrue,
                               d.witnessFalse));
   return true;

--- a/tests/unit-tests/RemoveUnconstrained_Exhaustive_Test.cpp
+++ b/tests/unit-tests/RemoveUnconstrained_Exhaustive_Test.cpp
@@ -848,6 +848,105 @@ TEST(RemoveUnconstrained_GroundPath, shared_predicate)
   c.checkSoundTop(top);
 }
 
+// --- ITE distribution: the predicate distributes over a single ITE on
+//     the path, P(g(ite(c, f(x), t))) => ite(c, v, P(g(t))). The result
+//     keeps the else side, so these check x's elimination and soundness
+//     rather than full collapse. ---
+
+TEST(RemoveUnconstrained_GroundPath, ite_distribution)
+{
+  // (= (ite (= y 0) (bvurem x 4) y) 2)  =>  ite((= y 0), v, (= y 2))
+  Context c;
+  ASTNode x = c.bv();
+  ASTNode y = c.bv();
+  ASTNode cond = c.hf->CreateNode(EQ, y, c.konst(0));
+  ASTNode ite = c.hf->CreateTerm(
+      ITE, W, cond, c.hf->CreateTerm(BVMOD, W, x, c.konst(4)), y);
+  ASTNode top = c.hf->CreateNode(EQ, ite, c.konst(2));
+
+  ASTNode result = c.run(top);
+  EXPECT_EQ(c.simp.Return_SolverMap()->count(x), 1u) << "x not eliminated";
+  ASTNode back = c.backSubstitute(top);
+  c.checkEquivalent(back, result);
+}
+
+TEST(RemoveUnconstrained_GroundPath, ite_distribution_with_suffix)
+{
+  // Ground steps above the ITE distribute too:
+  // (= (bvadd (ite c (bvurem x 4) y) 1) 3) => ite(c, v, (= (bvadd y 1) 3))
+  Context c;
+  ASTNode x = c.bv();
+  ASTNode y = c.bv();
+  ASTNode cond = c.hf->CreateNode(EQ, y, c.konst(1));
+  ASTNode ite = c.hf->CreateTerm(
+      ITE, W, cond, c.hf->CreateTerm(BVMOD, W, x, c.konst(4)), y);
+  ASTNode add = c.hf->CreateTerm(BVPLUS, W, ite, c.konst(1));
+  ASTNode top = c.hf->CreateNode(EQ, add, c.konst(3));
+
+  ASTNode result = c.run(top);
+  EXPECT_EQ(c.simp.Return_SolverMap()->count(x), 1u) << "x not eliminated";
+  ASTNode back = c.backSubstitute(top);
+  c.checkEquivalent(back, result);
+}
+
+TEST(RemoveUnconstrained_GroundPath, ite_distribution_else_branch)
+{
+  // x in the else branch: ite(c, y, chain(x)).
+  Context c;
+  ASTNode x = c.bv();
+  ASTNode y = c.bv();
+  ASTNode cond = c.hf->CreateNode(EQ, y, c.konst(0));
+  ASTNode ite = c.hf->CreateTerm(
+      ITE, W, cond, y, c.hf->CreateTerm(BVAND, W, x, c.konst(5)));
+  ASTNode top = c.hf->CreateNode(EQ, ite, c.konst(4));
+
+  ASTNode result = c.run(top);
+  EXPECT_EQ(c.simp.Return_SolverMap()->count(x), 1u) << "x not eliminated";
+  ASTNode back = c.backSubstitute(top);
+  c.checkEquivalent(back, result);
+}
+
+TEST(RemoveUnconstrained_GroundPath, ite_shared_no_distribution)
+{
+  // The ITE node is consumed twice: distributing from one consumer's
+  // viewpoint would be unsound, so x must survive.
+  Context c;
+  ASTNode x = c.bv();
+  ASTNode y = c.bv();
+  ASTNode cond = c.hf->CreateNode(EQ, y, c.konst(0));
+  ASTNode ite = c.hf->CreateTerm(
+      ITE, W, cond, c.hf->CreateTerm(BVMOD, W, x, c.konst(4)), y);
+  ASTNode top =
+      c.hf->CreateNode(AND, c.hf->CreateNode(EQ, ite, c.konst(2)),
+                       c.hf->CreateNode(BVGT, ite, c.konst(0)));
+
+  ASTNode result = c.run(top);
+  EXPECT_EQ(c.simp.Return_SolverMap()->count(x), 0u)
+      << "x eliminated through a shared ITE";
+  ASTNode back = c.backSubstitute(top);
+  c.checkEquivalent(back, result);
+}
+
+TEST(RemoveUnconstrained_GroundPath, ite_nested_declined)
+{
+  // Two ITE frames on one path: version 1 declines (one frame only).
+  Context c;
+  ASTNode x = c.bv();
+  ASTNode y = c.bv();
+  ASTNode z = c.bv();
+  ASTNode inner = c.hf->CreateTerm(
+      ITE, W, c.hf->CreateNode(EQ, y, c.konst(0)),
+      c.hf->CreateTerm(BVMOD, W, x, c.konst(4)), y);
+  ASTNode outer = c.hf->CreateTerm(
+      ITE, W, c.hf->CreateNode(EQ, z, c.konst(1)), inner, z);
+  ASTNode top = c.hf->CreateNode(EQ, outer, c.konst(2));
+
+  ASTNode result = c.run(top);
+  EXPECT_EQ(c.simp.Return_SolverMap()->count(x), 0u);
+  ASTNode back = c.backSubstitute(top);
+  c.checkEquivalent(back, result);
+}
+
 // --- Cases that must NOT collapse. ---
 
 TEST(RemoveUnconstrained_GroundPath, one_polarity_no_collapse)


### PR DESCRIPTION
## Summary

- On the bench-hard set, 99.6% of the operator kinds that stop the ground-path climb (34,631 events, 636 files) are a single kind: **ITE** — the unconstrained variable's chain enters one branch of a select whose condition involves other variables (flag tests, division-by-zero guards).
- Predicates distribute over ITE: `P(g(ite(c, f(x), t))) ≡ ite(c, P(g(f(x))), P(g(t)))`. When x occurs only in one branch, the x-side is an ordinary ground-path instance and collapses to a fresh boolean `v`; the rewrite leaves `ite(c, v, P(g(t)))`.
- x's witness definition is sound regardless of the condition: x only influences the formula when c selects its branch, and then the branch evaluates to exactly `v` by the collapse's forward-validated guarantee.
- One ITE frame per path in this version; the ITE must be single-use like every interior node; the ground suffix above the ITE is re-applied to the other branch. The splice reuses the comparison rule's `MutableASTNode::build` + `replaceWithAnotherNode` mechanics.

## Testing

- Five new tests: distribution through then/else branches, with a ground suffix above the ITE, a shared ITE that must refuse, nested frames that decline — each checks x's elimination plus back-substitution equivalence over every assignment (67/67 suite total).
- Full ctest and a 2,500-file differential sat/unsat sweep vs master to follow in the PR checks; corpus firing numbers measured on the bench-hard set will be posted as a comment.