### PR TITLE
Make the MSVC symbol-visibility plumbing correct, but still dormant

### DIFF
--- a/include/stp/Util/Attributes.h
+++ b/include/stp/Util/Attributes.h
@@ -36,9 +36,29 @@ THE SOFTWARE.
 #define ATTR_NORETURN
 #endif
 
+// The DLL_PUBLIC / DLL_LOCAL block below is duplicated verbatim in
+// include/stp/c_interface.h, and deliberately so: c_interface.h is the only
+// header STP installs, and this header ships nowhere, so the public C header
+// cannot include it. Do not "deduplicate" the two -- that would leave the
+// installed header with no definition of DLL_PUBLIC. Keep them in sync instead.
 #if defined(_MSC_VER)
-// NOTE: for now, we need STP_SHARED_LIB for clients of the statically linked
-// STP library, for which linking fails when DLL_PUBLIC is __declspec(dllimport).
+// MSVC symbol visibility. Two macros drive it, both set by lib/CMakeLists.txt:
+//
+//   STP_SHARED_LIB  libstp is a DLL. Defined only when BUILD_SHARED_LIBS is ON:
+//                   for the library's own sources, and, through the exported
+//                   target's interface, for clients that link it.
+//   STP_EXPORTS     this translation unit is part of libstp itself, rather than
+//                   a client compiling against these headers.
+//
+// A static build defines neither and gets an empty DLL_PUBLIC. That is the only
+// expansion that links for static: a static client that saw dllimport would
+// fail at link time. A shared build gets dllexport while the library is being
+// compiled and dllimport for everyone else.
+//
+// The mechanism is currently dormant -- no shared MSVC build of STP is produced
+// (the only Windows CI job is STATICCOMPILE=ON, which forces BUILD_SHARED_LIBS
+// OFF), so neither __declspec arm is ever taken. It is kept correct so that
+// enabling a Windows DLL build later works.
 #if defined(STP_SHARED_LIB) && defined(STP_EXPORTS)
 // This is visible when building the STP library as a DLL.
 #define DLL_PUBLIC __declspec(dllexport)

