### PR TITLE
SimplifyingNodeFactory: mirror the FP less-thans onto the greater-thans

### DIFF
--- a/lib/NodeFactory/SimplifyingNodeFactory.cpp
+++ b/lib/NodeFactory/SimplifyingNodeFactory.cpp
@@ -614,15 +614,32 @@ ASTNode SimplifyingNodeFactory::CreateNode(Kind kind, const ASTVec& children)
         result = NodeFactory::CreateNode(kind, children[0][0]);
       break;
 
-    // x < x and x > x are false, NaN included.
+    // Mirror the less-thans onto the greater-thans, as the bit-vector
+    // comparisons are above (BVLT -> BVGT): fp.lt(a, b) is fp.gt(b, a)
+    // exactly, NaN included -- both mean "ordered and strictly ordered", so
+    // the swap is a pure mirror -- and likewise for the non-strict pair.
+    // Downstream simplification then meets only the greater-than forms and
+    // needs half the comparison rules. (Unlike the total bit-vector order,
+    // this is as far as FP comparisons collapse: not(fp.lt) is geq-or-
+    // unordered, so the four kinds reduce to two, not one.)
     case stp::FP_LT:
+      if (children.size() == 2)
+        result = NodeFactory::CreateNode(stp::FP_GT, children[1], children[0]);
+      break;
+
+    case stp::FP_LEQ:
+      if (children.size() == 2)
+        result =
+            NodeFactory::CreateNode(stp::FP_GEQ, children[1], children[0]);
+      break;
+
+    // x > x is false, NaN included.
     case stp::FP_GT:
       if (children.size() == 2 && children[0] == children[1])
         result = ASTFalse;
       break;
 
-    // x <= x and x >= x hold exactly when x is not NaN.
-    case stp::FP_LEQ:
+    // x >= x holds exactly when x is not NaN.
     case stp::FP_GEQ:
       if (children.size() == 2 && children[0] == children[1])
         result = NodeFactory::CreateNode(

--- a/tests/api/C/fp-arithmetic.cpp
+++ b/tests/api/C/fp-arithmetic.cpp
@@ -182,7 +182,10 @@ TEST(fp_arithmetic, expr_kinds)
   Expr y = vc_varExpr(vc, "y", f);
 
   EXPECT_EQ(FP_ADD, getExprKind(vc_fpAddExpr(vc, rne, x, y)));
-  EXPECT_EQ(FP_LEQ, getExprKind(vc_fpLeqExpr(vc, x, y)));
+  // The factory mirrors the less-thans onto the greater-thans (as it does
+  // BVLT onto BVGT), so vc_fpLeqExpr hands back an fp.geq node with the
+  // operands swapped -- and getExprKind must label that node correctly.
+  EXPECT_EQ(FP_GEQ, getExprKind(vc_fpLeqExpr(vc, x, y)));
   EXPECT_EQ(FP_EQ, getExprKind(vc_fpEqExpr(vc, x, y)));
   EXPECT_EQ(FP_ISNAN, getExprKind(vc_fpIsNaNExpr(vc, x)));
   EXPECT_EQ(FP_TO_IEEE_BV, getExprKind(vc_fpToIEEEBV(vc, x)));

--- a/tests/query-files/fp-tests/comparison-mirror.smt2
+++ b/tests/query-files/fp-tests/comparison-mirror.smt2
@@ -1,0 +1,24 @@
+; RUN: %solver --exit-after-CNF %s | %OutputCheck %s
+; RUN: %solver --disable-simplifications %s | %OutputCheck %s
+;
+; The less-than comparisons mirror onto the greater-thans at node creation,
+; the way BVLT mirrors onto BVGT: fp.lt(a, b) = fp.gt(b, a) and
+; fp.leq(a, b) = fp.geq(b, a), exactly, NaN included.
+;
+; Each xor pairs a comparison with its mirror, so the formula is
+; unsatisfiable -- and the two RUN lines check that for different reasons.
+; With simplification, both xor operands intern as the SAME node and the
+; factory collapses xor(n, n) to false before any circuit exists, so
+; --exit-after-CNF still prints its verdict: that run passes only while the
+; mirror rule fires. With --disable-simplifications the hashing factory
+; keeps all four comparison kinds, both circuits are built, and the SAT
+; solver proves the semantic identity the rule relies on.
+;
+; CHECK: ^unsat
+(set-logic QF_FP)
+(declare-fun a () (_ FloatingPoint 3 5))
+(declare-fun b () (_ FloatingPoint 3 5))
+(assert (xor (fp.lt a b) (fp.gt b a)))
+(assert (xor (fp.leq a b) (fp.geq b a)))
+(check-sat)
+(exit)

--- a/tests/unit-tests/FPPrintBack_Test.cpp
+++ b/tests/unit-tests/FPPrintBack_Test.cpp
@@ -169,7 +169,11 @@ TEST(FPPrintBack, arithmetic_and_modes)
   )",
              {"(set-logic QF_BVFP)", "fp.add RNE", "fp.mul RTZ", "fp.sqrt RNA",
               "fp.roundToIntegral |r|", "fp.fma RTP", "fp.rem", "fp.min",
-              "fp.max", "fp.lt", "fp.leq", "fp.geq", "fp.gt",
+              // The source fp.lt/fp.leq print back as their mirrors: the
+              // factory rewrites them to swapped fp.gt/fp.geq at creation,
+              // exactly as bvult prints back as bvugt. The re-parse below
+              // still exercises the fp.lt/fp.leq parser paths.
+              "fp.max", "fp.geq", "fp.gt",
               // The mode's declaration must name the sort, not the 5-bit
               // carrier: the operations ask for the sort, so printing the
               // carrier gives back something that no longer parses -- which

--- a/tools/test_fprewrites/test_fprewrites.cpp
+++ b/tools/test_fprewrites/test_fprewrites.cpp
@@ -514,6 +514,27 @@ static void run(Ctx& c)
            c.nf->CreateNode(FP_GEQ, {x, x}) == notNan);
   }
 
