### PR TITLE
Slice equalities over concatenations of an unconstrained variable

### DIFF
--- a/lib/Simplifier/RemoveUnconstrained.cpp
+++ b/lib/Simplifier/RemoveUnconstrained.cpp
@@ -182,6 +182,17 @@ bool RemoveUnconstrained::tryGroundPathCollapse(
   const size_t MAX_ITE_FRAMES = 4;
   std::vector<IteFrame> frames;
 
+  // Concat frames: BVCONCAT nodes with a possibly-symbolic sibling.
+  // Equality distributes over concatenation slice by slice, so these
+  // need no image -- but only pure concatenation may then sit between
+  // the variable and the predicate, and the predicate must be EQ.
+  struct ConcatFrame
+  {
+    MutableASTNode* sibling;
+    bool pathHigh; // the path is child 0 (the high part)
+  };
+  std::vector<ConcatFrame> cframes;
+
   MutableASTNode* cur = &muteNode;
   for (unsigned depth = 0; depth < AchievableImage::MAX_PATH; depth++)
   {
@@ -191,6 +202,80 @@ bool RemoveUnconstrained::tryGroundPathCollapse(
 
     if (p.GetValueWidth() == 0)
     {
+      if (!cframes.empty())
+      {
+        // Slicing mode: an equality against ANY term splits by bit
+        // range. x is defined as its slice of the other side (falsity
+        // survives through the sibling slices' residual equalities, so
+        // no fresh boolean is needed).
+        if (p.GetKind() != EQ || kids.size() != 2)
+          return false;
+        const bool eqPathFirst = (kids[0] == cur);
+        if (kids[0] == kids[1] || (!eqPathFirst && kids[1] != cur))
+          return false;
+        MutableASTNode* otherM = eqPathFirst ? kids[1] : kids[0];
+        if (otherM->n.GetValueWidth() != cur->n.GetValueWidth())
+          return false;
+
+        // Unwrap the frames innermost-out into a high-to-low slice
+        // list; a NULL node marks the variable's own slice.
+        struct Slice
+        {
+          MutableASTNode* node;
+          unsigned width;
+        };
+        std::vector<Slice> slices;
+        slices.push_back({NULL, var.GetValueWidth()});
+        for (const ConcatFrame& cf : cframes)
+        {
+          const Slice s = {cf.sibling, cf.sibling->n.GetValueWidth()};
+          if (cf.pathHigh)
+            slices.push_back(s);
+          else
+            slices.insert(slices.begin(), s);
+        }
+
+        const ASTNode t = otherM->toASTNode(&bm);
+        ASTNode varDef;
+        ASTVec residuals;
+        vector<MutableASTNode*> vars;
+        std::unordered_set<MutableASTNode*> visited;
+        otherM->getAllVariablesRecursively(vars, visited);
+        long hiBit = (long)t.GetValueWidth() - 1;
+        for (const Slice& s : slices)
+        {
+          const long loBit = hiBit + 1 - (long)s.width;
+          ASTNode piece =
+              nf->CreateTerm(BVEXTRACT, s.width, t,
+                             bm.CreateBVConst(32, (unsigned long long)hiBit),
+                             bm.CreateBVConst(32, (unsigned long long)loBit));
+          if (s.node == NULL)
+            varDef = piece;
+          else
+          {
+            residuals.push_back(
+                nf->CreateNode(EQ, s.node->toASTNode(&bm), piece));
+            s.node->getAllVariablesRecursively(vars, visited);
+          }
+          hiBit = loBit - 1;
+        }
+        assert(hiBit == -1);
+        visited.clear();
+
+        ASTNode newP = (residuals.size() == 1)
+                           ? residuals[0]
+                           : nf->CreateNode(AND, residuals);
+
+        std::unordered_map<uint64_t, MutableASTNode*> create;
+        for (MutableASTNode* m : vars)
+          create.insert(std::make_pair(m->n.GetNodeNum(), m));
+        vars.clear();
+
+        parent.replaceWithAnotherNode(MutableASTNode::build(newP, create));
+        replace(var, varDef);
+        return true;
+      }
+
       // Boolean level: a predicate between the chain and a constant.
       if (!AchievableImage::predicateKind(p.GetKind()) || kids.size() != 2)
         return false;
@@ -209,6 +294,31 @@ bool RemoveUnconstrained::tryGroundPathCollapse(
 
     // Term level: one path child, constants everywhere else.
     const Kind kind = p.GetKind();
+
+    // Once slicing has begun, only further concatenation can follow.
+    if (!cframes.empty() && kind != BVCONCAT)
+      return false;
+
+    if (kind == BVCONCAT && kids.size() == 2 &&
+        ((kids[0] == cur) != (kids[1] == cur)))
+    {
+      const bool pathHigh = (kids[0] == cur);
+      MutableASTNode* sib = pathHigh ? kids[1] : kids[0];
+      // Enter slicing mode at the first symbolic sibling, but only from
+      // the bare variable (no image steps or ITE frames below); once in
+      // it, constant siblings become frames too.
+      if (!cframes.empty() ||
+          (!sib->n.isConstant() && steps.empty() && frames.empty()))
+      {
+        cframes.push_back({sib, pathHigh});
+        if (parent.parents.size() != 1)
+          return false;
+        cur = &parent;
+        continue;
+      }
+      // Constant sibling outside slicing mode: the ordinary image step
+      // below handles it.
+    }
 
     if (kind == ITE && p.GetValueWidth() > 0)
     {

--- a/tests/unit-tests/RemoveUnconstrained_Exhaustive_Test.cpp
+++ b/tests/unit-tests/RemoveUnconstrained_Exhaustive_Test.cpp
@@ -922,6 +922,128 @@ TEST(RemoveUnconstrained_GroundPath, ite_frame_cap_declines)
   c.checkEquivalent(back, result);
 }
 
+/////////////////////////////////////////////////////////////////////////////
+// Concat-frame equality slicing: (= (concat x y) t) with x single-use
+// splits by bit range -- x := its slice of t, one residual equality per
+// sibling slice. Pointwise sound (falsity survives through the sibling
+// residuals), so checkSoundTop applies.
+/////////////////////////////////////////////////////////////////////////////
+
+TEST(RemoveUnconstrained_ConcatSlice, basic)
+{
+  // (= (concat x y) t): x := extract_hi(t), residual (= y extract_lo(t)).
+  Context c;
+  ASTNode x = c.bv();
+  ASTNode y = c.bv();
+  ASTNode t = c.bv(2 * W);
+  ASTNode top = c.hf->CreateNode(
+      AND, c.hf->CreateNode(EQ, c.hf->CreateTerm(BVCONCAT, 2 * W, x, y), t),
+      c.anchorFor(y), c.anchorFor(t));
+
+  ASTNode result = c.run(top);
+  EXPECT_EQ(c.simp.Return_SolverMap()->count(x), 1u) << "x not eliminated";
+  ASTNode back = c.backSubstitute(top);
+  c.checkEquivalent(back, result);
+}
+
+TEST(RemoveUnconstrained_ConcatSlice, nested_with_constant_slice)
+{
+  // (= (concat 5:4 (concat x y)) t): the constant becomes a residual
+  // equality against t's high slice, y one against the low slice, and
+  // x := the middle slice.
+  Context c;
+  ASTNode x = c.bv();
+  ASTNode y = c.bv();
+  ASTNode t = c.bv(4 + 2 * W);
+  ASTNode inner = c.hf->CreateTerm(BVCONCAT, 2 * W, x, y);
+  ASTNode outer = c.hf->CreateTerm(BVCONCAT, 4 + 2 * W, c.konst(5, 4), inner);
+  ASTNode top = c.hf->CreateNode(AND, c.hf->CreateNode(EQ, outer, t),
+                                 c.anchorFor(y), c.anchorFor(t));
+
+  ASTNode result = c.run(top);
+  EXPECT_EQ(c.simp.Return_SolverMap()->count(x), 1u) << "x not eliminated";
+  ASTNode back = c.backSubstitute(top);
+  c.checkEquivalent(back, result);
+}
+
+TEST(RemoveUnconstrained_ConcatSlice, free_sibling_cascades)
+{
+  // y is also single-use: the residual (= y extract_lo(t)) re-enters the
+  // worklist and the EQ rule introduces the fresh boolean there --
+  // exactly when falsity would otherwise be lost.
+  Context c;
+  ASTNode x = c.bv();
+  ASTNode y = c.bv();
+  ASTNode t = c.bv(2 * W);
+  ASTNode top = c.hf->CreateNode(
+      AND, c.hf->CreateNode(EQ, c.hf->CreateTerm(BVCONCAT, 2 * W, x, y), t),
+      c.anchorFor(t));
+
+  ASTNode result = c.run(top);
+  EXPECT_EQ(c.simp.Return_SolverMap()->count(x), 1u);
+  EXPECT_EQ(c.simp.Return_SolverMap()->count(y), 1u);
+  ASTNode back = c.backSubstitute(top);
+  c.checkEquivalent(back, result);
+}
+
+TEST(RemoveUnconstrained_ConcatSlice, constant_other_side)
+{
+  // Built with the hashing factory, so the SimplifyingNodeFactory's own
+  // constant-splitting hasn't pre-empted the pass.
+  Context c;
+  ASTNode x = c.bv();
+  ASTNode y = c.bv();
+  ASTNode top = c.hf->CreateNode(
+      AND,
+      c.hf->CreateNode(EQ, c.hf->CreateTerm(BVCONCAT, 2 * W, x, y),
+                       c.konst(37, 2 * W)),
+      c.anchorFor(y));
+
+  ASTNode result = c.run(top);
+  EXPECT_EQ(c.simp.Return_SolverMap()->count(x), 1u);
+  ASTNode back = c.backSubstitute(top);
+  c.checkEquivalent(back, result);
+}
+
+TEST(RemoveUnconstrained_ConcatSlice, comparison_not_sliced)
+{
+  // Slicing distributes over equality only: a comparison must decline.
+  Context c;
+  ASTNode x = c.bv();
+  ASTNode y = c.bv();
+  ASTNode t = c.bv(2 * W);
+  ASTNode top = c.hf->CreateNode(
+      AND, c.hf->CreateNode(BVGT, c.hf->CreateTerm(BVCONCAT, 2 * W, x, y), t),
+      c.anchorFor(y), c.anchorFor(t));
+
+  ASTNode result = c.run(top);
+  EXPECT_EQ(c.simp.Return_SolverMap()->count(x), 0u);
+  ASTNode back = c.backSubstitute(top);
+  c.checkEquivalent(back, result);
+}
+
+TEST(RemoveUnconstrained_ConcatSlice, shared_concat_not_sliced)
+{
+  // The concat feeds two predicates: rewriting one context would be
+  // wrong, so the single-use check must refuse.
+  Context c;
+  ASTNode x = c.bv();
+  ASTNode y = c.bv();
+  ASTNode t = c.bv(2 * W);
+  ASTNode cc = c.hf->CreateTerm(BVCONCAT, 2 * W, x, y);
+  ASTVec conj;
+  conj.push_back(c.hf->CreateNode(EQ, cc, t));
+  conj.push_back(c.hf->CreateNode(BVGT, cc, c.konst(1, 2 * W)));
+  conj.push_back(c.anchorFor(y));
+  conj.push_back(c.anchorFor(t));
+  ASTNode top = c.hf->CreateNode(AND, conj);
+
+  ASTNode result = c.run(top);
+  EXPECT_EQ(c.simp.Return_SolverMap()->count(x), 0u);
+  ASTNode back = c.backSubstitute(top);
+  c.checkEquivalent(back, result);
+}
+
 // --- Cases that must NOT collapse. ---
 
 TEST(RemoveUnconstrained_GroundPath, one_polarity_no_collapse)


### PR DESCRIPTION
## Summary

- The factory already splits `(= (concat a b) K)` against a **constant**; equalities against symbolic terms never split, so `(= (concat x y) t)` with x single-use survives the pipeline (the log-slicing family is built almost entirely from such equalities).
- The climb now steps through `BVCONCAT` nodes with symbolic siblings (pure concatenation only, from the bare variable), and at an equality against **any** term slices by bit range: `x := extract_hi(t)`, one residual equality per sibling slice.
- **No fresh boolean is needed**: x's conjunct becomes identically true under its definition, and falsity survives through the sibling residuals. The rewrite is pointwise, so it holds in any polarity and under shared predicates, and when a sibling slice is itself free, its residual re-enters the worklist and the EQ rule introduces the boolean exactly where falsity would otherwise be lost.

## Testing

- Six new tests: basic split, nested frames with a constant slice, cascading free sibling, constant other side via the hashing factory, and refusals for comparisons and shared concats — back-substitution equivalence over every assignment (72/72 suite).
- Full ctest and the 2,500-file differential sweep vs master to follow; per-file impact on the log-slicing family to be posted as a comment.