### PR TITLE
Collapse predicates one-sidedly when their polarity is pure

### DIFF
--- a/include/stp/Simplifier/AchievableImage.h
+++ b/include/stp/Simplifier/AchievableImage.h
@@ -112,6 +112,13 @@ public:
   // it can, returns validated witnesses for x.
   Decision decide(Kind pred, bool pathIsFirstOperand, const ASTNode& k);
 
+  // Whether the predicate can be forced to `desired` by choice of x,
+  // with a validated witness. Weaker than decide(): the caller must
+  // separately establish that fixing this one outcome is sound (the
+  // predicate's global polarity only benefits from it).
+  bool decideOneSided(Kind pred, bool pathIsFirstOperand, const ASTNode& k,
+                      bool desired, ASTNode& witness);
+
   static bool handledKind(Kind k);
   static bool predicateKind(Kind k);
 

--- a/lib/Simplifier/AchievableImage.cpp
+++ b/lib/Simplifier/AchievableImage.cpp
@@ -1216,4 +1216,98 @@ AchievableImage::Decision AchievableImage::decide(Kind pred,
   decision.witnessFalse = bm.CreateBVConst(xFalse, varWidth); // takes ownership
   return decision;
 }
+
+bool AchievableImage::decideOneSided(Kind pred, bool pathIsFirstOperand,
+                                     const ASTNode& kNode, bool desired,
+                                     ASTNode& witness)
+{
+  if (!predicateKind(pred))
+    return false;
+  assert(kNode.isConstant() && kNode.GetValueWidth() == curWidth);
+  const CBV k = kNode.GetBVConst();
+
+  CBV x = NULL;
+
+  if (rep == Rep::Exact)
+  {
+    CBV member = NULL; // owned member of [lo, hi]
+    if (pred == EQ)
+    {
+      if (desired)
+      {
+        if (ucmp(lo, k) <= 0 && ucmp(k, hi) <= 0)
+          member = clone(k);
+      }
+      else
+      {
+        // Any member != k; an endpoint works unless the interval is
+        // the single point k.
+        if (ucmp(lo, k) != 0)
+          member = clone(lo);
+        else if (ucmp(hi, k) != 0)
+          member = clone(hi);
+      }
+    }
+    else
+    {
+      // The best member for the wanted polarity is an extreme in the
+      // comparison's order; see decide() for the signed correction.
+      CBV mn, mx;
+      const bool isSigned =
+          (pred == BVSGT || pred == BVSGE || pred == BVSLT || pred == BVSLE);
+      const bool crossing =
+          !CONSTANTBV::BitVector_bit_test(lo, curWidth - 1) &&
+          CONSTANTBV::BitVector_bit_test(hi, curWidth - 1);
+      if (isSigned && crossing)
+      {
+        mx = mkOnes(curWidth);
+        CONSTANTBV::BitVector_Bit_Off(mx, curWidth - 1);
+        mn = mkZero(curWidth);
+        CONSTANTBV::BitVector_Bit_On(mn, curWidth - 1);
+      }
+      else
+      {
+        mn = clone(lo);
+        mx = clone(hi);
+      }
+      const bool greater =
+          (pred == BVGT || pred == BVGE || pred == BVSGT || pred == BVSGE);
+      const bool trueAtMax = (greater == pathIsFirstOperand);
+      CBV candidate = (desired == trueAtMax) ? mx : mn;
+      if (evalPredicate(pred, pathIsFirstOperand, candidate, k) == desired)
+        member = clone(candidate);
+      destroy(mn);
+      destroy(mx);
+    }
+    if (member == NULL)
+      return false;
+    x = invertPrefix(member);
+  }
+  else
+  {
+    for (const Sample& s : samples)
+    {
+      if (evalPredicate(pred, pathIsFirstOperand, s.value, k) == desired)
+      {
+        x = clone(s.witness);
+        break;
+      }
+    }
+    if (x == NULL)
+      return false;
+  }
+
+  // As in decide(): this forward check is what makes the rewrite
+  // sound. A failure here is a transfer/inversion bug.
+  const bool ok = validate(x, pred, pathIsFirstOperand, k, desired);
+  assert(ok);
+  if (!ok)
+  {
+    destroy(x);
+    return false;
+  }
+
+  witness = bm.CreateBVConst(x, varWidth); // takes ownership
+  return true;
+}
 }

--- a/lib/Simplifier/RemoveUnconstrained.cpp
+++ b/lib/Simplifier/RemoveUnconstrained.cpp
@@ -127,6 +127,111 @@ static ASTNode applyStepToNode(NodeFactory* nf, STPMgr& bm,
   return nf->CreateTerm(s.kind, s.outWidth, s.constants[0], in);
 }
 
