### PR TITLE
Parsers: tell the error handler why parsing failed

### DIFF
--- a/lib/Parser/cvc.y
+++ b/lib/Parser/cvc.y
@@ -27,6 +27,8 @@ THE SOFTWARE.
 #include "stp/cpp_interface.h"
 #include "stp/Parser/LetMgr.h"
 #include "stp/Parser/parser.h"
+#include <sstream>
+#include <string>
 
   using namespace stp;
   using std::cout;
@@ -45,9 +47,19 @@ THE SOFTWARE.
   extern int cvclex(void);
   extern char* yytext;
   extern int cvclineno;
+  // Built once: printed for the user and handed to the error handler,
+  // which used to receive the empty string. See the note in smt2.y.
+  static std::string cvc_diagnostic(const char *s)
+  {
+    std::ostringstream o;
+    o << "CVC syntax error: line " << cvclineno << ": " << s;
+    return o.str();
+  }
+
   int yyerror(const char *s) {
-    cout << "CVC syntax error: line " << cvclineno << "\n" << s << endl;
-    FatalError("");
+    const std::string msg = cvc_diagnostic(s);
+    cout << msg << endl;
+    FatalError(msg.c_str());
     return YY_EXIT_FAILURE;
   }
   int yyerror(void* /*AssertsQuery*/, const char* s) { return yyerror(s); }
@@ -226,7 +238,7 @@ other_cmd       :
 /*   ASTVec aaa = GlobalParserInterface->GetAsserts(); */
 /*   if(aaa.size() == 0) */
 /*     { */
-/*       yyerror("Fatal Error: parsing:  GetAsserts() call: no assertions: "); */
+/*       yyerror("GetAsserts() call: no assertions"); */
 /*     } */
 
 /*   ASTNode asserts =  */
@@ -252,7 +264,7 @@ other_cmd       :
   ASTVec aaa = GlobalParserInterface->GetAsserts();
   if(aaa.size() == 0)
     {
-      yyerror("Fatal Error: parsing:  GetAsserts() call: no assertions: ");
+      yyerror("GetAsserts() call: no assertions");
     }
 
   ASTNode asserts = 
@@ -344,9 +356,9 @@ VarDecl         :      FORM_IDs ':' Type
   //do type checking. if doesn't pass then abort
   BVTypeCheck(*$5);
   if($3.indexwidth != $5->GetIndexWidth())
-    yyerror("Fatal Error: parsing: LET Expr: Type check fail: ");
+    yyerror("LET Expr: type check fail");
   if($3.valuewidth != $5->GetValueWidth())
-    yyerror("Fatal Error: parsing: LET Expr: Type check fail: ");
+    yyerror("LET Expr: type check fail");
                          
   for(vector<char*>::iterator i=$1->begin(),iend=$1->end();i!=iend;i++) {                         
     GlobalParserInterface->letMgr->LetExprMgr(*i,*$5);
@@ -359,9 +371,9 @@ VarDecl         :      FORM_IDs ':' Type
   //do type checking. if doesn't pass then abort
   BVTypeCheck(*$5);
   if($3.indexwidth != $5->GetIndexWidth())
-    yyerror("Fatal Error: parsing: LET Expr: Type check fail: ");
+    yyerror("LET Expr: type check fail");
   if($3.valuewidth != $5->GetValueWidth())
-    yyerror("Fatal Error: parsing: LET Expr: Type check fail: ");
+    yyerror("LET Expr: type check fail");
                          
   for(vector<char*>::iterator i=$1->begin(),iend=$1->end();i!=iend;i++) {                         
     GlobalParserInterface->letMgr->LetExprMgr(*i,*$5);
@@ -407,7 +419,7 @@ BvType          :      BV_TOK '(' NUMERAL_TOK ')'
     $$.valuewidth = length;
   }
   else
-    FatalError("Fatal Error: parsing: BITVECTORS must be of positive length: \n");
+    FatalError("parsing: bit-vectors must be of positive length");
 }
 ;
 BoolType        :      BOOLEAN_TOK
