### PR TITLE
Constant bit propagation: maximally precise multiplication at widths up to 14

### DIFF
--- a/lib/Simplifier/constantBitP/ConstantBitP_Multiplication.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_Multiplication.cpp
@@ -960,6 +960,7 @@ Result multiplyCore(vector<FixedBits*>& children, FixedBits& output,
 
     if (cc.rebuildSums() == CONFLICT)
       return CONFLICT;
+
     Result r = cc.fixedPoint();
 
     if (r == CONFLICT)
@@ -1122,6 +1123,1296 @@ Result inverseRelationPass(FixedBits& x, FixedBits& y, FixedBits& output,
   return NO_CHANGE;
 }
 
+// ------------------- exact reasoning over the low bits -------------------
+//
+// The low w = min(width, 8) bits of x, y and the output are related by
+// out_low == x_low * y_low (mod 2^w) — higher operand bits can't reach
+// down. Over at most 256 candidate values per side that relation can be
+// solved exactly: enumerate the surviving (a, b) pairs and fix every bit
+// that all survivors agree on. This is maximally precise for the width-w
+// sub-relation (and for the whole node when width <= 8), catching
+// correlations both the column counts and the inverse view lose — e.g.
+// <0*1> * <0*1> is 1 or 3 mod 8 either way, so output bit 2 is zero.
+//
+// The tables are facts about multiplication, not about propagator states:
+// bit b of M[a][i] is bit i of a*b mod 256, so "which b keep output bit i
+// consistent" is a 256-bit AND.
+
+struct ExactMulTables
+{
+  uint64_t M[256][8][4]; // M[a][i]: the set of b with bit i of a*b set.
+  uint64_t P[8][2][4];   // P[i][v]: the set of values whose bit i is v.
+
+  ExactMulTables()
+  {
+    memset(M, 0, sizeof(M));
+    memset(P, 0, sizeof(P));
+    for (unsigned a = 0; a < 256; a++)
+      for (unsigned b = 0; b < 256; b++)
+      {
+        const unsigned p = (a * b) & 255;
+        for (unsigned i = 0; i < 8; i++)
+          if ((p >> i) & 1)
+            M[a][i][b >> 6] |= (uint64_t)1 << (b & 63);
+      }
+    for (unsigned v = 0; v < 256; v++)
+      for (unsigned i = 0; i < 8; i++)
+        P[i][(v >> i) & 1][v >> 6] |= (uint64_t)1 << (v & 63);
+  }
+};
+
+static const ExactMulTables& exactTables()
+{
+  static const ExactMulTables t; // 66KB, built on the first multiply.
+  return t;
+}
+
+// The set of values 0..2^w-1 consistent with the fixed low bits of v.
+static void possibleLowValues(const FixedBits& v, unsigned w, uint64_t S[4])
+{
+  const ExactMulTables& t = exactTables();
+  if (w >= 8)
+    S[0] = S[1] = S[2] = S[3] = ~(uint64_t)0;
+  else
+  {
+    // Universe: the 2^w (<= 128) values representable in w bits. Beware
+    // 64-bit shifts: at w == 7 the second word is exactly full.
+    const unsigned count = 1u << w;
+    S[0] = (count >= 64) ? ~(uint64_t)0 : (((uint64_t)1 << count) - 1);
+    S[1] = (count >= 128) ? ~(uint64_t)0
+                          : ((count > 64) ? (((uint64_t)1 << (count - 64)) - 1)
+                                          : 0);
+    S[2] = S[3] = 0;
+  }
+  for (unsigned i = 0; i < w; i++)
+    if (v.isFixed(i))
+    {
+      const uint64_t* p = t.P[i][v.getValue(i) ? 1 : 0];
+      S[0] &= p[0];
+      S[1] &= p[1];
+      S[2] &= p[2];
+      S[3] &= p[3];
+    }
+}
+
+static inline bool emptySet(const uint64_t S[4])
+{
+  return (S[0] | S[1] | S[2] | S[3]) == 0;
+}
+
+static inline bool intersects(const uint64_t A[4], const uint64_t B[4])
+{
+  return ((A[0] & B[0]) | (A[1] & B[1]) | (A[2] & B[2]) | (A[3] & B[3])) != 0;
+}
+
+// Fix the unfixed low-w bits of v that every value in S agrees on. S is the
+// non-empty projection of the surviving solutions and was filtered by v's
+// fixed bits, so it can't disagree with one.
+static bool fixAgreedBits(FixedBits& v, unsigned w, const uint64_t S[4])
+{
+  const ExactMulTables& t = exactTables();
+  bool changed = false;
+  for (unsigned i = 0; i < w; i++)
+  {
+    if (v.isFixed(i))
+      continue;
+    const bool canBeOne = intersects(S, t.P[i][1]);
+    const bool canBeZero = intersects(S, t.P[i][0]);
+    if (canBeOne == canBeZero)
+      continue;
+    v.setFixed(i, true);
+    v.setValue(i, canBeOne);
+    changed = true;
+  }
+  return changed;
+}
+
+// One exact pass over the low min(width, 8) bits. Sets `progress` when a
+// bit was newly fixed; CONFLICT when the sub-relation has no solution.
+Result exactLowBitsPass(FixedBits& x, FixedBits& y, FixedBits& output,
+                        bool& progress)
+{
+  const unsigned w = std::min(x.getWidth(), 8u);
+  const ExactMulTables& t = exactTables();
+
+  // With nothing fixed below w every pair survives and no bit can fix.
+  bool anyFixed = false;
+  for (unsigned i = 0; i < w && !anyFixed; i++)
+    anyFixed = x.isFixed(i) || y.isFixed(i) || output.isFixed(i);
+  if (!anyFixed)
+    return NO_CHANGE;
+
+  const bool aliased = (&x == &y);
+
+  uint64_t Sx[4], Sy[4];
+  possibleLowValues(x, w, Sx);
+  possibleLowValues(y, w, Sy);
+
+  // The output's fixed bits below w, used to filter partners.
+  unsigned char outIdx[8];
+  bool outVal[8];
+  unsigned nOut = 0;
+  for (unsigned i = 0; i < w; i++)
+    if (output.isFixed(i))
+    {
+      outIdx[nOut] = (unsigned char)i;
+      outVal[nOut++] = output.getValue(i);
+    }
+
+  bool xFree = true, yFree = true;
+  for (unsigned i = 0; i < w && (xFree || yFree); i++)
+  {
+    xFree = xFree && !x.isFixed(i);
+    yFree = yFree && !y.isFixed(i);
+  }
+
+  // With no output constraint below w, no (a, b) can die, so the operands
+  // can't be pruned; and if an operand is completely free as well, the
+  // output join degenerates to "bits below the minimum trailing-zero count
+  // are zero" — exactly what useTrailingZeroesToFix already derives.
+  if (nOut == 0 && (xFree || yFree))
+    return NO_CHANGE;
+
+  uint64_t xSurv[4] = {0, 0, 0, 0}, ySurv[4] = {0, 0, 0, 0};
+  unsigned outSeen0 = 0, outSeen1 = 0; // output bit values witnessed.
+  const unsigned outAll = (w >= 8) ? 255u : ((1u << w) - 1);
+
+  if (nOut == 0 && !aliased)
+  {
+    // Every pair survives: only the output join is in question. Stop as
+    // soon as every output bit has been witnessed both ways.
+    for (unsigned wd = 0; wd < 4; wd++)
+    {
+      uint64_t bits = Sx[wd];
+      while (bits != 0 && (outSeen0 != outAll || outSeen1 != outAll))
+      {
+        const unsigned a = wd * 64 + ::stp::countTrailingZeroes64(bits);
+        bits &= bits - 1;
+        for (unsigned i = 0; i < w; i++)
+        {
+          const uint64_t* m = t.M[a][i];
+          if ((outSeen1 & (1u << i)) == 0 && intersects(Sy, m))
+            outSeen1 |= 1u << i;
+          if ((outSeen0 & (1u << i)) == 0 &&
+              ((Sy[0] & ~m[0]) | (Sy[1] & ~m[1]) | (Sy[2] & ~m[2]) |
+               (Sy[3] & ~m[3])) != 0)
+            outSeen0 |= 1u << i;
+        }
+      }
+    }
+    for (unsigned i = 0; i < w; i++)
+    {
+      const bool canBeOne = (outSeen1 >> i) & 1;
+      const bool canBeZero = (outSeen0 >> i) & 1;
+      assert(canBeOne || canBeZero);
+      if (canBeOne == canBeZero)
+        continue;
+      output.setFixed(i, true);
+      output.setValue(i, canBeOne);
+      progress = true;
+    }
+    return NO_CHANGE;
+  }
+
+  for (unsigned wd = 0; wd < 4; wd++)
+  {
+    uint64_t bits = Sx[wd];
+    while (bits != 0)
+    {
+      const unsigned a = wd * 64 + ::stp::countTrailingZeroes64(bits);
+      bits &= bits - 1;
+
+      if (aliased)
+      {
+        // A square: the partner is a itself.
+        bool ok = true;
+        for (unsigned f = 0; f < nOut && ok; f++)
+        {
+          const bool bit = (t.M[a][outIdx[f]][a >> 6] >> (a & 63)) & 1;
+          ok = (bit == outVal[f]);
+        }
+        if (!ok)
+          continue;
+        xSurv[a >> 6] |= (uint64_t)1 << (a & 63);
+        for (unsigned i = 0; i < w; i++)
+        {
+          if ((t.M[a][i][a >> 6] >> (a & 63)) & 1)
+            outSeen1 |= 1u << i;
+          else
+            outSeen0 |= 1u << i;
+        }
+        continue;
+      }
+
+      // B: the y values compatible with a and the fixed output bits.
+      uint64_t B[4] = {Sy[0], Sy[1], Sy[2], Sy[3]};
+      for (unsigned f = 0; f < nOut; f++)
+      {
+        const uint64_t* m = t.M[a][outIdx[f]];
+        if (outVal[f])
+        {
+          B[0] &= m[0];
+          B[1] &= m[1];
+          B[2] &= m[2];
+          B[3] &= m[3];
+        }
+        else
+        {
+          B[0] &= ~m[0];
+          B[1] &= ~m[1];
+          B[2] &= ~m[2];
+          B[3] &= ~m[3];
+        }
+      }
+      if (emptySet(B))
+        continue;
+
+      xSurv[a >> 6] |= (uint64_t)1 << (a & 63);
+      ySurv[0] |= B[0];
+      ySurv[1] |= B[1];
+      ySurv[2] |= B[2];
+      ySurv[3] |= B[3];
+
+      for (unsigned i = 0; i < w; i++)
+      {
+        const uint64_t* m = t.M[a][i];
+        if ((outSeen1 & (1u << i)) == 0 && intersects(B, m))
+          outSeen1 |= 1u << i;
+        if ((outSeen0 & (1u << i)) == 0 &&
+            ((B[0] & ~m[0]) | (B[1] & ~m[1]) | (B[2] & ~m[2]) |
+             (B[3] & ~m[3])) != 0)
+          outSeen0 |= 1u << i;
+      }
+    }
+  }
+
+  if (emptySet(xSurv))
+    return CONFLICT;
+
+  if (fixAgreedBits(x, w, xSurv))
+    progress = true;
+  if (!aliased && fixAgreedBits(y, w, ySurv))
+    progress = true;
+  for (unsigned i = 0; i < w; i++)
+  {
+    if (output.isFixed(i))
+      continue;
+    const bool canBeOne = (outSeen1 >> i) & 1;
+    const bool canBeZero = (outSeen0 >> i) & 1;
+    assert(canBeOne || canBeZero); // some pair survived.
+    if (canBeOne == canBeZero)
+      continue;
+    output.setFixed(i, true);
+    output.setValue(i, canBeOne);
+    progress = true;
+  }
+  return NO_CHANGE;
+}
+
+// ------------------- exact reasoning over small domains -------------------
+//
+// When few operand bits are unfixed the joint candidate space is tiny
+// (2^unfixed pairs), and the relation can be solved exactly over the FULL
+// width: enumerate every assignment of the unfixed bits, drop those whose
+// product contradicts a fixed output bit, and fix every bit all survivors
+// agree on. Unlike the low-8 solve this catches high-bit correlations; it
+// fires exactly where the residual imprecision was measured to live
+// (states with nearly-determined operands).
+
+static const unsigned LOG_MAX_WIDTH = 14; // logGroupExactPass's domain.
+
+// Fix the unfixed bits of v where the survivors' AND and OR agree. The
+// survivor set satisfies v's fixed bits by construction.
+static bool fixFromJoin(FixedBits& v, const uint64_t* andAcc,
+                        const uint64_t* orAcc, unsigned words)
+{
+  const unsigned width = v.getWidth();
+  bool changed = false;
+  for (unsigned w = 0; w < words; w++)
+  {
+    const uint64_t liveMask = (w == words - 1 && (width & 63) != 0)
+                                  ? (((uint64_t)1 << (width & 63)) - 1)
+                                  : ~(uint64_t)0;
+    uint64_t f, one;
+    v.fillPackedWord(w, f, one);
+    const uint64_t add = ~(andAcc[w] ^ orAcc[w]) & ~f & liveMask;
+    if (add != 0)
+    {
+      v.fixWordBits(w, add, andAcc[w]);
+      changed = true;
+    }
+  }
+  return changed;
+}
+
+// One pass of the bounded enumeration. Sets `progress` when a bit was
+// newly fixed; CONFLICT when no assignment is consistent.
+Result smallDomainPass(FixedBits& x, FixedBits& y, FixedBits& output,
+                       bool& progress)
+{
+  const unsigned width = x.getWidth();
+  const unsigned words = (width + 63) / 64;
+  const bool aliased = (&x == &y);
+
+  // At width <= 8 the low-bits solve is already exactly the full relation;
+  // re-deriving its result by enumeration is pure waste.
+  if (width <= 8)
+    return NO_CHANGE;
+
+  // Never strengthen the all-unfixed state. A square's structure fixes
+  // bits "from nothing" (bit 1 of t*t is always zero), but propagate()'s
+  // scheduler only visits a node once something near it has fixed bits,
+  // so deriving from bottom leaves never-visited nodes short of their own
+  // transfer's fixpoint (checkAtFixedPoint). The same facts are derived
+  // the moment any bit arrives — which is when the node gets scheduled.
+  bool anyFixed = false;
+  for (unsigned i = 0; i < width && !anyFixed; i++)
+    anyFixed = x.isFixed(i) || y.isFixed(i) || output.isFixed(i);
+  if (!anyFixed)
+    return NO_CHANGE;
+
+  // The assignments are walked in Gray-code order: consecutive ones differ
+  // in a single unfixed bit, so the product updates with one shifted
+  // add/subtract — O(words) per assignment, and the budget scales as
+  // assignments * words. Inside the log pass's domain the full budget
+  // upholds the maximal-precision contract; above it the tail of the
+  // 2^u distribution costs far more than the few bits it yields, so the
+  // walk is capped lower.
+  const unsigned MAX_BITS_LIMIT = 16; // compile-time cap, sizes pos[].
+  const unsigned MAX_BITS = (width <= LOG_MAX_WIDTH) ? MAX_BITS_LIMIT : 13;
+  const unsigned long MAX_WORK = 1ul << 17;
+
+  const unsigned unfixed = (width - x.countFixed()) +
+                           (aliased ? 0 : (width - y.countFixed()));
+  if (unfixed > MAX_BITS || ((unsigned long)1 << unfixed) * words > MAX_WORK)
+    return NO_CHANGE;
+
+  // With a fully unconstrained output the walk cannot prune the operands
+  // and only yields the output join, so the 2^u cost is tail-heavy for
+  // little return. At widths the log-group pass covers it computes that
+  // join in group space instead; above them the few derivable bits are
+  // not worth the walk.
+  if (output.countFixed() == 0 && unfixed > 13)
+    return NO_CHANGE;
+
+  // Positions of the unfixed bits, x's first.
+  unsigned char pos[MAX_BITS_LIMIT];
+  unsigned nx = 0, k = 0;
+  for (unsigned i = 0; i < width; i++)
+    if (!x.isFixed(i))
+      pos[k++] = (unsigned char)i;
+  nx = k;
+  if (!aliased)
+    for (unsigned i = 0; i < width; i++)
+      if (!y.isFixed(i))
+        pos[k++] = (unsigned char)i;
+  assert(k == unfixed);
+
+  const unsigned INLINE_WORDS = 8;
+  uint64_t stackBuf[11 * INLINE_WORDS];
+  std::vector<uint64_t> heapBuf;
+  uint64_t* buf = stackBuf;
+  if (words > INLINE_WORDS)
+  {
+    heapBuf.resize(11 * words);
+    buf = heapBuf.data();
+  }
+  uint64_t* a = buf;
+  uint64_t* b = buf + words;
+  uint64_t* p = buf + 2 * words;
+  uint64_t* xAnd = buf + 3 * words;
+  uint64_t* xOr = buf + 4 * words;
+  uint64_t* yAnd = buf + 5 * words;
+  uint64_t* yOr = buf + 6 * words;
+  uint64_t* oAnd = buf + 7 * words;
+  uint64_t* oOr = buf + 8 * words;
+  uint64_t* aBase = buf + 9 * words;
+  uint64_t* bBase = buf + 10 * words;
+
+  for (unsigned w = 0; w < words; w++)
+  {
+    uint64_t f, one;
+    x.fillPackedWord(w, f, one);
+    aBase[w] = one;
+    if (aliased)
+      bBase[w] = one;
+    else
+    {
+      y.fillPackedWord(w, f, one);
+      bBase[w] = one;
+    }
+  }
+
+  // The output's fixed bits, hoisted out of the walk.
+  std::vector<uint64_t> oBuf(2 * words);
+  uint64_t* oF = oBuf.data();
+  uint64_t* oV = oBuf.data() + words;
+  uint64_t oAnyFixed = 0;
+  for (unsigned w = 0; w < words; w++)
+  {
+    output.fillPackedWord(w, oF[w], oV[w]);
+    oAnyFixed |= oF[w];
+  }
+  // With no output constraint every assignment survives: the operand
+  // joins cannot prune, and the walk's only yield is the output join —
+  // which saturates long before the walk ends. Track only the output
+  // accumulators and stop once every live bit has been seen both ways.
+  const bool outFree = (oAnyFixed == 0);
+
+  // dst +=/-= (src << shift), mod 2^(64*words).
+  const auto addSubShifted = [words](uint64_t* dst, const uint64_t* src,
+                                     unsigned shift, bool subtract) {
+    if (shift >= words * 64)
+      return;
+    const unsigned wo = shift >> 6, sh = shift & 63;
+    uint64_t carry = 0;
+    for (unsigned w = wo; w < words; w++)
+    {
+      uint64_t s = src[w - wo] << sh;
+      if (sh != 0 && w - wo > 0)
+        s |= src[w - wo - 1] >> (64 - sh);
+      if (!subtract)
+      {
+        const uint64_t r = dst[w] + s;
+        uint64_t c = (r < s) ? 1 : 0;
+        const uint64_t r2 = r + carry;
+        c += (r2 < carry) ? 1 : 0;
+        dst[w] = r2;
+        carry = c;
+      }
+      else
+      {
+        const uint64_t sub = s + carry;
+        const uint64_t nb = ((sub < s) || (dst[w] < sub)) ? 1 : 0;
+        dst[w] -= sub;
+        carry = nb;
+      }
+    }
+  };
+  // dst +=/-= (1 << shift), mod 2^(64*words).
+  const auto addSubBit = [words](uint64_t* dst, unsigned shift,
+                                 bool subtract) {
+    if (shift >= words * 64)
+      return;
+    unsigned w = shift >> 6;
+    uint64_t c = (uint64_t)1 << (shift & 63);
+    if (!subtract)
+      for (; w < words && c != 0; w++)
+      {
+        const uint64_t r = dst[w] + c;
+        c = (r < c) ? 1 : 0;
+        dst[w] = r;
+      }
+    else
+      for (; w < words && c != 0; w++)
+      {
+        const uint64_t nb = (dst[w] < c) ? 1 : 0;
+        dst[w] -= c;
+        c = nb;
+      }
+  };
+
+  memcpy(a, aBase, words * sizeof(uint64_t));
+  memcpy(b, bBase, words * sizeof(uint64_t));
+  mulLowWords(p, a, b, words);
+
+  bool anySurvivor = false;
+  for (unsigned long m = 0;; m++)
+  {
+    // Evaluate the current assignment.
+    if (outFree)
+    {
+      if (!anySurvivor)
+      {
+        anySurvivor = true;
+        for (unsigned w = 0; w < words; w++)
+          oAnd[w] = oOr[w] = p[w];
+      }
+      else
+        for (unsigned w = 0; w < words; w++)
+        {
+          oAnd[w] &= p[w];
+          oOr[w] |= p[w];
+        }
+      if ((m & 15) == 15)
+      {
+        // Saturated once every live bit has been seen as 0 and as 1.
+        bool saturated = true;
+        for (unsigned w = 0; w < words && saturated; w++)
+        {
+          const uint64_t liveMask = (w == words - 1 && (width & 63) != 0)
+                                        ? (((uint64_t)1 << (width & 63)) - 1)
+                                        : ~(uint64_t)0;
+          saturated = ((oOr[w] & ~oAnd[w]) & liveMask) == liveMask;
+        }
+        if (saturated)
+          break;
+      }
+    }
+    else
+    {
+      bool ok = true;
+      for (unsigned w = 0; w < words && ok; w++)
+        ok = ((p[w] & oF[w]) == oV[w]);
+      if (ok)
+      {
+        if (!anySurvivor)
+        {
+          anySurvivor = true;
+          for (unsigned w = 0; w < words; w++)
+          {
+            xAnd[w] = xOr[w] = a[w];
+            yAnd[w] = yOr[w] = b[w];
+            oAnd[w] = oOr[w] = p[w];
+          }
+        }
+        else
+          for (unsigned w = 0; w < words; w++)
+          {
+            xAnd[w] &= a[w];
+            xOr[w] |= a[w];
+            yAnd[w] &= b[w];
+            yOr[w] |= b[w];
+            oAnd[w] &= p[w];
+            oOr[w] |= p[w];
+          }
+      }
+    }
+
+    if (m + 1 >= ((unsigned long)1 << k))
+      break;
+
+    // Gray step: flip the unfixed bit indexed by ctz(m+1).
+    const unsigned t = ::stp::countTrailingZeroes64(m + 1);
+    const unsigned i = pos[t];
+    const uint64_t bit = (uint64_t)1 << (i & 63);
+    if (aliased || t < nx) // an x bit (and for a square, both operands).
+    {
+      if (aliased)
+      {
+        // p tracks a^2: use the value of a *without* bit i either side.
+        if ((a[i >> 6] & bit) == 0)
+        {
+          addSubShifted(p, a, i + 1, false);
+          addSubBit(p, 2 * i, false);
+          a[i >> 6] |= bit;
+          b[i >> 6] |= bit;
+        }
+        else
+        {
+          a[i >> 6] &= ~bit;
+          b[i >> 6] &= ~bit;
+          addSubShifted(p, a, i + 1, true);
+          addSubBit(p, 2 * i, true);
+        }
+      }
+      else if ((a[i >> 6] & bit) == 0)
+      {
+        addSubShifted(p, b, i, false);
+        a[i >> 6] |= bit;
+      }
+      else
+      {
+        addSubShifted(p, b, i, true);
+        a[i >> 6] &= ~bit;
+      }
+    }
+    else // a y bit.
+    {
+      if ((b[i >> 6] & bit) == 0)
+      {
+        addSubShifted(p, a, i, false);
+        b[i >> 6] |= bit;
+      }
+      else
+      {
+        addSubShifted(p, a, i, true);
+        b[i >> 6] &= ~bit;
+      }
+    }
+  }
+
+  if (!anySurvivor)
+    return CONFLICT;
+
+  if (!outFree)
+  {
+    // With an unconstrained output every pair survived, so the operand
+    // joins are full and can fix nothing.
+    if (fixFromJoin(x, xAnd, xOr, words))
+      progress = true;
+    if (!aliased && fixFromJoin(y, yAnd, yOr, words))
+      progress = true;
+  }
+  if (fixFromJoin(output, oAnd, oOr, words))
+    progress = true;
+  return NO_CHANGE;
+}
+
+// --------------- exact reasoning via the odd group's structure ---------------
+//
+// Writing v = 2^s * u with u odd, x*y = 2^(s+t) * (u*w mod 2^(k-s-t)), and
+// the odd residues mod 2^m form {±1} x <3> (cyclic of order 2^(m-2) for
+// m >= 3). In log space multiplication is exponent addition, so "which u
+// in this stratum have a partner w making the product land in the allowed
+// set" is a difference set over Z/2 x Z/2^(m-2), computable by OR-ing
+// rotated bitset rows — no pairwise enumeration. Together with the
+// stratification by trailing zeros this yields the exact full join for
+// any state at width k, in time polynomial in 2^(k)/64 words rather than
+// pairs. Gated to 9 <= k <= LOG_MAX_WIDTH and to states the bounded
+// enumeration doesn't already solve exactly.
+
+struct OddLogTables
+{
+  // Per modulus 2^m: value -> (sign<<15 | exp), and (sign, exp) -> value.
+  std::vector<uint16_t> v2l[LOG_MAX_WIDTH + 1];
+  std::vector<uint16_t> l2v[LOG_MAX_WIDTH + 1];
+
+  OddLogTables()
+  {
+    for (unsigned m = 3; m <= LOG_MAX_WIDTH; m++)
+    {
+      const unsigned mod = 1u << m, half = 1u << (m - 2);
+      v2l[m].assign(mod, 0);
+      l2v[m].assign(2 * half, 0);
+      unsigned v = 1;
+      for (unsigned e = 0; e < half; e++)
+      {
+        v2l[m][v] = (uint16_t)e;
+        l2v[m][e] = (uint16_t)v;
+        const unsigned neg = (mod - v) & (mod - 1);
+        v2l[m][neg] = (uint16_t)(0x8000u | e);
+        l2v[m][half + e] = (uint16_t)neg;
+        v = (v * 3) & (mod - 1);
+      }
+    }
+  }
+};
+
+static const OddLogTables& oddLogTables()
+{
+  static const OddLogTables t; // ~100KB, built on first use.
+  return t;
+}
+
+// Odd residues mod 2^m as two sign rows of 2^(m-2) bits (m <= 14 -> at
+// most 64 words per row).
+struct OddSet
+{
+  static const unsigned MAXW = (1u << (LOG_MAX_WIDTH - 2)) / 64;
+  uint64_t row[2][MAXW];
+  unsigned m, half, words;
+
+  void clear(unsigned m_)
+  {
+    m = m_;
+    half = (m >= 2) ? (1u << (m - 2)) : 1;
+    words = (half + 63) / 64;
+    memset(row[0], 0, words * sizeof(uint64_t));
+    memset(row[1], 0, words * sizeof(uint64_t));
+  }
+  void addValue(unsigned v)
+  {
+    if (m < 3)
+    {
+      row[(m == 2 && v == 3) ? 1 : 0][0] |= 1;
+      return;
+    }
+    const uint16_t l = oddLogTables().v2l[m][v];
+    row[l >> 15][(l & 0x7fffu) >> 6] |= (uint64_t)1 << (l & 63);
+  }
+  bool contains(unsigned v) const
+  {
+    if (m < 3)
+      return (row[(m == 2 && v == 3) ? 1 : 0][0] & 1) != 0;
+    const uint16_t l = oddLogTables().v2l[m][v];
+    return (row[l >> 15][(l & 0x7fffu) >> 6] >> (l & 63)) & 1;
+  }
+  bool empty() const
+  {
+    uint64_t o = 0;
+    for (unsigned s = 0; s < 2; s++)
+      for (unsigned w = 0; w < words; w++)
+        o |= row[s][w];
+    return o == 0;
+  }
+  unsigned count() const
+  {
+    unsigned c = 0;
+    for (unsigned s = 0; s < 2; s++)
+      for (unsigned w = 0; w < words; w++)
+        c += ::stp::popCount64(row[s][w]);
+    return c;
+  }
+  bool full() const
+  {
+    const uint64_t top =
+        (half & 63) ? (((uint64_t)1 << (half & 63)) - 1) : ~(uint64_t)0;
+    for (unsigned s = 0; s < 2; s++)
+      for (unsigned w = 0; w < words; w++)
+        if ((row[s][w] | ((w == words - 1) ? ~top : 0)) != ~(uint64_t)0)
+          return false;
+    return true;
+  }
+  // Reduce mod 2^mNew (mNew <= m): exponent rows fold cyclically (ord(3)
+  // divides), signs are preserved.
+  void projectTo(OddSet& out, unsigned mNew) const
+  {
+    out.clear(mNew);
+    if (m < 3 || mNew < 3)
+    {
+      // Tiny targets: fall back to elementwise via values.
+      for (unsigned sgn = 0; sgn < 2; sgn++)
+        for (unsigned w = 0; w < words; w++)
+        {
+          uint64_t bits = row[sgn][w];
+          while (bits)
+          {
+            const unsigned e = w * 64 + ::stp::countTrailingZeroes64(bits);
+            bits &= bits - 1;
+            const unsigned v = (m < 3)
+                                   ? ((m == 2 && sgn) ? 3u : 1u)
+                                   : oddLogTables().l2v[m][sgn * half + e];
+            out.addValue(v & ((1u << mNew) - 1));
+          }
+        }
+      return;
+    }
+    const unsigned newHalf = out.half;
+    for (unsigned sgn = 0; sgn < 2; sgn++)
+    {
+      if (newHalf >= 64)
+      {
+        const unsigned nwm = out.words - 1; // power of two
+        for (unsigned w = 0; w < words; w++)
+          out.row[sgn][w & nwm] |= row[sgn][w];
+      }
+      else
+      {
+        const uint64_t chunkMask = ((uint64_t)1 << newHalf) - 1;
+        uint64_t acc = 0;
+        for (unsigned w = 0; w < words; w++)
+        {
+          uint64_t v = row[sgn][w];
+          for (unsigned off = 0; off < 64 && (w * 64 + off) < half;
+               off += newHalf)
+            acc |= (v >> off) & chunkMask;
+        }
+        out.row[sgn][0] |= acc;
+      }
+    }
+  }
+};
+
+// dst.row[.] |= rotate(src.row[.], r) with the sign twist sb.
+static void orRotatedRow(uint64_t* dst, const uint64_t* src, unsigned r,
+                         unsigned half, unsigned words)
+{
+  r &= (half - 1);
+  if (half <= 64)
+  {
+    const uint64_t mask =
+        (half == 64) ? ~(uint64_t)0 : (((uint64_t)1 << half) - 1);
+    uint64_t v = src[0] & mask;
+    if (r)
+      v = ((v << r) | (v >> (half - r))) & mask;
+    dst[0] |= v;
+    return;
+  }
+  // words is a power of two (half = 2^(m-2)), so modular indexing is a
+  // mask — the previous % here cost more than the ORs themselves.
+  const unsigned wo = r >> 6, sh = r & 63, wm = words - 1;
+  if (sh == 0)
+  {
+    for (unsigned w = 0; w < words; w++)
+      dst[w] |= src[(w - wo) & wm];
+  }
+  else
+  {
+    for (unsigned w = 0; w < words; w++)
+    {
+      const unsigned s1 = (w - wo) & wm;
+      const unsigned s0 = (s1 - 1) & wm;
+      dst[w] |= (src[s1] << sh) | (src[s0] >> (64 - sh));
+    }
+  }
+}
+
+// out |= { a + b : a in A, b in B } (negate B's exponents for the
+// difference set). Iterates the smaller operand, translating the larger;
+// stops early once out saturates.
+// Fill `out` completely (both sign rows over its modulus).
+static void setFull(OddSet& out)
+{
+  const uint64_t top = (out.half >= 64 || out.half == 0)
+                           ? ~(uint64_t)0
+                           : (((uint64_t)1 << out.half) - 1);
+  for (unsigned s = 0; s < 2; s++)
+    for (unsigned w = 0; w < out.words; w++)
+      out.row[s][w] = (w == out.words - 1) ? top : ~(uint64_t)0;
+}
+
+static void accumulateSum(OddSet& out, const OddSet& A, const OddSet& B,
+                          bool negateB)
+{
+  // Pigeonhole shortcuts on the group of size 2*half: a difference set
+  // A (-) B is full once |B| exceeds A's hole count (some translate of B
+  // must hit A for every offset), and a sumset is full once
+  // |A| + |B| exceeds the group size.
+  {
+    const unsigned groupSize = 2 * out.half;
+    const unsigned cA = A.count(), cB = B.count();
+    if (cA + cB > groupSize)
+    {
+      setFull(out);
+      return;
+    }
+    if (negateB && cB > groupSize - cA)
+    {
+      setFull(out);
+      return;
+    }
+  }
+  const OddSet* iter = &B;
+  const OddSet* base = &A;
+  bool negateIter = negateB;
+  OddSet Brefl;
+  if (A.count() < B.count())
+  {
+    if (!negateB)
+    {
+      // a + b is symmetric: iterate the smaller side.
+      iter = &A;
+      base = &B;
+    }
+    else
+    {
+      // A (-) B = union over a in A of translate(reflect(B), a): reflect
+      // once, then iterate the (smaller) A with plain offsets.
+      Brefl.clear(B.m);
+      const unsigned half_ = B.half;
+      for (unsigned s = 0; s < 2; s++)
+        for (unsigned w = 0; w < B.words; w++)
+        {
+          uint64_t bits = B.row[s][w];
+          while (bits)
+          {
+            const unsigned e = w * 64 + ::stp::countTrailingZeroes64(bits);
+            bits &= bits - 1;
+            const unsigned er = (half_ - e) & (half_ - 1);
+            Brefl.row[s][er >> 6] |= (uint64_t)1 << (er & 63);
+          }
+        }
+      iter = &A;
+      base = &Brefl;
+      negateIter = false;
+    }
+  }
+  const unsigned half = out.half, words = out.words;
+
+  unsigned sinceCheck = 0;
+  for (unsigned sb = 0; sb < 2; sb++)
+    for (unsigned w = 0; w < words; w++)
+    {
+      uint64_t bits = iter->row[sb][w];
+      while (bits)
+      {
+        const unsigned eb = w * 64 + ::stp::countTrailingZeroes64(bits);
+        bits &= bits - 1;
+        const unsigned r = negateIter ? ((half - eb) & (half - 1)) : eb;
+        for (unsigned sa = 0; sa < 2; sa++)
+          orRotatedRow(out.row[sa ^ sb], base->row[sa], r, half, words);
+        if (++sinceCheck >= 8)
+        {
+          sinceCheck = 0;
+          if (out.full())
+            return;
+        }
+      }
+    }
+}
+
+// dst |= src lifted from modulus 2^src.m to dst's larger modulus: the
+// exponent row of the coarser set tiles cyclically (3^e mod 2^m depends
+// only on e mod 2^(m-2)), signs map straight across.
+static void liftOrInto(OddSet& dst, const OddSet& src)
+{
+  assert(dst.m >= src.m);
+  if (src.m < 3)
+  {
+    // Coarse sign-only information: expand elementwise.
+    for (unsigned sgn = 0; sgn < 2; sgn++)
+      if (src.row[sgn][0] & 1)
+      {
+        // Every odd value with that residue mod 2^src.m.
+        const unsigned mod = 1u << src.m;
+        const unsigned res = (src.m == 2 && sgn) ? 3u : 1u;
+        for (unsigned u = 1; u < (2u * dst.half); u += 2)
+          if (src.m < 2 || (u & (mod - 1)) == res)
+            dst.addValue(u);
+      }
+    return;
+  }
+  const unsigned sh = src.half, dw = dst.words;
+  for (unsigned sgn = 0; sgn < 2; sgn++)
+  {
+    if (sh >= 64)
+    {
+      for (unsigned w = 0; w < dw; w++)
+        dst.row[sgn][w] |= src.row[sgn][w % src.words];
+    }
+    else
+    {
+      uint64_t pat = src.row[sgn][0];
+      for (unsigned width = sh; width < 64; width <<= 1)
+        pat |= pat << width;
+      for (unsigned w = 0; w < dw; w++)
+        dst.row[sgn][w] |= pat;
+    }
+  }
+}
+
+// Emit every element of `set` (odd part u, value u << shift) into the
+// value join accumulators.
+static void emitAll(const OddSet& set, unsigned shift, unsigned k,
+                    uint64_t& vAnd, uint64_t& vOr, bool& any)
+{
+  const unsigned bigHalf = set.half;
+  for (unsigned sgn = 0; sgn < 2; sgn++)
+    for (unsigned w = 0; w < set.words; w++)
+    {
+      uint64_t bits = set.row[sgn][w];
+      while (bits)
+      {
+        const unsigned e = w * 64 + ::stp::countTrailingZeroes64(bits);
+        bits &= bits - 1;
+        const unsigned u = (set.m < 3)
+                               ? ((set.m == 2 && sgn) ? 3u : 1u)
+                               : oddLogTables().l2v[set.m][sgn * bigHalf + e];
+        const uint64_t v = ((uint64_t)u << shift) & ((1u << k) - 1);
+        vAnd &= v;
+        vOr |= v;
+        any = true;
+      }
+    }
+}
+
+// The exact full-width join for k <= LOG_MAX_WIDTH via the group
+// decomposition. Values fit one word (k <= 14).
+Result logGroupExactPass(FixedBits& x, FixedBits& y, FixedBits& output,
+                         bool& progress, bool& fired)
+{
+  const unsigned k = x.getWidth();
+  if (k < 9 || k > LOG_MAX_WIDTH)
+    return NO_CHANGE;
+
+  // The bounded enumeration already produced the exact join for small
+  // unfixed counts; only larger states need this pass. When the output is
+  // completely unconstrained the enumeration bows out earlier (its walk
+  // can only feed the output join), so this pass takes over from there.
+  const bool aliased = (&x == &y);
+  const unsigned unfixed =
+      (k - x.countFixed()) + (aliased ? 0 : (k - y.countFixed()));
+  const unsigned enumCovers = (output.countFixed() == 0) ? 13 : 16;
+  if (unfixed <= enumCovers)
+    return NO_CHANGE;
+
+  // Nothing fixed anywhere -> the join fixes nothing.
+  bool anyFixed = false, anyOut = false, xAll = true, yAll = true;
+  for (unsigned i = 0; i < k; i++)
+  {
+    anyOut = anyOut || output.isFixed(i);
+    xAll = xAll && !x.isFixed(i);
+    yAll = yAll && !y.isFixed(i);
+    anyFixed = anyFixed || x.isFixed(i) || y.isFixed(i);
+  }
+  anyFixed = anyFixed || anyOut;
+  if (!anyFixed)
+    return NO_CHANGE;
+  // With an unconstrained output and one fully free operand, the join
+  // fixes only the trailing zeros the core already derives.
+  if (!anyOut && (xAll || yAll))
+    return NO_CHANGE;
+
+  fired = true; // the result below is the exact join: never rerun.
+
+  uint64_t xF, xV, yF, yV, oF, oV;
+  x.fillPackedWord(0, xF, xV);
+  y.fillPackedWord(0, yF, yV);
+  output.fillPackedWord(0, oF, oV);
+
+  static OddSet Xs[LOG_MAX_WIDTH], Ys[LOG_MAX_WIDTH], Os[LOG_MAX_WIDTH];
+  for (unsigned s = 0; s < k; s++)
+  {
+    Xs[s].clear(k - s);
+    Ys[s].clear(k - s);
+    Os[s].clear(k - s);
+  }
+  const unsigned mask = (1u << k) - 1;
+  const bool xHas0 = ((0 ^ xV) & xF) == 0, yHas0 = ((0 ^ yV) & yF) == 0,
+             oHas0 = ((0 ^ oV) & oF) == 0;
+  for (unsigned v = 1; v <= mask; v++)
+  {
+    const unsigned s = ::stp::countTrailingZeroes64(v), u = v >> s;
+    if (((v ^ xV) & xF) == 0)
+      Xs[s].addValue(u);
+    if (!aliased && ((v ^ yV) & yF) == 0)
+      Ys[s].addValue(u);
+    if (((v ^ oV) & oF) == 0)
+      Os[s].addValue(u);
+  }
+
+  uint64_t xAnd = mask, xOr = 0, yAnd = mask, yOr = 0, oAnd = mask, oOr = 0;
+  bool anyX = false, anyY = false, anyO = false;
+
+  if (aliased)
+  {
+    // Squares: single free variable, test each element directly.
+    if (xHas0 && oHas0)
+    {
+      xAnd = 0; // value 0 survives.
+      anyX = true;
+      oAnd &= 0;
+      oOr |= 0;
+      anyO = true;
+    }
+    for (unsigned s = 0; s < k; s++)
+    {
+      const unsigned m = k - s;
+      const unsigned bigHalf = Xs[s].half;
+      for (unsigned sgn = 0; sgn < 2; sgn++)
+        for (unsigned w = 0; w < Xs[s].words; w++)
+        {
+          uint64_t bits = Xs[s].row[sgn][w];
+          while (bits)
+          {
+            const unsigned e = w * 64 + ::stp::countTrailingZeroes64(bits);
+            bits &= bits - 1;
+            const unsigned u =
+                (m < 3) ? ((m == 2 && sgn) ? 3u : 1u)
+                        : oddLogTables().l2v[m][sgn * bigHalf + e];
+            const uint64_t sq =
+                (2 * s >= k) ? 0 : (((uint64_t)u * u) << (2 * s)) & mask;
+            const bool okOut = ((sq ^ oV) & oF) == 0;
+            if (!okOut)
+              continue;
+            const uint64_t v = ((uint64_t)u << s) & mask;
+            xAnd &= v;
+            xOr |= v;
+            anyX = true;
+            oAnd &= sq;
+            oOr |= sq;
+            anyO = true;
+          }
+        }
+    }
+    if (!anyX)
+      return CONFLICT;
+    // x and y are the same object; the output join comes from squares.
+    bool ch = false;
+    for (unsigned i = 0; i < k; i++)
+    {
+      if (!x.isFixed(i) && (((xAnd >> i) & 1) == ((xOr >> i) & 1)))
+      {
+        x.setFixed(i, true);
+        x.setValue(i, (xAnd >> i) & 1);
+        ch = true;
+      }
+      if (anyO && !output.isFixed(i) && (((oAnd >> i) & 1) == ((oOr >> i) & 1)))
+      {
+        output.setFixed(i, true);
+        output.setValue(i, (oAnd >> i) & 1);
+        ch = true;
+      }
+    }
+    if (ch)
+      progress = true;
+    return NO_CHANGE;
+  }
+
+  // Per-stratum survivor filters, unioned across partner strata; the
+  // final emission intersects each stratum with its filter once. The
+  // fullness flags let saturated pairs skip their correlations entirely.
+  static OddSet xFilt[LOG_MAX_WIDTH], yFilt[LOG_MAX_WIDTH],
+      oFilt[LOG_MAX_WIDTH];
+  bool xFull[LOG_MAX_WIDTH], yFull[LOG_MAX_WIDTH], oFull[LOG_MAX_WIDTH];
+  for (unsigned s = 0; s < k; s++)
+  {
+    xFilt[s].clear(k - s);
+    yFilt[s].clear(k - s);
+    oFilt[s].clear(k - s);
+    xFull[s] = yFull[s] = oFull[s] = false;
+  }
+
+  // x == 0 pairs: every admitted y survives (product 0), and vice versa.
+  if (xHas0 && oHas0)
+  {
+    bool anyPartner = yHas0;
+    for (unsigned t = 0; t < k && !anyPartner; t++)
+      anyPartner = !Ys[t].empty();
+    if (anyPartner)
+    {
+      xAnd = 0;
+      anyX = true;
+      oAnd = 0;
+      anyO = true;
+      if (yHas0)
+      {
+        yAnd = 0;
+        anyY = true;
+      }
+      for (unsigned t = 0; t < k; t++)
+      {
+        liftOrInto(yFilt[t], Ys[t]);
+        yFull[t] = yFull[t] || yFilt[t].full();
+      }
+    }
+  }
+  if (yHas0 && oHas0)
+  {
+    bool anyPartner = xHas0;
+    for (unsigned s = 0; s < k && !anyPartner; s++)
+      anyPartner = !Xs[s].empty();
+    if (anyPartner)
+    {
+      yAnd = 0;
+      anyY = true;
+      oAnd = 0;
+      anyO = true;
+      if (xHas0)
+      {
+        xAnd = 0;
+        anyX = true;
+      }
+      for (unsigned s = 0; s < k; s++)
+      {
+        liftOrInto(xFilt[s], Xs[s]);
+        xFull[s] = xFull[s] || xFilt[s].full();
+      }
+    }
+  }
+
+  for (unsigned s = 0; s < k; s++)
+  {
+    if (Xs[s].empty())
+      continue;
+    for (unsigned t = 0; t < k; t++)
+    {
+      if (Ys[t].empty())
+        continue;
+      if (s + t >= k)
+      {
+        // Product is zero regardless of the odd parts.
+        if (!oHas0)
+          continue;
+        oAnd = 0;
+        anyO = true;
+        if (!xFull[s])
+        {
+          liftOrInto(xFilt[s], Xs[s]);
+          xFull[s] = xFilt[s].full();
+        }
+        if (!yFull[t])
+        {
+          liftOrInto(yFilt[t], Ys[t]);
+          yFull[t] = yFilt[t].full();
+        }
+        continue;
+      }
+      if (xFull[s] && yFull[t] && oFull[s + t])
+        continue; // nothing left for this pair to contribute.
+      const unsigned m = k - s - t;
+      const OddSet& Om = Os[s + t];
+      if (Om.empty())
+        continue;
+
+      OddSet Xm, Ym;
+      Xs[s].projectTo(Xm, m);
+      Ys[t].projectTo(Ym, m);
+
+      // Existence check once: if no product of these strata can land in
+      // Om, the pair contributes nothing to any side.
+      OddSet D;
+      D.clear(m);
+      accumulateSum(D, Om, Ym, /*negate*/ true);
+      if (D.empty())
+        continue;
+
+      if (!xFull[s])
+      {
+        liftOrInto(xFilt[s], D);
+        xFull[s] = xFilt[s].full();
+      }
+      if (!yFull[t])
+      {
+        OddSet E;
+        E.clear(m);
+        accumulateSum(E, Om, Xm, true);
+        liftOrInto(yFilt[t], E);
+        yFull[t] = yFilt[t].full();
+      }
+      if (!oFull[s + t])
+      {
+        OddSet P;
+        P.clear(m);
+        accumulateSum(P, Xm, Ym, false);
+        for (unsigned sgn = 0; sgn < 2; sgn++)
+          for (unsigned w = 0; w < P.words; w++)
+            oFilt[s + t].row[sgn][w] |= Om.row[sgn][w] & P.row[sgn][w];
+        oFull[s + t] = oFilt[s + t].full();
+      }
+    }
+  }
+
+  // Emit: survivors of each stratum = stratum set AND its filter.
+  for (unsigned s = 0; s < k; s++)
+  {
+    OddSet t1;
+    t1.clear(k - s);
+    for (unsigned sgn = 0; sgn < 2; sgn++)
+      for (unsigned w = 0; w < t1.words; w++)
+        t1.row[sgn][w] = Xs[s].row[sgn][w] & xFilt[s].row[sgn][w];
+    emitAll(t1, s, k, xAnd, xOr, anyX);
+    for (unsigned sgn = 0; sgn < 2; sgn++)
+      for (unsigned w = 0; w < t1.words; w++)
+        t1.row[sgn][w] = Ys[s].row[sgn][w] & yFilt[s].row[sgn][w];
+    emitAll(t1, s, k, yAnd, yOr, anyY);
+    for (unsigned sgn = 0; sgn < 2; sgn++)
+      for (unsigned w = 0; w < t1.words; w++)
+        t1.row[sgn][w] = Os[s].row[sgn][w] & oFilt[s].row[sgn][w];
+    emitAll(t1, s, k, oAnd, oOr, anyO);
+  }
+
+  if (!anyX || !anyY || !anyO)
+    return CONFLICT;
+
+  bool ch = false;
+  for (unsigned i = 0; i < k; i++)
+  {
+    if (!x.isFixed(i) && (((xAnd >> i) & 1) == ((xOr >> i) & 1)))
+    {
+      x.setFixed(i, true);
+      x.setValue(i, (xAnd >> i) & 1);
+      ch = true;
+    }
+    if (!y.isFixed(i) && (((yAnd >> i) & 1) == ((yOr >> i) & 1)))
+    {
+      y.setFixed(i, true);
+      y.setValue(i, (yAnd >> i) & 1);
+      ch = true;
+    }
+    if (!output.isFixed(i) && (((oAnd >> i) & 1) == ((oOr >> i) & 1)))
+    {
+      output.setFixed(i, true);
+      output.setValue(i, (oAnd >> i) & 1);
+      ch = true;
+    }
+  }
+  if (ch)
+    progress = true;
+  return NO_CHANGE;
+}
+
 Result bvMultiplyBothWays(vector<FixedBits*>& children, FixedBits& output,
                           stp::STPMgr* /*bm*/, MultiplicationStats* ms)
 {
@@ -1135,8 +2426,11 @@ Result bvMultiplyBothWays(vector<FixedBits*>& children, FixedBits& output,
   assert(children[0]->getWidth() == children[1]->getWidth());
   assert(children[0]->getWidth() == output.getWidth());
 
-  // Alternate the two views of the constraint until a joint fixed point.
-  // Each productive inverse pass fixes at least one previously unfixed
+  bool logDone = false;
+
+  // Alternate the views of the constraint — the column fixpoint, the
+  // inverse relation, and the exact low-bits solve — until a joint fixed
+  // point. Each productive pass fixes at least one previously unfixed
   // bit, so this terminates; and the loop always ends with a core pass
   // that found nothing further, keeping the `ms` snapshot current.
   while (true)
@@ -1148,6 +2442,23 @@ Result bvMultiplyBothWays(vector<FixedBits*>& children, FixedBits& output,
     if (CONFLICT ==
         inverseRelationPass(*children[0], *children[1], output, progress))
       return CONFLICT;
+    if (CONFLICT ==
+        exactLowBitsPass(*children[0], *children[1], output, progress))
+      return CONFLICT;
+    if (CONFLICT ==
+        smallDomainPass(*children[0], *children[1], output, progress))
+      return CONFLICT;
+    if (!logDone)
+    {
+      // One firing computes the exact join, after which no pass can add
+      // anything; the flag stops the expensive recomputation on the
+      // wrap-up iterations of this loop.
+      bool fired = false;
+      if (CONFLICT == logGroupExactPass(*children[0], *children[1], output,
+                                        progress, fired))
+        return CONFLICT;
+      logDone = fired;
+    }
     if (!progress)
       break;
   }

--- a/tests/unit-tests/ConstantBitP_TransferFunctions_Test.cpp
+++ b/tests/unit-tests/ConstantBitP_TransferFunctions_Test.cpp
@@ -50,8 +50,10 @@ THE SOFTWARE.
 //    there says what is lost.
 //
 // The functions checked only for soundness (OVERAPPROXIMATES rather than
-// MAX_PRECISE below) are multiplication and the five division operations.
-// Everything else is confirmed maximally precise here.
+// MAX_PRECISE below) are the five division operations. Multiplication is
+// maximally precise up to width 8 (the exact low-bits solve covers the
+// whole relation there) and is checked as MAX_PRECISE at width 3; above
+// width 8 only its low 8 bits carry that guarantee.
 //
 // Every operator is checked twice: once with a distinct FixedBits per
 // operand, and once ALIASED, with one FixedBits shared between several
@@ -665,7 +667,7 @@ TEST_F(ConstantBitP_TransferFunctions, multiplicationExhaustiveWidth3)
         return bvMultiplyBothWays(children, out, &mgr, NULL);
       },
       [](const std::vector<unsigned>& v) { return (v[0] * v[1]) & 7; },
-      bv3(2), out3(), OVERAPPROXIMATES, SETTLES_IN_ONE_CALL, RESULT_IS_VAGUE);
+      bv3(2), out3(), MAX_PRECISE, SETTLES_IN_ONE_CALL, RESULT_IS_VAGUE);
 }
 
 // BVTypeCheck accepts BVMULT with more than two children, and the hashing
