### PR TITLE
Clear GlobalParserInterface when the interface it points at dies

### DIFF
--- a/include/stp/cpp_interface.h
+++ b/include/stp/cpp_interface.h
@@ -113,14 +113,18 @@ class Cpp_interface
   bool produce_models;
   bool changed_model_status;
 
+  // Set by the constructors that point GlobalParserBM at bm themselves, so
+  // that the destructor knows to clear it again. Constructors that leave the
+  // global alone leave it alone on the way out too -- callers such as the
+  // rewrite-rule tools set GlobalParserBM once and then build and destroy
+  // several interfaces over the same manager.
+  bool set_global_parser_bm;
+
 public:
   std::unique_ptr<LetMgr> letMgr;
   NodeFactory* nf;
 
-  ~Cpp_interface()
-  {
-    cleanUp();
-  }
+  DLL_PUBLIC ~Cpp_interface();
 
   DLL_PUBLIC Cpp_interface(STPMgr& bm_);
   DLL_PUBLIC Cpp_interface(STPMgr& bm_, NodeFactory* factory);

--- a/lib/Interface/c_interface.cpp
+++ b/lib/Interface/c_interface.cpp
@@ -1870,6 +1870,11 @@ Expr vc_parseExpr(VC vc, const char* infile)
   stp::ASTNode o = b->CreateNode(stp::AND, asserts, oo);
   stp::ASTNode* output = new stp::ASTNode(o);
   delete AssertsQuery;
+
+  // cpp_inter is about to go out of scope, so give back the global that
+  // points at it. (~Cpp_interface does this too, for the paths that don't
+  // reach here.)
+  stp::GlobalParserInterface = NULL;
   return output;
 }
 
@@ -2190,6 +2195,10 @@ int vc_parseMemExpr(VC vc, const char* s, Expr* oquery, Expr* oasserts)
   {
     *(stp::ASTNode**)oasserts = new stp::ASTNode(AssertsQuery[0]);
   }
+
+  // pi is about to go out of scope, so give back the global that points at
+  // it. (~Cpp_interface does this too, for the paths that don't reach here.)
+  stp::GlobalParserInterface = NULL;
   return 1;
 }
 

--- a/lib/Interface/cpp_interface.cpp
+++ b/lib/Interface/cpp_interface.cpp
@@ -88,9 +88,27 @@ void Cpp_interface::removeFrame()
 }
 
 Cpp_interface::Cpp_interface(STPMgr& bm_, NodeFactory* factory)
-    : bm(bm_), letMgr(new LetMgr(bm.ASTUndefined)), nf(factory)
+    : bm(bm_), set_global_parser_bm(false),
+      letMgr(new LetMgr(bm.ASTUndefined)), nf(factory)
 {
   init();
+}
+
+// Every writer of the parser globals borrows: whoever sets one clears it
+// again. GlobalParserInterface is cleared whichever constructor ran, because
+// the callers that assign it directly (the C interface's parse entry points)
+// point it at a stack local of theirs, which is this object. The guard keeps
+// an interface that has since been superseded from clearing a pointer that
+// now belongs to a live one.
+Cpp_interface::~Cpp_interface()
+{
+  cleanUp();
+
+  if (GlobalParserInterface == this)
+    GlobalParserInterface = NULL;
+
+  if (set_global_parser_bm && GlobalParserBM == &bm)
+    GlobalParserBM = NULL;
 }
 
 ASTVec& Cpp_interface::getCurrentSymbols()
@@ -569,7 +587,8 @@ void Cpp_interface::checkSat(const ASTVec& assertionsSMT2)
 // something which dereferences GlobalSTP, such as BBAsProp) construct the STP
 // themselves and assign it before that point.
 Cpp_interface::Cpp_interface(STPMgr& bm_)
