### PR TITLE
FP support (1/5): AST: an immutable source sort, and the floating-point node types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,10 @@ docs/_build
 .DS_Store
 .direnv
 build
+
+# Local build trees, dependency clones and crash dumps (root only: scripts/deps
+# is tracked)
+/build-*/
+/core.*
+/deps/
+/.cache/

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "lib/extlib-mimalloc"]
 	path = lib/extlib-mimalloc
 	url = https://github.com/microsoft/mimalloc.git
+[submodule "lib/extlib-symfpu/symfpu"]
+	path = lib/extlib-symfpu/symfpu
+	url = https://github.com/martin-cs/symfpu.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -845,6 +845,51 @@ endif()
 find_package(Perl REQUIRED)
 
 # -----------------------------------------------------------------------------
+# Floating-point support (opt-out; uses the header-only SymFPU library)
+# -----------------------------------------------------------------------------
+# SymFPU (BSD 3-Clause) is vendored as a pinned submodule, the same
+# arrangement as mimalloc above, so the default build has floating-point
+# support with nothing to install. When OFF, everything floating-point
+# stays out of the build except the always-compiled AST/parser/API surface,
+# which recognises floating-point input and rejects it with a "built
+# without floating-point support" error (see FloatBlaster.cpp's stubs and
+# checkFpSupported in smt2.y). The public headers and the libstp ABI are
+# identical either way.
+
+option(ENABLE_FLOATING_POINT
+       "SMT-LIB floating-point support (uses the vendored SymFPU library)" ON)
+add_feature_info(FloatingPoint ENABLE_FLOATING_POINT
+                 "Enables SMT-LIB floating-point support (via SymFPU)")
+
+if (ENABLE_FLOATING_POINT)
+    # The vendored submodule is the default; -DSYMFPU_INCLUDE_DIRS=<dir
+    # that CONTAINS a symfpu clone> overrides it with an external copy.
+    if (NOT SYMFPU_INCLUDE_DIRS)
+        set(SYMFPU_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/lib/extlib-symfpu")
+    endif()
+
+    find_package(SymFPU)
+
+    if (SymFPU_FOUND)
+        message(STATUS "OK, found SymFPU include dirs under ${SYMFPU_INCLUDE_DIRS}")
+    else()
+        message(FATAL_ERROR
+            "SymFPU (header-only, required for the floating-point support) "
+            "was not found. It is vendored as a submodule: run "
+            "git submodule update --init lib/extlib-symfpu/symfpu. An "
+            "external clone of https://github.com/martin-cs/symfpu works "
+            "too, via -DSYMFPU_INCLUDE_DIRS=<directory that CONTAINS the "
+            "symfpu clone>. To build without floating-point support, "
+            "configure with -DENABLE_FLOATING_POINT=OFF.")
+    endif()
+
+    # Let's get clean builds ...
+    include_directories(SYSTEM ${SYMFPU_INCLUDE_DIRS})
+
+    add_definitions(-DSTP_ENABLE_FLOATING_POINT)
+endif()
+
+# -----------------------------------------------------------------------------
 # Query definitions
 # -----------------------------------------------------------------------------
 get_directory_property( DirDefs DIRECTORY ${CMAKE_SOURCE_DIR} COMPILE_DEFINITIONS )

--- a/LICENSE_COMPONENTS
+++ b/LICENSE_COMPONENTS
@@ -4,6 +4,8 @@ STP imports code from the following libraries:
 		of Leland Stanford Junior University and by New York University.
 	* ABC Copyright (c) The Regents of the University of California.
 	* mimalloc Copyright (c) 2018-2025 Microsoft Corporation, Daan Leijen.
+	* SymFPU copyright (C) by the authors from 2018 (only compiled in when
+		floating-point support is enabled).
 	* ankerl::unordered_dense Copyright (c) 2022-2024 Martin Leitner-Ankerl.
 	* Mersenne Twister Copyright (C) 1997 - 2002 Makoto Matsumoto and Takuji
 		Nishimura, Copyright (C) 2000 - 2003 Richard J. Wagner.
@@ -107,6 +109,40 @@ mimalloc
 	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 	SOFTWARE.
+
+SymFPU
+	SymFPU is available under a choice of two licenses, GPL V3 or BSD
+	3-Clause; STP uses it under the BSD 3-Clause license, reproduced here.
+
+	SymFPU is copyright (C) by the authors from 2018
+
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are
+	met:
+
+	    (1) Redistributions of source code must retain the above copyright
+	        notice, this list of conditions and the following disclaimer.
+
+	    (2) Redistributions in binary form must reproduce the above copyright
+	        notice, this list of conditions and the following disclaimer in
+	        the documentation and/or other materials provided with the
+	        distribution.
+
+	    (3) The name of the author may not be used to
+	        endorse or promote products derived from this software without
+	        specific prior written permission.
+
+	THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+	IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+	WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+	DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
+	INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+	(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+	SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+	HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+	STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+	IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 
 ankerl::unordered_dense
 	Licensed under the MIT License <http://opensource.org/licenses/MIT>.

--- a/cmake/modules/FindSymFPU.cmake
+++ b/cmake/modules/FindSymFPU.cmake
@@ -1,0 +1,42 @@
+# AUTHORS: Andrew Teylu
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+# - Try to find SymFPU
+# Once done this will define
+#  SYMFPU_FOUND - System has SymFPU
+#  SYMFPU_INCLUDE_DIRS - The SymFPU include directories
+#  SYMFPU_DEFINITIONS - Compiler switches required for using SymFPU
+
+set(SYMFPU_DEFINITIONS "")
+
+# The header is found as <hint>/symfpu/core/unpackedFloat.h, so the hint in
+# SYMFPU_INCLUDE_DIRS must be the directory CONTAINING the symfpu clone, not
+# the clone itself.
+find_path(SYMFPU_INCLUDE_DIR symfpu/core/unpackedFloat.h
+          HINTS ${SYMFPU_INCLUDE_DIRS})
+
+set(SYMFPU_INCLUDE_DIRS ${SYMFPU_INCLUDE_DIR})
+
+include(FindPackageHandleStandardArgs)
+# handle the QUIETLY and REQUIRED arguments and set SYMFPU_FOUND to TRUE
+# if all listed variables are set
+find_package_handle_standard_args(SymFPU DEFAULT_MSG SYMFPU_INCLUDE_DIR)
+mark_as_advanced(SYMFPU_INCLUDE_DIR)
+

--- a/include/stp/AST/AST.h
+++ b/include/stp/AST/AST.h
@@ -63,10 +63,51 @@ struct ArithLess
     return arithless(n1, n2);
   }
 };
-bool isAtomic(Kind k);
 bool isCommutative(const Kind k);
 bool containsArrayOps(const ASTNode& n, STPMgr* stp);
+// Query-local source-theory checks. The first asks whether FP lowering is
+// needed; the second also includes RoundingMode-only syntax for printing.
+bool containsFloatingPoint(const ASTNode& n, STPMgr* stp);
+bool containsFloatingPointTheory(const ASTNode& n, STPMgr* stp);
 bool numberOfReadsLessThan(const ASTNode& n, int v);
+
+// Whether two constants spell the same bits. Node identity understates
+// this: a floating-point constant interns apart from the plain bitvector
+// constant with its bits (the format is part of a constant's identity),
+// so two distinct constant nodes may denote one bitvector value. Any
+// rule that concludes "different value" from "different constant nodes"
+// must compare through here instead.
+bool constantsSameBits(const ASTNode& a, const ASTNode& b);
+
+// Whether two constants are known to denote *different* values.
+//
+// This is the unsound direction, and the reason it has a name of its own:
+// `a != b` answers it correctly for plain bitvector constants and wrongly
+// for a floating-point or rounding-mode constant that shares its bits with
+// one, and the two spellings look alike at a glance. Every rule that skips
+// a write, proves two array indexes address different cells, or otherwise
+// concludes "different value" must ask through here, so that the sites which
+// depend on the distinction can be found by looking for this name.
+inline bool constantsDenoteDifferentValues(const ASTNode& a, const ASTNode& b)
+{
+  return !constantsSameBits(a, b);
+}
+
+// Whether `n` denotes bits to the bit-vector layers, which is not the same
+// question as GetType() == BITVECTOR_TYPE.
+//
+// FloatBlast removes every floating-point *operation* but deliberately leaves
+// float symbols, constants and the structural nodes over them as their packed
+// bits, still reporting FLOATINGPOINT_TYPE so that model reconstruction can
+// recover the sort. So a lowered formula handed to the bit-vector layers
+// contains float-typed leaves that are, at that boundary, ordinary bitvectors.
+//
+// Every bit-vector-only pass that classifies a node by GetType() needs this
+// question rather than the raw comparison, and it must be asked in one place:
+// spelling it out per call site is what left BitBlaster::simplify_during_bb
+// behind when the invariant was introduced, so that --bb.simplify-during-bb
+// aborted on any query with a float leaf in it.
+bool isBitsValued(const ASTNode& n);
 
 // If (a > b) in the termorder, then return 1 elseif (a < b) in the
 // termorder, then return -1 else return 0