@@ -755,8 +757,9 @@ TEST_F(ConstantBitP_TransferFunctions, multiplicationInverseSolvesOperand)
   EXPECT_TRUE(FixedBits::equals(y, fromString("0011")));
 }
 
-// Aliased square with an odd low prefix: t ≡ 3 (mod 8) means t*t ≡ 1
-// (mod 8), fixing the output's low bits while t itself stays untouched.
+// Aliased square with an odd low prefix: t is 3 or 11, and both squares
+// are 9 mod 16, so the output is completely determined. (The inverse view
+// alone gives the low three bits; the exact solve pins bit 3 too.)
 TEST_F(ConstantBitP_TransferFunctions, multiplicationInverseAliasedSquare)
 {
   FixedBits t = fromString("*011");
@@ -765,29 +768,118 @@ TEST_F(ConstantBitP_TransferFunctions, multiplicationInverseAliasedSquare)
   std::vector<FixedBits*> children = {&t, &t};
   bvMultiplyBothWays(children, out, &mgr, NULL);
 
-  EXPECT_TRUE(FixedBits::equals(out, fromString("*001")));
+  EXPECT_TRUE(FixedBits::equals(out, fromString("1001")));
   EXPECT_TRUE(FixedBits::equals(t, fromString("*011")));
 }
 
