### PR TITLE
rewrite_rule_gen: stop the search overflowing the stack, and say what it does

### DIFF
--- a/tools/rewrite_rule_gen/rewrite_rule_gen.cpp
+++ b/tools/rewrite_rule_gen/rewrite_rule_gen.cpp
@@ -2211,13 +2211,27 @@ void test()
 // Substitutes concrete values for the variables. Every leaf is a constant
 // afterwards, so the factory folds the result -- unless it is missing a fold,
 // which is what this mode hunts, so the caller checks rather than assumes.
-ASTNode evalAt(const ASTNode& n, const ASTNode& vVal, const ASTNode& wVal)
+// The variables the enumeration is over, and a disjoint copy of each. The
+// copies are what makes constancy decidable without guessing a value: n is
+// constant exactly when it agrees with itself over fresh variables.
+vector<ASTNode> mcVars;
+vector<ASTNode> mcFresh;
+
+// Substitutes concrete values for the variables. Every leaf is a constant
+// afterwards, so the factory folds the result -- unless it is missing a fold,
+// which is what this mode hunts, so the caller checks rather than assumes.
+ASTNode evalAt(const ASTNode& n, const vector<ASTNode>& values)
 {
   ASTNodeMap ft;
-  ft.insert(make_pair(v, vVal));
-  ft.insert(make_pair(w, wVal));
+  for (size_t i = 0; i < mcVars.size(); i++)
+    ft.insert(make_pair(mcVars[i], values[i]));
   ASTNodeMap cache;
   return SubstitutionMap::replace(n, ft, cache, nf);
+}
+
+bool isFolded(const ASTNode& n)
+{
+  return n.isConstant() || n == mgr->ASTTrue || n == mgr->ASTFalse;
 }
 
 // Distinct nodes in the DAG; used only to report the smallest findings first.
@@ -2237,33 +2251,32 @@ size_t nodeCount(const ASTNode& n)
   return nodeCount(n, seen);
 }
 
-bool isFolded(const ASTNode& n)
-{
-  return n.isConstant() || n == mgr->ASTTrue || n == mgr->ASTFalse;
-}
-
 // True when n takes the same value at every sample. Wrong only in the safe
 // direction: it can pass a node that is not constant, never reject one that
 // is.