--- a/include/stp/AST/ASTBVConst.h
+++ b/include/stp/AST/ASTBVConst.h
@@ -36,6 +36,8 @@ class ASTBVConst : public ASTInternal
 {
   friend class STPMgr;
   friend class ASTNode;
+  friend class ASTFPConst;
+  friend class ASTRMConst;
   friend class ASTNodeHasher;
   friend class ASTNodeEqual;
 
@@ -79,30 +81,44 @@ private:
   // friend equality operator
   friend bool operator==(const ASTBVConst& bvc1, const ASTBVConst& bvc2)
   {
-    if (bvc1.getValueWidth() != bvc2.getValueWidth())
+    if (bvc1.getDeclaredSourceSort() != bvc2.getDeclaredSourceSort())
       return false;
     return (0 == CONSTANTBV::BitVector_Compare(bvc1._bvconst, bvc2._bvconst));
   }
 
   // Call this when deleting a node that has been stored in the the
   // unique table
-  virtual void CleanUp();
+  void CleanUp() override;
 
   // Print function for bvconst -- return _bvconst value in bin
   // format (c_friendly is for printing hex. numbers that C
   // compilers will accept)
-  virtual void nodeprint(ostream& os, bool c_friendly = false);
+  void nodeprint(ostream& os, bool c_friendly = false) override;
 
   const static ASTVec astbv_empty_children;
 
-  void setIndexWidth( [[maybe_unused]] uint32_t i ) { assert(i == 0); }
-  uint32_t getIndexWidth() const { return 0; }
+  void setIndexWidth([[maybe_unused]] uint32_t i) override { assert(i == 0); }
+  uint32_t getIndexWidth() const override { return 0; }
 
-  void setValueWidth([[maybe_unused]] uint32_t v ) { assert(v == getValueWidth()); }
-  uint32_t getValueWidth() const { return bits_(_bvconst); }
+  void setValueWidth([[maybe_unused]] uint32_t v) override
+  {
+    assert(v == getValueWidth());
+  }
+  uint32_t getValueWidth() const override { return bits_(_bvconst); }
+
+  void setExpWidth(uint32_t) override { assert(false); }
+  uint32_t getExpWidth() const override { return 0; }
+
+  void setSigWidth(uint32_t) override { assert(false); }
+  uint32_t getSigWidth() const override { return 0; }
+
+  SourceSort getDeclaredSourceSort() const override
+  {
+    return SourceSort::bitVector(getValueWidth());
+  }
 
 public:
-  virtual ASTChildren GetChildren() const { return astbv_empty_children; }
+  ASTChildren GetChildren() const override { return astbv_empty_children; }
 
   virtual ~ASTBVConst()
   {
@@ -121,14 +137,15 @@ public:
 inline size_t
 ASTBVConst::ASTBVConstHasher::operator()(const ASTBVConst* bvc) const
 {
-  return CONSTANTBV::BitVector_Hash(bvc->_bvconst);
+  return CONSTANTBV::BitVector_Hash(bvc->_bvconst) ^
+         (bvc->getDeclaredSourceSort().hash() * 0x9e3779b97f4a7c15ULL);
 }
 
 inline bool
 ASTBVConst::ASTBVConstEqual::operator()(const ASTBVConst* bvc1,
                                         const ASTBVConst* bvc2) const
 {
-  if (bvc1->getValueWidth() != bvc2->getValueWidth())
+  if (bvc1->getDeclaredSourceSort() != bvc2->getDeclaredSourceSort())
   {
     return false;
   }

--- a/include/stp/AST/ASTFPConst.h
+++ b/include/stp/AST/ASTFPConst.h
@@ -1,0 +1,77 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: January 2021
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#ifndef ASTFPCONST_H
+#define ASTFPCONST_H
+
+#include "ASTBVConst.h"
+
+namespace stp
+{
+class STPMgr;
+
+// A bitvector constant that additionally carries a floating-point format.
+// Interned in the same unique table as plain bitvector constants: the
+// table's equality functor compares the format widths as well as the bits,
+// so 1.0f can never unify with the plain 32-bit pattern 0x3F800000, nor
+// with the same bits read at a different format.
+class ASTFPConst : public ASTBVConst
+{
+  friend class STPMgr;
+
+  uint32_t _sig_width;
+  uint32_t _exp_width;
+
+  // The format is part of the node's identity in the unique table, so it is
+  // fixed at construction. The setters only accept the stored value, in the
+  // style of ASTBVConst::setValueWidth.
+  void setSigWidth([[maybe_unused]] uint32_t sw) override
+  {
+    assert(sw == _sig_width);
+  }
+  uint32_t getSigWidth() const override { return _sig_width; }
+
+  void setExpWidth([[maybe_unused]] uint32_t ew) override
+  {
+    assert(ew == _exp_width);
+  }
+  uint32_t getExpWidth() const override { return _exp_width; }
+
+  SourceSort getDeclaredSourceSort() const override
+  {
+    return SourceSort::floatingPoint(_exp_width, _sig_width);
+  }
+
+  // Temporary-key constructor: shares `bv` without cloning or freeing it.
+  ASTFPConst(STPMgr* mgr, CBV bv, uint32_t exp_width, uint32_t sig_width);
+
+  // Copying constructor, used when interning a temporary key: clones the CBV.
+  ASTFPConst(const ASTFPConst& other);
+
+public:
+  virtual ~ASTFPConst() {}
+};
+
+} // namespace stp
+#endif

--- a/include/stp/AST/ASTInterior.h
+++ b/include/stp/AST/ASTInterior.h
@@ -98,16 +98,70 @@ class ASTInterior : public ASTInternal
   uint32_t _value_width;
   uint32_t _index_width;
 
-  virtual void setIndexWidth(uint32_t i) { _index_width = i; }
+  uint32_t _sig_width;
+  uint32_t _exp_width;
+
+  // Derived, and memoised on first request; see ASTInternal::cachedSourceSort.
+  // Points into the manager's intern pool, so it neither owns nor allocates.
+  //
+  // A width setter drops it, because the derivation reads the widths and
+  // legacy callers still set them after the node is built -- but only when the
+  // width actually changes. The node factories re-assert a node's widths on
+  // every hash-cons *hit* (HashingNodeFactory::CreateTerm), so invalidating
+  // unconditionally would throw the memo away on each of the DAG's incoming
+  // edges and leave the recomputation exactly as it was.
+  mutable const SourceSort* _source_sort_cache;
+
+  virtual void setIndexWidth(uint32_t i)
+  {
+    if (_index_width == i)
+      return;
+    _index_width = i;
+    _source_sort_cache = NULL;
+  }
   virtual uint32_t getIndexWidth() const { return _index_width; }
 
-  virtual void setValueWidth(uint32_t v) { _value_width = v; }
+  virtual void setValueWidth(uint32_t v)
+  {
+    if (_value_width == v)
+      return;
+    _value_width = v;
+    _source_sort_cache = NULL;
+  }
   virtual uint32_t getValueWidth() const { return _value_width; }
+
+  virtual void setSigWidth(uint32_t sw)
+  {
+    if (_sig_width == sw)
+      return;
+    _sig_width = sw;
+    _source_sort_cache = NULL;
+  }
+  virtual uint32_t getSigWidth() const { return _sig_width; }
+
+  virtual void setExpWidth(uint32_t ew)
+  {
+    if (_exp_width == ew)
+      return;
+    _exp_width = ew;
+    _source_sort_cache = NULL;
+  }
+  virtual uint32_t getExpWidth() const { return _exp_width; }
+
+  virtual const SourceSort* cachedSourceSort() const
+  {
+    return _source_sort_cache;
+  }
+  virtual void setCachedSourceSort(const SourceSort* s) const
+  {
+    _source_sort_cache = s;
+  }
 
 public:
   ASTInterior(STPMgr* mgr, Kind kind, const ASTVec& children)
       : ASTInternal(mgr, kind), _children(children), _value_width(0),
-        _index_width(0)
+        _index_width(0), _sig_width(0), _exp_width(0),
+        _source_sort_cache(NULL)
   {
     is_simplified = false;
     if (kind == NOT)
@@ -118,7 +172,8 @@ public:
   // avoiding a copy when the caller has a temporary to give up.
   ASTInterior(STPMgr* mgr, Kind kind, ASTVec&& children)
       : ASTInternal(mgr, kind), _children(std::move(children)), _value_width(0),
-        _index_width(0)
+        _index_width(0), _sig_width(0), _exp_width(0),
+        _source_sort_cache(NULL)
   {
     is_simplified = false;
     if (kind == NOT)
@@ -130,7 +185,9 @@ public:
   // ASTNode, does NOT invoke this.
   ASTInterior(const ASTInterior& int_node)
       : ASTInternal(int_node), _children(int_node._children),
-        _value_width(int_node._value_width), _index_width(int_node._index_width)
+        _value_width(int_node._value_width),
+        _index_width(int_node._index_width), _sig_width(int_node._sig_width),
+        _exp_width(int_node._exp_width), _source_sort_cache(NULL)
   {
     is_simplified = false;
   }
@@ -140,7 +197,8 @@ public:
   ASTInterior(ASTInterior&& int_node)
       : ASTInternal(int_node), _children(std::move(int_node._children)),
         _cached_hash(int_node._cached_hash), _value_width(int_node._value_width),
-        _index_width(int_node._index_width)
+        _index_width(int_node._index_width), _sig_width(int_node._sig_width),
+        _exp_width(int_node._exp_width), _source_sort_cache(NULL)
   {
     is_simplified = false;
   }

--- a/include/stp/AST/ASTInternal.h
+++ b/include/stp/AST/ASTInternal.h
@@ -29,6 +29,7 @@ THE SOFTWARE.
 // including ASTNode.h would create a circular include that forces the hot
 // ASTNode accessors (GetKind/GetNodeNum/...) to be defined out-of-line.
 #include "stp/AST/UsefulDefs.h"
+#include "stp/AST/SourceSort.h"
 #include <iostream>
 
 using std::ostream;
@@ -94,6 +95,41 @@ protected:
 
   virtual void setValueWidth(uint32_t) = 0;
   virtual uint32_t getValueWidth() const = 0;
+
+  virtual void setExpWidth(uint32_t) = 0;
+  virtual uint32_t getExpWidth() const = 0;
+
+  virtual void setSigWidth(uint32_t) = 0;
+  virtual uint32_t getSigWidth() const = 0;
+
+  // Source-language identity carried by leaves. Interior-node sorts are
+  // derived by ASTNode::GetSourceSort from their operator and children.
+  virtual SourceSort getDeclaredSourceSort() const
+  {
+    return SourceSort::unknown();
+  }
+
+  // Memo for the *derived* source sort, on the nodes that derive one.
+  //
+  // ASTNode::GetSourceSort walks children for READ, WRITE and ITE -- and for
+  // ITE it walks both branches -- so without a memo a shared-branch ITE DAG
+  // costs Theta(2^depth) per query and a store chain costs Theta(depth), on a
+  // graph of linear size. The front ends ask once per node they build, and
+  // containsFloatingPointTheory asks once per node of every query, so the
+  // recomputation is not incidental. This is the same treatment cacheFPFormat
+  // already gives the floating-point format, for the same reason, and it is
+  // sound for the same reason: the derivation reads only the node's kind,
+  // children and widths.
+  //
+  // The pointer is into the manager's intern pool, so a cached answer costs
+  // eight bytes and no allocation, and Unknown interns like any other sort --
+  // a non-null pointer to an Unknown sort is the negative cache.
+  //
+  // Only ASTInterior can hold one. Leaves either carry a declared sort or
+  // derive theirs from widths that legacy callers still set after
+  // construction, and both are already O(1).
+  virtual const SourceSort* cachedSourceSort() const { return NULL; }
+  virtual void setCachedSourceSort(const SourceSort*) const {}
 
   /*******************************************************************
    * ASTNode is of type BV      <==> ((indexwidth=0)&&(valuewidth>0))*

--- a/include/stp/AST/ASTNode.h
+++ b/include/stp/AST/ASTNode.h
@@ -228,6 +228,14 @@ public:
   unsigned int GetIndexWidth() const { return _int_node_ptr->getIndexWidth(); }
   DLL_PUBLIC unsigned int GetValueWidth() const
   {
+    // Invariant: a float-formatted node stores its packed width as the value
+    // width like any other term (the declaration rules and node builders all
+    // maintain this). The format is never the width's only source -- this
+    // accessor used to derive sig + exp on every call, solver-wide, to paper
+    // over declaration sites that left the value width zero.
+    assert(_int_node_ptr->getSigWidth() == 0 ||
+           _int_node_ptr->getValueWidth() ==
+               _int_node_ptr->getExpWidth() + _int_node_ptr->getSigWidth());
     return _int_node_ptr->getValueWidth();
   }
   void SetIndexWidth(unsigned int iw) const;
@@ -240,11 +248,49 @@ public:
     const unsigned int iw = GetIndexWidth();
     const unsigned int vw = GetValueWidth();
 
-    if (0 == iw)
-      return (0 == vw) ? BOOLEAN_TYPE : BITVECTOR_TYPE;
+    // Arrays first. An array of floats carries its *element's* format in the
+    // exponent and significand widths, so testing those first would call the
+    // array itself a float.
+    if (iw > 0)
+      return (vw > 0) ? ARRAY_TYPE : UNKNOWN_TYPE;
 
-    return (vw > 0) ? ARRAY_TYPE : UNKNOWN_TYPE;
+    if (GetSigWidth() != 0 && GetExpWidth() != 0)
+      return FLOATINGPOINT_TYPE;
+
+    return (0 == vw) ? BOOLEAN_TYPE : BITVECTOR_TYPE;
   }
+
+  // The immutable source-language sort. This is deliberately separate from
+  // GetType(), which remains the packed carrier classification consumed by
+  // STP's bit-vector pipeline.
+  //
+  // Memoised on the node; deriveSourceSort below is the derivation itself and
+  // runs at most once per node (see ASTInternal::cachedSourceSort).
+  SourceSort GetSourceSort() const;
+
+private:
+  // The derivation behind GetSourceSort, without the memo. Private so that
+  // nothing reintroduces the recomputation by calling it directly.
+  SourceSort deriveSourceSort() const;
+
+public:
+  unsigned int GetSigWidth() const;
+  unsigned int GetExpWidth() const;
+
+  // Work the floating-point format out from this node's kind and children and
+  // remember it. Called on demand by GetExpWidth/GetSigWidth; the format of an
+  // interior node is derived rather than assigned, so that rebuilding a node
+  // cannot lose it.
+  void cacheFPFormat() const;
+  void SetSigWidth(unsigned int sw) const;
+  void SetExpWidth(unsigned int ew) const;
+
+  // Whether a floating-point format may be *stored* on this node, rather than
+  // derived from its kind and children or not carried at all. SetExpWidth
+  // asserts on it and FloatBlaster::withFormat -- the funnel that decides
+  // where a format goes -- consults it; the rule, and what stamping a node
+  // that fails it would do, are with the definition.
+  bool canStoreFPFormat() const;
 
   // Hash is the node's unique id. Inlined: used by every ==/</hash lookup.
   size_t Hash() const { return _int_node_ptr ? _int_node_ptr->node_uid : 0; }

--- a/include/stp/AST/ASTRMConst.h
+++ b/include/stp/AST/ASTRMConst.h
@@ -1,0 +1,32 @@
+/********************************************************************
+ * A source-language RoundingMode literal over STP's 5-bit carrier.
+ ********************************************************************/
+#ifndef ASTRMCONST_H
+#define ASTRMCONST_H
+
+#include "ASTBVConst.h"
+
+namespace stp
+{
+class STPMgr;
+
+// Kept as kind BVCONST so every post-lowering bit-vector pass can consume it,
+// but interned separately from a plain five-bit constant through SourceSort.
+class ASTRMConst final : public ASTBVConst
+{
+  friend class STPMgr;
+
+  ASTRMConst(STPMgr* mgr, CBV bv);
+  ASTRMConst(const ASTRMConst& other);
+
+  SourceSort getDeclaredSourceSort() const override
+  {
+    return SourceSort::roundingMode();
+  }
+
+public:
+  ~ASTRMConst() override = default;
+};
+
+} // namespace stp
+#endif

--- a/include/stp/AST/ASTSymbol.h
+++ b/include/stp/AST/ASTSymbol.h
@@ -54,7 +54,8 @@ private:
   public:
     size_t operator()(const ASTSymbol* sym_ptr) const
     {
-      return CStringHash()(sym_ptr->_name);
+      return CStringHash()(sym_ptr->_name) ^
+             (sym_ptr->_source_sort.hash() * 0x9e3779b97f4a7c15ULL);
     };
   };
 
@@ -72,7 +73,8 @@ private:
 
   friend bool operator==(const ASTSymbol& sym1, const ASTSymbol& sym2)
   {
-    return (strcmp(sym1._name, sym2._name) == 0);
+    return strcmp(sym1._name, sym2._name) == 0 &&
+           sym1._source_sort == sym2._source_sort;
   }
 
   // Get the name of the symbol
@@ -80,28 +82,110 @@ private:
 
   // Print function for symbol -- return name. (c_friendly is for
   // printing hex. numbers that C compilers will accept)
-  virtual void nodeprint(ostream& os, bool c_friendly = false);
+  void nodeprint(ostream& os, bool c_friendly = false) override;
 
   // Call this when deleting a node that has been stored in the the
   // unique table
-  virtual void CleanUp();
+  void CleanUp() override;
 
   uint32_t _value_width;
   uint32_t _index_width;
 
-  virtual void setIndexWidth(uint32_t i) { _index_width = i; }
-  virtual uint32_t getIndexWidth() const { return _index_width; }
+  uint32_t _sig_width;
+  uint32_t _exp_width;
 
-  virtual void setValueWidth(uint32_t v) { _value_width = v; }
-  virtual uint32_t getValueWidth() const { return _value_width; }
+  // Fixed at construction for typed source symbols. Legacy internal symbols
+  // retain Unknown and may use the historical width setters.
+  const SourceSort _source_sort;
+
+  void setIndexWidth(uint32_t i) override
+  {
+    if (_source_sort.isKnown())
+    {
+      assert(i == _index_width);
+      return;
+    }
+    _index_width = i;
+  }
+  uint32_t getIndexWidth() const override { return _index_width; }
+
+  void setValueWidth(uint32_t v) override
+  {
+    if (_source_sort.isKnown())
+    {
+      assert(v == _value_width);
+      return;
+    }
+    _value_width = v;
+  }
+  uint32_t getValueWidth() const override { return _value_width; }
+
+  void setSigWidth(uint32_t sw) override
+  {
+    if (_source_sort.isKnown())
+    {
+      assert(sw == _sig_width);
+      return;
+    }
+    _sig_width = sw;
+  }
+  uint32_t getSigWidth() const override { return _sig_width; }
+
+  void setExpWidth(uint32_t ew) override
+  {
+    if (_source_sort.isKnown())
+    {
+      assert(ew == _exp_width);
+      return;
+    }
+    _exp_width = ew;
+  }
+  uint32_t getExpWidth() const override { return _exp_width; }
+
+  SourceSort getDeclaredSourceSort() const override { return _source_sort; }
 
 public:
-  virtual ASTChildren GetChildren() const { return empty_children; }
+  ASTChildren GetChildren() const override { return empty_children; }
 
   // Constructor.  This does NOT copy its argument.
   ASTSymbol(STPMgr* mgr, const char* const name)
-      : ASTInternal(mgr, SYMBOL), _name(name), _value_width(0), _index_width(0)
+      : ASTInternal(mgr, SYMBOL), _name(name), _value_width(0), _index_width(0),
+        _sig_width(0), _exp_width(0), _source_sort(SourceSort::unknown())
   {
+  }
+
+  ASTSymbol(STPMgr* mgr, const char* const name, const SourceSort& source_sort)
+      : ASTInternal(mgr, SYMBOL), _name(name), _value_width(0), _index_width(0),
+        _sig_width(0), _exp_width(0), _source_sort(source_sort)
+  {
+    switch (_source_sort.kind())
+    {
+      case SourceSort::Kind::Bool:
+        break;
+      case SourceSort::Kind::BitVector:
+        _value_width = _source_sort.bitVectorWidth();
+        break;
+      case SourceSort::Kind::FloatingPoint:
+        _exp_width = _source_sort.exponentWidth();
+        _sig_width = _source_sort.significandWidth();
+        _value_width = _source_sort.packedWidth();
+        break;
+      case SourceSort::Kind::RoundingMode:
+        _value_width = _source_sort.packedWidth();
+        break;
+      case SourceSort::Kind::Array:
+        _index_width = _source_sort.index().packedWidth();
+        _value_width = _source_sort.element().packedWidth();
+        if (_source_sort.element().kind() ==
+            SourceSort::Kind::FloatingPoint)
+        {
+          _exp_width = _source_sort.element().exponentWidth();
+          _sig_width = _source_sort.element().significandWidth();
+        }
+        break;
+      case SourceSort::Kind::Unknown:
+        break;
+    }
   }
 
   virtual ~ASTSymbol() {}
@@ -109,7 +193,9 @@ public:
   // Copy constructor
   ASTSymbol(const ASTSymbol& sym)
       : ASTInternal(sym.nodeManager, sym._kind), _name(sym._name),
-        _value_width(sym._value_width), _index_width(sym._index_width)
+        _value_width(sym._value_width), _index_width(sym._index_width),
+        _sig_width(sym._sig_width), _exp_width(sym._exp_width),
+        _source_sort(sym._source_sort)
   {
     // printf("inside ASTSymbol constructor %s\n", _name);
   }

--- a/include/stp/AST/MutableASTNode.h
+++ b/include/stp/AST/MutableASTNode.h
@@ -102,7 +102,8 @@ public:
     for (ParentsType::iterator it = parents.begin(); it != parents.end(); it++)
     {
       vector<MutableASTNode*>::iterator it2 = (*it)->children.begin();
-      bool found = false;
+      // Only consumed by the assert, which an NDEBUG build compiles out.
+      [[maybe_unused]] bool found = false;
       for (; it2 != (*it)->children.end(); it2++)
       {
         assert(*it2 != NULL);

--- a/include/stp/AST/SourceSort.h
+++ b/include/stp/AST/SourceSort.h
@@ -1,0 +1,199 @@
+/********************************************************************
+ * Immutable source-language sorts.
+ *
+ * STP's historical `types` describe the bit-vector/array carrier used by
+ * the solving pipeline.  FloatingPoint and RoundingMode are lowered onto
+ * those carriers, but they are not interchangeable with them at the public
+ * boundary.  SourceSort records that distinction without changing the
+ * representation expected by the legacy bit-vector passes.
+ ********************************************************************/
+#ifndef STP_SOURCESORT_H
+#define STP_SOURCESORT_H
+
+#include <cassert>
+#include <cstddef>
+#include <memory>
+#include <unordered_set>
+
+namespace stp
+{
+
+class SourceSort final
+{
+public:
+  enum class Kind
+  {
+    Unknown,
+    Bool,
+    BitVector,
+    FloatingPoint,
+    RoundingMode,
+    Array
+  };
+
+private:
+  Kind kind_;
+  unsigned first_;
+  unsigned second_;
+  std::shared_ptr<const SourceSort> index_;
+  std::shared_ptr<const SourceSort> element_;
+
+  SourceSort(Kind kind, unsigned first = 0, unsigned second = 0)
+      : kind_(kind), first_(first), second_(second)
+  {
+  }
+
+  SourceSort(const SourceSort& index, const SourceSort& element)
+      : kind_(Kind::Array), first_(0), second_(0),
+        index_(std::make_shared<const SourceSort>(index)),
+        element_(std::make_shared<const SourceSort>(element))
+  {
+  }
+
+public:
+  SourceSort() : SourceSort(Kind::Unknown) {}
+
+  static SourceSort unknown() { return SourceSort(); }
+  static SourceSort boolean() { return SourceSort(Kind::Bool); }
+
+  static SourceSort bitVector(unsigned width)
+  {
+    assert(width > 0);
+    return SourceSort(Kind::BitVector, width);
+  }
+
+  static SourceSort floatingPoint(unsigned exponent, unsigned significand)
+  {
+    assert(exponent > 0 && significand > 0);
+    return SourceSort(Kind::FloatingPoint, exponent, significand);
+  }
+
+  static SourceSort roundingMode()
+  {
+    return SourceSort(Kind::RoundingMode);
+  }
+
+  static SourceSort array(const SourceSort& index, const SourceSort& element)
+  {
+    assert(index.isScalar() && element.isScalar());
+    return SourceSort(index, element);
+  }
+
+  Kind kind() const { return kind_; }
+  bool isKnown() const { return kind_ != Kind::Unknown; }
+  bool isScalar() const
+  {
+    return kind_ == Kind::BitVector || kind_ == Kind::FloatingPoint ||
+           kind_ == Kind::RoundingMode;
+  }
+
+  bool containsFloatingPoint() const
+  {
+    if (kind_ == Kind::FloatingPoint)
+      return true;
+    return kind_ == Kind::Array &&
+           (index().containsFloatingPoint() ||
+            element().containsFloatingPoint());
+  }
+
+  // RoundingMode belongs to the SMT floating-point theory even when no
+  // FloatingPoint value occurs. Printers and other source-level decisions
+  // need that broader question; lowering itself usually needs the narrower
+  // containsFloatingPoint() predicate above.
+  bool usesFloatingPointTheory() const
+  {
+    if (kind_ == Kind::FloatingPoint || kind_ == Kind::RoundingMode)
+      return true;
+    return kind_ == Kind::Array &&
+           (index().usesFloatingPointTheory() ||
+            element().usesFloatingPointTheory());
+  }
+
+  unsigned bitVectorWidth() const
+  {
+    assert(kind_ == Kind::BitVector);
+    return first_;
+  }
+
+  unsigned exponentWidth() const
+  {
+    assert(kind_ == Kind::FloatingPoint);
+    return first_;
+  }
+
+  unsigned significandWidth() const
+  {
+    assert(kind_ == Kind::FloatingPoint);
+    return second_;
+  }
+
+  unsigned packedWidth() const
+  {
+    switch (kind_)
+    {
+      case Kind::Bool:
+        return 0;
+      case Kind::BitVector:
+        return first_;
+      case Kind::FloatingPoint:
+        return first_ + second_;
+      case Kind::RoundingMode:
+        return 5;
+      default:
+        assert(false && "packedWidth is defined only for scalar sorts");
+        return 0;
+    }
+  }
+
+  const SourceSort& index() const
+  {
+    assert(kind_ == Kind::Array);
+    return *index_;
+  }
+
+  const SourceSort& element() const
+  {
+    assert(kind_ == Kind::Array);
+    return *element_;
+  }
+
+  friend bool operator==(const SourceSort& left, const SourceSort& right)
+  {
+    if (left.kind_ != right.kind_ || left.first_ != right.first_ ||
+        left.second_ != right.second_)
+      return false;
+    if (left.kind_ != Kind::Array)
+      return true;
+    return left.index() == right.index() &&
+           left.element() == right.element();
+  }
+
+  friend bool operator!=(const SourceSort& left, const SourceSort& right)
+  {
+    return !(left == right);
+  }
+
+  size_t hash() const
+  {
+    size_t h = static_cast<size_t>(kind_);
+    h = h * 1315423911u + first_;
+    h = h * 1315423911u + second_;
+    if (kind_ == Kind::Array)
+    {
+      h = h * 1315423911u + index().hash();
+      h = h * 1315423911u + element().hash();
+    }
+    return h;
+  }
+
+  // For the manager's intern pool, which is what lets a derived sort be
+  // memoised on a node as a pointer.
+  struct Hasher
+  {
+    size_t operator()(const SourceSort& sort) const { return sort.hash(); }
+  };
+};
+
+} // namespace stp
+
+#endif

--- a/include/stp/AST/UsefulDefs.h
+++ b/include/stp/AST/UsefulDefs.h
@@ -64,6 +64,7 @@ class ASTInternal;
 class ASTInterior;
 class ASTSymbol;
 class ASTBVConst;
+class ASTFPConst;
 class BVSolver;
 
 /******************************************************************

--- a/include/stp/FloatBlaster/rounding_modes.h
+++ b/include/stp/FloatBlaster/rounding_modes.h
@@ -1,7 +1,7 @@
 /********************************************************************
- * AUTHORS: Vijay Ganesh, David L. Dill
+ * AUTHORS: Andrew Teylu
  *
- * BEGIN DATE: November, 2005
+ * BEGIN DATE: January 2021
  *
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -22,34 +22,32 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ********************************************************************/
 
-#include "stp/AST/ASTSymbol.h"
-#include "stp/AST/AST.h"
-#include "stp/STPManager/STP.h"
+// The one-hot rounding-mode encoding, split out of symbolic_fp.h so the
+// parser (which builds rounding-mode constants whether or not the SymFPU
+// backend is compiled in) does not drag in the SymFPU headers.
+
+#ifndef STP_FP_ROUNDING_MODES_H
+#define STP_FP_ROUNDING_MODES_H
 
 namespace stp
 {
-const ASTVec ASTSymbol::empty_children;
-
-// Get the name of the symbol
-const char* ASTSymbol::GetName() const
+namespace symbolic_fp
 {
-  return _name;
-}
 
-// Print function for symbol
-void ASTSymbol::nodeprint(ostream& os, bool /*c_friendly*/)
+// A rounding mode is a one-hot 5-bit bitvector: one bit per IEEE mode, so
+// an invalid mode is representable (all-zero, or multiple bits) and
+// roundingMode::valid() can constrain a symbolic one. The public C API's
+// VCRoundingMode mirrors these values.
+enum rounding_modes
 {
-  os << _name;
-}
+  ROUND_NEAREST_TIES_TO_EVEN = 1,
+  ROUND_TOWARD_POSITIVE = ROUND_NEAREST_TIES_TO_EVEN << 1,
+  ROUND_TOWARD_NEGATIVE = ROUND_TOWARD_POSITIVE << 1,
+  ROUND_TOWARD_ZERO = ROUND_TOWARD_NEGATIVE << 1,
+  ROUND_NEAREST_TIES_TO_AWAY = ROUND_TOWARD_ZERO << 1,
+};
 
-// Call this when deleting a node that has been stored in the the
-// unique table
-void ASTSymbol::CleanUp()
-{
-  nodeManager->_symbol_unique_table.erase(this);
-  nodeManager->unindexSymbolName(this);
-  free((char*)this->_name);
-  delete this;
-}
+} // namespace symbolic_fp
+} // namespace stp
 
-} // end of namespace
+#endif

--- a/include/stp/Globals/Globals.h
+++ b/include/stp/Globals/Globals.h
@@ -59,13 +59,19 @@ enum inputStatus
   TO_BE_UNKNOWN // Specified in the input file as unknown.
 };
 
-// return types for the GetType() function in ASTNode class
+// return types for the GetType() function in ASTNode class.
+// FLOATINGPOINT_TYPE is appended after UNKNOWN_TYPE, not slotted in sort
+// order. The legacy prefix of the C API's type_t mirrors these values
+// numerically, preserving values compiled into pre-floating-point clients.
+// Source-only sorts such as RoundingMode are intentionally absent here:
+// GetType() describes the carrier used by the bit-vector pipeline.
 enum types
 {
   BOOLEAN_TYPE = 0,
   BITVECTOR_TYPE,
   ARRAY_TYPE,
-  UNKNOWN_TYPE
+  UNKNOWN_TYPE,
+  FLOATINGPOINT_TYPE
 };
 
 enum SOLVER_RETURN_TYPE

--- a/include/stp/NodeFactory/NodeFactory.h
+++ b/include/stp/NodeFactory/NodeFactory.h
@@ -94,7 +94,13 @@ public:
   ASTNode getFalse();
   ASTNode getUndefined();
 
-  ASTNode CreateConstant(stp::CBV cbv, unsigned width);
+  // With a nonzero exp_width the constant is made as a floating-point
+  // constant of that format. A constant is a leaf, so unlike an interior
+  // node it cannot derive a format from its children; a caller replacing a
+  // float-valued node with a constant must pass the format through or the
+  // float-ness is lost.
+  ASTNode CreateConstant(stp::CBV cbv, unsigned width, unsigned exp_width = 0,
+                         unsigned sig_width = 0);
 
   ASTNode CreateOneConst(unsigned width);
   ASTNode CreateZeroConst(unsigned width);
@@ -102,6 +108,8 @@ public:
   ASTNode CreateSignedMinConst(unsigned width);
   
   ASTNode CreateBVConst(unsigned int width, unsigned long long int bvconst);
+  ASTNode CreateFPConst(const stp::ASTNode& bvconst, unsigned exp_width,
+                        unsigned sig_width);
 
   virtual std::string getName() = 0;
 };

--- a/include/stp/STPManager/STPManager.h
+++ b/include/stp/STPManager/STPManager.h
@@ -26,6 +26,8 @@ THE SOFTWARE.
 #define STPMGR_H
 
 #include "stp/AST/ASTBVConst.h"
+#include "stp/AST/ASTFPConst.h"
+#include "stp/AST/ASTRMConst.h"
 #include "stp/AST/ASTInterior.h"
 #include "stp/AST/ASTNode.h"
 #include "stp/AST/ASTSymbol.h"
@@ -39,6 +41,19 @@ THE SOFTWARE.
 
 namespace stp
 {
+
+// The five SMT-LIB floating-point special values. Their nodes are ordinary
+// packed interned constants (see STPMgr::CreateFPSpecialConst); a childless
+// special-value node would hash-cons every format's NaN to one mutable node.
+enum class FPSpecial
+{
+  NaN,
+  PlusInfinity,
+  MinusInfinity,
+  PlusZero,
+  MinusZero,
+};
+
 /*
  * STP Node Manager. Tools for managing AST nodes.
  */
@@ -186,6 +201,9 @@ private:
   // Called by ASTNode constructors to uniqueify ASTBVConst
   ASTBVConst* LookupOrCreateBVConst(ASTBVConst& s);
 
+  ASTFPConst* LookupOrCreateFPConst(ASTFPConst& s);
+  ASTRMConst* LookupOrCreateRMConst(ASTRMConst& s);
+
   // Cache of zero/one/max BVConsts of different widths.
   ASTVec zeroes;
   ASTVec ones;
@@ -196,9 +214,57 @@ private:
 
   CBV CreateBVConstVal;
 
+  // Name -> symbols declared under it, in declaration order.
+  //
+  // A symbol's source sort is part of its identity, so the unique table is
+  // keyed on (name, sort) and a name-only probe cannot be built for it. That
+  // is what turned the two name lookups below into a scan of every symbol --
+  // and they are not rare: LookupOrCreateSymbol(name) is how every internally
+  // minted symbol is made (ArrayTransformer's per-abstracted-read variable,
+  // RemoveUnconstrained's per-unconstrained-parent variable), so the scan made
+  // symbol creation quadratic on problems with no floating point in them.
+  //
+  // This index answers those lookups in constant time. Entries are appended
+  // where the unique table is inserted into and removed where a symbol is
+  // cleaned up, so the two stay in step; the vector is for the case the sorted
+  // key admits and the old name-keyed one could not -- one name at two sorts.
+  typedef ankerl::unordered_dense::map<std::string, std::vector<ASTSymbol*>>
+      SymbolNameIndex;
+  SymbolNameIndex _symbol_name_index;
+
+  // Distinct source sorts, interned so a derived one can be memoised on the
+  // node as a pointer. std::unordered_set rather than a dense map because the
+  // addresses have to stay put as it grows.
+  std::unordered_set<SourceSort, SourceSort::Hasher> _source_sort_pool;
+
+  // The symbols STP introduces under a name of its own choosing, so that the
+  // name identifies the object without being looked up in the symbol table.
+  // See introducedSymbol.
+  std::map<std::string, ASTNode> _introduced_by_name;
+
 public:
   bool LookupSymbol(const char* const name);
   bool LookupSymbol(const char* const name, ASTNode& output);
+
+  // Intern `sort` and return its stable address, for ASTInternal's source-sort
+  // memo. Unknown interns like anything else, so the memo needs no separate
+  // negative sentinel.
+  const SourceSort* internSourceSort(const SourceSort& sort)
+  {
+    return &*_source_sort_pool.insert(sort).first;
+  }
+
+  // How many times a source sort has actually been derived, as opposed to
+  // answered from a node's memo. Counted so that the memo is directly
+  // testable: a derivation walks children, so "once per node" versus "once
+  // per path" is the whole difference, and it cannot be read off a result
+  // that is correct either way.
+  uint64_t source_sort_derivations = 0;
+
+  // Record/forget a symbol in the name index. Called only from the unique
+  // table's insertion point and from ASTSymbol::CleanUp.
+  void indexSymbolName(ASTSymbol* symbol);
+  void unindexSymbolName(ASTSymbol* symbol);
 
   /****************************************************************
    * Public Flags                                                 *
@@ -258,6 +324,84 @@ public:
   ASTNode CreateBVConst(std::string strval, int base, int bit_width);
   ASTNode CreateBVConst(unsigned int width, unsigned long long int bvconst);
   ASTNode charToASTNode(unsigned char* strval, int base, int bit_width);
+
+  DLL_PUBLIC ASTNode CreateFPConst(const stp::ASTNode& bvconst,
+                                   unsigned exp_width, unsigned sig_width);
+  DLL_PUBLIC ASTNode CreateRMConst(unsigned mode);
+
+  // Restore a model carrier value to the immutable sort of the source term
+  // it answers. The solver itself continues to evaluate plain bitvectors.
+  ASTNode LiftSourceValue(const ASTNode& carrier,
+                          const SourceSort& source_sort);
+
+  // Create a source-language leaf atomically. Its complete sort participates
+  // in hash-consing and cannot subsequently be changed by width setters.
+  DLL_PUBLIC ASTNode CreateSourceSymbol(const char* name,
+                                        const SourceSort& source_sort);
+
+  // Conservative manager-lifetime hint: whether a floating-point node has
+  // ever been created. Set by the format funnels (CreateFPConst,
+  // ASTNode::SetExpWidth and FloatBlaster::withFormat, all through
+  // noteFloatingPoint). False is a cheap proof that no query needs FP
+  // lowering; true is not query state -- an unused term or a popped scope may
+  // have set it -- so positive decisions must also inspect the current DAG.
+  bool has_floating_point = false;
+
+  // The same hint for the floating-point *theory* rather than for floats: a
+  // RoundingMode symbol, constant or array element carries no format, so it
+  // never reaches noteFloatingPoint, yet it still needs FpTotalise to pin it
+  // to the five legal encodings. TopLevelSTP's theory test is the one place
+  // that needs the broader question, and without this latch it had no cheap
+  // negative and walked the DAG of every pure bit-vector query.
+  bool has_floating_point_theory = false;
+
+  void noteFloatingPointTheory() { has_floating_point_theory = true; }
+
+  // Record that a float of a real format has been built. Every float's format
+  // arrives through one of the funnels above, so calling this there is what
+  // makes the fast-negative hint complete -- and it must be called whether or
+  // not the format then needs storing on a node, since a node that derives its
+  // format from its kind and children may later occur in a query.
+  //
+  // It is also where a build without floating-point support refuses the C
+  // API's floating-point entry points. (The parser rejects floating-point
+  // input earlier, with a line number; see checkFpSupported in smt2.y.)
+  DLL_PUBLIC void noteFloatingPoint();
+
+  bool isRoundingModeSymbol(const ASTNode& n) const
+  {
+    return n.GetKind() == SYMBOL &&
+           n.GetSourceSort().kind() == SourceSort::Kind::RoundingMode;
+  }
+
+  // The five-way one-hot validity constraint for a RoundingMode symbol:
+  // (or (= s RNE) ... (= s RNA)). Every path that introduces a
+  // RoundingMode variable must assert this: the sort has exactly five values,
+  // while the 5-bit carrier has thirty-two.
+  ASTNode roundingModeValidConstraint(const ASTNode& s);
+
+  // Whether `n` denotes a value of SMT-LIB's RoundingMode source sort.
+  //
+  // Everything that takes a rounding mode must ask this rather than test the
+  // carrier's width. The sort has five values and the carrier thirty-two, and
+  // symfpu's roundingDecision falls through to truncate-with-overflow-to-max
+  // when every mode equality is false -- a sixth, non-IEEE mode. Accepting a
+  // bare (_ BitVec 5) there let an input compute under it.
+  bool isRoundingModeSortedTerm(const ASTNode& n) const;
+
+  DLL_PUBLIC ASTNode CreateFPSpecialConst(FPSpecial which, unsigned exp_width,
+                                          unsigned sig_width);
+
+  // The declared symbol under an array term. Complete index/element sorts
+  // live immutably on source symbols; WRITE and ITE derive them.
+  // Null when no symbol is underneath.
+  ASTNode arrayBaseSymbol(const ASTNode& arr) const;
+
+  // Compatibility queries over the immutable SourceSort representation.
+  bool arrayHasFpIndex(const ASTNode& arr, unsigned& exp_width,
+                       unsigned& sig_width) const;
+  bool arrayHasRmIndex(const ASTNode& arr) const;
+  bool arrayHasRmElement(const ASTNode& arr) const;
 
   /****************************************************************
    * Create Node functions                                        *
@@ -371,6 +515,11 @@ public:
   // Note, not maintained properly wrt push/pops
   vector<stp::ASTNode> decls;
 
+  // C API declarations have manager lifetime and no lexical binding frame.
+  // Keep their printed names unambiguous even if the caller clears the list
+  // used only for printing declarations.
+  std::map<std::string, SourceSort> c_api_source_sorts;
+
   // Nodes seen so far
   ASTNodeSet PLPrintNodeSet;
 
@@ -411,6 +560,16 @@ public:
     return CurrentSymbol;
   }
 
+  ASTNode CreateFreshSourceVariable(const SourceSort& source_sort,
+                                    std::string prefix)
+  {
+    char* d = (char*)alloca(sizeof(char) * (32 + prefix.length()));
+    sprintf(d, "@%s_%d", prefix.c_str(), _symbol_count++);
+    ASTNode current = CreateSourceSymbol(d, source_sort);
+    Introduced_SymbolsSet.insert(current);
+    return current;
+  }
+
   bool FoundIntroducedSymbolSet(const ASTNode& in)
   {
     if (Introduced_SymbolsSet.find(in) != Introduced_SymbolsSet.end())
@@ -418,6 +577,65 @@ public:
       return true;
     }
     return false;
+  }
+
+  // Whether `name` is in the namespace SMT-LIB 2 reserves for solver use.
+  //
+  // STP relies on that reservation rather than merely respecting it:
+  // CreateFreshVariable mints '@'-prefixed names, and so do the objects
+  // supplying the unspecified results of the partial floating-point
+  // operations. The public boundaries refuse to declare such a name, which is
+  // what makes the reliance sound -- see Cpp_interface::CreateSourceSymbol and
+  // createPublicSourceSymbol.
+  static bool isReservedSymbolName(const char* name)
+  {
+    return name != NULL && (name[0] == '@' || name[0] == '.');
+  }
+
+  // Record a symbol STP introduced rather than the user declaring it, so the
+  // counterexample printers leave it out. CreateFreshVariable does this for
+  // the names it mints; this is the way in for an introduced symbol whose
+  // *name* is load-bearing and so cannot be minted there -- the arrays and
+  // free bits supplying the unspecified results of the partial floating-point
+  // operations, whose identity is their name (see
+  // FloatBlaster::unspecifiedValue and FloatBlaster::unspecifiedCells).
+  void noteIntroducedSymbol(const ASTNode& in)
+  {
+    Introduced_SymbolsSet.insert(in);
+  }
+
+  // The one symbol STP introduces under `name`, minted on first request.
+  //
+  // Identity is the name here on purpose: the solve and the two counterexample
+  // re-derivations each rebuild these independently and have to arrive at the
+  // same object, which a minted-per-call fresh variable cannot give them.
+  //
+  // That identity used to be nothing but the name, handed to a lookup that
+  // matches on name alone and returns the first symbol declared under it at
+  // *any* sort -- and whose width setters are then silent no-ops. A user
+  // declaration at the matching sort therefore *became* the object: pinning a
+  // cell of fp.min's choice map decided the solver's "unspecified" answer, the
+  // user's own symbol vanished from the model, and a declaration at a
+  // different sort aborted on a width assert. The '@' prefix was the whole
+  // defence, and nothing enforced it.
+  //
+  // Now the map is the identity: after the first call the name is never looked
+  // up again, and the first call refuses rather than adopts a name already
+  // taken. The public boundaries make that refusal unreachable by rejecting
+  // reserved names outright, so it is a backstop and not an expected error.
+  DLL_PUBLIC ASTNode introducedSymbol(const std::string& name,
+                                      unsigned index_width,
+                                      unsigned value_width);
+
+  // Whether a counterexample entry belongs to an introduced symbol. Entries
+  // for an introduced *array* are keyed on the read rather than on the array
+  // itself, so look through one: testing the key alone let every read of an
+  // introduced array print.
+  bool isIntroducedCounterExampleEntry(const ASTNode& in)
+  {
+    return FoundIntroducedSymbolSet(in) ||
+           (in.GetKind() == READ && in.Degree() > 0 &&
+            FoundIntroducedSymbolSet(in[0]));
   }
 
   bool VarSeenInTerm(const ASTNode& var, const ASTNode& term);

--- a/lib/AST/ASTFPConst.cpp
+++ b/lib/AST/ASTFPConst.cpp
@@ -1,7 +1,7 @@
 /********************************************************************
- * AUTHORS: Vijay Ganesh, David L. Dill
+ * AUTHORS: Andrew Teylu
  *
- * BEGIN DATE: November, 2005
+ * BEGIN DATE: January 2021
  *
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -22,34 +22,24 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ********************************************************************/
 
-#include "stp/AST/ASTSymbol.h"
+#include "stp/AST/ASTFPConst.h"
+
 #include "stp/AST/AST.h"
-#include "stp/STPManager/STP.h"
 
 namespace stp
 {
-const ASTVec ASTSymbol::empty_children;
 
-// Get the name of the symbol
-const char* ASTSymbol::GetName() const
+ASTFPConst::ASTFPConst(STPMgr* mgr, CBV bv, uint32_t exp_width,
+                       uint32_t sig_width)
+    : ASTBVConst(mgr, bv, 0, /*managed_outside=*/true), _sig_width(sig_width),
+      _exp_width(exp_width)
 {
-  return _name;
 }
 
-// Print function for symbol
-void ASTSymbol::nodeprint(ostream& os, bool /*c_friendly*/)
+ASTFPConst::ASTFPConst(const ASTFPConst& other)
+    : ASTBVConst(other), _sig_width(other._sig_width),
+      _exp_width(other._exp_width)
 {
-  os << _name;
 }
 
-// Call this when deleting a node that has been stored in the the
-// unique table
-void ASTSymbol::CleanUp()
-{
-  nodeManager->_symbol_unique_table.erase(this);
-  nodeManager->unindexSymbolName(this);
-  free((char*)this->_name);
-  delete this;
-}
-
-} // end of namespace
+} // namespace stp

--- a/lib/AST/ASTKind.kinds
+++ b/lib/AST/ASTKind.kinds
@@ -18,7 +18,7 @@
 #
 #
 # name minkids maxkids category1 category2
-Categories:	Term	Form
+Categories:	Term	Form	FP
 
 # Leaf nodes.
 UNDEFINED	0	0
@@ -88,8 +88,123 @@ READ		2	2	Term
 WRITE		3	3	Term
 
 #Types: These kinds are used only in the API. Once processed inside
-#the API, they are never used again in the system 
+#the API, they are never used again in the system
 ARRAY           0       0
 BITVECTOR       0       0
 BOOLEAN         0       0
+FLOATINGPOINT   0       0
+ROUNDINGMODE    0       0
 
+# Floating point _terms_ (i.e., things that produce FPs)
+
+# fp.abs: fp -> fp
+# The public C API mirrors every kind below in include/stp/c_interface.h
+# (enum exprkind_t) by numeric value; keep the two in lockstep. Anchoring
+# static_asserts live next to getExprKind in lib/Interface/c_interface.cpp.
+FP_ABS                      1    1    Term    FP
+
+# fp.neg: fp -> fp
+FP_NEG                      1    1    Term    FP
+
+# fp.add: rm, fp, fp -> fp
+FP_ADD                      3    3    Term    FP
+
+# fp.sub: rm, fp, fp -> fp
+FP_SUB                      3    3    Term    FP
+
+# fp.mul: rm, fp, fp -> fp
+FP_MUL                      3    3    Term    FP
+
+# fp.div: rm, fp, fp -> fp
+FP_DIV                      3    3    Term    FP
+
+# fp.fma: rm, fp, fp, fp -> fp
+FP_FMA                      4    4    Term    FP
+
+# fp.sqrt: rm, fp -> fp
+FP_SQRT                     2    2    Term    FP
+
+# fp.rem: fp, fp -> fp
+FP_REM                      2    2    Term    FP
+
+# fp.roundToIntegral: rm, fp -> fp
+FP_ROUNDTOINTEGRAL          2    2    Term    FP
+
+# fp.min: fp, fp -> fp
+FP_MIN                      2    3    Term    FP
+
+# fp.max: fp, fp -> fp
+FP_MAX                      2    3    Term    FP
+
+# to_fp: eb, sb, bv -> fp        (reinterpret the bits)
+# to_fp: eb, sb, rm, fp -> fp     (reformat a float)
+FP_TOFP                     3   4    Term    FP
+
+# to_fp: eb, sb, rm, bv -> fp     (convert a SIGNED integer)
+#
+# A kind of its own, rather than the four-argument FP_TOFP it is spelled as
+# in SMT-LIB, because nothing downstream could otherwise tell the two apart.
+# The distinction is in the source's *sort*, and a blasted float is its packed
+# bits -- so by the time the blaster sees the operand, a float and an integer
+# look identical. Asking the operand's type made an integer source get read as
+# a float and answer the wrong thing. The parser and the C API know which one
+# was written, so they record it here.
+FP_TOFP_SIGNED              4    4    Term    FP
+
+# to_fp_unsigned: eb, sb, rm, bv -> fP
+FP_TOFP_UNSIGNED            4    4    Term    FP
+
+# fp.to_ubv: bw, rm, fp -> bv
+FP_TO_UBV                   3    4    Term    FP
+
+# fp.to_sbv: bw, rm, fp -> bv
+FP_TO_SBV                   3    4    Term    FP
+
+# fp -> its packed IEEE bits (reinterpret, canonicalising NaN); API-only, no
+# SMT-LIB syntax. One float in, an (eb + sb)-bit bitvector out.
+FP_TO_IEEE_BV               1    1    Term    FP
+
+# Floating point _formulae_ (i.e., things that produce Booleans)
+
+# fp.leq: fp, fp -> bool
+FP_LEQ              2    2    Form    FP
+
+# fp.lt: fp, fp -> bool
+FP_LT               2    2    Form    FP
+
+# fp.geq: fp, fp -> bool
+FP_GEQ              2    2    Form    FP
+
+# fp.gt: fp, fp -> bool
+FP_GT               2    2    Form    FP
+
+# fp.eq: fp, fp -> bool
+FP_EQ               2    2    Form    FP
+
+# fp.isNormal: fp -> bool
+FP_ISNORMAL         1    1    Form    FP
+
+# fp.isSubnormal: fp -> bool
+FP_ISSUBNORMAL      1    1    Form    FP
+
+# fp.isZero: fp -> bool
+FP_ISZERO           1    1    Form    FP
+
+# fp.isInfinite: fp -> bool
+FP_ISINFINITE       1    1    Form    FP
+
+# fp.isNaN: fp -> bool
+FP_ISNAN            1    1    Form    FP
+
+# fp.isNegative: fp -> bool
+FP_ISNEGATIVE       1    1    Form    FP
+
+# fp.isPositive: fp -> bool
+FP_ISPOSITIVE       1    1    Form    FP
+
+# FP `=`
+FP_SMT_EQ           2    2    Form    FP
+
+# The five special floating-point values (NaN, +/-oo, +/-zero) have no kinds
+# of their own: they are ordinary packed constants, built interned by
+# STPMgr::CreateFPSpecialConst so that the format is part of node identity.

--- a/lib/AST/ASTNode.cpp
+++ b/lib/AST/ASTNode.cpp
@@ -58,6 +58,235 @@ void ASTNode::SetValueWidth(unsigned int vw) const
   _int_node_ptr->setValueWidth(vw);
 }
 
