### PR TITLE
Stop truncating node ids to 32 bits

### DIFF
--- a/bindings/python/stp/stp.py.in
+++ b/bindings/python/stp/stp.py.in
@@ -207,7 +207,7 @@ _set_func('getVWidth', c_int32, _Expr)
 _set_func('getIWidth', c_int32, _Expr)
 _set_func('vc_printCounterExampleFile', None, _VC, c_int32)
 _set_func('exprName', c_char_p, _Expr)
-_set_func('getExprID', c_int32, _Expr)
+_set_func('getExprID', c_uint64, _Expr)
 _set_func('vc_parseMemExpr', c_int32, _VC, c_char_p, POINTER(_Expr), POINTER(_Expr))
 
 

--- a/include/stp/AST/ASTInternal.h
+++ b/include/stp/AST/ASTInternal.h
@@ -170,7 +170,7 @@ public:
     }
   }
 
-  unsigned GetNodeNum() const { return node_uid; }
+  uint64_t GetNodeNum() const { return node_uid; }
 
   virtual bool isSimplified() const { return false; }
 

--- a/include/stp/AST/ASTNode.h
+++ b/include/stp/AST/ASTNode.h
@@ -181,7 +181,7 @@ public:
   // Access node number. Inlined: ASTInternal is complete here (its header no
   // longer includes this one), so these fold to direct field reads at the
   // call sites. They are among the hottest calls in STP.
-  unsigned GetNodeNum() const { return _int_node_ptr->GetNodeNum(); }
+  uint64_t GetNodeNum() const { return _int_node_ptr->GetNodeNum(); }
 
   // Access kind.
   Kind GetKind() const { return _int_node_ptr->GetKind(); }

--- a/include/stp/Simplifier/DifficultyScore.h
+++ b/include/stp/Simplifier/DifficultyScore.h
@@ -35,7 +35,7 @@ class DifficultyScore // not copyable
 {
 private:
   // maps from nodeNumber to the previously calculated difficulty score..
-  std::map<int, long> cache;
+  std::map<uint64_t, long> cache;
   long evalCount = 0;
 
 public:

--- a/include/stp/Simplifier/MergeSame.h
+++ b/include/stp/Simplifier/MergeSame.h
@@ -101,7 +101,7 @@ public:
 
 
     // Node number to index in the children vector.
-    std::unordered_map<unsigned,unsigned> seen;
+    std::unordered_map<uint64_t,unsigned> seen;
 
     ASTNode result =n;
     if (n.GetKind() == AND)

--- a/include/stp/Simplifier/VariablesInExpression.h
+++ b/include/stp/Simplifier/VariablesInExpression.h
@@ -37,7 +37,7 @@ class VariablesInExpression
 private:
   void insert(const ASTNode& n, Symbols* s);
 
-  typedef std::unordered_map<int, Symbols*> ASTNodeToNodes;
+  typedef std::unordered_map<uint64_t, Symbols*> ASTNodeToNodes;
   ASTNodeToNodes symbol_graph;
 
 public:

--- a/include/stp/c_interface.h
+++ b/include/stp/c_interface.h
@@ -1267,7 +1267,7 @@ DLL_PUBLIC const char* exprName(Expr e);
 
 //! \brief Returns the internal node ID of the given expression.
 //!
-DLL_PUBLIC int getExprID(Expr ex);
+DLL_PUBLIC uint64_t getExprID(Expr ex);
 
 //! \brief Parses the given string in CVC or SMTLib1.0 format and extracts
 //!        query and assertion information into the 'outQuery' and 'outAsserts'

--- a/include/stp/cpp_interface.h
+++ b/include/stp/cpp_interface.h
@@ -53,14 +53,17 @@ class Cpp_interface
   // Used to cache prior queries.
   struct Entry
   {
+    // No node has this number, so it marks "nothing recorded yet".
+    static constexpr uint64_t NO_NODE = UINT64_MAX;
+
     explicit Entry(SOLVER_RETURN_TYPE result_)
     {
       result = result_;
-      node_number = -1;
+      node_number = NO_NODE;
     }
 
     SOLVER_RETURN_TYPE result;
-    int node_number; // a weak pointer.
+    uint64_t node_number; // a weak pointer.
   };
   vector<Entry> cache;
 

--- a/lib/AST/ASTmisc.cpp
+++ b/lib/AST/ASTmisc.cpp
@@ -92,7 +92,7 @@ bool arithless(const ASTNode& n1, const ASTNode& n2)
 }
 
 // counts the number of reads. Shortcut when we get to the limit.