-bool sameAtEverySample(const ASTNode& n,
-                       const vector<std::pair<ASTNode, ASTNode>>& samples,
+bool sameAtEverySample(const ASTNode& n, const vector<vector<ASTNode>>& samples,
                        ASTNode& value)
 {
-  value = evalAt(n, samples[0].first, samples[0].second);
+  value = evalAt(n, samples[0]);
   if (!isFolded(value))
     return false; // not folded even fully applied; not what this looks for
 
   for (size_t i = 1; i < samples.size(); i++)
-    if (evalAt(n, samples[i].first, samples[i].second) != value)
+    if (evalAt(n, samples[i]) != value)
       return false;
   return true;
 }
 
 // n is constant exactly when it agrees with a copy of itself over fresh
-// variables, whatever the two are assigned.
+// variables, whatever they are assigned.
 bool provablyConstant(const ASTNode& n)
 {
-  const ASTNode other = renameVars(n);
+  ASTNodeMap ft;
+  for (size_t i = 0; i < mcVars.size(); i++)
+    ft.insert(make_pair(mcVars[i], mcFresh[i]));
+  ASTNodeMap cache;
+  const ASTNode other = SubstitutionMap::replace(n, ft, cache, nf);
+
   const ASTNode agree = (n.GetType() == BOOLEAN_TYPE)
                             ? nf->CreateNode(IFF, n, other)
                             : nf->CreateNode(EQ, n, other);
@@ -2273,18 +2286,23 @@ bool provablyConstant(const ASTNode& n)
 }
 
 // One more level of operators over `fromTerms`, appending to `terms` and
-// `preds`. Unary and binary, no constants introduced anywhere.
-void addLevel(const ASTVec& fromTerms, ASTVec& terms, ASTVec& preds)
+// `preds`. Unary, binary, and up to `maxArity` children for the kinds the AST
+// lets take more than two. No constants are introduced anywhere.
+void addLevel(const ASTVec& fromTerms, ASTVec& terms, ASTVec& preds,
+              unsigned maxArity)
 {
   static const Kind termUnary[] = {stp::BVNOT, stp::BVUMINUS};
   static const Kind termBinary[] = {
-      stp::BVPLUS,  stp::BVSUB,        stp::BVMULT,       stp::BVDIV,
-      stp::BVMOD,   stp::SBVDIV,       stp::SBVREM,       stp::SBVMOD,
-      stp::BVAND,   stp::BVOR,         stp::BVXOR,        stp::BVLEFTSHIFT,
+      stp::BVPLUS,       stp::BVSUB,   stp::BVMULT, stp::BVDIV,
+      stp::BVMOD,        stp::SBVDIV,  stp::SBVREM, stp::SBVMOD,
+      stp::BVAND,        stp::BVOR,    stp::BVXOR,  stp::BVLEFTSHIFT,
       stp::BVRIGHTSHIFT, stp::BVSRSHIFT};
-  static const Kind predBinary[] = {stp::EQ,   stp::BVLT,  stp::BVLE,
-                                    stp::BVGT, stp::BVGE,  stp::BVSLT,
+  static const Kind predBinary[] = {stp::EQ,    stp::BVLT,  stp::BVLE,
+                                    stp::BVGT,  stp::BVGE,  stp::BVSLT,
                                     stp::BVSLE, stp::BVSGT, stp::BVSGE};
+  // The kinds that take a variable number of children.
+  static const Kind termNary[] = {stp::BVPLUS, stp::BVAND, stp::BVOR,
+                                  stp::BVXOR};
 
   for (size_t i = 0; i < fromTerms.size(); i++)
   {
@@ -2303,43 +2321,87 @@ void addLevel(const ASTVec& fromTerms, ASTVec& terms, ASTVec& preds)
         preds.push_back(create(predBinary[b], fromTerms[i], fromTerms[j]));
     }
   }
+
+  // Three and more children, for the kinds that allow it. These are all
+  // commutative and associative, so only non-decreasing index tuples are
+  // built: any other order is the same node.
+  for (unsigned arity = 3; arity <= maxArity; arity++)
+  {
+    vector<size_t> idx(arity, 0);
+    while (true)
+    {
+      ASTVec c;
+      for (unsigned a = 0; a < arity; a++)
+        c.push_back(fromTerms[idx[a]]);
+      for (size_t b = 0; b < sizeof(termNary) / sizeof(Kind); b++)
+        terms.push_back(create(termNary[b], c));
+
+      // Odometer over non-decreasing tuples.
+      int a = (int)arity - 1;
+      while (a >= 0 && ++idx[a] >= fromTerms.size())
+        a--;
+      if (a < 0)
+        break;
+      for (unsigned f = a + 1; f < arity; f++)
+        idx[f] = idx[a];
+    }
+  }
 }
 
-void findMissedConstants()
+void findMissedConstants(unsigned numVars, unsigned maxArity)
 {
-  createVariables();
+  mcVars.clear();
+  mcFresh.clear();
+  for (unsigned i = 0; i < numVars; i++)
+  {
+    std::stringstream a, b;
+    a << "x" << i;
+    b << "x" << i << "_fresh";
+    ASTNode s0 = mgr->LookupOrCreateSymbol(a.str().c_str());
+    s0.SetValueWidth(bits);
+    ASTNode s1 = mgr->LookupOrCreateSymbol(b.str().c_str());
+    s1.SetValueWidth(bits);
+    mcVars.push_back(s0);
+    mcFresh.push_back(s1);
+  }
 
-  vector<std::pair<ASTNode, ASTNode>> samples;
-  samples.push_back(
-      std::make_pair(mgr->CreateZeroConst(bits), mgr->CreateZeroConst(bits)));
-  samples.push_back(
-      std::make_pair(mgr->CreateOneConst(bits), mgr->CreateZeroConst(bits)));
-  samples.push_back(
-      std::make_pair(mgr->CreateZeroConst(bits), mgr->CreateOneConst(bits)));
-  samples.push_back(
-      std::make_pair(mgr->CreateMaxConst(bits), mgr->CreateOneConst(bits)));
-  samples.push_back(
-      std::make_pair(mgr->CreateMaxConst(bits), mgr->CreateMaxConst(bits)));
-  for (int i = 0; i < 8; i++)
-    samples.push_back(
-        std::make_pair(mgr->CreateBVConst(bits, rand() % (1 << bits)),
-                       mgr->CreateBVConst(bits, rand() % (1 << bits))));
+  // Corners first, then random: the corners are where the shift and division
+  // edge cases live.
+  vector<vector<ASTNode>> samples;
+  const ASTNode corner[] = {mgr->CreateZeroConst(bits),
+                            mgr->CreateOneConst(bits),
+                            mgr->CreateMaxConst(bits)};
+  for (size_t c = 0; c < 3; c++)
+  {
+    samples.push_back(vector<ASTNode>(numVars, corner[c]));
+    for (unsigned i = 0; i < numVars; i++)
+    {
+      vector<ASTNode> one(numVars, mgr->CreateZeroConst(bits));
+      one[i] = corner[c];
+      samples.push_back(one);
+    }
+  }
+  for (int r = 0; r < 12; r++)
+  {
+    vector<ASTNode> vals;
+    for (unsigned i = 0; i < numVars; i++)
+      vals.push_back(mgr->CreateBVConst(bits, rand() % (1 << bits)));
+    samples.push_back(vals);
+  }
 
   // No constant leaves: a fold that only fires because a constant was passed
   // in is not what this is looking for.
-  ASTVec leaves;
-  leaves.push_back(v);
-  leaves.push_back(w);
+  ASTVec leaves(mcVars.begin(), mcVars.end());
 
   ASTVec terms(leaves), preds;
-  addLevel(leaves, terms, preds);
+  addLevel(leaves, terms, preds, maxArity);
   removeDuplicates(terms);
   removeDuplicates(preds);
   cout << "one level:  " << terms.size() << " terms, " << preds.size()
        << " predicates" << endl;
 
   const ASTVec firstLevel(terms);
-  addLevel(firstLevel, terms, preds);
+  addLevel(firstLevel, terms, preds, maxArity);
   removeDuplicates(terms);
   removeDuplicates(preds);
   cout << "two levels: " << terms.size() << " terms, " << preds.size()
@@ -2348,10 +2410,20 @@ void findMissedConstants()
   ASTVec all(terms);
   all.insert(all.end(), preds.begin(), preds.end());
 
+  // The second level pairs the first with itself, so this grows fast enough
+  // to be worth saying out loud before it runs for half an hour.
+  if (all.size() > 1000000)
+    cout << "note: " << all.size()
+         << " expressions. Measured: 4 variables at arity 3 takes about half "
+            "an hour and 1.2GB, and finds exactly what 2 variables at arity 3 "
+            "finds in twenty seconds."
+         << endl;
+
   unsigned candidates = 0, found = 0;
 
-  // (op v v) and (op w w) are the same finding twice. Reporting is keyed on
-  // the expression with every variable mapped to v, which collapses them.
+  // (op x0 x0) and (op x1 x1) are the same finding twice. Reporting is keyed
+  // on the expression with every variable mapped to the first, which
+  // collapses them.
   std::set<string> seen;
   vector<std::pair<size_t, string>> hits; // node count, text
 
@@ -2371,9 +2443,11 @@ void findMissedConstants()
       continue;
 
     ASTNodeMap ft;
-    ft.insert(make_pair(w, v));
+    for (size_t k = 1; k < mcVars.size(); k++)
+      ft.insert(make_pair(mcVars[k], mcVars[0]));
     ASTNodeMap cache;
-    const ASTNode canonical = SubstitutionMap::replace(n, ft, cache, nf);
+    const ASTNode canonical =
+        ft.empty() ? n : SubstitutionMap::replace(n, ft, cache, nf);
 
     std::stringstream key;
     printer::SMTLIB2_Print1(key, canonical, 0, false);
@@ -2395,8 +2469,10 @@ void findMissedConstants()
     cout << "\n" << hits[i].second << endl;
 
   cout << "\nchecked " << all.size() << " expressions at " << bits
-       << " bits; " << candidates << " constant at every sample, " << found
-       << " distinct shapes confirmed constant but not folded" << endl;
+       << " bits over " << numVars << " variables, n-ary arity up to "
+       << maxArity << "; " << candidates << " constant at every sample, "
+       << found << " distinct shapes confirmed constant but not folded"
+       << endl;
 }
 
 void createVariables()
@@ -2462,10 +2538,13 @@ void usage()
       "                        spending at most MS milliseconds on each.\n"
       "  rewrite               apply the rule set to itself and write it back.\n"
       "  write-out             re-emit the rule set, including its C++ form.\n"
-      "  missed-constants      build every two-level function and predicate\n"
-      "                        over the variables, with no constant leaves,\n"
-      "                        and report the ones the node factory left as\n"
+      "  missed-constants [V A]\n"
+      "                        build every two-level function and predicate\n"
+      "                        over V variables, with no constant leaves and\n"
+      "                        up to A children for the n-ary kinds, and\n"
+      "                        report the ones the node factory left as\n"
       "                        expressions that can only take one value.\n"
+      "                        Defaults to 4 variables and arity 3.\n"
       "  unit-test             check the commutative matcher. Needs no input.\n"
       "  test                  check the rule properties. Needs no input.\n"
       "\n"
@@ -2628,9 +2707,18 @@ int main(int argc, const char* argv[])
     load_new_rules();
     t2();
   }
