### PR TITLE
Convert parameterised booleans in the CVC parser, not the pipeline

### DIFF
--- a/include/stp/AST/AST.h
+++ b/include/stp/AST/AST.h
@@ -65,7 +65,6 @@ struct ArithLess
 bool isAtomic(Kind k);
 bool isCommutative(const Kind k);
 bool containsArrayOps(const ASTNode& n, STPMgr* stp);
-bool containsParamBool(const ASTNode& n, STPMgr* stp);
 bool numberOfReadsLessThan(const ASTNode& n, int v);
 
 // If (a > b) in the termorder, then return 1 elseif (a < b) in the

--- a/include/stp/c_interface.h
+++ b/include/stp/c_interface.h
@@ -356,8 +356,10 @@ DLL_PUBLIC Expr vc_iteExpr(VC vc, Expr conditional, Expr thenExpr,
 //!
 DLL_PUBLIC Expr vc_boolToBVExpr(VC vc, Expr form);
 
-//! \brief Creates a parameterized boolean expression with the given boolean
-//!        variable expression and the parameter param.
+//! \brief Creates a boolean variable named after the application of the
+//!        given boolean variable expression to the parameter, e.g. "p(0x3)".
+//!        Two applications denote the same variable exactly when the names
+//!        match. The parameter must be a constant bit-vector expression.
 //!
 DLL_PUBLIC Expr vc_paramBoolExpr(VC vc, Expr var, Expr param);
 
@@ -1205,7 +1207,8 @@ enum exprkind_t
   XOR,  //!< Logical-xor (either-or) boolean expression
   IFF,  //!< If-and-only-if boolean expression
   IMPLIES,   //!< Implication boolean expression
-  PARAMBOOL, //!< Parameterized boolean expression
+  PARAMBOOL, //!< Parameterized boolean expression. No longer created;
+             //!< kept so that the later kind values don't change.
   READ,      //!< Array read expression
   WRITE,     //!< Array write expression
   ARRAY,     //!< Array creation expression

--- a/include/stp/cpp_interface.h
+++ b/include/stp/cpp_interface.h
@@ -162,6 +162,11 @@ public:
                                    unsigned long long int bvconst);
   DLL_PUBLIC ASTNode LookupOrCreateSymbol(const char* const name);
 
+  // A boolean variable applied to a constant, e.g. p(0x3), names an
+  // ordinary boolean variable "p(0x3)".
+  DLL_PUBLIC ASTNode CreateParameterisedBooleanVar(const ASTNode& var,
+                                                   const ASTNode& constant);
+
   void removeSymbol(ASTNode to_remove);
 
   // Declare a function. We can't keep references to the declared variables

--- a/lib/AST/ASTmisc.cpp
+++ b/lib/AST/ASTmisc.cpp
@@ -135,20 +135,6 @@ bool containsArrayOps(const ASTNode& n, STPMgr* mgr)
   return false;
 }
 
-// True if any descendants are parameterised booleans. Only the CVC
-// parser creates these; the ArrayTransformer converts them to
-// boolean variables.
-bool containsParamBool(const ASTNode& n, STPMgr* mgr)
-{
-  NodeIterator ni(n, mgr->ASTUndefined, *mgr);
-  ASTNode current;
-  while ((current = ni.next()) != ni.end())
-    if (PARAMBOOL == current.GetKind())
-      return true;
-
-  return false;
-}
-
 bool isCommutative(const Kind k)
 {
   switch (k)
@@ -556,15 +542,6 @@ bool BVTypeCheck_nonterm_kind(const ASTNode& n, const Kind& k)
       {
         FatalError("BVTypeCheck: index is greater or equal to the bitwidth.\n",
                    n);
-      }
-      break;
-
-    case PARAMBOOL:
-      if (2 != n.Degree())
-      {
-        FatalError(
-            "BVTypeCheck: PARAMBOOL formula can have exactly two childNodes",
-            n);
       }
       break;
 

--- a/lib/AbsRefineCounterExample/ArrayTransformer.cpp
+++ b/lib/AbsRefineCounterExample/ArrayTransformer.cpp
@@ -246,24 +246,6 @@ ASTNode ArrayTransformer::TransformFormula(const ASTNode& simpleForm)
       result = nf->CreateNode(k, vec);
       break;
     }