+// Constant-evaluate one collected step on a known input value.
+static ASTNode evalStepOnConstant(STPMgr& bm, const GroundStep& s,
+                                  const ASTNode& in)
+{
+  std::vector<CBV> args;
+  if (s.samePathAllOperands)
+  {
+    args.push_back(in.GetBVConst());
+    args.push_back(in.GetBVConst());
+  }
+  else if (s.kind == BVSX || s.kind == BVZX)
+  {
+    // The evaluator takes the new width from outWidth.
+    args.push_back(in.GetBVConst());
+  }
+  else
+  {
+    const size_t arity = s.constants.size() + 1;
+    size_t ci = 0;
+    for (size_t i = 0; i < arity; i++)
+    {
+      if (i == s.pathIndex)
+        args.push_back(in.GetBVConst());
+      else
+        args.push_back(s.constants[ci++].GetBVConst());
+    }
+  }
+  return bm.CreateBVConst(NonMemberBVConstEvaluator(s.kind, args, s.outWidth),
+                          s.outWidth);
+}
+
+/* Global polarity of a boolean node within the live mutable tree: the
+ * union, over every occurrence and every path to the root, of the
+ * negation parity along it. POL_POS alone means the formula is monotone
+ * non-decreasing in the node (making it true can only help), POL_NEG
+ * the dual. ITE conditions, XOR/IFF operands and anything unrecognised
+ * get both. Only pure single-polarity predicates admit the one-sided
+ * collapse. */
+static const unsigned POL_POS = 1;
+static const unsigned POL_NEG = 2;
+
+static unsigned flipPolarity(unsigned p)
+{
+  return ((p & POL_POS) ? POL_NEG : 0u) | ((p & POL_NEG) ? POL_POS : 0u);
+}
+
+static unsigned
+polarityOf(MutableASTNode* node,
+           std::unordered_map<MutableASTNode*, unsigned>& memo)
+{
+  const auto it = memo.find(node);
+  if (it != memo.end())
+    return it->second;
+
+  // A parentless node is the root. (Pruned nodes are unlinked from
+  // their children's parent sets, so every parent seen here is live.)
+  unsigned pol = node->parents.empty() ? POL_POS : 0;
+  for (MutableASTNode* p : node->parents)
+  {
+    if (p->n.GetValueWidth() != 0 || p->n.GetIndexWidth() != 0)
+    {
+      pol |= POL_POS | POL_NEG; // a term-level ITE's condition
+      continue;
+    }
+    const unsigned pp = polarityOf(p, memo);
+    const vector<MutableASTNode*>& kids = p->children;
+    for (size_t i = 0; i < kids.size(); i++)
+    {
+      if (kids[i] != node)
+        continue;
+      switch (p->n.GetKind())
+      {
+        case AND:
+        case OR:
+          pol |= pp;
+          break;
+        case NOT:
+        case NAND:
+        case NOR:
+          pol |= flipPolarity(pp);
+          break;
+        case IMPLIES:
+          pol |= (i == 0) ? flipPolarity(pp) : pp;
+          break;
+        case ITE: // boolean-valued: branches follow it, the condition both.
+          pol |= (i == 0) ? (POL_POS | POL_NEG) : pp;
+          break;
+        default: // XOR, IFF, PARAMBOOL, ...: no monotonicity.
+          pol |= POL_POS | POL_NEG;
+          break;
+      }
+    }
+    if (pol == (POL_POS | POL_NEG))
+      break;
+  }
+  memo.insert(std::make_pair(node, pol));
+  return pol;
+}
+
+static unsigned polarityOf(MutableASTNode* node)
+{
+  std::unordered_map<MutableASTNode*, unsigned> memo;
+  return polarityOf(node, memo);
+}
+
 /* When none of the per-kind rules fired for `var` (each detaches the
  * variable when it does), generalise: climb from the variable towards the
  * root while every node on the way is single-use and every sibling is a
@@ -152,6 +257,18 @@ static ASTNode applyStepToNode(NodeFactory* nf, STPMgr& bm,
  * changing its meaning. The predicate node itself may be shared, since
  * under the recorded definition every occurrence of it evaluates to v
  * (or to the distributed ITE, which is a pure equivalence).
+ *
+ * A non-constant sibling makes the image unknowable, but one value can
+ * survive it: forcing the path to an absorbing element (0 through
+ * bvand/bvmul, ones through bvor) fixes the chain regardless of the
+ * sibling -- e.g. (= (bvand x t) 0) is forced true by x := 0. A single
+ * known outcome can only collapse the predicate one way, which is
+ * sound exactly when the predicate's global polarity is pure and
+ * prefers that outcome: any model of the original formula can flip the
+ * predicate to the preferred value without falsifying it (monotonicity),
+ * and any model of the rewrite extends with x := witness, which
+ * realises the value. The same one-sided rule also rescues all-constant
+ * chains where only one polarity is achievable.
  */
 bool RemoveUnconstrained::tryGroundPathCollapse(
     MutableASTNode& muteNode, vector<MutableASTNode*>& variables)
@@ -192,6 +309,16 @@ bool RemoveUnconstrained::tryGroundPathCollapse(
     bool pathHigh; // the path is child 0 (the high part)
   };
   std::vector<ConcatFrame> cframes;