@@ -473,7 +485,7 @@ Formula         :     '(' Formula ')'
 |      FORMID_TOK '(' Expr ')'
 {
   if (stp::BVCONST != $3->GetKind())
-    yyerror("Fatal Error: the argument of a parameterised boolean must be a constant");
+    yyerror("the argument of a parameterised boolean must be a constant");
   $$ = new ASTNode(GlobalParserInterface->CreateParameterisedBooleanVar(*$1,*$3));
   delete $1;
   delete $3;
@@ -482,7 +494,7 @@ Formula         :     '(' Formula ')'
 {
   unsigned int width = $3->GetValueWidth();
   if(width <= (unsigned)$5)
-    yyerror("Fatal Error: BOOLEXTRACT: trying to boolextract a bit which beyond range");
+    yyerror("BOOLEXTRACT: trying to boolextract a bit which is beyond range");
                          
   ASTNode bit = GlobalParserInterface->CreateBVConst(32, $5);
   ASTNode * out = new ASTNode(GlobalParserInterface->nf->CreateNode(BOOLEXTRACT,*$3,bit));
@@ -1090,9 +1102,9 @@ LetDecl         :       STRING_TOK '=' Expr
   BVTypeCheck(*$5);
                           
   if($3.indexwidth != $5->GetIndexWidth())
-    yyerror("Fatal Error: parsing: LET Expr: Type check fail: ");
+    yyerror("LET Expr: type check fail");
   if($3.valuewidth != $5->GetValueWidth())
-    yyerror("Fatal Error: parsing: LET Expr: Type check fail: ");
+    yyerror("LET Expr: type check fail");
 
   GlobalParserInterface->letMgr->LetExprMgr($1,*$5);
   free( $1);
@@ -1114,9 +1126,9 @@ LetDecl         :       STRING_TOK '=' Expr
   BVTypeCheck(*$5);
 
   if($3.indexwidth != $5->GetIndexWidth())
-    yyerror("Fatal Error: parsing: LET Expr: Type check fail: ");
+    yyerror("LET Expr: type check fail");
   if($3.valuewidth != $5->GetValueWidth())
-    yyerror("Fatal Error: parsing: LET Expr: Type check fail: ");
+    yyerror("LET Expr: type check fail");
 
   //Do LET-expr management
   GlobalParserInterface->letMgr->LetExprMgr($1,*$5);

--- a/lib/Parser/smt.y
+++ b/lib/Parser/smt.y
@@ -37,6 +37,8 @@
 #include "stp/cpp_interface.h"
 #include "stp/Parser/LetMgr.h"
 #include "stp/Parser/parser.h"
+#include <sstream>
+#include <string>
 
   using namespace stp;
   using std::cout;
@@ -51,10 +53,20 @@
   extern int smtlineno;
   extern int smtlex(void);
 
+  // Built once: printed for the user and handed to the error handler,
+  // which used to receive the empty string. See the note in smt2.y.
+  static std::string smt_diagnostic(const char *s)
+  {
+    std::ostringstream o;
+    o << "syntax error: line " << smtlineno << ": " << s
+      << "  token: " << smttext;
+    return o.str();
+  }
+
   int yyerror(const char *s) {
-    cout << "syntax error: line " << smtlineno << "\n" << s << endl;
-    cout << "  token: " << smttext << endl;
-    FatalError("");
+    const std::string msg = smt_diagnostic(s);
+    cout << msg << endl;
+    FatalError(msg.c_str());
     return 1;
   }
   int yyerror(void* /*AssertsQuery*/, const char* s) { return yyerror(s); }
@@ -1055,7 +1067,7 @@ BITVEC_TOK LBRACKET_TOK NUMERAL_TOK RBRACKET_TOK
     $$.valuewidth = length;
   }
   else {
-    FatalError("Fatal Error: parsing: BITVECTORS must be of positive length: \n");
+    FatalError("parsing: bit-vectors must be of positive length");
   }
 }
 | ARRAY_TOK LBRACKET_TOK NUMERAL_TOK COLON_TOK NUMERAL_TOK RBRACKET_TOK
@@ -1066,14 +1078,14 @@ BITVEC_TOK LBRACKET_TOK NUMERAL_TOK RBRACKET_TOK
     $$.indexwidth = $3;
   }
   else {
-    FatalError("Fatal Error: parsing: BITVECTORS must be of positive length: \n");
+    FatalError("parsing: bit-vectors must be of positive length");
   }
 
   if(value_len > 0) {
     $$.valuewidth = $5;
   }
   else {
-    FatalError("Fatal Error: parsing: BITVECTORS must be of positive length: \n");
+    FatalError("parsing: bit-vectors must be of positive length");
   }
 }
 ;

--- a/lib/Parser/smt2.y
+++ b/lib/Parser/smt2.y
@@ -54,6 +54,8 @@
 #include "stp/Parser/parser.h"
 #include "parsesmt2.tab.h"
 #include "smt2_flex_header.h"
+#include <sstream>
+#include <string>
 
   using std::cout;
   using std::cerr;
@@ -197,15 +199,29 @@
   extern int smt2lineno;
   extern bool stringOnly;
 
