### PR TITLE
release: bump the version to 2.4.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -457,7 +457,7 @@ if (GIT_EXECUTABLE)
 else()
   set(GIT_SHA "GIT-hash-notfound")
 endif()
-set(STP_FULL_VERSION "2.4.0")
+set(STP_FULL_VERSION "2.4.1")
 
 string(REPLACE "." ";" STP_FULL_VERSION_LIST ${STP_FULL_VERSION})
 SetVersionNumber("PROJECT" ${STP_FULL_VERSION_LIST})

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ author = 'The STP Project'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '2.4.0'
+release = '2.4.1'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/releasing.rst
+++ b/docs/releasing.rst
@@ -11,7 +11,7 @@ Only the bump is done by hand. Pushing the tag runs
 binary and opens the release as a draft:
 
 #. Edit the version in the two files below, and commit to master.
-#. ``git tag 2.4.1 && git push origin 2.4.1``.
+#. ``git tag 2.4.2 && git push origin 2.4.2``.
 #. Read the draft the workflow leaves behind, then publish it.
 
 Where the version lives
@@ -19,8 +19,8 @@ Where the version lives
 
 Two files carry it, both edited by hand:
 
--  ``CMakeLists.txt`` -- ``set(STP_FULL_VERSION "2.4.0")``
--  ``docs/conf.py`` -- ``release = '2.4.0'``
+-  ``CMakeLists.txt`` -- ``set(STP_FULL_VERSION "2.4.1")``
+-  ``docs/conf.py`` -- ``release = '2.4.1'``
 
 Everything else derives from ``STP_FULL_VERSION``: ``include/stp/config.h``,
 ``STPConfigVersion.cmake``, the ``stp.1`` man page, the ``SOVERSION`` of
@@ -61,8 +61,8 @@ them, so pushing a branch tag will not cut a release.
 
 .. code-block:: bash
 
-    git tag 2.4.1
-    git push origin 2.4.1
+    git tag 2.4.2
+    git push origin 2.4.2
 
 That is the whole procedure. Three jobs follow:
 
@@ -232,4 +232,4 @@ After the release
 -  Bump the version again only when the next release is cut. Master carries
    the last released version between releases, so a build from master
    reports the release it followed rather than something like
-   ``2.4.1-dev``. That is the existing convention, not an oversight.
+   ``2.4.2-dev``. That is the existing convention, not an oversight.


### PR DESCRIPTION
Two bug fixes since 2.4.0, both crashes on plain QF_BV:

- #699 -- `conjoin_to_top` looped an index past `currentSorted` on stale multiplication column bounds.
- #702 -- `isqrt64`'s Newton seed `(n + 1) / 2` overflowed to zero at `n == UINT64_MAX`, and the next iteration divided by it. SIGFPE inside `RemoveUnconstrained` on a three-line query.

Nothing under `include/` changed, so this is a patch bump rather than a minor one: the soname stays `libstp.so.2.4` and `STPConfigVersion.cmake` keeps matching `find_package(STP 2.4)`, so packagers pick this up without rebuilding what links STP.

Both files that carry the version by hand, since the release workflow's `check version` job refuses to build a tag that disagrees with either. The examples in `docs/releasing.rst` move with them, following what the 2.4.0 bump did: the "where the version lives" entries name what master now carries, and the `git tag` commands name the release after this one.

Tagging waits on this landing and on CI being green on the merge commit.