### PR TITLE
Install winflexbison from its upstream release, not Chocolatey

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -493,6 +493,7 @@ jobs:
         $dir = Join-Path $env:RUNNER_TEMP 'winflexbison'
 
         $attempts = 3
+        $backoff = @(15, 45)   # seconds, between attempts
         $ok = $false
         for ($i = 1; $i -le $attempts; $i++) {
           try {
@@ -509,8 +510,10 @@ jobs:
             break
           } catch {
             Write-Host "::warning::winflexbison download attempt $i failed: $_"
+            # Not sleeping after the final attempt: it only delays a failure
+            # that has already been decided.
             if ($i -lt $attempts) {
-              $delay = 15 * $i
+              $delay = $backoff[$i - 1]
               "Retrying in $delay s..."
               Start-Sleep -Seconds $delay
             }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -472,8 +472,78 @@ jobs:
       with:
           submodules: 'true'
 
+    # Fetched straight from the upstream release rather than via
+    # 'choco install winflexbison3': community.chocolatey.org intermittently
+    # answers 503, and choco exits 0 when it does ("installed 0/0 packages"),
+    # so the miss surfaced minutes later as "Could NOT find BISON" during CMake
+    # configure. This also pins the toolchain, which the choco install did not.
+    #
+    # 2.5.24 is the version the choco package resolved to; the archive holds
+    # win_flex.exe, win_bison.exe and bison's data/ skeleton directory, which
+    # bison locates relative to its own path, so it is extracted as a unit.
     - name: Install flex and bison
-      run: choco install winflexbison3 --no-progress
+      env:
+        WFB_VERSION: '2.5.24'
+        WFB_SHA256: '39c6086ce211d5415500acc5ed2d8939861ca1696aee48909c7f6daf5122b505'
+      run: |
+        $ErrorActionPreference = 'Continue'
+        $ProgressPreference = 'SilentlyContinue'
+        $url = "https://github.com/lexxmark/winflexbison/releases/download/v$env:WFB_VERSION/win_flex_bison-$env:WFB_VERSION.zip"
+        $zip = Join-Path $env:RUNNER_TEMP 'win_flex_bison.zip'
+        $dir = Join-Path $env:RUNNER_TEMP 'winflexbison'
+
+        $attempts = 3
+        $ok = $false
+        for ($i = 1; $i -le $attempts; $i++) {
+          try {
+            "Downloading $url (attempt $i/$attempts)"
+            Remove-Item $zip -ErrorAction SilentlyContinue
+            Invoke-WebRequest -Uri $url -OutFile $zip -UseBasicParsing
+            # A truncated body or an error page served with a 200 shows up here
+            # rather than as a thrown exception, so retry on mismatch too.
+            $hash = (Get-FileHash $zip -Algorithm SHA256).Hash
+            if ($hash -ne $env:WFB_SHA256.ToUpper()) {
+              throw "SHA256 mismatch: got $hash, expected $($env:WFB_SHA256.ToUpper())"
+            }
+            $ok = $true
+            break
+          } catch {
+            Write-Host "::warning::winflexbison download attempt $i failed: $_"
+            if ($i -lt $attempts) {
+              $delay = 15 * $i
+              "Retrying in $delay s..."
+              Start-Sleep -Seconds $delay
+            }
+          }
+        }
+        if (-not $ok) {
+          Write-Host "::error::Could not download winflexbison $env:WFB_VERSION after $attempts attempts."
+          exit 1
+        }
+
+        Expand-Archive -Path $zip -DestinationPath $dir -Force
+        # CMake's FindBISON/FindFLEX search for these names on Windows.
+        foreach ($exe in 'win_bison.exe', 'win_flex.exe') {
+          $path = Join-Path $dir $exe
+          if (-not (Test-Path $path)) {
+            Write-Host "::error::$exe missing from the extracted archive."
+            exit 1
+          }
+          # Also catches a binary that unpacked but cannot run at all. Both
+          # are cleared first: if the launch fails, the assignment never runs
+          # and $LASTEXITCODE is left untouched, so the previous binary's
+          # output and exit code would otherwise be read as this one's success.
+          $out = $null
+          $global:LASTEXITCODE = $null
+          try { $out = (& $path --version 2>&1 | Out-String).Trim() } catch { $out = $null }
+          if ($LASTEXITCODE -ne 0 -or -not $out) {
+            Write-Host "::error::$exe failed to run (exit $LASTEXITCODE): $out"
+            exit 1
+          }
+          ($out -split "`n")[0]
+        }
+        # Applies to subsequent steps only, hence the full paths just above.
+        $dir | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
 
     - name: Install zlib
       run: |


### PR DESCRIPTION
The Windows job installs flex and bison with `choco install winflexbison3`. `community.chocolatey.org` intermittently answers 503, and **choco exits 0 when it does** — it prints `Chocolatey installed 0/0 packages` and the step passes. The miss then surfaces minutes later as `Could NOT find BISON (missing: BISON_EXECUTABLE)` during CMake configure, after vcpkg and the minisat build have already run. Example: [run 30353379324](https://github.com/stp/stp/actions/runs/30353379324/job/90257492913).

This fetches the pinned release archive from the upstream GitHub project instead and verifies its SHA256, dropping `community.chocolatey.org` as a dependency of the job. GitHub is already a hard dependency via `actions/checkout` and the minisat clone, so this removes a single point of failure rather than making the job more patient about it. It also pins the toolchain, which the unpinned `choco install` did not — 2.5.24 is the version the choco package resolved to, so the tool itself is unchanged.

The download retries three times (15s, 45s) and the step fails with an `::error::` annotation if it never succeeds, so an outage is reported where it happens instead of at configure time.

### Notes

- The archive holds `win_flex.exe`, `win_bison.exe` and bison's `data/` skeleton directory, which bison locates relative to its own path, so it is extracted as a unit.
- `$out` and `$LASTEXITCODE` are cleared before each `--version` check deliberately. If a binary fails to launch, the assignment never runs and the exit code is left untouched, so the previous binary's output and exit code would otherwise be read as this one's success — the same silent-pass class of bug as the choco issue being fixed.
- Verified by running the step under PowerShell 7.4: success, checksum mismatch, HTTP 404, missing binary, binary exiting nonzero, and a second binary failing to launch after the first succeeded. Every failure mode fails the step; only the success path writes to `$GITHUB_PATH`.

### Relationship to #685

#685 fixes the same bug by keeping Chocolatey and retrying it up to five times. That is a smaller change (11 lines vs ~70) and needs no pinned version, but every attempt still depends on `community.chocolatey.org`, so an outage that outlasts the backoff still fails the job. **These two are alternatives — only one should land.** Happy to close this one if the simpler approach is preferred.

One thing worth taking from this PR either way: #685's loop sleeps after its *final* attempt, so a hard failure spends 30+60+90+120+150s of sleep before throwing. Guarding that sleep with `if ($attempt -lt 5)` saves ~2.5 minutes on a failing run.