### PR TITLE
Share the CBV/uint64 primitives in one header

### DIFF
--- a/include/stp/Util/CBVOps.h
+++ b/include/stp/Util/CBVOps.h
@@ -1,0 +1,118 @@
+/********************************************************************
+ * AUTHORS: Trevor Hansen, Andrew Teylu
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+// Moving values between CONSTANTBV bit-vectors and machine words.
+//
+// Several analyses run a fast 64-bit path beside the bit-vector one and
+// need to cross between them. They each used to carry their own copy of
+// these, under different names and -- worse -- with different methods:
+// one read the vector's words through a raw pointer cast, which bakes in
+// both the width of the storage word and its endianness. Everything here
+// goes through the CONSTANTBV chunk interface instead, so the storage
+// layout stays CONSTANTBV's business.
+//
+// The chunk interface is the reason for the doubled-up reads and writes
+// below: a chunk carries at most an `unsigned long`, which isn't 64 bits
+// everywhere (Windows and 32-bit targets), so 64 bits move in two halves
+// of 32. Both chunk calls clamp: a chunk that runs past the vector's
+// width is cut back to the width, and one that starts at or beyond the
+// width does nothing and reads as zero. That clamping is what lets these
+// be free of width guards, and it is also what makes the constructor
+// below truncate rather than corrupt when handed too large a value.
+
+#ifndef CBVOPS_H_
+#define CBVOPS_H_
+
+#include "extlib-constbv/constantbv.h"
+#include <cstdint>
+
+namespace stp
+{
+
+// Same spelling as the one in AST/UsefulDefs.h, so that this header can
+// be used without dragging the AST in.
+typedef unsigned int* CBV;
+
+// The low `width` bits set, as a machine word. Saturates: a width of 64
+// or more gives all ones, so callers needn't special-case the shift
+// (shifting a 64-bit value by 64 is undefined).
+inline uint64_t mask64(unsigned width)
+{
+  return width >= 64 ? ~0ull : (1ull << width) - 1;
+}
+
+// A fresh all-ones vector of the given width. The caller owns it.
+inline CBV allOnes(unsigned width)
+{
+  CBV result = CONSTANTBV::BitVector_Create(width, true);
+  CONSTANTBV::BitVector_Fill(result);
+  return result;
+}
+
+// The 64 bits of x starting at any bit offset, as a machine word. Bits
+// at or above the vector's width read as zero, so no guards are needed
+// and any offset is allowed.
+inline uint64_t chunkAt(const CBV x, unsigned offset)
+{
+  uint64_t r = CONSTANTBV::BitVector_Chunk_Read(x, 32, offset);
+  r |= (uint64_t)CONSTANTBV::BitVector_Chunk_Read(x, 32, offset + 32) << 32;
+  return r;
+}
+
+// Bits [64k, 64k+63] of x as a machine word.
+inline uint64_t chunk64(const CBV x, unsigned k)
+{
+  return chunkAt(x, 64 * k);
+}
+
+// The inverse of chunk64. Bits of the value that fall above the vector's
+// width are dropped.
+inline void setChunk64(CBV x, unsigned k, uint64_t value)
+{
+  const unsigned offset = 64 * k;
+  CONSTANTBV::BitVector_Chunk_Store(x, 32, offset, value);
+  CONSTANTBV::BitVector_Chunk_Store(x, 32, offset + 32, value >> 32);
+}
+
+// The low (up to 64) bits of x as a machine word. A wider vector keeps
+// only its bottom 64 bits.
+inline uint64_t low64(const CBV x)
+{
+  return chunk64(x, 0);
+}
+
+// A fresh vector of the given width holding a machine word. The caller
+// owns it. Truncating: bits of the value at or above the width are
+// dropped, as are bits above 64 of a wider vector, which is left zero
+// there.
+inline CBV cbvFromU64(unsigned width, uint64_t value)
+{
+  CBV r = CONSTANTBV::BitVector_Create(width, true);
+  setChunk64(r, 0, value);
+  return r;
+}
+
+} // end namespace stp
+
+#endif

--- a/lib/Simplifier/AchievableImage.cpp
+++ b/lib/Simplifier/AchievableImage.cpp
@@ -25,6 +25,7 @@ THE SOFTWARE.
 #include "stp/Simplifier/AchievableImage.h"
 #include "stp/Simplifier/Simplifier.h"
 #include "stp/STPManager/STPManager.h"
+#include "stp/Util/CBVOps.h"
 
 namespace stp
 {
@@ -37,26 +38,10 @@ CBV mkZero(unsigned width)
   return CONSTANTBV::BitVector_Create(width, true);
 }
 
-CBV mkOnes(unsigned width)
-{
-  CBV v = mkZero(width);
-  CONSTANTBV::BitVector_Fill(v);
-  return v;
-}
-
 CBV mkOne(unsigned width)
 {
   CBV v = mkZero(width);
   CONSTANTBV::BitVector_increment(v);
-  return v;
-}
-
-CBV mkNum(unsigned width, unsigned value)
-{
-  CBV v = mkZero(width);
-  for (unsigned i = 0; i < sizeof(unsigned) * 8 && i < width; i++)
-    if ((value & (1u << i)) != 0)
-      CONSTANTBV::BitVector_Bit_On(v, i);
   return v;
 }
 
@@ -135,7 +120,7 @@ CBV umaxTake(const CBV a, CBV t)
 
 AchievableImage::AchievableImage(STPMgr& _bm, unsigned _varWidth)
     : bm(_bm), varWidth(_varWidth), rep(Rep::Exact), lo(mkZero(_varWidth)),
-      hi(mkOnes(_varWidth)), curWidth(_varWidth)
+      hi(allOnes(_varWidth)), curWidth(_varWidth)
 {
   assert(varWidth > 0);
 }
@@ -168,15 +153,6 @@ void AchievableImage::addHint(const ASTNode& k)
 
 namespace
 {
-// The low 64 bits of a CBV (which stores 32-bit words, low first).
-uint64_t low64(const CBV v)
-{
-  uint64_t r = ((unsigned*)v)[0];
-  if (bits_(v) > 32)
-    r |= ((uint64_t)((unsigned*)v)[1]) << 32;
-  return r;
-}
-
 // Deterministic integer square root (no libm: the result seeds samples,
 // and a last-ulp difference between platforms would change the CNF).
 uint64_t isqrt64(uint64_t n)
@@ -196,15 +172,6 @@ uint64_t isqrt64(uint64_t n)
   return x;
 }
 
-CBV mkNum64(unsigned width, uint64_t value)
-{
-  CBV v = mkZero(width);
-  for (unsigned i = 0; i < 64 && i < width; i++)
-    if ((value >> i) & 1)
-      CONSTANTBV::BitVector_Bit_On(v, i);
-  return v;
-}
-
 // Heuristic preimage of `out` under one step. Used only to generate
 // sample seeds -- witnesses are validated forward -- so it may be wrong,
 // just not useless. NULL when no sensible backward map exists.
@@ -222,7 +189,7 @@ CBV hintBackStep(const GroundStep& step, const CBV out)
       return r;
     }
     if (step.kind == BVMULT && W <= 64) // x * x: integer square root
-      return mkNum64(W, isqrt64(low64(out)));
+      return cbvFromU64(W, isqrt64(low64(out)));
     return NULL;
   }
 
@@ -272,7 +239,7 @@ CBV hintBackStep(const GroundStep& step, const CBV out)
       CBV t = widen(out, w);
       if (j == 0)
         return t;
-      CBV jc = mkNum(w, j);
+      CBV jc = cbvFromU64(w, j);
       CBV r = op2(BVLEFTSHIFT, t, jc, w);
       destroy(t);
       destroy(jc);
@@ -284,7 +251,7 @@ CBV hintBackStep(const GroundStep& step, const CBV out)
         return truncate(out, w);
       // x ++ c: drop the constant's low bits.
       const unsigned cw = step.constants[0].GetValueWidth();
-      CBV sc = mkNum(W, cw);
+      CBV sc = cbvFromU64(W, cw);
       CBV t = op2(BVRIGHTSHIFT, out, sc, W);
       destroy(sc);
       CBV r = truncate(t, w);
@@ -314,12 +281,12 @@ CBV hintBackStep(const GroundStep& step, const CBV out)
         if (!divides) // no exact preimage; fall back to the quotient
           return op2(BVDIV, out, c, W);
       }
-      CBV sc = mkNum(W, s);
+      CBV sc = cbvFromU64(W, s);
       CBV odd = op2(BVRIGHTSHIFT, c, sc, W);
       CBV shifted = op2(BVRIGHTSHIFT, out, sc, W);
       destroy(sc);
       CBV inv = clone(odd);
-      CBV two = mkNum(W, 2);
+      CBV two = cbvFromU64(W, 2);
       for (unsigned bits = 3; bits < W; bits *= 2)
       {
         CBV oi = op2(BVMULT, odd, inv, W);
@@ -573,7 +540,7 @@ bool AchievableImage::applyExact(const GroundStep& step)
       if (isZero(c))
       {
         // x / 0 is all-ones for every x.
-        CBV ones = mkOnes(w);
+        CBV ones = allOnes(w);
         setExact(clone(ones), ones, W);
         return true;
       }
@@ -652,7 +619,7 @@ bool AchievableImage::applyExact(const GroundStep& step)
       // i-j+1 bits; the truncation behaves like mod 2^(i-j+1).
       const unsigned j = step.constants[1].GetUnsignedConst();
       const unsigned len = W;
-      CBV jc = mkNum(w, j);
+      CBV jc = cbvFromU64(w, j);
       CBV ta = op2(BVRIGHTSHIFT, lo, jc, w);
       CBV tb = op2(BVRIGHTSHIFT, hi, jc, w);
       destroy(jc);
@@ -671,7 +638,7 @@ bool AchievableImage::applyExact(const GroundStep& step)
         if (ucmp(d, mask) >= 0) // a full cycle: every value reached
         {
           nl = mkZero(len);
-          nh = mkOnes(len);
+          nh = allOnes(len);
           exact = true;
         }
         destroy(d);
@@ -857,9 +824,9 @@ void AchievableImage::degradeToSamples(const GroundStep& degradingStep)
   }
   addSeed(mkZero(w));
   addSeed(mkOne(w));
-  addSeed(mkOnes(w));
+  addSeed(allOnes(w));
   { // signed extremes
-    CBV sMax = mkOnes(w);
+    CBV sMax = allOnes(w);
     CONSTANTBV::BitVector_Bit_Off(sMax, w - 1);
     addSeed(sMax);
     CBV sMin = mkZero(w);
@@ -996,7 +963,7 @@ CBV AchievableImage::invertStep(const GroundStep& step, const CBV inLo,
     {
       const unsigned j = step.constants[1].GetUnsignedConst();
       const unsigned len = step.outWidth;
-      CBV jc = mkNum(w, j);
+      CBV jc = cbvFromU64(w, j);
       CBV ta = op2(BVRIGHTSHIFT, inLo, jc, w);
       CBV tb = op2(BVRIGHTSHIFT, inHi, jc, w);
       CBV mask = mkLowMask(len, w);
@@ -1153,7 +1120,7 @@ AchievableImage::Decision AchievableImage::decide(Kind pred,
           CONSTANTBV::BitVector_bit_test(hi, curWidth - 1);
       if (isSigned && crossing)
       {
-        mx = mkOnes(curWidth);
+        mx = allOnes(curWidth);
         CONSTANTBV::BitVector_Bit_Off(mx, curWidth - 1);
         mn = mkZero(curWidth);
         CONSTANTBV::BitVector_Bit_On(mn, curWidth - 1);

--- a/lib/Simplifier/UnsignedIntervalAnalysis.cpp
+++ b/lib/Simplifier/UnsignedIntervalAnalysis.cpp
@@ -35,6 +35,7 @@ THE SOFTWARE.
 #include "stp/Simplifier/UnsignedInterval.h"
 #include "stp/Simplifier/StrengthReduction.h"
 #include "stp/Util/BitOps.h"
+#include "stp/Util/CBVOps.h"
 #include <iostream>
 #include <map>
 
@@ -83,32 +84,8 @@ namespace stp
     // untouched and its chunks below are all-zero against an upper
     // bound or all-one against a lower bound. ----
 
-    // The 64 bits of x starting at any bit offset, as a machine word.
-    // Chunk_Read clamps at the vector's width and reads zero past it, so
-    // no guards are needed. Two 32-bit reads because Chunk_Read is
-    // capped at the bits of an unsigned long, which isn't 64 everywhere.
-    uint64_t chunkAt(const CBV x, unsigned offset)
-    {
-      uint64_t r = CONSTANTBV::BitVector_Chunk_Read(x, 32, offset);
-      r |= (uint64_t)CONSTANTBV::BitVector_Chunk_Read(x, 32, offset + 32)
-           << 32;
-      return r;
-    }
-
-    // Bits [64k, 64k+63] of x as a machine word.
-    uint64_t chunk64(const CBV x, unsigned k)
-    {
-      return chunkAt(x, 64 * k);
-    }
-
-    // The inverse of chunk64. The value's bits above the vector's width
-    // must be zero.
-    void setChunk64(CBV x, unsigned k, uint64_t value)
-    {
-      const unsigned offset = 64 * k;
-      CONSTANTBV::BitVector_Chunk_Store(x, 32, offset, value);
-      CONSTANTBV::BitVector_Chunk_Store(x, 32, offset + 32, value >> 32);
-    }
+    // chunkAt / chunk64 / setChunk64, which the drivers below run over,
+    // are shared: see Util/CBVOps.h.
 
     // Which operand a chunk kernel changed.
     enum class Changed
@@ -789,19 +766,7 @@ namespace stp
     static const unsigned wordPathMaxWidth = 32;
 #endif
 
-    // The low (up to 64) bits of x as a machine word.
-    uint64_t low64(const CBV x)
-    {
-      return chunk64(x, 0);
-    }
-
-    // A fresh CBV holding a machine word. Needs value < 2^width.
-    CBV cbvFromU64(unsigned width, uint64_t value)
-    {
-      CBV r = CONSTANTBV::BitVector_Create(width, true);
-      setChunk64(r, 0, value);
-      return r;
-    }
+    // low64 and cbvFromU64 are shared: see Util/CBVOps.h.
 
     // The minimum of (a*i + b) mod m over 0 <= i < n; requires n >= 1,
     // a < m and b < m, with m <= 2^wordPathMaxWidth so nothing here can

--- a/lib/Simplifier/ValueSetAnalysis.cpp
+++ b/lib/Simplifier/ValueSetAnalysis.cpp
@@ -24,6 +24,7 @@ THE SOFTWARE.
 
 #include "stp/Simplifier/ValueSetAnalysis.h"
 #include "stp/Simplifier/Simplifier.h"
+#include "stp/Util/CBVOps.h"
 
 namespace stp
 {
@@ -38,21 +39,8 @@ namespace stp
 
   namespace
   {
-    CBV valueOf(unsigned width, uint64_t value)
-    {
-      CBV result = CONSTANTBV::BitVector_Create(width, true);
-      for (unsigned i = 0; i < width && i < 64; i++)
-        if ((value >> i) & 1)
-          CONSTANTBV::BitVector_Bit_On(result, i);
-      return result;
-    }
-
-    CBV allOnes(unsigned width)
-    {
-      CBV result = CONSTANTBV::BitVector_Create(width, true);
-      CONSTANTBV::BitVector_Fill(result);
-      return result;
-    }
+    // The conversions between vectors and machine words -- allOnes,
+    // mask64, low64 and cbvFromU64 -- are shared: see Util/CBVOps.h.
 
     // The shift amount, saturated at the width: shifting by the width or
     // more always gives the same answer.
@@ -157,37 +145,6 @@ namespace stp
         default:
           return NonMemberBVConstEvaluator(k, args, n.GetValueWidth());
       }
-    }
-
-    uint64_t mask64(unsigned width)
-    {
-      return width >= 64 ? ~0ull : (1ull << width) - 1;
-    }
-
-    // The value of a bit-vector of at most 64 bits. The chunk functions
-    // move at most an unsigned long per call, which is 32 bits on some
-    // platforms, so go in two halves.
-    uint64_t cbvToU64(const CBV v)
-    {
-      const unsigned width = bits_(v);
-      assert(width <= 64);
-      uint64_t result =
-          CONSTANTBV::BitVector_Chunk_Read(v, std::min(width, 32u), 0);
-      if (width > 32)
-        result |= (uint64_t)CONSTANTBV::BitVector_Chunk_Read(v, width - 32, 32)
-                  << 32;
-      return result;
-    }
-
-    CBV u64ToCBV(uint64_t v, unsigned width)
-    {
-      CBV result = CONSTANTBV::BitVector_Create(width, true);
-      CONSTANTBV::BitVector_Chunk_Store(result, std::min(width, 32u), 0,
-                                        (unsigned long)(v & 0xffffffffull));
-      if (width > 32)
-        CONSTANTBV::BitVector_Chunk_Store(result, width - 32, 32,
-                                          (unsigned long)(v >> 32));
-      return result;
     }
 
     size_t popcount64(uint64_t v)
@@ -417,7 +374,7 @@ namespace stp
     if (width > SMALL_WIDTH)
       return false;
     for (uint64_t v = 0; v < (1ull << width); v++)
-      out.push_back(valueOf(width, v));
+      out.push_back(cbvFromU64(width, v));
     return true;
   }
 
@@ -437,7 +394,7 @@ namespace stp
       if ((width + 1) * children[0]->size() > PRODUCT_CAP)
         return false;
       for (unsigned s = 0; s <= width; s++)
-        out.push_back(valueOf(width, s));
+        out.push_back(cbvFromU64(width, s));
       return true;
     }
 
@@ -622,7 +579,7 @@ namespace stp
 
     unsigned smallest = width;
     for (const CBV s : children[1]->values)
-      smallest = (unsigned)std::min<uint64_t>(smallest, cbvToU64(s));
+      smallest = (unsigned)std::min<uint64_t>(smallest, low64(s));
 
     // Shifted all the way out, an arithmetic shift still copies the sign
     // bit, so that bit always has to be varied.
@@ -709,7 +666,7 @@ namespace stp
       {
         members[i].reserve(children[i]->size());
         for (const CBV m : children[i]->values)
-          members[i].push_back(cbvToU64(m));
+          members[i].push_back(low64(m));
       }
       else if (!standIns64(n, i, children, widths[i], members[i], expandWith))
       {
@@ -789,7 +746,7 @@ namespace stp
     ValueSet* result = fresh(n);
     result->values.reserve(size);
     for (size_t i = 0; i < size; i++)
-      result->values.push_back(u64ToCBV(results[i], outWidth));
+      result->values.push_back(cbvFromU64(outWidth, results[i]));
 
     propagated++;
     return result;

--- a/lib/Simplifier/consteval.cpp
+++ b/lib/Simplifier/consteval.cpp
@@ -23,6 +23,7 @@ THE SOFTWARE.
 ********************************************************************/
 
 #include "stp/Simplifier/Simplifier.h"
