### PR TITLE
Bit-blast fp.gt/fp.lt over leaf operands natively

### DIFF
--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -126,6 +126,10 @@ public:
   bool bvplus_variant = true;
   bool conjoin_to_top = false;
 
+  // Bit-blast fp.gt/fp.lt over already-packed operands natively (sign-magnitude
+  // comparison of the IEEE bits) instead of via the SymFPU unpacking circuits.
+  bool fp_native_cmp = true;
+
   int64_t multiplication_variant = 1;
 
   // If the bit-blaster discovers new constants, should the term simplifier be

--- a/include/stp/ToSat/BitBlaster.h
+++ b/include/stp/ToSat/BitBlaster.h
@@ -193,6 +193,9 @@ class BitBlaster
   // Return bit-blasted form for BVLE, BVGE, BVGT, SBLE, etc.
   BBNode BBcompare(const ASTNode& form, BBNodeSet& support);
 
+  // bit blast a floating-point comparison (FP_GT/FP_LT) over packed operands
+  BBNode BBcompareFP(const ASTNode& form, BBNodeSet& support);
+
   // Return bit-blasted form for the overflow predicates BVUADDO, BVSADDO,
   // BVUMULO, BVSMULO, BVUSUBO, BVSSUBO.
   BBNode BBOverflow(const ASTNode& form, BBNodeSet& support);

--- a/lib/FloatBlaster/FloatBlast.cpp
+++ b/lib/FloatBlaster/FloatBlast.cpp
@@ -107,6 +107,56 @@ private:
                  "source sorts");
   }
 
