### PR TITLE
Remove Cpp_interface methods orphaned by the single-probe lexer migration

### DIFF
--- a/include/stp/cpp_interface.h
+++ b/include/stp/cpp_interface.h
@@ -61,16 +61,6 @@ class Cpp_interface
 
     SOLVER_RETURN_TYPE result;
     int node_number; // a weak pointer.
-
-    void print()
-    {
-      if (result == SOLVER_UNSATISFIABLE)
-        std::cerr << "u";
-      else if (result == SOLVER_SATISFIABLE)
-        std::cerr << "s";
-      else if (result == SOLVER_UNDECIDED)
-        std::cerr << "?";
-    }
   };
   vector<Entry> cache;
 
@@ -177,12 +167,9 @@ public:
   DLL_PUBLIC ASTNode applyFunction(const std::string& name,
                                    const ASTVec& params);
 
-  DLL_PUBLIC bool isBitVectorFunction(const std::string& name);
-  DLL_PUBLIC bool isBooleanFunction(const std::string& name);
   // Classify a name in a single map probe: returns the function's return
   // type (BITVECTOR_TYPE or BOOLEAN_TYPE), or UNKNOWN_TYPE when the name
-  // is not a stored function. Lets the lexer avoid a second probe that
-  // calling both isBitVectorFunction and isBooleanFunction would cost.
+  // is not a stored function.
   DLL_PUBLIC types functionReturnType(const std::string& name);
   bool hasFunctions() const { return !functions.empty(); }
 
@@ -230,7 +217,6 @@ public:
 
   // Useful when printing back, so that you can parse, but ignore the request.
   DLL_PUBLIC void ignoreCheckSat();
-  DLL_PUBLIC void printStatus();
   DLL_PUBLIC void checkSat(const ASTVec& assertionsSMT2);
 
   DLL_PUBLIC void deleteGlobal();

--- a/lib/Interface/cpp_interface.cpp
+++ b/lib/Interface/cpp_interface.cpp
@@ -286,24 +286,6 @@ ASTNode Cpp_interface::applyFunction(const string& name, const ASTVec& params)
   return SubstitutionMap::replace(f.function, fromTo, cache, nf);
 }
 