+#include "stp/Util/CBVOps.h"
 #include <cassert>
 
 namespace stp
@@ -43,13 +44,6 @@ static unsigned cbvToUnsigned(const CBV v)
       CONSTANTBV::Set_Max(v) >= ((signed long)sizeof(unsigned)) * 8)
     FatalError("BVConstEvaluator: constant doesn't fit an unsigned int");
   return *(unsigned*)v;
-}
-
-static CBV allOnes(unsigned width)
-{
-  CBV result = CONSTANTBV::BitVector_Create(width, true);
-  CONSTANTBV::BitVector_Fill(result);
-  return result;
 }
 
 CBV NonMemberBVConstEvaluator(const Kind k, const std::vector<CBV>& args,
@@ -518,11 +512,6 @@ bool NonMemberBVConstPredicateEvaluator(const Kind k, const CBV a, const CBV b)
       FatalError("BVConstEvaluator: not a two-argument predicate kind");
       return false;
   }
-}
-
-static uint64_t mask64(unsigned width)
-{
-  return width >= 64 ? ~0ull : (1ull << width) - 1;
 }
 
 static int64_t toSigned64(uint64_t v, unsigned width)


### PR DESCRIPTION
### Motivation

One small set of CONSTANTBV-to-machine-word primitives had grown four independent copies, in `ValueSetAnalysis.cpp`, `consteval.cpp`, `AchievableImage.cpp` and `UnsignedIntervalAnalysis.cpp`. They disagreed on spelling (`allOnes` vs `mkOnes`, `cbvToU64` vs `low64`, `valueOf` vs `u64ToCBV` vs `cbvFromU64` vs `mkNum64`), on argument order, and — the part worth fixing — on method.

