### PR TITLE
constantBitP: move the superseded multiply propagators out of the shipped file

### DIFF
--- a/lib/Simplifier/constantBitP/ConstantBitP_Multiplication.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_Multiplication.cpp
@@ -409,43 +409,16 @@ Result setToZero(FixedBits& y, unsigned from, unsigned to)
   return r;
 }
 
-// Finds the leading one in each of the two inputs.
-// If this position is i & j, then in the output
-// there can be no ones higher than i+j+1.
-Result useLeadingZeroesToFix_OLD(FixedBits& x, FixedBits& y, FixedBits& output)
-{
-  // Count the leading zeroes on x & y.
-  // Output should have about that many..
-  int xTop = x.topmostPossibleLeadingOne();
-  int yTop = y.topmostPossibleLeadingOne();
-
-  int maxOutputOneFromInputs = xTop + yTop + 1;
-
-  for (int i = output.getWidth() - 1; i > maxOutputOneFromInputs; i--)
-    if (!output.isFixed(i))
-    {
-      output.setFixed(i, true);
-      output.setValue(i, false);
-    }
-    else
-    {
-      if (output.getValue(i))
-        return CONFLICT;
-    }
-
-  return NOT_IMPLEMENTED;
-}
-
+// Zero the output bits that cannot be reached by any product of a value
+// admitted by x and one admitted by y: multiply the two largest admitted
+// values and take the position of that product's leading one as the bound.
+//
+// This subsumes an earlier version that bounded the product by the sum of
+// the operands' leading-one positions plus one. That version, and the
+// exhaustive check that this one fixes at least as much, now live in
+// tests/unit-tests/ConstantBitP_TransferFunctions_Test.cpp.
 Result useLeadingZeroesToFix(FixedBits& x, FixedBits& y, FixedBits& output)
 {
-// To check that the new implementation subsumes the old.
-#ifndef NDEBUG
-  FixedBits x_p = x;
-  FixedBits y_p = y;
-  FixedBits o_p = output;
-  useLeadingZeroesToFix_OLD(x_p, y_p, o_p);
-#endif
-
   const int bitWidth = x.getWidth();
   CBV x_c = CONSTANTBV::BitVector_Create(2 * bitWidth, true);
   CBV y_c = CONSTANTBV::BitVector_Create(2 * bitWidth, true);
@@ -487,13 +460,6 @@ Result useLeadingZeroesToFix(FixedBits& x, FixedBits& y, FixedBits& output)
     }
   }
 
-#ifndef NDEBUG
-  // Assert the new implementation fixes more than the old.
-  assert(FixedBits::in(x, x_p));
-  assert(FixedBits::in(y, y_p));
-  assert(FixedBits::in(output, o_p));
-#endif
-
   CONSTANTBV::BitVector_Destroy(x_c);
   CONSTANTBV::BitVector_Destroy(y_c);
   CONSTANTBV::BitVector_Destroy(result);
@@ -501,9 +467,12 @@ Result useLeadingZeroesToFix(FixedBits& x, FixedBits& y, FixedBits& output)
   return NOT_IMPLEMENTED;
 }
 
-Result trailingOneReasoning_OLD(FixedBits& x, FixedBits& y, FixedBits& output);
-
 // Remove from x any trailing "boths", that don't have support in y and output.
+//
+// This subsumes an earlier version that started the scan at x's minimum
+// trailing-one position rather than at bit zero. That version, and the
+// exhaustive check that this one leaves it nothing to find, now live in
+// tests/unit-tests/ConstantBitP_TransferFunctions_Test.cpp.
 Result trailingOneReasoning(FixedBits& x, FixedBits& y, FixedBits& output)
 {
   Result r = NO_CHANGE;
@@ -534,57 +503,6 @@ Result trailingOneReasoning(FixedBits& x, FixedBits& y, FixedBits& output)
     r = CHANGED;
   }
 