-bool Cpp_interface::isBitVectorFunction(const string& name)
-{
-  const auto found = functions.find(name);
-  if (found == functions.end())
-    return false;
-
-  return found->second.function.GetType() == BITVECTOR_TYPE;
-}
-
-bool Cpp_interface::isBooleanFunction(const string& name)
-{
-  const auto found = functions.find(name);
-  if (found == functions.end())
-    return false;
-
-  return found->second.function.GetType() == BOOLEAN_TYPE;
-}
-
 types Cpp_interface::functionReturnType(const string& name)
 {
   const auto found = functions.find(name);
@@ -498,15 +480,6 @@ void Cpp_interface::push()
 void Cpp_interface::ignoreCheckSat()
 {
   ignoreCheckSatRequest = true;
-}
-
-void Cpp_interface::printStatus()
-{
-  for (size_t i = 0, size = cache.size(); i < size; ++i)
-  {
-    cache[i].print();
-  }
-  cerr << endl;
 }
 
 // Does some simple caching of prior results.

--- a/lib/Parser/smt2.lex
+++ b/lib/Parser/smt2.lex
@@ -95,9 +95,8 @@
     // Checking the functions before the symbols saves a symbol-table
     // probe in files built almost entirely from define-funs. A name can't
     // legally be both, so the order isn't observable on valid input. A
-    // single functionReturnType probe classifies the name, avoiding the
-    // second map lookup that separate isBitVector/isBooleanFunction calls
-    // would cost on boolean-function references.
+    // single functionReturnType probe classifies the name, so a boolean-
+    // function reference costs one map lookup rather than two.
     else if (stp::GlobalParserInterface->hasFunctions())
     {
       const stp::types ft = stp::GlobalParserInterface->functionReturnType(s);


### PR DESCRIPTION
Removes three `Cpp_interface` methods that have no callers anywhere in the tree, plus the private `Entry::print` helper that existed only to serve one of them — four removals in total.

## Please read before merging: this is an API-surface question

**These three methods were marked `DLL_PUBLIC` and are exported from `libstp.so`.** Removing them deletes those symbols from the shipped library. An out-of-tree C++ consumer that calls `isBitVectorFunction`, `isBooleanFunction`, or `printStatus` **would break.**

Mitigating this, and the reason I think it is safe:

**`include/stp/cpp_interface.h` is not installed.** `lib/CMakeLists.txt:94` sets `PUBLIC_HEADER` to `include/stp/c_interface.h` and nothing else, and `install(TARGETS stp ...)` at `lib/CMakeLists.txt:256` installs only that. There is no `install(DIRECTORY include/)` rule anywhere. Confirmed empirically from the generated install script — the only header install command in the whole build is:

```
build-release/lib/cmake_install.cmake:159:
  file(INSTALL DESTINATION "/usr/local/include/stp" TYPE FILE
       FILES ".../include/stp/c_interface.h")
```

So a downstream consumer of an *installed* STP cannot even obtain these declarations. Only someone building against a source checkout could reach them.

This matters because `include/stp/c_interface.h` is a frozen C ABI where entries must never be removed. The C++ interface is parser-facing and much more plausibly internal — but **that is your call, not mine.** Happy to land this as-is, or to instead mark them `[[deprecated]]` for a release first. Tell me which and I will adjust.

## How they were orphaned

`isBitVectorFunction` / `isBooleanFunction` were orphaned by a specific migration — 5884e8cc ("Speed up SMT-LIB2 parsing of hard inputs (4 changes)", #585), first bullet, *"Classify function names in a single map probe during lexing"*:

> The SMT-LIB2 lexer called isBitVectorFunction then isBooleanFunction to decide a function-application token's type, doing two full functions-map finds [...]. Add functionReturnType, which returns the function's return type in one probe, and use it in the lexer.

The lexer was their only caller, and it now calls `functionReturnType` instead. After that commit only a **comment** at `smt2.lex:99` still named the pair; this PR updates that comment so the file stops documenting an API that no longer exists.

`printStatus` is dead for unrelated, older reasons. `Entry::print` is a private nested helper whose sole use was the loop body of `printStatus`.

## Verification

**Zero callers.** Searched `lib/`, `include/`, `tools/`, `tests/`, `bindings/`, `examples/`, `scripts/` and — importantly — the Bison and Flex sources (`lib/Parser/*.y`, `*.lex`) and the generated parser/scanner output in the build tree. That last part matters: this class genuinely has grammar-only callers (`getUserFlags` is called only from `cvc.y`, `hasFunctions` only from `smt2.lex`), so a `.cpp`/`.h`-only grep would be unsound here. The only hits for all three names were their own declaration and definition, plus the stale comment.

**Build.** Clean (from-scratch) configure and Release build, `-DNOCRYPTOMINISAT=ON`. Flex scanner regenerates correctly — the reworded comment appears in the generated `lexsmt2.cpp` and the old text is gone. No new warnings; all remaining warnings are pre-existing and in other files.

**Exported-symbol diff.** `nm -D --defined-only` over baseline vs. candidate `libstp.so`, demangled and sorted (583 → 580 symbols). Complete diff:

```
293,294d292
< stp::Cpp_interface::isBitVectorFunction(std::__cxx11::basic_string<...> const&)
< stp::Cpp_interface::isBooleanFunction(std::__cxx11::basic_string<...> const&)
306d303
< stp::Cpp_interface::printStatus()
```

Exactly the three removed methods and nothing else. (`Entry::print` was an inline member of a private nested struct and was never exported, so it does not appear.)

**Parser regression sweep.** Baseline and candidate binaries over 2501 `.smt2` files: **2501/2501 answers match**, 2213 sat / 288 unsat, no timeouts or errors on either arm.

One file, `big.smt2`, initially showed a mismatch. It is a 16MB incremental file with 2500 `check-sat`s, and my harness's 10s cap was truncating it mid-stream so `tail -1` caught different check-sats on the two runs — a harness artifact, not a behavior difference. Re-run to completion with no cap, both binaries produce **byte-identical 2500-line output**. Nothing else diverged.

**Multi-grammar coverage.** Full stdout compared (md5 per file), not just the sat/unsat line, so the cvc grammar's `Valid.`/`Invalid.` output is covered too:

| Grammar | Files | Result |
|---|---|---|
| SMT-LIB2 (`tests/query-files/**/*.smt2`) | 118 | byte-identical stdout + exit code |
| CVC (`tests/query-files/**/*.cvc`) | 61 | byte-identical stdout + exit code |

**Not run:** the `lit` suite — the shared `deps/gtest` is stale and `ENABLE_TESTING` will not configure in a worktree. The 179 query-files above were run directly against both binaries instead.

## Diff

`include/stp/cpp_interface.h`, `lib/Interface/cpp_interface.cpp`, and one comment in `lib/Parser/smt2.lex`: 3 files changed, 3 insertions(+), 45 deletions(-).
