### PR TITLE
Compile main_common.cpp once, through an object library

### DIFF
--- a/tools/stp/CMakeLists.txt
+++ b/tools/stp/CMakeLists.txt
@@ -21,10 +21,21 @@
 # -----------------------------------------------------------------------------
 # Create binary
 # -----------------------------------------------------------------------------
+# Everything the two front ends share: parsing, print-back, and the solve.
+# They differ only in how they read their options. An object library so the
+# translation unit is named once and compiled once, rather than stp_simple
+# reaching across directories for ../stp/main_common.cpp.
+#
+# Built whenever executables are, including under ONLY_SIMPLE, where
+# stp_simple is the only consumer.
+if(BUILD_EXECUTABLES)
+    add_library(stp_main_common OBJECT main_common.cpp)
+endif()
+
 if(BUILD_EXECUTABLES AND NOT ONLY_SIMPLE)
     add_executable(stp-bin
         main.cpp
-        main_common.cpp
+        $<TARGET_OBJECTS:stp_main_common>
     )
 
     set_target_properties(stp-bin PROPERTIES

--- a/tools/stp_simple/CMakeLists.txt
+++ b/tools/stp_simple/CMakeLists.txt
@@ -24,7 +24,7 @@
 if(BUILD_EXECUTABLES)
     add_executable(stp_simple-bin
         main_simple.cpp
-        ../stp/main_common.cpp
+        $<TARGET_OBJECTS:stp_main_common>
     )
 
     set_target_properties(stp_simple-bin PROPERTIES


### PR DESCRIPTION
Last item from the `tools/` audit. `stp` and `stp_simple` differ only in how they read their command-line options; everything else — parsing, print-back, the solve — is `Main` in `main_common.cpp`, which they already share properly through the base class.

The build did not. `tools/stp_simple/CMakeLists.txt` named `../stp/main_common.cpp`, reaching across directories for the source, so the translation unit was compiled twice — once per executable, in two different directory contexts. An `OBJECT` library in `tools/stp` names it once and both link the result.

It is created whenever `BUILD_EXECUTABLES` is on, including under `ONLY_SIMPLE`, where `stp_simple` is its only consumer.

## No behaviour change

`tools/stp_simple` sets no directory-level properties, so the translation unit was already compiled with the same flags in both places; now there is one set by construction. Checked from clean, both configurations:

| configuration | binaries | `main_common.cpp.o` |
| --- | --- | --- |
| normal | `stp`, `stp_simple` | 1 |
| `-DONLY_SIMPLE=ON` | `stp_simple` | 1 |

Both binaries solve; `ctest` 70/70 with `WERROR`.

## What was considered and rejected

The audit also suggested gating `stp_simple` on `ONLY_SIMPLE`, so normal builds stop producing a binary that `stp` supersedes and no test exercises.

Not done. openSUSE packages it deliberately — `scripts/suse/stp.changes`, Nov 2016: *"package also stp_simple, needed for cmake find_package"*. That recorded reason no longer holds (no binary is in the `STPTargets` export set, so `find_package(STP)` does not need it), but dropping a binary a distribution has shipped for a decade is not worth saving one small link. Happy to revisit if you would rather it went.