### PR TITLE
Depend on the ASTKind.h generator from stp_main_common

### DIFF
--- a/tools/stp/CMakeLists.txt
+++ b/tools/stp/CMakeLists.txt
@@ -30,6 +30,11 @@
 # stp_simple is the only consumer.
 if(BUILD_EXECUTABLES)
     add_library(stp_main_common OBJECT main_common.cpp)
+    # main_common.cpp reaches the generated ASTKind.h through NodeFactory.h.
+    # As a standalone object library it does not inherit the generator
+    # dependency from libstp, so name it here or a parallel build can compile
+    # this TU before ASTKind.h exists (as every other consumer target does).
+    add_dependencies(stp_main_common ASTKind_header)
 endif()
 
 if(BUILD_EXECUTABLES AND NOT ONLY_SIMPLE)


### PR DESCRIPTION
#724 moved the shared front-end translation unit into its own object library, `stp_main_common`. `main_common.cpp` reaches the generated `stp/AST/ASTKind.h` through `NodeFactory.h`, but an object library does not inherit libstp's dependency on the `ASTKind_header` custom target, so a parallel build can compile `main_common.cpp` before the header has been generated:

```
NodeFactory.h:28:10: fatal error: stp/AST/ASTKind.h: No such file or directory
   28 | #include "stp/AST/ASTKind.h"
```

Because it is timing-dependent it surfaces as an intermittent clean-build failure rather than a consistent one — a `-j` clean build breaks only when the compile of `main_common.cpp` happens to be scheduled ahead of the `ASTKind_header` generation, so whether it reproduces depends on core count and scheduling luck.

This names `ASTKind_header` as a dependency of `stp_main_common`, exactly as every other consumer target (`AST`, `printer`, `tosat`, `stpmgr`, ...) already does.

Verified deterministically by deleting the generated header and building only the object-library target: on `master`, `cmake --build build --target stp_main_common` fails with the error above and does not regenerate the header; with this change it runs the `ASTKind_header` generation first (`Built target ASTKind_header`) and then compiles `stp_main_common` cleanly.