-#ifndef NDEBUG
-  // Check that the old implementation is subsumed. On copies, because it
-  // fixes bits when it fires, and nothing should mutate inside assert().
-  FixedBits x_c(x), y_c(y), o_c(output);
-  assert(trailingOneReasoning_OLD(x_c, y_c, o_c) == NO_CHANGE);
-#endif
-  return r;
-}
-
-// Remove from x any trailing "boths", that don't have support in y and output.
-Result trailingOneReasoning_OLD(FixedBits& x, FixedBits& y, FixedBits& output)
-{
-  Result r = NO_CHANGE;
-
-  const int bitwidth = output.getWidth();
-
-  const int x_min = x.minimum_trailingOne();
-  const int x_max = x.maximum_trailingOne();
-
-  const int y_min = y.minimum_trailingOne();
-  const int y_max = y.maximum_trailingOne();
-
-  int output_max = output.maximum_trailingOne();
-
-  bool done = false;
-  for (int i = x_min; i <= std::min(x_max, bitwidth - 1); i++)
-  {
-    if (x[i] == '1')
-      break;
-
-    if (x[i] == '0')
-      continue;
-
-    assert(!done);
-    for (int j = y_min; j <= std::min(y_max, output_max); j++)
-    {
-      if (j + i >= bitwidth || (y[j] != '0' && output[i + j] != '0'))
-      {
-        done = true;
-        break;
-      }
-    }
-    if (!done)
-    {
-      x.setFixed(i, true);
-      x.setValue(i, false);
-      r = CHANGED;
-    }
-    else
-      break;
-  }
   return r;
 }
 

--- a/lib/Simplifier/constantBitP/ConstantBitP_Multiplication.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_Multiplication.cpp
@@ -48,24 +48,6 @@ using std::set;
 const bool debug_multiply = false;
 std::ostream& log = std::cerr;
 
-#if 0
-// The maximum size of the carry into a column for MULTIPLICATION
-    int
-    maximumCarryInForMultiplication(int column)
-      {
-      int result = 0;
-      int currIndex = 0;
-
-      while (currIndex < column)
-        {
-        currIndex++;
-        result = (result + currIndex) / 2;
-        }
-
-      return result;
-      }
-#endif
-
 static inline uint64_t rightShiftedWord(const uint64_t* m, unsigned words,
                                         unsigned s, unsigned j);
 static inline int convolutionAt(const uint64_t* a, const uint64_t* revB,
@@ -846,20 +828,6 @@ Result useTrailingFixedToFix(FixedBits& x, FixedBits& y, FixedBits& output)
   CONSTANTBV::BitVector_Destroy(result);
 
   return status;
-}
-
-void printColumns(signed* sumL, signed* sumH, int bitWidth)
-{
-  for (int i = 0; i < bitWidth; i++)
-  {
-    log << sumL[bitWidth - 1 - i] << " ";
-  }
-  log << endl;
-  for (int i = 0; i < bitWidth; i++)
-  {
-    log << sumH[bitWidth - 1 - i] << " ";
-  }
-  log << endl;
 }
 
 // One run of the column-based reasoning over x * y == output, to its own

--- a/tests/unit-tests/ConstantBitP_TransferFunctions_Test.cpp
+++ b/tests/unit-tests/ConstantBitP_TransferFunctions_Test.cpp
@@ -71,8 +71,10 @@ THE SOFTWARE.
 #include "stp/Simplifier/constantBitP/FixedBits.h"
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <functional>
 #include <memory>
+#include <random>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -87,7 +89,6 @@ namespace constantBitP
 {
 Result useLeadingZeroesToFix(FixedBits& x, FixedBits& y, FixedBits& output);
 Result trailingOneReasoning(FixedBits& x, FixedBits& y, FixedBits& output);
-Result trailingOneReasoning_OLD(FixedBits& x, FixedBits& y, FixedBits& output);
 Result multiplyCore(std::vector<FixedBits*>& children, FixedBits& output,
                     MultiplicationStats* ms);
 }
