### PR TITLE
SubstitutionMap: flat hash map for the solver map and replace() caches

### DIFF
--- a/include/stp/AST/AST.h
+++ b/include/stp/AST/AST.h
@@ -28,6 +28,7 @@ THE SOFTWARE.
 #include "ASTNode.h"
 #include "UsefulDefs.h"
 #include "stp/Util/Attributes.h"
+#include "extlib-unordered-dense/ankerl/unordered_dense.h"
 
 namespace stp
 {
@@ -93,6 +94,15 @@ unsigned int GetUnsignedConst(const ASTNode n);
 typedef std::unordered_map<ASTNode, ASTNode, ASTNode::ASTNodeHasher,
                            ASTNode::ASTNodeEqual>
     ASTNodeMap;
+
+// Flat open-addressing alternative to ASTNodeMap. Much faster to probe and
+// insert, but: values move on insert/erase (no pointer or reference
+// stability), erase reorders survivors, and iteration is in insertion order.
+// Only use where nothing points into the map and iteration order never
+// reaches a decision.
+typedef ankerl::unordered_dense::map<ASTNode, ASTNode, ASTNode::ASTNodeHasher,
+                                     ASTNode::ASTNodeEqual>
+    DenseNodeMap;
 
 typedef std::unordered_map<ASTNode, int32_t, ASTNode::ASTNodeHasher,
                            ASTNode::ASTNodeEqual>

--- a/include/stp/Simplifier/Simplifier.h
+++ b/include/stp/Simplifier/Simplifier.h
@@ -126,7 +126,8 @@ public:
 
   DLL_PUBLIC ASTNode applySubstitutionMap(const ASTNode& n);
   DLL_PUBLIC ASTNode applySubstitutionMapUntilArrays(const ASTNode& n);
-  ASTNode applySubstitutionMapUntilArrays(const ASTNode& n, ASTNodeMap& cache);
+  ASTNode applySubstitutionMapUntilArrays(const ASTNode& n,
+                                          DenseNodeMap& cache);
 
   
   #ifdef _MSC_VER
@@ -175,9 +176,9 @@ public:
     return substitutionMap.hasUnappliedSubstitutions();
   }
 
