### PR TITLE
cbitp: write derived constants back into the formula

### DIFF
--- a/lib/Simplifier/constantBitP/ConstantBitPropagation.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitPropagation.cpp
@@ -33,8 +33,10 @@ THE SOFTWARE.
 #include "stp/Simplifier/constantBitP/ConstantBitP_MaxPrecision.h"
 #include "stp/Simplifier/constantBitP/ConstantBitP_TransferFunctions.h"
 #include "stp/Simplifier/constantBitP/ConstantBitP_Utility.h"
+#include <algorithm>
 #include <fstream>
 #include <iostream>
+#include <vector>
 
 using std::endl;
 using std::cout;
@@ -287,9 +289,30 @@ ASTNode ConstantBitPropagation::topLevelBothWays(const ASTNode& top,
 
   ASTVec toConjoin;
 
-  // go through the fixedBits. If a node is entirely fixed.
-  // "and" it onto the top. Creates redundancy. Check that the
-  // node doesn't already depend on "top" directly.
+  // For each entirely fixed node: replace the node by its constant inside
+  // "top", and conjoin a fact that pins the node down, so the constraint
+  // isn't lost. The term-level facts are built from the original
+  // (pre-replacement) nodes, so they survive the replacement.
+  //
+  // The top-level conjuncts themselves are always fixed to true, so
+  // replacing each of them with TRUE and conjoining it back verbatim would
+  // rebuild the input and mask the term-level replacements underneath.
+  // Instead the boolean facts are collected first, rewritten with the term
+  // constants, and only acted on if that changed something or the fact
+  // isn't already part of "top".
+
+  // Term-level constants, later written into the boolean facts. Starts
+  // with the unconditionally fixed nodes.
+  ASTNodeMap termFacts(fromTo);
+
+  struct BoolFact
+  {
+    ASTNode node;
+    ASTNode proposition;
+    ASTNode constant;
+  };
+  std::vector<BoolFact> boolFacts;
+
   NodeToFixedBitsMap::NodeToFixedBitsMapType::iterator it, itEnd;
 
   // iterates through all the pairs of node->fixedBits.
@@ -311,77 +334,72 @@ ASTNode ConstantBitPropagation::topLevelBothWays(const ASTNode& top,
     if (BVEXTRACT == node.GetKind() || BVCONCAT == node.GetKind())
       continue;
 
-    // toAssign: conjoin it with the top level.
-    // toReplace: replace all references to it (except the one conjoined to the
-    // top) with this.
-    ASTNode propositionToAssert;
-    ASTNode constantToReplaceWith;
-    // skip the assigning and replacing.
-    bool doAssign = false;
+    // If it is already contained in the fromTo map, then it's one of the
+    // values that have fully been determined (previously). Not conjoined.
+    if (fromTo.find(node) != fromTo.end())
+      continue;
 
+    if (node.GetType() != BOOLEAN_TYPE && node.GetType() != BITVECTOR_TYPE)
+      FatalError("sadf234s");
+
+    ASTNode constNode = bitsToNode(node, bits);
+
+    if (SYMBOL == node.GetKind())
     {
-      // If it is already contained in the fromTo map, then it's one of the
-      // values
-      // that have fully been determined (previously). Not conjoined.
-      if (fromTo.find(node) != fromTo.end())
+      bool r = simplifier->UpdateSubstitutionMap(node, constNode);
+      assert(r);
+    }
+    else if (!conjoinToTop)
+    {
+      // Not allowed to strengthen the top, so the fact is unusable.
+    }
+    else if (node.GetType() == BOOLEAN_TYPE)
+    {
+      ASTNode prop = bits.getValue(0) ? node : nf->CreateNode(NOT, node);
+      boolFacts.push_back({node, prop, constNode});
+    }
+    else
+    {
+      assert(((unsigned)bits.getWidth()) == node.GetValueWidth());
+
+      ASTNode prop = nf->CreateNode(EQ, node, constNode);
+      if (top == prop)
         continue;
 
-      ASTNode constNode = bitsToNode(node, bits);
-
-      if (node.GetType() == BOOLEAN_TYPE)
-      {
-        if (SYMBOL == node.GetKind())
-        {
-          bool r = simplifier->UpdateSubstitutionMap(node, constNode);
-          assert(r);
-          doAssign = false;
-        }
-        else if (conjoinToTop && bits.getValue(0))
-        {
-          propositionToAssert = node;
-          constantToReplaceWith = constNode;
-          doAssign = true;
-        }
-        else if (conjoinToTop)
-        {
-          propositionToAssert = nf->CreateNode(NOT, node);
-          constantToReplaceWith = constNode;
-          doAssign = true;
-        }
-      }
-      else if (node.GetType() == BITVECTOR_TYPE)
-      {
-        assert(((unsigned)bits.getWidth()) == node.GetValueWidth());
-        if (SYMBOL == node.GetKind())
-        {
-          bool r = simplifier->UpdateSubstitutionMap(node, constNode);
-          assert(r);
-          doAssign = false;
-        }
-        else if (conjoinToTop)
-        {
-          propositionToAssert = nf->CreateNode(EQ, node, constNode);
-          constantToReplaceWith = constNode;
-          doAssign = true;
-        }
-      }
-      else
-        FatalError("sadf234s");
-    }
-
-    if (doAssign && top != propositionToAssert &&
-        !dependents->nodeDependsOn(top, propositionToAssert))
-    {
-      assert(!constantToReplaceWith.IsNull());
-      assert(constantToReplaceWith.isConstant());
-      assert(propositionToAssert.GetType() == BOOLEAN_TYPE);
-      assert(node.GetValueWidth() == constantToReplaceWith.GetValueWidth());
-
-      fromTo.insert(make_pair(node, constantToReplaceWith));
-      toConjoin.push_back(propositionToAssert);
-      assert(conjoinToTop);
+      fromTo.insert(make_pair(node, constNode));
+      termFacts.insert(make_pair(node, constNode));
+      if (nf->getTrue() != prop)
+        toConjoin.push_back(prop);
     }
   }
+
+  // Write the term constants into each boolean fact. A fact the constants
+  // don't change, and that "top" already contains, carries no new
+  // information: leave it (and the node's occurrences) alone.
+  {
+    ASTNodeMap propCache;
+    for (const auto& fact : boolFacts)
+    {
+      if (top == fact.proposition)
+        continue;
+
+      const ASTNode rewritten =
+          SubstitutionMap::replace(fact.proposition, termFacts, propCache, nf);
+
+      if (rewritten == fact.proposition &&
+          dependents->nodeDependsOn(top, fact.proposition))
+        continue;
+
+      fromTo.insert(make_pair(fact.node, fact.constant));
+      if (nf->getTrue() != rewritten)
+        toConjoin.push_back(rewritten);
+    }
+  }
+
+  // The fixedMap iteration order isn't defined; sort for determinism.
+  SortByExprNum(toConjoin);
+  toConjoin.erase(std::unique(toConjoin.begin(), toConjoin.end()),
+                  toConjoin.end());
 
   // Write the constants into the main graph.
   ASTNodeMap cache;

--- a/lib/Simplifier/constantBitP/ConstantBitPropagation.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitPropagation.cpp
@@ -228,6 +228,30 @@ ConstantBitPropagation::ConstantBitPropagation(stp::STPMgr* mgr_,
   topFixed = false;
 }
 
+// Rewrite the children of "n" with the map, then rebuild "n" on top of
+// them. Starting one level down means an entry for "n" itself in the map
+// can't fire: a node is never its own descendant, so the map can safely
+// hold a fact about "n" while "n"'s fact is being rebuilt.
+static ASTNode replaceChildren(const ASTNode& n, ASTNodeMap& fromTo,
+                               ASTNodeMap& cache, NodeFactory* nf)
+{
+  const ASTChildren originals = n.GetChildren();
+
+  ASTVec children;
+  children.reserve(n.Degree());
+  for (const auto& c : originals)
+    children.push_back(SubstitutionMap::replace(c, fromTo, cache, nf));
+
+  if (std::equal(children.begin(), children.end(), originals.begin(),
+                 originals.end()))
+    return n;
+
+  if (BOOLEAN_TYPE == n.GetType())
+    return nf->CreateNode(n.GetKind(), children);
+
+  return nf->CreateTerm(n.GetKind(), n.GetValueWidth(), children);
+}
+
 // Both way propagation. Initialising the top to "true".
 // The hardest thing to understand is the two cases:
 // 1) If we get the fixed bits of a node, without assuming the top node is true,
@@ -291,27 +315,23 @@ ASTNode ConstantBitPropagation::topLevelBothWays(const ASTNode& top,
 
   // For each entirely fixed node: replace the node by its constant inside
   // "top", and conjoin a fact that pins the node down, so the constraint
-  // isn't lost. The term-level facts are built from the original
-  // (pre-replacement) nodes, so they survive the replacement.
+  // isn't lost.
   //
-  // The top-level conjuncts themselves are always fixed to true, so
-  // replacing each of them with TRUE and conjoining it back verbatim would
-  // rebuild the input and mask the term-level replacements underneath.
-  // Instead the boolean facts are collected first, rewritten with the term
-  // constants, and only acted on if that changed something or the fact
-  // isn't already part of "top".
+  // Every fact is rewritten with every other fact's constant, so the
+  // constants discharge into the facts that pin them down. (The top-level
+  // conjuncts themselves are always fixed to true; without the rewriting,
+  // each conjunct would be erased by the replacement and then restored
+  // verbatim by its conjoined fact, putting the input back together.)
+  // All the rewriting shares one map and one cache: a fact's own map entry
+  // can't erase the fact, because the rewrite starts at the node's
+  // children, and a node is never its own descendant.
 
-  // Term-level constants, later written into the boolean facts. Starts
-  // with the unconditionally fixed nodes.
-  ASTNodeMap termFacts(fromTo);
-
-  struct BoolFact
+  struct Fact
   {
     ASTNode node;
-    ASTNode proposition;
     ASTNode constant;
   };
-  std::vector<BoolFact> boolFacts;
+  std::vector<Fact> facts;
 
   NodeToFixedBitsMap::NodeToFixedBitsMapType::iterator it, itEnd;
 
@@ -349,51 +369,32 @@ ASTNode ConstantBitPropagation::topLevelBothWays(const ASTNode& top,
       bool r = simplifier->UpdateSubstitutionMap(node, constNode);
       assert(r);
     }
-    else if (!conjoinToTop)
+    else if (conjoinToTop && node != top)
     {
-      // Not allowed to strengthen the top, so the fact is unusable.
-    }
-    else if (node.GetType() == BOOLEAN_TYPE)
-    {
-      ASTNode prop = bits.getValue(0) ? node : nf->CreateNode(NOT, node);
-      boolFacts.push_back({node, prop, constNode});
-    }
-    else
-    {
-      assert(((unsigned)bits.getWidth()) == node.GetValueWidth());
-
-      ASTNode prop = nf->CreateNode(EQ, node, constNode);
-      if (top == prop)
-        continue;
+      assert(node.GetType() == BOOLEAN_TYPE ||
+             ((unsigned)bits.getWidth()) == node.GetValueWidth());
 
       fromTo.insert(make_pair(node, constNode));
-      termFacts.insert(make_pair(node, constNode));
-      if (nf->getTrue() != prop)
-        toConjoin.push_back(prop);
+      facts.push_back({node, constNode});
     }
   }
 
-  // Write the term constants into each boolean fact. A fact the constants
-  // don't change, and that "top" already contains, carries no new
-  // information: leave it (and the node's occurrences) alone.
+  ASTNodeMap cache;
+
+  for (const auto& fact : facts)
   {
-    ASTNodeMap propCache;
-    for (const auto& fact : boolFacts)
-    {
-      if (top == fact.proposition)
-        continue;
+    const ASTNode rebuilt = replaceChildren(fact.node, fromTo, cache, nf);
 
-      const ASTNode rewritten =
-          SubstitutionMap::replace(fact.proposition, termFacts, propCache, nf);
+    ASTNode prop;
+    if (BOOLEAN_TYPE == fact.node.GetType())
+      prop = (nf->getTrue() == fact.constant) ? rebuilt
+                                              : nf->CreateNode(NOT, rebuilt);
+    else
+      prop = nf->CreateNode(EQ, rebuilt, fact.constant);
 
-      if (rewritten == fact.proposition &&
-          dependents->nodeDependsOn(top, fact.proposition))
-        continue;
-
-      fromTo.insert(make_pair(fact.node, fact.constant));
-      if (nf->getTrue() != rewritten)
-        toConjoin.push_back(rewritten);
-    }
+    // A fact that rewrites to true is implied by the others.
+    if (nf->getTrue() != prop)
+      toConjoin.push_back(prop);
   }
 
   // The fixedMap iteration order isn't defined; sort for determinism.
@@ -402,7 +403,6 @@ ASTNode ConstantBitPropagation::topLevelBothWays(const ASTNode& top,
                   toConjoin.end());
 
   // Write the constants into the main graph.
-  ASTNodeMap cache;
   ASTNode result = SubstitutionMap::replace(top, fromTo, cache, nf);
 
   if (0 != toConjoin.size())

--- a/tests/query-files/simplification-tests/cbitp_writeback.smt2
+++ b/tests/query-files/simplification-tests/cbitp_writeback.smt2
@@ -1,0 +1,21 @@
+; Constant bit propagation derives from the second assert that the
+; bvadd/extract/concat chain is constant, making the multiplier #xFFFFFFFE.
+; Writing those constants back lets the word-level simplifications collapse
+; the query to false: x + x*#xFFFFFFFE = -x, the double negation cancels,
+; and the third assert becomes (not (= x x)).
+; RUN: %solver --exit-after-CNF %s | %OutputCheck %s
+(set-logic QF_BV)
+(set-info :status unsat)
+
+(declare-fun x () (_ BitVec 32))
+
+(assert (not (bvsgt #x00000000 x)))
+(assert (= ((_ extract 31 31) x) #b0))
+(assert (not (= x (bvneg (bvadd x (bvmul x (concat ((_ extract 31 1)
+    (bvadd #xFFFFFFFF (concat (_ bv0 31) ((_ extract 31 31) x)))) #b0)))))))
+(assert (= #b1111111111111111111111111111111 ((_ extract 31 1)
+    (bvadd #xFFFFFFFF (concat (_ bv0 31) ((_ extract 31 31) x))))))
+
+; CHECK-NEXT: ^unsat
+(check-sat)
+(exit)


### PR DESCRIPTION
Constant bit propagation regularly proves interior nodes constant under the assumption that the top is true, but the write-back rejected any fact whose defining proposition already appeared inside the top — and the proposition usually folds straight back to the very conjunct the information came from (`EQ(node, const)` simplifies to the asserted equality), so almost nothing was ever written back.

Dropping that rejection alone turns out to be a no-op: every top-level conjunct is itself a boolean node fixed to true, so each conjunct is erased by the replacement (`conjunct → TRUE`) and then restored verbatim by the conjoined fact, masking the term-level substitutions underneath it.

Instead, this collects the boolean facts first and rewrites them with the discovered term-level constants before conjoining:

- **Term facts** are conjoined verbatim. They are built from the original (pre-replacement) nodes and conjoined after the replacement runs over the top, so `top ⟺ top[n:=c] ∧ (n=c)` holds whether or not the equality already appears inside the top.
- **Boolean facts** are rewritten with the term constants before being conjoined. This is justified because the term facts are conjoined verbatim, and a term fact is never written into its own defining equality. A boolean fact the constants don't change, and that the top already contains, is left in place — same as the old guard, avoiding erase-and-restore churn.
- The conjoined facts are sorted by expression number and deduplicated, so the output doesn't depend on the fixed-bits map's iteration order.

### Example

```smt2
(assert (not (bvsgt #x00000000 x)))
(assert (= ((_ extract 31 31) x) #b0))
(assert (not (= x (bvneg (bvadd x (bvmul x (concat ((_ extract 31 1)
   (bvadd #xFFFFFFFF (concat (_ bv0 31) ((_ extract 31 31) x)))) #b0)))))))
(assert (= #b1111111111111111111111111111111 ((_ extract 31 1)
   (bvadd #xFFFFFFFF (concat (_ bv0 31) ((_ extract 31 31) x))))))
```

cbitp fixes bit 31 of x from the second assert and derives that the whole `bvadd/extract/concat` chain is constant, making the multiplier `#xFFFFFFFE`. Previously all of that was discarded and the problem went to the SAT solver. Now the constants are written in, and the word-level simplifications finish the job: `x + x·#xFFFFFFFE = -x`, the double negation cancels, and the query collapses to false before bit-blasting.

### Validation

- 2500-file fuzzed-corpus differential sweep against the previous build: all answers agree, no skips.
- Assertion-enabled build (with counterexample construction) clean over all 2500 corpus files plus the motivating instance.
- Coarse timing over 300 corpus files within noise.
- `answer_diff` over the 40-file real-benchmark corpus is still running; I'll post the result as a comment.

Node counts can grow slightly on some inputs (~5% post-pipeline on one Sydr benchmark, neutral elsewhere sampled) because the conjoined facts substitute only term constants while the top substitutes everything, so rewritten copies share less structure. The existing difficulty-score reversion still guards the net-harm case.