### PR TITLE
cbitp: store the parent lists in one flat CSR adjacency

### DIFF
--- a/include/stp/Simplifier/constantBitP/Dependencies.h
+++ b/include/stp/Simplifier/constantBitP/Dependencies.h
@@ -27,6 +27,9 @@ THE SOFTWARE.
 
 #include "stp/AST/AST.h"
 #include "extlib-unordered-dense/ankerl/unordered_dense.h"
+#include <utility>
+#include <vector>
+
 namespace simplifier
 {
 namespace constantBitP
@@ -37,99 +40,158 @@ using std::endl;
 using stp::ASTNode;
 
 // From a child, get the parents of that node.
+//
+// Stored as one flat CSR-style adjacency: every node in the DAG gets a dense
+// index, all parent lists live back-to-back in a single array, and an
+// offsets array delimits each node's slice. Building is one DFS that emits
+// (child, parent) pairs plus a stable counting sort, so there are no
+// per-node containers to allocate, and iterating a node's parents walks
+// contiguous memory. Parents appear in each slice in the order the DFS
+// first saw the edge, which is the same order the previous per-node
+// insertion-ordered sets iterated in.
 class Dependencies
 {
-public:
-  typedef ankerl::unordered_dense::set<ASTNode, ASTNode::ASTNodeHasher,
-                                       ASTNode::ASTNodeEqual>
-      DependentsSet;
-
 private:
-  typedef ankerl::unordered_dense::map<uint64_t, DependentsSet*>
-      NodeToDependentNodeMap;
-  NodeToDependentNodeMap dependents;
+  typedef ankerl::unordered_dense::map<uint64_t, uint32_t> IndexMap;
 
-  const DependentsSet empty;
+  IndexMap index;               // node id -> dense index; doubles as "visited"
+  std::vector<ASTNode> nodes;   // dense index -> node
+  std::vector<uint32_t> offsets; // size N+1; parents of i at [offsets[i], offsets[i+1])
+  std::vector<ASTNode> parents;  // parent nodes themselves: iteration stays
+                                 // one contiguous walk, no indirection
 
-  bool checkInvariant() const
+  // (childIdx, parentIdx) in DFS discovery order; cleared after compaction.
+  typedef std::vector<std::pair<uint32_t, uint32_t>> EdgeList;
+
+  uint32_t discover(const ASTNode& n)
   {
-    // TODO only one node with a single dependent.
-    return true;
+    const auto it = index.try_emplace(n.GetNodeNum(), (uint32_t)nodes.size());
+    if (it.second)
+      nodes.push_back(n);
+    return it.first->second;
   }
 
-  // All the nodes that depend on the value of a particular node.
-  void build(const ASTNode& current, const ASTNode& prior)
+  // A (parent -> child) edge repeats only when a node lists the same child
+  // more than once (e.g. BVPLUS(x,x)); dedup by scanning the earlier
+  // children, or through a set once the quadratic scan would bite.
+  void build(const ASTNode& current, const uint32_t currentIdx,
+             EdgeList& edges)
   {
-    if (current.isConstant()) // don't care about what depends on constants.
-      return;
+    const unsigned degree = current.Degree();
 
-    DependentsSet* vec;
-    bool firstVisit;
-    const auto it = dependents.find(current.GetNodeNum());
-    if (dependents.end() == it)
-    {
-      // add it in with a reference to the vector.
-      vec = new DependentsSet();
-      dependents.insert({current.GetNodeNum(), vec});
-      firstVisit = true;
-    }
-    else
-    {
-      vec = it->second;
-      firstVisit = false;
-    }
+    ankerl::unordered_dense::set<uint64_t> seenWide;
+    const bool wide = degree > 32;
 
-    if (prior != current) // initially called with both the same.
+    for (unsigned i = 0; i < degree; i++)
     {
-      if (!vec->insert(prior).second)
-        return; // already been added in.
-    }
+      const ASTNode& child = current[i];
+      if (child.isConstant()) // don't care about what depends on constants.
+        continue;
 
-    // On a repeat visit through a new parent, the edges to the children
-    // are already recorded; descending again would redo a hash find per
-    // child for every extra parent.
-    if (!firstVisit)
-      return;
+      const uint64_t childId = child.GetNodeNum();
 
-    for (const auto &child: current)
-    {
-      build(child, current);
+      if (wide)
+      {
+        if (!seenWide.insert(childId).second)
+          continue;
+      }
+      else
+      {
+        bool repeated = false;
+        for (unsigned j = 0; j < i; j++)
+          if (current[j].GetNodeNum() == childId)
+          {
+            repeated = true;
+            break;
+          }
+        if (repeated)
+          continue;
+      }
+
+      // By value: the recursive call inserts into `index`, which can move
+      // the entry the iterator points at.
+      const auto r = index.try_emplace(childId, (uint32_t)nodes.size());
+      const uint32_t childIdx = r.first->second;
+      const bool firstVisit = r.second;
+      if (firstVisit)
+        nodes.push_back(child);
+      edges.emplace_back(childIdx, currentIdx);
+
+      // On a repeat visit through a new parent, the edges to the children
+      // are already recorded.
+      if (firstVisit)
+        build(child, childIdx, edges);
     }
+  }
+
+  void compact(const EdgeList& edges)
+  {
+    offsets.assign(nodes.size() + 1, 0);
+    for (const auto& e : edges)
+      offsets[e.first + 1]++;
+    for (size_t i = 1; i < offsets.size(); i++)
+      offsets[i] += offsets[i - 1];
+
+    parents.resize(edges.size()); // null ASTNodes, then counting-sorted in
+    std::vector<uint32_t> cursor(offsets.begin(), offsets.end() - 1);
+    for (const auto& e : edges) // stable: keeps per-child discovery order
+      parents[cursor[e.first]++] = nodes[e.second];
   }
 
 public:
-
   Dependencies(const Dependencies&) = delete;
   Dependencies& operator=(const Dependencies&) = delete;
 
   Dependencies(const ASTNode& top)
   {
-    build(top, top);
-    assert(checkInvariant());
+    if (top.isConstant())
+      return;
+
+    EdgeList edges;
+    build(top, discover(top), edges);
+    compact(edges);
   }
 
-  ~Dependencies()
+  // A node's slice of the flat parent array.
+  class ParentRange
   {
-    for (const auto& it : dependents)
-      delete it.second;
-  }
+    const ASTNode* from;
+    const ASTNode* to;
 
-  const DependentsSet* getDependents(const ASTNode& n) const
+  public:
+    ParentRange(const ASTNode* from_, const ASTNode* to_)
+        : from(from_), to(to_)
+    {
+    }
+
+    const ASTNode* begin() const { return from; }
+    const ASTNode* end() const { return to; }
+    size_t size() const { return to - from; }
+  };
+
+  ParentRange getDependents(const ASTNode& n) const
   {
-    if (n.isConstant())
-      return &empty;
-    const auto it = dependents.find(n.GetNodeNum());
-    if (it == dependents.end())
-      return &empty;
-
-    return it->second;
+    if (!n.isConstant())
+    {
+      const auto it = index.find(n.GetNodeNum());
+      if (it != index.end())
+      {
+        const uint32_t i = it->second;
+        return ParentRange(parents.data() + offsets[i],
+                           parents.data() + offsets[i + 1]);
+      }
+    }
+    return ParentRange(nullptr, nullptr);
   }
 
   // The higher node depends on the lower node.
   // The value produces by the lower node is read by the higher node.
   bool nodeDependsOn(const ASTNode& higher, const ASTNode& lower) const
   {
-    return getDependents(lower)->count(higher) > 0;
+    for (const ASTNode& p : getDependents(lower))
+      if (p == higher)
+        return true;
+    return false;
   }
 };
 }

