### PR TITLE
Seed the ground-path square root without overflowing

### DIFF
--- a/lib/Simplifier/AchievableImage.cpp
+++ b/lib/Simplifier/AchievableImage.cpp
@@ -183,11 +183,15 @@ uint64_t isqrt64(uint64_t n)
 {
   if (n == 0)
     return 0;
-  uint64_t x = n, y = (x + 1) / 2;
+  // The Newton seed is ceil(n/2), written so that it can't overflow:
+  // (n + 1) / 2 wraps to zero at n == UINT64_MAX, and the first
+  // iteration then divides by it. Every smaller n gets the same seed,
+  // so no other input's result moves.
+  uint64_t x = n, y = n / 2 + (n & 1);
   while (y < x)
   {
     x = y;
-    y = (x + n / x) / 2;
+    y = (x + n / x) / 2; // x >= isqrt(n) here, so n / x <= x: no overflow
   }
   return x;
 }

--- a/tests/query-files/simplification-tests/unconstrained-ground-path3.smt2
+++ b/tests/query-files/simplification-tests/unconstrained-ground-path3.smt2
@@ -1,0 +1,29 @@
+; RUN: %solver %s | %OutputCheck %s
+; CHECK: ^unsat
+(set-logic QF_BV)
+(set-info :smt-lib-version 2.0)
+(set-info :category "check")
+(set-info :status unsat)
+
+; The ground-path collapse back-propagates the predicate's constant down
+; the chain to seed its samples. Here that walks all-ones into the
+; squaring step, whose heuristic preimage is an integer square root, and
+; isqrt64(2^64-1) overflowed its Newton seed to zero and then divided by
+; it -- a SIGFPE during RemoveUnconstrained, before any decision was made.
+;
+; The shift is load-bearing: topLevel_other skips a variable whose
+; sibling is the variable itself, so (bvmul x x) alone never reaches the
+; collapse, and a shift by a constant has no per-kind rule of its own.
+; The width must be exactly 64 for the back-propagated value to be the
+; UINT64_MAX that overflows.
+(declare-fun x () (_ BitVec 64))
+(assert (= (bvmul (bvlshr x #x0000000000000001) (bvlshr x #x0000000000000001)) #xffffffffffffffff))
+
+; Same crash reached with the constant back-propagated rather than
+; written out: bvnot maps 0 to all-ones on the way down the chain.
+(declare-fun y () (_ BitVec 64))
+(assert (bvule (bvnot (bvmul (bvudiv y #x0000000000000003) (bvudiv y #x0000000000000003))) #x0000000000000000))
+
+; Unsat either way: a square is 0 or 1 mod 4, never 3.
+(check-sat)
+(exit)

--- a/tests/unit-tests/AchievableImage_Exhaustive_Test.cpp
+++ b/tests/unit-tests/AchievableImage_Exhaustive_Test.cpp
@@ -587,6 +587,35 @@ TEST(AchievableImage_Exhaustive, hint_backprop_through_shifted_window)
   EXPECT_LE(evalChain64(steps, d.witnessFalse.GetUnsignedConst()), K);
 }
 
+TEST(AchievableImage_Exhaustive, hint_backprop_square_of_all_ones)
+{
+  // (= (bvmul t t) 0xFFFFFFFFFFFFFFFF) back-propagates all-ones into
+  // the squaring step, whose heuristic preimage is the integer square
+  // root. At exactly 2^64-1 the Newton seed overflowed to zero and the
+  // first iteration divided by it -- SIGFPE, before any decision was
+  // even attempted. (e.g. (= (bvmul (bvlshr x 1) (bvlshr x 1)) ~0)
+  // killed the solver during RemoveUnconstrained.)
+  Ctx c;
+  const unsigned w = 64;
+  const uint64_t root = 0xFFFFFFFFull;   // floor(sqrt(2^64-1)) == 2^32-1
+  const uint64_t square = root * root;   // 0xFFFFFFFE00000001
+
+  const std::vector<GroundStep> steps = {c.same(BVMULT, w)};
+  AchievableImage img(c.mgr, w);
+  img.addHintChain(steps, c.konst(0xFFFFFFFFFFFFFFFFull, w));
+  for (const GroundStep& s : steps)
+    ASSERT_TRUE(img.apply(s));
+
+  // The recovered hint seeds the samples, so the value it squares to is
+  // achievable -- which is what makes the root observable from outside.
+  AchievableImage::Decision d = img.decide(EQ, true, c.konst(square, w));
+  ASSERT_TRUE(d.collapse);
+  EXPECT_EQ(d.witnessTrue, c.konst(root, w));
+
+  // All-ones itself is 3 mod 4, so it is no square: nothing to collapse.
+  EXPECT_FALSE(img.decide(EQ, true, c.konst(0xFFFFFFFFFFFFFFFFull, w)).collapse);
+}
+
 TEST(AchievableImage_Exhaustive, wide_chain_width128)
 {
   // ((x mod 100) + 7) >u 50 at width 128: stays exact, collapses, and


### PR DESCRIPTION
#680 added `isqrt64` to seed the ground-path collapse's backward hint chain. Its Newton seed `(n + 1) / 2` overflows to zero at `n == UINT64_MAX`, and the next iteration then divides by it.

`hintBackStep` calls it for a `(bvmul t t)` step of width 64, so any chain whose back-propagated target is all-ones takes a SIGFPE inside `RemoveUnconstrained`. That needs nothing but plain QF_BV — no floating point, no arrays — and crashes master today, 2.4.0 included:

```smt2
(set-logic QF_BV)
(declare-fun x () (_ BitVec 64))
(assert (= (bvmul (bvlshr x #x0000000000000001) (bvlshr x #x0000000000000001)) #xffffffffffffffff))
(check-sat)
```

```
$ stp --SMTLIB2 crash.smt2 ; echo $?
136
```

(136 is a hardware trap, so there is no assertion text.)

Fixed here by seeding with `n / 2 + (n & 1)`: the same `ceil(n/2)` without the overflow. Every smaller `n` keeps the seed it had, so no existing result — or the CNF built from it — moves, and `UINT64_MAX` now returns the exact root `2^32 - 1`. Checked against the old function over ~11M inputs.

Two regression tests, both SIGFPE without the fix: a unit test that back-propagates all-ones through a width-64 square and checks the recovered root is really used, and `unconstrained-ground-path3.smt2`.

Found by a murxla campaign that was fuzzing a downstream floating-point branch; the trace was FP-heavy but minimises to this bit-vector core, and the crashing code is FP-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
