### PR TITLE
Array extensionality (1/6): record an author, and settle on one spelling of a name

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -28,6 +28,8 @@ Current Authors
 
 * Ryan Govostes
 
+* Andrew Teylu
+
 Other Significant Author
 ------------------------
 * Trevor Alexander Hansen

--- a/README.markdown
+++ b/README.markdown
@@ -270,5 +270,5 @@ You will need to install [cmake](https://cmake.org/download/) and follow the ste
 * Mate Soos
 * Dan Liew
 * Ryan Govostes
-* Andrew V. Teylu
+* Andrew Teylu
 * And many others...

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -259,7 +259,7 @@ History and authors
 The initial versions of STP were written primarily by Vijay Ganesh as
 part of his PhD thesis. STP was subsequently developed by Trevor
 Hansen during his PhD. The current authors are Trevor Hansen, Mate Soos, 
-Ryan Govostes and Andrew V. Teylu. STP is based on the
+Ryan Govostes and Andrew Teylu. STP is based on the
 following papers:
 
 -  `A Decision Procedure for Bit-Vectors and


### PR DESCRIPTION
# Array extensionality (1/6): record an author, and settle on one spelling of a name

Adds Andrew Teylu to `AUTHORS`, and drops the middle initial from the two places the name already appeared, so the credit reads the same everywhere.

No code. It leads the array-extensionality series only because it was found alongside it — it has nothing to do with extensionality, and can be merged on its own.

## Testing

Full suite unchanged: 97/97 ctest, 280/280 lit.