--- a/lib/Simplifier/constantBitP/ConstantBitPropagation.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitPropagation.cpp
@@ -446,7 +446,7 @@ void notHandled(const Kind& k)
 // add to the work list any nodes that take the result of the "n" node.
 void ConstantBitPropagation::scheduleUp(const ASTNode& n)
 {
-  for (const auto &it : *dependents->getDependents(n))
+  for (const auto &it : dependents->getDependents(n))
     workList->push(it);
 }
 
@@ -580,7 +580,7 @@ void ConstantBitPropagation::propagate()
           // rescheduled - except 'n' itself: the transfer function that
           // just ran left 'n' at its fixed point for exactly these child
           // values, so an immediate revisit derives nothing.
-          for (const auto& parent : *dependents->getDependents(n[i]))
+          for (const auto& parent : dependents->getDependents(n[i]))
             if (!(parent == n))
               workList->push(parent);
 


### PR DESCRIPTION
## What

`Dependencies` (the child-to-parents map that constant bit propagation uses to schedule upward propagation) kept one heap-allocated hash set of parent nodes per DAG node, built with a hash insert per edge and deleted entry by entry — and CBP rebuilds the whole structure three times per solve. Its only two consumers just iterate a node's parents, so the set machinery bought nothing.

This replaces the per-node sets with a flat CSR-style adjacency: a dense node-id→index map (which doubles as the DFS visited set), an offsets array, and a single flat array holding every parent list back to back. One DFS emits (child, parent) pairs and a stable counting sort packs them, so each parent list keeps exactly the order the old insertion-ordered sets iterated in — which is what keeps the emitted CNF byte-identical. Duplicate edges from a node repeating a child (e.g. `BVPLUS(x,x)`) are deduped during the walk, linearly for small arities and through a scratch set for wide nodes.

One deliberate layout choice: the flat array stores the parent `ASTNode`s themselves, not their dense indices. A first version stored `uint32` indices and regressed iteration-heavy instances by double-digit percentages despite a lower instruction count — the old dense sets already held the parents contiguously, and the index adds one indirection per element on the hot `scheduleUp` walk. Keeping the payload inline preserves that locality while still collapsing millions of per-node allocations into two arrays.

## Measurements

Constant Bit Propagation is currently the largest word-level stage on the slowest QF_BV pre-SAT instances. Interleaved wall-clock A/B against master, Release build, three rounds with alternating arm order, medians of the CBP stage timer:

| Instance (QF_BV) | CBP stage | Total (to CNF) |
|---|---|---|
| asp/Labyrinth/laby_22_22_17.lp | 10.08s → 9.32s (−7.6%) | 41.83s → 41.43s |
| asp/DisjunctiveScheduling/disjunctiveScheduling.in9 | 8.98s → 8.49s (−5.5%) | 25.95s → 25.34s |
| 20210312-Bouvier/vlsat3_a97 | 12.64s → 12.04s (−4.7%) | 35.25s → 34.29s |
| brummayerbiere2/smulov4bw1024 (control, ~40ms CBP) | flat | flat |

Retired-instruction counts also drop on all three (−0.2% to −1.4% whole-run).

## Validation

- CNF output byte-identical to master over a 40-file corpus of hard pre-SAT instances (39 identical, 1 skip where the baseline emits no CNF).
- ctest 70/70 in a Debug + assertions build, including the lit query-file suite.
- `nodeDependsOn` had no callers; it is kept but reimplemented as a scan over the parent slice.
