### PR TITLE
Guard the multiplication column bounds against a shrunken column

### DIFF
--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -1988,6 +1988,20 @@ void BitBlaster<BBNode, BBNodeManagerT>::mult_BubbleSorterWithBounds(
 
   if (uf->conjoin_to_top)
   {
+    // minTrue/maxTrue are the bounds constant bit propagation recorded for this
+    // node. They can ask for more true bits than the column has entries: the
+    // formula reaching the bit-blaster may have been rewritten since the bounds
+    // were taken, and nothing invalidates them when it is. Requiring more than
+    // 'height' ones, or at most a negative number of them, is unsatisfiable.
+    // Conjoining false settles the query, so the result bit is arbitrary - but
+    // one still has to be produced, because the caller consumes exactly one.
+    if (minTrue > height || maxTrue < 0)
+    {
+      support.insert(BBFalse);
+      current.push_back(BBFalse);
+      return;
+    }
+
     for (int j = 0; j < minTrue; j++)
     {
       support.insert(currentSorted[j]);


### PR DESCRIPTION
## The bug

`mult_BubbleSorterWithBounds` indexes `currentSorted[j]` for `j < minTrue` and for `j >= maxTrue` without checking either against `height`:

```cpp
for (int j = 0; j < minTrue; j++)            // nothing bounds this by height
{
  support.insert(currentSorted[j]);
  currentSorted[j] = BBTrue;
}
for (int j = height - 1; j >= maxTrue; j--)  // nothing clamps this at 0
```

`currentSorted` has exactly `height` entries — the number of terms in one partial-product column, plus carries from the column below. `minTrue`/`maxTrue` are `sumL[i]`/`sumH[i]`, bounds that constant bit propagation recorded for this `BVMULT` node. Nothing invalidates the `MultiplicationStats` map when the formula is later rewritten (`msm->map[n] = ms` is its only mutation), so a column can arrive at the bit-blaster with fewer entries than its bounds require. The loop then walks off the end of the vector, inserts freed memory into `support`, and segfaults in `std::hash<BBNodeAIG>` dereferencing the poison pattern as an AIG node.

Only `bb.mult-variant=5` passes real bounds — every other caller uses the vacuous header defaults (`minTrue = 0`, `maxTrue = INT_MAX`), so variant 4 is safe by accident. Reproducing needs all four of `--difficulty-reversion=0 --bb.mult-variant=5 --bb.mult-v2=1 --bb.conjoin-constant=1`.

Concretely, on a width-14 `BVMULT(BVCONST, BVAND)`: at column 7 the recorded bounds are `sumL = sumH = 3` while the column holds a single entry, because the second multiplicand bit-blasts to 0 and every partial product is false. `currentSorted[1]` is then out of range.

## The fix

Demanding more than `height` true bits, or at most a negative number of them, is unsatisfiable, so conjoin false and leave the column. A bare `return` would not do: `multWithBounds` asserts `products[i].size() == 1` and reads `products[i].back()`, so a result bit still has to be pushed. Its value is arbitrary once false is conjoined to the top, and `BBFalse` is what `setColumnsToZero` and `multWithBounds` already use as their collapse filler.

Early exit rather than clamping the two loops with `std::min`/`std::max`: after the guard returns, neither loop can go out of range, so the clamps would be dead weight.

## On declaring unsat from bounds that may be stale

`currentSorted` is the unary representation of the sum of the column's `height` terms, so that sum can be neither greater than `height` nor negative — both guarded conditions are contradictions on their face, whatever derived them.

The guard also adds no new trust in these bounds. `setColumnsToZero` already forces whole columns false on `sumH[i] == 0`, and the pre-existing `minTrue` loop already asserts column bits true. If the bounds could be wrong for a *satisfiable* formula, STP would already be unsound through those paths, independent of this change.

## Testing

- `ctest`: 67/67 pass.
- Differential over a 2501-file `QF_BV` fuzz corpus with the four flags above, fixed vs unfixed: `compared=2501 mismatches=0 crashes=0`.
- The condition never fires on master with that corpus, which is why plain master does not crash on it. To exercise the guard I built against a local branch whose stronger multiply propagator fixes many more bits and does produce the disagreement: 2 of those 2501 files segfault before this change, and afterwards return the correct answers (`unsat` and `sat`, matching master). Differential there: `compared=2501 mismatches=0 crashes=0`.

No regression test: I could not construct a query file that reaches the condition on master, and `mult_BubbleSorterWithBounds` is a private template member with no existing unit-test harness, so testing it directly would mean building one for a defensive guard. Happy to add either if you would prefer it.