### PR TITLE
CodeQL: run on PRs, scan the whole build, drop third-party alerts

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,6 +3,8 @@ name: "CodeQL"
 on:
   push:
     branches: [master]
+  pull_request:
+    branches: [master]
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * 1'
@@ -13,15 +15,14 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      # required for all workflows
+      actions: read
+      contents: read
       security-events: write
 
     strategy:
       fail-fast: false
       matrix:
-        # Override automatic language detection by changing the below list
-        # Supported options are ['csharp', 'cpp', 'go', 'java', 'javascript', 'python']
-        language: ['cpp']
+        language: ['cpp', 'python']
 
     steps:
     - name: Checkout repository
@@ -29,12 +30,8 @@ jobs:
       with:
         submodules: 'true'
 
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
-      with:
-        languages: ${{ matrix.language }}
-
     - name: Packages
+      if: matrix.language == 'cpp'
       run: |
         sudo apt-get update
         sudo apt-get install -y \
@@ -44,17 +41,84 @@ jobs:
           flex \
           git \
           libboost-program-options-dev \
+          python3 \
+          python3-pip \
+          python3-setuptools \
           zlib1g-dev
+        # ENABLE_TESTING is a hard configure error without lit, even though
+        # this job only builds the tests and never runs them.
+        sudo pip3 install -U lit
 
+    # The solver libraries are built before CodeQL is initialized, so their
+    # compilation is not traced into the database. gtest cannot be handled
+    # the same way (tests/CMakeLists.txt compiles it as part of the STP
+    # build); it is cloned here and filtered out of the results below.
+    #
+    # CryptoMiniSat is built shared, unlike everywhere else: this is the one
+    # build that links CMS and CaDiCaL at the same time, and a static CMS
+    # drags its own FetchContent-built libcadical.a onto libstp's link line,
+    # where it collides with the newer CaDiCaL from setup-cadical.sh. A
+    # shared libcryptominisat5 keeps its bundled cadical internal.
     - name: Dependencies
-      run: ./scripts/deps/setup-minisat.sh
+      if: matrix.language == 'cpp'
+      run: |
+        ./scripts/deps/setup-minisat.sh
+        ./scripts/deps/setup-cms.sh -DBUILD_SHARED_LIBS=ON
+        ./scripts/deps/setup-cadical.sh
+        ./scripts/deps/setup-gtest.sh
 
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v4
+      with:
+        languages: ${{ matrix.language }}
+
+    # CodeQL only sees C++ code that is actually compiled, so every optional
+    # component is switched on: the CryptoMiniSat and CaDiCaL backends, the
+    # unit tests and the extra tools.
+    #
+    # CADICAL_LIBRARY is pinned by hand: CMS installs its own bundled cadical
+    # into deps/install, and find_library searches CMAKE_PREFIX_PATH (which
+    # CMakeLists points at deps/install) before the CADICAL_DIR hint, so
+    # without the pin libstp links the older library against the 3.x headers.
     - name: Build
+      if: matrix.language == 'cpp'
       run: |
         mkdir build
         cd build
-        cmake -DNOCRYPTOMINISAT:BOOL=ON ..
+        cmake \
+          -DNOCRYPTOMINISAT:BOOL=OFF \
+          -DUSE_CADICAL:BOOL=ON \
+          -DCADICAL_DIR:PATH="$GITHUB_WORKSPACE/deps/cadical" \
+          -DCADICAL_LIBRARY:FILEPATH="$GITHUB_WORKSPACE/deps/cadical/build/libcadical.a" \
+          -DENABLE_TESTING:BOOL=ON \
+          -DBUILD_EXTRA_TOOLS:BOOL=ON \
+          -DPYTHON_EXECUTABLE:PATH="$(which python3)" \
+          ..
         make -j"$(nproc)"
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4
+      with:
+        category: "/language:${{ matrix.language }}"
+        output: sarif-results
+        upload: failure-only
+
+    # A CodeQL config's paths-ignore only filters interpreted languages, so
+    # vendored code the build compiles (extlib-abc, mimalloc, gtest) has to
+    # be dropped from the SARIF instead.
+    - name: Filter out third-party code
+      uses: advanced-security/filter-sarif@v1
+      with:
+        patterns: |
+          -lib/extlib-abc/**
+          -lib/extlib-mimalloc/**
+          -lib/extlib-symfpu/**
+          -deps/**
+        input: sarif-results/${{ matrix.language }}.sarif
+        output: sarif-results/${{ matrix.language }}.sarif
+
+    - name: Upload results
+      uses: github/codeql-action/upload-sarif@v4
+      with:
+        category: "/language:${{ matrix.language }}"
+        sarif_file: sarif-results/${{ matrix.language }}.sarif


### PR DESCRIPTION
The CodeQL workflow only ran on pushes to `master` plus a weekly cron, and its build was the minimal one: minisat only, no tests, no tools. CodeQL for C++ analyses exactly what is compiled, so the CryptoMiniSat and CaDiCaL backends, the unit tests and the extra tools were never scanned — while everything the build did compile that is not ours (extlib-abc, mimalloc, gtest, and minisat, built after `codeql-action/init` and therefore traced) was reported as if it were STP code.

### Changes

- **`pull_request` trigger**: alerts now show up as PR checks instead of only after merge.
- **Deps build before `init`**: the solver libraries are compiled outside the CodeQL tracer, so they stay out of the database.
- **Full-coverage build**: CryptoMiniSat, CaDiCaL, `ENABLE_TESTING` and `BUILD_EXTRA_TOOLS` are all on, so every backend, the tests and the tools are compiled and analysed. `ENABLE_TESTING` needs `lit` at configure time even though this job never runs tests, hence the pip install.
- **Python matrix leg**: the bindings and scripts get scanned too (needs no build).
- **Third-party filtering**: results pass through `advanced-security/filter-sarif` before upload, dropping `lib/extlib-abc`, `lib/extlib-mimalloc`, `lib/extlib-symfpu` and `deps/`. A CodeQL config's `paths-ignore` only applies to interpreted languages, so vendored code the STP build itself compiles cannot be excluded any other way.

### CMS + CaDiCaL in one build

This is the first configuration to link CryptoMiniSat and CaDiCaL at the same time, and it did not work out of the box — CMS ≥ 5.14 builds and installs its own (older) CaDiCaL via FetchContent:

- a static `libcryptominisat5` drags its bundled `libcadical.a` onto libstp's link line, where it collides with the rel-3.0.1 archive (multiple-definition errors), so CMS is built shared for this job (`setup-cms.sh -DBUILD_SHARED_LIBS=ON`, no script changes needed);
- `find_library` searches `CMAKE_PREFIX_PATH` (which includes `deps/install`) before the `CADICAL_DIR` hint, so without an explicit `CADICAL_LIBRARY` pin libstp links CMS's older library against the 3.x headers and fails on the `declare_more_variables`/`val` symbols.

Both are documented in comments in the workflow. Validated locally: the workflow's exact configure plus a full build, then `sat` smoke tests on `--cryptominisat`, `--cadical` and `--minisat`. The GitHub-side machinery (CodeQL tracing, the SARIF filter step, the upload, the python leg) can only be validated by this PR's own run, so the first thing to check here is the CodeQL workflow result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)