### PR TITLE
Price the ITE distribution instead of capping its frames

### DIFF
--- a/lib/Simplifier/RemoveUnconstrained.cpp
+++ b/lib/Simplifier/RemoveUnconstrained.cpp
@@ -180,7 +180,7 @@ bool RemoveUnconstrained::tryGroundPathCollapse(
     bool pathThen;
     size_t stepsBelow;
   };
-  const size_t MAX_ITE_FRAMES = 4;
+  const size_t MAX_ITE_FRAMES = 8;
   std::vector<IteFrame> frames;
 
   MutableASTNode* cur = &muteNode;

--- a/lib/Simplifier/RemoveUnconstrained.cpp
+++ b/lib/Simplifier/RemoveUnconstrained.cpp
@@ -56,6 +56,7 @@ THE SOFTWARE.
  */
 
 #include "stp/Simplifier/RemoveUnconstrained.h"
+#include "stp/Simplifier/DifficultyScore.h"
 #include "stp/AST/MutableASTNode.h"
 #include "stp/Extensionality/ExtensionalityContext.h"
 #include "stp/UninterpretedFunctions/UFContext.h"
@@ -618,9 +619,10 @@ bool RemoveUnconstrained::tryGroundPathCollapse(
   ASTNode predConst;
   MutableASTNode* predOther = NULL; // set instead when the side is symbolic.
 
-  // ITE frames on the path, innermost first. Each frame costs one
-  // rebuilt predicate around its other branch, so growth is linear in
-  // the frame count; the cap bounds it.
+  // ITE frames on the path, innermost first. Each frame re-applies the
+  // steps above it to that frame's other branch, so the distributed form
+  // holds one copy of the suffix chain per frame. The climb bounds the
+  // count at MAX_PATH; whether the copies are worth it is priced below.
   struct IteFrame
   {
     MutableASTNode* cond;
@@ -628,7 +630,6 @@ bool RemoveUnconstrained::tryGroundPathCollapse(
     bool pathThen;
     size_t stepsBelow;
   };
-  const size_t MAX_ITE_FRAMES = 4;
   std::vector<IteFrame> frames;
 
   MutableASTNode* cur = &muteNode;
@@ -667,8 +668,7 @@ bool RemoveUnconstrained::tryGroundPathCollapse(
     {
       // Capture a distribution frame and keep climbing; the ITE
       // contributes no image step (on x's branch it is the identity).
-      if (frames.size() >= MAX_ITE_FRAMES || p.GetIndexWidth() != 0 ||
-          kids.size() != 3)
+      if (p.GetIndexWidth() != 0 || kids.size() != 3)
         return false;
       const bool inThen = (kids[1] == cur);
       if ((!inThen && kids[2] != cur) || kids[1] == kids[2] || kids[0] == cur)
@@ -948,6 +948,16 @@ bool RemoveUnconstrained::tryGroundPathCollapse(
     fr.other->getAllVariablesRecursively(vars, visited);
   }
   visited.clear();
+
+  // Whether the copies collapse again depends on the other branches, not on
+  // how many frames there are: price the built term against the one it
+  // replaces and decline when it grew. (v is left unused on that path;
+  // introduced symbols are never printed.)
+  {
+    DifficultyScore ds;
+    if (ds.score(inner, &bm) > ds.score(predicate->toASTNode(&bm), &bm))
+      return false;
+  }
 
   // Splice the new formula in, reusing the existing mutable nodes for the
   // variables it mentions (same mechanics as the comparison rule).

--- a/tests/unit-tests/RemoveUnconstrained_Exhaustive_Test.cpp
+++ b/tests/unit-tests/RemoveUnconstrained_Exhaustive_Test.cpp
@@ -972,14 +972,14 @@ TEST(RemoveUnconstrained_GroundPath, ite_three_frames_with_suffixes)
 
 TEST(RemoveUnconstrained_GroundPath, ite_frame_cap_declines)
 {
-  // Five stacked frames exceed MAX_ITE_FRAMES: x must survive. One
+  // Nine stacked frames exceed MAX_ITE_FRAMES: x must survive. One
   // shared condition variable keeps the equivalence check enumerable.
   Context c;
   ASTNode x = c.bv();
   ASTNode y = c.bv();
   ASTNode t = c.hf->CreateTerm(BVMOD, W, x, c.konst(4));
-  for (int i = 0; i < 5; i++)
-    t = c.hf->CreateTerm(ITE, W, c.hf->CreateNode(EQ, y, c.konst(i)), t,
+  for (int i = 0; i < 9; i++)
+    t = c.hf->CreateTerm(ITE, W, c.hf->CreateNode(EQ, y, c.konst(i % 8)), t,
                          c.konst(7));
   ASTNode top = c.hf->CreateNode(EQ, t, c.konst(2));
 

--- a/tests/unit-tests/RemoveUnconstrained_Exhaustive_Test.cpp
+++ b/tests/unit-tests/RemoveUnconstrained_Exhaustive_Test.cpp
@@ -1207,22 +1207,49 @@ TEST(RemoveUnconstrained_GroundPath, ite_three_frames_with_suffixes)
   c.checkEquivalent(back, result);
 }
 
-TEST(RemoveUnconstrained_GroundPath, ite_frame_cap_declines)
+TEST(RemoveUnconstrained_GroundPath, ite_deep_stack_distributes)
 {
-  // Five stacked frames exceed MAX_ITE_FRAMES: x must survive. One
-  // shared condition variable keeps the equivalence check enumerable.
+  // Nine frames, deeper than any fixed cap would allow. Every other branch
+  // is a constant, so each re-applied suffix folds away and the distributed
+  // form is smaller than the predicate it replaces: it must be taken. One
+  // shared condition variable keeps the equivalence check enumerable, its
+  // constant wrapped to the W-bit range.
   Context c;
   ASTNode x = c.bv();
   ASTNode y = c.bv();
   ASTNode t = c.hf->CreateTerm(BVMOD, W, x, c.konst(4));
-  for (int i = 0; i < 5; i++)
-    t = c.hf->CreateTerm(ITE, W, c.hf->CreateNode(EQ, y, c.konst(i)), t,
+  for (unsigned i = 0; i < 9; i++)
+    t = c.hf->CreateTerm(ITE, W,
+                         c.hf->CreateNode(EQ, y, c.konst(i % (1u << W))), t,
                          c.konst(7));
   ASTNode top = c.hf->CreateNode(EQ, t, c.konst(2));
 
   ASTNode result = c.run(top);
+  EXPECT_EQ(c.simp.Return_SolverMap()->count(x), 1u) << "x not eliminated";
+  ASTNode back = c.backSubstitute(top);
+  c.checkEquivalent(back, result);
+}
+
+TEST(RemoveUnconstrained_GroundPath, ite_growth_declines)
+{
+  // The same distribution with the chain above the frames instead, and
+  // distinct symbolic other branches: every frame gets its own copy of the
+  // remainder and none of them collapse. Bigger than the predicate it
+  // replaces, so x must survive.
+  Context c;
+  ASTNode x = c.bv();
+  ASTNode y = c.bv();
+  ASTNode z = c.bv();
+  ASTNode t = x;
+  for (unsigned i = 0; i < 4; i++)
+    t = c.hf->CreateTerm(ITE, W, c.hf->CreateNode(EQ, y, c.konst(i)), t,
+                         c.hf->CreateTerm(BVMULT, W, z, c.konst(i + 1)));
+  t = c.hf->CreateTerm(BVMOD, W, t, c.konst(3));
+  ASTNode top = c.hf->CreateNode(EQ, t, c.konst(2));
+
+  ASTNode result = c.run(top);
   EXPECT_EQ(c.simp.Return_SolverMap()->count(x), 0u)
-      << "x eliminated past the frame cap";
+      << "x eliminated by a rewrite that grew the formula";
   ASTNode back = c.backSubstitute(top);
   c.checkEquivalent(back, result);
 }


### PR DESCRIPTION
Replaces `MAX_ITE_FRAMES` in `RemoveUnconstrained::tryGroundPathCollapse` with a measurement of what the rewrite actually costs.

This PR previously raised that cap from four to eight. Measuring it showed the raise bought nothing (geomean 0.9996, −0.02% summed difficulty over the spear family, with more files getting larger than smaller), so the change has been replaced with one that addresses the underlying problem instead.

### What the cap was standing in for

Ground-path collapse climbs from an unconstrained variable `x` towards the root while every node on the way is single-use and every sibling is a constant, and replaces the predicate it reaches with a fresh boolean. Term-level ITEs are allowed to sit on that path because the predicate distributes over them:

```
P(g(ite(c, f(x), t)))  ==>  ite(c, v, P(g(t)))
```

applied per frame from the innermost out. Each frame re-applies the ground steps recorded above it to that frame's other branch, so the rewritten form holds one copy of the suffix chain per frame where the original held one in total.

Whether that costs anything is decided by the other branches, not by the frame count, because the copies are hash-consed against each other:

- other branches `(bvadd y i)` under a constant multiply — `(bvmul (bvadd y i) c)` simplifies to `(bvadd (bvmul y c) (i*c))`, so every frame shares the one multiplier and the rewrite is free at any depth.
- other branches `(bvand y m_i)` under a division — nothing merges, and each frame keeps its own divider.

A frame count cannot separate those. At four it refused deep ladders that cost nothing and admitted shallow stacks that tripled the formula.

### The change

Drop the cap. After the distributed term is built and before it is spliced in, price it against the term it replaces with `DifficultyScore` — STP's existing estimate of the AIG AND-nodes a formula would blast to, summed over distinct nodes so it prices sharing correctly — and decline when it came out bigger. The frame count is still bounded, by the climb's own `MAX_PATH`, so the speculative build is bounded too.

### Measurements

A four-deep ITE ladder over a 64-bit division, CNF clauses:

| | k=1 | k=2 | k=3 | k=4 |
|---|---|---|---|---|
| rewrite declined outright | 3,110 | 3,220 | 3,438 | 3,563 |
| cap 4 (before this PR) | 13,636 | 28,119 | 39,361 | 53,392 |
| this PR | 13,636 | 3,220 | 3,438 | 3,563 |

The guard recovers the declined baseline exactly from two frames on.

Corpus effect, measured as effective difficulty score (the pre-simplification score where difficulty reversion fires, since that discards the round), engagement filter computed per comparison:

| vs cap 4 | engaged | geomean | summed | smaller / larger |
|---|---|---|---|---|
| rewrite off entirely | 1,633 | 1.0657 | +8.15% | 277 / 1,323 |
| cap 8 | 972 | 0.9996 | −0.02% | 342 / 468 |
| **this PR** | 1,030 | 0.9995 | −0.03% | **569 / 394** |

That is over the spear family (1,695 files), which is where essentially all the engagement is: across a 40-file sample of every QF_BV family (1,265 files) only 47 files are touched by the rewrite at all and only 27 by this change, at +0.05% summed. So the headline is neutrality, not a speedup — what the change buys is that the pathological case is no longer reachable, and an unexplained constant is gone.

Cost is below the noise floor: −0.16% instructions over twelve of the engaged files, because the rewrites it declines save more downstream work than the scoring costs.

### Tests and verification

The nine-frame stack that previously had to decline at the cap now distributes — its branches are constants, so each re-applied suffix folds away — and a new four-frame stack with symbolic branches and a remainder above them must decline. Both check back-substitution equivalence over every assignment of their free variables. The pass's suite is 94/94 and `ctest` is 183/183. A differential sweep over a 2,501-file fuzz corpus against the capped behaviour agrees on all 2,501 answers (2,213 sat, 288 unsat, no timeouts).