+// Work out an interior node's floating-point format from its kind and its
+// children, returning false when the node does not denote a float.
+//
+// The format used to be pure per-node state that whoever built the node was
+// expected to stamp on afterwards. That does not survive contact with the
+// preprocessing pipeline: dozens of places rebuild nodes, and any that
+// forgets leaves a float claiming a format of (0, 0), which the blaster does
+// not reject -- it computes the wrong bits, or underflows a width. Deriving
+// the format instead means a rebuilt node cannot lose it, because there is
+// nothing to lose.
+//
+// Leaves still have to store it: a symbol's format is declared, and a
+// constant's is fixed when it is made (see STPMgr::CreateFPConst). Interior
+// nodes are all covered here.
+static bool deriveFPFormat(const ASTNode& n, unsigned int& e, unsigned int& s)
+{
+  switch (n.GetKind())
+  {
+    // to_fp names its target format in its first two children, rather than
+    // inheriting one from an operand. So does the C API's floating-point
+    // *type* node (vc_fpType) -- covering it here is what makes
+    // vc_getExpWidth/vc_getSigWidth work on a type, as documented.
+    case FP_TOFP:
+    case FP_TOFP_SIGNED:
+    case FP_TOFP_UNSIGNED:
+    case FLOATINGPOINT:
+    {
+      if (n.Degree() < 2 || !n[0].isConstant() || !n[1].isConstant())
+        return false;
+
+      e = n[0].GetUnsignedConst();
+      s = n[1].GetUnsignedConst();
+      return e != 0 && s != 0;
+    }
+
+    // A read from an array of floats yields a float in the element's format,
+    // which the array node carries.
+    case READ:
+    {
+      if (n.Degree() < 1)
+        return false;
+
+      e = n[0].GetExpWidth();
+      s = n[0].GetSigWidth();
+      return e != 0 && s != 0;
+    }
+
+    // A store to an array of floats is itself an array of floats: carry the
+    // element format from the array child, so a read over a store chain can
+    // derive its format (the recursion bottoms out at the array symbol,
+    // whose declaration set it).
+    case WRITE:
+    {
+      if (n.Degree() < 1)
+        return false;
+
+      e = n[0].GetExpWidth();
+      s = n[0].GetSigWidth();
+      return e != 0 && s != 0;
+    }
+
+    // A float-valued ITE takes the format of its branches (children 1 and 2,
+    // which share it). Checked first and cheaply because bitvector ITEs are
+    // everywhere: for those the branch carries no format and this returns at
+    // once.
+    case ITE:
+    {
+      if (n.Degree() != 3)
+        return false;
+
+      e = n[1].GetExpWidth();
+      s = n[1].GetSigWidth();
+      if (e == 0)
+      {
+        e = n[2].GetExpWidth();
+        s = n[2].GetSigWidth();
+      }
+      return e != 0 && s != 0;
+    }
+
+    // The rest produce a float in the format of their float operand. Which
+    // child that is varies -- the arithmetic operations lead with a rounding
+    // mode -- and an operand that was folded to a constant may have lost its
+    // own format, so take the first child that has one.
+    case FP_ABS:
+    case FP_NEG:
+    case FP_ADD:
+    case FP_SUB:
+    case FP_MUL:
+    case FP_DIV:
+    case FP_FMA:
+    case FP_SQRT:
+    case FP_REM:
+    case FP_ROUNDTOINTEGRAL:
+    case FP_MIN:
+    case FP_MAX:
+    {
+      for (size_t i = 0; i < n.Degree(); i++)
+      {
+        const unsigned int child_exp = n[i].GetExpWidth();
+        if (child_exp != 0)
+        {
+          e = child_exp;
+          s = n[i].GetSigWidth();
+          return true;
+        }
+      }
+      return false;
+    }
+
+    default:
+      return false;
+  }
+}
+
+// Sentinel cached in _exp_width once derivation has concluded "not a
+// float". Without it every format query on a formatless node re-walks its
+// children -- quadratic on store chains and ITE spines, since WRITE and ITE
+// derive through their children. A later SetExpWidth (from a declaration or
+// the blaster stamping its output) simply overwrites it.
+static const uint32_t FP_NOT_A_FLOAT = 0xFFFFFFFFu;
+
+// Derive once and keep the answer -- positive or negative. The fields are
+// already mutable, and an interior node can hold them, so this costs one
+// walk per node rather than one per query.
+void ASTNode::cacheFPFormat() const
+{
+  unsigned int e = 0;
+  unsigned int s = 0;
+
+  const bool is_float = deriveFPFormat(*this, e, s);
+
+  // A BVCONST has nowhere to put either answer (its setters reject it);
+  // float constants are made as ASTFPConst instead, and re-deriving on a
+  // childless node is cheap.
+  if (GetKind() == BVCONST ||
+      (Degree() == 0 &&
+       _int_node_ptr->getDeclaredSourceSort().isKnown()))
+    return;
+
+  if (!is_float)
+  {
+    _int_node_ptr->setExpWidth(FP_NOT_A_FLOAT);
+    return;
+  }
+
+  _int_node_ptr->setExpWidth(e);
+  _int_node_ptr->setSigWidth(s);
+}
+
+unsigned int ASTNode::GetExpWidth() const
+{
+  unsigned int stored = _int_node_ptr->getExpWidth();
+  if (stored == FP_NOT_A_FLOAT)
+    return 0;
+  if (stored != 0)
+    return stored;
+
+  cacheFPFormat();
+  stored = _int_node_ptr->getExpWidth();
+  return stored == FP_NOT_A_FLOAT ? 0 : stored;
+}
+
+// A float's format may be stored only where it cannot be shared with a plain
+// bitvector use of the same node:
+//
+//  - on a leaf, whose sort is declared (a symbol) or fixed when it is made
+//    (an ASTFPConst, which interns apart from the plain constant holding the
+//    same bits);
+//  - on an interior node whose *kind* says it is a float, where it is derived
+//    from the kind and children rather than assigned (see deriveFPFormat) and
+//    so cannot disagree with anything;
+//  - on an array, where it describes the elements rather than the node.
+//
+// Never on a bitvector-kind interior node. Nodes are hash-consed and the
+// format is per-node state, so a format stamped on the bits a float lowers to
+// retypes everything else that denotes those bits: the input's own bitvectors
+// start reporting FLOATINGPOINT_TYPE solver-wide, bitvector operations over
+// them stop type checking, and to_fp reads an integer as a float. Lowering
+// therefore hands its format to the blaster as an argument instead (see
+// FloatBlaster::operandFormat and FloatBlast).
+bool ASTNode::canStoreFPFormat() const
+{
+  return Degree() == 0 || is_FP_kind(GetKind()) || GetKind() == FLOATINGPOINT ||
+         GetIndexWidth() > 0;
+}
+
+void ASTNode::SetExpWidth(unsigned int _ew) const
+{
+  // A format may be set, re-set to the same value, or cleared -- never
+  // changed. Two contexts disagreeing about a shared node's format is the
+  // hash-consing corruption this trips on.
+  assert(_int_node_ptr->getExpWidth() == 0 ||
+         _int_node_ptr->getExpWidth() == 0xFFFFFFFFu /* not-a-float cache */ ||
+         _ew == 0 || _int_node_ptr->getExpWidth() == _ew);
+
+  // Callers stamp only what can hold a stamp; withFormat is where that is
+  // decided, for the callers that do not already know.
+  assert(_ew == 0 || canStoreFPFormat());
+  // One of the funnels through which a float's format arrives, so this is
+  // where the manager learns that floats are in play. Not the only one:
+  // a node that derives its format needs no stamp and never reaches here,
+  // which is why withFormat -- the entry point that decides whether the
+  // stamp is needed -- notes it too.
+  if (_ew != 0)
+    _int_node_ptr->nodeManager->noteFloatingPoint();
+  _int_node_ptr->setExpWidth(_ew);
+}
+
+unsigned int ASTNode::GetSigWidth() const
+{
+  if (_int_node_ptr->getExpWidth() == FP_NOT_A_FLOAT)
+    return 0;
+
+  const unsigned int stored = _int_node_ptr->getSigWidth();
+  if (stored != 0)
+    return stored;
+
+  cacheFPFormat();
+  return _int_node_ptr->getSigWidth();
+}
+
+void ASTNode::SetSigWidth(unsigned int _sw) const
+{
+  assert(_int_node_ptr->getSigWidth() == 0 || _sw == 0 ||
+         _int_node_ptr->getSigWidth() == _sw);
+  _int_node_ptr->setSigWidth(_sw);
+}
+
 // return the type of the ASTNode:
 //
 // 0 iff BOOLEAN; 1 iff BITVECTOR; 2 iff ARRAY; 3 iff UNKNOWN;