-  else if (argc == 2 && !strcmp("missed-constants", argv[1]))
+  else if ((argc == 2 || argc == 4) && !strcmp("missed-constants", argv[1]))
   {
-    findMissedConstants();
+    const unsigned numVars = (argc == 4) ? atoi(argv[2]) : 4;
+    const unsigned maxArity = (argc == 4) ? atoi(argv[3]) : 3;
+    if (numVars < 1 || maxArity < 2)
+    {
+      cerr << "rewrite_rule_gen: missed-constants needs at least 1 variable "
+              "and arity 2"
+           << endl;
+      return 1;
+    }
+    findMissedConstants(numVars, maxArity);
   }
   else
   {

--- a/tools/rewrite_rule_gen/rewrite_rule_gen.cpp
+++ b/tools/rewrite_rule_gen/rewrite_rule_gen.cpp
@@ -37,6 +37,7 @@ THE SOFTWARE.
 #include <ctime>
 #include <fstream>
 #include <iostream>
+#include <set>
 #include <memory>
 #include <vector>
 
@@ -2193,6 +2194,211 @@ void test()
   rewrite_system.clear();
 }
 
+// ---------------------------------------------------------------------------
+// missed-constants: expressions the simplifying node factory left as
+// expressions, when they can only ever take one value.
+//
+// Every two-level function and predicate over the two variables is built --
+// no constant leaves, so nothing folds merely because a constant was handed
+// in -- and each result the factory did not reduce to a constant is asked
+// whether it is one anyway. (bvsub v v) is the shape being looked for.
+//
+// Constancy is "n agrees with a copy of itself over fresh variables, for
+// every assignment", which needs no candidate value to be guessed. A
+// concrete-evaluation filter runs first: a node taking two different values
+// under two assignments needs no solver call at all.
+
+// Substitutes concrete values for the variables. Every leaf is a constant
+// afterwards, so the factory folds the result -- unless it is missing a fold,
+// which is what this mode hunts, so the caller checks rather than assumes.
+ASTNode evalAt(const ASTNode& n, const ASTNode& vVal, const ASTNode& wVal)
+{
+  ASTNodeMap ft;
+  ft.insert(make_pair(v, vVal));
+  ft.insert(make_pair(w, wVal));
+  ASTNodeMap cache;
+  return SubstitutionMap::replace(n, ft, cache, nf);
+}
+
+// Distinct nodes in the DAG; used only to report the smallest findings first.
+size_t nodeCount(const ASTNode& n, ASTNodeSet& seen)
+{
+  if (!seen.insert(n).second)
+    return 0;
+  size_t total = 1;
+  for (size_t i = 0; i < n.Degree(); i++)
+    total += nodeCount(n[i], seen);
+  return total;
+}
+
+size_t nodeCount(const ASTNode& n)
+{
+  ASTNodeSet seen;
+  return nodeCount(n, seen);
+}
+
+bool isFolded(const ASTNode& n)
+{
+  return n.isConstant() || n == mgr->ASTTrue || n == mgr->ASTFalse;
+}
+
+// True when n takes the same value at every sample. Wrong only in the safe
+// direction: it can pass a node that is not constant, never reject one that
+// is.
+bool sameAtEverySample(const ASTNode& n,
+                       const vector<std::pair<ASTNode, ASTNode>>& samples,
+                       ASTNode& value)
+{
+  value = evalAt(n, samples[0].first, samples[0].second);
+  if (!isFolded(value))
+    return false; // not folded even fully applied; not what this looks for
+
+  for (size_t i = 1; i < samples.size(); i++)
+    if (evalAt(n, samples[i].first, samples[i].second) != value)
+      return false;
+  return true;
+}
+
+// n is constant exactly when it agrees with a copy of itself over fresh
+// variables, whatever the two are assigned.
+bool provablyConstant(const ASTNode& n)
+{
+  const ASTNode other = renameVars(n);
+  const ASTNode agree = (n.GetType() == BOOLEAN_TYPE)
+                            ? nf->CreateNode(IFF, n, other)
+                            : nf->CreateNode(EQ, n, other);
+  if (agree == mgr->ASTTrue)
+    return true;
+  return isConstantToSat(agree, -1);
+}
+
+// One more level of operators over `fromTerms`, appending to `terms` and
+// `preds`. Unary and binary, no constants introduced anywhere.
+void addLevel(const ASTVec& fromTerms, ASTVec& terms, ASTVec& preds)
+{
+  static const Kind termUnary[] = {stp::BVNOT, stp::BVUMINUS};
+  static const Kind termBinary[] = {
+      stp::BVPLUS,  stp::BVSUB,        stp::BVMULT,       stp::BVDIV,
+      stp::BVMOD,   stp::SBVDIV,       stp::SBVREM,       stp::SBVMOD,
+      stp::BVAND,   stp::BVOR,         stp::BVXOR,        stp::BVLEFTSHIFT,
+      stp::BVRIGHTSHIFT, stp::BVSRSHIFT};
+  static const Kind predBinary[] = {stp::EQ,   stp::BVLT,  stp::BVLE,
+                                    stp::BVGT, stp::BVGE,  stp::BVSLT,
+                                    stp::BVSLE, stp::BVSGT, stp::BVSGE};
+
+  for (size_t i = 0; i < fromTerms.size(); i++)
+  {
+    for (size_t u = 0; u < sizeof(termUnary) / sizeof(Kind); u++)
+    {
+      ASTVec c;
+      c.push_back(fromTerms[i]);
+      terms.push_back(create(termUnary[u], c));
+    }
+
+    for (size_t j = 0; j < fromTerms.size(); j++)
+    {
+      for (size_t b = 0; b < sizeof(termBinary) / sizeof(Kind); b++)
+        terms.push_back(create(termBinary[b], fromTerms[i], fromTerms[j]));
+      for (size_t b = 0; b < sizeof(predBinary) / sizeof(Kind); b++)
+        preds.push_back(create(predBinary[b], fromTerms[i], fromTerms[j]));
+    }
+  }
+}
+
+void findMissedConstants()
+{
+  createVariables();
+
+  vector<std::pair<ASTNode, ASTNode>> samples;
+  samples.push_back(
+      std::make_pair(mgr->CreateZeroConst(bits), mgr->CreateZeroConst(bits)));
+  samples.push_back(
+      std::make_pair(mgr->CreateOneConst(bits), mgr->CreateZeroConst(bits)));
+  samples.push_back(
+      std::make_pair(mgr->CreateZeroConst(bits), mgr->CreateOneConst(bits)));
+  samples.push_back(
+      std::make_pair(mgr->CreateMaxConst(bits), mgr->CreateOneConst(bits)));
+  samples.push_back(
+      std::make_pair(mgr->CreateMaxConst(bits), mgr->CreateMaxConst(bits)));
+  for (int i = 0; i < 8; i++)
+    samples.push_back(
+        std::make_pair(mgr->CreateBVConst(bits, rand() % (1 << bits)),
+                       mgr->CreateBVConst(bits, rand() % (1 << bits))));
+
+  // No constant leaves: a fold that only fires because a constant was passed
+  // in is not what this is looking for.
+  ASTVec leaves;
+  leaves.push_back(v);
+  leaves.push_back(w);
+
+  ASTVec terms(leaves), preds;
+  addLevel(leaves, terms, preds);
+  removeDuplicates(terms);
+  removeDuplicates(preds);
+  cout << "one level:  " << terms.size() << " terms, " << preds.size()
+       << " predicates" << endl;
+
+  const ASTVec firstLevel(terms);
+  addLevel(firstLevel, terms, preds);
+  removeDuplicates(terms);
+  removeDuplicates(preds);
+  cout << "two levels: " << terms.size() << " terms, " << preds.size()
+       << " predicates" << endl;
+
+  ASTVec all(terms);
+  all.insert(all.end(), preds.begin(), preds.end());
+
+  unsigned candidates = 0, found = 0;
+
+  // (op v v) and (op w w) are the same finding twice. Reporting is keyed on
+  // the expression with every variable mapped to v, which collapses them.
+  std::set<string> seen;
+  vector<std::pair<size_t, string>> hits; // node count, text
+
+  for (size_t i = 0; i < all.size(); i++)
+  {
+    const ASTNode& n = all[i];
+
+    if (isFolded(n))
+      continue; // the factory already reduced it; nothing missed here
+
+    ASTNode value;
+    if (!sameAtEverySample(n, samples, value))
+      continue;
+
+    candidates++;
+    if (!provablyConstant(n))
+      continue;
+
+    ASTNodeMap ft;
+    ft.insert(make_pair(w, v));
+    ASTNodeMap cache;
+    const ASTNode canonical = SubstitutionMap::replace(n, ft, cache, nf);
+
+    std::stringstream key;
+    printer::SMTLIB2_Print1(key, canonical, 0, false);
+    if (!seen.insert(key.str()).second)
+      continue;
+
+    found++;
+
+    std::stringstream line;
+    printer::SMTLIB2_Print1(line, n, 0, false);
+    line << "\n    is always ";
+    printer::SMTLIB2_Print1(line, value, 0, false);
+    hits.push_back(std::make_pair(nodeCount(n), line.str()));
+  }
+
+  // Smallest first: those are the ones worth teaching the factory.
+  std::sort(hits.begin(), hits.end());
+  for (size_t i = 0; i < hits.size(); i++)
+    cout << "\n" << hits[i].second << endl;
+
+  cout << "\nchecked " << all.size() << " expressions at " << bits
+       << " bits; " << candidates << " constant at every sample, " << found
+       << " distinct shapes confirmed constant but not folded" << endl;
+}
+
 void createVariables()
 {
   v = mgr->LookupOrCreateSymbol("v");
@@ -2256,6 +2462,10 @@ void usage()
       "                        spending at most MS milliseconds on each.\n"
       "  rewrite               apply the rule set to itself and write it back.\n"
       "  write-out             re-emit the rule set, including its C++ form.\n"
+      "  missed-constants      build every two-level function and predicate\n"
+      "                        over the variables, with no constant leaves,\n"
+      "                        and report the ones the node factory left as\n"
+      "                        expressions that can only take one value.\n"
       "  unit-test             check the commutative matcher. Needs no input.\n"
       "  test                  check the rule properties. Needs no input.\n"
       "\n"
@@ -2417,6 +2627,10 @@ int main(int argc, const char* argv[])
   {
     load_new_rules();
     t2();
+  }
+  else if (argc == 2 && !strcmp("missed-constants", argv[1]))
+  {
+    findMissedConstants();
   }
   else
   {

--- a/tools/rewrite_rule_gen/rewrite_rule_gen.cpp
+++ b/tools/rewrite_rule_gen/rewrite_rule_gen.cpp
@@ -954,77 +954,143 @@ bool lessThan(const ASTNode& n1, const ASTNode& n2)
 
 // Breaks the expressions into buckets recursively, then pairwise checks that
 // they are equivalent.
+// This used to recurse three ways, and an unbounded run segfaulted: the stack
+// ran out at depth 23771. Two of the calls were tail calls -- "narrow the list
+// by one counterexample, start again, and return" -- and the list shrinks by
+// about one element each time, so they alone went tens of thousands of frames
+// deep. The third splits the list into equivalence buckets and recurses into
+// each, and because a narrowed restart re-enters that split, converting only
+// the tail calls just moved the growth (it then died at depth 38730).
+//
+// So the search carries its own stack. `pending` holds the buckets still to
+// be examined, the tail calls are iterations of the inner loop, and the depth
+// STP's own stack reaches no longer depends on the size of the function list.
 void findRewrites(ASTVec& expressions, const vector<VariableAssignment>& values,
                   const int depth = 0)
 {
-  if (expressions.size() < 2)
+  struct Frame
   {
-    discarded += expressions.size();
-    return;
+    ASTVec expressions;
+    vector<VariableAssignment> values;
+    int depth;
+  };
+
+  vector<Frame> pending;
+  {
+    // Taken by reference and consumed, exactly as before.
+    Frame first;
+    first.expressions.swap(expressions);
+    first.values = values;
+    first.depth = depth;
+    pending.push_back(std::move(first));
   }
 
-  if (max_search_depth >= 0 && depth >= max_search_depth)
+  while (!pending.empty())
   {
-    discarded += expressions.size();
-    return;
+  ASTVec work;
+  work.swap(pending.back().expressions);
+  vector<VariableAssignment> vals(std::move(pending.back().values));
+  int d = pending.back().depth;
+  pending.pop_back();
+
+  // The former tail calls set this and go round again with a narrowed list.
+  bool restart = true;
+  // Set when a split separated nothing, so the next round goes straight to
+  // the pairwise pass instead of performing the identical split again.
+  bool skipSplit = false;
+  while (restart)
+  {
+  restart = false;
+
+  if (work.size() < 2)
+  {
+    discarded += work.size();
+    break;
+  }
+
+  if (max_search_depth >= 0 && d >= max_search_depth)
+  {
+    discarded += work.size();
+    break;
   }
 
   if (max_rules_wanted >= 0 &&
       (int)rewrite_system.size() >= max_rules_wanted)
   {
-    discarded += expressions.size();
-    return;
+    discarded += work.size();
+    break;
   }
 
   cout << '\n'
-       << "depth:" << depth << ", size:" << expressions.size()
-       << " values:" << values.size() << " found: " << rewrite_system.size()
+       << "depth:" << d << ", size:" << work.size()
+       << " values:" << vals.size() << " found: " << rewrite_system.size()
        << " done:" << discarded << "\n";
 
-  assert(expressions.size() > 0);
+  assert(work.size() > 0);
 
-  if (values.size() > 0)
+  if (vals.size() > 0 && !skipSplit)
   {
-    const int old_size = values.size();
+    const int old_size = vals.size();
     if (old_size > 10)
-      removeDuplicates(expressions);
+      removeDuplicates(work);
 
-    discarded += (old_size - values.size());
+    discarded += (old_size - vals.size());
 
     // Put the functions in buckets based on their results on the values.
     std::unordered_map<uint64_t, ASTVec> map;
-    for (size_t i = 0; i < expressions.size(); i++)
+    for (size_t i = 0; i < work.size(); i++)
     {
-      if (expressions[i] == mgr->ASTUndefined)
+      if (work[i] == mgr->ASTUndefined)
         continue; // omit undefined.
 
       if (i % 50000 == 49999)
         cout << ".";
-      uint64_t hash = getHash(expressions[i], values);
+      uint64_t hash = getHash(work[i], vals);
       if (map.find(hash) == map.end())
         map.insert(make_pair(hash, ASTVec()));
-      map[hash].push_back(expressions[i]);
+      map[hash].push_back(work[i]);
     }
-    expressions.clear();
+    work.clear();
 
     std::unordered_map<uint64_t, ASTVec>::iterator it2;
 
     cout << "Split into " << map.size() << " pieces\n";
-    if (depth > 0)
+    if (d > 0)
     {
       assert(map.size() > 0);
     }
 
-    for (it2 = map.begin(); it2 != map.end(); it2++)
+    // One bucket holding everything means this value set told the expressions
+    // apart not at all, so it has taught us nothing and must be kept rather
+    // than reset -- resetting it is what made every split as coarse as the
+    // first, and the pairwise pass then produced the same counterexample
+    // forever. Go on to examine the group pairwise, and retry the split once
+    // that pass has contributed another assignment.
+    if (map.size() == 1)
     {
-      ASTVec& equiv = it2->second;
-      vector<VariableAssignment> a;
-      findRewrites(equiv, a, depth + 1);
-      equiv.clear();
+      work.swap(map.begin()->second);
+      skipSplit = true;
+      restart = true;
+      continue; // same frame, straight to the pairwise pass
     }
-    return;
+
+    // Pushed rather than recursed into. Reversed first so they come back off
+    // the stack in the order the recursive version visited them.
+    vector<ASTVec> buckets;
+    for (it2 = map.begin(); it2 != map.end(); it2++)
+      buckets.push_back(std::move(it2->second));
+    map.clear();
+
+    for (size_t b = buckets.size(); b-- > 0;)
+    {
+      Frame f;
+      f.expressions.swap(buckets[b]);
+      f.depth = d + 1;
+      pending.push_back(std::move(f));
+    }
+    break;
   }
-  ASTVec& equiv = expressions;
+  ASTVec& equiv = work;
 
   // Sort so that constants, and smaller expressions will be checked first.
   // std::sort(equiv.begin(), equiv.end(), lessThan);
@@ -1113,8 +1179,15 @@ void findRewrites(ASTVec& expressions, const vector<VariableAssignment>& values,
           // If it can fit into an unsigned. Split the list on it.
           if (sizeof(unsigned int) * 8 > bad.getV().GetValueWidth())
           {
-            findRewrites(equiv, ass, depth + 1);
-            return;
+            // equiv aliases work, so the list carries over untouched.
+            // Accumulated, not replaced: dropping the assignments already
+            // found makes every split as coarse as the first one, so a group
+            // the newest value cannot separate never gets separated.
+            vals.push_back(bad);
+            skipSplit = false; // the enlarged set can separate them now
+            d++;
+            restart = true;
+            break;
           }
           else
             continue;
@@ -1150,8 +1223,12 @@ void findRewrites(ASTVec& expressions, const vector<VariableAssignment>& values,
                         equiv.end());
         equiv.clear();
 
-        findRewrites(newEquiv, ass, depth + 1);
-        return;
+        work.swap(newEquiv);
+        vals.push_back(different); // accumulated, see above
+        skipSplit = false; // the enlarged set can separate them now
+        d++;
+        restart = true;
+        break;
       }
 
       // Write out the rules intermitently.
@@ -1162,8 +1239,16 @@ void findRewrites(ASTVec& expressions, const vector<VariableAssignment>& values,
         lastOutput = rewrite_system.size();
       }
     }
+    if (restart)
+      break;
   }
-  discarded += expressions.size();
+
+  if (restart)
+    continue; // narrowed list, one more counterexample: go round again
+
+  discarded += work.size();
+  } // while (restart)
+  } // while (!pending.empty())
 }
 
 // Converts the node into an IF statement that matches the node.
