### PR TITLE
Solve multiply hints exactly with the odd part's modular inverse

### DIFF
--- a/lib/Simplifier/AchievableImage.cpp
+++ b/lib/Simplifier/AchievableImage.cpp
@@ -291,10 +291,47 @@ CBV hintBackStep(const GroundStep& step, const CBV out)
       return op2(BVAND, out, step.constants[0].GetBVConst(), W);
     case BVMULT:
     {
-      // Divide out the constant: exact whenever it divides `out` with
-      // no overflow, a serviceable seed otherwise.
+      // Solve c*x == out (mod 2^w) exactly: with c = 2^s * o (o odd),
+      // solutions exist iff 2^s divides out, and then
+      // x = (out >> s) * inverse(o). The inverse comes from Newton
+      // iteration (i' = i*(2 - o*i)), which doubles correct low bits
+      // each round starting from i = o (correct mod 8 for odd o).
       const CBV c = step.constants[0].GetBVConst();
-      return isZero(c) ? NULL : op2(BVDIV, out, c, W);
+      if (isZero(c))
+        return NULL;
+      const unsigned s = (unsigned)CONSTANTBV::Set_Min(c);
+      if (s > 0)
+      {
+        CBV lowMask = mkLowMask(s, W);
+        CBV masked = op2(BVAND, out, lowMask, W);
+        const bool divides = isZero(masked);
+        destroy(lowMask);
+        destroy(masked);
+        if (!divides) // no exact preimage; fall back to the quotient
+          return op2(BVDIV, out, c, W);
+      }
+      CBV sc = mkNum(W, s);
+      CBV odd = op2(BVRIGHTSHIFT, c, sc, W);
+      CBV shifted = op2(BVRIGHTSHIFT, out, sc, W);
+      destroy(sc);
+      CBV inv = clone(odd);
+      CBV two = mkNum(W, 2);
+      for (unsigned bits = 3; bits < W; bits *= 2)
+      {
+        CBV oi = op2(BVMULT, odd, inv, W);
+        CBV corr = op2(BVSUB, two, oi, W);
+        destroy(oi);
+        CBV next = op2(BVMULT, inv, corr, W);
+        destroy(corr);
+        destroy(inv);
+        inv = next;
+      }
+      destroy(two);
+      destroy(odd);
+      CBV r = op2(BVMULT, shifted, inv, W);
+      destroy(shifted);
+      destroy(inv);
+      return r;
     }
     case SBVDIV:
     {


### PR DESCRIPTION
## Summary

- The backward hint map for a constant multiply used integer division, which can't find preimages that wrap: `c·x ≡ k (mod 2^w)` with x above `2^w/c` was invisible, leaving width-8 equality probes through even multiplies at a 69% hit-rate.
- Writing `c = 2^s·o` (o odd): solutions exist iff `2^s | k`, and then `x = (k ≫ s)·o⁻¹ (mod 2^w)` — computed by Newton iteration on CBVs (`i' = i·(2 − o·i)`, doubling correct low bits from a seed correct mod 8), exact at any width and deterministic (no libm, no platform-dependent seeds).
- When `2^s ∤ k` the equality has no solution through that path; the old quotient heuristic remains as the fallback seed.

## Testing

- `sample_coverage_width8_report` (exhaustive, every constant against a brute-force oracle): even-multiply equalities 69% → **100%**; all families now 98–100% except squares (36%/92%, which would need modular square roots).
- Full engine suite 10/10; the hint is a seed only — witnesses remain forward-validated before any rewrite.