### PR TITLE
RemoveUnconstrained: eliminate fp.gt over an unconstrained float

### DIFF
--- a/lib/Simplifier/RemoveUnconstrained.cpp
+++ b/lib/Simplifier/RemoveUnconstrained.cpp
@@ -37,6 +37,7 @@ THE SOFTWARE.
 #include "stp/Simplifier/RemoveUnconstrained.h"
 #include "stp/AST/MutableASTNode.h"
 #include "stp/Extensionality/ExtensionalityContext.h"
+#include "stp/FloatBlaster/FloatBlaster.h"
 #include "stp/Simplifier/AchievableImage.h"
 #include "stp/Simplifier/constantBitP/Dependencies.h"
 
@@ -690,6 +691,92 @@ ASTNode RemoveUnconstrained::topLevel_other(const ASTNode& n,
           MutableASTNode* newN = MutableASTNode::build(n, create);
           muteParent.replaceWithAnotherNode(newN);
           // assert(muteParent.checkInvariant());
+        }
+      }
+      break;
+
+      case FP_GT:
+      {
+        // fp.gt over an unconstrained float, handled here while the
+        // comparison is still one source node and the variable one use --
+        // after FloatBlast the variable feeds its unpack circuit many times
+        // over and stops looking unconstrained. The witnesses are IEEE's
+        // extremes: NaN makes any ordered comparison false, and an infinity
+        // of the right sign makes fp.gt true whenever any value can.
+        if (numberOfChildren != 2)
+          break;
+
+        const SourceSort sort = var.GetSourceSort();
+        if (sort.kind() != SourceSort::Kind::FloatingPoint)
+          break;
+
+        const unsigned exp_width = sort.exponentWidth();
+        const unsigned sig_width = sort.significandWidth();
+
+        // A format the blaster refuses has to keep refusing: eliminating
+        // the comparison first would turn that loud refusal into a quiet
+        // wrong-looking answer.
+        if (!FloatBlaster::formatSupported(exp_width, sig_width))
+          break;
+
+        width = var.GetValueWidth();
+
+        // NaN and the infinities intern canonically (CreateFPConst funnels
+        // every NaN payload to the one quiet NaN), so recognising them in a
+        // constant operand is node identity.
+        const ASTNode nan =
+            bm.CreateFPSpecialConst(FPSpecial::NaN, exp_width, sig_width);
+
+        if (mutable_children[0]->isUnconstrained() &&
+            mutable_children[1]->isUnconstrained() &&
+            children[0].GetSourceSort() == children[1].GetSourceSort())
+        {
+          // x > y: true via (+oo, +0), false via (NaN, NaN).
+          ASTNode v = replaceParentWithFresh(muteParent, variable_array);
+          replace(children[0],
+                  nf->CreateTerm(ITE, width, v,
+                                 bm.CreateFPSpecialConst(
+                                     FPSpecial::PlusInfinity, exp_width,
+                                     sig_width),
+                                 nan));
+          replace(children[1],
+                  nf->CreateTerm(ITE, width, v,
+                                 bm.CreateFPSpecialConst(FPSpecial::PlusZero,
+                                                         exp_width, sig_width),
+                                 nan));
+        }
+        else if (other.GetSourceSort() == sort)
+        {
+          // FP constant folding is deferred solver-wide, so a literal
+          // usually arrives as to_fp's three-child reinterpret form over
+          // constant bits, not as an interned constant. Resolve it locally,
+          // through the canonicalising funnel (CreateFPConst), so NaN
+          // payloads compare by node identity below. `other` itself is not
+          // rewritten; it leaves the formula along with the predicate.
+          ASTNode constant = other;
+          if (constant.GetKind() == FP_TOFP && constant.Degree() == 3 &&
+              constant[2].GetKind() == BVCONST)
+            constant = bm.CreateFPConst(constant[2], exp_width, sig_width);
+
+          if (!constant.isConstant())
+            break;
+
+          const bool varOnLHS = (children[0] == var);
+
+          // The constant the variable's side cannot beat: nothing exceeds
+          // +oo (variable on the left), nothing lies below -oo (variable on
+          // the right) -- and nothing compares to NaN.
+          const ASTNode unbeatable = bm.CreateFPSpecialConst(
+              varOnLHS ? FPSpecial::PlusInfinity : FPSpecial::MinusInfinity,
+              exp_width, sig_width);
+
+          if (constant == nan || constant == unbeatable)
+            continue; // Always false; the blasted circuit collapses it.
+
+          // Both outcomes achievable: the variable's own extreme wins,
+          // NaN loses.
+          ASTNode v = replaceParentWithFresh(muteParent, variable_array);
+          replace(var, nf->CreateTerm(ITE, width, v, unbeatable, nan));
         }
       }
       break;

