### PR TITLE
release: bump the version to 2.4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -457,7 +457,7 @@ if (GIT_EXECUTABLE)
 else()
   set(GIT_SHA "GIT-hash-notfound")
 endif()
-set(STP_FULL_VERSION "2.3.4")
+set(STP_FULL_VERSION "2.4.0")
 
 string(REPLACE "." ";" STP_FULL_VERSION_LIST ${STP_FULL_VERSION})
 SetVersionNumber("PROJECT" ${STP_FULL_VERSION_LIST})

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ author = 'The STP Project'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '2.3.4'
+release = '2.4.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/releasing.rst
+++ b/docs/releasing.rst
@@ -11,7 +11,7 @@ Only the bump is done by hand. Pushing the tag runs
 binary and opens the release as a draft:
 
 #. Edit the version in the two files below, and commit to master.
-#. ``git tag 2.3.5 && git push origin 2.3.5``.
+#. ``git tag 2.4.1 && git push origin 2.4.1``.
 #. Read the draft the workflow leaves behind, then publish it.
 
 Where the version lives
@@ -19,8 +19,8 @@ Where the version lives
 
 Two files carry it, both edited by hand:
 
--  ``CMakeLists.txt`` -- ``set(STP_FULL_VERSION "2.3.4")``
--  ``docs/conf.py`` -- ``release = '2.3.4'``
+-  ``CMakeLists.txt`` -- ``set(STP_FULL_VERSION "2.4.0")``
+-  ``docs/conf.py`` -- ``release = '2.4.0'``
 
 Everything else derives from ``STP_FULL_VERSION``: ``include/stp/config.h``,
 ``STPConfigVersion.cmake``, the ``stp.1`` man page, the ``SOVERSION`` of
@@ -61,8 +61,8 @@ them, so pushing a branch tag will not cut a release.
 
 .. code-block:: bash
 
-    git tag 2.3.5
-    git push origin 2.3.5
+    git tag 2.4.1
+    git push origin 2.4.1
 
 That is the whole procedure. Three jobs follow:
 
@@ -101,9 +101,9 @@ build discardable before anyone has fetched it.
    and 2.3.1 went out that way.
 -  Press "Publish release".
 
-The release GitHub currently shows as latest is titled ``v2.3.4`` and
-points at the ``2.3.4_cadical`` branch tag rather than the ``2.3.4`` tag --
-an accident of how that one was cut, not something to copy.
+The release titled ``v2.3.4`` points at the ``2.3.4_cadical`` branch tag
+rather than at the ``2.3.4`` tag -- an accident of how that one was cut,
+not something to copy.
 
 What gets built
 ---------------
@@ -232,4 +232,4 @@ After the release
 -  Bump the version again only when the next release is cut. Master carries
    the last released version between releases, so a build from master
    reports the release it followed rather than something like
-   ``2.3.5-dev``. That is the existing convention, not an oversight.
+   ``2.4.1-dev``. That is the existing convention, not an oversight.


### PR DESCRIPTION
Version bump ahead of tagging 2.4.0. Nothing else changes.

## Why minor, not patch

232 commits since 2.3.4. The public API has grown — `c_interface.h` (+133
lines) and `cpp_interface.h` (+35) both gained symbols — though nothing was
removed, so this is additive for existing callers.

Per `docs/releasing.rst`, a minor bump is the one that changes the soname:

- `libstp.so.2.3` becomes `libstp.so.2.4`
- `STPConfigVersion.cmake` stops matching `find_package(STP 2.3)`

so distribution packagers have to rebuild anything that links STP. Verified
by configuring this branch: `PROJECT_VERSION 2.4.0`, `libstp.so.2.4`, and
the config gate is now on `2.4`.

## What changed

- `CMakeLists.txt` — `STP_FULL_VERSION`
- `docs/conf.py` — `release`

Both carry the version by hand and the release workflow's `check version`
job refuses to build a tag that disagrees with either. Everything else
derives from `STP_FULL_VERSION`.

`docs/releasing.rst` moves with them: the two lines quoting the current
file contents, and the `git tag` examples (now 2.4.1). The note about the
`v2.3.4` release loses its "currently shows as latest", which stops being
true as soon as this ships.

## After merging

`git tag 2.4.0 && git push origin 2.4.0` runs `release.yml`, which builds
the static CryptoMiniSat binary, checks it and opens a **draft** release
with `SHA256SUMS` attached. Nothing is public until the draft is published
by hand.