+  // The diagnostic, built once. It is the body of the SMT-LIB (error ...)
+  // response on stdout and also what the fatal path hands to the error
+  // handler -- which used to receive the empty string, so a caller that
+  // registered one through vc_registerErrorHandler learned that parsing
+  // had failed but never why, and the command line printed two labelled
+  // blank lines after a perfectly good response.
+  static std::string smt2_diagnostic(const char *s)
+  {
+    std::ostringstream o;
+    o << "syntax error: line " << smt2lineno << " " << s
+      << "  token: " << smt2text;
+    return o.str();
+  }
+
   int yyerror(const char *s) {
-    cout << "(error \"syntax error: line " << smt2lineno << " " << s << "  token: " << smt2text << "\")" << endl;
+    cout << "(error \"" << smt2_diagnostic(s) << "\")" << endl;
     return 1;
   }
 
   int fatal_yyerror(const char *s) 
   {
     yyerror(s);
-    stp::FatalError("");
+    stp::FatalError(smt2_diagnostic(s).c_str());
   }
 
   ASTNode* createNode(Kind k, ASTVec * c)
@@ -808,14 +824,14 @@ STRING_TOK LPAREN_TOK RPAREN_TOK LPAREN_TOK ARRAY_TOK LPAREN_TOK UNDERSCORE_TOK 
     s.SetIndexWidth($9);
   }
   else {
-    fatal_yyerror("Fatal Error: parsing: BITVECTORS must be of positive length: \n");
+    fatal_yyerror("bit-vectors must be of positive length");
   }
 
   if(value_len > 0) {
     s.SetValueWidth($14);
   }
   else {
-    fatal_yyerror("Fatal Error: parsing: BITVECTORS must be of positive length: \n");
+    fatal_yyerror("bit-vectors must be of positive length");
   }
 
   ASTVec empty;
@@ -929,14 +945,14 @@ STRING_TOK LPAREN_TOK RPAREN_TOK LPAREN_TOK UNDERSCORE_TOK BITVEC_TOK NUMERAL_TO
     s.SetIndexWidth($9);
   }
   else {
-    fatal_yyerror("Fatal Error: parsing: BITVECTORS must be of positive length: \n");
+    fatal_yyerror("bit-vectors must be of positive length");
   }
 
   if(value_len > 0) {
     s.SetValueWidth($14);
   }
   else {
-    fatal_yyerror("Fatal Error: parsing: BITVECTORS must be of positive length: \n");
+    fatal_yyerror("bit-vectors must be of positive length");
   }
   delete $1;
 }
@@ -972,14 +988,14 @@ STRING_TOK  LPAREN_TOK UNDERSCORE_TOK BITVEC_TOK NUMERAL_TOK RPAREN_TOK
     s.SetIndexWidth($7);
   }
   else {
-    fatal_yyerror("Fatal Error: parsing: BITVECTORS must be of positive length: \n");
+    fatal_yyerror("bit-vectors must be of positive length");
   }
 
   if(value_len > 0) {
     s.SetValueWidth($12);
   }
   else {
-    fatal_yyerror("Fatal Error: parsing: BITVECTORS must be of positive length: \n");
+    fatal_yyerror("bit-vectors must be of positive length");
   }
   delete $1;
 }

--- a/tests/query-files/misc-tests/parser-error-messages.smt2
+++ b/tests/query-files/misc-tests/parser-error-messages.smt2
@@ -1,0 +1,48 @@
+; A malformed input must be diagnosed on every channel that carries the
+; diagnosis, and this file is malformed: the assertion at the bottom is
+; missing an operand.
+;
+; There are three such channels, and each one used to lose the message:
+;
+;   stdout   the SMT-LIB (error "...") response, which a caller's result
+;            parser reads. This one had the text, but the productions that
+;            report a bad width put "Fatal Error: parsing: " and a newline
+;            inside it, splitting a single-line response across two lines.
+;   stderr   FatalError's own line. It was handed the empty string, so it
+;            printed "Fatal Error: " and nothing after it.
+;   handler  the callback a library caller installs with
+;            vc_registerErrorHandler, which is how an embedder learns that
+;            parsing failed. It received the same empty string, so it
+;            learned nothing about why. The command line installs one that
+;            prints "STP Error: ", which is what makes that path checkable
+;            from here rather than only from C.
+;
+; Pinning text after each label is the whole point: a blank message is what
+; the bug looked like, and only a positive match rules it out. The line
+; number is deliberately left as a pattern, so that editing this comment
+; does not rewrite the test.
+;
+; The 'not' wrapper checks the exit status through the pipe, as in
+; bad-cli-options.smt2 next door -- a parser that crashed rather than
+; exiting would fail the RUN line on its own.
+
+; RUN: not %solver %s 2>&1 | %OutputCheck %s
+; CHECK-NOT: terminate called
+; CHECK: ^\(error "syntax error: line [0-9]+ too few arguments to eq\.  token: \)"\)$
+; CHECK: ^Fatal Error: syntax error: line [0-9]+ too few arguments to eq\.  token: \)$
+; CHECK: ^STP Error: syntax error: line [0-9]+ too few arguments to eq\.  token: \)$
+
+; The response on stdout is one line and carries no "Fatal Error" wording:
+; it is a protocol answer, not a log line.
+; RUN: not %solver %s 2>/dev/null | %OutputCheck %s --check-prefix=STDOUT
+; STDOUT-NOT: Fatal Error
+; STDOUT: ^\(error "syntax error: line [0-9]+ too few arguments to eq\.  token: \)"\)$
+
+; And a caller reading only stderr still learns the reason.
+; RUN: not %solver %s 2>&1 >/dev/null | %OutputCheck %s --check-prefix=STDERR
+; STDERR: ^Fatal Error: syntax error: line [0-9]+ too few arguments to eq\.  token: \)$
+
+(set-logic QF_BV)
+(declare-fun x () (_ BitVec 8))
+(assert (= x ))
+(check-sat)