-    case PARAMBOOL:
-    {
-      // If the parameteric boolean variable is of the form
-      // VAR(const), then convert it into a Boolean variable of the
-      // form "VAR(const)".
-      //
-      // Else if the paramteric boolean variable is of the form
-      // VAR(expression), then simply return it
-      if (BVCONST == simpleForm[1].GetKind())
-      {
-        result = bm->NewParameterized_BooleanVar(simpleForm[0], simpleForm[1]);
-      }
-      else
-      {
-        result = simpleForm;
-      }
-      break;
-    }
     default:
     {
       if (k == SYMBOL && BOOLEAN_TYPE == simpleForm.GetType())

--- a/lib/AbsRefineCounterExample/CounterExample.cpp
+++ b/lib/AbsRefineCounterExample/CounterExample.cpp
@@ -555,10 +555,6 @@ ASTNode AbsRefine_CounterExample::ComputeFormulaUsingModel(const ASTNode& form)
                    form);
     }
     break;
-    case PARAMBOOL:
-      output = bm->NewParameterized_BooleanVar(form[0], form[1]);
-      output = ComputeFormulaUsingModel(output);
-      break;
     default:
       cerr << _kind_names[k];
       FatalError(" ComputeFormulaUsingModel: "

--- a/lib/Interface/c_interface.cpp
+++ b/lib/Interface/c_interface.cpp
@@ -1062,10 +1062,13 @@ Expr vc_paramBoolExpr(VC vc, Expr boolvar, Expr parameter)
 
   assert(BVTypeCheck(*c));
   assert(BVTypeCheck(*t));
-  stp::ASTNode o;
 
-  o = b->CreateNode(stp::PARAMBOOL, *c, *t);
-  // BVTypeCheck(o);
+  if (stp::BVCONST != t->GetKind())
+    stp::FatalError("vc_paramBoolExpr: the parameter must be a constant "
+                    "bit-vector",
+                    *t);
+
+  stp::ASTNode o = b->NewParameterized_BooleanVar(*c, *t);
   stp::ASTNode* output = new stp::ASTNode(o);
   // if(cinterface_exprdelete_on) created_exprs.push_back(output);
   return output;

--- a/lib/Interface/cpp_interface.cpp
+++ b/lib/Interface/cpp_interface.cpp
@@ -196,6 +196,12 @@ ASTNode Cpp_interface::LookupOrCreateSymbol(const char* const name)
   return bm.LookupOrCreateSymbol(name);
 }
 
+ASTNode Cpp_interface::CreateParameterisedBooleanVar(const ASTNode& var,
+                                                     const ASTNode& constant)
+{
+  return bm.NewParameterized_BooleanVar(var, constant);
+}
+
 void Cpp_interface::removeSymbol(ASTNode to_remove)
 {
   bool removed = false;

--- a/lib/Parser/cvc.y
+++ b/lib/Parser/cvc.y
@@ -470,9 +470,11 @@ Formula         :     '(' Formula ')'
 {  
   $$ = new ASTNode(GlobalParserInterface->letMgr->ResolveID(*$1)); delete $1;
 }
-|      FORMID_TOK '(' Expr ')' 
+|      FORMID_TOK '(' Expr ')'
 {
-  $$ = new ASTNode(GlobalParserInterface->nf->CreateNode(PARAMBOOL,*$1,*$3));
+  if (stp::BVCONST != $3->GetKind())
+    yyerror("Fatal Error: the argument of a parameterised boolean must be a constant");
+  $$ = new ASTNode(GlobalParserInterface->CreateParameterisedBooleanVar(*$1,*$3));
   delete $1;
   delete $3;
 }

--- a/lib/Parser/smt2.y
+++ b/lib/Parser/smt2.y
@@ -110,7 +110,6 @@
   using stp::XOR;          //!< Logical-xor (either-or) boolean expression
   using stp::IFF;          //!< If-and-only-if boolean expression
   using stp::IMPLIES;      //!< Implication boolean expression
-  using stp::PARAMBOOL;    //!< Parameterized boolean expression
   using stp::READ;         //!< Array read expression
   using stp::WRITE;        //!< Array write expression
   using stp::ARRAY;        //!< Array creation expression
@@ -170,7 +169,6 @@
   using stp::XOR;          //!< Logical-xor (either-or) boolean expression
   using stp::IFF;          //!< If-and-only-if boolean expression
   using stp::IMPLIES;      //!< Implication boolean expression
-  using stp::PARAMBOOL;    //!< Parameterized boolean expression
   using stp::READ;         //!< Array read expression
   using stp::WRITE;        //!< Array write expression
   using stp::ARRAY;        //!< Array creation expression

--- a/lib/Printer/PLPrinter.cpp
+++ b/lib/Printer/PLPrinter.cpp
@@ -268,13 +268,6 @@ void PL_Print1(ostream& os, const ASTNode& n, int indentation, bool letize,
       PL_Print1(os, c[2], indentation, letize, bm);
       os << endl << "ENDIF";
       break;
-    case PARAMBOOL:
-      PL_Print1(os, c[0], indentation, letize, bm);
-      os << "(";
-      PL_Print1(os, c[1], indentation, letize, bm);
-      os << ")";
-      break;
-
     case BVLT: // two arity, prefixed function name.
     case BVLE:
     case BVGT:

--- a/lib/STPManager/STP.cpp
+++ b/lib/STPManager/STP.cpp
@@ -305,10 +305,6 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input)
 
   bool arrayops = containsArrayOps(inputToSat, bm);
 
-  // The transformer also converts parameterised booleans (only the CVC
-  // parser creates them), so it can't be skipped while any are present.
-  bool needsTransform = arrayops || containsParamBool(inputToSat, bm);
-
   // If the number of array reads is small. We rewrite them through.
   // The bit-vector simplifications are more thorough than the array
   // simplifications. For example,
@@ -332,9 +328,8 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input)
     removed = true;
 
     // With ackermannisation on, the transform removes every array