+// The exact low-bits solve catches correlations the column counts and the
+// inverse view both lose: x and y are each 1 or 3 (mod 8), so the product
+// is 1 or 3 as well and output bit 2 must be zero.
+TEST_F(ConstantBitP_TransferFunctions, multiplicationExactLowBitsCorrelation)
+{
+  FixedBits x = fromString("0*1");
+  FixedBits y = fromString("0*1");
+  FixedBits out = fromString("***");
+
+  std::vector<FixedBits*> children = {&x, &y};
+  bvMultiplyBothWays(children, out, &mgr, NULL);
+
+  EXPECT_TRUE(FixedBits::equals(out, fromString("0*1")));
+  EXPECT_TRUE(FixedBits::equals(x, fromString("0*1")));
+  EXPECT_TRUE(FixedBits::equals(y, fromString("0*1")));
+}
+
+// The same correlation contradicted is a conflict only the exact solve
+// sees: no product of two values in {1,3} has bit 2 set.
+TEST_F(ConstantBitP_TransferFunctions, multiplicationExactLowBitsConflict)
+{
+  FixedBits x = fromString("0*1");
+  FixedBits y = fromString("0*1");
+  FixedBits out = fromString("1**");
+
+  std::vector<FixedBits*> children = {&x, &y};
+  EXPECT_EQ(CONFLICT, bvMultiplyBothWays(children, out, &mgr, NULL));
+}
+
+// Above width 8 the exact solve still covers the low 8 bits: with x == 3,
+// output bit 2 of 3*y is y1 XOR y1 == 0 whenever y2 == 0 and y0 == 1,
+// independent of the unfixed y1 — a correlation the column intervals lose
+// to the carry.
+TEST_F(ConstantBitP_TransferFunctions, multiplicationExactLowBitsWideWidth)
+{
+  FixedBits x = fromString("0000000000000011");
+  FixedBits y = fromString("*************0*1");
+  FixedBits out = fromString("****************");
+
+  std::vector<FixedBits*> children = {&x, &y};
+  bvMultiplyBothWays(children, out, &mgr, NULL);
+
+  EXPECT_TRUE(out.isFixedToOne(0));
+  EXPECT_TRUE(out.isFixedToZero(2));
+  EXPECT_FALSE(out.isFixed(1)); // y1 really is free: 3*1=3, 3*3=9.
+  EXPECT_TRUE(FixedBits::equals(y, fromString("*************0*1")));
+}
+
+// Aliased square through the exact solve: t in {1,3} gives t*t in {1,9},
+// both 001 mod 8, so the output is completely determined.
+TEST_F(ConstantBitP_TransferFunctions, multiplicationExactLowBitsAliased)
+{
+  FixedBits t = fromString("0*1");
+  FixedBits out = fromString("***");
+
+  std::vector<FixedBits*> children = {&t, &t};
+  bvMultiplyBothWays(children, out, &mgr, NULL);
+
+  EXPECT_TRUE(FixedBits::equals(out, fromString("001")));
+  EXPECT_TRUE(FixedBits::equals(t, fromString("0*1")));
+}
+
+// With only six unfixed operand bits the bounded enumeration solves the
+// relation exactly over the full width: two (x, y) pairs survive, agreeing
+// on all of x, on y bit 2, and on output bit 7 — high-bit correlations
+// the column counts, the inverse view and the low-8 solve all miss.
+// (Brute-force verified: the expectations are the join of the survivors.)
+TEST_F(ConstantBitP_TransferFunctions, multiplicationSmallDomainEnumeration)
+{
+  FixedBits x = fromString("110*1*111*");
+  FixedBits y = fromString("1*10**0110");
+  FixedBits out = fromString("11**110100");
+
+  std::vector<FixedBits*> children = {&x, &y};
+  bvMultiplyBothWays(children, out, &mgr, NULL);
+
+  EXPECT_TRUE(FixedBits::equals(x, fromString("1101111110")));
+  EXPECT_TRUE(FixedBits::equals(y, fromString("1010*00110")));
+  EXPECT_TRUE(FixedBits::equals(out, fromString("111*110100")));
+}
+
+// The same state with output bit 7 forced to zero admits no solution at
+// all (both survivors above have it set) — a conflict only the bounded
+// enumeration detects.
+TEST_F(ConstantBitP_TransferFunctions, multiplicationSmallDomainConflict)
+{
+  FixedBits x = fromString("110*1*111*");
+  FixedBits y = fromString("1*10**0110");
+  FixedBits out = fromString("110*110100");
+
+  std::vector<FixedBits*> children = {&x, &y};
+  EXPECT_EQ(CONFLICT, bvMultiplyBothWays(children, out, &mgr, NULL));
+}
+
 // With no odd fixed low prefix on either operand the inverse view doesn't