-void numberOfReadsLessThan(const ASTNode& n, std::unordered_set<int>& visited,
+void numberOfReadsLessThan(const ASTNode& n, std::unordered_set<uint64_t>& visited,
                            int& soFar, const int limit)
 {
   if (n.isAtom())
@@ -116,7 +116,7 @@ void numberOfReadsLessThan(const ASTNode& n, std::unordered_set<int>& visited,
 // True if the number of reads in "n" is less than "limit"
 bool numberOfReadsLessThan(const ASTNode& n, int limit)
 {
-  std::unordered_set<int> visited;
+  std::unordered_set<uint64_t> visited;
   int reads = 0;
   numberOfReadsLessThan(n, visited, reads, limit);
   return reads < limit;

--- a/lib/Interface/c_interface.cpp
+++ b/lib/Interface/c_interface.cpp
@@ -2102,7 +2102,7 @@ const char* exprName(Expr e)
   return ((stp::ASTNode*)e)->GetName();
 }
 
-int getExprID(Expr ex)
+uint64_t getExprID(Expr ex)
 {
   stp::ASTNode q = (*(stp::ASTNode*)ex);
   return q.GetNodeNum();

--- a/lib/Interface/cpp_interface.cpp
+++ b/lib/Interface/cpp_interface.cpp
@@ -501,7 +501,7 @@ void Cpp_interface::checkSat(const ASTVec& assertionsSMT2)
   }
 
   Entry& last_run = cache.back();
-  if (((unsigned)last_run.node_number != assertionsSMT2.back().GetNodeNum()) &&
+  if ((last_run.node_number != assertionsSMT2.back().GetNodeNum()) &&
       (last_run.result == SOLVER_SATISFIABLE))
   {
     // extra asserts might have been added to it,

--- a/lib/Printer/GDLPrinter.cpp
+++ b/lib/Printer/GDLPrinter.cpp
@@ -41,7 +41,7 @@ using namespace stp;
 void outputBitVec(const ASTNode n, ostream& os);
 
 void GDL_Print1(ostream& os, const ASTNode& n,
-                std::unordered_set<int>* alreadyOutput,
+                std::unordered_set<uint64_t>* alreadyOutput,
                 string (*annotate)(const ASTNode&))
 {
   // check if this node has already been printed. If so return.
@@ -134,7 +134,7 @@ ostream& GDL_Print(ostream& os, const ASTNode n,
   os << "display_edge_labels: yes" << endl;
 
   // create hashmap to hold integers (node numbers).
-  std::unordered_set<int> alreadyOutput;
+  std::unordered_set<uint64_t> alreadyOutput;
 
   GDL_Print1(os, n, &alreadyOutput, annotate);
   ;

--- a/lib/Printer/dotPrinter.cpp
+++ b/lib/Printer/dotPrinter.cpp
@@ -38,7 +38,7 @@ using namespace stp;
 void outputBitVec(const ASTNode n, ostream& os);
 
 void Dot_Print1(ostream& os, const ASTNode n,
-                std::unordered_set<int>* alreadyOutput)
+                std::unordered_set<uint64_t>* alreadyOutput)
 {
 
   // check if this node has already been printed. If so return.
@@ -88,7 +88,7 @@ ostream& Dot_Print(ostream& os, const ASTNode n)
   os << "digraph G{" << endl;
 
   // create hashmap to hold integers (node numbers).
-  std::unordered_set<int> alreadyOutput;
+  std::unordered_set<uint64_t> alreadyOutput;
 
   Dot_Print1(os, n, &alreadyOutput);
 


### PR DESCRIPTION
`node_uid` is a `uint64_t` counter on `ASTInternal`, but both `GetNodeNum()` accessors returned `unsigned`, so every reader saw it modulo 2^32. The counter is a thread-local incremented by two per node and is never reset — not per `STPMgr`, not per query — so it accumulates over a thread's whole lifetime. A process that creates 2^31 nodes wraps it.

That is out of reach for the command line tool, which does one solve per process: the largest QF_BV file I measured ends at a top-node uid of about 5 million, so roughly 2.5 million node creations for one solve. It is not out of reach for long-lived library use — repeated `vc_query` on one `VC`, the language bindings, or a symbolic execution engine driving STP for hours.

### The accessor is not where the damage would be done

`ASTInterior` sets a `NOT` node's uid to `children[0].GetNodeNum() + 1`, so the truncated value is stored, not merely observed. Past the wrap a `NOT` node is minted with a small uid colliding with a live older node's, breaking the "a node's uid exceeds its children's" invariant that the `NOT(NOT(x))` ban in `HashingNodeFactory`, the `exprless` ordering and an assert in `ASTmisc` all rely on. Widening the accessor fixes that site by construction.

Containers keyed on an `ASTNode` are unaffected: `Hash()` already reads the full 64 bits and `ASTNodeEqual` compares pointers. Only containers keyed on the integer were exposed, and a collision there is a silent wrong answer rather than a crash — `Flatten`'s `fromTo` would hand back the wrong replacement node, and `Dependencies` would merge two nodes' parent sets.

### What changed

Most of those containers already declared `uint64_t` keys and were simply being fed a truncated value. The ones that did not are widened here: `MergeSame`'s index map, `VariablesInExpression`'s symbol graph, `DifficultyScore`'s memo, the two graph printers' visited sets, and the read counter in `ASTmisc`. `Cpp_interface::Entry::node_number` becomes a `uint64_t` with an explicit `NO_NODE` sentinel, replacing an `int` `-1` that was compared through an `(unsigned)` cast.

A `-Wconversion -fsyntax-only` sweep over `lib/` and `tools/` reports no remaining narrowing of a node id.

### API change

`getExprID` is widened to `uint64_t`, which changes the C API in `include/stp/c_interface.h`. It is the one caller of `GetNodeNum` outside the library, its result is an opaque identity, and returning a truncated one defeats the point of the fix. The ctypes binding is updated to `c_uint64` to match.

### Verification

- `ctest`: 70/70 on a Debug + assertions build, including `python-interface-tests`, which exercises the changed binding, and the C API tests.
- Differential answers over the 2501-file fuzz corpus against a baseline binary: 2488 agree, 0 disagree, 13 timeouts.
- CNF byte-comparison over a 40-file QF_BV corpus with `--output-CNF --exit-after-CNF`: 39 identical, 0 mismatched, 1 emits no CNF.