+
+  // Singleton mode: a symbolic sibling at an absorbing operator ends
+  // image tracking, but one value survives it -- forcing the path to
+  // the operator's absorbing element fixes the output regardless of
+  // the sibling, e.g. x := 0 makes (bvand x t) zero for every t. From
+  // there only that single value (and x's witness for it) is known, so
+  // only the one-sided, polarity-gated collapse can fire.
+  bool singleton = false;
+  ASTNode knownVal;         // constant at the chain's current width
+  ASTNode singletonWitness; // constant at var's width
 
   MutableASTNode* cur = &muteNode;
   for (unsigned depth = 0; depth < AchievableImage::MAX_PATH; depth++)
@@ -305,10 +432,11 @@ bool RemoveUnconstrained::tryGroundPathCollapse(
       const bool pathHigh = (kids[0] == cur);
       MutableASTNode* sib = pathHigh ? kids[1] : kids[0];
       // Enter slicing mode at the first symbolic sibling, but only from
-      // the bare variable (no image steps or ITE frames below); once in
-      // it, constant siblings become frames too.
+      // the bare variable (no image steps, ITE frames or absorbing
+      // steps below); once in it, constant siblings become frames too.
       if (!cframes.empty() ||
-          (!sib->n.isConstant() && steps.empty() && frames.empty()))
+          (!sib->n.isConstant() && steps.empty() && frames.empty() &&
+           !singleton))
       {
         cframes.push_back({sib, pathHigh});
         if (parent.parents.size() != 1)
@@ -354,7 +482,71 @@ bool RemoveUnconstrained::tryGroundPathCollapse(
         nonConstSibling = true;
     }
     if (nonConstSibling)
-      return false;
+    {
+      // Enter (or stay in) singleton mode if the path can be forced to
+      // this operator's absorbing element.
+      ASTNode absorbIn, absorbOut;
+      const unsigned inW = cur->n.GetValueWidth();
+      if ((kind == BVAND || kind == BVMULT) && pathCount == 1)
+      {
+        absorbIn = bm.CreateZeroConst(inW);
+        absorbOut = bm.CreateZeroConst(p.GetValueWidth());
+      }
+      else if (kind == BVOR && pathCount == 1)
+      {
+        absorbIn = bm.CreateMaxConst(inW);
+        absorbOut = bm.CreateMaxConst(p.GetValueWidth());
+      }
+      else if ((kind == BVLEFTSHIFT || kind == BVRIGHTSHIFT ||
+                kind == BVSRSHIFT || kind == BVMOD || kind == SBVREM ||
+                kind == SBVMOD) &&
+               pathCount == 1 && pathIdx == 0)
+      {
+        // Zero shifted by anything is zero; STP defines remainder-by-
+        // zero as the dividend, so a zero dividend gives zero for
+        // every divisor, including zero.
+        absorbIn = bm.CreateZeroConst(inW);
+        absorbOut = bm.CreateZeroConst(p.GetValueWidth());
+      }
+      else
+        return false;
+
+      // A frame's other branch gets the suffix steps re-applied as
+      // nodes, which a symbolic sibling can't be -- so no frame may
+      // sit below a symbolic step. (Frames captured above one are
+      // fine: their suffixes only hold the steps recorded after them.)
+      if (!frames.empty())
+        return false;
+
+      if (singleton)
+      {
+        if (knownVal != absorbIn)
+          return false;
+      }
+      else
+      {
+        // Ask the image of the steps so far for a witness reaching the
+        // absorbing element (trivially x itself when the variable
+        // feeds the operator directly).
+        AchievableImage prefix(bm, var.GetValueWidth());
+        prefix.addHint(absorbIn);
+        for (const GroundStep& s : steps)
+          if (!prefix.apply(s))
+            return false;
+        if (!prefix.decideOneSided(EQ, true, absorbIn, true,
+                                   singletonWitness))
+          return false;
+        singleton = true;
+      }
+      knownVal = absorbOut;
+
+      // The symbolic step is NOT recorded in `steps`: it never reaches
+      // an image, and later frames' suffixes must exclude it.
+      if (parent.parents.size() != 1)
+        return false;
+      cur = &parent;
+      continue;
+    }
     // Both operands being the path -- (bvmul t t), squaring -- is still
     // a unary function of the path value; anything else duplicated is
     // not a chain.
@@ -421,6 +613,10 @@ bool RemoveUnconstrained::tryGroundPathCollapse(
 
     steps.push_back(step);
 
+    // In singleton mode the known value flows through by evaluation.
+    if (singleton)
+      knownVal = evalStepOnConstant(bm, step, knownVal);
+
     // Interior nodes must be single-use to step past them.
     if (parent.parents.size() != 1)
       return false;
@@ -429,35 +625,87 @@ bool RemoveUnconstrained::tryGroundPathCollapse(
   if (predicate == NULL)
     return false; // too deep
 
-  // Phase 2: flow the achievable image up the collected path and decide.
-  AchievableImage image(bm, var.GetValueWidth());
-  image.addHintChain(steps, predConst);
-  for (const GroundStep& step : steps)
-    if (!image.apply(step))
-      return false;
+  // Phase 2: decide. Two-sided when both polarities of the predicate
+  // are achievable: it becomes a fresh boolean. Otherwise one-sided:
+  // when one forced outcome is achievable and the predicate's global
+  // polarity is pure and points the same way, fixing that outcome only
+  // helps, so the predicate becomes a constant and var its witness.
+  ASTNode inner;  // what the predicate becomes on the path branch
+  ASTNode varDef; // the recorded definition of var
+  bool twoSided = false;
+  AchievableImage::Decision d;
 
-  AchievableImage::Decision d = image.decide(predKind, pathFirst, predConst);
-  if (!d.collapse)
-    return false;
-
-  if (frames.empty())
+  if (!singleton)
   {
-    // The predicate has width 0, so this creates a fresh boolean and
-    // prunes the whole path out of the mutable tree.
-    ASTNode v = replaceParentWithFresh(*predicate, variables);
-    replace(var, nf->CreateTerm(ITE, var.GetValueWidth(), v, d.witnessTrue,
-                                d.witnessFalse));
+    // Flow the achievable image up the collected path.
+    AchievableImage image(bm, var.GetValueWidth());
+    image.addHintChain(steps, predConst);
+    for (const GroundStep& step : steps)
+      if (!image.apply(step))
+        return false;
+
+    d = image.decide(predKind, pathFirst, predConst);
+    if (d.collapse)
+      twoSided = true;
+    else
+    {
+      const unsigned pol = polarityOf(predicate);
+      if (pol == POL_POS &&
+          image.decideOneSided(predKind, pathFirst, predConst, true, varDef))
+        inner = bm.ASTTrue;
+      else if (pol == POL_NEG && image.decideOneSided(predKind, pathFirst,
+                                                      predConst, false,
+                                                      varDef))
+        inner = bm.ASTFalse;
+      else
+        return false;
+    }
+  }
+  else
+  {
+    // Singleton mode: exactly one outcome of the predicate is known.
+    const bool outcome =
+        pathFirst ? NonMemberBVConstPredicateEvaluator(
+                        predKind, knownVal.GetBVConst(), predConst.GetBVConst())
+                  : NonMemberBVConstPredicateEvaluator(
+                        predKind, predConst.GetBVConst(), knownVal.GetBVConst());
+    const unsigned pol = polarityOf(predicate);
+    if (outcome ? (pol != POL_POS) : (pol != POL_NEG))
+      return false;
+    inner = outcome ? bm.ASTTrue : bm.ASTFalse;
+    varDef = singletonWitness;
+  }
+
+  if (twoSided)
+  {
+    if (frames.empty())
+    {
+      // The predicate has width 0, so this creates a fresh boolean and
+      // prunes the whole path out of the mutable tree.
+      ASTNode v = replaceParentWithFresh(*predicate, variables);
+      replace(var, nf->CreateTerm(ITE, var.GetValueWidth(), v, d.witnessTrue,
+                                  d.witnessFalse));
+      return true;
+    }
+    inner = bm.CreateFreshVariable(0, 0, "unconstrained_ite");
+    varDef = nf->CreateTerm(ITE, var.GetValueWidth(), inner, d.witnessTrue,
+                            d.witnessFalse);
+  }
+  else if (frames.empty())
+  {
+    // One-sided, no frames: the predicate is simply the constant.
+    predicate->replaceWithAnotherNode(MutableASTNode::build(inner));
+    replace(var, varDef);
     return true;
   }
 
   // Distribute the predicate over the captured frames, innermost out:
   //   P(...ite(c_i, path_i, t_i)...)
   //     ==>  ite(c_k, ... ite(c_1, v, P(above_1(t_1))) ..., P(above_k(t_k)))
-  // where above_i re-applies every ground step recorded above frame i.
-  ASTNode v = bm.CreateFreshVariable(0, 0, "unconstrained_ite");
+  // where above_i re-applies every ground step recorded above frame i,
+  // and v is the fresh boolean (or, one-sided, the forced constant).
   vector<MutableASTNode*> vars;
   std::unordered_set<MutableASTNode*> visited;
-  ASTNode inner = v;
   for (const IteFrame& fr : frames)
   {
     ASTNode gt = fr.other->toASTNode(&bm);
@@ -483,8 +731,7 @@ bool RemoveUnconstrained::tryGroundPathCollapse(
   MutableASTNode* newN = MutableASTNode::build(inner, create);
   predicate->replaceWithAnotherNode(newN);
 
-  replace(var, nf->CreateTerm(ITE, var.GetValueWidth(), v, d.witnessTrue,
-                              d.witnessFalse));
+  replace(var, varDef);
   return true;
 }
 

--- a/tests/unit-tests/RemoveUnconstrained_Exhaustive_Test.cpp
+++ b/tests/unit-tests/RemoveUnconstrained_Exhaustive_Test.cpp
@@ -235,6 +235,50 @@ struct Context
     checkEquivalent(back, result);
   }
 
+  // Exhaustively decide satisfiability of `n` over its free variables.
+  bool satisfiable(const ASTNode& n)
+  {
+    ASTNodeSet symSet;
+    collectSymbols(n, symSet);
+    std::vector<ASTNode> syms(symSet.begin(), symSet.end());
+
+    unsigned long combos = 1;
+    for (const auto& s : syms)
+      combos *= domainSize(s);
+    EXPECT_LE(combos, 1u << 16)
+        << "too many assignments (" << combos << ") -- lower the width";
+
+    for (unsigned long c = 0; c < combos; c++)
+    {
+      ASTNodeMap assignment;
+      unsigned long rest = c;
+      for (size_t i = 0; i < syms.size(); i++)
+      {
+        const unsigned size = domainSize(syms[i]);
+        assignment.insert({syms[i], valueFor(syms[i], rest % size)});
+        rest /= size;
+      }
+      if (eval(n, assignment) == mgr.ASTTrue)
+        return true;
+    }
+    return false;
+  }
+
+  // For the one-sided (polarity-gated) collapse. The back-substitution
+  // identity still holds -- the witness decides the predicate regardless
+  // of the other variables -- but it is NOT sufficient there: a rewrite
+  // gated on the WRONG polarity would pass it while changing
+  // satisfiability. So additionally check satisfiability is unchanged.
+  ASTNode checkEquisat(const ASTNode& top)
+  {
+    ASTNode result = run(top);
+    ASTNode back = backSubstitute(top);
+    checkEquivalent(back, result);
+    EXPECT_EQ(satisfiable(top), satisfiable(result))
+        << "rewrite changed satisfiability";
+    return result;
+  }
+
   void checkSound(const ASTNode& opNode)
   {
     ASTNode top;
@@ -1072,4 +1116,313 @@ TEST(RemoveUnconstrained_GroundPath, shared_interior_no_collapse)
 
   Context c;
   c.checkSoundTop(build(c));
+}
+
+/////////////////////////////////////////////////////////////////////////////
+// 4) One-sided (polarity-gated) collapse. A symbolic sibling on the path
+//    ends image tracking, but forcing the path to the operator's absorbing
+//    element -- x := 0 through bvand/bvmul, ones through bvor -- fixes the
+//    chain's value regardless of the sibling. That single known outcome
+//    collapses the predicate to a constant, which is sound exactly when the
+//    predicate's global polarity is pure and prefers it. The same rule
+//    rescues all-constant chains where only one polarity is achievable.
+//
+//    Every test here goes through checkEquisat: the pointwise back-
+//    substitution check alone cannot catch a wrong-polarity rewrite.
+/////////////////////////////////////////////////////////////////////////////
+
+TEST(RemoveUnconstrained_OneSided, and_mask_zero_positive)
+{
+  // The motivating alignment-check idiom: (= (bvand x t) 0) with symbolic
+  // t, occurring positively. x := 0 forces it true.
+  Context c;
+  ASTNode x = c.bv();
+  ASTNode t = c.bv();
+  ASTNode p =
+      c.hf->CreateNode(EQ, c.hf->CreateTerm(BVAND, W, x, t), c.konst(0));
+  ASTNode top =
+      c.hf->CreateNode(AND, p, c.hf->CreateNode(BVGT, t, c.konst(1)));
+
+  c.checkEquisat(top);
+  EXPECT_EQ(c.simp.Return_SolverMap()->count(x), 1u) << "x not eliminated";
+}
+
+TEST(RemoveUnconstrained_OneSided, and_mask_nonzero_positive_declines)
+{
+  // (= (bvand x t) 5) positively: the only known value (0) makes it
+  // FALSE, and forcing a positive occurrence false is not sound -- some
+  // other choice of x might satisfy it. Must decline.
+  Context c;
+  ASTNode x = c.bv();
+  ASTNode t = c.bv();
+  ASTNode p =
+      c.hf->CreateNode(EQ, c.hf->CreateTerm(BVAND, W, x, t), c.konst(5));
+  ASTNode top =
+      c.hf->CreateNode(AND, p, c.hf->CreateNode(BVGT, t, c.konst(1)));
+
+  c.checkEquisat(top);
+  EXPECT_EQ(c.simp.Return_SolverMap()->count(x), 0u)
+      << "x eliminated against the polarity";
+}
+
+TEST(RemoveUnconstrained_OneSided, and_mask_nonzero_negative)
+{
+  // (not (= (bvand x t) 5)): the equality occurs negatively and x := 0
+  // forces it false -- exactly what a negative occurrence wants.
+  Context c;
+  ASTNode x = c.bv();
+  ASTNode t = c.bv();
+  ASTNode p =
+      c.hf->CreateNode(EQ, c.hf->CreateTerm(BVAND, W, x, t), c.konst(5));
+  ASTNode top = c.hf->CreateNode(AND, c.hf->CreateNode(NOT, p),
+                                 c.hf->CreateNode(BVGT, t, c.konst(1)));
+
+  c.checkEquisat(top);
+  EXPECT_EQ(c.simp.Return_SolverMap()->count(x), 1u) << "x not eliminated";
+}
+
+TEST(RemoveUnconstrained_OneSided, and_mask_zero_negative_declines)
+{
+  // (not (= (bvand x t) 0)): forcing the equality TRUE under a negative
+  // occurrence would flip a satisfiable formula (t > 1, bvand x t != 0)
+  // to unsatisfiable. The polarity gate must refuse.
+  Context c;
+  ASTNode x = c.bv();
+  ASTNode t = c.bv();
+  ASTNode p =
+      c.hf->CreateNode(EQ, c.hf->CreateTerm(BVAND, W, x, t), c.konst(0));
+  ASTNode top = c.hf->CreateNode(AND, c.hf->CreateNode(NOT, p),
+                                 c.hf->CreateNode(BVGT, t, c.konst(1)));
+
+  c.checkEquisat(top);
+  EXPECT_EQ(c.simp.Return_SolverMap()->count(x), 0u)
+      << "x eliminated against the polarity";
+}
+
+TEST(RemoveUnconstrained_OneSided, or_mask_ones_positive)
+{
+  // bvor's absorbing element is all-ones: x := 7 forces (bvor x t) = 7.
+  Context c;
+  ASTNode x = c.bv();
+  ASTNode t = c.bv();
+  ASTNode p =
+      c.hf->CreateNode(EQ, c.hf->CreateTerm(BVOR, W, x, t), c.konst(7));
+  ASTNode top =
+      c.hf->CreateNode(AND, p, c.hf->CreateNode(BVGT, t, c.konst(1)));
+
+  c.checkEquisat(top);
+  EXPECT_EQ(c.simp.Return_SolverMap()->count(x), 1u) << "x not eliminated";
+}
+
+TEST(RemoveUnconstrained_OneSided, mult_symbolic_zero)
+{
+  Context c;
+  ASTNode x = c.bv();
+  ASTNode t = c.bv();
+  ASTNode p =
+      c.hf->CreateNode(EQ, c.hf->CreateTerm(BVMULT, W, x, t), c.konst(0));
+  ASTNode top =
+      c.hf->CreateNode(AND, p, c.hf->CreateNode(BVGT, t, c.konst(1)));
+
+  c.checkEquisat(top);
+  EXPECT_EQ(c.simp.Return_SolverMap()->count(x), 1u) << "x not eliminated";
+}
+
+TEST(RemoveUnconstrained_OneSided, shift_symbolic_zero)
+{
+  // A zero VALUE operand absorbs a symbolic shift amount.
+  Context c;
+  ASTNode x = c.bv();
+  ASTNode t = c.bv();
+  ASTNode p = c.hf->CreateNode(
+      EQ, c.hf->CreateTerm(BVLEFTSHIFT, W, x, t), c.konst(0));
+  ASTNode top =
+      c.hf->CreateNode(AND, p, c.hf->CreateNode(BVGT, t, c.konst(0)));
+
+  c.checkEquisat(top);
+  EXPECT_EQ(c.simp.Return_SolverMap()->count(x), 1u) << "x not eliminated";
+}
+
+TEST(RemoveUnconstrained_OneSided, urem_symbolic_divisor)
+{
+  // A zero dividend gives zero for every divisor (STP defines
+  // remainder-by-zero as the dividend).
+  Context c;
+  ASTNode x = c.bv();
+  ASTNode t = c.bv();
+  ASTNode p =
+      c.hf->CreateNode(EQ, c.hf->CreateTerm(BVMOD, W, x, t), c.konst(0));
+  ASTNode top =
+      c.hf->CreateNode(AND, p, c.hf->CreateNode(BVGT, t, c.konst(1)));
+
+  c.checkEquisat(top);
+  EXPECT_EQ(c.simp.Return_SolverMap()->count(x), 1u) << "x not eliminated";
+}
+
+TEST(RemoveUnconstrained_OneSided, ground_steps_above_absorbing)
+{
+  // (= (bvadd (bvand x t) 3) 3): the known value 0 flows through the
+  // constant add by evaluation.
+  Context c;
+  ASTNode x = c.bv();
+  ASTNode t = c.bv();
+  ASTNode add = c.hf->CreateTerm(
+      BVPLUS, W, c.hf->CreateTerm(BVAND, W, x, t), c.konst(3));
+  ASTNode top =
+      c.hf->CreateNode(AND, c.hf->CreateNode(EQ, add, c.konst(3)),
+                       c.hf->CreateNode(BVGT, t, c.konst(1)));
+
+  c.checkEquisat(top);
+  EXPECT_EQ(c.simp.Return_SolverMap()->count(x), 1u) << "x not eliminated";
+}
+
+TEST(RemoveUnconstrained_OneSided, ground_steps_below_absorbing)
+{
+  // (= (bvand (bvurem x 4) t) 0): the absorbing element must be reached
+  // THROUGH the prefix chain; the image supplies a witness with
+  // (x mod 4) = 0.
+  Context c;
+  ASTNode x = c.bv();
+  ASTNode t = c.bv();
+  ASTNode band = c.hf->CreateTerm(
+      BVAND, W, c.hf->CreateTerm(BVMOD, W, x, c.konst(4)), t);
+  ASTNode top =
+      c.hf->CreateNode(AND, c.hf->CreateNode(EQ, band, c.konst(0)),
+                       c.hf->CreateNode(BVGT, t, c.konst(1)));
+
+  c.checkEquisat(top);
+  EXPECT_EQ(c.simp.Return_SolverMap()->count(x), 1u) << "x not eliminated";
+}
+
+TEST(RemoveUnconstrained_OneSided, ite_frame_above_absorbing)
+{
+  // (= (ite (= y 0) (bvand x t) y) 0) positively: the predicate
+  // distributes over the frame, ite((= y 0), true, (= y 0)), with
+  // x := 0 recorded unconditionally.
+  Context c;
+  ASTNode x = c.bv();
+  ASTNode t = c.bv();
+  ASTNode y = c.bv();
+  ASTNode ite =
+      c.hf->CreateTerm(ITE, W, c.hf->CreateNode(EQ, y, c.konst(0)),
+                       c.hf->CreateTerm(BVAND, W, x, t), y);
+  ASTNode top =
+      c.hf->CreateNode(AND, c.hf->CreateNode(EQ, ite, c.konst(0)),
+                       c.hf->CreateNode(BVGT, t, c.konst(1)));
+
+  c.checkEquisat(top);
+  EXPECT_EQ(c.simp.Return_SolverMap()->count(x), 1u) << "x not eliminated";
+}
+
+TEST(RemoveUnconstrained_OneSided, ite_frame_below_absorbing_declines)
+{
+  // The frame's other branch would need the symbolic bvand re-applied
+  // around it, which the rebuild cannot express: a frame below the
+  // absorbing step must decline.
+  Context c;
+  ASTNode x = c.bv();
+  ASTNode t = c.bv();
+  ASTNode y = c.bv();
+  ASTNode ite =
+      c.hf->CreateTerm(ITE, W, c.hf->CreateNode(EQ, y, c.konst(0)),
+                       c.hf->CreateTerm(BVMOD, W, x, c.konst(4)), y);
+  ASTNode band = c.hf->CreateTerm(BVAND, W, ite, t);
+  ASTNode top =
+      c.hf->CreateNode(AND, c.hf->CreateNode(EQ, band, c.konst(0)),
+                       c.hf->CreateNode(BVGT, t, c.konst(1)));
+
+  c.checkEquisat(top);
+  EXPECT_EQ(c.simp.Return_SolverMap()->count(x), 0u)
+      << "x eliminated past a frame below the absorbing step";
+}
+
+TEST(RemoveUnconstrained_OneSided, xor_polarity_declines)
+{
+  // Under XOR the predicate has both polarities: no forced outcome is
+  // safe.
+  Context c;
+  ASTNode x = c.bv();
+  ASTNode t = c.bv();
+  ASTNode p =
+      c.hf->CreateNode(EQ, c.hf->CreateTerm(BVAND, W, x, t), c.konst(0));
+  ASTNode top =
+      c.hf->CreateNode(XOR, p, c.hf->CreateNode(BVGT, t, c.konst(1)));
+
+  c.checkEquisat(top);
+  EXPECT_EQ(c.simp.Return_SolverMap()->count(x), 0u)
+      << "x eliminated under mixed polarity";
+}
+
+TEST(RemoveUnconstrained_OneSided, shared_predicate_positive)
+{
+  // The predicate node has two parents, both positive: still pure, so
+  // both occurrences become true at once.
+  Context c;
+  ASTNode x = c.bv();
+  ASTNode t = c.bv();
+  ASTNode y = c.bv();
+  ASTNode z = c.bv();
+  ASTNode p =
+      c.hf->CreateNode(EQ, c.hf->CreateTerm(BVAND, W, x, t), c.konst(0));
+  ASTNode top = c.hf->CreateNode(
+      AND, c.hf->CreateNode(OR, p, c.anchorFor(y)),
+      c.hf->CreateNode(OR, p, c.anchorFor(z)),
+      c.hf->CreateNode(BVGT, t, c.konst(1)));
+
+  c.checkEquisat(top);
+  EXPECT_EQ(c.simp.Return_SolverMap()->count(x), 1u) << "x not eliminated";
+}
+
+TEST(RemoveUnconstrained_OneSided, shared_predicate_mixed_declines)
+{
+  // One positive and one negative occurrence: no single forced outcome
+  // helps both.
+  Context c;
+  ASTNode x = c.bv();
+  ASTNode t = c.bv();
+  ASTNode y = c.bv();
+  ASTNode z = c.bv();
+  ASTNode p =
+      c.hf->CreateNode(EQ, c.hf->CreateTerm(BVAND, W, x, t), c.konst(0));
+  ASTNode top = c.hf->CreateNode(
+      AND, c.hf->CreateNode(OR, p, c.anchorFor(y)),
+      c.hf->CreateNode(OR, c.hf->CreateNode(NOT, p), c.anchorFor(z)),
+      c.hf->CreateNode(BVGT, t, c.konst(1)));
+
+  c.checkEquisat(top);
+  EXPECT_EQ(c.simp.Return_SolverMap()->count(x), 0u)
+      << "x eliminated under mixed polarity";
+}
+
+TEST(RemoveUnconstrained_OneSided, image_only_false_achievable_negative)
+{
+  // All-constant chain, one achievable polarity: (= (zero_extend x) 63)
+  // can only be false. Positively that must decline (the existing
+  // one_polarity_no_collapse test); under a NOT the one-sided rule
+  // forces it false.
+  Context c;
+  ASTNode x = c.bv();
+  ASTNode y = c.bv();
+  ASTNode zx = c.hf->CreateTerm(BVZX, 2 * W, x, c.konst(2 * W, 32));
+  ASTNode p = c.hf->CreateNode(EQ, zx, c.konst(63, 2 * W));
+  ASTNode top = c.hf->CreateNode(AND, c.hf->CreateNode(NOT, p),
+                                 c.anchorFor(y));
+
+  c.checkEquisat(top);
+  EXPECT_EQ(c.simp.Return_SolverMap()->count(x), 1u) << "x not eliminated";
+}
+
+TEST(RemoveUnconstrained_OneSided, image_only_true_achievable_positive)
+{
+  // (bvult (zero_extend x) 20) is true for the whole image [0,7]: only
+  // one polarity achievable, and a positive occurrence wants it.
+  Context c;
+  ASTNode x = c.bv();
+  ASTNode y = c.bv();
+  ASTNode zx = c.hf->CreateTerm(BVZX, 2 * W, x, c.konst(2 * W, 32));
+  ASTNode p = c.hf->CreateNode(BVLT, zx, c.konst(20, 2 * W));
+  ASTNode top = c.hf->CreateNode(AND, p, c.anchorFor(y));
+
+  c.checkEquisat(top);
+  EXPECT_EQ(c.simp.Return_SolverMap()->count(x), 1u) << "x not eliminated";
 }


### PR DESCRIPTION
Stacked on #691 (base is `concat-equality-slicing`; only the top commit is new).

The ground-path collapse required every sibling on the path to be a constant, so `(= (bvand x t) 0)` with symbolic `t` could not eliminate an unconstrained `x` — even though `x := 0` forces the bvand, and with it the equality, regardless of `t`.

**Singleton mode.** A symbolic sibling now switches the climb into singleton mode when the path can be forced to the operator's absorbing element: 0 through `bvand`/`bvmul`, all-ones through `bvor`, a zero value operand through the shifts, a zero dividend through the remainders (STP defines remainder-by-zero as the dividend). The absorbing element may be reached through a ground prefix (the image supplies a validated witness), and the known value flows through later constant steps by evaluation. Only that single outcome of the predicate is then known, so the collapse is one-sided: it fires exactly when the predicate's global polarity is pure and prefers the forced outcome. Making a positive-only predicate true (or a negative-only one false) cannot falsify a model of the original (monotonicity), and any model of the rewrite extends with `x := witness`, which realises the value — so satisfiability is preserved both ways. The predicate becomes a constant and the witness lands in the substitution map, so models reconstruct as usual. ITE frames above the absorbing step still distribute; frames below it decline (their rebuilt other-branch would need the symbolic step re-applied).

**Image fallback.** The same rule rescues all-constant chains where the image can achieve only one polarity (`AchievableImage::decideOneSided`), e.g. `(not (= (zero_extend x) 63))`: the two-sided decide fails for lack of a true witness, but under pure negative polarity forcing false suffices. This converts the previously deliberate `decide_declined` refusals when the polarity allows.

**Polarity** is computed by walking the mutable tree upward from the predicate through AND/OR (same), NOT/NAND/NOR (flip), IMPLIES (antecedent flips), and boolean ITE branches; ITE conditions, XOR/IFF operands and anything unrecognised count as both polarities and decline. Shared predicates are fine when all occurrences agree.

**Testing.** 17 new exhaustive tests including the must-decline cases (wrong polarity, mixed polarity, shared mixed-polarity predicate, frame below the absorbing step). The suite gains a satisfiability-equality check: the pointwise back-substitution identity still holds for one-sided rewrites (the witness decides the predicate independently of the other variables) but cannot by itself catch a wrong-polarity rewrite — a deliberately inverted gate passes pointwise while flipping sat to unsat. Full suite 89/89, ctest 69/69 (Debug + assertions), 2500-file differential sat/unsat sweep vs an old-master baseline: 0 disagreements, 0 skips. Model construction verified end-to-end (`x = 0` comes back out of the solver on the motivating formula).

**Measured corpus yield: small but real.** Temporary instrumentation (reverted): 0 fires on a 1000-file sample (400 random QF_BV + 600 from the families where ground-path fires cluster), but the full 4661-file hard set finds **7 firing files (all Sage2), 10 fires** -- 9 via the image fallback (exactly the old `decide_declined` constant-predicate population, now converted under pure polarity) and 1 genuine singleton-mode fire (Sage2/bench_15975). A differential check on the firing files at 60 s agrees everywhere both sides solve (one file times out on both binaries). So this is a capability-class extension (the alignment-check idiom `(x & mask) == 0` with a symbolic mask) whose corpus rate is below random-sample resolution; it is CNF-behaviour-neutral wherever it does not fire.
