### PR TITLE
FP support (2/5): FloatBlaster: lower the floating-point theory onto SymFPU's circuits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,10 @@ docs/_build
 .DS_Store
 .direnv
 build
+
+# Local build trees, dependency clones and crash dumps (root only: scripts/deps
+# is tracked)
+/build-*/
+/core.*
+/deps/
+/.cache/

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "lib/extlib-mimalloc"]
 	path = lib/extlib-mimalloc
 	url = https://github.com/microsoft/mimalloc.git
+[submodule "lib/extlib-symfpu/symfpu"]
+	path = lib/extlib-symfpu/symfpu
+	url = https://github.com/martin-cs/symfpu.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -845,6 +845,51 @@ endif()
 find_package(Perl REQUIRED)
 
 # -----------------------------------------------------------------------------
+# Floating-point support (opt-out; uses the header-only SymFPU library)
+# -----------------------------------------------------------------------------
+# SymFPU (BSD 3-Clause) is vendored as a pinned submodule, the same
+# arrangement as mimalloc above, so the default build has floating-point
+# support with nothing to install. When OFF, everything floating-point
+# stays out of the build except the always-compiled AST/parser/API surface,
+# which recognises floating-point input and rejects it with a "built
+# without floating-point support" error (see FloatBlaster.cpp's stubs and
+# checkFpSupported in smt2.y). The public headers and the libstp ABI are
+# identical either way.
+
+option(ENABLE_FLOATING_POINT
+       "SMT-LIB floating-point support (uses the vendored SymFPU library)" ON)
+add_feature_info(FloatingPoint ENABLE_FLOATING_POINT
+                 "Enables SMT-LIB floating-point support (via SymFPU)")
+
+if (ENABLE_FLOATING_POINT)
+    # The vendored submodule is the default; -DSYMFPU_INCLUDE_DIRS=<dir
+    # that CONTAINS a symfpu clone> overrides it with an external copy.
+    if (NOT SYMFPU_INCLUDE_DIRS)
+        set(SYMFPU_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/lib/extlib-symfpu")
+    endif()
+
+    find_package(SymFPU)
+
+    if (SymFPU_FOUND)
+        message(STATUS "OK, found SymFPU include dirs under ${SYMFPU_INCLUDE_DIRS}")
+    else()
+        message(FATAL_ERROR
+            "SymFPU (header-only, required for the floating-point support) "
+            "was not found. It is vendored as a submodule: run "
+            "git submodule update --init lib/extlib-symfpu/symfpu. An "
+            "external clone of https://github.com/martin-cs/symfpu works "
+            "too, via -DSYMFPU_INCLUDE_DIRS=<directory that CONTAINS the "
+            "symfpu clone>. To build without floating-point support, "
+            "configure with -DENABLE_FLOATING_POINT=OFF.")
+    endif()
+
+    # Let's get clean builds ...
+    include_directories(SYSTEM ${SYMFPU_INCLUDE_DIRS})
+
+    add_definitions(-DSTP_ENABLE_FLOATING_POINT)
+endif()
+
+# -----------------------------------------------------------------------------
 # Query definitions
 # -----------------------------------------------------------------------------
 get_directory_property( DirDefs DIRECTORY ${CMAKE_SOURCE_DIR} COMPILE_DEFINITIONS )

--- a/LICENSE_COMPONENTS
+++ b/LICENSE_COMPONENTS
@@ -4,6 +4,8 @@ STP imports code from the following libraries:
 		of Leland Stanford Junior University and by New York University.
 	* ABC Copyright (c) The Regents of the University of California.
 	* mimalloc Copyright (c) 2018-2025 Microsoft Corporation, Daan Leijen.
+	* SymFPU copyright (C) by the authors from 2018 (only compiled in when
+		floating-point support is enabled).
 	* ankerl::unordered_dense Copyright (c) 2022-2024 Martin Leitner-Ankerl.
 	* Mersenne Twister Copyright (C) 1997 - 2002 Makoto Matsumoto and Takuji
 		Nishimura, Copyright (C) 2000 - 2003 Richard J. Wagner.
@@ -107,6 +109,40 @@ mimalloc
 	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 	SOFTWARE.
+
+SymFPU
+	SymFPU is available under a choice of two licenses, GPL V3 or BSD
+	3-Clause; STP uses it under the BSD 3-Clause license, reproduced here.
+
+	SymFPU is copyright (C) by the authors from 2018
+
+	Redistribution and use in source and binary forms, with or without
+	modification, are permitted provided that the following conditions are
+	met:
+
+	    (1) Redistributions of source code must retain the above copyright
+	        notice, this list of conditions and the following disclaimer.
+
+	    (2) Redistributions in binary form must reproduce the above copyright
+	        notice, this list of conditions and the following disclaimer in
+	        the documentation and/or other materials provided with the
+	        distribution.
+
+	    (3) The name of the author may not be used to
+	        endorse or promote products derived from this software without
+	        specific prior written permission.
+
+	THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+	IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+	WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+	DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
+	INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+	(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+	SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+	HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+	STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+	IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+	POSSIBILITY OF SUCH DAMAGE.
 
 ankerl::unordered_dense
 	Licensed under the MIT License <http://opensource.org/licenses/MIT>.

--- a/cmake/modules/FindSymFPU.cmake
+++ b/cmake/modules/FindSymFPU.cmake
@@ -1,0 +1,42 @@
+# AUTHORS: Andrew Teylu
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+# - Try to find SymFPU
+# Once done this will define
+#  SYMFPU_FOUND - System has SymFPU
+#  SYMFPU_INCLUDE_DIRS - The SymFPU include directories
+#  SYMFPU_DEFINITIONS - Compiler switches required for using SymFPU
+
+set(SYMFPU_DEFINITIONS "")
+
+# The header is found as <hint>/symfpu/core/unpackedFloat.h, so the hint in
+# SYMFPU_INCLUDE_DIRS must be the directory CONTAINING the symfpu clone, not
+# the clone itself.
+find_path(SYMFPU_INCLUDE_DIR symfpu/core/unpackedFloat.h
+          HINTS ${SYMFPU_INCLUDE_DIRS})
+
+set(SYMFPU_INCLUDE_DIRS ${SYMFPU_INCLUDE_DIR})
+
+include(FindPackageHandleStandardArgs)
+# handle the QUIETLY and REQUIRED arguments and set SYMFPU_FOUND to TRUE
+# if all listed variables are set
+find_package_handle_standard_args(SymFPU DEFAULT_MSG SYMFPU_INCLUDE_DIR)
+mark_as_advanced(SYMFPU_INCLUDE_DIR)
+

--- a/include/stp/AST/AST.h
+++ b/include/stp/AST/AST.h
@@ -63,10 +63,51 @@ struct ArithLess
     return arithless(n1, n2);
   }
 };
-bool isAtomic(Kind k);
 bool isCommutative(const Kind k);
 bool containsArrayOps(const ASTNode& n, STPMgr* stp);
+// Query-local source-theory checks. The first asks whether FP lowering is
+// needed; the second also includes RoundingMode-only syntax for printing.
+bool containsFloatingPoint(const ASTNode& n, STPMgr* stp);
+bool containsFloatingPointTheory(const ASTNode& n, STPMgr* stp);
 bool numberOfReadsLessThan(const ASTNode& n, int v);
+
+// Whether two constants spell the same bits. Node identity understates
+// this: a floating-point constant interns apart from the plain bitvector
+// constant with its bits (the format is part of a constant's identity),
+// so two distinct constant nodes may denote one bitvector value. Any
+// rule that concludes "different value" from "different constant nodes"
+// must compare through here instead.
+bool constantsSameBits(const ASTNode& a, const ASTNode& b);
+
+// Whether two constants are known to denote *different* values.
+//
+// This is the unsound direction, and the reason it has a name of its own:
+// `a != b` answers it correctly for plain bitvector constants and wrongly
+// for a floating-point or rounding-mode constant that shares its bits with
+// one, and the two spellings look alike at a glance. Every rule that skips
+// a write, proves two array indexes address different cells, or otherwise
+// concludes "different value" must ask through here, so that the sites which
+// depend on the distinction can be found by looking for this name.
+inline bool constantsDenoteDifferentValues(const ASTNode& a, const ASTNode& b)
+{
+  return !constantsSameBits(a, b);
+}
+
+// Whether `n` denotes bits to the bit-vector layers, which is not the same
+// question as GetType() == BITVECTOR_TYPE.
+//
+// FloatBlast removes every floating-point *operation* but deliberately leaves
+// float symbols, constants and the structural nodes over them as their packed
+// bits, still reporting FLOATINGPOINT_TYPE so that model reconstruction can
+// recover the sort. So a lowered formula handed to the bit-vector layers
+// contains float-typed leaves that are, at that boundary, ordinary bitvectors.
+//
+// Every bit-vector-only pass that classifies a node by GetType() needs this
+// question rather than the raw comparison, and it must be asked in one place:
+// spelling it out per call site is what left BitBlaster::simplify_during_bb
+// behind when the invariant was introduced, so that --bb.simplify-during-bb
+// aborted on any query with a float leaf in it.
+bool isBitsValued(const ASTNode& n);
 
 // If (a > b) in the termorder, then return 1 elseif (a < b) in the
 // termorder, then return -1 else return 0

--- a/include/stp/AST/ASTBVConst.h
+++ b/include/stp/AST/ASTBVConst.h
@@ -36,6 +36,8 @@ class ASTBVConst : public ASTInternal
 {
   friend class STPMgr;
   friend class ASTNode;
+  friend class ASTFPConst;
+  friend class ASTRMConst;
   friend class ASTNodeHasher;
   friend class ASTNodeEqual;
 
@@ -79,30 +81,44 @@ private:
   // friend equality operator
   friend bool operator==(const ASTBVConst& bvc1, const ASTBVConst& bvc2)
   {
-    if (bvc1.getValueWidth() != bvc2.getValueWidth())
+    if (bvc1.getDeclaredSourceSort() != bvc2.getDeclaredSourceSort())
       return false;
     return (0 == CONSTANTBV::BitVector_Compare(bvc1._bvconst, bvc2._bvconst));
   }
 
   // Call this when deleting a node that has been stored in the the
   // unique table
-  virtual void CleanUp();
+  void CleanUp() override;
 
   // Print function for bvconst -- return _bvconst value in bin
   // format (c_friendly is for printing hex. numbers that C
   // compilers will accept)
-  virtual void nodeprint(ostream& os, bool c_friendly = false);
+  void nodeprint(ostream& os, bool c_friendly = false) override;
 
   const static ASTVec astbv_empty_children;
 
-  void setIndexWidth( [[maybe_unused]] uint32_t i ) { assert(i == 0); }
-  uint32_t getIndexWidth() const { return 0; }
+  void setIndexWidth([[maybe_unused]] uint32_t i) override { assert(i == 0); }
+  uint32_t getIndexWidth() const override { return 0; }
 
-  void setValueWidth([[maybe_unused]] uint32_t v ) { assert(v == getValueWidth()); }
-  uint32_t getValueWidth() const { return bits_(_bvconst); }
+  void setValueWidth([[maybe_unused]] uint32_t v) override
+  {
+    assert(v == getValueWidth());
+  }
+  uint32_t getValueWidth() const override { return bits_(_bvconst); }
+
+  void setExpWidth(uint32_t) override { assert(false); }
+  uint32_t getExpWidth() const override { return 0; }
+
+  void setSigWidth(uint32_t) override { assert(false); }
+  uint32_t getSigWidth() const override { return 0; }
+
+  SourceSort getDeclaredSourceSort() const override
+  {
+    return SourceSort::bitVector(getValueWidth());
+  }
 
 public:
-  virtual ASTChildren GetChildren() const { return astbv_empty_children; }
+  ASTChildren GetChildren() const override { return astbv_empty_children; }
 
   virtual ~ASTBVConst()
   {
@@ -121,14 +137,15 @@ public:
 inline size_t
 ASTBVConst::ASTBVConstHasher::operator()(const ASTBVConst* bvc) const
 {
-  return CONSTANTBV::BitVector_Hash(bvc->_bvconst);
+  return CONSTANTBV::BitVector_Hash(bvc->_bvconst) ^
+         (bvc->getDeclaredSourceSort().hash() * 0x9e3779b97f4a7c15ULL);
 }
 
 inline bool
 ASTBVConst::ASTBVConstEqual::operator()(const ASTBVConst* bvc1,
                                         const ASTBVConst* bvc2) const
 {
-  if (bvc1->getValueWidth() != bvc2->getValueWidth())
+  if (bvc1->getDeclaredSourceSort() != bvc2->getDeclaredSourceSort())
   {
     return false;
   }

--- a/include/stp/AST/ASTFPConst.h
+++ b/include/stp/AST/ASTFPConst.h
@@ -1,0 +1,77 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: January 2021
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#ifndef ASTFPCONST_H
+#define ASTFPCONST_H
+
+#include "ASTBVConst.h"
+
+namespace stp
+{
+class STPMgr;
+
+// A bitvector constant that additionally carries a floating-point format.
+// Interned in the same unique table as plain bitvector constants: the
+// table's equality functor compares the format widths as well as the bits,
+// so 1.0f can never unify with the plain 32-bit pattern 0x3F800000, nor
+// with the same bits read at a different format.
+class ASTFPConst : public ASTBVConst
+{
+  friend class STPMgr;
+
+  uint32_t _sig_width;
+  uint32_t _exp_width;
+
+  // The format is part of the node's identity in the unique table, so it is
+  // fixed at construction. The setters only accept the stored value, in the
+  // style of ASTBVConst::setValueWidth.
+  void setSigWidth([[maybe_unused]] uint32_t sw) override
+  {
+    assert(sw == _sig_width);
+  }
+  uint32_t getSigWidth() const override { return _sig_width; }
+
+  void setExpWidth([[maybe_unused]] uint32_t ew) override
+  {
+    assert(ew == _exp_width);
+  }
+  uint32_t getExpWidth() const override { return _exp_width; }
+
+  SourceSort getDeclaredSourceSort() const override
+  {
+    return SourceSort::floatingPoint(_exp_width, _sig_width);
+  }
+
+  // Temporary-key constructor: shares `bv` without cloning or freeing it.
+  ASTFPConst(STPMgr* mgr, CBV bv, uint32_t exp_width, uint32_t sig_width);
+
+  // Copying constructor, used when interning a temporary key: clones the CBV.
+  ASTFPConst(const ASTFPConst& other);
+
+public:
+  virtual ~ASTFPConst() {}
+};
+
+} // namespace stp
+#endif

--- a/include/stp/AST/ASTInterior.h
+++ b/include/stp/AST/ASTInterior.h
@@ -98,16 +98,70 @@ class ASTInterior : public ASTInternal
   uint32_t _value_width;
   uint32_t _index_width;
 
-  virtual void setIndexWidth(uint32_t i) { _index_width = i; }
+  uint32_t _sig_width;
+  uint32_t _exp_width;
+
+  // Derived, and memoised on first request; see ASTInternal::cachedSourceSort.
+  // Points into the manager's intern pool, so it neither owns nor allocates.
+  //
+  // A width setter drops it, because the derivation reads the widths and
+  // legacy callers still set them after the node is built -- but only when the
+  // width actually changes. The node factories re-assert a node's widths on
+  // every hash-cons *hit* (HashingNodeFactory::CreateTerm), so invalidating
+  // unconditionally would throw the memo away on each of the DAG's incoming
+  // edges and leave the recomputation exactly as it was.
+  mutable const SourceSort* _source_sort_cache;
+
+  virtual void setIndexWidth(uint32_t i)
+  {
+    if (_index_width == i)
+      return;
+    _index_width = i;
+    _source_sort_cache = NULL;
+  }
   virtual uint32_t getIndexWidth() const { return _index_width; }
 
-  virtual void setValueWidth(uint32_t v) { _value_width = v; }
+  virtual void setValueWidth(uint32_t v)
+  {
+    if (_value_width == v)
+      return;
+    _value_width = v;
+    _source_sort_cache = NULL;
+  }
   virtual uint32_t getValueWidth() const { return _value_width; }
+
+  virtual void setSigWidth(uint32_t sw)
+  {
+    if (_sig_width == sw)
+      return;
+    _sig_width = sw;
+    _source_sort_cache = NULL;
+  }
+  virtual uint32_t getSigWidth() const { return _sig_width; }
+
+  virtual void setExpWidth(uint32_t ew)
+  {
+    if (_exp_width == ew)
+      return;
+    _exp_width = ew;
+    _source_sort_cache = NULL;
+  }
+  virtual uint32_t getExpWidth() const { return _exp_width; }
+
+  virtual const SourceSort* cachedSourceSort() const
+  {
+    return _source_sort_cache;
+  }
+  virtual void setCachedSourceSort(const SourceSort* s) const
+  {
+    _source_sort_cache = s;
+  }
 
 public:
   ASTInterior(STPMgr* mgr, Kind kind, const ASTVec& children)
       : ASTInternal(mgr, kind), _children(children), _value_width(0),
-        _index_width(0)
+        _index_width(0), _sig_width(0), _exp_width(0),
+        _source_sort_cache(NULL)
   {
     is_simplified = false;
     if (kind == NOT)
@@ -118,7 +172,8 @@ public:
   // avoiding a copy when the caller has a temporary to give up.
   ASTInterior(STPMgr* mgr, Kind kind, ASTVec&& children)
       : ASTInternal(mgr, kind), _children(std::move(children)), _value_width(0),
-        _index_width(0)
+        _index_width(0), _sig_width(0), _exp_width(0),
+        _source_sort_cache(NULL)
   {
     is_simplified = false;
     if (kind == NOT)
@@ -130,7 +185,9 @@ public:
   // ASTNode, does NOT invoke this.
   ASTInterior(const ASTInterior& int_node)
       : ASTInternal(int_node), _children(int_node._children),
-        _value_width(int_node._value_width), _index_width(int_node._index_width)
+        _value_width(int_node._value_width),
+        _index_width(int_node._index_width), _sig_width(int_node._sig_width),
+        _exp_width(int_node._exp_width), _source_sort_cache(NULL)
   {
     is_simplified = false;
   }
@@ -140,7 +197,8 @@ public:
   ASTInterior(ASTInterior&& int_node)
       : ASTInternal(int_node), _children(std::move(int_node._children)),
         _cached_hash(int_node._cached_hash), _value_width(int_node._value_width),
-        _index_width(int_node._index_width)
+        _index_width(int_node._index_width), _sig_width(int_node._sig_width),
+        _exp_width(int_node._exp_width), _source_sort_cache(NULL)
   {
     is_simplified = false;
   }

--- a/include/stp/AST/ASTInternal.h
+++ b/include/stp/AST/ASTInternal.h
@@ -29,6 +29,7 @@ THE SOFTWARE.
 // including ASTNode.h would create a circular include that forces the hot
 // ASTNode accessors (GetKind/GetNodeNum/...) to be defined out-of-line.
 #include "stp/AST/UsefulDefs.h"
+#include "stp/AST/SourceSort.h"
 #include <iostream>
 
 using std::ostream;
@@ -94,6 +95,41 @@ protected:
 
   virtual void setValueWidth(uint32_t) = 0;
   virtual uint32_t getValueWidth() const = 0;
+
+  virtual void setExpWidth(uint32_t) = 0;
+  virtual uint32_t getExpWidth() const = 0;
+
+  virtual void setSigWidth(uint32_t) = 0;
+  virtual uint32_t getSigWidth() const = 0;
+
+  // Source-language identity carried by leaves. Interior-node sorts are
+  // derived by ASTNode::GetSourceSort from their operator and children.
+  virtual SourceSort getDeclaredSourceSort() const
+  {
+    return SourceSort::unknown();
+  }
+
+  // Memo for the *derived* source sort, on the nodes that derive one.
+  //
+  // ASTNode::GetSourceSort walks children for READ, WRITE and ITE -- and for
+  // ITE it walks both branches -- so without a memo a shared-branch ITE DAG
+  // costs Theta(2^depth) per query and a store chain costs Theta(depth), on a
+  // graph of linear size. The front ends ask once per node they build, and
+  // containsFloatingPointTheory asks once per node of every query, so the
+  // recomputation is not incidental. This is the same treatment cacheFPFormat
+  // already gives the floating-point format, for the same reason, and it is
+  // sound for the same reason: the derivation reads only the node's kind,
+  // children and widths.
+  //
+  // The pointer is into the manager's intern pool, so a cached answer costs
+  // eight bytes and no allocation, and Unknown interns like any other sort --
+  // a non-null pointer to an Unknown sort is the negative cache.
+  //
+  // Only ASTInterior can hold one. Leaves either carry a declared sort or
+  // derive theirs from widths that legacy callers still set after
+  // construction, and both are already O(1).
+  virtual const SourceSort* cachedSourceSort() const { return NULL; }
+  virtual void setCachedSourceSort(const SourceSort*) const {}
 
   /*******************************************************************
    * ASTNode is of type BV      <==> ((indexwidth=0)&&(valuewidth>0))*

--- a/include/stp/AST/ASTNode.h
+++ b/include/stp/AST/ASTNode.h
@@ -228,6 +228,14 @@ public:
   unsigned int GetIndexWidth() const { return _int_node_ptr->getIndexWidth(); }
   DLL_PUBLIC unsigned int GetValueWidth() const
   {
+    // Invariant: a float-formatted node stores its packed width as the value
+    // width like any other term (the declaration rules and node builders all
+    // maintain this). The format is never the width's only source -- this
+    // accessor used to derive sig + exp on every call, solver-wide, to paper
+    // over declaration sites that left the value width zero.
+    assert(_int_node_ptr->getSigWidth() == 0 ||
+           _int_node_ptr->getValueWidth() ==
+               _int_node_ptr->getExpWidth() + _int_node_ptr->getSigWidth());
     return _int_node_ptr->getValueWidth();
   }
   void SetIndexWidth(unsigned int iw) const;
@@ -240,11 +248,49 @@ public:
     const unsigned int iw = GetIndexWidth();
     const unsigned int vw = GetValueWidth();
 
-    if (0 == iw)
-      return (0 == vw) ? BOOLEAN_TYPE : BITVECTOR_TYPE;
+    // Arrays first. An array of floats carries its *element's* format in the
+    // exponent and significand widths, so testing those first would call the
+    // array itself a float.
+    if (iw > 0)
+      return (vw > 0) ? ARRAY_TYPE : UNKNOWN_TYPE;
 
-    return (vw > 0) ? ARRAY_TYPE : UNKNOWN_TYPE;
+    if (GetSigWidth() != 0 && GetExpWidth() != 0)
+      return FLOATINGPOINT_TYPE;
+
+    return (0 == vw) ? BOOLEAN_TYPE : BITVECTOR_TYPE;
   }
+
+  // The immutable source-language sort. This is deliberately separate from
+  // GetType(), which remains the packed carrier classification consumed by
+  // STP's bit-vector pipeline.
+  //
+  // Memoised on the node; deriveSourceSort below is the derivation itself and
+  // runs at most once per node (see ASTInternal::cachedSourceSort).
+  SourceSort GetSourceSort() const;
+
+private:
+  // The derivation behind GetSourceSort, without the memo. Private so that
+  // nothing reintroduces the recomputation by calling it directly.
+  SourceSort deriveSourceSort() const;
+
+public:
+  unsigned int GetSigWidth() const;
+  unsigned int GetExpWidth() const;
+
+  // Work the floating-point format out from this node's kind and children and
+  // remember it. Called on demand by GetExpWidth/GetSigWidth; the format of an
+  // interior node is derived rather than assigned, so that rebuilding a node
+  // cannot lose it.
+  void cacheFPFormat() const;
+  void SetSigWidth(unsigned int sw) const;
+  void SetExpWidth(unsigned int ew) const;
+
+  // Whether a floating-point format may be *stored* on this node, rather than
+  // derived from its kind and children or not carried at all. SetExpWidth
+  // asserts on it and FloatBlaster::withFormat -- the funnel that decides
+  // where a format goes -- consults it; the rule, and what stamping a node
+  // that fails it would do, are with the definition.
+  bool canStoreFPFormat() const;
 
   // Hash is the node's unique id. Inlined: used by every ==/</hash lookup.
   size_t Hash() const { return _int_node_ptr ? _int_node_ptr->node_uid : 0; }

--- a/include/stp/AST/ASTRMConst.h
+++ b/include/stp/AST/ASTRMConst.h
@@ -1,0 +1,32 @@
+/********************************************************************
+ * A source-language RoundingMode literal over STP's 5-bit carrier.
+ ********************************************************************/
+#ifndef ASTRMCONST_H
+#define ASTRMCONST_H
+
+#include "ASTBVConst.h"
+
+namespace stp
+{
+class STPMgr;
+
+// Kept as kind BVCONST so every post-lowering bit-vector pass can consume it,
+// but interned separately from a plain five-bit constant through SourceSort.
+class ASTRMConst final : public ASTBVConst
+{
+  friend class STPMgr;
+
+  ASTRMConst(STPMgr* mgr, CBV bv);
+  ASTRMConst(const ASTRMConst& other);
+
+  SourceSort getDeclaredSourceSort() const override
+  {
+    return SourceSort::roundingMode();
+  }
+
+public:
+  ~ASTRMConst() override = default;
+};
+
+} // namespace stp
+#endif

--- a/include/stp/AST/ASTSymbol.h
+++ b/include/stp/AST/ASTSymbol.h
@@ -54,7 +54,8 @@ private:
   public:
     size_t operator()(const ASTSymbol* sym_ptr) const
     {
-      return CStringHash()(sym_ptr->_name);
+      return CStringHash()(sym_ptr->_name) ^
+             (sym_ptr->_source_sort.hash() * 0x9e3779b97f4a7c15ULL);
     };
   };
 
@@ -72,7 +73,8 @@ private:
 
   friend bool operator==(const ASTSymbol& sym1, const ASTSymbol& sym2)
   {
-    return (strcmp(sym1._name, sym2._name) == 0);
+    return strcmp(sym1._name, sym2._name) == 0 &&
+           sym1._source_sort == sym2._source_sort;
   }
 
   // Get the name of the symbol
@@ -80,28 +82,110 @@ private:
 
   // Print function for symbol -- return name. (c_friendly is for
   // printing hex. numbers that C compilers will accept)
-  virtual void nodeprint(ostream& os, bool c_friendly = false);
+  void nodeprint(ostream& os, bool c_friendly = false) override;
 
   // Call this when deleting a node that has been stored in the the
   // unique table
-  virtual void CleanUp();
+  void CleanUp() override;
 
   uint32_t _value_width;
   uint32_t _index_width;
 
-  virtual void setIndexWidth(uint32_t i) { _index_width = i; }
-  virtual uint32_t getIndexWidth() const { return _index_width; }
+  uint32_t _sig_width;
+  uint32_t _exp_width;
 
-  virtual void setValueWidth(uint32_t v) { _value_width = v; }
-  virtual uint32_t getValueWidth() const { return _value_width; }
+  // Fixed at construction for typed source symbols. Legacy internal symbols
+  // retain Unknown and may use the historical width setters.
+  const SourceSort _source_sort;
+
+  void setIndexWidth(uint32_t i) override
+  {
+    if (_source_sort.isKnown())
+    {
+      assert(i == _index_width);
+      return;
+    }
+    _index_width = i;
+  }
+  uint32_t getIndexWidth() const override { return _index_width; }
+
+  void setValueWidth(uint32_t v) override
+  {
+    if (_source_sort.isKnown())
+    {
+      assert(v == _value_width);
+      return;
+    }
+    _value_width = v;
+  }
+  uint32_t getValueWidth() const override { return _value_width; }
+
+  void setSigWidth(uint32_t sw) override
+  {
+    if (_source_sort.isKnown())
+    {
+      assert(sw == _sig_width);
+      return;
+    }
+    _sig_width = sw;
+  }
+  uint32_t getSigWidth() const override { return _sig_width; }
+
+  void setExpWidth(uint32_t ew) override
+  {
+    if (_source_sort.isKnown())
+    {
+      assert(ew == _exp_width);
+      return;
+    }
+    _exp_width = ew;
+  }
+  uint32_t getExpWidth() const override { return _exp_width; }
+
+  SourceSort getDeclaredSourceSort() const override { return _source_sort; }
 
 public:
-  virtual ASTChildren GetChildren() const { return empty_children; }
+  ASTChildren GetChildren() const override { return empty_children; }
 
   // Constructor.  This does NOT copy its argument.
   ASTSymbol(STPMgr* mgr, const char* const name)
-      : ASTInternal(mgr, SYMBOL), _name(name), _value_width(0), _index_width(0)
+      : ASTInternal(mgr, SYMBOL), _name(name), _value_width(0), _index_width(0),
+        _sig_width(0), _exp_width(0), _source_sort(SourceSort::unknown())
   {
+  }
+
+  ASTSymbol(STPMgr* mgr, const char* const name, const SourceSort& source_sort)
+      : ASTInternal(mgr, SYMBOL), _name(name), _value_width(0), _index_width(0),
+        _sig_width(0), _exp_width(0), _source_sort(source_sort)
+  {
+    switch (_source_sort.kind())
+    {
+      case SourceSort::Kind::Bool:
+        break;
+      case SourceSort::Kind::BitVector:
+        _value_width = _source_sort.bitVectorWidth();
+        break;
+      case SourceSort::Kind::FloatingPoint:
+        _exp_width = _source_sort.exponentWidth();
+        _sig_width = _source_sort.significandWidth();
+        _value_width = _source_sort.packedWidth();
+        break;
+      case SourceSort::Kind::RoundingMode:
+        _value_width = _source_sort.packedWidth();
+        break;
+      case SourceSort::Kind::Array:
+        _index_width = _source_sort.index().packedWidth();
+        _value_width = _source_sort.element().packedWidth();
+        if (_source_sort.element().kind() ==
+            SourceSort::Kind::FloatingPoint)
+        {
+          _exp_width = _source_sort.element().exponentWidth();
+          _sig_width = _source_sort.element().significandWidth();
+        }
+        break;
+      case SourceSort::Kind::Unknown:
+        break;
+    }
   }
 
   virtual ~ASTSymbol() {}
@@ -109,7 +193,9 @@ public:
   // Copy constructor
   ASTSymbol(const ASTSymbol& sym)
       : ASTInternal(sym.nodeManager, sym._kind), _name(sym._name),
-        _value_width(sym._value_width), _index_width(sym._index_width)
+        _value_width(sym._value_width), _index_width(sym._index_width),
+        _sig_width(sym._sig_width), _exp_width(sym._exp_width),
+        _source_sort(sym._source_sort)
   {
     // printf("inside ASTSymbol constructor %s\n", _name);
   }

--- a/include/stp/AST/MutableASTNode.h
+++ b/include/stp/AST/MutableASTNode.h
@@ -102,7 +102,8 @@ public:
     for (ParentsType::iterator it = parents.begin(); it != parents.end(); it++)
     {
       vector<MutableASTNode*>::iterator it2 = (*it)->children.begin();
-      bool found = false;
+      // Only consumed by the assert, which an NDEBUG build compiles out.
+      [[maybe_unused]] bool found = false;
       for (; it2 != (*it)->children.end(); it2++)
       {
         assert(*it2 != NULL);

--- a/include/stp/AST/SourceSort.h
+++ b/include/stp/AST/SourceSort.h
@@ -1,0 +1,199 @@
+/********************************************************************
+ * Immutable source-language sorts.
+ *
+ * STP's historical `types` describe the bit-vector/array carrier used by
+ * the solving pipeline.  FloatingPoint and RoundingMode are lowered onto
+ * those carriers, but they are not interchangeable with them at the public
+ * boundary.  SourceSort records that distinction without changing the
+ * representation expected by the legacy bit-vector passes.
+ ********************************************************************/
+#ifndef STP_SOURCESORT_H
+#define STP_SOURCESORT_H
+
+#include <cassert>
+#include <cstddef>
+#include <memory>
+#include <unordered_set>
+
+namespace stp
+{
+
+class SourceSort final
+{
+public:
+  enum class Kind
+  {
+    Unknown,
+    Bool,
+    BitVector,
+    FloatingPoint,
+    RoundingMode,
+    Array
+  };
+
+private:
+  Kind kind_;
+  unsigned first_;
+  unsigned second_;
+  std::shared_ptr<const SourceSort> index_;
+  std::shared_ptr<const SourceSort> element_;
+
+  SourceSort(Kind kind, unsigned first = 0, unsigned second = 0)
+      : kind_(kind), first_(first), second_(second)
+  {
+  }
+
+  SourceSort(const SourceSort& index, const SourceSort& element)
+      : kind_(Kind::Array), first_(0), second_(0),
+        index_(std::make_shared<const SourceSort>(index)),
+        element_(std::make_shared<const SourceSort>(element))
+  {
+  }
+
+public:
+  SourceSort() : SourceSort(Kind::Unknown) {}
+
+  static SourceSort unknown() { return SourceSort(); }
+  static SourceSort boolean() { return SourceSort(Kind::Bool); }
+
+  static SourceSort bitVector(unsigned width)
+  {
+    assert(width > 0);
+    return SourceSort(Kind::BitVector, width);
+  }
+
+  static SourceSort floatingPoint(unsigned exponent, unsigned significand)
+  {
+    assert(exponent > 0 && significand > 0);
+    return SourceSort(Kind::FloatingPoint, exponent, significand);
+  }
+
+  static SourceSort roundingMode()
+  {
+    return SourceSort(Kind::RoundingMode);
+  }
+
+  static SourceSort array(const SourceSort& index, const SourceSort& element)
+  {
+    assert(index.isScalar() && element.isScalar());
+    return SourceSort(index, element);
+  }
+
+  Kind kind() const { return kind_; }
+  bool isKnown() const { return kind_ != Kind::Unknown; }
+  bool isScalar() const
+  {
+    return kind_ == Kind::BitVector || kind_ == Kind::FloatingPoint ||
+           kind_ == Kind::RoundingMode;
+  }
+
+  bool containsFloatingPoint() const
+  {
+    if (kind_ == Kind::FloatingPoint)
+      return true;
+    return kind_ == Kind::Array &&
+           (index().containsFloatingPoint() ||
+            element().containsFloatingPoint());
+  }
+
+  // RoundingMode belongs to the SMT floating-point theory even when no
+  // FloatingPoint value occurs. Printers and other source-level decisions
+  // need that broader question; lowering itself usually needs the narrower
+  // containsFloatingPoint() predicate above.
+  bool usesFloatingPointTheory() const
+  {
+    if (kind_ == Kind::FloatingPoint || kind_ == Kind::RoundingMode)
+      return true;
+    return kind_ == Kind::Array &&
+           (index().usesFloatingPointTheory() ||
+            element().usesFloatingPointTheory());
+  }
+
+  unsigned bitVectorWidth() const
+  {
+    assert(kind_ == Kind::BitVector);
+    return first_;
+  }
+
+  unsigned exponentWidth() const
+  {
+    assert(kind_ == Kind::FloatingPoint);
+    return first_;
+  }
+
+  unsigned significandWidth() const
+  {
+    assert(kind_ == Kind::FloatingPoint);
+    return second_;
+  }
+
+  unsigned packedWidth() const
+  {
+    switch (kind_)
+    {
+      case Kind::Bool:
+        return 0;
+      case Kind::BitVector:
+        return first_;
+      case Kind::FloatingPoint:
+        return first_ + second_;
+      case Kind::RoundingMode:
+        return 5;
+      default:
+        assert(false && "packedWidth is defined only for scalar sorts");
+        return 0;
+    }
+  }
+
+  const SourceSort& index() const
+  {
+    assert(kind_ == Kind::Array);
+    return *index_;
+  }
+
+  const SourceSort& element() const
+  {
+    assert(kind_ == Kind::Array);
+    return *element_;
+  }
+
+  friend bool operator==(const SourceSort& left, const SourceSort& right)
+  {
+    if (left.kind_ != right.kind_ || left.first_ != right.first_ ||
+        left.second_ != right.second_)
+      return false;
+    if (left.kind_ != Kind::Array)
+      return true;
+    return left.index() == right.index() &&
+           left.element() == right.element();
+  }
+
+  friend bool operator!=(const SourceSort& left, const SourceSort& right)
+  {
+    return !(left == right);
+  }
+
+  size_t hash() const
+  {
+    size_t h = static_cast<size_t>(kind_);
+    h = h * 1315423911u + first_;
+    h = h * 1315423911u + second_;
+    if (kind_ == Kind::Array)
+    {
+      h = h * 1315423911u + index().hash();
+      h = h * 1315423911u + element().hash();
+    }
+    return h;
+  }
+
+  // For the manager's intern pool, which is what lets a derived sort be
+  // memoised on a node as a pointer.
+  struct Hasher
+  {
+    size_t operator()(const SourceSort& sort) const { return sort.hash(); }
+  };
+};
+
+} // namespace stp
+
+#endif

--- a/include/stp/AST/UsefulDefs.h
+++ b/include/stp/AST/UsefulDefs.h
@@ -64,6 +64,7 @@ class ASTInternal;
 class ASTInterior;
 class ASTSymbol;
 class ASTBVConst;
+class ASTFPConst;
 class BVSolver;
 
 /******************************************************************

--- a/include/stp/FloatBlaster/FloatBlast.h
+++ b/include/stp/FloatBlaster/FloatBlast.h
@@ -1,0 +1,125 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: January 2021
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#ifndef FLOATBLAST_H
+#define FLOATBLAST_H
+
+#include "stp/AST/AST.h"
+#include "stp/STPManager/STPManager.h"
+
+#include <cstddef>
+#include <memory>
+
+namespace stp
+{
+
+// Lowers every floating-point operation in a formula to its bitvector
+// circuit.
+//
+// This used to happen inside simplification: SimplifyTerm's floating-point
+// arm simplified each float child -- which blasted it -- then rebuilt the
+// operation over the resulting bits and blasted that. The intermediate is an
+// FP_ADD whose children are bitvectors, which is not a well-formed node, and
+// the only thing that made it pass the type checker was stamping a float
+// format onto it and onto its blasted children.
+//
+// That stamp is the defect. Nodes are hash-consed and the format is per-node
+// state, so stamping the bits a float blasts to retypes whatever else already
+// denotes those bits. A plain bitvector the input also uses starts reporting
+// FLOATINGPOINT_TYPE, solver-wide: bitvector operations over it fail to type
+// check, and to_fp's four-argument form -- which tells "convert this integer"
+// from "reformat this float" by asking its operand's type -- reads an integer
+// as a float and answers the wrong thing.
+//
+// Separating the two passes removes the need for the stamp rather than
+// working around it. Simplification now sees floating-point operations as
+// floating-point operations, with formats derived from their source sorts;
+// this pass then replaces the whole floating-point layer with bits.
+//
+// The source graph and the bit-vector graph deliberately have different
+// views here. A floating-point source node is represented internally by one
+// cached SymFPU unpacked value. FP operations and predicates consume that
+// value directly, so a chain is not packed after every operation only to be
+// unpacked by the next one. Packing is delayed until a real carrier boundary:
+// an explicit IEEE-bit conversion, an array element, or a floating-point
+// term returned for model evaluation. This preserves one rounding per source
+// operation while avoiding representation round-trips between operations.
+//
+// Runs after FpTotalise -- which supplies the extra child the partial
+// operations need -- and before the formula reaches the simplifier, so the
+// blasted circuit gets simplified like any other bitvector circuit.
+class FloatBlast // not copyable
+{
+public:
+  struct Statistics
+  {
+    // Actual SymFPU decode/encode constructions (cache misses only).
+    size_t unpack_builds = 0;
+    size_t pack_builds = 0;
+
+    // Unpacked results built for source FP operations and conversions. Each
+    // arithmetic entry is the operation's final, rounded SymFPU result.
+    size_t unpacked_operation_builds = 0;
+    size_t unpacked_cache_hits = 0;
+  };
+
+  FloatBlast(STPMgr* bm_);
+  ~FloatBlast();
+
+  FloatBlast(const FloatBlast&) = delete;
+  FloatBlast& operator=(const FloatBlast&) = delete;
+
+  // Returns `n` with every floating-point operation replaced by the bits it
+  // computes. Idempotent: a formula with none left is returned unchanged.
+  ASTNode topLevel(const ASTNode& n);
+
+  // Lower one floating-point node on its own, for a caller that holds the
+  // node it built and wants the bits -- or the Boolean -- it computes: the
+  // constant evaluator folding an all-constant operation, and the model
+  // evaluator reducing one over a model.
+  //
+  // This used to be a second entry point with its own ~30-case switch over
+  // the whole floating-point signature (FloatBlaster::BlastNode), taking the
+  // operation apart into a kind plus already-blasted children because that
+  // was what the packed formulation needed. The two switches agreed on every
+  // kind, and had to keep agreeing by hand: an operation added to one and
+  // not the other compiles, and fails only on the path that reaches the one
+  // that was missed. There is one table now.
+  static ASTNode lowerOperation(STPMgr* bm, const ASTNode& n);
+
+  // Cumulative, context-local counters. Besides diagnostics, these make the
+  // intended lazy boundary directly testable instead of inferring it from a
+  // hash-consed output DAG in which redundant construction can be hidden.
+  const Statistics& statistics() const noexcept;
+
+private:
+  // SymFPU types stay out of this public header, and therefore out of builds
+  // configured without floating-point support.
+  class Impl;
+  std::unique_ptr<Impl> impl;
+};
+
+} // namespace stp
+
+#endif

--- a/include/stp/FloatBlaster/FloatBlaster.h
+++ b/include/stp/FloatBlaster/FloatBlaster.h
@@ -1,0 +1,176 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: January 2021
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#ifndef FLOATBLASTER_H
+#define FLOATBLASTER_H
+
+#include "stp/AST/AST.h"
+#include "stp/STPManager/STPManager.h"
+#include <cstdint>
+#include <utility>
+
+namespace stp
+{
+
+// Lowers one floating-point operation to the pure-bitvector circuit symfpu
+// builds for it. Every entry point takes the manager whose nodes are being
+// blasted, and the static-trait backend keeps that context thread-local, so
+// independent managers in different threads never blast into one another.
+class FloatBlaster
+{
+public:
+  // The format of an operation's floating-point *operands*, which is what
+  // symfpu needs to unpack them, and which is not always the result's format:
+  // fp.to_ubv yields a bitvector, and to_fp's four-argument form converts
+  // between two formats.
+  //
+  // Read it off the node the input built, before blasting has replaced its
+  // children with bits. Taking it from a blasted operand is what made the
+  // blaster depend on the format being stamped onto those bits -- a stamp
+  // that lands on a hash-consed node the input may still be using as a plain
+  // bitvector, which is a whole family of wrong answers and aborts.
+  //
+  // Follows the same rule as deriveFPFormat: the first child that carries a
+  // format. The others are rounding modes, widths and to_fp's format
+  // arguments, none of which do.
+  static std::pair<unsigned int, unsigned int> operandFormat(const ASTNode& n);
+  static std::pair<unsigned int, unsigned int>
+  operandFormat(const ASTVec& children);
+
+  // Return `n` carrying the floating-point format (exp_width, sig_width).
+  //
+  // A float's format is per-node state, so it is lost whenever a node is
+  // rebuilt -- which every constant fold and every simplification does.
+  // A plain ASTBVConst has no room for it, so a folded constant is re-made
+  // as an interned ASTFPConst. Anywhere that rebuilds a floating-point node
+  // has to put the format back through here.
+  static ASTNode withFormat(STPMgr* bm, const ASTNode& n,
+                            unsigned int exp_width, unsigned int sig_width);
+
+  // The canonical packed bits of a float: pack(unpack(f)). Collapses the NaN
+  // payloads, which SMT-LIB equality does not distinguish, while keeping +0
+  // and -0 apart. The format-taking form serves callers holding a term that
+  // does not carry the format itself.
+  static ASTNode canonicalBits(STPMgr* bm, const ASTNode& f);
+  static ASTNode canonicalBits(STPMgr* bm, const ASTNode& f,
+                               unsigned int exp_width, unsigned int sig_width);
+
+  // fp.rem's circuit unrolls one divide step per representable exponent
+  // difference -- 2^eb + sb - 4 steps (symfpu's maximumExponentDifference)
+  // -- so its *depth* grows exponentially in the exponent width. Past
+  // roughly binary64 scale the circuit outruns both the recursive
+  // traversals (a stack overflow) and any hope of solving, so every
+  // entrance for fp.rem funnels through remSupported and refuses instead.
+  // binary64 needs 2097 steps; the limit leaves headroom for wide
+  // significands at eb = 11 while refusing every eb >= 12.
+  static const uint64_t REM_UNROLL_LIMIT = 2304;
+  static uint64_t remUnrollSteps(unsigned exp_width, unsigned sig_width);
+  static bool remSupported(unsigned exp_width, unsigned sig_width);
+
+  // How wide symfpu makes the *unpacked* exponent for a format --
+  // unpackedFloat<t>::exponentWidth (symfpu/core/unpackedFloat.h), replicated
+  // here as remUnrollSteps replicates maximumExponentDifference, because the
+  // refusals below have to link in builds without floating-point support,
+  // where symfpu's headers are not compiled at all.
+  static unsigned unpackedExponentWidth(unsigned exp_width,
+                                        unsigned sig_width);
+
+  // Whether symfpu can build *any* circuit at this format. Every operation
+  // unpacks its operands, and symfpu::unpack asserts
+  //
+  //   INVARIANT(unpackedExWidth > exWidth)      // symfpu/core/packing.h
+  //
+  // to keep its exponent arithmetic from overflowing. exponentWidth returns
+  // the packed width unchanged once sb <= 3 -- the subnormals fit in the gap
+  // without a wider exponent -- so that reads eb > eb and the invariant does
+  // not hold. With assertions on the solve aborts; with them off (which is
+  // what CMAKE_BUILD_TYPE=Release forces) the widths underflow and the
+  // circuit builder walks off the end of a bitvector. Refuse instead, at the
+  // entrances, the way fp.rem is refused.
+  static bool formatSupported(unsigned exp_width, unsigned sig_width);
+
+  // Whether fp.roundToIntegral in particular can be built at this format.
+  // symfpu::roundToIntegral resizes a value of width unpackedExWidth + 1 to
+  // the unpacked significand width, choosing between matchWidth (which may
+  // only widen) and extract on
+  //
+  //   significandWidth >= exponentWidth         // symfpu/core/convert.h:122
+  //
+  // one short of the width it is actually resizing. When the two widths are
+  // *equal* the guard sends a value one bit too wide into matchWidth. The
+  // extract arm is what should run there and is already correct -- the collar
+  // above it bounds the value, which is why upstream's guard wants to read
+  // `>` -- so this refusal can go once the pinned submodule carries that
+  // one-character fix.
+  static bool roundToIntegralSupported(unsigned exp_width,
+                                       unsigned sig_width);
+
+  // A read of the array supplying an operation's unspecified results. Identity
+  // is the name, so every occurrence of an operation at a given signature
+  // reads one and the same array -- which is what makes the result a function
+  // of the operands rather than an arbitrary value per use.
+  //
+  // The name has to spell the operation's whole SMT-LIB signature, because
+  // that is all that separates one of these functions from another. `operands`
+  // are the floating-point operands *carrying their formats*, and each one's
+  // (exp, sig) goes into the name: a format is not recoverable from a packed
+  // width, and two formats of equal packed width -- (_ FloatingPoint 8 24) and
+  // (_ FloatingPoint 24 8), say -- are different sorts, so fp.to_ubv at each is
+  // a different function and may answer differently. Sharing one array between
+  // them equates two independent unspecified choices and loses models.
+  //
+  // For fp.to_ubv/fp.to_sbv, whose index really is a rounding mode and a whole
+  // packed value. An operation whose unspecified choice ranges over a handful
+  // of cases wants unspecifiedCells instead.
+  static ASTNode unspecifiedValue(STPMgr* bm, const char* tag,
+                                  const ASTVec& operands, const ASTNode& index,
+                                  unsigned int value_width);
+
+  // The same congruent map, for an operation whose unspecified choice has been
+  // shown to depend on only a few bits of its operands: one free bitvector
+  // symbol with one bit per case, to be selected between by the caller.
+  //
+  // An array is the general answer -- a solver without uninterpreted functions
+  // has nothing else that is both free and congruent over an unbounded index
+  // domain. But it is a heavy one, and its weight is not local: FpTotalise runs
+  // before containsArrayOps and numberOfReadsLessThan, so reads it introduces
+  // are indistinguishable from the user's. A pure QF_FP problem acquires "array
+  // operations" it never had, and a QF_ABVFP problem can stop Ackermannising
+  // the user's own arrays because unrelated floating-point operations pushed
+  // the read count past a threshold.
+  //
+  // Over a *finite, small* domain none of that is needed. The cells are free
+  // and the selection is a mux, so the result is a function of the operands by
+  // construction, and hash-consing supplies the congruence the array's index
+  // equalities were supplying. Same freedom, same congruence, no reads, no
+  // congruence axioms, and no perturbation of how the user's arrays are solved.
+  //
+  // Identity is the name here too, and for the same reason: the solve and the
+  // two counterexample re-derivations have to mint the same object.
+  static ASTNode unspecifiedCells(STPMgr* bm, const char* tag,
+                                  const ASTVec& operands,
+                                  unsigned int cell_count);
+};
+} // namespace stp
+#endif

--- a/include/stp/FloatBlaster/FpEncodingContext.h
+++ b/include/stp/FloatBlaster/FpEncodingContext.h
@@ -1,0 +1,51 @@
+/********************************************************************
+ * Solve-local floating-point lowering and model-lifting context.
+ ********************************************************************/
+#ifndef FPENCODINGCONTEXT_H
+#define FPENCODINGCONTEXT_H
+
+#include "stp/AST/AST.h"
+#include "stp/FloatBlaster/FloatBlast.h"
+#include "stp/FloatBlaster/FpTotalise.h"
+#include "stp/STPManager/STPManager.h"
+
+namespace stp
+{
+
+// Owns every mapping created while one solver invocation lowers source FP
+// expressions to their bit-vector encoding. The context deliberately lives
+// past the SAT call: get-value and counterexample checking must use the same
+// totalisation arrays and the same lowering map as the solved formula.
+class FpEncodingContext final
+{
+public:
+  explicit FpEncodingContext(STPMgr* bm_);
+  DLL_PUBLIC ~FpEncodingContext();
+
+  FpEncodingContext(const FpEncodingContext&) = delete;
+  FpEncodingContext& operator=(const FpEncodingContext&) = delete;
+
+  // Totalise partial operations, canonicalise rich array indices, and add
+  // formula-level source-sort side conditions.
+  ASTNode prepare(const ASTNode& source);
+
+  // Lower a prepared expression to its packed bit-vector circuit. Kept
+  // separate because the word-level simplifiers run between these two steps.
+  ASTNode lowerPrepared(const ASTNode& prepared);
+
+  // Lazily obtain the target-language encoding of a source expression for
+  // model evaluation, reusing the solve's preparation and lowering caches.
+  ASTNode encodeForModel(const ASTNode& source);
+
+private:
+  void requireOriginalNodeFactory() const;
+
+  STPMgr* bm;
+  NodeFactory* node_factory;
+  FpTotalise totalise;
+  FloatBlast blast;
+};
+
+} // namespace stp
+
+#endif

--- a/include/stp/FloatBlaster/FpTotalise.h
+++ b/include/stp/FloatBlaster/FpTotalise.h
@@ -1,0 +1,173 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: July 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#ifndef FPTOTALISE_H
+#define FPTOTALISE_H
+
+#include "stp/AST/AST.h"
+#include "stp/STPManager/STPManager.h"
+
+namespace stp
+{
+
+// Makes the partial floating-point operations total.
+//
+// SMT-LIB leaves four operations unspecified on some of their inputs:
+// fp.min and fp.max may return either zero given +0 and -0, and fp.to_ubv
+// and fp.to_sbv may return anything at all for NaN, the infinities, and
+// values out of range for the target width. The blaster needs a concrete
+// value to use in those cases, and it has to be one the solver is free to
+// choose -- but also a *function* of the operands, so that equal inputs give
+// equal results. An unconstrained value per occurrence would give the
+// freedom and lose the congruence, which is unsound for equality reasoning.
+//
+// STP has no uninterpreted functions, so the map is built from what it does
+// have. This pass rewrites each partial operation into a total one carrying
+// that map's answer as an extra child.
+//
+// Which map depends on how big the choice's domain is. fp.to_ubv/fp.to_sbv
+// are unspecified over a rounding mode and a whole packed value, so they read
+// a shared array -- an array being exactly a congruent map: one per operation
+// and signature, read at an index built from the operands. fp.min/fp.max are
+// unspecified on four sign-bit combinations and no more (see zeroChoice), so
+// they select between four free bits. Both are functions of the operands;
+// only the first needs the array theory to be one.
+//
+// It has to be a pass rather than something done when the node is built or
+// when it is blasted. Introducing the array during blasting is too late --
+// the solver never sees it, so the counterexample evaluator cannot read a
+// value for it out of the model, and the refinement loop fails to converge.
+// Running here, before the array transformer and before the reads are
+// counted, puts the array in the problem like any other. That placement is
+// also why the small choice must *not* be an array: a read introduced here is
+// indistinguishable from the user's to every heuristic downstream.
+//
+// A pleasant side effect either way: the extra child is not constant, so
+// these nodes stop being candidates for constant folding, which is what we
+// want. Their results genuinely are not constants even when their operands
+// are.
+//
+// The pass also adapts array accesses whose index or element sort is
+// floating-point or RoundingMode, for the same reason at the same moment:
+//
+//  - A read or write over a float-indexed array has its index rewritten to
+//    canonical bits. SMT-LIB '=' on floats identifies every NaN with every
+//    NaN, while everything downstream -- the simplifier's read-over-write
+//    rules, the array transformer's index equalities, refinement's
+//    bit-level congruence axioms -- compares raw index bits. Quotienting
+//    the index here, before any of them run, lets all of it stay purely
+//    bitvector. (Float *constants* already intern canonically, which is
+//    what keeps the node-creation-time constant comparisons sound before
+//    this pass gets its turn.)
+//
+//  - Every rounding mode the formula names out of thin air -- a declared
+//    RoundingMode symbol, or a read from a RoundingMode-element array -- is
+//    pinned to the five legal encodings. Without the constraint the
+//    carrier's 27 junk patterns would be satisfiable "modes", and they are
+//    not merely unlikely: they are a sixth behaviour a formula can tell
+//    from all five (see topLevel).
+//
+//    Conjoined at solve time rather than asserted at creation, so every
+//    route here -- parser or C API, before or after push/pop/
+//    reset-assertions -- is covered. The symbols are also pinned where they
+//    are declared, which is the right thing whenever that assertion
+//    survives; it is not what makes them safe. Assertions are levelled and
+//    the nodes are not, so a symbol built inside a vc_push/vc_pop bracket
+//    outlives the constraint that was supposed to hold it.
+class FpTotalise // not copyable
+{
+public:
+  FpTotalise(STPMgr* bm_);
+
+  FpTotalise(const FpTotalise&) = delete;
+  FpTotalise& operator=(const FpTotalise&) = delete;
+
+  // Returns `n` with every partial floating-point operation replaced by its
+  // total form. Idempotent: operations that already carry an unspecified
+  // value are left alone.
+  ASTNode topLevel(const ASTNode& n);
+
+private:
+  ASTNode visit(const ASTNode& n);
+
+  // The canonical form of an index over a float-indexed array whose index
+  // format is (exp_width, sig_width): constants re-intern through the
+  // canonicalising constant funnel, source FP expressions become an explicit
+  // FP_TO_IEEE_BV boundary, and legacy raw carriers use canonicalBits.
+  ASTNode canonicalIndex(const ASTNode& index, unsigned int exp_width,
+                         unsigned int sig_width);
+
+  // Make a source FP value's canonical carrier boundary explicit in the
+  // source DAG. FloatBlast can then share its cached unpacked value with the
+  // surrounding operation instead of this pass eagerly building a separate
+  // unpack/pack circuit.
+  ASTNode canonicalSourceBits(const ASTNode& value);
+
+  // Collect the validity constraint of every term in `n` that denotes a
+  // rounding mode out of thin air: a declared RoundingMode symbol, or a READ
+  // over a RoundingMode-element array.
+  void collectRoundingModeTerms(const ASTNode& n, ASTNodeSet& seen,
+                                ASTVec& constraints);
+
+  // Rebuild `n` around new children, preserving its widths -- including the
+  // floating-point format, which is per-node state that rebuilding drops.
+  ASTNode rebuild(const ASTNode& n, const ASTVec& children);
+
+  // The array read supplying the unspecified value. `index` addresses it and
+  // `floats` are the operation's floating-point operands, which name the
+  // array -- a format is not recoverable from a packed width, and the same
+  // operation at two formats is two different unspecified functions.
+  ASTNode unspecified(const char* tag, const ASTNode& index,
+                      const ASTVec& floats, unsigned int value_width);
+
+  // The index for fp.to_ubv/fp.to_sbv: the rounding mode and the float's
+  // canonical bits. The result is unspecified for NaN, the infinities and
+  // anything out of range, and which of those applies depends on the whole
+  // value, so the whole value goes into the index.
+  ASTNode conversionIndex(const ASTNode& rounding_mode, const ASTNode& value);
+
+  // The unspecified value for fp.min/fp.max: four free bits, selected between
+  // by the two operands' sign bits and nothing else. See the definition for
+  // why four cells are not merely sound but exactly complete, and for why this
+  // one does not go through an array.
+  ASTNode zeroChoice(const char* tag, const ASTNode& left,
+                     const ASTNode& right, const ASTVec& floats);
+
+  // A float's sign, taken from its canonical packed bits.
+  ASTNode signBit(const ASTNode& value);
+
+  STPMgr* bm;
+  NodeFactory* nf;
+  // `traversal_cache` preserves DAG sharing only for one topLevel walk and is
+  // released immediately afterwards. `persistent_cache` keeps just the
+  // source FP/array nodes whose encoding changed and may be requested again
+  // during model evaluation. Retaining every ordinary BV node here can keep
+  // enormous pre-simplification DAGs alive for the lifetime of the model.
+  ASTNodeMap traversal_cache;
+  ASTNodeMap persistent_cache;
+};
+
+} // namespace stp
+
+#endif

--- a/include/stp/FloatBlaster/rounding_modes.h
+++ b/include/stp/FloatBlaster/rounding_modes.h
@@ -1,7 +1,7 @@
 /********************************************************************
- * AUTHORS: Vijay Ganesh, David L. Dill
+ * AUTHORS: Andrew Teylu
  *
- * BEGIN DATE: November, 2005
+ * BEGIN DATE: January 2021
  *
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -22,34 +22,32 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ********************************************************************/
 
-#include "stp/AST/ASTSymbol.h"
-#include "stp/AST/AST.h"
-#include "stp/STPManager/STP.h"
+// The one-hot rounding-mode encoding, split out of symbolic_fp.h so the
+// parser (which builds rounding-mode constants whether or not the SymFPU
+// backend is compiled in) does not drag in the SymFPU headers.
+
+#ifndef STP_FP_ROUNDING_MODES_H
+#define STP_FP_ROUNDING_MODES_H
 
 namespace stp
 {
-const ASTVec ASTSymbol::empty_children;
-
-// Get the name of the symbol
-const char* ASTSymbol::GetName() const
+namespace symbolic_fp
 {
-  return _name;
-}
 
-// Print function for symbol
-void ASTSymbol::nodeprint(ostream& os, bool /*c_friendly*/)
+// A rounding mode is a one-hot 5-bit bitvector: one bit per IEEE mode, so
+// an invalid mode is representable (all-zero, or multiple bits) and
+// roundingMode::valid() can constrain a symbolic one. The public C API's
+// VCRoundingMode mirrors these values.
+enum rounding_modes
 {
-  os << _name;
-}
+  ROUND_NEAREST_TIES_TO_EVEN = 1,
+  ROUND_TOWARD_POSITIVE = ROUND_NEAREST_TIES_TO_EVEN << 1,
+  ROUND_TOWARD_NEGATIVE = ROUND_TOWARD_POSITIVE << 1,
+  ROUND_TOWARD_ZERO = ROUND_TOWARD_NEGATIVE << 1,
+  ROUND_NEAREST_TIES_TO_AWAY = ROUND_TOWARD_ZERO << 1,
+};
 
-// Call this when deleting a node that has been stored in the the
-// unique table
-void ASTSymbol::CleanUp()
-{
-  nodeManager->_symbol_unique_table.erase(this);
-  nodeManager->unindexSymbolName(this);
-  free((char*)this->_name);
-  delete this;
-}
+} // namespace symbolic_fp
+} // namespace stp
 
-} // end of namespace
+#endif

--- a/include/stp/FloatBlaster/symbolic_fp.h
+++ b/include/stp/FloatBlaster/symbolic_fp.h
@@ -1,0 +1,366 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: January 2021
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+// STP's backend for symfpu: the value classes symfpu computes with
+// (propositions, signed/unsigned bitvectors, rounding modes) implemented as
+// thin wrappers over ASTNode, building circuits through the manager's node
+// factory. blast_* lower one floating-point operation each; FloatBlaster
+// dispatches to them.
+
+#ifndef SYMBOLIC_FP_H
+#define SYMBOLIC_FP_H
+
+#include "stp/AST/AST.h"
+#include "stp/FloatBlaster/rounding_modes.h"
+#include "stp/STPManager/STPManager.h"
+
+#include <cassert>
+#include <type_traits>
+
+// symfpu states its preconditions, postconditions and invariants through
+// three macros, and calls them with arguments of two quite different kinds:
+// a plain `bool` -- a width, a position, a flag it can settle while building
+// the circuit -- or a `prop`. For this back end a `prop` is not a value. It
+// is a circuit constructor: PRECONDITION(uf.valid(format)) builds a
+// wellFormed conjunction, a getSubnormalAmount, an orderEncode and a mask
+// test, every node of it through the manager's simplifying factory.
+//
+// symfpu's default expansion is an ordinary function call, `t::precondition(X)`,
+// so the argument is fully evaluated before the overload that receives it can
+// decide what to do with it -- and the `prop` overload can only throw it away,
+// since a symbolic property cannot be checked while the circuit is being
+// built. valid() and wellFormed() are reached from nowhere else in symfpu, so
+// every node those arguments construct is dead on arrival, in every build
+// configuration: the overload is empty with and without NDEBUG.
+//
+// properties.h guards all three macros with #ifndef precisely so that a back
+// end can say otherwise. Say otherwise. `decltype` does not evaluate its
+// operand, so asking the type first costs nothing and lets the `bool`
+// properties -- which are real checks, and cheap -- go on being asserted while
+// the `prop` ones are never built at all.
+//
+// Both branches still have to compile, which is what keeps this honest: it
+// stays a question about the argument's type, not a blanket suppression, so a
+// symfpu update that changed a property's shape would not slip through.
+//
+// This must come before any symfpu header, which is why every translation unit
+// that uses symfpu includes *this* header first. Enforced rather than trusted:
+// getting the order wrong would not fail, it would silently restore the
+// expansion that builds and discards the circuits, and nothing downstream
+// would look any different.
+#ifdef SYMFPU_PROPERTIES
+#error "stp/FloatBlaster/symbolic_fp.h must be included before any symfpu \
+header, so that it defines PRECONDITION/POSTCONDITION/INVARIANT before \
+symfpu/utils/properties.h supplies its own."
+#endif
+
+namespace stp
+{
+namespace symbolic_fp
+{
+
+// The two halves of the decision above. The `bool` overload is the check
+// symfpu wanted; the template one exists so that the branch the macro
+// discards is still *well-formed* for a `prop`, which outside a template it
+// has to be -- `if constexpr` only skips instantiating a discarded branch
+// inside one, and every symfpu use of these macros happens to be in a
+// template. Without the overload this compiles there and nowhere else.
+inline void assertProperty(const bool holds)
+{
+  assert(holds);
+  (void)holds;
+}
+
+template <class T> inline void assertProperty(const T&) {}
+
+} // namespace symbolic_fp
+} // namespace stp
+
+#define STP_SYMFPU_PROPERTY(X)                                                 \
+  do                                                                           \
+  {                                                                            \
+    if constexpr (std::is_same_v<std::decay_t<decltype(X)>, bool>)             \
+      ::stp::symbolic_fp::assertProperty(X);                                   \
+  } while (false)
+
+#define PRECONDITION(X) STP_SYMFPU_PROPERTY(X)
+#define POSTCONDITION(X) STP_SYMFPU_PROPERTY(X)
+#define INVARIANT(X) STP_SYMFPU_PROPERTY(X)
+
+#include "symfpu/core/unpackedFloat.h"
+
+namespace stp
+{
+namespace symbolic_fp
+{
+
+typedef uint32_t bitWidthType;
+class roundingMode;
+class floatingPointTypeInfo;
+class proposition;
+template <bool T> class bitVector;
+
+class traits
+{
+public:
+  typedef bitWidthType bwt;
+  typedef roundingMode rm;
+  typedef floatingPointTypeInfo fpt;
+  typedef proposition prop;
+  typedef bitVector<true> sbv;
+  typedef bitVector<false> ubv;
+
+  static roundingMode RNE(void);
+  static roundingMode RNA(void);
+  static roundingMode RTP(void);
+  static roundingMode RTN(void);
+  static roundingMode RTZ(void);
+
+  static void precondition(const bool b);
+  static void postcondition(const bool b);
+  static void invariant(const bool b);
+  static void precondition(const prop& p);
+  static void postcondition(const prop& p);
+  static void invariant(const prop& p);
+};
+
+typedef traits::bwt bwt;
+typedef symfpu::unpackedFloat<traits> uf;
+
+class nodeWrapper : public ASTNode
+{
+protected:
+  nodeWrapper(const ASTNode& n);
+};
+
+class proposition : public nodeWrapper
+{
+protected:
+  bool checkNodeType(const ASTNode& node);
+
+  friend ::symfpu::ite<proposition, proposition>;
+
+public:
+  proposition(const ASTNode n);
+  proposition(bool v);
+  proposition(const proposition& old);
+
+  proposition operator!(void) const;
+  proposition operator&&(const proposition& op) const;
+  proposition operator||(const proposition& op) const;
+  proposition operator==(const proposition& op) const;
+  proposition operator^(const proposition& op) const;
+};
+
+// A rounding mode needs no valid() here: a symbolic mode can only enter via
+// a declared RoundingMode symbol, and the declaration itself asserts the
+// one-hot validity constraint (Cpp_interface::addRoundingModeSymbol).
+class roundingMode : public nodeWrapper
+{
+protected:
+  friend ::symfpu::ite<proposition, roundingMode>;
+
+public:
+  roundingMode(const ASTNode n);
+  roundingMode(const unsigned v);
+  roundingMode(const roundingMode& old);
+
+  proposition operator==(const roundingMode& op) const;
+};
+
+template <bool T> struct signedToLiteralType;
+
+template <> struct signedToLiteralType<true>
+{
+  typedef int literalType;
+};
+
+template <> struct signedToLiteralType<false>
+{
+  typedef unsigned int literalType;
+};
+
+template <bool isSigned> class bitVector : public nodeWrapper
+{
+protected:
+  typedef typename signedToLiteralType<isSigned>::literalType literalType;
+
+  ASTNode fromProposition(const ASTNode& node) const;
+  bool checkNodeType(const ASTNode& n);
+  friend bitVector<!isSigned>;
+
+  friend ::symfpu::ite<proposition, bitVector<isSigned>>;
+
+public:
+  bitVector(const ASTNode n);
+  bitVector(const bwt w, const unsigned v);
+  bitVector(const proposition& p);
+  bitVector(const bitVector<isSigned>& old);
+
+  bwt getWidth(void) const;
+
+  static bitVector<isSigned> one(const bwt& w);
+  static bitVector<isSigned> zero(const bwt& w);
+  static bitVector<isSigned> allOnes(const bwt& w);
+
+  proposition isAllOnes() const;
+  proposition isAllZeros() const;
+
+  static bitVector<isSigned> maxValue(const bwt& w);
+  static bitVector<isSigned> minValue(const bwt& w);
+
+  bitVector<isSigned> operator<<(const bitVector<isSigned>& op) const;
+  bitVector<isSigned> operator>>(const bitVector<isSigned>& op) const;
+  bitVector<isSigned> operator|(const bitVector<isSigned>& op) const;
+  bitVector<isSigned> operator&(const bitVector<isSigned>& op) const;
+  bitVector<isSigned> operator+(const bitVector<isSigned>& op) const;
+  bitVector<isSigned> operator-(const bitVector<isSigned>& op) const;
+  bitVector<isSigned> operator*(const bitVector<isSigned>& op) const;
+  bitVector<isSigned> operator/(const bitVector<isSigned>& op) const;
+  bitVector<isSigned> operator%(const bitVector<isSigned>& op) const;
+  bitVector<isSigned> operator-(void) const;
+  bitVector<isSigned> operator~(void) const;
+  bitVector<isSigned> increment() const;
+  bitVector<isSigned> decrement() const;
+  bitVector<isSigned> signExtendRightShift(const bitVector<isSigned>& op) const;
+
+  bitVector<isSigned> modularLeftShift(const bitVector<isSigned>& op) const;
+  bitVector<isSigned> modularRightShift(const bitVector<isSigned>& op) const;
+  bitVector<isSigned> modularIncrement() const;
+  bitVector<isSigned> modularDecrement() const;
+  bitVector<isSigned> modularAdd(const bitVector<isSigned>& op) const;
+  bitVector<isSigned> modularSubtract(const bitVector<isSigned>& op) const;
+  bitVector<isSigned> modularNegate() const;
+
+  proposition operator==(const bitVector<isSigned>& op) const;
+  proposition operator<=(const bitVector<isSigned>& op) const;
+  proposition operator>=(const bitVector<isSigned>& op) const;
+  proposition operator<(const bitVector<isSigned>& op) const;
+  proposition operator>(const bitVector<isSigned>& op) const;
+
+  bitVector<true> toSigned(void) const;
+  bitVector<false> toUnsigned(void) const;
+
+  bitVector<isSigned> extend(bwt extension) const;
+  bitVector<isSigned> contract(bwt reduction) const;
+  bitVector<isSigned> resize(bwt newSize) const;
+  bitVector<isSigned> matchWidth(const bitVector<isSigned>& op) const;
+  bitVector<isSigned> append(const bitVector<isSigned>& op) const;
+
+  bitVector<isSigned> extract(bwt upper, bwt lower) const;
+};
+
+class floatingPointTypeInfo
+{
+public:
+  floatingPointTypeInfo(unsigned exp, unsigned sig);
+  floatingPointTypeInfo(const floatingPointTypeInfo& old);
+
+  bitWidthType exponentWidth(void) const;
+  bitWidthType significandWidth(void) const;
+
+  bitWidthType packedWidth(void) const;
+  bitWidthType packedExponentWidth(void) const;
+  bitWidthType packedSignificandWidth(void) const;
+
+private:
+  bitWidthType m_exp;
+  bitWidthType m_sig;
+};
+
+// Point the backend at the manager whose nodes are being blasted. symfpu
+// constructs backend values through static trait calls (traits::RNE() takes
+// no context), so the manager and factory have to live in file statics;
+// this repoints them, and is called before every top-level blast.
+void init(STPMgr* bm);
+
+// Operations over SymFPU's unpacked representation.  FloatBlast uses these
+// to keep a floating-point DAG unpacked across consecutive operations and
+// materialise packed IEEE bits only at a real carrier boundary.  The packed
+// blast_* facade below remains for callers that lower one operation at a
+// time (notably the constant evaluator).
+namespace unpacked
+{
+uf decode(const floatingPointTypeInfo& size, const ASTNode& packed);
+ASTNode encode(const floatingPointTypeInfo& size, const uf& value);
+
+// A floating-point-valued source ITE is an ITE over every component of the
+// unpacked representation.  `condition` is a Boolean ASTNode.
+uf select(const ASTNode& condition, const uf& when_true,
+          const uf& when_false);
+
+ASTNode smtEqual(const floatingPointTypeInfo& size, const uf& lhs,
+                 const uf& rhs);
+
+uf add(const floatingPointTypeInfo& size, const ASTNode& rm, const uf& lhs,
+       const uf& rhs);
+uf sub(const floatingPointTypeInfo& size, const ASTNode& rm, const uf& lhs,
+       const uf& rhs);
+uf mul(const floatingPointTypeInfo& size, const ASTNode& rm, const uf& lhs,
+       const uf& rhs);
+uf div(const floatingPointTypeInfo& size, const ASTNode& rm, const uf& lhs,
+       const uf& rhs);
+uf fma(const floatingPointTypeInfo& size, const ASTNode& rm, const uf& x,
+       const uf& y, const uf& z);
+uf sqrt(const floatingPointTypeInfo& size, const ASTNode& rm, const uf& value);
+uf rem(const floatingPointTypeInfo& size, const uf& lhs, const uf& rhs);
+uf min(const floatingPointTypeInfo& size, const uf& lhs, const uf& rhs,
+       const ASTNode& zero_case);
+uf max(const floatingPointTypeInfo& size, const uf& lhs, const uf& rhs,
+       const ASTNode& zero_case);
+uf abs(const floatingPointTypeInfo& size, const uf& value);
+uf neg(const floatingPointTypeInfo& size, const uf& value);
+uf roundToIntegral(const floatingPointTypeInfo& size, const ASTNode& rm,
+                   const uf& value);
+
+// Floating-point consumers whose result is already in the target language.
+ASTNode toBV(const floatingPointTypeInfo& size, const ASTNode& rm,
+             const uf& value, bitWidthType target_width,
+             const ASTNode& undef, bool is_signed);
+ASTNode ieeeEqual(const floatingPointTypeInfo& size, const uf& lhs,
+                  const uf& rhs);
+ASTNode lessThan(const floatingPointTypeInfo& size, const uf& lhs,
+                 const uf& rhs);
+ASTNode lessThanOrEqual(const floatingPointTypeInfo& size, const uf& lhs,
+                        const uf& rhs);
+ASTNode isNormal(const floatingPointTypeInfo& size, const uf& value);
+ASTNode isSubnormal(const floatingPointTypeInfo& size, const uf& value);
+ASTNode isZero(const floatingPointTypeInfo& size, const uf& value);
+ASTNode isInfinite(const floatingPointTypeInfo& size, const uf& value);
+ASTNode isNaN(const floatingPointTypeInfo& size, const uf& value);
+ASTNode isNegative(const floatingPointTypeInfo& size, const uf& value);
+ASTNode isPositive(const floatingPointTypeInfo& size, const uf& value);
+
+uf convertBVToFloat(const floatingPointTypeInfo& target, const ASTNode& rm,
+                    const ASTNode& bits, bool is_signed);
+uf convertFloatToFloat(const floatingPointTypeInfo& source,
+                       const floatingPointTypeInfo& target,
+                       const ASTNode& rm, const uf& value);
+} // namespace unpacked
+
+} // namespace symbolic_fp
+
+} // namespace stp
+
+#endif

--- a/include/stp/Globals/Globals.h
+++ b/include/stp/Globals/Globals.h
@@ -59,13 +59,19 @@ enum inputStatus
   TO_BE_UNKNOWN // Specified in the input file as unknown.
 };
 
-// return types for the GetType() function in ASTNode class
+// return types for the GetType() function in ASTNode class.
+// FLOATINGPOINT_TYPE is appended after UNKNOWN_TYPE, not slotted in sort
+// order. The legacy prefix of the C API's type_t mirrors these values
+// numerically, preserving values compiled into pre-floating-point clients.
+// Source-only sorts such as RoundingMode are intentionally absent here:
+// GetType() describes the carrier used by the bit-vector pipeline.
 enum types
 {
   BOOLEAN_TYPE = 0,
   BITVECTOR_TYPE,
   ARRAY_TYPE,
-  UNKNOWN_TYPE
+  UNKNOWN_TYPE,
+  FLOATINGPOINT_TYPE
 };
 
 enum SOLVER_RETURN_TYPE

--- a/include/stp/NodeFactory/NodeFactory.h
+++ b/include/stp/NodeFactory/NodeFactory.h
@@ -94,7 +94,13 @@ public:
   ASTNode getFalse();
   ASTNode getUndefined();
 
-  ASTNode CreateConstant(stp::CBV cbv, unsigned width);
+  // With a nonzero exp_width the constant is made as a floating-point
+  // constant of that format. A constant is a leaf, so unlike an interior
+  // node it cannot derive a format from its children; a caller replacing a
+  // float-valued node with a constant must pass the format through or the
+  // float-ness is lost.
+  ASTNode CreateConstant(stp::CBV cbv, unsigned width, unsigned exp_width = 0,
+                         unsigned sig_width = 0);
 
   ASTNode CreateOneConst(unsigned width);
   ASTNode CreateZeroConst(unsigned width);
@@ -102,6 +108,8 @@ public:
   ASTNode CreateSignedMinConst(unsigned width);
   
   ASTNode CreateBVConst(unsigned int width, unsigned long long int bvconst);
+  ASTNode CreateFPConst(const stp::ASTNode& bvconst, unsigned exp_width,
+                        unsigned sig_width);
 
   virtual std::string getName() = 0;
 };

--- a/include/stp/NodeFactory/SimplifyingNodeFactory.h
+++ b/include/stp/NodeFactory/SimplifyingNodeFactory.h
@@ -104,6 +104,10 @@ private:
   ASTNode handle_bvand(unsigned int width, const ASTVec& children);
   ASTNode create_gt_node(const ASTVec& children);
 
+  // abs/neg of a constant float: clear (flip=false) or flip (flip=true) the
+  // sign bit, keeping the rest of the packed bits and the format.
+  ASTNode foldFPSign(const ASTNode& fpConst, bool flip);
+
   ASTNode plusRules(const ASTVec& oldChildren);
 
 };

--- a/include/stp/STPManager/STP.h
+++ b/include/stp/STPManager/STP.h
@@ -28,6 +28,7 @@ THE SOFTWARE.
 #include "stp/AST/AST.h"
 #include "stp/AbsRefineCounterExample/AbsRefine_CounterExample.h"
 #include "stp/AbsRefineCounterExample/ArrayTransformer.h"
+#include "stp/FloatBlaster/FpEncodingContext.h"
 #include "stp/Parser/LetMgr.h"
 #include "stp/STPManager/STPManager.h"
 #include "stp/Simplifier/BVSolver.h"
@@ -36,6 +37,8 @@ THE SOFTWARE.
 #include "stp/Util/Attributes.h"
 #include "stp/ToSat/ToSATAIG.h"
 #include "stp/Simplifier/NodeDomainAnalysis.h"
+
+#include <memory>
 
 namespace stp
 {
@@ -68,6 +71,10 @@ class STP
 
   SATSolver* get_new_sat_solver();
 
+  // The source-to-carrier mapping for the most recent solve. It remains
+  // alive after TopLevelSTP returns so model queries use that exact encoding.
+  std::unique_ptr<FpEncodingContext> fpEncodingContext;
+
 public:
   STPMgr* bm;
   Simplifier* simp;
@@ -99,6 +106,8 @@ public:
   // NB doesn't delete the STPMgr.
   void deleteObjects()
   {
+    fpEncodingContext.reset();
+
     delete Ctr_Example;
     Ctr_Example = NULL;
 
@@ -134,6 +143,7 @@ public:
       tosat->ClearAllTables();
     if (Ctr_Example != NULL)
       Ctr_Example->ClearAllTables();
+    fpEncodingContext.reset();
     // bm->ClearAllTables();
   }
 };

--- a/include/stp/STPManager/STPManager.h
+++ b/include/stp/STPManager/STPManager.h
@@ -26,6 +26,8 @@ THE SOFTWARE.
 #define STPMGR_H
 
 #include "stp/AST/ASTBVConst.h"
+#include "stp/AST/ASTFPConst.h"
+#include "stp/AST/ASTRMConst.h"
 #include "stp/AST/ASTInterior.h"
 #include "stp/AST/ASTNode.h"
 #include "stp/AST/ASTSymbol.h"
@@ -39,6 +41,19 @@ THE SOFTWARE.
 
 namespace stp
 {
+
+// The five SMT-LIB floating-point special values. Their nodes are ordinary
+// packed interned constants (see STPMgr::CreateFPSpecialConst); a childless
+// special-value node would hash-cons every format's NaN to one mutable node.
+enum class FPSpecial
+{
+  NaN,
+  PlusInfinity,
+  MinusInfinity,
+  PlusZero,
+  MinusZero,
+};
+
 /*
  * STP Node Manager. Tools for managing AST nodes.
  */
@@ -186,6 +201,9 @@ private:
   // Called by ASTNode constructors to uniqueify ASTBVConst
   ASTBVConst* LookupOrCreateBVConst(ASTBVConst& s);
 
+  ASTFPConst* LookupOrCreateFPConst(ASTFPConst& s);
+  ASTRMConst* LookupOrCreateRMConst(ASTRMConst& s);
+
   // Cache of zero/one/max BVConsts of different widths.
   ASTVec zeroes;
   ASTVec ones;
@@ -196,9 +214,57 @@ private:
 
   CBV CreateBVConstVal;
 
+  // Name -> symbols declared under it, in declaration order.
+  //
+  // A symbol's source sort is part of its identity, so the unique table is
+  // keyed on (name, sort) and a name-only probe cannot be built for it. That
+  // is what turned the two name lookups below into a scan of every symbol --
+  // and they are not rare: LookupOrCreateSymbol(name) is how every internally
+  // minted symbol is made (ArrayTransformer's per-abstracted-read variable,
+  // RemoveUnconstrained's per-unconstrained-parent variable), so the scan made
+  // symbol creation quadratic on problems with no floating point in them.
+  //
+  // This index answers those lookups in constant time. Entries are appended
+  // where the unique table is inserted into and removed where a symbol is
+  // cleaned up, so the two stay in step; the vector is for the case the sorted
+  // key admits and the old name-keyed one could not -- one name at two sorts.
+  typedef ankerl::unordered_dense::map<std::string, std::vector<ASTSymbol*>>
+      SymbolNameIndex;
+  SymbolNameIndex _symbol_name_index;
+
+  // Distinct source sorts, interned so a derived one can be memoised on the
+  // node as a pointer. std::unordered_set rather than a dense map because the
+  // addresses have to stay put as it grows.
+  std::unordered_set<SourceSort, SourceSort::Hasher> _source_sort_pool;
+
+  // The symbols STP introduces under a name of its own choosing, so that the
+  // name identifies the object without being looked up in the symbol table.
+  // See introducedSymbol.
+  std::map<std::string, ASTNode> _introduced_by_name;
+
 public:
   bool LookupSymbol(const char* const name);
   bool LookupSymbol(const char* const name, ASTNode& output);
+
+  // Intern `sort` and return its stable address, for ASTInternal's source-sort
+  // memo. Unknown interns like anything else, so the memo needs no separate
+  // negative sentinel.
+  const SourceSort* internSourceSort(const SourceSort& sort)
+  {
+    return &*_source_sort_pool.insert(sort).first;
+  }
+
+  // How many times a source sort has actually been derived, as opposed to
+  // answered from a node's memo. Counted so that the memo is directly
+  // testable: a derivation walks children, so "once per node" versus "once
+  // per path" is the whole difference, and it cannot be read off a result
+  // that is correct either way.
+  uint64_t source_sort_derivations = 0;
+
+  // Record/forget a symbol in the name index. Called only from the unique
+  // table's insertion point and from ASTSymbol::CleanUp.
+  void indexSymbolName(ASTSymbol* symbol);
+  void unindexSymbolName(ASTSymbol* symbol);
 
   /****************************************************************
    * Public Flags                                                 *
@@ -258,6 +324,84 @@ public:
   ASTNode CreateBVConst(std::string strval, int base, int bit_width);
   ASTNode CreateBVConst(unsigned int width, unsigned long long int bvconst);
   ASTNode charToASTNode(unsigned char* strval, int base, int bit_width);
+
+  DLL_PUBLIC ASTNode CreateFPConst(const stp::ASTNode& bvconst,
+                                   unsigned exp_width, unsigned sig_width);
+  DLL_PUBLIC ASTNode CreateRMConst(unsigned mode);
+
+  // Restore a model carrier value to the immutable sort of the source term
+  // it answers. The solver itself continues to evaluate plain bitvectors.
+  ASTNode LiftSourceValue(const ASTNode& carrier,
+                          const SourceSort& source_sort);
+
+  // Create a source-language leaf atomically. Its complete sort participates
+  // in hash-consing and cannot subsequently be changed by width setters.
+  DLL_PUBLIC ASTNode CreateSourceSymbol(const char* name,
+                                        const SourceSort& source_sort);
+
+  // Conservative manager-lifetime hint: whether a floating-point node has
+  // ever been created. Set by the format funnels (CreateFPConst,
+  // ASTNode::SetExpWidth and FloatBlaster::withFormat, all through
+  // noteFloatingPoint). False is a cheap proof that no query needs FP
+  // lowering; true is not query state -- an unused term or a popped scope may
+  // have set it -- so positive decisions must also inspect the current DAG.
+  bool has_floating_point = false;
+
+  // The same hint for the floating-point *theory* rather than for floats: a
+  // RoundingMode symbol, constant or array element carries no format, so it
+  // never reaches noteFloatingPoint, yet it still needs FpTotalise to pin it
+  // to the five legal encodings. TopLevelSTP's theory test is the one place
+  // that needs the broader question, and without this latch it had no cheap
+  // negative and walked the DAG of every pure bit-vector query.
+  bool has_floating_point_theory = false;
+
+  void noteFloatingPointTheory() { has_floating_point_theory = true; }
+
+  // Record that a float of a real format has been built. Every float's format
+  // arrives through one of the funnels above, so calling this there is what
+  // makes the fast-negative hint complete -- and it must be called whether or
+  // not the format then needs storing on a node, since a node that derives its
+  // format from its kind and children may later occur in a query.
+  //
+  // It is also where a build without floating-point support refuses the C
+  // API's floating-point entry points. (The parser rejects floating-point
+  // input earlier, with a line number; see checkFpSupported in smt2.y.)
+  DLL_PUBLIC void noteFloatingPoint();
+
+  bool isRoundingModeSymbol(const ASTNode& n) const
+  {
+    return n.GetKind() == SYMBOL &&
+           n.GetSourceSort().kind() == SourceSort::Kind::RoundingMode;
+  }
+
+  // The five-way one-hot validity constraint for a RoundingMode symbol:
+  // (or (= s RNE) ... (= s RNA)). Every path that introduces a
+  // RoundingMode variable must assert this: the sort has exactly five values,
+  // while the 5-bit carrier has thirty-two.
+  ASTNode roundingModeValidConstraint(const ASTNode& s);
+
+  // Whether `n` denotes a value of SMT-LIB's RoundingMode source sort.
+  //
+  // Everything that takes a rounding mode must ask this rather than test the
+  // carrier's width. The sort has five values and the carrier thirty-two, and
+  // symfpu's roundingDecision falls through to truncate-with-overflow-to-max
+  // when every mode equality is false -- a sixth, non-IEEE mode. Accepting a
+  // bare (_ BitVec 5) there let an input compute under it.
+  bool isRoundingModeSortedTerm(const ASTNode& n) const;
+
+  DLL_PUBLIC ASTNode CreateFPSpecialConst(FPSpecial which, unsigned exp_width,
+                                          unsigned sig_width);
+
+  // The declared symbol under an array term. Complete index/element sorts
+  // live immutably on source symbols; WRITE and ITE derive them.
+  // Null when no symbol is underneath.
+  ASTNode arrayBaseSymbol(const ASTNode& arr) const;
+
+  // Compatibility queries over the immutable SourceSort representation.
+  bool arrayHasFpIndex(const ASTNode& arr, unsigned& exp_width,
+                       unsigned& sig_width) const;
+  bool arrayHasRmIndex(const ASTNode& arr) const;
+  bool arrayHasRmElement(const ASTNode& arr) const;
 
   /****************************************************************
    * Create Node functions                                        *
@@ -371,6 +515,11 @@ public:
   // Note, not maintained properly wrt push/pops
   vector<stp::ASTNode> decls;
 
+  // C API declarations have manager lifetime and no lexical binding frame.
+  // Keep their printed names unambiguous even if the caller clears the list
+  // used only for printing declarations.
+  std::map<std::string, SourceSort> c_api_source_sorts;
+
   // Nodes seen so far
   ASTNodeSet PLPrintNodeSet;
 
@@ -411,6 +560,16 @@ public:
     return CurrentSymbol;
   }
 
+  ASTNode CreateFreshSourceVariable(const SourceSort& source_sort,
+                                    std::string prefix)
+  {
+    char* d = (char*)alloca(sizeof(char) * (32 + prefix.length()));
+    sprintf(d, "@%s_%d", prefix.c_str(), _symbol_count++);
+    ASTNode current = CreateSourceSymbol(d, source_sort);
+    Introduced_SymbolsSet.insert(current);
+    return current;
+  }
+
   bool FoundIntroducedSymbolSet(const ASTNode& in)
   {
     if (Introduced_SymbolsSet.find(in) != Introduced_SymbolsSet.end())
@@ -418,6 +577,65 @@ public:
       return true;
     }
     return false;
+  }
+
+  // Whether `name` is in the namespace SMT-LIB 2 reserves for solver use.
+  //
+  // STP relies on that reservation rather than merely respecting it:
+  // CreateFreshVariable mints '@'-prefixed names, and so do the objects
+  // supplying the unspecified results of the partial floating-point
+  // operations. The public boundaries refuse to declare such a name, which is
+  // what makes the reliance sound -- see Cpp_interface::CreateSourceSymbol and
+  // createPublicSourceSymbol.
+  static bool isReservedSymbolName(const char* name)
+  {
+    return name != NULL && (name[0] == '@' || name[0] == '.');
+  }
+
+  // Record a symbol STP introduced rather than the user declaring it, so the
+  // counterexample printers leave it out. CreateFreshVariable does this for
+  // the names it mints; this is the way in for an introduced symbol whose
+  // *name* is load-bearing and so cannot be minted there -- the arrays and
+  // free bits supplying the unspecified results of the partial floating-point
+  // operations, whose identity is their name (see
+  // FloatBlaster::unspecifiedValue and FloatBlaster::unspecifiedCells).
+  void noteIntroducedSymbol(const ASTNode& in)
+  {
+    Introduced_SymbolsSet.insert(in);
+  }
+
+  // The one symbol STP introduces under `name`, minted on first request.
+  //
+  // Identity is the name here on purpose: the solve and the two counterexample
+  // re-derivations each rebuild these independently and have to arrive at the
+  // same object, which a minted-per-call fresh variable cannot give them.
+  //
+  // That identity used to be nothing but the name, handed to a lookup that
+  // matches on name alone and returns the first symbol declared under it at
+  // *any* sort -- and whose width setters are then silent no-ops. A user
+  // declaration at the matching sort therefore *became* the object: pinning a
+  // cell of fp.min's choice map decided the solver's "unspecified" answer, the
+  // user's own symbol vanished from the model, and a declaration at a
+  // different sort aborted on a width assert. The '@' prefix was the whole
+  // defence, and nothing enforced it.
+  //
+  // Now the map is the identity: after the first call the name is never looked
+  // up again, and the first call refuses rather than adopts a name already
+  // taken. The public boundaries make that refusal unreachable by rejecting
+  // reserved names outright, so it is a backstop and not an expected error.
+  DLL_PUBLIC ASTNode introducedSymbol(const std::string& name,
+                                      unsigned index_width,
+                                      unsigned value_width);
+
+  // Whether a counterexample entry belongs to an introduced symbol. Entries
+  // for an introduced *array* are keyed on the read rather than on the array
+  // itself, so look through one: testing the key alone let every read of an
+  // introduced array print.
+  bool isIntroducedCounterExampleEntry(const ASTNode& in)
+  {
+    return FoundIntroducedSymbolSet(in) ||
+           (in.GetKind() == READ && in.Degree() > 0 &&
+            FoundIntroducedSymbolSet(in[0]));
   }
 
   bool VarSeenInTerm(const ASTNode& var, const ASTNode& term);

--- a/lib/AST/ASTFPConst.cpp
+++ b/lib/AST/ASTFPConst.cpp
@@ -1,7 +1,7 @@
 /********************************************************************
- * AUTHORS: Vijay Ganesh, David L. Dill
+ * AUTHORS: Andrew Teylu
  *
- * BEGIN DATE: November, 2005
+ * BEGIN DATE: January 2021
  *
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -22,34 +22,24 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ********************************************************************/
 
-#include "stp/AST/ASTSymbol.h"
+#include "stp/AST/ASTFPConst.h"
+
 #include "stp/AST/AST.h"
-#include "stp/STPManager/STP.h"
 
 namespace stp
 {
-const ASTVec ASTSymbol::empty_children;
 
-// Get the name of the symbol
-const char* ASTSymbol::GetName() const
+ASTFPConst::ASTFPConst(STPMgr* mgr, CBV bv, uint32_t exp_width,
+                       uint32_t sig_width)
+    : ASTBVConst(mgr, bv, 0, /*managed_outside=*/true), _sig_width(sig_width),
+      _exp_width(exp_width)
 {
-  return _name;
 }
 
-// Print function for symbol
-void ASTSymbol::nodeprint(ostream& os, bool /*c_friendly*/)
+ASTFPConst::ASTFPConst(const ASTFPConst& other)
+    : ASTBVConst(other), _sig_width(other._sig_width),
+      _exp_width(other._exp_width)
 {
-  os << _name;
 }
 
-// Call this when deleting a node that has been stored in the the
-// unique table
-void ASTSymbol::CleanUp()
-{
-  nodeManager->_symbol_unique_table.erase(this);
-  nodeManager->unindexSymbolName(this);
-  free((char*)this->_name);
-  delete this;
-}
-
-} // end of namespace
+} // namespace stp

--- a/lib/AST/ASTKind.kinds
+++ b/lib/AST/ASTKind.kinds
@@ -18,7 +18,7 @@
 #
 #
 # name minkids maxkids category1 category2
-Categories:	Term	Form
+Categories:	Term	Form	FP
 
 # Leaf nodes.
 UNDEFINED	0	0
@@ -88,8 +88,123 @@ READ		2	2	Term
 WRITE		3	3	Term
 
 #Types: These kinds are used only in the API. Once processed inside
-#the API, they are never used again in the system 
+#the API, they are never used again in the system
 ARRAY           0       0
 BITVECTOR       0       0
 BOOLEAN         0       0
+FLOATINGPOINT   0       0
+ROUNDINGMODE    0       0
 
+# Floating point _terms_ (i.e., things that produce FPs)
+
+# fp.abs: fp -> fp
+# The public C API mirrors every kind below in include/stp/c_interface.h
+# (enum exprkind_t) by numeric value; keep the two in lockstep. Anchoring
+# static_asserts live next to getExprKind in lib/Interface/c_interface.cpp.
+FP_ABS                      1    1    Term    FP
+
+# fp.neg: fp -> fp
+FP_NEG                      1    1    Term    FP
+
+# fp.add: rm, fp, fp -> fp
+FP_ADD                      3    3    Term    FP
+
+# fp.sub: rm, fp, fp -> fp
+FP_SUB                      3    3    Term    FP
+
+# fp.mul: rm, fp, fp -> fp
+FP_MUL                      3    3    Term    FP
+
+# fp.div: rm, fp, fp -> fp
+FP_DIV                      3    3    Term    FP
+
+# fp.fma: rm, fp, fp, fp -> fp
+FP_FMA                      4    4    Term    FP
+
+# fp.sqrt: rm, fp -> fp
+FP_SQRT                     2    2    Term    FP
+
+# fp.rem: fp, fp -> fp
+FP_REM                      2    2    Term    FP
+
+# fp.roundToIntegral: rm, fp -> fp
+FP_ROUNDTOINTEGRAL          2    2    Term    FP
+
+# fp.min: fp, fp -> fp
+FP_MIN                      2    3    Term    FP
+
+# fp.max: fp, fp -> fp
+FP_MAX                      2    3    Term    FP
+
+# to_fp: eb, sb, bv -> fp        (reinterpret the bits)
+# to_fp: eb, sb, rm, fp -> fp     (reformat a float)
+FP_TOFP                     3   4    Term    FP
+
+# to_fp: eb, sb, rm, bv -> fp     (convert a SIGNED integer)
+#
+# A kind of its own, rather than the four-argument FP_TOFP it is spelled as
+# in SMT-LIB, because nothing downstream could otherwise tell the two apart.
+# The distinction is in the source's *sort*, and a blasted float is its packed
+# bits -- so by the time the blaster sees the operand, a float and an integer
+# look identical. Asking the operand's type made an integer source get read as
+# a float and answer the wrong thing. The parser and the C API know which one
+# was written, so they record it here.
+FP_TOFP_SIGNED              4    4    Term    FP
+
+# to_fp_unsigned: eb, sb, rm, bv -> fP
+FP_TOFP_UNSIGNED            4    4    Term    FP
+
+# fp.to_ubv: bw, rm, fp -> bv
+FP_TO_UBV                   3    4    Term    FP
+
+# fp.to_sbv: bw, rm, fp -> bv
+FP_TO_SBV                   3    4    Term    FP
+
+# fp -> its packed IEEE bits (reinterpret, canonicalising NaN); API-only, no
+# SMT-LIB syntax. One float in, an (eb + sb)-bit bitvector out.
+FP_TO_IEEE_BV               1    1    Term    FP
+
+# Floating point _formulae_ (i.e., things that produce Booleans)
+
+# fp.leq: fp, fp -> bool
+FP_LEQ              2    2    Form    FP
+
+# fp.lt: fp, fp -> bool
+FP_LT               2    2    Form    FP
+
+# fp.geq: fp, fp -> bool
+FP_GEQ              2    2    Form    FP
+
+# fp.gt: fp, fp -> bool
+FP_GT               2    2    Form    FP
+
+# fp.eq: fp, fp -> bool
+FP_EQ               2    2    Form    FP
+
+# fp.isNormal: fp -> bool
+FP_ISNORMAL         1    1    Form    FP
+
+# fp.isSubnormal: fp -> bool
+FP_ISSUBNORMAL      1    1    Form    FP
+
+# fp.isZero: fp -> bool
+FP_ISZERO           1    1    Form    FP
+
+# fp.isInfinite: fp -> bool
+FP_ISINFINITE       1    1    Form    FP
+
+# fp.isNaN: fp -> bool
+FP_ISNAN            1    1    Form    FP
+
+# fp.isNegative: fp -> bool
+FP_ISNEGATIVE       1    1    Form    FP
+
+# fp.isPositive: fp -> bool
+FP_ISPOSITIVE       1    1    Form    FP
+
+# FP `=`
+FP_SMT_EQ           2    2    Form    FP
+
+# The five special floating-point values (NaN, +/-oo, +/-zero) have no kinds
+# of their own: they are ordinary packed constants, built interned by
+# STPMgr::CreateFPSpecialConst so that the format is part of node identity.

--- a/lib/AST/ASTNode.cpp
+++ b/lib/AST/ASTNode.cpp
@@ -58,6 +58,235 @@ void ASTNode::SetValueWidth(unsigned int vw) const
   _int_node_ptr->setValueWidth(vw);
 }
 
+// Work out an interior node's floating-point format from its kind and its
+// children, returning false when the node does not denote a float.
+//
+// The format used to be pure per-node state that whoever built the node was
+// expected to stamp on afterwards. That does not survive contact with the
+// preprocessing pipeline: dozens of places rebuild nodes, and any that
+// forgets leaves a float claiming a format of (0, 0), which the blaster does
+// not reject -- it computes the wrong bits, or underflows a width. Deriving
+// the format instead means a rebuilt node cannot lose it, because there is
+// nothing to lose.
+//
+// Leaves still have to store it: a symbol's format is declared, and a
+// constant's is fixed when it is made (see STPMgr::CreateFPConst). Interior
+// nodes are all covered here.
+static bool deriveFPFormat(const ASTNode& n, unsigned int& e, unsigned int& s)
+{
+  switch (n.GetKind())
+  {
+    // to_fp names its target format in its first two children, rather than
+    // inheriting one from an operand. So does the C API's floating-point
+    // *type* node (vc_fpType) -- covering it here is what makes
+    // vc_getExpWidth/vc_getSigWidth work on a type, as documented.
+    case FP_TOFP:
+    case FP_TOFP_SIGNED:
+    case FP_TOFP_UNSIGNED:
+    case FLOATINGPOINT:
+    {
+      if (n.Degree() < 2 || !n[0].isConstant() || !n[1].isConstant())
+        return false;
+
+      e = n[0].GetUnsignedConst();
+      s = n[1].GetUnsignedConst();
+      return e != 0 && s != 0;
+    }
+
+    // A read from an array of floats yields a float in the element's format,
+    // which the array node carries.
+    case READ:
+    {
+      if (n.Degree() < 1)
+        return false;
+
+      e = n[0].GetExpWidth();
+      s = n[0].GetSigWidth();
+      return e != 0 && s != 0;
+    }
+
+    // A store to an array of floats is itself an array of floats: carry the
+    // element format from the array child, so a read over a store chain can
+    // derive its format (the recursion bottoms out at the array symbol,
+    // whose declaration set it).
+    case WRITE:
+    {
+      if (n.Degree() < 1)
+        return false;
+
+      e = n[0].GetExpWidth();
+      s = n[0].GetSigWidth();
+      return e != 0 && s != 0;
+    }
+
+    // A float-valued ITE takes the format of its branches (children 1 and 2,
+    // which share it). Checked first and cheaply because bitvector ITEs are
+    // everywhere: for those the branch carries no format and this returns at
+    // once.
+    case ITE:
+    {
+      if (n.Degree() != 3)
+        return false;
+
+      e = n[1].GetExpWidth();
+      s = n[1].GetSigWidth();
+      if (e == 0)
+      {
+        e = n[2].GetExpWidth();
+        s = n[2].GetSigWidth();
+      }
+      return e != 0 && s != 0;
+    }
+
+    // The rest produce a float in the format of their float operand. Which
+    // child that is varies -- the arithmetic operations lead with a rounding
+    // mode -- and an operand that was folded to a constant may have lost its
+    // own format, so take the first child that has one.
+    case FP_ABS:
+    case FP_NEG:
+    case FP_ADD:
+    case FP_SUB:
+    case FP_MUL:
+    case FP_DIV:
+    case FP_FMA:
+    case FP_SQRT:
+    case FP_REM:
+    case FP_ROUNDTOINTEGRAL:
+    case FP_MIN:
+    case FP_MAX:
+    {
+      for (size_t i = 0; i < n.Degree(); i++)
+      {
+        const unsigned int child_exp = n[i].GetExpWidth();
+        if (child_exp != 0)
+        {
+          e = child_exp;
+          s = n[i].GetSigWidth();
+          return true;
+        }
+      }
+      return false;
+    }
+
+    default:
+      return false;
+  }
+}
+
+// Sentinel cached in _exp_width once derivation has concluded "not a
+// float". Without it every format query on a formatless node re-walks its
+// children -- quadratic on store chains and ITE spines, since WRITE and ITE
+// derive through their children. A later SetExpWidth (from a declaration or
+// the blaster stamping its output) simply overwrites it.
+static const uint32_t FP_NOT_A_FLOAT = 0xFFFFFFFFu;
+
+// Derive once and keep the answer -- positive or negative. The fields are
+// already mutable, and an interior node can hold them, so this costs one
+// walk per node rather than one per query.
+void ASTNode::cacheFPFormat() const
+{
+  unsigned int e = 0;
+  unsigned int s = 0;
+
+  const bool is_float = deriveFPFormat(*this, e, s);
+
+  // A BVCONST has nowhere to put either answer (its setters reject it);
+  // float constants are made as ASTFPConst instead, and re-deriving on a
+  // childless node is cheap.
+  if (GetKind() == BVCONST ||
+      (Degree() == 0 &&
+       _int_node_ptr->getDeclaredSourceSort().isKnown()))
+    return;
+
+  if (!is_float)
+  {
+    _int_node_ptr->setExpWidth(FP_NOT_A_FLOAT);
+    return;
+  }
+
+  _int_node_ptr->setExpWidth(e);
+  _int_node_ptr->setSigWidth(s);
+}
+
+unsigned int ASTNode::GetExpWidth() const
+{
+  unsigned int stored = _int_node_ptr->getExpWidth();
+  if (stored == FP_NOT_A_FLOAT)
+    return 0;
+  if (stored != 0)
+    return stored;
+
+  cacheFPFormat();
+  stored = _int_node_ptr->getExpWidth();
+  return stored == FP_NOT_A_FLOAT ? 0 : stored;
+}
+
+// A float's format may be stored only where it cannot be shared with a plain
+// bitvector use of the same node:
+//
+//  - on a leaf, whose sort is declared (a symbol) or fixed when it is made
+//    (an ASTFPConst, which interns apart from the plain constant holding the
+//    same bits);
+//  - on an interior node whose *kind* says it is a float, where it is derived
+//    from the kind and children rather than assigned (see deriveFPFormat) and
+//    so cannot disagree with anything;
+//  - on an array, where it describes the elements rather than the node.
+//
+// Never on a bitvector-kind interior node. Nodes are hash-consed and the
+// format is per-node state, so a format stamped on the bits a float lowers to
+// retypes everything else that denotes those bits: the input's own bitvectors
+// start reporting FLOATINGPOINT_TYPE solver-wide, bitvector operations over
+// them stop type checking, and to_fp reads an integer as a float. Lowering
+// therefore hands its format to the blaster as an argument instead (see
+// FloatBlaster::operandFormat and FloatBlast).
+bool ASTNode::canStoreFPFormat() const
+{
+  return Degree() == 0 || is_FP_kind(GetKind()) || GetKind() == FLOATINGPOINT ||
+         GetIndexWidth() > 0;
+}
+
+void ASTNode::SetExpWidth(unsigned int _ew) const
+{
+  // A format may be set, re-set to the same value, or cleared -- never
+  // changed. Two contexts disagreeing about a shared node's format is the
+  // hash-consing corruption this trips on.
+  assert(_int_node_ptr->getExpWidth() == 0 ||
+         _int_node_ptr->getExpWidth() == 0xFFFFFFFFu /* not-a-float cache */ ||
+         _ew == 0 || _int_node_ptr->getExpWidth() == _ew);
+
+  // Callers stamp only what can hold a stamp; withFormat is where that is
+  // decided, for the callers that do not already know.
+  assert(_ew == 0 || canStoreFPFormat());
+  // One of the funnels through which a float's format arrives, so this is
+  // where the manager learns that floats are in play. Not the only one:
+  // a node that derives its format needs no stamp and never reaches here,
+  // which is why withFormat -- the entry point that decides whether the
+  // stamp is needed -- notes it too.
+  if (_ew != 0)
+    _int_node_ptr->nodeManager->noteFloatingPoint();
+  _int_node_ptr->setExpWidth(_ew);
+}
+
+unsigned int ASTNode::GetSigWidth() const
+{
+  if (_int_node_ptr->getExpWidth() == FP_NOT_A_FLOAT)
+    return 0;
+
+  const unsigned int stored = _int_node_ptr->getSigWidth();
+  if (stored != 0)
+    return stored;
+
+  cacheFPFormat();
+  return _int_node_ptr->getSigWidth();
+}
+
+void ASTNode::SetSigWidth(unsigned int _sw) const
+{
+  assert(_int_node_ptr->getSigWidth() == 0 || _sw == 0 ||
+         _int_node_ptr->getSigWidth() == _sw);
+  _int_node_ptr->setSigWidth(_sw);
+}
+
 // return the type of the ASTNode:
 //
 // 0 iff BOOLEAN; 1 iff BITVECTOR; 2 iff ARRAY; 3 iff UNKNOWN;
@@ -75,6 +304,120 @@ const char* ASTNode::GetName() const
     FatalError("GetName: Called GetName on a non-symbol: ", *this);
 
   return ((ASTSymbol*)_int_node_ptr)->GetName();
+}
+
+// Memoised wrapper over deriveSourceSort.
+//
+// The derivation walks children for READ, WRITE and ITE -- and for ITE it
+// walks *both* branches -- so recomputing it costs Theta(2^depth) on a
+// shared-branch ITE DAG and Theta(depth) on a store chain, on a graph of
+// linear size. That is not a cost paid once: the front ends ask for every
+// node they build, and containsFloatingPointTheory asks for every node of
+// every query, including queries with no floating point in them.
+//
+// Memoising is sound for the same reason the floating-point format's memo is
+// (see cacheFPFormat): the derivation reads only the node's kind, children
+// and widths, and the first two are the hash-cons key. The widths are not, so
+// the setters drop the memo.
+SourceSort ASTNode::GetSourceSort() const
+{
+  if (IsNull())
+    return SourceSort::unknown();
+
+  if (const SourceSort* cached = _int_node_ptr->cachedSourceSort())
+    return *cached;
+
+  _int_node_ptr->nodeManager->source_sort_derivations++;
+  const SourceSort derived = deriveSourceSort();
+  _int_node_ptr->setCachedSourceSort(
+      _int_node_ptr->nodeManager->internSourceSort(derived));
+  return derived;
+}
+
+SourceSort ASTNode::deriveSourceSort() const
+{
+  if (GetKind() == UNDEFINED)
+    return SourceSort::unknown();
+
+  // API type nodes denote the corresponding source sort even though they
+  // are not themselves value-bearing terms.
+  switch (GetKind())
+  {
+    case BOOLEAN:
+      return SourceSort::boolean();
+    case BITVECTOR:
+      if (Degree() == 1 && (*this)[0].GetKind() == BVCONST)
+        return SourceSort::bitVector((*this)[0].GetUnsignedConst());
+      break;
+    case FLOATINGPOINT:
+      if (Degree() == 2 && (*this)[0].GetKind() == BVCONST &&
+          (*this)[1].GetKind() == BVCONST)
+        return SourceSort::floatingPoint((*this)[0].GetUnsignedConst(),
+                                         (*this)[1].GetUnsignedConst());
+      break;
+    case ROUNDINGMODE:
+      return SourceSort::roundingMode();
+    case ARRAY:
+      if (Degree() == 2)
+      {
+        const SourceSort index = (*this)[0].GetSourceSort();
+        const SourceSort element = (*this)[1].GetSourceSort();
+        if (index.isScalar() && element.isScalar())
+          return SourceSort::array(index, element);
+      }
+      break;
+    default:
+      break;
+  }
+
+  // Typed constants and symbols carry their sort as immutable identity.
+  const SourceSort declared = _int_node_ptr->getDeclaredSourceSort();
+  if (declared.isKnown())
+    return declared;
+
+  // The only source expressions whose carrier does not identify the result
+  // sort are the structural ones below. Derive them from their children.
+  if (GetKind() == READ && Degree() >= 1)
+  {
+    const SourceSort array = (*this)[0].GetSourceSort();
+    return array.kind() == SourceSort::Kind::Array
+               ? array.element()
+               : SourceSort::unknown();
+  }
+
+  if (GetKind() == WRITE && Degree() >= 1)
+    return (*this)[0].GetSourceSort();
+
+  if (GetKind() == ITE && Degree() == 3)
+  {
+    const SourceSort then_sort = (*this)[1].GetSourceSort();
+    const SourceSort else_sort = (*this)[2].GetSourceSort();
+    return then_sort == else_sort ? then_sort : SourceSort::unknown();
+  }
+
+  // Compatibility for internal and legacy leaves that predate typed source
+  // symbols. New public declarations do not take this path.
+  switch (GetType())
+  {
+    case BOOLEAN_TYPE:
+      return SourceSort::boolean();
+    case BITVECTOR_TYPE:
+      return GetValueWidth() == 0 ? SourceSort::unknown()
+                                  : SourceSort::bitVector(GetValueWidth());
+    case FLOATINGPOINT_TYPE:
+      return SourceSort::floatingPoint(GetExpWidth(), GetSigWidth());
+    case ARRAY_TYPE:
+    {
+      const SourceSort index = SourceSort::bitVector(GetIndexWidth());
+      const SourceSort element =
+          GetExpWidth() == 0
+              ? SourceSort::bitVector(GetValueWidth())
+              : SourceSort::floatingPoint(GetExpWidth(), GetSigWidth());
+      return SourceSort::array(index, element);
+    }
+    default:
+      return SourceSort::unknown();
+  }
 }
 
 // Get the value of bvconst from a bvconst.  It's an error if kind

--- a/lib/AST/ASTRMConst.cpp
+++ b/lib/AST/ASTRMConst.cpp
@@ -1,0 +1,17 @@
+/********************************************************************
+ * A source-language RoundingMode literal over STP's 5-bit carrier.
+ ********************************************************************/
+#include "stp/AST/ASTRMConst.h"
+#include "stp/AST/AST.h"
+
+namespace stp
+{
+
+ASTRMConst::ASTRMConst(STPMgr* mgr, CBV bv)
+    : ASTBVConst(mgr, bv, 0, /*managed_outside=*/true)
+{
+}
+
+ASTRMConst::ASTRMConst(const ASTRMConst& other) : ASTBVConst(other) {}
+
+} // namespace stp

--- a/lib/AST/ASTmisc.cpp
+++ b/lib/AST/ASTmisc.cpp
@@ -122,6 +122,19 @@ bool numberOfReadsLessThan(const ASTNode& n, int limit)
   return reads < limit;
 }
 
+// See the declaration for why this exists: constants of one value need
+// not be one node, because a floating-point constant interns apart from
+// the plain constant with its bits.
+bool constantsSameBits(const ASTNode& a, const ASTNode& b)
+{
+  assert(a.GetKind() == BVCONST && b.GetKind() == BVCONST);
+  if (a == b)
+    return true;
+  return a.GetValueWidth() == b.GetValueWidth() &&
+         0 == CONSTANTBV::BitVector_Lexicompare(a.GetBVConst(),
+                                                b.GetBVConst());
+}
+
 // True if any descendants are arrays.
 bool containsArrayOps(const ASTNode& n, STPMgr* mgr)
 {
@@ -132,6 +145,32 @@ bool containsArrayOps(const ASTNode& n, STPMgr* mgr)
     if (current.GetIndexWidth() > 0)
       return true;
 
+  return false;
+}
+
+bool containsFloatingPoint(const ASTNode& n, STPMgr* mgr)
+{
+  NodeIterator ni(n, mgr->ASTUndefined, *mgr);
+  ASTNode current;
+  while ((current = ni.next()) != ni.end())
+  {
+    if (is_FP_kind(current.GetKind()) ||
+        current.GetSourceSort().containsFloatingPoint())
+      return true;
+  }
+  return false;
+}
+
+bool containsFloatingPointTheory(const ASTNode& n, STPMgr* mgr)
+{
+  NodeIterator ni(n, mgr->ASTUndefined, *mgr);
+  ASTNode current;
+  while ((current = ni.next()) != ni.end())
+  {
+    if (is_FP_kind(current.GetKind()) ||
+        current.GetSourceSort().usesFloatingPointTheory())
+      return true;
+  }
   return false;
 }
 
@@ -204,18 +243,6 @@ void SortByArith(ASTVec& v)
   sort(v.begin(), v.end(), ArithLess{});
 }
 
-bool isAtomic(Kind kind)
-{
-  if (TRUE == kind || FALSE == kind || EQ == kind || BVLT == kind ||
-      BVLE == kind || BVGT == kind || BVGE == kind || BVSLT == kind ||
-      BVSLE == kind || BVSGT == kind || BVSGE == kind || BVUADDO == kind ||
-      BVSADDO == kind || BVUMULO == kind || BVSMULO == kind ||
-      BVUSUBO == kind || BVSSUBO == kind || SYMBOL == kind ||
-      BOOLEXTRACT == kind)
-    return true;
-  return false;
-}
-
 // If there is a lot of sharing in the graph, this will take a long
 // time.  it doesn't mark subgraphs as already having been
 // typechecked.
@@ -257,12 +284,50 @@ void buildListOfSymbols(const ASTNode& n, ASTNodeSet& visited,
     buildListOfSymbols(n[i], visited, symbols);
 }
 
+// A float is carried internally as its packed bits, so after FloatBlast a
+// float-typed leaf may stand in a bitvector circuit -- but this is not public
+// subtyping. The parser and C API reject BV operations over FP terms; this
+// predicate exists for lowered and model-evaluation nodes built inside STP.
+// A leaf's format is declared (a symbol) or
+// fixed when it is made (an ASTFPConst, which interns apart from the plain
+// constant with the same bits); a read, a store and an ITE derive theirs from
+// the array or the branches they carry; an operation's comes from its kind.
+// See deriveFPFormat: in every one of those cases the format follows from the
+// node, so nothing can disagree about it.
+//
+// A bitvector-kind interior node is entitled to none. Its format could only
+// have been stamped on by whoever lowered a float to those bits -- and nodes
+// are hash-consed, so that stamp retypes every other use of the same bits.
+// The input's own bitvectors start reporting FLOATINGPOINT_TYPE solver-wide.
+// That is what BVSRSHIFT and the comparison predicates used to abort on, and
+// what made to_fp read an integer source as a float and answer wrongly.
+// ASTNode::SetExpWidth now refuses such a stamp; this rejects the result of
+// one wherever the bits are used, so the two ends agree.
+// Declared in AST.h; shared, because every bit-vector-only pass that
+// classifies a node by GetType() has to ask this question and they must all
+// ask it the same way.
+bool isBitsValued(const ASTNode& n)
+{
+  const types t = n.GetType();
+
+  if (BITVECTOR_TYPE == t)
+    return true;
+  if (FLOATINGPOINT_TYPE != t)
+    return false;
+
+  const Kind k = n.GetKind();
+  return 0 == n.Degree() || is_FP_kind(k) || READ == k || WRITE == k ||
+         ITE == k;
+}
+
 void checkChildrenAreBV(const ASTChildren& v, const ASTNode& n)
 {
-  for (auto it = v.begin(), itend = v.end(); it != itend;
-       it++)
+  // See isBitsValued. (This check was fully disabled during the
+  // floating-point work because blasted circuits mix float-stamped and plain
+  // children; accepting both types restores it for the genuine errors.)
+  for (auto it = v.begin(), itend = v.end(); it != itend; it++)
   {
-    if (BITVECTOR_TYPE != it->GetType())
+    if (!isBitsValued(*it))
     {
       cerr << "The type is: " << it->GetType() << endl;
       FatalError(
@@ -338,6 +403,23 @@ ASTVec FlattenKind(Kind k, const ASTChildren& children, int maxDepth)
   return flat_children;
 }
 
+// Rounding modes are carried as 5-bit one-hot bitvectors, so a well-formed
+// one is any 5-bit bitvector: a literal from the grammar, or a symbol of
+// SMT-LIB's RoundingMode sort.
+//
+// Deliberately the carrier's shape and not the sort. Whether a term really
+// denotes one of RoundingMode's five values is
+// STPMgr::isRoundingModeSortedTerm, and that is what the parser and the C
+// API ask before building an operation -- but this runs over nodes STP
+// builds for itself as well, including the operations model evaluation
+// rebuilds with their children resolved, whose rounding mode can be the
+// model's value for a read the solve never constrained. Those are
+// well-formed and must type check.
+static bool isRoundingMode(const ASTNode& n)
+{
+  return n.GetType() == BITVECTOR_TYPE && n.GetValueWidth() == 5;
+}
+
 bool BVTypeCheck_term_kind(const ASTNode& n, const Kind& k)
 {
   // Symbols are a large share of the nodes built while parsing and have no
@@ -351,7 +433,7 @@ bool BVTypeCheck_term_kind(const ASTNode& n, const Kind& k)
   switch (k)
   {
     case BVCONST:
-      if (BITVECTOR_TYPE != n.GetType())
+      if (BITVECTOR_TYPE != n.GetType() && FLOATINGPOINT_TYPE != n.GetType())
         FatalError("BVTypeCheck: The term t does not typecheck, where t = \n",
                    n);
       break;
@@ -359,17 +441,43 @@ bool BVTypeCheck_term_kind(const ASTNode& n, const Kind& k)
     case ITE:
       if (n.Degree() != 3)
         FatalError("BVTypeCheck: should have exactly 3 args\n", n);
-      if (BOOLEAN_TYPE != n[0].GetType() || (n[1].GetType() != n[2].GetType()))
+      // At this internal checker boundary a lowered float branch and its
+      // packed-bit circuit are one class. Public construction has already
+      // required the source-level branches to have exactly the same sort.
+      if (BOOLEAN_TYPE != n[0].GetType() ||
+          (n[1].GetType() == BOOLEAN_TYPE) != (n[2].GetType() == BOOLEAN_TYPE))
         FatalError("BVTypeCheck: The term t does not typecheck, where t = \n",
                    n);
       if (n[1].GetValueWidth() != n[2].GetValueWidth())
+      {
         FatalError("BVTypeCheck: length of THENbranch != length of "
                    "ELSEbranch in the term t = \n",
                    n);
+      }
       if (n[1].GetIndexWidth() != n[2].GetIndexWidth())
         FatalError("BVTypeCheck: length of THENbranch != length of "
                    "ELSEbranch in the term t = \n",
                    n);
+      // Branches that BOTH claim to be floats must agree on the format, as
+      // for EQ below: two formats can share one packed width -- (8, 24) and
+      // (24, 8) are both 32 bits -- so the width checks cannot tell them
+      // apart, and the node would derive whichever branch's format comes
+      // first (see deriveFPFormat) and silently read the other branch's
+      // bits at it. A float branch and a plain bitvector branch remain legal
+      // only here: that mix arises once lowering replaces a branch with its
+      // circuit, after the public sort check.
+      if (n[1].GetExpWidth() != 0 && n[2].GetExpWidth() != 0 &&
+          (n[1].GetExpWidth() != n[2].GetExpWidth() ||
+           n[1].GetSigWidth() != n[2].GetSigWidth()))
+      {
+        cerr << "expwidth of THENbranch: " << n[1].GetExpWidth() << endl;
+        cerr << "expwidth of ELSEbranch: " << n[2].GetExpWidth() << endl;
+        cerr << "sigwidth of THENbranch: " << n[1].GetSigWidth() << endl;
+        cerr << "sigwidth of ELSEbranch: " << n[2].GetSigWidth() << endl;
+        FatalError("BVTypeCheck: the THENbranch and ELSEbranch differ in "
+                   "floating-point format in the term t = \n",
+                   n);
+      }
       break;
 
     case READ:
@@ -387,8 +495,13 @@ bool BVTypeCheck_term_kind(const ASTNode& n, const Kind& k)
       }
       if (ARRAY_TYPE != n[0].GetType())
         FatalError("First parameter to read should be an array", n[0]);
-      if (BITVECTOR_TYPE != n[1].GetType())
-        FatalError("Second parameter to read should be a bitvector", n[1]);
+      // A float-indexed array's index is a float laid out as its packed
+      // bits, exactly as a float element is (see WRITE's value below). The
+      // pre-solve pass rewrites such indexes to canonical bits.
+      if (BITVECTOR_TYPE != n[1].GetType() &&
+          FLOATINGPOINT_TYPE != n[1].GetType())
+        FatalError("Second parameter to read should be a bitvector or a float",
+                   n[1]);
       break;
 
     case WRITE:
@@ -404,10 +517,18 @@ bool BVTypeCheck_term_kind(const ASTNode& n, const Kind& k)
                    n);
       if (ARRAY_TYPE != n[0].GetType())
         FatalError("First parameter to read should be an array", n[0]);
-      if (BITVECTOR_TYPE != n[1].GetType())
-        FatalError("Second parameter to read should be a bitvector", n[1]);
-      if (BITVECTOR_TYPE != n[2].GetType())
-        FatalError("Third parameter to read should be a bitvector", n[2]);
+      // As for READ: a float index rides as its packed bits.
+      if (BITVECTOR_TYPE != n[1].GetType() &&
+          FLOATINGPOINT_TYPE != n[1].GetType())
+        FatalError("Second parameter to write should be a bitvector or a float",
+                   n[1]);
+      // The element of an array of floats is a float. It is laid out exactly
+      // like a bitvector of the same width -- the array carries the format --
+      // so everything below this point treats the two alike.
+      if (BITVECTOR_TYPE != n[2].GetType() &&
+          FLOATINGPOINT_TYPE != n[2].GetType())
+        FatalError("Third parameter to write should be a bitvector or a float",
+                   n[2]);
       break;
 
     case BVDIV:
@@ -507,6 +628,270 @@ bool BVTypeCheck_term_kind(const ASTNode& n, const Kind& k)
                    "the bitwidth.\n",
                    n);
       break;
+    // The arithmetic operations take a rounding mode as their first child,
+    // then their float operands; the rest take only floats. A rounding mode
+    // is carried as a 5-bit one-hot bitvector (see symbolic_fp.h).
+    case FP_ABS:
+    case FP_NEG:
+    case FP_ADD:
+    case FP_SUB:
+    case FP_MUL:
+    case FP_DIV:
+    case FP_FMA:
+    case FP_SQRT:
+    case FP_REM:
+    case FP_ROUNDTOINTEGRAL:
+    case FP_MIN:
+    case FP_MAX:
+    {
+      unsigned int expected_args;
+      unsigned int first_float;
+
+      switch (k)
+      {
+        case FP_ABS:
+        case FP_NEG:
+          expected_args = 1;
+          first_float = 0;
+          break;
+        case FP_SQRT:
+        case FP_ROUNDTOINTEGRAL:
+          expected_args = 2;
+          first_float = 1;
+          break;
+        case FP_REM:
+          expected_args = 2;
+          first_float = 0;
+          break;
+        // fp.min/fp.max gain a third child -- the choice of zero -- once
+        // FpTotalise has run, so both arities are well formed.
+        case FP_MIN:
+        case FP_MAX:
+          expected_args = n.Degree() == 3 ? 3 : 2;
+          first_float = 0;
+          break;
+        case FP_FMA:
+          expected_args = 4;
+          first_float = 1;
+          break;
+        default: // FP_ADD, FP_SUB, FP_MUL, FP_DIV
+          expected_args = 3;
+          first_float = 1;
+          break;
+      }
+
+      std::string error_msg("");
+      bool failed(false);
+
+      if (n.Degree() != expected_args)
+      {
+        error_msg = "<fp> has the wrong number of arguments";
+        failed = true;
+      }
+      else if (first_float == 1 && !isRoundingMode(n[0]))
+      {
+        error_msg = "first argument to <fp> is not a rounding mode";
+        failed = true;
+      }
+
+      // The trailing choice-of-zero child is a 1-bit bitvector, not a float,
+      // so it is checked separately.
+      const bool has_choice = (k == FP_MIN || k == FP_MAX) && n.Degree() == 3;
+      const unsigned int last_float = has_choice ? n.Degree() - 1 : n.Degree();
+
+      if (!failed && has_choice &&
+          (n[2].GetType() != BITVECTOR_TYPE || n[2].GetValueWidth() != 1))
+      {
+        error_msg = "<fp> min/max's choice of zero is not a 1-bit bitvector";
+        failed = true;
+      }
+
+      for (unsigned int i = first_float; !failed && i < last_float; i++)
+      {
+        if (n[i].GetType() != FLOATINGPOINT_TYPE)
+        {
+          error_msg = "argument to <fp> is not an fp";
+          failed = true;
+        }
+        else if (n[i].GetSigWidth() != n[first_float].GetSigWidth() ||
+                 n[i].GetExpWidth() != n[first_float].GetExpWidth())
+        {
+          error_msg = "arguments to <fp> differ in format";
+          failed = true;
+        }
+      }
+
+      if (failed)
+      {
+        cerr << error_msg << endl;
+        FatalError(error_msg.c_str(), n);
+      }
+      break;
+    }
+
+    // ((_ to_fp e s) bv) is (e, s, bits); ((_ to_fp e s) rm f) is
+    // (e, s, rm, expr). The e/s children record the target format.
+    case FP_TOFP:
+    {
+      std::string error_msg("");
+      bool failed(false);
+
+      if (n.Degree() != 3 && n.Degree() != 4)
+      {
+        error_msg = "to_fp should have 3 or 4 args";
+        failed = true;
+      }
+      else if (!n[0].isConstant() || !n[1].isConstant())
+      {
+        error_msg = "to_fp's format arguments must be constants";
+        failed = true;
+      }
+      // The target format is checked against the e/s children rather than
+      // against the node's own exp/sig widths: the node factory type checks
+      // while creating the node, which is before the parser has had a chance
+      // to stamp the format onto it.
+      else if (n.Degree() == 3)
+      {
+        // The packed bits are judged by width, and a float is allowed to
+        // stand for them (see isBitsValued). Blasting ((_ to_fp e s) bits)
+        // yields those same bits stamped with the format -- and nodes are
+        // hash-consed, so the stamp can land on the very node 'bits' names,
+        // which reports FLOATINGPOINT_TYPE from then on. It holds the same
+        // e + s bits either way; insisting on BITVECTOR_TYPE aborted the
+        // re-solve of a formula that had just solved.
+        if (!isBitsValued(n[2]) ||
+            n[2].GetValueWidth() !=
+                n[0].GetUnsignedConst() + n[1].GetUnsignedConst())
+        {
+          error_msg = "to_fp's argument is not a bitvector of width e + s";
+          failed = true;
+        }
+      }
+      else if (!isRoundingMode(n[2]))
+      {
+        error_msg = "to_fp's second argument is not a rounding mode";
+        failed = true;
+      }
+      // With a rounding mode this reformats a float. Converting a signed
+      // integer is FP_TOFP_SIGNED; the sorts differ, so the kinds do.
+      else if (n[3].GetType() != FLOATINGPOINT_TYPE)
+      {
+        error_msg = "to_fp's argument is not an fp";
+        failed = true;
+      }
+
+      if (failed)
+      {
+        cerr << error_msg << endl;
+        FatalError(error_msg.c_str(), n);
+      }
+      break;
+    }
+
+    // ((_ to_fp e s) rm bv) over a signed integer, and its unsigned
+    // counterpart: (e, s, rm, bits) for both.
+    case FP_TOFP_SIGNED:
+    case FP_TOFP_UNSIGNED:
+    {
+      std::string error_msg("");
+      bool failed(false);
+
+      if (n.Degree() != 4)
+      {
+        error_msg = "to_fp/to_fp_unsigned over an integer should have 4 args";
+        failed = true;
+      }
+      else if (!n[0].isConstant() || !n[1].isConstant())
+      {
+        error_msg = "to_fp's format arguments must be constants";
+        failed = true;
+      }
+      else if (!isRoundingMode(n[2]))
+      {
+        error_msg = "to_fp's second argument is not a rounding mode";
+        failed = true;
+      }
+      // The integer this converts rides in a bitvector -- or in a float leaf,
+      // whose bits are just as good and which isBitsValued admits. What it
+      // must not be is a bitvector some lowering has stamped a format onto.
+      else if (!isBitsValued(n[3]))
+      {
+        error_msg = "to_fp's integer argument is not a bitvector";
+        failed = true;
+      }
+
+      if (failed)
+      {
+        cerr << error_msg << endl;
+        FatalError(error_msg.c_str(), n);
+      }
+      break;
+    }
+
+    // ((_ fp.to_ubv m) rm x): (m, rm, x), plus the unspecified value once
+    // FpTotalise has run. Yields a bitvector of width m.
+    case FP_TO_UBV:
+    case FP_TO_SBV:
+    {
+      std::string error_msg("");
+      bool failed(false);
+
+      if (n.Degree() != 3 && n.Degree() != 4)
+      {
+        error_msg = "fp.to_ubv/fp.to_sbv should have 3 or 4 args";
+        failed = true;
+      }
+      else if (!n[0].isConstant())
+      {
+        error_msg = "fp.to_ubv/fp.to_sbv's width must be a constant";
+        failed = true;
+      }
+      else if (n.GetValueWidth() != n[0].GetUnsignedConst())
+      {
+        error_msg = "fp.to_ubv/fp.to_sbv's result width does not match";
+        failed = true;
+      }
+      else if (!isRoundingMode(n[1]))
+      {
+        error_msg =
+            "fp.to_ubv/fp.to_sbv's first argument is not a rounding mode";
+        failed = true;
+      }
+      else if (n[2].GetType() != FLOATINGPOINT_TYPE)
+      {
+        error_msg = "fp.to_ubv/fp.to_sbv's argument is not an fp";
+        failed = true;
+      }
+      else if (n.Degree() == 4 &&
+               (n[3].GetType() != BITVECTOR_TYPE ||
+                n[3].GetValueWidth() != n.GetValueWidth()))
+      {
+        error_msg =
+            "fp.to_ubv/fp.to_sbv's unspecified value has the wrong width";
+        failed = true;
+      }
+
+      if (failed)
+      {
+        cerr << error_msg << endl;
+        FatalError(error_msg.c_str(), n);
+      }
+      break;
+    }
+
+    // fp -> IEEE bits: one float in, an (eb + sb)-bit bitvector out.
+    case FP_TO_IEEE_BV:
+    {
+      if (n.Degree() != 1 || n[0].GetType() != FLOATINGPOINT_TYPE)
+      {
+        FatalError("fp -> IEEE bits takes one floating-point argument", n);
+      }
+      if (n.GetValueWidth() != n[0].GetExpWidth() + n[0].GetSigWidth())
+      {
+        FatalError("fp -> IEEE bits result width must be exp + sig width", n);
+      }
+      break;
+    }
 
     default:
       cerr << _kind_names[k];
@@ -549,13 +934,25 @@ bool BVTypeCheck_nonterm_kind(const ASTNode& n, const Kind& k)
       if (n.Degree() != 2)
         FatalError("BVTypeCheck: should have exactly 2 args\n", n);
 
-      if (!(n[0].GetValueWidth() == n[1].GetValueWidth() &&
-            n[0].GetIndexWidth() == n[1].GetIndexWidth()))
+      // The widths must always match. A blasted float keeps its bitvector
+      // shape, so a float-stamped node may be equated with a plain bitvector
+      // of the same width -- but two nodes that BOTH claim to be floats must
+      // agree on the format: (8, 24) and (24, 8) share a total width of 32
+      // yet are different sorts.
+      if (n[0].GetValueWidth() != n[1].GetValueWidth() ||
+          n[0].GetIndexWidth() != n[1].GetIndexWidth() ||
+          (n[0].GetExpWidth() != 0 && n[1].GetExpWidth() != 0 &&
+           (n[0].GetExpWidth() != n[1].GetExpWidth() ||
+            n[0].GetSigWidth() != n[1].GetSigWidth())))
       {
         cerr << "valuewidth of lhs of EQ: " << n[0].GetValueWidth() << endl;
         cerr << "valuewidth of rhs of EQ: " << n[1].GetValueWidth() << endl;
         cerr << "indexwidth of lhs of EQ: " << n[0].GetIndexWidth() << endl;
         cerr << "indexwidth of rhs of EQ: " << n[1].GetIndexWidth() << endl;
+        cerr << "expwidth of lhs of EQ: " << n[0].GetExpWidth() << endl;
+        cerr << "expwidth of rhs of EQ: " << n[1].GetExpWidth() << endl;
+        cerr << "sigwidth of lhs of EQ: " << n[0].GetSigWidth() << endl;
+        cerr << "sigwidth of rhs of EQ: " << n[1].GetSigWidth() << endl;
         FatalError(
             "BVTypeCheck: terms in atomic formulas must be of equal length", n);
       }
@@ -583,8 +980,10 @@ bool BVTypeCheck_nonterm_kind(const ASTNode& n, const Kind& k)
                    n);
       }
       if (n[0].GetValueWidth() != n[1].GetValueWidth())
+      {
         FatalError(
             "BVTypeCheck: terms in atomic formulas must be of equal length", n);
+      }
       if (n[0].GetIndexWidth() != n[1].GetIndexWidth())
       {
         FatalError(
@@ -627,7 +1026,69 @@ bool BVTypeCheck_nonterm_kind(const ASTNode& n, const Kind& k)
         FatalError("BVTypeCheck:ITE must have exactly 3 ChildNodes", n);
       break;
 
+    // The classification predicates: one float in, a Boolean out.
+    case FP_ISNORMAL:
+    case FP_ISSUBNORMAL:
+    case FP_ISZERO:
+    case FP_ISINFINITE:
+    case FP_ISNAN:
+    case FP_ISNEGATIVE:
+    case FP_ISPOSITIVE:
+      if (n.Degree() != 1)
+        FatalError("BVTypeCheck: <fp> predicate takes exactly 1 arg", n);
+      if (n[0].GetType() != FLOATINGPOINT_TYPE)
+        FatalError("BVTypeCheck: argument of <fp> predicate is not an fp", n);
+      break;
+
+    case FP_LEQ:
+    case FP_LT:
+    case FP_GEQ:
+    case FP_GT:
+    case FP_EQ:
+    case FP_SMT_EQ:
+    {
+
+      std::string error_msg("");
+      bool failed(false);
+
+      if (n.Degree() != 2)
+      {
+        error_msg = "<fp> should have exactly 2 args";
+        failed = true;
+      }
+      else if (n[0].GetType() != FLOATINGPOINT_TYPE)
+      {
+        error_msg = "lhs of <fp> is not an fp";
+        failed = true;
+      }
+      else if (n[1].GetType() != FLOATINGPOINT_TYPE)
+      {
+        error_msg = "rhs of <fp> is not an fp";
+        failed = true;
+      }
+      else if (n[0].GetSigWidth() != n[1].GetSigWidth())
+      {
+        error_msg = "arguments to <fp> differ in sig width";
+        cerr << n[0].GetSigWidth() << " " << n[1].GetSigWidth();
+        failed = true;
+      }
+      else if (n[0].GetExpWidth() != n[1].GetExpWidth())
+      {
+        error_msg = "arguments to <fp> differ in exp width";
+        cerr << n[0].GetExpWidth() << " " << n[1].GetExpWidth();
+        failed = true;
+      }
+
+      if (failed)
+      {
+        cerr << error_msg << endl;
+        FatalError(error_msg.c_str(), n);
+      }
+      break;
+    }
+
     default:
+      cerr << _kind_names[k];
       FatalError("BVTypeCheck: Unrecognized kind: ");
       break;
   }

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -41,6 +41,8 @@ add_library(AST OBJECT
     ASTNode.cpp
     ASTUtil.cpp
     ASTBVConst.cpp
+    ASTFPConst.cpp
+    ASTRMConst.cpp
     ASTmisc.cpp
     ASTSymbol.cpp
     MutableASTNode.cpp

--- a/lib/AbsRefineCounterExample/ArrayTransformer.cpp
+++ b/lib/AbsRefineCounterExample/ArrayTransformer.cpp
@@ -127,7 +127,8 @@ void ArrayTransformer::assertTransformPostConditions(const ASTNode& term,
   if (!p.second)
     return;
 
-  const Kind k = term.GetKind();
+  // Only consumed by the asserts, which an NDEBUG build compiles out.
+  [[maybe_unused]] const Kind k = term.GetKind();
 
   // Check the array reads / writes have been removed
   assert(READ != k);

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -53,6 +53,7 @@ endif()
 add_subdirectory(Globals)
 add_subdirectory(AST)
 add_subdirectory(AbsRefineCounterExample)
+add_subdirectory(FloatBlaster)
 add_subdirectory(Simplifier)
 add_subdirectory(Printer)
 add_subdirectory(Parser)
@@ -78,6 +79,7 @@ set(stp_lib_targets
     abstractionrefinement
     tosat
     sat
+    floatblaster
     simplifier
     constantbv
     cinterface

--- a/lib/FloatBlaster/CMakeLists.txt
+++ b/lib/FloatBlaster/CMakeLists.txt
@@ -1,4 +1,4 @@
-# AUTHORS: Dan Liew, Ryan Govostes, Mate Soos
+# AUTHORS: Andrew Teylu
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -18,21 +18,19 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-add_subdirectory(stp)
-add_subdirectory(stp_simple)
-
-option(BUILD_EXTRA_TOOLS "Build extra tools" OFF)
-if (BUILD_EXTRA_TOOLS)
-  add_subdirectory(rewrite_rule_gen)
-  add_subdirectory(propagator_bench)
+# FloatBlaster.cpp and FpTotalise.cpp always build: withFormat/FpTotalise
+# are SymFPU-free, and without ENABLE_FLOATING_POINT the blast entry points
+# become "built without floating-point support" stubs (the ifdefs are in
+# FloatBlaster.cpp). Only symbolic_fp.cpp -- the SymFPU backend -- needs
+# the library itself.
+set(floatblaster_sources
+    FloatBlaster.cpp
+    FloatBlast.cpp
+    FpEncodingContext.cpp
+    FpTotalise.cpp
+)
+if (ENABLE_FLOATING_POINT)
+    list(APPEND floatblaster_sources symbolic_fp.cpp)
 endif()
-
-# The floating-point self-test tools: ordinary executables that exit
-# non-zero on failure. Built when testing needs them or when the extra
-# tools are asked for -- not in a default build. They are registered with
-# CTest from tests/CMakeLists.txt, which is processed after
-# enable_testing() and after the checks that can turn ENABLE_TESTING off.
-if (ENABLE_FLOATING_POINT AND (ENABLE_TESTING OR BUILD_EXTRA_TOOLS))
-    add_subdirectory(test_fpbackend)
-endif()
-
+add_library(floatblaster OBJECT ${floatblaster_sources})
+add_dependencies(floatblaster ASTKind_header)

--- a/lib/FloatBlaster/FloatBlast.cpp
+++ b/lib/FloatBlaster/FloatBlast.cpp
@@ -1,0 +1,607 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: January 2021
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#include "stp/FloatBlaster/FloatBlast.h"
+
+#include "stp/FloatBlaster/FloatBlaster.h"
+
+#ifdef STP_ENABLE_FLOATING_POINT
+#include "stp/FloatBlaster/symbolic_fp.h"
+
+#include <cassert>
+#include <unordered_map>
+#endif
+
+namespace stp
+{
+
+#ifdef STP_ENABLE_FLOATING_POINT
+
+class FloatBlast::Impl
+{
+public:
+  explicit Impl(STPMgr* bm_)
+      : bm(bm_), node_factory(bm_->defaultNodeFactory)
+  {
+  }
+
+  ASTNode topLevel(const ASTNode& n)
+  {
+    if (bm->defaultNodeFactory != node_factory)
+      FatalError("FloatBlast reused after the node factory changed");
+
+    // SymFPU's STP backend is thread-local rather than object-local. Another
+    // checker may have used this thread since our previous model query.
+    symbolic_fp::init(bm);
+
+    traversal_cache.clear();
+    const ASTNode out = lower(n);
+    traversal_cache.clear();
+    return out;
+  }
+
+  const FloatBlast::Statistics& statistics() const noexcept { return stats; }
+
+private:
+  typedef std::unordered_map<ASTNode, std::unique_ptr<symbolic_fp::uf>,
+                             ASTNode::ASTNodeHasher, ASTNode::ASTNodeEqual>
+      UnpackedMap;
+
+  symbolic_fp::floatingPointTypeInfo formatOf(const ASTNode& n) const
+  {
+    const SourceSort sort = n.GetSourceSort();
+    if (sort.kind() != SourceSort::Kind::FloatingPoint)
+      FatalError("FloatBlast expected a floating-point source expression: ",
+                 n);
+
+    const unsigned int exponent = sort.exponentWidth();
+    const unsigned int significand = sort.significandWidth();
+    if (!FloatBlaster::formatSupported(exponent, significand))
+      FatalError("FloatBlast: this floating-point format is not supported: "
+                 "SymFPU needs an unpacked exponent wider than the source "
+                 "format's exponent");
+
+    return symbolic_fp::floatingPointTypeInfo(exponent, significand);
+  }
+
+  // fp.min, fp.max, fp.to_ubv and fp.to_sbv carry one more child after
+  // FpTotalise has run -- the array read supplying their unspecified answer
+  // -- and the operations cannot be lowered without it. BVTypeCheck
+  // deliberately accepts both arities, so the requirement is not in the
+  // node's type; it was an assert here, which under NDEBUG read past the end
+  // of the children instead of saying so.
+  void requireTotalised(const ASTNode& n, size_t expected) const
+  {
+    if (n.Degree() != expected)
+      FatalError("FloatBlast: this partial floating-point operation has not "
+                 "been totalised; FpTotalise has to run before it is "
+                 "lowered: ",
+                 n);
+  }
+
+  void requireSameFormat(const ASTNode& left, const ASTNode& right) const
+  {
+    if (left.GetSourceSort() != right.GetSourceSort())
+      FatalError("FloatBlast received floating-point operands of different "
+                 "source sorts");
+  }
+
+  ASTNode rebuild(const ASTNode& n, const ASTVec& children)
+  {
+    if (n.GetType() == BOOLEAN_TYPE)
+      return node_factory->CreateNode(n.GetKind(), children);
+
+    if (n.GetIndexWidth() > 0)
+      return node_factory->CreateArrayTerm(n.GetKind(), n.GetIndexWidth(),
+                                           n.GetValueWidth(), children);
+
+    return node_factory->CreateTerm(n.GetKind(), n.GetValueWidth(), children);
+  }
+
+  // Target-language view. Source FP values are packed only if their caller
+  // genuinely needs an AST carrier; FP predicates and conversions bypass
+  // this function and consume the unpacked view directly.
+  ASTNode lower(const ASTNode& n)
+  {
+    if (n.GetSourceSort().kind() == SourceSort::Kind::FloatingPoint)
+      return asPacked(n);
+
+    if (n.Degree() == 0)
+      return n;
+
+    const ASTNodeMap::const_iterator persistent = terminal_cache.find(n);
+    if (persistent != terminal_cache.end())
+      return persistent->second;
+
+    const ASTNodeMap::const_iterator current = traversal_cache.find(n);
+    if (current != traversal_cache.end())
+      return current->second;
+
+    ASTNode out;
+    if (is_FP_kind(n.GetKind()))
+    {
+      out = lowerFpTerminal(n);
+      terminal_cache[n] = out;
+    }
+    else
+    {
+      ASTVec children;
+      children.reserve(n.Degree());
+      bool changed = false;
+      for (size_t i = 0; i < n.Degree(); ++i)
+      {
+        const ASTNode child = lower(n[i]);
+        changed = changed || child != n[i];
+        children.push_back(child);
+      }
+      out = changed ? rebuild(n, children) : n;
+    }
+
+    traversal_cache[n] = out;
+    return out;
+  }
+
+  // Ordinary packed view. Leaves and structural carrier nodes already are
+  // the bits that store the source value, so preserve them (and any NaN
+  // payload they happen to contain). A genuine FP operation has no such
+  // target representation and is encoded lazily from its cached UF.
+  ASTNode asPacked(const ASTNode& n)
+  {
+    const ASTNodeMap::const_iterator cached = packed_cache.find(n);
+    if (cached != packed_cache.end())
+      return cached->second;
+
+    (void)formatOf(n); // exact source-sort/format validation at the boundary
+
+    ASTNode out;
+    if (n.Degree() == 0)
+    {
+      out = n;
+    }
+    else if (n.GetKind() == READ)
+    {
+      ASTVec children;
+      children.reserve(n.Degree());
+      bool changed = false;
+      for (size_t i = 0; i < n.Degree(); ++i)
+      {
+        const ASTNode child = lower(n[i]);
+        changed = changed || child != n[i];
+        children.push_back(child);
+      }
+      out = changed ? rebuild(n, children) : n;
+    }
+    else if (n.GetKind() == ITE)
+    {
+      assert(n.Degree() == 3);
+      ASTVec children;
+      children.reserve(3);
+      children.push_back(lower(n[0]));
+      children.push_back(asPacked(n[1]));
+      children.push_back(asPacked(n[2]));
+      out = (children[0] == n[0] && children[1] == n[1] &&
+             children[2] == n[2])
+                ? n
+                : rebuild(n, children);
+    }
+    else if (!is_FP_kind(n.GetKind()))
+    {
+      // Compatibility for legacy carrier expressions which were explicitly
+      // declared/stamped as FP. Rebuild their carrier children first, then
+      // leave the operation itself in the target language.
+      ASTVec children;
+      children.reserve(n.Degree());
+      bool changed = false;
+      for (size_t i = 0; i < n.Degree(); ++i)
+      {
+        const ASTNode child = lower(n[i]);
+        changed = changed || child != n[i];
+        children.push_back(child);
+      }
+      out = changed ? rebuild(n, children) : n;
+    }
+    else
+    {
+      const ASTNodeMap::const_iterator canonical = canonical_packed_cache.find(n);
+      if (canonical != canonical_packed_cache.end())
+        out = canonical->second;
+      else
+      {
+        out = symbolic_fp::unpacked::encode(formatOf(n), asUnpacked(n));
+        ++stats.pack_builds;
+        canonical_packed_cache[n] = out;
+      }
+    }
+
+    packed_cache[n] = out;
+    return out;
+  }
+
+  // Canonical packed view. This is deliberately distinct from asPacked:
+  // SMT FP equality identifies all NaNs, so semantic quotient boundaries
+  // (FP_TO_IEEE_BV and totalisation/array indexes) must collapse payloads.
+  ASTNode canonicalPacked(const ASTNode& n)
+  {
+    const ASTNodeMap::const_iterator cached = canonical_packed_cache.find(n);
+    if (cached != canonical_packed_cache.end())
+      return cached->second;
+
+    const ASTNode out =
+        symbolic_fp::unpacked::encode(formatOf(n), asUnpacked(n));
+    ++stats.pack_builds;
+    canonical_packed_cache[n] = out;
+
+    // A real FP operation's ordinary packed representation is the same
+    // SymFPU encoding. Raw leaves/READs/ITEs intentionally remain distinct.
+    if (is_FP_kind(n.GetKind()))
+      packed_cache[n] = out;
+    return out;
+  }
+
+  const symbolic_fp::uf& remember(const ASTNode& n,
+                                   std::unique_ptr<symbolic_fp::uf> value)
+  {
+    const std::pair<UnpackedMap::iterator, bool> inserted =
+        unpacked_cache.emplace(n, std::move(value));
+    assert(inserted.second);
+    return *inserted.first->second;
+  }
+
+  const symbolic_fp::uf& decodeCarrier(const ASTNode& n,
+                                        const ASTNode& carrier)
+  {
+    ++stats.unpack_builds;
+    return remember(n, std::unique_ptr<symbolic_fp::uf>(
+                           new symbolic_fp::uf(symbolic_fp::unpacked::decode(
+                               formatOf(n), carrier))));
+  }
+
+  // Unpacked source view. Every entry is either one actual decode of an
+  // opaque carrier or the final (already rounded) result of exactly one
+  // source FP operation. References remain stable because values are owned
+  // separately from the hash table's buckets.
+  const symbolic_fp::uf& asUnpacked(const ASTNode& n)
+  {
+    const UnpackedMap::const_iterator cached = unpacked_cache.find(n);
+    if (cached != unpacked_cache.end())
+    {
+      ++stats.unpacked_cache_hits;
+      return *cached->second;
+    }
+
+    const symbolic_fp::floatingPointTypeInfo result_format = formatOf(n);
+    const Kind kind = n.GetKind();
+
+    if (n.Degree() == 0)
+      return decodeCarrier(n, n);
+
+    if (kind == READ)
+    {
+      // Break the asPacked/asUnpacked recursion explicitly: a READ is an
+      // opaque packed cell, but its array and index may still need lowering.
+      ASTVec children;
+      children.reserve(n.Degree());
+      bool changed = false;
+      for (size_t i = 0; i < n.Degree(); ++i)
+      {
+        const ASTNode child = lower(n[i]);
+        changed = changed || child != n[i];
+        children.push_back(child);
+      }
+      const ASTNode carrier = changed ? rebuild(n, children) : n;
+      packed_cache[n] = carrier;
+      return decodeCarrier(n, carrier);
+    }
+
+    std::unique_ptr<symbolic_fp::uf> result;
+    switch (kind)
+    {
+      case ITE:
+        assert(n.Degree() == 3);
+        requireSameFormat(n[1], n[2]);
+        result.reset(new symbolic_fp::uf(symbolic_fp::unpacked::select(
+            lower(n[0]), asUnpacked(n[1]), asUnpacked(n[2]))));
+        break;
+
+      case FP_ABS:
+        result.reset(new symbolic_fp::uf(
+            symbolic_fp::unpacked::abs(result_format, asUnpacked(n[0]))));
+        break;
+      case FP_NEG:
+        result.reset(new symbolic_fp::uf(
+            symbolic_fp::unpacked::neg(result_format, asUnpacked(n[0]))));
+        break;
+
+      case FP_ADD:
+      case FP_SUB:
+      case FP_MUL:
+      case FP_DIV:
+        requireSameFormat(n[1], n[2]);
+        if (kind == FP_ADD)
+          result.reset(new symbolic_fp::uf(symbolic_fp::unpacked::add(
+              result_format, lower(n[0]), asUnpacked(n[1]),
+              asUnpacked(n[2]))));
+        else if (kind == FP_SUB)
+          result.reset(new symbolic_fp::uf(symbolic_fp::unpacked::sub(
+              result_format, lower(n[0]), asUnpacked(n[1]),
+              asUnpacked(n[2]))));
+        else if (kind == FP_MUL)
+          result.reset(new symbolic_fp::uf(symbolic_fp::unpacked::mul(
+              result_format, lower(n[0]), asUnpacked(n[1]),
+              asUnpacked(n[2]))));
+        else
+          result.reset(new symbolic_fp::uf(symbolic_fp::unpacked::div(
+              result_format, lower(n[0]), asUnpacked(n[1]),
+              asUnpacked(n[2]))));
+        break;
+
+      case FP_FMA:
+        requireSameFormat(n[1], n[2]);
+        requireSameFormat(n[1], n[3]);
+        result.reset(new symbolic_fp::uf(symbolic_fp::unpacked::fma(
+            result_format, lower(n[0]), asUnpacked(n[1]), asUnpacked(n[2]),
+            asUnpacked(n[3]))));
+        break;
+
+      case FP_SQRT:
+        result.reset(new symbolic_fp::uf(symbolic_fp::unpacked::sqrt(
+            result_format, lower(n[0]), asUnpacked(n[1]))));
+        break;
+
+      case FP_REM:
+      {
+        const SourceSort sort = n.GetSourceSort();
+        if (!FloatBlaster::remSupported(sort.exponentWidth(),
+                                        sort.significandWidth()))
+          FatalError("FloatBlast: fp.rem is not supported at this format: "
+                     "its circuit is exponential in the exponent width");
+        requireSameFormat(n[0], n[1]);
+        result.reset(new symbolic_fp::uf(symbolic_fp::unpacked::rem(
+            result_format, asUnpacked(n[0]), asUnpacked(n[1]))));
+        break;
+      }
+
+      case FP_MIN:
+      case FP_MAX:
+      {
+        requireTotalised(n, 3);
+        requireSameFormat(n[0], n[1]);
+        const ASTNode choice = node_factory->CreateNode(
+            EQ, lower(n[2]), bm->CreateOneConst(1));
+        result.reset(new symbolic_fp::uf(
+            kind == FP_MIN
+                ? symbolic_fp::unpacked::min(result_format, asUnpacked(n[0]),
+                                             asUnpacked(n[1]), choice)
+                : symbolic_fp::unpacked::max(result_format, asUnpacked(n[0]),
+                                             asUnpacked(n[1]), choice)));
+        break;
+      }
+
+      case FP_ROUNDTOINTEGRAL:
+      {
+        const SourceSort sort = n.GetSourceSort();
+        if (!FloatBlaster::roundToIntegralSupported(sort.exponentWidth(),
+                                                    sort.significandWidth()))
+          FatalError("FloatBlast: fp.roundToIntegral is not supported at "
+                     "this format");
+        result.reset(new symbolic_fp::uf(
+            symbolic_fp::unpacked::roundToIntegral(
+                result_format, lower(n[0]), asUnpacked(n[1]))));
+        break;
+      }
+
+      case FP_TOFP:
+        if (n.Degree() == 3)
+        {
+          ++stats.unpack_builds;
+          result.reset(new symbolic_fp::uf(symbolic_fp::unpacked::decode(
+              result_format, lower(n[2]))));
+        }
+        else
+        {
+          assert(n.Degree() == 4);
+          result.reset(new symbolic_fp::uf(
+              symbolic_fp::unpacked::convertFloatToFloat(
+                  formatOf(n[3]), result_format, lower(n[2]),
+                  asUnpacked(n[3]))));
+        }
+        break;
+
+      case FP_TOFP_SIGNED:
+      case FP_TOFP_UNSIGNED:
+        assert(n.Degree() == 4);
+        result.reset(new symbolic_fp::uf(
+            symbolic_fp::unpacked::convertBVToFloat(
+                result_format, lower(n[2]), lower(n[3]),
+                kind == FP_TOFP_SIGNED)));
+        break;
+
+      default:
+      {
+        // A legacy non-FP carrier node may still have a declared/stored FP
+        // source sort. Decode the rebuilt carrier once rather than guessing
+        // an operation from its width.
+        if (is_FP_kind(kind))
+          FatalError("FloatBlast: unhandled floating-point result kind: ", n);
+
+        ASTVec children;
+        children.reserve(n.Degree());
+        bool changed = false;
+        for (size_t i = 0; i < n.Degree(); ++i)
+        {
+          const ASTNode child = lower(n[i]);
+          changed = changed || child != n[i];
+          children.push_back(child);
+        }
+        const ASTNode carrier = changed ? rebuild(n, children) : n;
+        packed_cache[n] = carrier;
+        return decodeCarrier(n, carrier);
+      }
+    }
+
+    assert(result.get() != nullptr);
+    if (kind != ITE)
+      ++stats.unpacked_operation_builds;
+    return remember(n, std::move(result));
+  }
+
+  ASTNode lowerFpTerminal(const ASTNode& n)
+  {
+    const Kind kind = n.GetKind();
+    switch (kind)
+    {
+      case FP_TO_UBV:
+      case FP_TO_SBV:
+        requireTotalised(n, 4);
+        return symbolic_fp::unpacked::toBV(
+            formatOf(n[2]), lower(n[1]), asUnpacked(n[2]),
+            n[0].GetUnsignedConst(), lower(n[3]), kind == FP_TO_SBV);
+
+      case FP_TO_IEEE_BV:
+        assert(n.Degree() == 1);
+        return canonicalPacked(n[0]);
+
+      case FP_SMT_EQ:
+        requireSameFormat(n[0], n[1]);
+        return symbolic_fp::unpacked::smtEqual(
+            formatOf(n[0]), asUnpacked(n[0]), asUnpacked(n[1]));
+
+      case FP_EQ:
+        requireSameFormat(n[0], n[1]);
+        return symbolic_fp::unpacked::ieeeEqual(
+            formatOf(n[0]), asUnpacked(n[0]), asUnpacked(n[1]));
+      case FP_LT:
+        requireSameFormat(n[0], n[1]);
+        return symbolic_fp::unpacked::lessThan(
+            formatOf(n[0]), asUnpacked(n[0]), asUnpacked(n[1]));
+      case FP_LEQ:
+        requireSameFormat(n[0], n[1]);
+        return symbolic_fp::unpacked::lessThanOrEqual(
+            formatOf(n[0]), asUnpacked(n[0]), asUnpacked(n[1]));
+      case FP_GT:
+        requireSameFormat(n[0], n[1]);
+        return symbolic_fp::unpacked::lessThan(
+            formatOf(n[0]), asUnpacked(n[1]), asUnpacked(n[0]));
+      case FP_GEQ:
+        requireSameFormat(n[0], n[1]);
+        return symbolic_fp::unpacked::lessThanOrEqual(
+            formatOf(n[0]), asUnpacked(n[1]), asUnpacked(n[0]));
+
+      case FP_ISNORMAL:
+        return symbolic_fp::unpacked::isNormal(formatOf(n[0]),
+                                               asUnpacked(n[0]));
+      case FP_ISSUBNORMAL:
+        return symbolic_fp::unpacked::isSubnormal(formatOf(n[0]),
+                                                  asUnpacked(n[0]));
+      case FP_ISZERO:
+        return symbolic_fp::unpacked::isZero(formatOf(n[0]),
+                                             asUnpacked(n[0]));
+      case FP_ISINFINITE:
+        return symbolic_fp::unpacked::isInfinite(formatOf(n[0]),
+                                                 asUnpacked(n[0]));
+      case FP_ISNAN:
+        return symbolic_fp::unpacked::isNaN(formatOf(n[0]),
+                                            asUnpacked(n[0]));
+      case FP_ISNEGATIVE:
+        return symbolic_fp::unpacked::isNegative(formatOf(n[0]),
+                                                 asUnpacked(n[0]));
+      case FP_ISPOSITIVE:
+        return symbolic_fp::unpacked::isPositive(formatOf(n[0]),
+                                                 asUnpacked(n[0]));
+
+      default:
+        FatalError("FloatBlast: unhandled target-valued floating-point kind: ",
+                   n);
+    }
+  }
+
+  STPMgr* bm;
+  NodeFactory* node_factory;
+  FloatBlast::Statistics stats;
+
+  // Only the source/target FP boundary survives between calls. Generic BV
+  // traversal state is released after every root to avoid retaining whole
+  // pre-simplification DAGs for the lifetime of a model.
+  ASTNodeMap traversal_cache;
+  ASTNodeMap terminal_cache;
+  ASTNodeMap packed_cache;
+  ASTNodeMap canonical_packed_cache;
+  UnpackedMap unpacked_cache;
+};
+
+#else
+
+// Floating-point syntax is rejected before solving in this configuration.
+// Keeping the pass as an identity gives FpEncodingContext the same link and
+// ownership surface in both builds without exposing SymFPU in the header.
+class FloatBlast::Impl
+{
+public:
+  explicit Impl(STPMgr*) {}
+  ASTNode topLevel(const ASTNode& n) { return n; }
+  const FloatBlast::Statistics& statistics() const noexcept { return stats; }
+
+private:
+  FloatBlast::Statistics stats;
+};
+
+#endif
+
+FloatBlast::FloatBlast(STPMgr* bm_) : impl(new Impl(bm_)) {}
+
+FloatBlast::~FloatBlast() = default;
+
+ASTNode FloatBlast::topLevel(const ASTNode& n) { return impl->topLevel(n); }
+
+#ifdef STP_ENABLE_FLOATING_POINT
+
+ASTNode FloatBlast::lowerOperation(STPMgr* bm, const ASTNode& n)
+{
+  // A context of its own: these callers lower one node, unrelated to the
+  // solve's, and must not share or disturb its caches.
+  FloatBlast lower(bm);
+  return lower.topLevel(n);
+}
+
+#else
+
+// Fail closed, as the rest of the floating-point surface does in this
+// configuration: the parser and the STPMgr funnels reject floating-point
+// input long before a constant fold or a model query could reach here, so
+// arriving means a caller bypassed them. topLevel stays an identity because
+// FpEncodingContext needs the same ownership surface in both builds.
+ASTNode FloatBlast::lowerOperation(STPMgr*, const ASTNode&)
+{
+  FatalError("FloatBlast: this STP was built without floating-point "
+             "support; reconfigure with -DENABLE_FLOATING_POINT=ON");
+}
+
+#endif
+
+const FloatBlast::Statistics& FloatBlast::statistics() const noexcept
+{
+  return impl->statistics();
+}
+
+} // namespace stp

--- a/lib/FloatBlaster/FloatBlaster.cpp
+++ b/lib/FloatBlaster/FloatBlaster.cpp
@@ -1,0 +1,315 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: January 2021
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#include "stp/FloatBlaster/FloatBlaster.h"
+#include "stp/Globals/Globals.h"
+#include <cassert>
+#include <string>
+
+#ifdef STP_ENABLE_FLOATING_POINT
+// The symfpu circuits are built behind the blast_* entry points; nothing
+// here touches symfpu directly.
+#include "stp/FloatBlaster/symbolic_fp.h"
+#endif
+
+namespace stp
+{
+
+ASTNode FloatBlaster::withFormat(STPMgr* bm, const ASTNode& n,
+                                 unsigned int exp_width,
+                                 unsigned int sig_width)
+{
+  if (exp_width == 0 && sig_width == 0)
+    return n;
+
+  // Asking for a real format means a float is in the problem, whatever this
+  // then does with `n`. Noted before the early returns below, because those
+  // are the cases where nothing is stamped and SetExpWidth -- the other place
+  // the manager hears about floats -- is never reached. Missing it leaves the
+  // floating-point passes switched off and the float reaches the bit-blaster.
+  bm->noteFloatingPoint();
+
+  if (n.GetExpWidth() == exp_width && n.GetSigWidth() == sig_width)
+    return n;
+
+  // Only a float-shaped value can carry a float's format; a rounding mode or
+  // one of to_fp's format arguments must be left alone.
+  if (n.GetValueWidth() != exp_width + sig_width)
+    return n;
+
+  // ASTBVConst cannot hold a format; ASTFPConst can. The float-stamped
+  // constant is a distinct interned node, so this never retypes the shared
+  // plain constant.
+  if (n.GetKind() == BVCONST)
+    return bm->CreateFPConst(n, exp_width, sig_width);
+
+  // A bitvector-kind interior node has nowhere to put a format: nodes are
+  // hash-consed and the format is per-node state, so a stamp here would retype
+  // every other use of the same bits (see ASTNode::canStoreFPFormat). Leave it
+  // the bitvector it is.
+  //
+  // What reaches this is a caller carrying one node's format over to another
+  // -- a rebuild, a fold, a pull-up -- and meeting a node the format was never
+  // its to hold. Once the floating-point layer is lowered a float and its
+  // packed bits are the same node to everything but the format, and structure
+  // that survives lowering goes on deriving a format from the float symbol
+  // underneath it: (ite c (fp.abs x) x) over a Float64 x is an ordinary 64-bit
+  // if-then-else by then, and still answers 11/53, because its else branch is
+  // x and x's format is declared (see deriveFPFormat). Fold the condition, as
+  // the simplifier does once it turns out to be a tautology, and what is left
+  // is the circuit lowering built for (fp.abs x): bits, needing no format,
+  // with the blaster long finished with them.
+  if (!n.canStoreFPFormat())
+    return n;
+
+  ASTNode out(n);
+  out.SetExpWidth(exp_width);
+  out.SetSigWidth(sig_width);
+  return out;
+}
+
+// Defined outside the feature gate: it only reads widths, and the callers
+// that thread the format into the blaster are compiled either way.
+std::pair<unsigned int, unsigned int>
+FloatBlaster::operandFormat(const ASTVec& children)
+{
+  for (size_t i = 0; i < children.size(); i++)
+  {
+    const unsigned int exp_width = children[i].GetExpWidth();
+    if (exp_width != 0)
+      return std::make_pair(exp_width, children[i].GetSigWidth());
+  }
+
+  // No float operand: ((_ to_fp e s) bits) and ((_ to_fp_unsigned e s) rm bv)
+  // read their source as bits, and name the only format they need in their
+  // own e/s children.
+  return std::make_pair(0u, 0u);
+}
+
+std::pair<unsigned int, unsigned int>
+FloatBlaster::operandFormat(const ASTNode& n)
+{
+  return operandFormat(toASTVec(n.GetChildren()));
+}
+
+#ifdef STP_ENABLE_FLOATING_POINT
+ASTNode FloatBlaster::canonicalBits(STPMgr* bm, const ASTNode& f)
+{
+  return canonicalBits(bm, f, f.GetExpWidth(), f.GetSigWidth());
+}
+
+// The format-taking form, for callers that know the format but hold a term
+// that does not carry it -- a plain bitvector standing where a float-sorted
+// value belongs (an array index over a float-indexed array, say).
+ASTNode FloatBlaster::canonicalBits(STPMgr* bm, const ASTNode& f,
+                                    unsigned int exp_width,
+                                    unsigned int sig_width)
+{
+  // Point symfpu at the manager being blasted (see symbolic_fp::init).
+  symbolic_fp::init(bm);
+
+  // Unpack then pack: the round trip is what collapses the NaN payloads
+  // while keeping +0 and -0 apart.
+  const symbolic_fp::floatingPointTypeInfo format(exp_width, sig_width);
+  return symbolic_fp::unpacked::encode(
+      format, symbolic_fp::unpacked::decode(format, f));
+}
+#else
+
+// Fail-closed stubs so the link surface is identical with and without
+// floating-point support. The parser and the STPMgr funnels reject
+// floating-point input long before these could run (see checkFpSupported in
+// smt2.y and SetExpWidth/CreateFPConst), so reaching one means a caller
+// bypassed those checks.
+
+ASTNode FloatBlaster::canonicalBits(STPMgr*, const ASTNode&)
+{
+  FatalError("canonicalBits: this STP was built without floating-point "
+             "support; reconfigure with -DENABLE_FLOATING_POINT=ON");
+}
+
+ASTNode FloatBlaster::canonicalBits(STPMgr*, const ASTNode&, unsigned int,
+                                    unsigned int)
+{
+  FatalError("canonicalBits: this STP was built without floating-point "
+             "support; reconfigure with -DENABLE_FLOATING_POINT=ON");
+}
+
+#endif
+
+// Pure arithmetic, defined outside the feature gate: the parser refers to
+// it whenever it builds an fp.rem, including in builds without
+// floating-point support (where that path is unreachable but still links).
+uint64_t FloatBlaster::remUnrollSteps(unsigned exp_width, unsigned sig_width)
+{
+  if (exp_width >= 63)
+    return UINT64_MAX; // would overflow; certainly over any limit
+  return ((uint64_t)1 << exp_width) + sig_width - 4;
+}
+
+bool FloatBlaster::remSupported(unsigned exp_width, unsigned sig_width)
+{
+  return remUnrollSteps(exp_width, sig_width) <= REM_UNROLL_LIMIT;
+}
+
+// symfpu's bitsToRepresent (symfpu/core/nondet.h and friends): how many bits
+// it takes to write `n`.
+static unsigned bitsToRepresent(uint64_t n)
+{
+  unsigned bits = 0;
+  while (n != 0)
+  {
+    bits++;
+    n >>= 1;
+  }
+  return bits;
+}
+
+// Kept line for line with symfpu's unpackedFloat<t>::exponentWidth so the two
+// can be diffed; see the header for why it is replicated rather than called.
+// The one deviation is the overflow guard in the last branch, which symfpu
+// does not have -- and which has to stay in that branch, since anywhere
+// earlier it stops being a guard and starts being a wrong answer.
+unsigned FloatBlaster::unpackedExponentWidth(unsigned exp_width,
+                                             unsigned sig_width)
+{
+  if (sig_width <= 3)
+  {
+    // Subnormals fit into the gap between the minimum normal exponent and
+    // what a signed number of this width can hold, so no widening is needed
+    // -- and, as formatSupported records, symfpu's own unpack then rejects
+    // the format.
+    return exp_width;
+  }
+
+  if (bitsToRepresent(sig_width - 3) < exp_width - 1)
+  {
+    // Significand is short compared to the exponent range: one extra bit.
+    return exp_width + 1;
+  }
+
+  // Significand is long compared to the exponent range. Only this branch
+  // shifts, so only this branch needs the guard below -- putting it any
+  // earlier answers for the branch above as well, and answers it wrong.
+  if (exp_width >= 63)
+    return UINT_MAX; // the shift would overflow; certainly wide enough
+
+  return bitsToRepresent(((uint64_t)1 << (exp_width - 1)) + sig_width - 3) + 1;
+}
+
+bool FloatBlaster::formatSupported(unsigned exp_width, unsigned sig_width)
+{
+  return unpackedExponentWidth(exp_width, sig_width) > exp_width;
+}
+
+bool FloatBlaster::roundToIntegralSupported(unsigned exp_width,
+                                            unsigned sig_width)
+{
+  // unpackedFloat<t>::significandWidth is the format's significand width
+  // unchanged, so sig_width is the width convert.h compares against.
+  return unpackedExponentWidth(exp_width, sig_width) != sig_width;
+}
+
+// The stem every unspecified-value name is built on: the operation, then the
+// formats of its floating-point operands.
+//
+// The '@' prefix puts the name in the namespace SMT-LIB 2 reserves for solver
+// use (as CreateFreshVariable does), so it cannot collide with a conforming
+// input's own symbols.
+//
+// The formats are what the packed widths cannot stand in for -- see the header.
+// Every caller holds format-carrying source operands: the pass runs before
+// lowering, and model evaluation reuses that same pass through the solve's
+// encoding context. A caller that lost the format would quietly mint a
+// *different* object from the one the solve constrained, so refuse rather than
+// answer from the wrong one.
+static std::string unspecifiedName(const char* tag, const ASTVec& operands)
+{
+  std::string name("@fp_unspecified_");
+  name += tag;
+
+  for (size_t i = 0; i < operands.size(); i++)
+  {
+    const unsigned int exp_width = operands[i].GetExpWidth();
+    const unsigned int sig_width = operands[i].GetSigWidth();
+
+    if (exp_width == 0 || sig_width == 0)
+      FatalError("unspecifiedName: a partial floating-point operation's "
+                 "operand reached totalisation without its format: ",
+                 operands[i]);
+
+    name += "_";
+    name += std::to_string(exp_width);
+    name += "x";
+    name += std::to_string(sig_width);
+  }
+
+  return name;
+}
+
+ASTNode FloatBlaster::unspecifiedCells(STPMgr* bm, const char* tag,
+                                       const ASTVec& operands,
+                                       unsigned int cell_count)
+{
+  std::string name = unspecifiedName(tag, operands);
+  name += "_";
+  name += std::to_string(cell_count);
+
+  // Through the manager's registry of its own named symbols: the name has to
+  // identify the object across the solve and the two counterexample
+  // re-derivations, and going back through the symbol table for it is what let
+  // a user declaration be adopted as this one. Introduced, so the printers
+  // skip it -- the model must not answer with a symbol the user never
+  // declared -- which introducedSymbol records too.
+  return bm->introducedSymbol(name, 0, cell_count);
+}
+
+ASTNode FloatBlaster::unspecifiedValue(STPMgr* bm, const char* tag,
+                                       const ASTVec& operands,
+                                       const ASTNode& index,
+                                       unsigned int value_width)
+{
+  const unsigned int index_width = index.GetValueWidth();
+
+  std::string name = unspecifiedName(tag, operands);
+  name += "_";
+  name += std::to_string(index_width);
+  name += "_";
+  name += std::to_string(value_width);
+
+  // Not CreateFreshVariable, whose minted names would differ between the solve
+  // and the two counterexample re-derivations and so would not be the same
+  // array; the manager's registry of its own named symbols gives that
+  // stability without the name having to be looked up in the symbol table,
+  // where a user declaration under it would be adopted as this array. It is
+  // introduced all the same, which introducedSymbol records, or the model
+  // answers with a symbol the user never declared and in a sort their
+  // signature does not have. The solver still gets the array -- only the
+  // printers skip it, and CheckCounterExample needs its cell values.
+  const ASTNode array = bm->introducedSymbol(name, index_width, value_width);
+
+  return bm->CreateTerm(READ, value_width, array, index);
+}
+
+} // namespace stp

--- a/lib/FloatBlaster/FpEncodingContext.cpp
+++ b/lib/FloatBlaster/FpEncodingContext.cpp
@@ -1,0 +1,41 @@
+/********************************************************************
+ * Solve-local floating-point lowering and model-lifting context.
+ ********************************************************************/
+#include "stp/FloatBlaster/FpEncodingContext.h"
+
+namespace stp
+{
+
+FpEncodingContext::FpEncodingContext(STPMgr* bm_)
+    : bm(bm_), node_factory(bm_->defaultNodeFactory), totalise(bm_), blast(bm_)
+{
+}
+
+FpEncodingContext::~FpEncodingContext() = default;
+
+void FpEncodingContext::requireOriginalNodeFactory() const
+{
+  if (bm->defaultNodeFactory != node_factory)
+    FatalError("floating-point encoding context reused after the node factory "
+               "changed");
+}
+
+ASTNode FpEncodingContext::prepare(const ASTNode& source)
+{
+  requireOriginalNodeFactory();
+  return totalise.topLevel(source);
+}
+
+ASTNode FpEncodingContext::lowerPrepared(const ASTNode& prepared)
+{
+  requireOriginalNodeFactory();
+  return blast.topLevel(prepared);
+}
+
+ASTNode FpEncodingContext::encodeForModel(const ASTNode& source)
+{
+  requireOriginalNodeFactory();
+  return lowerPrepared(prepare(source));
+}
+
+} // namespace stp

--- a/lib/FloatBlaster/FpTotalise.cpp
+++ b/lib/FloatBlaster/FpTotalise.cpp
@@ -1,0 +1,369 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: July 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#include "stp/FloatBlaster/FpTotalise.h"
+
+#include "stp/FloatBlaster/FloatBlaster.h"
+
+#include <string>
+
+namespace stp
+{
+
+FpTotalise::FpTotalise(STPMgr* bm_) : bm(bm_), nf(bm_->defaultNodeFactory) {}
+
+ASTNode FpTotalise::topLevel(const ASTNode& n)
+{
+  traversal_cache.clear();
+  ASTNode out = visit(n);
+
+  // Pin every rounding mode the final formula names -- declared symbols and
+  // rounding-mode-element reads alike -- to the five legal encodings (see the
+  // class comment). The walk runs over the visited output so it also sees
+  // reads that visit() itself introduced or reshaped.
+  //
+  // The symbols carry a constraint from their declaration too, but that one
+  // is asserted at whatever level was current then, and the node outlives the
+  // level: a symbol built inside a vc_push/vc_pop bracket comes out of it
+  // hash-consed and unpinned, and answers with a junk encoding. Re-pinning
+  // here is what makes the guarantee independent of the assertion stack; the
+  // repeat is a duplicate conjunct whenever the original survived.
+  //
+  // Formulas only: the pinning is a side condition conjoined onto the
+  // result, and a term has nowhere to hold one. Model evaluation totalises
+  // bare floating-point terms before blasting them (see
+  // TermToConstTermUsingModel); wrapping such a term in an AND hands the
+  // blaster a formula kind it cannot blast.
+  //
+  // What makes that safe is that the terms reaching model evaluation come
+  // from the assertions, whose reads this pass has already pinned -- so each
+  // one resolves to a model value the pinned formula held to a legal
+  // encoding. It is *not* that an unpinned carrier would be harmless. An
+  // encoding matching none of the five leaves every equality in symfpu's
+  // roundingDecision false, which truncates and overflows to max like RTZ
+  // but, in makeRoundingResult, leaves returnZero false too -- so an
+  // underflow gives the minimum subnormal where RTZ gives zero. Truncating
+  // rules out RTP and underflowing to the minimum rules out RTZ: the
+  // combination is a sixth behaviour, in no standard, and a formula can tell
+  // it from all five. Everything that introduces a rounding mode has to pin
+  // it; nothing may rely on the junk encodings being equivalent to a mode.
+  if (n.GetType() == BOOLEAN_TYPE)
+  {
+    ASTNodeSet seen;
+    ASTVec constraints;
+    collectRoundingModeTerms(out, seen, constraints);
+    if (!constraints.empty())
+    {
+      constraints.push_back(out);
+      out = nf->CreateNode(AND, constraints);
+    }
+  }
+
+  traversal_cache.clear();
+  return out;
+}
+
+ASTNode FpTotalise::canonicalIndex(const ASTNode& index, unsigned int exp_width,
+                                   unsigned int sig_width)
+{
+  // A second pass over prepared syntax must retain the explicit deferred
+  // boundary, rather than mistake its bit-vector result for a legacy raw
+  // carrier and eagerly expand another unpack/pack circuit around it.
+  if (index.GetKind() == FP_TO_IEEE_BV)
+  {
+    if (index.Degree() != 1 ||
+        index[0].GetSourceSort() !=
+            SourceSort::floatingPoint(exp_width, sig_width))
+      FatalError("FpTotalise: an existing canonical float array index has "
+                 "the wrong source format: ",
+                 index);
+    return index;
+  }
+
+  const SourceSort source_sort = index.GetSourceSort();
+  if (source_sort.kind() == SourceSort::Kind::FloatingPoint)
+  {
+    if (source_sort.exponentWidth() != exp_width ||
+        source_sort.significandWidth() != sig_width)
+      FatalError("FpTotalise: a float array index disagrees with the array's "
+                 "declared index format: ",
+                 index);
+
+    return canonicalSourceBits(index);
+  }
+
+  // Compatibility for a plain bitvector standing where a float belongs (the
+  // legacy parsers accepted these). Constants can be re-interned through the
+  // typed FP funnel; a symbolic raw carrier still needs the old eager form,
+  // because it has no FP source sort with which to build FP_TO_IEEE_BV.
+  if (index.GetKind() == BVCONST)
+    return bm->CreateFPConst(index, exp_width, sig_width);
+
+  if (source_sort.kind() == SourceSort::Kind::BitVector ||
+      source_sort.kind() == SourceSort::Kind::Unknown)
+  {
+    return FloatBlaster::canonicalBits(bm, index, exp_width, sig_width);
+  }
+
+  FatalError("FpTotalise: a float array index is not a scalar bitvector or "
+             "floating-point source value: ",
+             index);
+}
+
+ASTNode FpTotalise::canonicalSourceBits(const ASTNode& value)
+{
+  const SourceSort sort = value.GetSourceSort();
+  if (sort.kind() != SourceSort::Kind::FloatingPoint)
+    FatalError("FpTotalise expected a floating-point source value: ", value);
+
+  // Float constants are interned in canonical SMT form already. Keeping the
+  // constant avoids constructing an operation which constant evaluation
+  // would immediately fold back to the same node.
+  if (value.GetKind() == BVCONST)
+    return value;
+
+  return nf->CreateTerm(FP_TO_IEEE_BV, sort.packedWidth(), value);
+}
+
+void FpTotalise::collectRoundingModeTerms(const ASTNode& n, ASTNodeSet& seen,
+                                          ASTVec& constraints)
+{
+  if (!seen.insert(n).second)
+    return;
+
+  // Leaves are visited now, where they were skipped before: a declared
+  // RoundingMode symbol is a leaf, and it is exactly as much in need of
+  // pinning as a read is.
+  if (n.GetKind() == SYMBOL)
+  {
+    if (bm->isRoundingModeSymbol(n))
+      constraints.push_back(bm->roundingModeValidConstraint(n));
+    return;
+  }
+
+  if (n.GetKind() == READ && bm->arrayHasRmElement(n[0]))
+    constraints.push_back(bm->roundingModeValidConstraint(n));
+
+  for (size_t i = 0; i < n.Degree(); i++)
+    collectRoundingModeTerms(n[i], seen, constraints);
+}
+
+ASTNode FpTotalise::rebuild(const ASTNode& n, const ASTVec& children)
+{
+  ASTNode out;
+
+  if (n.GetType() == BOOLEAN_TYPE)
+    out = nf->CreateNode(n.GetKind(), children);
+  else if (n.GetIndexWidth() > 0)
+    out = nf->CreateArrayTerm(n.GetKind(), n.GetIndexWidth(),
+                              n.GetValueWidth(), children);
+  else
+    out = nf->CreateTerm(n.GetKind(), n.GetValueWidth(), children);
+
+  return FloatBlaster::withFormat(bm, out, n.GetExpWidth(), n.GetSigWidth());
+}
+
+ASTNode FpTotalise::unspecified(const char* tag, const ASTNode& index,
+                                const ASTVec& floats,
+                                unsigned int value_width)
+{
+  // `floats` rather than the index: the index is what the array is addressed
+  // *by*, the formats are part of what array it is.
+  return FloatBlaster::unspecifiedValue(bm, tag, floats, index, value_width);
+}
+
+ASTNode FpTotalise::conversionIndex(const ASTNode& rounding_mode,
+                                    const ASTNode& value)
+{
+  // Index on canonical bits, not raw ones. SMT-LIB equality on floats makes
+  // every NaN equal to every other, so operands that are equal may still
+  // differ in payload; indexing on raw bits would let them read different
+  // slots and answer differently, losing the very congruence this array
+  // exists to provide. FP_TO_IEEE_BV records that round-trip as a source
+  // boundary; FloatBlast later collapses the payload while keeping +0 and
+  // -0 apart, and can reuse the same unpacked operand as the operation.
+  const ASTNode canonical = canonicalSourceBits(value);
+  const unsigned int width =
+      rounding_mode.GetValueWidth() + canonical.GetValueWidth();
+  return bm->CreateTerm(BVCONCAT, width, rounding_mode, canonical);
+}
+
+ASTNode FpTotalise::signBit(const ASTNode& value)
+{
+  const ASTNode canonical = canonicalSourceBits(value);
+  const unsigned int top = canonical.GetValueWidth() - 1;
+  const ASTNode position = bm->CreateBVConst(32, top);
+  return nf->CreateTerm(BVEXTRACT, 1, canonical, position, position);
+}
+
+// fp.min and fp.max are unspecified only on (+0, -0) and (-0, +0), and the
+// choice is a function of the two sign bits -- so the map that supplies it
+// needs four cells, not one per pair of packed values.
+//
+// Reading symfpu's ordering() (symfpu/core/compare.h:85-152), the choice
+// arrives as its `equality` argument and changes the answer in exactly three
+// places: both operands the same infinity, both operands zero, and both
+// operands equal in sign, exponent and significand. In the first and third
+// the enclosing ITE selects between two values that are equal, so the choice
+// is unobservable; only the zero case can be seen, and there the result is
+// determined by which zero is returned. (unpackedFloat::wellFormed is what
+// makes the first and third genuinely unobservable: it forces the default
+// exponent and significand whenever the nan/inf/zero flag is set.)
+//
+// Four cells is therefore not an approximation but exactly complete: the
+// (+0, -0) and (-0, +0) cells stay independent, as SMT-LIB requires, and the
+// cells the other sign pairs select are unobservable.
+//
+// Having proved the domain is four points, hold it in four bits. The array
+// this used to read was sound, and is still the right encoding for
+// fp.to_ubv/fp.to_sbv where the domain really is a rounding mode and a whole
+// packed value -- but for a four-point map it buys nothing and costs a great
+// deal that is not local. FpTotalise runs before containsArrayOps and
+// numberOfReadsLessThan, so a read it introduces is indistinguishable from the
+// user's: ten fp.mins turn a pure QF_FP query into an "array" problem, forcing
+// counterexample construction on and skipping the size-reducing fixed point,
+// and three of them are enough to stop a QF_ABVFP query Ackermannising the
+// user's own arrays. Narrowing the index from 2(e+s) bits to two, as this
+// previously did, shrinks each index term but not the number of reads, so it
+// did not address any of that.
+//
+// The cells are free and the selection is a mux, so the result is still a
+// function of the operands; hash-consing gives the congruence the array's
+// index equalities were giving. The mux is still not constant, so these nodes
+// still stay out of constant folding, which is what we want -- their results
+// genuinely are not constants even when their operands are.
+ASTNode FpTotalise::zeroChoice(const char* tag, const ASTNode& left,
+                               const ASTNode& right, const ASTVec& floats)
+{
+  const ASTNode cells = FloatBlaster::unspecifiedCells(bm, tag, floats, 4);
+
+  ASTNode bit[4];
+  for (unsigned int i = 0; i < 4; i++)
+  {
+    const ASTNode position = bm->CreateBVConst(32, i);
+    bit[i] = nf->CreateTerm(BVEXTRACT, 1, cells, position, position);
+  }
+
+  const ASTNode zero = bm->CreateZeroConst(1);
+  const ASTNode left_positive = nf->CreateNode(EQ, signBit(left), zero);
+  const ASTNode right_positive = nf->CreateNode(EQ, signBit(right), zero);
+
+  return nf->CreateTerm(
+      ITE, 1, left_positive,
+      nf->CreateTerm(ITE, 1, right_positive, bit[0], bit[1]),
+      nf->CreateTerm(ITE, 1, right_positive, bit[2], bit[3]));
+}
+
+ASTNode FpTotalise::visit(const ASTNode& n)
+{
+  if (n.Degree() == 0)
+    return n;
+
+  const ASTNodeMap::const_iterator persistent = persistent_cache.find(n);
+  if (persistent != persistent_cache.end())
+    return persistent->second;
+  const ASTNodeMap::const_iterator current = traversal_cache.find(n);
+  if (current != traversal_cache.end())
+    return current->second;
+
+  ASTVec children;
+  children.reserve(n.Degree() + 1);
+
+  bool changed = false;
+  for (size_t i = 0; i < n.Degree(); i++)
+  {
+    const ASTNode c = visit(n[i]);
+    changed = changed || (c != n[i]);
+    children.push_back(c);
+  }
+
+  const Kind k = n.GetKind();
+
+  // fp.min/fp.max: which zero comes back for (+0, -0) is unspecified. Carried
+  // as a 1-bit bitvector rather than a Boolean, because every child of a term
+  // has to be a term -- the array transformer walks them all. The blaster
+  // turns it into a proposition.
+  if ((k == FP_MIN || k == FP_MAX) && children.size() == 2)
+  {
+    ASTVec floats;
+    floats.push_back(children[0]);
+    floats.push_back(children[1]);
+
+    children.push_back(zeroChoice(k == FP_MIN ? "min_zero" : "max_zero",
+                                  children[0], children[1], floats));
+    changed = true;
+  }
+  // fp.to_ubv/fp.to_sbv: unspecified for NaN, the infinities and anything out
+  // of range. Children are (m, rm, x); the rounding mode joins the float in
+  // the index, since the same float may convert differently under different
+  // modes.
+  else if ((k == FP_TO_UBV || k == FP_TO_SBV) && children.size() == 3)
+  {
+    ASTVec floats;
+    floats.push_back(children[2]);
+
+    children.push_back(
+        unspecified(k == FP_TO_UBV ? "to_ubv" : "to_sbv",
+                    conversionIndex(children[1], children[2]), floats,
+                    n.GetValueWidth()));
+    changed = true;
+  }
+  // An access over a float-indexed array addresses canonical bits (see the
+  // class comment). Each solve totalises the raw assertions afresh -- the
+  // rewritten formula is solve-local -- so a canonicalised index never
+  // comes back through here, and identical raw indexes hash-cons to
+  // identical canonical circuits across solves.
+  else if (k == READ || k == WRITE)
+  {
+    unsigned int index_exp = 0;
+    unsigned int index_sig = 0;
+    if (bm->arrayHasFpIndex(children[0], index_exp, index_sig))
+    {
+      const ASTNode canon =
+          canonicalIndex(children[1], index_exp, index_sig);
+      if (canon != children[1])
+      {
+        children[1] = canon;
+        changed = true;
+      }
+    }
+  }
+
+  const ASTNode out = changed ? rebuild(n, children) : n;
+
+  traversal_cache[n] = out;
+  const SourceSort source_sort = n.GetSourceSort();
+  const bool fp_array_access =
+      (k == READ || k == WRITE) && n.Degree() > 0 &&
+      n[0].GetSourceSort().kind() == SourceSort::Kind::Array &&
+      n[0].GetSourceSort().index().kind() ==
+          SourceSort::Kind::FloatingPoint;
+  if (out != n &&
+      (is_FP_kind(k) || fp_array_access ||
+       source_sort.kind() == SourceSort::Kind::FloatingPoint))
+    persistent_cache[n] = out;
+  return out;
+}
+
+} // namespace stp

--- a/lib/FloatBlaster/symbolic_fp.cpp
+++ b/lib/FloatBlaster/symbolic_fp.cpp
@@ -1,0 +1,923 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: January 2021
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#include "stp/FloatBlaster/symbolic_fp.h"
+
+#include "stp/NodeFactory/NodeFactory.h"
+#include "stp/STPManager/STPManager.h"
+
+#include <cassert>
+
+#include "symfpu/core/add.h"
+#include "symfpu/core/classify.h"
+#include "symfpu/core/compare.h"
+#include "symfpu/core/convert.h"
+#include "symfpu/core/divide.h"
+#include "symfpu/core/fma.h"
+#include "symfpu/core/ite.h"
+#include "symfpu/core/multiply.h"
+#include "symfpu/core/packing.h"
+#include "symfpu/core/remainder.h"
+#include "symfpu/core/sign.h"
+#include "symfpu/core/sqrt.h"
+#include "symfpu/core/unpackedFloat.h"
+#include "symfpu/utils/numberOfRoundingModes.h"
+
+using namespace stp;
+using namespace stp::symbolic_fp;
+
+// The manager and factory the circuits are built into. symfpu constructs
+// backend values through static trait calls (traits::RNE() and friends take
+// no context), so the context has to live in file statics; init() repoints
+// them before every top-level blast (see FloatBlast::topLevel).
+// Each thread needs its own pair: independent validity checkers may blast in
+// parallel, and a process-global pair would make one thread build through the
+// other thread's manager and concurrently mutate its hash-cons tables.
+// The factory is the manager's default (simplifying) factory: constant
+// operands fold as the circuit is built, which is what lets the constant
+// evaluator blast-fold floating-point operations on constants.
+static THREAD_LOCAL_IE STPMgr* s_bm = nullptr;
+static THREAD_LOCAL_IE NodeFactory* s_nf = nullptr;
+
+namespace stp
+{
+namespace symbolic_fp
+{
+void init(STPMgr* bm)
+{
+  assert(bm != nullptr);
+  s_bm = bm;
+  s_nf = bm->defaultNodeFactory;
+}
+} // namespace symbolic_fp
+} // namespace stp
+
+nodeWrapper::nodeWrapper(const ASTNode& n) : ASTNode(n) {}
+
+/****************************************************************
+ * roundingMode                                                 *
+ ****************************************************************/
+
+roundingMode::roundingMode(unsigned int v)
+    : nodeWrapper(s_bm->CreateBVConst(SYMFPU_NUMBER_OF_ROUNDING_MODES, v))
+{
+}
+
+roundingMode::roundingMode(const ASTNode n) : nodeWrapper(n) {}
+
+roundingMode::roundingMode(const roundingMode& old) : nodeWrapper(old) {}
+
+proposition roundingMode::operator==(const roundingMode& op) const
+{
+  return proposition(s_nf->CreateNode(EQ, *this, op));
+}
+
+roundingMode traits::RNE(void)
+{
+  return roundingMode(ROUND_NEAREST_TIES_TO_EVEN);
+}
+
+roundingMode traits::RNA(void)
+{
+  return roundingMode(ROUND_NEAREST_TIES_TO_AWAY);
+}
+
+roundingMode traits::RTP(void)
+{
+  return roundingMode(ROUND_TOWARD_POSITIVE);
+}
+
+roundingMode traits::RTN(void)
+{
+  return roundingMode(ROUND_TOWARD_NEGATIVE);
+}
+
+roundingMode traits::RTZ(void)
+{
+  return roundingMode(ROUND_TOWARD_ZERO);
+}
+
+void traits::precondition(const bool b)
+{
+  assert(b);
+  (void)b;
+}
+
+void traits::postcondition(const bool b)
+{
+  assert(b);
+  (void)b;
+}
+
+void traits::invariant(const bool b)
+{
+  assert(b);
+  (void)b;
+}
+
+// Symbolic properties cannot be checked at blast time.
+void traits::precondition(const prop&) {}
+
+void traits::postcondition(const prop&) {}
+
+void traits::invariant(const prop&) {}
+
+/****************************************************************
+ * proposition                                                  *
+ ****************************************************************/
+
+proposition::proposition(const ASTNode n) : nodeWrapper(n)
+{
+  assert(checkNodeType(*this));
+}
+
+proposition::proposition(bool v)
+    : nodeWrapper(v ? s_bm->ASTTrue : s_bm->ASTFalse)
+{
+  assert(checkNodeType(*this));
+}
+
+proposition::proposition(const proposition& old) : nodeWrapper(old)
+{
+  assert(checkNodeType(*this));
+}
+
+bool proposition::checkNodeType(const ASTNode& node)
+{
+  return node.GetType() == stp::BOOLEAN_TYPE;
+}
+
+proposition proposition::operator!(void) const
+{
+  return proposition(s_nf->CreateNode(NOT, *this));
+}
+
+proposition proposition::operator&&(const proposition& op) const
+{
+  return proposition(s_nf->CreateNode(AND, *this, op));
+}
+
+proposition proposition::operator||(const proposition& op) const
+{
+  return proposition(s_nf->CreateNode(OR, *this, op));
+}
+
+proposition proposition::operator==(const proposition& op) const
+{
+  return proposition(s_nf->CreateNode(IFF, *this, op));
+}
+
+proposition proposition::operator^(const proposition& op) const
+{
+  return proposition(s_nf->CreateNode(XOR, *this, op));
+}
+
+/****************************************************************
+ * bitVector                                                    *
+ ****************************************************************/
+
+template <bool isSigned>
+bitVector<isSigned>::bitVector(const ASTNode n) : nodeWrapper(n)
+{
+  assert(checkNodeType(*this));
+}
+
+template <bool isSigned>
+bool bitVector<isSigned>::checkNodeType(const ASTNode& n)
+{
+  // Floats are carried packed, so a float-typed node is bits too.
+  return (n.GetType() == stp::BITVECTOR_TYPE ||
+          n.GetType() == stp::FLOATINGPOINT_TYPE) &&
+         n.GetValueWidth() > 0;
+}
+
+template <bool isSigned>
+bitVector<isSigned>::bitVector(const bitWidthType w, const unsigned v)
+    : nodeWrapper(s_bm->CreateBVConst(w, v))
+{
+  assert(checkNodeType(*this));
+}
+
+template <bool isSigned>
+bitVector<isSigned>::bitVector(const proposition& p)
+    : nodeWrapper(fromProposition(p))
+{
+}
+
+template <bool isSigned>
+bitVector<isSigned>::bitVector(const bitVector<isSigned>& old)
+    : nodeWrapper(old)
+{
+  assert(checkNodeType(*this));
+}
+
+// symfpu's propositions are Boolean nodes; where it stores one into a
+// bitvector, select a bit.
+template <bool isSigned>
+ASTNode bitVector<isSigned>::fromProposition(const ASTNode& node) const
+{
+  return s_nf->CreateTerm(ITE, 1, node, s_bm->CreateOneConst(1),
+                          s_bm->CreateZeroConst(1));
+}
+
+template <bool isSigned> bitWidthType bitVector<isSigned>::getWidth(void) const
+{
+  const bitWidthType ret = GetValueWidth();
+  assert(ret > 0);
+  return ret;
+}
+
+template <bool isSigned>
+bitVector<isSigned> bitVector<isSigned>::one(const bitWidthType& w)
+{
+  return bitVector<isSigned>(w, 1);
+}
+
+template <bool isSigned>
+bitVector<isSigned> bitVector<isSigned>::zero(const bitWidthType& w)
+{
+  return bitVector<isSigned>(w, 0);
+}
+
+template <bool isSigned>
+bitVector<isSigned> bitVector<isSigned>::allOnes(const bitWidthType& w)
+{
+  return bitVector<isSigned>(~zero(w));
+}
+
+template <bool isSigned> proposition bitVector<isSigned>::isAllOnes() const
+{
+  return (*this == bitVector<isSigned>::allOnes(this->getWidth()));
+}
+
+template <bool isSigned> proposition bitVector<isSigned>::isAllZeros() const
+{
+  return (*this == bitVector<isSigned>::zero(this->getWidth()));
+}
+
+template <> bitVector<true> bitVector<true>::maxValue(const bitWidthType& w)
+{
+  // A clear sign bit followed by ones.
+  bitVector<true> leadingZero(bitVector<true>::zero(1));
+  bitVector<true> base(bitVector<true>::allOnes(w - 1));
+  return bitVector<true>(s_nf->CreateTerm(BVCONCAT, w, leadingZero, base));
+}
+
+template <> bitVector<false> bitVector<false>::maxValue(const bitWidthType& w)
+{
+  return bitVector<false>::allOnes(w);
+}
+
+template <> bitVector<true> bitVector<true>::minValue(const bitWidthType& w)
+{
+  // The most negative two's-complement value is a set sign bit followed by
+  // zeros. This used to build a *clear* sign bit followed by zeros, which is
+  // simply 0 -- so the signed minimum compared equal to zero.
+  bitVector<true> leadingOne(bitVector<true>::one(1));
+  bitVector<true> base(bitVector<true>::zero(w - 1));
+  return bitVector<true>(s_nf->CreateTerm(BVCONCAT, w, leadingOne, base));
+}
+
+template <> bitVector<false> bitVector<false>::minValue(const bitWidthType& w)
+{
+  return bitVector<false>::zero(w);
+}
+
+template <bool isSigned>
+bitVector<isSigned>
+bitVector<isSigned>::operator<<(const bitVector<isSigned>& op) const
+{
+  return bitVector<isSigned>(
+      s_nf->CreateTerm(BVLEFTSHIFT, getWidth(), *this, op));
+}
+
+template <bool isSigned>
+bitVector<isSigned>
+bitVector<isSigned>::operator>>(const bitVector<isSigned>& op) const
+{
+  return bitVector<isSigned>(s_nf->CreateTerm(
+      isSigned ? BVSRSHIFT : BVRIGHTSHIFT, getWidth(), *this, op));
+}
+
+template <bool isSigned>
+bitVector<isSigned>
+bitVector<isSigned>::operator|(const bitVector<isSigned>& op) const
+{
+  return bitVector<isSigned>(s_nf->CreateTerm(BVOR, getWidth(), *this, op));
+}
+
+template <bool isSigned>
+bitVector<isSigned>
+bitVector<isSigned>::operator&(const bitVector<isSigned>& op) const
+{
+  return bitVector<isSigned>(s_nf->CreateTerm(BVAND, getWidth(), *this, op));
+}
+
+template <bool isSigned>
+bitVector<isSigned>
+bitVector<isSigned>::operator+(const bitVector<isSigned>& op) const
+{
+  return bitVector<isSigned>(s_nf->CreateTerm(BVPLUS, getWidth(), *this, op));
+}
+
+template <bool isSigned>
+bitVector<isSigned>
+bitVector<isSigned>::operator-(const bitVector<isSigned>& op) const
+{
+  return bitVector<isSigned>(s_nf->CreateTerm(BVSUB, getWidth(), *this, op));
+}
+
+template <bool isSigned>
+bitVector<isSigned>
+bitVector<isSigned>::operator*(const bitVector<isSigned>& op) const
+{
+  return bitVector<isSigned>(s_nf->CreateTerm(BVMULT, getWidth(), *this, op));
+}
+
+template <bool isSigned>
+bitVector<isSigned>
+bitVector<isSigned>::operator/(const bitVector<isSigned>& op) const
+{
+  return bitVector<isSigned>(
+      s_nf->CreateTerm(isSigned ? SBVDIV : BVDIV, getWidth(), *this, op));
+}
+
+template <bool isSigned>
+bitVector<isSigned>
+bitVector<isSigned>::operator%(const bitVector<isSigned>& op) const
+{
+  // SymFPU's other symbolic backends map signed % to signed remainder (the
+  // quotient truncates toward zero, and the result follows the dividend's
+  // sign). SMT-LIB bvsmod follows the divisor's sign instead.
+  return bitVector<isSigned>(
+      s_nf->CreateTerm(isSigned ? SBVREM : BVMOD, getWidth(), *this, op));
+}
+
+template <bool isSigned>
+bitVector<isSigned> bitVector<isSigned>::operator-(void) const
+{
+  return bitVector<isSigned>(s_nf->CreateTerm(BVUMINUS, getWidth(), *this));
+}
+
+template <bool isSigned>
+bitVector<isSigned> bitVector<isSigned>::operator~(void) const
+{
+  return bitVector<isSigned>(s_nf->CreateTerm(BVNOT, getWidth(), *this));
+}
+
+template <bool isSigned>
+bitVector<isSigned> bitVector<isSigned>::increment() const
+{
+  return *this + one(getWidth());
+}
+
+template <bool isSigned>
+bitVector<isSigned> bitVector<isSigned>::decrement() const
+{
+  return *this - one(getWidth());
+}
+
+template <bool isSigned>
+bitVector<isSigned>
+bitVector<isSigned>::signExtendRightShift(const bitVector<isSigned>& op) const
+{
+  return bitVector<isSigned>(
+      s_nf->CreateTerm(BVSRSHIFT, getWidth(), *this, op));
+}
+
+// symfpu distinguishes the modular operations (that may wrap) from the
+// plain ones (guarded by preconditions); on bitvectors they coincide.
+template <bool isSigned>
+bitVector<isSigned>
+bitVector<isSigned>::modularLeftShift(const bitVector<isSigned>& op) const
+{
+  return *this << op;
+}
+
+template <bool isSigned>
+bitVector<isSigned>
+bitVector<isSigned>::modularRightShift(const bitVector<isSigned>& op) const
+{
+  return *this >> op;
+}
+
+template <bool isSigned>
+bitVector<isSigned> bitVector<isSigned>::modularIncrement() const
+{
+  return this->increment();
+}
+
+template <bool isSigned>
+bitVector<isSigned> bitVector<isSigned>::modularDecrement() const
+{
+  return this->decrement();
+}
+
+template <bool isSigned>
+bitVector<isSigned>
+bitVector<isSigned>::modularAdd(const bitVector<isSigned>& op) const
+{
+  return *this + op;
+}
+
+template <bool isSigned>
+bitVector<isSigned>
+bitVector<isSigned>::modularSubtract(const bitVector<isSigned>& op) const
+{
+  return *this - op;
+}
+
+template <bool isSigned>
+bitVector<isSigned> bitVector<isSigned>::modularNegate() const
+{
+  return -(*this);
+}
+
+template <bool isSigned>
+proposition bitVector<isSigned>::operator==(const bitVector<isSigned>& op) const
+{
+  // As with the orderings below: symfpu compares values, so a narrower
+  // operand is brought up to width rather than mis-typing the EQ. (symfpu
+  // only calls == width-matched today; <= and >= are built from < and ==,
+  // and would hand a width-mismatched pair straight through.)
+  if (getWidth() < op.getWidth())
+    return proposition(s_nf->CreateNode(EQ, matchWidth(op), op));
+  if (op.getWidth() < getWidth())
+    return proposition(s_nf->CreateNode(EQ, *this, op.matchWidth(*this)));
+  return proposition(s_nf->CreateNode(EQ, *this, op));
+}
+
+template <bool isSigned>
+proposition bitVector<isSigned>::operator<(const bitVector<isSigned>& op) const
+{
+  // symfpu compares values of different widths in a few places; bring the
+  // narrower operand up first.
+  const Kind k = isSigned ? BVSLT : BVLT;
+  if (getWidth() < op.getWidth())
+    return proposition(s_nf->CreateNode(k, matchWidth(op), op));
+  if (op.getWidth() < getWidth())
+    return proposition(s_nf->CreateNode(k, *this, op.matchWidth(*this)));
+  return proposition(s_nf->CreateNode(k, *this, op));
+}
+
+template <bool isSigned>
+proposition bitVector<isSigned>::operator<=(const bitVector<isSigned>& op) const
+{
+  return (*this < op) || (*this == op);
+}
+
+template <bool isSigned>
+proposition bitVector<isSigned>::operator>=(const bitVector<isSigned>& op) const
+{
+  return (*this > op) || (*this == op);
+}
+
+template <bool isSigned>
+proposition bitVector<isSigned>::operator>(const bitVector<isSigned>& op) const
+{
+  return proposition(
+      s_nf->CreateNode(isSigned ? BVSLT : BVLT, op, *this));
+}
+
+template <bool isSigned>
+bitVector<true> bitVector<isSigned>::toSigned(void) const
+{
+  return bitVector<true>(*this);
+}
+
+template <bool isSigned>
+bitVector<false> bitVector<isSigned>::toUnsigned(void) const
+{
+  return bitVector<false>(*this);
+}
+
+template <>
+bitVector<true> bitVector<true>::extend(bitWidthType extension) const
+{
+  if (extension == 0)
+    return *this;
+
+  const bitWidthType new_length = getWidth() + extension;
+  return bitVector<true>(
+      s_nf->CreateTerm(BVSX, new_length, *this,
+                       s_bm->CreateBVConst(32, new_length)));
+}
+
+template <>
+bitVector<false> bitVector<false>::extend(bitWidthType extension) const
+{
+  // Extending by nothing is the identity. Falling through would ask for a
+  // zero-width constant to concatenate, which STP rejects. symfpu's
+  // conversion path does call this with an extension of zero.
+  if (extension == 0)
+    return *this;
+
+  const bitWidthType new_length = getWidth() + extension;
+  return bitVector<false>(
+      s_nf->CreateTerm(BVCONCAT, new_length,
+                       s_bm->CreateZeroConst(extension), *this));
+}
+
+template <bool isSigned>
+bitVector<isSigned> bitVector<isSigned>::contract(bitWidthType reduction) const
+{
+  // Fail closed for the same reason as matchWidth: the subtraction below is
+  // unsigned, so an over-large reduction underflows into an extract of an
+  // absurd range rather than stopping.
+  if (this->getWidth() <= reduction)
+  {
+    FatalError("symbolic_fp: contract would remove every bit of a bitvector; "
+               "symfpu asked to narrow a value past its own width");
+  }
+  return extract((this->getWidth() - 1) - reduction, 0);
+}
+
+template <bool isSigned>
+bitVector<isSigned> bitVector<isSigned>::resize(bitWidthType newSize) const
+{
+  const bitWidthType width = this->getWidth();
+
+  if (newSize > width)
+    return this->extend(newSize - width);
+  if (newSize < width)
+    return this->contract(width - newSize);
+  return *this;
+}
+
+template <bool isSigned>
+bitVector<isSigned>
+bitVector<isSigned>::matchWidth(const bitVector<isSigned>& op) const
+{
+  // Fail closed rather than assert. bitWidthType is unsigned, so a violated
+  // precondition does not merely widen the wrong way -- the subtraction wraps
+  // to about 2^32, extend asks for a constant of that width, and the circuit
+  // builder walks off the end of a bitvector. An assert would catch it, but
+  // CMAKE_BUILD_TYPE=Release compiles asserts out (CMakeLists.txt forces
+  // ENABLE_ASSERTIONS off there), so the builds users ship are exactly the
+  // ones that would segfault. FloatBlaster::formatSupported and
+  // roundToIntegralSupported refuse the formats where symfpu is known to
+  // reach here; this catches any that were missed.
+  if (this->getWidth() > op.getWidth())
+  {
+    FatalError("symbolic_fp: matchWidth cannot narrow a bitvector; symfpu "
+               "asked to resize a value wider than its target, which means a "
+               "floating-point format reached the blaster that "
+               "FloatBlaster::formatSupported should have refused");
+  }
+  if (this->getWidth() == op.getWidth())
+    return *this;
+  return this->extend(op.getWidth() - this->getWidth());
+}
+
+template <bool isSigned>
+bitVector<isSigned>
+bitVector<isSigned>::append(const bitVector<isSigned>& op) const
+{
+  return bitVector<isSigned>(s_nf->CreateTerm(
+      BVCONCAT, getWidth() + op.getWidth(), *this, op));
+}
+
+template <bool isSigned>
+bitVector<isSigned> bitVector<isSigned>::extract(bitWidthType upper,
+                                                 bitWidthType lower) const
+{
+  assert(upper >= lower);
+  return bitVector<isSigned>(
+      s_nf->CreateTerm(BVEXTRACT, (upper - lower) + 1, *this,
+                       s_bm->CreateBVConst(32, upper),
+                       s_bm->CreateBVConst(32, lower)));
+}
+
+/****************************************************************
+ * floatingPointTypeInfo                                        *
+ ****************************************************************/
+
+floatingPointTypeInfo::floatingPointTypeInfo(unsigned exp, unsigned sig)
+    : m_exp(exp), m_sig(sig)
+{
+}
+
+floatingPointTypeInfo::floatingPointTypeInfo(const floatingPointTypeInfo& old)
+    : m_exp(old.exponentWidth()), m_sig(old.significandWidth())
+{
+}
+
+bitWidthType floatingPointTypeInfo::exponentWidth(void) const
+{
+  return m_exp;
+}
+
+bitWidthType floatingPointTypeInfo::significandWidth(void) const
+{
+  return m_sig;
+}
+
+bitWidthType floatingPointTypeInfo::packedWidth(void) const
+{
+  return exponentWidth() + significandWidth();
+}
+
+bitWidthType floatingPointTypeInfo::packedExponentWidth(void) const
+{
+  return exponentWidth();
+}
+
+bitWidthType floatingPointTypeInfo::packedSignificandWidth(void) const
+{
+  return significandWidth() - 1;
+}
+
+/****************************************************************
+ * symfpu ITE dispatch                                          *
+ ****************************************************************/
+
+namespace symfpu
+{
+
+template <> struct ite<symbolic_fp::proposition, symbolic_fp::proposition>
+{
+  static const symbolic_fp::proposition
+  iteOp(const symbolic_fp::proposition& cond,
+        const symbolic_fp::proposition& l, const symbolic_fp::proposition& r)
+  {
+    return symbolic_fp::proposition(s_nf->CreateNode(stp::ITE, cond, l, r));
+  }
+};
+
+#define STP_SYM_ITE_TERM(T)                                                    \
+  template <> struct ite<symbolic_fp::proposition, T>                          \
+  {                                                                            \
+    static const T iteOp(const symbolic_fp::proposition& cond, const T& l,     \
+                         const T& r)                                           \
+    {                                                                          \
+      assert(l.GetValueWidth() == r.GetValueWidth());                          \
+      return T(s_nf->CreateTerm(stp::ITE, l.GetValueWidth(), cond, l, r));     \
+    }                                                                          \
+  }
+
+STP_SYM_ITE_TERM(symbolic_fp::traits::rm);
+STP_SYM_ITE_TERM(symbolic_fp::traits::sbv);
+STP_SYM_ITE_TERM(symbolic_fp::traits::ubv);
+
+#undef STP_SYM_ITE_TERM
+
+// symfpu's divide path calls ITE with a literal bool condition rather than a
+// proposition (core/divide.h, computing the result-exponent bounds), so the
+// backend has to provide a bool-conditioned ITE as well. The condition is a
+// compile-time constant, so this just selects a branch.
+template <class T> struct ite<bool, T>
+{
+  static const T iteOp(const bool& cond, const T& l, const T& r)
+  {
+    return cond ? l : r;
+  }
+};
+
+} // namespace symfpu
+
+/****************************************************************
+ * blast_*: one floating-point operation each                   *
+ ****************************************************************/
+
+namespace stp
+{
+namespace symbolic_fp
+{
+
+namespace
+{
+void assertUnpackedFormat(const floatingPointTypeInfo& size, const uf& value)
+{
+  assert(value.getExponent().getWidth() == uf::exponentWidth(size));
+  assert(value.getSignificand().getWidth() == uf::significandWidth(size));
+  (void)size;
+  (void)value;
+}
+} // namespace
+
+namespace unpacked
+{
+
+uf decode(const floatingPointTypeInfo& size, const ASTNode& packed)
+{
+  assert(packed.GetValueWidth() == size.packedWidth());
+  return symfpu::unpack<traits>(size, packed);
+}
+
+ASTNode encode(const floatingPointTypeInfo& size, const uf& value)
+{
+  assertUnpackedFormat(size, value);
+  return symfpu::pack<traits>(size, value);
+}
+
+uf select(const ASTNode& condition, const uf& when_true,
+          const uf& when_false)
+{
+  assert(condition.GetType() == BOOLEAN_TYPE);
+  assert(when_true.getExponent().getWidth() ==
+         when_false.getExponent().getWidth());
+  assert(when_true.getSignificand().getWidth() ==
+         when_false.getSignificand().getWidth());
+  return symfpu::ite<proposition, uf>::iteOp(
+      proposition(condition), when_true, when_false);
+}
+
+ASTNode smtEqual(const floatingPointTypeInfo& size, const uf& lhs,
+                 const uf& rhs)
+{
+  assertUnpackedFormat(size, lhs);
+  assertUnpackedFormat(size, rhs);
+  return symfpu::smtlibEqual<traits>(size, lhs, rhs);
+}
+
+uf add(const floatingPointTypeInfo& size, const ASTNode& rm, const uf& lhs,
+       const uf& rhs)
+{
+  assertUnpackedFormat(size, lhs);
+  assertUnpackedFormat(size, rhs);
+  return symfpu::add<traits>(size, rm, lhs, rhs, true);
+}
+
+uf sub(const floatingPointTypeInfo& size, const ASTNode& rm, const uf& lhs,
+       const uf& rhs)
+{
+  assertUnpackedFormat(size, lhs);
+  assertUnpackedFormat(size, rhs);
+  return symfpu::add<traits>(size, rm, lhs, rhs, false);
+}
+
+uf mul(const floatingPointTypeInfo& size, const ASTNode& rm, const uf& lhs,
+       const uf& rhs)
+{
+  assertUnpackedFormat(size, lhs);
+  assertUnpackedFormat(size, rhs);
+  return symfpu::multiply<traits>(size, rm, lhs, rhs);
+}
+
+uf div(const floatingPointTypeInfo& size, const ASTNode& rm, const uf& lhs,
+       const uf& rhs)
+{
+  assertUnpackedFormat(size, lhs);
+  assertUnpackedFormat(size, rhs);
+  return symfpu::divide<traits>(size, rm, lhs, rhs);
+}
+
+uf fma(const floatingPointTypeInfo& size, const ASTNode& rm, const uf& x,
+       const uf& y, const uf& z)
+{
+  assertUnpackedFormat(size, x);
+  assertUnpackedFormat(size, y);
+  assertUnpackedFormat(size, z);
+  return symfpu::fma<traits>(size, rm, x, y, z);
+}
+
+uf sqrt(const floatingPointTypeInfo& size, const ASTNode& rm, const uf& value)
+{
+  assertUnpackedFormat(size, value);
+  return symfpu::sqrt<traits>(size, rm, value);
+}
+
+uf rem(const floatingPointTypeInfo& size, const uf& lhs, const uf& rhs)
+{
+  assertUnpackedFormat(size, lhs);
+  assertUnpackedFormat(size, rhs);
+  return symfpu::remainder<traits>(size, lhs, rhs);
+}
+
+uf min(const floatingPointTypeInfo& size, const uf& lhs, const uf& rhs,
+       const ASTNode& zero_case)
+{
+  assertUnpackedFormat(size, lhs);
+  assertUnpackedFormat(size, rhs);
+  return symfpu::min<traits>(size, lhs, rhs, proposition(zero_case));
+}
+
+uf max(const floatingPointTypeInfo& size, const uf& lhs, const uf& rhs,
+       const ASTNode& zero_case)
+{
+  assertUnpackedFormat(size, lhs);
+  assertUnpackedFormat(size, rhs);
+  return symfpu::max<traits>(size, lhs, rhs, proposition(zero_case));
+}
+
+uf abs(const floatingPointTypeInfo& size, const uf& value)
+{
+  assertUnpackedFormat(size, value);
+  return symfpu::absolute<traits>(size, value);
+}
+
+uf neg(const floatingPointTypeInfo& size, const uf& value)
+{
+  assertUnpackedFormat(size, value);
+  return symfpu::negate<traits>(size, value);
+}
+
+uf roundToIntegral(const floatingPointTypeInfo& size, const ASTNode& rm,
+                   const uf& value)
+{
+  assertUnpackedFormat(size, value);
+  return symfpu::roundToIntegral<traits>(size, rm, value);
+}
+
+ASTNode toBV(const floatingPointTypeInfo& size, const ASTNode& rm,
+             const uf& value, bitWidthType target_width,
+             const ASTNode& undef, bool is_signed)
+{
+  assertUnpackedFormat(size, value);
+  if (is_signed)
+    return symfpu::convertFloatToSBV<traits>(size, rm, value, target_width,
+                                             traits::sbv(undef));
+
+  return symfpu::convertFloatToUBV<traits>(size, rm, value, target_width,
+                                           traits::ubv(undef));
+}
+
+ASTNode ieeeEqual(const floatingPointTypeInfo& size, const uf& lhs,
+                  const uf& rhs)
+{
+  assertUnpackedFormat(size, lhs);
+  assertUnpackedFormat(size, rhs);
+  return symfpu::ieee754Equal<traits>(size, lhs, rhs);
+}
+
+ASTNode lessThan(const floatingPointTypeInfo& size, const uf& lhs,
+                 const uf& rhs)
+{
+  assertUnpackedFormat(size, lhs);
+  assertUnpackedFormat(size, rhs);
+  return symfpu::lessThan<traits>(size, lhs, rhs);
+}
+
+ASTNode lessThanOrEqual(const floatingPointTypeInfo& size, const uf& lhs,
+                        const uf& rhs)
+{
+  assertUnpackedFormat(size, lhs);
+  assertUnpackedFormat(size, rhs);
+  return symfpu::lessThanOrEqual<traits>(size, lhs, rhs);
+}
+
+#define STP_UNPACKED_CLASSIFY(name, symfpu_fn)                                 \
+  ASTNode name(const floatingPointTypeInfo& size, const uf& value)             \
+  {                                                                            \
+    assertUnpackedFormat(size, value);                                          \
+    return symfpu::symfpu_fn<traits>(size, value);                              \
+  }
+
+STP_UNPACKED_CLASSIFY(isNormal, isNormal)
+STP_UNPACKED_CLASSIFY(isSubnormal, isSubnormal)
+STP_UNPACKED_CLASSIFY(isZero, isZero)
+STP_UNPACKED_CLASSIFY(isInfinite, isInfinite)
+STP_UNPACKED_CLASSIFY(isNaN, isNaN)
+STP_UNPACKED_CLASSIFY(isNegative, isNegative)
+STP_UNPACKED_CLASSIFY(isPositive, isPositive)
+
+#undef STP_UNPACKED_CLASSIFY
+
+uf convertBVToFloat(const floatingPointTypeInfo& target, const ASTNode& rm,
+                    const ASTNode& bits, bool is_signed)
+{
+  return is_signed
+             ? symfpu::convertSBVToFloat<traits>(target, rm, traits::sbv(bits))
+             : symfpu::convertUBVToFloat<traits>(target, rm, traits::ubv(bits));
+}
+
+uf convertFloatToFloat(const floatingPointTypeInfo& source,
+                       const floatingPointTypeInfo& target,
+                       const ASTNode& rm, const uf& value)
+{
+  assertUnpackedFormat(source, value);
+  return symfpu::convertFloatToFloat<traits>(source, target, rm, value);
+}
+
+} // namespace unpacked
+
+// Instantiate both bit-vector flavours in full. symfpu only uses a subset of
+// the interface, so without this the rest is never emitted and cannot be
+// exercised from outside this file -- including by a test.
+template class bitVector<true>;
+template class bitVector<false>;
+
+} // namespace symbolic_fp
+
+} // namespace stp

--- a/lib/NodeFactory/NodeFactory.cpp
+++ b/lib/NodeFactory/NodeFactory.cpp
@@ -154,9 +154,13 @@ ASTNode NodeFactory::CreateSymbol(const char* const name, unsigned indexWidth,
   return n;
 }
 
-ASTNode NodeFactory::CreateConstant(stp::CBV cbv, unsigned width)
+ASTNode NodeFactory::CreateConstant(stp::CBV cbv, unsigned width,
+                                    unsigned exp_width, unsigned sig_width)
 {
-  return bm.CreateBVConst(cbv, width);
+  ASTNode c = bm.CreateBVConst(cbv, width);
+  if (exp_width != 0)
+    c = bm.CreateFPConst(c, exp_width, sig_width);
+  return c;
 }
 
 ASTNode NodeFactory::CreateOneConst(unsigned width)
@@ -186,4 +190,10 @@ ASTNode NodeFactory::CreateBVConst(unsigned int width,
                                    unsigned long long int bvconst)
 {
   return bm.CreateBVConst(width, bvconst);
+}
+
+ASTNode NodeFactory::CreateFPConst(const stp::ASTNode& bvconst,
+                                   unsigned exp_width, unsigned sig_width)
+{
+  return bm.CreateFPConst(bvconst, exp_width, sig_width);
 }

--- a/lib/NodeFactory/SimplifyingNodeFactory.cpp
+++ b/lib/NodeFactory/SimplifyingNodeFactory.cpp
@@ -1757,7 +1757,7 @@ ASTNode SimplifyingNodeFactory::plusRules(const ASTVec& oldChildren)
 
 
 // If the shift is bigger than the bitwidth, replace by an extract.
-ASTNode convertArithmeticKnownShiftAmount(const Kind k,
+ASTNode convertArithmeticKnownShiftAmount([[maybe_unused]] const Kind k,
                                                       const ASTVec& children,
                                                       STPMgr& bm,
                                                       NodeFactory* nf)

--- a/lib/NodeFactory/SimplifyingNodeFactory.cpp
+++ b/lib/NodeFactory/SimplifyingNodeFactory.cpp
@@ -76,6 +76,38 @@ static unsigned lowestOneBit(const stp::ASTNode& n)
   return position;
 }
 
+// Recognise the packed floating-point constants +1.0 and -1.0 at any format:
+// returns 1 for +1.0, -1 for -1.0, and 0 otherwise. Both have an all-zero
+// significand and a biased exponent equal to the bias 2^(eb-1)-1 -- that is,
+// the exponent field is 0 1..1, its top bit clear and its remaining eb-1 bits
+// set -- and the sign bit selects between them. Read straight from the packed
+// representation, so it holds for every width.
+static int fpConstPlusMinusOne(const stp::ASTNode& c)
+{
+  if (c.GetKind() != stp::BVCONST)
+    return 0;
+  const unsigned eb = c.GetExpWidth();
+  const unsigned sb = c.GetSigWidth();
+  // A real IEEE format has eb, sb >= 2, and the packed width must be eb + sb
+  // for the bit indices below to be in range.
+  if (eb < 2 || sb < 2 || c.GetValueWidth() != eb + sb)
+    return 0;
+  stp::CBV bits = c.GetBVConst();
+  // Significand field: bits [0 .. sb-2] all zero.
+  for (unsigned i = 0; i + 1 < sb; i++)
+    if (CONSTANTBV::BitVector_bit_test(bits, i))
+      return 0;
+  // Exponent field is [sb-1 .. sb+eb-2]; the bias is 0 1..1, so its top bit
+  // (sb+eb-2) is clear and its lower eb-1 bits (sb-1 .. sb+eb-3) are all set.
+  if (CONSTANTBV::BitVector_bit_test(bits, sb + eb - 2))
+    return 0;
+  for (unsigned i = sb - 1; i + 1 < sb + eb - 1; i++)
+    if (!CONSTANTBV::BitVector_bit_test(bits, i))
+      return 0;
+  // Matched ±1.0; the sign bit (the top bit) chooses the sign.
+  return CONSTANTBV::BitVector_bit_test(bits, eb + sb - 1) ? -1 : 1;
+}
+
 bool SimplifyingNodeFactory::children_all_constants(
     const ASTVec& children) const
 {
@@ -105,6 +137,21 @@ ASTNode SimplifyingNodeFactory::get_largest_number(const unsigned width)
   CONSTANTBV::BitVector_Fill(max);
   CONSTANTBV::BitVector_Bit_Off(max, width - 1);
   return bm.CreateBVConst(max, width);
+}
+
+ASTNode SimplifyingNodeFactory::foldFPSign(const ASTNode& fpConst, bool flip)
+{
+  const unsigned width = fpConst.GetValueWidth(); // packed: sign is the top bit
+  stp::CBV bits = CONSTANTBV::BitVector_Clone(fpConst.GetBVConst());
+  if (!flip) // abs: clear the sign
+    CONSTANTBV::BitVector_Bit_Off(bits, width - 1);
+  else if (CONSTANTBV::BitVector_bit_test(bits, width - 1)) // neg: flip it
+    CONSTANTBV::BitVector_Bit_Off(bits, width - 1);
+  else
+    CONSTANTBV::BitVector_Bit_On(bits, width - 1);
+
+  return bm.CreateFPConst(bm.CreateBVConst(bits, width),
+                          fpConst.GetExpWidth(), fpConst.GetSigWidth());
 }
 
 ASTNode SimplifyingNodeFactory::create_gt_node(const ASTVec& children)
@@ -292,13 +339,22 @@ ASTNode SimplifyingNodeFactory::CreateNode(Kind kind, const ASTVec& children)
 {
   assert(kind != SYMBOL);
   // These are created specially.
+  //
+
+  /* we need to bypass the constant evaluation if we're creating an FP term
+   * (a table lookup: the FP category comes from ASTKind.kinds) */
+  const bool is_fp_operation = is_FP_kind(kind);
 
   // If all the parameters are constant, return the constant value.
   // The bitblaster calls CreateNode with a boolean vector. We don't try to
   // simplify those.
+  // The type kinds (BOOLEAN..ROUNDINGMODE, API-only nodes) are exempt: a
+  // childless one has "all children constant" vacuously, and the constant
+  // evaluator has no business seeing a type.
   if (kind != stp::UNDEFINED && kind != stp::BOOLEAN &&
       kind != stp::BITVECTOR && kind != stp::ARRAY &&
-      children_all_constants(children))
+      kind != stp::FLOATINGPOINT && kind != stp::ROUNDINGMODE &&
+      !is_fp_operation && children_all_constants(children))
   {
     const ASTNode& hash = hashing.CreateNode(kind, children);
     const ASTNode& c = NonMemberBVConstEvaluator(&bm, hash);
@@ -521,6 +577,54 @@ ASTNode SimplifyingNodeFactory::CreateNode(Kind kind, const ASTVec& children)
       }
       break;
     }
+
+    // ----- Cheap floating-point rewrites, applied before bit-blasting. -----
+    // These fire on the word-level node, so they shrink the circuit symfpu
+    // would otherwise build. Structural only -- constant folding is left to
+    // the blaster, which is why the FP kinds bypass the constant-fold path
+    // above.
+
+    // Classification ignores the sign, so a wrapping abs or neg can be peeled
+    // off. isPositive and isNegative are deliberately excluded: they are the
+    // two predicates that do depend on the sign.
+    case stp::FP_ISNORMAL:
+    case stp::FP_ISSUBNORMAL:
+    case stp::FP_ISZERO:
+    case stp::FP_ISINFINITE:
+    case stp::FP_ISNAN:
+      if (children[0].GetKind() == stp::FP_ABS ||
+          children[0].GetKind() == stp::FP_NEG)
+        result = NodeFactory::CreateNode(kind, children[0][0]);
+      break;
+
+    // x < x and x > x are false, NaN included.
+    case stp::FP_LT:
+    case stp::FP_GT:
+      if (children.size() == 2 && children[0] == children[1])
+        result = ASTFalse;
+      break;
+
+    // x <= x and x >= x hold exactly when x is not NaN.
+    case stp::FP_LEQ:
+    case stp::FP_GEQ:
+      if (children.size() == 2 && children[0] == children[1])
+        result = NodeFactory::CreateNode(
+            stp::NOT, NodeFactory::CreateNode(stp::FP_ISNAN, children[0]));
+      break;
+
+    // Both float equalities are symmetric. Order the operands so that x ~ y
+    // and y ~ x become the same node and share their blasted circuit.
+    case stp::FP_EQ:
+    case stp::FP_SMT_EQ:
+      if (children.size() == 2 &&
+          children[0].GetNodeNum() > children[1].GetNodeNum())
+      {
+        ASTVec swapped;
+        swapped.push_back(children[1]);
+        swapped.push_back(children[0]);
+        result = hashing.CreateNode(kind, swapped);
+      }
+      break;
 
     default:
       result = hashing.CreateNode(kind, children);
@@ -782,10 +886,11 @@ ASTNode SimplifyingNodeFactory::CreateSimpleEQ(const ASTVec& children)
     // terms are syntactically the same
     return ASTTrue;
 
-  // here the terms are definitely not syntactically equal but may be
-  // semantically equal.
+  // Two constant nodes still may be semantically equal: a float constant
+  // interns apart from the plain constant with its bits, so compare the
+  // bits, not the identities.
   if (stp::BVCONST == k1 && stp::BVCONST == k2)
-    return ASTFalse;
+    return stp::constantsSameBits(in1, in2) ? ASTTrue : ASTFalse;
 
   if ((k1 == BVNOT && k2 == BVNOT) || (k1 == BVUMINUS && k2 == BVUMINUS))
     return NodeFactory::CreateNode(EQ, in1[0], in2[0]);
@@ -1274,9 +1379,13 @@ ASTNode SimplifyingNodeFactory::chaseRead(const ASTVec& children,
       // cerr << "-";
       return write[2];
     }
-    else if (read_is_const && stp::BVCONST == write_index.GetKind())
+    else if (read_is_const && stp::BVCONST == write_index.GetKind() &&
+             stp::constantsDenoteDifferentValues(readIndex, write_index))
     {
-      // They are definately different. Ignore this.
+      // Different bits, so definately different. (Distinct constant
+      // nodes alone prove nothing: a float constant interns apart from
+      // the plain constant with its bits; skipping a write this read
+      // hits reads the wrong cell.)
       // cerr << "+";
     }
     else
@@ -1874,8 +1983,12 @@ ASTNode SimplifyingNodeFactory::CreateTerm(Kind kind, unsigned int width,
 
   assert(bm.hashingNodeFactory == &hashing);
 
+  /* we need to bypass the constant evaluation if we're creating an FP term
+   * (a table lookup: the FP category comes from ASTKind.kinds) */
+  const bool is_fp_operation = is_FP_kind(kind);
+
   // If all the parameters are constant, return the constant value.
-  if (children_all_constants(children))
+  if (children_all_constants(children) && !is_fp_operation)
   {
     const ASTNode& hash = hashing.CreateTerm(kind, width, children);
     const ASTNode& c = NonMemberBVConstEvaluator(&bm, hash);
@@ -2917,6 +3030,148 @@ ASTNode SimplifyingNodeFactory::CreateTerm(Kind kind, unsigned int width,
       if (children[0].GetKind() == stp::WRITE)
       {
         result = chaseRead(children, width);
+      }
+      break;
+
+    // ----- Cheap floating-point rewrites, applied before bit-blasting. -----
+    // See the matching block in CreateNode.
+
+    // min(x, x) = max(x, x) = x. The two float operands are children 0 and 1;
+    // the totalising pass may append a choice-of-zero child, but it runs after
+    // this, and the identity holds whether or not it is present.
+    case stp::FP_MIN:
+    case stp::FP_MAX:
+      if (children.size() >= 2 && children[0] == children[1])
+        result = children[0];
+      break;
+
+    // abs(abs x) = abs(neg x) = abs x. On a constant, fold at construction --
+    // the cheap floating-point cases (unlike the arithmetic, which the
+    // constant evaluator folds by bit-blasting -- and would recurse through
+    // here) are pure sign-bit edits, so do them directly and keep the format.
+    // abs clears the sign; neg flips it. Both leave a NaN's payload alone,
+    // matching IEEE fp.abs/fp.neg (and SMT-LIB, where NaN is a single value).
+    case stp::FP_ABS:
+      if (children[0].GetKind() == stp::FP_ABS ||
+          children[0].GetKind() == stp::FP_NEG)
+        result = NodeFactory::CreateTerm(stp::FP_ABS, width, children[0][0]);
+      else if (children[0].GetKind() == stp::BVCONST)
+        result = foldFPSign(children[0], /*flip=*/false);
+      break;
+
+    // neg(neg x) = x.
+    case stp::FP_NEG:
+      if (children[0].GetKind() == stp::FP_NEG)
+        result = children[0][0];
+      else if (children[0].GetKind() == stp::BVCONST)
+        result = foldFPSign(children[0], /*flip=*/true);
+      break;
+
+    // fp.sub(rm, x, y) = fp.add(rm, x, fp.neg y). IEEE-754 defines subtraction
+    // as addition of the negation -- exact for every rounding mode and for
+    // signed zeros -- so lower it and reuse the add machinery (its constant
+    // folding, its commutative ordering, one adder to blast rather than two).
+    case stp::FP_SUB:
+      if (children.size() == 3)
+        result = NodeFactory::CreateTerm(
+            stp::FP_ADD, width, children[0], children[1],
+            NodeFactory::CreateTerm(stp::FP_NEG, width, children[2]));
+      break;
+
+    // fp.add is commutative in its two float operands (child 0 is the rounding
+    // mode). Order them so x + y and y + x share a node.
+    case stp::FP_ADD:
+      if (children.size() == 3 &&
+          children[1].GetNodeNum() > children[2].GetNodeNum())
+      {
+        ASTVec reordered;
+        reordered.push_back(children[0]);
+        reordered.push_back(children[2]);
+        reordered.push_back(children[1]);
+        result = hashing.CreateTerm(stp::FP_ADD, width, reordered);
+      }
+      break;
+
+    // fp.mul is commutative, and has two exact identity operands: x * 1.0 = x
+    // and x * -1.0 = -x, for every value and every rounding mode. 1.0 is the
+    // multiplicative identity and -1.0 its negation, so the product is exactly
+    // x or -x and no rounding happens (NaN, the infinities and the signed zeros
+    // all carry through). Either float operand (child 1 or 2) may be the
+    // constant; child 0 is the rounding mode.
+    case stp::FP_MUL:
+      if (children.size() == 3)
+      {
+        for (unsigned k = 1; result.IsNull() && k <= 2; k++)
+        {
+          const int pm = fpConstPlusMinusOne(children[k]);
+          if (pm == 1)
+            result = children[3 - k];
+          else if (pm == -1)
+            result =
+                NodeFactory::CreateTerm(stp::FP_NEG, width, children[3 - k]);
+        }
+        // Otherwise order the operands so x * y and y * x share a node.
+        if (result.IsNull() &&
+            children[1].GetNodeNum() > children[2].GetNodeNum())
+        {
+          ASTVec reordered;
+          reordered.push_back(children[0]);
+          reordered.push_back(children[2]);
+          reordered.push_back(children[1]);
+          result = hashing.CreateTerm(stp::FP_MUL, width, reordered);
+        }
+      }
+      break;
+
+    // fp.div by 1.0 is exact: x / 1.0 = x. Only the divisor (child 2) folds --
+    // 1.0 / x is not x -- so the dividend is left alone. (-1.0 is deliberately
+    // not handled here; x / -1.0 -> -x could be added the same way.)
+    case stp::FP_DIV:
+      if (children.size() == 3 && fpConstPlusMinusOne(children[2]) == 1)
+        result = children[1];
+      break;
+
+    // fp.fma(rm, x, y, z) computes round(x*y + z); the two multiplicands x
+    // and y (children 1 and 2) are symmetric, so order them, keeping the
+    // rounding mode (child 0) and the addend (child 3) in place.
+    case stp::FP_FMA:
+      if (children.size() == 4 &&
+          children[1].GetNodeNum() > children[2].GetNodeNum())
+      {
+        ASTVec reordered;
+        reordered.push_back(children[0]);
+        reordered.push_back(children[2]);
+        reordered.push_back(children[1]);
+        reordered.push_back(children[3]);
+        result = hashing.CreateTerm(stp::FP_FMA, width, reordered);
+      }
+      break;
+
+    // fp.rem(a, b) is exact, so several structural identities hold. Applied
+    // one per construction; the recursive calls re-simplify, so nested cases
+    // compose. Child 0 is the dividend a, child 1 the divisor b -- there is
+    // no rounding mode.
+    case stp::FP_REM:
+      if (children.size() == 2)
+      {
+        // rem(rem(a, b), b) = rem(a, b): a second remainder by the same
+        // divisor is a no-op.
+        if (children[0].GetKind() == stp::FP_REM &&
+            children[0][1] == children[1])
+          result = children[0];
+        // rem(a, -b) = rem(a, |b|) = rem(a, b): the divisor's sign is
+        // irrelevant.
+        else if (children[1].GetKind() == stp::FP_ABS ||
+                 children[1].GetKind() == stp::FP_NEG)
+          result = NodeFactory::CreateTerm(stp::FP_REM, width, children[0],
+                                           children[1][0]);
+        // rem(-a, b) = -rem(a, b): negating the dividend negates the result,
+        // so lift the negation out where it can meet another and cancel.
+        else if (children[0].GetKind() == stp::FP_NEG)
+          result = NodeFactory::CreateTerm(
+              stp::FP_NEG, width,
+              NodeFactory::CreateTerm(stp::FP_REM, width, children[0][0],
+                                      children[1]));
       }
       break;
 

--- a/lib/STPManager/STP.cpp
+++ b/lib/STPManager/STP.cpp
@@ -1,5 +1,5 @@
 /********************************************************************
- * AUTHORS: Vijay Ganesh, Trevor Hansen, Andrew V. Jones
+ * AUTHORS: Vijay Ganesh, Trevor Hansen, Andrew Teylu
  *
  * BEGIN DATE: November, 2005
  *
@@ -165,6 +165,11 @@ SOLVER_RETURN_TYPE STP::TopLevelSTP(const ASTNode& inputasserts,
                                     const ASTNode& query)
 {
 
+  // One encoding context per actual solve. Keep it after this function
+  // returns so counterexample/get-value requests reuse the exact mappings
+  // that introduced unspecified-value arrays and lowered the solved formula.
+  fpEncodingContext.reset(new FpEncodingContext(bm));
+
   // Unfortunatey this is a global variable,which the aux function needs to
   // overwrite sometimes.
   bool saved_ack = bm->UserFlags.ackermannisation;
@@ -180,7 +185,27 @@ SOLVER_RETURN_TYPE STP::TopLevelSTP(const ASTNode& inputasserts,
     original_input = inputasserts;
   }
 
+  // The latch is the same kind of cheap fast-negative the lowering test below
+  // uses, widened to cover RoundingMode -- which carries no format, so it
+  // never reaches noteFloatingPoint, and which is exactly why this test could
+  // not use has_floating_point. Without a negative every pure bit-vector
+  // query walked its whole DAG asking each node for its source sort.
+  const bool input_uses_floating_point_theory =
+      bm->has_floating_point_theory &&
+      containsFloatingPointTheory(original_input, bm);
+
+  // Make the partial floating-point operations total, canonicalise the
+  // indexes of float-indexed arrays, and pin every rounding mode the formula
+  // names to the five legal encodings -- before the formula is used for
+  // anything. See FpTotalise. This is query-local: an unused or popped FP
+  // term must not send a later pure-BV query through an FP-only pass.
+  // RoundingMode-element arrays and RoundingMode symbols can each appear
+  // without a single float node, hence the broader source-theory test.
+  if (input_uses_floating_point_theory)
+    original_input = fpEncodingContext->prepare(original_input);
+
   SATSolver* newS = get_new_sat_solver();
+
   SOLVER_RETURN_TYPE result = solve_by_sat_solver(newS, original_input);
   delete newS;
 
@@ -291,6 +316,13 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input)
 {
   bm->ASTNodeStats("input asserts and query: ", original_input);
 
+  // has_floating_point is deliberately only a manager-lifetime fast-negative
+  // hint. A float built in a popped scope (or never asserted at all) must not
+  // send this query through the lowering pass. Do not reset the hint on pop:
+  // public AST handles may retain the old node and use it in a later query.
+  const bool input_has_floating_point =
+      bm->has_floating_point && containsFloatingPoint(original_input, bm);
+
   DifficultyScore difficulty;
   if (bm->UserFlags.stats_flag)
     cerr << "Difficulty Initially:" << difficulty.score(original_input, bm)
@@ -382,6 +414,33 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input)
   {
     inputToSat =
         callSizeReducing(inputToSat, bvSolver.get(), pe.get(), domain.get());
+  }
+
+  // Lower floating-point operations before the first pass that invokes the
+  // bit-blaster. From here on the formula is a packed-bit circuit: float
+  // symbols, constants and reads retain sort metadata for model reconstruction,
+  // but no FP operation reaches a bitvector-only pass.
+  //
+  // This remains after all of the size-reducing passes above. In particular,
+  // RemoveUnconstrained must see a float symbol rather than its exposed bits.
+  // The old location was just below the difficulty snapshot, but that let the
+  // optional bit-blast simplification here receive FP_EQ and other floating-
+  // point nodes when --bit-blast-simplification enabled it.
+  //
+  // See FloatBlast for why this is a pass of its own: doing it inside
+  // simplification meant building floating-point nodes over bitvector
+  // children and stamping a float format on them to make them type check,
+  // and that stamp landed on hash-consed nodes the input still used as plain
+  // bitvectors.
+  if (input_has_floating_point)
+  {
+    inputToSat = fpEncodingContext->lowerPrepared(inputToSat);
+    bm->ASTNodeStats("After floating-point lowering: ", inputToSat);
+
+    // The threshold controls the cost of bit-blasting the formula in its
+    // lowered form, so compare it with that form's difficulty rather than the
+    // much smaller word-level FP syntax. The always setting (-1) is unchanged.
+    initial_difficulty_score = difficulty.score(inputToSat, bm);
   }
 
   long bitblasted_difficulty = -1;

--- a/lib/STPManager/STPManager.cpp
+++ b/lib/STPManager/STPManager.cpp
@@ -24,6 +24,7 @@ THE SOFTWARE.
 
 // to get the PRIu64 macro from inttypes, this needs to be defined.
 #include "stp/STPManager/STPManager.h"
+#include "stp/FloatBlaster/rounding_modes.h"
 #include "stp/Printer/SMTLIBPrinter.h"
 #include "stp/Util/CBVOps.h"
 #include "stp/Util/NodeIterator.h"
@@ -138,9 +139,29 @@ ostream& operator<<(ostream& os, const ASTNodeMap& nmap)
 ////////////////////////////////////////////////////////////////
 ASTNode STPMgr::LookupOrCreateSymbol(const char* const name)
 {
+  // This legacy entry point has no sort parameter. Preserve its historical
+  // name lookup semantics for internal clients, while all typed public
+  // declarations go through CreateSourceSymbol instead.
+  ASTNode existing;
+  if (LookupSymbol(name, existing))
+    return existing;
+
   ASTSymbol temp_sym(this, name);
   ASTNode n(LookupOrCreateSymbol(temp_sym));
   return n;
+}
+
+ASTNode STPMgr::CreateSourceSymbol(const char* const name,
+                                   const SourceSort& source_sort)
+{
+  if (!source_sort.isKnown())
+    FatalError("CreateSourceSymbol requires a known source sort");
+  if (source_sort.containsFloatingPoint())
+    noteFloatingPoint();
+  else if (source_sort.usesFloatingPointTheory())
+    noteFloatingPointTheory();
+  ASTSymbol temp_sym(this, name, source_sort);
+  return ASTNode(LookupOrCreateSymbol(temp_sym));
 }
 
 // FIXME: _name is now a constant field, and this assigns to it
@@ -168,10 +189,15 @@ ASTSymbol* STPMgr::LookupOrCreateSymbol(ASTSymbol& s)
     // _name because it's const).  Can cast the iterator to
     // non-const -- carefully.
     // std::string strname(s_ptr->GetName());
-    ASTSymbol* s_ptr1 = new ASTSymbol(this, strdup(s_ptr->GetName()));
+    ASTSymbol* s_ptr1 =
+        new ASTSymbol(this, strdup(s_ptr->GetName()), s_ptr->_source_sort);
     s_ptr1->_value_width = s_ptr->_value_width;
+    s_ptr1->_index_width = s_ptr->_index_width;
+    s_ptr1->_exp_width = s_ptr->_exp_width;
+    s_ptr1->_sig_width = s_ptr->_sig_width;
     std::pair<ASTSymbolSet::const_iterator, bool> p =
         _symbol_unique_table.insert(s_ptr1);
+    indexSymbolName(s_ptr1);
     return *p.first;
   }
   else
@@ -179,6 +205,56 @@ ASTSymbol* STPMgr::LookupOrCreateSymbol(ASTSymbol& s)
     // return symbol found in table.
     return *it;
   }
+}
+
+ASTNode STPMgr::introducedSymbol(const std::string& name,
+                                 unsigned index_width, unsigned value_width)
+{
+  const std::map<std::string, ASTNode>::const_iterator found =
+      _introduced_by_name.find(name);
+  if (found != _introduced_by_name.end())
+    return found->second;
+
+  // Only ever on the first request, and only reachable if a public boundary
+  // let a reserved name through, which is precisely what they refuse. Adopting
+  // the existing symbol instead -- which is what the name-only lookup below
+  // does unaided -- makes a user's declaration into one of STP's own objects.
+  if (LookupSymbol(name.c_str()))
+    FatalError("introducedSymbol: a symbol STP reserves for itself has "
+               "already been declared: ",
+               ASTUndefined, 0);
+
+  const ASTNode symbol =
+      defaultNodeFactory->CreateSymbol(name.c_str(), index_width, value_width);
+  noteIntroducedSymbol(symbol);
+  _introduced_by_name[name] = symbol;
+  return symbol;
+}
+
+void STPMgr::indexSymbolName(ASTSymbol* symbol)
+{
+  _symbol_name_index[symbol->GetName()].push_back(symbol);
+}
+
+void STPMgr::unindexSymbolName(ASTSymbol* symbol)
+{
+  const SymbolNameIndex::iterator entry =
+      _symbol_name_index.find(symbol->GetName());
+  if (entry == _symbol_name_index.end())
+    return;
+
+  std::vector<ASTSymbol*>& declared = entry->second;
+  for (size_t i = 0; i < declared.size(); i++)
+  {
+    if (declared[i] == symbol)
+    {
+      declared.erase(declared.begin() + i);
+      break;
+    }
+  }
+
+  if (declared.empty())
+    _symbol_name_index.erase(entry);
 }
 
 bool STPMgr::LookupSymbol(ASTSymbol& s)
@@ -191,27 +267,27 @@ bool STPMgr::LookupSymbol(ASTSymbol& s)
     return true;
 }
 
+// The two name-only lookups. A symbol's sort is part of its identity, so
+// these cannot probe the unique table; they go through the name index, which
+// is maintained alongside it (see _symbol_name_index).
 bool STPMgr::LookupSymbol(const char* const name)
 {
-  ASTSymbol s(this, name);
-  ASTSymbol* s_ptr = &s; // it's a temporary key.
-
-  if (_symbol_unique_table.find(s_ptr) == _symbol_unique_table.end())
-    return false;
-  else
-    return true;
+  return _symbol_name_index.find(name) != _symbol_name_index.end();
 }
 
 bool STPMgr::LookupSymbol(const char* const name, ASTNode& output)
 {
-  ASTSymbol temp_sym(this, name);
-  ASTSymbolSet::const_iterator it = _symbol_unique_table.find(&temp_sym);
-  if (it != _symbol_unique_table.end())
-  {
-    output = ASTNode(*it);
-    return true;
-  }
-  return false;
+  const SymbolNameIndex::const_iterator entry = _symbol_name_index.find(name);
+  if (entry == _symbol_name_index.end())
+    return false;
+
+  // The first symbol declared under the name, where the old scan returned
+  // whichever the table happened to iterate first. Only a name declared at
+  // two different sorts can tell the difference, and then a deterministic
+  // answer is the better one.
+  assert(!entry->second.empty());
+  output = ASTNode(entry->second.front());
+  return true;
 }
 
 // Create a ASTBVConst node
@@ -249,7 +325,10 @@ ASTNode STPMgr::CreateBVConst(unsigned int width,
                                       c_val);
     if (shift_amount < (sizeof(bvconst) * 8))
     {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshift-count-overflow"
       bvconst >>= shift_amount;
+#pragma GCC diagnostic pop
     }
     else
     {
@@ -344,6 +423,279 @@ ASTNode STPMgr::CreateBVConst(CBV bv, unsigned width)
   ASTNode n(LookupOrCreateBVConst(temp_bvconst));
   CONSTANTBV::BitVector_Destroy(bv);
   return n;
+}
+
+void STPMgr::noteFloatingPoint()
+{
+#ifndef STP_ENABLE_FLOATING_POINT
+  FatalError("this STP was built without floating-point support; "
+             "reconfigure with -DENABLE_FLOATING_POINT=ON");
+#else
+  has_floating_point = true;
+  has_floating_point_theory = true;
+#endif
+}
+
+ASTNode STPMgr::CreateFPConst(const stp::ASTNode& bvconst,
+                              unsigned exp_width, unsigned sig_width)
+{
+#ifndef STP_ENABLE_FLOATING_POINT
+  (void)bvconst;
+  (void)exp_width;
+  (void)sig_width;
+  FatalError("this STP was built without floating-point support; "
+             "reconfigure with -DENABLE_FLOATING_POINT=ON");
+#else
+  assert(bvconst.GetKind() == BVCONST);
+  assert(exp_width + sig_width == bvconst.GetValueWidth());
+
+  // Temporary key sharing the source's CBV; interning clones it.
+  ASTBVConst* src = (ASTBVConst*)bvconst._int_node_ptr;
+
+  // Every NaN pattern interns as the one canonical quiet NaN. SMT-LIB's
+  // FloatingPoint sort has a single NaN, and no operation can recover a
+  // payload (fp.to_ieee_bv canonicalises; symfpu carries none) -- but the
+  // node-creation-time simplifiers do compare constants by identity and by
+  // bit pattern (chaseRead's "definately different" skip, CreateSimpleEQ's
+  // constant case), and they run before any pass could quotient NaN. Two
+  // NaN literals with different payloads used as array indexes would be
+  // "proved" to address different cells. Baking the quotient into the
+  // constant itself makes those comparisons exact: distinct floating-point
+  // constants of one format now denote distinct values.
+  {
+    CBV b = src->GetBVConst();
+    const unsigned stored_sig = sig_width - 1; // the hidden bit is not stored
+    bool exp_all_ones = true;
+    for (unsigned i = 0; exp_all_ones && i < exp_width; i++)
+      exp_all_ones = CONSTANTBV::BitVector_bit_test(b, stored_sig + i);
+    bool sig_nonzero = false;
+    for (unsigned i = 0; !sig_nonzero && i < stored_sig; i++)
+      sig_nonzero = CONSTANTBV::BitVector_bit_test(b, i);
+
+    if (exp_all_ones && sig_nonzero)
+    {
+      // Already canonical -- positive, and only the quiet bit set -- means
+      // stop, or the CreateFPSpecialConst below would recurse forever.
+      bool low_payload_zero = true;
+      for (unsigned i = 0; low_payload_zero && i + 1 < stored_sig; i++)
+        low_payload_zero = !CONSTANTBV::BitVector_bit_test(b, i);
+      const bool canonical =
+          low_payload_zero &&
+          CONSTANTBV::BitVector_bit_test(b, stored_sig - 1) &&
+          !CONSTANTBV::BitVector_bit_test(b, exp_width + sig_width - 1);
+      if (!canonical)
+        return CreateFPSpecialConst(FPSpecial::NaN, exp_width, sig_width);
+    }
+  }
+
+  ASTFPConst temp(this, src->GetBVConst(), exp_width, sig_width);
+
+  noteFloatingPoint();
+
+  ASTNode n(LookupOrCreateFPConst(temp));
+  assert(n.GetKind() == BVCONST);
+  return n;
+#endif
+}
+
+// As LookupOrCreateBVConst. The same table holds both flavours of constant:
+// the equality functor compares the format widths too, so a floating-point
+// constant never unifies with a plain bitvector constant of the same bits.
+ASTFPConst* STPMgr::LookupOrCreateFPConst(ASTFPConst& s)
+{
+  ASTBVConstSet::const_iterator it = _bvconst_unique_table.find(&s);
+  if (it != _bvconst_unique_table.end())
+    return static_cast<ASTFPConst*>(*it);
+
+  ASTFPConst* s_copy = new ASTFPConst(s);
+  _bvconst_unique_table.insert(s_copy);
+  return s_copy;
+}
+
+ASTNode STPMgr::CreateRMConst(unsigned mode)
+{
+#ifndef STP_ENABLE_FLOATING_POINT
+  (void)mode;
+  FatalError("this STP was built without floating-point support; "
+             "reconfigure with -DENABLE_FLOATING_POINT=ON");
+#else
+  using namespace symbolic_fp;
+  switch (mode)
+  {
+    case ROUND_NEAREST_TIES_TO_EVEN:
+    case ROUND_TOWARD_POSITIVE:
+    case ROUND_TOWARD_NEGATIVE:
+    case ROUND_TOWARD_ZERO:
+    case ROUND_NEAREST_TIES_TO_AWAY:
+      break;
+    default:
+      FatalError("CreateRMConst requires one of the five rounding modes");
+  }
+
+  // A rounding mode has no format, so noteFloatingPoint is never reached for
+  // it -- but it still needs FpTotalise's pinning pass to run.
+  noteFloatingPointTheory();
+
+  const ASTNode bits = CreateBVConst(5, mode);
+  ASTBVConst* src = static_cast<ASTBVConst*>(bits._int_node_ptr);
+  ASTRMConst temp(this, src->GetBVConst());
+  return ASTNode(LookupOrCreateRMConst(temp));
+#endif
+}
+
+ASTRMConst* STPMgr::LookupOrCreateRMConst(ASTRMConst& s)
+{
+  const ASTBVConstSet::const_iterator it = _bvconst_unique_table.find(&s);
+  if (it != _bvconst_unique_table.end())
+    return static_cast<ASTRMConst*>(*it);
+
+  ASTRMConst* copy = new ASTRMConst(s);
+  _bvconst_unique_table.insert(copy);
+  return copy;
+}
+
+ASTNode STPMgr::LiftSourceValue(const ASTNode& carrier,
+                                const SourceSort& source_sort)
+{
+  switch (source_sort.kind())
+  {
+    case SourceSort::Kind::FloatingPoint:
+      if (carrier.GetKind() != BVCONST ||
+          carrier.GetValueWidth() != source_sort.packedWidth())
+        FatalError("LiftSourceValue: invalid floating-point carrier: ",
+                   carrier);
+      return CreateFPConst(carrier, source_sort.exponentWidth(),
+                           source_sort.significandWidth());
+    case SourceSort::Kind::RoundingMode:
+      if (carrier.GetKind() != BVCONST || carrier.GetValueWidth() != 5)
+        FatalError("LiftSourceValue: invalid RoundingMode carrier: ", carrier);
+      return CreateRMConst(carrier.GetUnsignedConst());
+    case SourceSort::Kind::Bool:
+      if (carrier != ASTTrue && carrier != ASTFalse)
+        FatalError("LiftSourceValue: invalid Boolean carrier: ", carrier);
+      return carrier;
+    case SourceSort::Kind::BitVector:
+      if (carrier.GetKind() != BVCONST ||
+          carrier.GetValueWidth() != source_sort.bitVectorWidth())
+        FatalError("LiftSourceValue: invalid bitvector carrier: ", carrier);
+      return carrier;
+    default:
+      FatalError("LiftSourceValue: cannot lift this source sort");
+  }
+}
+
+ASTNode STPMgr::roundingModeValidConstraint(const ASTNode& s)
+{
+  using namespace symbolic_fp;
+  ASTVec one_of;
+  for (const unsigned mode :
+       {ROUND_NEAREST_TIES_TO_EVEN, ROUND_TOWARD_POSITIVE,
+        ROUND_TOWARD_NEGATIVE, ROUND_TOWARD_ZERO, ROUND_NEAREST_TIES_TO_AWAY})
+  {
+    one_of.push_back(
+        defaultNodeFactory->CreateNode(EQ, s, CreateRMConst(mode)));
+  }
+  return defaultNodeFactory->CreateNode(OR, one_of);
+}
+
+bool STPMgr::isRoundingModeSortedTerm(const ASTNode& n) const
+{
+  return n.GetSourceSort().kind() == SourceSort::Kind::RoundingMode;
+}
+
+ASTNode STPMgr::arrayBaseSymbol(const ASTNode& arr) const
+{
+  ASTNode n = arr;
+  while (true)
+  {
+    switch (n.GetKind())
+    {
+      case SYMBOL:
+        return n;
+      case WRITE:
+        n = n[0];
+        break;
+      case ITE:
+      {
+        // Both branches type as arrays of one bit layout; requiring one
+        // *sort* keeps a read from being canonicalised under one branch's
+        // index sort and taken raw under the other's.
+        const ASTNode left = arrayBaseSymbol(n[1]);
+        const ASTNode right = arrayBaseSymbol(n[2]);
+        if (left.IsNull())
+          return right;
+        if (!right.IsNull() && left.GetSourceSort() != right.GetSourceSort())
+          FatalError("arrayBaseSymbol: an if-then-else mixes arrays whose "
+                     "index or element sorts differ: ",
+                     n);
+        return left;
+      }
+      default:
+        return ASTNode();
+    }
+  }
+}
+
+bool STPMgr::arrayHasFpIndex(const ASTNode& arr, unsigned& exp_width,
+                             unsigned& sig_width) const
+{
+  const SourceSort sort = arr.GetSourceSort();
+  if (sort.kind() != SourceSort::Kind::Array ||
+      sort.index().kind() != SourceSort::Kind::FloatingPoint)
+    return false;
+  exp_width = sort.index().exponentWidth();
+  sig_width = sort.index().significandWidth();
+  return true;
+}
+
+bool STPMgr::arrayHasRmIndex(const ASTNode& arr) const
+{
+  const SourceSort sort = arr.GetSourceSort();
+  return sort.kind() == SourceSort::Kind::Array &&
+         sort.index().kind() == SourceSort::Kind::RoundingMode;
+}
+
+bool STPMgr::arrayHasRmElement(const ASTNode& arr) const
+{
+  const SourceSort sort = arr.GetSourceSort();
+  return sort.kind() == SourceSort::Kind::Array &&
+         sort.element().kind() == SourceSort::Kind::RoundingMode;
+}
+
+ASTNode STPMgr::CreateFPSpecialConst(FPSpecial which, unsigned exp_width,
+                                     unsigned sig_width)
+{
+  if (exp_width == 0 || sig_width == 0)
+    FatalError("CreateFPSpecialConst: a floating-point format needs nonzero "
+               "exponent and significand widths");
+
+  const unsigned width = exp_width + sig_width;
+  const unsigned stored_sig = sig_width - 1; // the hidden bit is not stored
+
+  // Packed layout, LSB first: [significand | exponent | sign].
+  CBV bits = CONSTANTBV::BitVector_Create(width, true);
+
+  const bool negative =
+      which == FPSpecial::MinusInfinity || which == FPSpecial::MinusZero;
+  const bool exp_all_ones = which == FPSpecial::NaN ||
+                            which == FPSpecial::PlusInfinity ||
+                            which == FPSpecial::MinusInfinity;
+
+  if (negative)
+    CONSTANTBV::BitVector_Bit_On(bits, width - 1);
+  for (unsigned i = 0; exp_all_ones && i < exp_width; i++)
+    CONSTANTBV::BitVector_Bit_On(bits, stored_sig + i);
+  // symfpu's canonical NaN: exponent all ones and only the top stored-
+  // significand bit set (pack() emits nanPattern(packedSigWidth) =
+  // 1 << (stored_sig - 1), the quiet-bit convention). Matching it keeps the
+  // interned constant bit-identical to the NaN every blasted operation
+  // produces. Semantically either way is a NaN; bit-identical is tidier.
+  if (which == FPSpecial::NaN && stored_sig > 0)
+    CONSTANTBV::BitVector_Bit_On(bits, stored_sig - 1);
+
+  // CreateBVConst destroys `bits`.
+  ASTNode packed = CreateBVConst(bits, width);
+  return CreateFPConst(packed, exp_width, sig_width);
 }
 
 ASTNode STPMgr::CreateZeroConst(unsigned width)
@@ -657,6 +1009,7 @@ STPMgr::~STPMgr()
 
   Introduced_SymbolsSet.clear();
   _symbol_unique_table.clear();
+  _symbol_name_index.clear();
   _bvconst_unique_table.clear();
 
   vector<ASTVec*>::iterator it = _asserts.begin();

--- a/lib/Sat/CryptoMinisat5.cpp
+++ b/lib/Sat/CryptoMinisat5.cpp
@@ -203,7 +203,7 @@ void CryptoMiniSat5::solveAndDump()
 // return value carries no information.
 uint32_t CryptoMiniSat5::getFixedCountWithAssumptions(const stp::SATSolver::vec_literals& assumps, const std::unordered_set<unsigned>& literals, bool& conflict )
 {
-  const uint64_t conf = s->get_sum_conflicts();
+  [[maybe_unused]] const uint64_t conf = s->get_sum_conflicts();
   assert(conf == 0);
 
 

--- a/lib/Simplifier/BVSolver.cpp
+++ b/lib/Simplifier/BVSolver.cpp
@@ -56,6 +56,30 @@ namespace stp
 const bool flatten_ands = true;
 const bool debug_bvsolver = false;
 
+// Whether eliminating `var` in favour of `value` keeps the floating-point
+// format `var` carries.
+//
+// A float's format is per-node state that only a leaf, a floating-point-kind
+// node or an array can hold (see ASTNode::canStoreFPFormat), so an ordinary
+// bitvector term -- everything this file builds to replace a variable with --
+// answers (0, 0) whatever it denotes. The floating-point layer is still
+// unlowered while the solver runs: FloatBlast comes after the size-reducing
+// passes, and it reads an operation's format off its operands, because by
+// then they are the only thing that still says what sort they are (see
+// FloatBlaster::operandFormat). So a float-typed variable rewritten into a
+// concatenation leaves fp.isZero and friends blasting against a format of
+// (0, 0) -- a packed width of zero against a 64-bit operand.
+//
+// Non-floats compare (0, 0) against (0, 0), so this is only ever a question
+// about floats. The same invariant UpdateSubstitutionMap asserts; the
+// solver map's own entry point does not check, so the check has to happen
+// here, before the equation that justifies the entry is discarded.
+static bool keepsFPFormat(const ASTNode& var, const ASTNode& value)
+{
+  return var.GetExpWidth() == value.GetExpWidth() &&
+         var.GetSigWidth() == value.GetSigWidth();
+}
+
 // The simplify functions can increase the size of the DAG,
 // so we have the option to disable simplifications.
 ASTNode BVSolver::simplifyNode(const ASTNode n)
@@ -270,6 +294,11 @@ ASTNode BVSolver::substitute(const ASTNode& eq, const ASTNode& lhs,
         return eq;
       }
 
+      // The right-hand side stands in for the variable everywhere, so it has
+      // to be the same sort of thing -- as a float too, not just as bits.
+      if (!keepsFPFormat(lhs, rhs))
+        return eq;
+
       if (!_simp->UpdateSolverMap(lhs, rhs))
       {
         return eq;
@@ -290,6 +319,15 @@ ASTNode BVSolver::substitute(const ASTNode& eq, const ASTNode& lhs,
       }
 
       if (vars.VarSeenInTerm(lhs[0], rhs))
+      {
+        return eq;
+      }
+
+      // Solving here renames the whole variable, not just the bits the
+      // extract names: below it becomes a concatenation, which carries no
+      // floating-point format at all. So a float-typed variable is left
+      // alone, extract equation and all. See keepsFPFormat.
+      if (lhs[0].GetExpWidth() != 0)
       {
         return eq;
       }
@@ -332,6 +370,15 @@ ASTNode BVSolver::substitute(const ASTNode& eq, const ASTNode& lhs,
       }
 
       bool ChosenVar_Is_Extract = (BVEXTRACT == lhs[1].GetKind());
+
+      // The variable becomes a multiple of the right-hand side, or a
+      // concatenation ending in one. Both are bitvector terms with no
+      // floating-point format to carry, so a float-typed variable is left
+      // alone. See keepsFPFormat.
+      if ((ChosenVar_Is_Extract ? lhs[1][0] : lhs[1]).GetExpWidth() != 0)
+      {
+        return eq;
+      }
 
       // if coeff is even, then we know that all the coeffs in the eqn
       // are even. Simply return the eqn

--- a/lib/Simplifier/PropagateEqualities.cpp
+++ b/lib/Simplifier/PropagateEqualities.cpp
@@ -239,12 +239,24 @@ void PropagateEqualities::processCandidates()
           return left->id > right->id;
       return false;
     };
+  // Fill the backing vector first and heapify once, rather than pushing
+  // into an empty queue element by element: that is O(n) instead of
+  // O(n log n), and the pop order is unchanged because cmp is a total order
+  // (equal variable counts are broken by the unique id).
+  //
+  // It also sidesteps a GCC false positive. Move-constructing the queue from
+  // an *empty* reserved vector runs make_heap over a range GCC cannot see is
+  // empty, and it then derives an absurd trip count and reports
+  // -Waggressive-loop-optimizations, which is fatal under -Werror in a
+  // release build.
   vector<qType> qStore;
   qStore.reserve(mapped.size());
-  std::priority_queue < qType, vector<qType>, decltype(cmp) > q(cmp, std::move(qStore));
 
   for (const auto& e: mapped)
-    q.push(&e.second);
+    qStore.push_back(&e.second);
+
+  std::priority_queue<qType, vector<qType>, decltype(cmp)> q(
+      cmp, std::move(qStore));
 
   std::vector<uint64_t> replacedOrder;
   replacedOrder.reserve(mapped.size());

--- a/lib/Simplifier/RemoveUnconstrained.cpp
+++ b/lib/Simplifier/RemoveUnconstrained.cpp
@@ -96,6 +96,10 @@ RemoveUnconstrained::replaceParentWithFresh(MutableASTNode& mute,
   const ASTNode& parent = mute.n;
   ASTNode v =
       bm.CreateFreshVariable(0, parent.GetValueWidth(), "unconstrained");
+  // A float-valued parent's stand-in must carry the format too, or the
+  // blaster later meets a formatless bitvector where a float belongs.
+  v.SetExpWidth(parent.GetExpWidth());
+  v.SetSigWidth(parent.GetSigWidth());
   mute.replaceWithVar(v, variables);
   return v;
 }

--- a/lib/Simplifier/Simplifier.cpp
+++ b/lib/Simplifier/Simplifier.cpp
@@ -23,6 +23,7 @@ THE SOFTWARE.
 ********************************************************************/
 
 #include "stp/Simplifier/Simplifier.h"
+#include "stp/FloatBlaster/FloatBlaster.h"
 #include <cassert>
 #include <cmath>
 
@@ -406,6 +407,40 @@ ASTNode Simplifier::SimplifyAtomicFormula(const ASTNode& a, bool pushNeg)
       output = pushNeg ? nf->CreateNode(NOT, output) : output;
       break;
     }
+    case FP_LEQ:
+    case FP_LT:
+    case FP_GEQ:
+    case FP_GT:
+    case FP_EQ:
+    case FP_ISNORMAL:
+    case FP_ISSUBNORMAL:
+    case FP_ISZERO:
+    case FP_ISINFINITE:
+    case FP_ISNAN:
+    case FP_ISNEGATIVE:
+    case FP_ISPOSITIVE:
+    case FP_SMT_EQ:
+    {
+      // Rebuild at the node's real arity: the comparisons are binary but the
+      // classification predicates are unary. Nothing here lowers anything --
+      // see the floating-point arm of simplify_term_switch, and FloatBlast.
+      ASTVec simplified;
+      simplified.reserve(a.Degree());
+
+      for (unsigned int i = 0; i < a.Degree(); i++)
+        simplified.push_back(SimplifyTerm(a[i]));
+
+      // The factory may rewrite the predicate rather than build it: constant
+      // operands fold to true/false, and the same-operand rules fire (fp.leq
+      // of a term with itself comes back as (not (fp.isNaN ...))) -- interned
+      // constants compare pointer-equal, so equal values are the same
+      // operand.
+      output = nf->CreateNode(kind, simplified);
+      if (pushNeg)
+        output = nf->CreateNode(NOT, output);
+
+      break;
+    }
     default:
       FatalError("SimplifyAtomicFormula: "
                  "NO atomic formula of the kind: ",
@@ -610,6 +645,16 @@ ASTNode Simplifier::PullUpITE(const ASTNode& in)
     result = nf->CreateTerm(ITE, in.GetValueWidth(), in[0][0], l1, l2);
   }
 
+  // A rebuilt node cannot lose the input's floating-point format. The
+  // interesting case is not a float operation (those derive their format
+  // from their children) but a plain bitvector node carrying a format
+  // *stamp*: the canonicalised index of a float-indexed array is a
+  // bitvector circuit stamped with the index's format (see FpTotalise),
+  // and pulling an if-then-else out of, say, its concatenation must
+  // keep the stamp or the node changes type. No-op for everything else.
+  result = FloatBlaster::withFormat(_bm, result, in.GetExpWidth(),
+                                    in.GetSigWidth());
+
   assert(result.GetType() == in.GetType());
   assert(result.GetValueWidth() == in.GetValueWidth());
   assert(result.GetIndexWidth() == in.GetIndexWidth());
@@ -645,8 +690,9 @@ ASTNode Simplifier::ITEOpt_InEqs(const ASTNode& in)
   }
   else if (BVCONST == k1 && BVCONST == k2)
   {
-    assert(in1 != in2);
-    output = ASTFalse;
+    // Distinct constant nodes may still spell one value (a float
+    // constant interns apart from the plain constant with its bits).
+    output = constantsSameBits(in1, in2) ? ASTTrue : ASTFalse;
   }
   else if (ITE == k1 && BVCONST == in1[1].GetKind() &&
            BVCONST == in1[2].GetKind() && BVCONST == k2)
@@ -661,13 +707,17 @@ ASTNode Simplifier::ITEOpt_InEqs(const ASTNode& in)
     // c = ITE(cond,d,c) <=> NOT(cond)
     //
     // similarly ITE(cond,d,c) = d <=> NOT(cond)
+    // The "other branch differs" side conditions compare values, not
+    // nodes: with both branches spelling one value the equality holds
+    // whatever the condition, and folding to the condition would be
+    // wrong.
     ASTNode cond = in1[0];
-    if (in1[1] == in2 && (in2 != in1[2]))
+    if (in1[1] == in2 && constantsDenoteDifferentValues(in2, in1[2]))
     {
       // ITE(cond, c, d) = c <=> cond
       output = cond;
     }
-    else if (in1[2] == in2 && (in2 != in1[1]))
+    else if (in1[2] == in2 && constantsDenoteDifferentValues(in2, in1[1]))
     {
       cond = SimplifyFormula(cond, true);
       output = cond;
@@ -682,12 +732,12 @@ ASTNode Simplifier::ITEOpt_InEqs(const ASTNode& in)
            BVCONST == in2[2].GetKind() && BVCONST == k1)
   {
     ASTNode cond = in2[0];
-    if (in2[1] == in1 && (in1 != in2[2]))
+    if (in2[1] == in1 && constantsDenoteDifferentValues(in1, in2[2]))
     {
       // ITE(cond, c, d) = c <=> cond
       output = cond;
     }
-    else if (in2[2] == in1 && (in1 != in2[1]))
+    else if (in2[2] == in1 && constantsDenoteDifferentValues(in1, in2[1]))
     {
       cond = SimplifyFormula(cond, true);
       output = cond;
@@ -720,10 +770,11 @@ ASTNode Simplifier::CreateSimplifiedEQ(const ASTNode& in1, const ASTNode& in2)
     // terms are syntactically the same
     return ASTTrue;
 
-  // here the terms are definitely not syntactically equal but may be
-  // semantically equal.
+  // Two constant nodes still may be semantically equal: a float constant
+  // interns apart from the plain constant with its bits, so compare the
+  // bits, not the identities.
   if (BVCONST == k1 && BVCONST == k2)
-    return ASTFalse;
+    return constantsSameBits(in1, in2) ? ASTTrue : ASTFalse;
 
   // Check if some of the leading constant bits are different. Fancier code
   // would check
@@ -1397,6 +1448,20 @@ ASTNode Simplifier::SimplifyTerm(const ASTNode& actualInputterm)
           v.push_back(SimplifyTerm(toProcess[i]));
         else if (toProcess[i].GetType() == BOOLEAN_TYPE)
           v.push_back(SimplifyFormula(toProcess[i], false));
+        // A floating-point child is a term like any other: simplify it, so
+        // the floating-point identities and constant folds fire (see the
+        // matching arm of simplify_term_switch -- which, like everything
+        // here, lowers nothing; lowering is FloatBlast's own pass). It
+        // needs an arm of its own only because its type is neither
+        // BITVECTOR nor BOOLEAN, and the catch-all below would carry it
+        // through unsimplified. Historically -- when lowering still
+        // happened inside simplification -- this same line made several
+        // satisfiable QF_ABVFP queries answer unsat; both causes (rebuilds
+        // dropping the per-node float format, and the operand sort
+        // inverting the floating-point comparisons) were fixed in
+        // fbb96cd8, and the nested-fp lit tests pin the behaviour.
+        else if (toProcess[i].GetType() == FLOATINGPOINT_TYPE)
+          v.push_back(SimplifyTerm(toProcess[i]));
         else
           v.push_back(toProcess[i]);
       }
@@ -1406,6 +1471,15 @@ ASTNode Simplifier::SimplifyTerm(const ASTNode& actualInputterm)
       {
         output = nf->CreateArrayTerm(k, actualInputterm.GetIndexWidth(),
                                      inputValueWidth, v);
+
+        // Rebuilding drops the floating-point format, which is per-node state
+        // rather than something the kind implies. Carry it over: the rebuilt
+        // node has the same kind and children, so it denotes a float of the
+        // same format, and everything downstream (the blaster in particular)
+        // reads the format off the node.
+        output = FloatBlaster::withFormat(_bm, output,
+                                          actualInputterm.GetExpWidth(),
+                                          actualInputterm.GetSigWidth());
       }
       else
         output = actualInputterm;
@@ -2456,6 +2530,58 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
 
       break;
     }
+    case FP_ABS:
+    case FP_NEG:
+    case FP_ADD:
+    case FP_SUB:
+    case FP_MUL:
+    case FP_DIV:
+    case FP_FMA:
+    case FP_SQRT:
+    case FP_REM:
+    case FP_ROUNDTOINTEGRAL:
+    case FP_MIN:
+    case FP_MAX:
+    case FP_TOFP:
+    case FP_TOFP_SIGNED:
+    case FP_TOFP_UNSIGNED:
+    case FP_TO_UBV:
+    case FP_TO_SBV:
+    case FP_TO_IEEE_BV:
+    {
+      // Rebuild with the same kind and arity. Only the float operands are
+      // simplified: the other children -- the rounding mode of the arithmetic
+      // operations, and to_fp's format arguments -- are constants the blaster
+      // reads directly, so simplifying them buys nothing and risks rewriting
+      // them into a form it does not recognise.
+      //
+      // Nothing here lowers anything. A floating-point operation simplifies
+      // to a floating-point operation, with its format derived from its kind
+      // and children as always; FloatBlast replaces the whole layer with bits
+      // in one pass, before the formula ever reaches this code. Blasting from
+      // inside simplification meant rebuilding an FP_ADD over bitvector
+      // children -- a node that does not type check, and which only passed
+      // because a float format was stamped onto it and its blasted children.
+      // Nodes are hash-consed, so that stamp landed on whatever else denoted
+      // the same bits.
+      ASTVec simplified;
+      simplified.reserve(inputterm.Degree());
+
+      for (unsigned int i = 0; i < inputterm.Degree(); i++)
+      {
+        if (inputterm[i].GetType() != FLOATINGPOINT_TYPE)
+          simplified.push_back(inputterm[i]);
+        else
+          simplified.push_back(SimplifyTerm(inputterm[i]));
+      }
+
+      // The factory may fold the operation as it rebuilds it (abs/neg of a
+      // constant, x*1.0, x/1.0), which is the whole point of going back
+      // through it; whatever comes back is what this term simplifies to.
+      output = nf->CreateTerm(k, inputValueWidth, simplified);
+      break;
+    }
+
     case WRITE:
     default:
       FatalError("SimplifyTerm: Control should never reach here:", inputterm,

--- a/lib/Simplifier/Simplifier.cpp
+++ b/lib/Simplifier/Simplifier.cpp
@@ -1287,7 +1287,7 @@ ASTNode Simplifier::pullUpBVSX(ASTNode output)
   assert(output.GetChildren().size() == 2);
   assert(output[0].GetKind() == BVSX);
   assert(output[1].GetKind() == BVSX);
-  const Kind k = output.GetKind();
+  [[maybe_unused]] const Kind k = output.GetKind();
 
   assert(BVMULT == k || SBVDIV == k || BVPLUS == k);
   const int inputValueWidth = output.GetValueWidth();

--- a/lib/Simplifier/SplitExtracts.cpp
+++ b/lib/Simplifier/SplitExtracts.cpp
@@ -80,7 +80,7 @@ namespace stp
 
       for (const auto& e: nodeToExtracts )
       {
-        const auto& symbol = e.first;
+        [[maybe_unused]] const auto& symbol = e.first;
         assert(symbol.GetKind() == SYMBOL);
 
         auto ranges = e.second;

--- a/lib/Simplifier/StrengthReduction.cpp
+++ b/lib/Simplifier/StrengthReduction.cpp
@@ -390,7 +390,16 @@ namespace stp
           newN = nf->getFalse();
       }
       else
-        newN = nf->CreateConstant(b->GetBVConst(), n.GetValueWidth());
+      {
+        // The replaced node's floating-point format (if it has one) must be
+        // passed along: a constant is a leaf, so unlike the interior node it
+        // stands in for it cannot derive a format from children. A bare
+        // bitvector constant put where a float was makes the parent
+        // operation's rebuild abort -- fp.neg of a constant folds by making
+        // a floating-point constant, of format (0, 0) then.
+        newN = nf->CreateConstant(b->GetBVConst(), n.GetValueWidth(),
+                                  n.GetExpWidth(), n.GetSigWidth());
+      }
 
       replaceWithConstant++;
     }

--- a/lib/Simplifier/SubstitutionMap.cpp
+++ b/lib/Simplifier/SubstitutionMap.cpp
@@ -180,6 +180,12 @@ ASTNode SubstitutionMap::replace(const ASTNode& n, NodeMapType& fromTo,
     return n;
   }
 
+  // Floating-point special constants (NaN, +/-oo, +/-zero) are nullary leaves
+  // that the BVCONST/TRUE/FALSE test above does not cover, so they reach here
+  // with no children. They are values: there is nothing to substitute into.
+  if (n.Degree() == 0)
+    return n;
+
   const ASTChildren children = n.GetChildren();
   assert(children.size() > 0);
   // Should have no leaves left here.
@@ -407,8 +413,15 @@ bool SubstitutionMap::UpdateSubstitutionMap(const ASTNode& e0,
     return false;
 
   assert(e0 != e1);
-  assert(e0.GetValueWidth() == e1.GetValueWidth());
-  assert(e0.GetIndexWidth() == e1.GetIndexWidth());
+  // A substituted pair must agree as bitvectors/arrays AND as floats. The
+  // format check is trivially true for non-floats (both report (0, 0)); for
+  // floats the widths agree whenever the formats do, since a float's value
+  // width is exp_width + sig_width. These used to be a disjunction, which
+  // any two non-float nodes satisfied through the vacuous format arm.
+  assert(e0.GetValueWidth() == e1.GetValueWidth() &&
+         e0.GetIndexWidth() == e1.GetIndexWidth());
+  assert(e0.GetExpWidth() == e1.GetExpWidth() &&
+         e0.GetSigWidth() == e1.GetSigWidth());
 
   if (e0.GetKind() == SYMBOL)
   {

--- a/lib/Simplifier/UnsignedIntervalAnalysis.cpp
+++ b/lib/Simplifier/UnsignedIntervalAnalysis.cpp
@@ -743,7 +743,8 @@ namespace stp
     {
       CBV r = mkZero(bits_(x));
       CBV tmp = CONSTANTBV::BitVector_Clone(x); // Mul_Pos destroys this one.
-      CONSTANTBV::ErrCode e = CONSTANTBV::BitVector_Mul_Pos(r, tmp, y, true);
+      [[maybe_unused]] CONSTANTBV::ErrCode e =
+          CONSTANTBV::BitVector_Mul_Pos(r, tmp, y, true);
       assert(0 == e);
       CONSTANTBV::BitVector_Destroy(tmp);
       return r;
@@ -1322,7 +1323,7 @@ namespace stp
         // divisor. Division by zero gives all ones, so this lower bound
         // holds even if the divisor might be zero.
         CBV dividend = CONSTANTBV::BitVector_Clone(top->minV);
-        CONSTANTBV::ErrCode e = CONSTANTBV::BitVector_Div_Pos(
+        [[maybe_unused]] CONSTANTBV::ErrCode e = CONSTANTBV::BitVector_Div_Pos(
             result->minV, dividend, c1->maxV, remainder);
         assert(0 == e);
         CONSTANTBV::BitVector_Destroy(dividend);
@@ -1429,8 +1430,9 @@ namespace stp
             CBV quotientMax = CONSTANTBV::BitVector_Create(width, true);
 
             CBV dividend = CONSTANTBV::BitVector_Clone(children[0]->minV);
-            CONSTANTBV::ErrCode e = CONSTANTBV::BitVector_Div_Pos(
-                quotientMin, dividend, divisor, remainderMin);
+            [[maybe_unused]] CONSTANTBV::ErrCode e =
+                CONSTANTBV::BitVector_Div_Pos(quotientMin, dividend, divisor,
+                                              remainderMin);
             assert(0 == e);
             CONSTANTBV::BitVector_Destroy(dividend);
 

--- a/lib/Simplifier/constantBitP/ConstantBitP_Boolean.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_Boolean.cpp
@@ -339,7 +339,7 @@ Result bvImpliesBothWays(vector<FixedBits*>& children, FixedBits& result)
   FixedBits& b = (*children[1]);
 
   assert(a.getWidth() == result.getWidth());
-  const int bitWidth = a.getWidth();
+  [[maybe_unused]] const int bitWidth = a.getWidth();
   assert(bitWidth == 1);
 
   Result r = NO_CHANGE;

--- a/lib/Simplifier/constantBitP/ConstantBitP_Multiplication.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_Multiplication.cpp
@@ -157,7 +157,7 @@ Result fixIfCanForMultiplication(vector<FixedBits*>& children,
   Result result = NO_CHANGE;
 
   // only one of the conditionals can run.
-  bool run = false;
+  [[maybe_unused]] bool run = false;
 
   // We need every value that is unfixed to be set to one.
   if (aspirationalSum == columnOnes + columnOneFixed + columnUnfixed &&
@@ -433,7 +433,8 @@ Result useLeadingZeroesToFix(FixedBits& x, FixedBits& y, FixedBits& output)
   }
 
   stp::CBV result = CONSTANTBV::BitVector_Create(2 * bitWidth + 1, true);
-  CONSTANTBV::ErrCode ec = CONSTANTBV::BitVector_Multiply(result, x_c, y_c);
+  [[maybe_unused]] CONSTANTBV::ErrCode ec =
+      CONSTANTBV::BitVector_Multiply(result, x_c, y_c);
   assert(ec == CONSTANTBV::ErrCode_Ok);
 
   for (int j = (2 * bitWidth) - 1; j >= 0; j--)

--- a/lib/Simplifier/constantBitP/ConstantBitP_TransferFunctions.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_TransferFunctions.cpp
@@ -259,14 +259,14 @@ Result bvSignExtendBothWays(vector<FixedBits*>& children, FixedBits& output)
 
 Result bvExtractBothWays(vector<FixedBits*>& children, FixedBits& output)
 {
-  const size_t numberOfChildren = children.size();
+  [[maybe_unused]] const size_t numberOfChildren = children.size();
   const unsigned outputBitWidth = output.getWidth();
 
   Result result = NO_CHANGE;
 
   assert(3 == numberOfChildren);
 
-  unsigned top = children[1]->getUnsignedValue();
+  [[maybe_unused]] unsigned top = children[1]->getUnsignedValue();
   unsigned bottom = children[2]->getUnsignedValue();
 
   FixedBits& input = *(children[0]);

--- a/lib/Simplifier/constantBitP/ConstantBitPropagation.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitPropagation.cpp
@@ -151,6 +151,13 @@ ASTNodeMap ConstantBitPropagation::getAllFixed()
     if (BVCONCAT == node.GetKind())
       continue;
 
+    // Constant-bit propagation only reasons about Boolean and bit-vector
+    // values. A floating-point node has value width zero, so it is given a
+    // placeholder FixedBits that does not describe its packed contents; it must
+    // never be turned back into a constant here.
+    if (node.GetType() != BOOLEAN_TYPE && node.GetType() != BITVECTOR_TYPE)
+      continue;
+
     if (bits.isTotallyFixed())
     {
       toFrom.insert(make_pair(node, bitsToNode(node, bits)));
@@ -359,8 +366,10 @@ ASTNode ConstantBitPropagation::topLevelBothWays(const ASTNode& top,
     if (fromTo.find(node) != fromTo.end())
       continue;
 
+    // Only Boolean and bit-vector nodes can be replaced by a constant here; a
+    // floating-point node's FixedBits is a placeholder (see getAllFixed()).
     if (node.GetType() != BOOLEAN_TYPE && node.GetType() != BITVECTOR_TYPE)
-      FatalError("sadf234s");
+      continue;
 
     ASTNode constNode = bitsToNode(node, bits);
 

--- a/lib/Simplifier/constantBitP/ConstantBitPropagation.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitPropagation.cpp
@@ -366,7 +366,8 @@ ASTNode ConstantBitPropagation::topLevelBothWays(const ASTNode& top,
 
     if (SYMBOL == node.GetKind())
     {
-      bool r = simplifier->UpdateSubstitutionMap(node, constNode);
+      [[maybe_unused]] bool r =
+          simplifier->UpdateSubstitutionMap(node, constNode);
       assert(r);
     }
     else if (conjoinToTop && node != top)

--- a/lib/Simplifier/consteval.cpp
+++ b/lib/Simplifier/consteval.cpp
@@ -22,6 +22,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ********************************************************************/
 
+#include "stp/FloatBlaster/FloatBlast.h"
+#include "stp/FloatBlaster/FloatBlaster.h"
 #include "stp/Simplifier/Simplifier.h"
 #include "stp/Util/CBVOps.h"
 #include <cassert>
@@ -796,12 +798,14 @@ ASTNode NonMemberBVConstEvaluator(STPMgr* _bm, const Kind k,
 
     case ITE:
     {
-      if (ASTTrue == input_children[0])
+      // As with NOT: the condition must be read after eager folding.
+      if (ASTTrue == children[0])
         OutputNode = children[1];
-      else if (ASTFalse == input_children[0])
+      else if (ASTFalse == children[0])
         OutputNode = children[2];
       else
       {
+        std::cerr << children[0];
         FatalError(
             "BVConstEvaluator: ITE condiional must be either TRUE or FALSE:");
       }
@@ -815,14 +819,17 @@ ASTNode NonMemberBVConstEvaluator(STPMgr* _bm, const Kind k,
       OutputNode = ASTFalse;
       break;
     case NOT:
-      if (ASTTrue == input_children[0])
+      // Test the eagerly-folded child, like every other case: the raw
+      // input child may be an unsimplified formula that folds to a
+      // constant (e.g. when the caller built the tree with a
+      // non-simplifying factory).
+      if (ASTTrue == children[0])
         return ASTFalse;
-      else if (ASTFalse == input_children[0])
+      else if (ASTFalse == children[0])
         return ASTTrue;
       else
       {
-        std::cerr << ASTFalse;
-        std::cerr << input_children[0];
+        std::cerr << children[0];
         FatalError("BVConstEvaluator: unexpected not input");
       }
 
@@ -928,7 +935,173 @@ ASTNode NonMemberBVConstEvaluator(STPMgr* _bm, const Kind k,
         OutputNode = ASTFalse;
       break;
     }
+    case FP_LEQ:
+    case FP_LT:
+    case FP_GEQ:
+    case FP_GT:
+    case FP_EQ:
+    case FP_ISNORMAL:
+    case FP_ISSUBNORMAL:
+    case FP_ISZERO:
+    case FP_ISINFINITE:
+    case FP_ISNAN:
+    case FP_ISNEGATIVE:
+    case FP_ISPOSITIVE:
+    case FP_ABS:
+    case FP_NEG:
+    case FP_ADD:
+    case FP_SUB:
+    case FP_MUL:
+    case FP_DIV:
+    case FP_FMA:
+    case FP_SQRT:
+    case FP_REM:
+    case FP_ROUNDTOINTEGRAL:
+    case FP_MIN:
+    case FP_MAX:
+    case FP_TOFP:
+    case FP_TOFP_SIGNED:
+    case FP_TOFP_UNSIGNED:
+    case FP_TO_UBV:
+    case FP_TO_SBV:
+    case FP_TO_IEEE_BV:
+    case FP_SMT_EQ:
+    {
+      // A float's format is carried on the node, not implied by its kind, so
+      // it is lost every time a node is rebuilt -- and evaluating a nested
+      // operation rebuilds one. The inner operation's result comes back from
+      // NonMemberBVConstEvaluator as a bare BVCONST with no format, and the
+      // outer operation then blasts it against a format of (0, 0). That does
+      // not fail; it computes the wrong bits. Recover the format from
+      // whichever child still has one and put it back on the others.
+      unsigned int exp_width = 0;
+      unsigned int sig_width = 0;
 
+      if (k == FP_TOFP || k == FP_TOFP_SIGNED || k == FP_TOFP_UNSIGNED)
+      {
+        // to_fp names its target format in its first two children rather
+        // than inheriting it from an operand.
+        assert(children.size() >= 2);
+        exp_width = children[0].GetUnsignedConst();
+        sig_width = children[1].GetUnsignedConst();
+      }
+      else
+      {
+        for (size_t i = 0; i < children.size(); i++)
+        {
+          if (children[i].GetExpWidth() != 0)
+          {
+            exp_width = children[i].GetExpWidth();
+            sig_width = children[i].GetSigWidth();
+            break;
+          }
+        }
+      }
+
+      ASTVec formatted;
+      formatted.reserve(children.size());
+
+      // to_fp's operands are not floats to be re-formatted: children 0 and 1
+      // are the target format, and the source is either a float that already
+      // carries its own format or a bitvector that must stay one. Stamping a
+      // format onto that source would make a 32-bit integer argument look
+      // like a Float32 and take the reformat path instead of the convert one.
+      const bool format_children =
+          (k != FP_TOFP && k != FP_TOFP_SIGNED && k != FP_TOFP_UNSIGNED &&
+           k != FP_TO_UBV && k != FP_TO_SBV);
+
+      // fp.to_ubv/fp.to_sbv are the same story from the other side: their
+      // children are (m, rm, x, unspecified), of which only x is a float, and
+      // their *result* is a bitvector. Both the width argument and the result
+      // happen to be as wide as e + s in the common 32-bit case, so stamping
+      // a format on them would turn an integer into a Float32.
+
+      for (size_t i = 0; i < children.size(); i++)
+      {
+        if (!format_children)
+        {
+          formatted.push_back(children[i]);
+          continue;
+        }
+
+        // Rounding modes and to_fp's format arguments are bitvectors that
+        // are not floats; leave them alone. A float operand is as wide as
+        // the format it is packed in.
+        //
+        // A plain BVCONST cannot carry a format at all -- ASTBVConst's
+        // getExpWidth() is hardwired to 0 and its setter asserts -- so the
+        // constant has to be re-made as an ASTFPConst first. That is what
+        // CreateFPConst is for, and what the lowering pass does with its
+        // own result.
+        formatted.push_back(
+            FloatBlaster::withFormat(_bm, children[i], exp_width, sig_width));
+      }
+
+      // The predicates are formulas; everything else is a term of the node's
+      // own width (which for to_ubv/to_sbv is the target width, not
+      // exp + sig). CreateNode would leave a term's value width zero.
+      const bool boolean_result =
+          k == FP_LEQ || k == FP_LT || k == FP_GEQ || k == FP_GT ||
+          k == FP_EQ || k == FP_SMT_EQ || k == FP_ISNORMAL ||
+          k == FP_ISSUBNORMAL || k == FP_ISZERO || k == FP_ISINFINITE ||
+          k == FP_ISNAN || k == FP_ISNEGATIVE || k == FP_ISPOSITIVE;
+
+      ASTNode temp(boolean_result ? _bm->CreateNode(k, formatted)
+                                  : _bm->CreateTerm(k, inputwidth, formatted));
+
+      // Only a floating-point *result* carries a floating-point format. The
+      // classifications and comparisons return a Boolean and to_ubv/to_sbv
+      // return a bit-vector; stamping a format on temp for those is wrong,
+      // because lowering would then copy temp's format onto its output --
+      // poisoning the shared Boolean constant, whose GetType() afterwards reads
+      // FLOATINGPOINT and sends the constant evaluator down its bit-vector
+      // (GetBVConst) path. temp's type already distinguishes the cases.
+      const bool float_result = (temp.GetType() == FLOATINGPOINT_TYPE);
+      if (float_result)
+      {
+        temp.SetExpWidth(exp_width);
+        temp.SetSigWidth(sig_width);
+      }
+
+      // The factory may have rewritten the operation as it was built:
+      // folded it to a constant (abs/neg of a constant is a sign-bit edit,
+      // x*1.0 folds to x), or into different structure entirely -- fp.leq of
+      // a term with itself becomes (not (fp.isNaN ...)). Interned constants
+      // compare pointer-equal, so the same-operand rules do fire here. In
+      // either case evaluate what came back rather than blasting it: the
+      // blaster only handles floating-point operations, and asserts on
+      // anything else.
+      if (temp.GetKind() != k)
+      {
+        OutputNode =
+            temp.isConstant() ? temp : NonMemberBVConstEvaluator(_bm, temp);
+        if (float_result)
+          OutputNode =
+              FloatBlaster::withFormat(_bm, OutputNode, exp_width, sig_width);
+        break;
+      }
+
+      // One table, the same one the solver's lowering pass uses, reached with
+      // the node rather than with its parts: it reads each operand's format
+      // from its source sort, so nothing here has to work out which child
+      // carries the format and pass it alongside.
+      ASTNode blasted(FloatBlast::lowerOperation(_bm, temp));
+
+      // How much work the next line is depends on the installed factory: a
+      // simplifying one has already folded the circuit to its answer while
+      // building it, so this is a no-op; a hashing one hands back the circuit
+      // itself, and it is evaluated here. Both are supported, which is what
+      // the memo in NonMemberBVConstEvaluator is for -- the circuit is a
+      // deeply shared DAG, and evaluating it by paths does not finish.
+      OutputNode = NonMemberBVConstEvaluator(_bm, blasted);
+
+      // Carry the format out, so an enclosing operation sees a formatted
+      // operand rather than a bare bit-vector.
+      if (float_result)
+        OutputNode =
+            FloatBlaster::withFormat(_bm, OutputNode, exp_width, sig_width);
+      break;
+    }
     default:
       FatalError("BVConstEvaluator: The input kind is not supported yet:");
       break;
@@ -948,14 +1121,72 @@ ASTNode NonMemberBVConstEvaluator(STPMgr* _bm, const Kind k,
   return OutputNode;
 }
 
+// One evaluation per distinct node, rather than one per path to it.
+//
+// The argument is a DAG and the walk below is a tree walk, so without this a
+// shared subterm is re-evaluated once for every route into it. That is
+// affordable for the word-level bit-vector nodes this was written for, whose
+// sharing is shallow. It is not affordable for a lowered floating-point
+// circuit: those are deeply shared by construction, and the floating-point
+// arm above folds by lowering the operation and then evaluating the circuit
+// it gets back. A single Float(3,4) fp.add does not finish.
+//
+// It has not bitten because the CLI and the C API both install the
+// simplifying factory, which folds as it builds -- so lowerOperation hands
+// back a BVCONST that is already the answer and the evaluation below is a
+// no-op. That is a property of the caller's configuration, not of this
+// module, and STPMgr's own constructor installs the hashing factory instead.
+//
+// Children are evaluated here rather than left to the kind-and-children
+// overload, which does the same thing one level down but has no memo to
+// consult. Handing it constants throughout makes its own recursion
+// unreachable; the two agree on everything else, since it evaluates every
+// child eagerly regardless of kind.
+static ASTNode evaluateMemoised(STPMgr* mgr, const ASTNode& t,
+                                ASTNodeMap& memo)
+{
+  if (t.isConstant())
+    return t;
+
+  const ASTNodeMap::const_iterator cached = memo.find(t);
+  if (cached != memo.end())
+    return cached->second;
+
+  ASTVec children;
+  children.reserve(t.Degree());
+  for (size_t i = 0; i < t.Degree(); i++)
+    children.push_back(evaluateMemoised(mgr, t[i], memo));
+
+  const ASTNode out = NonMemberBVConstEvaluator(mgr, t.GetKind(), children,
+                                                t.GetValueWidth());
+  memo[t] = out;
+  return out;
+}
+
 // Const evaluator logical and arithmetic operations.
 ASTNode NonMemberBVConstEvaluator(STPMgr* mgr, const ASTNode& t)
 {
   if (t.isConstant())
     return t;
 
-  return NonMemberBVConstEvaluator(mgr, t.GetKind(), toASTVec(t.GetChildren()),
-                                   t.GetValueWidth());
+  // The common case by far: an operation over constants, reached from the
+  // simplifying factory's fold. There is nothing under it to share, so it
+  // does not pay for a memo it would use once.
+  bool children_are_constant = true;
+  for (size_t i = 0; i < t.Degree(); i++)
+    if (!t[i].isConstant())
+    {
+      children_are_constant = false;
+      break;
+    }
+
+  if (children_are_constant)
+    return NonMemberBVConstEvaluator(mgr, t.GetKind(),
+                                     toASTVec(t.GetChildren()),
+                                     t.GetValueWidth());
+
+  ASTNodeMap memo;
+  return evaluateMemoised(mgr, t, memo);
 }
 
 } // end of namespace stp

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -2384,7 +2384,7 @@ BBNodeVec BitBlaster::v9(vector<list<BBNode>>& products,
     vector<BBNode> sorted; // The current column (sorted) gets put into here.
     vector<BBNode> prior;  // Prior is always empty in this..
 
-    const unsigned size = products[column].size();
+    [[maybe_unused]] const unsigned size = products[column].size();
     sortingNetworkAdd(support, products[column], sorted, prior);
 
     assert(products[column].size() == 1);

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -273,7 +273,11 @@ void BitBlaster::getConsts(const ASTNode& form,
   for (auto it = BBTermMemo.begin(); it != BBTermMemo.end(); it++)
   {
     const ASTNode& n = it->first;
-    assert(n.GetType() == BITVECTOR_TYPE);
+    // FloatBlast removes FP operations but deliberately leaves float symbols
+    // and constants as their packed-bit leaves. They are bit-blaster terms at
+    // this internal boundary even though their public sort remains
+    // FLOATINGPOINT_TYPE for model reconstruction.
+    assert(isBitsValued(n));
 
     if (n.isConstant())
       continue;
@@ -504,7 +508,8 @@ void BitBlaster::updateTerm(const ASTNode& n,
   {
     if (bbFixed)
     {
-      b = new FixedBits(n.GetType() == BOOLEAN_TYPE ? 1 : n.GetValueWidth(),
+      const unsigned int num_bits = n.GetValueWidth();
+      b = new FixedBits(n.GetType() == BOOLEAN_TYPE ? 1 : num_bits,
                         n.GetType() == BOOLEAN_TYPE);
       cb->fixedMap->map->insert(std::pair<ASTNode, FixedBits*>(n, b));
       if (debug_bitblaster)
@@ -602,7 +607,11 @@ BitBlaster::simplify_during_bb(ASTNode& term,
 
   for (int i = 0; i < numberOfChildren; i++)
   {
-    if (term[i].GetType() == BITVECTOR_TYPE)
+    // isBitsValued, not GetType() == BITVECTOR_TYPE: a lowered formula still
+    // carries float-typed leaves, which are bits here (see isBitsValued).
+    // Testing the type directly is what made this function abort on every
+    // query with a float symbol or constant left in it.
+    if (isBitsValued(term[i]))
     {
       ch.push_back(BBTerm(term[i], support));
     }
@@ -758,6 +767,7 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term,
 
   const auto kids_end = term.end();
   const unsigned int num_bits = term.GetValueWidth();
+
   switch (k)
   {
     case BVNOT:
@@ -1115,11 +1125,33 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term,
       result = tmp_res;
       break;
     }
+    case FP_ABS:
+    case FP_NEG:
+    case FP_ADD:
+    case FP_SUB:
+    case FP_MUL:
+    case FP_DIV:
+    case FP_FMA:
+    case FP_SQRT:
+    case FP_REM:
+    case FP_ROUNDTOINTEGRAL:
+    case FP_MIN:
+    case FP_MAX:
+    case FP_TOFP:
+    case FP_TOFP_SIGNED:
+    case FP_TOFP_UNSIGNED:
+    case FP_TO_UBV:
+    case FP_TO_SBV:
+    case FP_TO_IEEE_BV:
+    {
+      FatalError("BBForm: FP terms should not reach the bit-blaster: ", term);
+      break;
+    }
     default:
       FatalError("BBTerm: Illegal kind to BBTerm", term);
   }
 
-  assert(result.size() == term.GetValueWidth());
+  assert(result.size() == num_bits);
 
   if (debug_do_check)
     check(result, term);
@@ -1289,6 +1321,24 @@ const BBNode BitBlaster::BBForm(const ASTNode& form,
     case BVSSUBO:
     {
       result = BBOverflow(form, support);
+      break;
+    }
+    case FP_LEQ:
+    case FP_LT:
+    case FP_GEQ:
+    case FP_GT:
+    case FP_EQ:
+    case FP_ISNORMAL:
+    case FP_ISSUBNORMAL:
+    case FP_ISZERO:
+    case FP_ISINFINITE:
+    case FP_ISNAN:
+    case FP_ISNEGATIVE:
+    case FP_ISPOSITIVE:
+    case FP_SMT_EQ:
+    {
+      FatalError("BBForm: FP formulas should not reach the bit-blaster: ",
+                 form);
       break;
     }
     default:

--- a/lib/ToSat/ToCNFAIG.cpp
+++ b/lib/ToSat/ToCNFAIG.cpp
@@ -227,8 +227,17 @@ Cnf_Dat_t* ToCNFAIG::derive_cnf(BBNodeManagerAIG& mgr)
 
     case UserDefinedFlags::CNF_EFFORT_MEDIUM:
     default:
-      // Cut enumeration and technology mapping, ABC's Cnf_Derive().
-      return Cnf_Derive(mgr.aigMgr, 0);
+    {
+      // Cut enumeration and technology mapping, as in ABC's Cnf_Derive().
+      // That convenience wrapper reuses one process-global Cnf_Man_t, so two
+      // independent STP instances deriving CNF concurrently overwrite the
+      // same cut/mapping state. ABC exposes the underlying per-manager entry
+      // point; keep the manager local to this conversion instead.
+      Cnf_Man_t* cnfMan = Cnf_ManStart();
+      Cnf_Dat_t* result = Cnf_DeriveWithMan(cnfMan, mgr.aigMgr, 0);
+      Cnf_ManStop(cnfMan);
+      return result;
+    }
   }
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -176,3 +176,13 @@ option(TEST_UNITS
 if(TEST_UNITS)
     add_subdirectory(unit-tests)
 endif()
+
+# -----------------------------------------------------------------------------
+# The floating-point self-test tools (built under tools/ whenever
+# ENABLE_FLOATING_POINT and ENABLE_TESTING are on) exit non-zero on failure,
+# so they run as plain CTest tests.
+# -----------------------------------------------------------------------------
+
+if (ENABLE_FLOATING_POINT)
+    add_test(NAME test_fpbackend COMMAND test_fpbackend)
+endif()

--- a/tests/api/C/counter-example-reading.cpp
+++ b/tests/api/C/counter-example-reading.cpp
@@ -18,7 +18,7 @@ TEST(counter_example_reading, one)
   Expr AplusBplus42 =
       vc_bv32PlusExpr(vc, AplusB, vc_bv32ConstExprFromInt(vc, 42));
 
-  assert(0 == vc_query(vc, falseExpr));
+  ASSERT_EQ(0, vc_query(vc, falseExpr));
 
 // Don't do this,
 #if 0

--- a/tests/api/C/counterexample.cpp
+++ b/tests/api/C/counterexample.cpp
@@ -35,25 +35,25 @@ TEST(counterexample, one)
   Expr eq = vc_eqExpr(vc, A, c42);
 
   vc_assertFormula(vc, eq);
-  assert(0 == vc_query(vc, falseExpr));
+  ASSERT_EQ(0, vc_query(vc, falseExpr));
 
   Expr ce = vc_getCounterExample(vc, A);
-  assert(42 == getBVInt(ce));
+  ASSERT_EQ(42, getBVInt(ce));
 
   Expr Aplus42 = vc_bvPlusExpr(vc, 32, A, c42);
   ce = vc_getCounterExample(vc, Aplus42);
-  assert(84 == getBVInt(ce));
+  ASSERT_EQ(84, getBVInt(ce));
 
   ce = vc_getCounterExample(vc, falseExpr);
-  assert(0 == vc_isBool(ce));
+  ASSERT_EQ(0, vc_isBool(ce));
 
   Expr trueExpr = vc_notExpr(vc, falseExpr);
   ce = vc_getCounterExample(vc, trueExpr);
-  assert(1 == vc_isBool(ce));
+  ASSERT_EQ(1, vc_isBool(ce));
 
   Expr eq2 = vc_eqExpr(vc, Aplus42, vc_bvConstExprFromInt(vc, 32, 84));
   ce = vc_getCounterExample(vc, eq2);
-  assert(1 == vc_isBool(ce));
+  ASSERT_EQ(1, vc_isBool(ce));
 
   vc_Destroy(vc);
 }

--- a/tests/api/C/failing_solvermap.cpp
+++ b/tests/api/C/failing_solvermap.cpp
@@ -21,10 +21,10 @@ TEST(failing_solvermap, one)
 
   vc_assertFormula(vc,
                    vc_bvGtExpr(vc, AplusB, vc_bv32ConstExprFromInt(vc, 100)));
-  assert(0 == vc_query(vc, falseExpr));
+  ASSERT_EQ(0, vc_query(vc, falseExpr));
   vc_assertFormula(
       vc, vc_bvGtExpr(vc, AplusBplus42, vc_bv32ConstExprFromInt(vc, 5)));
-  assert(0 == vc_query(vc, falseExpr));
+  ASSERT_EQ(0, vc_query(vc, falseExpr));
 
   vc_Destroy(vc);
 }

--- a/tests/unit-tests/BVSolver_Test.cpp
+++ b/tests/unit-tests/BVSolver_Test.cpp
@@ -1,0 +1,165 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: July 2026
+ *
+ * LICENSE: Please view LICENSE file in the home dir of this Program
+ ********************************************************************/
+
+// The word-level solver eliminates a variable by recording a
+// replacement for it in the solver map. A float's format is per-node
+// state that only a leaf, a floating-point-kind node or an array can
+// hold (see ASTNode::canStoreFPFormat), so the bitvector terms the
+// solver builds -- a fresh variable concatenated with the solved bits,
+// a multiple of the right-hand side -- carry none, and eliminating a
+// float-typed variable into one drops its format.
+//
+// That matters because the solver runs while the floating-point layer
+// is still unlowered: FloatBlast comes after the size-reducing passes
+// and reads an operation's format off its operands, which by then are
+// the only thing that still says what sort they are. A float-typed
+// variable rewritten into a concatenation left fp.isZero blasting
+// against a format of (0, 0) -- a packed width of zero against a
+// 64-bit operand -- and the blaster aborted:
+//
+//   symbolic_fp.cpp: blast_is_zero: Assertion
+//     `expr.GetValueWidth() == size.packedWidth()' failed.
+//
+// The equations below are the shapes the solver knows how to take
+// apart, over a float-typed variable. See
+// fp-array-extensionality.cpp's
+// float_cell_pinned_under_chain_equality_unsat for the fuzzer's query
+// that produced the first of them.
+
+#include "stp/Simplifier/BVSolver.h"
+#include "stp/AST/AST.h"
+#include "stp/NodeFactory/SimplifyingNodeFactory.h"
+#include "stp/STPManager/STPManager.h"
+#include "stp/Simplifier/Simplifier.h"
+#include "stp/Simplifier/SubstitutionMap.h"
+#include <gtest/gtest.h>
+
+using namespace stp;
+
+namespace
+{
+
+const unsigned int EXP_WIDTH = 11;
+const unsigned int SIG_WIDTH = 53;
+const unsigned int FLOAT_WIDTH = EXP_WIDTH + SIG_WIDTH;
+
+struct Fixture
+{
+  STPMgr mgr;
+  SimplifyingNodeFactory snf;
+  SubstitutionMap sm;
+  Simplifier simp;
+  BVSolver solver;
+
+  Fixture()
+      : snf(*(mgr.hashingNodeFactory), mgr), sm(&mgr), simp(&mgr, &sm),
+        solver(&mgr, &simp)
+  {
+    mgr.defaultNodeFactory = &snf;
+  }
+
+  // A Float64 variable, made the way the array transformer makes one
+  // for a read of a float-element array: a symbol as wide as the
+  // packed format, carrying that format.
+  ASTNode floatVar(const char* name)
+  {
+    ASTNode f = mgr.CreateSymbol(name, 0, FLOAT_WIDTH);
+    f.SetExpWidth(EXP_WIDTH);
+    f.SetSigWidth(SIG_WIDTH);
+    return f;
+  }
+
+  ASTNode extract(const ASTNode& term, unsigned int high, unsigned int low)
+  {
+    return mgr.CreateTerm(BVEXTRACT, high - low + 1, term,
+                          mgr.CreateBVConst(32, high),
+                          mgr.CreateBVConst(32, low));
+  }
+
+  // Whether the format survives solving: what an fp.isZero over `f`
+  // reads as its operand, once the solver map has been applied, must
+  // still be a Float64. That is exactly what the blaster asks the
+  // operand for.
+  void operandKeepsFormat(const ASTNode& f)
+  {
+    const ASTNode after = simp.applySubstitutionMap(mgr.CreateNode(FP_ISZERO, f));
+    ASSERT_EQ(1u, after.Degree());
+    EXPECT_EQ(EXP_WIDTH, after[0].GetExpWidth());
+    EXPECT_EQ(SIG_WIDTH, after[0].GetSigWidth());
+    EXPECT_EQ(FLOAT_WIDTH, after[0].GetValueWidth());
+  }
+};
+
+} // namespace
+
+// (= ((_ extract 51 0) f) #x0000000000000): a float's significand half
+// pinned to a constant, which is what the extensional array
+// procedure's NaN test leaves behind once the float it compares
+// against is a known constant. Solving this renames f itself, to a
+// fresh 12-bit variable concatenated with the solved 52 bits.
+TEST(BVSolver, float_variable_survives_low_extract_equation)
+{
+  Fixture f;
+
+  const ASTNode x = f.floatVar("x");
+  const ASTNode eq = f.mgr.CreateNode(
+      EQ, f.extract(x, SIG_WIDTH - 2, 0), f.mgr.CreateZeroConst(SIG_WIDTH - 1));
+
+  f.solver.TopLevelBVSolve(eq, false);
+
+  f.operandKeepsFormat(x);
+}
+
+// (= (bvmul #x3 f) #x0): an odd coefficient over the whole variable.
+// Solving multiplies through by the coefficient's inverse, and
+// replaces f by the product -- another term with no format.
+TEST(BVSolver, float_variable_survives_odd_coefficient_equation)
+{
+  Fixture f;
+
+  const ASTNode x = f.floatVar("x");
+  const ASTNode product = f.mgr.CreateTerm(
+      BVMULT, FLOAT_WIDTH, f.mgr.CreateBVConst(FLOAT_WIDTH, 3), x);
+  const ASTNode eq =
+      f.mgr.CreateNode(EQ, product, f.mgr.CreateZeroConst(FLOAT_WIDTH));
+
+  f.solver.TopLevelBVSolve(eq, false);
+
+  f.operandKeepsFormat(x);
+}
+
+// A whole float variable equated to a plain bitvector term. The term
+// denotes the same 64 bits, but carries no format for the blaster to
+// read, so it cannot stand in for the variable.
+TEST(BVSolver, float_variable_survives_formatless_replacement)
+{
+  Fixture f;
+
+  const ASTNode x = f.floatVar("x");
+  const ASTNode bits = f.mgr.CreateSymbol("bits", 0, FLOAT_WIDTH);
+  const ASTNode eq =
+      f.mgr.CreateNode(EQ, x, f.mgr.CreateTerm(BVNOT, FLOAT_WIDTH, bits));
+
+  f.solver.TopLevelBVSolve(eq, false);
+
+  f.operandKeepsFormat(x);
+}
+
+// The same equations over a plain bitvector variable are still solved:
+// the guard is about formats, and a non-float has none to lose.
+TEST(BVSolver, plain_bitvector_variable_is_still_solved)
+{
+  Fixture f;
+
+  const ASTNode x = f.mgr.CreateSymbol("x", 0, FLOAT_WIDTH);
+  const ASTNode eq = f.mgr.CreateNode(
+      EQ, f.extract(x, SIG_WIDTH - 2, 0), f.mgr.CreateZeroConst(SIG_WIDTH - 1));
+
+  EXPECT_EQ(f.mgr.ASTTrue, f.solver.TopLevelBVSolve(eq, false));
+  EXPECT_TRUE(f.simp.InsideSubstitutionMap(x));
+}

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -33,7 +33,34 @@ AddSTPGTest(SplitExtracts_Test.cpp)
 # pays for, so both configurations have to cover them.
 AddSTPGTest(SourceSortMemo_Test.cpp)
 if (ENABLE_FLOATING_POINT)
+    AddSTPGTest(FloatBlast_Test.cpp)
+    AddSTPGTest(FpTotalise_Test.cpp)
     AddSTPGTest(SourceSort_Test.cpp)
+    # Builds float/rounding-mode constants, which is the whole point.
+    AddSTPGTest(ConstantIdentity_Test.cpp)
+    AddSTPGTest(FpConstantFold_Test.cpp)
+    # The oracle is the hardware, evaluated under a rounding mode set with
+    # fesetround. Without this the compiler assumes the default mode and
+    # folds the reference arithmetic while compiling, so every non-default
+    # mode disagrees for a reason that has nothing to do with STP.
+    if (TARGET FpConstantFold_TestTests AND NOT MSVC)
+        target_compile_options(FpConstantFold_TestTests PRIVATE -frounding-math)
+        # And on 32-bit x86 the default is x87, which keeps a 64-bit
+        # significand and so double-rounds on the way to binary64: the
+        # hardware then disagrees with a correctly-rounded result, e.g.
+        # 3.0 / 1.0000000000000002 under RNE. binary32 has guard bits to
+        # spare, which is why only the binary64 tests would notice. SSE2
+        # arithmetic is correctly rounded, so ask for it and the oracle is
+        # IEEE again rather than skipping the coverage.
+        if (CMAKE_SIZEOF_VOID_P EQUAL 4)
+            include(CheckCXXCompilerFlag)
+            check_cxx_compiler_flag("-msse2 -mfpmath=sse" HAVE_SSE_MATH_FLAGS)
+            if (HAVE_SSE_MATH_FLAGS)
+                target_compile_options(FpConstantFold_TestTests
+                                       PRIVATE -msse2 -mfpmath=sse)
+            endif()
+        endif()
+    endif()
     # Builds float-typed symbols, so it needs the floating-point funnels
     # (SetExpWidth) to be more than a fatal error.
     AddSTPGTest(BVSolver_Test.cpp)

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -28,6 +28,16 @@ AddSTPGTest(FindPureLiterals_Test.cpp)
 AddSTPGTest(Flatten_Test.cpp)
 AddSTPGTest(NodeDomainAnalysis_Test.cpp)
 AddSTPGTest(SplitExtracts_Test.cpp)
+# Not under ENABLE_FLOATING_POINT: the source-sort memo and the symbol name
+# index are AST machinery that floating point introduced but that every build
+# pays for, so both configurations have to cover them.
+AddSTPGTest(SourceSortMemo_Test.cpp)
+if (ENABLE_FLOATING_POINT)
+    AddSTPGTest(SourceSort_Test.cpp)
+    # Builds float-typed symbols, so it needs the floating-point funnels
+    # (SetExpWidth) to be more than a fatal error.
+    AddSTPGTest(BVSolver_Test.cpp)
+endif()
 AddSTPGTest(StrengthReduction_Test.cpp)
 AddSTPGTest(StrengthReduction_Exhaustive_Test.cpp)
 AddSTPGTest(RemoveUnconstrained_Exhaustive_Test.cpp)

--- a/tests/unit-tests/ConstantIdentity_Test.cpp
+++ b/tests/unit-tests/ConstantIdentity_Test.cpp
@@ -1,0 +1,183 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: August 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+// A constant's source sort is part of its identity, so a floating-point or
+// rounding-mode constant interns apart from the plain bitvector constant
+// holding the same bits. STP's older code could assume the converse of
+// "same node implies same value" -- that distinct constant nodes denote
+// distinct values -- and that assumption is now wrong.
+//
+// The unsound direction is the one that proves *distinctness*: an array
+// index rule that skips a write because the two index constants are
+// different nodes reads the wrong cell. Every such site has to compare bits
+// through constantsSameBits. These tests build the collision explicitly and
+// then drive each decision site over it, so that a site which reverts to
+// node identity fails here rather than in a fuzz campaign.
+
+#include "stp/AST/AST.h"
+#include "stp/NodeFactory/SimplifyingNodeFactory.h"
+#include "stp/STPManager/STPManager.h"
+#include "stp/Simplifier/Simplifier.h"
+#include "stp/Simplifier/SubstitutionMap.h"
+#include "stp/FloatBlaster/rounding_modes.h"
+
+#include <gtest/gtest.h>
+
+using namespace stp;
+
+namespace
+{
+
+struct Fixture
+{
+  STPMgr mgr;
+  SimplifyingNodeFactory snf;
+  SubstitutionMap sm;
+  Simplifier simp;
+
+  Fixture() : snf(*(mgr.hashingNodeFactory), mgr), sm(&mgr), simp(&mgr, &sm)
+  {
+    mgr.defaultNodeFactory = &snf;
+  }
+
+  NodeFactory& nf() { return snf; }
+
+  // 0x3F800000 is 1.0f, and is also just a 32-bit number someone may write.
+  // The two intern apart, because a constant's source sort is part of its
+  // identity.
+  ASTNode plain() { return mgr.CreateBVConst(32, 0x3F800000u); }
+  ASTNode typed() { return mgr.CreateFPConst(plain(), 8, 24); }
+};
+
+} // namespace
+
+TEST(ConstantIdentity, the_collision_exists_at_all)
+{
+  Fixture f;
+  const ASTNode typed = f.typed();
+  const ASTNode plain = f.plain();
+
+  // If these ever become the same node the rest of the file is vacuous, so
+  // assert the premise rather than assume it.
+  EXPECT_NE(typed, plain);
+  EXPECT_EQ(BVCONST, typed.GetKind());
+  EXPECT_EQ(BVCONST, plain.GetKind());
+  EXPECT_EQ(typed.GetValueWidth(), plain.GetValueWidth());
+  EXPECT_TRUE(constantsSameBits(typed, plain));
+}
+
+TEST(ConstantIdentity, rounding_mode_constants_collide_with_plain_ones)
+{
+  Fixture f;
+  // The modes are one-hot, so RNE is 5-bit 1 -- a bit pattern any bitvector
+  // problem may also hold.
+  const ASTNode rne =
+      f.mgr.CreateRMConst(symbolic_fp::ROUND_NEAREST_TIES_TO_EVEN);
+  const ASTNode bits =
+      f.mgr.CreateBVConst(5, symbolic_fp::ROUND_NEAREST_TIES_TO_EVEN);
+
+  EXPECT_NE(rne, bits);
+  EXPECT_TRUE(constantsSameBits(rne, bits));
+}
+
+// Equality of two constants is decided on bits, not on node identity.
+TEST(ConstantIdentity, equality_folds_on_bits)
+{
+  Fixture f;
+  EXPECT_EQ(f.mgr.ASTTrue, f.nf().CreateNode(EQ, f.typed(), f.plain()));
+
+  // And a genuine difference still folds the other way.
+  const ASTNode other = f.mgr.CreateBVConst(32, 0x3F800001u);
+  EXPECT_EQ(f.mgr.ASTFalse, f.nf().CreateNode(EQ, f.typed(), other));
+}
+
+// Read-over-write may only skip a write when the two indexes are *values*
+// that differ. Skipping on node identity reads straight past the cell that
+// was written and answers with whatever is underneath.
+TEST(ConstantIdentity, read_over_write_does_not_skip_a_matching_cell)
+{
+  Fixture f;
+  const ASTNode typed = f.typed();
+  const ASTNode plain = f.plain();
+  const ASTNode a = f.mgr.CreateSourceSymbol(
+      "a", SourceSort::array(SourceSort::bitVector(32),
+                             SourceSort::bitVector(8)));
+  const ASTNode stored = f.mgr.CreateBVConst(8, 0x2A);
+  const ASTNode other_value = f.mgr.CreateBVConst(8, 0x2B);
+
+  // Write at the typed constant, read at the plain one: same cell.
+  const ASTNode write =
+      f.nf().CreateArrayTerm(WRITE, 32, 8, {a, typed, stored});
+  EXPECT_EQ(stored, f.nf().CreateTerm(READ, 8, write, plain));
+
+  // ... and the other way round.
+  const ASTNode write2 =
+      f.nf().CreateArrayTerm(WRITE, 32, 8, {a, plain, stored});
+  EXPECT_EQ(stored, f.nf().CreateTerm(READ, 8, write2, typed));
+
+  // A write at a genuinely different index is still skipped, so the rule
+  // has not simply been disabled: the read sees the cell underneath.
+  const ASTNode different = f.mgr.CreateBVConst(32, 0x3F800001u);
+  const ASTNode inner =
+      f.nf().CreateArrayTerm(WRITE, 32, 8, {a, typed, stored});
+  const ASTNode layered = f.nf().CreateArrayTerm(
+      WRITE, 32, 8, {inner, different, other_value});
+  EXPECT_EQ(stored, f.nf().CreateTerm(READ, 8, layered, plain));
+}
+
+// The simplifier reaches the same decisions through its own path.
+TEST(ConstantIdentity, simplifier_equality_folds_on_bits)
+{
+  Fixture f;
+  EXPECT_EQ(f.mgr.ASTTrue, f.simp.CreateSimplifiedEQ(f.typed(), f.plain()));
+
+  const ASTNode other = f.mgr.CreateBVConst(32, 0x3F800001u);
+  EXPECT_EQ(f.mgr.ASTFalse, f.simp.CreateSimplifiedEQ(f.typed(), other));
+}
+
+// ite(c, x, x) collapses on node identity, and deliberately does not collapse
+// two constants that merely share bits.
+//
+// This is the direction where identity is the *right* test. The two nodes
+// have different source sorts, so there is no answer to collapse to: picking
+// either branch retypes the expression, and a float and its packed bits are
+// not interchangeable at the public boundary. Leaving the ITE alone keeps
+// the value right, and the front ends reject a mixed float/bitvector ITE
+// before it can be built anyway (ite-mixed-float-bv-rejected.smt2). Recorded
+// as a test so that "fixing" it later is a deliberate act.
+TEST(ConstantIdentity, ite_collapses_on_identity_not_on_bits)
+{
+  Fixture f;
+  const ASTNode cond =
+      f.mgr.CreateSourceSymbol("p", SourceSort::boolean());
+
+  const ASTNode same =
+      f.nf().CreateTerm(ITE, 32, cond, f.plain(), f.plain());
+  EXPECT_EQ(f.plain(), same);
+
+  const ASTNode mixed =
+      f.nf().CreateTerm(ITE, 32, cond, f.typed(), f.plain());
+  EXPECT_FALSE(mixed.isConstant());
+  EXPECT_EQ(ITE, mixed.GetKind());
+}

--- a/tests/unit-tests/FloatBlast_Test.cpp
+++ b/tests/unit-tests/FloatBlast_Test.cpp
@@ -1,0 +1,283 @@
+/********************************************************************
+ * Tests for the floating-point source-to-carrier lowering boundary.
+ ********************************************************************/
+
+#include "stp/AST/AST.h"
+#include "stp/FloatBlaster/FloatBlast.h"
+#include "stp/FloatBlaster/FpTotalise.h"
+#include "stp/FloatBlaster/rounding_modes.h"
+#include "stp/STPManager/STPManager.h"
+
+#include <gtest/gtest.h>
+#include <set>
+
+using namespace stp;
+
+namespace
+{
+
+bool containsFloatingPointKind(const ASTNode& n, ASTNodeSet& visited)
+{
+  if (!visited.insert(n).second)
+    return false;
+
+  if (is_FP_kind(n.GetKind()))
+    return true;
+
+  for (size_t i = 0; i < n.Degree(); ++i)
+  {
+    if (containsFloatingPointKind(n[i], visited))
+      return true;
+  }
+  return false;
+}
+
+bool containsFloatingPointKind(const ASTNode& n)
+{
+  ASTNodeSet visited;
+  return containsFloatingPointKind(n, visited);
+}
+
+size_t countKind(const ASTNode& n, Kind kind, ASTNodeSet& visited)
+{
+  if (!visited.insert(n).second)
+    return 0;
+
+  size_t count = n.GetKind() == kind ? 1 : 0;
+  for (size_t i = 0; i < n.Degree(); ++i)
+    count += countKind(n[i], kind, visited);
+  return count;
+}
+
+size_t countKind(const ASTNode& n, Kind kind)
+{
+  ASTNodeSet visited;
+  return countKind(n, kind, visited);
+}
+
+ASTNode rne(STPMgr& mgr)
+{
+  return mgr.CreateRMConst(
+      symbolic_fp::ROUND_NEAREST_TIES_TO_EVEN);
+}
+
+} // namespace
+
+TEST(FloatBlast, shared_chain_stays_unpacked_until_a_carrier_boundary)
+{
+  STPMgr mgr;
+  const SourceSort fp16 = SourceSort::floatingPoint(5, 11);
+  const ASTNode x = mgr.CreateSourceSymbol("x", fp16);
+  const ASTNode y = mgr.CreateSourceSymbol("y", fp16);
+  const ASTNode rounding_mode = rne(mgr);
+
+  // `sum` is deliberately shared by both operands of the multiply. A
+  // packed-only traversal builds unpack(sum) twice here even though AST
+  // hash-consing may hide the duplicate circuit in the final DAG.
+  const ASTNode sum =
+      mgr.CreateTerm(FP_ADD, 16, ASTVec{rounding_mode, x, y});
+  const ASTNode product =
+      mgr.CreateTerm(FP_MUL, 16, ASTVec{rounding_mode, sum, sum});
+  const ASTNode predicate = mgr.CreateNode(FP_ISZERO, product);
+
+  FloatBlast lower(&mgr);
+  const ASTNode lowered_predicate = lower.topLevel(predicate);
+
+  EXPECT_FALSE(containsFloatingPointKind(lowered_predicate));
+  EXPECT_EQ(2u, lower.statistics().unpack_builds);
+  EXPECT_EQ(2u, lower.statistics().unpacked_operation_builds);
+  EXPECT_EQ(0u, lower.statistics().pack_builds);
+  EXPECT_GE(lower.statistics().unpacked_cache_hits, 1u);
+
+  // Asking for the IEEE carrier is a real pack boundary. The same context
+  // must reuse product's cached UF and build exactly one encoding for it.
+  const ASTNode ieee = mgr.CreateTerm(FP_TO_IEEE_BV, 16, product);
+  const ASTNode lowered_ieee = lower.topLevel(ieee);
+
+  EXPECT_FALSE(containsFloatingPointKind(lowered_ieee));
+  EXPECT_EQ(16u, lowered_ieee.GetValueWidth());
+  EXPECT_EQ(2u, lower.statistics().unpack_builds);
+  EXPECT_EQ(2u, lower.statistics().unpacked_operation_builds);
+  EXPECT_EQ(1u, lower.statistics().pack_builds);
+}
+
+TEST(FloatBlast, format_conversion_feeds_the_next_operation_unpacked)
+{
+  STPMgr mgr;
+  const ASTNode half =
+      mgr.CreateSourceSymbol("half", SourceSort::floatingPoint(5, 11));
+  const ASTNode rounding_mode = rne(mgr);
+
+  // ((_ to_fp 8 24) RNE half), followed by another FP operation and a
+  // Boolean consumer. The conversion creates an FP32 UF directly; it must
+  // not encode that UF merely so fp.neg can decode it again.
+  const ASTNode converted = mgr.CreateTerm(
+      FP_TOFP, 32,
+      ASTVec{mgr.CreateBVConst(32, 8), mgr.CreateBVConst(32, 24),
+             rounding_mode, half});
+  const ASTNode negated = mgr.CreateTerm(FP_NEG, 32, converted);
+  const ASTNode predicate = mgr.CreateNode(FP_ISNORMAL, negated);
+
+  FloatBlast lower(&mgr);
+  const ASTNode lowered = lower.topLevel(predicate);
+
+  EXPECT_FALSE(containsFloatingPointKind(lowered));
+  EXPECT_EQ(1u, lower.statistics().unpack_builds);
+  EXPECT_EQ(2u, lower.statistics().unpacked_operation_builds);
+  EXPECT_EQ(0u, lower.statistics().pack_builds);
+}
+
+TEST(FloatBlast, reinterpret_cache_distinguishes_equal_width_formats)
+{
+  STPMgr mgr;
+  const ASTNode bits =
+      mgr.CreateSourceSymbol("bits", SourceSort::bitVector(16));
+
+  // Both formats have a 16-bit carrier, and both reinterpret exactly the same
+  // BV node. They nevertheless require different SymFPU decodes: the cache
+  // key is the typed source operation, not just its child or packed width.
+  const ASTNode binary16 = mgr.CreateTerm(
+      FP_TOFP, 16,
+      ASTVec{mgr.CreateBVConst(32, 5), mgr.CreateBVConst(32, 11), bits});
+  const ASTNode exponent8 = mgr.CreateTerm(
+      FP_TOFP, 16,
+      ASTVec{mgr.CreateBVConst(32, 8), mgr.CreateBVConst(32, 8), bits});
+
+  const ASTNode binary16_normal = mgr.CreateNode(FP_ISNORMAL, binary16);
+  const ASTNode exponent8_normal = mgr.CreateNode(FP_ISNORMAL, exponent8);
+  const ASTNode both =
+      mgr.CreateNode(AND, binary16_normal, exponent8_normal);
+
+  FloatBlast lower(&mgr);
+  const ASTNode lowered = lower.topLevel(both);
+
+  EXPECT_FALSE(containsFloatingPointKind(lowered));
+  EXPECT_EQ(2u, lower.statistics().unpack_builds);
+  EXPECT_EQ(2u, lower.statistics().unpacked_operation_builds);
+  EXPECT_EQ(0u, lower.statistics().pack_builds);
+}
+
+TEST(FloatBlast, totalisation_defers_canonical_boundaries_to_lowering)
+{
+  STPMgr mgr;
+  const SourceSort fp16 = SourceSort::floatingPoint(5, 11);
+  const ASTNode x = mgr.CreateSourceSymbol("x", fp16);
+  const ASTNode y = mgr.CreateSourceSymbol("y", fp16);
+  const ASTNode rounding_mode = rne(mgr);
+
+  const ASTNode sum =
+      mgr.CreateTerm(FP_ADD, 16, ASTVec{rounding_mode, x, y});
+  const ASTNode minimum = mgr.CreateTerm(FP_MIN, 16, ASTVec{sum, x});
+  const ASTNode predicate = mgr.CreateNode(FP_ISZERO, minimum);
+
+  FpTotalise totalise(&mgr);
+  const ASTNode prepared = totalise.topLevel(predicate);
+
+  // fp.min's unspecified signed-zero choice is indexed by canonical forms of
+  // both operands. Totalisation records those as source boundaries rather
+  // than eagerly constructing independent SymFPU decode/encode circuits.
+  EXPECT_EQ(2u, countKind(prepared, FP_TO_IEEE_BV));
+  EXPECT_EQ(prepared, totalise.topLevel(prepared));
+
+  FloatBlast lower(&mgr);
+  const ASTNode lowered = lower.topLevel(prepared);
+
+  EXPECT_FALSE(containsFloatingPointKind(lowered));
+  EXPECT_EQ(2u, lower.statistics().unpack_builds);
+  EXPECT_EQ(2u, lower.statistics().unpacked_operation_builds);
+  EXPECT_EQ(2u, lower.statistics().pack_builds);
+}
+
+// Every floating-point kind reaches an arm of the lowering table.
+//
+// There used to be two tables over this signature -- the unpacked one here
+// and a packed one in FloatBlaster::BlastNode -- and keeping them in step was
+// a manual obligation: a kind added to one and not the other compiles, and
+// fails only on the path that reaches the one that was missed. There is one
+// table now, so the remaining risk is a kind that reaches no arm at all.
+// Both ends of the table fail closed with a FatalError, so an omission
+// aborts this test rather than silently answering.
+TEST(FloatBlast, every_floating_point_kind_is_lowered)
+{
+  STPMgr mgr;
+  const SourceSort fp32 = SourceSort::floatingPoint(8, 24);
+  const ASTNode x = mgr.CreateSourceSymbol("x", fp32);
+  const ASTNode y = mgr.CreateSourceSymbol("y", fp32);
+  const ASTNode z = mgr.CreateSourceSymbol("z", fp32);
+  const ASTNode rm = rne(mgr);
+  const ASTNode bits = mgr.CreateSourceSymbol("b", SourceSort::bitVector(32));
+  const ASTNode choice =
+      mgr.CreateSourceSymbol("c", SourceSort::bitVector(1));
+  const ASTNode undef =
+      mgr.CreateSourceSymbol("u", SourceSort::bitVector(16));
+  const ASTNode eight = mgr.CreateBVConst(32, 8);
+  const ASTNode twentyfour = mgr.CreateBVConst(32, 24);
+  const ASTNode sixteen = mgr.CreateBVConst(32, 16);
+
+  // One representative per kind, in the arity the blaster is entitled to
+  // assume -- the partial operations after FpTotalise has added their
+  // unspecified-value child.
+  std::vector<std::pair<Kind, ASTNode>> cases;
+  auto term = [&](Kind k, unsigned w, const ASTVec& kids) {
+    cases.push_back({k, mgr.CreateTerm(k, w, kids)});
+  };
+  auto form = [&](Kind k, const ASTVec& kids) {
+    cases.push_back({k, mgr.CreateNode(k, kids)});
+  };
+
+  term(FP_ABS, 32, {x});
+  term(FP_NEG, 32, {x});
+  term(FP_ADD, 32, {rm, x, y});
+  term(FP_SUB, 32, {rm, x, y});
+  term(FP_MUL, 32, {rm, x, y});
+  term(FP_DIV, 32, {rm, x, y});
+  term(FP_FMA, 32, {rm, x, y, z});
+  term(FP_SQRT, 32, {rm, x});
+  term(FP_REM, 32, {x, y});
+  term(FP_ROUNDTOINTEGRAL, 32, {rm, x});
+  term(FP_MIN, 32, {x, y, choice});
+  term(FP_MAX, 32, {x, y, choice});
+  term(FP_TOFP, 32, {eight, twentyfour, bits});
+  term(FP_TOFP, 32, {eight, twentyfour, rm, x});
+  term(FP_TOFP_SIGNED, 32, {eight, twentyfour, rm, bits});
+  term(FP_TOFP_UNSIGNED, 32, {eight, twentyfour, rm, bits});
+  term(FP_TO_UBV, 16, {sixteen, rm, x, undef});
+  term(FP_TO_SBV, 16, {sixteen, rm, x, undef});
+  term(FP_TO_IEEE_BV, 32, {x});
+  form(FP_LEQ, {x, y});
+  form(FP_LT, {x, y});
+  form(FP_GEQ, {x, y});
+  form(FP_GT, {x, y});
+  form(FP_EQ, {x, y});
+  form(FP_SMT_EQ, {x, y});
+  form(FP_ISNORMAL, {x});
+  form(FP_ISSUBNORMAL, {x});
+  form(FP_ISZERO, {x});
+  form(FP_ISINFINITE, {x});
+  form(FP_ISNAN, {x});
+  form(FP_ISNEGATIVE, {x});
+  form(FP_ISPOSITIVE, {x});
+
+  // Every FP kind in the tree is represented, so adding one without adding
+  // an arm for it fails here rather than at the first input that uses it.
+  // FP_SMT_EQ is the last kind in ASTKind.kinds; a new one is appended after
+  // it, so the scan has to reach it.
+  std::set<int> covered;
+  for (const auto& c : cases)
+    covered.insert(static_cast<int>(c.first));
+  for (int k = 0; k <= static_cast<int>(FP_SMT_EQ); k++)
+  {
+    if (!is_FP_kind(static_cast<Kind>(k)))
+      continue;
+    EXPECT_EQ(1u, covered.count(k)) << "no representative for "
+                                    << _kind_names[k];
+  }
+
+  for (const auto& c : cases)
+  {
+    FloatBlast lower(&mgr);
+    const ASTNode lowered = lower.topLevel(c.second);
+    EXPECT_FALSE(containsFloatingPointKind(lowered))
+        << _kind_names[c.first] << " was not lowered";
+  }
+}

--- a/tests/unit-tests/FpConstantFold_Test.cpp
+++ b/tests/unit-tests/FpConstantFold_Test.cpp
@@ -1,0 +1,442 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: August 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+// Floating-point constant folding, against the hardware.
+//
+// STP folds an all-constant floating-point operation by building its symfpu
+// circuit and evaluating it, so the folded value comes from the same source
+// as the solved one and the two cannot disagree. That is the right property
+// and it is why the fold costs what it does: a Float64 fp.add of two
+// literals builds and tears down thousands of interned nodes, about half a
+// millisecond, where concrete arithmetic is sub-microsecond.
+//
+// Replacing it means giving symfpu a *literal* traits backend -- its core
+// algorithms are templated precisely so that a second backend reuses the
+// IEEE semantics and supplies only the bit-vector primitives (upstream ships
+// simpleExecutable for this, though its 64-bit words cannot hold the
+// 106-bit intermediates a Float64 multiply needs, so STP would need its own
+// over CBV). The risk in that change is not the semantics but the
+// primitives, and its failure mode is a silently wrong constant.
+//
+// These tests are the gate for it. IEEE-754 requires +, -, *, / and sqrt to
+// be correctly rounded, so the hardware is an exact oracle for the two
+// native formats under the four native rounding modes, independent of
+// anything in STP. They pass against the circuit path today; a literal
+// backend has to keep them passing.
+
+#include "stp/AST/AST.h"
+#include "stp/FloatBlaster/rounding_modes.h"
+#include "stp/NodeFactory/SimplifyingNodeFactory.h"
+#include "stp/STPManager/STPManager.h"
+#include "stp/Simplifier/Simplifier.h"
+#include "stp/Util/CBVOps.h"
+
+#include <gtest/gtest.h>
+
+#include <cfenv>
+#include <cmath>
+#include <cstring>
+#include <limits>
+#include <vector>
+
+using namespace stp;
+
+namespace
+{
+
+struct Fixture
+{
+  STPMgr mgr;
+  SimplifyingNodeFactory snf;
+
+  Fixture() : snf(*(mgr.hashingNodeFactory), mgr)
+  {
+    mgr.defaultNodeFactory = &snf; // the production wiring
+  }
+
+  ASTNode fpConst(unsigned eb, unsigned sb, uint64_t bits)
+  {
+    return mgr.CreateFPConst(mgr.CreateBVConst(eb + sb, bits), eb, sb);
+  }
+
+  ASTNode rm(unsigned mode) { return mgr.CreateRMConst(mode); }
+
+  // Fold `k` over already-constant operands and return the packed bits.
+  uint64_t fold(Kind k, unsigned width, const ASTVec& kids)
+  {
+    const ASTNode folded =
+        NonMemberBVConstEvaluator(&mgr, k, kids, width);
+    EXPECT_TRUE(folded.isConstant());
+    // Not a single 64-bit Chunk_Read: that returns unsigned long, which is
+    // 32 bits on a 32-bit host, so every binary64 result would lose its top
+    // half while binary32 came through intact. chunk64 reads two 32-bit
+    // chunks, as everything else in the tree does.
+    return chunk64(folded.GetBVConst(), 0);
+  }
+};
+
+uint32_t bitsOf(float f)
+{
+  uint32_t b;
+  std::memcpy(&b, &f, sizeof b);
+  return b;
+}
+uint64_t bitsOf(double d)
+{
+  uint64_t b;
+  std::memcpy(&b, &d, sizeof b);
+  return b;
+}
+float floatOf(uint32_t b)
+{
+  float f;
+  std::memcpy(&f, &b, sizeof f);
+  return f;
+}
+double doubleOf(uint64_t b)
+{
+  double d;
+  std::memcpy(&d, &b, sizeof d);
+  return d;
+}
+
+struct Mode
+{
+  unsigned stp;
+  int native;
+  const char* name;
+};
+
+// RNA has no native counterpart, so it is not covered here; the query-file
+// corpus distinguishes all five.
+const Mode MODES[] = {
+    {symbolic_fp::ROUND_NEAREST_TIES_TO_EVEN, FE_TONEAREST, "RNE"},
+    {symbolic_fp::ROUND_TOWARD_POSITIVE, FE_UPWARD, "RTP"},
+    {symbolic_fp::ROUND_TOWARD_NEGATIVE, FE_DOWNWARD, "RTN"},
+    {symbolic_fp::ROUND_TOWARD_ZERO, FE_TOWARDZERO, "RTZ"},
+};
+
+// Specials, subnormals, exact powers, and values whose results need rounding
+// in every direction.
+const double VALUES[] = {
+    0.0,
+    -0.0,
+    1.0,
+    -1.0,
+    2.0,
+    0.5,
+    3.0,
+    -7.5,
+    1e-300,
+    -1e-300,
+    1e300,
+    -1e300,
+    4.9406564584124654e-324, // the smallest Float64 subnormal
+    2.2250738585072009e-308, // the largest Float64 subnormal
+    1.0000000000000002,      // one ulp above 1.0
+    123456789.123456789,
+    std::numeric_limits<double>::infinity(),
+    -std::numeric_limits<double>::infinity(),
+    std::numeric_limits<double>::quiet_NaN(),
+};
+
+// Every NaN is one value in SMT-LIB, so compare NaN results as a class.
+bool sameDouble(uint64_t got, uint64_t want)
+{
+  const double g = doubleOf(got);
+  const double w = doubleOf(want);
+  if (std::isnan(g) && std::isnan(w))
+    return true;
+  return got == want;
+}
+bool sameFloat(uint32_t got, uint32_t want)
+{
+  const float g = floatOf(got);
+  const float w = floatOf(want);
+  if (std::isnan(g) && std::isnan(w))
+    return true;
+  return got == want;
+}
+
+struct ScopedRound
+{
+  int saved;
+  explicit ScopedRound(int mode) : saved(std::fegetround())
+  {
+    std::fesetround(mode);
+  }
+  ~ScopedRound() { std::fesetround(saved); }
+};
+
+// The oracle has to be evaluated at *runtime*, under the mode ScopedRound
+// set. Operands read through volatile force that: without it the compiler
+// folds the arithmetic while compiling, under the default mode, and the
+// three non-default modes then disagree with STP for a reason that has
+// nothing to do with STP. (The file is also built with -frounding-math, so
+// the compiler does not assume the default mode for what is left.)
+template <class T> T runtimeAdd(T a, T b)
+{
+  volatile T x = a, y = b;
+  volatile T result = x + y;
+  return result;
+}
+template <class T> T runtimeSub(T a, T b)
+{
+  volatile T x = a, y = b;
+  volatile T result = x - y;
+  return result;
+}
+template <class T> T runtimeMul(T a, T b)
+{
+  volatile T x = a, y = b;
+  volatile T result = x * y;
+  return result;
+}
+template <class T> T runtimeDiv(T a, T b)
+{
+  volatile T x = a, y = b;
+  volatile T result = x / y;
+  return result;
+}
+template <class T> T runtimeSqrt(T a)
+{
+  volatile T x = a;
+  volatile T result = std::sqrt(x);
+  return result;
+}
+template <class T> T runtimeNearbyint(T a)
+{
+  volatile T x = a;
+  volatile T result = std::nearbyint(x);
+  return result;
+}
+template <class T> T runtimeFma(T a, T b, T c)
+{
+  volatile T x = a, y = b, z = c;
+  volatile T result = std::fma(x, y, z);
+  return result;
+}
+template <class T> T runtimeRemainder(T a, T b)
+{
+  volatile T x = a, y = b;
+  volatile T result = std::remainder(x, y);
+  return result;
+}
+
+} // namespace
+
+TEST(FpConstantFold, binary64_arithmetic_matches_the_hardware)
+{
+  Fixture f;
+  for (const Mode& mode : MODES)
+  {
+    const ASTNode rm = f.rm(mode.stp);
+    for (double a : VALUES)
+    {
+      for (double b : VALUES)
+      {
+        const ASTNode x = f.fpConst(11, 53, bitsOf(a));
+        const ASTNode y = f.fpConst(11, 53, bitsOf(b));
+
+        double add, sub, mul, div;
+        {
+          ScopedRound rounding(mode.native);
+          add = runtimeAdd(a, b);
+          sub = runtimeSub(a, b);
+          mul = runtimeMul(a, b);
+          div = runtimeDiv(a, b);
+        }
+
+        EXPECT_TRUE(sameDouble(f.fold(FP_ADD, 64, {rm, x, y}), bitsOf(add)))
+            << mode.name << " fp.add " << a << " " << b;
+        EXPECT_TRUE(sameDouble(f.fold(FP_SUB, 64, {rm, x, y}), bitsOf(sub)))
+            << mode.name << " fp.sub " << a << " " << b;
+        EXPECT_TRUE(sameDouble(f.fold(FP_MUL, 64, {rm, x, y}), bitsOf(mul)))
+            << mode.name << " fp.mul " << a << " " << b;
+        EXPECT_TRUE(sameDouble(f.fold(FP_DIV, 64, {rm, x, y}), bitsOf(div)))
+            << mode.name << " fp.div " << a << " " << b;
+      }
+    }
+  }
+}
+
+TEST(FpConstantFold, binary32_arithmetic_matches_the_hardware)
+{
+  Fixture f;
+  for (const Mode& mode : MODES)
+  {
+    const ASTNode rm = f.rm(mode.stp);
+    for (double da : VALUES)
+    {
+      for (double db : VALUES)
+      {
+        const float a = static_cast<float>(da);
+        const float b = static_cast<float>(db);
+        const ASTNode x = f.fpConst(8, 24, bitsOf(a));
+        const ASTNode y = f.fpConst(8, 24, bitsOf(b));
+
+        float add, sub, mul, div;
+        {
+          ScopedRound rounding(mode.native);
+          add = runtimeAdd(a, b);
+          sub = runtimeSub(a, b);
+          mul = runtimeMul(a, b);
+          div = runtimeDiv(a, b);
+        }
+
+        EXPECT_TRUE(sameFloat(
+            static_cast<uint32_t>(f.fold(FP_ADD, 32, {rm, x, y})), bitsOf(add)))
+            << mode.name << " fp.add " << a << " " << b;
+        EXPECT_TRUE(sameFloat(
+            static_cast<uint32_t>(f.fold(FP_SUB, 32, {rm, x, y})), bitsOf(sub)))
+            << mode.name << " fp.sub " << a << " " << b;
+        EXPECT_TRUE(sameFloat(
+            static_cast<uint32_t>(f.fold(FP_MUL, 32, {rm, x, y})), bitsOf(mul)))
+            << mode.name << " fp.mul " << a << " " << b;
+        EXPECT_TRUE(sameFloat(
+            static_cast<uint32_t>(f.fold(FP_DIV, 32, {rm, x, y})), bitsOf(div)))
+            << mode.name << " fp.div " << a << " " << b;
+      }
+    }
+  }
+}
+
+TEST(FpConstantFold, sqrt_fma_and_roundtointegral_match_the_hardware)
+{
+  Fixture f;
+  for (const Mode& mode : MODES)
+  {
+    const ASTNode rm = f.rm(mode.stp);
+    const ASTNode addend = f.fpConst(11, 53, bitsOf(1.5));
+    for (double a : VALUES)
+    {
+      const ASTNode x = f.fpConst(11, 53, bitsOf(a));
+
+      double root, integral;
+      {
+        ScopedRound rounding(mode.native);
+        root = runtimeSqrt(a);
+        integral = runtimeNearbyint(a);
+      }
+      EXPECT_TRUE(sameDouble(f.fold(FP_SQRT, 64, {rm, x}), bitsOf(root)))
+          << mode.name << " fp.sqrt " << a;
+      EXPECT_TRUE(
+          sameDouble(f.fold(FP_ROUNDTOINTEGRAL, 64, {rm, x}), bitsOf(integral)))
+          << mode.name << " fp.roundToIntegral " << a;
+
+      for (double b : VALUES)
+      {
+        const ASTNode y = f.fpConst(11, 53, bitsOf(b));
+        double fused;
+        {
+          ScopedRound rounding(mode.native);
+          fused = runtimeFma(a, b, 1.5);
+        }
+        EXPECT_TRUE(
+            sameDouble(f.fold(FP_FMA, 64, {rm, x, y, addend}), bitsOf(fused)))
+            << mode.name << " fp.fma " << a << " " << b;
+      }
+    }
+  }
+}
+
+// fp.rem is exact and takes no rounding mode, so it gets one pass rather
+// than one per mode. It is also the most expensive circuit here -- binary64
+// unrolls 2097 divide steps -- so running it four times was most of this
+// file's cost and none of its coverage.
+TEST(FpConstantFold, remainder_matches_the_hardware)
+{
+  Fixture f;
+  for (double a : VALUES)
+  {
+    const ASTNode x = f.fpConst(11, 53, bitsOf(a));
+    for (double b : VALUES)
+    {
+      const ASTNode y = f.fpConst(11, 53, bitsOf(b));
+      const double rem = runtimeRemainder(a, b);
+      EXPECT_TRUE(sameDouble(f.fold(FP_REM, 64, {x, y}), bitsOf(rem)))
+          << "fp.rem " << a << " " << b;
+    }
+  }
+}
+
+// Hard-coded, so it does not depend on the oracle machinery at all: 1.0/3.0
+// is the classic case where the four modes disagree, and these are the four
+// answers the hardware gives (verified separately) and the ones STP's solver
+// produces end to end.
+TEST(FpConstantFold, one_third_matches_known_values_under_every_mode)
+{
+  Fixture f;
+  const uint64_t one = 0x3FF0000000000000ull;
+  const uint64_t three = 0x4008000000000000ull;
+  const struct
+  {
+    unsigned mode;
+    uint64_t want;
+    const char* name;
+  } cases[] = {
+      {symbolic_fp::ROUND_NEAREST_TIES_TO_EVEN, 0x3FD5555555555555ull, "RNE"},
+      {symbolic_fp::ROUND_TOWARD_POSITIVE, 0x3FD5555555555556ull, "RTP"},
+      {symbolic_fp::ROUND_TOWARD_NEGATIVE, 0x3FD5555555555555ull, "RTN"},
+      {symbolic_fp::ROUND_TOWARD_ZERO, 0x3FD5555555555555ull, "RTZ"},
+  };
+
+  for (const auto& c : cases)
+  {
+    const ASTNode rm = f.rm(c.mode);
+    const ASTNode x = f.fpConst(11, 53, one);
+    const ASTNode y = f.fpConst(11, 53, three);
+    EXPECT_EQ(c.want, f.fold(FP_DIV, 64, {rm, x, y})) << c.name << " 1.0/3.0";
+  }
+}
+
+// The fold must not depend on which node factory the embedder installed.
+//
+// Every other test here runs the production wiring, where defaultNodeFactory
+// is the simplifying factory: it folds as it builds, so lowerOperation hands
+// the evaluator a BVCONST that is already the answer and the evaluation is a
+// no-op. STPMgr's own constructor installs the hashing factory instead, and
+// then the same call hands back the whole symfpu circuit -- a deeply shared
+// DAG, which an evaluator that walks paths rather than nodes cannot finish.
+//
+// The format is deliberately tiny. Float(3,4) is about the smallest symfpu
+// will build (formatSupported refuses sb <= 3), and its fp.add circuit is a
+// few hundred nodes -- linear if each is visited once, and hopeless
+// otherwise. Nothing here checks the *value*; the tests above do that, and
+// against the hardware. This one checks only that it arrives.
+TEST(FpConstantFold, folds_under_a_non_simplifying_factory)
+{
+  STPMgr mgr; // hashingNodeFactory, as the constructor leaves it
+
+  const unsigned eb = 3, sb = 4;
+  const ASTNode one = mgr.CreateFPConst(mgr.CreateBVConst(eb + sb, 0x38), eb, sb);
+  const ASTNode rne =
+      mgr.CreateRMConst(stp::symbolic_fp::ROUND_NEAREST_TIES_TO_EVEN);
+
+  const ASTNode folded = NonMemberBVConstEvaluator(
+      &mgr, FP_ADD, ASTVec{rne, one, one}, eb + sb);
+
+  EXPECT_TRUE(folded.isConstant());
+  EXPECT_EQ(eb + sb, folded.GetValueWidth());
+}

--- a/tests/unit-tests/FpTotalise_Test.cpp
+++ b/tests/unit-tests/FpTotalise_Test.cpp
@@ -1,0 +1,252 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: August 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+// The shape of the maps that make the partial operations total.
+//
+// fp.min/fp.max are unspecified only on (+0, -0) and (-0, +0), so their
+// choice map is four free bits selected between by the two sign bits and
+// introduces no array at all; fp.to_ubv/fp.to_sbv are unspecified on NaN,
+// the infinities and anything out of range, which depends on the whole
+// value, so theirs is an array indexed on the rounding mode and the whole
+// float. The end-to-end consequences are in tests/query-files/fp-tests;
+// these pin the encoding itself, which the answers cannot show -- and which
+// arrays a query acquires is not observable from its answer at all, though
+// it decides how the user's own arrays get solved.
+
+#include "stp/AST/AST.h"
+#include "stp/FloatBlaster/FpTotalise.h"
+#include "stp/FloatBlaster/rounding_modes.h"
+#include "stp/NodeFactory/SimplifyingNodeFactory.h"
+#include "stp/STPManager/STPManager.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+using namespace stp;
+
+namespace
+{
+
+struct Fixture
+{
+  STPMgr mgr;
+  SimplifyingNodeFactory snf;
+
+  Fixture() : snf(*(mgr.hashingNodeFactory), mgr)
+  {
+    mgr.defaultNodeFactory = &snf;
+  }
+
+  ASTNode rne()
+  {
+    return mgr.CreateRMConst(symbolic_fp::ROUND_NEAREST_TIES_TO_EVEN);
+  }
+};
+
+// The extra child FpTotalise appends is whatever supplies the unspecified
+// value: an array read for the conversions, a mux over free bits for
+// fp.min/fp.max.
+const ASTNode& unspecified(const ASTNode& totalised, size_t child)
+{
+  return totalised[child];
+}
+
+// The introduced symbol underneath an unspecified value -- the array for a
+// conversion, the cells for a choice. Identity lives in the name, so that is
+// what this looks for.
+ASTNode unspecifiedSymbol(const ASTNode& n)
+{
+  if (n.GetKind() == SYMBOL &&
+      std::string(n.GetName()).rfind("@fp_unspecified_", 0) == 0)
+    return n;
+
+  for (size_t i = 0; i < n.Degree(); i++)
+  {
+    const ASTNode found = unspecifiedSymbol(n[i]);
+    if (!found.IsNull())
+      return found;
+  }
+  return ASTNode();
+}
+
+bool containsRead(const ASTNode& n)
+{
+  if (n.GetKind() == READ)
+    return true;
+  for (size_t i = 0; i < n.Degree(); i++)
+    if (containsRead(n[i]))
+      return true;
+  return false;
+}
+
+} // namespace
+
+TEST(FpTotalise, min_selects_four_free_bits_on_two_sign_bits)
+{
+  Fixture f;
+  const SourceSort fp32 = SourceSort::floatingPoint(8, 24);
+  const ASTNode x = f.mgr.CreateSourceSymbol("x", fp32);
+  const ASTNode y = f.mgr.CreateSourceSymbol("y", fp32);
+  const ASTNode min = f.mgr.CreateTerm(FP_MIN, 32, ASTVec{x, y});
+  ASSERT_EQ(2u, min.Degree());
+
+  FpTotalise totalise(&f.mgr);
+  const ASTNode out = totalise.topLevel(min);
+
+  ASSERT_EQ(FP_MIN, out.GetKind());
+  ASSERT_EQ(3u, out.Degree()); // the choice is now a child
+
+  const ASTNode& choice = unspecified(out, 2);
+  EXPECT_EQ(1u, choice.GetValueWidth()); // one bit of choice
+
+  const ASTNode cells = unspecifiedSymbol(choice);
+  ASSERT_FALSE(cells.IsNull());
+  EXPECT_EQ(4u, cells.GetValueWidth()); // ... one of four cells
+  EXPECT_EQ(0u, cells.GetIndexWidth()); // ... held in a scalar, not an array
+}
+
+// The whole point of the four-cell encoding: a query whose only "arrays"
+// would have been the ones totalisation invented has none. FpTotalise runs
+// before containsArrayOps and numberOfReadsLessThan, so a read introduced
+// here is indistinguishable from the user's and changes how the user's own
+// arrays are solved.
+TEST(FpTotalise, min_introduces_no_array)
+{
+  Fixture f;
+  const SourceSort fp32 = SourceSort::floatingPoint(8, 24);
+  const ASTNode x = f.mgr.CreateSourceSymbol("x", fp32);
+  const ASTNode y = f.mgr.CreateSourceSymbol("y", fp32);
+
+  FpTotalise totalise(&f.mgr);
+  const ASTNode min =
+      totalise.topLevel(f.mgr.CreateTerm(FP_MIN, 32, ASTVec{x, y}));
+  const ASTNode max =
+      totalise.topLevel(f.mgr.CreateTerm(FP_MAX, 32, ASTVec{x, y}));
+
+  EXPECT_FALSE(containsRead(min));
+  EXPECT_FALSE(containsRead(max));
+
+  // ... whereas a conversion, whose domain really is unbounded, still does.
+  const ASTNode to_ubv = totalise.topLevel(f.mgr.CreateTerm(
+      FP_TO_UBV, 16, ASTVec{f.mgr.CreateBVConst(32, 16), f.rne(), x}));
+  EXPECT_TRUE(containsRead(to_ubv));
+}
+
+TEST(FpTotalise, max_uses_different_cells_from_min)
+{
+  Fixture f;
+  const SourceSort fp32 = SourceSort::floatingPoint(8, 24);
+  const ASTNode x = f.mgr.CreateSourceSymbol("x", fp32);
+  const ASTNode y = f.mgr.CreateSourceSymbol("y", fp32);
+
+  FpTotalise totalise(&f.mgr);
+  const ASTNode min =
+      totalise.topLevel(f.mgr.CreateTerm(FP_MIN, 32, ASTVec{x, y}));
+  const ASTNode max =
+      totalise.topLevel(f.mgr.CreateTerm(FP_MAX, 32, ASTVec{x, y}));
+
+  // Same shape, different cells: fp.min and fp.max choose independently.
+  EXPECT_NE(unspecifiedSymbol(unspecified(min, 2)),
+            unspecifiedSymbol(unspecified(max, 2)));
+}
+
+TEST(FpTotalise, each_format_gets_its_own_choice_cells)
+{
+  Fixture f;
+  const ASTNode x =
+      f.mgr.CreateSourceSymbol("x", SourceSort::floatingPoint(8, 24));
+  const ASTNode y =
+      f.mgr.CreateSourceSymbol("y", SourceSort::floatingPoint(8, 24));
+  const ASTNode p =
+      f.mgr.CreateSourceSymbol("p", SourceSort::floatingPoint(11, 53));
+  const ASTNode q =
+      f.mgr.CreateSourceSymbol("q", SourceSort::floatingPoint(11, 53));
+
+  FpTotalise totalise(&f.mgr);
+  const ASTNode single =
+      totalise.topLevel(f.mgr.CreateTerm(FP_MIN, 32, ASTVec{x, y}));
+  const ASTNode dbl =
+      totalise.topLevel(f.mgr.CreateTerm(FP_MIN, 64, ASTVec{p, q}));
+
+  // Both are four-cell maps, so only the name keeps them apart -- and it
+  // must, because fp.min at two formats is two unspecified functions.
+  const ASTNode single_cells = unspecifiedSymbol(unspecified(single, 2));
+  const ASTNode dbl_cells = unspecifiedSymbol(unspecified(dbl, 2));
+  ASSERT_FALSE(single_cells.IsNull());
+  ASSERT_FALSE(dbl_cells.IsNull());
+  EXPECT_EQ(4u, single_cells.GetValueWidth());
+  EXPECT_EQ(4u, dbl_cells.GetValueWidth());
+  EXPECT_NE(single_cells, dbl_cells);
+}
+
+// The same operands must select the same cell, or the map is not a function
+// and fp.min stops being congruent. Hash-consing is what supplies this now
+// that there are no index equalities to do it.
+TEST(FpTotalise, the_same_operands_select_the_same_cell)
+{
+  Fixture f;
+  const SourceSort fp32 = SourceSort::floatingPoint(8, 24);
+  const ASTNode x = f.mgr.CreateSourceSymbol("x", fp32);
+  const ASTNode y = f.mgr.CreateSourceSymbol("y", fp32);
+
+  FpTotalise totalise(&f.mgr);
+  const ASTNode a =
+      totalise.topLevel(f.mgr.CreateTerm(FP_MIN, 32, ASTVec{x, y}));
+  const ASTNode b =
+      totalise.topLevel(f.mgr.CreateTerm(FP_MIN, 32, ASTVec{x, y}));
+  EXPECT_EQ(a, b);
+
+  // ... and swapping them selects a different cell, because (+0,-0) and
+  // (-0,+0) are separately unspecified. Same cells, different mux.
+  const ASTNode swapped =
+      totalise.topLevel(f.mgr.CreateTerm(FP_MIN, 32, ASTVec{y, x}));
+  EXPECT_EQ(unspecifiedSymbol(unspecified(a, 2)),
+            unspecifiedSymbol(unspecified(swapped, 2)));
+  EXPECT_NE(unspecified(a, 2), unspecified(swapped, 2));
+}
+
+// fp.to_ubv is unspecified on NaN, the infinities and out-of-range values,
+// which is not a function of the sign, so its index keeps the whole float
+// and the rounding mode.
+TEST(FpTotalise, to_ubv_indexes_on_the_rounding_mode_and_the_whole_value)
+{
+  Fixture f;
+  const ASTNode x =
+      f.mgr.CreateSourceSymbol("x", SourceSort::floatingPoint(8, 24));
+  const ASTNode to_ubv = f.mgr.CreateTerm(
+      FP_TO_UBV, 16,
+      ASTVec{f.mgr.CreateBVConst(32, 16), f.rne(), x});
+
+  FpTotalise totalise(&f.mgr);
+  const ASTNode out = totalise.topLevel(to_ubv);
+
+  ASSERT_EQ(FP_TO_UBV, out.GetKind());
+  ASSERT_EQ(4u, out.Degree());
+
+  const ASTNode& read = unspecified(out, 3);
+  ASSERT_EQ(READ, read.GetKind());
+  EXPECT_EQ(16u, read.GetValueWidth());     // the target width
+  EXPECT_EQ(5u + 32u, read[1].GetValueWidth()); // rounding mode ++ float
+}

--- a/tests/unit-tests/SourceSortMemo_Test.cpp
+++ b/tests/unit-tests/SourceSortMemo_Test.cpp
@@ -1,0 +1,249 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: August 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+// A node's source sort is derived from its children -- through both branches
+// of an ITE -- so without a memo the derivation costs one walk per *path*
+// rather than one per node. The result is correct either way, which is why
+// these tests count derivations rather than compare sorts: the count is the
+// only place the difference shows.
+
+#include "stp/AST/AST.h"
+#include "stp/STPManager/STPManager.h"
+
+#include <gtest/gtest.h>
+
+using namespace stp;
+
+namespace
+{
+
+// A spine of `depth` stores over one array, as a memory model or a lookup
+// table produces. Each WRITE derives its sort from the array beneath it.
+ASTNode storeChain(STPMgr& mgr, unsigned depth)
+{
+  const SourceSort array =
+      SourceSort::array(SourceSort::bitVector(16), SourceSort::bitVector(8));
+  ASTNode current = mgr.CreateSourceSymbol("a", array);
+
+  for (unsigned i = 0; i < depth; i++)
+  {
+    const ASTNode index = mgr.CreateBVConst(16, i);
+    const ASTNode value = mgr.CreateBVConst(8, i % 256);
+    current = mgr.CreateArrayTerm(WRITE, 16, 8, {current, index, value});
+  }
+  return current;
+}
+
+// Two interleaved ITE spines: every level's branches are the previous
+// level's two nodes, so the node count is linear in the depth while the
+// number of root-to-leaf paths is 2^depth.
+ASTNode iteDiamond(STPMgr& mgr, unsigned depth)
+{
+  ASTNode left = mgr.CreateSourceSymbol("x", SourceSort::bitVector(8));
+  ASTNode right = mgr.CreateSourceSymbol("y", SourceSort::bitVector(8));
+
+  for (unsigned i = 0; i < depth; i++)
+  {
+    const std::string cname = "c" + std::to_string(i);
+    const std::string ename = "e" + std::to_string(i);
+    const ASTNode c = mgr.CreateSourceSymbol(cname.c_str(),
+                                             SourceSort::boolean());
+    const ASTNode e = mgr.CreateSourceSymbol(ename.c_str(),
+                                             SourceSort::boolean());
+
+    const ASTNode next_left = mgr.CreateTerm(ITE, 8, c, left, right);
+    const ASTNode next_right = mgr.CreateTerm(ITE, 8, e, right, left);
+    left = next_left;
+    right = next_right;
+  }
+  return left;
+}
+
+} // namespace
+
+TEST(SourceSortMemo, ite_diamond_derives_once_per_node_not_once_per_path)
+{
+  STPMgr mgr;
+  const unsigned depth = 40; // 2^40 paths; a per-path walk cannot finish.
+  const ASTNode root = iteDiamond(mgr, depth);
+
+  mgr.source_sort_derivations = 0;
+  const SourceSort sort = root.GetSourceSort();
+
+  EXPECT_EQ(SourceSort::bitVector(8), sort);
+  // Two ITEs per level plus the leaves beneath them; the bound is deliberately
+  // loose, because the point is that it is linear in the depth at all.
+  EXPECT_LE(mgr.source_sort_derivations, 4 * depth + 16);
+}
+
+TEST(SourceSortMemo, store_chain_derives_once_per_node)
+{
+  STPMgr mgr;
+  const unsigned depth = 2000;
+  const ASTNode root = storeChain(mgr, depth);
+
+  mgr.source_sort_derivations = 0;
+  const SourceSort sort = root.GetSourceSort();
+
+  EXPECT_EQ(SourceSort::Kind::Array, sort.kind());
+  EXPECT_EQ(SourceSort::bitVector(8), sort.element());
+  EXPECT_LE(mgr.source_sort_derivations, depth + 16);
+}
+
+TEST(SourceSortMemo, asking_again_costs_no_derivation)
+{
+  STPMgr mgr;
+  const ASTNode root = storeChain(mgr, 64);
+  root.GetSourceSort();
+
+  mgr.source_sort_derivations = 0;
+  EXPECT_EQ(root.GetSourceSort(), root.GetSourceSort());
+  EXPECT_EQ(0u, mgr.source_sort_derivations);
+}
+
+// The node factories re-assert a node's widths on every hash-cons hit, so a
+// memo dropped on every width *assignment* rather than on every width
+// *change* is no memo at all -- it would be discarded once per incoming edge.
+TEST(SourceSortMemo, reasserting_the_same_width_keeps_the_memo)
+{
+  STPMgr mgr;
+  const ASTNode x = mgr.CreateSourceSymbol("x", SourceSort::bitVector(8));
+  const ASTNode y = mgr.CreateSourceSymbol("y", SourceSort::bitVector(8));
+  const ASTNode sum = mgr.CreateTerm(BVPLUS, 8, x, y);
+
+  EXPECT_EQ(SourceSort::bitVector(8), sum.GetSourceSort());
+
+  mgr.source_sort_derivations = 0;
+  sum.SetValueWidth(8); // what the node factory does on every lookup
+  EXPECT_EQ(SourceSort::bitVector(8), sum.GetSourceSort());
+  EXPECT_EQ(0u, mgr.source_sort_derivations);
+}
+
+TEST(SourceSortMemo, changing_a_width_drops_the_memo)
+{
+  STPMgr mgr;
+  const ASTNode x = mgr.CreateSourceSymbol("x", SourceSort::bitVector(8));
+  const ASTNode y = mgr.CreateSourceSymbol("y", SourceSort::bitVector(8));
+  const ASTNode sum = mgr.CreateTerm(BVPLUS, 8, x, y);
+
+  EXPECT_EQ(SourceSort::bitVector(8), sum.GetSourceSort());
+
+  sum.SetValueWidth(16);
+  EXPECT_EQ(SourceSort::bitVector(16), sum.GetSourceSort());
+
+  sum.SetValueWidth(8); // put it back, so the node is left as it was found
+  EXPECT_EQ(SourceSort::bitVector(8), sum.GetSourceSort());
+}
+
+// A symbol's sort is part of its identity, so a name-only probe cannot be
+// built for the unique table. These cover the name index that answers the
+// name-only lookups instead -- which is what keeps creating a symbol from
+// being linear in the number of symbols already made.
+TEST(SymbolNameIndex, finds_a_typed_declaration_by_name_alone)
+{
+  STPMgr mgr;
+  const ASTNode declared =
+      mgr.CreateSourceSymbol("v", SourceSort::bitVector(32));
+
+  EXPECT_TRUE(mgr.LookupSymbol("v"));
+  ASTNode found;
+  EXPECT_TRUE(mgr.LookupSymbol("v", found));
+  EXPECT_EQ(declared, found);
+
+  EXPECT_FALSE(mgr.LookupSymbol("not_declared"));
+  ASTNode missing;
+  EXPECT_FALSE(mgr.LookupSymbol("not_declared", missing));
+}
+
+// The legacy untyped entry point resolves a name to whatever was declared
+// under it, rather than minting a second, sort-less symbol beside it.
+TEST(SymbolNameIndex, untyped_lookup_reuses_the_typed_declaration)
+{
+  STPMgr mgr;
+  const ASTNode declared =
+      mgr.CreateSourceSymbol("w", SourceSort::bitVector(16));
+  const ASTNode again = mgr.LookupOrCreateSymbol("w");
+
+  EXPECT_EQ(declared, again);
+  EXPECT_EQ(SourceSort::bitVector(16), again.GetSourceSort());
+}
+
+// One name at two sorts is what the sorted key admits and the old name-keyed
+// one could not; the index has to keep both, and answer deterministically.
+TEST(SymbolNameIndex, keeps_every_sort_declared_under_one_name)
+{
+  STPMgr mgr;
+  const ASTNode first = mgr.CreateSourceSymbol("s", SourceSort::bitVector(8));
+  const ASTNode second =
+      mgr.CreateSourceSymbol("s", SourceSort::bitVector(16));
+
+  EXPECT_NE(first, second);
+  EXPECT_TRUE(mgr.LookupSymbol("s"));
+
+  ASTNode found;
+  EXPECT_TRUE(mgr.LookupSymbol("s", found));
+  EXPECT_EQ(first, found); // the first declared, not an arbitrary one
+
+  ASTNode again;
+  EXPECT_TRUE(mgr.LookupSymbol("s", again));
+  EXPECT_EQ(found, again);
+}
+
+// CreateFreshVariable asserts the name it mints is unused, so the index has
+// to see every symbol the manager holds, however it was made.
+TEST(SymbolNameIndex, sees_internally_minted_symbols)
+{
+  STPMgr mgr;
+  const ASTNode fresh = mgr.CreateFreshVariable(0, 8, "unconstrained");
+
+  EXPECT_TRUE(mgr.LookupSymbol(fresh.GetName()));
+  ASTNode found;
+  EXPECT_TRUE(mgr.LookupSymbol(fresh.GetName(), found));
+  EXPECT_EQ(fresh, found);
+}
+
+#ifdef STP_ENABLE_FLOATING_POINT
+// A float-indexed array of rounding modes: none of it is expressible in the
+// index/value/exp/sig widths, so it exercises the derivation rather than the
+// GetType() fallback beneath it.
+TEST(SourceSortMemo, memo_preserves_sorts_the_widths_cannot_express)
+{
+  STPMgr mgr;
+  const SourceSort array = SourceSort::array(SourceSort::floatingPoint(8, 24),
+                                             SourceSort::roundingMode());
+  const ASTNode a = mgr.CreateSourceSymbol("a", array);
+  const ASTNode i =
+      mgr.CreateSourceSymbol("i", SourceSort::floatingPoint(8, 24));
+  const ASTNode r = mgr.CreateSourceSymbol("r", SourceSort::roundingMode());
+  const ASTNode write = mgr.CreateArrayTerm(WRITE, 32, 5, {a, i, r});
+  const ASTNode read = mgr.CreateTerm(READ, 5, write, i);
+
+  EXPECT_EQ(array, write.GetSourceSort());
+  EXPECT_EQ(SourceSort::roundingMode(), read.GetSourceSort());
+
+  // Asked twice, answered the same -- the memo is not a different answer.
+  EXPECT_EQ(array, write.GetSourceSort());
+  EXPECT_EQ(SourceSort::roundingMode(), read.GetSourceSort());
+}
+#endif

--- a/tests/unit-tests/SourceSort_Test.cpp
+++ b/tests/unit-tests/SourceSort_Test.cpp
@@ -1,0 +1,67 @@
+#include "stp/AST/AST.h"
+#include "stp/STPManager/STPManager.h"
+
+#include <gtest/gtest.h>
+
+using namespace stp;
+
+TEST(SourceSort, distinguishes_equal_width_float_formats)
+{
+  const SourceSort single = SourceSort::floatingPoint(8, 24);
+  const SourceSort other32 = SourceSort::floatingPoint(11, 21);
+  EXPECT_EQ(32u, single.packedWidth());
+  EXPECT_EQ(32u, other32.packedWidth());
+  EXPECT_NE(single, other32);
+  EXPECT_NE(single, SourceSort::bitVector(32));
+}
+
+TEST(SourceSort, rounding_mode_literal_is_not_its_carrier)
+{
+  STPMgr mgr;
+  const ASTNode rm = mgr.CreateRMConst(1);
+  const ASTNode rm_again = mgr.CreateRMConst(1);
+  const ASTNode bits = mgr.CreateBVConst(5, 1);
+
+  EXPECT_NE(rm, bits);
+  EXPECT_EQ(rm, rm_again);
+  EXPECT_EQ(BVCONST, rm.GetKind());
+  EXPECT_EQ(BVCONST, bits.GetKind());
+  EXPECT_EQ(SourceSort::Kind::RoundingMode, rm.GetSourceSort().kind());
+  EXPECT_EQ(SourceSort::Kind::BitVector, bits.GetSourceSort().kind());
+  EXPECT_TRUE(constantsSameBits(rm, bits));
+}
+
+TEST(SourceSort, derives_array_reads_writes_and_ites)
+{
+  STPMgr mgr;
+  const SourceSort index = SourceSort::floatingPoint(8, 24);
+  const SourceSort element = SourceSort::roundingMode();
+  const SourceSort array = SourceSort::array(index, element);
+
+  const ASTNode a = mgr.CreateSourceSymbol("a", array);
+  const ASTNode b = mgr.CreateSourceSymbol("b", array);
+  const ASTNode i = mgr.CreateSourceSymbol("i", index);
+  const ASTNode r = mgr.CreateSourceSymbol("r", element);
+  const ASTNode c = mgr.CreateSourceSymbol("c", SourceSort::boolean());
+
+  const ASTNode read = mgr.CreateTerm(READ, 5, a, i);
+  const ASTNode write = mgr.CreateArrayTerm(WRITE, 32, 5, {a, i, r});
+  const ASTNode choice = mgr.CreateArrayTerm(ITE, 32, 5, {c, a, b});
+
+  EXPECT_EQ(element, read.GetSourceSort());
+  EXPECT_EQ(array, write.GetSourceSort());
+  EXPECT_EQ(array, choice.GetSourceSort());
+}
+
+TEST(SourceSort, typed_same_name_symbols_do_not_retype_each_other)
+{
+  STPMgr mgr;
+  const ASTNode rm =
+      mgr.CreateSourceSymbol("x", SourceSort::roundingMode());
+  const ASTNode bits =
+      mgr.CreateSourceSymbol("x", SourceSort::bitVector(5));
+
+  EXPECT_NE(rm, bits);
+  EXPECT_EQ(SourceSort::Kind::RoundingMode, rm.GetSourceSort().kind());
+  EXPECT_EQ(SourceSort::Kind::BitVector, bits.GetSourceSort().kind());
+}

--- a/tests/unit-tests/SplitExtracts_Test.cpp
+++ b/tests/unit-tests/SplitExtracts_Test.cpp
@@ -242,17 +242,16 @@ TEST(SplitExtracts_Test , __LINE__)
   ASSERT_EQ(2, c.split.getIntroduced());
 }
 
-// One instance is unextracted
+// One instance is unextracted. (The reassembled side must be the full 20
+// bits: = between different widths is ill-sorted and now rejected at parse.)
 TEST(SplitExtracts_Test , __LINE__)
 {
   const std::string input = R"(
-    (assert 
-      (= 
-        (concat 
-         (concat 
-           (((_ extract 4 0 ) v1) )  
-           (((_ extract 8 5 ) v1) ))
-           (((_ extract 3 3 ) v1) ))  
+    (assert
+      (=
+        (concat
+           (((_ extract 4 0 ) v1) )
+           (((_ extract 19 5 ) v1) ))
           v1
        )
     )
@@ -263,10 +262,14 @@ TEST(SplitExtracts_Test , __LINE__)
   ASSERT_EQ(0, c.split.getIntroduced());
 }
 
-// The (8,5) doesn't intersect.
+// The (8,5) doesn't intersect. (The other side must match the concat's 10
+// bits -- = between different widths is ill-sorted and now rejected at
+// parse -- so compare against a fresh 10-bit variable, which contributes no
+// extracts of its own.)
 TEST(SplitExtracts_Test , __LINE__)
 {
   const std::string input = R"(
+    (declare-fun w10 () (_ BitVec 10))
     (assert
       (=
         (concat
@@ -274,7 +277,7 @@ TEST(SplitExtracts_Test , __LINE__)
            (((_ extract 4 0 ) v1) )
            (((_ extract 8 5 ) v1) ))
            (((_ extract 3 3 ) v1) ))
-          v0
+          w10
        )
     )
   )";

--- a/tools/stp/main_common.cpp
+++ b/tools/stp/main_common.cpp
@@ -28,8 +28,8 @@ THE SOFTWARE.
 #include "sat/cnf/cnf.h"
 
 #include "stp/Parser/parser.h"
-#include "stp/cpp_interface.h"
 #include "stp/ToSat/ToSATAIG.h"
+#include "stp/cpp_interface.h"
 #include <memory>
 
 extern void errorHandler(const char* error_msg);

--- a/tools/test_fpbackend/CMakeLists.txt
+++ b/tools/test_fpbackend/CMakeLists.txt
@@ -1,0 +1,24 @@
+# AUTHORS: Andrew Teylu
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+add_executable(test_fpbackend test_fpbackend.cpp)
+target_link_libraries(test_fpbackend stp)
+
+# EOF

--- a/tools/test_fpbackend/test_fpbackend.cpp
+++ b/tools/test_fpbackend/test_fpbackend.cpp
@@ -1,0 +1,380 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: July 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+// Unit tests for stp::symbolic_fp::bitVector, the bit-vector backend that
+// symfpu builds floating-point circuits out of, and for the float-to-integer
+// conversions layered on it.
+//
+// symfpu exercises only part of this interface, and a wrong answer in the part
+// it does use shows up as a mis-rounded float many layers away -- so these are
+// worth checking directly. Each operation is applied to constants and the
+// resulting term folded, so the answer can be compared with one worked out by
+// hand. Written after finding that bitVector<true>::minValue returned 0
+// rather than the most negative value.
+
+#include "stp/FloatBlaster/symbolic_fp.h"
+#include "stp/STPManager/STPManager.h"
+#include "stp/NodeFactory/SimplifyingNodeFactory.h"
+#include "stp/Simplifier/Simplifier.h"
+#include "stp/AST/AST.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+using namespace stp;
+using namespace stp::symbolic_fp;
+
+static STPMgr* bm = nullptr;
+static int failures = 0;
+static int checks = 0;
+
+// Fold a term to a constant and return its value.
+static uint64_t value_of(const ASTNode& n)
+{
+  const ASTNode c = NonMemberBVConstEvaluator(bm, n);
+  if (c.GetKind() != BVCONST)
+  {
+    printf("    (not a constant!)\n");
+    return ~0ull;
+  }
+  // GetUnsignedConst only handles <= 32 bits; read the bits directly.
+  uint64_t v = 0;
+  const unsigned w = c.GetValueWidth();
+  for (unsigned i = 0; i < w && i < 64; i++)
+    if (CONSTANTBV::BitVector_bit_test(c.GetBVConst(), i))
+      v |= (1ull << i);
+  return v;
+}
+
+static void check(const char* what, uint64_t got, uint64_t want)
+{
+  checks++;
+  const bool ok = (got == want);
+  if (!ok)
+    failures++;
+  printf("  %-46s got=%-12llu want=%-12llu %s\n", what,
+         (unsigned long long)got, (unsigned long long)want,
+         ok ? "ok" : "** MISMATCH **");
+}
+
+// symfpu states its properties through PRECONDITION/POSTCONDITION/INVARIANT,
+// and calls them with either a plain bool or a prop. This backend redefines
+// all three (see symbolic_fp.h): a prop here is a circuit constructor whose
+// result nothing can check while the circuit is being built, so constructing
+// it at all is pure waste -- while the bool properties are real checks and
+// must keep firing. These two counters pin both halves.
+static int props_constructed = 0;
+static int bools_evaluated = 0;
+
+// Never actually called, and that is the assertion: the property macros
+// discard a prop argument without evaluating it, so props_constructed must
+// stay at zero. Clang sees an internal function with no call site and warns
+// that it will not be emitted, which here is the expected outcome.
+[[maybe_unused]] static proposition countedProp()
+{
+  ++props_constructed;
+  return proposition(true);
+}
+
+static bool countedBool()
+{
+  ++bools_evaluated;
+  return true;
+}
+
+static void check_width(const char* what, unsigned got, unsigned want)
+{
+  checks++;
+  const bool ok = (got == want);
+  if (!ok)
+    failures++;
+  printf("  %-46s width=%-10u want=%-10u %s\n", what, got, want,
+         ok ? "ok" : "** MISMATCH **");
+}
+
+// Every float here is a Float32; blast_fp_to_bv now takes that format
+// explicitly rather than reading it back off the operand node.
+static const floatingPointTypeInfo binary32(8, 24);
+
+// Build a Float32 constant from its IEEE bits.
+static ASTNode f32(uint32_t bits)
+{
+  ASTNode n = bm->CreateBVConst(32, bits);
+  return bm->CreateFPConst(n, 8, 24);
+}
+
+// fp.to_ubv/fp.to_sbv from packed bits. The solver keeps its floats unpacked
+// between operations and only this tool wants a one-shot packed form, so the
+// decode is spelled out here rather than kept as a second entry point in the
+// backend -- there is one lowering table now, and this is not another one.
+static ASTNode blast_fp_to_bv(const floatingPointTypeInfo& size,
+                              const ASTNode& rm, const ASTNode& expr,
+                              bitWidthType target_width, const ASTNode& undef,
+                              bool is_signed)
+{
+  return unpacked::toBV(size, rm, unpacked::decode(size, expr), target_width,
+                        undef, is_signed);
+}
+
+static uint32_t bits_of(float f)
+{
+  uint32_t u;
+  memcpy(&u, &f, 4);
+  return u;
+}
+
+template <bool S> static bitVector<S> mk(unsigned w, unsigned v)
+{
+  return bitVector<S>(w, v);
+}
+
+int main()
+{
+  bm = new STPMgr();
+  GlobalParserBM = bm;
+  auto* nf = new SimplifyingNodeFactory(*bm->hashingNodeFactory, *bm);
+  bm->defaultNodeFactory = nf;
+  symbolic_fp::init(bm);
+
+  printf("== constructors and constants ==\n");
+  check("ubv(8, 5)", value_of(mk<false>(8, 5)), 5);
+  check("ubv::zero(8)", value_of(bitVector<false>::zero(8)), 0);
+  check("ubv::one(8)", value_of(bitVector<false>::one(8)), 1);
+  check("ubv::allOnes(8)", value_of(bitVector<false>::allOnes(8)), 0xFF);
+  check("ubv::maxValue(8)", value_of(bitVector<false>::maxValue(8)), 0xFF);
+  check("ubv::minValue(8)", value_of(bitVector<false>::minValue(8)), 0);
+  check("sbv::maxValue(8)", value_of(bitVector<true>::maxValue(8)), 0x7F);
+  check("sbv::minValue(8)", value_of(bitVector<true>::minValue(8)), 0x80);
+
+  printf("== arithmetic ==\n");
+  check("ubv 5 + 3", value_of(mk<false>(8, 5) + mk<false>(8, 3)), 8);
+  check("ubv 5 - 3", value_of(mk<false>(8, 5) - mk<false>(8, 3)), 2);
+  check("ubv 5 * 3", value_of(mk<false>(8, 5) * mk<false>(8, 3)), 15);
+  check("ubv 15 / 3", value_of(mk<false>(8, 15) / mk<false>(8, 3)), 5);
+  check("ubv 17 % 5", value_of(mk<false>(8, 17) % mk<false>(8, 5)), 2);
+  check("sbv -7 % 3 (remainder)",
+        value_of(mk<true>(8, 0xF9) % mk<true>(8, 3)), 0xFF);
+  check("sbv 7 % -3 (remainder)",
+        value_of(mk<true>(8, 7) % mk<true>(8, 0xFD)), 1);
+  check("sbv -7 % -3 (remainder)",
+        value_of(mk<true>(8, 0xF9) % mk<true>(8, 0xFD)), 0xFF);
+  check("ubv -(5)", value_of(-mk<false>(8, 5)), 0xFB);
+  check("ubv ~(5)", value_of(~mk<false>(8, 5)), 0xFA);
+  check("ubv 5.increment()", value_of(mk<false>(8, 5).increment()), 6);
+  check("ubv 5.decrement()", value_of(mk<false>(8, 5).decrement()), 4);
+
+  printf("== modular arithmetic ==\n");
+  check("ubv 250 modularAdd 10", value_of(mk<false>(8, 250).modularAdd(mk<false>(8, 10))), 4);
+  check("ubv 5 modularSubtract 10", value_of(mk<false>(8, 5).modularSubtract(mk<false>(8, 10))), 251);
+  check("ubv 255 modularIncrement", value_of(mk<false>(8, 255).modularIncrement()), 0);
+  check("ubv 0 modularDecrement", value_of(mk<false>(8, 0).modularDecrement()), 255);
+  check("ubv 5 modularNegate", value_of(mk<false>(8, 5).modularNegate()), 251);
+  check("ubv 1 modularLeftShift 3", value_of(mk<false>(8, 1).modularLeftShift(mk<false>(8, 3))), 8);
+  check("ubv 128 modularRightShift 3", value_of(mk<false>(8, 128).modularRightShift(mk<false>(8, 3))), 16);
+
+  printf("== bitwise and shifts ==\n");
+  check("ubv 0xF0 | 0x0F", value_of(mk<false>(8, 0xF0) | mk<false>(8, 0x0F)), 0xFF);
+  check("ubv 0xF3 & 0x0F", value_of(mk<false>(8, 0xF3) & mk<false>(8, 0x0F)), 0x03);
+  check("ubv 1 << 4", value_of(mk<false>(8, 1) << mk<false>(8, 4)), 16);
+  check("ubv 128 >> 4", value_of(mk<false>(8, 128) >> mk<false>(8, 4)), 8);
+  check("sbv 0x80 >> 3 (arithmetic)", value_of(mk<true>(8, 0x80) >> mk<true>(8, 3)), 0xF0);
+  check("sbv 0x80 signExtendRightShift 3",
+        value_of(mk<true>(8, 0x80).signExtendRightShift(mk<true>(8, 3))), 0xF0);
+
+  printf("== width manipulation ==\n");
+  check("ubv 5 extend(4)", value_of(mk<false>(8, 5).extend(4)), 5);
+  check_width("ubv 5 extend(4) width", mk<false>(8, 5).extend(4).getWidth(), 12);
+  check("ubv 5 extend(0)", value_of(mk<false>(8, 5).extend(0)), 5);
+  check_width("ubv 5 extend(0) width", mk<false>(8, 5).extend(0).getWidth(), 8);
+  check("sbv -5 extend(4)", value_of(mk<true>(8, 0xFB).extend(4)), 0xFFB);
+  check_width("sbv -5 extend(4) width", mk<true>(8, 0xFB).extend(4).getWidth(), 12);
+  check("sbv 5 extend(0)", value_of(mk<true>(8, 5).extend(0)), 5);
+  check("ubv 0x1FF contract(4)", value_of(mk<false>(12, 0x1FF).contract(4)), 0xFF);
+  check_width("ubv contract(4) width", mk<false>(12, 0x1FF).contract(4).getWidth(), 8);
+  check("ubv 5 resize(16)", value_of(mk<false>(8, 5).resize(16)), 5);
+  check_width("ubv 5 resize(16) width", mk<false>(8, 5).resize(16).getWidth(), 16);
+  check("ubv 0x1FF resize(8)", value_of(mk<false>(12, 0x1FF).resize(8)), 0xFF);
+  check("ubv 5 resize(8) (no change)", value_of(mk<false>(8, 5).resize(8)), 5);
+  check("ubv 5 matchWidth(w16)",
+        value_of(mk<false>(8, 5).matchWidth(mk<false>(16, 0))), 5);
+  check_width("ubv 5 matchWidth(w16) width",
+              mk<false>(8, 5).matchWidth(mk<false>(16, 0)).getWidth(), 16);
+  check("sbv -5 matchWidth(w16)",
+        value_of(mk<true>(8, 0xFB).matchWidth(mk<true>(16, 0))), 0xFFFB);
+  check("ubv 5 matchWidth(same)",
+        value_of(mk<false>(8, 5).matchWidth(mk<false>(8, 0))), 5);
+  check("ubv 0xAB append 0xCD",
+        value_of(mk<false>(8, 0xAB).append(mk<false>(8, 0xCD))), 0xABCD);
+  check("ubv 0xABCD extract(15,8)",
+        value_of(mk<false>(16, 0xABCD).extract(15, 8)), 0xAB);
+  check("ubv 0xABCD extract(7,0)",
+        value_of(mk<false>(16, 0xABCD).extract(7, 0)), 0xCD);
+  check("ubv 0xABCD extract(11,4)",
+        value_of(mk<false>(16, 0xABCD).extract(11, 4)), 0xBC);
+
+  printf("== sign conversion ==\n");
+  check("ubv 0xFB toSigned", value_of(mk<false>(8, 0xFB).toSigned()), 0xFB);
+  check("sbv 0xFB toUnsigned", value_of(mk<true>(8, 0xFB).toUnsigned()), 0xFB);
+
+  printf("== predicates (1 = true) ==\n");
+  auto p = [](const proposition& q) -> uint64_t {
+    const ASTNode n = q;
+    return (n == GlobalParserBM->ASTTrue) ? 1
+           : (n == GlobalParserBM->ASTFalse)
+               ? 0
+               : value_of(n) /* not folded */;
+  };
+  check("ubv 0xFF isAllOnes", p(mk<false>(8, 0xFF).isAllOnes()), 1);
+  check("ubv 0xFE isAllOnes", p(mk<false>(8, 0xFE).isAllOnes()), 0);
+  check("ubv 0 isAllZeros", p(mk<false>(8, 0).isAllZeros()), 1);
+  check("ubv 1 isAllZeros", p(mk<false>(8, 1).isAllZeros()), 0);
+  check("ubv 5 == 5", p(mk<false>(8, 5) == mk<false>(8, 5)), 1);
+  check("ubv 5 == 6", p(mk<false>(8, 5) == mk<false>(8, 6)), 0);
+  check("ubv 5 < 6", p(mk<false>(8, 5) < mk<false>(8, 6)), 1);
+  check("ubv 6 < 5", p(mk<false>(8, 6) < mk<false>(8, 5)), 0);
+  check("ubv 5 <= 5", p(mk<false>(8, 5) <= mk<false>(8, 5)), 1);
+  check("ubv 6 > 5", p(mk<false>(8, 6) > mk<false>(8, 5)), 1);
+  check("ubv 5 >= 5", p(mk<false>(8, 5) >= mk<false>(8, 5)), 1);
+  check("ubv 0xFF > 1 (unsigned)", p(mk<false>(8, 0xFF) > mk<false>(8, 1)), 1);
+  check("sbv 0xFF < 1 (signed, -1 < 1)", p(mk<true>(8, 0xFF) < mk<true>(8, 1)), 1);
+  check("sbv 0xFF > 1 (signed, -1 > 1 false)", p(mk<true>(8, 0xFF) > mk<true>(8, 1)), 0);
+  check("sbv 0x80 <= 0x7F (signed min <= max)",
+        p(mk<true>(8, 0x80) <= mk<true>(8, 0x7F)), 1);
+  check("sbv 0x7F >= 0x80 (signed max >= min)",
+        p(mk<true>(8, 0x7F) >= mk<true>(8, 0x80)), 1);
+
+  const roundingMode rtz(traits::RTZ());
+  const roundingMode rne(traits::RNE());
+
+  // A distinctive undefined value, so it is obvious when it leaks out.
+  const bitVector<false> undef_u(32, 0xDEAD);
+  const bitVector<true> undef_s(32, 0xDEAD);
+
+  printf("== convertFloatToUBV (RTZ), undef = 0xDEAD ==\n");
+  const struct
+  {
+    float in;
+    uint64_t want;
+    const char* name;
+  } ucases[] = {
+      {4.0f, 4, "to_ubv(4.0)"},       {0.0f, 0, "to_ubv(0.0)"},
+      {1.0f, 1, "to_ubv(1.0)"},       {7.9f, 7, "to_ubv(7.9) trunc"},
+      {255.0f, 255, "to_ubv(255.0)"}, {65536.0f, 65536, "to_ubv(65536.0)"},
+      {-1.0f, 0xDEAD, "to_ubv(-1.0) undefined"},
+  };
+
+  for (const auto& c : ucases)
+  {
+    const ASTNode r =
+        blast_fp_to_bv(binary32, rtz, f32(bits_of(c.in)), 32, undef_u,
+                       /* is_signed */ false);
+    check(c.name, value_of(r), c.want);
+  }
+
+  printf("== convertFloatToSBV (RTZ), undef = 0xDEAD ==\n");
+  const struct
+  {
+    float in;
+    uint64_t want;
+    const char* name;
+  } scases[] = {
+      {4.0f, 4, "to_sbv(4.0)"},
+      {-4.0f, 0xFFFFFFFC, "to_sbv(-4.0)"},
+      {0.0f, 0, "to_sbv(0.0)"},
+      {-1.0f, 0xFFFFFFFF, "to_sbv(-1.0)"},
+      {7.9f, 7, "to_sbv(7.9) trunc"},
+      {-7.9f, 0xFFFFFFF9, "to_sbv(-7.9) trunc toward zero"},
+  };
+
+  for (const auto& c : scases)
+  {
+    const ASTNode r =
+        blast_fp_to_bv(binary32, rtz, f32(bits_of(c.in)), 32, undef_s,
+                       /* is_signed */ true);
+    check(c.name, value_of(r), c.want);
+  }
+
+  printf("== convertFloatToUBV (RNE) ==\n");
+  {
+    const ASTNode r =
+        blast_fp_to_bv(binary32, rne, f32(bits_of(7.5f)), 32, undef_u, false);
+    check("to_ubv RNE(7.5) -> 8 (ties to even)", value_of(r), 8);
+  }
+  {
+    const ASTNode r =
+        blast_fp_to_bv(binary32, rne, f32(bits_of(4.0f)), 32, undef_u, false);
+    check("to_ubv RNE(4.0)", value_of(r), 4);
+  }
+
+  printf("== narrow target widths ==\n");
+  {
+    const ASTNode r = blast_fp_to_bv(binary32, rtz, f32(bits_of(4.0f)), 8,
+                                     bitVector<false>(8, 0xAB), false);
+    check("to_ubv(4.0) width 8", value_of(r), 4);
+  }
+
+  printf("== symbolic undefined value (as at formula level) ==\n");
+  {
+    // The array read the totalising pass introduces becomes a plain symbol
+    // once the array transformer has run, so this is what the blaster really
+    // sees. The result should still fold to the converted value, because the
+    // "is it undefined?" condition is constant-false for 4.0.
+    ASTNode sym = bm->defaultNodeFactory->CreateSymbol("undef_sym", 0, 32);
+    const ASTNode r = blast_fp_to_bv(binary32, rtz, f32(bits_of(4.0f)), 32,
+                                     bitVector<false>(sym), false);
+    printf("  result kind = %s, width = %u\n",
+           _kind_names[r.GetKind()], r.GetValueWidth());
+    check("to_ubv(4.0) with symbolic undef", value_of(r), 4);
+  }
+
+  printf("== symfpu property hooks ==\n");
+  {
+    // A prop-valued property must not be constructed at all. symfpu's default
+    // expansion is a plain call, so the argument would be fully built and then
+    // dropped by an overload that can do nothing with it -- and valid()/
+    // wellFormed(), which is what these arguments are, are reached from
+    // nowhere else in symfpu. Every node of that is dead, in every build
+    // configuration, and it is a large fraction of what lowering constructs.
+    props_constructed = 0;
+    PRECONDITION(countedProp());
+    POSTCONDITION(countedProp());
+    INVARIANT(countedProp());
+    check("prop properties construct nothing", props_constructed, 0);
+
+    // A bool-valued property is a real check on a width or a flag symfpu has
+    // already settled, so it must still be evaluated -- and asserted, in a
+    // build with assertions on. Suppressing these too would be a regression,
+    // which is why this is a type question and not a blanket suppression.
+    bools_evaluated = 0;
+    PRECONDITION(countedBool());
+    POSTCONDITION(countedBool());
+    INVARIANT(countedBool());
+    check("bool properties are still evaluated", bools_evaluated, 3);
+  }
+
+  printf("\n%d checks, %d failures\n", checks, failures);
+  return failures != 0;
+}


### PR DESCRIPTION
# FP support 2/5 — FloatBlaster: lower the floating-point theory onto SymFPU's circuits

**This PR builds on top of #740** (1/5 — AST sort layer). Please review and merge it first; this branch contains its commits.

The backend for the sorts 1/5 introduced. Still not reachable from a query — the parser is 3/5 — but this is where the semantics live, so it is the commit to read if you want to know whether STP's floating point is *correct*.

## SymFPU, and what `symbolic_fp` is

SymFPU is a header-only library of bit-blasted IEEE-754 circuits, parameterised by a back-end traits class that says how to build a proposition, a bitvector and so on. `symbolic_fp` is that traits class for STP: it builds SymFPU's terms through STP's node factory, so the circuits arrive already subject to STP's rewrites rather than as an opaque blob.

## Lowering is a pass, not a simplification

`FloatBlast` runs from `TopLevelSTP` after the size-reducing passes and before anything that invokes the bit-blaster. It has to be a pass of its own. Doing it inside simplification meant building floating-point nodes over bitvector children and stamping a format on them to make them type check — and that stamp landed on hash-consed nodes the input still used as plain bitvectors, which is a wrong answer, not just a confusing one.

The ordering matters in both directions and is worth checking during review:

- **after** the size-reducing passes, so `RemoveUnconstrained` sees a float symbol rather than its exposed bits;
- **before** the optional bit-blast simplification, which would otherwise receive `FP_EQ` and friends when `--bit-blast-simplification` is on.

The bit-blasting difficulty threshold is re-scored against the lowered form, since that is what is actually about to be blasted.

## Making the partial operations total

`FpTotalise` runs first. SMT-LIB leaves some results unspecified — `fp.min` and `fp.max` at the two zeros, the conversions out of range — and "unspecified" is not "arbitrary per occurrence": the answer must be a *function* of the operands and congruent within a format. Each partial operation gets an extra operand naming its unspecified answer, drawn from an array keyed by the operand formats rather than by their widths.

Rounding modes are pinned here too. The carrier is five bits, so thirty-two encodings exist for five values, and SymFPU's `roundingDecision` falls through to truncate-with-overflow-to-max when every mode equality is false — silently inventing a sixth, non-IEEE mode. Every path that introduces a `RoundingMode` variable asserts the five-way one-hot constraint.

`FpEncodingContext` holds the solve-local source-to-carrier mapping, so a later `get-value` can be answered against the same mappings the solve used.

## Constant folding

A fully constant floating-point expression folds against SymFPU at construction rather than being blasted, so it never reaches the SAT solver.

## Testing

**78/78 ctest** (five new), **189/189 lit** unchanged.

- `FloatBlast_Test` — the lowering pass.
- `FpTotalise_Test` — totalisation and rounding-mode pinning.
- `FpConstantFold_Test` — **the oracle is the hardware.** Reference values are computed by the CPU under a rounding mode set with `fesetround`, which is why the target is compiled with `-frounding-math`; without it the compiler assumes the default mode and folds the reference arithmetic at compile time, so every non-default mode disagrees for a reason that has nothing to do with STP.
- `ConstantIdentity_Test` — that constants with equal bits are equal nodes.
- `test_fpbackend` — a standalone tool, registered with CTest, that checks the backend's circuits against the hardware.

## Note for the reviewer

`STP.h` / `STP.cpp` here create the encoding context but do not yet hand it to the counterexample layer; that wiring arrives in 3/5 along with the layer that consumes it. It is the only deliberate loose end in the series.
