### PR TITLE
Replace shared non-surjective terms with image-constrained fresh variables

### DIFF
--- a/include/stp/Simplifier/RemoveUnconstrained.h
+++ b/include/stp/Simplifier/RemoveUnconstrained.h
@@ -33,6 +33,7 @@ THE SOFTWARE.
 #include "stp/AST/AST.h"
 #include "stp/AST/MutableASTNode.h"
 #include "stp/STPManager/STPManager.h"
+#include "stp/Simplifier/AchievableImage.h"
 #include "stp/Simplifier/Simplifier.h"
 
 namespace stp
@@ -51,6 +52,14 @@ class RemoveUnconstrained
 
   bool tryGroundPathCollapse(MutableASTNode& muteNode,
                              vector<MutableASTNode*>& variables);
+
+  bool tryImageConstrainShared(const ASTNode& var, MutableASTNode& sharedNode,
+                               const GroundStep& step,
+                               vector<MutableASTNode*>& variables);
+
+  // Membership constraints produced by tryImageConstrainShared during a
+  // topLevel_other() run; conjoined onto the result before returning.
+  ASTVec imageConstraints;
 
   void replace(const ASTNode& from, const ASTNode to);
 

--- a/lib/Simplifier/RemoveUnconstrained.cpp
+++ b/lib/Simplifier/RemoveUnconstrained.cpp
@@ -128,6 +128,202 @@ static ASTNode applyStepToNode(NodeFactory* nf, STPMgr& bm,
   return nf->CreateTerm(s.kind, s.outWidth, s.constants[0], in);
 }
 
