### PR TITLE
Share the small-constant CBV constructors too

### DIFF
--- a/include/stp/Simplifier/StrengthReduction.h
+++ b/include/stp/Simplifier/StrengthReduction.h
@@ -52,7 +52,6 @@ class StrengthReduction
   unsigned replaceWithSimpler =0;
 
   CBV littleOne;
-  CBV littleZero;
   NodeFactory* nf;
   UserDefinedFlags* uf;
 

--- a/include/stp/Simplifier/UnsignedInterval.h
+++ b/include/stp/Simplifier/UnsignedInterval.h
@@ -30,6 +30,7 @@ THE SOFTWARE.
 #define UNSIGNEDINTERVAL_H_
 
 #include "stp/AST/AST.h"
+#include "stp/Util/CBVOps.h"
 #include <iostream>
 
 namespace stp
@@ -51,9 +52,8 @@ struct UnsignedInterval
 
   UnsignedInterval(unsigned width)
   {
-    minV = CONSTANTBV::BitVector_Create(width, true);
-    maxV = CONSTANTBV::BitVector_Create(width, true);
-    CONSTANTBV::BitVector_Fill(maxV);
+    minV = mkZero(width);
+    maxV = allOnes(width);
   }
 
   ~UnsignedInterval()
@@ -148,16 +148,17 @@ struct UnsignedInterval
   {
     const unsigned width = a->getWidth(); 
 
-    CBV zero = CONSTANTBV::BitVector_Create(width, true); 
-    
+    CBV zero = mkZero(width);
+
     if (CONSTANTBV::BitVector_is_empty(a->minV) && !CONSTANTBV::BitVector_is_empty(a->maxV))
     {
       // Split zero into it's own segment if it's the minimum.
        UnsignedInterval * split0 = new UnsignedInterval(CONSTANTBV::BitVector_Clone(zero), CONSTANTBV::BitVector_Clone(zero));
        a_vec.push_back(split0);
+       CONSTANTBV::BitVector_Destroy(zero);
 
-       CONSTANTBV::BitVector_increment(zero);
-       UnsignedInterval * split1 = new UnsignedInterval(zero, CONSTANTBV::BitVector_Clone(a->maxV));
+       // What's left runs from one up to the maximum.
+       UnsignedInterval * split1 = new UnsignedInterval(mkOne(width), CONSTANTBV::BitVector_Clone(a->maxV));
        split(split1,a_vec);
        delete split1;
        return;
@@ -168,9 +169,11 @@ struct UnsignedInterval
        // Split zero into it's own segment if it's the maximum.
        UnsignedInterval * split0 = new UnsignedInterval(CONSTANTBV::BitVector_Clone(zero), CONSTANTBV::BitVector_Clone(zero));
        a_vec.push_back(split0);
+       CONSTANTBV::BitVector_Destroy(zero);
 
-       CONSTANTBV::BitVector_decrement(zero);
-       UnsignedInterval * split1 = new UnsignedInterval(CONSTANTBV::BitVector_Clone(a->minV), zero);
+       // What's left runs from the minimum up to the last value before
+       // the wrap, which is all ones.
+       UnsignedInterval * split1 = new UnsignedInterval(CONSTANTBV::BitVector_Clone(a->minV), allOnes(width));
        split(split1,a_vec);
        delete split1;
        return;
@@ -179,8 +182,7 @@ struct UnsignedInterval
     if (a->in(zero) && !CONSTANTBV::BitVector_is_empty(a->minV))
     {
       // Split at zero if it's in the middle somewhere.
-       CBV negativeOne = CONSTANTBV::BitVector_Create(width, true);
-       CONSTANTBV::BitVector_Fill(negativeOne);
+       CBV negativeOne = allOnes(width);
 
        UnsignedInterval * split0 = new UnsignedInterval(CONSTANTBV::BitVector_Clone(a->minV), negativeOne);
        UnsignedInterval * split1 = new UnsignedInterval(zero, CONSTANTBV::BitVector_Clone(a->maxV));

--- a/include/stp/Util/CBVOps.h
+++ b/include/stp/Util/CBVOps.h
@@ -62,10 +62,34 @@ inline uint64_t mask64(unsigned width)
   return width >= 64 ? ~0ull : (1ull << width) - 1;
 }
 
-// A fresh all-ones vector of the given width. The caller owns it.
+// The small constants. Each returns a fresh vector that the caller owns.
+//
+// These say what the value is, which the raw constructor does not: the
+// boolean of BitVector_Create is a zero-fill flag, so a bare
+// BitVector_Create(width, true) reads as an allocation rather than as
+// the number zero. mkZero and mkOne are spelt after STPMgr's
+// CreateZeroConst and CreateOneConst, which build the same two values as
+// AST nodes.
+//
+// Take care not to read mkOne as allOnes: mkOne is 1, allOnes is
+// 2^width - 1. They agree only at width 1, which is why the boolean
+// analyses can use either.
+
+inline CBV mkZero(unsigned width)
+{
+  return CONSTANTBV::BitVector_Create(width, true);
+}
+
+inline CBV mkOne(unsigned width)
+{
+  CBV result = mkZero(width);
+  CONSTANTBV::BitVector_increment(result);
+  return result;
+}
+
 inline CBV allOnes(unsigned width)
 {
-  CBV result = CONSTANTBV::BitVector_Create(width, true);
+  CBV result = mkZero(width);
   CONSTANTBV::BitVector_Fill(result);
   return result;
 }

--- a/lib/STPManager/STPManager.cpp
+++ b/lib/STPManager/STPManager.cpp
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // to get the PRIu64 macro from inttypes, this needs to be defined.
 #include "stp/STPManager/STPManager.h"
 #include "stp/Printer/SMTLIBPrinter.h"
+#include "stp/Util/CBVOps.h"
 #include "stp/Util/NodeIterator.h"
 #include <cmath>
 #include <cstdint>
@@ -359,7 +360,7 @@ ASTNode STPMgr::CreateZeroConst(unsigned width)
     return zeroes[width];
   else
   {
-    CBV z = CONSTANTBV::BitVector_Create(width, true);
+    CBV z = mkZero(width);
     return CreateBVConst(z, width);
   }
 }
@@ -378,8 +379,7 @@ ASTNode STPMgr::CreateOneConst(unsigned width)
     return ones[width];
   else
   {
-    CBV o = CONSTANTBV::BitVector_Create(width, true);
-    CONSTANTBV::BitVector_increment(o);
+    CBV o = mkOne(width);
 
     return CreateBVConst(o, width);
   }
@@ -387,9 +387,8 @@ ASTNode STPMgr::CreateOneConst(unsigned width)
 
 ASTNode STPMgr::CreateTwoConst(unsigned width)
 {
-  CBV two = CONSTANTBV::BitVector_Create(width, true);
-  CONSTANTBV::BitVector_increment(two);
-  CONSTANTBV::BitVector_increment(two);
+  // Truncating, as the repeated increments were: two is zero at width 1.
+  CBV two = cbvFromU64(width, 2);
 
   return CreateBVConst(two, width);
 }
@@ -408,8 +407,7 @@ ASTNode STPMgr::CreateMaxConst(unsigned width)
     return max[width];
   else
   {
-    CBV max = CONSTANTBV::BitVector_Create(width, false);
-    CONSTANTBV::BitVector_Fill(max);
+    CBV max = allOnes(width);
 
     return CreateBVConst(max, width);
   }

--- a/lib/Simplifier/AchievableImage.cpp
+++ b/lib/Simplifier/AchievableImage.cpp
@@ -33,18 +33,6 @@ namespace stp
 namespace
 {
 
-CBV mkZero(unsigned width)
-{
-  return CONSTANTBV::BitVector_Create(width, true);
-}
-
-CBV mkOne(unsigned width)
-{
-  CBV v = mkZero(width);
-  CONSTANTBV::BitVector_increment(v);
-  return v;
-}
-
 // The bottom `bits` bits set, at the given width.
 CBV mkLowMask(unsigned bits, unsigned width)
 {

--- a/lib/Simplifier/StrengthReduction.cpp
+++ b/lib/Simplifier/StrengthReduction.cpp
@@ -25,6 +25,7 @@ THE SOFTWARE.
 #include "stp/Simplifier/Simplifier.h"
 #include "stp/Simplifier/StrengthReduction.h"
 #include "stp/Simplifier/constantBitP/FixedBits.h"
+#include "stp/Util/CBVOps.h"
 #include <iostream>
 
 namespace stp
@@ -916,9 +917,7 @@ namespace stp
 
   StrengthReduction::StrengthReduction(NodeFactory* _nf, UserDefinedFlags * _uf)
   {
-    littleOne = CONSTANTBV::BitVector_Create(1, true);
-    littleZero = CONSTANTBV::BitVector_Create(1, true);
-    CONSTANTBV::BitVector_Fill(littleOne);
+    littleOne = mkOne(1);
     nf = _nf;
     uf = _uf;
 
@@ -929,7 +928,6 @@ namespace stp
   StrengthReduction::~StrengthReduction()
   {
     CONSTANTBV::BitVector_Destroy(littleOne);
-    CONSTANTBV::BitVector_Destroy(littleZero);
   }
 
   void StrengthReduction::stats(string name)

--- a/lib/Simplifier/UnsignedIntervalAnalysis.cpp
+++ b/lib/Simplifier/UnsignedIntervalAnalysis.cpp
@@ -730,23 +730,18 @@ namespace stp
     // ---- Helpers for the multiplication bounds. The bitvectors in this
     // group share one width, chosen wide enough that nothing overflows. ----
 
-    CBV zeroOf(unsigned width)
-    {
-      return CONSTANTBV::BitVector_Create(width, true);
-    }
-
     // A fresh copy of x at a bigger width.
     CBV widenTo(const CBV x, unsigned width)
     {
       assert(width >= bits_(x));
-      CBV r = zeroOf(width);
+      CBV r = mkZero(width);
       CONSTANTBV::BitVector_Interval_Copy(r, x, 0, 0, bits_(x));
       return r;
     }
 
     CBV mulFresh(const CBV x, const CBV y)
     {
-      CBV r = zeroOf(bits_(x));
+      CBV r = mkZero(bits_(x));
       CBV tmp = CONSTANTBV::BitVector_Clone(x); // Mul_Pos destroys this one.
       CONSTANTBV::ErrCode e = CONSTANTBV::BitVector_Mul_Pos(r, tmp, y, true);
       assert(0 == e);
@@ -913,8 +908,8 @@ namespace stp
 
         if (known)
         {
-          resultMin = zeroOf(width);
-          resultMax = zeroOf(width);
+          resultMin = mkZero(width);
+          resultMax = mkZero(width);
           for (unsigned i = 0; i < width; i++)
           {
             if ((apMin >> i) & 1)
@@ -949,8 +944,8 @@ namespace stp
         // Every product sits between the bound products, which agree above
         // the width, so the low bits run between the bounds' low bits
         // without wrapping: exact.
-        resultMin = zeroOf(width);
-        resultMax = zeroOf(width);
+        resultMin = mkZero(width);
+        resultMax = mkZero(width);
         for (unsigned i = 0; i < width; i++)
         {
           if (CONSTANTBV::BitVector_bit_test(lowProduct, i))
@@ -992,7 +987,7 @@ namespace stp
 
     if (emptyCBV.find(width) == emptyCBV.end())
     {
-      emptyCBV[width] = CONSTANTBV::BitVector_Create(width, true);
+      emptyCBV[width] = mkZero(width);
     }
     
     assert(CONSTANTBV::BitVector_is_empty(emptyCBV[width]));  
@@ -1006,10 +1001,7 @@ namespace stp
 
     if (emptyIntervals.find(width) == emptyIntervals.end())
     {
-      stp::CBV min = CONSTANTBV::BitVector_Create(width, true);
-      stp::CBV max = CONSTANTBV::BitVector_Create(width, true);
-      CONSTANTBV::BitVector_Fill(max);
-      emptyIntervals[width] = new UnsignedInterval(min,max);
+      emptyIntervals[width] = new UnsignedInterval(mkZero(width), allOnes(width));
     }
 
     UnsignedInterval* r = emptyIntervals[width];
@@ -2121,9 +2113,8 @@ namespace stp
 
   UnsignedIntervalAnalysis::UnsignedIntervalAnalysis(STPMgr& _bm) : bm(_bm)
   {
-    littleZero = getEmptyCBV(1);
-    littleOne = CONSTANTBV::BitVector_Create(1, true);
-    CONSTANTBV::BitVector_Fill(littleOne);
+    littleZero = getEmptyCBV(1); // owned by emptyCBV, not by us.
+    littleOne = mkOne(1);
   }
 
   UnsignedIntervalAnalysis::~UnsignedIntervalAnalysis()


### PR DESCRIPTION
Follow-up to #707, which moved the CBV/uint64 primitives that had several *named* copies. This sweeps the level below it: the small constants zero and one, which were duplicated as an idiom — a named pair local to one file, a third differently-named copy in another, and a bare `BitVector_Create(width, true)` open-coded everywhere else.

**Note on stacking.** The brief for this work assumed #707 was still open and asked for a stacked PR. #707 has since been merged (`a6be559d`) and the `dedupe-cbv-u64-helpers` branch is gone from origin, so this is based on `master` instead and stands on its own.

## What is added, and why named forms at all

`cbvFromU64(width, 0)` and `cbvFromU64(width, 1)` already express both values, so the named forms have to earn their place. They do, for two reasons.

The call site reads better — `mkOne(w)` says what it is where `cbvFromU64(w, 1)` makes you decode an argument. More importantly, `mkZero` gives the codebase one spelling for "a fresh zero vector", which is the actual problem here: `BitVector_Create(width, true)` only says "zero" if you already know the boolean is a zero-fill flag, and read literally it looks like an allocation. Three separate places had independently wrapped it — `mkZero`, `zeroOf`, and the open-coded copies — precisely because the raw call does not read as the value it produces. `mkZero` is also cheaper than `cbvFromU64(w, 0)`: one `BitVector_Create`, no chunk stores.

## Naming

`mkZero(width)` and `mkOne(width)`, sitting beside the existing `allOnes(width)`.

The inconsistency with `allOnes` is deliberate. Bare `zero(width)` / `one(width)` in namespace `stp` would be far too generic for a header this widely included, so the constructors need a prefix, while `allOnes` is already a noun phrase naming its value and does not. The `mk` spelling is the one `AchievableImage.cpp` already used, so that file's fourteen call sites are untouched by the move, and it echoes `STPMgr::CreateZeroConst` / `CreateOneConst`, which build the same two values as AST nodes.

The header carries an explicit warning about the one real hazard: `mkOne` is 1, `allOnes` is 2^width - 1, they differ by one letter, and they coincide only at width 1 — which is why the boolean analyses can use either.

`mkTwo` is **not** added. Two appears exactly once in the tree (`STPMgr::CreateTwoConst`), which is not enough to earn a name in a shared header; that site uses `cbvFromU64(width, 2)`, which truncates at width 1 exactly as the two repeated increments did.

## Copies removed

| Removed | From | Uses |
| --- | --- | --- |
| `mkZero` | `AchievableImage.cpp` | 9 |
| `mkOne` | `AchievableImage.cpp` | 5 |
| `zeroOf` | `UnsignedIntervalAnalysis.cpp` | 6 |

`zeroOf` was not in the brief for this sweep — it is a third copy of `mkZero` under a third name, found while auditing that file's ~33 `BitVector_Create` calls.

## Open-coded sites converted

Converted only where the vector **is** the constant, rather than an accumulator that happens to start at zero:

- `STPMgr::CreateZeroConst`, `CreateOneConst` and `CreateMaxConst`, plus `CreateTwoConst` via `cbvFromU64`
- `UnsignedInterval`'s width constructor
- `UnsignedInterval::split` — the zero, and the one and all-ones it built by mutating a variable still named `zero`
- `UnsignedIntervalAnalysis::getEmptyCBV`, `getEmptyInterval` and `littleOne`

## Sites deliberately left alone

- **The accumulators.** Most of `UnsignedIntervalAnalysis`'s `BitVector_Create(w, true)` calls — `mn`/`mx` filled by chunk loops, `remainder`, `quotient`, `a2`/`b2`/`prod` — allocate a scratch vector for an interval bound. They are not the constant zero, and calling them `mkZero` would say something untrue about what the vector holds a line later.
- **`NodeDomainAnalysis.cpp`, entirely.** The brief flagged line 376, but that is `BitVector_increment(v)` advancing a walker through an enumeration, not building a one. Lines 121 and 173 are the accumulator pattern above. Nothing in this file is in scope.
- **`UnsignedInterval::split`'s `signedMin`**, `AchievableImage`'s `truncate`, and `StrengthReduction`'s `a2`/`b2`/`product` in `multMayOverflow` — same reasoning.
- **In-place fills** (`UnsignedInterval::resetToComplete`, and two widenings in `UnsignedIntervalAnalysis`) mutate an existing vector rather than construct one, so `allOnes` does not apply.
- **`STPManager.cpp:228` and `:282`** — `BitVector_Create(65, true)` for the reused `CreateBVConstVal` scratch buffer, immediately `Resize`d and `Empty`d. An allocation, not a constant.
- **`ValueSetAnalysis.cpp`** — has ~9 sites that look in scope. Deferred pending #711, which is restructuring that file heavily.

## Two dead-code findings

**`StrengthReduction::littleZero` is dead.** It was allocated in the constructor and destroyed in the destructor and **never read anywhere in the tree**. It is deleted rather than migrated: this is a dead field, not a deduplication. Its sibling `littleOne`, which is read once, now comes from `mkOne(1)`. `UnsignedIntervalAnalysis` keeps its own `littleZero`, which *is* read (11 sites) and is a borrowed pointer into the `emptyCBV` cache rather than an owned allocation; that distinction is now commented, since it is why the destructor frees only `littleOne`.

**`UnsignedInterval::split` is unreachable.** Found while checking coverage: it has no caller anywhere outside its own recursion, and the symbol is not emitted into the binary at all. Its four conversions are therefore correct but unexercised by any input — see the verification note below for how they were checked instead. Whether the function should simply be deleted seems worth deciding separately; this PR leaves it in place.

## Verification

Both arms were built static (`-DBUILD_SHARED_LIBS=OFF`) so each binary is self-contained and the comparison cannot pass vacuously:

```
baseline  769d786f6cbd4cba772d969dc79e24e7d8f7cca13653727fc86f0350f75c0bbf
candidate 1603dd99821bfb65251ddac7790edc1c33146996c9d5685ce50418b31b531dbe
ldd: "not a dynamic executable" for both
```

- **Answers over `tests/query-files`**: 179 files (118 `.smt2`, 61 `.cvc`), comparing full stdout + stderr + exit code, not just the answer line. **179 identical, 0 differing, 0 skipped.**
- **CNF byte-identity** over the 40-file pre-CNF corpus: **39 identical, 0 mismatched, 1 skipped.** The skip is baseline-side (`catchconv-15803.smt2` emits no CNF under `--output-CNF --exit-after-CNF` on either arm), not a candidate failure.
- **Coverage.** Temporary counters, reverted before committing, confirmed the corpus actually enters the changed code rather than passing vacuously. Over the 179 test files: `CreateZeroConst` 5740 hits / 83 files, `CreateOneConst` 6134 / 94, `CreateMaxConst` 4894 / 67, `UnsignedInterval(width)` 94 / 9, `getEmptyCBV` 203 / 177, `getEmptyInterval` 101 / 43, `UnsignedIntervalAnalysis::littleOne` 189 / 177 and read 4 / 4, its `littleZero` read 3 / 3, the ex-`zeroOf` sites 17693 / 15, `StrengthReduction::littleOne` 378 / 177 and read 11 / 4, `AchievableImage` 10 / 4.
- **The two paths the corpora never reach** were verified directly rather than waved through. `UnsignedInterval::split` (unreachable, above) was compiled against the old and the new header and run over every interval at widths 1 to 6: **2793 cases, byte-identical segmentation**, and clean under valgrind — 0 errors, all heap blocks freed, which is what checks the two `BitVector_Destroy` calls the rewrite adds. `CreateTwoConst` is reached only from `BVSolver` and fired on neither corpus, so `cbvFromU64(w, 2)` was checked against `Create + increment + increment` at **widths 1 to 200, 0 mismatches**, including the width-1 wrap to zero. The same harness checked `allOnes` against `Create(w, false) + Fill` and `mkOne` / `mkZero` against their old bodies over the same range.
- **A second counter run over the 40-file pre-CNF corpus** (harder QF_BV) agreed: `CreateZeroConst` 801 hits / 12 files, `CreateOneConst` 770 / 12, `CreateMaxConst` 808 / 12, `UnsignedInterval(width)` 9477 / 7, `getEmptyInterval` 150 / 11, `AchievableImage` 2385 / 4, `StrengthReduction::littleOne` read 390 / 4. Only 12 of the 40 files report at all, because a file killed by the timeout never runs the counter's static destructor. Crucially the same two paths — `CreateTwoConst` and `split` — again showed zero hits, which is what motivated the direct harnesses above.

- **Warnings**: the same set of 16 in both arms, with line numbers shifted in `UnsignedIntervalAnalysis.cpp` where lines were deleted. No new warnings.

No functional change intended.