-  ASTNodeMap* Return_SolverMap() 
-  { 
-    return substitutionMap.Return_SolverMap(); 
+  DenseNodeMap* Return_SolverMap()
+  {
+    return substitutionMap.Return_SolverMap();
   }
 
   void haveAppliedSubstitutionMap()

--- a/include/stp/Simplifier/SubstitutionMap.h
+++ b/include/stp/Simplifier/SubstitutionMap.h
@@ -41,7 +41,7 @@ const bool debug_substn = false;
 class DLL_PUBLIC SubstitutionMap
 {
 
-  ASTNodeMap* SolverMap;
+  DenseNodeMap* SolverMap;
   STPMgr* bm;
   ASTNode ASTTrue, ASTFalse, ASTUndefined;
 
@@ -73,7 +73,7 @@ public:
     ASTFalse = bm->CreateNode(FALSE);
     ASTUndefined = bm->CreateNode(UNDEFINED);
 
-    SolverMap = new ASTNodeMap(INITIAL_TABLE_SIZE);
+    SolverMap = new DenseNodeMap(INITIAL_TABLE_SIZE);
     loopCount = 0;
     substitutionsLastApplied = 0;
   }
@@ -111,7 +111,7 @@ public:
   // value by reference in the argument 'output'
   bool InsideSubstitutionMap(const ASTNode& key, ASTNode& output)
   {
-    ASTNodeMap::iterator it = SolverMap->find(key);
+    const auto it = SolverMap->find(key);
     if (it != SolverMap->end())
     {
       output = it->second;
@@ -138,7 +138,7 @@ public:
     return false;
   }
 
-  ASTNodeMap* Return_SolverMap() { return SolverMap; }
+  DenseNodeMap* Return_SolverMap() { return SolverMap; }
 
   //Returns TRUE if key is not in SolverMap
   bool InsideSubstitutionMap(const ASTNode& key)
@@ -167,14 +167,20 @@ public:
   ASTNode applySubstitutionMap(const ASTNode& n);
 
   ASTNode applySubstitutionMapUntilArrays(const ASTNode& n);
-  ASTNode applySubstitutionMapUntilArrays(const ASTNode& n, ASTNodeMap& cache);
+  ASTNode applySubstitutionMapUntilArrays(const ASTNode& n,
+                                          DenseNodeMap& cache);
 
   // Replace any nodes in "n" that exist in the fromTo map.
   // NB the fromTo map is changed.
-  static ASTNode replace(const ASTNode& n, ASTNodeMap& fromTo,
-                         ASTNodeMap& cache, NodeFactory* nf);
-  static ASTNode replace(const ASTNode& n, ASTNodeMap& fromTo,
-                         ASTNodeMap& cache, NodeFactory* nf, bool stopAtArrays,
+  // Templated on the map type: the SolverMap paths use DenseNodeMap, while
+  // external callers keep their ASTNodeMaps. Both are explicitly
+  // instantiated in SubstitutionMap.cpp.
+  template <class NodeMapType>
+  static ASTNode replace(const ASTNode& n, NodeMapType& fromTo,
+                         NodeMapType& cache, NodeFactory* nf);
+  template <class NodeMapType>
+  static ASTNode replace(const ASTNode& n, NodeMapType& fromTo,
+                         NodeMapType& cache, NodeFactory* nf, bool stopAtArrays,
                          bool preventInfiniteLoops);
 
   #ifdef _MSC_VER

--- a/lib/Simplifier/BVSolver.cpp
+++ b/lib/Simplifier/BVSolver.cpp
@@ -531,7 +531,7 @@ ASTNode BVSolver::TopLevelBVSolve(const ASTNode& _input,
 
   ASTVec eveneqns;
   bool any_solved = false;
-  ASTNodeMap cache;
+  DenseNodeMap cache;
   for (ASTVec::iterator it = c.begin(), itend = c.end(); it != itend; it++)
   {
     /*

--- a/lib/Simplifier/Simplifier.cpp
+++ b/lib/Simplifier/Simplifier.cpp
@@ -146,7 +146,7 @@ ASTNode Simplifier::applySubstitutionMapUntilArrays(const ASTNode& n)
   return substitutionMap.applySubstitutionMapUntilArrays(n);
 }
 
-ASTNode Simplifier::applySubstitutionMapUntilArrays(const ASTNode& n, ASTNodeMap& cache)
+ASTNode Simplifier::applySubstitutionMapUntilArrays(const ASTNode& n, DenseNodeMap& cache)
 {
   return substitutionMap.applySubstitutionMapUntilArrays(n,cache);
 }

--- a/lib/Simplifier/SubstitutionMap.cpp
+++ b/lib/Simplifier/SubstitutionMap.cpp
@@ -73,7 +73,7 @@ int TermOrder(const ASTNode& a, const ASTNode& b)
 ASTNode SubstitutionMap::applySubstitutionMap(const ASTNode& n)
 {
   bm->GetRunTimes()->start(RunTimes::ApplyingSubstitutions);
-  ASTNodeMap cache;
+  DenseNodeMap cache;
   ASTNode result = replace(n, *SolverMap, cache, bm->defaultNodeFactory, false, false);
 
   bm->GetRunTimes()->stop(RunTimes::ApplyingSubstitutions);
@@ -97,12 +97,12 @@ ASTNode SubstitutionMap::applySubstitutionMapAtTopLevel(const ASTNode& topLevel)
 // not always idempotent.
 ASTNode SubstitutionMap::applySubstitutionMapUntilArrays(const ASTNode& n)
 {
-  ASTNodeMap cache;
+  DenseNodeMap cache;
   return applySubstitutionMapUntilArrays(n, cache);
 }
 
 // not always idempotent.
-ASTNode SubstitutionMap::applySubstitutionMapUntilArrays(const ASTNode& n, ASTNodeMap& cache)
+ASTNode SubstitutionMap::applySubstitutionMapUntilArrays(const ASTNode& n, DenseNodeMap& cache)
 {
   bm->GetRunTimes()->start(RunTimes::ApplyingSubstitutions);
   ASTNode result = replace(n, *SolverMap, cache, bm->defaultNodeFactory, true, false);
@@ -111,8 +111,9 @@ ASTNode SubstitutionMap::applySubstitutionMapUntilArrays(const ASTNode& n, ASTNo
 }
 
 
-ASTNode SubstitutionMap::replace(const ASTNode& n, ASTNodeMap& fromTo,
-                                 ASTNodeMap& cache, NodeFactory* nf)
+template <class NodeMapType>
+ASTNode SubstitutionMap::replace(const ASTNode& n, NodeMapType& fromTo,
+                                 NodeMapType& cache, NodeFactory* nf)
 {
   if (0 == fromTo.size())
     return n;
@@ -129,22 +130,26 @@ ASTNode SubstitutionMap::replace(const ASTNode& n, ASTNodeMap& fromTo,
 // NB: You can't use this to map from "5" to the symbol "x" say.
 // It's optimised for the symbol to something case.
 
-ASTNode SubstitutionMap::replace(const ASTNode& n, ASTNodeMap& fromTo,
-                                 ASTNodeMap& cache, NodeFactory* nf,
+template <class NodeMapType>
+ASTNode SubstitutionMap::replace(const ASTNode& n, NodeMapType& fromTo,
+                                 NodeMapType& cache, NodeFactory* nf,
                                  bool stopAtArrays, bool preventInfinite)
 {
   const Kind k = n.GetKind();
   if (k == BVCONST || k == TRUE || k == FALSE)
     return n;
 
-  ASTNodeMap::const_iterator it;
+  typename NodeMapType::const_iterator it;
 
   if ((it = cache.find(n)) != cache.end())
     return it->second;
 
   if ((it = fromTo.find(n)) != fromTo.end())
   {
-    const ASTNode& r = it->second;
+    // By value, not by reference: the recursive calls below can insert into
+    // and erase from fromTo, and a DenseNodeMap moves its elements when that
+    // happens -- a reference here would dangle.
+    const ASTNode r = it->second;
     assert(r.GetIndexWidth() == n.GetIndexWidth());
 
     if (preventInfinite)
@@ -249,6 +254,17 @@ ASTNode SubstitutionMap::replace(const ASTNode& n, ASTNodeMap& fromTo,
   cache.insert(make_pair(n, result));
   return result;
 }
+
+// The two map types replace() runs over: the SolverMap paths use
+// DenseNodeMap; external callers pass ASTNodeMaps.
+template ASTNode SubstitutionMap::replace<ASTNodeMap>(const ASTNode&,
+    ASTNodeMap&, ASTNodeMap&, NodeFactory*);
+template ASTNode SubstitutionMap::replace<ASTNodeMap>(const ASTNode&,
+    ASTNodeMap&, ASTNodeMap&, NodeFactory*, bool, bool);
+template ASTNode SubstitutionMap::replace<DenseNodeMap>(const ASTNode&,
+    DenseNodeMap&, DenseNodeMap&, NodeFactory*);
+template ASTNode SubstitutionMap::replace<DenseNodeMap>(const ASTNode&,
+    DenseNodeMap&, DenseNodeMap&, NodeFactory*, bool, bool);
 
 // Adds to the dependency graph that n0 depends on the variables in n1.
 // It's not the transitive closure of the dependencies. Just the variables in

--- a/tests/unit-tests/RemoveUnconstrained_Exhaustive_Test.cpp
+++ b/tests/unit-tests/RemoveUnconstrained_Exhaustive_Test.cpp
@@ -147,8 +147,8 @@ struct Context
     ASTNode cur = n;
     for (int i = 0; i < 64; i++)
     {
-      ASTNodeMap fromTo = *simp.Return_SolverMap(); // replace() mutates it.
-      ASTNodeMap cache;
+      DenseNodeMap fromTo = *simp.Return_SolverMap(); // replace() mutates it.
+      DenseNodeMap cache;
       ASTNode next = SubstitutionMap::replace(cur, fromTo, cache, &snf);
       if (next == cur)
         return cur;

--- a/tests/unit-tests/SplitExtracts_Test.cpp
+++ b/tests/unit-tests/SplitExtracts_Test.cpp
@@ -113,8 +113,8 @@ struct Context
    // application reaches the fixed point.
    ASTNode backSubstitute(const ASTNode& n)
    {
-     stp::ASTNodeMap fromTo = *simplifier.Return_SolverMap(); // replace() mutates it.
-     stp::ASTNodeMap cache;
+     stp::DenseNodeMap fromTo = *simplifier.Return_SolverMap(); // replace() mutates it.
+     stp::DenseNodeMap cache;
      return stp::SubstitutionMap::replace(n, fromTo, cache, &snf);
    }
 


### PR DESCRIPTION
Follow-up to #730 targeting the next profile item: the `ASTNodeMap` hash traffic inside `SubstitutionMap::replace` and `applySubstitutionMap` (~9-10% of pre-SAT time on substitution-heavy instances, chained-bucket probes plus a heap allocation per cached node).

## Changes

- New `DenseNodeMap` typedef in `AST.h` — `ankerl::unordered_dense` keyed identically to `ASTNodeMap`, with a comment stating the safety rules (no pointer/reference stability, erase reorders, insertion-order iteration).
- The `SolverMap` and every `replace()` cache on its paths (including BVSolver's shared cache) switch to `DenseNodeMap`.
- `replace()` becomes a template over the map type, explicitly instantiated for both `ASTNodeMap` and `DenseNodeMap` — external callers that build their own fromTo maps (`getConsts`, `getAllFixed`, StrengthReduction, the C++ interface, rewrite_rule_gen) are unchanged.
- **A latent hazard becomes real with a dense map and is fixed**: `replace()` held `const ASTNode& r = it->second` — a reference into `fromTo` — across recursive calls that insert into and erase from `fromTo` (the write-through at the erase/reinsert). Dense maps move elements on both operations, so the reference would dangle. It is now taken by value (one refcount bump).

## Why the output is unchanged

No consumer of these maps is iteration-order sensitive — audited: the difficulty-reversion constant filter, the counterexample copy (a pure range insert, post-SAT anyway), and the stats printout. Substitution order is unchanged, so the CNF is byte-identical against master over the 40-file pre-CNF corpus. Full test suite passes (70/70, including the two unit tests updated for the new SolverMap type).

## Measurements

Three-arm interleaved A/B (this change vs current master content, Release without assertions, arm order rotating per round, medians of three):

| Instance (QF_BV/asp/Labyrinth) | Applying Substitutions | Whole pre-CNF run |
|---|---|---|
| laby_22_22_17 | 5.83s → 4.29s (**−26%**) | 48.5s → 46.8s (−3.4%) |
| laby_21_21_12 | 4.44s → 2.93s (**−34%**) | 39.0s → 35.9s (−8.0%) |
| laby_20_20_04 | 3.74s → 2.48s (**−34%**) | 31.3s → 28.2s (−9.7%) |

All nine same-round total comparisons favour this change. Instruction counts are flat-to-slightly-up for container swaps like this (more ALU work per probe, far fewer memory stalls), so wall time under interleaving is the honest metric here; the byte-identical CNF is the correctness gate.