-// apply, and bvMultiplyBothWays must behave exactly like the core column
-// reasoning.
-TEST_F(ConstantBitP_TransferFunctions, multiplicationEvenPrefixMatchesCore)
+// apply (the exact low-bits solve still runs; here it confirms exactly
+// what the columns derive: x ≡ 2 mod 4 times an odd y ends in binary 10).
+TEST_F(ConstantBitP_TransferFunctions, multiplicationEvenPrefix)
 {
   FixedBits x = fromString("**10");
   FixedBits y = fromString("***1");
   FixedBits out = fromString("****");
 
-  FixedBits cx(x), cy(y), cout_(out);
-  std::vector<FixedBits*> coreChildren = {&cx, &cy};
-  multiplyCore(coreChildren, cout_, NULL);
-
   std::vector<FixedBits*> children = {&x, &y};
   bvMultiplyBothWays(children, out, &mgr, NULL);
 
-  EXPECT_TRUE(FixedBits::equals(x, cx));
-  EXPECT_TRUE(FixedBits::equals(y, cy));
-  EXPECT_TRUE(FixedBits::equals(out, cout_));
+  EXPECT_TRUE(FixedBits::equals(x, fromString("**10")));
+  EXPECT_TRUE(FixedBits::equals(y, fromString("***1")));
   EXPECT_TRUE(FixedBits::equals(out, fromString("**10")));
 }
 