@@ -75,6 +304,120 @@ const char* ASTNode::GetName() const
     FatalError("GetName: Called GetName on a non-symbol: ", *this);
 
   return ((ASTSymbol*)_int_node_ptr)->GetName();
+}
+
+// Memoised wrapper over deriveSourceSort.
+//
+// The derivation walks children for READ, WRITE and ITE -- and for ITE it
+// walks *both* branches -- so recomputing it costs Theta(2^depth) on a
+// shared-branch ITE DAG and Theta(depth) on a store chain, on a graph of
+// linear size. That is not a cost paid once: the front ends ask for every
+// node they build, and containsFloatingPointTheory asks for every node of
+// every query, including queries with no floating point in them.
+//
+// Memoising is sound for the same reason the floating-point format's memo is
+// (see cacheFPFormat): the derivation reads only the node's kind, children
+// and widths, and the first two are the hash-cons key. The widths are not, so
+// the setters drop the memo.
+SourceSort ASTNode::GetSourceSort() const
+{
+  if (IsNull())
+    return SourceSort::unknown();
+
+  if (const SourceSort* cached = _int_node_ptr->cachedSourceSort())
+    return *cached;
+
+  _int_node_ptr->nodeManager->source_sort_derivations++;
+  const SourceSort derived = deriveSourceSort();
+  _int_node_ptr->setCachedSourceSort(
+      _int_node_ptr->nodeManager->internSourceSort(derived));
+  return derived;
+}
+
+SourceSort ASTNode::deriveSourceSort() const
+{
+  if (GetKind() == UNDEFINED)
+    return SourceSort::unknown();
+
+  // API type nodes denote the corresponding source sort even though they
+  // are not themselves value-bearing terms.
+  switch (GetKind())
+  {
+    case BOOLEAN:
+      return SourceSort::boolean();
+    case BITVECTOR:
+      if (Degree() == 1 && (*this)[0].GetKind() == BVCONST)
+        return SourceSort::bitVector((*this)[0].GetUnsignedConst());
+      break;
+    case FLOATINGPOINT:
+      if (Degree() == 2 && (*this)[0].GetKind() == BVCONST &&
+          (*this)[1].GetKind() == BVCONST)
+        return SourceSort::floatingPoint((*this)[0].GetUnsignedConst(),
+                                         (*this)[1].GetUnsignedConst());
+      break;
+    case ROUNDINGMODE:
+      return SourceSort::roundingMode();
+    case ARRAY:
+      if (Degree() == 2)
+      {
+        const SourceSort index = (*this)[0].GetSourceSort();
+        const SourceSort element = (*this)[1].GetSourceSort();
+        if (index.isScalar() && element.isScalar())
+          return SourceSort::array(index, element);
+      }
+      break;
+    default:
+      break;
+  }
+
+  // Typed constants and symbols carry their sort as immutable identity.
+  const SourceSort declared = _int_node_ptr->getDeclaredSourceSort();
+  if (declared.isKnown())
+    return declared;
+
+  // The only source expressions whose carrier does not identify the result
+  // sort are the structural ones below. Derive them from their children.
+  if (GetKind() == READ && Degree() >= 1)
+  {
+    const SourceSort array = (*this)[0].GetSourceSort();
+    return array.kind() == SourceSort::Kind::Array
+               ? array.element()
+               : SourceSort::unknown();
+  }
+
+  if (GetKind() == WRITE && Degree() >= 1)
+    return (*this)[0].GetSourceSort();
+
+  if (GetKind() == ITE && Degree() == 3)
+  {
+    const SourceSort then_sort = (*this)[1].GetSourceSort();
+    const SourceSort else_sort = (*this)[2].GetSourceSort();
+    return then_sort == else_sort ? then_sort : SourceSort::unknown();
+  }
+
+  // Compatibility for internal and legacy leaves that predate typed source
+  // symbols. New public declarations do not take this path.
+  switch (GetType())
+  {
+    case BOOLEAN_TYPE:
+      return SourceSort::boolean();
+    case BITVECTOR_TYPE:
+      return GetValueWidth() == 0 ? SourceSort::unknown()
+                                  : SourceSort::bitVector(GetValueWidth());
+    case FLOATINGPOINT_TYPE:
+      return SourceSort::floatingPoint(GetExpWidth(), GetSigWidth());
+    case ARRAY_TYPE:
+    {
+      const SourceSort index = SourceSort::bitVector(GetIndexWidth());
+      const SourceSort element =
+          GetExpWidth() == 0
+              ? SourceSort::bitVector(GetValueWidth())
+              : SourceSort::floatingPoint(GetExpWidth(), GetSigWidth());
+      return SourceSort::array(index, element);
+    }
+    default:
+      return SourceSort::unknown();
+  }
 }
 
 // Get the value of bvconst from a bvconst.  It's an error if kind

--- a/lib/AST/ASTRMConst.cpp
+++ b/lib/AST/ASTRMConst.cpp
@@ -1,0 +1,17 @@
+/********************************************************************
+ * A source-language RoundingMode literal over STP's 5-bit carrier.
+ ********************************************************************/
+#include "stp/AST/ASTRMConst.h"
+#include "stp/AST/AST.h"
+
+namespace stp
+{
+
+ASTRMConst::ASTRMConst(STPMgr* mgr, CBV bv)
+    : ASTBVConst(mgr, bv, 0, /*managed_outside=*/true)
+{
+}
+
+ASTRMConst::ASTRMConst(const ASTRMConst& other) : ASTBVConst(other) {}
+
+} // namespace stp

--- a/lib/AST/ASTmisc.cpp
+++ b/lib/AST/ASTmisc.cpp
@@ -122,6 +122,19 @@ bool numberOfReadsLessThan(const ASTNode& n, int limit)
   return reads < limit;
 }
 
+// See the declaration for why this exists: constants of one value need
+// not be one node, because a floating-point constant interns apart from
+// the plain constant with its bits.
+bool constantsSameBits(const ASTNode& a, const ASTNode& b)
+{
+  assert(a.GetKind() == BVCONST && b.GetKind() == BVCONST);
+  if (a == b)
+    return true;
+  return a.GetValueWidth() == b.GetValueWidth() &&
+         0 == CONSTANTBV::BitVector_Lexicompare(a.GetBVConst(),
+                                                b.GetBVConst());
+}
+
 // True if any descendants are arrays.
 bool containsArrayOps(const ASTNode& n, STPMgr* mgr)
 {
@@ -132,6 +145,32 @@ bool containsArrayOps(const ASTNode& n, STPMgr* mgr)
     if (current.GetIndexWidth() > 0)
       return true;
 
+  return false;
+}
+
+bool containsFloatingPoint(const ASTNode& n, STPMgr* mgr)
+{
+  NodeIterator ni(n, mgr->ASTUndefined, *mgr);
+  ASTNode current;
+  while ((current = ni.next()) != ni.end())
+  {
+    if (is_FP_kind(current.GetKind()) ||
+        current.GetSourceSort().containsFloatingPoint())
+      return true;
+  }
+  return false;
+}
+
+bool containsFloatingPointTheory(const ASTNode& n, STPMgr* mgr)
+{
+  NodeIterator ni(n, mgr->ASTUndefined, *mgr);
+  ASTNode current;
+  while ((current = ni.next()) != ni.end())
+  {
+    if (is_FP_kind(current.GetKind()) ||
+        current.GetSourceSort().usesFloatingPointTheory())
+      return true;
+  }
   return false;
 }
 
@@ -204,18 +243,6 @@ void SortByArith(ASTVec& v)
   sort(v.begin(), v.end(), ArithLess{});
 }
 
-bool isAtomic(Kind kind)
-{
-  if (TRUE == kind || FALSE == kind || EQ == kind || BVLT == kind ||
-      BVLE == kind || BVGT == kind || BVGE == kind || BVSLT == kind ||
-      BVSLE == kind || BVSGT == kind || BVSGE == kind || BVUADDO == kind ||
-      BVSADDO == kind || BVUMULO == kind || BVSMULO == kind ||
-      BVUSUBO == kind || BVSSUBO == kind || SYMBOL == kind ||
-      BOOLEXTRACT == kind)
-    return true;
-  return false;
-}
-
 // If there is a lot of sharing in the graph, this will take a long
 // time.  it doesn't mark subgraphs as already having been
 // typechecked.
@@ -257,12 +284,50 @@ void buildListOfSymbols(const ASTNode& n, ASTNodeSet& visited,
     buildListOfSymbols(n[i], visited, symbols);
 }
 
