### PR TITLE
cbitp: iterate bvsmod's transfer function to an internal fixed point

### DIFF
--- a/lib/Simplifier/constantBitP/ConstantBitP_Division.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_Division.cpp
@@ -1636,19 +1636,39 @@ Result bvSignedModulusBothWays(vector<FixedBits*>& children, FixedBits& output,
     return NO_CHANGE;
   }
 
-  const Result r0 = bvSignedModulusStructural(children, output, bm);
-  if (CONFLICT == r0)
-    return CONFLICT;
+  // Iterate the two passes to an internal fixed point. A single decompose
+  // pass can fix operand bits whose consequences only a re-run sees: an
+  // output fixed to a value no divisor admits first forces the dividend,
+  // and only the next pass notices the contradiction. propagate() gives
+  // each node exactly one call, so a state this function would itself
+  // refute must not survive the return. Terminates because a CHANGED pass
+  // fixes at least one more bit, bounded by 3 * width.
+  bool changed = false;
+  while (true)
+  {
+    const Result r0 = bvSignedModulusStructural(children, output, bm);
+    if (CONFLICT == r0)
+      return CONFLICT;
 
-  // The sign-case decomposition is expensive and deduces little when the
-  // divisor may be zero; bail out early like the other signed operations.
-  if (children[1]->containsZero())
-    return r0;
+    // The sign-case decomposition is expensive and deduces little when the
+    // divisor may be zero; skip it like the other signed operations.
+    if (children[1]->containsZero())
+    {
+      if (r0 != CHANGED)
+        break;
+      changed = true;
+      continue;
+    }
 
-  const Result r1 = bvSignedModulusDecompose(children, output, bm);
-  if (CONFLICT == r1)
-    return CONFLICT;
-  return merge(r0, r1);
+    const Result r1 = bvSignedModulusDecompose(children, output, bm);
+    if (CONFLICT == r1)
+      return CONFLICT;
+
+    if (r0 != CHANGED && r1 != CHANGED)
+      break;
+    changed = true;
+  }
+  return changed ? CHANGED : NO_CHANGE;
 }
 
 Result bvSignedRemainderBothWays(vector<FixedBits*>& children,

--- a/tests/unit-tests/ConstantBitP_TransferFunctions_Test.cpp
+++ b/tests/unit-tests/ConstantBitP_TransferFunctions_Test.cpp
@@ -641,21 +641,20 @@ TEST_F(ConstantBitP_TransferFunctions, signedRemainderExhaustiveWidth3)
       OVERAPPROXIMATES, SETTLES_IN_ONE_CALL, RESULT_IS_VAGUE);
 }
 
-// bvsmod is the only transfer function that fails to settle on a single call
-// with *distinct* children: 795 of the 19683 width-3 starting states derive
-// more on a later call, and 671 of those end in a CONFLICT the first call
-// missed. propagate() only ever gives it one call, so that reasoning is
-// currently unreachable in the solver.
+// bvsmod used to be the only transfer function that failed to settle on a
+// single call with *distinct* children: 795 of the 19683 width-3 starting
+// states derived more on a later call, 671 of them a CONFLICT the first
+// call missed. It now iterates its structural and decompose passes to an
+// internal fixed point, so it must settle in one call like everything else.
 TEST_F(ConstantBitP_TransferFunctions, signedModulusExhaustiveWidth3)
 {
-  const unsigned bvsmodNeedsThreeCalls = 3;
   exhaustiveCheck(
       "bvsmod",
       [this](std::vector<FixedBits*>& children, FixedBits& out) {
         return bvSignedModulusBothWays(children, out, &mgr);
       },
       evaluatorSemantics(&mgr, stp::SBVMOD, 3), bv3(2), out3(),
-      OVERAPPROXIMATES, bvsmodNeedsThreeCalls);
+      OVERAPPROXIMATES, SETTLES_IN_ONE_CALL);
 }
 
 TEST_F(ConstantBitP_TransferFunctions, multiplicationExhaustiveWidth3)


### PR DESCRIPTION
A single call to `bvSignedModulusBothWays` could refine its operands into a state the same function would immediately refute. With the output fixed to a value no divisor admits, the surviving sign case of the decompose pass back-propagates `u = output - divisor` through its bvurem/bvadd pipeline and fully fixes the dividend, returning CHANGED; only a second call — which `propagate()` never grants, by design — would notice the contradiction and return CONFLICT.

With `--bb.conjoin-constant=1` this left the fixed-bits map short of a fixed point after bit-blasting, tripping the debug-only check in `BBForm`: `assert(status != CONFLICT)` in `getUpdatedFixedBits`, reached through `checkAtFixedPoint`. Found on a fuzzed unsat QF_BV formula whose bvsmod output was propagated equal to its negative constant divisor `t`, which the smod result range `(t, 0]` makes impossible. Release builds don't crash; they just miss the early unsat and recover it in the SAT solver.

The fix iterates the structural and decompose passes until neither reports CHANGED. This terminates because every CHANGED pass fixes at least one more bit, bounded by 3×width. bvsmod was the only transfer function that failed to settle in one call with distinct operands — 795 of the 19683 width-3 starting states derived more on a later call, 671 of them a CONFLICT the first call missed — so the exhaustive settling test now requires `SETTLES_IN_ONE_CALL` of it like every other propagator.

Testing: the transfer-function exhaustive suite passes with the tightened bound (all 19683 width-3 states settle in one call); the full unit/query-file test suite passes (70/70); the crashing formula now answers unsat under the crashing flag set. A differential sweep of 931 bvsmod-containing fuzzed files comparing `--bb.conjoin-constant=1` against `--disable-cbitp` shows no crashes and no answer changes, including an incremental file where all 2500 per-query answers were compared.
