### PR TITLE
Simplifier: flat hash maps for the simplification memo tables

### DIFF
--- a/include/stp/Simplifier/Simplifier.h
+++ b/include/stp/Simplifier/Simplifier.h
@@ -76,10 +76,12 @@ private:
   ASTNode ASTTrue, ASTFalse, ASTUndefined;
 
   // Memo table for simplifcation. Key is unsimplified node, and
-  // value is simplified node.
-  ASTNodeMap* SimplifyMap;
-  ASTNodeMap* SimplifyNegMap;
-  ASTNodeMap MultInverseMap;
+  // value is simplified node. Flat maps: probed and written once per node
+  // visit across the whole recursive simplifier, never iterated except to
+  // filter constants (order-independent).
+  DenseNodeMap* SimplifyMap;
+  DenseNodeMap* SimplifyNegMap;
+  DenseNodeMap MultInverseMap;
 
   NodeFactory* nf;
 
@@ -91,8 +93,8 @@ public:
   {
     nf = _bm->defaultNodeFactory;
 
-    SimplifyMap = new ASTNodeMap(INITIAL_TABLE_SIZE);
-    SimplifyNegMap = new ASTNodeMap(INITIAL_TABLE_SIZE);
+    SimplifyMap = new DenseNodeMap(INITIAL_TABLE_SIZE);
+    SimplifyNegMap = new DenseNodeMap(INITIAL_TABLE_SIZE);
 
     ASTTrue = nf->getTrue();
     ASTFalse = nf->getFalse();

--- a/lib/Simplifier/Simplifier.cpp
+++ b/lib/Simplifier/Simplifier.cpp
@@ -74,7 +74,7 @@ bool Simplifier::CheckSimplifyMap(const ASTNode& key, ASTNode& output,
     return true;
   }
 
-  ASTNodeMap::iterator it, itend;
+  DenseNodeMap::iterator it, itend;
   it = pushNeg ? SimplifyNegMap->find(key) : SimplifyMap->find(key);
   itend = pushNeg ? SimplifyNegMap->end() : SimplifyMap->end();
 
@@ -169,8 +169,8 @@ bool Simplifier::UpdateSubstitutionMap(const ASTNode& e0, const ASTNode& e1)
 
 bool Simplifier::CheckMultInverseMap(const ASTNode& key, ASTNode& output)
 {
-  ASTNodeMap::iterator it;
-  if ((it = MultInverseMap.find(key)) != MultInverseMap.end())
+  const auto it = MultInverseMap.find(key);
+  if (it != MultInverseMap.end())
   {
     output = it->second;
     return true;
@@ -1273,9 +1273,9 @@ bool Simplifier::hasBeenSimplified(const ASTNode& n)
   if (n.GetKind() == SYMBOL)
     return true;
 
-  ASTNodeMap::const_iterator it;
   // If it's in the simplification map, it has been simplified.
-  if ((it = SimplifyMap->find(n)) == SimplifyMap->end())
+  const auto it = SimplifyMap->find(n);
+  if (it == SimplifyMap->end())
     return false;
 
   return (it->second == n);
@@ -3019,13 +3019,16 @@ void Simplifier::ResetSimplifyMaps()
   // deletes the contents.  The destructor seems to clear everything
   // anyway.
 
+  // (With the dense maps the delete/new and clear() are both cheap -- one
+  // vector teardown -- but the delete also returns the memory.)
+
   // SimplifyMap->clear();
   delete SimplifyMap;
-  SimplifyMap = new ASTNodeMap(INITIAL_TABLE_SIZE);
+  SimplifyMap = new DenseNodeMap(INITIAL_TABLE_SIZE);
 
   // SimplifyNegMap->clear();
   delete SimplifyNegMap;
-  SimplifyNegMap = new ASTNodeMap(INITIAL_TABLE_SIZE);
+  SimplifyNegMap = new DenseNodeMap(INITIAL_TABLE_SIZE);
 }
 
 void Simplifier::printCacheStatus()


### PR DESCRIPTION
Next site in the container series (#730/#733/#734): the Simplifier's memo tables — `SimplifyMap`/`SimplifyNegMap`, probed and written once per node visit across the whole recursive simplifier and torn down on every `*_TopLevel` call, plus the small `MultInverseMap`.

## Changes

- All three switch to `ankerl::unordered_dense` (`DenseNodeMap`).
- `ResetSimplifyMaps`'s delete-and-reallocate workaround (std's `clear()` walks every bucket of a large table) is kept but is now cheap either way — one vector teardown — with the comment updated.
- Two explicitly-typed iterator declarations become `auto`/dense.

## Why the output is unchanged

Access is fully encapsulated in `CheckSimplifyMap`/`UpdateSimplifyMap`, which copy values out immediately — no iterators or references into the maps survive any call that could mutate them. The single iteration site (`FindConsts_TopLevel`) filters constant entries into another map, which is order-independent. Verified: CNF byte-identical against master over the 40-file pre-CNF corpus; full test suite passes (70/70).

## Measurements

Interleaved A/B, three rounds with arm order alternating, Release without assertions, medians:

| Instance | Simplifying stage | Whole pre-CNF run |
|---|---|---|
| 20230221-oisc-gurtner AND-NESTED-12-32 | 3.15s → 2.60s (**−17%**) | 43.1s → 42.2s (−2.1%, all 3 rounds) |
| asp/Labyrinth laby_20_20_04 | 1.59s → 1.29s (**−19%**) | 28.4s → 27.8s (−2.1%, all 3 rounds) |
| bmc-bv/ex19 (control, stage negligible) | flat | flat |