### PR TITLE
SimplifyingNodeFactory: fold (bvsdiv x x)

### DIFF
--- a/lib/NodeFactory/SimplifyingNodeFactory.cpp
+++ b/lib/NodeFactory/SimplifyingNodeFactory.cpp
@@ -2756,6 +2756,17 @@ ASTNode SimplifyingNodeFactory::CreateTerm(Kind kind, unsigned int width,
             NodeFactory::CreateTerm(
                 SBVDIV, width, children[0],
                 NodeFactory::CreateTerm(BVUMINUS, width, children[1])));
+      else if (children[0] == children[1])
+        // x / x is 1 wherever the division is a real one. The remaining case
+        // is 0 / 0, which takes the total-division value the rule above
+        // gives: zero is not negative, so all ones. SBVMOD already has the
+        // matching x smod x rule; this one was missing, and without it
+        // nothing downstream can tell that the quotient is never zero.
+        result = NodeFactory::CreateTerm(
+            ITE, width,
+            NodeFactory::CreateNode(EQ, children[0],
+                                    bm.CreateZeroConst(width)),
+            bm.CreateMaxConst(width), bm.CreateOneConst(width));
       break;
 
     case SBVREM:


### PR DESCRIPTION
Adds one rule to `case SBVDIV:` in `SimplifyingNodeFactory`:

```
(bvsdiv x x)  ->  (ite (= x 0) ones 1)
```

`SBVMOD` has had an `x smod x -> 0` rule for a long time; `SBVDIV` never got the matching one. Every rule in its `case` is guarded on one of the children being constant, so `(bvsdiv v v)` on a symbolic `v` went through untouched, and nothing downstream could tell that the quotient is never zero.

Division in STP is total, which is what makes the fold a single expression rather than a partial one. `x / x` is 1 wherever the division is a real one, and the only remaining case is `0 / 0`, which takes the value the neighbouring `x / 0` rule already gives: zero is not negative, so all ones. At width 1 the two branches are both `0b1` and the `ite` collapses again.

## Soundness

Checked against a binary built **without** the rule. That detail is the trap worth flagging: with the rule in place, both sides of the equivalence fold to the same node before the solver ever runs, so the check comes back unsat for free and proves nothing. It has to be run on a build that cannot perform the fold.

Negating `(bvsdiv v v) = (ite (= v 0) ones 1)` is unsat at widths 1, 4, 6, 8, 16 and 32. As a control, the deliberately wrong claim that `(bvsdiv v v) = 1` everywhere comes back sat, confirming the harness can distinguish the two.

## Provenance and effect

Found by the new `missed-constants` mode of `rewrite_rule_gen` (#727), which enumerates two-level expressions with no constant leaves and reports the ones the node factory leaves unfolded even though they can only ever take a single value.

| | distinct shapes reported at 6 bits |
| --- | --- |
| before | 105 |
| after | 47 |

All 63 shapes involving `bvsdiv` disappear. The ones beyond `(bvsdiv v v)` itself were consequences of it, among them `(bvsmod v (bvsdiv v v))`, `(bvsrem v (bvsdiv v v))`, `(bvmul (bvsdiv v v) (bvsdiv v v))` and `(= 0 (bvsdiv v v))`.

## Testing

Full build with `-DWERROR=ON -DENABLE_TESTING=ON -DBUILD_EXTRA_TOOLS=ON` and CryptoMiniSat enabled: warning-free. `ctest`: 70/70 passed, 0 failed.