-    // operation, and it converts any parameterised booleans too.
+    // operation.
     arrayops = false;
-    needsTransform = false;
     assert(!containsArrayOps(inputToSat, bm));
   }
 
@@ -666,7 +661,7 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input)
   }
   revert.reset(NULL);
 
-  if (needsTransform)
+  if (arrayops)
   {
     inputToSat = arrayTransformer->TransformFormula_TopLevel(inputToSat);
     bm->ASTNodeStats("after transformation: ", inputToSat);

--- a/lib/Simplifier/Simplifier.cpp
+++ b/lib/Simplifier/Simplifier.cpp
@@ -348,13 +348,6 @@ ASTNode Simplifier::SimplifyAtomicFormula(const ASTNode& a, bool pushNeg)
       }
       output = pushNeg ? nf->CreateNode(NOT, output) : output;
       break;
-    case PARAMBOOL:
-    {
-      ASTNode term = SimplifyTerm(a[1]);
-      output = nf->CreateNode(PARAMBOOL, a[0], term);
-      output = pushNeg ? nf->CreateNode(NOT, output) : output;
-      break;
-    }
     case BOOLEXTRACT:
     {
       ASTNode term = SimplifyTerm(a[0]);


### PR DESCRIPTION
In the CVC language a boolean variable can be applied to an argument, `p(0hex3)`. Despite the function-application syntax there are no function semantics: each application just names an ordinary boolean variable ("p(0x3)"), and two applications denote the same variable exactly when the generated names match. The conversion is purely syntactic, so this does it in the parser action and `PARAMBOOL` nodes are never created.

Previously the conversion happened in the ArrayTransformer, which meant a whole extra reason the transform pass had to run, plus handling in the simplifier, counterexample builder, printer and type checker. All of those cases are now dead and removed, and the `containsParamBool` escape added to the transform-skip guard in #678 collapses to plain `containsArrayOps`.

Non-constant arguments previously behaved badly in two different ways: an argument that stayed symbolic died much later with `Fatal Error: BBForm: Illegal kind: PARAMBOOL`, while an argument that was provably equal to a constant (e.g. `ASSERT x = 0hex3; ASSERT p(x);`) was silently treated as an opaque atom with no relationship to `p(0hex3)`. Both now fail at parse time with a clear message. Arguments that constant-fold at parse time (e.g. `p(BVPLUS(4, 0hex1, 0hex2))`) keep working since the parser's simplifying node factory folds them before the action runs.

`vc_paramBoolExpr` performs the same eager conversion for C API callers, and errors on non-constant parameters. The `PARAMBOOL` enumerator stays in `exprkind_t` (and the internal kind list) so the kind values after it don't change.

Tested against a same-config master build: all 43 sample CVC tests are output-identical; targeted tests confirm constant and constant-foldable arguments behave identically and symbolic arguments now produce the parse error; 40-file smt2 differential (20 with arrays) is clean.