--- a/tests/query-files/misc-tests/parser-zero-width-array-index.smt2
+++ b/tests/query-files/misc-tests/parser-zero-width-array-index.smt2
@@ -1,0 +1,30 @@
+; An array declared with a zero-width index. The productions that reject a
+; non-positive width are the ones whose message was worst formed: it read
+;
+;   (error "syntax error: line 2 Fatal Error: parsing: BITVECTORS must be
+;     of positive length:
+;     token: )")
+;
+; -- the label of a different channel quoted inside the response, and a
+; newline in the middle of it, so what should be one line a caller can read
+; back arrived as two.
+;
+; The wording lives in one place now and says only what went wrong; the
+; framing belongs to whichever channel prints it.
+
+; RUN: not %solver %s 2>&1 | %OutputCheck %s
+; CHECK-NOT: terminate called
+; CHECK: ^\(error "syntax error: line [0-9]+ bit-vectors must be of positive length  token: \)"\)$
+; CHECK: ^Fatal Error: syntax error: line [0-9]+ bit-vectors must be of positive length  token: \)$
+
+; The response is one line: the text and the closing quote are on it, and
+; nothing follows on a line of its own.
+; RUN: not %solver %s 2>/dev/null | %OutputCheck %s --check-prefix=STDOUT
+; STDOUT-NOT: Fatal Error
+; STDOUT-NOT: ^ *token:
+; STDOUT: ^\(error ".*positive length  token: \)"\)$
+
+(set-logic QF_ABV)
+(declare-fun a () (Array (_ BitVec 0) (_ BitVec 8)))
+(assert (= (select a #b0) #x00))
+(check-sat)


### PR DESCRIPTION
A syntax error in an input file printed a correct diagnostic and then two labelled blank lines:

  (error "syntax error: line 3 too few arguments to eq.  token: )")
  Fatal Error:
  STP Error:

All three parsers built the message for their own output and then called FatalError(""). FatalError prints "Fatal Error: " and whatever it was given, and hands the same string to vc_error_hdlr -- so with an empty one, the command line printed two labels with nothing after them.

The blank lines are the cosmetic half. The other half is that vc_error_hdlr is the callback a library caller registers through vc_registerErrorHandler, and it is how an embedder learns a parse failed. It was told that much and nothing else: not the line, not the token, not the reason. The CLI's own handler is what prints the second blank line, which is why the defect is visible from the shell at all.

So build the diagnostic once per parser and use it for both: the text the parser prints and the text the fatal path carries. Nothing about which channel gets what changes -- SMT-LIB2 still answers on stdout with its (error "...") response, the others still print their own form.

Six productions in smt2.y, three in smt.y and one in cvc.y also put "Fatal Error: parsing: " inside the message, plus a trailing newline. Under smt2.y that framing ended up quoted inside the response and the newline split it, so a single-line answer arrived as two:

  (error "syntax error: line 2 Fatal Error: parsing: BITVECTORS must be
    of positive length:
    token: )")

Those messages now say only what went wrong; the framing belongs to whichever channel prints them. Same for the other nine sites in cvc.y that carried the prefix.

Tested by two query files: one covers a plain syntax error and pins text after each of the three labels, since a blank message is what the bug looked like and only a positive match rules that out; the other covers a zero-width array index and pins that the response is one line. Both fail without this change. The line number is left as a pattern so that editing the comments does not rewrite the test.