### PR DESCRIPTION
Builds on #672's inverse-relation pass (now in master). Draft for review.

Three new passes join the column fixpoint and the inverse view, alternating until a joint fixed point:

1. **Exact low-8 solve** — `out ≡ x·y (mod 2^8)` involves only the low bytes, and over ≤256 candidate values per side that sub-relation is solved exactly (64 KB lazily-built bit-sliced multiplication table). Maximal for the low-8 sub-relation at any width; the whole relation at width ≤ 8.
2. **Bounded Gray-code enumeration** — with ≤16 unfixed operand bits (13 above width 14, and fewer when the output is fully unconstrained), walk every assignment; consecutive assignments differ in one bit so each product updates with one shifted add. The surviving assignments' join is the exact full-width answer.
3. **Odd-group discrete-log solve** (widths 9–14, beyond the enumeration's budget) — writing `v = 2^s·u` with `u` odd, the odd residues mod `2^m` form `{±1}×⟨3⟩`, so partner-existence is a difference set over `Z/2 × Z/2^(m-2)`, computed with rotated-bitset ORs, pigeonhole-full shortcuts (a translate set larger than the target's hole count covers everything), and smaller-side iteration via a reflected operand. Exact for every remaining state.

Together: **`bvMultiplyBothWays` is maximally precise — every fixable bit fixed, every unsatisfiable state a CONFLICT — for all states at widths ≤ 14**, plus low-8-exact and small-domain-exact coverage above that. Published known-bits multiplies (Linux eBPF tnums, LLVM KnownBits, CP bit-vector propagators) are sound but not maximal.