@@ -1113,35 +1114,280 @@ TEST_F(ConstantBitP_TransferFunctions, leadingZeroesConflictDoesNotLeak)
   EXPECT_EQ(CONFLICT, useLeadingZeroesToFix(x, y, out));
 }
 
-// trailingOneReasoning checks in debug builds that trailingOneReasoning_OLD
-// finds nothing further. That is only safe if the old reasoning is subsumed
-// by the new and never mutates its arguments afterwards. Verify both,
-// exhaustively, at width 3.
+// ---------------------------------------------------------------------------
+// Superseded multiply propagators, and the proof that the current ones
+// subsume them.
+//
+// These two functions used to live in ConstantBitP_Multiplication.cpp purely
+// so that the current implementations could run them on copies inside
+// #ifndef NDEBUG and assert that the new result fixed at least as much. That
+// put ~150 lines of dead-in-Release code in the shipped translation unit and
+// paid an extra propagator run on every invocation of an assertions build.
+//
+// The property is real and worth keeping, so both the old implementations and
+// the subsumption checks moved here. What changed is *which inputs* the
+// property is checked against: the in-line assert saw whatever states real
+// formulas drove the propagator into, whereas these tests enumerate the
+// input space directly - exhaustively at small widths, randomly at larger
+// ones. At any width covered exhaustively that is strictly stronger, since
+// every reachable state at that width is among the triples enumerated. Above
+// that bound it is a sample rather than a sweep.
+// ---------------------------------------------------------------------------
+
+// Superseded by useLeadingZeroesToFix. Bounds the product's leading one by
+// the sum of the operands' leading-one positions plus one, and zeroes the
+// output bits above it. The current version multiplies out the two largest
+// admitted values instead, which is never a weaker bound: with x < 2^(xTop+1)
+// and y < 2^(yTop+1) the product is below 2^(xTop+yTop+2), so its leading one
+// sits at or below xTop+yTop+1.
+Result useLeadingZeroesToFix_OLD(FixedBits& x, FixedBits& y, FixedBits& output)
+{
+  // Count the leading zeroes on x & y.
+  // Output should have about that many..
+  int xTop = x.topmostPossibleLeadingOne();
+  int yTop = y.topmostPossibleLeadingOne();
+
+  int maxOutputOneFromInputs = xTop + yTop + 1;
+
+  for (int i = output.getWidth() - 1; i > maxOutputOneFromInputs; i--)
+    if (!output.isFixed(i))
+    {
+      output.setFixed(i, true);
+      output.setValue(i, false);
+    }
+    else
+    {
+      if (output.getValue(i))
+        return CONFLICT;
+    }
+
+  return NOT_IMPLEMENTED;
+}
+
+// Superseded by trailingOneReasoning. Same idea - clear a trailing unfixed
+// bit of x that has no support in y and the output - but the scan starts at
+// x's minimum trailing-one position and stops at the first bit it cannot
+// clear. The current version scans from bit zero.
+Result trailingOneReasoning_OLD(FixedBits& x, FixedBits& y, FixedBits& output)
+{
+  Result r = NO_CHANGE;
+
+  const int bitwidth = output.getWidth();
+
+  const int x_min = x.minimum_trailingOne();
+  const int x_max = x.maximum_trailingOne();
+
+  const int y_min = y.minimum_trailingOne();
+  const int y_max = y.maximum_trailingOne();
+
+  int output_max = output.maximum_trailingOne();
+
+  bool done = false;
+  for (int i = x_min; i <= std::min(x_max, bitwidth - 1); i++)
+  {
+    if (x[i] == '1')
+      break;
+
+    if (x[i] == '0')
+      continue;
+
+    assert(!done);
+    for (int j = y_min; j <= std::min(y_max, output_max); j++)
+    {
+      if (j + i >= bitwidth || (y[j] != '0' && output[i + j] != '0'))
+      {
+        done = true;
+        break;
+      }
+    }
+    if (!done)
+    {
+      x.setFixed(i, true);
+      x.setValue(i, false);
+      r = CHANGED;
+    }
+    else
+      break;
+  }
+  return r;
+}
+
+// A width-`width` FixedBits with each bit independently unfixed, zero or one,
+// then - half the time each - a run of leading bits and a run of trailing
+// bits forced to zero.
+//
+// The bias matters. Both propagators reason about runs of zeroes at the ends
+// of an operand, and under a uniform trit draw at width 48 the top bit is
+// unfixed or one about two thirds of the time, so the leading-zero reasoning
+// has nothing to work with on almost every sample. Without the bias the
+// random arm of these tests contributes essentially nothing.
+FixedBits randomFixedBits(unsigned width, std::mt19937& rng)
+{
+  FixedBits result(width, false);
+  std::uniform_int_distribution<int> trit(0, 2);
+  for (unsigned i = 0; i < width; i++)
+  {
+    const int t = trit(rng);
+    if (t != 0)
+    {
+      result.setFixed(i, true);
+      result.setValue(i, t == 2);
+    }
+  }
+
+  std::uniform_int_distribution<unsigned> coin(0, 1);
+  std::uniform_int_distribution<unsigned> runLength(0, width);
+
+  if (coin(rng) == 1)
+  {
+    const unsigned lead = runLength(rng);
+    for (unsigned i = width - lead; i < width; i++)
+    {
+      result.setFixed(i, true);
+      result.setValue(i, false);
+    }
+  }
+
+  if (coin(rng) == 1)
+  {
+    const unsigned trail = std::min(runLength(rng), width);
+    for (unsigned i = 0; i < trail; i++)
+    {
+      result.setFixed(i, true);
+      result.setValue(i, false);
+    }
+  }
+
+  return result;
+}
+
+// Widths enumerated exhaustively. 3^4 = 81 assignments per operand, so 81^3
+// triples at the top width; going one wider is 27x that.
+const unsigned EXHAUSTIVE_UPTO = 4;
+
+// Widths sampled, and how many triples at each.
+const unsigned RANDOM_FROM = 5;
+const unsigned RANDOM_UPTO = 48;
+const unsigned RANDOM_TRIPLES = 3000;
+
+// Run `check` over every (x, y, output) triple at widths 1..EXHAUSTIVE_UPTO,
+// then over RANDOM_TRIPLES sampled triples at each larger width.
+void forEachTriple(
+    const std::function<void(FixedBits&, FixedBits&, FixedBits&)>& check)
+{
+  for (unsigned width = 1; width <= EXHAUSTIVE_UPTO; width++)
+  {
+    unsigned combinations = 1;
+    for (unsigned i = 0; i < width; i++)
+      combinations *= 3;
+
+    for (unsigned i = 0; i < combinations; i++)
+      for (unsigned j = 0; j < combinations; j++)
+        for (unsigned k = 0; k < combinations; k++)
+        {
+          FixedBits x = fromTernary(width, i);
+          FixedBits y = fromTernary(width, j);
+          FixedBits out = fromTernary(width, k);
+          check(x, y, out);
+          if (::testing::Test::HasFatalFailure())
+            return;
+        }
+  }
+
+  std::mt19937 rng(20240607); // fixed seed: a failure must be reproducible.
+  for (unsigned width = RANDOM_FROM; width <= RANDOM_UPTO; width++)
+    for (unsigned n = 0; n < RANDOM_TRIPLES; n++)
+    {
+      FixedBits x = randomFixedBits(width, rng);
+      FixedBits y = randomFixedBits(width, rng);
+      FixedBits out = randomFixedBits(width, rng);
+      check(x, y, out);
+      if (::testing::Test::HasFatalFailure())
+        return;
+    }
+}
+
+// trailingOneReasoning must leave trailingOneReasoning_OLD nothing to find,
+// and the old reasoning must not mutate its arguments once the new one has
+// run. This replaces an assert that ran inside trailingOneReasoning itself.
 TEST_F(ConstantBitP_TransferFunctions, trailingOneReasoningSubsumesOld)
 {
-  const unsigned width = 3;
-  unsigned combinations = 1;
-  for (unsigned i = 0; i < width; i++)
-    combinations *= 3;
+  // Triples on which the old reasoning fixes something when run first. If
+  // this stays at zero the subsumption below holds trivially and the test is
+  // worthless, so it is checked at the end. It was 129382 when written; the
+  // floor is deliberately far below that so retuning the generator does not
+  // turn into a spurious failure.
+  unsigned oldFiresAlone = 0;
 
-  for (unsigned i = 0; i < combinations; i++)
-    for (unsigned j = 0; j < combinations; j++)
-      for (unsigned k = 0; k < combinations; k++)
-      {
-        FixedBits x = fromTernary(width, i);
-        FixedBits y = fromTernary(width, j);
-        FixedBits out = fromTernary(width, k);
-        trailingOneReasoning(x, y, out);
+  forEachTriple([&](FixedBits& x, FixedBits& y, FixedBits& out) {
+    FixedBits xa(x), ya(y), outa(out);
+    if (trailingOneReasoning_OLD(xa, ya, outa) == CHANGED)
+      oldFiresAlone++;
 
-        FixedBits x2(x), y2(y), out2(out);
-        const Result old = trailingOneReasoning_OLD(x2, y2, out2);
+    trailingOneReasoning(x, y, out);
 
-        ASSERT_EQ(NO_CHANGE, old)
-            << "old reasoning fired after new on " << str(x) << " * " << str(y)
-            << " = " << str(out);
-        ASSERT_TRUE(FixedBits::equals(x, x2))
-            << "old reasoning mutated " << str(x) << " to " << str(x2);
-      }
+    FixedBits x2(x), y2(y), out2(out);
+    const Result old = trailingOneReasoning_OLD(x2, y2, out2);
+
+    ASSERT_EQ(NO_CHANGE, old)
+        << "old reasoning fired after new on " << str(x) << " * " << str(y)
+        << " = " << str(out);
+    ASSERT_TRUE(FixedBits::equals(x, x2))
+        << "old reasoning mutated " << str(x) << " to " << str(x2);
+  });
+
+  EXPECT_GT(oldFiresAlone, 1000u)
+      << "the old reasoning almost never fires on these inputs, so the "
+         "subsumption check above is close to vacuous";
+}
+
+// useLeadingZeroesToFix must fix at least every bit useLeadingZeroesToFix_OLD
+// fixes, and must report CONFLICT whenever the old one does. This replaces
+// asserts that ran inside useLeadingZeroesToFix itself.
+TEST_F(ConstantBitP_TransferFunctions, leadingZeroesSubsumesOld)
+{
+  // Triples on which the old version fixes an output bit or reports a
+  // conflict. Where it does neither, "the new one fixed at least as much" is
+  // trivially true, so the count is checked at the end. It was 23986 when
+  // written.
+  //
+  // This is the reason the check is worth more here than it was as an in-line
+  // assert. There the old version ran on states the column reasoning had
+  // already saturated: over 11504 invocations of useLeadingZeroesToFix across
+  // a 2501-file corpus it fixed a bit on exactly none of them, so the
+  // assertion it guarded was vacuous every single time.
+  unsigned oldFires = 0;
+
+  forEachTriple([&](FixedBits& x, FixedBits& y, FixedBits& out) {
+    FixedBits x_p(x), y_p(y), o_p(out);
+    const Result old = useLeadingZeroesToFix_OLD(x_p, y_p, o_p);
+    if (old == CONFLICT || !FixedBits::equals(o_p, out))
+      oldFires++;
+
+    const Result now = useLeadingZeroesToFix(x, y, out);
+
+    if (old == CONFLICT)
+    {
+      ASSERT_EQ(CONFLICT, now)
+          << "old found a conflict the new one missed on " << str(x_p) << " * "
+          << str(y_p) << " = " << str(o_p);
+      return; // both bailed early, so neither is at its fixed point.
+    }
+
+    if (now == CONFLICT)
+      return; // the new one stops mid-scan, as it did when this was an assert.
+
+    ASSERT_TRUE(FixedBits::in(x, x_p))
+        << "new fixed less of x: " << str(x) << " vs " << str(x_p);
+    ASSERT_TRUE(FixedBits::in(y, y_p))
+        << "new fixed less of y: " << str(y) << " vs " << str(y_p);
+    ASSERT_TRUE(FixedBits::in(out, o_p))
+        << "new fixed less of the output: " << str(out) << " vs " << str(o_p);
+  });
+
+  EXPECT_GT(oldFires, 1000u)
+      << "the old version almost never fixes anything on these inputs, so "
+         "the subsumption check above is close to vacuous";
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
`ConstantBitP_Multiplication.cpp` carried about 150 lines that existed only to serve two debug assertions. This moves them out of the shipped translation unit and into the unit test that already exercised part of the property.

## Call graph

None of these helpers are declared in any header. They have external linkage but the only out-of-file references are the forward declarations in `tests/unit-tests/ConstantBitP_TransferFunctions_Test.cpp`. What a Release build (`NDEBUG` defined) actually compiles and calls, before this change:

| function | callers in a Release build | callers only under `#ifndef NDEBUG` |
| --- | --- | --- |
| `bvMultiplyBothWays` | public entry point | — |
| `multiplyCore` | `bvMultiplyBothWays`, `inverseRelationPass`, unit test | — |
| `useTrailingZeroesToFix` | `multiplyCore` (x2, live) | `multiplyCore`'s debug block |
| `trailingOneReasoning` | `useTrailingZeroesToFix` (x2, live), unit test | — |
| `setToZero` | `useTrailingZeroesToFix` | — |
| `adjustColumns`, `fixIfCanForMultiplication` | `multiplyCore` | — |
| `useLeadingZeroesToFix` | **none**, unit test only | `multiplyCore`'s debug block |
| `useTrailingFixedToFix` | **none** | `multiplyCore`'s debug block |
| `useLeadingZeroesToFix_OLD` | **none** | inside `useLeadingZeroesToFix` |
| `trailingOneReasoning_OLD` | **none**, unit test only | inside `trailingOneReasoning` |
| `printColumns` | **none anywhere** | — |
| `maximumCarryInForMultiplication` | fenced out behind `#if 0` | — |

So the live/dead split was not what the shape of the file suggests. `useLeadingZeroesToFix` and `useTrailingFixedToFix` look like ordinary propagators sitting alongside `useTrailingZeroesToFix`, but nothing in a Release build ever calls them — their only in-library caller is the `#ifndef NDEBUG` fixed-point check at the end of `multiplyCore`. This was confirmed empirically: instrumented counters over a 2501-file corpus recorded `useLeadingZeroesToFix` entered 11504 times and that debug block entered 11504 times — exactly one call per block execution, and none from anywhere else.

Both are left in place. They are still reached from the debug block, and `useLeadingZeroesToFix` is still covered by the tests. Only the `_OLD` pair and the two genuinely dead functions move or go.

## What changed

Commit 1 deletes `printColumns` (no caller anywhere in the tree) and the `#if 0` `maximumCarryInForMultiplication`. No behavioural change in any configuration.

Commit 2 moves `useLeadingZeroesToFix_OLD` and `trailingOneReasoning_OLD`, and the subsumption checks that were their only reason to exist, into `ConstantBitP_TransferFunctions_Test.cpp`.

## The coverage tradeoff — this is not a free win

The subsumption asserts check a real property: each current propagator must fix at least as many bits as the one it replaced. Today that is checked on **every invocation in every assertions-enabled build, against whatever states real formulas happen to produce**. A unit test only checks it against states the test chooses. That is a genuine reduction in the breadth of inputs, and it is the honest cost here.

Two things reduce, but do not eliminate, that cost.

**The tests enumerate rather than sample a hand-picked case.** Every `(x, y, output)` triple at widths 1–4, then 3000 sampled triples at each width from 5 to 48. At any exhaustively covered width this is strictly stronger than the in-line assert, because every state reachable at that width is among the triples enumerated. Above width 4 it is a sample rather than a sweep, and that is where the real loss sits.

The sampler is biased towards runs of fixed zeroes at the ends of an operand, since that is the structure both propagators reason about. Without the bias the random arm contributed almost nothing: under a uniform trit draw at width 48 the top bit is unfixed-or-one about two thirds of the time, so the leading-zero reasoning has nothing to work with. Adding the bias raised the number of triples on which the old leading-zeroes version actually fires from 5241 to 23986.

**For the leading-zeroes check specifically, the move is a clear gain.** Instrumented over 2501 files, `useLeadingZeroesToFix_OLD` was called 11504 times and fixed a bit on **zero** of them. It runs on states the column reasoning has already saturated, so `o_p` always equalled `output` and `assert(FixedBits::in(output, o_p))` reduced to `in(output, output)`. That assertion was vacuous on every real input it ever saw. The replacement test fires on 23986 enumerated triples, and additionally checks a property the assert never did: that the new version reports `CONFLICT` whenever the old one does.

The `trailingOneReasoning` check is the one that loses something. It ran 24345 times on live propagator state (not copies), and the old version returned `NO_CHANGE` every time. Exhaustive coverage at widths 1–4 strictly dominates it there; above width 4, sampling replaces "whatever real formulas produce".

To stop either check from quietly decaying into the vacuous state the leading-zeroes assert was already in, each test counts the triples on which the old version actually fires and fails if that count is low.

## Verification

**The Release CNF byte-compare proves nothing about this change** — everything touched is compiled out when `NDEBUG` is defined. It is here only to confirm nothing leaked into the Release build.

Both arms of every comparison were built with `-DBUILD_SHARED_LIBS=OFF`. With the default shared build, `stp` is a ~390KB binary whose `RUNPATH` points into the build tree, so a baseline copied aside resolves `libstp.so` to the rebuilt library and both arms execute identical code. All four binaries below report "not a dynamic executable" under `ldd`, and the two binaries in each pair have distinct SHA-256 hashes.

- **Release CNF byte-compare** (static baseline vs static candidate, 40-file precnf corpus): 39 identical, 0 mismatched, 1 skipped (baseline emits no CNF). As expected — and, as noted, not evidence of safety.
- **Assertions build, 2501 files** (`~/solvers/work`, 20s timeout), static baseline vs static candidate: identical answers on all 2501 (2213 sat, 288 unsat), 2500 clean exits and 1 timeout in both arms, zero assertion failures in either.
- **Assertions build, 40-file precnf corpus** (120s timeout): zero assertion failures in either arm, answers identical between arms. These are deliberately hard instances and an assertions build is slow, so only 11 of the 40 reached an answer within the timeout (7 sat, 4 unsat); the other 29 timed out identically in both arms. The 2501-file run above is the load-bearing one.
- **`tests/query-files`, 118 files**, run through all four binaries: identical answers everywhere (73 sat, 43 unsat, 2 with no answer line), zero assertion failures.
- **The asserts being removed were reachable.** Instrumented counters on the pre-change assertions build over the 2501-file corpus: the `multiplyCore` debug block ran 11504 times across 650 of the 2501 files, `useLeadingZeroesToFix_OLD` was called 11504 times, `trailingOneReasoning_OLD` 24345 times. So this is not dead code that never executed — it just never found anything. The instrumentation was reverted and is not part of this PR.

**Unit tests ran locally.** `-DENABLE_TESTING=ON -DPYTHON_EXECUTABLE=/usr/bin/python3` configured without trouble in the worktree. `ConstantBitP_TransferFunctions_TestTests`: 43/43 pass, including the two relocated subsumption tests and their non-vacuity guards. The two new tests take about 2.5s and 3.0s.
