### PR TITLE
README: build in parallel, make the python example copy-pasteable

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -65,8 +65,8 @@ Overflowing a 32-bit integer using the python interface:
 import stp
 
 s = stp.Solver()
-x = s.bitvec('x')
-y = s.bitvec('y')
+x = s.bitvec('x', width=32)
+y = s.bitvec('y', width=32)
 s.add(x + y < 20)
 s.add(x > 10)
 s.add(y > 10)

--- a/README.markdown
+++ b/README.markdown
@@ -25,7 +25,7 @@ git submodule init && git submodule update
 mkdir build
 cd build
 cmake ..
-cmake --build .
+cmake --build . -j$(nproc)
 sudo cmake --install .
 ```
 
@@ -61,18 +61,17 @@ stp myproblem.smt2
 ```
 
 Overflowing a 32-bit integer using the python interface:
-```
-In [1]: import stp
-In [2]: a = stp.Solver()
-In [3]: x = a.bitvec('x')
-In [4]: y = a.bitvec('y')
-In [5]: a.add(x + y < 20)
-In [6]: a.add(x  > 10)
-In [7]: a.add(y  > 10)
-In [8]: a.check()
-Out[8]: True
-In [9]: a.model()
-Out[9]: {'x': 4294967287, 'y': 11}
+```python
+import stp
+
+s = stp.Solver()
+x = s.bitvec('x')
+y = s.bitvec('y')
+s.add(x + y < 20)
+s.add(x > 10)
+s.add(y > 10)
+print(s.check())  # True
+print(s.model())  # e.g. {'x': 4294967287, 'y': 11}
 ```
 
 STP also reads from standard input, as in the Docker example above.
@@ -135,7 +134,7 @@ $ git clone https://github.com/stp/minisat
 $ cd minisat
 $ mkdir build && cd build
 $ cmake ..
-$ cmake --build .
+$ cmake --build . -j$(nproc)
 $ sudo cmake --install .
 $ command -v ldconfig && sudo ldconfig
 ```
@@ -147,7 +146,7 @@ $ git clone https://github.com/msoos/cryptominisat
 $ cd cryptominisat
 $ mkdir build && cd build
 $ cmake ..
-$ cmake --build .
+$ cmake --build . -j$(nproc)
 $ sudo cmake --install .
 $ command -v ldconfig && sudo ldconfig
 ```
@@ -189,7 +188,7 @@ If you did not install these development libraries, then `MINISAT_LIBDIR` can be
 ```
 $ mkdir build && cd build
 $ cmake -DSTATICCOMPILE=ON ..
-$ cmake --build .
+$ cmake --build . -j$(nproc)
 $ sudo cmake --install .
 $ command -v ldconfig && sudo ldconfig
 ```
@@ -230,7 +229,7 @@ pip install lit
 mkdir build
 cd build
 cmake -DENABLE_TESTING=ON ..
-make
+make -j$(nproc)
 make test
 ```
 


### PR DESCRIPTION
Two small documentation fixes:

* The build instructions now use `cmake --build . -j$(nproc)` (and `make -j$(nproc)` in the testing section). A serial build spends most of its time compiling ABC's ~1000 files, and the plain `cmake --build .` is what most people copy-paste from the quick install.

* The python interface example is now a plain script with the outputs shown as comments, instead of an IPython transcript whose `In [n]:` prompts have to be stripped before it can be run. It also gets a `python` fence for syntax highlighting. Verified the snippet runs as written against an installed build; the model comment says "e.g." since any satisfying assignment may be returned.