### PR TITLE
NodeDomainAnalysis: flat hash maps for the domain tables

### DIFF
--- a/include/stp/Simplifier/NodeDomainAnalysis.h
+++ b/include/stp/Simplifier/NodeDomainAnalysis.h
@@ -41,9 +41,18 @@ namespace stp
 {
 using simplifier::constantBitP::FixedBits;
 
-using NodeToUnsignedIntervalMap = std::unordered_map<const ASTNode, UnsignedInterval*, ASTNode::ASTNodeHasher, ASTNode::ASTNodeEqual>;
-using NodeToFixedBitsMap = std::unordered_map<const ASTNode, FixedBits*, ASTNode::ASTNodeHasher, ASTNode::ASTNodeEqual>;
-using NodeToValueSetMap = std::unordered_map<const ASTNode, ValueSet*, ASTNode::ASTNodeHasher, ASTNode::ASTNodeEqual>;
+// Flat hash maps: buildMap probes and inserts these once per node, and
+// StrengthReduction probes them several times per node visited. They are
+// never iterated except by the destructor (order-independent deletes). Keys
+// are plain ASTNode (not const) because a dense map moves its elements; the
+// pointed-to domain objects live on the heap and are unaffected by moves.
+// NodeToUnsignedIntervalMap is defined in UnsignedIntervalAnalysis.h.
+using NodeToFixedBitsMap =
+    ankerl::unordered_dense::map<ASTNode, FixedBits*, ASTNode::ASTNodeHasher,
+                                 ASTNode::ASTNodeEqual>;
+using NodeToValueSetMap =
+    ankerl::unordered_dense::map<ASTNode, ValueSet*, ASTNode::ASTNodeHasher,
+                                 ASTNode::ASTNodeEqual>;
 
 class NodeDomainAnalysis
 {

--- a/include/stp/Simplifier/StrengthReduction.h
+++ b/include/stp/Simplifier/StrengthReduction.h
@@ -67,8 +67,8 @@ class StrengthReduction
 
 public:
 
-  using NodeToUnsignedIntervalMap = std::unordered_map<const ASTNode, UnsignedInterval*, ASTNode::ASTNodeHasher, ASTNode::ASTNodeEqual>;
-  using NodeToFixedBitsMap = std::unordered_map<const ASTNode, FixedBits*, ASTNode::ASTNodeHasher, ASTNode::ASTNodeEqual>;
+  // The domain-map types come from NodeDomainAnalysis.h (the owner of the
+  // data); duplicating them here previously shadowed those definitions.
 
   StrengthReduction(NodeFactory *nf, UserDefinedFlags *uf);
   

--- a/include/stp/Simplifier/UnsignedIntervalAnalysis.h
+++ b/include/stp/Simplifier/UnsignedIntervalAnalysis.h
@@ -41,6 +41,13 @@ namespace stp
 {
 using std::make_pair;
 
+// Shared with NodeDomainAnalysis and StrengthReduction (this header is the
+// lowest in the include order, so the type lives here). Flat map: probed per
+// node visit, iterated only for order-independent cleanup.
+using NodeToUnsignedIntervalMap =
+    ankerl::unordered_dense::map<ASTNode, UnsignedInterval*,
+                                 ASTNode::ASTNodeHasher, ASTNode::ASTNodeEqual>;
+
 class UnsignedIntervalAnalysis
 {
   STPMgr& bm;
@@ -62,8 +69,6 @@ class UnsignedIntervalAnalysis
   std::unordered_map<unsigned, CBV> emptyCBV;
 
 public:
-
-  using NodeToUnsignedIntervalMap = std::unordered_map<const ASTNode, UnsignedInterval*, ASTNode::ASTNodeHasher, ASTNode::ASTNodeEqual>;
 
   UnsignedIntervalAnalysis(STPMgr& _bm);
   

--- a/lib/Simplifier/UnsignedIntervalAnalysis.cpp
+++ b/lib/Simplifier/UnsignedIntervalAnalysis.cpp
@@ -44,8 +44,6 @@ using std::map;
 namespace stp
 {
 
-  using NodeToUnsignedIntervalMap = std::unordered_map<const ASTNode, UnsignedInterval*, ASTNode::ASTNodeHasher, ASTNode::ASTNodeEqual>;
-
   void UnsignedIntervalAnalysis::stats()
   {
     std::cerr << "{UnsignedIntervalAnalysis} TODO propagator not implemented: "


### PR DESCRIPTION
Continuation of #730/#733's container work, next profile item: the node→domain tables (FixedBits / UnsignedInterval / ValueSet) that NodeDomainAnalysis builds and StrengthReduction probes several times per node, whose teardown deletes were also visible in profiles (~2.4% destructor self-time on constant-bit-heavy instances).

## Changes

- The three domain tables switch to `ankerl::unordered_dense` (keys become plain `ASTNode` rather than `const ASTNode` since dense maps move elements; the pointed-to domain objects are heap-allocated and unaffected). They are never iterated except for order-independent cleanup deletes, and `buildMap`/`visit` hold only raw heap pointers across recursion — no references into the maps — so the output is unchanged.
- **The change exposed and removes a latent typedef mess**: the same map types were declared four times (NodeDomainAnalysis.h, StrengthReduction.h public class scope, UnsignedIntervalAnalysis.h class scope, and UnsignedIntervalAnalysis.cpp namespace scope), silently shadowing one another. Each type now has exactly one definition — the interval map in UnsignedIntervalAnalysis.h (lowest in the include order), the other two in NodeDomainAnalysis.h — with comments stating ownership.
- UnsignedIntervalAnalysis's standalone `visited` map shares the dense type (audited: same safe access shape as `buildMap`).

## Validation

CNF byte-identical against master over the 40-file pre-CNF corpus; full test suite passes (70/70).

## Measurements

Interleaved A/B, three rounds with arm order alternating, Release without assertions, medians:

| Instance | Strength Reduction | Whole pre-CNF run |
|---|---|---|
| asp/DisjunctiveScheduling in9 | 2.22s → 2.34s | **27.37s → 26.46s (−3.3%, all 3 rounds)** |
| 2019-Wolf-fmbench ponylink | 1.21s → 1.05s (−13%) | 17.36s → 17.22s (within noise) |
| asp/Labyrinth laby_20_20_04 | 2.05s → 1.91s (−7%) | 28.56s → 27.75s (−2.8%) |

A modest win concentrated on domain-analysis-heavy instances, plus the deduplication. (For contrast, the same conversion attempted on ConstantBitPropagation's remaining maps measured flat-to-negative and was dropped — its hot tables were already dense.)