### PR TITLE
Support Python 3.14 AST constants, and test the bindings against it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,35 @@ jobs:
         ./tools/rewrite_rule_gen/rewrite_rule_gen generate 5 3
       working-directory: build
 
+    # The bindings walk the CPython AST, whose node types drift between
+    # releases: 3.14 removed NodeVisitor's visit_Num fallback, so every
+    # numeric literal in an @stp-decorated function began reaching
+    # ASTtoSTP.generic_visit and raising "Constant is not yet supported!".
+    # Nothing above catches that -- the build configures against whatever
+    # python3 the runner ships, which trails the newest release -- so run
+    # the binding tests once more against the newest one. stp.py.in has no
+    # configure-time substitutions, so the interpreter can be swapped
+    # under the same build tree; no second build is needed.
+    #
+    # Bump the version when a newer Python is released. The point is to be
+    # a step ahead of what the distributions ship, not to pin one version
+    # forever. Last on the gcc leg only: the interpreter is what is under
+    # test, not the compiler, and setup-python puts its own python3 first
+    # on PATH, which no later step should inherit.
+    - name: Set up the newest Python
+      if: matrix.name == 'gcc'
+      uses: actions/setup-python@v7
+      with:
+        python-version: '3.14'
+
+    - name: Python bindings against the newest Python
+      if: matrix.name == 'gcc'
+      run: |
+        python3 --version
+        python3 tests.py
+        python3 allocator_tests.py
+      working-directory: build/tests/api/python
+
   build-cadical:
     name: gcc (cadical)
     runs-on: ubuntu-latest

--- a/bindings/python/stp/stp.py.in
+++ b/bindings/python/stp/stp.py.in
@@ -821,6 +821,14 @@ class ASTtoSTP(ast.NodeVisitor):
     def visit_Num(self, node):
         return node.n
 
+    def visit_Constant(self, node):
+        # Numeric literals have been represented by ast.Constant since
+        # Python 3.8.  NodeVisitor kept dispatching them through visit_Num
+        # for compatibility until Python 3.14 removed that fallback.
+        if isinstance(node.value, (int, float, complex)):
+            return node.value
+        return self.generic_visit(node)
+
     def visit_BoolOp(self, node):
         ops = {
             ast.And: self.s.and_,


### PR DESCRIPTION
The `@stp` decorator compiles a Python function by walking its CPython AST, so `ASTtoSTP` needs a visitor for every node kind it can meet. Numeric literals have parsed as `ast.Constant` since 3.8, and `ast.NodeVisitor` kept dispatching them to the older `visit_Num` for compatibility. Python 3.14 removed that fallback, so every numeric literal now reaches `ASTtoSTP.generic_visit`, which raises:

```
Exception: Constant is not yet supported!
```

That is any use of the decorator with a literal in it — `tests.py::test_ast` is one, so the `python-interface-tests` suite fails outright on 3.14.

The first commit adds `visit_Constant`, returning the value for the numeric types `visit_Num` used to handle and falling through to `generic_visit` otherwise, so a string or other unsupported constant still reports itself the way it always did. `visit_Num` stays: it is dead on anything recent, but it costs nothing and still serves an interpreter old enough to produce `ast.Num`.

The second commit puts a Python 3.14 run in CI, because nothing there would have caught this. Every job configures against `which python3`, which is whatever the runner image ships, and that trails the newest release by a year or more — the bug reached users before it reached a build. The binding tests need no build of their own: `stp.py.in` has no configure-time substitutions and `tests.py` holds the interface directory as an absolute path, so a second interpreter runs against the tree the job has already built. Two steps at the end of the gcc leg, after everything that uses the runner's `python3`, since `setup-python` puts its own first on `PATH`.

The version is pinned rather than floating. Something that tracked "newest" would turn CI red on unrelated pull requests the day a release lands, and the maintainer would find out from a confused contributor; bumping it should be a deliberate step, and the comment in the workflow says so.

Verified by running `tests.py` and `allocator_tests.py` against 3.10, 3.11, 3.12, 3.13, 3.14 and 3.15 on one build tree. All six pass with the fix. Without it, 3.10 through 3.13 still pass — `NodeVisitor` kept forwarding `Constant` to `visit_Num` that far — and only 3.14 and 3.15 fail, which is why the new job pins a version ahead of what the runners ship instead of testing whatever is already there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