One subtlety found by fuzzing: no pass may strengthen the all-unfixed state (a square's bit 1 is always 0 — derivable "from nothing"), because the propagation scheduler never visits nodes with no fixed bits nearby, leaving them short of their own transfer's fixpoint (`checkAtFixedPoint` catches it). The facts are derived as soon as any bit reaches the node instead.

### Verification

- Exhaustive over **every** ternary state at widths 3/4/5 (14.9M states): zero below-maximal, zero missed conflicts, zero unsound bits.
- Brute-force-join comparison over sampled states at widths 9–14 incl. hard strata: zero gaps; 1.4M random-witness soundness checks to width 200 (aliased squares included).
- The width-3 exhaustive gtest upgraded `OVERAPPROXIMATES` → `MAX_PRECISE` as a permanent contract; 8 new targeted gtests.
- 2,501-file corpus differential vs the pre-change solver: identical verdicts; ~1 hour of fuzz.sh clean (after the bottom-state fix).
- `propagator_bench`'s built-in verdict: master "90.4% of deducible bits, 5,419 missed conflicts (exhaustive w=4)" → this branch "100.0%" on every measured configuration.

### Cost (propagator_bench vs master, interleaved arms, static Release builds)

- Dense states (5% unfixed): 1.05–1.2× both-ways at widths 8–64 — the regime real propagation operates in.
- Enumeration-active cells: 1.4–2.6×, deducing up to ~1.7× more bits (w64, 20% unfixed, both-ways: 12.4 → 15.6 bits at 1.42×).
- The perfection premium concentrates on loose states at widths 9–14 (up to ~200 µs/call at width 14, where proving nothing is deducible costs as much as deducing). On corpus runs the multiply transfer is well under 1% of solve time; if the premium ever shows in a profile, the log pass has a single gate to loosen.

Memory: ~165 KB of lazily built static tables.