### PR TITLE
PropagateEqualities: incremental update of candidate variable sets

### DIFF
--- a/include/stp/Simplifier/PropagateEqualities.h
+++ b/include/stp/Simplifier/PropagateEqualities.h
@@ -30,6 +30,7 @@ THE SOFTWARE.
 #include "stp/Simplifier/Simplifier.h"
 #include "stp/Simplifier/PropagateEqualities.h"
 #include "stp/Simplifier/NodeSimplifier.h"
+#include "extlib-unordered-dense/ankerl/unordered_dense.h"
 
 /* 
   Finds formulae asserted at the top level, and removes the variables, e.g:
@@ -52,7 +53,10 @@ class PropagateEqualities : public NodeSimplifier
   const ASTNode ASTTrue, ASTFalse;
 
 public:
-  using IdSet =  std::unordered_set<uint64_t>;
+  // Flat open-addressing set: the sets are hot (closure folds, membership
+  // probes), and only their *contents* matter to the algorithm, never their
+  // iteration order.
+  using IdSet = ankerl::unordered_dense::set<uint64_t>;
 
   struct CandidateInfo
   {

--- a/include/stp/Simplifier/PropagateEqualities.h
+++ b/include/stp/Simplifier/PropagateEqualities.h
@@ -51,9 +51,20 @@ class PropagateEqualities : public NodeSimplifier
   STPMgr* bm;
   const ASTNode ASTTrue, ASTFalse;
 
+public:
   using IdSet =  std::unordered_set<uint64_t>;
-  using MapToNodeSet = std::unordered_map<uint64_t, std::tuple <ASTNode, ASTNode, IdSet, int > > ;
 
+  struct CandidateInfo
+  {
+    ASTNode lhs;
+    ASTNode rhs;
+    IdSet vars;  // candidate-LHS variables in rhs, with replacements folded in
+    int id;      // insertion order; priority-queue tie-break for determinism
+    size_t upTo; // how many replacements have been folded into vars
+  };
+  using MapToNodeSet = std::unordered_map<uint64_t, CandidateInfo>;
+
+private:
   IdSet alreadyVisited;
 
   void buildCandidateList(const ASTNode& a);

--- a/lib/Simplifier/PropagateEqualities.cpp
+++ b/lib/Simplifier/PropagateEqualities.cpp
@@ -36,9 +36,12 @@ void log([[maybe_unused]] std::string s)
 #endif
 }
 
-typedef std::unordered_set<uint64_t> IdSet;
-typedef std::unordered_map<uint64_t, uint64_t> IdToId;
-typedef std::unordered_map<uint64_t, IdSet> IdToIdSet;
+typedef PropagateEqualities::IdSet IdSet;
+typedef ankerl::unordered_dense::map<uint64_t, uint64_t> IdToId;
+typedef ankerl::unordered_dense::map<uint64_t, IdSet> IdToIdSet;
+// Values must stay pointer-stable: the priority queue and update() hold
+// pointers/references into the map while it is queried, so this stays a
+// node-based std::unordered_map (mapped is never inserted into after build).
 typedef PropagateEqualities::MapToNodeSet MapToNodeSet;
 
 void tagNodes(const ASTNode& n, const uint64_t tag, IdToId& nodeToTag, ASTNodeSet& shared)
@@ -117,6 +120,7 @@ MapToNodeSet PropagateEqualities::buildMapOfLHStoVariablesInRHS(const IdSet& all
   // Without the id field, which we sort the priority queue on, the order that the rules were applied
   // was not deterministic, giving diffent CNF.
   MapToNodeSet mapped;
+  mapped.reserve(candidates.size());
   int id =0;
 
   for (const auto& e: candidates)
@@ -231,13 +235,17 @@ void PropagateEqualities::processCandidates()
           return left->id > right->id;
       return false;
     };
-  std::priority_queue < qType, vector<qType>, decltype(cmp) > q(cmp);
+  vector<qType> qStore;
+  qStore.reserve(mapped.size());
+  std::priority_queue < qType, vector<qType>, decltype(cmp) > q(cmp, std::move(qStore));
 
   for (const auto& e: mapped)
     q.push(&e.second);
 
   std::vector<uint64_t> replacedOrder;
+  replacedOrder.reserve(mapped.size());
   IdToId replacedIndex;
+  replacedIndex.reserve(mapped.size());
 
   while (!q.empty())
   {

--- a/lib/Simplifier/PropagateEqualities.cpp
+++ b/lib/Simplifier/PropagateEqualities.cpp
@@ -39,7 +39,7 @@ void log([[maybe_unused]] std::string s)
 typedef std::unordered_set<uint64_t> IdSet;
 typedef std::unordered_map<uint64_t, uint64_t> IdToId;
 typedef std::unordered_map<uint64_t, IdSet> IdToIdSet;
-typedef std::unordered_map<uint64_t, std::tuple <ASTNode, ASTNode, IdSet, int > > MapToNodeSet;
+typedef PropagateEqualities::MapToNodeSet MapToNodeSet;
 
 void tagNodes(const ASTNode& n, const uint64_t tag, IdToId& nodeToTag, ASTNodeSet& shared)
 {
@@ -71,10 +71,10 @@ void intersection(const ASTNode& n, IdSet& visited, IdSet& variables, const IdSe
   if (!visited.insert(n_id).second)
     return;
 
-  if (cache.find(n_id) != cache.end())
+  const auto cit = cache.find(n_id);
+  if (cit != cache.end())
   {
-    const auto& item = cache.find(n_id)->second;
-    variables.insert(item.begin(), item.end());
+    variables.insert(cit->second.begin(), cit->second.end());
     return;
   }
  
@@ -124,34 +124,85 @@ MapToNodeSet PropagateEqualities::buildMapOfLHStoVariablesInRHS(const IdSet& all
     IdSet visited;
     IdSet variables;
     intersection(e.second, visited, variables, allLhsVariables, cache);
-    mapped.insert(std::make_pair(e.first.GetNodeNum(), std::make_tuple(e.first, e.second, variables, id++)));
+    mapped.insert(std::make_pair(
+        e.first.GetNodeNum(),
+        PropagateEqualities::CandidateInfo{e.first, e.second,
+                                          std::move(variables), id++, 0}));
   }
 
   return mapped;
 }
 
-void update(const uint64_t n, MapToNodeSet& m, const IdSet& replaced)
+// Bring candidate `start`'s variable set up to date with the replacements
+// performed so far. Each candidate remembers how many replacements it has
+// already folded in (upTo), so only the newly replaced variables need
+// checking. Invariant: a replaced variable still present in a set must have
+// been replaced after that set's upTo, and an up-to-date set contains no
+// replaced variables at all -- which is why folding a dependency's set in
+// cannot re-introduce work, and why the fold order doesn't matter.
+static void update(const uint64_t start, MapToNodeSet& m,
+                   const std::vector<uint64_t>& replacedOrder,
+                   const IdToId& replacedIndex)
 {
-    auto& variables = std::get<2>(m[n]);
-    vector<uint64_t> toRemove;
-    vector<IdSet*> toAdd;
+  const size_t now = replacedOrder.size();
 
-    // all the variables that get inserted have already been updated.
-    for (const auto& v: variables)
+  struct Frame
+  {
+    uint64_t n;
+    std::vector<uint64_t> deps;
+    bool expanded = false;
+  };
+  std::vector<Frame> stack;
+  stack.push_back({start, {}, false});
+
+  while (!stack.empty())
+  {
+    Frame& f = stack.back();
+    assert(m.find(f.n) != m.end());
+    PropagateEqualities::CandidateInfo& ci = m.find(f.n)->second;
+
+    if (!f.expanded)
     {
-      if (replaced.find(v) != replaced.end())
-      {
-          // It's been replaced.
-          update(v,m,replaced);
-          toRemove.push_back(v);
-          toAdd.push_back(&std::get<2>(m.find(v)->second));
-      }
-    }
-    for (const auto& e: toRemove)
-      variables.erase(e);
+      f.expanded = true;
 
-    for (const auto& e: toAdd)
-      variables.insert(e->begin(), e->end()); 
+      // Find the replaced variables in ci.vars, probing whichever side is
+      // smaller: the pending replacements, or the set itself.
+      if (now - ci.upTo < ci.vars.size())
+      {
+        for (size_t i = ci.upTo; i < now; i++)
+          if (ci.vars.count(replacedOrder[i]) != 0)
+            f.deps.push_back(replacedOrder[i]);
+      }
+      else
+      {
+        for (const auto v : ci.vars)
+        {
+          const auto it = replacedIndex.find(v);
+          if (it != replacedIndex.end() && it->second >= ci.upTo)
+            f.deps.push_back(v);
+        }
+      }
+
+      bool pushed = false;
+      for (const auto v : f.deps)
+        if (m.find(v)->second.upTo != now)
+        {
+          stack.push_back({v, {}, false});
+          pushed = true;
+        }
+      if (pushed)
+        continue; // fold once the dependencies are up to date themselves
+    }
+
+    for (const auto v : f.deps)
+    {
+      ci.vars.erase(v);
+      const IdSet& add = m.find(v)->second.vars;
+      ci.vars.insert(add.begin(), add.end());
+    }
+    ci.upTo = now;
+    stack.pop_back();
+  }
 }
 
 void PropagateEqualities::processCandidates()
@@ -171,39 +222,33 @@ void PropagateEqualities::processCandidates()
   MapToNodeSet mapped;
   mapped = buildMapOfLHStoVariablesInRHS(allLhsVariables);
 
-  typedef std::tuple<ASTNode, ASTNode, const IdSet*, int> qType;
-  auto cmp = [](qType left, qType right) 
-    { 
-      if (std::get<2>(left)->size() > std::get<2>(right)->size())
+  typedef const CandidateInfo* qType;
+  auto cmp = [](qType left, qType right)
+    {
+      if (left->vars.size() > right->vars.size())
           return true;
-      if (std::get<2>(left)->size() == std::get<2>(right)->size())
-          return std::get<3>(left) > std::get<3>(right);
+      if (left->vars.size() == right->vars.size())
+          return left->id > right->id;
       return false;
-    };  
+    };
   std::priority_queue < qType, vector<qType>, decltype(cmp) > q(cmp);
 
   for (const auto& e: mapped)
-  {
-    const ASTNode& lhs = std::get<0>(e.second);
-    const ASTNode& rhs = std::get<1>(e.second);
-    const IdSet* varsInRHS = &(std::get<2>(e.second));
-    const int id = std::get<3>(e.second);
-    auto d = std::make_tuple(lhs,rhs,varsInRHS,id);
-    q.push(d);
-  }
+    q.push(&e.second);
 
-  IdSet variablesReplacedAlready;
+  std::vector<uint64_t> replacedOrder;
+  IdToId replacedIndex;
 
   while (!q.empty())
   {
-    auto e = q.top();
+    const CandidateInfo* e = q.top();
     q.pop();
 
-    const ASTNode& lhs = std::get<0>(e);
+    const ASTNode& lhs = e->lhs;
     const uint64_t lhs_id = lhs.GetNodeNum();
 
-    const ASTNode& rhs = std::get<1>(e);
-    const IdSet& rhsVariables = *std::get<2>(e);
+    const ASTNode& rhs = e->rhs;
+    const IdSet& rhsVariables = e->vars;
 
     assert(SYMBOL == lhs.GetKind());
 
@@ -211,28 +256,29 @@ void PropagateEqualities::processCandidates()
     if (rhsVariables.find(lhs_id) != rhsVariables.end())
       continue; // Loops already, so no more processing.
 
-    if (variablesReplacedAlready.find(lhs_id) != variablesReplacedAlready.end())
+    if (replacedIndex.find(lhs_id) != replacedIndex.end())
       continue; // already replaced.
 
-    update(lhs.GetNodeNum(), mapped, variablesReplacedAlready);
-    
-    if (!q.empty() && 5* std::get<2>(q.top())->size() < rhsVariables.size())
+    update(lhs_id, mapped, replacedOrder, replacedIndex);
+
+    if (!q.empty() && 5* q.top()->vars.size() < rhsVariables.size())
     {
       // The priority queue doesn't automatically update as the priorties change.
       // If the next item in the priority queue is much smaller, loop.
       q.push(e);
       continue;
     }
- 
+
     if (rhsVariables.find(lhs_id) == rhsVariables.end())
     {
       simp->UpdateSubstitutionMapFewChecks(lhs, rhs);
-      variablesReplacedAlready.insert(lhs_id);
+      replacedIndex.emplace(lhs_id, replacedOrder.size());
+      replacedOrder.push_back(lhs_id);
     }
   }
 
   if (bm->UserFlags.stats_flag)
-    std::cerr <<  "{PropagateEqualities} Applied:" << variablesReplacedAlready.size() << std::endl;
+    std::cerr <<  "{PropagateEqualities} Applied:" << replacedOrder.size() << std::endl;
 
   candidates.clear();
 }


### PR DESCRIPTION
## Problem

`PropagateEqualities::update()` rescans a candidate's entire variable set against the replaced-variable set on every call, one hash probe per element. The sets grow as replacements get folded in, so on instances with long equality chains this goes quadratic. On `asp/Labyrinth` benchmarks, Variable Elimination is the single most expensive stage of the whole solve (~40s on `laby_22_22_17`, versus ~2s of SAT solving), and profiling attributes about half of that to these rescans — and much of the rest to the chained-bucket hash traffic of the sets themselves.

## Changes

**Commit 1 — incremental update():**
- Each candidate records how many replacements it has already folded in (`upTo`). `update()` only probes the replacements made since then — or the set itself, whichever side is smaller. This is exact rather than approximate: an up-to-date set contains no replaced variables, and the dependency sets folded in are themselves brought up to date first, so any replaced variable still present in a set must postdate that set's `upTo`.
- `update()` is converted from recursion (one frame per chain link — a stack-overflow risk on ASP-style equality chains) to an explicit stack.
- The priority queue stores `CandidateInfo*` instead of `tuple<ASTNode, ASTNode, const IdSet*, int>`. The comparator already read set sizes live through the stored pointer, so the ordering is unchanged; this removes two refcounted ASTNode copies per heap move.
- `intersection()` does one cache lookup instead of two.

**Commit 2 — flat hash sets:**
- `IdSet` and the id-keyed maps switch from `std::unordered_set/map` to the already-vendored `ankerl::unordered_dense` (used by STPMgr's unique tables since #723-era work). The remaining profile cost was chained-bucket pointer-chasing in the closure folds and membership probes; the flat table replaces those with sequential probes over packed 8-byte slots.
- The candidate map stays a node-based `std::unordered_map`: the priority queue holds pointers into its values, and node-based maps guarantee pointer stability (the map is never inserted into after being built).
- Queue storage and the replacement log are reserved up front.

## Why the output is unchanged

The pass's only visible effect is the sequence of `UpdateSubstitutionMapFewChecks` calls, which is determined by set contents/sizes and the tie-break ids — never by set iteration order (fold order and dependency traversal order are content-independent, and the pop order is a total order because ids are unique). Both commits preserve set contents exactly, so the substitution order and the emitted CNF are identical.

Verified: byte-identical CNF against master on a 40-file pre-CNF-heavy QF_BV corpus (`--output-CNF --exit-after-CNF`), run after each commit. Full test suite passes after each commit.

## Measurements

Interleaved A/B, three rounds with arm order alternating, both binaries Release without assertions, medians of three:

| Instance (QF_BV/asp/Labyrinth) | Variable Elimination | Whole pre-CNF run |
|---|---|---|
| laby_22_22_17 | 24.6s → 12.3s (**−50%**) | 60.0s → 47.7s (−20%) |
| laby_21_21_12 | 17.0s → 8.2s (**−52%**) | 46.8s → 38.4s (−18%) |
| laby_20_20_04 | 11.4s → 6.1s (**−46%**) | 36.2s → 31.2s (−14%) |

The candidate won all nine pairings; commit 1 alone contributes ~10% and commit 2 the rest. The remaining stage cost is `intersection()`/`tagNodes` DFS work and the closure-union writes, which are inherent to materializing per-candidate transitive variable closures; reducing those would change the substitution order, so it's left for a separate change with different validation.