--- a/tests/query-files/fp-tests/unconstrained-fp-gt-extremes.smt2
+++ b/tests/query-files/fp-tests/unconstrained-fp-gt-extremes.smt2
@@ -1,0 +1,34 @@
+; RUN: %solver %s | %OutputCheck %s
+;
+; The extremes the unconstrained-fp.gt rule must not mis-eliminate: nothing
+; exceeds +oo, nothing lies below -oo, and nothing compares to NaN. Each
+; query is unsatisfiable, and each stresses one guard of the rule (the rule
+; declines these and leaves them to the blasted circuit, which must then
+; agree). Queries are separate so one wrong answer cannot mask another.
+;
+; CHECK: ^unsat
+(set-logic QF_FP)
+(push 1)
+(declare-fun a () (_ FloatingPoint 8 24))
+(assert (fp.gt a (_ +oo 8 24)))
+(check-sat)
+(pop 1)
+; CHECK: ^unsat
+(push 1)
+(declare-fun b () (_ FloatingPoint 8 24))
+(assert (fp.gt b (_ NaN 8 24)))
+(check-sat)
+(pop 1)
+; CHECK: ^unsat
+(push 1)
+(declare-fun c () (_ FloatingPoint 8 24))
+(assert (fp.gt (_ -oo 8 24) c))
+(check-sat)
+(pop 1)
+; CHECK: ^unsat
+(push 1)
+(declare-fun d () (_ FloatingPoint 8 24))
+(assert (fp.gt (_ NaN 8 24) d))
+(check-sat)
+(pop 1)
+(exit)

--- a/tests/query-files/fp-tests/unconstrained-fp-gt.smt2
+++ b/tests/query-files/fp-tests/unconstrained-fp-gt.smt2
@@ -1,0 +1,32 @@
+; RUN: %solver --exit-after-CNF %s | %OutputCheck %s
+;
+; An unconstrained float compared against an ordinary constant is eliminated
+; before the comparison is ever blasted: RemoveUnconstrained replaces the
+; fp.gt with a fresh boolean and records x := ite(v, +oo, NaN), so the solve
+; never builds the unpack circuit.
+;
+; --exit-after-CNF makes this a test that the elimination actually FIRES,
+; not merely that the answer is right: every assertion here collapses at the
+; word level, so the sat is decided before CNF generation and printed even
+; though the run stops there. If the rule regresses, the comparisons reach
+; the bit-blaster, the run exits at the CNF with no verdict, and the CHECK
+; fails. (Same convention as simplification-tests/.) Both literal spellings of the constant
+; must work: (fp ...) literals intern as constants at parse, while
+; ((_ to_fp e s) bits) stays a reinterpret term that the rule resolves
+; itself.
+;
+; The two constants here are 1.3 (binary64) spelled both ways; both asserts
+; are satisfied by x = +oo, y = +oo.
+;
+; CHECK: ^sat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 11 53))
+(declare-fun y () (_ FloatingPoint 11 53))
+(assert (fp.gt x ((_ to_fp 11 53) #x3FF4CCCCCCCCCCCD)))
+(assert (fp.gt y (fp #b0 #b01111111111 #b0100110011001100110011001100110011001100110011001101)))
+; Both sides unconstrained: eliminated with the witness pair (+oo, +0).
+(declare-fun z () (_ FloatingPoint 11 53))
+(declare-fun w () (_ FloatingPoint 11 53))
+(assert (fp.gt z w))
+(check-sat)
+(exit)


### PR DESCRIPTION
An unconstrained float under an `fp.gt` was being lowered to its full SymFPU circuit — around 160 word-level nodes and 2200 CNF clauses at binary64 for a single `(fp.gt x c)` — even though the query needs no SAT call at all. RemoveUnconstrained runs before FloatBlast, while the comparison is still one source node and the variable still occurs in it exactly once; afterwards the variable feeds its unpack circuit many times over and stops looking unconstrained. This adds the pass's first floating-point rule, so such comparisons are decided at the word level the way `BVGT` ones already are.

The rule mirrors the neighbouring `BVGT` case, with IEEE's extremes as witnesses: NaN makes any ordered comparison false, and an infinity of the right sign makes `fp.gt` true whenever any value can. Against a constant, the predicate is replaced by a fresh boolean `v` with `x := ite(v, +-oo, NaN)` recorded — `+oo` when the variable is on the left, `-oo` on the right — so model construction falls out of the recorded ite as usual. When both sides are unconstrained the witness pair is `(+oo, +0)` / `(NaN, NaN)`.

Two deliberate refusals: the always-false extremes (`x > +oo`, `x > NaN`, `-oo > x`, `NaN > x`) are left for the blasted circuit to collapse, exactly as the `BVGT` rule leaves its own always-false cases; and formats the blaster refuses are skipped, so that refusal stays loud instead of being quietly eliminated away.

One wrinkle: FP constant folding is deferred solver-wide, so a literal operand usually arrives as `to_fp`'s three-child reinterpret form over constant bits rather than as an interned constant — only `(fp ...)` literals intern at parse. The rule resolves that form locally through the `CreateFPConst` funnel (which also canonicalises NaN payloads, keeping the node-identity comparisons sound) without rewriting the operand or changing what the parser builds.

Tested with two new lit tests (the satisfiable shapes in both literal spellings plus the both-unconstrained form, and the four always-false extremes as separate queries), and exhaustively at the 8-bit format (3, 5): all 256 constants on either side of an unconstrained variable, elimination on versus off, with no disagreements; the emitted witness was also re-checked through the elimination-off path. The full query-files suite passes.

If this shape looks right, `fp.lt`/`fp.leq`/`fp.geq`, `fp.eq` and the classification predicates admit the same treatment with the same witness analysis.