### PR TITLE
get-value: answer unsupported when no model was constructed (fixes #751)

### DIFF
--- a/lib/Interface/cpp_interface.cpp
+++ b/lib/Interface/cpp_interface.cpp
@@ -821,6 +821,12 @@ void Cpp_interface::getAssertions()
 
 void Cpp_interface::getValue(const ASTVec& v)
 {
+  if (!bm.UserFlags.construct_counterexample_flag)
+  {
+    unsupported();
+    return;
+  }
+
   std::ostringstream os;
 
   os << "(" << std::endl;


### PR DESCRIPTION
Fixes #751 — in a `-DCMAKE_BUILD_TYPE=Release` build, `(get-value ...)` could report a value the assertions rule out (e.g. `#x0` for a variable asserted equal to `#x3`), because no counterexample was ever constructed and the lookup fell through to the all-zero completion path. Nothing in the output distinguished that from a real model value.

This gives `getValue()` the same `construct_counterexample_flag` guard `getModel()` already has: if no model was constructed, answer `unsupported` instead of a wrong value.

Behavior on the issue's reproducer, Release build:

| query | before | after |
| --- | --- | --- |
| no options | `sat` then **`#x0`** | `sat` then `unsupported` |
| `(set-option :produce-models true)` | `sat` then `#x3` | unchanged |
| `-d` | `sat` then `#x3` | unchanged |

Notes:

- Assertion builds (the default, and most CI legs) are behaviorally unchanged, because the `#ifndef NDEBUG` override in `TopLevelSTPAux` still forces model construction there.
- The two query tests that use `get-value` without `:produce-models` are unaffected: `fp-tests/model-eval-fp-predicate.smt2` runs with `-d`, and `sample-smt-tests/named.smt2` only CHECKs the `sat` line (its `get-value` on named terms already answered `unsupported` via the non-SYMBOL check). Both verified against a Release build of this branch.
- This is the minimal fix (option 2 in the issue). The other two points there — having a model request trigger construction/re-solve, and reconsidering the `NDEBUG` override that makes debug and release disagree — are left open.