+  // A comparison operand that is (or resolves to) a leaf the lowering
+  // leaves untouched: a symbol or an interned constant. FP constant folding
+  // is deferred solver-wide, so a literal usually arrives as to_fp's
+  // three-child reinterpret form over constant bits; resolve it through the
+  // canonicalising funnel (CreateFPConst), the same lookthrough
+  // RemoveUnconstrained's comparison rule uses. Returns null for anything
+  // else -- in particular for FP operations, whose values are cached
+  // unpacked and belong on the SymFPU path.
+  ASTNode comparisonLeaf(const ASTNode& n) const
+  {
+    if (n.Degree() == 0)
+      return n;
+    if (n.GetKind() == FP_TOFP && n.Degree() == 3 &&
+        n[2].GetKind() == BVCONST)
+    {
+      const SourceSort sort = n.GetSourceSort();
+      return bm->CreateFPConst(n[2], sort.exponentWidth(),
+                               sort.significandWidth());
+    }
+    return ASTNode();
+  }
+
+  // fp.gt/fp.lt over leaf operands skip SymFPU entirely: the source
+  // comparison survives to the bit-blaster, which compares the packed IEEE
+  // bits directly (BBcompareFP). Returns the surviving node -- `n` itself,
+  // or the comparison rebuilt over resolved constant operands, both purely
+  // float-sorted so no FP node is ever built over packed carriers -- or
+  // null when the comparison has to take the SymFPU path.
+  //
+  // A comparison of two constants must not survive: constant folding and
+  // model evaluation lower the node over its constant children and rely on
+  // the result collapsing to TRUE/FALSE through the simplifying factory
+  // (ComputeFormulaUsingModel asserts lowering changed the node).
+  ASTNode nativeComparisonSurvivor(const ASTNode& n) const
+  {
+    if (!bm->UserFlags.fp_native_cmp)
+      return ASTNode();
+    const ASTNode left = comparisonLeaf(n[0]);
+    if (left.IsNull())
+      return ASTNode();
+    const ASTNode right = comparisonLeaf(n[1]);
+    if (right.IsNull())
+      return ASTNode();
+    if (left.isConstant() && right.isConstant())
+      return ASTNode();
+    if (left == n[0] && right == n[1])
+      return n;
+    return node_factory->CreateNode(n.GetKind(), left, right);
+  }
+
   ASTNode rebuild(const ASTNode& n, const ASTVec& children)
   {
     if (n.GetType() == BOOLEAN_TYPE)
@@ -492,17 +542,27 @@ private:
         return symbolic_fp::unpacked::ieeeEqual(
             formatOf(n[0]), asUnpacked(n[0]), asUnpacked(n[1]));
       case FP_LT:
+      {
         requireSameFormat(n[0], n[1]);
+        const ASTNode survivor = nativeComparisonSurvivor(n);
+        if (!survivor.IsNull())
+          return survivor;
         return symbolic_fp::unpacked::lessThan(
             formatOf(n[0]), asUnpacked(n[0]), asUnpacked(n[1]));
+      }
       case FP_LEQ:
         requireSameFormat(n[0], n[1]);
         return symbolic_fp::unpacked::lessThanOrEqual(
             formatOf(n[0]), asUnpacked(n[0]), asUnpacked(n[1]));
       case FP_GT:
+      {
         requireSameFormat(n[0], n[1]);
+        const ASTNode survivor = nativeComparisonSurvivor(n);
+        if (!survivor.IsNull())
+          return survivor;
         return symbolic_fp::unpacked::lessThan(
             formatOf(n[0]), asUnpacked(n[1]), asUnpacked(n[0]));
+      }
       case FP_GEQ:
         requireSameFormat(n[0], n[1]);
         return symbolic_fp::unpacked::lessThanOrEqual(

--- a/lib/STPManager/STP.cpp
+++ b/lib/STPManager/STP.cpp
@@ -539,8 +539,11 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
 
   // Lower floating-point operations before the first pass that invokes the
   // bit-blaster. From here on the formula is a packed-bit circuit: float
-  // symbols, constants and reads retain sort metadata for model reconstruction,
-  // but no FP operation reaches a bitvector-only pass.
+  // symbols, constants and reads retain sort metadata for model
+  // reconstruction. The only FP operations that survive are fp.gt/fp.lt over
+  // leaf operands, which the bit-blaster encodes natively (see
+  // BBcompareFP); every downstream pass already has an FP_GT/FP_LT arm
+  // because these kinds used to reach them before lowering existed.
   //
   // This remains after all of the size-reducing passes above. In particular,
   // RemoveUnconstrained must see a float symbol rather than its exposed bits.

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -1323,10 +1323,15 @@ const BBNode BitBlaster::BBForm(const ASTNode& form,
       result = BBOverflow(form, support);
       break;
     }
-    case FP_LEQ:
-    case FP_LT:
-    case FP_GEQ:
     case FP_GT:
+    case FP_LT:
+    {
+      result = BBcompareFP(form, support);
+      break;
+    }
+
+    case FP_LEQ:
+    case FP_GEQ:
     case FP_EQ:
     case FP_ISNORMAL:
     case FP_ISSUBNORMAL:
@@ -3052,6 +3057,83 @@ BBNode BitBlaster::BBcompare(const ASTNode& form,
       cerr << "BBCompare: Illegal kind" << form << endl;
       FatalError("", form);
   }
+}
+
+// Bit-blasted form for FP_GT and FP_LT over packed IEEE-754 operands.
+// FloatBlast leaves these comparisons in place when both operands are leaves
+// (symbols, interned constants); their packed bits are compared directly,
+// with no unpacking. Sign-magnitude maps onto an unsigned total order with a
+// per-bit XOR against the sign:
+//
+//   key(f) = not(sign(f)) ++ (f[w-2:0] xor sign(f))
+//   a > b  = not(isNaN(a)) and not(isNaN(b))
+//            and not(isZero(a) and isZero(b)) and key(a) >u key(b)
+//
+// The keys order every pair correctly except (+0, -0): their keys are
+// adjacent with no other float's key between them, so the only misordered
+// pair is repaired by the both-zero conjunct. (A greater-or-equal variant
+// would need the correction ORed in instead.) isNaN tests the exponent and
+// significand fields, so operands with arbitrary NaN payloads compare as
+// NaN.
+BBNode BitBlaster::BBcompareFP(const ASTNode& form, BBNodeSet& support)
+{
+  assert(form.GetKind() == FP_GT || form.GetKind() == FP_LT);
+  // fp.lt(a,b) is exactly fp.gt(b,a).
+  const ASTNode& a = form.GetKind() == FP_GT ? form[0] : form[1];
+  const ASTNode& b = form.GetKind() == FP_GT ? form[1] : form[0];
+
+  const SourceSort sort = a.GetSourceSort();
+  assert(sort.kind() == SourceSort::Kind::FloatingPoint);
+  const unsigned sb = sort.significandWidth();
+  const unsigned w = sort.exponentWidth() + sb;
+  assert(a.GetValueWidth() == w);
+  assert(b.GetValueWidth() == w);
+  assert(sb >= 2 && w >= sb + 1);
+
+  // Bit i of a packed operand is bit i of the IEEE encoding: significand
+  // field in bits [0, sb-2], exponent field in bits [sb-1, w-2], sign at
+  // w-1.
+  const BBNodeVec aBits = BBTerm(a, support);
+  const BBNodeVec bBits = BBTerm(b, support);
+
+  auto isNaN = [this](const BBNodeVec& p, unsigned sig, unsigned width) {
+    BBNodeVec expField(p.begin() + (sig - 1), p.begin() + (width - 1));
+    BBNodeVec sigField(p.begin(), p.begin() + (sig - 1));
+    const BBNode expAllOnes = nf->CreateNode(AND, expField);
+    const BBNode sigNonZero = nf->CreateNode(OR, sigField);
+    return nf->CreateNode(AND, expAllOnes, sigNonZero);
+  };
+
+  auto isZero = [this](const BBNodeVec& p, unsigned width) {
+    BBNodeVec magnitude(p.begin(), p.begin() + (width - 1));
+    return nf->CreateNode(NOR, magnitude);
+  };
+
+  auto key = [this](const BBNodeVec& p, unsigned width) {
+    const BBNode& sign = p[width - 1];
+    BBNodeVec k;
+    k.reserve(width);
+    for (unsigned i = 0; i < width - 1; i++)
+      k.push_back(nf->CreateNode(XOR, p[i], sign));
+    k.push_back(nf->CreateNode(NOT, sign));
+    return k;
+  };
+
+  const BBNode aNotNaN = nf->CreateNode(NOT, isNaN(aBits, sb, w));
+  const BBNode bNotNaN = nf->CreateNode(NOT, isNaN(bBits, sb, w));
+  const BBNode bothZero =
+      nf->CreateNode(AND, isZero(aBits, w), isZero(bBits, w));
+  const BBNodeVec aKey = key(aBits, w);
+  const BBNodeVec bKey = key(bBits, w);
+  const BBNode greater = BBBVLE(bKey, aKey, false, true); // key(a) >u key(b)
+
+  BBNodeVec conjuncts;
+  conjuncts.reserve(4);
+  conjuncts.push_back(aNotNaN);
+  conjuncts.push_back(bNotNaN);
+  conjuncts.push_back(nf->CreateNode(NOT, bothZero));
+  conjuncts.push_back(greater);
+  return nf->CreateNode(AND, conjuncts);
 }
 
 // Return bit-blasted form for the overflow predicates BVUADDO, BVSADDO,

--- a/tests/query-files/fp-tests/native-comparison-agrees-with-leq.smt2
+++ b/tests/query-files/fp-tests/native-comparison-agrees-with-leq.smt2
@@ -1,0 +1,21 @@
+; RUN: %solver %s | %OutputCheck %s
+; RUN: %solver --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck %s
+;
+; For ordered (non-NaN) operands, fp.gt is exactly the negation of fp.leq.
+; fp.gt over symbols blasts natively (BBcompareFP) while fp.leq is not
+; migrated and lowers through SymFPU, so the SAT solver proves the native
+; and SymFPU encodings agree on every ordered binary32 pair -- +/-0,
+; infinities and subnormals included. (NaN operands, where gt and leq are
+; both false and the identity does not hold, are excluded here and covered
+; by native-comparison-nan-never-gt.smt2.)
+;
+; CHECK: ^unsat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(declare-fun y () (_ FloatingPoint 8 24))
+(assert (not (fp.isNaN x)))
+(assert (not (fp.isNaN y)))
+(assert (xor (fp.gt x y) (not (fp.leq x y))))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/native-comparison-model.smt2
+++ b/tests/query-files/fp-tests/native-comparison-model.smt2
@@ -1,0 +1,20 @@
+; RUN: %solver %s | %OutputCheck %s
+; RUN: %solver --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck %s
+;
+; A satisfiable pair of native comparisons pinning x into (1.0, 2.0). Every
+; sat answer is validated internally by substituting the model into the
+; ORIGINAL fp.gt/fp.lt nodes and folding them through SymFPU
+; (CheckCounterExample), so this test cross-checks a concrete native model
+; against the SymFPU semantics on every run. x appears twice so
+; RemoveUnconstrained cannot discharge the comparisons before they blast.
+; The (fp ...) literal spelling interns at parse, keeping the operands leaves
+; even under --disable-simplifications.
+;
+; CHECK: ^sat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(assert (fp.gt x (fp #b0 #b01111111 #b00000000000000000000000))) ; x > 1.0
+(assert (fp.lt x (fp #b0 #b10000000 #b00000000000000000000000))) ; x < 2.0
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/native-comparison-nan-never-gt.smt2
+++ b/tests/query-files/fp-tests/native-comparison-nan-never-gt.smt2
@@ -1,0 +1,22 @@
+; RUN: %solver %s | %OutputCheck %s
+; RUN: %solver --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck %s
+;
+; fp.gt over leaf operands survives lowering and is bit-blasted natively
+; (BBcompareFP); fp.isNaN still lowers through SymFPU. A NaN operand -- on
+; either side, with ANY payload the SAT solver can pick -- must make the
+; comparison false, so this cross-encoding formula is unsatisfiable. The
+; native encoding tests the exponent and significand fields rather than a
+; canonical NaN pattern; a payload-sensitive isNaN would make this sat.
+; The third run proves the SymFPU path agrees.
+;
+; CHECK: ^unsat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(declare-fun y () (_ FloatingPoint 8 24))
+(declare-fun z () (_ FloatingPoint 8 24))
+(declare-fun w () (_ FloatingPoint 8 24))
+(assert (or (and (fp.gt x y) (fp.isNaN x))
+            (and (fp.gt z w) (fp.isNaN w))))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/native-comparison-to-fp-literal.smt2
+++ b/tests/query-files/fp-tests/native-comparison-to-fp-literal.smt2
@@ -1,0 +1,20 @@
+; RUN: %solver %s | %OutputCheck %s
+; RUN: %solver --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck %s
+;
+; The usual spelling of a binary64 literal is to_fp's reinterpret form,
+; which stays an unfolded three-child FP_TOFP term solver-wide (FP constant
+; folding is deferred). The native-comparison gate resolves that form to
+; the interned constant -- the same lookthrough RemoveUnconstrained uses --
+; so these comparisons blast natively rather than falling back to SymFPU.
+; x appears twice so RemoveUnconstrained cannot discharge the comparisons
+; first; 1.3 < x < 2.0 is satisfiable, and the sat model is validated
+; internally against SymFPU's constant evaluation.
+;
+; CHECK: ^sat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 11 53))
+(assert (fp.gt x ((_ to_fp 11 53) #x3FF4CCCCCCCCCCCD))) ; x > 1.3
+(assert (fp.lt x ((_ to_fp 11 53) #x4000000000000000))) ; x < 2.0
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/native-comparison-zero-order.smt2
+++ b/tests/query-files/fp-tests/native-comparison-zero-order.smt2
@@ -1,0 +1,19 @@
+; RUN: %solver %s | %OutputCheck %s
+; RUN: %solver --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck %s
+;
+; No zero is greater than another zero: +0 and -0 compare equal despite
+; having different packed bits. In the native encoding (BBcompareFP) their
+; sign-magnitude keys are adjacent, and (fp.gt +0 -0) is the single pair the
+; key comparison misorders; the both-zero conjunct repairs exactly it. If
+; that conjunct regresses, x = +0, y = -0 satisfies this formula.
+;
+; CHECK: ^unsat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(declare-fun y () (_ FloatingPoint 8 24))
+(assert (fp.isZero x))
+(assert (fp.isZero y))
+(assert (fp.gt x y))
+(check-sat)
+(exit)

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -35,6 +35,14 @@ AddSTPGTest(SourceSortMemo_Test.cpp)
 if (ENABLE_FLOATING_POINT)
     AddSTPGTest(FPPrintBack_Test.cpp)
     AddSTPGTest(FloatBlast_Test.cpp)
+    # The native-comparison differential instantiates BBNodeManagerAIG, whose
+    # inline members call ABC. A shared libstp localises ABC's symbols
+    # (--exclude-libs), so this test links its own copy; the AIG package keeps
+    # all of its state in the manager struct, which is shared fine. Linking
+    # the archive by file keeps ABC's interface flags (-fno-exceptions) off
+    # the test's own compilation.
+    target_link_libraries(FloatBlast_TestTests $<TARGET_FILE:libabc-pic>)
+    add_dependencies(FloatBlast_TestTests libabc-pic)
     AddSTPGTest(FpTotalise_Test.cpp)
     AddSTPGTest(SourceSort_Test.cpp)
     # Builds float/rounding-mode constants, which is the whole point.

--- a/tests/unit-tests/FloatBlast_Test.cpp
+++ b/tests/unit-tests/FloatBlast_Test.cpp
@@ -7,6 +7,9 @@
 #include "stp/FloatBlaster/FpTotalise.h"
 #include "stp/FloatBlaster/rounding_modes.h"
 #include "stp/STPManager/STPManager.h"
+#include "stp/Simplifier/Simplifier.h"
+#include "stp/ToSat/BBNodeManagerAIG.h"
+#include "stp/ToSat/BitBlaster.h"
 
 #include <gtest/gtest.h>
 #include <set>
@@ -200,6 +203,10 @@ TEST(FloatBlast, totalisation_defers_canonical_boundaries_to_lowering)
 TEST(FloatBlast, every_floating_point_kind_is_lowered)
 {
   STPMgr mgr;
+  // fp.gt/fp.lt over leaves deliberately survive lowering when the native
+  // comparison is on (see native_comparison_survives_for_leaf_operands).
+  // This sweep checks that every kind has a SymFPU arm, so turn it off.
+  mgr.UserFlags.fp_native_cmp = false;
   const SourceSort fp32 = SourceSort::floatingPoint(8, 24);
   const ASTNode x = mgr.CreateSourceSymbol("x", fp32);
   const ASTNode y = mgr.CreateSourceSymbol("y", fp32);
@@ -280,4 +287,120 @@ TEST(FloatBlast, every_floating_point_kind_is_lowered)
     EXPECT_FALSE(containsFloatingPointKind(lowered))
         << _kind_names[c.first] << " was not lowered";
   }
+}
+
+// fp.gt/fp.lt over leaf operands are not expanded to SymFPU circuits: the
+// source node passes through lowering unchanged and the bit-blaster encodes
+// it natively over the packed bits (BBcompareFP). Everything else -- other
+// comparison kinds, operands that are FP operations, constant pairs, and
+// every comparison once the flag is off -- still lowers through SymFPU.
+TEST(FloatBlast, native_comparison_survives_for_leaf_operands)
+{
+  STPMgr mgr;
+  ASSERT_TRUE(mgr.UserFlags.fp_native_cmp); // on by default
+  const SourceSort fp32 = SourceSort::floatingPoint(8, 24);
+  const ASTNode x = mgr.CreateSourceSymbol("x", fp32);
+  const ASTNode y = mgr.CreateSourceSymbol("y", fp32);
+  const ASTNode one =
+      mgr.CreateFPConst(mgr.CreateBVConst(32, 0x3f800000u), 8, 24);
+  const ASTNode two =
+      mgr.CreateFPConst(mgr.CreateBVConst(32, 0x40000000u), 8, 24);
+  const ASTNode sum =
+      mgr.CreateTerm(FP_ADD, 32, ASTVec{rne(mgr), x, y});
+
+  auto lowered = [&mgr](const ASTNode& n) {
+    FloatBlast lower(&mgr);
+    return lower.topLevel(n);
+  };
+
+  // Leaf operands: the comparison itself survives, and nothing else does.
+  const ASTNode gt_symbols = mgr.CreateNode(FP_GT, x, y);
+  EXPECT_EQ(gt_symbols, lowered(gt_symbols));
+  const ASTNode gt_constant = mgr.CreateNode(FP_GT, x, one);
+  EXPECT_EQ(gt_constant, lowered(gt_constant));
+  const ASTNode lt_constant = mgr.CreateNode(FP_LT, x, one);
+  EXPECT_EQ(lt_constant, lowered(lt_constant));
+
+  // FP constant folding is deferred solver-wide, so literals usually arrive
+  // as to_fp's three-child reinterpret form over constant bits. The gate
+  // resolves that form to the interned constant and the comparison survives
+  // rebuilt over it.
+  const ASTNode one_reinterpreted = mgr.CreateTerm(
+      FP_TOFP, 32,
+      ASTVec{mgr.CreateBVConst(32, 8), mgr.CreateBVConst(32, 24),
+             mgr.CreateBVConst(32, 0x3f800000u)});
+  EXPECT_EQ(gt_constant,
+            lowered(mgr.CreateNode(FP_GT, x, one_reinterpreted)));
+
+  // An FP-operation operand keeps the whole comparison on the SymFPU path:
+  // its value is cached unpacked and the unpacked comparison is cheaper
+  // than packing it.
+  EXPECT_FALSE(
+      containsFloatingPointKind(lowered(mgr.CreateNode(FP_GT, sum, y))));
+
+  // A constant pair must not survive -- constant folding and model
+  // evaluation rely on lowering replacing the node (they collapse the
+  // SymFPU circuit built over the constants).
+  EXPECT_FALSE(
+      containsFloatingPointKind(lowered(mgr.CreateNode(FP_GT, one, two))));
+
+  // The other comparison kinds are not migrated.
+  EXPECT_FALSE(
+      containsFloatingPointKind(lowered(mgr.CreateNode(FP_GEQ, x, y))));
+  EXPECT_FALSE(
+      containsFloatingPointKind(lowered(mgr.CreateNode(FP_LEQ, x, y))));
+
+  // Flag off: the old behaviour, everything lowers.
+  mgr.UserFlags.fp_native_cmp = false;
+  EXPECT_FALSE(containsFloatingPointKind(lowered(gt_symbols)));
+}
+
+// The native encoding and SymFPU must agree on every comparison. At the
+// smallest supported format, (3, 4), all 128 x 128 packed operand pairs are
+// checked for both fp.gt and fp.lt: the native verdict comes from
+// bit-blasting the comparison over constant operands (the AIG collapses to
+// a constant), the reference from SymFPU's fold-by-construction constant
+// evaluation. The sweep includes +/-0, +/-infinity, NaN and every subnormal
+// pair.
+TEST(FloatBlast, native_comparison_agrees_with_symfpu_exhaustively)
+{
+  STPMgr mgr;
+  SubstitutionMap substitutions(&mgr);
+  Simplifier simp(&mgr, &substitutions);
+  BBNodeManagerAIG aig;
+  BitBlaster bb(&aig, &simp, mgr.defaultNodeFactory, &mgr.UserFlags);
+
+  const unsigned eb = 3, sb = 4;
+  const unsigned width = eb + sb;
+  const unsigned values = 1u << width;
+
+  std::vector<ASTNode> constants;
+  constants.reserve(values);
+  for (unsigned i = 0; i < values; i++)
+    constants.push_back(mgr.CreateFPConst(mgr.CreateBVConst(width, i), eb, sb));
+
+  unsigned checked = 0;
+  for (unsigned i = 0; i < values; i++)
+  {
+    for (unsigned j = 0; j < values; j++)
+    {
+      for (const Kind kind : {FP_GT, FP_LT})
+      {
+        const ASTNode comparison =
+            mgr.CreateNode(kind, constants[i], constants[j]);
+
+        const ASTNode reference = NonMemberBVConstEvaluator(&mgr, comparison);
+        ASSERT_TRUE(reference == mgr.ASTTrue || reference == mgr.ASTFalse);
+
+        const BBNode native = bb.BBForm(comparison);
+        ASSERT_TRUE(native == aig.getTrue() || native == aig.getFalse());
+
+        ASSERT_EQ(reference == mgr.ASTTrue, native == aig.getTrue())
+            << _kind_names[kind] << " disagrees on operands " << i << ", "
+            << j;
+        ++checked;
+      }
+    }
+  }
+  EXPECT_EQ(2 * values * values, checked);
 }

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -372,6 +372,11 @@ void ExtraMain::create_options()
       "When constant-bit propagation detects a constant bit during AIG construction, assert the AIG node and replace it, in the AIG, by the constant bit"
       )
 
+    ("bb.fp-native-cmp",
+      BOOL_ARG(bm->UserFlags.fp_native_cmp),
+      "Bit-blast fp.gt/fp.lt over already-packed operands natively instead of via the SymFPU unpacking circuits"
+      )
+
     ("bb.simplify-during-bb",
       BOOL_ARG(bm->UserFlags.simplify_during_BB_flag),
       "When bit-blasting discovers that a non-constant child of a term blasts to an all-constant vector, rebuild the term with that constant and re-run the word-level term simplifier on it. Has no effect unless the rewriting simplifier is also on, i.e. not with --disable-opt-inc or --disable-simplifications"


### PR DESCRIPTION
fp.gt and fp.lt whose operands are leaves — symbols, interned constants, or to_fp's reinterpret form over constant bits — no longer expand to SymFPU circuits. FloatBlast leaves the source comparison in place and the bit-blaster encodes it directly over the packed IEEE bits (`BBcompareFP`).

The encoding: sign-magnitude maps onto an unsigned total order with a per-bit XOR against the sign — `key(f) = ~sign ++ (bits[w-2:0] ^ sign)` — so the whole comparison is the XORs, two field tests per operand (NaN, zero) and one existing `BBBVLE` comparator. The keys misorder exactly one pair, `fp.gt(+0, -0)`, whose keys are adjacent with nothing between; a both-zero conjunct repairs it. isNaN tests the exponent/significand fields, so arbitrary NaN payloads compare as NaN.

**Why it wins**: the expensive part of the SymFPU route for a leaf comparison is unpacking the operands (CLZ priority encoder + barrel shifter per operand for subnormal normalisation); the comparison over unpacked fields is nearly free. Comparing packed bits needs no unpacking at all. Measured on binary64 probes (same binary, flag A/B):

| query | config | SymFPU (vars/clauses) | native | ratio |
|---|---|---|---|---|
| `fp.gt x 1.3` | `--disable-simplifications` | 1557 / 4475 | 377 / 935 | 4.1x / 4.8x |
| `1.3 < x < 2.0` (to_fp literals) | default | 607 / 2291 | 119 / 295 | 5.1x / 7.8x |
| same | `--disable-simplifications` | 1589 / 4571 | 379 / 941 | 4.2x / 4.9x |

**The gate** (`FloatBlast::nativeComparisonSurvivor`) keeps this sound and non-regressing:

- Operands that are FP operations stay on the SymFPU path: their values are cached *unpacked*, and packing them costs more than the nearly-free unpacked comparison saves.
- A literal usually arrives as to_fp's three-child reinterpret form over constant bits, not as an interned constant (FP constant folding is deferred solver-wide). The gate resolves that form through the canonicalising `CreateFPConst` funnel — the same lookthrough `RemoveUnconstrained`'s comparison rule uses. Without it the common spelling of the motivating query never fires.
- A comparison of two constants must not survive: constant folding and model evaluation lower the node over its constant children and rely on the result collapsing to a constant (`ComputeFormulaUsingModel` asserts lowering changed the node).

Because the surviving node and its children are exactly the original well-sorted ones, nothing is rebuilt over packed carriers, so the format-stamping hazard documented in FloatBlast.h does not arise. And because FP_GT/FP_LT reached every downstream pass before lowering existed, they all have arms already — no pass outside FloatBlast and the bit-blaster changes.

The old behaviour stays selectable as `--bb.fp-native-cmp=false`; the flag is deliberately not cleared by `--disable-simplifications`, which now also exercises the native path.

**Verification**

- Exhaustive differential at format (3, 4): all 128x128 constant pairs for both kinds, native AIG blast vs SymFPU constant evaluation — 32768 checks, 0 mismatches (`FloatBlast_Test`).
- New lit tests pin: NaN with any payload on either side is never greater; no zero exceeds another zero (kills the both-zero conjunct if it regresses); native fp.gt agrees with SymFPU fp.leq on all ordered binary32 pairs (SAT-proved cross-encoding identity); the to_fp lookthrough fires end-to-end; and a sat model that `CheckCounterExample` validates through SymFPU's semantics. Each runs under default flags, `--disable-simplifications` and `--bb.fp-native-cmp=false`.
- Full suites green with `-DENABLE_FLOATING_POINT=ON` (101/101, asserts on) and `=OFF` (74/74; the new bit-blaster case compiles without SymFPU and is unreachable there).

Known non-win, accepted: when *other* SymFPU operations share the comparison's operands, the all-SymFPU form can be smaller (the unpack amortises across consumers). Gating on that would make emission depend on traversal order, so it is not attempted.

Follow-ups: fp.geq/fp.leq (the zero correction flips to an OR), float-array READ and ITE operands in the gate, and a pack-carrier node to lift the gate for arithmetic-result operands.