### PR TITLE
Array extensionality (2/6): the consistency checker and its lemmas

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -28,6 +28,8 @@ Current Authors
 
 * Ryan Govostes
 
+* Andrew Teylu
+
 Other Significant Author
 ------------------------
 * Trevor Alexander Hansen

--- a/README.markdown
+++ b/README.markdown
@@ -270,5 +270,5 @@ You will need to install [cmake](https://cmake.org/download/) and follow the ste
 * Mate Soos
 * Dan Liew
 * Ryan Govostes
-* Andrew V. Teylu
+* Andrew Teylu
 * And many others...

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -259,7 +259,7 @@ History and authors
 The initial versions of STP were written primarily by Vijay Ganesh as
 part of his PhD thesis. STP was subsequently developed by Trevor
 Hansen during his PhD. The current authors are Trevor Hansen, Mate Soos, 
-Ryan Govostes and Andrew V. Teylu. STP is based on the
+Ryan Govostes and Andrew Teylu. STP is based on the
 following papers:
 
 -  `A Decision Procedure for Bit-Vectors and

--- a/include/stp/AST/ASTNode.h
+++ b/include/stp/AST/ASTNode.h
@@ -147,7 +147,7 @@ public:
     return k == BVLT || k == BVLE || k == BVGT || k == BVGE || k == BVSLT ||
            k == BVSLE || k == BVSGT || k == BVSGE || k == BVUADDO ||
            k == BVSADDO || k == BVUMULO || k == BVSMULO || k == BVUSUBO ||
-           k == BVSSUBO || k == EQ;
+           k == BVSSUBO || k == EQ || k == ARRAY_EQ;
   }
 
   // delegates to the ASTInternal node.

--- a/include/stp/Extensionality/ExtChecker.h
+++ b/include/stp/Extensionality/ExtChecker.h
@@ -1,0 +1,400 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: July, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+/*
+ * The consistency checker of the lemmas-on-demand decision procedure
+ * for the extensional theory of arrays:
+ *
+ *   Robert Brummayer, Armin Biere: "Lemmas on Demand for the
+ *   Extensional Theory of Arrays", JSAT 6 (2010) 165-201.
+ *
+ * A candidate assignment sigma produced by the SAT solver assigns
+ * values to the abstraction variables of reads and array equalities,
+ * but knows nothing of the array axioms; the checker decides whether
+ * sigma can be extended to a genuine array model (paper section 7).
+ * It maintains the paper's map rho from each array term to the set of
+ * accesses currently known to constrain it, and runs the paper's
+ * propagation rules to a fixed point over a FIFO work list:
+ *
+ *   I     seed every access at its own array (section 7.2);
+ *   D / U propagate an access down through / up over a write when
+ *         sigma assigns its index differently from the write index,
+ *         following the read-over-write axiom A3 (sections 7.2, 7.3);
+ *   R / L propagate accesses across an array equality whose Boolean
+ *         abstraction variable sigma assigns true (section 7.3);
+ *   C     on every insertion, compare against the access already at
+ *         the destination for the same concrete index: a different
+ *         concrete value violates the (adapted) read-congruence axiom
+ *         A1 and yields a conflict (section 7.2).
+ *
+ * The work list is FIFO and rule I seeds every access before the
+ * fixed point starts, so discovery is breadth-first per access: the
+ * first arrival of an access at an array -- the one whose path gets
+ * recorded -- came along a shortest propagation path. That gives the
+ * minimization of section 11.1 without a separate post-conflict
+ * search.
+ *
+ * Exactly how far that reaches is worth stating, because the pass does
+ * not stop at the first conflict the way the paper's does. An arrival
+ * that conflicts is recorded as seen but is not queued, so the access
+ * stops at the array it conflicted at. Shortest paths are therefore a
+ * property of the graph in which each access's own conflict sites are
+ * terminal: the first conflict of a pass has shortest paths on both
+ * sides unconditionally, and a later one has the shortest paths still
+ * available to it. A later conflict can consequently carry a longer
+ * premise than an exhaustive search would give it, and a pair that can
+ * only meet through an earlier conflict site is not reported at all --
+ * it resurfaces in a later refinement round, once a lemma has moved the
+ * candidate. Pinned at both ends by the ConflictPremiseUsesShortestPaths
+ * and ConflictingArrivalStopsAtTheConflictArray unit tests; do not
+ * replace the deque with a stack.
+ *
+ * Following section 11.2, rho keeps one representative access per
+ * concrete index of each array, in a hash keyed by the index value: a
+ * congruence lookup is a single probe rather than a scan, and an
+ * access arriving with the same concrete index and the same concrete
+ * value as the representative is dropped without further propagation.
+ *
+ * Dropping it is complete, but the reason is about the whole class of
+ * accesses carrying that concrete (index, value) pair rather than about
+ * the two accesses at hand. It is not the case that the representative
+ * reaches everything the duplicate would have: the representative can
+ * be dropped in its turn at a later array, or stop there on a conflict.
+ * What holds is that no rule can tell members of the class apart. Every
+ * rule's applicability depends on the source array, on sigma, and on
+ * the access's concrete index -- write indices stepped over, array
+ * equalities and if-then-else conditions sigma decided -- and never on
+ * which member carries it. So the class reaches exactly the arrays any
+ * one member would, at most one member is ever resident at an array,
+ * and whether an arrival conflicts depends only on its concrete index
+ * and value meeting a different value there. Every conflict a member
+ * would find, therefore, some member does find -- possibly credited to
+ * a different one of them.
+ *
+ * On a conflict it builds the paper's lemma (section 8): the
+ * conjunction of the index equality, the write-index disequalities
+ * collected along both propagation paths, and the positive array
+ * equalities crossed, implies equality of the two access values. The
+ * lemma is produced twice: once over the original terms (the theory
+ * lemma) and once over the abstraction variables and scalar names
+ * (alpha of the lemma, the form actually added to the SAT solver).
+ * Finally it verifies the witness constraints of preprocessing step 1:
+ * an array equality assigned false must have differing values at its
+ * witness index lambda (axiom A4').
+ *
+ * The checker is pure: it never creates terms in the host query, adds
+ * clauses, or calls SAT. Insertion is first-path-wins: the first
+ * arrival of an access at an array fixes its recorded path there and no
+ * later arrival displaces it, so each (array, access) pair is inserted
+ * at most once. Arrivals are not the same as insertions -- one dropped
+ * as represented leaves no record behind, so a later arrival by another
+ * route repeats the constant-work test and reaches the same verdict,
+ * sigma being fixed and representatives never changing. That is why the
+ * skip counters count arrivals rather than pairs. Concrete values are
+ * hash-consed BVCONST nodes, making value comparison node identity at
+ * any bit width.
+ */
+
+#ifndef EXTCHECKER_H
+#define EXTCHECKER_H
+
+#include "stp/AST/AST.h"
+#include <map>
+#include <string>
+#include <vector>
+
+namespace stp
+{
+
+// One access: a read, or a write treated as a read of itself (the
+// paper's polymorphic "access" node, section 11.4, which makes the
+// explicit read(write(a,i,e),i) = e constraints of preprocessing step 2
+// unnecessary). For a read the site is its array operand and the value
+// is its read-abstraction variable; for a write the site is the write
+// node itself and the value is the written element.
+// indexName/valueName are the scalar leaves a lemma will be encoded
+// over (SYMBOLs already present in the bit-blasted formula, or
+// constants); indexTerm/valueTerm are the original terms, used for the
+// theory-level form of the lemma.
+struct ExtAccess
+{
+  size_t id;
+  bool isWrite;
+  ASTNode site;
+  ASTNode indexTerm;
+  ASTNode valueTerm;
+  ASTNode indexName;
+  ASTNode valueName;
+};
+
+// One condition collected along an access's propagation path, and later
+// contributed to the lemma premise. Rules D and U contribute an
+// index disequality (the access index differs from the write index
+// stepped over); rules R and L contribute the array equality crossed;
+// rules T-down and T-up contribute the if-then-else condition under
+// which the branch they stepped over is the selected one.
+// Array equalities only ever appear positively in lemmas: R/L fire
+// only when sigma assigns the equality true (paper section 10.2). An
+// if-then-else condition appears with the polarity sigma gave it,
+// because both of its branches are selectable.
+struct ExtGuard
+{
+  enum Kind
+  {
+    INDEX_NE,
+    EQ_PROXY,
+    ITE_COND_POS,
+    ITE_COND_NEG
+  };
+  Kind kind = INDEX_NE;
+
+  // Each predecessor link stores one shared four-node payload instead of
+  // reserving separate ASTNodes for all variants. Complete paths are
+  // materialized only when a conflict certificate is emitted:
+  //
+  // INDEX_NE: theoryA/theoryB are the original index terms;
+  //           absA/absB are their scalar names.
+  // EQ_PROXY: theoryA/theoryB are the canonical array operands;
+  //           absA is the Boolean equality proxy.
+  // ITE_COND_{POS,NEG}: theoryA is the original condition;
+  //                     absA is its reified Boolean name. The kind
+  //                     records the selected branch's polarity.
+  ASTNode theoryA, theoryB;
+  ASTNode absA, absB;
+  size_t eqRecord = 0;
+};
+
+// An owned array-valued if-then-else, kept as a term rather than
+// eliminated (paper section 4.1 declines to do this "to simplify our
+// presentation"; the direct integration it mentions is what this is).
+// condName reifies the condition as a Boolean symbol, so that the
+// value the checker reads is the one the SAT solver assigned rather
+// than something re-evaluated from the counterexample -- the failure
+// class that made a scalar name disagree with its term -- and so that
+// a lemma premise has a single encoded literal to name.
+struct ExtIteNode
+{
+  ASTNode ite;
+  ASTNode condTerm;
+  ASTNode condName;
+  ASTNode thn;
+  ASTNode els;
+};
+
+struct ExtEqEdge
+{
+  size_t record;
+  ASTNode left;
+  ASTNode right;
+  ASTNode proxy;
+};
+
+// A witness obligation from preprocessing step 1 (paper section 4):
+// for the array equality a = b, a fresh index lambda and the virtual
+// reads read(a,lambda) / read(b,lambda) were created, constrained by
+// a != b -> read(a,lambda) != read(b,lambda). If sigma assigns the
+// equality's Boolean abstraction variable false, the two witness read
+// values must therefore differ; since the constraint was part of the
+// bit-blasted formula, a violation indicates an integration bug, not
+// a refinable candidate.
+struct ExtWitness
+{
+  size_t record;
+  ASTNode proxy;
+  ASTNode index;
+  ASTNode leftValue;
+  ASTNode rightValue;
+};
+
+// Per-write-node data needed by the D and U rules.
+struct ExtWriteNode
+{
+  ASTNode write;
+  ASTNode base;
+  ASTNode indexTerm;
+  ASTNode indexName;
+};
+
+// The array subgraph of the preprocessed formula, frozen for one
+// solve: accesses, write edges, equality edges, and the witness
+// obligations of preprocessing step 1. All vectors carry a fixed
+// deterministic order (noted per field below), so checker runs -- and
+// therefore lemmas and models -- are reproducible; the maps are used
+// for lookup only.
+struct ExtGraph
+{
+  std::vector<ExtAccess> accesses; // in stable seed order
+
+  std::map<ASTNode, ExtWriteNode> writes;             // write node -> info
+  std::map<ASTNode, std::vector<ASTNode>> writeParents; // base -> writes
+                                                        // (each sorted by
+                                                        // node number)
+  std::vector<ExtEqEdge> eqEdges;
+  // array -> indices into eqEdges; per source sorted by
+  // (record, destination node number, rule) where R_EQ sorts before
+  // L_EQ, so each array's equality edges fire in a fixed order.
+  std::map<ASTNode, std::vector<size_t>> eqAdjacency;
+
+  std::map<ASTNode, ExtIteNode> ites;                 // ite node -> info
+  std::map<ASTNode, std::vector<ASTNode>> iteParents; // branch -> ites
+                                                      // (each sorted by
+                                                      // node number)
+
+  std::vector<ExtWitness> witnesses; // sorted by record id
+};
+
+// Access to the candidate assignment sigma. Every checker-visible term
+// must have a concrete value in the candidate; a missing value is an
+// integration error, never a reason to default. bvValue must return a
+// BVCONST node; boolValue a Boolean. Implementations wrap either
+// AbsRefine_CounterExample or a plain map (unit tests).
+class ExtModelView
+{
+public:
+  virtual ~ExtModelView() {}
+  virtual ASTNode bvValue(const ASTNode& term) = 0;
+  virtual bool boolValue(const ASTNode& term) = 0;
+};
+
+// One atom of a lemma premise or conclusion, after canonicalization
+// (duplicate atoms dropped, reflexive equalities removed, deterministic
+// order). BV_EQ/BV_NE carry the
+// operand pair for the layer (abstract: scalar names; theory: original
+// terms). ARRAY_EQ appears only in the theory lemma; BOOL_LIT (a
+// positive proxy, or a positively-taken if-then-else condition) and
+// BOOL_LIT_NEG (a negatively-taken one) only in the abstract lemma.
+struct ExtLemmaAtom
+{
+  enum Op
+  {
+    BV_EQ = 0,
+    BV_NE = 1,
+    ARRAY_EQ = 2,
+    BOOL_LIT = 4,
+    BOOL_LIT_NEG = 5
+  };
+  Op op;
+  ASTNode a, b;     // BV_EQ / BV_NE operands, or ARRAY_EQ array operands
+  ASTNode boolTerm; // BOOL_LIT proxy
+  size_t eqRecord;  // for ARRAY_EQ / BOOL_LIT
+
+  bool operator==(const ExtLemmaAtom& o) const
+  {
+    return op == o.op && a == o.a && b == o.b && boolTerm == o.boolTerm;
+  }
+};
+
+// A congruence conflict found by rule C, together with the lemma built
+// from it (paper section 8): both access ids, the common
+// array, concrete values, per-side guard paths, plus the canonicalized
+// premises and the conclusion pair for the theory and abstract layers.
+struct ExtConflict
+{
+  ASTNode commonArray;
+  size_t leftAccess;  // the previously inserted representative
+  size_t rightAccess; // the arriving access
+  ASTNode indexValue;
+  ASTNode leftValue, rightValue;
+  std::vector<ExtGuard> leftGuards, rightGuards;
+
+  std::vector<ExtLemmaAtom> abstractPremise; // canonical order
+  ASTNode abstractConclusionA, abstractConclusionB;
+
+  std::vector<ExtLemmaAtom> theoryPremise; // canonical order
+  ASTNode theoryConclusionA, theoryConclusionB;
+};
+
+struct ExtEvent
+{
+  enum Kind
+  {
+    SEED,
+    PROPAGATE,
+    SKIP_SEEN,
+    SKIP_REPRESENTED, // section 11.2: same concrete index and value as
+                      // the representative already at the array
+    CONFLICT,
+    WITNESS_CHECK
+  };
+  int seq;
+  Kind kind;
+  const char* rule;
+  ASTNode source; // null for seeds / witness checks
+  ASTNode destination;
+  size_t access;
+  ASTNode indexValue;  // null on SKIP_SEEN
+  ASTNode accessValue; // null on SKIP_SEEN
+};
+
+struct ExtCheckResult
+{
+  enum Status
+  {
+    CONSISTENT,
+    CONFLICT,
+    WITNESS_VIOLATION
+  };
+  Status status;
+  // Every independent congruence conflict the pass found, in discovery
+  // order; non-empty iff status == CONFLICT. The pass does not stop at
+  // the first, because each conflict yields a lemma that is valid on
+  // its own (its premise holds and its conclusion fails in the very
+  // same candidate), and emitting them together spares a whole
+  // solve-from-scratch per lemma. "Found", not "exists": a conflicting
+  // arrival does not propagate onward, so this is not an exhaustive
+  // enumeration of the disagreeing pairs in the candidate. See the
+  // shortest-path discussion at the top of this file.
+  std::vector<ExtConflict> conflicts;
+  // conflicts[0] -- the conflict a first-conflict-wins pass would have
+  // stopped at. Kept for callers that want just the earliest one.
+  ExtConflict conflict;      // valid iff status == CONFLICT
+  size_t violatedRecord;     // valid iff status == WITNESS_VIOLATION
+
+  // When the candidate is consistent, the fixed point of rho gives the
+  // observed contents of every array: pairs of concrete
+  // (index, value) BVCONSTs for every rho entry. Valid iff CONSISTENT.
+  std::map<ASTNode, std::vector<std::pair<ASTNode, ASTNode>>> observed;
+
+  std::vector<ExtEvent> events;
+  std::map<std::string, int> stats;
+
+  // Proof-storage diagnostics. The fixed point stores one constant-size
+  // predecessor entry per reached (array, access) pair; guards are copied
+  // into complete vectors only for emitted conflict certificates.
+  size_t proofPathEntries = 0;
+  size_t materializedGuardCount = 0;
+};
+
+class ExtChecker
+{
+public:
+  // Runs one full check of the candidate model against the graph.
+  // Pure: no SAT access, no term allocation into the host query.
+  static ExtCheckResult check(const ExtGraph& graph, ExtModelView& model,
+                              bool recordEvents = false);
+};
+
+} // namespace stp
+
+#endif // EXTCHECKER_H

--- a/lib/AST/ASTKind.kinds
+++ b/lib/AST/ASTKind.kinds
@@ -208,3 +208,8 @@ FP_SMT_EQ           2    2    Form    FP
 # The five special floating-point values (NaN, +/-oo, +/-zero) have no kinds
 # of their own: they are ordinary packed constants, built interned by
 # STPMgr::CreateFPSpecialConst so that the format is part of node identity.
+
+# Opaque whole-array equality. Kept last so the numeric values exported by
+# c_interface.h remain stable. The extensionality prepass lowers this before
+# ordinary solving.
+ARRAY_EQ        2       2       Form

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -53,6 +53,7 @@ endif()
 add_subdirectory(Globals)
 add_subdirectory(AST)
 add_subdirectory(AbsRefineCounterExample)
+add_subdirectory(Extensionality)
 add_subdirectory(FloatBlaster)
 add_subdirectory(Simplifier)
 add_subdirectory(Printer)
@@ -77,6 +78,7 @@ set(stp_lib_targets
     AST
     stpmgr
     abstractionrefinement
+    extensionality
     tosat
     sat
     floatblaster

--- a/lib/Extensionality/CMakeLists.txt
+++ b/lib/Extensionality/CMakeLists.txt
@@ -1,0 +1,25 @@
+# AUTHORS: Andrew Teylu
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+add_library(extensionality OBJECT
+    ExtChecker.cpp
+)
+
+add_dependencies(extensionality ASTKind_header)

--- a/lib/Extensionality/ExtChecker.cpp
+++ b/lib/Extensionality/ExtChecker.cpp
@@ -1,0 +1,671 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: July, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+// The consistency checking and lemma generation algorithm of
+// Brummayer & Biere, "Lemmas on Demand for the Extensional Theory of
+// Arrays", JSAT 6 (2010), sections 7 and 8. See ExtChecker.h for an
+// overview of the rules and data model.
+
+#include "stp/Extensionality/ExtChecker.h"
+#include <algorithm>
+#include <deque>
+#include <unordered_map>
+#include <utility>
+
+namespace stp
+{
+
+namespace
+{
+
+typedef std::pair<ASTNode, size_t> PairKey;
+
+typedef std::unordered_map<ASTNode, size_t, ASTNode::ASTNodeHasher,
+                           ASTNode::ASTNodeEqual>
+    RhoIndexMap;
+
+// One predecessor-linked shortest-path entry. A propagation stores exactly
+// one incoming guard and a key for its predecessor; complete guard vectors are
+// materialized only for the two paths of an emitted conflict. This preserves
+// the FIFO/first-arrival shortest-path proof while making fixed-point storage
+// linear in the number of reached (array, access) pairs.
+struct PathRecord
+{
+  bool hasPredecessor = false;
+  PairKey predecessor;
+  ExtGuard incomingGuard;
+};
+
+struct CheckerState
+{
+  const ExtGraph& graph;
+  ExtModelView& model;
+  const bool recordEvents;
+
+  std::map<PairKey, PathRecord> paths;
+  // rho, split per section 11.2: one representative access per
+  // concrete index of each array, keyed by the index value so a
+  // congruence lookup is a single probe; plus the representatives in
+  // insertion order, for the observed-contents export. rhoByIndex is
+  // lookup-only: propagation, conflict, and model order must continue
+  // to come from the deterministic graph/work-list order and rho vectors.
+  std::map<ASTNode, RhoIndexMap> rhoByIndex;
+  std::map<ASTNode, std::vector<size_t>> rho; // insertion order preserved
+  std::deque<PairKey> worklist;
+  ExtCheckResult result;
+  int seq;
+  size_t materializedGuardCount;
+
+  CheckerState(const ExtGraph& g, ExtModelView& m, bool ev)
+      : graph(g), model(m), recordEvents(ev), seq(0),
+        materializedGuardCount(0)
+  {
+  }
+
+  ASTNode accessIndex(size_t id)
+  {
+    return model.bvValue(graph.accesses[id].indexName);
+  }
+
+  ASTNode accessValue(size_t id)
+  {
+    return model.bvValue(graph.accesses[id].valueName);
+  }
+
+  void event(ExtEvent::Kind kind, const char* rule, const ASTNode& source,
+             const ASTNode& destination, size_t access,
+             const ASTNode& indexValue, const ASTNode& accessValue)
+  {
+    if (!recordEvents)
+    {
+      seq++;
+      return;
+    }
+    ExtEvent e;
+    e.seq = seq++;
+    e.kind = kind;
+    e.rule = rule;
+    e.source = source;
+    e.destination = destination;
+    e.access = access;
+    e.indexValue = indexValue;
+    e.accessValue = accessValue;
+    result.events.push_back(e);
+  }
+
+  // Walk one predecessor chain back to its seed, turning the stored
+  // one-guard-per-link entries into the complete path a conflict
+  // certificate reports.
+  std::vector<ExtGuard> materializeGuards(const PathRecord& tail)
+  {
+    std::vector<ExtGuard> reversed;
+    const PathRecord* current = &tail;
+    while (current->hasPredecessor)
+    {
+      reversed.push_back(current->incomingGuard);
+      materializedGuardCount++;
+      const std::map<PairKey, PathRecord>::const_iterator predecessor =
+          paths.find(current->predecessor);
+      if (predecessor == paths.end())
+        FatalError("array-equality: a proof path lost its predecessor");
+      current = &predecessor->second;
+    }
+    std::reverse(reversed.begin(), reversed.end());
+    return reversed;
+  }
+
+  void finishProofDiagnostics()
+  {
+    result.proofPathEntries = paths.size();
+    result.materializedGuardCount = materializedGuardCount;
+  }
+
+  // Bring one access to one array, and run congruence (rule C) on the
+  // spot, against the single representative rho keeps for that array
+  // and concrete index (section 11.2).
+  //
+  // Three outcomes. An arrival at a pair already recorded is skipped:
+  // insertion is first-path-wins and the recorded path stays. An
+  // arrival matching the representative in both concrete index and
+  // concrete value is dropped without insertion or propagation --
+  // complete because no rule can tell members of a concrete
+  // (index, value) class apart; see ExtChecker.h for why that is not
+  // the same claim as "the representative reaches everything this
+  // access would". Note that this one records nothing, so the same
+  // access arriving again by another route repeats the test; the
+  // counters below therefore count arrivals, not pairs. Otherwise the
+  // access is inserted, becomes the representative if the index was
+  // free, and is queued.
+  //
+  // A representative already there with a different concrete value is a
+  // conflict: it is appended to result.conflicts (without the lemma,
+  // which buildLemmas adds afterwards) and the pass carries on, so it
+  // collects further independent conflicts instead of stopping at the
+  // earliest. It does not enumerate every disagreeing pair in the
+  // candidate -- a conflicting arrival is not queued, so pairs that
+  // could only meet beyond it are left to a later refinement round.
+  void insert(const ASTNode& destination, size_t accessId,
+              const ExtGuard* incomingGuard, const char* rule,
+              const ASTNode& source)
+  {
+    const PairKey key(destination, accessId);
+    if (paths.find(key) != paths.end())
+    {
+      result.stats["skipped_seen"]++;
+      event(ExtEvent::SKIP_SEEN, rule, source, destination, accessId,
+            ASTNode(), ASTNode());
+      return;
+    }
+
+    PathRecord candidatePath;
+    if (incomingGuard != NULL)
+    {
+      if (source.IsNull())
+        FatalError("array-equality: a guarded proof step has no source");
+      candidatePath.hasPredecessor = true;
+      candidatePath.predecessor = PairKey(source, accessId);
+      candidatePath.incomingGuard = *incomingGuard;
+    }
+    else if (!source.IsNull())
+    {
+      FatalError("array-equality: a non-seed proof step has no guard", source);
+    }
+
+    const ASTNode idx = accessIndex(accessId);
+    const ASTNode val = accessValue(accessId);
+
+    RhoIndexMap& byIndex = rhoByIndex[destination];
+    const std::pair<RhoIndexMap::iterator, bool> representative =
+        byIndex.emplace(idx, accessId);
+    if (!representative.second)
+    {
+      const size_t otherId = representative.first->second;
+      if (accessValue(otherId) != val)
+      {
+        ExtConflict c;
+        c.commonArray = destination;
+        c.leftAccess = otherId;
+        c.rightAccess = accessId;
+        c.indexValue = idx;
+        c.leftValue = accessValue(otherId);
+        c.rightValue = val;
+        const std::map<PairKey, PathRecord>::const_iterator otherPath =
+            paths.find(PairKey(destination, otherId));
+        if (otherPath == paths.end())
+          FatalError("array-equality: rho representative has no proof path",
+                     destination);
+        c.leftGuards = materializeGuards(otherPath->second);
+        c.rightGuards = materializeGuards(candidatePath);
+        result.stats["conflicts"]++;
+        event(ExtEvent::CONFLICT, rule, source, destination, accessId, idx,
+              val);
+        result.conflicts.push_back(std::move(c));
+
+        // Record the pair as visited so a later path to it cannot report
+        // the same conflict twice, but keep the arriving access out of
+        // rho -- its value disagrees with the representative already
+        // there -- and out of the work list, so nothing propagates
+        // onward from a conflicting arrival. The representative keeps
+        // the array's slot for this index, exactly as when the pass
+        // stopped here.
+        //
+        // This is what bounds the section 11.1 minimization to the
+        // first conflict: the access's search tree ends here, so a
+        // later conflict involving it uses whatever route remains, and
+        // a pair that could only have met through this array is left
+        // for a later refinement round. Queueing it instead would
+        // restore exact minimization at the cost of an unbounded number
+        // of further conflicts per pass, all derived from an already
+        // refuted candidate.
+        paths[key] = candidatePath;
+        return;
+      }
+      result.stats["skipped_represented"]++;
+      event(ExtEvent::SKIP_REPRESENTED, rule, source, destination, accessId,
+            idx, val);
+      return;
+    }
+
+    paths[key] = candidatePath;
+    rho[destination].push_back(accessId);
+    worklist.push_back(key);
+    result.stats["insertions"]++;
+
+    ExtEvent::Kind kind;
+    if (rule[0] == 'I' && rule[1] == '_')
+    {
+      result.stats["seeds"]++;
+      kind = ExtEvent::SEED;
+    }
+    else
+    {
+      result.stats["propagations"]++;
+      result.stats[std::string("rule_") + rule]++;
+      kind = ExtEvent::PROPAGATE;
+    }
+    event(kind, rule, source, destination, accessId, idx, val);
+  }
+};
+
+// Deterministic total order for premise atoms: rank by atom op
+// (bv_eq < bv_ne < array_eq < bool_lit), then by operand node numbers.
+bool atomLess(const ExtLemmaAtom& x, const ExtLemmaAtom& y)
+{
+  if (x.op != y.op)
+    return x.op < y.op;
+  uint64_t xa = x.a.IsNull() ? 0 : x.a.GetNodeNum();
+  uint64_t ya = y.a.IsNull() ? 0 : y.a.GetNodeNum();
+  if (xa != ya)
+    return xa < ya;
+  uint64_t xb = x.b.IsNull() ? 0 : x.b.GetNodeNum();
+  uint64_t yb = y.b.IsNull() ? 0 : y.b.GetNodeNum();
+  if (xb != yb)
+    return xb < yb;
+  uint64_t xt = x.boolTerm.IsNull() ? 0 : x.boolTerm.GetNodeNum();
+  uint64_t yt = y.boolTerm.IsNull() ? 0 : y.boolTerm.GetNodeNum();
+  return xt < yt;
+}
+
+// Canonicalize a premise: drop reflexive equalities (an index compared
+// with itself contributes nothing), drop exact duplicate atoms, and
+// sort deterministically. The guard paths feeding this are as short as
+// the pass could make them (section 11.1, a property of the FIFO work
+// list -- exactly shortest for the first conflict, and shortest among
+// the routes still open for a later one; see ExtChecker.h); beyond
+// that only exact duplicates are removed, no semantic subsumption.
+std::vector<ExtLemmaAtom> canonicalAtoms(const std::vector<ExtLemmaAtom>& in)
+{
+  std::vector<ExtLemmaAtom> out;
+  out.reserve(in.size());
+  for (size_t i = 0; i < in.size(); i++)
+  {
+    const ExtLemmaAtom& a = in[i];
+    if (a.op == ExtLemmaAtom::BV_EQ && a.a == a.b)
+      continue;
+    out.push_back(a);
+  }
+  // Preserve which input occurrence survives when two logical atoms
+  // compare equal. ExtLemmaAtom carries proof metadata outside atomLess
+  // and operator==, so an unstable sort would make that choice incidental.
+  std::stable_sort(out.begin(), out.end(), atomLess);
+  out.erase(std::unique(out.begin(), out.end()), out.end());
+  return out;
+}
+
+void guardsToAtoms(const std::vector<ExtGuard>& guards, bool abstractLayer,
+                   std::vector<ExtLemmaAtom>& out)
+{
+  for (size_t i = 0; i < guards.size(); i++)
+  {
+    const ExtGuard& g = guards[i];
+    ExtLemmaAtom a;
+    if (g.kind == ExtGuard::INDEX_NE)
+    {
+      a.op = ExtLemmaAtom::BV_NE;
+      a.a = abstractLayer ? g.absA : g.theoryA;
+      a.b = abstractLayer ? g.absB : g.theoryB;
+      a.eqRecord = 0;
+    }
+    else if (g.kind == ExtGuard::ITE_COND_POS ||
+             g.kind == ExtGuard::ITE_COND_NEG)
+    {
+      // The condition with the polarity sigma gave it. Unlike an array
+      // equality, an if-then-else guard can be either way round: both
+      // branches are selectable, and the rule fired on whichever one
+      // sigma selected.
+      a.op = g.kind == ExtGuard::ITE_COND_POS ? ExtLemmaAtom::BOOL_LIT
+                                              : ExtLemmaAtom::BOOL_LIT_NEG;
+      a.boolTerm = abstractLayer ? g.absA : g.theoryA;
+      a.eqRecord = 0;
+    }
+    else if (abstractLayer)
+    {
+      a.op = ExtLemmaAtom::BOOL_LIT;
+      a.boolTerm = g.absA;
+      a.eqRecord = g.eqRecord;
+    }
+    else
+    {
+      a.op = ExtLemmaAtom::ARRAY_EQ;
+      a.a = g.theoryA;
+      a.b = g.theoryB;
+      a.eqRecord = g.eqRecord;
+    }
+    out.push_back(a);
+  }
+}
+
+// Self-check: a lemma is only worth adding if the candidate that
+// produced it falsifies it — every premise atom must be true and the
+// conclusion false under sigma. Otherwise adding it could not rule the
+// candidate out and refinement might not terminate; abort loudly.
+void validateAbstractLemma(const ExtConflict& c, ExtModelView& model)
+{
+  for (size_t i = 0; i < c.abstractPremise.size(); i++)
+  {
+    const ExtLemmaAtom& a = c.abstractPremise[i];
+    bool holds;
+    if (a.op == ExtLemmaAtom::BV_EQ)
+      holds = model.bvValue(a.a) == model.bvValue(a.b);
+    else if (a.op == ExtLemmaAtom::BV_NE)
+      holds = model.bvValue(a.a) != model.bvValue(a.b);
+    else if (a.op == ExtLemmaAtom::BOOL_LIT)
+      holds = model.boolValue(a.boolTerm);
+    else if (a.op == ExtLemmaAtom::BOOL_LIT_NEG)
+      holds = !model.boolValue(a.boolTerm);
+    else
+      holds = false; // ARRAY_EQ can't appear in the abstract lemma
+    if (!holds)
+      FatalError("array-equality: generated lemma premise is not true "
+                 "in the candidate assignment that produced it");
+  }
+  if (model.bvValue(c.abstractConclusionA) ==
+      model.bvValue(c.abstractConclusionB))
+    FatalError("array-equality: generated lemma is not false in the "
+               "candidate assignment that produced it");
+}
+
+// Build the lemma of paper section 8 for a conflict between accesses
+// x and y at common array d:
+//
+//   index(x) = index(y)
+//     and the write-index disequalities of both propagation paths
+//     and the array equalities crossed by both paths
+//   =>  value(x) = value(y)
+//
+// built once over the original terms (the theory lemma) and once over
+// abstraction variables and scalar names (the refinement actually
+// encoded into the SAT solver).
+void buildLemmas(ExtConflict& c, const ExtGraph& graph, ExtModelView& model)
+{
+  const ExtAccess& left = graph.accesses[c.leftAccess];
+  const ExtAccess& right = graph.accesses[c.rightAccess];
+
+  {
+    std::vector<ExtLemmaAtom> atoms;
+    ExtLemmaAtom indexEq;
+    indexEq.op = ExtLemmaAtom::BV_EQ;
+    indexEq.a = left.indexName;
+    indexEq.b = right.indexName;
+    indexEq.eqRecord = 0;
+    atoms.push_back(indexEq);
+    guardsToAtoms(c.leftGuards, true, atoms);
+    guardsToAtoms(c.rightGuards, true, atoms);
+    c.abstractPremise = canonicalAtoms(atoms);
+    c.abstractConclusionA = left.valueName;
+    c.abstractConclusionB = right.valueName;
+  }
+
+  {
+    std::vector<ExtLemmaAtom> atoms;
+    ExtLemmaAtom indexEq;
+    indexEq.op = ExtLemmaAtom::BV_EQ;
+    indexEq.a = left.indexTerm;
+    indexEq.b = right.indexTerm;
+    indexEq.eqRecord = 0;
+    atoms.push_back(indexEq);
+    guardsToAtoms(c.leftGuards, false, atoms);
+    guardsToAtoms(c.rightGuards, false, atoms);
+    c.theoryPremise = canonicalAtoms(atoms);
+    c.theoryConclusionA = left.valueTerm;
+    c.theoryConclusionB = right.valueTerm;
+  }
+
+  validateAbstractLemma(c, model);
+}
+
+} // namespace
+
+ExtCheckResult ExtChecker::check(const ExtGraph& graph, ExtModelView& model,
+                                 bool recordEvents)
+{
+  CheckerState st(graph, model, recordEvents);
+
+  // Rule I: seed every access at its own array, with an empty
+  // propagation path, in the stable access order.
+  for (size_t i = 0; i < graph.accesses.size(); i++)
+  {
+    const ExtAccess& a = graph.accesses[i];
+    const char* rule = a.isWrite ? "I_WRITE" : "I_READ";
+    st.insert(a.site, a.id, NULL, rule, ASTNode());
+  }
+
+  // Fixed-point computation over a FIFO work list (the "working queue
+  // that manages future read propagations" of section 7.3); for each
+  // pair the edges fire in the order D, U, R/L, then the T rules.
+  //
+  // The FIFO discipline is load-bearing: with every access seeded
+  // before the fixed point starts, discovery is breadth-first per
+  // access, so an access's recorded path to any array is a shortest
+  // propagation path among the routes still open to it. That is the
+  // lemma minimization of section 11.1, obtained without the separate
+  // post-conflict search a depth-first (stack) working list would need.
+  //
+  // "Still open" because a conflicting arrival is not queued (see
+  // insert), so an access stops at an array it conflicted at. The first
+  // conflict of a pass is unaffected -- nothing has been truncated when
+  // it fires -- but a later one can carry a longer premise than an
+  // exhaustive search would give it. Pinned at both ends by the
+  // ConflictPremiseUsesShortestPaths and
+  // ConflictingArrivalStopsAtTheConflictArray unit tests; do not
+  // replace the deque with a stack.
+  while (!st.worklist.empty())
+  {
+    const PairKey cur = st.worklist.front();
+    st.worklist.pop_front();
+    const ASTNode source = cur.first;
+    const size_t accessId = cur.second;
+    const ASTNode accessIdxVal = st.accessIndex(accessId);
+
+    // Every rule fires for every pair: a conflict on one edge no longer
+    // cuts the remaining edges short, so the pass collects the
+    // independent conflicts an early return would have hidden.
+
+    // Rule D: propagate down through a write whose index differs
+    // from the access index under sigma (axiom A3).
+    std::map<ASTNode, ExtWriteNode>::const_iterator wit =
+        graph.writes.find(source);
+    if (wit != graph.writes.end())
+    {
+      const ExtWriteNode& w = wit->second;
+      if (accessIdxVal != model.bvValue(w.indexName))
+      {
+        ExtGuard g;
+        g.kind = ExtGuard::INDEX_NE;
+        g.theoryA = graph.accesses[accessId].indexTerm;
+        g.theoryB = w.indexTerm;
+        g.absA = graph.accesses[accessId].indexName;
+        g.absB = w.indexName;
+        g.eqRecord = 0;
+        st.insert(w.base, accessId, &g, "D_WRITE", source);
+      }
+    }
+
+    // Rule U: propagate up over every write on top of this array
+    // whose index differs from the access index under sigma. Upward
+    // propagation is what makes extensional reasoning complete
+    // (section 7.3).
+    {
+      std::map<ASTNode, std::vector<ASTNode>>::const_iterator pit =
+          graph.writeParents.find(source);
+      if (pit != graph.writeParents.end())
+      {
+        const std::vector<ASTNode>& parents = pit->second;
+        for (size_t i = 0; i < parents.size(); i++)
+        {
+          const ExtWriteNode& w = graph.writes.find(parents[i])->second;
+          if (accessIdxVal != model.bvValue(w.indexName))
+          {
+            ExtGuard g;
+            g.kind = ExtGuard::INDEX_NE;
+            g.theoryA = graph.accesses[accessId].indexTerm;
+            g.theoryB = w.indexTerm;
+            g.absA = graph.accesses[accessId].indexName;
+            g.absB = w.indexName;
+            g.eqRecord = 0;
+            st.insert(w.write, accessId, &g, "U_WRITE", source);
+          }
+        }
+      }
+    }
+
+    // Rules R and L: propagate across array equalities, in both
+    // directions, but only when sigma assigns the equality's Boolean
+    // abstraction variable true.
+    {
+      std::map<ASTNode, std::vector<size_t>>::const_iterator eit =
+          graph.eqAdjacency.find(source);
+      if (eit != graph.eqAdjacency.end())
+      {
+        const std::vector<size_t>& adj = eit->second;
+        for (size_t i = 0; i < adj.size(); i++)
+        {
+          const ExtEqEdge& e = graph.eqEdges[adj[i]];
+          if (!model.boolValue(e.proxy))
+            continue;
+          const bool fromLeft = (e.left == source);
+          const ASTNode destination = fromLeft ? e.right : e.left;
+          const char* rule = fromLeft ? "R_EQ" : "L_EQ";
+          ExtGuard g;
+          g.kind = ExtGuard::EQ_PROXY;
+          g.theoryA = e.left;
+          g.theoryB = e.right;
+          g.absA = e.proxy;
+          g.eqRecord = e.record;
+          st.insert(destination, accessId, &g, rule, source);
+        }
+      }
+    }
+
+    // Rules T-down and T-up: propagate across an array-valued
+    // if-then-else, in both directions, between it and whichever branch
+    // sigma selects. These are R and L with the equality proxy replaced
+    // by the condition literal and the destination chosen by sigma
+    // rather than fixed by the edge. Exactly one of the two branches is
+    // live per candidate, so unlike an equality there is no proxy left
+    // over for the solver to guess.
+    //
+    // The condition is read through its reified name, never re-evaluated
+    // from the counterexample: the value the rule branches on has to be
+    // the one the bit-blasted circuit took, or the wrong edge is live
+    // and a conflict-free fixed point certifies a model that does not
+    // satisfy the if-then-else axiom.
+    {
+      // T-down: source is the if-then-else, destination its branch.
+      std::map<ASTNode, ExtIteNode>::const_iterator dit =
+          graph.ites.find(source);
+      if (dit != graph.ites.end())
+      {
+        const ExtIteNode& t = dit->second;
+        const bool cond = model.boolValue(t.condName);
+        ExtGuard g;
+        g.kind = cond ? ExtGuard::ITE_COND_POS : ExtGuard::ITE_COND_NEG;
+        g.theoryA = t.condTerm;
+        g.absA = t.condName;
+        st.insert(cond ? t.thn : t.els, accessId, &g, "T_DOWN", source);
+      }
+
+      // T-up: source is a branch, destination every if-then-else that
+      // selects it.
+      std::map<ASTNode, std::vector<ASTNode>>::const_iterator uit =
+          graph.iteParents.find(source);
+      if (uit != graph.iteParents.end())
+      {
+        const std::vector<ASTNode>& above = uit->second;
+        for (size_t i = 0; i < above.size(); i++)
+        {
+          const ExtIteNode& t = graph.ites.find(above[i])->second;
+          const bool cond = model.boolValue(t.condName);
+          // Only from the selected branch. A branch can be both, in
+          // which case either polarity carries the access up and the
+          // first match is taken.
+          if (!((cond && t.thn == source) || (!cond && t.els == source)))
+            continue;
+          ExtGuard g;
+          g.kind = cond ? ExtGuard::ITE_COND_POS : ExtGuard::ITE_COND_NEG;
+          g.theoryA = t.condTerm;
+          g.absA = t.condName;
+          st.insert(t.ite, accessId, &g, "T_UP", source);
+        }
+      }
+    }
+  }
+
+  // The fixed point ran to completion, so report every conflict it
+  // found. Each is a lemma in its own right: its premise holds and its
+  // conclusion fails under the one candidate sigma this pass ran
+  // against, which does not change while the pass runs, so a conflict
+  // found late is neither weakened nor invalidated by an earlier one.
+  if (!st.result.conflicts.empty())
+  {
+    for (size_t i = 0; i < st.result.conflicts.size(); i++)
+      buildLemmas(st.result.conflicts[i], graph, model);
+    st.result.conflict = st.result.conflicts[0];
+    st.result.status = ExtCheckResult::CONFLICT;
+    st.finishProofDiagnostics();
+    return std::move(st.result);
+  }
+
+  // Verify the witnesses of preprocessing step 1, in record order: a
+  // false array equality must differ at its witness index lambda.
+  for (size_t i = 0; i < graph.witnesses.size(); i++)
+  {
+    const ExtWitness& w = graph.witnesses[i];
+    const bool proxyVal = model.boolValue(w.proxy);
+    const ASTNode leftVal = model.bvValue(w.leftValue);
+    const ASTNode rightVal = model.bvValue(w.rightValue);
+    st.event(ExtEvent::WITNESS_CHECK, "WITNESS", ASTNode(), ASTNode(),
+             w.record, model.bvValue(w.index), leftVal);
+    st.result.stats["witness_checks"]++;
+    if (!proxyVal && leftVal == rightVal)
+    {
+      st.result.status = ExtCheckResult::WITNESS_VIOLATION;
+      st.result.violatedRecord = w.record;
+      st.finishProofDiagnostics();
+      return std::move(st.result);
+    }
+  }
+
+  // Conflict-free: export the observed (index, value) pairs of every
+  // array; rho's fixed point defines the completed array contents
+  // (unobserved indices default to zero when a model is printed).
+  for (std::map<ASTNode, std::vector<size_t>>::const_iterator it =
+           st.rho.begin();
+       it != st.rho.end(); ++it)
+  {
+    std::vector<std::pair<ASTNode, ASTNode>>& obs =
+        st.result.observed[it->first];
+    for (size_t i = 0; i < it->second.size(); i++)
+    {
+      const size_t id = it->second[i];
+      obs.push_back(std::make_pair(st.accessIndex(id), st.accessValue(id)));
+    }
+  }
+
+  st.result.status = ExtCheckResult::CONSISTENT;
+  st.finishProofDiagnostics();
+  return std::move(st.result);
+}
+
+} // namespace stp


### PR DESCRIPTION
# Array extensionality (2/6): the consistency checker and its lemmas

**This PR builds on top of #745** (1/6 — the AUTHORS housekeeping). Please review and merge it first; this branch contains its commit.

SMT-LIB's theory of arrays is extensional: two arrays are equal exactly when they agree at every index. STP has never decided that — `=` over two array terms was refused — and this series adds it, behind an option that defaults off.

## What's in it

The part that decides nothing on its own. Given a candidate model, `ExtChecker` says whether the array equalities in it hold, and when one does not, produces the lemma that rules that model out. It is a pure function of the model and the equalities: it owns no state, and nothing calls it yet.

The refutation for a failed equality is a **witness index** — some index at which the two arrays disagree — so the lemma says "if these arrays are equal then they agree here". Certification runs the same rules in the other direction: an equality asserted true has to survive the reads the model actually observed.

`ARRAY_EQ` joins the kinds, since an array equality has to be a node before any of this can look at it.

## Why it is separable

`ExtChecker` has zero references to `ExtensionalityContext` — the dependency runs one way — so the checker can be read and reviewed without the registry that feeds it. The registry, and the solver loop that drives both, are the next two commits.

## Testing

97/97 ctest, 280/280 lit. No new tests here: the unit suite for the core spans both this and the registry, and it needs the solver loop to run, so it lands in 4/6. Reviewable as a pure function against the lemma rules.
