### PR TITLE
Register --bb.simplify-during-bb so simplify_during_bb() is reachable

### DIFF
--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -359,6 +359,11 @@ void ExtraMain::create_options()
     ("bb.conjoin-constant", 
       BOOL_ARG(bm->UserFlags.conjoin_to_top),
       "When constant-bit propagation detects a constant bit during AIG construction, assert the AIG node and replace it, in the AIG, by the constant bit"
+      )
+
+    ("bb.simplify-during-bb",
+      BOOL_ARG(bm->UserFlags.simplify_during_BB_flag),
+      "When bit-blasting discovers that a non-constant child of a term blasts to an all-constant vector, rebuild the term with that constant and re-run the word-level term simplifier on it. Has no effect unless the rewriting simplifier is also on, i.e. not with --disable-opt-inc or --disable-simplifications"
       );
 
 


### PR DESCRIPTION
Originally branched from `de-template-bitblaster` (#714) because that PR restructured `BitBlaster`. #714 merged while this was in progress, so this is now rebased straight onto master and has no stacking constraint. The diff is confined to `tools/stp/main.cpp`.

## What this does

Registers `--bb.simplify-during-bb` so that `BitBlaster::simplify_during_bb()` can actually be reached. Five lines in the Bit-blasting options group. **The default is unchanged** — this makes a capability available, it does not turn anything on.

## Why the option did not already exist

`git log -S simplify_during_BB_flag --all` and `git log -S simplify_during_bb --all` give a clear answer, and it is not "the wiring was lost".

The optimisation went in as cc0c9992 (2010-08-28), commit message "Changes to inactive by default code", gated only on `optimize_flag` — i.e. on by default. Later the *same day*, 8ce3ece6: *"Fix. I thought the code I checked-in just now wasn't active. But it was. This patch adds a flag to disable the prior patch."* That commit added `simplify_during_BB_flag = false` and ANDed it into the guard.

So the flag was born as an off-switch, and an on-switch was never added. `git log --all -S "simplify_during_BB_flag = true"` and the equivalent without spaces both return nothing: the flag has never been assigned `true` anywhere in the history of the repository, and no command-line option for it has ever existed. It was reachable-by-default for a few hours in August 2010 and has been dead ever since. 995d65de (2016-08-14) later extracted the inline block into the `simplify_during_bb()` function it is today, but did not change reachability.

## What the optimisation is

The only feedback edge from the bit level back to the word level. When a term's child is not an AST constant but bit-blasts to an all-constant vector — because constant-bit propagation or the AIG construction figured out every bit — the term is rebuilt with a real `BVCONST` child, `SimplifyTerm` is re-run over it, and the old node's `FixedBits` are merged into the new node before propagating. So `ite(x,y,z)` where `x` has become known-true blasts as `y`. Blasting is otherwise strictly one-way. That is worth having reachable.

## The guard

The guard is `uf->optimize_flag && uf->simplify_during_BB_flag`, so the new option is a no-op under `--disable-opt-inc` or `--disable-simplifications`. I have left the guard alone and documented the dependency in the option's help string, rather than dropping the `optimize_flag` conjunct. Removing it would widen when the path fires, which is a behaviour change that does not belong inside a plumbing change — and the path calls `simp->SimplifyTerm`, so requiring the simplifier to be enabled is defensible on its own terms.

## Verification

The path had never executed in a shipped build, so it was treated as unverified rather than as a working feature needing a switch. Two static (`-DBUILD_SHARED_LIBS=OFF`) release binaries, distinct sha256, `ldd` reporting "not a dynamic executable" for both, so no chance of a build-tree `RUNPATH` making the comparison vacuous.

**Soundness — the flag must never change an answer.** Same binary, flag off vs flag on, comparing full stdout+stderr and exit code file by file:

| Corpus | Files | Identical | Diverged | Skipped |
|---|---|---|---|---|
| `tests/query-files/**` | 186 | 186 | 0 | 0 |
| A fuzz corpus of ~2500 generated QF_BV/QF_ABV queries | 2501 | 2501 | 0 | 0 |

No divergence anywhere, including on the 313 files where the path actually fires.

**Assertions build** (`-DCMAKE_BUILD_TYPE=Debug -DENABLE_ASSERTIONS=ON`), flag on, over exactly the 313 files that exercise the path: 313 ran, 0 failures, 0 timeouts. The `assert(BVTypeCheck(n_term))` and the `ConstantBitPropagation` worklist/`FixedBits` bookkeeping all hold up. Over the query files, the single non-zero exit is `let-tests/let_009.smt2`, which is a deliberate negative parser test and fails identically with the flag off.

**Default unchanged.** CNF byte-compare, baseline vs this branch, no flag, over a 40-file corpus of hard QF_BV queries: 39 identical, 0 mismatched, 1 skipped (the baseline itself emits no CNF for that file, so there is nothing to compare).

**Unit tests:** 70/70. **Builds:** gcc and clang, both clean, no new warnings.

## Does it fire, and does it help?

Temporary instrumentation, reverted before committing, counting how often the `newConst` branch is taken.

| Corpus | Files | Files where it fires | `simplify_during_bb` calls | `newConst` taken | Term actually changed | Simplified term already in the memo |
|---|---|---|---|---|---|---|
| `tests/query-files/**` | 186 | 2 | 1,761 | 3 | 3 | 1 |
| Fuzz corpus | 2501 | 313 (12.5%) | 228,846 | 6,540 (2.9%) | 6,540 | 5,412 |
| 40 hard QF_BV queries | 38 | 8 | 698,776 | 2,851 | 2,851 | 2,715 |

So it fires, on a meaningful fraction of real input, and every single time the branch is taken the re-simplified term differs from the original. It is not vestigial.

**But it does not pay for itself.** CNF size, flag off vs on, on the files where it fires:

| Corpus | Files | Smaller CNF | Larger CNF | Vars off to on | Clauses off to on |
|---|---|---|---|---|---|
| Fuzz corpus (firing subset) | 313 | 24 | 43 | 240,085 to 241,442 (+0.6%) | 1,085,500 to 1,090,589 (+0.5%) |
| Hard corpus (firing subset) | 8 (7 emit CNF) | 1 | 6 | 669,893 to 769,636 (+14.9%) | 2,904,639 to 3,334,079 (+14.8%) |

The hard-corpus regression is concentrated: `picorv32_mutBX_QF_BV_NONINCR` goes from 166,079 vars / 691,153 clauses to 261,715 / 1,103,414 — around +58% and +60%. Solve time on the tractable hard files, interleaved A/B with rotated arm order, agrees: `predicate_593` is 3.56s / 3.12s with the flag off against 4.45s / 5.22s with it on; the two `s3_*` files are a wash; `newton.4.2.i` times out at 180s either way.

The likely mechanism is that re-simplifying produces a *different* AST node, and the memo table is keyed by node, so the AIG structure already built for the original term is not reused. The 5,412-of-6,540 memo-hit rate says the simplified term is usually already blasted, which recovers some of that — but evidently not all of it, and on the larger formulas the lost sharing dominates.

## What this PR is claiming

That the path is sound, that it is exercised, that it does not fire by default, and that it is now switchable so the behaviour can be measured. It is **not** claiming the optimisation is a win — on the evidence above it is a small net loss on generated queries and a substantial one on large hard queries, which is a good reason for the default to stay off and a reasonable explanation for why it was switched off in 2010 in the first place. Having it reachable means the next person to look at it can measure instead of guess, and the underlying idea (feeding bit-level constant discoveries back to the word level) is worth keeping alive even if this particular realisation of it loses sharing.