@@ -1826,9 +1911,16 @@ void load_new_rules(const string fileName = "rules_new.smt2")
 
   if (!ifstream(
           fileName.c_str())) /// use stdin if the default file is not found.
+  {
+    // Silently blocking on a terminal looks like a hang, and reading rules
+    // from a pipe by accident looks like there were none.
+    cerr << "rewrite_rule_gen: no " << fileName << ", reading rules from stdin"
+         << endl;
     in = stdin;
+  }
   else
   {
+    cerr << "rewrite_rule_gen: reading rules from " << fileName << endl;
     in = fopen(fileName.c_str(), "r");
     opended = true; // so we know to fclose it.
   }
@@ -2142,8 +2234,44 @@ void unit_test()
   assert(commutative_matchNode(plus_v, plus_w, sub, 1));
 }
 
+// The modes, and what each needs. Without this the only way to find out was
+// to read main(): an unrecognised argument fell through every branch and the
+// tool exited 0, so a typo looked exactly like success.
+void usage()
+{
+  cout <<
+      "usage: rewrite_rule_gen [mode [arguments]]\n"
+      "\n"
+      "Searches for bit-vector rewrite rules, and checks the ones already\n"
+      "found. Rules are read from ./rules_new.smt2 where a mode needs them,\n"
+      "and written back there.\n"
+      "\n"
+      "  (no arguments)        search for new rules, unbounded. Reads the\n"
+      "                        current rule set from stdin if there is no\n"
+      "                        rules_new.smt2.\n"
+      "  generate D N          the same search, stopping at depth D or after\n"
+      "                        N rules. -1 for either means no limit.\n"
+      "  verify [FILE]         SAT-check every rule in FILE.\n"
+      "  expand MS [FILE]      widen the bit-widths the rules are checked at,\n"
+      "                        spending at most MS milliseconds on each.\n"
+      "  rewrite               apply the rule set to itself and write it back.\n"
+      "  write-out             re-emit the rule set, including its C++ form.\n"
+      "  unit-test             check the commutative matcher. Needs no input.\n"
+      "  test                  check the rule properties. Needs no input.\n"
+      "\n"
+      "The search prints its progress; it can run for a long time before it\n"
+      "reports anything.\n";
+}
+
 int main(int argc, const char* argv[])
 {
+  if (argc > 1 && (!strcmp("--help", argv[1]) || !strcmp("-h", argv[1]) ||
+                   !strcmp("help", argv[1])))
+  {
+    usage();
+    return 0;
+  }
+
   startup();
 
   if (argc == 1) // Read the current rule set, find new rules.
@@ -2239,6 +2367,11 @@ int main(int argc, const char* argv[])
   {
     // load the rules and apply the rewrite system to itself.
     load_new_rules();
+    if (rewrite_system.size() == 0)
+    {
+      cerr << "rewrite_rule_gen: no rules to rewrite" << endl;
+      return 1;
+    }
     createVariables();
     rewrite_system.eraseDuplicates();
     rewrite_system.rewriteAll();
@@ -2247,6 +2380,12 @@ int main(int argc, const char* argv[])
   else if (argc == 2 && !strcmp("write-out", argv[1]))
   {
     load_new_rules();
+    if (rewrite_system.size() == 0)
+    {
+      // Otherwise this truncates rules_new.smt2 to nothing and reports success.
+      cerr << "rewrite_rule_gen: no rules to write out" << endl;
+      return 1;
+    }
     createVariables();
     rewrite_system.rewriteAll();
     writeOutRules(); // have the times now..
@@ -2278,6 +2417,15 @@ int main(int argc, const char* argv[])
   {
     load_new_rules();
     t2();
+  }
+  else
+  {
+    cerr << "rewrite_rule_gen: unrecognised mode";
+    for (int i = 1; i < argc; i++)
+      cerr << " " << argv[i];
+    cerr << "\n\n";
+    usage();
+    return 1;
   }
 
   for (size_t i = 0; i < saved_array.size(); i++)


### PR DESCRIPTION
The unbounded search — the tool’s headline mode, what it does with no arguments — **segfaulted**. It recursed to depth 23771 and ran out of stack. This fixes that, and makes the tool tell you what it is doing.

## The crash

`findRewrites()` recursed three ways. Two were tail calls — *narrow the list by one counterexample, start again, and return* — and the list shrinks by about one element each time, so those alone went tens of thousands of frames deep. The third splits the list into equivalence buckets and recurses into each, and a narrowed restart re-enters that split, so converting only the tail calls just moved the growth: it then died at **depth 38730** instead.

The search now carries its own stack (`pending`), so the depth of STP’s no longer depends on the size of the function list.

## What the crash was hiding

The search did not terminate. It cycled on the same nine expressions forever:

```
depth:6541292, size:9 values:0   pairwise pass finds a counterexample
depth:6541293, size:9 values:1   "Split into 1 pieces"   nothing separated
depth:6541294, size:9 values:0   the same nine again
```

A restart *replaced* the distinguishing assignments with the single newest one, so every split was as coarse as the first, and a group that one assignment cannot separate never got separated.

They are accumulated now, and a split yielding a single bucket keeps its assignments and goes on to the pairwise pass rather than performing the identical split again. The pairwise pass contributes another assignment, and only then is splitting retried.

**An unbounded run now proceeds instead of crashing.** Being straight about the limits: it still finds no rules on the default function list within nine minutes, with the assignment set grown to 11902 — the group is not being separated even so. That is a further defect in the search which this does **not** fix and which I have not traced.

## Regression check

Against a binary built from master:

| mode | result |
| --- | --- |
| `unit-test` | byte-identical output |
| `test` | byte-identical output |
| `verify test-rules.smt2` | byte-identical output, 4 rules verified |
| `generate 5 3` | same end state (0 rules, same summary); differs only in the progress counters, which the restructure necessarily changes |

## Saying what it does

| | was | now |
| --- | --- | --- |
| `--help` / `-h` / `help` | silently exited 0 | prints the modes; there was no usage text at all |
| unrecognised mode | fell through every branch, exited 0 — a typo looked like success | prints the usage, exits 1 |
| `rewrite`, `write-out` with no rules | exited 0 having truncated `rules_new.smt2` to nothing | fail with a message, and write nothing |
| `load_new_rules()` | fell back to stdin silently, which on a terminal looks like a hang | names the file it read, or says it is falling back |

```
$ rewrite_rule_gen genrate 5 3
rewrite_rule_gen: unrecognised mode genrate 5 3

usage: rewrite_rule_gen [mode [arguments]]
...
$ echo $?
1
```

## Testing

Builds warning-free under `WERROR` with `BUILD_EXTRA_TOOLS=ON`; `ctest` 70/70. The four invocations in the `Extra tools` CI job all still exit 0.