+// A float is carried internally as its packed bits, so after FloatBlast a
+// float-typed leaf may stand in a bitvector circuit -- but this is not public
+// subtyping. The parser and C API reject BV operations over FP terms; this
+// predicate exists for lowered and model-evaluation nodes built inside STP.
+// A leaf's format is declared (a symbol) or
+// fixed when it is made (an ASTFPConst, which interns apart from the plain
+// constant with the same bits); a read, a store and an ITE derive theirs from
+// the array or the branches they carry; an operation's comes from its kind.
+// See deriveFPFormat: in every one of those cases the format follows from the
+// node, so nothing can disagree about it.
+//
+// A bitvector-kind interior node is entitled to none. Its format could only
+// have been stamped on by whoever lowered a float to those bits -- and nodes
+// are hash-consed, so that stamp retypes every other use of the same bits.
+// The input's own bitvectors start reporting FLOATINGPOINT_TYPE solver-wide.
+// That is what BVSRSHIFT and the comparison predicates used to abort on, and
+// what made to_fp read an integer source as a float and answer wrongly.
+// ASTNode::SetExpWidth now refuses such a stamp; this rejects the result of
+// one wherever the bits are used, so the two ends agree.
+// Declared in AST.h; shared, because every bit-vector-only pass that
+// classifies a node by GetType() has to ask this question and they must all
+// ask it the same way.
+bool isBitsValued(const ASTNode& n)
+{
+  const types t = n.GetType();
+
+  if (BITVECTOR_TYPE == t)
+    return true;
+  if (FLOATINGPOINT_TYPE != t)
+    return false;
+
+  const Kind k = n.GetKind();
+  return 0 == n.Degree() || is_FP_kind(k) || READ == k || WRITE == k ||
+         ITE == k;
+}
+
 void checkChildrenAreBV(const ASTChildren& v, const ASTNode& n)
 {
-  for (auto it = v.begin(), itend = v.end(); it != itend;
-       it++)
+  // See isBitsValued. (This check was fully disabled during the
+  // floating-point work because blasted circuits mix float-stamped and plain
+  // children; accepting both types restores it for the genuine errors.)
+  for (auto it = v.begin(), itend = v.end(); it != itend; it++)
   {
-    if (BITVECTOR_TYPE != it->GetType())
+    if (!isBitsValued(*it))
     {
       cerr << "The type is: " << it->GetType() << endl;
       FatalError(
@@ -338,6 +403,23 @@ ASTVec FlattenKind(Kind k, const ASTChildren& children, int maxDepth)
   return flat_children;
 }
 
+// Rounding modes are carried as 5-bit one-hot bitvectors, so a well-formed
+// one is any 5-bit bitvector: a literal from the grammar, or a symbol of
+// SMT-LIB's RoundingMode sort.
+//
+// Deliberately the carrier's shape and not the sort. Whether a term really
+// denotes one of RoundingMode's five values is
+// STPMgr::isRoundingModeSortedTerm, and that is what the parser and the C
+// API ask before building an operation -- but this runs over nodes STP
+// builds for itself as well, including the operations model evaluation
+// rebuilds with their children resolved, whose rounding mode can be the
+// model's value for a read the solve never constrained. Those are
+// well-formed and must type check.
+static bool isRoundingMode(const ASTNode& n)
+{
+  return n.GetType() == BITVECTOR_TYPE && n.GetValueWidth() == 5;
+}
+
 bool BVTypeCheck_term_kind(const ASTNode& n, const Kind& k)
 {
   // Symbols are a large share of the nodes built while parsing and have no
@@ -351,7 +433,7 @@ bool BVTypeCheck_term_kind(const ASTNode& n, const Kind& k)
   switch (k)
   {
     case BVCONST:
-      if (BITVECTOR_TYPE != n.GetType())
+      if (BITVECTOR_TYPE != n.GetType() && FLOATINGPOINT_TYPE != n.GetType())
         FatalError("BVTypeCheck: The term t does not typecheck, where t = \n",
                    n);
       break;
@@ -359,17 +441,43 @@ bool BVTypeCheck_term_kind(const ASTNode& n, const Kind& k)
     case ITE:
       if (n.Degree() != 3)
         FatalError("BVTypeCheck: should have exactly 3 args\n", n);
-      if (BOOLEAN_TYPE != n[0].GetType() || (n[1].GetType() != n[2].GetType()))
+      // At this internal checker boundary a lowered float branch and its
+      // packed-bit circuit are one class. Public construction has already
+      // required the source-level branches to have exactly the same sort.
+      if (BOOLEAN_TYPE != n[0].GetType() ||
+          (n[1].GetType() == BOOLEAN_TYPE) != (n[2].GetType() == BOOLEAN_TYPE))
         FatalError("BVTypeCheck: The term t does not typecheck, where t = \n",
                    n);
       if (n[1].GetValueWidth() != n[2].GetValueWidth())
+      {
         FatalError("BVTypeCheck: length of THENbranch != length of "
                    "ELSEbranch in the term t = \n",
                    n);
+      }
       if (n[1].GetIndexWidth() != n[2].GetIndexWidth())
         FatalError("BVTypeCheck: length of THENbranch != length of "
                    "ELSEbranch in the term t = \n",
                    n);
+      // Branches that BOTH claim to be floats must agree on the format, as
+      // for EQ below: two formats can share one packed width -- (8, 24) and
+      // (24, 8) are both 32 bits -- so the width checks cannot tell them
+      // apart, and the node would derive whichever branch's format comes
+      // first (see deriveFPFormat) and silently read the other branch's
+      // bits at it. A float branch and a plain bitvector branch remain legal
+      // only here: that mix arises once lowering replaces a branch with its
+      // circuit, after the public sort check.
+      if (n[1].GetExpWidth() != 0 && n[2].GetExpWidth() != 0 &&
+          (n[1].GetExpWidth() != n[2].GetExpWidth() ||
+           n[1].GetSigWidth() != n[2].GetSigWidth()))
+      {
+        cerr << "expwidth of THENbranch: " << n[1].GetExpWidth() << endl;
+        cerr << "expwidth of ELSEbranch: " << n[2].GetExpWidth() << endl;
+        cerr << "sigwidth of THENbranch: " << n[1].GetSigWidth() << endl;
+        cerr << "sigwidth of ELSEbranch: " << n[2].GetSigWidth() << endl;
+        FatalError("BVTypeCheck: the THENbranch and ELSEbranch differ in "
+                   "floating-point format in the term t = \n",
+                   n);
+      }
       break;
 
     case READ:
@@ -387,8 +495,13 @@ bool BVTypeCheck_term_kind(const ASTNode& n, const Kind& k)
       }
       if (ARRAY_TYPE != n[0].GetType())
         FatalError("First parameter to read should be an array", n[0]);
-      if (BITVECTOR_TYPE != n[1].GetType())
-        FatalError("Second parameter to read should be a bitvector", n[1]);
+      // A float-indexed array's index is a float laid out as its packed
+      // bits, exactly as a float element is (see WRITE's value below). The
+      // pre-solve pass rewrites such indexes to canonical bits.
+      if (BITVECTOR_TYPE != n[1].GetType() &&
+          FLOATINGPOINT_TYPE != n[1].GetType())
+        FatalError("Second parameter to read should be a bitvector or a float",
+                   n[1]);
       break;
 
     case WRITE:
@@ -404,10 +517,18 @@ bool BVTypeCheck_term_kind(const ASTNode& n, const Kind& k)
                    n);
       if (ARRAY_TYPE != n[0].GetType())
         FatalError("First parameter to read should be an array", n[0]);
-      if (BITVECTOR_TYPE != n[1].GetType())
-        FatalError("Second parameter to read should be a bitvector", n[1]);
-      if (BITVECTOR_TYPE != n[2].GetType())
-        FatalError("Third parameter to read should be a bitvector", n[2]);
+      // As for READ: a float index rides as its packed bits.
+      if (BITVECTOR_TYPE != n[1].GetType() &&
+          FLOATINGPOINT_TYPE != n[1].GetType())
+        FatalError("Second parameter to write should be a bitvector or a float",
+                   n[1]);
+      // The element of an array of floats is a float. It is laid out exactly
+      // like a bitvector of the same width -- the array carries the format --
+      // so everything below this point treats the two alike.
+      if (BITVECTOR_TYPE != n[2].GetType() &&
+          FLOATINGPOINT_TYPE != n[2].GetType())
+        FatalError("Third parameter to write should be a bitvector or a float",
+                   n[2]);
       break;
 
     case BVDIV:
@@ -507,6 +628,270 @@ bool BVTypeCheck_term_kind(const ASTNode& n, const Kind& k)
                    "the bitwidth.\n",
                    n);
       break;
+    // The arithmetic operations take a rounding mode as their first child,
+    // then their float operands; the rest take only floats. A rounding mode
+    // is carried as a 5-bit one-hot bitvector (see symbolic_fp.h).
+    case FP_ABS:
+    case FP_NEG:
+    case FP_ADD:
+    case FP_SUB:
+    case FP_MUL:
+    case FP_DIV:
+    case FP_FMA:
+    case FP_SQRT:
+    case FP_REM:
+    case FP_ROUNDTOINTEGRAL:
+    case FP_MIN:
+    case FP_MAX:
+    {
+      unsigned int expected_args;
+      unsigned int first_float;
+
+      switch (k)
+      {
+        case FP_ABS:
+        case FP_NEG:
+          expected_args = 1;
+          first_float = 0;
+          break;
+        case FP_SQRT:
+        case FP_ROUNDTOINTEGRAL:
+          expected_args = 2;
+          first_float = 1;
+          break;
+        case FP_REM:
+          expected_args = 2;
+          first_float = 0;
+          break;
+        // fp.min/fp.max gain a third child -- the choice of zero -- once
+        // FpTotalise has run, so both arities are well formed.
+        case FP_MIN:
+        case FP_MAX:
+          expected_args = n.Degree() == 3 ? 3 : 2;
+          first_float = 0;
+          break;
+        case FP_FMA:
+          expected_args = 4;
+          first_float = 1;
+          break;
+        default: // FP_ADD, FP_SUB, FP_MUL, FP_DIV
+          expected_args = 3;
+          first_float = 1;
+          break;
+      }
+
+      std::string error_msg("");
+      bool failed(false);
+
+      if (n.Degree() != expected_args)
+      {
+        error_msg = "<fp> has the wrong number of arguments";
+        failed = true;
+      }
+      else if (first_float == 1 && !isRoundingMode(n[0]))
+      {
+        error_msg = "first argument to <fp> is not a rounding mode";
+        failed = true;
+      }
+
+      // The trailing choice-of-zero child is a 1-bit bitvector, not a float,
+      // so it is checked separately.
+      const bool has_choice = (k == FP_MIN || k == FP_MAX) && n.Degree() == 3;
+      const unsigned int last_float = has_choice ? n.Degree() - 1 : n.Degree();
+
+      if (!failed && has_choice &&
+          (n[2].GetType() != BITVECTOR_TYPE || n[2].GetValueWidth() != 1))
+      {
+        error_msg = "<fp> min/max's choice of zero is not a 1-bit bitvector";
+        failed = true;
+      }
+
+      for (unsigned int i = first_float; !failed && i < last_float; i++)
+      {
+        if (n[i].GetType() != FLOATINGPOINT_TYPE)
+        {
+          error_msg = "argument to <fp> is not an fp";
+          failed = true;
+        }
+        else if (n[i].GetSigWidth() != n[first_float].GetSigWidth() ||
+                 n[i].GetExpWidth() != n[first_float].GetExpWidth())
+        {
+          error_msg = "arguments to <fp> differ in format";
+          failed = true;
+        }
+      }
+
+      if (failed)
+      {
+        cerr << error_msg << endl;
+        FatalError(error_msg.c_str(), n);
+      }
+      break;
+    }
+
+    // ((_ to_fp e s) bv) is (e, s, bits); ((_ to_fp e s) rm f) is
+    // (e, s, rm, expr). The e/s children record the target format.
+    case FP_TOFP:
+    {
+      std::string error_msg("");
+      bool failed(false);
+
+      if (n.Degree() != 3 && n.Degree() != 4)
+      {
+        error_msg = "to_fp should have 3 or 4 args";
+        failed = true;
+      }
+      else if (!n[0].isConstant() || !n[1].isConstant())
+      {
+        error_msg = "to_fp's format arguments must be constants";
+        failed = true;
+      }
+      // The target format is checked against the e/s children rather than
+      // against the node's own exp/sig widths: the node factory type checks
+      // while creating the node, which is before the parser has had a chance
+      // to stamp the format onto it.
+      else if (n.Degree() == 3)
+      {
+        // The packed bits are judged by width, and a float is allowed to
+        // stand for them (see isBitsValued). Blasting ((_ to_fp e s) bits)
+        // yields those same bits stamped with the format -- and nodes are
+        // hash-consed, so the stamp can land on the very node 'bits' names,
+        // which reports FLOATINGPOINT_TYPE from then on. It holds the same
+        // e + s bits either way; insisting on BITVECTOR_TYPE aborted the
+        // re-solve of a formula that had just solved.
+        if (!isBitsValued(n[2]) ||
+            n[2].GetValueWidth() !=
+                n[0].GetUnsignedConst() + n[1].GetUnsignedConst())
+        {
+          error_msg = "to_fp's argument is not a bitvector of width e + s";
+          failed = true;
+        }
+      }
+      else if (!isRoundingMode(n[2]))
+      {
+        error_msg = "to_fp's second argument is not a rounding mode";
+        failed = true;
+      }
+      // With a rounding mode this reformats a float. Converting a signed
+      // integer is FP_TOFP_SIGNED; the sorts differ, so the kinds do.
+      else if (n[3].GetType() != FLOATINGPOINT_TYPE)
+      {
+        error_msg = "to_fp's argument is not an fp";
+        failed = true;
+      }
+
+      if (failed)
+      {
+        cerr << error_msg << endl;
+        FatalError(error_msg.c_str(), n);
+      }
+      break;
+    }
+
+    // ((_ to_fp e s) rm bv) over a signed integer, and its unsigned
+    // counterpart: (e, s, rm, bits) for both.
+    case FP_TOFP_SIGNED:
+    case FP_TOFP_UNSIGNED:
+    {
+      std::string error_msg("");
+      bool failed(false);
+
+      if (n.Degree() != 4)
+      {
+        error_msg = "to_fp/to_fp_unsigned over an integer should have 4 args";
+        failed = true;
+      }
+      else if (!n[0].isConstant() || !n[1].isConstant())
+      {
+        error_msg = "to_fp's format arguments must be constants";
+        failed = true;
+      }
+      else if (!isRoundingMode(n[2]))
+      {
+        error_msg = "to_fp's second argument is not a rounding mode";
+        failed = true;
+      }
+      // The integer this converts rides in a bitvector -- or in a float leaf,
+      // whose bits are just as good and which isBitsValued admits. What it
+      // must not be is a bitvector some lowering has stamped a format onto.
+      else if (!isBitsValued(n[3]))
+      {
+        error_msg = "to_fp's integer argument is not a bitvector";
+        failed = true;
+      }
+
+      if (failed)
+      {
+        cerr << error_msg << endl;
+        FatalError(error_msg.c_str(), n);
+      }
+      break;
+    }
+
+    // ((_ fp.to_ubv m) rm x): (m, rm, x), plus the unspecified value once
+    // FpTotalise has run. Yields a bitvector of width m.
+    case FP_TO_UBV:
+    case FP_TO_SBV:
+    {
+      std::string error_msg("");
+      bool failed(false);
+
+      if (n.Degree() != 3 && n.Degree() != 4)
+      {
+        error_msg = "fp.to_ubv/fp.to_sbv should have 3 or 4 args";
+        failed = true;
+      }
+      else if (!n[0].isConstant())
+      {
+        error_msg = "fp.to_ubv/fp.to_sbv's width must be a constant";
+        failed = true;
+      }
+      else if (n.GetValueWidth() != n[0].GetUnsignedConst())
+      {
+        error_msg = "fp.to_ubv/fp.to_sbv's result width does not match";
+        failed = true;
+      }
+      else if (!isRoundingMode(n[1]))
+      {
+        error_msg =
+            "fp.to_ubv/fp.to_sbv's first argument is not a rounding mode";
+        failed = true;
+      }
+      else if (n[2].GetType() != FLOATINGPOINT_TYPE)
+      {
+        error_msg = "fp.to_ubv/fp.to_sbv's argument is not an fp";
+        failed = true;
+      }
+      else if (n.Degree() == 4 &&
+               (n[3].GetType() != BITVECTOR_TYPE ||
+                n[3].GetValueWidth() != n.GetValueWidth()))
+      {
+        error_msg =
+            "fp.to_ubv/fp.to_sbv's unspecified value has the wrong width";
+        failed = true;
+      }
+
+      if (failed)
+      {
+        cerr << error_msg << endl;
+        FatalError(error_msg.c_str(), n);
+      }
+      break;
+    }
+
+    // fp -> IEEE bits: one float in, an (eb + sb)-bit bitvector out.
+    case FP_TO_IEEE_BV:
+    {
+      if (n.Degree() != 1 || n[0].GetType() != FLOATINGPOINT_TYPE)
+      {
+        FatalError("fp -> IEEE bits takes one floating-point argument", n);
+      }
+      if (n.GetValueWidth() != n[0].GetExpWidth() + n[0].GetSigWidth())
+      {
+        FatalError("fp -> IEEE bits result width must be exp + sig width", n);
+      }
+      break;
+    }
 
     default:
       cerr << _kind_names[k];
@@ -549,13 +934,25 @@ bool BVTypeCheck_nonterm_kind(const ASTNode& n, const Kind& k)
       if (n.Degree() != 2)
         FatalError("BVTypeCheck: should have exactly 2 args\n", n);
 
-      if (!(n[0].GetValueWidth() == n[1].GetValueWidth() &&
-            n[0].GetIndexWidth() == n[1].GetIndexWidth()))
+      // The widths must always match. A blasted float keeps its bitvector
+      // shape, so a float-stamped node may be equated with a plain bitvector
+      // of the same width -- but two nodes that BOTH claim to be floats must
+      // agree on the format: (8, 24) and (24, 8) share a total width of 32
+      // yet are different sorts.
+      if (n[0].GetValueWidth() != n[1].GetValueWidth() ||
+          n[0].GetIndexWidth() != n[1].GetIndexWidth() ||
+          (n[0].GetExpWidth() != 0 && n[1].GetExpWidth() != 0 &&
+           (n[0].GetExpWidth() != n[1].GetExpWidth() ||
+            n[0].GetSigWidth() != n[1].GetSigWidth())))
       {
         cerr << "valuewidth of lhs of EQ: " << n[0].GetValueWidth() << endl;
         cerr << "valuewidth of rhs of EQ: " << n[1].GetValueWidth() << endl;
         cerr << "indexwidth of lhs of EQ: " << n[0].GetIndexWidth() << endl;
         cerr << "indexwidth of rhs of EQ: " << n[1].GetIndexWidth() << endl;
+        cerr << "expwidth of lhs of EQ: " << n[0].GetExpWidth() << endl;
+        cerr << "expwidth of rhs of EQ: " << n[1].GetExpWidth() << endl;
+        cerr << "sigwidth of lhs of EQ: " << n[0].GetSigWidth() << endl;
+        cerr << "sigwidth of rhs of EQ: " << n[1].GetSigWidth() << endl;
         FatalError(
             "BVTypeCheck: terms in atomic formulas must be of equal length", n);
       }
@@ -583,8 +980,10 @@ bool BVTypeCheck_nonterm_kind(const ASTNode& n, const Kind& k)
                    n);
       }
       if (n[0].GetValueWidth() != n[1].GetValueWidth())
+      {
         FatalError(
             "BVTypeCheck: terms in atomic formulas must be of equal length", n);
+      }
       if (n[0].GetIndexWidth() != n[1].GetIndexWidth())
       {
         FatalError(
@@ -627,7 +1026,69 @@ bool BVTypeCheck_nonterm_kind(const ASTNode& n, const Kind& k)
         FatalError("BVTypeCheck:ITE must have exactly 3 ChildNodes", n);
       break;
 
+    // The classification predicates: one float in, a Boolean out.
+    case FP_ISNORMAL:
+    case FP_ISSUBNORMAL:
+    case FP_ISZERO:
+    case FP_ISINFINITE:
+    case FP_ISNAN:
+    case FP_ISNEGATIVE:
+    case FP_ISPOSITIVE:
+      if (n.Degree() != 1)
+        FatalError("BVTypeCheck: <fp> predicate takes exactly 1 arg", n);
+      if (n[0].GetType() != FLOATINGPOINT_TYPE)
+        FatalError("BVTypeCheck: argument of <fp> predicate is not an fp", n);
+      break;
+
+    case FP_LEQ:
+    case FP_LT:
+    case FP_GEQ:
+    case FP_GT:
+    case FP_EQ:
+    case FP_SMT_EQ:
+    {
+
+      std::string error_msg("");
+      bool failed(false);
+
+      if (n.Degree() != 2)
+      {
+        error_msg = "<fp> should have exactly 2 args";
+        failed = true;
+      }
+      else if (n[0].GetType() != FLOATINGPOINT_TYPE)
+      {
+        error_msg = "lhs of <fp> is not an fp";
+        failed = true;
+      }
+      else if (n[1].GetType() != FLOATINGPOINT_TYPE)
+      {
+        error_msg = "rhs of <fp> is not an fp";
+        failed = true;
+      }
+      else if (n[0].GetSigWidth() != n[1].GetSigWidth())
+      {
+        error_msg = "arguments to <fp> differ in sig width";
+        cerr << n[0].GetSigWidth() << " " << n[1].GetSigWidth();
+        failed = true;
+      }
+      else if (n[0].GetExpWidth() != n[1].GetExpWidth())
+      {
+        error_msg = "arguments to <fp> differ in exp width";
+        cerr << n[0].GetExpWidth() << " " << n[1].GetExpWidth();
+        failed = true;
+      }
+
+      if (failed)
+      {
+        cerr << error_msg << endl;
+        FatalError(error_msg.c_str(), n);
+      }
+      break;
+    }
+
     default:
+      cerr << _kind_names[k];
       FatalError("BVTypeCheck: Unrecognized kind: ");
       break;
   }

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -41,6 +41,8 @@ add_library(AST OBJECT
     ASTNode.cpp
     ASTUtil.cpp
     ASTBVConst.cpp
+    ASTFPConst.cpp
+    ASTRMConst.cpp
     ASTmisc.cpp
     ASTSymbol.cpp
     MutableASTNode.cpp

--- a/lib/AbsRefineCounterExample/ArrayTransformer.cpp
+++ b/lib/AbsRefineCounterExample/ArrayTransformer.cpp
@@ -127,7 +127,8 @@ void ArrayTransformer::assertTransformPostConditions(const ASTNode& term,
   if (!p.second)
     return;
 
-  const Kind k = term.GetKind();
+  // Only consumed by the asserts, which an NDEBUG build compiles out.
+  [[maybe_unused]] const Kind k = term.GetKind();
 
   // Check the array reads / writes have been removed
   assert(READ != k);

--- a/lib/NodeFactory/NodeFactory.cpp
+++ b/lib/NodeFactory/NodeFactory.cpp
@@ -154,9 +154,13 @@ ASTNode NodeFactory::CreateSymbol(const char* const name, unsigned indexWidth,
   return n;
 }
 
-ASTNode NodeFactory::CreateConstant(stp::CBV cbv, unsigned width)
+ASTNode NodeFactory::CreateConstant(stp::CBV cbv, unsigned width,
+                                    unsigned exp_width, unsigned sig_width)
 {
-  return bm.CreateBVConst(cbv, width);
+  ASTNode c = bm.CreateBVConst(cbv, width);
+  if (exp_width != 0)
+    c = bm.CreateFPConst(c, exp_width, sig_width);
+  return c;
 }
 
 ASTNode NodeFactory::CreateOneConst(unsigned width)
@@ -186,4 +190,10 @@ ASTNode NodeFactory::CreateBVConst(unsigned int width,
                                    unsigned long long int bvconst)
 {
   return bm.CreateBVConst(width, bvconst);
+}
+
+ASTNode NodeFactory::CreateFPConst(const stp::ASTNode& bvconst,
+                                   unsigned exp_width, unsigned sig_width)
+{
+  return bm.CreateFPConst(bvconst, exp_width, sig_width);
 }

--- a/lib/NodeFactory/SimplifyingNodeFactory.cpp
+++ b/lib/NodeFactory/SimplifyingNodeFactory.cpp
@@ -1757,7 +1757,7 @@ ASTNode SimplifyingNodeFactory::plusRules(const ASTVec& oldChildren)
 
 
 // If the shift is bigger than the bitwidth, replace by an extract.
-ASTNode convertArithmeticKnownShiftAmount(const Kind k,
+ASTNode convertArithmeticKnownShiftAmount([[maybe_unused]] const Kind k,
                                                       const ASTVec& children,
                                                       STPMgr& bm,
                                                       NodeFactory* nf)

--- a/lib/STPManager/STPManager.cpp
+++ b/lib/STPManager/STPManager.cpp
@@ -24,6 +24,7 @@ THE SOFTWARE.
 
 // to get the PRIu64 macro from inttypes, this needs to be defined.
 #include "stp/STPManager/STPManager.h"
+#include "stp/FloatBlaster/rounding_modes.h"
 #include "stp/Printer/SMTLIBPrinter.h"
 #include "stp/Util/CBVOps.h"
 #include "stp/Util/NodeIterator.h"
@@ -138,9 +139,29 @@ ostream& operator<<(ostream& os, const ASTNodeMap& nmap)
 ////////////////////////////////////////////////////////////////
 ASTNode STPMgr::LookupOrCreateSymbol(const char* const name)
 {
+  // This legacy entry point has no sort parameter. Preserve its historical
+  // name lookup semantics for internal clients, while all typed public
+  // declarations go through CreateSourceSymbol instead.
+  ASTNode existing;
+  if (LookupSymbol(name, existing))
+    return existing;
+
   ASTSymbol temp_sym(this, name);
   ASTNode n(LookupOrCreateSymbol(temp_sym));
   return n;
+}
+
+ASTNode STPMgr::CreateSourceSymbol(const char* const name,
+                                   const SourceSort& source_sort)
+{
+  if (!source_sort.isKnown())
+    FatalError("CreateSourceSymbol requires a known source sort");
+  if (source_sort.containsFloatingPoint())
+    noteFloatingPoint();
+  else if (source_sort.usesFloatingPointTheory())
+    noteFloatingPointTheory();
+  ASTSymbol temp_sym(this, name, source_sort);
+  return ASTNode(LookupOrCreateSymbol(temp_sym));
 }
 
 // FIXME: _name is now a constant field, and this assigns to it
@@ -168,10 +189,15 @@ ASTSymbol* STPMgr::LookupOrCreateSymbol(ASTSymbol& s)
     // _name because it's const).  Can cast the iterator to
     // non-const -- carefully.
     // std::string strname(s_ptr->GetName());
-    ASTSymbol* s_ptr1 = new ASTSymbol(this, strdup(s_ptr->GetName()));
+    ASTSymbol* s_ptr1 =
+        new ASTSymbol(this, strdup(s_ptr->GetName()), s_ptr->_source_sort);
     s_ptr1->_value_width = s_ptr->_value_width;
+    s_ptr1->_index_width = s_ptr->_index_width;
+    s_ptr1->_exp_width = s_ptr->_exp_width;
+    s_ptr1->_sig_width = s_ptr->_sig_width;
     std::pair<ASTSymbolSet::const_iterator, bool> p =
         _symbol_unique_table.insert(s_ptr1);
+    indexSymbolName(s_ptr1);
     return *p.first;
   }
   else
@@ -179,6 +205,56 @@ ASTSymbol* STPMgr::LookupOrCreateSymbol(ASTSymbol& s)
     // return symbol found in table.
     return *it;
   }
+}
+
+ASTNode STPMgr::introducedSymbol(const std::string& name,
+                                 unsigned index_width, unsigned value_width)
+{
+  const std::map<std::string, ASTNode>::const_iterator found =
+      _introduced_by_name.find(name);
+  if (found != _introduced_by_name.end())
+    return found->second;
+
+  // Only ever on the first request, and only reachable if a public boundary
+  // let a reserved name through, which is precisely what they refuse. Adopting
+  // the existing symbol instead -- which is what the name-only lookup below
+  // does unaided -- makes a user's declaration into one of STP's own objects.
+  if (LookupSymbol(name.c_str()))
+    FatalError("introducedSymbol: a symbol STP reserves for itself has "
+               "already been declared: ",
+               ASTUndefined, 0);
+
+  const ASTNode symbol =
+      defaultNodeFactory->CreateSymbol(name.c_str(), index_width, value_width);
+  noteIntroducedSymbol(symbol);
+  _introduced_by_name[name] = symbol;
+  return symbol;
+}
+
+void STPMgr::indexSymbolName(ASTSymbol* symbol)
+{
+  _symbol_name_index[symbol->GetName()].push_back(symbol);
+}
+
+void STPMgr::unindexSymbolName(ASTSymbol* symbol)
+{
+  const SymbolNameIndex::iterator entry =
+      _symbol_name_index.find(symbol->GetName());
+  if (entry == _symbol_name_index.end())
+    return;
+
+  std::vector<ASTSymbol*>& declared = entry->second;
+  for (size_t i = 0; i < declared.size(); i++)
+  {
+    if (declared[i] == symbol)
+    {
+      declared.erase(declared.begin() + i);
+      break;
+    }
+  }
+
+  if (declared.empty())
+    _symbol_name_index.erase(entry);
 }
 
 bool STPMgr::LookupSymbol(ASTSymbol& s)
@@ -191,27 +267,27 @@ bool STPMgr::LookupSymbol(ASTSymbol& s)
     return true;
 }
 
