### PR TITLE
Retry and verify the winflexbison3 install on Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -473,7 +473,17 @@ jobs:
           submodules: 'true'
 
     - name: Install flex and bison
-      run: choco install winflexbison3 --no-progress
+      # choco exits 0 even when the package feed is down ("installed 0/0
+      # packages"), which surfaces later as a confusing missing-BISON
+      # configure error. Retry the install and verify the tools landed.
+      run: |
+        foreach ($attempt in 1..5) {
+          choco install winflexbison3 --no-progress
+          if ((Get-Command win_bison -ErrorAction SilentlyContinue) -and (Get-Command win_flex -ErrorAction SilentlyContinue)) { exit 0 }
+          Write-Host "winflexbison3 not installed (attempt $attempt), retrying..."
+          Start-Sleep -Seconds (30 * $attempt)
+        }
+        throw "winflexbison3 install failed after 5 attempts"
 
     - name: Install zlib
       run: |


### PR DESCRIPTION
The Windows job on master failed at Configure with `Could NOT find BISON` (run 30353379324). The real cause was upstream: community.chocolatey.org returned 503 during `choco install winflexbison3`, and choco exited 0 anyway after "Chocolatey installed 0/0 packages", so the install step passed silently.

Retry the install up to five times with backoff, and fail the step outright if `win_bison`/`win_flex` never appear, so a feed outage either recovers or fails at the step that caused it.