`AchievableImage::low64` read the vector's storage through a raw `(unsigned*)v` cast, assuming 32-bit words held low-first. It looked identical to its two siblings but made a portability assumption neither of them made: the other two go through `BitVector_Chunk_Read`, which is what keeps the storage layout CONSTANTBV's business. It now does too.

They are now one set of `inline` functions in `include/stp/Util/CBVOps.h`, alongside `BitOps.h`:

| | |
|---|---|
| `mask64(width)` | the low `width` bits set, saturating at 64 |
| `allOnes(width)` | a fresh all-ones vector |
| `chunkAt` / `chunk64` / `setChunk64` | 64 bits at a bit offset, and the inverse |
| `low64(x)` | the low (up to 64) bits of a vector |
| `cbvFromU64(width, value)` | a fresh vector holding a machine word |

The "why" comments that were worth keeping came along: in particular why 64 bits move in two halves of 32 (a chunk carries at most an `unsigned long`, which isn't 64 bits everywhere) and why the chunk calls' clamping makes width guards unnecessary.

Genuinely local helpers stayed local — `mkZero`, `mkOne`, `mkLowMask`, `isqrt64`, `hintBackStep`, `shiftAmount`, `boolCBV`, and the chunk-loop kernels in `UnsignedIntervalAnalysis.cpp`. The three chunk accessors moved because `low64` and `cbvFromU64` are defined in terms of them; the drivers that use them pervasively read exactly as before.

### The contract, where the four constructors disagreed

Two of them (`valueOf`, `mkNum64`) looped over `min(width, 64)` bits and so truncated; `u64ToCBV` took `(value, width)`; `cbvFromU64` documented a `value < 2^width` precondition.

**Truncating semantics win, without an assert.** The precondition turned out never to have been load-bearing: `BitVector_Chunk_Store` already clamps a chunk to the vector's width (`if ((offset + chunksize) > bits) chunksize = bits - offset;`) and does nothing at all when the chunk starts at or past the width, so the `Chunk_Store` form truncates exactly as the bit loops did. One function covers all four call patterns. It is documented as truncating rather than asserting, because an assert would turn a case callers were previously allowed to hit into a debug-build abort — which is not a behaviour-neutral change.

The surviving argument order is `(width, value)`, which three of the four already used. `u64ToCBV`'s one call site was flipped to match.

`AchievableImage::mkNum(width, unsigned)` was folded in as well: its loop over `min(width, 32)` bits is exactly the truncating 64-bit case.

### Neutrality evidence

The change is meant to be invisible to the solver, so it is checked that way rather than argued.

`bench-hard/cnf_neutral.sh` against a binary built from the parent commit, over the 40-file pre-CNF corpus:

```
identical: 39   mismatched: 0   skipped: 1
```

The skipped file (`QF_BV/uclid/catchconv/catchconv-15803.smt2`) is one the *baseline* emits no CNF for, so there is nothing to compare; it answers `unsat` under both binaries.

All 118 `.smt2` files under `tests/query-files/` also give byte-identical output under both binaries.

Release build is clean: the only warnings from the touched files are the three pre-existing `unused variable 'e'` ones in `UnsignedIntervalAnalysis.cpp`, unchanged.

### Follow-up, deliberately not in this PR

`cbvToUnsigned` in `consteval.cpp` is the remaining raw `*(unsigned*)v` read. It returns `unsigned` rather than `uint64_t` and has its own `FatalError` width guard, so it does not fit any of the signatures here; converting it to `BitVector_Chunk_Read` is a separate, self-contained change.