+// The two name-only lookups. A symbol's sort is part of its identity, so
+// these cannot probe the unique table; they go through the name index, which
+// is maintained alongside it (see _symbol_name_index).
 bool STPMgr::LookupSymbol(const char* const name)
 {
-  ASTSymbol s(this, name);
-  ASTSymbol* s_ptr = &s; // it's a temporary key.
-
-  if (_symbol_unique_table.find(s_ptr) == _symbol_unique_table.end())
-    return false;
-  else
-    return true;
+  return _symbol_name_index.find(name) != _symbol_name_index.end();
 }
 
 bool STPMgr::LookupSymbol(const char* const name, ASTNode& output)
 {
-  ASTSymbol temp_sym(this, name);
-  ASTSymbolSet::const_iterator it = _symbol_unique_table.find(&temp_sym);
-  if (it != _symbol_unique_table.end())
-  {
-    output = ASTNode(*it);
-    return true;
-  }
-  return false;
+  const SymbolNameIndex::const_iterator entry = _symbol_name_index.find(name);
+  if (entry == _symbol_name_index.end())
+    return false;
+
+  // The first symbol declared under the name, where the old scan returned
+  // whichever the table happened to iterate first. Only a name declared at
+  // two different sorts can tell the difference, and then a deterministic
+  // answer is the better one.
+  assert(!entry->second.empty());
+  output = ASTNode(entry->second.front());
+  return true;
 }
 
 // Create a ASTBVConst node
@@ -249,7 +325,10 @@ ASTNode STPMgr::CreateBVConst(unsigned int width,
                                       c_val);
     if (shift_amount < (sizeof(bvconst) * 8))
     {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshift-count-overflow"
       bvconst >>= shift_amount;
+#pragma GCC diagnostic pop
     }
     else
     {
@@ -344,6 +423,279 @@ ASTNode STPMgr::CreateBVConst(CBV bv, unsigned width)
   ASTNode n(LookupOrCreateBVConst(temp_bvconst));
   CONSTANTBV::BitVector_Destroy(bv);
   return n;
+}
+
+void STPMgr::noteFloatingPoint()
+{
+#ifndef STP_ENABLE_FLOATING_POINT
+  FatalError("this STP was built without floating-point support; "
+             "reconfigure with -DENABLE_FLOATING_POINT=ON");
+#else
+  has_floating_point = true;
+  has_floating_point_theory = true;
+#endif
+}
+
+ASTNode STPMgr::CreateFPConst(const stp::ASTNode& bvconst,
+                              unsigned exp_width, unsigned sig_width)
+{
+#ifndef STP_ENABLE_FLOATING_POINT
+  (void)bvconst;
+  (void)exp_width;
+  (void)sig_width;
+  FatalError("this STP was built without floating-point support; "
+             "reconfigure with -DENABLE_FLOATING_POINT=ON");
+#else
+  assert(bvconst.GetKind() == BVCONST);
+  assert(exp_width + sig_width == bvconst.GetValueWidth());
+
+  // Temporary key sharing the source's CBV; interning clones it.
+  ASTBVConst* src = (ASTBVConst*)bvconst._int_node_ptr;
+
+  // Every NaN pattern interns as the one canonical quiet NaN. SMT-LIB's
+  // FloatingPoint sort has a single NaN, and no operation can recover a
+  // payload (fp.to_ieee_bv canonicalises; symfpu carries none) -- but the
+  // node-creation-time simplifiers do compare constants by identity and by
+  // bit pattern (chaseRead's "definately different" skip, CreateSimpleEQ's
+  // constant case), and they run before any pass could quotient NaN. Two
+  // NaN literals with different payloads used as array indexes would be
+  // "proved" to address different cells. Baking the quotient into the
+  // constant itself makes those comparisons exact: distinct floating-point
+  // constants of one format now denote distinct values.
+  {
+    CBV b = src->GetBVConst();
+    const unsigned stored_sig = sig_width - 1; // the hidden bit is not stored
+    bool exp_all_ones = true;
+    for (unsigned i = 0; exp_all_ones && i < exp_width; i++)
+      exp_all_ones = CONSTANTBV::BitVector_bit_test(b, stored_sig + i);
+    bool sig_nonzero = false;
+    for (unsigned i = 0; !sig_nonzero && i < stored_sig; i++)
+      sig_nonzero = CONSTANTBV::BitVector_bit_test(b, i);
+
+    if (exp_all_ones && sig_nonzero)
+    {
+      // Already canonical -- positive, and only the quiet bit set -- means
+      // stop, or the CreateFPSpecialConst below would recurse forever.
+      bool low_payload_zero = true;
+      for (unsigned i = 0; low_payload_zero && i + 1 < stored_sig; i++)
+        low_payload_zero = !CONSTANTBV::BitVector_bit_test(b, i);
+      const bool canonical =
+          low_payload_zero &&
+          CONSTANTBV::BitVector_bit_test(b, stored_sig - 1) &&
+          !CONSTANTBV::BitVector_bit_test(b, exp_width + sig_width - 1);
+      if (!canonical)
+        return CreateFPSpecialConst(FPSpecial::NaN, exp_width, sig_width);
+    }
+  }
+
+  ASTFPConst temp(this, src->GetBVConst(), exp_width, sig_width);
+
+  noteFloatingPoint();
+
+  ASTNode n(LookupOrCreateFPConst(temp));
+  assert(n.GetKind() == BVCONST);
+  return n;
+#endif
+}
+
+// As LookupOrCreateBVConst. The same table holds both flavours of constant:
+// the equality functor compares the format widths too, so a floating-point
+// constant never unifies with a plain bitvector constant of the same bits.
+ASTFPConst* STPMgr::LookupOrCreateFPConst(ASTFPConst& s)
+{
+  ASTBVConstSet::const_iterator it = _bvconst_unique_table.find(&s);
+  if (it != _bvconst_unique_table.end())
+    return static_cast<ASTFPConst*>(*it);
+
+  ASTFPConst* s_copy = new ASTFPConst(s);
+  _bvconst_unique_table.insert(s_copy);
+  return s_copy;
+}
+
+ASTNode STPMgr::CreateRMConst(unsigned mode)
+{
+#ifndef STP_ENABLE_FLOATING_POINT
+  (void)mode;
+  FatalError("this STP was built without floating-point support; "
+             "reconfigure with -DENABLE_FLOATING_POINT=ON");
+#else
+  using namespace symbolic_fp;
+  switch (mode)
+  {
+    case ROUND_NEAREST_TIES_TO_EVEN:
+    case ROUND_TOWARD_POSITIVE:
+    case ROUND_TOWARD_NEGATIVE:
+    case ROUND_TOWARD_ZERO:
+    case ROUND_NEAREST_TIES_TO_AWAY:
+      break;
+    default:
+      FatalError("CreateRMConst requires one of the five rounding modes");
+  }
+
+  // A rounding mode has no format, so noteFloatingPoint is never reached for
+  // it -- but it still needs FpTotalise's pinning pass to run.
+  noteFloatingPointTheory();
+
+  const ASTNode bits = CreateBVConst(5, mode);
+  ASTBVConst* src = static_cast<ASTBVConst*>(bits._int_node_ptr);
+  ASTRMConst temp(this, src->GetBVConst());
+  return ASTNode(LookupOrCreateRMConst(temp));
+#endif
+}
+
+ASTRMConst* STPMgr::LookupOrCreateRMConst(ASTRMConst& s)
+{
+  const ASTBVConstSet::const_iterator it = _bvconst_unique_table.find(&s);
+  if (it != _bvconst_unique_table.end())
+    return static_cast<ASTRMConst*>(*it);
+
+  ASTRMConst* copy = new ASTRMConst(s);
+  _bvconst_unique_table.insert(copy);
+  return copy;
+}
+
+ASTNode STPMgr::LiftSourceValue(const ASTNode& carrier,
+                                const SourceSort& source_sort)
+{
+  switch (source_sort.kind())
+  {
+    case SourceSort::Kind::FloatingPoint:
+      if (carrier.GetKind() != BVCONST ||
+          carrier.GetValueWidth() != source_sort.packedWidth())
+        FatalError("LiftSourceValue: invalid floating-point carrier: ",
+                   carrier);
+      return CreateFPConst(carrier, source_sort.exponentWidth(),
+                           source_sort.significandWidth());
+    case SourceSort::Kind::RoundingMode:
+      if (carrier.GetKind() != BVCONST || carrier.GetValueWidth() != 5)
+        FatalError("LiftSourceValue: invalid RoundingMode carrier: ", carrier);
+      return CreateRMConst(carrier.GetUnsignedConst());
+    case SourceSort::Kind::Bool:
+      if (carrier != ASTTrue && carrier != ASTFalse)
+        FatalError("LiftSourceValue: invalid Boolean carrier: ", carrier);
+      return carrier;
+    case SourceSort::Kind::BitVector:
+      if (carrier.GetKind() != BVCONST ||
+          carrier.GetValueWidth() != source_sort.bitVectorWidth())
+        FatalError("LiftSourceValue: invalid bitvector carrier: ", carrier);
+      return carrier;
+    default:
+      FatalError("LiftSourceValue: cannot lift this source sort");
+  }
+}
+
+ASTNode STPMgr::roundingModeValidConstraint(const ASTNode& s)
+{
+  using namespace symbolic_fp;
+  ASTVec one_of;
+  for (const unsigned mode :
+       {ROUND_NEAREST_TIES_TO_EVEN, ROUND_TOWARD_POSITIVE,
+        ROUND_TOWARD_NEGATIVE, ROUND_TOWARD_ZERO, ROUND_NEAREST_TIES_TO_AWAY})
+  {
+    one_of.push_back(
+        defaultNodeFactory->CreateNode(EQ, s, CreateRMConst(mode)));
+  }
+  return defaultNodeFactory->CreateNode(OR, one_of);
+}
+
+bool STPMgr::isRoundingModeSortedTerm(const ASTNode& n) const
+{
+  return n.GetSourceSort().kind() == SourceSort::Kind::RoundingMode;
+}
+
+ASTNode STPMgr::arrayBaseSymbol(const ASTNode& arr) const
+{
+  ASTNode n = arr;
+  while (true)
+  {
+    switch (n.GetKind())
+    {
+      case SYMBOL:
+        return n;
+      case WRITE:
+        n = n[0];
+        break;
+      case ITE:
+      {
+        // Both branches type as arrays of one bit layout; requiring one
+        // *sort* keeps a read from being canonicalised under one branch's
+        // index sort and taken raw under the other's.
+        const ASTNode left = arrayBaseSymbol(n[1]);
+        const ASTNode right = arrayBaseSymbol(n[2]);
+        if (left.IsNull())
+          return right;
+        if (!right.IsNull() && left.GetSourceSort() != right.GetSourceSort())
+          FatalError("arrayBaseSymbol: an if-then-else mixes arrays whose "
+                     "index or element sorts differ: ",
+                     n);
+        return left;
+      }
+      default:
+        return ASTNode();
+    }
+  }
+}
+
+bool STPMgr::arrayHasFpIndex(const ASTNode& arr, unsigned& exp_width,
+                             unsigned& sig_width) const
+{
+  const SourceSort sort = arr.GetSourceSort();
+  if (sort.kind() != SourceSort::Kind::Array ||
+      sort.index().kind() != SourceSort::Kind::FloatingPoint)
+    return false;
+  exp_width = sort.index().exponentWidth();
+  sig_width = sort.index().significandWidth();
+  return true;
+}
+
+bool STPMgr::arrayHasRmIndex(const ASTNode& arr) const
+{
+  const SourceSort sort = arr.GetSourceSort();
+  return sort.kind() == SourceSort::Kind::Array &&
+         sort.index().kind() == SourceSort::Kind::RoundingMode;
+}
+
+bool STPMgr::arrayHasRmElement(const ASTNode& arr) const
+{
+  const SourceSort sort = arr.GetSourceSort();
+  return sort.kind() == SourceSort::Kind::Array &&
+         sort.element().kind() == SourceSort::Kind::RoundingMode;
+}
+
+ASTNode STPMgr::CreateFPSpecialConst(FPSpecial which, unsigned exp_width,
+                                     unsigned sig_width)
+{
+  if (exp_width == 0 || sig_width == 0)
+    FatalError("CreateFPSpecialConst: a floating-point format needs nonzero "
+               "exponent and significand widths");
+
+  const unsigned width = exp_width + sig_width;
+  const unsigned stored_sig = sig_width - 1; // the hidden bit is not stored
+
+  // Packed layout, LSB first: [significand | exponent | sign].
+  CBV bits = CONSTANTBV::BitVector_Create(width, true);
+
+  const bool negative =
+      which == FPSpecial::MinusInfinity || which == FPSpecial::MinusZero;
+  const bool exp_all_ones = which == FPSpecial::NaN ||
+                            which == FPSpecial::PlusInfinity ||
+                            which == FPSpecial::MinusInfinity;
+
+  if (negative)
+    CONSTANTBV::BitVector_Bit_On(bits, width - 1);
+  for (unsigned i = 0; exp_all_ones && i < exp_width; i++)
+    CONSTANTBV::BitVector_Bit_On(bits, stored_sig + i);
+  // symfpu's canonical NaN: exponent all ones and only the top stored-
+  // significand bit set (pack() emits nanPattern(packedSigWidth) =
+  // 1 << (stored_sig - 1), the quiet-bit convention). Matching it keeps the
+  // interned constant bit-identical to the NaN every blasted operation
+  // produces. Semantically either way is a NaN; bit-identical is tidier.
+  if (which == FPSpecial::NaN && stored_sig > 0)
+    CONSTANTBV::BitVector_Bit_On(bits, stored_sig - 1);
+
+  // CreateBVConst destroys `bits`.
+  ASTNode packed = CreateBVConst(bits, width);
+  return CreateFPConst(packed, exp_width, sig_width);
 }
 
 ASTNode STPMgr::CreateZeroConst(unsigned width)
@@ -657,6 +1009,7 @@ STPMgr::~STPMgr()
 
   Introduced_SymbolsSet.clear();
   _symbol_unique_table.clear();
+  _symbol_name_index.clear();
   _bvconst_unique_table.clear();
 
   vector<ASTVec*>::iterator it = _asserts.begin();

--- a/lib/Sat/CryptoMinisat5.cpp
+++ b/lib/Sat/CryptoMinisat5.cpp
@@ -203,7 +203,7 @@ void CryptoMiniSat5::solveAndDump()
 // return value carries no information.
 uint32_t CryptoMiniSat5::getFixedCountWithAssumptions(const stp::SATSolver::vec_literals& assumps, const std::unordered_set<unsigned>& literals, bool& conflict )
 {
-  const uint64_t conf = s->get_sum_conflicts();
+  [[maybe_unused]] const uint64_t conf = s->get_sum_conflicts();
   assert(conf == 0);
 
 

--- a/lib/Simplifier/BVSolver.cpp
+++ b/lib/Simplifier/BVSolver.cpp
@@ -56,6 +56,30 @@ namespace stp
 const bool flatten_ands = true;
 const bool debug_bvsolver = false;
 
+// Whether eliminating `var` in favour of `value` keeps the floating-point
+// format `var` carries.
+//
+// A float's format is per-node state that only a leaf, a floating-point-kind
+// node or an array can hold (see ASTNode::canStoreFPFormat), so an ordinary
+// bitvector term -- everything this file builds to replace a variable with --
+// answers (0, 0) whatever it denotes. The floating-point layer is still
+// unlowered while the solver runs: FloatBlast comes after the size-reducing
+// passes, and it reads an operation's format off its operands, because by
+// then they are the only thing that still says what sort they are (see
+// FloatBlaster::operandFormat). So a float-typed variable rewritten into a
+// concatenation leaves fp.isZero and friends blasting against a format of
+// (0, 0) -- a packed width of zero against a 64-bit operand.
+//
+// Non-floats compare (0, 0) against (0, 0), so this is only ever a question
+// about floats. The same invariant UpdateSubstitutionMap asserts; the
+// solver map's own entry point does not check, so the check has to happen
+// here, before the equation that justifies the entry is discarded.
+static bool keepsFPFormat(const ASTNode& var, const ASTNode& value)
+{
+  return var.GetExpWidth() == value.GetExpWidth() &&
+         var.GetSigWidth() == value.GetSigWidth();
+}
+
 // The simplify functions can increase the size of the DAG,
 // so we have the option to disable simplifications.
 ASTNode BVSolver::simplifyNode(const ASTNode n)
@@ -270,6 +294,11 @@ ASTNode BVSolver::substitute(const ASTNode& eq, const ASTNode& lhs,
         return eq;
       }
 
+      // The right-hand side stands in for the variable everywhere, so it has
+      // to be the same sort of thing -- as a float too, not just as bits.
+      if (!keepsFPFormat(lhs, rhs))
+        return eq;
+
       if (!_simp->UpdateSolverMap(lhs, rhs))
       {
         return eq;
@@ -290,6 +319,15 @@ ASTNode BVSolver::substitute(const ASTNode& eq, const ASTNode& lhs,
       }
 
       if (vars.VarSeenInTerm(lhs[0], rhs))
+      {
+        return eq;
+      }
+
+      // Solving here renames the whole variable, not just the bits the
+      // extract names: below it becomes a concatenation, which carries no
+      // floating-point format at all. So a float-typed variable is left
+      // alone, extract equation and all. See keepsFPFormat.
+      if (lhs[0].GetExpWidth() != 0)
       {
         return eq;
       }
@@ -332,6 +370,15 @@ ASTNode BVSolver::substitute(const ASTNode& eq, const ASTNode& lhs,
       }
 
       bool ChosenVar_Is_Extract = (BVEXTRACT == lhs[1].GetKind());
+
+      // The variable becomes a multiple of the right-hand side, or a
+      // concatenation ending in one. Both are bitvector terms with no
+      // floating-point format to carry, so a float-typed variable is left
+      // alone. See keepsFPFormat.
+      if ((ChosenVar_Is_Extract ? lhs[1][0] : lhs[1]).GetExpWidth() != 0)
+      {
+        return eq;
+      }
 
       // if coeff is even, then we know that all the coeffs in the eqn
       // are even. Simply return the eqn

--- a/lib/Simplifier/PropagateEqualities.cpp
+++ b/lib/Simplifier/PropagateEqualities.cpp
@@ -239,12 +239,24 @@ void PropagateEqualities::processCandidates()
           return left->id > right->id;
       return false;
     };
+  // Fill the backing vector first and heapify once, rather than pushing
+  // into an empty queue element by element: that is O(n) instead of
+  // O(n log n), and the pop order is unchanged because cmp is a total order
+  // (equal variable counts are broken by the unique id).
+  //
+  // It also sidesteps a GCC false positive. Move-constructing the queue from
+  // an *empty* reserved vector runs make_heap over a range GCC cannot see is
+  // empty, and it then derives an absurd trip count and reports
+  // -Waggressive-loop-optimizations, which is fatal under -Werror in a
+  // release build.
   vector<qType> qStore;
   qStore.reserve(mapped.size());
-  std::priority_queue < qType, vector<qType>, decltype(cmp) > q(cmp, std::move(qStore));
 
   for (const auto& e: mapped)
-    q.push(&e.second);
+    qStore.push_back(&e.second);
+
+  std::priority_queue<qType, vector<qType>, decltype(cmp)> q(
+      cmp, std::move(qStore));
 
   std::vector<uint64_t> replacedOrder;
   replacedOrder.reserve(mapped.size());

--- a/lib/Simplifier/RemoveUnconstrained.cpp
+++ b/lib/Simplifier/RemoveUnconstrained.cpp
@@ -96,6 +96,10 @@ RemoveUnconstrained::replaceParentWithFresh(MutableASTNode& mute,
   const ASTNode& parent = mute.n;
   ASTNode v =
       bm.CreateFreshVariable(0, parent.GetValueWidth(), "unconstrained");
+  // A float-valued parent's stand-in must carry the format too, or the
+  // blaster later meets a formatless bitvector where a float belongs.
+  v.SetExpWidth(parent.GetExpWidth());
+  v.SetSigWidth(parent.GetSigWidth());
   mute.replaceWithVar(v, variables);
   return v;
 }

--- a/lib/Simplifier/Simplifier.cpp
+++ b/lib/Simplifier/Simplifier.cpp
@@ -1287,7 +1287,7 @@ ASTNode Simplifier::pullUpBVSX(ASTNode output)
   assert(output.GetChildren().size() == 2);
   assert(output[0].GetKind() == BVSX);
   assert(output[1].GetKind() == BVSX);
-  const Kind k = output.GetKind();
+  [[maybe_unused]] const Kind k = output.GetKind();
 
   assert(BVMULT == k || SBVDIV == k || BVPLUS == k);
   const int inputValueWidth = output.GetValueWidth();

--- a/lib/Simplifier/SplitExtracts.cpp
+++ b/lib/Simplifier/SplitExtracts.cpp
@@ -80,7 +80,7 @@ namespace stp
 
       for (const auto& e: nodeToExtracts )
       {
-        const auto& symbol = e.first;
+        [[maybe_unused]] const auto& symbol = e.first;
         assert(symbol.GetKind() == SYMBOL);
 
         auto ranges = e.second;

--- a/lib/Simplifier/StrengthReduction.cpp
+++ b/lib/Simplifier/StrengthReduction.cpp
@@ -390,7 +390,16 @@ namespace stp
           newN = nf->getFalse();
       }
       else
-        newN = nf->CreateConstant(b->GetBVConst(), n.GetValueWidth());
+      {
+        // The replaced node's floating-point format (if it has one) must be
+        // passed along: a constant is a leaf, so unlike the interior node it
+        // stands in for it cannot derive a format from children. A bare
+        // bitvector constant put where a float was makes the parent
+        // operation's rebuild abort -- fp.neg of a constant folds by making
+        // a floating-point constant, of format (0, 0) then.
+        newN = nf->CreateConstant(b->GetBVConst(), n.GetValueWidth(),
+                                  n.GetExpWidth(), n.GetSigWidth());
+      }
 
       replaceWithConstant++;
     }