--- a/include/stp/c_interface.h
+++ b/include/stp/c_interface.h
@@ -45,9 +45,29 @@ extern "C" {
 /// into code that includes it.
 /////////////////////////////////////////////////////////////////////////////
 
+// The DLL_PUBLIC / DLL_LOCAL block below is duplicated verbatim from
+// include/stp/Util/Attributes.h, and deliberately so: this is the only header
+// STP installs, and Attributes.h ships nowhere, so it cannot be included from
+// here. Do not "deduplicate" the two -- that would leave this header with no
+// definition of DLL_PUBLIC once installed. Keep them in sync instead.
 #if defined(_MSC_VER)
-// NOTE: for now, we need STP_SHARED_LIB for clients of the statically linked
-// STP library, for which linking fails when DLL_PUBLIC is __declspec(dllimport).
+// MSVC symbol visibility. Two macros drive it, both set by lib/CMakeLists.txt:
+//
+//   STP_SHARED_LIB  libstp is a DLL. Defined only when BUILD_SHARED_LIBS is ON:
+//                   for the library's own sources, and, through the exported
+//                   target's interface, for clients that link it.
+//   STP_EXPORTS     this translation unit is part of libstp itself, rather than
+//                   a client compiling against these headers.
+//
+// A static build defines neither and gets an empty DLL_PUBLIC. That is the only
+// expansion that links for static: a static client that saw dllimport would
+// fail at link time. A shared build gets dllexport while the library is being
+// compiled and dllimport for everyone else.
+//
+// The mechanism is currently dormant -- no shared MSVC build of STP is produced
+// (the only Windows CI job is STATICCOMPILE=ON, which forces BUILD_SHARED_LIBS
+// OFF), so neither __declspec arm is ever taken. It is kept correct so that
+// enabling a Windows DLL build later works.
 #if defined(STP_SHARED_LIB) && defined(STP_EXPORTS)
 // This is visible when building the STP library as a DLL.
 #define DLL_PUBLIC __declspec(dllexport)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -18,8 +18,37 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-# Enable symbol exports
-add_definitions(-D STP_EXPORTS)
+# Symbol visibility, see the DLL_PUBLIC block in include/stp/Util/Attributes.h
+# (duplicated in include/stp/c_interface.h). Both macros only ever do anything
+# under MSVC; the GNU/clang branch of that block tests neither of them, so on
+# every non-MSVC build these definitions are inert.
+#
+# STP_EXPORTS means "this translation unit is part of libstp", as opposed to a
+# client compiling against the installed headers. It must reach every source
+# that goes into the library, which is all of lib/ and its subdirectories --
+# hence directory scope here, ahead of the add_subdirectory() calls that create
+# the object libraries. It is deliberately not set for tools/, bindings/ or the
+# tests: those are clients of the library and want the import side.
+#
+# This used to read add_definitions(-D STP_EXPORTS). CMake's -D handling does
+# not match a bare -D followed by a separate argument, so neither token became a
+# compile definition; both fell through to the directory's COMPILE_OPTIONS and
+# only reached the compiler because they happened to stay adjacent on the
+# command line -- invisible to COMPILE_DEFINITIONS and to anything that inspects
+# it.
+add_compile_definitions(STP_EXPORTS)
+
+# STP_SHARED_LIB means "libstp is a DLL". Only then may the __declspec arms be
+# used: a static MSVC build that saw __declspec(dllimport) would fail to link,
+# which is why the #else fallback to an empty DLL_PUBLIC is the correct one for
+# static and must stay reachable. STATICCOMPILE forces BUILD_SHARED_LIBS OFF, so
+# static builds (including the Windows CI job) keep the empty expansion.
+#
+# Note this is currently dormant: no shared MSVC build of STP is produced, so
+# nothing has exercised the __declspec arms.
+if (BUILD_SHARED_LIBS)
+    add_compile_definitions(STP_SHARED_LIB)
+endif()
 
 add_subdirectory(Globals)
 add_subdirectory(AST)
@@ -88,6 +117,24 @@ endif()
 add_library(stp
     ${stp_lib_objects}
 )
+
+# The directory-scope definitions above cover the object libraries this target
+# is assembled from. Repeating STP_EXPORTS as a PRIVATE requirement keeps it
+# attached to the library target itself rather than only to the directory, so it
+# still applies if sources are ever added to stp directly -- and, more to the
+# point, it documents that STP_EXPORTS is a build-of-the-library requirement and
+# must never become part of the link interface.
+#
+# STP_SHARED_LIB is the opposite: consumers need it too. A client compiling
+# against the installed c_interface.h must see STP_SHARED_LIB (so DLL_PUBLIC is
+# a __declspec) with STP_EXPORTS unset (so it resolves to dllimport). Putting it
+# in the INTERFACE requirements records it in the exported STPTargets.cmake, so
+# anything that links the imported stp target picks it up automatically, and
+# in-tree consumers (tools/, bindings/, tests/) get it for free.
+target_compile_definitions(stp PRIVATE STP_EXPORTS)
+if (BUILD_SHARED_LIBS)
+    target_compile_definitions(stp INTERFACE STP_SHARED_LIB)
+endif()
 
 # Set the public header so it will be installed
 set_target_properties(stp PROPERTIES


### PR DESCRIPTION
STP's MSVC symbol-visibility machinery could never do anything, and two of its pieces were malformed. This makes the mechanism correct while leaving it dormant, so that turning on a Windows DLL build later works. It is a no-op for every build that exists today.

## What was wrong

**`STP_EXPORTS` was never a compile definition.** `lib/CMakeLists.txt` read `add_definitions(-D STP_EXPORTS)` — `-D` and `STP_EXPORTS` as two separate arguments. CMake's `-D` handling does not match that form, so neither token became a compile definition; both fell through to the directory's `COMPILE_OPTIONS`. It reached the compiler at all only because the two tokens happened to stay adjacent on the command line, and it was invisible to `COMPILE_DEFINITIONS` and to anything that inspects it. In a generated `flags.make` on master it shows up at the end of `CXX_FLAGS` as `-D STP_EXPORTS`, not in `CXX_DEFINES`.

**`STP_SHARED_LIB` was defined nowhere.** It is tested in four places — twice in `include/stp/Util/Attributes.h` and twice in `include/stp/c_interface.h` — and no CMakeLists, `.cmake` file, script or workflow defined it anywhere in the tree. On MSVC that meant `DLL_PUBLIC` always expanded to empty and both `__declspec` arms were unreachable.

**Consumers could not be told either.** For a client to link against a future DLL it must see `STP_SHARED_LIB` with `STP_EXPORTS` unset, so `DLL_PUBLIC` resolves to `dllimport`. Nothing propagated that.

## What this does

`add_compile_definitions(STP_EXPORTS)` for everything under `lib/`, which is exactly the set of translation units that make up libstp. It is deliberately not set for `tools/`, `bindings/` or the tests — those are clients and want the import side.

`STP_SHARED_LIB` is defined only when `BUILD_SHARED_LIBS` is ON: for the library's own sources, and as an `INTERFACE` compile definition on the `stp` target for its consumers. Getting that condition backwards is the failure the old comment warned about — a static MSVC build that saw `__declspec(dllimport)` fails to link, which is why the `#else` fallback to an empty `DLL_PUBLIC` is correct for static and stays reachable. `STATICCOMPILE=ON` forces `BUILD_SHARED_LIBS` OFF, so the Windows CI job keeps getting an empty `DLL_PUBLIC`, exactly as today.

The `INTERFACE` definition is recorded in both the build-tree and the install-tree `STPTargets.cmake`, so in-tree consumers and external `find_package(STP)` users pick it up automatically. This is the minimum needed to make the definitions propagate; it does **not** attempt the larger target-based-export modernisation (the exported target still carries no include directories, which is why `STPConfig.cmake.in` still hand-rolls `STP_INCLUDE_DIRS`). That remains a separate change.

The `NOTE:` comment above each `DLL_PUBLIC` block read backwards and is rewritten. Both copies now state plainly what each macro means, that static gets an empty expansion while shared gets `dllexport` for the library and `dllimport` for clients, and that the mechanism is currently dormant.

The block is duplicated verbatim between `Attributes.h` and `c_interface.h` on purpose: `c_interface.h` is the only header STP installs and `Attributes.h` ships nowhere, so the public C header cannot include it. Both copies now say so, so the next person does not "deduplicate" them and leave the installed header with no `DLL_PUBLIC`.

## The MSVC path is reasoned about, not executed

No MSVC was available, and the project's only Windows coverage is the static (`STATICCOMPILE=ON`) CI job, which by construction takes the same empty-`DLL_PUBLIC` branch as before. What is demonstrated below is the *CMake* behaviour — that the right definitions reach the right translation units in the right configurations — plus the argument about what MSVC would then see. No shared MSVC build has been compiled or linked.

## Evidence that the definitions now land

Library sources (`lib/Globals`), `CXX_DEFINES` from the generated build files:

- static configure: `... -DSTP_EXPORTS -D__STDC_LIMIT_MACROS` — present as a real definition, no `STP_SHARED_LIB`.
- shared configure: `... -DSTP_EXPORTS -DSTP_SHARED_LIB -D__STDC_LIMIT_MACROS`.

Client sources in the same trees (`tools/stp`, and the gtest targets in a testing build):

- static: neither macro — empty `DLL_PUBLIC`, which is the only thing that links for static MSVC.
- shared: `-DSTP_SHARED_LIB` and no `STP_EXPORTS` — i.e. `dllimport`.

Exported target, both the build-tree `STPTargets.cmake` and the install-tree one generated under `CMakeFiles/Export`:

```
set_target_properties(stp PROPERTIES
  INTERFACE_COMPILE_DEFINITIONS "STP_SHARED_LIB"
)
```

present for a shared configure, absent for a static one. Configuring `examples/simple` against the shared package through `find_package(STP)` yields `C_DEFINES = -DSTP_SHARED_LIB` for the example's own translation unit, and it builds and links — that is the consumer-propagation path working end to end.

## Evidence this is a no-op today

The MSVC block is inside `#if defined(_MSC_VER)`, and the GNU/clang branch tests neither macro, so on Linux this can only be inert. Confirmed:

- Two static Release binaries, built from the same tree before and after the change, differ in whole-file `sha256sum` (build id, and the debug-info `comp_dir`, which is the build directory name) and both are statically linked with no libstp dependency at all — so no vacuous comparison through a shared library. Their `.text` sections are **byte-identical**: 16,441,087 bytes, same SHA-256.
- CNF byte-comparison over a 40-file hard-query corpus: 39 identical, 0 mismatched, 1 skipped because the baseline emits no CNF for it at all.
- Full stdout, stderr and exit-code comparison over all 187 files under `tests/query-files/`: 187 identical, 0 differing.
- Configure and build succeed, shared and static, under both gcc and clang. Warning sets are unchanged: all warnings come from the vendored ABC submodule and from pre-existing unused-variable sites in STP, and none mention a macro or a visibility attribute.
- Unit test suite in a shared-libs testing build: 70/70 pass.

## Noted, not fixed

`_empty_ASTVec` is declared `DLL_PUBLIC extern` in three headers: `include/stp/AST/UsefulDefs.h` and `include/stp/NodeFactory/NodeFactory.h` as `ASTVec`, and `include/stp/Globals/Globals.h` as `std::vector<ASTNode>`. All three are in `namespace stp`, and `ASTVec` is a typedef for `std::vector<ASTNode>` in both places that spell it that way, so all three name the same object with equivalent types; there is exactly one definition, in `lib/Globals/Globals.cpp`, and the built shared library contains exactly one `stp::_empty_ASTVec` symbol. The three declarations exist so that `Globals.h` and `NodeFactory.h` can stay lightweight rather than pull in `UsefulDefs.h`, and translation units that see all three compile fine. So the redundancy is harmless as it stands and no change is made here.

It does matter for the eventual DLL, though, and is worth a follow-up: exporting an instance of an STL class template across a DLL boundary is the classic MSVC C4251 situation, and this object is additionally used as a default argument in headers (so clients bind a reference to the imported object) and is mutated from client code at shutdown, which under a DLL build would run a client-side instantiation of `vector::clear()` over an object owned by the DLL. The clean fix is to stop exporting the object and hand out a function returning a reference, which is a bigger, separate change.

Also noticed while testing, pre-existing on master and out of scope here: the exported target for a **static** build is unusable by external consumers. `INTERFACE_LINK_LIBRARIES` contains a `$<TARGET_FILE:libabc-pic>` generator expression naming a target no consumer has, so `find_package(STP)` against a static build tree fails at generate time. A shared build is unaffected. This reproduces identically before and after this change.