-    : bm(bm_), letMgr(new LetMgr(bm.ASTUndefined)), nf(bm_.defaultNodeFactory)
+    : bm(bm_), set_global_parser_bm(true),
+      letMgr(new LetMgr(bm.ASTUndefined)), nf(bm_.defaultNodeFactory)
 {
   nf = bm.defaultNodeFactory;
   startup();


### PR DESCRIPTION
**Latent, not live** — with one caveat. No in-tree code path reads the stale pointer, because every parser entry point in the tree assigns `GlobalParserInterface` before the parse that reads it, so the dangling value is always overwritten before use. But `GlobalParserInterface` is `DLL_PUBLIC extern` and `stp::SMT2Parse()` / `SMTParse()` / `CVCParse()` are public API, so a caller that parses through the C API and then uses the C++ parser entry points does read the destroyed object. I built that caller: under `-fsanitize=address` with `detect_stack_use_after_return=1` it is reported as `stack-use-after-return`, naming the destroyed local `pi` in `vc_parseMemExpr`, with the read coming from `SMT2Parse` dereferencing `GlobalParserInterface->letMgr`. Without a sanitizer the same program segfaults. So it is reachable from public API, but not from anything STP itself does today.

`stp::GlobalParserInterface` was pointed at a `Cpp_interface` in three places and never pointed back at null in any of them. `vc_parseExpr` and `vc_parseMemExpr` each construct a `Cpp_interface` as a stack local, assign the global to it, and null `GlobalSTP` and `GlobalParserBM` on both parser branches afterwards — but not `GlobalParserInterface`. When the function returns the local is destroyed and the global holds a pointer into a dead frame. Separately, the one-argument `Cpp_interface` constructor sets both `GlobalParserInterface = this` and `GlobalParserBM = &bm_`, and `~Cpp_interface` cleared neither. Checking the history: the null was never there at any of the three sites — this is an original omission, not something that got dropped.

The fix applies the rule #717 established for `GlobalSTP`: everyone borrows, and whoever sets a borrowed global clears it. `~Cpp_interface` moves out of line and clears `GlobalParserInterface`, guarded on the global still pointing at the object being destroyed. The guard is load-bearing rather than decorative: overlapping lifetimes are real in this tree — `Main::parse_file` holds two `Cpp_interface` objects over the same `STPMgr` simultaneously (there is already a comment in `Cpp_interface::init()` about that pair), and the unit-test fixtures hold one alongside their manager. An unconditional null in the destructor would let a superseded interface clear a pointer that belongs to a live one. Because the guard tests identity rather than which constructor ran, the one destructor covers all three sites; the two C interface entry points also clear the global explicitly where their local goes out of scope, matching how they already return `GlobalSTP` and `GlobalParserBM`, and leaving the destructor as the backstop for any path that does not reach the end of the function. Neither function has an early return between the assignment and the end today, so no scope guard was needed.

`GlobalParserBM` is treated more narrowly, deliberately: it is cleared only by the constructor that set it, tracked with a private flag. Unlike `GlobalParserInterface`, a stale `GlobalParserBM` is not a dangling pointer — the `STPMgr` normally outlives the interface — and other callers rely on that. The rewrite-rule tools set `GlobalParserBM` once at startup and then build and destroy several `Cpp_interface` objects over the same manager while continuing to parse; clearing it from every destructor would take the global away from them.

Full writer list for the two globals and whether each cleans up. Before this change: `vc_parseExpr` and `vc_parseMemExpr` set `GlobalParserInterface` and did not clear it (fixed here); they set and cleared `GlobalParserBM` correctly already. The one-argument `Cpp_interface` constructor set both and cleared neither (fixed here). `Main::parse_file` sets `GlobalParserInterface` and clears it at the end — correct. `Main::Main` sets `GlobalParserBM` for the process lifetime and `Main::~Main` deletes the manager without clearing it, a separate and much shorter-lived dangle at shutdown, left alone here. The three rewrite-rule-generator entry points each set `GlobalParserInterface` and clear it — correct. The propagator benchmark tool sets `GlobalParserBM` at startup and never clears it; program-lifetime, left alone. The unit-test fixtures set both from their constructors without clearing, which the guarded destructor now handles for `GlobalParserInterface`.

Verification, all counts real:

- Dangling-pointer driver covering all three entry points plus a nested-lifetime case, built against both arms. Before: `vc_parseMemExpr`, `vc_parseExpr` and the one-argument constructor all leave `GlobalParserInterface` set, and in the nested case the outer interface's destructor leaves a stale pointer behind. After: all four report null, exit 0.
- ASan reproduce-then-fix as described above.
- CNF byte-compare over a 40-file hard-query corpus: 39 identical, 0 mismatched, 1 skipped (the baseline emits no CNF for that file — pre-existing).
- Answers over `tests/query-files/**` comparing full stdout, stderr and exit status: 187 files, 187 identical, 0 differing.
- C API parse driver over every CVC query file, both `vc_parseExpr` and `vc_parseMemExpr`, comparing full stdout, stderr and exit status: 122 runs, 122 identical, 0 differing.
- Unit tests: 70/70 pass.
- gcc and clang release builds, plus a `BUILD_EXTRA_TOOLS` build: no new warnings. The two extra tools that are gated behind CryptoMiniSat, and so not built here, were syntax-checked against the new header.

Both comparison binaries are fully static, so none of the comparisons pass vacuously through a shared library; their hashes differ.
