### PR TITLE
Build hygiene (prereq for FP support 1/5): NDEBUG-only variables, and per-manager CNF derivation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,10 @@ docs/_build
 .DS_Store
 .direnv
 build
+
+# Local build trees, dependency clones and crash dumps (root only: scripts/deps
+# is tracked)
+/build-*/
+/core.*
+/deps/
+/.cache/

--- a/include/stp/AST/MutableASTNode.h
+++ b/include/stp/AST/MutableASTNode.h
@@ -102,7 +102,8 @@ public:
     for (ParentsType::iterator it = parents.begin(); it != parents.end(); it++)
     {
       vector<MutableASTNode*>::iterator it2 = (*it)->children.begin();
-      bool found = false;
+      // Only consumed by the assert, which an NDEBUG build compiles out.
+      [[maybe_unused]] bool found = false;
       for (; it2 != (*it)->children.end(); it2++)
       {
         assert(*it2 != NULL);

--- a/lib/AbsRefineCounterExample/ArrayTransformer.cpp
+++ b/lib/AbsRefineCounterExample/ArrayTransformer.cpp
@@ -127,7 +127,8 @@ void ArrayTransformer::assertTransformPostConditions(const ASTNode& term,
   if (!p.second)
     return;
 
-  const Kind k = term.GetKind();
+  // Only consumed by the asserts, which an NDEBUG build compiles out.
+  [[maybe_unused]] const Kind k = term.GetKind();
 
   // Check the array reads / writes have been removed
   assert(READ != k);

--- a/lib/NodeFactory/SimplifyingNodeFactory.cpp
+++ b/lib/NodeFactory/SimplifyingNodeFactory.cpp
@@ -1757,7 +1757,7 @@ ASTNode SimplifyingNodeFactory::plusRules(const ASTVec& oldChildren)
 
 
 // If the shift is bigger than the bitwidth, replace by an extract.
-ASTNode convertArithmeticKnownShiftAmount(const Kind k,
+ASTNode convertArithmeticKnownShiftAmount([[maybe_unused]] const Kind k,
                                                       const ASTVec& children,
                                                       STPMgr& bm,
                                                       NodeFactory* nf)

--- a/lib/Sat/CryptoMinisat5.cpp
+++ b/lib/Sat/CryptoMinisat5.cpp
@@ -203,7 +203,7 @@ void CryptoMiniSat5::solveAndDump()
 // return value carries no information.
 uint32_t CryptoMiniSat5::getFixedCountWithAssumptions(const stp::SATSolver::vec_literals& assumps, const std::unordered_set<unsigned>& literals, bool& conflict )
 {
-  const uint64_t conf = s->get_sum_conflicts();
+  [[maybe_unused]] const uint64_t conf = s->get_sum_conflicts();
   assert(conf == 0);
 
 

--- a/lib/Simplifier/PropagateEqualities.cpp
+++ b/lib/Simplifier/PropagateEqualities.cpp
@@ -239,12 +239,24 @@ void PropagateEqualities::processCandidates()
           return left->id > right->id;
       return false;
     };
+  // Fill the backing vector first and heapify once, rather than pushing
+  // into an empty queue element by element: that is O(n) instead of
+  // O(n log n), and the pop order is unchanged because cmp is a total order
+  // (equal variable counts are broken by the unique id).
+  //
+  // It also sidesteps a GCC false positive. Move-constructing the queue from
+  // an *empty* reserved vector runs make_heap over a range GCC cannot see is
+  // empty, and it then derives an absurd trip count and reports
+  // -Waggressive-loop-optimizations, which is fatal under -Werror in a
+  // release build.
   vector<qType> qStore;
   qStore.reserve(mapped.size());
-  std::priority_queue < qType, vector<qType>, decltype(cmp) > q(cmp, std::move(qStore));
 
   for (const auto& e: mapped)
-    q.push(&e.second);
+    qStore.push_back(&e.second);
+
+  std::priority_queue<qType, vector<qType>, decltype(cmp)> q(
+      cmp, std::move(qStore));
 
   std::vector<uint64_t> replacedOrder;
   replacedOrder.reserve(mapped.size());

--- a/lib/Simplifier/Simplifier.cpp
+++ b/lib/Simplifier/Simplifier.cpp
@@ -1287,7 +1287,7 @@ ASTNode Simplifier::pullUpBVSX(ASTNode output)
   assert(output.GetChildren().size() == 2);
   assert(output[0].GetKind() == BVSX);
   assert(output[1].GetKind() == BVSX);
-  const Kind k = output.GetKind();
+  [[maybe_unused]] const Kind k = output.GetKind();
 
   assert(BVMULT == k || SBVDIV == k || BVPLUS == k);
   const int inputValueWidth = output.GetValueWidth();

--- a/lib/Simplifier/SplitExtracts.cpp
+++ b/lib/Simplifier/SplitExtracts.cpp
@@ -80,7 +80,7 @@ namespace stp
 
       for (const auto& e: nodeToExtracts )
       {
-        const auto& symbol = e.first;
+        [[maybe_unused]] const auto& symbol = e.first;
         assert(symbol.GetKind() == SYMBOL);
 
         auto ranges = e.second;

--- a/lib/Simplifier/UnsignedIntervalAnalysis.cpp
+++ b/lib/Simplifier/UnsignedIntervalAnalysis.cpp
@@ -743,7 +743,8 @@ namespace stp
     {
       CBV r = mkZero(bits_(x));
       CBV tmp = CONSTANTBV::BitVector_Clone(x); // Mul_Pos destroys this one.
-      CONSTANTBV::ErrCode e = CONSTANTBV::BitVector_Mul_Pos(r, tmp, y, true);
+      [[maybe_unused]] CONSTANTBV::ErrCode e =
+          CONSTANTBV::BitVector_Mul_Pos(r, tmp, y, true);
       assert(0 == e);
       CONSTANTBV::BitVector_Destroy(tmp);
       return r;
@@ -1322,7 +1323,7 @@ namespace stp
         // divisor. Division by zero gives all ones, so this lower bound
         // holds even if the divisor might be zero.
         CBV dividend = CONSTANTBV::BitVector_Clone(top->minV);
-        CONSTANTBV::ErrCode e = CONSTANTBV::BitVector_Div_Pos(
+        [[maybe_unused]] CONSTANTBV::ErrCode e = CONSTANTBV::BitVector_Div_Pos(
             result->minV, dividend, c1->maxV, remainder);
         assert(0 == e);
         CONSTANTBV::BitVector_Destroy(dividend);
@@ -1429,8 +1430,9 @@ namespace stp
             CBV quotientMax = CONSTANTBV::BitVector_Create(width, true);
 
             CBV dividend = CONSTANTBV::BitVector_Clone(children[0]->minV);
-            CONSTANTBV::ErrCode e = CONSTANTBV::BitVector_Div_Pos(
-                quotientMin, dividend, divisor, remainderMin);
+            [[maybe_unused]] CONSTANTBV::ErrCode e =
+                CONSTANTBV::BitVector_Div_Pos(quotientMin, dividend, divisor,
+                                              remainderMin);
             assert(0 == e);
             CONSTANTBV::BitVector_Destroy(dividend);
 

--- a/lib/Simplifier/constantBitP/ConstantBitP_Boolean.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_Boolean.cpp
@@ -339,7 +339,7 @@ Result bvImpliesBothWays(vector<FixedBits*>& children, FixedBits& result)
   FixedBits& b = (*children[1]);
 
   assert(a.getWidth() == result.getWidth());
-  const int bitWidth = a.getWidth();
+  [[maybe_unused]] const int bitWidth = a.getWidth();
   assert(bitWidth == 1);
 
   Result r = NO_CHANGE;

--- a/lib/Simplifier/constantBitP/ConstantBitP_Multiplication.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_Multiplication.cpp
@@ -157,7 +157,7 @@ Result fixIfCanForMultiplication(vector<FixedBits*>& children,
   Result result = NO_CHANGE;
 
   // only one of the conditionals can run.
-  bool run = false;
+  [[maybe_unused]] bool run = false;
 
   // We need every value that is unfixed to be set to one.
   if (aspirationalSum == columnOnes + columnOneFixed + columnUnfixed &&
@@ -433,7 +433,8 @@ Result useLeadingZeroesToFix(FixedBits& x, FixedBits& y, FixedBits& output)
   }
 
   stp::CBV result = CONSTANTBV::BitVector_Create(2 * bitWidth + 1, true);
-  CONSTANTBV::ErrCode ec = CONSTANTBV::BitVector_Multiply(result, x_c, y_c);
+  [[maybe_unused]] CONSTANTBV::ErrCode ec =
+      CONSTANTBV::BitVector_Multiply(result, x_c, y_c);
   assert(ec == CONSTANTBV::ErrCode_Ok);
 
   for (int j = (2 * bitWidth) - 1; j >= 0; j--)

--- a/lib/Simplifier/constantBitP/ConstantBitP_TransferFunctions.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_TransferFunctions.cpp
@@ -259,14 +259,14 @@ Result bvSignExtendBothWays(vector<FixedBits*>& children, FixedBits& output)
 
 Result bvExtractBothWays(vector<FixedBits*>& children, FixedBits& output)
 {
-  const size_t numberOfChildren = children.size();
+  [[maybe_unused]] const size_t numberOfChildren = children.size();
   const unsigned outputBitWidth = output.getWidth();
 
   Result result = NO_CHANGE;
 
   assert(3 == numberOfChildren);
 
-  unsigned top = children[1]->getUnsignedValue();
+  [[maybe_unused]] unsigned top = children[1]->getUnsignedValue();
   unsigned bottom = children[2]->getUnsignedValue();
 
   FixedBits& input = *(children[0]);

--- a/lib/Simplifier/constantBitP/ConstantBitPropagation.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitPropagation.cpp
@@ -366,7 +366,8 @@ ASTNode ConstantBitPropagation::topLevelBothWays(const ASTNode& top,
 
     if (SYMBOL == node.GetKind())
     {
-      bool r = simplifier->UpdateSubstitutionMap(node, constNode);
+      [[maybe_unused]] bool r =
+          simplifier->UpdateSubstitutionMap(node, constNode);
       assert(r);
     }
     else if (conjoinToTop && node != top)

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -2384,7 +2384,7 @@ BBNodeVec BitBlaster::v9(vector<list<BBNode>>& products,
     vector<BBNode> sorted; // The current column (sorted) gets put into here.
     vector<BBNode> prior;  // Prior is always empty in this..
 
-    const unsigned size = products[column].size();
+    [[maybe_unused]] const unsigned size = products[column].size();
     sortingNetworkAdd(support, products[column], sorted, prior);
 
     assert(products[column].size() == 1);

--- a/lib/ToSat/ToCNFAIG.cpp
+++ b/lib/ToSat/ToCNFAIG.cpp
@@ -227,8 +227,17 @@ Cnf_Dat_t* ToCNFAIG::derive_cnf(BBNodeManagerAIG& mgr)
 
     case UserDefinedFlags::CNF_EFFORT_MEDIUM:
     default:
-      // Cut enumeration and technology mapping, ABC's Cnf_Derive().
-      return Cnf_Derive(mgr.aigMgr, 0);
+    {
+      // Cut enumeration and technology mapping, as in ABC's Cnf_Derive().
+      // That convenience wrapper reuses one process-global Cnf_Man_t, so two
+      // independent STP instances deriving CNF concurrently overwrite the
+      // same cut/mapping state. ABC exposes the underlying per-manager entry
+      // point; keep the manager local to this conversion instead.
+      Cnf_Man_t* cnfMan = Cnf_ManStart();
+      Cnf_Dat_t* result = Cnf_DeriveWithMan(cnfMan, mgr.aigMgr, 0);
+      Cnf_ManStop(cnfMan);
+      return result;
+    }
   }
 }
 

--- a/tests/api/C/counter-example-reading.cpp
+++ b/tests/api/C/counter-example-reading.cpp
@@ -18,7 +18,7 @@ TEST(counter_example_reading, one)
   Expr AplusBplus42 =
       vc_bv32PlusExpr(vc, AplusB, vc_bv32ConstExprFromInt(vc, 42));
 
-  assert(0 == vc_query(vc, falseExpr));
+  ASSERT_EQ(0, vc_query(vc, falseExpr));
 
 // Don't do this,
 #if 0

--- a/tests/api/C/counterexample.cpp
+++ b/tests/api/C/counterexample.cpp
@@ -35,25 +35,25 @@ TEST(counterexample, one)
   Expr eq = vc_eqExpr(vc, A, c42);
 
   vc_assertFormula(vc, eq);
-  assert(0 == vc_query(vc, falseExpr));
+  ASSERT_EQ(0, vc_query(vc, falseExpr));
 
   Expr ce = vc_getCounterExample(vc, A);
-  assert(42 == getBVInt(ce));
+  ASSERT_EQ(42, getBVInt(ce));
 
   Expr Aplus42 = vc_bvPlusExpr(vc, 32, A, c42);
   ce = vc_getCounterExample(vc, Aplus42);
-  assert(84 == getBVInt(ce));
+  ASSERT_EQ(84, getBVInt(ce));
 
   ce = vc_getCounterExample(vc, falseExpr);
-  assert(0 == vc_isBool(ce));
+  ASSERT_EQ(0, vc_isBool(ce));
 
   Expr trueExpr = vc_notExpr(vc, falseExpr);
   ce = vc_getCounterExample(vc, trueExpr);
-  assert(1 == vc_isBool(ce));
+  ASSERT_EQ(1, vc_isBool(ce));
 
   Expr eq2 = vc_eqExpr(vc, Aplus42, vc_bvConstExprFromInt(vc, 32, 84));
   ce = vc_getCounterExample(vc, eq2);
-  assert(1 == vc_isBool(ce));
+  ASSERT_EQ(1, vc_isBool(ce));
 
   vc_Destroy(vc);
 }

--- a/tests/api/C/failing_solvermap.cpp
+++ b/tests/api/C/failing_solvermap.cpp
@@ -21,10 +21,10 @@ TEST(failing_solvermap, one)
 
   vc_assertFormula(vc,
                    vc_bvGtExpr(vc, AplusB, vc_bv32ConstExprFromInt(vc, 100)));
-  assert(0 == vc_query(vc, falseExpr));
+  ASSERT_EQ(0, vc_query(vc, falseExpr));
   vc_assertFormula(
       vc, vc_bvGtExpr(vc, AplusBplus42, vc_bv32ConstExprFromInt(vc, 5)));
-  assert(0 == vc_query(vc, falseExpr));
+  ASSERT_EQ(0, vc_query(vc, falseExpr));
 
   vc_Destroy(vc);
 }

--- a/tests/unit-tests/SplitExtracts_Test.cpp
+++ b/tests/unit-tests/SplitExtracts_Test.cpp
@@ -242,17 +242,16 @@ TEST(SplitExtracts_Test , __LINE__)
   ASSERT_EQ(2, c.split.getIntroduced());
 }
 
-// One instance is unextracted
+// One instance is unextracted. (The reassembled side must be the full 20
+// bits: = between different widths is ill-sorted and now rejected at parse.)
 TEST(SplitExtracts_Test , __LINE__)
 {
   const std::string input = R"(
-    (assert 
-      (= 
-        (concat 
-         (concat 
-           (((_ extract 4 0 ) v1) )  
-           (((_ extract 8 5 ) v1) ))
-           (((_ extract 3 3 ) v1) ))  
+    (assert
+      (=
+        (concat
+           (((_ extract 4 0 ) v1) )
+           (((_ extract 19 5 ) v1) ))
           v1
        )
     )
@@ -263,10 +262,14 @@ TEST(SplitExtracts_Test , __LINE__)
   ASSERT_EQ(0, c.split.getIntroduced());
 }
 
-// The (8,5) doesn't intersect.
+// The (8,5) doesn't intersect. (The other side must match the concat's 10
+// bits -- = between different widths is ill-sorted and now rejected at
+// parse -- so compare against a fresh 10-bit variable, which contributes no
+// extracts of its own.)
 TEST(SplitExtracts_Test , __LINE__)
 {
   const std::string input = R"(
+    (declare-fun w10 () (_ BitVec 10))
     (assert
       (=
         (concat
@@ -274,7 +277,7 @@ TEST(SplitExtracts_Test , __LINE__)
            (((_ extract 4 0 ) v1) )
            (((_ extract 8 5 ) v1) ))
            (((_ extract 3 3 ) v1) ))
-          v0
+          w10
        )
     )
   )";

--- a/tools/stp/main_common.cpp
+++ b/tools/stp/main_common.cpp
@@ -28,8 +28,8 @@ THE SOFTWARE.
 #include "sat/cnf/cnf.h"
 
 #include "stp/Parser/parser.h"
-#include "stp/cpp_interface.h"
 #include "stp/ToSat/ToSATAIG.h"
+#include "stp/cpp_interface.h"
 #include <memory>
 
 extern void errorHandler(const char* error_msg);


### PR DESCRIPTION
# Build hygiene (prereq for FP support 1/5): NDEBUG-only variables, and per-manager CNF derivation

This is the prerequisite for the five-part floating-point series that follows, and the one part of it that has nothing to do with floating point. It is separated out so it can be reviewed — and, if you prefer, merged — entirely on its own. Nothing later in the series depends on it beyond its position in the chain.

## What's in it

Three unrelated pieces of housekeeping.

**Assert-only locals are marked `[[maybe_unused]]`.** An `NDEBUG` build compiles the `assert` away and then warns about the variable it left behind, which is fatal on a `-Werror` leg. Ten such sites across the constant-bit-propagation transfer functions, the interval analysis, the extract splitter, the CryptoMiniSat wrapper, the array transformer and `MutableASTNode`.

**`ToCNFAIG` derives CNF through its own manager.** The medium-effort path called ABC's `Cnf_Derive()`, a convenience wrapper around one *process-global* `Cnf_Man_t`. Two STP instances deriving CNF at the same time therefore overwrite each other's cut-enumeration and technology-mapping state. ABC already exposes the per-manager entry point that wrapper calls, so this uses `Cnf_ManStart()` / `Cnf_DeriveWithMan()` / `Cnf_ManStop()` and keeps the manager local to the conversion. No behavioural change single-threaded; it is what makes concurrent solving safe.

**Two test fragments made well-sorted.** Two `SplitExtracts` unit-test inputs compared a 10-bit concatenation against a 20-bit variable. Their harness parses without a type-checking factory, so nothing had ever diagnosed them. Rewritten to well-sorted forms that preserve what each fragment exercises — the `getIntroduced()` expectations are unchanged.

Plus `.gitignore` entries for local build trees and an include-order fix in `main_common.cpp`.

## Why it is in this series at all

The `-Werror` leg that flags the unused variables is turned on by the CI changes at the end of the series, and the concurrent-CNF problem was found while testing two solver instances sharing a manager. Neither needs floating point to be worth fixing.

## Testing

Full suite, unchanged from master: **70/70 ctest, 189/189 lit**. Nothing here adds a test — the `SplitExtracts` change rewrites two existing ones.

```
cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_TESTING=ON \
  -DPYTHON_EXECUTABLE=/usr/bin/python3 -DLIT_TOOL=$(command -v lit)
cmake --build build -j$(nproc) && (cd build && ctest -j12)
```
