### PR TITLE
Array extensionality (3/6): the registry, and what a model has to answer

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -28,6 +28,8 @@ Current Authors
 
 * Ryan Govostes
 
+* Andrew Teylu
+
 Other Significant Author
 ------------------------
 * Trevor Alexander Hansen

--- a/README.markdown
+++ b/README.markdown
@@ -270,5 +270,5 @@ You will need to install [cmake](https://cmake.org/download/) and follow the ste
 * Mate Soos
 * Dan Liew
 * Ryan Govostes
-* Andrew V. Teylu
+* Andrew Teylu
 * And many others...

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -259,7 +259,7 @@ History and authors
 The initial versions of STP were written primarily by Vijay Ganesh as
 part of his PhD thesis. STP was subsequently developed by Trevor
 Hansen during his PhD. The current authors are Trevor Hansen, Mate Soos, 
-Ryan Govostes and Andrew V. Teylu. STP is based on the
+Ryan Govostes and Andrew Teylu. STP is based on the
 following papers:
 
 -  `A Decision Procedure for Bit-Vectors and

--- a/include/stp/AST/AST.h
+++ b/include/stp/AST/AST.h
@@ -93,6 +93,35 @@ inline bool constantsDenoteDifferentValues(const ASTNode& a, const ASTNode& b)
   return !constantsSameBits(a, b);
 }
 
+// The plain bit-vector constant spelling the same bits as `c`, or `c`
+// itself when it already is one. A floating-point or rounding-mode
+// constant interns apart from the plain constant with its bits, so two
+// nodes can spell one value -- and anything that keys a container or
+// builds a lookup node from a constant is asking about the spelling
+// unless it normalises through here first.
+ASTNode plainBitVectorConstant(STPMgr* bm, const ASTNode& c);
+
+// Whether two constants denote the same value *of a given sort*, which
+// for a floating-point sort is a weaker question than sharing bits.
+//
+// SMT-LIB's = on floats is identity of values, and NaN is one value with
+// many packings, so two cells or indexes holding different NaN payloads
+// hold the same value. Every other float value has exactly one packing,
+// and every bit-vector and rounding-mode value has exactly one encoding,
+// so for those this is constantsSameBits. The extensionality layer
+// builds the circuit form of the same rule (packedFloatEq); this is the
+// form for constants already in hand, used where the model is read back
+// rather than constrained.
+bool constantsSameSourceValue(const ASTNode& a, const ASTNode& b,
+                              const SourceSort& sort);
+
+inline bool constantsDenoteDifferentSourceValues(const ASTNode& a,
+                                                 const ASTNode& b,
+                                                 const SourceSort& sort)
+{
+  return !constantsSameSourceValue(a, b, sort);
+}
+
 // Whether `n` denotes bits to the bit-vector layers, which is not the same
 // question as GetType() == BITVECTOR_TYPE.
 //

--- a/include/stp/AST/ASTNode.h
+++ b/include/stp/AST/ASTNode.h
@@ -147,7 +147,7 @@ public:
     return k == BVLT || k == BVLE || k == BVGT || k == BVGE || k == BVSLT ||
            k == BVSLE || k == BVSGT || k == BVSGE || k == BVUADDO ||
            k == BVSADDO || k == BVUMULO || k == BVSMULO || k == BVUSUBO ||
-           k == BVSSUBO || k == EQ;
+           k == BVSSUBO || k == EQ || k == ARRAY_EQ;
   }
 
   // delegates to the ASTInternal node.

--- a/include/stp/AbsRefineCounterExample/AbsRefine_CounterExample.h
+++ b/include/stp/AbsRefineCounterExample/AbsRefine_CounterExample.h
@@ -35,6 +35,26 @@ THE SOFTWARE.
 
 namespace stp
 {
+// Polarity control for the reified bit-vector equality helper. LEFT_ONLY
+// constrains (bits equal -> literal), RIGHT_ONLY constrains
+// (literal -> bits equal), BOTH gives the full equivalence.
+enum class Polarity
+{
+  LEFT_ONLY,
+  RIGHT_ONLY,
+  BOTH
+};
+
+// Resolve (or freshly allocate) the SAT variable vector of a SYMBOL.
+void getSatVariables(const ASTNode& a, vector<unsigned>& v_a,
+                     SATSolver& SatSolver, ToSATBase::ASTNodeToSATVar& satVar);
+
+// Adds clauses constraining a fresh SAT variable to (partially) reify
+// the bit-vector equality a = b, and returns that variable.
+Minisat::Var getEquals(SATSolver& SatSolver, const ASTNode& a,
+                       const ASTNode& b, ToSATBase::ASTNodeToSATVar& satVar,
+                       Polarity polary = Polarity::BOTH);
+
 class FpEncodingContext;
 
 class AbsRefine_CounterExample // not copyable
@@ -69,13 +89,60 @@ private:
 
   FpEncodingContext& requireFpEncodingContext() const;
 
-  // Checks if the counterexample is good. In order for the
-  // counterexample to be ok, every assert must evaluate to true
-  // w.r.t couner_example, and the query must evaluate to
-  // false. Otherwise we know that the counter_example is bogus.
-  void CheckCounterExample(bool t);
+  // Re-evaluates the query the user actually submitted against the
+  // finished model. This must not reconstruct the formula from STPMgr's
+  // assertion/query registry: solve-boundary passes (notably opaque
+  // array-equality lowering) are local to the root handed to the solve
+  // and deliberately do not mutate that public registry.
+  //
+  // checked_input is the root as submitted, *before* array-equality
+  // lowering -- not the semantic root the solve ran on. Passing the
+  // semantic root instead would re-ask a question the caller has
+  // already had answered, and the memo would answer it from cache.
+  //
+  // Be precise about what the extra reach buys, because it is less than
+  // it looks: an opaque ARRAY_EQ is still present in this root, but it
+  // is evaluated through its recorded lowering, which is the value the
+  // verdict already rested on. So this walk covers the Boolean skeleton
+  // the lowering rebuilt around the equalities -- not the equalities.
+  // Their own content is checked separately, by comparing each
+  // abstraction variable against the array cells the model publishes
+  // (ExtensionalityContext::recheckCertifiedEqualities, called at the
+  // end of this function).
+  void CheckCounterExample(bool t, const ASTNode& checked_input);
 
   // Accepts a term and turns it into a constant-term w.r.t
+  // The cells the model records for a set of array nodes, keyed by
+  // (array, index) with the index normalised to its plain bit-vector
+  // spelling.
+  //
+  // Keyed that way on purpose. A cell is a property of the *value* of
+  // its index, but a floating-point constant interns apart from the
+  // plain constant with its bits -- so 1.0f and 0x3F800000 are two
+  // nodes naming one cell, and looking a cell up by building a READ
+  // node asks about the spelling. Whichever spelling the model happened
+  // to record under would be found and the other missed, and the miss
+  // completes to zero: one array reads a cell the other does not, and
+  // two equal arrays are reported as differing.
+  typedef std::map<std::pair<ASTNode, ASTNode>, ASTNode> ModelCells;
+  void CollectModelCells(const ASTNodeSet& arrays, ModelCells& out);
+
+  // The value the model gives one cell of an array term, without
+  // recording anything: the recorded cell if there is one, else the
+  // written value if a write at this level hits the index, else the
+  // same question one level down, else defaultCellValue. Answers with a
+  // plain bitvector constant, for the reason given on
+  // TermToConstTermUsingModel below -- its results are compared by
+  // node identity.
+  ASTNode ReadUsingModel(const ASTNode& arrayTerm,
+                         const ASTNode& concreteIndex,
+                         const ModelCells& cells);
+
+  // The array-valued nodes an array term is built from -- itself, the
+  // base of every write, both branches of every array if-then-else.
+  // These are the nodes the model can hold cells against.
+  static void CollectArrayNodes(const ASTNode& arrayTerm, ASTNodeSet& out);
+
   // counter_example. Always answers with a plain bitvector constant: a
   // float constant interns separately from the bitvector constant with
   // the same bits, and evaluation results are compared (write-hit
@@ -133,6 +200,30 @@ public:
 
   void ClearComputeFormulaMap(void) { ComputeFormulaMap.clear(); }
 
+  // Publish an array observation certified by the array-equality
+  // consistency check: READ over a constant index mapped to its
+  // concrete value. A different existing value is an integration
+  // error, never a choice between two model authorities.
+  void InsertIntoCounterExampleMap(const ASTNode& key, const ASTNode& value)
+  {
+    ASTNodeMap::const_iterator it = CounterExampleMap.find(key);
+    if (it != CounterExampleMap.end() && !(it->second == value))
+      FatalError("array-equality: certified array observation conflicts with "
+                 "an existing counterexample entry",
+                 key);
+    CounterExampleMap[key] = value;
+  }
+
+  // Exact lookup in the materialized SAT assignment. Unlike the general
+  // model evaluator, this never invents a default for a symbol that was
+  // absent from the bit-blast. The extensionality checker uses it for
+  // every scalar name on which a refinement certificate depends.
+  ASTNode LookupAssignedValue(const ASTNode& key) const
+  {
+    ASTNodeMap::const_iterator it = CounterExampleMap.find(key);
+    return it == CounterExampleMap.end() ? ASTNode() : it->second;
+  }
+
   // Prints the counterexample to stdout
   void PrintCounterExample_InOrder(bool t);
 
@@ -140,9 +231,29 @@ public:
   // to e
   ASTNode GetCounterExample(const ASTNode& e);
 
+  // Model access for the array-equality consistency checker: must work
+  // mid-solve on the current candidate, regardless of the ValidFlag
+  // left over from an earlier query in incremental use.
+  ASTNode ModelValueOfTerm(const ASTNode& t)
+  {
+    return TermToConstTermUsingModel(t, false);
+  }
+  ASTNode ModelValueOfFormula(const ASTNode& f)
+  {
+    return ComputeFormulaUsingModel(f);
+  }
+
   // queries the counterexample, and returns a vector of index-value pairs for e
   vector<std::pair<ASTNode, ASTNode>> GetCounterExampleArray(bool t,
                                                              const ASTNode& e);
+
+  // The observed (index, value) model entries of one array symbol,
+  // deduplicated per concrete index and sorted in ascending unsigned
+  // index order. Shared by the programmatic model API and the SMT-LIB2
+  // model printer so both surfaces expose the same deterministic
+  // observations.
+  vector<std::pair<ASTNode, ASTNode>>
+  GetSortedArrayModelEntries(const ASTNode& arraySym);
 
   int CounterExampleSize(void) const { return CounterExampleMap.size(); }
 
@@ -154,12 +265,67 @@ public:
   // Computes the truth value of a formula w.r.t counter_example
   ASTNode ComputeFormulaUsingModel(const ASTNode& form);
 
+  // Do two array terms denote the same array in the finished model?
+  //
+  // Decided from the model alone -- no abstraction variable, no
+  // record, no lowering -- so it can answer for an equality the solve
+  // never reasoned about, and it is an independent opinion where the
+  // solve did. Cells the model records nothing for read as
+  // defaultCellValue, which is the completion the model printer and the
+  // programmatic model API both apply, so the answer is the one a
+  // reader of the printed model would get.
+  //
+  // The cells at which two array terms can differ are finite and
+  // known: every index the model records against an array either term
+  // is built from, plus every index written to by a write in either
+  // term. Anywhere else both terms read the same default.
+  bool ArraysEqualUsingModel(const ASTNode& left, const ASTNode& right);
+
+  // Whether ArraysEqualUsingModel can answer about this array term at
+  // all. Ask before asking; see the definition for the one case it
+  // cannot.
+  bool arrayEqualityIsModelDecidable(const ASTNode& arrayTerm) const;
+
+  // What a cell of this array holds when the model records nothing for
+  // it.
+  //
+  // Every reader of a published model has to answer this identically:
+  // the printer emits it as the constant array underneath the observed
+  // cells, ReadUsingModel and the read evaluator return it for an index
+  // with no entry, and the array-equality checker completes both sides
+  // with it before comparing contents. A site that disagrees makes the
+  // model contradict itself -- an equality reads false through its
+  // lowering's reads while the printed arrays are identical -- and that
+  // is invisible until something compares two of the answers. So the
+  // value is decided once, here, and every site asks rather than
+  // spelling it out.
+  //
+  // Keyed on the array because it is a property of the element sort,
+  // not of the element width: RoundingMode is a one-hot encoding whose
+  // all-zero pattern denotes no mode at all, so a five-bit array of
+  // modes cannot be completed with the same constant a five-bit array
+  // of bitvectors is.
+  ASTNode defaultCellValue(const ASTNode& arrayTerm) const;
+
+  // ComputeFormulaUsingModel for a caller asking a question about the
+  // model rather than assembling it: whatever the evaluation would
+  // have recorded is rolled back. See the note on ModelQuery in the
+  // implementation for why that matters.
+  ASTNode QueryFormulaAgainstModel(const ASTNode& form);
+
   /****************************************************************
    * Array Refinement functions                                   *
    ****************************************************************/
+  // original_input is the semantic root this solve ran on, and is what
+  // the model is evaluated against to decide the verdict. submitted_input
+  // is the root as the user handed it over, before array-equality
+  // lowering; it differs only when lowering did something, and it is
+  // what --check-counterexample re-evaluates. Callers with no lowered
+  // form to distinguish pass the same node twice.
   SOLVER_RETURN_TYPE
   CallSAT_ResultCheck(SATSolver& SatSolver, const ASTNode& modified_input,
-                      const ASTNode& original_input, ToSATBase* tosat,
+                      const ASTNode& original_input,
+                      const ASTNode& submitted_input, ToSATBase* tosat,
                       bool refinement);
 
   SOLVER_RETURN_TYPE

--- a/include/stp/Extensionality/ExtChecker.h
+++ b/include/stp/Extensionality/ExtChecker.h
@@ -1,0 +1,400 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: July, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+/*
+ * The consistency checker of the lemmas-on-demand decision procedure
+ * for the extensional theory of arrays:
+ *
+ *   Robert Brummayer, Armin Biere: "Lemmas on Demand for the
+ *   Extensional Theory of Arrays", JSAT 6 (2010) 165-201.
+ *
+ * A candidate assignment sigma produced by the SAT solver assigns
+ * values to the abstraction variables of reads and array equalities,
+ * but knows nothing of the array axioms; the checker decides whether
+ * sigma can be extended to a genuine array model (paper section 7).
+ * It maintains the paper's map rho from each array term to the set of
+ * accesses currently known to constrain it, and runs the paper's
+ * propagation rules to a fixed point over a FIFO work list:
+ *
+ *   I     seed every access at its own array (section 7.2);
+ *   D / U propagate an access down through / up over a write when
+ *         sigma assigns its index differently from the write index,
+ *         following the read-over-write axiom A3 (sections 7.2, 7.3);
+ *   R / L propagate accesses across an array equality whose Boolean
+ *         abstraction variable sigma assigns true (section 7.3);
+ *   C     on every insertion, compare against the access already at
+ *         the destination for the same concrete index: a different
+ *         concrete value violates the (adapted) read-congruence axiom
+ *         A1 and yields a conflict (section 7.2).
+ *
+ * The work list is FIFO and rule I seeds every access before the
+ * fixed point starts, so discovery is breadth-first per access: the
+ * first arrival of an access at an array -- the one whose path gets
+ * recorded -- came along a shortest propagation path. That gives the
+ * minimization of section 11.1 without a separate post-conflict
+ * search.
+ *
+ * Exactly how far that reaches is worth stating, because the pass does
+ * not stop at the first conflict the way the paper's does. An arrival
+ * that conflicts is recorded as seen but is not queued, so the access
+ * stops at the array it conflicted at. Shortest paths are therefore a
+ * property of the graph in which each access's own conflict sites are
+ * terminal: the first conflict of a pass has shortest paths on both
+ * sides unconditionally, and a later one has the shortest paths still
+ * available to it. A later conflict can consequently carry a longer
+ * premise than an exhaustive search would give it, and a pair that can
+ * only meet through an earlier conflict site is not reported at all --
+ * it resurfaces in a later refinement round, once a lemma has moved the
+ * candidate. Pinned at both ends by the ConflictPremiseUsesShortestPaths
+ * and ConflictingArrivalStopsAtTheConflictArray unit tests; do not
+ * replace the deque with a stack.
+ *
+ * Following section 11.2, rho keeps one representative access per
+ * concrete index of each array, in a hash keyed by the index value: a
+ * congruence lookup is a single probe rather than a scan, and an
+ * access arriving with the same concrete index and the same concrete
+ * value as the representative is dropped without further propagation.
+ *
+ * Dropping it is complete, but the reason is about the whole class of
+ * accesses carrying that concrete (index, value) pair rather than about
+ * the two accesses at hand. It is not the case that the representative
+ * reaches everything the duplicate would have: the representative can
+ * be dropped in its turn at a later array, or stop there on a conflict.
+ * What holds is that no rule can tell members of the class apart. Every
+ * rule's applicability depends on the source array, on sigma, and on
+ * the access's concrete index -- write indices stepped over, array
+ * equalities and if-then-else conditions sigma decided -- and never on
+ * which member carries it. So the class reaches exactly the arrays any
+ * one member would, at most one member is ever resident at an array,
+ * and whether an arrival conflicts depends only on its concrete index
+ * and value meeting a different value there. Every conflict a member
+ * would find, therefore, some member does find -- possibly credited to
+ * a different one of them.
+ *
+ * On a conflict it builds the paper's lemma (section 8): the
+ * conjunction of the index equality, the write-index disequalities
+ * collected along both propagation paths, and the positive array
+ * equalities crossed, implies equality of the two access values. The
+ * lemma is produced twice: once over the original terms (the theory
+ * lemma) and once over the abstraction variables and scalar names
+ * (alpha of the lemma, the form actually added to the SAT solver).
+ * Finally it verifies the witness constraints of preprocessing step 1:
+ * an array equality assigned false must have differing values at its
+ * witness index lambda (axiom A4').
+ *
+ * The checker is pure: it never creates terms in the host query, adds
+ * clauses, or calls SAT. Insertion is first-path-wins: the first
+ * arrival of an access at an array fixes its recorded path there and no
+ * later arrival displaces it, so each (array, access) pair is inserted
+ * at most once. Arrivals are not the same as insertions -- one dropped
+ * as represented leaves no record behind, so a later arrival by another
+ * route repeats the constant-work test and reaches the same verdict,
+ * sigma being fixed and representatives never changing. That is why the
+ * skip counters count arrivals rather than pairs. Concrete values are
+ * hash-consed BVCONST nodes, making value comparison node identity at
+ * any bit width.
+ */
+
+#ifndef EXTCHECKER_H
+#define EXTCHECKER_H
+
+#include "stp/AST/AST.h"
+#include <map>
+#include <string>
+#include <vector>
+
+namespace stp
+{
+
+// One access: a read, or a write treated as a read of itself (the
+// paper's polymorphic "access" node, section 11.4, which makes the
+// explicit read(write(a,i,e),i) = e constraints of preprocessing step 2
+// unnecessary). For a read the site is its array operand and the value
+// is its read-abstraction variable; for a write the site is the write
+// node itself and the value is the written element.
+// indexName/valueName are the scalar leaves a lemma will be encoded
+// over (SYMBOLs already present in the bit-blasted formula, or
+// constants); indexTerm/valueTerm are the original terms, used for the
+// theory-level form of the lemma.
+struct ExtAccess
+{
+  size_t id;
+  bool isWrite;
+  ASTNode site;
+  ASTNode indexTerm;
+  ASTNode valueTerm;
+  ASTNode indexName;
+  ASTNode valueName;
+};
+
+// One condition collected along an access's propagation path, and later
+// contributed to the lemma premise. Rules D and U contribute an
+// index disequality (the access index differs from the write index
+// stepped over); rules R and L contribute the array equality crossed;
+// rules T-down and T-up contribute the if-then-else condition under
+// which the branch they stepped over is the selected one.
+// Array equalities only ever appear positively in lemmas: R/L fire
+// only when sigma assigns the equality true (paper section 10.2). An
+// if-then-else condition appears with the polarity sigma gave it,
+// because both of its branches are selectable.
+struct ExtGuard
+{
+  enum Kind
+  {
+    INDEX_NE,
+    EQ_PROXY,
+    ITE_COND_POS,
+    ITE_COND_NEG
+  };
+  Kind kind = INDEX_NE;
+
+  // Each predecessor link stores one shared four-node payload instead of
+  // reserving separate ASTNodes for all variants. Complete paths are
+  // materialized only when a conflict certificate is emitted:
+  //
+  // INDEX_NE: theoryA/theoryB are the original index terms;
+  //           absA/absB are their scalar names.
+  // EQ_PROXY: theoryA/theoryB are the canonical array operands;
+  //           absA is the Boolean equality proxy.
+  // ITE_COND_{POS,NEG}: theoryA is the original condition;
+  //                     absA is its reified Boolean name. The kind
+  //                     records the selected branch's polarity.
+  ASTNode theoryA, theoryB;
+  ASTNode absA, absB;
+  size_t eqRecord = 0;
+};
+
+// An owned array-valued if-then-else, kept as a term rather than
+// eliminated (paper section 4.1 declines to do this "to simplify our
+// presentation"; the direct integration it mentions is what this is).
+// condName reifies the condition as a Boolean symbol, so that the
+// value the checker reads is the one the SAT solver assigned rather
+// than something re-evaluated from the counterexample -- the failure
+// class that made a scalar name disagree with its term -- and so that
+// a lemma premise has a single encoded literal to name.
+struct ExtIteNode
+{
+  ASTNode ite;
+  ASTNode condTerm;
+  ASTNode condName;
+  ASTNode thn;
+  ASTNode els;
+};
+
+struct ExtEqEdge
+{
+  size_t record;
+  ASTNode left;
+  ASTNode right;
+  ASTNode proxy;
+};
+
+// A witness obligation from preprocessing step 1 (paper section 4):
+// for the array equality a = b, a fresh index lambda and the virtual
+// reads read(a,lambda) / read(b,lambda) were created, constrained by
+// a != b -> read(a,lambda) != read(b,lambda). If sigma assigns the
+// equality's Boolean abstraction variable false, the two witness read
+// values must therefore differ; since the constraint was part of the
+// bit-blasted formula, a violation indicates an integration bug, not
+// a refinable candidate.
+struct ExtWitness
+{
+  size_t record;
+  ASTNode proxy;
+  ASTNode index;
+  ASTNode leftValue;
+  ASTNode rightValue;
+};
+
+// Per-write-node data needed by the D and U rules.
+struct ExtWriteNode
+{
+  ASTNode write;
+  ASTNode base;
+  ASTNode indexTerm;
+  ASTNode indexName;
+};
+
+// The array subgraph of the preprocessed formula, frozen for one
+// solve: accesses, write edges, equality edges, and the witness
+// obligations of preprocessing step 1. All vectors carry a fixed
+// deterministic order (noted per field below), so checker runs -- and
+// therefore lemmas and models -- are reproducible; the maps are used
+// for lookup only.
+struct ExtGraph
+{
+  std::vector<ExtAccess> accesses; // in stable seed order
+
+  std::map<ASTNode, ExtWriteNode> writes;             // write node -> info
+  std::map<ASTNode, std::vector<ASTNode>> writeParents; // base -> writes
+                                                        // (each sorted by
+                                                        // node number)
+  std::vector<ExtEqEdge> eqEdges;
+  // array -> indices into eqEdges; per source sorted by
+  // (record, destination node number, rule) where R_EQ sorts before
+  // L_EQ, so each array's equality edges fire in a fixed order.
+  std::map<ASTNode, std::vector<size_t>> eqAdjacency;
+
+  std::map<ASTNode, ExtIteNode> ites;                 // ite node -> info
+  std::map<ASTNode, std::vector<ASTNode>> iteParents; // branch -> ites
+                                                      // (each sorted by
+                                                      // node number)
+
+  std::vector<ExtWitness> witnesses; // sorted by record id
+};
+
+// Access to the candidate assignment sigma. Every checker-visible term
+// must have a concrete value in the candidate; a missing value is an
+// integration error, never a reason to default. bvValue must return a
+// BVCONST node; boolValue a Boolean. Implementations wrap either
+// AbsRefine_CounterExample or a plain map (unit tests).
+class ExtModelView
+{
+public:
+  virtual ~ExtModelView() {}
+  virtual ASTNode bvValue(const ASTNode& term) = 0;
+  virtual bool boolValue(const ASTNode& term) = 0;
+};
+
+// One atom of a lemma premise or conclusion, after canonicalization
+// (duplicate atoms dropped, reflexive equalities removed, deterministic
+// order). BV_EQ/BV_NE carry the
+// operand pair for the layer (abstract: scalar names; theory: original
+// terms). ARRAY_EQ appears only in the theory lemma; BOOL_LIT (a
+// positive proxy, or a positively-taken if-then-else condition) and
+// BOOL_LIT_NEG (a negatively-taken one) only in the abstract lemma.
+struct ExtLemmaAtom
+{
+  enum Op
+  {
+    BV_EQ = 0,
+    BV_NE = 1,
+    ARRAY_EQ = 2,
+    BOOL_LIT = 4,
+    BOOL_LIT_NEG = 5
+  };
+  Op op;
+  ASTNode a, b;     // BV_EQ / BV_NE operands, or ARRAY_EQ array operands
+  ASTNode boolTerm; // BOOL_LIT proxy
+  size_t eqRecord;  // for ARRAY_EQ / BOOL_LIT
+
+  bool operator==(const ExtLemmaAtom& o) const
+  {
+    return op == o.op && a == o.a && b == o.b && boolTerm == o.boolTerm;
+  }
+};
+
+// A congruence conflict found by rule C, together with the lemma built
+// from it (paper section 8): both access ids, the common
+// array, concrete values, per-side guard paths, plus the canonicalized
+// premises and the conclusion pair for the theory and abstract layers.
+struct ExtConflict
+{
+  ASTNode commonArray;
+  size_t leftAccess;  // the previously inserted representative
+  size_t rightAccess; // the arriving access
+  ASTNode indexValue;
+  ASTNode leftValue, rightValue;
+  std::vector<ExtGuard> leftGuards, rightGuards;
+
+  std::vector<ExtLemmaAtom> abstractPremise; // canonical order
+  ASTNode abstractConclusionA, abstractConclusionB;
+
+  std::vector<ExtLemmaAtom> theoryPremise; // canonical order
+  ASTNode theoryConclusionA, theoryConclusionB;
+};
+
+struct ExtEvent
+{
+  enum Kind
+  {
+    SEED,
+    PROPAGATE,
+    SKIP_SEEN,
+    SKIP_REPRESENTED, // section 11.2: same concrete index and value as
+                      // the representative already at the array
+    CONFLICT,
+    WITNESS_CHECK
+  };
+  int seq;
+  Kind kind;
+  const char* rule;
+  ASTNode source; // null for seeds / witness checks
+  ASTNode destination;
+  size_t access;
+  ASTNode indexValue;  // null on SKIP_SEEN
+  ASTNode accessValue; // null on SKIP_SEEN
+};
+
+struct ExtCheckResult
+{
+  enum Status
+  {
+    CONSISTENT,
+    CONFLICT,
+    WITNESS_VIOLATION
+  };
+  Status status;
+  // Every independent congruence conflict the pass found, in discovery
+  // order; non-empty iff status == CONFLICT. The pass does not stop at
+  // the first, because each conflict yields a lemma that is valid on
+  // its own (its premise holds and its conclusion fails in the very
+  // same candidate), and emitting them together spares a whole
+  // solve-from-scratch per lemma. "Found", not "exists": a conflicting
+  // arrival does not propagate onward, so this is not an exhaustive
+  // enumeration of the disagreeing pairs in the candidate. See the
+  // shortest-path discussion at the top of this file.
+  std::vector<ExtConflict> conflicts;
+  // conflicts[0] -- the conflict a first-conflict-wins pass would have
+  // stopped at. Kept for callers that want just the earliest one.
+  ExtConflict conflict;      // valid iff status == CONFLICT
+  size_t violatedRecord;     // valid iff status == WITNESS_VIOLATION
+
+  // When the candidate is consistent, the fixed point of rho gives the
+  // observed contents of every array: pairs of concrete
+  // (index, value) BVCONSTs for every rho entry. Valid iff CONSISTENT.
+  std::map<ASTNode, std::vector<std::pair<ASTNode, ASTNode>>> observed;
+
+  std::vector<ExtEvent> events;
+  std::map<std::string, int> stats;
+
+  // Proof-storage diagnostics. The fixed point stores one constant-size
+  // predecessor entry per reached (array, access) pair; guards are copied
+  // into complete vectors only for emitted conflict certificates.
+  size_t proofPathEntries = 0;
+  size_t materializedGuardCount = 0;
+};
+
+class ExtChecker
+{
+public:
+  // Runs one full check of the candidate model against the graph.
+  // Pure: no SAT access, no term allocation into the host query.
+  static ExtCheckResult check(const ExtGraph& graph, ExtModelView& model,
+                              bool recordEvents = false);
+};
+
+} // namespace stp
+
+#endif // EXTCHECKER_H

--- a/include/stp/Extensionality/ExtensionalityContext.h
+++ b/include/stp/Extensionality/ExtensionalityContext.h
@@ -1,0 +1,577 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: July, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+/*
+ * Host-side state of the lemmas-on-demand decision procedure for the
+ * extensional theory of arrays (Brummayer & Biere, JSAT 6 (2010))
+ * inside STP:
+ *
+ *  - query-local array-equality records: construction preserves an opaque
+ *    ARRAY_EQ, then the completed solve root is traversed after function
+ *    substitution. Each reachable canonical operand pair is replaced by a
+ *    fresh Boolean abstraction (paper section 5) and receives the witness
+ *    constraints from preprocessing step 1 (section 4);
+ *  - the complete per-solve array graph reachable from the prepared root
+ *    (all participating arrays, writes and reads), frozen just before STP's
+ *    main array transformation;
+ *  - the pending refinement lemma between a failed candidate check and
+ *    the re-solve, and its encoding into the incremental SAT solver;
+ *  - the completed array model of an accepted candidate.
+ *
+ * Lifetime: one context per STPMgr, created lazily when a completed root first
+ * reaches array-equality lowering. Generated records, proxies and witness
+ * symbols are per-solve. The opaque public AST is durable; a current-solve
+ * opaque-to-lowered map remains only long enough to evaluate public handles
+ * in that solve's model.
+ */
+
+#ifndef EXTENSIONALITYCONTEXT_H
+#define EXTENSIONALITYCONTEXT_H
+
+#include "stp/AST/AST.h"
+#include "stp/Extensionality/ExtChecker.h"
+#include "stp/Sat/SATSolver.h"
+#include "stp/ToSat/ToSATBase.h"
+#include <map>
+#include <set>
+#include <vector>
+
+namespace stp
+{
+
+class STPMgr;
+class Simplifier;
+class ArrayTransformer;
+class AbsRefine_CounterExample;
+class ToSATBase;
+
+class ExtensionalityContext
+{
+public:
+  // One solve-local abstracted array equality. The construction operands are
+  // the solve-specialized array terms seen by solve-boundary lowering, after
+  // function/let substitution has finished. Ordinary preprocessing may still
+  // rewrite them; prepare() recovers their current (canonical) forms from the
+  // anchor equations, which travel through the same rewriting as the rest of
+  // the formula.
+  struct Record
+  {
+    size_t id;
+    ASTNode proxy;             // ordinary Boolean SYMBOL
+    ASTNode constructionLeft;
+    ASTNode constructionRight;
+    ASTNode canonicalLeft;     // per-solve, set by prepare()
+    ASTNode canonicalRight;    // per-solve, set by prepare()
+    ASTNode lambda;            // fresh witness index symbol
+    ASTNode nameL, nameR;      // scalar names of the witness reads
+    // Constraint bundle conjoined once into this record's solve. The
+    // last conjunct is preprocessing step 1 of the paper -- the witness
+    // for array inequality, a != b -> read(a,l) != read(b,l) -- and the
+    // two defining equations name the virtual reads so they stay in
+    // the formula (and therefore in the bit-blast) in every case:
+    //   nameL = read(constructionLeft, lambda)
+    //   nameR = read(constructionRight, lambda)
+    //   proxy OR nameL != nameR
+    ASTNode anchorL, anchorR, witnessClause;
+    // For arrays whose index sort quotients its bit patterns (a float
+    // index: every NaN pattern is one value; a RoundingMode index: only
+    // the five one-hot patterns denote), lambda must range over the
+    // denoting patterns -- a "witness" at any other pattern would sit at
+    // an index no select can reach. Null for plain bitvector indexes.
+    ASTNode indexSortClause;
+  };
+
+  explicit ExtensionalityContext(STPMgr* bm);
+
+  //--------------------------------------------------------------------
+  // Query-local record table and activation
+  //--------------------------------------------------------------------
+
+  // The formula abstraction of an array equality (paper section 5), called by
+  // solve-boundary lowering for each reachable well-typed equality. Returns
+  // the fresh (or, for a repeated pair in this solve, reused) Boolean
+  // abstraction variable; reflexive
+  // requests fold to true; and an equality between a chain of writes
+  // and the chain's own base is solved outright, returning the
+  // rewritten read-equality formula with no record minted (see
+  // solveWriteChain). Mixed index/element widths are an error.
+  ASTNode makeEquality(const ASTNode& a, const ASTNode& b);
+
+  // Replace every reachable opaque ARRAY_EQ in a completed query by its
+  // Boolean abstraction and witness record. This is deliberately a solve-
+  // boundary operation: function/let substitution must have specialized the
+  // equality's operands before they disappear behind a proxy.
+  ASTNode lowerArrayEqualities(const ASTNode& root);
+  ASTNode lowerArrayEqualities(const ASTNode& root,
+                               const ASTNodeMap& preLoweringRewrites);
+
+  // Look up the Boolean formula used for an opaque equality in the current
+  // solve. This is the sole metadata retained for public-handle model
+  // evaluation; generated proxies and witness records are never durable
+  // across solves.
+  bool getCurrentLowering(const ASTNode& opaque, ASTNode& lowered) const;
+
+  // Marks the window in which a solve owns the array graph. It holds the
+  // registry seal for that window and releases it however the solve
+  // exits -- any record minted after the solve took its constraint
+  // snapshot would be active without a defining witness bundle -- and it
+  // is what activeInSolve() tests.
+  class SolveScope
+  {
+    ExtensionalityContext* ctx;
+
+  public:
+    explicit SolveScope(ExtensionalityContext* c) : ctx(c)
+    {
+      if (ctx != NULL)
+        ctx->solveInProgress = true;
+    }
+    ~SolveScope()
+    {
+      if (ctx != NULL)
+      {
+        ctx->registrySealed = false;
+        ctx->solveInProgress = false;
+      }
+    }
+    SolveScope(const SolveScope&) = delete;
+    SolveScope& operator=(const SolveScope&) = delete;
+  };
+
+  bool enabled() const;
+  // The decision procedure participates in a solve exactly when the
+  // feature is on and at least one lowered equality record is reachable from
+  // this solve's completed root (possibly through another active record).
+  // Nothing else switches it on: a query with array if-then-elses but
+  // no equality mints no record, so it is decided by STP's ordinary
+  // array machinery at exactly the cost it would pay with the feature
+  // off.
+  bool active() const { return enabled() && !activeRecordIds.empty(); }
+
+  // The same ownership, restricted to the solve that established it.
+  //
+  // active() deliberately outlives its solve: the model surfaces --
+  // (get-model), vc_getCounterExampleArray, term evaluation through the
+  // counterexample -- read the frozen graph and the certified
+  // observations after TopLevelSTPAux has returned, and they must keep
+  // seeing them until the next solve calls beginSolve(). Only
+  // activeRecordIds clears it, so between one solve and the next it
+  // still reports the previous query's ownership.
+  //
+  // That makes it the wrong predicate for holding STP's own passes off
+  // the array graph. Those have to stand back only while the solve that
+  // owns the graph is running; anything that reaches the simplifier, the
+  // substitution map or unconstrained-variable removal outside that
+  // window -- a direct vc_simplify, an assertion arriving for the next
+  // query -- is ordinary work and should get ordinary treatment.
+  // SolveScope marks the window, and every pass gate tests this instead.
+  bool activeInSolve() const { return solveInProgress && active(); }
+
+  const std::vector<Record>& getRecords() const { return records; }
+  size_t getActiveRecordCount() const { return activeRecordIds.size(); }
+
+  // Symbols the decision procedure depends on: abstraction variables,
+  // witness indices and witness-read names, and the scalar names given
+  // to lemma leaves. STP's substitution passes must not eliminate them
+  // -- each must still be present when the formula is bit-blasted so
+  // that refinement lemmas can be encoded over its SAT variables.
+  bool isProtected(const ASTNode& s) const
+  {
+    return protectedSymbols.find(s) != protectedSymbols.end();
+  }
+
+  // Conservative pre-preprocessing inventory of the array symbols in an
+  // active solve. The final graph is built from the whole prepared formula,
+  // so this set is a pre/post ownership tripwire: it must anticipate every
+  // array symbol the checker may later own.
+  bool wasArrayAnticipated(const ASTNode& arraySymbol) const
+  {
+    return anticipatedArraySymbols.find(arraySymbol) !=
+           anticipatedArraySymbols.end();
+  }
+
+  //--------------------------------------------------------------------
+  // Per-solve pipeline (TopLevelSTPAux)
+  //--------------------------------------------------------------------
+
+  // Reset all per-solve state (records, lowering map, graph, names, pending
+  // lemmas and model). Called immediately before lowering the next root.
+  void beginSolve();
+
+  // Conjoin every current-root-active record's constraint bundle (the
+  // witness clause of preprocessing step 1 plus the defining equations
+  // of its virtual reads) before STP preprocessing, so the bundles are
+  // simplified together with the rest of the formula. At this same
+  // boundary, inventory the complete expanded root while read-deleting
+  // substitutions can still be prevented. Array-valued if-then-elses
+  // remain structural and are handled by the checker's T rules.
+  ASTNode conjoinRecordConstraints(const ASTNode& root);
+
+  // Final preparation, run after STP's simplifications and immediately
+  // before its main array transformation:
+  //  - recover each record's canonical operands from its anchors;
+  //  - inventory the complete array graph reachable from the prepared
+  //    formula. Once an equality activates the procedure, it owns every
+  //    read in that graph; splitting congruence reasoning between it and
+  //    STP's legacy refinement is not closed under shared scalar indexes;
+  //  - inventory the graph's writes as accesses (paper section 11.4)
+  //    and give every compound write index/value a scalar name that
+  //    will be part of the initial bit-blast, so lemmas can later be
+  //    encoded over existing SAT variables.
+  // Returns the extended input to hand to the array transformation;
+  // after this point the graph must not change for the rest of the
+  // solve.
+  ASTNode prepare(const ASTNode& root);
+
+  // The main array transform is the only operation allowed to consume the
+  // frozen read inventory.  It must start from the exact node returned by
+  // prepare(), account for every reachable READ either by recording the
+  // abstraction it produced or by identifying a branch made unreachable by
+  // constant term-ITE selection, and finish before the checker graph is
+  // bound.  These are integration tripwires: a future transformer shortcut
+  // may not silently leave part of the checker-owned graph unrepresented.
+  void beginReadTransform(const ASTNode& preparedRoot);
+  void noteAbstractedRead(const ASTNode& originalRead,
+                          const ASTNode& transformedIndex,
+                          const ASTNode& valueSymbol);
+  void noteEliminatedReadSubtree(const ASTNode& deadTerm);
+  void finishReadTransform();
+
+  bool arrayGraphFrozen() const { return arrayGraphIsFrozen; }
+  bool checkerReady() const { return graphBound; }
+  bool ownsArray(const ASTNode& arrayNode) const
+  {
+    return ownedArrays.find(arrayNode) != ownedArrays.end();
+  }
+
+  // Reads in the owned graph route their index through the transform's
+  // fresh-index-variable pass even when the index is already a plain
+  // variable: an index occurring only inside reads would otherwise
+  // vanish from the bit-blasted formula, leaving future lemmas over it
+  // without SAT variables.
+  bool needsIndexAnchor(const ASTNode& arrayNode) const
+  {
+    return arrayGraphIsFrozen && ownsArray(arrayNode);
+  }
+
+  // After the main array transformation: collect the checker's access
+  // inventory -- every owned read (including the witness reads) now has
+  // its read-abstraction variable and index variable, and every owned
+  // write its scalar names -- and freeze the graph handed to the
+  // consistency checker.
+  void bindAfterTransform(ArrayTransformer* at);
+
+  //--------------------------------------------------------------------
+  // Candidate checking and refinement (the loop of paper section 6)
+  //--------------------------------------------------------------------
+
+  enum CandidateOutcome
+  {
+    EXT_SKIPPED,
+    EXT_CONSISTENT,
+    EXT_CONFLICT,
+    EXT_WITNESS_ERROR
+  };
+
+  enum CertificationAction
+  {
+    RETURN_SAT,
+    ADD_EXT_LEMMA,
+    RUN_HOST_REFINEMENT,
+    INTERNAL_ERROR
+  };
+
+  // Decide what to do with a materialized candidate, given STP's own
+  // model evaluation and the array consistency check. An array conflict
+  // takes precedence over the ordinary result -- active solves never
+  // enter STP's ordinary read refinement, so only the array
+  // lemma can rule such a candidate out -- and a candidate is only ever
+  // reported satisfiable when both checks pass on the same assignment.
+  // When the checker is active, ordinary read refinement is not a
+  // fallback: the checker owns the complete graph. Consequently a
+  // conflict-free checker result paired with ordinary model failure is
+  // an integration invariant violation, not an undecided outcome.
+  static CertificationAction decideCertification(bool ordinaryResult,
+                                                 bool checkerActive,
+                                                 CandidateOutcome ext);
+
+  // Run the pure checker against the current candidate model. On
+  // conflict the certificate is stored as the pending lemma. On a
+  // conflict-free fixed point, publish the observed array contents
+  // into the counterexample map -- so model evaluation and the model
+  // APIs see the certified contents -- and then verify every access's
+  // scalar names against its terms evaluated in the completed model.
+  // A mismatch is an internal ownership/encoding error: with the whole
+  // graph registered, read congruence must already have produced a
+  // checker conflict.
+  CandidateOutcome checkCandidate(AbsRefine_CounterExample* ce);
+
+  bool hasPendingLemma() const { return pendingLemmaValid; }
+
+  // Encode every pending lemma into the persistent incremental SAT
+  // solver, then clear them. The lemma premise/conclusion atoms are
+  // reified over the SAT variables of already-encoded symbols -- the
+  // refinement is clauses over the existing CNF, never a fresh
+  // word-level formula handed back to the bit-blaster.
+  //
+  // A round emits the whole batch the consistency check found, not just
+  // the earliest conflict. Each lemma is independently valid under the
+  // candidate that produced it, so the batch rules out that candidate
+  // by many more facts than one clause could, and the reified equality
+  // literals the lemmas share are built once.
+  void encodePendingLemmas(SATSolver& solver, ToSATBase* tosat);
+
+  // A lemma atom the simplifier can decide from its defining terms
+  // needs no equality circuit, and its literal is dropped from the
+  // clause. Dropping is equivalence-preserving on only one side per
+  // position: a premise may go when the atom is valid, the conclusion
+  // when it is unsatisfiable. The other direction yields a strictly
+  // stronger clause -- a silent wrong unsat -- so the fold reports its
+  // direction and the encoder checks it here.
+  enum FoldVerdict
+  {
+    FOLD_UNDECIDED = 0, // no structural verdict; build the circuit
+    FOLD_VALID = -1,    // "a = b" holds in every model
+    FOLD_UNSAT = -2     // "a = b" holds in none
+  };
+
+  enum LemmaPosition
+  {
+    LEMMA_PREMISE,
+    LEMMA_CONCLUSION
+  };
+
+  // The verdict that permits dropping a structurally decided atom from
+  // this position, or FOLD_UNDECIDED where no verdict does. Pure, so
+  // the rule lives in one place and its truth table is pinned by a unit
+  // test instead of being restated at each call site.
+  static FoldVerdict requiredFoldVerdict(ExtLemmaAtom::Op op,
+                                         LemmaPosition where);
+
+  // Re-derive every active equality from the certified model instead of
+  // from the abstraction the solve reasoned over, and report the first
+  // disagreement. Returns NULL when every abstraction variable matches
+  // the array contents published under it, else a static reason string.
+  //
+  // This is what --check-counterexample can contribute here that
+  // re-evaluating the query cannot. That walk reaches an opaque
+  // equality and resolves it through the lowering map -- the same
+  // answer the verdict already rested on -- so it confirms the Boolean
+  // skeleton and nothing about extensionality. Comparing the published
+  // cells asks the other question: whether the model STP is about to
+  // print actually makes the equalities take the values the solver
+  // assigned them. A propagation rule that missed an edge shows up as a
+  // true abstraction variable over two arrays whose certified contents
+  // differ; a lost witness as a false one over two that agree.
+  const char* recheckCertifiedEqualities(AbsRefine_CounterExample* ce) const;
+
+  // Do two certified observation lists denote the same array? Every
+  // cell no observation mentions holds `absent` on both sides, so the
+  // two arrays agree everywhere exactly when they agree at every index
+  // either one observes. Pure, so the rule is pinned by a unit test
+  // rather than restated at its call site.
+  //
+  // `absent` is the caller's business, and the caller must take it from
+  // AbsRefine_CounterExample::defaultCellValue: comparing contents with
+  // one completion while the model publishes another is exactly the
+  // disagreement recheckCertifiedEqualities exists to catch, and it
+  // would then be catching itself.
+  static bool contentsAgree(
+      const std::vector<std::pair<ASTNode, ASTNode>>& left,
+      const std::vector<std::pair<ASTNode, ASTNode>>& right,
+      const ASTNode& absent, const SourceSort& elementSort);
+
+  // Validate one bit-vector lemma leaf: it must be a fixed-width
+  // constant, or a SYMBOL whose complete SAT-variable vector was
+  // encoded by the initial bit-blast (present, full width, every bit
+  // encoded). Returns NULL when valid, else a static reason string.
+  // Pure -- no allocation and no SAT mutation -- so lemma encoding
+  // reports a precise internal error instead of silently inventing
+  // fresh, unconstrained SAT variables for a term the candidate was
+  // never checked against.
+  static const char* checkPreencodedBV(const ASTNode& n,
+                                       const ToSATBase::ASTNodeToSATVar& satVar);
+
+  // Every symbol EXTCHK relies on keeps its SAT variables (frozen
+  // against backend variable elimination).
+  // Lemma leaves whose semantics live entirely in future refinement
+  // lemmas: the abstraction variables of owned reads and their index
+  // symbols. Such a symbol can legally be absent from the bit-blasted
+  // formula -- an owned read's only occurrence may itself sit inside
+  // another abstracted term -- and the translator then allocates
+  // fresh SAT variables for it before the first solve, which is
+  // exactly the unconstrained semantics the blasted formula gives it.
+  // Names defined by equations (witness reads, scalar names) are
+  // deliberately not in this set: for them, absence from the
+  // bit-blast means a defining equation was lost, and lemma encoding
+  // must keep failing loudly.
+  const std::set<ASTNode>& getLemmaOnlySymbols() const
+  {
+    return lemmaOnlySymbols;
+  }
+
+  const std::set<ASTNode>& getFrozenSymbols() const
+  {
+    return protectedSymbols;
+  }
+
+  // Scalar name -> the term its defining equation binds it to.
+  const std::map<ASTNode, ASTNode>& getNameToTerm() const
+  {
+    return nameToTermMap;
+  }
+
+  // Statistics for --stats.
+  int lemmasEmitted;
+
+  // Lemma atoms the simplifier decided from their defining terms at
+  // encoding time (no equality circuit was built and no literal
+  // entered the clause). Cumulative over the context lifetime.
+  int lemmaAtomsFolded;
+
+private:
+  STPMgr* bm;
+
+  // Equality between a chain of writes and the chain's own base array,
+  // solved by rewriting instead of abstraction; returns the null node
+  // when the shape does not apply. See the definition for the
+  // equivalence.
+  ASTNode solveWriteChain(const ASTNode& a, const ASTNode& b) const;
+
+  std::vector<Record> records;
+  std::map<std::pair<ASTNode, ASTNode>, size_t> keyToRecord;
+  std::map<ASTNode, size_t> proxyToRecord;
+  // Sorted record ids reachable in the current solve. Only these records
+  // contribute semantic constraints, protection and checker edges.
+  std::vector<size_t> activeRecordIds;
+  ASTNodeMap currentLowerings; // opaque ARRAY_EQ -> current lowered formula
+  std::set<ASTNode> protectedSymbols;
+  std::set<ASTNode> lemmaOnlySymbols; // per-solve; see the accessor
+  std::set<ASTNode> anticipatedArraySymbols;
+
+  // True only between SolveScope's construction and destruction. Owned
+  // entirely by that scope -- beginSolve() deliberately does not touch
+  // it, because beginSolve() is also how scope operations (pop,
+  // reset-assertions) discard a finished solve's state, which happens
+  // outside any solve.
+  bool solveInProgress;
+
+  // Set once a solve has taken its copy of the registry's constraints.
+  // Minting a record after that point would leave it active with
+  // nothing in the formula defining it, so refuse loudly rather than
+  // let it happen quietly. Cleared by beginSolve().
+  bool registrySealed;
+
+  // ---- per-solve state ----
+  bool arrayGraphIsFrozen;
+  std::set<ASTNode> ownedArrays;
+  std::map<ASTNode, ExtWriteNode> ownedWrites; // write node -> info
+  std::map<ASTNode, std::vector<ASTNode>> ownedWriteParents;
+  std::map<ASTNode, ExtIteNode> ownedItes; // ite node -> info
+  std::map<ASTNode, std::vector<ASTNode>> ownedIteParents;
+  std::vector<ExtEqEdge> eqEdges;
+  std::map<ASTNode, std::vector<size_t>> eqAdjacency;
+  std::vector<ExtWitness> witnessObls;
+  std::map<ASTNode, ASTNode> scalarNames; // term -> name symbol
+  std::map<ASTNode, ASTNode> nameToTermMap; // name symbol -> its term
+  ExtGraph graph;                         // bound after transform
+  bool graphBound;
+
+  struct ReadBinding
+  {
+    ASTNode array;
+    ASTNode index;
+    ASTNode symbol;
+
+    bool operator==(const ReadBinding& other) const
+    {
+      return array == other.array && index == other.index &&
+             symbol == other.symbol;
+    }
+
+    bool operator<(const ReadBinding& other) const
+    {
+      if (array != other.array)
+        return array < other.array;
+      if (index != other.index)
+        return index < other.index;
+      return symbol < other.symbol;
+    }
+  };
+
+  // Exact solve-boundary handshake with ArrayTransformer.  preparedReads is
+  // collected from the final root including preparation's own naming
+  // equations, not from the earlier graph-discovery root.
+  ASTNode preparedTransformRoot;
+  std::set<ASTNode> preparedReads;
+  std::map<ASTNode, ReadBinding> transformedReads;
+  std::set<ASTNode> eliminatedReads;
+  bool readTransformInProgress;
+  bool readTransformComplete;
+
+  bool pendingLemmaValid;
+  std::vector<ExtConflict> pendingLemmas;
+
+  // Encode one lemma as the clause NOT p1 OR ... OR NOT pk OR
+  // conclusion; the shared reified-literal cache means later lemmas in
+  // a batch reuse the equality variables the earlier ones built.
+  void encodeOneLemma(const ExtConflict& lemma, SATSolver& solver,
+                      ToSATBase* tosat);
+
+  // reified equality cache, scoped to the current SAT instance
+  std::map<std::pair<uint64_t, uint64_t>, int> eqLitCache;
+
+  // last consistent observations for model export
+  std::map<ASTNode, std::vector<std::pair<ASTNode, ASTNode>>> lastObserved;
+
+  // helpers
+  // Publish the conflict-free observed (index, value) pairs of every
+  // owned array -- including write and array-if-then-else nodes -- into
+  // the counterexample map, so model
+  // evaluation, the model APIs, and the printers all see the array
+  // contents the consistency check certified. Called by checkCandidate
+  // on every conflict-free fixed point, before the name verification.
+  void publishObservations(AbsRefine_CounterExample* ce);
+  // With the observations published, check that every access's scalar
+  // names evaluate exactly like the terms they stand for.
+  bool namesAgreeWithCandidate(ExtModelView& view,
+                               AbsRefine_CounterExample* ce) const;
+  void collectAnticipatedArraySymbols(const ASTNode& n);
+  void activateReachableRecords(const ASTNode& loweredRoot);
+  ASTNode freshName(const ASTNode& term, ASTVec& namingConstraints);
+  // The Boolean analogue of freshName, for an if-then-else condition:
+  // a fresh symbol constrained equivalent to the condition, so that the
+  // checker branches on a value the SAT solver assigned rather than one
+  // re-derived from the counterexample, and so that a lemma premise has
+  // one encoded literal to name.
+  ASTNode conditionName(const ASTNode& cond, ASTVec& namingConstraints);
+  // Collect every array-valued node reachable from the prepared root.
+  void computeArrayGraph(const ASTNode& root, std::set<ASTNode>& arrays,
+                         std::map<ASTNode, std::vector<ASTNode>>& parents);
+  void locateCanonicalOperands(const ASTNode& root);
+};
+
+} // namespace stp
+
+#endif // EXTENSIONALITYCONTEXT_H

--- a/include/stp/STPManager/STPManager.h
+++ b/include/stp/STPManager/STPManager.h
@@ -41,6 +41,7 @@ THE SOFTWARE.
 
 namespace stp
 {
+class ExtensionalityContext;
 
 // The five SMT-LIB floating-point special values. Their nodes are ordinary
 // packed interned constants (see STPMgr::CreateFPSpecialConst); a childless
@@ -91,6 +92,8 @@ private:
   // Table for variable names, let names etc.
   ASTSymbolSet _symbol_unique_table;
 
+  ExtensionalityContext* extensionality = nullptr;
+
   // Table to uniquefy bvconst
   ASTBVConstSet _bvconst_unique_table;
 
@@ -99,6 +102,16 @@ private:
 public:
   HashingNodeFactory* hashingNodeFactory;
   NodeFactory* defaultNodeFactory;
+
+  // State of the array-equality (extensional arrays) decision procedure:
+  // solve-local equality records, the complete per-solve array graph, and
+  // pending refinement. Created lazily when a completed solve root containing
+  // an opaque equality first reaches lowering.
+  DLL_PUBLIC ExtensionalityContext* getExtensionality();
+  ExtensionalityContext* getExtensionalityIfAny() const
+  {
+    return extensionality;
+  }
 
   // frequently used nodes
   ASTNode ASTFalse, ASTTrue, ASTUndefined;
@@ -498,6 +511,15 @@ public:
 
   const ASTVec GetAsserts();
   const ASTVec getVectorOfAsserts();
+
+  // Every assertion currently on the stack, appended to out. Unlike
+  // getVectorOfAsserts() this does not collapse each level into a
+  // single conjunct, so it is safe to call outside a solve.
+  void collectAsserts(ASTVec& out) const
+  {
+    for (size_t i = 0; i < _asserts.size(); i++)
+      out.insert(out.end(), _asserts[i]->begin(), _asserts[i]->end());
+  }
 
   // add a query/assertion to the current logical context
   void AddAssert(const ASTNode& assert);

--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -1,5 +1,5 @@
 /********************************************************************
- * AUTHORS: Vijay Ganesh, Andrew V. Jones
+ * AUTHORS: Vijay Ganesh, Andrew Teylu
  *
  * BEGIN DATE: November, 2005
  *
@@ -81,6 +81,13 @@ public:
 
   // eagerly write through the array's function congruence axioms.
   bool ackermannisation = false;
+
+  // Decide whole-array equality/disequality (the extensional theory of
+  // arrays) with the lemmas-on-demand procedure of Brummayer & Biere
+  // (JSAT 2010). Runtime semantic option; it must be set before a
+  // whole-array equality is constructed. Construction preserves an opaque
+  // ARRAY_EQ, which is lowered only after the complete query is assembled.
+  bool enable_array_equality = false;
 
   // construct the counterexample in terms of original variable based
   // on the counterexample returned by SAT solver

--- a/lib/AST/ASTKind.kinds
+++ b/lib/AST/ASTKind.kinds
@@ -208,3 +208,8 @@ FP_SMT_EQ           2    2    Form    FP
 # The five special floating-point values (NaN, +/-oo, +/-zero) have no kinds
 # of their own: they are ordinary packed constants, built interned by
 # STPMgr::CreateFPSpecialConst so that the format is part of node identity.
+
+# Opaque whole-array equality. Kept last so the numeric values exported by
+# c_interface.h remain stable. The extensionality prepass lowers this before
+# ordinary solving.
+ARRAY_EQ        2       2       Form

--- a/lib/AST/ASTmisc.cpp
+++ b/lib/AST/ASTmisc.cpp
@@ -135,6 +135,51 @@ bool constantsSameBits(const ASTNode& a, const ASTNode& b)
                                                 b.GetBVConst());
 }
 
+// See the declaration.
+ASTNode plainBitVectorConstant(STPMgr* bm, const ASTNode& c)
+{
+  assert(c.isConstant());
+  const SourceSort::Kind sort = c.GetSourceSort().kind();
+  if (c.GetKind() != BVCONST ||
+      (c.GetExpWidth() == 0 && sort != SourceSort::Kind::RoundingMode))
+    return c;
+  return bm->CreateBVConst(CONSTANTBV::BitVector_Clone(c.GetBVConst()),
+                           c.GetValueWidth());
+}
+
+// Whether the packed floating-point constant x of format (eb, sb) holds
+// a NaN: an all-ones exponent over a nonzero significand, the layout
+// being [sign | exponent eb | significand sb-1]. The value-level twin of
+// the circuit ExtensionalityContext builds as isPackedNaN; keep the two
+// reading alike.
+static bool packedConstantIsNaN(const ASTNode& x, unsigned eb, unsigned sb)
+{
+  const unsigned w = eb + sb;
+  if (x.GetKind() != BVCONST || x.GetValueWidth() != w)
+    return false;
+  CBV bits = x.GetBVConst();
+  for (unsigned i = sb - 1; i + 1 < w; i++)
+    if (!CONSTANTBV::BitVector_bit_test(bits, i))
+      return false;
+  for (unsigned i = 0; i + 1 < sb; i++)
+    if (CONSTANTBV::BitVector_bit_test(bits, i))
+      return true;
+  return false;
+}
+
+// See the declaration.
+bool constantsSameSourceValue(const ASTNode& a, const ASTNode& b,
+                              const SourceSort& sort)
+{
+  if (constantsSameBits(a, b))
+    return true;
+  if (sort.kind() != SourceSort::Kind::FloatingPoint)
+    return false;
+  const unsigned eb = sort.exponentWidth();
+  const unsigned sb = sort.significandWidth();
+  return packedConstantIsNaN(a, eb, sb) && packedConstantIsNaN(b, eb, sb);
+}
+
 // True if any descendants are arrays.
 bool containsArrayOps(const ASTNode& n, STPMgr* mgr)
 {
@@ -187,6 +232,7 @@ bool isCommutative(const Kind k)
     case BVPLUS:
     case BVMULT:
     case EQ:
+    case ARRAY_EQ:
     case AND:
     case OR:
     case NAND:
@@ -955,6 +1001,19 @@ bool BVTypeCheck_nonterm_kind(const ASTNode& n, const Kind& k)
         cerr << "sigwidth of rhs of EQ: " << n[1].GetSigWidth() << endl;
         FatalError(
             "BVTypeCheck: terms in atomic formulas must be of equal length", n);
+      }
+      break;
+
+    case ARRAY_EQ:
+      if (n.Degree() != 2)
+        FatalError("BVTypeCheck: ARRAY_EQ should have exactly 2 args\n", n);
+
+      if (n[0].GetType() != ARRAY_TYPE || n[1].GetType() != ARRAY_TYPE ||
+          n[0].GetValueWidth() != n[1].GetValueWidth() ||
+          n[0].GetIndexWidth() != n[1].GetIndexWidth())
+      {
+        FatalError("BVTypeCheck: ARRAY_EQ requires identically typed arrays",
+                   n);
       }
       break;
 

--- a/lib/AbsRefineCounterExample/AbstractionRefinement.cpp
+++ b/lib/AbsRefineCounterExample/AbstractionRefinement.cpp
@@ -24,6 +24,7 @@ THE SOFTWARE.
 
 #include "stp/AST/AST.h"
 #include "stp/AbsRefineCounterExample/AbsRefine_CounterExample.h"
+#include "stp/Extensionality/ExtensionalityContext.h"
 #include "stp/STPManager/STPManager.h"
 #include <cassert>
 #include <math.h>
@@ -36,13 +37,6 @@ using std::map;
 /******************************************************************
  * Abstraction Refinement related functions
  ******************************************************************/
-
-enum Polarity
-{
-  LEFT_ONLY,
-  RIGHT_ONLY,
-  BOTH
-};
 
 void getSatVariables(const ASTNode& a, vector<unsigned>& v_a,
                      SATSolver& SatSolver, ToSATBase::ASTNodeToSATVar& satVar)
@@ -71,8 +65,7 @@ void getSatVariables(const ASTNode& a, vector<unsigned>& v_a,
 // Because it's used to create array axionms (a=b)-> (c=d), it can be
 // used to only add one of the two polarities.
 Minisat::Var getEquals(SATSolver& SatSolver, const ASTNode& a, const ASTNode& b,
-                       ToSATBase::ASTNodeToSATVar& satVar,
-                       Polarity polary = BOTH)
+                       ToSATBase::ASTNodeToSATVar& satVar, Polarity polary)
 {
   const unsigned width = a.GetValueWidth();
   assert(width == b.GetValueWidth());
@@ -94,7 +87,7 @@ Minisat::Var getEquals(SATSolver& SatSolver, const ASTNode& a, const ASTNode& b,
     {
       SATSolver::vec_literals s;
 
-      if (polary != RIGHT_ONLY)
+      if (polary != Polarity::RIGHT_ONLY)
       {
         int nv0 = SatSolver.newVar();
         s.push(SATSolver::mkLit(v_a[i], true));
@@ -112,7 +105,7 @@ Minisat::Var getEquals(SATSolver& SatSolver, const ASTNode& a, const ASTNode& b,
         all.push(SATSolver::mkLit(nv0, true));
       }
 
-      if (polary != LEFT_ONLY)
+      if (polary != Polarity::LEFT_ONLY)
       {
         s.push(SATSolver::mkLit(v_a[i], true));
         s.push(SATSolver::mkLit(v_b[i], false));
@@ -148,7 +141,7 @@ Minisat::Var getEquals(SATSolver& SatSolver, const ASTNode& a, const ASTNode& b,
     CBV v = constant.GetBVConst();
     for (unsigned i = 0; i < width; i++)
     {
-      if (polary != RIGHT_ONLY)
+      if (polary != Polarity::RIGHT_ONLY)
       {
         if (CONSTANTBV::BitVector_bit_test(v, i))
           all.push(SATSolver::mkLit(vec[i], true));
@@ -156,7 +149,7 @@ Minisat::Var getEquals(SATSolver& SatSolver, const ASTNode& a, const ASTNode& b,
           all.push(SATSolver::mkLit(vec[i], false));
       }
 
-      if (polary != LEFT_ONLY)
+      if (polary != Polarity::LEFT_ONLY)
       {
         SATSolver::vec_literals p;
         p.push(SATSolver::mkLit(result, true));
@@ -232,10 +225,10 @@ struct AxiomToBe
 void applyAxiomToSAT(SATSolver& SatSolver, AxiomToBe& toBe,
                      ToSATBase::ASTNodeToSATVar& satVar)
 {
-  Minisat::Var a =
-      getEquals(SatSolver, toBe.index0, toBe.index1, satVar, LEFT_ONLY);
-  Minisat::Var b =
-      getEquals(SatSolver, toBe.value0, toBe.value1, satVar, RIGHT_ONLY);
+  Minisat::Var a = getEquals(SatSolver, toBe.index0, toBe.index1, satVar,
+                             Polarity::LEFT_ONLY);
+  Minisat::Var b = getEquals(SatSolver, toBe.value0, toBe.value1, satVar,
+                             Polarity::RIGHT_ONLY);
   SATSolver::vec_literals satSolverClause;
   satSolverClause.push(SATSolver::mkLit(a, true));
   satSolverClause.push(SATSolver::mkLit(b, false));
@@ -289,6 +282,12 @@ AbsRefine_CounterExample::SATBased_ArrayReadRefinement(
                       ArrayTransform->arrayToIndexToRead.begin(),
                       ArrayTransform->arrayToIndexToRead.end());
   sort(arrayToIndex.begin(), arrayToIndex.end(), sortBySize);
+
+  ExtensionalityContext* ext = bm->getExtensionalityIfAny();
+  const bool extActive = ext != NULL && ext->activeInSolve();
+  if (extActive)
+    FatalError("array-equality: legacy array-read refinement was invoked "
+               "during a solve owned by the extensionality checker");
 
   // In these loops we try to construct Leibnitz axioms and add it to
   // the solve(). We add only those axioms that are false in the
@@ -392,7 +391,8 @@ AbsRefine_CounterExample::SATBased_ArrayReadRefinement(
 
         SOLVER_RETURN_TYPE res2;
         bm->GetRunTimes()->stop(RunTimes::ArrayReadRefinement);
-        res2 = CallSAT_ResultCheck(SatSolver, ASTTrue, original_input, tosat,
+        res2 = CallSAT_ResultCheck(SatSolver, ASTTrue, original_input,
+                                   original_input, tosat,
                                    true);
 
         if (SOLVER_UNDECIDED != res2)
@@ -413,7 +413,8 @@ AbsRefine_CounterExample::SATBased_ArrayReadRefinement(
     applyAxiomsToSolver(satVar, RemainingAxiomsVec, SatSolver);
 
     bm->GetRunTimes()->stop(RunTimes::ArrayReadRefinement);
-    return CallSAT_ResultCheck(SatSolver, ASTTrue, original_input, tosat, true);
+    return CallSAT_ResultCheck(SatSolver, ASTTrue, original_input,
+                               original_input, tosat, true);
   }
 // For difficult problems, I suspec this is a better way to do it.
 // However because it can cause an extra three SAT solver calls, it slows down
@@ -443,7 +444,8 @@ AbsRefine_CounterExample::SATBased_ArrayReadRefinement(
       bm->GetRunTimes()->stop(RunTimes::ArrayReadRefinement);
       SOLVER_RETURN_TYPE res2;
       res2 =
-          CallSAT_ResultCheck(SatSolver, ASTTrue, original_input, tosat, true);
+          CallSAT_ResultCheck(SatSolver, ASTTrue, original_input,
+                              original_input, tosat, true);
       if (SOLVER_UNDECIDED != res2)
         return res2;
 
@@ -452,6 +454,7 @@ AbsRefine_CounterExample::SATBased_ArrayReadRefinement(
     assert(current_position == RemainingAxiomsVec.size());
     RemainingAxiomsVec.clear();
     assert(SOLVER_UNDECIDED == CallSAT_ResultCheck(SatSolver, ASTTrue,
+                                                   original_input,
                                                    original_input, tosat,
                                                    true));
   }

--- a/lib/AbsRefineCounterExample/CounterExample.cpp
+++ b/lib/AbsRefineCounterExample/CounterExample.cpp
@@ -23,11 +23,13 @@ THE SOFTWARE.
 ********************************************************************/
 
 #include "stp/AbsRefineCounterExample/AbsRefine_CounterExample.h"
+#include "stp/Extensionality/ExtensionalityContext.h"
 #include "stp/FloatBlaster/FloatBlast.h"
 #include "stp/FloatBlaster/FloatBlaster.h"
 #include "stp/FloatBlaster/FpEncodingContext.h"
 #include "stp/Printer/printers.h"
 #include "stp/ToSat/ToSATAIG.h"
+#include <memory>
 
 const bool debug_counterexample = false;
 
@@ -172,6 +174,53 @@ void AbsRefine_CounterExample::ConstructCounterExample(
     }
   }
 
+  // In an active array-equality solve the consistency checker owns the
+  // complete array graph. Its input is the scalar SAT assignment above;
+  // do not pre-populate concrete READ(array, value(index)) entries here.
+  // Two syntactically different indexes can have the same candidate value,
+  // and collapsing their read abstractions into one map key before rule C
+  // runs loses exactly the disagreement the checker must turn into a lemma.
+  // A conflict-free check publishes one validated observation batch later.
+  {
+    ExtensionalityContext* ext = bm->getExtensionalityIfAny();
+    if (ext != NULL && ext->active())
+    {
+      if (!ext->checkerReady())
+        FatalError("array-equality: a SAT candidate was materialized before "
+                   "the complete array graph was bound");
+      // SAT backends may leave a don't-care Boolean literal undefined.
+      // Complete such directly encoded symbols with false, just as the BV
+      // loop above completes undefined bits with zero. Preserve any concrete
+      // value copied from the solver map.
+      for (ToSATBase::ASTNodeToSATVar::const_iterator it =
+               satVarToSymbol.begin();
+           it != satVarToSymbol.end(); ++it)
+      {
+        const ASTNode& symbol = it->first;
+        if (symbol.GetType() != BOOLEAN_TYPE)
+          continue;
+        ASTNodeMap::const_iterator assigned = CounterExampleMap.find(symbol);
+        if (assigned == CounterExampleMap.end())
+          CounterExampleMap[symbol] = ASTFalse;
+        else if (ext->isProtected(symbol) &&
+                 !(assigned->second.GetKind() == TRUE ||
+                   assigned->second.GetKind() == FALSE))
+          FatalError("array-equality: a protected Boolean SAT name has a "
+                     "non-Boolean counterexample value",
+                     symbol);
+      }
+
+      for (ASTNodeMap::const_iterator it = CounterExampleMap.begin();
+           it != CounterExampleMap.end(); ++it)
+        if (it->first.GetKind() == READ)
+          FatalError("array-equality: preprocessing placed an array-read "
+                     "observation in the candidate before the complete "
+                     "graph was checked",
+                     it->first);
+      return;
+    }
+  }
+
   for (ArrayTransformer::ArrType::const_iterator
            it = ArrayTransform->arrayToIndexToRead.begin(),
            itend = ArrayTransform->arrayToIndexToRead.end();
@@ -193,8 +242,8 @@ void AbsRefine_CounterExample::ConstructCounterExample(
       // construct the appropriate array-read and store it in the
       // counterexample
       ASTNode arrayread_index = TermToConstTermUsingModel(index, false);
-      ASTNode key =
-          bm->CreateTerm(READ, array.GetValueWidth(), array, arrayread_index);
+      ASTNode key = bm->defaultNodeFactory->CreateTerm(
+          READ, array.GetValueWidth(), array, arrayread_index);
 
       // Get the ITE corresponding to the array-read and convert it
       // to a constant against the model
@@ -352,6 +401,76 @@ AbsRefine_CounterExample::TermToConstTermUsingModel_inner(const ASTNode& term,
                    arrName);
       }
 
+      // With array equality active, every read in the solve is
+      // evaluated through its read-abstraction variable -- never by
+      // expanding its write chain against the model. The consistency
+      // checker, not the model-side expander, is the authority for
+      // these reads: the abstraction variable holds whatever the SAT
+      // solver assigned, and any disagreement with the array axioms is
+      // exactly what the checker turns into a lemma.
+      //
+      // An owned read with no recorded abstraction variable was
+      // simplified out of the formula before solving; it is evaluated
+      // from the certified array contents instead: the recorded
+      // observation at the concrete index if one exists at this level,
+      // else the concrete write-hit value, else recurse into the base
+      // array, defaulting to zero. This agrees with every recorded
+      // access whenever the checker certifies the candidate.
+      {
+        ExtensionalityContext* ext = bm->getExtensionalityIfAny();
+        if (ext != NULL && ext->active() && ext->arrayGraphFrozen() &&
+            ext->ownsArray(arrName))
+        {
+          const ASTNode idxVal = TermToConstTermUsingModel(index, false);
+          NodeFactory* hf = bm->hashingNodeFactory;
+          ASTNode level = arrName;
+          ASTNode val;
+          while (true)
+          {
+            const ASTNode key = hf->CreateTerm(READ, level.GetValueWidth(),
+                                               level, idxVal);
+            ASTNodeMap::const_iterator cit = CounterExampleMap.find(key);
+            if (cit != CounterExampleMap.end())
+            {
+              val = cit->second;
+              if (BVCONST != val.GetKind())
+                val = TermToConstTermUsingModel(val, false);
+              break;
+            }
+            if (WRITE == level.GetKind())
+            {
+              const ASTNode writeIdx = TermToConstTermUsingModel(level[1],
+                                                                 false);
+              if (writeIdx == idxVal)
+              {
+                val = TermToConstTermUsingModel(level[2], false);
+                break;
+              }
+              level = level[0];
+              continue;
+            }
+            if (ITE == level.GetKind() && level.GetType() == ARRAY_TYPE)
+            {
+              const ASTNode cond = ComputeFormulaUsingModel(level[0]);
+              if (cond == ASTTrue)
+                level = level[1];
+              else if (cond == ASTFalse)
+                level = level[2];
+              else
+                FatalError("array-equality: an owned array if-then-else "
+                           "condition has no concrete model value",
+                           level[0]);
+              continue;
+            }
+            // base array with no observation
+            val = defaultCellValue(level);
+            break;
+          }
+          CounterExampleMap[term] = val;
+          return val;
+        }
+      }
+
       if (WRITE == arrName.GetKind()) // READ over a WRITE
       {
         ASTNode wrtterm = Expand_ReadOverWrite_UsingModel(term, ArrayReadFlag);
@@ -429,6 +548,34 @@ AbsRefine_CounterExample::TermToConstTermUsingModel_inner(const ASTNode& term,
       {
         // return the array read over a constantindex
         output = modelentry;
+      }
+      else if (bm->UserFlags.enable_array_equality)
+      {
+        // Has been simplified out, so any value will do -- but only one
+        // value agrees with the model that is published. With array
+        // equality enabled the model surface prints a total
+        // interpretation per array, and this is a cell of it that no
+        // observation covers, so it is the completion or nothing.
+        // Inventing something else makes evaluation disagree with every
+        // other reader: an array equality evaluates false through its
+        // lowering's reads while the printed arrays are identical, which
+        // is the disagreement the post-solve audit trips on -- and,
+        // unaudited, a (get-model) that falsifies the query it answered
+        // sat. Both of this arm's former answers were such an invention:
+        // all-ones for a bitvector cell the printer filled with zero,
+        // and RNE for a RoundingMode cell that ReadUsingModel and the
+        // checker were still completing with all-zero bits.
+        //
+        // Memoising the invented value instead cannot close that gap.
+        // Model queries run inside a scope that restores the
+        // counterexample map afterwards, so the entry is rolled back
+        // and the next reader invents the value again against a model
+        // that never recorded it. Agreeing with the completion the rest
+        // of the model already uses needs no bookkeeping at all.
+        //
+        // Gated on the option: with it off the counterexample map, and
+        // so vc_getCounterExampleArray, must stay exactly as before.
+        output = defaultCellValue(arrName);
       }
       else
       {
@@ -660,6 +807,39 @@ ASTNode AbsRefine_CounterExample::ComputeFormulaUsingModel(const ASTNode& form)
         output = ASTFalse;
       }
       break;
+    case ARRAY_EQ:
+    {
+      ExtensionalityContext* ext = bm->getExtensionalityIfAny();
+      ASTNode lowered;
+      if (ext != NULL && ext->getCurrentLowering(form, lowered))
+      {
+        // This solve decided the equality; its lowering is the answer.
+        output = ComputeFormulaUsingModel(lowered);
+      }
+      else
+      {
+        // It did not: either the equality belongs to an earlier query,
+        // or lowering discarded it -- an equality nested in a conjunct
+        // that solving a write chain against its own base dropped as
+        // shadowed. There is no abstraction variable to consult, and
+        // the one that used to be consulted here had never been
+        // assigned, so it read false while the model gave the two
+        // arrays identical contents.
+        //
+        // Ask the model instead. It is the same model the caller is
+        // about to print, so the answer agrees with it by construction,
+        // which is the property the abstraction variable could not
+        // offer.
+        if (!arrayEqualityIsModelDecidable(form[0]) ||
+            !arrayEqualityIsModelDecidable(form[1]))
+          FatalError("array-equality: cannot evaluate an opaque equality "
+                     "over float-indexed arrays that was not reachable in "
+                     "the most recent solve",
+                     form);
+        output = ArraysEqualUsingModel(form[0], form[1]) ? ASTTrue : ASTFalse;
+      }
+      break;
+    }
     case BOOLEXTRACT:
     {
       ASTNode t0 = TermToConstTermUsingModel(form[0]);
@@ -806,7 +986,8 @@ ASTNode AbsRefine_CounterExample::ComputeFormulaUsingModel(const ASTNode& form)
   return output;
 }
 
-void AbsRefine_CounterExample::CheckCounterExample(bool t)
+void AbsRefine_CounterExample::CheckCounterExample(
+    bool t, const ASTNode& checked_input)
 {
   // input is valid, no counterexample to check
   if (bm->ValidFlag)
@@ -817,35 +998,286 @@ void AbsRefine_CounterExample::CheckCounterExample(bool t)
     FatalError("CheckCounterExample: "
                "No CounterExample to check",
                ASTUndefined);
-  // These are the raw stored assertions, not the prepared formula. When the
-  // evaluator reaches an FP subgraph it delegates to the solve's encoding
-  // context, whose totalisation cache maps it to the same unspecified-value
-  // arrays used by the SAT problem.
-  const ASTVec c = bm->GetAsserts();
-
+  // Check the exact semantic root used by this solve. TopLevelSTP has already
+  // totalised its floating-point operations and CallSAT_ResultCheck has kept
+  // this root aligned with solve-boundary array-equality lowering; rebuilding
+  // the check from the manager's parsed assertions would lose both facts.
   if (bm->UserFlags.stats_flag)
     printf("checking counterexample\n");
 
-  for (ASTVec::const_iterator it = c.begin(), itend = c.end(); it != itend;
-       it++)
+  if (debug_counterexample)
+    cerr << "checking " << checked_input;
+
+  // Drop the formula memo first. Its entries were produced while the
+  // model was still being assembled -- before the array-equality
+  // consistency check published its certified observations, in an
+  // active solve -- and reusing them would let this check confirm the
+  // answer with the very values it is supposed to be re-deriving. What
+  // is deliberately kept is CounterExampleMap: that is the model, not a
+  // cache of conclusions about it.
+  ClearComputeFormulaMap();
+
+  if (ASTFalse == ComputeFormulaUsingModel(checked_input))
+    FatalError("CheckCounterExample:counterexample bogus: "
+               "the submitted query evaluates to FALSE under the "
+               "counterexample: NOT OK",
+               checked_input);
+
+  // The walk above resolves each opaque array equality through its
+  // recorded lowering, so it re-derives the Boolean skeleton but takes
+  // the equalities themselves on trust. Ask the other half of the
+  // question here: does the model that is about to be printed give the
+  // equalities the values the solver assigned them?
+  // Deliberately not gated on active(): an equality lowering solved
+  // outright -- a write chain against its own base, or a reflexive fold
+  // -- mints no record, so there is nothing active to gate on, and it
+  // is exactly the case with no consistency checker behind it.
+  ExtensionalityContext* ext = bm->getExtensionalityIfAny();
+  if (ext != NULL && ext->enabled())
   {
-    if (debug_counterexample)
-      cerr << "checking" << *it;
-
-    if (ASTFalse == ComputeFormulaUsingModel(*it))
-      FatalError("CheckCounterExample:counterexample bogus:"
-                 "assert evaluates to FALSE under counterexample: "
-                 "NOT OK",
-                 *it);
+    const char* reason = ext->recheckCertifiedEqualities(this);
+    if (reason != NULL)
+      FatalError(reason);
   }
+}
 
-  // The smtlib ones don't have a query defined.
-  if ((bm->GetQuery() != ASTUndefined) &&
-      ASTTrue == ComputeFormulaUsingModel(bm->GetQuery()))
-    FatalError("CheckCounterExample:counterexample bogus:"
-               "query evaluates to TRUE under counterexample: "
-               "NOT OK",
-               bm->GetQuery());
+// Asking the model a question must not change it. Evaluation memoises,
+// and where it cannot account for a read it invents a value and records
+// it -- so a question would otherwise leave cells behind that the model
+// printer and vc_getCounterExampleArray then report as part of the
+// answer. Both public query entry points roll the model back to what it
+// was; the invented values are deterministic, so anything that needs
+// one again gets the same one.
+namespace
+{
+class ModelQuery
+{
+  ASTNodeMap& cells;
+  ASTNodeMap& formulas;
+  const ASTNodeMap savedCells;
+  const ASTNodeMap savedFormulas;
+
+public:
+  ModelQuery(ASTNodeMap& c, ASTNodeMap& f)
+      : cells(c), formulas(f), savedCells(c), savedFormulas(f)
+  {
+  }
+  ~ModelQuery()
+  {
+    cells = savedCells;
+    formulas = savedFormulas;
+  }
+  ModelQuery(const ModelQuery&) = delete;
+  ModelQuery& operator=(const ModelQuery&) = delete;
+};
+} // namespace
+
+// See the header.
+void AbsRefine_CounterExample::CollectArrayNodes(const ASTNode& arrayTerm,
+                                                 ASTNodeSet& out)
+{
+  ASTVec pending(1, arrayTerm);
+  while (!pending.empty())
+  {
+    const ASTNode n = pending.back();
+    pending.pop_back();
+    if (!out.insert(n).second)
+      continue;
+    if (WRITE == n.GetKind())
+      pending.push_back(n[0]);
+    else if (ITE == n.GetKind() && ARRAY_TYPE == n.GetType())
+    {
+      pending.push_back(n[1]);
+      pending.push_back(n[2]);
+    }
+  }
+}
+
+// See the header. Zero bits is +0.0 for a float element and a perfectly
+// ordinary bitvector otherwise, so the only sort needing its own answer
+// is RoundingMode, whose one-hot encoding leaves all-zero denoting
+// nothing at all. RNE is the mode published for such a cell -- the same
+// choice cvc5 makes, and IEEE 754's default rounding direction; the
+// value is a don't-care, so what matters is that every site takes it
+// from here and none of them invents its own.
+ASTNode
+AbsRefine_CounterExample::defaultCellValue(const ASTNode& arrayTerm) const
+{
+  if (bm->arrayHasRmElement(arrayTerm))
+    return bm->CreateBVConst(5, symbolic_fp::ROUND_NEAREST_TIES_TO_EVEN);
+  return bm->CreateZeroConst(arrayTerm.GetValueWidth());
+}
+
+// See the header. This is the walk the read path already performs for
+// an array the extensionality checker owns, lifted out so that it can
+// be asked about any array term, including one from a solve that never
+// owned anything.
+void AbsRefine_CounterExample::CollectModelCells(const ASTNodeSet& arrays,
+                                                 ModelCells& out)
+{
+  for (ASTNodeMap::const_iterator it = CounterExampleMap.begin();
+       it != CounterExampleMap.end(); ++it)
+  {
+    if (READ != it->first.GetKind() || !it->first[1].isConstant() ||
+        arrays.find(it->first[0]) == arrays.end())
+      continue;
+    const std::pair<ASTNode, ASTNode> key(
+        it->first[0], plainBitVectorConstant(bm, it->first[1]));
+    // One cell recorded under both spellings of its index must not
+    // become two entries; the records agree, being the same cell.
+    if (out.find(key) == out.end())
+      out[key] = it->second;
+  }
+}
+
+ASTNode AbsRefine_CounterExample::ReadUsingModel(const ASTNode& arrayTerm,
+                                                 const ASTNode& concreteIndex,
+                                                 const ModelCells& cells)
+{
+  ASTNode level = arrayTerm;
+  while (true)
+  {
+    const ModelCells::const_iterator recorded =
+        cells.find(std::make_pair(level, concreteIndex));
+    if (recorded != cells.end())
+      return BVCONST == recorded->second.GetKind()
+                 ? recorded->second
+                 : TermToConstTermUsingModel(recorded->second, false);
+
+    if (WRITE == level.GetKind())
+    {
+      // Stepping over the write is a claim that the two indexes address
+      // different cells, so it is asked on bits.
+      if (!constantsDenoteDifferentValues(
+              TermToConstTermUsingModel(level[1], false), concreteIndex))
+        return TermToConstTermUsingModel(level[2], false);
+      level = level[0];
+      continue;
+    }
+
+    if (ITE == level.GetKind() && ARRAY_TYPE == level.GetType())
+    {
+      const ASTNode cond = ComputeFormulaUsingModel(level[0]);
+      if (ASTTrue == cond)
+        level = level[1];
+      else if (ASTFalse == cond)
+        level = level[2];
+      else
+        FatalError("ReadUsingModel: an array if-then-else condition has no "
+                   "truth value in the model",
+                   level[0]);
+      continue;
+    }
+
+    // A base array the model records nothing for at this index. It
+    // holds what the printer fills it with.
+    return defaultCellValue(level);
+  }
+}
+
+// See the header. The one restriction, in one place.
+//
+// A float-indexed array is answerable, but only through the solve's own
+// encoding context: the solve canonicalises float indexes and records
+// the model against the lowered carrier access, so the operands must be
+// lowered the same way before the walk can find a cell. Without that
+// context -- outside a solve, or in a unit fixture that never made one
+// -- the question cannot be put.
+bool AbsRefine_CounterExample::arrayEqualityIsModelDecidable(
+    const ASTNode& arrayTerm) const
+{
+  const SourceSort sort = arrayTerm.GetSourceSort();
+  return sort.kind() != SourceSort::Kind::Array ||
+         !sort.index().usesFloatingPointTheory() || fpEncodingContext != NULL;
+}
+
+bool AbsRefine_CounterExample::ArraysEqualUsingModel(const ASTNode& left,
+                                                     const ASTNode& right)
+{
+  if (left == right)
+    return true;
+
+  ModelQuery unchanged(CounterExampleMap, ComputeFormulaMap);
+
+  // Two floating-point sorts, two independent problems; an array can
+  // have either, both, or neither.
+  //
+  // A float *element* changes only the comparison: cells are compared
+  // for the same value rather than the same bits, because NaN is one
+  // value with many packings. The walk is unaffected.
+  //
+  // A float *index* changes where the cells are. The solve canonicalises
+  // those indexes and records the model against the lowered carrier
+  // access, so the operands have to be lowered the same way before a
+  // cell can be found at all. Stay in encoded mode from there for the
+  // reason the term evaluator gives where it does the same: the lowered
+  // DAG keeps its source-sort metadata, and a nested access would
+  // otherwise be taken for a fresh source boundary and canonicalised
+  // again.
+  SourceSort elementSort = SourceSort::unknown();
+  bool encode = false;
+  {
+    const SourceSort arraySort = left.GetSourceSort();
+    if (arraySort.kind() == SourceSort::Kind::Array)
+    {
+      elementSort = arraySort.element();
+      encode = fpEncodingContext != NULL && fpEncodedEvaluationDepth == 0 &&
+               arraySort.index().usesFloatingPointTheory();
+    }
+  }
+  const ASTNode lowered_left =
+      encode ? requireFpEncodingContext().encodeForModel(left) : left;
+  const ASTNode lowered_right =
+      encode ? requireFpEncodingContext().encodeForModel(right) : right;
+  std::unique_ptr<ScopedFpEncodedEvaluation> evaluating;
+  if (encode)
+    evaluating.reset(new ScopedFpEncodedEvaluation(fpEncodedEvaluationDepth));
+  if (lowered_left == lowered_right)
+    return true;
+
+  ASTNodeSet arrays;
+  CollectArrayNodes(lowered_left, arrays);
+  CollectArrayNodes(lowered_right, arrays);
+  ModelCells cells;
+  CollectModelCells(arrays, cells);
+
+  // Every cell the model records against one of those arrays, plus every
+  // index a write in either term writes to -- a write's own cell need
+  // not be recorded, and stepping over it is exactly what makes the
+  // array above it differ from the one below.
+  //
+  // Both sources are already normalised, and both have to be: an index
+  // is a value, and two spellings of one value would be two candidates,
+  // the one that does not match the recorded cell finding nothing and
+  // completing to zero. The cell keys are normalised where they are
+  // built; a written index is whatever the term evaluator returns, and
+  // that is documented to be a plain constant for this very reason.
+  std::set<ASTNode> indexes;
+  for (ModelCells::const_iterator it = cells.begin(); it != cells.end(); ++it)
+    indexes.insert(it->first.second);
+  for (ASTNodeSet::const_iterator it = arrays.begin(); it != arrays.end();
+       ++it)
+    if (WRITE == it->GetKind())
+      indexes.insert(TermToConstTermUsingModel((*it)[1], false));
+
+  // By value at the element's sort, never by node identity: a
+  // float-element cell holds a floating-point constant, which interns
+  // apart from the plain constant with the same bits -- and the zero an
+  // unobserved cell completes to is exactly such a plain constant.
+  for (std::set<ASTNode>::const_iterator it = indexes.begin();
+       it != indexes.end(); ++it)
+    if (constantsDenoteDifferentSourceValues(
+            ReadUsingModel(lowered_left, *it, cells),
+            ReadUsingModel(lowered_right, *it, cells), elementSort))
+      return false;
+  return true;
+}
+
+// See the header.
+ASTNode AbsRefine_CounterExample::QueryFormulaAgainstModel(const ASTNode& form)
+{
+  ModelQuery unchanged(CounterExampleMap, ComputeFormulaMap);
+  return ComputeFormulaUsingModel(form);
 }
 
 /* FUNCTION: queries the value of expr given the current counterexample.
@@ -872,6 +1304,71 @@ ASTNode AbsRefine_CounterExample::GetCounterExample(const ASTNode& expr)
                              expr.GetSourceSort());
 }
 
+// The observed (index, value) entries of one array symbol, evaluated to
+// constants, one entry per concrete index, in ascending unsigned index
+// order -- so the programmatic model API is deterministic and agrees
+// with the printed model. The CounterExampleMap is keyed by hash-consed
+// READ(array, index) nodes, so one index can only carry one entry;
+// conflicting duplicates would mean a broken model and fail loudly.
+vector<std::pair<ASTNode, ASTNode>>
+AbsRefine_CounterExample::GetSortedArrayModelEntries(const ASTNode& arraySym)
+{
+  vector<std::pair<ASTNode, ASTNode>> entries;
+
+  // Take a copy of the counterexample map, 'cause TermToConstTermUsingModel
+  // changes it. Which breaks the iterator otherwise.
+  const ASTNodeMap c(CounterExampleMap);
+
+  // The element sort decides when two recorded values for one cell are
+  // really two values: NaN has many packings and one meaning.
+  const SourceSort arraySort = arraySym.GetSourceSort();
+  const SourceSort elementSort =
+      arraySort.kind() == SourceSort::Kind::Array ? arraySort.element()
+                                                  : SourceSort::unknown();
+
+  std::map<ASTNode, ASTNode> byIndex;
+  for (const auto& e : c)
+  {
+    const ASTNode& f = e.first;
+    if (f.GetKind() == READ && f[0] == arraySym && f[1].GetKind() == BVCONST)
+    {
+      ASTNode rhs;
+      if (BITVECTOR_TYPE == e.second.GetType() ||
+          FLOATINGPOINT_TYPE == e.second.GetType())
+      {
+        rhs = TermToConstTermUsingModel(e.second, false);
+      }
+      else
+      {
+        rhs = ComputeFormulaUsingModel(e.second);
+      }
+      assert(rhs.isConstant());
+      // Key on the plain spelling of the index, not on the node. A
+      // rounding-mode or float constant interns apart from the plain
+      // constant with its bits, so one cell can be recorded under two
+      // index nodes -- and keying on the node makes that one cell two
+      // entries, which the printer then emits as two stores of the same
+      // value to the same index.
+      auto ins = byIndex.insert(
+          std::make_pair(plainBitVectorConstant(bm, f[1]), rhs));
+      if (!ins.second && constantsDenoteDifferentSourceValues(
+                             ins.first->second, rhs, elementSort))
+        FatalError("GetSortedArrayModelEntries: conflicting model values "
+                   "for one concrete array index",
+                   f);
+    }
+  }
+
+  entries.assign(byIndex.begin(), byIndex.end());
+  std::sort(entries.begin(), entries.end(),
+            [](const std::pair<ASTNode, ASTNode>& x,
+               const std::pair<ASTNode, ASTNode>& y) {
+              return CONSTANTBV::BitVector_Lexicompare(
+                         x.first.GetBVConst(), y.first.GetBVConst()) < 0;
+            });
+  return entries;
+}
+
 // FUNCTION: queries the counterexample, and returns the number of array
 // locations for e
 vector<std::pair<ASTNode, ASTNode>>
@@ -892,55 +1389,70 @@ AbsRefine_CounterExample::GetCounterExampleArray(bool t, const ASTNode& e)
     return entries;
   }
 
-  // Take a copy of the counterexample map, 'cause TermToConstTermUsingModel
-  // changes it. Which breaks the iterator otherwise.
-  const ASTNodeMap c(CounterExampleMap);
-
-  ASTNodeMap::const_iterator it = c.begin();
-  ASTNodeMap::const_iterator itend = c.end();
-  for (; it != itend; it++)
+  // With array equality disabled, keep the pre-extension extraction
+  // path -- including its unordered traversal -- byte for byte. The
+  // deterministic sorted path below applies only when the extension is
+  // enabled.
+  if (!bm->UserFlags.enable_array_equality)
   {
-    const ASTNode& f = it->first;
-    const ASTNode& se = it->second;
+    // Take a copy of the counterexample map, 'cause TermToConstTermUsingModel
+    // changes it. Which breaks the iterator otherwise.
+    const ASTNodeMap c(CounterExampleMap);
 
-    if (ARRAY_TYPE == se.GetType())
+    ASTNodeMap::const_iterator it = c.begin();
+    ASTNodeMap::const_iterator itend = c.end();
+    for (; it != itend; it++)
     {
-      FatalError("TermToConstTermUsingModel: "
-                 "entry in counterexample is an arraytype. bogus:",
-                 se);
-    }
+      const ASTNode& f = it->first;
+      const ASTNode& se = it->second;
 
-    // skip over introduced variables, and over the reads of an introduced
-    // array -- those entries are keyed on the read, not on the array
-    if (bm->isIntroducedCounterExampleEntry(f))
-    {
-      continue;
-    }
-    if (f.GetKind() == READ && f[0] == e && f[0].GetKind() == SYMBOL &&
-        f[1].GetKind() == BVCONST)
-    {
-      ASTNode rhs;
-      if (BITVECTOR_TYPE == se.GetType() || FLOATINGPOINT_TYPE == se.GetType())
+      if (ARRAY_TYPE == se.GetType())
       {
-        rhs = TermToConstTermUsingModel(se, false);
+        FatalError("TermToConstTermUsingModel: "
+                   "entry in counterexample is an arraytype. bogus:",
+                   se);
       }
-      else
-      {
-        rhs = ComputeFormulaUsingModel(se);
-      }
-      assert(rhs.isConstant());
 
-      // Hand the pair back at the array's declared sorts, for the reason
-      // GetCounterExample re-stamps its result: an index that is a bare
-      // bit-vector is not accepted back as an index of a float-indexed
-      // array, and a bare element cannot be equated with a read of a
-      // float-element one.
-      const SourceSort array_sort = e.GetSourceSort();
-      assert(array_sort.kind() == SourceSort::Kind::Array);
-      entries.push_back(std::make_pair(
-          bm->LiftSourceValue(f[1], array_sort.index()),
-          bm->LiftSourceValue(rhs, array_sort.element())));
+      // skip over introduced variables, and over the reads of an introduced
+      // array -- those entries are keyed on the read, not on the array
+      if (bm->isIntroducedCounterExampleEntry(f))
+      {
+        continue;
+      }
+      if (f.GetKind() == READ && f[0] == e && f[0].GetKind() == SYMBOL &&
+          f[1].GetKind() == BVCONST)
+      {
+        ASTNode rhs;
+        if (BITVECTOR_TYPE == se.GetType() || FLOATINGPOINT_TYPE == se.GetType())
+        {
+          rhs = TermToConstTermUsingModel(se, false);
+        }
+        else
+        {
+          rhs = ComputeFormulaUsingModel(se);
+        }
+        assert(rhs.isConstant());
+        entries.push_back(std::make_pair(f[1], rhs));
+      }
     }
+  }
+  else if (e.GetKind() == SYMBOL)
+  {
+    entries = GetSortedArrayModelEntries(e);
+  }
+
+  // Hand the pairs back at the array's declared sorts, for the reason
+  // GetCounterExample re-stamps its result: an index that is a bare
+  // bit-vector is not accepted back as an index of a float-indexed array,
+  // and a bare element cannot be equated with a read of a float-element
+  // one. Done here rather than in either extraction path, so the model
+  // printer keeps seeing GetSortedArrayModelEntries' raw constants.
+  const SourceSort array_sort = e.GetSourceSort();
+  assert(array_sort.kind() == SourceSort::Kind::Array);
+  for (std::pair<ASTNode, ASTNode>& entry : entries)
+  {
+    entry.first = bm->LiftSourceValue(entry.first, array_sort.index());
+    entry.second = bm->LiftSourceValue(entry.second, array_sort.element());
   }
 
   return entries;
@@ -1148,54 +1660,185 @@ void AbsRefine_CounterExample::outputLine(std::ostream& os, const ASTNode &f, AS
 void AbsRefine_CounterExample::PrintFullCounterExampleSMTLIB2(std::ostream& os)
 {
   const ASTNodeSet symbols = bm->getSymbols();
+
+  // With array equality disabled, follow the pre-extension output
+  // path byte for byte, legacy array format and all. The repaired
+  // printer below applies only when the extension is enabled.
+  if (!bm->UserFlags.enable_array_equality)
+  {
+    for (ASTNode f: symbols)
+    {
+        if (ARRAY_TYPE != f.GetType())
+          outputLine(os, f, f); // Can't do arrays because we need the reads.
+    }
+
+    ASTNodeMap c; // believe we need a copy because iterator gets invalidated?
+    for (const auto& e: CounterExampleMap)
+    {
+      if (READ == e.first.GetKind())
+          c.insert(e);
+    }
+
+    // The map iterates in an order that follows interning history, which
+    // varies across configurations of the solver. Sort the observed reads
+    // by array name and then by index, so one query prints one model text
+    // everywhere. Solver-map entries can carry a read at a symbolic index
+    // next to the concrete observations, so indexes are only compared as
+    // bits when both are constants; symbolic ones sort after, by name
+    // when possible.
+    const auto nodeBefore = [](const ASTNode& a, const ASTNode& b) {
+      if (a.GetKind() == SYMBOL && b.GetKind() == SYMBOL)
+        return strcmp(a.GetName(), b.GetName()) < 0;
+      return a.GetNodeNum() < b.GetNodeNum();
+    };
+    std::vector<std::pair<ASTNode, ASTNode>> reads(c.begin(), c.end());
+    std::sort(reads.begin(), reads.end(),
+              [&nodeBefore](const std::pair<ASTNode, ASTNode>& x,
+                            const std::pair<ASTNode, ASTNode>& y) {
+                const ASTNode& ax = x.first[0];
+                const ASTNode& ay = y.first[0];
+                if (ax != ay)
+                  return nodeBefore(ax, ay);
+                const ASTNode& ix = x.first[1];
+                const ASTNode& iy = y.first[1];
+                const bool cx = ix.isConstant();
+                const bool cy = iy.isConstant();
+                if (cx && cy)
+                  return CONSTANTBV::BitVector_Lexicompare(ix.GetBVConst(),
+                                                           iy.GetBVConst()) < 0;
+                if (cx != cy)
+                  return cx;
+                return nodeBefore(ix, iy);
+              });
+
+    for (const auto& e : reads)
+    {
+      outputLine(os, e.first, e.second);
+    }
+    os.flush();
+    return;
+  }
+
   for (ASTNode f: symbols)
   {
       if (ARRAY_TYPE != f.GetType())
-        outputLine(os, f, f); // Can't do arrays because we need the reads.
+        outputLine(os, f, f); // Arrays are printed below, from the reads.
   }
 
-  ASTNodeMap c; // believe we need a copy because iterator gets invalidated?
-  for (const auto& e: CounterExampleMap)
-  {
-    if (READ == e.first.GetKind())
-        c.insert(e);
-  }
-
-  // The map iterates in an order that follows interning history, which
-  // varies across configurations of the solver. Sort the observed reads
-  // by array name and then by index, so one query prints one model text
-  // everywhere. Solver-map entries can carry a read at a symbolic index
-  // next to the concrete observations, so indexes are only compared as
-  // bits when both are constants; symbolic ones sort after, by name
-  // when possible.
-  const auto nodeBefore = [](const ASTNode& a, const ASTNode& b) {
-    if (a.GetKind() == SYMBOL && b.GetKind() == SYMBOL)
-      return strcmp(a.GetName(), b.GetName()) < 0;
-    return a.GetNodeNum() < b.GetNodeNum();
-  };
-  std::vector<std::pair<ASTNode, ASTNode>> reads(c.begin(), c.end());
-  std::sort(reads.begin(), reads.end(),
-            [&nodeBefore](const std::pair<ASTNode, ASTNode>& x,
-                          const std::pair<ASTNode, ASTNode>& y) {
-              const ASTNode& ax = x.first[0];
-              const ASTNode& ay = y.first[0];
-              if (ax != ay)
-                return nodeBefore(ax, ay);
-              const ASTNode& ix = x.first[1];
-              const ASTNode& iy = y.first[1];
-              const bool cx = ix.isConstant();
-              const bool cy = iy.isConstant();
-              if (cx && cy)
-                return CONSTANTBV::BitVector_Lexicompare(ix.GetBVConst(),
-                                                         iy.GetBVConst()) < 0;
-              if (cx != cy)
-                return cx;
-              return nodeBefore(ix, iy);
+  // Arrays: emit one valid nullary define-fun per array symbol whose
+  // body is the constant defaultCellValue array with every observed
+  // (index, value) pair stored on top, in ascending concrete-index
+  // order. The printed model replays in a conforming SMT-LIB2 solver.
+  // This is the surface every other completion site has to match: what
+  // is printed here is what the model says about a cell nothing
+  // observed.
+  vector<ASTNode> arrays;
+  for (ASTNode f : symbols)
+    if (ARRAY_TYPE == f.GetType() && !bm->FoundIntroducedSymbolSet(f))
+      arrays.push_back(f);
+  std::sort(arrays.begin(), arrays.end(),
+            [](const ASTNode& x, const ASTNode& y) {
+              return strcmp(x.GetName(), y.GetName()) < 0;
             });
 
-  for (const auto& e : reads)
+  for (const ASTNode& array : arrays)
   {
-    outputLine(os, e.first, e.second);
+    // Shared with GetCounterExampleArray, so the text and programmatic
+    // model surfaces expose identical deterministic observations.
+    vector<std::pair<ASTNode, ASTNode>> entries =
+        GetSortedArrayModelEntries(array);
+
+    const unsigned iw = array.GetIndexWidth();
+    const unsigned vw = array.GetValueWidth();
+
+    // The define-fun prints the array's true sorts -- the element float
+    // format lives on the symbol, a float index format and RoundingMode
+    // on either side in the manager's registries -- with (fp ...)
+    // literals for float cells and indexes and mode names for
+    // RoundingMode ones, so it replays against the original
+    // declaration.
+    const unsigned eb = array.GetExpWidth();
+    const unsigned sb = array.GetSigWidth();
+    unsigned ieb = 0, isb = 0;
+    const bool fpIndex = bm->arrayHasFpIndex(array, ieb, isb);
+    const bool rmIndex = bm->arrayHasRmIndex(array);
+    const bool rmElement = bm->arrayHasRmElement(array);
+
+    std::ostringstream sortText;
+    sortText << "(Array ";
+    if (fpIndex)
+      sortText << "(_ FloatingPoint " << ieb << " " << isb << ")";
+    else if (rmIndex)
+      sortText << "RoundingMode";
+    else
+      sortText << "(_ BitVec " << iw << ")";
+    sortText << " ";
+    if (eb != 0)
+      sortText << "(_ FloatingPoint " << eb << " " << sb << ")";
+    else if (rmElement)
+      sortText << "RoundingMode";
+    else
+      sortText << "(_ BitVec " << vw << ")";
+    sortText << ")";
+
+    const auto printCell = [&](const ASTNode& cell) {
+      if (eb != 0)
+      {
+        os << " ";
+        printer::outputFloatingPointSMTLIB2(cell, os, eb, sb);
+        return;
+      }
+      if (rmElement)
+      {
+        const char* name = printer::roundingModeName(cell.GetUnsignedConst());
+        if (name == NULL)
+          FatalError("array-equality: a RoundingMode cell of the model "
+                     "is not one of the five modes",
+                     cell);
+        os << " " << name;
+        return;
+      }
+      printer::outputBitVecSMTLIB2(cell, os);
+    };
+    const auto printIndex = [&](const ASTNode& index) {
+      if (fpIndex)
+      {
+        os << " ";
+        printer::outputFloatingPointSMTLIB2(index, os, ieb, isb);
+        return;
+      }
+      if (rmIndex)
+      {
+        const char* name = printer::roundingModeName(index.GetUnsignedConst());
+        if (name == NULL)
+          FatalError("array-equality: a RoundingMode index of the model "
+                     "is not one of the five modes",
+                     index);
+        os << " " << name;
+        return;
+      }
+      printer::outputBitVecSMTLIB2(index, os);
+    };
+
+    os << "(define-fun |";
+    array.nodeprint(os);
+    os << "| () " << sortText.str();
+    for (size_t i = 0; i < entries.size(); i++)
+      os << " (store";
+    os << " ((as const " << sortText.str() << ")";
+    // The unobserved cells' value, printed through the same cell
+    // printer as an observed one, so that what is published here is
+    // demonstrably the value every other reader completes with rather
+    // than text that happens to match it.
+    printCell(defaultCellValue(array));
+    os << ")";
+    for (size_t i = 0; i < entries.size(); i++)
+    {
+      printIndex(entries[i].first);
+      printCell(entries[i].second);
+      os << ")";
+    }
+    os << ")" << std::endl;
   }
 
   os.flush();
@@ -1454,6 +2097,7 @@ SOLVER_RETURN_TYPE
 AbsRefine_CounterExample::CallSAT_ResultCheck(SATSolver& SatSolver,
                                               const ASTNode& modified_input,
                                               const ASTNode& original_input,
+                                              const ASTNode& submitted_input,
                                               ToSATBase* tosat, bool refinement)
 {
   bool sat = tosat->CallSAT(SatSolver, modified_input, refinement);
@@ -1481,6 +2125,51 @@ AbsRefine_CounterExample::CallSAT_ResultCheck(SATSolver& SatSolver,
       ToSATBase::ASTNodeToSATVar m = tosat->SATVar_to_SymbolIndexMap();
       PrintSATModel(SatSolver, m);
     }
+    // Array equality: the consistency checker runs on every candidate
+    // whenever the current solve has an active lowered equality -- even when
+    // STP's ordinary model evaluation already failed -- and an array
+    // conflict takes priority. In an active solve every read belongs to
+    // this checker, so only its array lemmas can rule such a candidate
+    // out; skipping an ordinary-false candidate could therefore loop
+    // without progress.
+    // A candidate is reported satisfiable only when both checks pass
+    // on the same assignment. Any active satisfiable candidate is
+    // required below to have a fully bound graph.
+    //
+    // The checker runs before the ordinary evaluation so that its
+    // conflict-free fixed point can be published into the model first:
+    // an owned read that was simplified out of the transformed formula
+    // is evaluated from the certified array contents, which must agree
+    // with every observation the propagation derived (e.g. a read
+    // observing a value across a true array equality). Publication and
+    // the verification of the scalar names against the completed model
+    // happen inside checkCandidate.
+    ExtensionalityContext* ext = bm->getExtensionalityIfAny();
+    const bool extRegistered = ext != NULL && ext->active();
+    if (extRegistered && !ext->checkerReady())
+      FatalError("array-equality: a SAT candidate reached model checking "
+                 "before the complete array graph was bound");
+    const bool extActive = extRegistered;
+    ExtensionalityContext::CandidateOutcome extOutcome =
+        ExtensionalityContext::EXT_SKIPPED;
+    if (extActive)
+      extOutcome = ext->checkCandidate(this);
+
+    // A conflicting candidate has no certified array model. Its complete
+    // checker certificate is already pending, so do not run ordinary model
+    // evaluation: that path is allowed to fill defaults and caches for a
+    // completed model, which this candidate deliberately is not.
+    if (extOutcome == ExtensionalityContext::EXT_CONFLICT)
+    {
+      if (!ext->hasPendingLemma())
+        FatalError("array-equality: a checker conflict has no pending lemma");
+      bm->GetRunTimes()->stop(RunTimes::CounterExampleGeneration);
+      return SOLVER_UNDECIDED;
+    }
+    if (extActive && extOutcome != ExtensionalityContext::EXT_CONSISTENT)
+      FatalError("array-equality: the checker could neither certify nor "
+                 "refute a materialized candidate");
+
     // check if the counterexample is good or not
     ASTNode orig_result = ComputeFormulaUsingModel(original_input);
     if (!(ASTTrue == orig_result || ASTFalse == orig_result))
@@ -1488,32 +2177,50 @@ AbsRefine_CounterExample::CallSAT_ResultCheck(SATSolver& SatSolver,
                  "true or false against model");
     bm->GetRunTimes()->stop(RunTimes::CounterExampleGeneration);
 
-    // if the counterexample is indeed a good one, then return
-    // invalid
-    if (ASTTrue == orig_result)
+    switch (ExtensionalityContext::decideCertification(
+        ASTTrue == orig_result, extActive, extOutcome))
     {
-      if (bm->UserFlags.check_counterexample_flag)
+      case ExtensionalityContext::ADD_EXT_LEMMA:
+        // the pending certificate is retained; the extensionality refinement
+        // driver installs its clause and re-solves
+        return SOLVER_UNDECIDED;
+
+      case ExtensionalityContext::INTERNAL_ERROR:
+        FatalError("CallSAT_ResultCheck: the complete array checker and "
+                   "the bit-blasted/model-evaluation path disagree on the "
+                   "same candidate -- the array-equality integration is "
+                   "broken");
+        return SOLVER_ERROR; // unreachable
+
+      case ExtensionalityContext::RETURN_SAT:
       {
-        CheckCounterExample(SatSolver.okay());
+        if (bm->UserFlags.check_counterexample_flag)
+        {
+          CheckCounterExample(SatSolver.okay(), submitted_input);
+        }
+
+        if ((bm->UserFlags.stats_flag ||
+             bm->UserFlags.print_counterexample_flag) &&
+            (!bm->UserFlags.smtlib2_parser_flag))
+        {
+          PrintCounterExample(SatSolver.okay());
+          PrintCounterExample_InOrder(SatSolver.okay());
+        }
+        return SOLVER_INVALID;
       }
 
-      if ((bm->UserFlags.stats_flag || bm->UserFlags.print_counterexample_flag) && (!bm->UserFlags.smtlib2_parser_flag))
+      case ExtensionalityContext::RUN_HOST_REFINEMENT:
+      default:
       {
-        PrintCounterExample(SatSolver.okay());
-        PrintCounterExample_InOrder(SatSolver.okay());
-      }
-      return SOLVER_INVALID;
-    }
-    // counterexample is bogus: flag it
-    else
-    {
-      if (bm->UserFlags.stats_flag && bm->UserFlags.print_nodes_flag)
-      {
-        cout << "Supposedly bogus one: \n";
-        PrintCounterExample(true);
-      }
+        // counterexample is bogus: flag it
+        if (bm->UserFlags.stats_flag && bm->UserFlags.print_nodes_flag)
+        {
+          cout << "Supposedly bogus one: \n";
+          PrintCounterExample(true);
+        }
 
-      return SOLVER_UNDECIDED;
+        return SOLVER_UNDECIDED;
+      }
     }
   }
   else

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -53,6 +53,7 @@ endif()
 add_subdirectory(Globals)
 add_subdirectory(AST)
 add_subdirectory(AbsRefineCounterExample)
+add_subdirectory(Extensionality)
 add_subdirectory(FloatBlaster)
 add_subdirectory(Simplifier)
 add_subdirectory(Printer)
@@ -77,6 +78,7 @@ set(stp_lib_targets
     AST
     stpmgr
     abstractionrefinement
+    extensionality
     tosat
     sat
     floatblaster

--- a/lib/Extensionality/CMakeLists.txt
+++ b/lib/Extensionality/CMakeLists.txt
@@ -20,6 +20,7 @@
 
 add_library(extensionality OBJECT
     ExtChecker.cpp
+    ExtensionalityContext.cpp
 )
 
 add_dependencies(extensionality ASTKind_header)

--- a/lib/Extensionality/CMakeLists.txt
+++ b/lib/Extensionality/CMakeLists.txt
@@ -1,0 +1,25 @@
+# AUTHORS: Andrew Teylu
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+add_library(extensionality OBJECT
+    ExtChecker.cpp
+)
+
+add_dependencies(extensionality ASTKind_header)

--- a/lib/Extensionality/ExtChecker.cpp
+++ b/lib/Extensionality/ExtChecker.cpp
@@ -1,0 +1,671 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: July, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+// The consistency checking and lemma generation algorithm of
+// Brummayer & Biere, "Lemmas on Demand for the Extensional Theory of
+// Arrays", JSAT 6 (2010), sections 7 and 8. See ExtChecker.h for an
+// overview of the rules and data model.
+
+#include "stp/Extensionality/ExtChecker.h"
+#include <algorithm>
+#include <deque>
+#include <unordered_map>
+#include <utility>
+
+namespace stp
+{
+
+namespace
+{
+
+typedef std::pair<ASTNode, size_t> PairKey;
+
+typedef std::unordered_map<ASTNode, size_t, ASTNode::ASTNodeHasher,
+                           ASTNode::ASTNodeEqual>
+    RhoIndexMap;
+
+// One predecessor-linked shortest-path entry. A propagation stores exactly
+// one incoming guard and a key for its predecessor; complete guard vectors are
+// materialized only for the two paths of an emitted conflict. This preserves
+// the FIFO/first-arrival shortest-path proof while making fixed-point storage
+// linear in the number of reached (array, access) pairs.
+struct PathRecord
+{
+  bool hasPredecessor = false;
+  PairKey predecessor;
+  ExtGuard incomingGuard;
+};
+
+struct CheckerState
+{
+  const ExtGraph& graph;
+  ExtModelView& model;
+  const bool recordEvents;
+
+  std::map<PairKey, PathRecord> paths;
+  // rho, split per section 11.2: one representative access per
+  // concrete index of each array, keyed by the index value so a
+  // congruence lookup is a single probe; plus the representatives in
+  // insertion order, for the observed-contents export. rhoByIndex is
+  // lookup-only: propagation, conflict, and model order must continue
+  // to come from the deterministic graph/work-list order and rho vectors.
+  std::map<ASTNode, RhoIndexMap> rhoByIndex;
+  std::map<ASTNode, std::vector<size_t>> rho; // insertion order preserved
+  std::deque<PairKey> worklist;
+  ExtCheckResult result;
+  int seq;
+  size_t materializedGuardCount;
+
+  CheckerState(const ExtGraph& g, ExtModelView& m, bool ev)
+      : graph(g), model(m), recordEvents(ev), seq(0),
+        materializedGuardCount(0)
+  {
+  }
+
+  ASTNode accessIndex(size_t id)
+  {
+    return model.bvValue(graph.accesses[id].indexName);
+  }
+
+  ASTNode accessValue(size_t id)
+  {
+    return model.bvValue(graph.accesses[id].valueName);
+  }
+
+  void event(ExtEvent::Kind kind, const char* rule, const ASTNode& source,
+             const ASTNode& destination, size_t access,
+             const ASTNode& indexValue, const ASTNode& accessValue)
+  {
+    if (!recordEvents)
+    {
+      seq++;
+      return;
+    }
+    ExtEvent e;
+    e.seq = seq++;
+    e.kind = kind;
+    e.rule = rule;
+    e.source = source;
+    e.destination = destination;
+    e.access = access;
+    e.indexValue = indexValue;
+    e.accessValue = accessValue;
+    result.events.push_back(e);
+  }
+
+  // Walk one predecessor chain back to its seed, turning the stored
+  // one-guard-per-link entries into the complete path a conflict
+  // certificate reports.
+  std::vector<ExtGuard> materializeGuards(const PathRecord& tail)
+  {
+    std::vector<ExtGuard> reversed;
+    const PathRecord* current = &tail;
+    while (current->hasPredecessor)
+    {
+      reversed.push_back(current->incomingGuard);
+      materializedGuardCount++;
+      const std::map<PairKey, PathRecord>::const_iterator predecessor =
+          paths.find(current->predecessor);
+      if (predecessor == paths.end())
+        FatalError("array-equality: a proof path lost its predecessor");
+      current = &predecessor->second;
+    }
+    std::reverse(reversed.begin(), reversed.end());
+    return reversed;
+  }
+
+  void finishProofDiagnostics()
+  {
+    result.proofPathEntries = paths.size();
+    result.materializedGuardCount = materializedGuardCount;
+  }
+
+  // Bring one access to one array, and run congruence (rule C) on the
+  // spot, against the single representative rho keeps for that array
+  // and concrete index (section 11.2).
+  //
+  // Three outcomes. An arrival at a pair already recorded is skipped:
+  // insertion is first-path-wins and the recorded path stays. An
+  // arrival matching the representative in both concrete index and
+  // concrete value is dropped without insertion or propagation --
+  // complete because no rule can tell members of a concrete
+  // (index, value) class apart; see ExtChecker.h for why that is not
+  // the same claim as "the representative reaches everything this
+  // access would". Note that this one records nothing, so the same
+  // access arriving again by another route repeats the test; the
+  // counters below therefore count arrivals, not pairs. Otherwise the
+  // access is inserted, becomes the representative if the index was
+  // free, and is queued.
+  //
+  // A representative already there with a different concrete value is a
+  // conflict: it is appended to result.conflicts (without the lemma,
+  // which buildLemmas adds afterwards) and the pass carries on, so it
+  // collects further independent conflicts instead of stopping at the
+  // earliest. It does not enumerate every disagreeing pair in the
+  // candidate -- a conflicting arrival is not queued, so pairs that
+  // could only meet beyond it are left to a later refinement round.
+  void insert(const ASTNode& destination, size_t accessId,
+              const ExtGuard* incomingGuard, const char* rule,
+              const ASTNode& source)
+  {
+    const PairKey key(destination, accessId);
+    if (paths.find(key) != paths.end())
+    {
+      result.stats["skipped_seen"]++;
+      event(ExtEvent::SKIP_SEEN, rule, source, destination, accessId,
+            ASTNode(), ASTNode());
+      return;
+    }
+
+    PathRecord candidatePath;
+    if (incomingGuard != NULL)
+    {
+      if (source.IsNull())
+        FatalError("array-equality: a guarded proof step has no source");
+      candidatePath.hasPredecessor = true;
+      candidatePath.predecessor = PairKey(source, accessId);
+      candidatePath.incomingGuard = *incomingGuard;
+    }
+    else if (!source.IsNull())
+    {
+      FatalError("array-equality: a non-seed proof step has no guard", source);
+    }
+
+    const ASTNode idx = accessIndex(accessId);
+    const ASTNode val = accessValue(accessId);
+
+    RhoIndexMap& byIndex = rhoByIndex[destination];
+    const std::pair<RhoIndexMap::iterator, bool> representative =
+        byIndex.emplace(idx, accessId);
+    if (!representative.second)
+    {
+      const size_t otherId = representative.first->second;
+      if (accessValue(otherId) != val)
+      {
+        ExtConflict c;
+        c.commonArray = destination;
+        c.leftAccess = otherId;
+        c.rightAccess = accessId;
+        c.indexValue = idx;
+        c.leftValue = accessValue(otherId);
+        c.rightValue = val;
+        const std::map<PairKey, PathRecord>::const_iterator otherPath =
+            paths.find(PairKey(destination, otherId));
+        if (otherPath == paths.end())
+          FatalError("array-equality: rho representative has no proof path",
+                     destination);
+        c.leftGuards = materializeGuards(otherPath->second);
+        c.rightGuards = materializeGuards(candidatePath);
+        result.stats["conflicts"]++;
+        event(ExtEvent::CONFLICT, rule, source, destination, accessId, idx,
+              val);
+        result.conflicts.push_back(std::move(c));
+
+        // Record the pair as visited so a later path to it cannot report
+        // the same conflict twice, but keep the arriving access out of
+        // rho -- its value disagrees with the representative already
+        // there -- and out of the work list, so nothing propagates
+        // onward from a conflicting arrival. The representative keeps
+        // the array's slot for this index, exactly as when the pass
+        // stopped here.
+        //
+        // This is what bounds the section 11.1 minimization to the
+        // first conflict: the access's search tree ends here, so a
+        // later conflict involving it uses whatever route remains, and
+        // a pair that could only have met through this array is left
+        // for a later refinement round. Queueing it instead would
+        // restore exact minimization at the cost of an unbounded number
+        // of further conflicts per pass, all derived from an already
+        // refuted candidate.
+        paths[key] = candidatePath;
+        return;
+      }
+      result.stats["skipped_represented"]++;
+      event(ExtEvent::SKIP_REPRESENTED, rule, source, destination, accessId,
+            idx, val);
+      return;
+    }
+
+    paths[key] = candidatePath;
+    rho[destination].push_back(accessId);
+    worklist.push_back(key);
+    result.stats["insertions"]++;
+
+    ExtEvent::Kind kind;
+    if (rule[0] == 'I' && rule[1] == '_')
+    {
+      result.stats["seeds"]++;
+      kind = ExtEvent::SEED;
+    }
+    else
+    {
+      result.stats["propagations"]++;
+      result.stats[std::string("rule_") + rule]++;
+      kind = ExtEvent::PROPAGATE;
+    }
+    event(kind, rule, source, destination, accessId, idx, val);
+  }
+};
+
+// Deterministic total order for premise atoms: rank by atom op
+// (bv_eq < bv_ne < array_eq < bool_lit), then by operand node numbers.
+bool atomLess(const ExtLemmaAtom& x, const ExtLemmaAtom& y)
+{
+  if (x.op != y.op)
+    return x.op < y.op;
+  uint64_t xa = x.a.IsNull() ? 0 : x.a.GetNodeNum();
+  uint64_t ya = y.a.IsNull() ? 0 : y.a.GetNodeNum();
+  if (xa != ya)
+    return xa < ya;
+  uint64_t xb = x.b.IsNull() ? 0 : x.b.GetNodeNum();
+  uint64_t yb = y.b.IsNull() ? 0 : y.b.GetNodeNum();
+  if (xb != yb)
+    return xb < yb;
+  uint64_t xt = x.boolTerm.IsNull() ? 0 : x.boolTerm.GetNodeNum();
+  uint64_t yt = y.boolTerm.IsNull() ? 0 : y.boolTerm.GetNodeNum();
+  return xt < yt;
+}
+
+// Canonicalize a premise: drop reflexive equalities (an index compared
+// with itself contributes nothing), drop exact duplicate atoms, and
+// sort deterministically. The guard paths feeding this are as short as
+// the pass could make them (section 11.1, a property of the FIFO work
+// list -- exactly shortest for the first conflict, and shortest among
+// the routes still open for a later one; see ExtChecker.h); beyond
+// that only exact duplicates are removed, no semantic subsumption.
+std::vector<ExtLemmaAtom> canonicalAtoms(const std::vector<ExtLemmaAtom>& in)
+{
+  std::vector<ExtLemmaAtom> out;
+  out.reserve(in.size());
+  for (size_t i = 0; i < in.size(); i++)
+  {
+    const ExtLemmaAtom& a = in[i];
+    if (a.op == ExtLemmaAtom::BV_EQ && a.a == a.b)
+      continue;
+    out.push_back(a);
+  }
+  // Preserve which input occurrence survives when two logical atoms
+  // compare equal. ExtLemmaAtom carries proof metadata outside atomLess
+  // and operator==, so an unstable sort would make that choice incidental.
+  std::stable_sort(out.begin(), out.end(), atomLess);
+  out.erase(std::unique(out.begin(), out.end()), out.end());
+  return out;
+}
+
+void guardsToAtoms(const std::vector<ExtGuard>& guards, bool abstractLayer,
+                   std::vector<ExtLemmaAtom>& out)
+{
+  for (size_t i = 0; i < guards.size(); i++)
+  {
+    const ExtGuard& g = guards[i];
+    ExtLemmaAtom a;
+    if (g.kind == ExtGuard::INDEX_NE)
+    {
+      a.op = ExtLemmaAtom::BV_NE;
+      a.a = abstractLayer ? g.absA : g.theoryA;
+      a.b = abstractLayer ? g.absB : g.theoryB;
+      a.eqRecord = 0;
+    }
+    else if (g.kind == ExtGuard::ITE_COND_POS ||
+             g.kind == ExtGuard::ITE_COND_NEG)
+    {
+      // The condition with the polarity sigma gave it. Unlike an array
+      // equality, an if-then-else guard can be either way round: both
+      // branches are selectable, and the rule fired on whichever one
+      // sigma selected.
+      a.op = g.kind == ExtGuard::ITE_COND_POS ? ExtLemmaAtom::BOOL_LIT
+                                              : ExtLemmaAtom::BOOL_LIT_NEG;
+      a.boolTerm = abstractLayer ? g.absA : g.theoryA;
+      a.eqRecord = 0;
+    }
+    else if (abstractLayer)
+    {
+      a.op = ExtLemmaAtom::BOOL_LIT;
+      a.boolTerm = g.absA;
+      a.eqRecord = g.eqRecord;
+    }
+    else
+    {
+      a.op = ExtLemmaAtom::ARRAY_EQ;
+      a.a = g.theoryA;
+      a.b = g.theoryB;
+      a.eqRecord = g.eqRecord;
+    }
+    out.push_back(a);
+  }
+}
+
+// Self-check: a lemma is only worth adding if the candidate that
+// produced it falsifies it — every premise atom must be true and the
+// conclusion false under sigma. Otherwise adding it could not rule the
+// candidate out and refinement might not terminate; abort loudly.
+void validateAbstractLemma(const ExtConflict& c, ExtModelView& model)
+{
+  for (size_t i = 0; i < c.abstractPremise.size(); i++)
+  {
+    const ExtLemmaAtom& a = c.abstractPremise[i];
+    bool holds;
+    if (a.op == ExtLemmaAtom::BV_EQ)
+      holds = model.bvValue(a.a) == model.bvValue(a.b);
+    else if (a.op == ExtLemmaAtom::BV_NE)
+      holds = model.bvValue(a.a) != model.bvValue(a.b);
+    else if (a.op == ExtLemmaAtom::BOOL_LIT)
+      holds = model.boolValue(a.boolTerm);
+    else if (a.op == ExtLemmaAtom::BOOL_LIT_NEG)
+      holds = !model.boolValue(a.boolTerm);
+    else
+      holds = false; // ARRAY_EQ can't appear in the abstract lemma
+    if (!holds)
+      FatalError("array-equality: generated lemma premise is not true "
+                 "in the candidate assignment that produced it");
+  }
+  if (model.bvValue(c.abstractConclusionA) ==
+      model.bvValue(c.abstractConclusionB))
+    FatalError("array-equality: generated lemma is not false in the "
+               "candidate assignment that produced it");
+}
+
+// Build the lemma of paper section 8 for a conflict between accesses
+// x and y at common array d:
+//
+//   index(x) = index(y)
+//     and the write-index disequalities of both propagation paths
+//     and the array equalities crossed by both paths
+//   =>  value(x) = value(y)
+//
+// built once over the original terms (the theory lemma) and once over
+// abstraction variables and scalar names (the refinement actually
+// encoded into the SAT solver).
+void buildLemmas(ExtConflict& c, const ExtGraph& graph, ExtModelView& model)
+{
+  const ExtAccess& left = graph.accesses[c.leftAccess];
+  const ExtAccess& right = graph.accesses[c.rightAccess];
+
+  {
+    std::vector<ExtLemmaAtom> atoms;
+    ExtLemmaAtom indexEq;
+    indexEq.op = ExtLemmaAtom::BV_EQ;
+    indexEq.a = left.indexName;
+    indexEq.b = right.indexName;
+    indexEq.eqRecord = 0;
+    atoms.push_back(indexEq);
+    guardsToAtoms(c.leftGuards, true, atoms);
+    guardsToAtoms(c.rightGuards, true, atoms);
+    c.abstractPremise = canonicalAtoms(atoms);
+    c.abstractConclusionA = left.valueName;
+    c.abstractConclusionB = right.valueName;
+  }
+
+  {
+    std::vector<ExtLemmaAtom> atoms;
+    ExtLemmaAtom indexEq;
+    indexEq.op = ExtLemmaAtom::BV_EQ;
+    indexEq.a = left.indexTerm;
+    indexEq.b = right.indexTerm;
+    indexEq.eqRecord = 0;
+    atoms.push_back(indexEq);
+    guardsToAtoms(c.leftGuards, false, atoms);
+    guardsToAtoms(c.rightGuards, false, atoms);
+    c.theoryPremise = canonicalAtoms(atoms);
+    c.theoryConclusionA = left.valueTerm;
+    c.theoryConclusionB = right.valueTerm;
+  }
+
+  validateAbstractLemma(c, model);
+}
+
+} // namespace
+
+ExtCheckResult ExtChecker::check(const ExtGraph& graph, ExtModelView& model,
+                                 bool recordEvents)
+{
+  CheckerState st(graph, model, recordEvents);
+
+  // Rule I: seed every access at its own array, with an empty
+  // propagation path, in the stable access order.
+  for (size_t i = 0; i < graph.accesses.size(); i++)
+  {
+    const ExtAccess& a = graph.accesses[i];
+    const char* rule = a.isWrite ? "I_WRITE" : "I_READ";
+    st.insert(a.site, a.id, NULL, rule, ASTNode());
+  }
+
+  // Fixed-point computation over a FIFO work list (the "working queue
+  // that manages future read propagations" of section 7.3); for each
+  // pair the edges fire in the order D, U, R/L, then the T rules.
+  //
+  // The FIFO discipline is load-bearing: with every access seeded
+  // before the fixed point starts, discovery is breadth-first per
+  // access, so an access's recorded path to any array is a shortest
+  // propagation path among the routes still open to it. That is the
+  // lemma minimization of section 11.1, obtained without the separate
+  // post-conflict search a depth-first (stack) working list would need.
+  //
+  // "Still open" because a conflicting arrival is not queued (see
+  // insert), so an access stops at an array it conflicted at. The first
+  // conflict of a pass is unaffected -- nothing has been truncated when
+  // it fires -- but a later one can carry a longer premise than an
+  // exhaustive search would give it. Pinned at both ends by the
+  // ConflictPremiseUsesShortestPaths and
+  // ConflictingArrivalStopsAtTheConflictArray unit tests; do not
+  // replace the deque with a stack.
+  while (!st.worklist.empty())
+  {
+    const PairKey cur = st.worklist.front();
+    st.worklist.pop_front();
+    const ASTNode source = cur.first;
+    const size_t accessId = cur.second;
+    const ASTNode accessIdxVal = st.accessIndex(accessId);
+
+    // Every rule fires for every pair: a conflict on one edge no longer
+    // cuts the remaining edges short, so the pass collects the
+    // independent conflicts an early return would have hidden.
+
+    // Rule D: propagate down through a write whose index differs
+    // from the access index under sigma (axiom A3).
+    std::map<ASTNode, ExtWriteNode>::const_iterator wit =
+        graph.writes.find(source);
+    if (wit != graph.writes.end())
+    {
+      const ExtWriteNode& w = wit->second;
+      if (accessIdxVal != model.bvValue(w.indexName))
+      {
+        ExtGuard g;
+        g.kind = ExtGuard::INDEX_NE;
+        g.theoryA = graph.accesses[accessId].indexTerm;
+        g.theoryB = w.indexTerm;
+        g.absA = graph.accesses[accessId].indexName;
+        g.absB = w.indexName;
+        g.eqRecord = 0;
+        st.insert(w.base, accessId, &g, "D_WRITE", source);
+      }
+    }
+
+    // Rule U: propagate up over every write on top of this array
+    // whose index differs from the access index under sigma. Upward
+    // propagation is what makes extensional reasoning complete
+    // (section 7.3).
+    {
+      std::map<ASTNode, std::vector<ASTNode>>::const_iterator pit =
+          graph.writeParents.find(source);
+      if (pit != graph.writeParents.end())
+      {
+        const std::vector<ASTNode>& parents = pit->second;
+        for (size_t i = 0; i < parents.size(); i++)
+        {
+          const ExtWriteNode& w = graph.writes.find(parents[i])->second;
+          if (accessIdxVal != model.bvValue(w.indexName))
+          {
+            ExtGuard g;
+            g.kind = ExtGuard::INDEX_NE;
+            g.theoryA = graph.accesses[accessId].indexTerm;
+            g.theoryB = w.indexTerm;
+            g.absA = graph.accesses[accessId].indexName;
+            g.absB = w.indexName;
+            g.eqRecord = 0;
+            st.insert(w.write, accessId, &g, "U_WRITE", source);
+          }
+        }
+      }
+    }
+
+    // Rules R and L: propagate across array equalities, in both
+    // directions, but only when sigma assigns the equality's Boolean
+    // abstraction variable true.
+    {
+      std::map<ASTNode, std::vector<size_t>>::const_iterator eit =
+          graph.eqAdjacency.find(source);
+      if (eit != graph.eqAdjacency.end())
+      {
+        const std::vector<size_t>& adj = eit->second;
+        for (size_t i = 0; i < adj.size(); i++)
+        {
+          const ExtEqEdge& e = graph.eqEdges[adj[i]];
+          if (!model.boolValue(e.proxy))
+            continue;
+          const bool fromLeft = (e.left == source);
+          const ASTNode destination = fromLeft ? e.right : e.left;
+          const char* rule = fromLeft ? "R_EQ" : "L_EQ";
+          ExtGuard g;
+          g.kind = ExtGuard::EQ_PROXY;
+          g.theoryA = e.left;
+          g.theoryB = e.right;
+          g.absA = e.proxy;
+          g.eqRecord = e.record;
+          st.insert(destination, accessId, &g, rule, source);
+        }
+      }
+    }
+
+    // Rules T-down and T-up: propagate across an array-valued
+    // if-then-else, in both directions, between it and whichever branch
+    // sigma selects. These are R and L with the equality proxy replaced
+    // by the condition literal and the destination chosen by sigma
+    // rather than fixed by the edge. Exactly one of the two branches is
+    // live per candidate, so unlike an equality there is no proxy left
+    // over for the solver to guess.
+    //
+    // The condition is read through its reified name, never re-evaluated
+    // from the counterexample: the value the rule branches on has to be
+    // the one the bit-blasted circuit took, or the wrong edge is live
+    // and a conflict-free fixed point certifies a model that does not
+    // satisfy the if-then-else axiom.
+    {
+      // T-down: source is the if-then-else, destination its branch.
+      std::map<ASTNode, ExtIteNode>::const_iterator dit =
+          graph.ites.find(source);
+      if (dit != graph.ites.end())
+      {
+        const ExtIteNode& t = dit->second;
+        const bool cond = model.boolValue(t.condName);
+        ExtGuard g;
+        g.kind = cond ? ExtGuard::ITE_COND_POS : ExtGuard::ITE_COND_NEG;
+        g.theoryA = t.condTerm;
+        g.absA = t.condName;
+        st.insert(cond ? t.thn : t.els, accessId, &g, "T_DOWN", source);
+      }
+
+      // T-up: source is a branch, destination every if-then-else that
+      // selects it.
+      std::map<ASTNode, std::vector<ASTNode>>::const_iterator uit =
+          graph.iteParents.find(source);
+      if (uit != graph.iteParents.end())
+      {
+        const std::vector<ASTNode>& above = uit->second;
+        for (size_t i = 0; i < above.size(); i++)
+        {
+          const ExtIteNode& t = graph.ites.find(above[i])->second;
+          const bool cond = model.boolValue(t.condName);
+          // Only from the selected branch. A branch can be both, in
+          // which case either polarity carries the access up and the
+          // first match is taken.
+          if (!((cond && t.thn == source) || (!cond && t.els == source)))
+            continue;
+          ExtGuard g;
+          g.kind = cond ? ExtGuard::ITE_COND_POS : ExtGuard::ITE_COND_NEG;
+          g.theoryA = t.condTerm;
+          g.absA = t.condName;
+          st.insert(t.ite, accessId, &g, "T_UP", source);
+        }
+      }
+    }
+  }
+
+  // The fixed point ran to completion, so report every conflict it
+  // found. Each is a lemma in its own right: its premise holds and its
+  // conclusion fails under the one candidate sigma this pass ran
+  // against, which does not change while the pass runs, so a conflict
+  // found late is neither weakened nor invalidated by an earlier one.
+  if (!st.result.conflicts.empty())
+  {
+    for (size_t i = 0; i < st.result.conflicts.size(); i++)
+      buildLemmas(st.result.conflicts[i], graph, model);
+    st.result.conflict = st.result.conflicts[0];
+    st.result.status = ExtCheckResult::CONFLICT;
+    st.finishProofDiagnostics();
+    return std::move(st.result);
+  }
+
+  // Verify the witnesses of preprocessing step 1, in record order: a
+  // false array equality must differ at its witness index lambda.
+  for (size_t i = 0; i < graph.witnesses.size(); i++)
+  {
+    const ExtWitness& w = graph.witnesses[i];
+    const bool proxyVal = model.boolValue(w.proxy);
+    const ASTNode leftVal = model.bvValue(w.leftValue);
+    const ASTNode rightVal = model.bvValue(w.rightValue);
+    st.event(ExtEvent::WITNESS_CHECK, "WITNESS", ASTNode(), ASTNode(),
+             w.record, model.bvValue(w.index), leftVal);
+    st.result.stats["witness_checks"]++;
+    if (!proxyVal && leftVal == rightVal)
+    {
+      st.result.status = ExtCheckResult::WITNESS_VIOLATION;
+      st.result.violatedRecord = w.record;
+      st.finishProofDiagnostics();
+      return std::move(st.result);
+    }
+  }
+
+  // Conflict-free: export the observed (index, value) pairs of every
+  // array; rho's fixed point defines the completed array contents
+  // (unobserved indices default to zero when a model is printed).
+  for (std::map<ASTNode, std::vector<size_t>>::const_iterator it =
+           st.rho.begin();
+       it != st.rho.end(); ++it)
+  {
+    std::vector<std::pair<ASTNode, ASTNode>>& obs =
+        st.result.observed[it->first];
+    for (size_t i = 0; i < it->second.size(); i++)
+    {
+      const size_t id = it->second[i];
+      obs.push_back(std::make_pair(st.accessIndex(id), st.accessValue(id)));
+    }
+  }
+
+  st.result.status = ExtCheckResult::CONSISTENT;
+  st.finishProofDiagnostics();
+  return std::move(st.result);
+}
+
+} // namespace stp

--- a/lib/Extensionality/ExtensionalityContext.cpp
+++ b/lib/Extensionality/ExtensionalityContext.cpp
@@ -1,0 +1,2035 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: July, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#include "stp/Extensionality/ExtensionalityContext.h"
+#include "stp/AbsRefineCounterExample/AbsRefine_CounterExample.h"
+#include "stp/AbsRefineCounterExample/ArrayTransformer.h"
+#include "stp/STPManager/STPManager.h"
+#include "stp/Simplifier/SubstitutionMap.h"
+#include "stp/ToSat/ToSATBase.h"
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <functional>
+
+namespace stp
+{
+
+namespace
+{
+
+bool isArrayType(const ASTNode& n)
+{
+  return n.GetType() == ARRAY_TYPE;
+}
+
+bool nodeNumLess(const ASTNode& a, const ASTNode& b)
+{
+  return a.GetNodeNum() < b.GetNodeNum();
+}
+
+// Why this layer normalises every constant it keeps through
+// plainBitVectorConstant (see AST.h): it works on packed bits and
+// compares model constants by node identity, so a float-element write
+// value held as a float constant would never compare equal to the same
+// bits read back from the SAT assignment, and the checker would report
+// the same phantom conflict on every refinement iteration. Scalar
+// names, checker model values and lemma leaves are all kept plain.
+
+// Whether the packed floating-point cell x of format (eb, sb) holds a NaN:
+// an all-ones exponent with a nonzero significand, the layout being
+// [sign | exponent eb | significand sb-1]. Built as a plain bitvector
+// circuit because witness clauses can be minted during preparation, after
+// the floating-point lowering has already run.
+ASTNode isPackedNaN(NodeFactory* hf, const ASTNode& x, unsigned eb,
+                    unsigned sb)
+{
+  const unsigned w = eb + sb;
+  const ASTNode exponent =
+      hf->CreateTerm(BVEXTRACT, eb, x, hf->CreateBVConst(32, w - 2),
+                     hf->CreateBVConst(32, sb - 1));
+  const ASTNode significand =
+      hf->CreateTerm(BVEXTRACT, sb - 1, x, hf->CreateBVConst(32, sb - 2),
+                     hf->CreateBVConst(32, 0));
+  return hf->CreateNode(
+      AND, hf->CreateNode(EQ, exponent, hf->CreateMaxConst(eb)),
+      hf->CreateNode(
+          NOT, hf->CreateNode(EQ, significand, hf->CreateZeroConst(sb - 1))));
+}
+
+// SMT-LIB's = between two packed floating-point cells of format (eb, sb).
+// Equal bits is too strong a test: every NaN bit pattern denotes the one
+// NaN value, so two cells holding different payloads hold the same value.
+// Every other value has exactly one packing, so the cells are equal
+// exactly when their bits agree or both are NaN. Built as a plain
+// bitvector circuit for the same reason isPackedNaN is.
+ASTNode packedFloatEq(NodeFactory* hf, const ASTNode& l, const ASTNode& r,
+                      unsigned eb, unsigned sb)
+{
+  return hf->CreateNode(OR, hf->CreateNode(EQ, l, r),
+                        hf->CreateNode(AND, isPackedNaN(hf, l, eb, sb),
+                                       isPackedNaN(hf, r, eb, sb)));
+}
+
+// The packed bits of the one canonical quiet NaN of format (eb, sb):
+// positive sign, all-ones exponent, only the quiet bit of the stored
+// significand set -- exactly the pattern CreateFPConst interns every NaN
+// literal to and pack produces for a symbolic NaN, so pinning a witness
+// index to it keeps bit-level index congruence equal to value congruence.
+ASTNode canonicalQuietNaN(STPMgr* bm, unsigned eb, unsigned sb)
+{
+  const unsigned w = eb + sb;
+  const unsigned stored_sig = sb - 1; // the hidden bit is not stored
+  CBV bits = CONSTANTBV::BitVector_Create(w, true);
+  for (unsigned i = 0; i < eb; i++)
+    CONSTANTBV::BitVector_Bit_On(bits, stored_sig + i);
+  CONSTANTBV::BitVector_Bit_On(bits, stored_sig - 1);
+  return bm->CreateBVConst(bits, w);
+}
+
+// Postorder DAG collection of every node beneath (and including) n.
+void collectDag(const ASTNode& n, ASTNodeSet& visited)
+{
+  if (!visited.insert(n).second)
+    return;
+  for (unsigned k = 0; k < n.Degree(); k++)
+    collectDag(n[k], visited);
+}
+
+// The current form of an equality operand, read back from its witness
+// anchor. The anchor was recorded as name = read(operand, lambda), and
+// what this returns is whatever array that read now stands over.
+//
+// Two rewrites in the tree can act on a read of that shape, and they
+// are dangerous in different ways.
+//
+// Distributing the read over an array if-then-else changes the shape,
+// so it cannot go unnoticed -- and it is suppressed while the procedure
+// is active anyway, because the checker reasons about those directly
+// and needs the read left where it stands.
+//
+// Chasing the read through a write does not change the shape. It
+// returns a read at the same index over a strictly deeper array, which
+// would pass every check here and hand back an operand the equality was
+// never about. Nothing suppresses it: SimplifyingNodeFactory::chaseRead
+// runs on every READ built over a WRITE. What makes it safe is that it
+// only steps over a write whose index it can prove different from the
+// read index, and lambda is fresh -- no term outside the two anchors
+// mentions it, so no context-free rule can decide "write index =
+// lambda" either way, and the chase stops at the first write. That is a
+// property of the formula rather than of this function, so
+// locateCanonicalOperands checks it directly instead of leaving it as
+// an argument in a comment.
+//
+// Anything else means an anchor was rewritten beyond recognition:
+// refuse loudly rather than guess.
+// Does any node of this DAG belong to `needles`? Iterative post-order,
+// because the terms it is asked about are as deep as the user's write
+// chains and if-then-else nests.
+bool subtreeMentions(const ASTNode& root, const std::set<ASTNode>& needles)
+{
+  std::map<ASTNode, bool> found;
+  std::vector<std::pair<ASTNode, bool>> stack;
+  stack.push_back(std::make_pair(root, false));
+  while (!stack.empty())
+  {
+    const ASTNode n = stack.back().first;
+    const bool expanded = stack.back().second;
+    stack.pop_back();
+    if (found.find(n) != found.end())
+      continue;
+    if (!expanded)
+    {
+      // Children are pushed after this node's second visit, so they are
+      // all answered before it is.
+      stack.push_back(std::make_pair(n, true));
+      for (unsigned k = 0; k < n.Degree(); k++)
+        if (found.find(n[k]) == found.end())
+          stack.push_back(std::make_pair(n[k], false));
+      continue;
+    }
+    bool here = needles.find(n) != needles.end();
+    for (unsigned k = 0; !here && k < n.Degree(); k++)
+      here = found[n[k]];
+    found[n] = here;
+  }
+  return found[root];
+}
+
+ASTNode recoverAnchoredOperand(const ASTNode& rhs, const ASTNode& lambda,
+                               const ASTNode& proxy)
+{
+  if (rhs.GetKind() == READ)
+  {
+    if (rhs[1] != lambda)
+      FatalError("array-equality: a witness read's index was rewritten "
+                 "away, although witness indices are protected from "
+                 "substitution",
+                 proxy);
+    return rhs[0];
+  }
+  if (rhs.GetKind() == ITE)
+    FatalError("array-equality: a witness read was distributed over an "
+               "array if-then-else, although that is suppressed while the "
+               "procedure is active",
+               proxy);
+  FatalError("array-equality: a witness-read defining equation was "
+             "rewritten into a shape operand recovery does not "
+             "recognize",
+             proxy);
+  return rhs; // unreachable; FatalError does not return
+}
+
+} // namespace
+
+ExtensionalityContext::ExtensionalityContext(STPMgr* bm_)
+    : lemmasEmitted(0), lemmaAtomsFolded(0), bm(bm_), solveInProgress(false),
+      registrySealed(false),
+      arrayGraphIsFrozen(false), graphBound(false),
+      readTransformInProgress(false), readTransformComplete(false),
+      pendingLemmaValid(false)
+{
+}
+
+bool ExtensionalityContext::enabled() const
+{
+  return bm->UserFlags.enable_array_equality;
+}
+
+void ExtensionalityContext::collectAnticipatedArraySymbols(const ASTNode& n)
+{
+  ASTNodeSet visited;
+  collectDag(n, visited);
+  for (ASTNodeSet::const_iterator it = visited.begin(); it != visited.end();
+       ++it)
+    if (it->GetKind() == SYMBOL && isArrayType(*it))
+      anticipatedArraySymbols.insert(*it);
+}
+
+// An equality between a chain of writes and the chain's own base
+// array,
+//
+//   write(...write(base, i_n, v_n)..., i_1, v_1) = base
+//
+// (i_1 outermost), holds exactly when every written value is already
+// in the base at its index, unless an outer write shadows it:
+//
+//   AND_k [ i_k = i_1 OR ... OR i_k = i_{k-1}
+//           OR read(base, i_k) = v_k ]
+//
+// This dissolves the common "array unchanged except at a few indices"
+// frame-condition shape into plain bitvector-and-read constraints --
+// no abstraction variable, no witness, no refinement. The two-sided
+// variant, where both operands stack writes on a shared deeper base,
+// is deliberately not attempted: its guards grow quadratically, and
+// the general lemmas-on-demand procedure already covers that shape.
+//
+// The cell comparison is the element sort's equality, not bit equality:
+// over a float-element array two cells are equal when their bits agree
+// or both are NaN (packedFloatEq). Comparing the bits alone lets a NaN
+// payload that the base holds and a written value that is the canonical
+// NaN -- what every symfpu-computed NaN packs to -- "differ", so the
+// chain and its base come apart when they hold the same array. The
+// index comparisons need no such qualification: an index sort that
+// quotients its bit patterns has had its indexes canonicalised by
+// FpTotalise before an opaque equality over the array is lowered.
+//
+// Built with the plain hashing factory; the result is ordinary formula
+// content that STP's later passes simplify as usual. A conjunct whose
+// index term is identical to an outer write's index term is certainly
+// shadowed and is dropped here, since the hashing factory would not
+// fold the reflexive equality itself. The outermost write never has
+// outer writes, so the conjunction is never empty.
+ASTNode ExtensionalityContext::solveWriteChain(const ASTNode& a,
+                                               const ASTNode& b) const
+{
+  for (int orientation = 0; orientation < 2; orientation++)
+  {
+    const ASTNode& chain = (orientation == 0) ? a : b;
+    const ASTNode& base = (orientation == 0) ? b : a;
+
+    // Peel writes off the chain side, outermost first, until the base
+    // side appears; anything else is not this shape.
+    ASTVec writesOutermostFirst;
+    ASTNode cur = chain;
+    bool matched = false;
+    while (cur.GetKind() == WRITE)
+    {
+      writesOutermostFirst.push_back(cur);
+      cur = cur[0];
+      if (cur == base)
+      {
+        matched = true;
+        break;
+      }
+    }
+    if (!matched)
+      continue;
+
+    NodeFactory* hf = bm->hashingNodeFactory;
+    const unsigned ew = base.GetValueWidth();
+    const SourceSort baseSort = base.GetSourceSort();
+    assert(baseSort.kind() == SourceSort::Kind::Array);
+    const SourceSort elementSort = baseSort.element();
+    const bool floatElements =
+        elementSort.kind() == SourceSort::Kind::FloatingPoint;
+    const unsigned eb = floatElements ? elementSort.exponentWidth() : 0;
+    const unsigned sb = floatElements ? elementSort.significandWidth() : 0;
+    ASTVec conjuncts;
+    for (size_t k = 0; k < writesOutermostFirst.size(); k++)
+    {
+      const ASTNode& indexK = writesOutermostFirst[k][1];
+      const ASTNode& valueK = writesOutermostFirst[k][2];
+      ASTVec disjuncts;
+      bool certainlyShadowed = false;
+      for (size_t m = 0; m < k; m++)
+      {
+        const ASTNode& indexM = writesOutermostFirst[m][1];
+        if (indexK == indexM)
+        {
+          certainlyShadowed = true;
+          break;
+        }
+        disjuncts.push_back(hf->CreateNode(EQ, indexK, indexM));
+      }
+      if (certainlyShadowed)
+        continue;
+      const ASTNode cell = hf->CreateTerm(READ, ew, base, indexK);
+      disjuncts.push_back(eb != 0 ? packedFloatEq(hf, cell, valueK, eb, sb)
+                                  : hf->CreateNode(EQ, cell, valueK));
+      conjuncts.push_back(disjuncts.size() == 1
+                              ? disjuncts[0]
+                              : hf->CreateNode(OR, disjuncts));
+    }
+    return conjuncts.size() == 1 ? conjuncts[0]
+                                 : hf->CreateNode(AND, conjuncts);
+  }
+  return ASTNode();
+}
+
+// The equality arm of the paper's formula abstraction (section 5), applied by
+// solve-boundary lowering: return a fresh Boolean abstraction variable and
+// cache the pair's witness bundle. Reflexive
+// requests fold to true. The record's constraint bundle corresponds
+// to the paper's preprocessing step 1 -- a fresh witness index
+// lambda, the two virtual reads read(a,lambda) and read(b,lambda)
+// (kept alive through named defining equations), and the witness
+// clause "proxy OR nameL != nameR". The paper orders that
+// preprocessing before abstraction; here the bundle is built
+// alongside the variable, over the construction operands, with the
+// plain hashing factory so no simplifying rewrite can alter the
+// recorded terms, and enters the formula at solve time.
+ASTNode ExtensionalityContext::makeEquality(const ASTNode& a, const ASTNode& b)
+{
+  const SourceSort aSort = a.GetSourceSort();
+  const SourceSort bSort = b.GetSourceSort();
+  if (!isArrayType(a) || !isArrayType(b) ||
+      aSort.kind() != SourceSort::Kind::Array ||
+      bSort.kind() != SourceSort::Kind::Array ||
+      a.GetIndexWidth() != b.GetIndexWidth() ||
+      a.GetValueWidth() != b.GetValueWidth())
+  {
+    FatalError("array-equality: equality between arrays requires "
+               "identical index and element widths",
+               a);
+  }
+
+  // Same packed width is not the same sort: a floating-point-element
+  // array and a bitvector-element array of one packed width (or two
+  // floating-point formats splitting one width differently) may not be
+  // equated, mirroring the parser's rejection of = between a float and
+  // a bitvector.
+  if (aSort.element() != bSort.element())
+  {
+    FatalError("array-equality: equality between arrays requires "
+               "identical element sorts",
+               a);
+  }
+
+  if (aSort.index() != bSort.index())
+    FatalError("array-equality: equality between arrays requires "
+               "identical index sorts",
+               a);
+
+  // TopLevelSTP totalises the complete formula while ARRAY_EQ is still an
+  // opaque, traversable node, before solve-boundary lowering calls here.
+  // In particular its operands' partial FP operations, float indexes and
+  // rounding modes have already been handled. Index canonicalisation is not
+  // structurally idempotent, so applying FpTotalise again here would create a
+  // second wrapper and disconnect the equality records from the constraints
+  // established by that whole-formula pass.
+  if (a == b)
+    return bm->ASTTrue;
+
+  // A chain of writes equated with its own base needs no abstraction
+  // at all; solve it by rewriting.
+  {
+    const ASTNode solved = solveWriteChain(a, b);
+    if (!solved.IsNull())
+      return solved;
+  }
+
+  // The hashing factory sorts EQ children, so callers may present the
+  // operands in either order; canonicalize the registry key the same
+  // way.
+  const bool ordered = a.GetNodeNum() < b.GetNodeNum();
+  const ASTNode& left = ordered ? a : b;
+  const ASTNode& right = ordered ? b : a;
+
+  const std::pair<ASTNode, ASTNode> key(left, right);
+  std::map<std::pair<ASTNode, ASTNode>, size_t>::const_iterator it =
+      keyToRecord.find(key);
+  if (it != keyToRecord.end())
+  {
+    // The key is the operand pair, so a hit is a record built from these
+    // very operands. Check it, because nothing downstream ever recovers
+    // the pair an abstraction variable stands for: a key that collapsed
+    // two distinct equalities would hand this one a variable standing
+    // for the other one's arrays, and the witness bundle, the checker
+    // edges and the model would then all be consistent about the wrong
+    // question.
+    const Record& existing = records[it->second];
+    if (!(existing.constructionLeft == left &&
+          existing.constructionRight == right))
+      FatalError("array-equality: the record registry returned an "
+                 "abstraction variable built from a different operand pair",
+                 left);
+    return existing.proxy;
+  }
+
+  if (registrySealed)
+    FatalError("array-equality: an array equality was built during a "
+               "solve, after the registry's constraints were taken; its "
+               "witness bundle could not reach the formula",
+               left);
+
+  NodeFactory* hf = bm->hashingNodeFactory;
+  const unsigned iw = left.GetIndexWidth();
+  const unsigned ew = left.GetValueWidth();
+
+  Record r;
+  r.id = records.size();
+  r.proxy = bm->CreateFreshVariable(0, 0, "ext_eq");
+  r.constructionLeft = left;
+  r.constructionRight = right;
+  r.lambda = bm->CreateFreshVariable(0, iw, "ext_lam");
+  r.nameL = bm->CreateFreshVariable(0, ew, "ext_wit");
+  r.nameR = bm->CreateFreshVariable(0, ew, "ext_wit");
+
+  ASTNode readL = hf->CreateTerm(READ, ew, left, r.lambda);
+  ASTNode readR = hf->CreateTerm(READ, ew, right, r.lambda);
+  r.anchorL = hf->CreateNode(EQ, r.nameL, readL);
+  r.anchorR = hf->CreateNode(EQ, r.nameR, readR);
+
+  // The witness disequality. Bitvector cells differ exactly when their
+  // bits differ. Packed floating-point cells denote the one NaN value
+  // under every NaN bit pattern (SMT-LIB = on floats is identity of
+  // values, and symfpu carries no payload), so differing bits witness
+  // a real difference only when the cells are not both NaN -- without
+  // that qualification a false equality between float arrays could be
+  // "witnessed" by two NaN payloads of pointwise-equal arrays.
+  ASTNode differ =
+      hf->CreateNode(NOT, hf->CreateNode(EQ, r.nameL, r.nameR));
+  const SourceSort arraySort = left.GetSourceSort();
+  assert(arraySort.kind() == SourceSort::Kind::Array);
+  const SourceSort elementSort = arraySort.element();
+  if (elementSort.kind() == SourceSort::Kind::FloatingPoint)
+  {
+    const unsigned eb = elementSort.exponentWidth();
+    const unsigned sb = elementSort.significandWidth();
+    differ = hf->CreateNode(
+        AND, differ,
+        hf->CreateNode(NOT,
+                       hf->CreateNode(AND, isPackedNaN(hf, r.nameL, eb, sb),
+                                      isPackedNaN(hf, r.nameR, eb, sb))));
+  }
+  else if (elementSort.kind() == SourceSort::Kind::RoundingMode)
+  {
+    // RoundingMode cells denote only through the five one-hot patterns,
+    // so a witness difference must be a difference of modes: both cells
+    // are pinned valid. (The reads of the formula are pinned by
+    // FpTotalise; these virtual reads enter the formula after it ran.)
+    differ = hf->CreateNode(
+        AND, differ,
+        hf->CreateNode(AND, bm->roundingModeValidConstraint(r.nameL),
+                       bm->roundingModeValidConstraint(r.nameR)));
+  }
+  r.witnessClause = hf->CreateNode(OR, r.proxy, differ);
+
+  // Where the index sort quotients its bit patterns, the witness index
+  // may only range over the denoting patterns; see indexSortClause.
+  {
+    const SourceSort indexSort = arraySort.index();
+    if (indexSort.kind() == SourceSort::Kind::FloatingPoint)
+    {
+      const unsigned ieb = indexSort.exponentWidth();
+      const unsigned isb = indexSort.significandWidth();
+      r.indexSortClause = hf->CreateNode(
+          OR, hf->CreateNode(NOT, isPackedNaN(hf, r.lambda, ieb, isb)),
+          hf->CreateNode(EQ, r.lambda, canonicalQuietNaN(bm, ieb, isb)));
+    }
+    else if (indexSort.kind() == SourceSort::Kind::RoundingMode)
+    {
+      r.indexSortClause = bm->roundingModeValidConstraint(r.lambda);
+    }
+  }
+
+  protectedSymbols.insert(r.proxy);
+  protectedSymbols.insert(r.lambda);
+  protectedSymbols.insert(r.nameL);
+  protectedSymbols.insert(r.nameR);
+  keyToRecord[key] = r.id;
+  proxyToRecord[r.proxy] = r.id;
+  records.push_back(r);
+  return records.back().proxy;
+}
+
+ASTNode ExtensionalityContext::lowerArrayEqualities(const ASTNode& root)
+{
+  const ASTNodeMap noRewrites;
+  return lowerArrayEqualities(root, noRewrites);
+}
+
+ASTNode ExtensionalityContext::lowerArrayEqualities(
+    const ASTNode& root, const ASTNodeMap& preLoweringRewrites)
+{
+  if (!enabled())
+    FatalError("array-equality: opaque equality reached lowering while the "
+               "decision procedure is disabled");
+
+  ASTNodeMap cache;
+  NodeFactory* hf = bm->hashingNodeFactory;
+  std::function<ASTNode(const ASTNode&)> lower = [&](const ASTNode& n) {
+    ASTNodeMap::const_iterator found = cache.find(n);
+    if (found != cache.end())
+      return found->second;
+
+    const ASTChildren children = n.GetChildren();
+    ASTVec loweredChildren;
+    bool changed = false;
+    loweredChildren.reserve(children.size());
+    for (const ASTNode& originalChild : children)
+    {
+      const ASTNode child = lower(originalChild);
+      loweredChildren.push_back(child);
+      changed = changed || child != originalChild;
+    }
+
+    ASTNode result;
+    if (n.GetKind() == ARRAY_EQ)
+    {
+      assert(loweredChildren.size() == 2);
+      result = makeEquality(loweredChildren[0], loweredChildren[1]);
+      currentLowerings[n] = result;
+    }
+    else if (!changed)
+    {
+      result = n;
+    }
+    else if (n.GetValueWidth() == 0)
+    {
+      result = hf->CreateNode(n.GetKind(), loweredChildren);
+    }
+    else if (n.GetIndexWidth() > 0)
+    {
+      result = hf->CreateArrayTerm(n.GetKind(), n.GetIndexWidth(),
+                                   n.GetValueWidth(), loweredChildren);
+    }
+    else
+    {
+      result = hf->CreateTerm(n.GetKind(), n.GetValueWidth(), loweredChildren);
+    }
+
+    cache.insert(std::make_pair(n, result));
+    return result;
+  };
+
+  const ASTNode lowered = lower(root);
+
+  // FpTotalise runs before this pass. If it changed an operand of an opaque
+  // equality, the public expression handle still names the original node
+  // while this traversal saw a rebuilt one. Alias only rewrites whose result
+  // was reachable from this solve's root; `cache` is the reachability proof
+  // and supplies the exact post-lowering formula (including TRUE when
+  // totalisation made the operands reflexive).
+  for (ASTNodeMap::const_iterator it = preLoweringRewrites.begin();
+       it != preLoweringRewrites.end(); ++it)
+  {
+    assert(it->first.GetKind() == ARRAY_EQ);
+
+    // Rebuilding ARRAY_EQ can prove reflexivity. That value remains exact
+    // even if an enclosing Boolean simplification dropped it from the final
+    // root, so retain the proved result for the original public handle.
+    if (it->second.GetKind() != ARRAY_EQ)
+    {
+      assert(it->second.GetType() == BOOLEAN_TYPE);
+      currentLowerings[it->first] = it->second;
+      continue;
+    }
+
+    const ASTNodeMap::const_iterator loweredRewrite = cache.find(it->second);
+    if (loweredRewrite != cache.end())
+      currentLowerings[it->first] = loweredRewrite->second;
+  }
+
+  // ARRAY_EQ is legal only in the user-facing AST. Ordinary simplification,
+  // array transformation and bit-blasting intentionally have no case for it.
+  ASTNodeSet nodes;
+  collectDag(lowered, nodes);
+  for (ASTNodeSet::const_iterator it = nodes.begin(); it != nodes.end(); ++it)
+    if (it->GetKind() == ARRAY_EQ)
+      FatalError("array-equality: query lowering left an opaque equality", *it);
+
+  activateReachableRecords(lowered);
+
+  return lowered;
+}
+
+bool ExtensionalityContext::getCurrentLowering(const ASTNode& opaque,
+                                               ASTNode& lowered) const
+{
+  const ASTNodeMap::const_iterator it = currentLowerings.find(opaque);
+  if (it == currentLowerings.end())
+    return false;
+  lowered = it->second;
+  return true;
+}
+
+void ExtensionalityContext::activateReachableRecords(
+    const ASTNode& loweredRoot)
+{
+  std::set<size_t> activeIds;
+  ASTNodeSet visited;
+  ASTVec pending(1, loweredRoot);
+  while (!pending.empty())
+  {
+    const ASTNode node = pending.back();
+    pending.pop_back();
+    if (!visited.insert(node).second)
+      continue;
+
+    const std::map<ASTNode, size_t>::const_iterator proxy =
+        proxyToRecord.find(node);
+    if (proxy != proxyToRecord.end() && activeIds.insert(proxy->second).second)
+    {
+      const Record& r = records[proxy->second];
+      // An outer equality can hide an inner equality proxy in an array-ITE
+      // condition or another operand subterm. Follow cached operands so that
+      // activation is the transitive closure, not merely the proxies still
+      // visible at the Boolean root.
+      pending.push_back(r.constructionLeft);
+      pending.push_back(r.constructionRight);
+    }
+
+    for (unsigned i = 0; i < node.Degree(); ++i)
+      pending.push_back(node[i]);
+  }
+
+  activeRecordIds.assign(activeIds.begin(), activeIds.end());
+
+  // Forget the lowering of every equality this solve did not keep. The
+  // map is written for each opaque node as it is visited, before there
+  // is any activation to consult, and lowering can then throw the
+  // result away: an equality between a write chain and its own base is
+  // solved by rewriting, and a conjunct of that rewriting is dropped
+  // when an outer write to the same index certainly shadows it, taking
+  // a nested equality's abstraction variable with it. The record is
+  // never activated, so the variable occurs in no constraint and the
+  // solver never assigns it -- but the entry survived, and the model
+  // surfaces resolve public handles through it. They would then report
+  // the two arrays unequal, because an unassigned Boolean completes to
+  // false, while the same model prints them identically.
+  //
+  // A proxy that did not activate is exactly an equality unreachable in
+  // this solve, so its entry has nothing left to say. Reflexive and
+  // rewritten lowerings carry no proxy and are unaffected.
+  for (ASTNodeMap::iterator it = currentLowerings.begin();
+       it != currentLowerings.end();)
+  {
+    const std::map<ASTNode, size_t>::const_iterator record =
+        proxyToRecord.find(it->second);
+    if (record != proxyToRecord.end() &&
+        activeIds.find(record->second) == activeIds.end())
+      it = currentLowerings.erase(it);
+    else
+      ++it;
+  }
+
+  anticipatedArraySymbols.clear();
+  for (size_t i = 0; i < activeRecordIds.size(); ++i)
+  {
+    const Record& r = records[activeRecordIds[i]];
+    collectAnticipatedArraySymbols(r.constructionLeft);
+    collectAnticipatedArraySymbols(r.constructionRight);
+  }
+}
+
+void ExtensionalityContext::beginSolve()
+{
+  registrySealed = false;
+  records.clear();
+  keyToRecord.clear();
+  proxyToRecord.clear();
+  activeRecordIds.clear();
+  currentLowerings.clear();
+  protectedSymbols.clear();
+  anticipatedArraySymbols.clear();
+  arrayGraphIsFrozen = false;
+  ownedArrays.clear();
+  ownedWrites.clear();
+  ownedWriteParents.clear();
+  ownedItes.clear();
+  ownedIteParents.clear();
+  eqEdges.clear();
+  eqAdjacency.clear();
+  witnessObls.clear();
+  // Scalar and condition names are rebuilt for each preprocessed formula.
+  scalarNames.clear();
+  nameToTermMap.clear();
+  lemmaOnlySymbols.clear();
+  graph = ExtGraph();
+  graphBound = false;
+  preparedTransformRoot = ASTNode();
+  preparedReads.clear();
+  transformedReads.clear();
+  eliminatedReads.clear();
+  readTransformInProgress = false;
+  readTransformComplete = false;
+  pendingLemmaValid = false;
+  pendingLemmas.clear();
+  eqLitCache.clear();
+  lastObserved.clear();
+}
+
+ASTNode ExtensionalityContext::conjoinRecordConstraints(const ASTNode& root)
+{
+  if (activeRecordIds.empty())
+    return root;
+  ASTVec conjuncts;
+  conjuncts.push_back(root);
+  for (size_t i = 0; i < activeRecordIds.size(); i++)
+  {
+    const Record& r = records[activeRecordIds[i]];
+    conjuncts.push_back(r.anchorL);
+    conjuncts.push_back(r.anchorR);
+    conjuncts.push_back(r.witnessClause);
+    if (!r.indexSortClause.IsNull())
+      conjuncts.push_back(r.indexSortClause);
+  }
+  ASTNode out = bm->defaultNodeFactory->CreateNode(AND, conjuncts);
+
+  // Anticipate the complete owned graph before any pass can act on the
+  // answer. Once an equality is active, the checker owns every array read in
+  // the solve: access indices and values may themselves contain reads of
+  // otherwise unrelated arrays, so a syntactic equality cone is not closed
+  // under scalar data dependencies.
+  //
+  // All READ-headed substitutions are suppressed while the procedure is
+  // active. anticipatedArraySymbols instead records this complete ownership
+  // boundary before preprocessing, so prepare() can reject any array symbol
+  // introduced later by a pass. It must therefore come from the whole root,
+  // not just equality operands: an unrelated array or an array-ITE branch is
+  // owned too.
+  collectAnticipatedArraySymbols(out);
+
+  // Everything the decision procedure needs is now in this solve's
+  // formula; anything minted after this point could not be.
+  registrySealed = true;
+  return out;
+}
+
+// Recover each record's canonical operands from its anchor equations
+// in the current formula. The anchors were conjoined before STP's
+// simplifications ran, so they were rewritten by exactly the passes
+// that rewrote the rest of the formula; the array operand under each
+// witness read is therefore the current form of the recorded operand.
+// Fails loudly when an anchor is missing or malformed -- a protected
+// definition was eliminated, which the substitution guards should have
+// prevented.
+void ExtensionalityContext::locateCanonicalOperands(const ASTNode& root)
+{
+  // Only the witness names are ever looked up below, so only they are
+  // collected: a protected lambda or proxy turning up in an equation of
+  // the same shape is none of this function's business.
+  std::set<ASTNode> witnessNames;
+  std::set<ASTNode> witnessIndexes;
+  for (size_t i = 0; i < activeRecordIds.size(); i++)
+  {
+    const Record& r = records[activeRecordIds[i]];
+    witnessNames.insert(r.nameL);
+    witnessNames.insert(r.nameR);
+    witnessIndexes.insert(r.lambda);
+  }
+
+  // name symbol -> the anchored right-hand side: the witness read, or
+  // the if-then-else the simplifier pushed it into.
+  //
+  // Exactly one equation of this shape may exist per name. The names
+  // are fresh, so no user term mentions them; they occur only in their
+  // own anchor and in the witness clause, whose equality has the other
+  // NAME on its far side and so does not match here; substitution
+  // cannot move them (SubstitutionMap::extensionalityProtected refuses
+  // any pair with a protected symbol on either side) and unconstrained
+  // removal cannot delete them (MutableASTNode's untouchable set); and
+  // because nodes are immutable and hash-consed, a rewritten anchor's
+  // predecessor is no longer reachable from the root, so the walk
+  // cannot see both.
+  //
+  // That is a property of every pass that runs in between, not
+  // something this function can arrange, and the walk visits the whole
+  // DAG rather than the top-level conjuncts -- so a second equation of
+  // this shape would be believed even nested under a disjunction. The
+  // container is hash-ordered, so silently keeping the last one found
+  // would pick a different operand from run to run and certify the
+  // candidate against the wrong arrays. Refuse instead.
+  std::map<ASTNode, ASTNode> anchorRhs;
+  ASTNodeSet visited;
+  collectDag(root, visited);
+  for (ASTNodeSet::const_iterator it = visited.begin(); it != visited.end();
+       ++it)
+  {
+    const ASTNode& n = *it;
+
+    // No write index mentions a witness index. That is what stops a
+    // read-over-write chase from stepping an anchor onto a deeper array
+    // and handing recovery an operand the equality was never about (see
+    // recoverAnchoredOperand): the chase steps over a write only when it
+    // can decide that write's index against the read's, and a
+    // context-free rule can decide nothing about a fresh symbol the
+    // write index does not mention.
+    //
+    // Deliberately not the stronger "a witness index appears only as an
+    // anchor read's index". It legitimately appears elsewhere -- a
+    // constraint confining it to the patterns its sort denotes is one,
+    // and a sort whose values are not all denoting needs exactly that --
+    // and no such position gives a rewrite anything to work with. Only a
+    // write index does.
+    if (n.GetKind() == WRITE && subtreeMentions(n[1], witnessIndexes))
+      FatalError("array-equality: a write index mentions a witness index, "
+                 "so a rewrite could decide that write against an anchor "
+                 "read and move the operand recovery reads",
+                 n);
+
+    if (n.GetKind() != EQ || n.Degree() != 2)
+      continue;
+    for (int side = 0; side < 2; side++)
+    {
+      const ASTNode& s = n[side];
+      const ASTNode& other = n[1 - side];
+      if (s.GetKind() != SYMBOL ||
+          witnessNames.find(s) == witnessNames.end() ||
+          !(other.GetKind() == READ || other.GetKind() == ITE))
+        continue;
+      const std::map<ASTNode, ASTNode>::const_iterator prev = anchorRhs.find(s);
+      if (prev != anchorRhs.end() && !(prev->second == other))
+        FatalError("array-equality: a witness read's defining equation "
+                   "occurs twice with different right-hand sides, so which "
+                   "one gives the equality operand's current form is not "
+                   "determined",
+                   s);
+      anchorRhs[s] = other;
+    }
+  }
+
+  for (size_t i = 0; i < activeRecordIds.size(); i++)
+  {
+    Record& r = records[activeRecordIds[i]];
+    std::map<ASTNode, ASTNode>::const_iterator lit = anchorRhs.find(r.nameL);
+    std::map<ASTNode, ASTNode>::const_iterator rit = anchorRhs.find(r.nameR);
+    if (lit == anchorRhs.end() || rit == anchorRhs.end())
+      FatalError("array-equality: a witness-read defining equation was "
+                 "lost during preprocessing, so the current form of an "
+                 "equality operand cannot be recovered",
+                 r.proxy);
+    r.canonicalLeft = recoverAnchoredOperand(lit->second, r.lambda, r.proxy);
+    r.canonicalRight = recoverAnchoredOperand(rit->second, r.lambda, r.proxy);
+  }
+}
+
+// Compute the owned array-term graph directly from every array-valued
+// node reachable in the prepared root. Record write parenthood at the
+// same time; array-if-then-else parenthood is populated with its reified
+// condition below, after scalar naming.
+void ExtensionalityContext::computeArrayGraph(
+    const ASTNode& root, std::set<ASTNode>& arrays,
+    std::map<ASTNode, std::vector<ASTNode>>& parents)
+{
+  arrays.clear();
+  parents.clear();
+
+  ASTNodeSet visited;
+  collectDag(root, visited);
+  for (ASTNodeSet::const_iterator it = visited.begin(); it != visited.end();
+       ++it)
+  {
+    const ASTNode& n = *it;
+    if (isArrayType(n))
+      arrays.insert(n);
+    if (n.GetKind() == WRITE)
+      parents[n[0]].push_back(n);
+  }
+  for (std::map<ASTNode, std::vector<ASTNode>>::iterator it = parents.begin();
+       it != parents.end(); ++it)
+    std::sort(it->second.begin(), it->second.end(), nodeNumLess);
+}
+
+// Create or reuse a scalar name for a checker-visible term and queue
+// its defining constraint name = term. The defining equation is
+// conjoined before bit-blasting, so the name has SAT variables and a
+// lemma mentioning the term can be encoded over them.
+ASTNode ExtensionalityContext::freshName(const ASTNode& term,
+                                         ASTVec& namingConstraints)
+{
+  if (term.isConstant())
+    return plainBitVectorConstant(bm, term);
+  std::map<ASTNode, ASTNode>::const_iterator it = scalarNames.find(term);
+  if (it != scalarNames.end())
+    return it->second;
+  ASTNode name = bm->CreateFreshVariable(0, term.GetValueWidth(), "ext_name");
+  protectedSymbols.insert(name);
+  namingConstraints.push_back(
+      bm->defaultNodeFactory->CreateNode(EQ, name, term));
+  scalarNames[term] = name;
+  nameToTermMap[name] = term;
+  return name;
+}
+
+// See the header. The Boolean analogue of freshName.
+ASTNode ExtensionalityContext::conditionName(const ASTNode& cond,
+                                             ASTVec& namingConstraints)
+{
+  std::map<ASTNode, ASTNode>::const_iterator it = scalarNames.find(cond);
+  if (it != scalarNames.end())
+    return it->second;
+  ASTNode name = bm->CreateFreshVariable(0, 0, "ext_cond");
+  protectedSymbols.insert(name);
+  namingConstraints.push_back(
+      bm->defaultNodeFactory->CreateNode(IFF, name, cond));
+  scalarNames[cond] = name;
+  nameToTermMap[name] = cond;
+  return name;
+}
+
+// Final preparation before STP's main array transformation: recover
+// canonical operands, collect and freeze the complete array graph,
+// inventory its writes as accesses (section 11.4), and give every
+// compound write index/value a scalar name.
+//
+// Array-valued if-then-elses remain structural and are inventoried here;
+// the consistency checker's T-up/T-down rules reason about the selected
+// branch directly.
+ASTNode ExtensionalityContext::prepare(const ASTNode& root_)
+{
+  if (!active())
+    FatalError("array-equality: preparation ran without an active equality");
+  if (arrayGraphIsFrozen || graphBound)
+    FatalError("array-equality: the complete array graph was prepared twice");
+  ASTNode root = root_;
+  ASTVec extraConstraints;
+
+  std::set<ASTNode> arrays;
+  std::map<ASTNode, std::vector<ASTNode>> parents;
+
+  locateCanonicalOperands(root);
+  computeArrayGraph(root, arrays, parents);
+
+  for (size_t i = 0; i < activeRecordIds.size(); ++i)
+  {
+    const Record& r = records[activeRecordIds[i]];
+    if (arrays.find(r.canonicalLeft) == arrays.end() ||
+        arrays.find(r.canonicalRight) == arrays.end())
+      FatalError("array-equality: a canonical equality operand is absent "
+                 "from the complete prepared array graph",
+                 r.proxy);
+  }
+
+  // anticipatedArraySymbols is the ownership inventory before preprocessing;
+  // this graph contains the arrays that remain afterwards. Because
+  // conjoinRecordConstraints walked the complete formula, the first set must
+  // cover every symbol in the second unless a pass introduced new array
+  // structure after the boundary. The checker graph is frozen here, so make
+  // that maintenance invariant explicit rather than silently accepting the
+  // new symbol.
+  for (std::set<ASTNode>::const_iterator it = arrays.begin();
+       it != arrays.end(); ++it)
+  {
+    if (it->GetKind() == SYMBOL && !wasArrayAnticipated(*it))
+      FatalError("array-equality: an array symbol entered the prepared graph "
+                 "without appearing at the pre-preprocessing ownership "
+                 "boundary",
+                 *it);
+  }
+
+  // Freeze the complete graph; it must not change for the rest of the solve.
+  ownedArrays = arrays;
+  ownedWriteParents = parents;
+
+  // Inventory the owned graph's writes as accesses (a write is treated as a
+  // read of its own index yielding the written value, paper section
+  // 11.4), and give their indexes and values scalar names: writes occur
+  // inside array terms, so their scalar children can otherwise disappear
+  // when every read of the array is directly abstracted.
+  std::vector<ASTNode> writeNodes;
+  for (std::set<ASTNode>::const_iterator it = arrays.begin();
+       it != arrays.end(); ++it)
+    if (it->GetKind() == WRITE)
+      writeNodes.push_back(*it);
+  std::sort(writeNodes.begin(), writeNodes.end(), nodeNumLess);
+
+  for (size_t i = 0; i < writeNodes.size(); i++)
+  {
+    const ASTNode& w = writeNodes[i];
+    ExtWriteNode info;
+    info.write = w;
+    info.base = w[0];
+    info.indexTerm = w[1];
+    info.indexName = freshName(w[1], extraConstraints);
+    ownedWrites[w] = info;
+    // write value names are needed when the access list is built
+    freshName(w[2], extraConstraints);
+  }
+
+  // Inventory the owned graph's array-valued if-then-elses. Unlike section
+  // 4.1's elimination, these stay as terms: the checker reasons about
+  // them directly with rules T-down/T-up, which fire on whichever
+  // branch sigma selects. That costs one Boolean literal per
+  // if-then-else instead of two array equalities, two witness indices
+  // and four virtual reads -- and, because exactly one branch is live
+  // per candidate, it leaves no unconstrained proxy for the solver to
+  // guess and the checker to refute.
+  //
+  // The condition is reified as a Boolean symbol here. The checker must
+  // branch on the value the bit-blasted circuit took; re-deriving it
+  // from the counterexample is the failure class that let a scalar name
+  // disagree with its term, and here it would make the wrong branch
+  // live and certify a model that does not satisfy the if-then-else
+  // axiom. The same symbol is what a lemma premise names.
+  std::vector<ASTNode> iteNodes;
+  for (std::set<ASTNode>::const_iterator it = arrays.begin();
+       it != arrays.end(); ++it)
+    if (it->GetKind() == ITE && isArrayType(*it))
+      iteNodes.push_back(*it);
+  std::sort(iteNodes.begin(), iteNodes.end(), nodeNumLess);
+
+  for (size_t i = 0; i < iteNodes.size(); i++)
+  {
+    const ASTNode& t = iteNodes[i];
+    ExtIteNode info;
+    info.ite = t;
+    info.condTerm = t[0];
+    info.condName = conditionName(t[0], extraConstraints);
+    info.thn = t[1];
+    info.els = t[2];
+    ownedItes[t] = info;
+    ownedIteParents[t[1]].push_back(t);
+    if (t[2] != t[1])
+      ownedIteParents[t[2]].push_back(t);
+  }
+  for (std::map<ASTNode, std::vector<ASTNode>>::iterator it =
+           ownedIteParents.begin();
+       it != ownedIteParents.end(); ++it)
+    std::sort(it->second.begin(), it->second.end(), nodeNumLess);
+
+  // Equality edges over canonical operands + witness obligations.
+  for (size_t i = 0; i < activeRecordIds.size(); i++)
+  {
+    const Record& r = records[activeRecordIds[i]];
+    ExtEqEdge e;
+    e.record = r.id;
+    e.left = r.canonicalLeft;
+    e.right = r.canonicalRight;
+    e.proxy = r.proxy;
+    eqEdges.push_back(e);
+
+    ExtWitness w;
+    w.record = r.id;
+    w.proxy = r.proxy;
+    w.index = r.lambda;
+    w.leftValue = r.nameL;
+    w.rightValue = r.nameR;
+    witnessObls.push_back(w);
+  }
+
+  // adjacency, sorted by (record, other endpoint) per source
+  {
+    std::map<ASTNode, std::vector<std::pair<std::pair<size_t, uint64_t>,
+                                            size_t>>> adj;
+    for (size_t i = 0; i < eqEdges.size(); i++)
+    {
+      const ExtEqEdge& e = eqEdges[i];
+      adj[e.left].push_back(std::make_pair(
+          std::make_pair(e.record, e.right.GetNodeNum()), i));
+      if (!(e.left == e.right))
+        adj[e.right].push_back(std::make_pair(
+            std::make_pair(e.record, e.left.GetNodeNum()), i));
+    }
+    for (std::map<ASTNode,
+                  std::vector<std::pair<std::pair<size_t, uint64_t>,
+                                        size_t>>>::iterator it = adj.begin();
+         it != adj.end(); ++it)
+    {
+      std::sort(it->second.begin(), it->second.end());
+      std::vector<size_t>& out = eqAdjacency[it->first];
+      for (size_t i = 0; i < it->second.size(); i++)
+        out.push_back(it->second[i].second);
+    }
+  }
+
+  const ASTNode prepared =
+      extraConstraints.empty()
+          ? root
+          : bm->defaultNodeFactory->CreateNode(AND, root, extraConstraints);
+
+  // This is the last word-level root before the array transform.  Inventory
+  // that exact DAG, including the naming equations just added above.  Graph
+  // discovery alone is not a sufficient hand-off invariant: a later
+  // transformer shortcut could otherwise omit a checker-owned read while
+  // leaving all of its array nodes present.
+  ASTNodeSet finalDag;
+  collectDag(prepared, finalDag);
+  for (ASTNodeSet::const_iterator it = finalDag.begin(); it != finalDag.end();
+       ++it)
+  {
+    if (it->GetKind() == ARRAY_EQ)
+      FatalError("array-equality: an opaque equality reached the final "
+                 "prepared root",
+                 *it);
+    if (it->GetKind() != READ)
+      continue;
+    if (ownedArrays.find((*it)[0]) == ownedArrays.end())
+      FatalError("array-equality: a read in the final prepared root is "
+                 "outside the complete owned array graph",
+                 *it);
+    preparedReads.insert(*it);
+  }
+
+  preparedTransformRoot = prepared;
+  arrayGraphIsFrozen = true;
+  return prepared;
+}
+
+void ExtensionalityContext::beginReadTransform(const ASTNode& root)
+{
+  if (!arrayGraphIsFrozen || preparedTransformRoot.IsNull())
+    FatalError("array-equality: read transformation began before final "
+               "preparation");
+  if (readTransformInProgress || readTransformComplete)
+    FatalError("array-equality: the prepared read inventory was transformed "
+               "twice");
+  if (root != preparedTransformRoot)
+    FatalError("array-equality: the array transformer did not receive the "
+               "exact final prepared root",
+               root);
+  readTransformInProgress = true;
+}
+
+void ExtensionalityContext::noteAbstractedRead(
+    const ASTNode& originalRead, const ASTNode& transformedIndex,
+    const ASTNode& valueSymbol)
+{
+  if (!readTransformInProgress)
+    FatalError("array-equality: a read abstraction was reported outside the "
+               "prepared transform");
+  if (originalRead.GetKind() != READ ||
+      preparedReads.find(originalRead) == preparedReads.end())
+    FatalError("array-equality: the transformer abstracted a read absent "
+               "from the final prepared root",
+               originalRead);
+  if (!ownsArray(originalRead[0]))
+    FatalError("array-equality: the transformer abstracted a read outside "
+               "the complete owned array graph",
+               originalRead);
+  if (transformedIndex.GetValueWidth() != originalRead[1].GetValueWidth() ||
+      valueSymbol.GetValueWidth() != originalRead.GetValueWidth())
+    FatalError("array-equality: a read abstraction has incompatible scalar "
+               "widths",
+               originalRead);
+
+  ReadBinding binding;
+  binding.array = originalRead[0];
+  binding.index = transformedIndex;
+  binding.symbol = valueSymbol;
+  const std::map<ASTNode, ReadBinding>::const_iterator old =
+      transformedReads.find(originalRead);
+  if (old != transformedReads.end())
+  {
+    if (old->second.array != binding.array ||
+        old->second.index != binding.index ||
+        old->second.symbol != binding.symbol)
+      FatalError("array-equality: one prepared read acquired two different "
+                 "transformer bindings",
+                 originalRead);
+    return;
+  }
+  transformedReads[originalRead] = binding;
+}
+
+void ExtensionalityContext::noteEliminatedReadSubtree(
+    const ASTNode& deadTerm)
+{
+  if (!readTransformInProgress)
+    FatalError("array-equality: a dead read subtree was reported outside the "
+               "prepared transform");
+  ASTNodeSet deadDag;
+  collectDag(deadTerm, deadDag);
+  for (ASTNodeSet::const_iterator it = deadDag.begin(); it != deadDag.end();
+       ++it)
+  {
+    if (it->GetKind() != READ)
+      continue;
+    if (preparedReads.find(*it) == preparedReads.end())
+      FatalError("array-equality: constant term-ITE elimination reported a "
+                 "read absent from the final prepared root",
+                 *it);
+    eliminatedReads.insert(*it);
+  }
+}
+
+void ExtensionalityContext::finishReadTransform()
+{
+  if (!readTransformInProgress)
+    FatalError("array-equality: the prepared read transform was not in "
+               "progress");
+  for (std::set<ASTNode>::const_iterator it = preparedReads.begin();
+       it != preparedReads.end(); ++it)
+    if (transformedReads.find(*it) == transformedReads.end() &&
+        eliminatedReads.find(*it) == eliminatedReads.end())
+      FatalError("array-equality: a read in the final prepared root was "
+                 "neither abstracted nor eliminated by constant term-ITE "
+                 "selection",
+                 *it);
+  readTransformInProgress = false;
+  readTransformComplete = true;
+}
+
+// After the main ArrayTransformer pass: the complete read inventory
+// (ordinary reads plus witness reads) now carries its abstraction and index
+// symbols; bind everything into the immutable checker graph.
+void ExtensionalityContext::bindAfterTransform(ArrayTransformer* at)
+{
+  if (!arrayGraphIsFrozen)
+    FatalError("array-equality: binding began before the complete array "
+               "graph was frozen");
+  if (graphBound)
+    FatalError("array-equality: the complete array graph was bound twice");
+  if (!readTransformComplete || readTransformInProgress)
+    FatalError("array-equality: binding began before the exact prepared read "
+               "inventory was accounted for");
+
+  graph = ExtGraph();
+
+  std::set<ReadBinding> reportedBindings;
+  for (std::map<ASTNode, ReadBinding>::const_iterator it =
+           transformedReads.begin();
+       it != transformedReads.end(); ++it)
+    reportedBindings.insert(it->second);
+
+  std::set<ReadBinding> tableBindings;
+
+  // reads, deterministically ordered by (array, index) node numbers
+  struct ReadRow
+  {
+    ASTNode array;
+    ASTNode index;
+    ASTNode symbol;
+    ASTNode indexSymbol;
+    bool operator<(const ReadRow& o) const
+    {
+      if (array.GetNodeNum() != o.array.GetNodeNum())
+        return array.GetNodeNum() < o.array.GetNodeNum();
+      return index.GetNodeNum() < o.index.GetNodeNum();
+    }
+  };
+  std::vector<ReadRow> reads;
+  // The transformer must have put every read into the complete graph.
+  // There is deliberately no complementary host-refinement partition:
+  // sharing scalar indexes across such a partition was the source of
+  // candidates that neither subsystem could prove or refute.
+  for (ArrayTransformer::ArrType::const_iterator it =
+           at->arrayToIndexToRead.begin();
+       it != at->arrayToIndexToRead.end(); ++it)
+  {
+    if (!ownsArray(it->first))
+      FatalError("array-equality: the transformer registered a read outside "
+                 "the complete owned array graph",
+                 it->first);
+    for (std::map<ASTNode, ArrayTransformer::ArrayRead>::const_iterator it2 =
+             it->second.begin();
+         it2 != it->second.end(); ++it2)
+    {
+      ReadRow row;
+      row.array = it->first;
+      row.index = it2->first;
+      row.symbol = it2->second.symbol;
+      row.indexSymbol = it2->second.index_symbol;
+      reads.push_back(row);
+
+      ReadBinding binding;
+      binding.array = row.array;
+      binding.index = row.index;
+      binding.symbol = row.symbol;
+      tableBindings.insert(binding);
+    }
+  }
+  if (reportedBindings != tableBindings)
+    FatalError("array-equality: the transformer's read table does not exactly "
+               "match the bindings reported for the final prepared root");
+  std::sort(reads.begin(), reads.end());
+
+  for (size_t i = 0; i < reads.size(); i++)
+  {
+    const ReadRow& row = reads[i];
+    ExtAccess a;
+    a.id = graph.accesses.size();
+    a.isWrite = false;
+    a.site = row.array;
+    a.indexTerm = row.index;
+    NodeFactory* hf = bm->hashingNodeFactory;
+    a.valueTerm = hf->CreateTerm(READ, row.array.GetValueWidth(), row.array,
+                                 row.index);
+    a.indexName = row.indexSymbol.IsNull() ? row.index : row.indexSymbol;
+    a.valueName = row.symbol;
+    if (!(a.indexName.GetKind() == SYMBOL || a.indexName.isConstant()))
+      FatalError("array-equality: an owned read index has no "
+                 "bit-blasted scalar name to encode lemmas over",
+                 row.index);
+    // An owned read's semantics live entirely in refinement lemmas, so
+    // its abstraction variable and index may legally never reach the
+    // bit-blasted formula (the read's only occurrence can sit inside
+    // another abstracted term); the translator allocates fresh SAT
+    // variables for whichever of these it never saw.
+    lemmaOnlySymbols.insert(a.valueName);
+    if (a.indexName.GetKind() == SYMBOL)
+      lemmaOnlySymbols.insert(a.indexName);
+    graph.accesses.push_back(a);
+  }
+
+  // writes, deterministically ordered by node number
+  std::vector<ASTNode> writeNodes;
+  for (std::map<ASTNode, ExtWriteNode>::const_iterator it = ownedWrites.begin();
+       it != ownedWrites.end(); ++it)
+    writeNodes.push_back(it->first);
+  std::sort(writeNodes.begin(), writeNodes.end(), nodeNumLess);
+  for (size_t i = 0; i < writeNodes.size(); i++)
+  {
+    const ExtWriteNode& info = ownedWrites[writeNodes[i]];
+    ExtAccess a;
+    a.id = graph.accesses.size();
+    a.isWrite = true;
+    a.site = info.write;
+    a.indexTerm = info.indexTerm;
+    a.valueTerm = info.write[2];
+    a.indexName = info.indexName;
+    std::map<ASTNode, ASTNode>::const_iterator nit =
+        scalarNames.find(info.write[2]);
+    a.valueName = info.write[2].isConstant()
+                      ? info.write[2]
+                      : (nit != scalarNames.end() ? nit->second : ASTNode());
+    if (a.valueName.IsNull())
+      FatalError("array-equality: an owned write value has no "
+                 "bit-blasted scalar name to encode lemmas over",
+                 info.write);
+    graph.accesses.push_back(a);
+  }
+
+  // The property that lets namesAgreeWithCandidate skip the witness
+  // names: every witness read reached the inventory. It holds by
+  // construction -- the anchor is protected from substitution, and
+  // locateCanonicalOperands fails loudly if one is lost, so the read is
+  // in the transformed formula; the transformer registers it; and the
+  // operand it reads is in the owned graph, so bindAfterTransform harvests
+  // it.
+  // Defend it at runtime so release builds cannot silently certify an
+  // incomplete graph.
+  for (size_t i = 0; i < activeRecordIds.size(); i++)
+  {
+    const Record& r = records[activeRecordIds[i]];
+    bool haveL = false, haveR = false;
+    for (size_t z = 0; z < graph.accesses.size(); z++)
+    {
+      const ExtAccess& acc = graph.accesses[z];
+      if (acc.isWrite || !(acc.indexTerm == r.lambda))
+        continue;
+      haveL = haveL || acc.site == r.canonicalLeft;
+      haveR = haveR || acc.site == r.canonicalRight;
+    }
+    if (!haveL || !haveR)
+      FatalError("array-equality: a witness read is absent from the complete "
+                 "owned access graph",
+                 r.proxy);
+  }
+
+  graph.writes = ownedWrites;
+  graph.writeParents = ownedWriteParents;
+  graph.ites = ownedItes;
+  graph.iteParents = ownedIteParents;
+  graph.eqEdges = eqEdges;
+  graph.eqAdjacency = eqAdjacency;
+  graph.witnesses = witnessObls;
+  graphBound = true;
+}
+
+namespace
+{
+// The candidate assignment sigma, read out of STP's materialized
+// counterexample.
+class CEModelView : public ExtModelView
+{
+  AbsRefine_CounterExample* ce;
+  STPMgr* bm;
+
+public:
+  CEModelView(AbsRefine_CounterExample* ce_, STPMgr* bm_)
+      : ce(ce_), bm(bm_)
+  {
+  }
+
+  virtual ASTNode bvValue(const ASTNode& term)
+  {
+    if (term.GetKind() == BVCONST)
+      return plainBitVectorConstant(bm, term);
+    if (term.GetKind() != SYMBOL)
+      FatalError("array-equality: the checker requested a bit-vector term "
+                 "instead of its scalar SAT name",
+                 term);
+    ASTNode v = ce->LookupAssignedValue(term);
+    if (v.IsNull() || v.GetKind() != BVCONST ||
+        v.GetValueWidth() != term.GetValueWidth())
+      FatalError("array-equality: the materialized SAT assignment has no "
+                 "concrete value for a scalar name the consistency checker "
+                 "depends on",
+                 term);
+    // Substitution entries can hand a float-element symbol back as a
+    // float constant; the checker compares constants by node identity,
+    // so give it the plain twin.
+    return plainBitVectorConstant(bm, v);
+  }
+
+  virtual bool boolValue(const ASTNode& term)
+  {
+    if (term.GetKind() == TRUE || term.GetKind() == FALSE)
+      return term.GetKind() == TRUE;
+    if (term.GetKind() != SYMBOL)
+      FatalError("array-equality: the checker requested a Boolean term "
+                 "instead of its scalar SAT name",
+                 term);
+    ASTNode v = ce->LookupAssignedValue(term);
+    if (v.IsNull() || !(v.GetKind() == TRUE || v.GetKind() == FALSE))
+      FatalError("array-equality: the materialized SAT assignment has no "
+                 "Boolean value for a scalar name the consistency checker "
+                 "depends on",
+                 term);
+    return v.GetKind() == TRUE;
+  }
+};
+} // namespace
+
+ExtensionalityContext::CertificationAction
+ExtensionalityContext::decideCertification(bool ordinaryResult,
+                                           bool checkerActive,
+                                           CandidateOutcome ext)
+{
+  if (!checkerActive)
+  {
+    if (!(ext == EXT_SKIPPED || ext == EXT_CONSISTENT))
+      return INTERNAL_ERROR;
+    return ordinaryResult ? RETURN_SAT : RUN_HOST_REFINEMENT;
+  }
+  if (ext == EXT_CONFLICT)
+    return ADD_EXT_LEMMA;
+  if (ext == EXT_WITNESS_ERROR)
+    return INTERNAL_ERROR;
+  if (ext != EXT_CONSISTENT)
+    return INTERNAL_ERROR;
+  // With the complete array graph owned here, a conflict-free fixed
+  // point must make the semantic input true on the same scalar
+  // assignment. There is no second array-refinement subsystem to hand
+  // a disagreement to.
+  return ordinaryResult ? RETURN_SAT : INTERNAL_ERROR;
+}
+
+ExtensionalityContext::CandidateOutcome
+ExtensionalityContext::checkCandidate(AbsRefine_CounterExample* ce)
+{
+  if (!graphBound)
+    FatalError("array-equality: candidate checking began before the complete "
+               "array graph was bound");
+  if (pendingLemmaValid || !pendingLemmas.empty())
+    FatalError("array-equality: a new candidate was checked before the prior "
+               "conflict certificates were encoded");
+  lastObserved.clear();
+  CEModelView view(ce, bm);
+  ExtCheckResult res = ExtChecker::check(graph, view, false);
+  switch (res.status)
+  {
+    case ExtCheckResult::CONSISTENT:
+      lastObserved = res.observed;
+      // Publishing first makes the certified array contents visible
+      // to term evaluation; only then can an owned read's term be
+      // compared against its name.
+      publishObservations(ce);
+      if (!namesAgreeWithCandidate(view, ce))
+        FatalError("array-equality: a scalar name disagrees with its term "
+                   "after the complete array graph reached a conflict-free "
+                   "fixed point");
+      return EXT_CONSISTENT;
+    case ExtCheckResult::CONFLICT:
+      if (res.conflicts.empty())
+        FatalError("array-equality: the checker reported a conflict without "
+                   "a refinement certificate");
+      pendingLemmas.swap(res.conflicts);
+      pendingLemmaValid = true;
+      return EXT_CONFLICT;
+    case ExtCheckResult::WITNESS_VIOLATION:
+    default:
+      return EXT_WITNESS_ERROR;
+  }
+}
+
+// The checker reads the candidate through scalar names whose defining
+// equations were part of the initial bit-blast. Verify, with certified
+// observations published, that every name still evaluates exactly like
+// its term. Since every read abstraction is in this graph, a mismatch
+// is an ownership/encoding invariant violation rather than a third
+// refinement outcome; equal concrete indexes with different values
+// must already have produced a rule-C conflict.
+bool ExtensionalityContext::namesAgreeWithCandidate(
+    ExtModelView& view, AbsRefine_CounterExample* ce) const
+{
+  for (size_t i = 0; i < graph.accesses.size(); i++)
+  {
+    const ExtAccess& a = graph.accesses[i];
+    if (!(a.indexName == a.indexTerm))
+    {
+      const ASTNode termValue = ce->ModelValueOfTerm(a.indexTerm);
+      if (termValue.IsNull() || termValue.GetKind() != BVCONST ||
+          termValue.GetValueWidth() != a.indexTerm.GetValueWidth())
+        FatalError("array-equality: an access index has no concrete value in "
+                   "the certified model",
+                   a.indexTerm);
+      if (view.bvValue(a.indexName) != termValue)
+        return false;
+    }
+    if (!(a.valueName == a.valueTerm))
+    {
+      const ASTNode termValue = ce->ModelValueOfTerm(a.valueTerm);
+      if (termValue.IsNull() || termValue.GetKind() != BVCONST ||
+          termValue.GetValueWidth() != a.valueTerm.GetValueWidth())
+        FatalError("array-equality: an access value has no concrete value in "
+                   "the certified model",
+                   a.valueTerm);
+      if (view.bvValue(a.valueName) != termValue)
+        return false;
+    }
+  }
+
+  // Each reified if-then-else condition against the condition it names.
+  // The checker branches on these to decide which branch is live, so a
+  // name that disagrees with its term selects the wrong one and can
+  // certify a model that does not satisfy the if-then-else axiom. This
+  // is the same guard the access names get, for the same reason, and it
+  // is the failure class the direct integration reopened.
+  for (std::map<ASTNode, ExtIteNode>::const_iterator it = ownedItes.begin();
+       it != ownedItes.end(); ++it)
+  {
+    const ASTNode termValue = ce->ModelValueOfFormula(it->second.condTerm);
+    if (termValue.IsNull() ||
+        !(termValue.GetKind() == TRUE || termValue.GetKind() == FALSE))
+      FatalError("array-equality: an array-if-then-else condition has no "
+                 "concrete value in the certified model",
+                 it->second.condTerm);
+    if (view.boolValue(it->second.condName) != (termValue.GetKind() == TRUE))
+      return false;
+  }
+
+  // The witness names -- the records' nameL and nameR, which the
+  // checker's witness loop reads directly -- need no comparison of
+  // their own. Each is anchored by nameL = read(left, lambda) in the
+  // bit-blasted formula, so the candidate gives it the value of that
+  // read's abstraction variable; that read is always in the inventory
+  // (bindAfterTransform asserts it), so the loop above has already
+  // checked its variable against its term. Transitivity does the rest.
+  return true;
+}
+
+// Encode the pending lemma into the persistent incremental SAT solver
+// as the clause
+//   NOT p1 OR ... OR NOT pk OR conclusion
+// over reified equality literals of already-encoded scalar symbols.
+// This is the abstraction alpha of the theory lemma (paper section 8);
+// adding it as clauses over the existing CNF is what makes each
+// refinement iteration incremental -- no new word-level formula is
+// ever handed back to the bit-blaster.
+// A lemma leaf is legal only as a constant or as a SYMBOL with a
+// stable, completely encoded SAT-variable vector. Anything else is an
+// internal error, never a reason to allocate fresh SAT variables in
+// the middle of refinement: a freshly invented variable would carry no
+// connection to the term the candidate assignment was checked against,
+// so the resulting clause could fail to rule the candidate out.
+const char*
+ExtensionalityContext::checkPreencodedBV(const ASTNode& n,
+                                         const ToSATBase::ASTNodeToSATVar& satVar)
+{
+  if (n.isConstant())
+    return NULL;
+  if (n.GetKind() != SYMBOL)
+    return "array-equality: lemma leaf is neither a constant nor a "
+           "variable";
+  ToSATBase::ASTNodeToSATVar::const_iterator it = satVar.find(n);
+  if (it == satVar.end())
+    return "array-equality: lemma leaf was never bit-blasted (it has no "
+           "SAT-variable vector)";
+  if (it->second.size() != n.GetValueWidth())
+    return "array-equality: lemma leaf's SAT-variable vector has the "
+           "wrong width";
+  for (size_t i = 0; i < it->second.size(); i++)
+    if (it->second[i] == ~((unsigned)0))
+      return "array-equality: lemma leaf has an unencoded SAT-variable "
+             "bit";
+  return NULL;
+}
+
+void ExtensionalityContext::encodePendingLemmas(SATSolver& solver,
+                                                ToSATBase* tosat)
+{
+  if (!pendingLemmaValid || pendingLemmas.empty())
+    FatalError("array-equality: lemma encoding began without a pending "
+               "certificate");
+  for (size_t i = 0; i < pendingLemmas.size(); i++)
+    encodeOneLemma(pendingLemmas[i], solver, tosat);
+  pendingLemmas.clear();
+  pendingLemmaValid = false;
+}
+
+// See the header. A premise is dropped when it is valid, the
+// conclusion when it is unsatisfiable; a lemma conclusion is always an
+// equality, so BV_NE there is not a position the encoder produces.
+ExtensionalityContext::FoldVerdict
+ExtensionalityContext::requiredFoldVerdict(ExtLemmaAtom::Op op,
+                                           LemmaPosition where)
+{
+  if (where == LEMMA_PREMISE)
+  {
+    if (op == ExtLemmaAtom::BV_EQ)
+      return FOLD_VALID;
+    if (op == ExtLemmaAtom::BV_NE)
+      return FOLD_UNSAT;
+    return FOLD_UNDECIDED;
+  }
+  return op == ExtLemmaAtom::BV_EQ ? FOLD_UNSAT : FOLD_UNDECIDED;
+}
+
+void ExtensionalityContext::encodeOneLemma(const ExtConflict& pendingLemma,
+                                           SATSolver& solver,
+                                           ToSATBase* tosat)
+{
+  ToSATBase::ASTNodeToSATVar& satVar = tosat->SATVar_to_SymbolIndexMap();
+
+  // Validate every bit-vector leaf of the lemma before any SAT
+  // mutation, so a violation is a localized internal error and
+  // getEquals below can never fall into its fresh-variable fallback.
+  {
+    std::vector<ASTNode> leaves;
+    for (size_t i = 0; i < pendingLemma.abstractPremise.size(); i++)
+    {
+      const ExtLemmaAtom& atom = pendingLemma.abstractPremise[i];
+      if (atom.op == ExtLemmaAtom::BV_EQ || atom.op == ExtLemmaAtom::BV_NE)
+      {
+        leaves.push_back(atom.a);
+        leaves.push_back(atom.b);
+      }
+    }
+    leaves.push_back(pendingLemma.abstractConclusionA);
+    leaves.push_back(pendingLemma.abstractConclusionB);
+    for (size_t i = 0; i < leaves.size(); i++)
+    {
+      const char* reason = checkPreencodedBV(leaves[i], satVar);
+      if (reason != NULL)
+        FatalError(reason, leaves[i]);
+    }
+  }
+
+  SATSolver::vec_literals clause;
+
+  // Returns the reified equality variable q with q <-> (a = b) -- full
+  // equivalence in both directions -- or, when the atom needs no circuit
+  // because it is structurally decided, one of the two sentinels below.
+  //
+  // Which sentinel it is matters. Dropping a literal from the clause is
+  // only equivalence-preserving on one side per position: a premise may
+  // be dropped when it is valid, the conclusion when it is
+  // unsatisfiable. Dropping on the other side yields a strictly
+  // stronger clause -- a silent wrong unsat. So the fold reports its
+  // direction and each consumer checks it against the position it is
+  // filling; a mismatch is an internal error, not something to encode.
+  struct EqLit
+  {
+    ExtensionalityContext* self;
+    SATSolver& solver;
+    ToSATBase::ASTNodeToSATVar& satVar;
+    EqLit(ExtensionalityContext* s, SATSolver& sol,
+          ToSATBase::ASTNodeToSATVar& sv)
+        : self(s), solver(sol), satVar(sv)
+    {
+    }
+    int operator()(const ASTNode& a, const ASTNode& b)
+    {
+      // Two constants: equal iff the same *bits*. That used to be the same
+      // question as being the same node, and is not any more -- a
+      // floating-point or rounding-mode constant carries its source sort as
+      // part of its identity, so it interns apart from the plain bit-vector
+      // constant holding its bits.
+      //
+      // The two sides here are names from accesses on arrays being equated,
+      // so their sorts agree and both constants are the same flavour; the
+      // pair that could differ cannot reach this. It is asked on bits
+      // anyway, because the answer feeds FOLD_UNSAT and so decides whether
+      // a conclusion is dropped, and getting that wrong is the
+      // strictly-stronger clause the comment above warns about -- too sharp
+      // an edge to leave resting on an invariant that holds for a reason
+      // outside this function.
+      if (a.isConstant() && b.isConstant())
+        return constantsSameBits(a, b) ? FOLD_VALID : FOLD_UNSAT;
+      const uint64_t na = a.GetNodeNum(), nb = b.GetNodeNum();
+      const std::pair<uint64_t, uint64_t> key(std::min(na, nb),
+                                              std::max(na, nb));
+      std::map<std::pair<uint64_t, uint64_t>, int>::const_iterator it =
+          self->eqLitCache.find(key);
+      if (it != self->eqLitCache.end())
+        return it->second;
+
+      // An atom the simplifier can decide from the defining terms needs
+      // no circuit: each name equals its term through the anchoring
+      // equations, so the factory's verdict on the terms is a verdict on
+      // the names. Write indices that are offsets from a shared pointer
+      // are the common win: the simplifying factory cancels the shared
+      // operand and decides the equality, sparing the SAT solver a
+      // 32-bit arithmetic case split per lemma.
+      //
+      // This transfers to the SAT abstraction only because the factory's
+      // EQ path treats every READ subterm as an opaque leaf --
+      // CreateSimpleEQ has no array rule and constructs no READ, so
+      // chaseRead cannot fire on it. The defining equations are
+      // conjoined before the array transform, so what SAT holds is
+      // "name = T(term)" with T abstracting reads into lazily
+      // axiomatized variables; a factory verdict that used an array
+      // axiom would not survive T. Anyone adding an array rule to the
+      // EQ dispatch has to revisit this.
+      {
+        const std::map<ASTNode, ASTNode>& n2t = self->nameToTermMap;
+        std::map<ASTNode, ASTNode>::const_iterator ta = n2t.find(a);
+        std::map<ASTNode, ASTNode>::const_iterator tb = n2t.find(b);
+        const ASTNode& termA = (ta == n2t.end()) ? a : ta->second;
+        const ASTNode& termB = (tb == n2t.end()) ? b : tb->second;
+        const ASTNode folded =
+            self->bm->defaultNodeFactory->CreateNode(EQ, termA, termB);
+        if (folded.GetKind() == TRUE || folded.GetKind() == FALSE)
+        {
+          const int verdict =
+              folded.GetKind() == TRUE ? FOLD_VALID : FOLD_UNSAT;
+          self->lemmaAtomsFolded++;
+          self->eqLitCache[key] = verdict;
+          return verdict;
+        }
+      }
+
+      const int q = getEquals(solver, a, b, satVar, Polarity::BOTH);
+      // Unlike the host's read axioms, which build their reified
+      // variables fresh for each clause, these are cached and reused by
+      // later refinement rounds -- with the solver's own simplification
+      // running in between. A backend that eliminates variables would
+      // be handed a dead one, so keep them.
+      solver.setFrozen(q);
+      self->eqLitCache[key] = q;
+      return q;
+    }
+  } eqLit(this, solver, satVar);
+
+  for (size_t i = 0; i < pendingLemma.abstractPremise.size(); i++)
+  {
+    const ExtLemmaAtom& atom = pendingLemma.abstractPremise[i];
+    if (atom.op == ExtLemmaAtom::BV_EQ || atom.op == ExtLemmaAtom::BV_NE)
+    {
+      const int q = eqLit(atom.a, atom.b);
+      if (q < 0)
+      {
+        // The premise is dropped only on the side that keeps the clause
+        // equivalent. The other direction makes the premise
+        // unsatisfiable, so the lemma is vacuous and the shortened
+        // clause asserts something the theory does not entail.
+        // validateAbstractLemma has already established that the atom
+        // holds in the candidate, so reaching here means the structural
+        // verdict disagrees with the candidate.
+        if (q != requiredFoldVerdict(atom.op, LEMMA_PREMISE))
+          FatalError("array-equality: a lemma premise was structurally "
+                     "decided against the polarity the conflict needs, so "
+                     "dropping its literal would strengthen the clause",
+                     atom.a);
+        continue;
+      }
+      // premise literal appears negated in the final clause
+      clause.push(SATSolver::mkLit(q, atom.op == ExtLemmaAtom::BV_EQ));
+    }
+    else
+    {
+      assert(atom.op == ExtLemmaAtom::BOOL_LIT ||
+             atom.op == ExtLemmaAtom::BOOL_LIT_NEG);
+      ToSATBase::ASTNodeToSATVar::const_iterator vit =
+          satVar.find(atom.boolTerm);
+      if (vit == satVar.end() || vit->second.size() != 1 ||
+          vit->second[0] == ~((unsigned)0))
+        FatalError("array-equality: an equality abstraction variable "
+                   "was never bit-blasted, so the lemma cannot be "
+                   "encoded",
+                   atom.boolTerm);
+      // A premise literal appears negated in the clause, so a
+      // negatively-taken condition appears positively.
+      clause.push(SATSolver::mkLit(vit->second[0],
+                                   atom.op == ExtLemmaAtom::BOOL_LIT));
+    }
+  }
+
+  {
+    const int q =
+        eqLit(pendingLemma.abstractConclusionA, pendingLemma.abstractConclusionB);
+    if (q >= 0)
+      clause.push(SATSolver::mkLit(q, false));
+    else if (q != requiredFoldVerdict(ExtLemmaAtom::BV_EQ, LEMMA_CONCLUSION))
+      // The conclusion may be dropped only when it is unsatisfiable:
+      // the premises then cannot all hold, and the negated premises
+      // alone are the theory-valid clause. A structurally valid
+      // conclusion makes the whole lemma a tautology, and dropping its
+      // literal would leave a clause forbidding the premises for no
+      // reason.
+      FatalError("array-equality: a lemma conclusion was structurally "
+                 "decided true, so dropping its literal would leave an "
+                 "unsound clause",
+                 pendingLemma.abstractConclusionA);
+  }
+
+  if (clause.size() == 0)
+    FatalError("array-equality: refinement produced an empty clause "
+               "(the candidate should have been unsatisfiable already)");
+
+  solver.addClause(clause);
+  lemmasEmitted++;
+}
+
+// Publish the conflict-free observed values of every owned array
+// (symbols, writes, and array-if-then-else terms alike) into the
+// counterexample map, so model evaluation, the model
+// APIs, and the printers see the array contents certified by the
+// consistency check. Indices with no observation default to zero at
+// lookup/print time.
+void ExtensionalityContext::publishObservations(AbsRefine_CounterExample* ce)
+{
+  ASTNodeMap batch;
+  for (std::map<ASTNode,
+                std::vector<std::pair<ASTNode, ASTNode>>>::const_iterator it =
+           lastObserved.begin();
+       it != lastObserved.end(); ++it)
+  {
+    const ASTNode& array = it->first;
+    NodeFactory* hf = bm->hashingNodeFactory;
+    for (size_t i = 0; i < it->second.size(); i++)
+    {
+      const ASTNode key = hf->CreateTerm(READ, array.GetValueWidth(), array,
+                                         it->second[i].first);
+      ASTNodeMap::const_iterator prior = batch.find(key);
+      if (prior != batch.end() && !(prior->second == it->second[i].second))
+        FatalError("array-equality: a conflict-free checker result assigns "
+                   "two values to one concrete array cell",
+                   key);
+      batch[key] = it->second[i].second;
+    }
+  }
+
+  // Validate the entire batch before mutating the public model. Active
+  // candidates normally have no READ entries yet; this check also makes
+  // that ownership boundary fail closed if a future preprocessing path
+  // introduces one.
+  for (ASTNodeMap::const_iterator it = batch.begin(); it != batch.end(); ++it)
+  {
+    const ASTNode prior = ce->LookupAssignedValue(it->first);
+    if (!prior.IsNull() && !(prior == it->second))
+      FatalError("array-equality: certified array observation conflicts with "
+                 "an existing counterexample entry",
+                 it->first);
+  }
+  for (ASTNodeMap::const_iterator it = batch.begin(); it != batch.end(); ++it)
+    ce->InsertIntoCounterExampleMap(it->first, it->second);
+
+  // No model evaluation should precede certification, but clearing the
+  // cache here makes publication an explicit phase boundary.
+  ce->ClearComputeFormulaMap();
+}
+
+// See the header. Unobserved cells hold `absent` on both sides, so two
+// arrays agree everywhere exactly when they agree at every index either
+// one observes.
+bool ExtensionalityContext::contentsAgree(
+    const std::vector<std::pair<ASTNode, ASTNode>>& left,
+    const std::vector<std::pair<ASTNode, ASTNode>>& right,
+    const ASTNode& absent, const SourceSort& elementSort)
+{
+  std::map<ASTNode, ASTNode> leftCells, rightCells;
+  for (size_t i = 0; i < left.size(); i++)
+    leftCells[left[i].first] = left[i].second;
+  for (size_t i = 0; i < right.size(); i++)
+    rightCells[right[i].first] = right[i].second;
+
+  // Cells are compared by value at the element's sort, never by node
+  // identity. A float-element cell holds a floating-point constant,
+  // which interns apart from the plain bit-vector constant with the same
+  // bits -- and one side of most of these comparisons is exactly such a
+  // plain constant, the zero an unobserved cell completes to. Node
+  // identity would report two identical arrays as differing; equal bits
+  // would do the same to two NaN payloads, which are one value.
+  for (std::map<ASTNode, ASTNode>::const_iterator it = leftCells.begin();
+       it != leftCells.end(); ++it)
+  {
+    const std::map<ASTNode, ASTNode>::const_iterator other =
+        rightCells.find(it->first);
+    if (constantsDenoteDifferentSourceValues(
+            it->second, other == rightCells.end() ? absent : other->second,
+            elementSort))
+      return false;
+  }
+  // Only the indexes the first array does not observe are left to check;
+  // there it holds `absent`.
+  for (std::map<ASTNode, ASTNode>::const_iterator it = rightCells.begin();
+       it != rightCells.end(); ++it)
+    if (leftCells.find(it->first) == leftCells.end() &&
+        constantsDenoteDifferentSourceValues(it->second, absent, elementSort))
+      return false;
+  return true;
+}
+
+// See the header. Runs against the published model, so it must come
+// after publishObservations -- the contents it compares are the ones
+// the model APIs and the printers will hand back.
+const char* ExtensionalityContext::recheckCertifiedEqualities(
+    AbsRefine_CounterExample* ce) const
+{
+  if (!activeRecordIds.empty() && !graphBound)
+    return "array-equality: the counterexample check ran before the "
+           "complete array graph was bound";
+
+  static const std::vector<std::pair<ASTNode, ASTNode>> unobserved;
+  typedef std::map<ASTNode, std::vector<std::pair<ASTNode, ASTNode>>> ObsMap;
+
+  // The certified cells of every active record's canonical operands
+  // against its abstraction variable. Empty when the only equalities in
+  // the query were ones lowering solved outright, which is why the
+  // second loop below is not conditioned on this one having run.
+  for (size_t i = 0; i < activeRecordIds.size(); i++)
+  {
+    const Record& r = records[activeRecordIds[i]];
+    // Both loops decide an equality by comparing the cells the model
+    // published. Whether that is answerable at all is one question,
+    // asked in one place.
+    if (!ce->arrayEqualityIsModelDecidable(r.constructionLeft) ||
+        !ce->arrayEqualityIsModelDecidable(r.constructionRight))
+      continue;
+    const ASTNode assigned = ce->LookupAssignedValue(r.proxy);
+    if (assigned.IsNull() ||
+        !(assigned.GetKind() == TRUE || assigned.GetKind() == FALSE))
+      return "array-equality: an equality abstraction variable has no "
+             "Boolean value in the model it was certified against";
+
+    // An array the fixed point never reached observes nothing, so it is
+    // the constant array the printer would emit for it. Taking the cell
+    // value from the model surface rather than spelling it out here is
+    // what keeps this comparison asking about the model that gets
+    // published.
+    // Observations are keyed on the canonical operands, but the
+    // completion is asked of the constructed one: it follows the
+    // element sort, and the canonical form is what the solve rewrote
+    // its way to, which need not still carry the sort the user wrote.
+    const ObsMap::const_iterator obsL = lastObserved.find(r.canonicalLeft);
+    const ObsMap::const_iterator obsR = lastObserved.find(r.canonicalRight);
+    const ASTNode absent = ce->defaultCellValue(r.constructionLeft);
+    // The element sort comes from the operands the user wrote: the
+    // canonical forms are post-lowering carriers, and what a cell means
+    // is a property of the source sort, not of its carrier. That is
+    // also why the default above is asked of the construction operand.
+    const SourceSort constructionSort = r.constructionLeft.GetSourceSort();
+    const SourceSort elementSort =
+        constructionSort.kind() == SourceSort::Kind::Array
+            ? constructionSort.element()
+            : SourceSort::unknown();
+    const bool agree =
+        contentsAgree(obsL == lastObserved.end() ? unobserved : obsL->second,
+                      obsR == lastObserved.end() ? unobserved : obsR->second,
+                      absent, elementSort);
+
+    if (agree != (assigned.GetKind() == TRUE))
+      return agree ? "array-equality: the model makes an array equality's "
+                     "operands identical at every certified cell, but its "
+                     "abstraction variable was assigned false -- the "
+                     "witness of preprocessing step 1 did not hold"
+                   : "array-equality: an array equality's abstraction "
+                     "variable was assigned true, but the model gives its "
+                     "operands different contents -- read propagation "
+                     "across the equality was incomplete";
+  }
+
+  // The same question asked of every equality this solve lowered, and
+  // asked about the operands the user wrote rather than the canonical
+  // forms the checker reasoned over.
+  //
+  // This is the part re-evaluating the query cannot reach. That walk
+  // resolves an opaque equality through exactly this map, so it agrees
+  // with the lowering by construction and a lowering that says
+  // something other than what its operands do in the finished model is
+  // invisible to it. Two lowerings mint no record at all and so are
+  // covered by nothing else: the reflexive fold, and the rewritten form
+  // of a write chain equated with its own base -- the one place the
+  // decision procedure is bypassed entirely, where a wrong rewrite is a
+  // wrong answer with no checker behind it.
+  for (ASTNodeMap::const_iterator it = currentLowerings.begin();
+       it != currentLowerings.end(); ++it)
+  {
+    // Same restriction, same reason; see the loop above.
+    if (!ce->arrayEqualityIsModelDecidable(it->first[0]) ||
+        !ce->arrayEqualityIsModelDecidable(it->first[1]))
+      continue;
+    const ASTNode verdict = ce->QueryFormulaAgainstModel(it->second);
+    if (!(verdict.GetKind() == TRUE || verdict.GetKind() == FALSE))
+      return "array-equality: an array equality's lowering has no truth "
+             "value in the model that answered the query";
+    if (ce->ArraysEqualUsingModel(it->first[0], it->first[1]) !=
+        (verdict.GetKind() == TRUE))
+      return verdict.GetKind() == TRUE
+                 ? "array-equality: an array equality's lowering is true in "
+                   "the model, but the model gives the two operands the "
+                   "user equated different contents"
+                 : "array-equality: an array equality's lowering is false in "
+                   "the model, but the model gives the two operands the "
+                   "user equated identical contents";
+  }
+  return NULL;
+}
+
+} // namespace stp

--- a/lib/STPManager/STP.cpp
+++ b/lib/STPManager/STP.cpp
@@ -778,8 +778,11 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input)
     bm->print_stats();
 
   // If it doesn't contain array operations, use ABC's CNF generation.
+  // The submitted and original forms coincide until the array-equality
+  // pass introduces a lowered form of its own; see the next commit.
   res = Ctr_Example->CallSAT_ResultCheck(NewSolver, inputToSat, original_input,
-                                         satBase, maybeRefinement);
+                                         original_input, satBase,
+                                         maybeRefinement);
 
   if (bm->soft_timeout_expired)
   {

--- a/lib/STPManager/STPManager.cpp
+++ b/lib/STPManager/STPManager.cpp
@@ -24,6 +24,7 @@ THE SOFTWARE.
 
 // to get the PRIu64 macro from inttypes, this needs to be defined.
 #include "stp/STPManager/STPManager.h"
+#include "stp/Extensionality/ExtensionalityContext.h"
 #include "stp/FloatBlaster/rounding_modes.h"
 #include "stp/Printer/SMTLIBPrinter.h"
 #include "stp/Util/CBVOps.h"
@@ -983,9 +984,19 @@ ASTNode STPMgr::NewParameterized_BooleanVar(const ASTNode& var,
 }
 
 // If ASTNode remain with references (somewhere), this will segfault.
+ExtensionalityContext* STPMgr::getExtensionality()
+{
+  if (extensionality == NULL)
+    extensionality = new ExtensionalityContext(this);
+  return extensionality;
+}
+
 STPMgr::~STPMgr()
 {
   ClearAllTables();
+
+  delete extensionality;
+  extensionality = NULL;
 
   printer::NodeLetVarMap.clear();
   printer::NodeLetVarVec.clear();

--- a/lib/Simplifier/constantBitP/ConstantBitP_MaxPrecision.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_MaxPrecision.cpp
@@ -302,7 +302,8 @@ bool maxBoundsPrecision(vector<FixedBits*> children, FixedBits& output,
 
     toSolve = at.TransformFormula_TopLevel(toSolve);
     total = beev->CreateNode(AND, total, toSolve);
-    int result = ce.CallSAT_ResultCheck(newS, total, total, &tosat, true);
+    int result =
+        ce.CallSAT_ResultCheck(newS, total, total, total, &tosat, true);
 
     if (2 == result)
       FatalError("error from solver");
@@ -486,7 +487,7 @@ bool maxPrecision(vector<FixedBits*> children, FixedBits& output, Kind kind,
     if (first)
     {
       beev->SetQuery(beev->ASTUndefined);
-      result = ce.CallSAT_ResultCheck(newS, expr, expr, &tosat, true);
+      result = ce.CallSAT_ResultCheck(newS, expr, expr, expr, &tosat, true);
     }
     else
     {
@@ -496,7 +497,7 @@ bool maxPrecision(vector<FixedBits*> children, FixedBits& output, Kind kind,
 
       beev->SetQuery(beev->ASTUndefined);
       result = ce.CallSAT_ResultCheck(newS, beev->ASTTrue, beev->ASTTrue,
-                                      &tosat, true);
+                                      beev->ASTTrue, &tosat, true);
     }
 
     if (2 == result)

--- a/tools/rewrite_rule_gen/rewrite_rule_gen.cpp
+++ b/tools/rewrite_rule_gen/rewrite_rule_gen.cpp
@@ -837,7 +837,7 @@ bool isConstantToSat(const ASTNode& query, int64_t timeout_max_confl)
     ss->setMaxConflicts(timeout_max_confl);
 
   SOLVER_RETURN_TYPE r = GlobalSTP->Ctr_Example->CallSAT_ResultCheck(
-      *ss, query2, query2, GlobalSTP->tosat, false);
+      *ss, query2, query2, query2, GlobalSTP->tosat, false);
 
   return (r == SOLVER_VALID); // unsat, always true
 }


### PR DESCRIPTION
# Array extensionality (3/6): the registry, and what a model has to answer

**This PR builds on top of #746** (2/6 — the consistency checker). Please review and merge it first; this branch contains its commits.

The state behind the checker.

## The registry

`ExtensionalityContext` owns the array equalities a query names: which array terms they relate, the proxy each is represented by while the bit-vector solver runs, the witness index that refutes one, and the scope each belongs to, so a pushed equality retires with its frame.

Two array terms that denote the same array must be **one** entry, so the registry canonicalises what it is given — through if-then-else, through store chains, and modulo NaN payloads for float elements, which are one value in SMT-LIB however many bit patterns spell them.

## What a model has to answer

The counterexample layer gains the questions the registry asks of a candidate model: what a term evaluates to, whether a formula holds, whether two arrays agree on the cells the model actually observed, and what an unobserved cell completes to. These are **queries, not printing** — they read the model the SAT solver returned, rather than the one shown to a user.

## Why these two arrive together

I tried to split them and could not. `ExtensionalityContext` needs the new model-query members (`LookupAssignedValue`, `ArraysEqualUsingModel`, `defaultCellValue`, …), and `CounterExample.cpp` consults the registry in fifteen places when deciding an array equality. It is a genuine cycle, so they ship as one commit.

## Note for the reviewer

`CallSAT_ResultCheck` grows a third input here, and all three of its callers are updated — including `rewrite_rule_gen`, which only builds under `BUILD_EXTRA_TOOLS` and is easy to miss.

Nothing sets the option yet, so this changes no answer STP gives. The solver loop that drives it, and the tests that exercise it, are the next commit.

## Testing

97/97 ctest, 280/280 lit — unchanged, as it must be while the feature is unreachable.
