### PR TITLE
Build deps MiniSat static so installed stp is self-contained

### DIFF
--- a/scripts/deps/setup-minisat.sh
+++ b/scripts/deps/setup-minisat.sh
@@ -16,10 +16,18 @@ mkdir build && cd build
 # minisat's cmake_minimum_required predates 3.5, which CMake 4 removed
 # support for; the same floor is passed in the Windows CI job.
 #
+# Build a static (PIC) library, like setup-cms.sh does for CryptoMiniSat: it
+# gets linked into libstp, so the installed stp/libstp do not depend on a
+# libminisat.so that this script only installs inside the source checkout.
+# minisat's CMake never sets PIC itself, so ask for it globally; without it
+# the archive cannot be folded into the shared libstp.so. This also serves
+# static STP builds, which look for libminisat.a.
+#
 # Extra arguments are forwarded to CMake, so a caller that needs a different
-# flavour of the library can ask for one: a static STP build looks for
-# libminisat.a, which only appears with -DSTATICCOMPILE=ON.
-cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.12 -DCMAKE_INSTALL_PREFIX:PATH="${install_dir}" "$@" ..
+# flavour of the library can still ask for one.
+cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.12 -DSTATICCOMPILE=ON \
+      -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+      -DCMAKE_INSTALL_PREFIX:PATH="${install_dir}" "$@" ..
 cmake --build . --parallel "$(nproc)"
 cmake --install .
 cd ..


### PR DESCRIPTION
Same defect #675 fixed for CryptoMiniSat, but in the mandatory solver: `setup-minisat.sh` installs MiniSat only into `deps/install` inside the checkout, yet built it shared, so `libstp.so` carried a `NEEDED libminisat.so.2` entry with RUNPATH `/usr/local/lib` only. An installed stp from the README quickstart fails at load time on a clean machine with `libminisat.so.2: cannot open shared object file`. It went unnoticed because build trees resolve via the build RPATH, and any machine that ever installed MiniSat system-wide still has a copy lying around in `/usr/local/lib`.

This builds MiniSat as a static PIC archive instead, so it folds into the shared `libstp.so` and the existing `--exclude-libs,ALL --gc-sections` handling keeps its symbols private. Unlike CryptoMiniSat (which sets `POSITION_INDEPENDENT_CODE` globally itself, making #675 a one-flag change), MiniSat's CMake never sets PIC, so it is forced from the command line — without it the archive cannot link into a shared library.

Static STP builds keep finding the `libminisat.a` they want, so callers no longer need to pass `-DSTATICCOMPILE=ON` themselves; the Windows CI job still does, harmlessly.

Verified:
* `readelf -d libstp.so` shows no `libminisat` entry (nor `libz` — MiniSat's unused gzip DIMACS reader now gets garbage-collected); only libstdc++/libm/libgcc/libc remain.
* Answers agree with a reference build over 60 `tests/query-files` (`--minisat`).
* The installed `libstp.so` ctypes-loads standalone from an otherwise empty prefix and creates a validity checker.