+  // The less-thans mirror onto the greater-thans (as BVLT does onto BVGT):
+  // fp.lt(a, b) = fp.gt(b, a) and fp.leq(a, b) = fp.geq(b, a), exactly, NaN
+  // included. Structural: the factory must produce the mirrored node.
+  // Semantic: the mirror must agree with the un-normalised original on every
+  // pair of floats, which is what makes the structural check trustworthy.
+  {
+    ASTNode x = c.fp(EB, SB), y = c.fp(EB, SB);
+
+    const ASTNode lt = c.nf->CreateNode(FP_LT, {x, y});
+    report("fp.lt(a, b) -> fp.gt(b, a)",
+           lt == c.hf->CreateNode(FP_GT, {y, x}));
+    std::string why = c.firstDisagreement(c.hf->CreateNode(FP_LT, {x, y}), lt);
+    report("fp.lt mirror exact on all pairs", why.empty(), why);
+
+    const ASTNode leq = c.nf->CreateNode(FP_LEQ, {x, y});
+    report("fp.leq(a, b) -> fp.geq(b, a)",
+           leq == c.hf->CreateNode(FP_GEQ, {y, x}));
+    why = c.firstDisagreement(c.hf->CreateNode(FP_LEQ, {x, y}), leq);
+    report("fp.leq mirror exact on all pairs", why.empty(), why);
+  }
+
   // fp.eq / fp.smt_eq are symmetric; the factory canonicalises operand order so
   // that x ~ y and y ~ x are the same node (and share a blasted circuit).
   {


### PR DESCRIPTION
The factory already converts every bit-vector less-than into a swapped greater-than (`BVLT -> BVGT` and friends), which is why downstream passes only ever needed rules for the greater-than kinds. The floating-point comparisons had no such canonicalisation, so anything consuming FP comparisons faces four kinds where two suffice.

`fp.lt(a, b)` is `fp.gt(b, a)` exactly, NaN included — both mean "ordered and strictly ordered", so the swap is a pure mirror — and likewise for `fp.leq`/`fp.geq`. This rewrites the less-thans at node creation. Unlike the total bit-vector order, this is as far as FP comparisons collapse: `not(fp.lt)` is geq-*or-unordered*, so the four kinds reduce to two, not one.

The x-vs-x rules keep their meaning through the mirror (`x < x` reaches the `FP_GT` arm and still folds to false), and FloatBlast's `FP_LT`/`FP_LEQ` arms stay as ground truth, since the hashing factory (`--disable-simplifications`) still builds those kinds verbatim.

Testing: `test_fprewrites` gains four checks — the mirror fires structurally, and agrees with the un-normalised original on every operand pair of the exhaustive test format. A new lit test asserts the xor of each comparison with its mirror is unsat, twice over: once under `--exit-after-CNF` through the simplifying factory (the xor operands intern as one node and collapse before any circuit exists, so the verdict prints only while the rule fires), and once under `--disable-simplifications` (the SAT solver proves the semantic identity over the full circuits). The full query-files suite passes.

A follow-on benefit: once this lands, the unconstrained-variable elimination for `fp.gt` (#753) automatically covers `fp.lt` spellings too — `fp.lt x c` normalises to `fp.gt(c, x)`, which is the arm that rule already handles; a future `FP_GEQ` arm would pick up `fp.leq` the same way.