--- a/lib/Simplifier/SubstitutionMap.cpp
+++ b/lib/Simplifier/SubstitutionMap.cpp
@@ -180,6 +180,12 @@ ASTNode SubstitutionMap::replace(const ASTNode& n, NodeMapType& fromTo,
     return n;
   }
 
+  // Floating-point special constants (NaN, +/-oo, +/-zero) are nullary leaves
+  // that the BVCONST/TRUE/FALSE test above does not cover, so they reach here
+  // with no children. They are values: there is nothing to substitute into.
+  if (n.Degree() == 0)
+    return n;
+
   const ASTChildren children = n.GetChildren();
   assert(children.size() > 0);
   // Should have no leaves left here.
@@ -407,8 +413,15 @@ bool SubstitutionMap::UpdateSubstitutionMap(const ASTNode& e0,
     return false;
 
   assert(e0 != e1);
-  assert(e0.GetValueWidth() == e1.GetValueWidth());
-  assert(e0.GetIndexWidth() == e1.GetIndexWidth());
+  // A substituted pair must agree as bitvectors/arrays AND as floats. The
+  // format check is trivially true for non-floats (both report (0, 0)); for
+  // floats the widths agree whenever the formats do, since a float's value
+  // width is exp_width + sig_width. These used to be a disjunction, which
+  // any two non-float nodes satisfied through the vacuous format arm.
+  assert(e0.GetValueWidth() == e1.GetValueWidth() &&
+         e0.GetIndexWidth() == e1.GetIndexWidth());
+  assert(e0.GetExpWidth() == e1.GetExpWidth() &&
+         e0.GetSigWidth() == e1.GetSigWidth());
 
   if (e0.GetKind() == SYMBOL)
   {

--- a/lib/Simplifier/UnsignedIntervalAnalysis.cpp
+++ b/lib/Simplifier/UnsignedIntervalAnalysis.cpp
@@ -743,7 +743,8 @@ namespace stp
     {
       CBV r = mkZero(bits_(x));
       CBV tmp = CONSTANTBV::BitVector_Clone(x); // Mul_Pos destroys this one.
-      CONSTANTBV::ErrCode e = CONSTANTBV::BitVector_Mul_Pos(r, tmp, y, true);
+      [[maybe_unused]] CONSTANTBV::ErrCode e =
+          CONSTANTBV::BitVector_Mul_Pos(r, tmp, y, true);
       assert(0 == e);
       CONSTANTBV::BitVector_Destroy(tmp);
       return r;
@@ -1322,7 +1323,7 @@ namespace stp
         // divisor. Division by zero gives all ones, so this lower bound
         // holds even if the divisor might be zero.
         CBV dividend = CONSTANTBV::BitVector_Clone(top->minV);
-        CONSTANTBV::ErrCode e = CONSTANTBV::BitVector_Div_Pos(
+        [[maybe_unused]] CONSTANTBV::ErrCode e = CONSTANTBV::BitVector_Div_Pos(
             result->minV, dividend, c1->maxV, remainder);
         assert(0 == e);
         CONSTANTBV::BitVector_Destroy(dividend);
@@ -1429,8 +1430,9 @@ namespace stp
             CBV quotientMax = CONSTANTBV::BitVector_Create(width, true);
 
             CBV dividend = CONSTANTBV::BitVector_Clone(children[0]->minV);
-            CONSTANTBV::ErrCode e = CONSTANTBV::BitVector_Div_Pos(
-                quotientMin, dividend, divisor, remainderMin);
+            [[maybe_unused]] CONSTANTBV::ErrCode e =
+                CONSTANTBV::BitVector_Div_Pos(quotientMin, dividend, divisor,
+                                              remainderMin);
             assert(0 == e);
             CONSTANTBV::BitVector_Destroy(dividend);
 

--- a/lib/Simplifier/constantBitP/ConstantBitP_Boolean.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_Boolean.cpp
@@ -339,7 +339,7 @@ Result bvImpliesBothWays(vector<FixedBits*>& children, FixedBits& result)
   FixedBits& b = (*children[1]);
 
   assert(a.getWidth() == result.getWidth());
-  const int bitWidth = a.getWidth();
+  [[maybe_unused]] const int bitWidth = a.getWidth();
   assert(bitWidth == 1);
 
   Result r = NO_CHANGE;

--- a/lib/Simplifier/constantBitP/ConstantBitP_Multiplication.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_Multiplication.cpp
@@ -157,7 +157,7 @@ Result fixIfCanForMultiplication(vector<FixedBits*>& children,
   Result result = NO_CHANGE;
 
   // only one of the conditionals can run.
-  bool run = false;
+  [[maybe_unused]] bool run = false;
 
   // We need every value that is unfixed to be set to one.
   if (aspirationalSum == columnOnes + columnOneFixed + columnUnfixed &&
@@ -433,7 +433,8 @@ Result useLeadingZeroesToFix(FixedBits& x, FixedBits& y, FixedBits& output)
   }
 
   stp::CBV result = CONSTANTBV::BitVector_Create(2 * bitWidth + 1, true);
-  CONSTANTBV::ErrCode ec = CONSTANTBV::BitVector_Multiply(result, x_c, y_c);
+  [[maybe_unused]] CONSTANTBV::ErrCode ec =
+      CONSTANTBV::BitVector_Multiply(result, x_c, y_c);
   assert(ec == CONSTANTBV::ErrCode_Ok);
 
   for (int j = (2 * bitWidth) - 1; j >= 0; j--)

--- a/lib/Simplifier/constantBitP/ConstantBitP_TransferFunctions.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_TransferFunctions.cpp
@@ -259,14 +259,14 @@ Result bvSignExtendBothWays(vector<FixedBits*>& children, FixedBits& output)
 
 Result bvExtractBothWays(vector<FixedBits*>& children, FixedBits& output)
 {
-  const size_t numberOfChildren = children.size();
+  [[maybe_unused]] const size_t numberOfChildren = children.size();
   const unsigned outputBitWidth = output.getWidth();
 
   Result result = NO_CHANGE;
 
   assert(3 == numberOfChildren);
 
-  unsigned top = children[1]->getUnsignedValue();
+  [[maybe_unused]] unsigned top = children[1]->getUnsignedValue();
   unsigned bottom = children[2]->getUnsignedValue();
 
   FixedBits& input = *(children[0]);

--- a/lib/Simplifier/constantBitP/ConstantBitPropagation.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitPropagation.cpp
@@ -151,6 +151,13 @@ ASTNodeMap ConstantBitPropagation::getAllFixed()
     if (BVCONCAT == node.GetKind())
       continue;
 
+    // Constant-bit propagation only reasons about Boolean and bit-vector
+    // values. A floating-point node has value width zero, so it is given a
+    // placeholder FixedBits that does not describe its packed contents; it must
+    // never be turned back into a constant here.
+    if (node.GetType() != BOOLEAN_TYPE && node.GetType() != BITVECTOR_TYPE)
+      continue;
+
     if (bits.isTotallyFixed())
     {
       toFrom.insert(make_pair(node, bitsToNode(node, bits)));
@@ -359,8 +366,10 @@ ASTNode ConstantBitPropagation::topLevelBothWays(const ASTNode& top,
     if (fromTo.find(node) != fromTo.end())
       continue;
 
+    // Only Boolean and bit-vector nodes can be replaced by a constant here; a
+    // floating-point node's FixedBits is a placeholder (see getAllFixed()).
     if (node.GetType() != BOOLEAN_TYPE && node.GetType() != BITVECTOR_TYPE)
-      FatalError("sadf234s");
+      continue;
 
     ASTNode constNode = bitsToNode(node, bits);
 

--- a/lib/Simplifier/constantBitP/ConstantBitPropagation.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitPropagation.cpp
@@ -366,7 +366,8 @@ ASTNode ConstantBitPropagation::topLevelBothWays(const ASTNode& top,
 
     if (SYMBOL == node.GetKind())
     {
-      bool r = simplifier->UpdateSubstitutionMap(node, constNode);
+      [[maybe_unused]] bool r =
+          simplifier->UpdateSubstitutionMap(node, constNode);
       assert(r);
     }
     else if (conjoinToTop && node != top)

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -2384,7 +2384,7 @@ BBNodeVec BitBlaster::v9(vector<list<BBNode>>& products,
     vector<BBNode> sorted; // The current column (sorted) gets put into here.
     vector<BBNode> prior;  // Prior is always empty in this..
 
-    const unsigned size = products[column].size();
+    [[maybe_unused]] const unsigned size = products[column].size();
     sortingNetworkAdd(support, products[column], sorted, prior);
 
     assert(products[column].size() == 1);

--- a/lib/ToSat/ToCNFAIG.cpp
+++ b/lib/ToSat/ToCNFAIG.cpp
@@ -227,8 +227,17 @@ Cnf_Dat_t* ToCNFAIG::derive_cnf(BBNodeManagerAIG& mgr)
 
     case UserDefinedFlags::CNF_EFFORT_MEDIUM:
     default:
-      // Cut enumeration and technology mapping, ABC's Cnf_Derive().
-      return Cnf_Derive(mgr.aigMgr, 0);
+    {
+      // Cut enumeration and technology mapping, as in ABC's Cnf_Derive().
+      // That convenience wrapper reuses one process-global Cnf_Man_t, so two
+      // independent STP instances deriving CNF concurrently overwrite the
+      // same cut/mapping state. ABC exposes the underlying per-manager entry
+      // point; keep the manager local to this conversion instead.
+      Cnf_Man_t* cnfMan = Cnf_ManStart();
+      Cnf_Dat_t* result = Cnf_DeriveWithMan(cnfMan, mgr.aigMgr, 0);
+      Cnf_ManStop(cnfMan);
+      return result;
+    }
   }
 }
 

--- a/tests/api/C/counter-example-reading.cpp
+++ b/tests/api/C/counter-example-reading.cpp
@@ -18,7 +18,7 @@ TEST(counter_example_reading, one)
   Expr AplusBplus42 =
       vc_bv32PlusExpr(vc, AplusB, vc_bv32ConstExprFromInt(vc, 42));
 
-  assert(0 == vc_query(vc, falseExpr));
+  ASSERT_EQ(0, vc_query(vc, falseExpr));
 
 // Don't do this,
 #if 0

--- a/tests/api/C/counterexample.cpp
+++ b/tests/api/C/counterexample.cpp
@@ -35,25 +35,25 @@ TEST(counterexample, one)
   Expr eq = vc_eqExpr(vc, A, c42);
 
   vc_assertFormula(vc, eq);
-  assert(0 == vc_query(vc, falseExpr));
+  ASSERT_EQ(0, vc_query(vc, falseExpr));
 
   Expr ce = vc_getCounterExample(vc, A);
-  assert(42 == getBVInt(ce));
+  ASSERT_EQ(42, getBVInt(ce));
 
   Expr Aplus42 = vc_bvPlusExpr(vc, 32, A, c42);
   ce = vc_getCounterExample(vc, Aplus42);
-  assert(84 == getBVInt(ce));
+  ASSERT_EQ(84, getBVInt(ce));
 
   ce = vc_getCounterExample(vc, falseExpr);
-  assert(0 == vc_isBool(ce));
+  ASSERT_EQ(0, vc_isBool(ce));
 
   Expr trueExpr = vc_notExpr(vc, falseExpr);
   ce = vc_getCounterExample(vc, trueExpr);
-  assert(1 == vc_isBool(ce));
+  ASSERT_EQ(1, vc_isBool(ce));
 
   Expr eq2 = vc_eqExpr(vc, Aplus42, vc_bvConstExprFromInt(vc, 32, 84));
   ce = vc_getCounterExample(vc, eq2);
-  assert(1 == vc_isBool(ce));
+  ASSERT_EQ(1, vc_isBool(ce));
 
   vc_Destroy(vc);
 }

--- a/tests/api/C/failing_solvermap.cpp
+++ b/tests/api/C/failing_solvermap.cpp
@@ -21,10 +21,10 @@ TEST(failing_solvermap, one)
 
   vc_assertFormula(vc,
                    vc_bvGtExpr(vc, AplusB, vc_bv32ConstExprFromInt(vc, 100)));
-  assert(0 == vc_query(vc, falseExpr));
+  ASSERT_EQ(0, vc_query(vc, falseExpr));
   vc_assertFormula(
       vc, vc_bvGtExpr(vc, AplusBplus42, vc_bv32ConstExprFromInt(vc, 5)));
-  assert(0 == vc_query(vc, falseExpr));
+  ASSERT_EQ(0, vc_query(vc, falseExpr));
 
   vc_Destroy(vc);
 }

--- a/tests/unit-tests/BVSolver_Test.cpp
+++ b/tests/unit-tests/BVSolver_Test.cpp
@@ -1,0 +1,165 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: July 2026
+ *
+ * LICENSE: Please view LICENSE file in the home dir of this Program
+ ********************************************************************/
+
+// The word-level solver eliminates a variable by recording a
+// replacement for it in the solver map. A float's format is per-node
+// state that only a leaf, a floating-point-kind node or an array can
+// hold (see ASTNode::canStoreFPFormat), so the bitvector terms the
+// solver builds -- a fresh variable concatenated with the solved bits,
+// a multiple of the right-hand side -- carry none, and eliminating a
+// float-typed variable into one drops its format.
+//
+// That matters because the solver runs while the floating-point layer
+// is still unlowered: FloatBlast comes after the size-reducing passes
+// and reads an operation's format off its operands, which by then are
+// the only thing that still says what sort they are. A float-typed
+// variable rewritten into a concatenation left fp.isZero blasting
+// against a format of (0, 0) -- a packed width of zero against a
+// 64-bit operand -- and the blaster aborted:
+//
+//   symbolic_fp.cpp: blast_is_zero: Assertion
+//     `expr.GetValueWidth() == size.packedWidth()' failed.
+//
+// The equations below are the shapes the solver knows how to take
+// apart, over a float-typed variable. See
+// fp-array-extensionality.cpp's
+// float_cell_pinned_under_chain_equality_unsat for the fuzzer's query
+// that produced the first of them.
+
+#include "stp/Simplifier/BVSolver.h"
+#include "stp/AST/AST.h"
+#include "stp/NodeFactory/SimplifyingNodeFactory.h"
+#include "stp/STPManager/STPManager.h"
+#include "stp/Simplifier/Simplifier.h"
+#include "stp/Simplifier/SubstitutionMap.h"
+#include <gtest/gtest.h>
+
+using namespace stp;
+
+namespace
+{
+
+const unsigned int EXP_WIDTH = 11;
+const unsigned int SIG_WIDTH = 53;
+const unsigned int FLOAT_WIDTH = EXP_WIDTH + SIG_WIDTH;
+
+struct Fixture
+{
+  STPMgr mgr;
+  SimplifyingNodeFactory snf;
+  SubstitutionMap sm;
+  Simplifier simp;
+  BVSolver solver;
+
+  Fixture()
+      : snf(*(mgr.hashingNodeFactory), mgr), sm(&mgr), simp(&mgr, &sm),
+        solver(&mgr, &simp)
+  {
+    mgr.defaultNodeFactory = &snf;
+  }
+
+  // A Float64 variable, made the way the array transformer makes one
+  // for a read of a float-element array: a symbol as wide as the
+  // packed format, carrying that format.
+  ASTNode floatVar(const char* name)
+  {
+    ASTNode f = mgr.CreateSymbol(name, 0, FLOAT_WIDTH);
+    f.SetExpWidth(EXP_WIDTH);
+    f.SetSigWidth(SIG_WIDTH);
+    return f;
+  }
+
+  ASTNode extract(const ASTNode& term, unsigned int high, unsigned int low)
+  {
+    return mgr.CreateTerm(BVEXTRACT, high - low + 1, term,
+                          mgr.CreateBVConst(32, high),
+                          mgr.CreateBVConst(32, low));
+  }
+
+  // Whether the format survives solving: what an fp.isZero over `f`
+  // reads as its operand, once the solver map has been applied, must
+  // still be a Float64. That is exactly what the blaster asks the
+  // operand for.
+  void operandKeepsFormat(const ASTNode& f)
+  {
+    const ASTNode after = simp.applySubstitutionMap(mgr.CreateNode(FP_ISZERO, f));
+    ASSERT_EQ(1u, after.Degree());
+    EXPECT_EQ(EXP_WIDTH, after[0].GetExpWidth());
+    EXPECT_EQ(SIG_WIDTH, after[0].GetSigWidth());
+    EXPECT_EQ(FLOAT_WIDTH, after[0].GetValueWidth());
+  }
+};
+
+} // namespace
+
+// (= ((_ extract 51 0) f) #x0000000000000): a float's significand half
+// pinned to a constant, which is what the extensional array
+// procedure's NaN test leaves behind once the float it compares
+// against is a known constant. Solving this renames f itself, to a
+// fresh 12-bit variable concatenated with the solved 52 bits.
+TEST(BVSolver, float_variable_survives_low_extract_equation)
+{
+  Fixture f;
+
+  const ASTNode x = f.floatVar("x");
+  const ASTNode eq = f.mgr.CreateNode(
+      EQ, f.extract(x, SIG_WIDTH - 2, 0), f.mgr.CreateZeroConst(SIG_WIDTH - 1));
+
+  f.solver.TopLevelBVSolve(eq, false);
+
+  f.operandKeepsFormat(x);
+}
+
+// (= (bvmul #x3 f) #x0): an odd coefficient over the whole variable.
+// Solving multiplies through by the coefficient's inverse, and
+// replaces f by the product -- another term with no format.
+TEST(BVSolver, float_variable_survives_odd_coefficient_equation)
+{
+  Fixture f;
+
+  const ASTNode x = f.floatVar("x");
+  const ASTNode product = f.mgr.CreateTerm(
+      BVMULT, FLOAT_WIDTH, f.mgr.CreateBVConst(FLOAT_WIDTH, 3), x);
+  const ASTNode eq =
+      f.mgr.CreateNode(EQ, product, f.mgr.CreateZeroConst(FLOAT_WIDTH));
+
+  f.solver.TopLevelBVSolve(eq, false);
+
+  f.operandKeepsFormat(x);
+}
+
+// A whole float variable equated to a plain bitvector term. The term
+// denotes the same 64 bits, but carries no format for the blaster to
+// read, so it cannot stand in for the variable.
+TEST(BVSolver, float_variable_survives_formatless_replacement)
+{
+  Fixture f;
+
+  const ASTNode x = f.floatVar("x");
+  const ASTNode bits = f.mgr.CreateSymbol("bits", 0, FLOAT_WIDTH);
+  const ASTNode eq =
+      f.mgr.CreateNode(EQ, x, f.mgr.CreateTerm(BVNOT, FLOAT_WIDTH, bits));
+
+  f.solver.TopLevelBVSolve(eq, false);
+
+  f.operandKeepsFormat(x);
+}
+
+// The same equations over a plain bitvector variable are still solved:
+// the guard is about formats, and a non-float has none to lose.
+TEST(BVSolver, plain_bitvector_variable_is_still_solved)
+{
+  Fixture f;
+
+  const ASTNode x = f.mgr.CreateSymbol("x", 0, FLOAT_WIDTH);
+  const ASTNode eq = f.mgr.CreateNode(
+      EQ, f.extract(x, SIG_WIDTH - 2, 0), f.mgr.CreateZeroConst(SIG_WIDTH - 1));
+
+  EXPECT_EQ(f.mgr.ASTTrue, f.solver.TopLevelBVSolve(eq, false));
+  EXPECT_TRUE(f.simp.InsideSubstitutionMap(x));
+}

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -28,6 +28,16 @@ AddSTPGTest(FindPureLiterals_Test.cpp)
 AddSTPGTest(Flatten_Test.cpp)
 AddSTPGTest(NodeDomainAnalysis_Test.cpp)
 AddSTPGTest(SplitExtracts_Test.cpp)
+# Not under ENABLE_FLOATING_POINT: the source-sort memo and the symbol name
+# index are AST machinery that floating point introduced but that every build
+# pays for, so both configurations have to cover them.
+AddSTPGTest(SourceSortMemo_Test.cpp)
+if (ENABLE_FLOATING_POINT)
+    AddSTPGTest(SourceSort_Test.cpp)
+    # Builds float-typed symbols, so it needs the floating-point funnels
+    # (SetExpWidth) to be more than a fatal error.
+    AddSTPGTest(BVSolver_Test.cpp)
+endif()
 AddSTPGTest(StrengthReduction_Test.cpp)
 AddSTPGTest(StrengthReduction_Exhaustive_Test.cpp)
 AddSTPGTest(RemoveUnconstrained_Exhaustive_Test.cpp)

--- a/tests/unit-tests/SourceSortMemo_Test.cpp
+++ b/tests/unit-tests/SourceSortMemo_Test.cpp
@@ -1,0 +1,249 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: August 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+// A node's source sort is derived from its children -- through both branches
+// of an ITE -- so without a memo the derivation costs one walk per *path*
+// rather than one per node. The result is correct either way, which is why
+// these tests count derivations rather than compare sorts: the count is the
+// only place the difference shows.
+
+#include "stp/AST/AST.h"
+#include "stp/STPManager/STPManager.h"
+
+#include <gtest/gtest.h>
+
+using namespace stp;
+
+namespace
+{
+
+// A spine of `depth` stores over one array, as a memory model or a lookup
+// table produces. Each WRITE derives its sort from the array beneath it.
+ASTNode storeChain(STPMgr& mgr, unsigned depth)
+{
+  const SourceSort array =
+      SourceSort::array(SourceSort::bitVector(16), SourceSort::bitVector(8));
+  ASTNode current = mgr.CreateSourceSymbol("a", array);
+
+  for (unsigned i = 0; i < depth; i++)
+  {
+    const ASTNode index = mgr.CreateBVConst(16, i);
+    const ASTNode value = mgr.CreateBVConst(8, i % 256);
+    current = mgr.CreateArrayTerm(WRITE, 16, 8, {current, index, value});
+  }
+  return current;
+}
+
+// Two interleaved ITE spines: every level's branches are the previous
+// level's two nodes, so the node count is linear in the depth while the
+// number of root-to-leaf paths is 2^depth.
+ASTNode iteDiamond(STPMgr& mgr, unsigned depth)
+{
+  ASTNode left = mgr.CreateSourceSymbol("x", SourceSort::bitVector(8));
+  ASTNode right = mgr.CreateSourceSymbol("y", SourceSort::bitVector(8));
+
+  for (unsigned i = 0; i < depth; i++)
+  {
+    const std::string cname = "c" + std::to_string(i);
+    const std::string ename = "e" + std::to_string(i);
+    const ASTNode c = mgr.CreateSourceSymbol(cname.c_str(),
+                                             SourceSort::boolean());
+    const ASTNode e = mgr.CreateSourceSymbol(ename.c_str(),
+                                             SourceSort::boolean());
+
+    const ASTNode next_left = mgr.CreateTerm(ITE, 8, c, left, right);
+    const ASTNode next_right = mgr.CreateTerm(ITE, 8, e, right, left);
+    left = next_left;
+    right = next_right;
+  }
+  return left;
+}
+
+} // namespace
+
+TEST(SourceSortMemo, ite_diamond_derives_once_per_node_not_once_per_path)
+{
+  STPMgr mgr;
+  const unsigned depth = 40; // 2^40 paths; a per-path walk cannot finish.
+  const ASTNode root = iteDiamond(mgr, depth);
+
+  mgr.source_sort_derivations = 0;
+  const SourceSort sort = root.GetSourceSort();
+
+  EXPECT_EQ(SourceSort::bitVector(8), sort);
+  // Two ITEs per level plus the leaves beneath them; the bound is deliberately
+  // loose, because the point is that it is linear in the depth at all.
+  EXPECT_LE(mgr.source_sort_derivations, 4 * depth + 16);
+}
+
+TEST(SourceSortMemo, store_chain_derives_once_per_node)
+{
+  STPMgr mgr;
+  const unsigned depth = 2000;
+  const ASTNode root = storeChain(mgr, depth);
+
+  mgr.source_sort_derivations = 0;
+  const SourceSort sort = root.GetSourceSort();
+
+  EXPECT_EQ(SourceSort::Kind::Array, sort.kind());
+  EXPECT_EQ(SourceSort::bitVector(8), sort.element());
+  EXPECT_LE(mgr.source_sort_derivations, depth + 16);
+}
+
+TEST(SourceSortMemo, asking_again_costs_no_derivation)
+{
+  STPMgr mgr;
+  const ASTNode root = storeChain(mgr, 64);
+  root.GetSourceSort();
+
+  mgr.source_sort_derivations = 0;
+  EXPECT_EQ(root.GetSourceSort(), root.GetSourceSort());
+  EXPECT_EQ(0u, mgr.source_sort_derivations);
+}
+
+// The node factories re-assert a node's widths on every hash-cons hit, so a
+// memo dropped on every width *assignment* rather than on every width
+// *change* is no memo at all -- it would be discarded once per incoming edge.
+TEST(SourceSortMemo, reasserting_the_same_width_keeps_the_memo)
+{
+  STPMgr mgr;
+  const ASTNode x = mgr.CreateSourceSymbol("x", SourceSort::bitVector(8));
+  const ASTNode y = mgr.CreateSourceSymbol("y", SourceSort::bitVector(8));
+  const ASTNode sum = mgr.CreateTerm(BVPLUS, 8, x, y);
+
+  EXPECT_EQ(SourceSort::bitVector(8), sum.GetSourceSort());
+
+  mgr.source_sort_derivations = 0;
+  sum.SetValueWidth(8); // what the node factory does on every lookup
+  EXPECT_EQ(SourceSort::bitVector(8), sum.GetSourceSort());
+  EXPECT_EQ(0u, mgr.source_sort_derivations);
+}
+
+TEST(SourceSortMemo, changing_a_width_drops_the_memo)
+{
+  STPMgr mgr;
+  const ASTNode x = mgr.CreateSourceSymbol("x", SourceSort::bitVector(8));
+  const ASTNode y = mgr.CreateSourceSymbol("y", SourceSort::bitVector(8));
+  const ASTNode sum = mgr.CreateTerm(BVPLUS, 8, x, y);
+
+  EXPECT_EQ(SourceSort::bitVector(8), sum.GetSourceSort());
+
+  sum.SetValueWidth(16);
+  EXPECT_EQ(SourceSort::bitVector(16), sum.GetSourceSort());
+
+  sum.SetValueWidth(8); // put it back, so the node is left as it was found
+  EXPECT_EQ(SourceSort::bitVector(8), sum.GetSourceSort());
+}
+
+// A symbol's sort is part of its identity, so a name-only probe cannot be
+// built for the unique table. These cover the name index that answers the
+// name-only lookups instead -- which is what keeps creating a symbol from
+// being linear in the number of symbols already made.
+TEST(SymbolNameIndex, finds_a_typed_declaration_by_name_alone)
+{
+  STPMgr mgr;
+  const ASTNode declared =
+      mgr.CreateSourceSymbol("v", SourceSort::bitVector(32));
+
+  EXPECT_TRUE(mgr.LookupSymbol("v"));
+  ASTNode found;
+  EXPECT_TRUE(mgr.LookupSymbol("v", found));
+  EXPECT_EQ(declared, found);
+
+  EXPECT_FALSE(mgr.LookupSymbol("not_declared"));
+  ASTNode missing;
+  EXPECT_FALSE(mgr.LookupSymbol("not_declared", missing));
+}
+
+// The legacy untyped entry point resolves a name to whatever was declared
+// under it, rather than minting a second, sort-less symbol beside it.
+TEST(SymbolNameIndex, untyped_lookup_reuses_the_typed_declaration)
+{
+  STPMgr mgr;
+  const ASTNode declared =
+      mgr.CreateSourceSymbol("w", SourceSort::bitVector(16));
+  const ASTNode again = mgr.LookupOrCreateSymbol("w");
+
+  EXPECT_EQ(declared, again);
+  EXPECT_EQ(SourceSort::bitVector(16), again.GetSourceSort());
+}
+
+// One name at two sorts is what the sorted key admits and the old name-keyed
+// one could not; the index has to keep both, and answer deterministically.
+TEST(SymbolNameIndex, keeps_every_sort_declared_under_one_name)
+{
+  STPMgr mgr;
+  const ASTNode first = mgr.CreateSourceSymbol("s", SourceSort::bitVector(8));
+  const ASTNode second =
+      mgr.CreateSourceSymbol("s", SourceSort::bitVector(16));
+
+  EXPECT_NE(first, second);
+  EXPECT_TRUE(mgr.LookupSymbol("s"));
+
+  ASTNode found;
+  EXPECT_TRUE(mgr.LookupSymbol("s", found));
+  EXPECT_EQ(first, found); // the first declared, not an arbitrary one
+
+  ASTNode again;
+  EXPECT_TRUE(mgr.LookupSymbol("s", again));
+  EXPECT_EQ(found, again);
+}
+
+// CreateFreshVariable asserts the name it mints is unused, so the index has
+// to see every symbol the manager holds, however it was made.
+TEST(SymbolNameIndex, sees_internally_minted_symbols)
+{
+  STPMgr mgr;
+  const ASTNode fresh = mgr.CreateFreshVariable(0, 8, "unconstrained");
+
+  EXPECT_TRUE(mgr.LookupSymbol(fresh.GetName()));
+  ASTNode found;
+  EXPECT_TRUE(mgr.LookupSymbol(fresh.GetName(), found));
+  EXPECT_EQ(fresh, found);
+}
+
+#ifdef STP_ENABLE_FLOATING_POINT
+// A float-indexed array of rounding modes: none of it is expressible in the
+// index/value/exp/sig widths, so it exercises the derivation rather than the
+// GetType() fallback beneath it.
+TEST(SourceSortMemo, memo_preserves_sorts_the_widths_cannot_express)
+{
+  STPMgr mgr;
+  const SourceSort array = SourceSort::array(SourceSort::floatingPoint(8, 24),
+                                             SourceSort::roundingMode());
+  const ASTNode a = mgr.CreateSourceSymbol("a", array);
+  const ASTNode i =
+      mgr.CreateSourceSymbol("i", SourceSort::floatingPoint(8, 24));
+  const ASTNode r = mgr.CreateSourceSymbol("r", SourceSort::roundingMode());
+  const ASTNode write = mgr.CreateArrayTerm(WRITE, 32, 5, {a, i, r});
+  const ASTNode read = mgr.CreateTerm(READ, 5, write, i);
+
+  EXPECT_EQ(array, write.GetSourceSort());
+  EXPECT_EQ(SourceSort::roundingMode(), read.GetSourceSort());
+
+  // Asked twice, answered the same -- the memo is not a different answer.
+  EXPECT_EQ(array, write.GetSourceSort());
+  EXPECT_EQ(SourceSort::roundingMode(), read.GetSourceSort());
+}
+#endif

--- a/tests/unit-tests/SourceSort_Test.cpp
+++ b/tests/unit-tests/SourceSort_Test.cpp
@@ -1,0 +1,67 @@
+#include "stp/AST/AST.h"
+#include "stp/STPManager/STPManager.h"
+
+#include <gtest/gtest.h>
+
+using namespace stp;
+
+TEST(SourceSort, distinguishes_equal_width_float_formats)
+{
+  const SourceSort single = SourceSort::floatingPoint(8, 24);
+  const SourceSort other32 = SourceSort::floatingPoint(11, 21);
+  EXPECT_EQ(32u, single.packedWidth());
+  EXPECT_EQ(32u, other32.packedWidth());
+  EXPECT_NE(single, other32);
+  EXPECT_NE(single, SourceSort::bitVector(32));
+}
+
+TEST(SourceSort, rounding_mode_literal_is_not_its_carrier)
+{
+  STPMgr mgr;
+  const ASTNode rm = mgr.CreateRMConst(1);
+  const ASTNode rm_again = mgr.CreateRMConst(1);
+  const ASTNode bits = mgr.CreateBVConst(5, 1);
+
+  EXPECT_NE(rm, bits);
+  EXPECT_EQ(rm, rm_again);
+  EXPECT_EQ(BVCONST, rm.GetKind());
+  EXPECT_EQ(BVCONST, bits.GetKind());
+  EXPECT_EQ(SourceSort::Kind::RoundingMode, rm.GetSourceSort().kind());
+  EXPECT_EQ(SourceSort::Kind::BitVector, bits.GetSourceSort().kind());
+  EXPECT_TRUE(constantsSameBits(rm, bits));
+}
+
+TEST(SourceSort, derives_array_reads_writes_and_ites)
+{
+  STPMgr mgr;
+  const SourceSort index = SourceSort::floatingPoint(8, 24);
+  const SourceSort element = SourceSort::roundingMode();
+  const SourceSort array = SourceSort::array(index, element);
+
+  const ASTNode a = mgr.CreateSourceSymbol("a", array);
+  const ASTNode b = mgr.CreateSourceSymbol("b", array);
+  const ASTNode i = mgr.CreateSourceSymbol("i", index);
+  const ASTNode r = mgr.CreateSourceSymbol("r", element);
+  const ASTNode c = mgr.CreateSourceSymbol("c", SourceSort::boolean());
+
+  const ASTNode read = mgr.CreateTerm(READ, 5, a, i);
+  const ASTNode write = mgr.CreateArrayTerm(WRITE, 32, 5, {a, i, r});
+  const ASTNode choice = mgr.CreateArrayTerm(ITE, 32, 5, {c, a, b});
+
+  EXPECT_EQ(element, read.GetSourceSort());
+  EXPECT_EQ(array, write.GetSourceSort());
+  EXPECT_EQ(array, choice.GetSourceSort());
+}
+
+TEST(SourceSort, typed_same_name_symbols_do_not_retype_each_other)
+{
+  STPMgr mgr;
+  const ASTNode rm =
+      mgr.CreateSourceSymbol("x", SourceSort::roundingMode());
+  const ASTNode bits =
+      mgr.CreateSourceSymbol("x", SourceSort::bitVector(5));
+
+  EXPECT_NE(rm, bits);
+  EXPECT_EQ(SourceSort::Kind::RoundingMode, rm.GetSourceSort().kind());
+  EXPECT_EQ(SourceSort::Kind::BitVector, bits.GetSourceSort().kind());
+}

--- a/tests/unit-tests/SplitExtracts_Test.cpp
+++ b/tests/unit-tests/SplitExtracts_Test.cpp
@@ -242,17 +242,16 @@ TEST(SplitExtracts_Test , __LINE__)
   ASSERT_EQ(2, c.split.getIntroduced());
 }
 
-// One instance is unextracted
+// One instance is unextracted. (The reassembled side must be the full 20
+// bits: = between different widths is ill-sorted and now rejected at parse.)
 TEST(SplitExtracts_Test , __LINE__)
 {
   const std::string input = R"(
-    (assert 
-      (= 
-        (concat 
-         (concat 
-           (((_ extract 4 0 ) v1) )  
-           (((_ extract 8 5 ) v1) ))
-           (((_ extract 3 3 ) v1) ))  
+    (assert
+      (=
+        (concat
+           (((_ extract 4 0 ) v1) )
+           (((_ extract 19 5 ) v1) ))
           v1
        )
     )
@@ -263,10 +262,14 @@ TEST(SplitExtracts_Test , __LINE__)
   ASSERT_EQ(0, c.split.getIntroduced());
 }
 
-// The (8,5) doesn't intersect.
+// The (8,5) doesn't intersect. (The other side must match the concat's 10
+// bits -- = between different widths is ill-sorted and now rejected at
+// parse -- so compare against a fresh 10-bit variable, which contributes no
+// extracts of its own.)
 TEST(SplitExtracts_Test , __LINE__)
 {
   const std::string input = R"(
+    (declare-fun w10 () (_ BitVec 10))
     (assert
       (=
         (concat
@@ -274,7 +277,7 @@ TEST(SplitExtracts_Test , __LINE__)
            (((_ extract 4 0 ) v1) )
            (((_ extract 8 5 ) v1) ))
            (((_ extract 3 3 ) v1) ))
-          v0
+          w10
        )
     )
   )";

--- a/tools/stp/main_common.cpp
+++ b/tools/stp/main_common.cpp
@@ -28,8 +28,8 @@ THE SOFTWARE.
 #include "sat/cnf/cnf.h"
 
 #include "stp/Parser/parser.h"
-#include "stp/cpp_interface.h"
 #include "stp/ToSat/ToSATAIG.h"
+#include "stp/cpp_interface.h"
 #include <memory>
 
 extern void errorHandler(const char* error_msg);


### PR DESCRIPTION
# FP support 1/5 — AST: an immutable source sort, and the floating-point node types

**This PR builds on top of #739** (the build-hygiene prerequisite). Please review and merge it first; this branch contains its commit.

The AST layer of SMT-LIB's floating-point theory: the kinds, the two new constant classes, and the sort machinery all of it hangs off.

**Nothing here can be reached from a query.** There is no syntax for it in the parser and no backend behind it, so this changes no answer STP gives. It is the vocabulary the rest of the series is written in, and it is reviewable on its own terms: is this the right representation?

## The problem it solves

A float is carried internally as its packed IEEE bits, so a bitvector value width cannot say what sort a node is — `(_ FloatingPoint 8 24)` and `(_ FloatingPoint 24 8)` are both 32 bits and are different sorts. Two pieces of state answer that:

- **A format on the node** (exponent and significand width). Only a leaf, a floating-point-kind node or an array can hold one; an ordinary bitvector term answers `(0, 0)` whatever it denotes. An operation's format is *derived* from its operands rather than stamped on it, because by the time lowering runs the operands are the only thing that still says what sort they are.
- **`SourceSort`** — the sort a term was written at: bitvector, floating point, `RoundingMode`, or an array over those. Interned in the manager so a derived sort memoises onto a node as a pointer, and fixed at construction for a leaf, where there are no children to derive it from.

Floating-point and `RoundingMode` constants intern like bitvector constants with the format part of the key, so one format's NaN cannot hash-cons to another's.

## The part that is not new machinery

Four existing size-reducing passes now decline to rewrite a variable into a bitvector term when that would drop a format the term cannot carry: `BVSolver`'s three substitution shapes, `RemoveUnconstrained`'s fresh parent, `StrengthReduction`'s constant, and `SubstitutionMap`'s invariant. Constant-bit propagation likewise stops short of turning a node it only has placeholder bits for back into a constant.

**For a query with no floating point in it, every one of these is vacuous** — both sides compare `(0, 0)`. That is worth checking during review, because it is the one place this commit touches code that runs on every query.

A symbol-name index is added alongside: a symbol's source sort is part of its identity, so the unique table is keyed on `(name, sort)` and the two name-only lookups became a scan of every symbol. Those lookups are how every internally minted symbol is made, so without the index symbol creation is quadratic on problems with no floating point in them.

## Build

`-DENABLE_FLOATING_POINT` (default ON) arrives here, and SymFPU is vendored as a pinned submodule the way mimalloc already is. SymFPU itself is not used until 2/5 — the option is here because the AST-level tests need the define.

## Testing

**73/73 ctest** (three new suites), **189/189 lit** unchanged.

- `SourceSort_Test` — sort construction and equality.
- `SourceSortMemo_Test` — that a sort is derived once per *node*, not once per path. Not gated on `ENABLE_FLOATING_POINT`: the memo and the name index are machinery every build pays for, so both configurations cover them.
- `BVSolver_Test` — that the solver declines the substitutions above.