+/* A shared non-surjective single-step chain: t = op(x, c) has several
+ * parents, so no predicate-level collapse is possible -- pinning x for
+ * one consumer would change the others. But t's image is exactly and
+ * cheaply expressible, so replace t ITSELF with a fresh variable v,
+ * conjoin "v is in the image" onto the formula, and define x as a
+ * projection of v:
+ *
+ *    exists x. phi(t(x))   <=>   exists v. v in Image(t)  /\  phi(v)
+ *
+ * e.g. shared (concat 0 x) becomes v with high bits pinned to zero and
+ * x := extract(v). Consumers then see a variable, which the
+ * symbol-keyed passes (equality propagation, the bit-vector solver, the
+ * disjoint-extract splitter, this pass itself) can work with.
+ *
+ * Note this rewrite satisfies equisatisfiability with model mapping (a
+ * model of the result maps back through x := projection(v)), not the
+ * stronger pointwise identity the constant-witness rules satisfy: off
+ * the image, t(projection(v)) differs from v, which is exactly what the
+ * conjoined constraint excludes.
+ */
+bool RemoveUnconstrained::tryImageConstrainShared(
+    const ASTNode& var, MutableASTNode& sharedNode, const GroundStep& step,
+    vector<MutableASTNode*>& variables)
+{
+  if (step.samePathAllOperands)
+    return false; // squares: image genuinely scattered
+
+  const unsigned w = step.inWidth;
+  const unsigned W = step.outWidth;
+
+  const auto extractOf = [&](const ASTNode& n, unsigned high, unsigned low) {
+    return nf->CreateTerm(BVEXTRACT, high - low + 1, n,
+                          bm.CreateBVConst(32, high),
+                          bm.CreateBVConst(32, low));
+  };
+  // A constant's value when it fits a machine word.
+  const auto constToU64 = [](const ASTNode& n, uint64_t& out) {
+    const CBV c = n.GetBVConst();
+    if (CONSTANTBV::Set_Max(c) >= 32)
+      return false;
+    out = ((unsigned*)c)[0];
+    return true;
+  };
+
+  ASTNode v = bm.CreateFreshVariable(0, W, "unconstrained_image");
+  ASTNode constraint, projection;
+
+  switch (step.kind)
+  {
+    case BVCONCAT:
+    {
+      const ASTNode c = step.constants[0];
+      const unsigned cw = c.GetValueWidth();
+      if (step.pathIndex == 1) // c ++ x: the high bits equal c
+      {
+        constraint = nf->CreateNode(EQ, extractOf(v, W - 1, w), c);
+        projection = extractOf(v, w - 1, 0);
+      }
+      else // x ++ c: the low bits equal c
+      {
+        constraint = nf->CreateNode(EQ, extractOf(v, cw - 1, 0), c);
+        projection = extractOf(v, W - 1, cw);
+      }
+      break;
+    }
+
+    case BVZX:
+    {
+      if (W == w)
+        return false;
+      constraint =
+          nf->CreateNode(EQ, extractOf(v, W - 1, w), bm.CreateZeroConst(W - w));
+      projection = extractOf(v, w - 1, 0);
+      break;
+    }
+
+    case BVSX:
+    {
+      if (W == w)
+        return false;
+      // The image is the fixed points of re-extension.
+      projection = extractOf(v, w - 1, 0);
+      constraint = nf->CreateNode(
+          EQ, v,
+          nf->CreateTerm(BVSX, W, projection, bm.CreateBVConst(32, W)));
+      break;
+    }
+
+    case BVMULT:
+    {
+      // c = 2^s * o with o odd and s > 0 (odd constants are bijective
+      // and consumed by the per-kind rule): the image is the multiples
+      // of 2^s, and x = (v >> s) * o^-1 inverts it.
+      const CBV c = step.constants[0].GetBVConst();
+      if (CONSTANTBV::BitVector_is_empty(c))
+        return false;
+      const unsigned s = (unsigned)CONSTANTBV::Set_Min(c);
+      if (s == 0)
+        return false;
+      CBV oc = CONSTANTBV::BitVector_Create(W, true);
+      CONSTANTBV::BitVector_Interval_Copy(oc, c, 0, s, W - s);
+      const ASTNode oInv =
+          simplifier->MultiplicativeInverse(bm.CreateBVConst(oc, W));
+      constraint = nf->CreateNode(EQ, extractOf(v, s - 1, 0),
+                                  bm.CreateZeroConst(s));
+      projection = nf->CreateTerm(
+          BVMULT, W, oInv,
+          nf->CreateTerm(BVRIGHTSHIFT, W, v, bm.CreateBVConst(W, s)));
+      break;
+    }
+
+    case BVLEFTSHIFT:
+    {
+      uint64_t k;
+      if (step.pathIndex != 0 || !constToU64(step.constants[0], k) || k == 0 ||
+          k >= W)
+        return false;
+      constraint = nf->CreateNode(EQ, extractOf(v, (unsigned)k - 1, 0),
+                                  bm.CreateZeroConst((unsigned)k));
+      projection = nf->CreateTerm(BVRIGHTSHIFT, W, v, step.constants[0]);
+      break;
+    }
+
+    case BVRIGHTSHIFT:
+    {
+      uint64_t k;
+      if (step.pathIndex != 0 || !constToU64(step.constants[0], k) || k == 0 ||
+          k >= W)
+        return false;
+      constraint = nf->CreateNode(EQ, extractOf(v, W - 1, W - (unsigned)k),
+                                  bm.CreateZeroConst((unsigned)k));
+      projection = nf->CreateTerm(BVLEFTSHIFT, W, v, step.constants[0]);
+      break;
+    }
+
+    case BVAND:
+    {
+      // A low mask behaves as mod 2^kb: high bits zero, x := v.
+      const CBV c = step.constants[0].GetBVConst();
+      if (CONSTANTBV::BitVector_is_empty(c) ||
+          CONSTANTBV::BitVector_is_full(c))
+        return false;
+      const unsigned kb = (unsigned)CONSTANTBV::Set_Max(c) + 1;
+      CBV lowMask = CONSTANTBV::BitVector_Create(W, true);
+      CONSTANTBV::BitVector_Interval_Fill(lowMask, 0, kb - 1);
+      const bool isLowMask = CONSTANTBV::BitVector_equal(c, lowMask);
+      CONSTANTBV::BitVector_Destroy(lowMask);
+      if (!isLowMask || kb >= W)
+        return false;
+      constraint = nf->CreateNode(EQ, extractOf(v, W - 1, kb),
+                                  bm.CreateZeroConst(W - kb));
+      projection = v;
+      break;
+    }
+
+    case BVMOD:
+    {
+      const ASTNode c = step.constants[0];
+      if (step.pathIndex != 0 ||
+          CONSTANTBV::BitVector_is_empty(c.GetBVConst()))
+        return false;
+      constraint = nf->CreateNode(BVLT, v, c);
+      projection = v;
+      break;
+    }
+
+    case BVDIV:
+    {
+      const ASTNode c = step.constants[0];
+      if (step.pathIndex != 0 ||
+          CONSTANTBV::BitVector_is_empty(c.GetBVConst()))
+        return false;
+      // Image is [0, allones / c]; x = v * c re-divides to v within it.
+      std::vector<CBV> args = {nullptr, nullptr};
+      CBV ones = CONSTANTBV::BitVector_Create(W, true);
+      CONSTANTBV::BitVector_Fill(ones);
+      args[0] = ones;
+      args[1] = c.GetBVConst();
+      CBV q = NonMemberBVConstEvaluator(BVDIV, args, W);
+      CONSTANTBV::BitVector_Destroy(ones);
+      constraint = nf->CreateNode(BVLE, v, bm.CreateBVConst(q, W));
+      projection = nf->CreateTerm(BVMULT, W, v, c);
+      break;
+    }
+
+    default:
+      return false;
+  }
+
+  assert(projection.GetValueWidth() == var.GetValueWidth());
+  sharedNode.replaceWithVar(v, variables);
+  replace(var, projection);
+  imageConstraints.push_back(constraint);
+  return true;
+}
+
 /* When none of the per-kind rules fired for `var` (each detaches the
  * variable when it does), generalise: climb from the variable towards the
  * root while every node on the way is single-use and every sibling is a
@@ -312,9 +508,15 @@ bool RemoveUnconstrained::tryGroundPathCollapse(
 
     steps.push_back(step);
 
-    // Interior nodes must be single-use to step past them.
+    // Interior nodes must be single-use to step past them. A shared
+    // single-step chain may still be eliminated by constraining a fresh
+    // variable to its image.
     if (parent.parents.size() != 1)
+    {
+      if (steps.size() == 1 && frames.empty())
+        return tryImageConstrainShared(var, parent, steps[0], variables);
       return false;
+    }
     cur = &parent;
   }
   if (predicate == NULL)
@@ -481,6 +683,8 @@ ASTNode RemoveUnconstrained::topLevel_other(const ASTNode& n,
     return n; // top level is an unconstrained symbol/.
 
   this->simplifier = simplifier;
+
+  imageConstraints.clear();
 
   MutableASTNode* topMutable = MutableASTNode::build(n);
 
@@ -1061,6 +1265,17 @@ ASTNode RemoveUnconstrained::topLevel_other(const ASTNode& n,
 
   ASTNode result = topMutable->toASTNode(&bm);
   topMutable->cleanup();
+
+  // Membership constraints for image-constrained fresh variables join
+  // the formula here, once the mutable tree is materialised.
+  if (!imageConstraints.empty())
+  {
+    ASTVec conj;
+    conj.push_back(result);
+    conj.insert(conj.end(), imageConstraints.begin(), imageConstraints.end());
+    result = nf->CreateNode(AND, conj);
+    imageConstraints.clear();
+  }
   // cout << result;
   if (result.GetKind() == SYMBOL)
   {

--- a/tests/unit-tests/RemoveUnconstrained_Exhaustive_Test.cpp
+++ b/tests/unit-tests/RemoveUnconstrained_Exhaustive_Test.cpp
@@ -256,6 +256,69 @@ struct Context
     checkEquivalent(back, result);
   }
 
+  // Equisatisfiability with model mapping, for the image-constrained
+  // rewrite: a fresh variable stands for a shared term, with a
+  // membership constraint conjoined. The pointwise identity the
+  // constant-witness rules satisfy does not hold off the image, so
+  // instead check that (a) every assignment satisfying `result` also
+  // satisfies the back-substituted original -- models map back -- and
+  // (b) original and result are satisfiable together or not at all.
+  void checkEquisat(const ASTNode& original, const ASTNode& result)
+  {
+    ASTNode back = backSubstitute(original);
+
+    ASTNodeSet symSet;
+    collectSymbols(result, symSet);
+    collectSymbols(back, symSet);
+    std::vector<ASTNode> syms(symSet.begin(), symSet.end());
+    unsigned long combos = 1;
+    for (const auto& s : syms)
+      combos *= domainSize(s);
+    ASSERT_LE(combos, 1u << 16) << "too many assignments";
+
+    bool resultSat = false;
+    for (unsigned long c = 0; c < combos; c++)
+    {
+      ASTNodeMap assignment;
+      unsigned long rest = c;
+      for (size_t i = 0; i < syms.size(); i++)
+      {
+        const unsigned size = domainSize(syms[i]);
+        assignment.insert({syms[i], valueFor(syms[i], rest % size)});
+        rest /= size;
+      }
+      ASTNodeMap a2 = assignment;
+      if (eval(result, assignment) == mgr.ASTTrue)
+      {
+        resultSat = true;
+        ASSERT_EQ(eval(back, a2), mgr.ASTTrue)
+            << "a model of the result failed to map back at assignment " << c;
+      }
+    }
+
+    ASTNodeSet oset;
+    collectSymbols(original, oset);
+    std::vector<ASTNode> osyms(oset.begin(), oset.end());
+    unsigned long ocombos = 1;
+    for (const auto& s : osyms)
+      ocombos *= domainSize(s);
+    ASSERT_LE(ocombos, 1u << 16);
+    bool origSat = false;
+    for (unsigned long c = 0; c < ocombos && !origSat; c++)
+    {
+      ASTNodeMap assignment;
+      unsigned long rest = c;
+      for (size_t i = 0; i < osyms.size(); i++)
+      {
+        const unsigned size = domainSize(osyms[i]);
+        assignment.insert({osyms[i], valueFor(osyms[i], rest % size)});
+        rest /= size;
+      }
+      origSat = (eval(original, assignment) == mgr.ASTTrue);
+    }
+    ASSERT_EQ(origSat, resultSat) << "satisfiability changed";
+  }
+
   // As checkSound, but the operator takes the surviving `keep` as one operand
   // (used for the binary comparisons, which have a dedicated one-sided rule).
   void checkSoundWithKeep(Kind k, bool termLevel)
@@ -1004,18 +1067,105 @@ TEST(RemoveUnconstrained_GroundPath, one_polarity_no_collapse)
   });
 }
 
-TEST(RemoveUnconstrained_GroundPath, shared_interior_no_collapse)
-{
-  // (x mod 4) is used twice: forcing x to witness values would change the
-  // second use, so the climb must refuse to step past a shared interior
-  // node. Also check the pass stays sound on this shape.
-  auto build = [](Context& c) {
-    ASTNode t = c.hf->CreateTerm(BVMOD, W, c.bv(), c.konst(4));
-    return c.hf->CreateNode(AND, c.hf->CreateNode(EQ, t, c.konst(2)),
-                            c.hf->CreateNode(BVGT, t, c.konst(1)));
-  };
-  expectNoCollapse(build);
+/////////////////////////////////////////////////////////////////////////////
+// 4) Image-constrained fresh variables: a shared non-surjective
+//    single-step term t(x) is replaced by a fresh v, "v in Image(t)" is
+//    conjoined, and x := projection(v). Checked with checkEquisat, since
+//    the pointwise identity doesn't hold off the image.
+/////////////////////////////////////////////////////////////////////////////
 
+// Runs the pass on `top`, requiring x to be eliminated and the rewrite
+// to be equisatisfiable with mapping models.
+static void checkImageConstrained(Context& c, const ASTNode& x,
+                                  const ASTNode& top)
+{
+  ASTNode result = c.run(top);
+  EXPECT_EQ(c.simp.Return_SolverMap()->count(x), 1u) << "x not eliminated";
+  c.checkEquisat(top, result);
+}
+
+TEST(RemoveUnconstrained_ImageConstrained, shared_urem)
+{
+  // (x mod 4) used twice: no predicate-level collapse is possible, but
+  // the term becomes v with (bvult v 4) conjoined and x := v.
   Context c;
-  c.checkSoundTop(build(c));
+  ASTNode x = c.bv();
+  ASTNode t = c.hf->CreateTerm(BVMOD, W, x, c.konst(4));
+  ASTNode top = c.hf->CreateNode(AND, c.hf->CreateNode(EQ, t, c.konst(2)),
+                                 c.hf->CreateNode(BVGT, t, c.konst(1)));
+  checkImageConstrained(c, x, top);
+}
+
+TEST(RemoveUnconstrained_ImageConstrained, shared_zero_extend)
+{
+  Context c;
+  ASTNode x = c.bv();
+  ASTNode t = c.hf->CreateTerm(BVZX, 2 * W, x, c.konst(2 * W, 32));
+  ASTNode top =
+      c.hf->CreateNode(AND, c.hf->CreateNode(EQ, t, c.konst(2, 2 * W)),
+                       c.hf->CreateNode(BVGT, t, c.konst(1, 2 * W)));
+  checkImageConstrained(c, x, top);
+}
+
+TEST(RemoveUnconstrained_ImageConstrained, shared_sign_extend)
+{
+  Context c;
+  ASTNode x = c.bv();
+  ASTNode t = c.hf->CreateTerm(BVSX, 2 * W, x, c.konst(2 * W, 32));
+  ASTNode top =
+      c.hf->CreateNode(AND, c.hf->CreateNode(EQ, t, c.konst(7, 2 * W)),
+                       c.hf->CreateNode(BVSGT, t, c.konst(0, 2 * W)));
+  checkImageConstrained(c, x, top);
+}
+
+TEST(RemoveUnconstrained_ImageConstrained, shared_concat_low_constant)
+{
+  // x ++ 2-bit constant, shared: low bits pinned, x := high extract.
+  Context c;
+  ASTNode x = c.bv();
+  ASTNode t = c.hf->CreateTerm(BVCONCAT, W + 2, x, c.konst(2, 2));
+  ASTNode top =
+      c.hf->CreateNode(AND, c.hf->CreateNode(EQ, t, c.konst(6, W + 2)),
+                       c.hf->CreateNode(BVGT, t, c.konst(1, W + 2)));
+  checkImageConstrained(c, x, top);
+}
+
+TEST(RemoveUnconstrained_ImageConstrained, shared_even_multiply)
+{
+  // 6 = 2 * 3: image is the even values; x := (v >> 1) * inverse(3).
+  Context c;
+  ASTNode x = c.bv();
+  ASTNode t = c.hf->CreateTerm(BVMULT, W, c.konst(6), x);
+  ASTNode top = c.hf->CreateNode(AND, c.hf->CreateNode(EQ, t, c.konst(4)),
+                                 c.hf->CreateNode(BVGT, t, c.konst(1)));
+  checkImageConstrained(c, x, top);
+}
+
+TEST(RemoveUnconstrained_ImageConstrained, shared_ashr_not_rewritten)
+{
+  // Arithmetic right shift isn't in the shape table: x must survive.
+  Context c;
+  ASTNode x = c.bv();
+  ASTNode t = c.hf->CreateTerm(BVSRSHIFT, W, x, c.konst(1));
+  ASTNode top = c.hf->CreateNode(AND, c.hf->CreateNode(EQ, t, c.konst(2)),
+                                 c.hf->CreateNode(BVGT, t, c.konst(1)));
+  ASTNode result = c.run(top);
+  EXPECT_EQ(c.simp.Return_SolverMap()->count(x), 0u);
+  ASTNode back = c.backSubstitute(top);
+  c.checkEquivalent(back, result);
+}
+
+TEST(RemoveUnconstrained_ImageConstrained, shared_multi_step_not_rewritten)
+{
+  // The shared node sits two steps up ((x mod 4) + 1): single-step only.
+  Context c;
+  ASTNode x = c.bv();
+  ASTNode t = c.hf->CreateTerm(
+      BVPLUS, W, c.hf->CreateTerm(BVMOD, W, x, c.konst(4)), c.konst(1));
+  ASTNode top = c.hf->CreateNode(AND, c.hf->CreateNode(EQ, t, c.konst(2)),
+                                 c.hf->CreateNode(BVGT, t, c.konst(1)));
+  ASTNode result = c.run(top);
+  EXPECT_EQ(c.simp.Return_SolverMap()->count(x), 0u);
+  ASTNode back = c.backSubstitute(top);
+  c.checkEquivalent(back, result);
 }


### PR DESCRIPTION
## Summary

- The largest single shape among the remaining ground-path misses is a **shared derived term**: `zx(x)`, sign-extensions, checksum chunks of a single-use variable consumed by several parents (16k zero-extension events alone on bench-hard). Predicate-level collapse is impossible there, and a plain fresh variable is unsound (the image is smaller than the domain).
- When the variable's single-step chain ends at a shared `t = op(x, c)` whose image is exactly and cheaply expressible, replace **t itself** with a fresh `v`, conjoin `v ∈ Image(t)`, and define `x := projection(v)`: `∃x. φ(t(x)) ⟺ ∃v. v ∈ Image(t) ∧ φ(v)`.
- Shape table: concat with constant either side, zx (high bits zero), sx (fixed point of re-extension), even multiplies (low bits zero + odd-part inverse), constant shifts, low masks, constant modulus/division (interval bounds).
- Consumers then see a *variable*, unlocking the symbol-keyed passes (equality propagation, BVSolver, the disjoint-extract splitter, this pass itself).
- This rewrite is equisatisfiable **with model mapping**, not pointwise-identical after back-substitution — the new `checkEquisat` harness verifies both properties over every assignment.

## Testing

- Seven new tests: the five rewritten shapes, a kind outside the table (must decline), and a multi-step shared chain (must decline); suite 75/75.
- Full ctest and a 2,500-file differential sat/unsat sweep vs master to follow in checks; bench-hard impact numbers to be posted as a comment. Sized beforehand: 1,073 of 1,074 shared-node files on the hard set have ≥1 convertible node (833 fully convertible).