### PR TITLE
Extend native comparison bit-blasting to fp.geq/fp.leq

### DIFF
--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -126,8 +126,9 @@ public:
   bool bvplus_variant = true;
   bool conjoin_to_top = false;
 
-  // Bit-blast fp.gt/fp.lt over already-packed operands natively (sign-magnitude
-  // comparison of the IEEE bits) instead of via the SymFPU unpacking circuits.
+  // Bit-blast the floating-point ordering comparisons over already-packed
+  // operands natively (sign-magnitude comparison of the IEEE bits) instead
+  // of via the SymFPU unpacking circuits.
   bool fp_native_cmp = true;
 
   int64_t multiplication_variant = 1;

--- a/include/stp/ToSat/BitBlaster.h
+++ b/include/stp/ToSat/BitBlaster.h
@@ -193,7 +193,8 @@ class BitBlaster
   // Return bit-blasted form for BVLE, BVGE, BVGT, SBLE, etc.
   BBNode BBcompare(const ASTNode& form, BBNodeSet& support);
 
-  // bit blast a floating-point comparison (FP_GT/FP_LT) over packed operands
+  // bit blast a floating-point ordering comparison (FP_GT, FP_LT, FP_GEQ,
+  // FP_LEQ) over packed operands
   BBNode BBcompareFP(const ASTNode& form, BBNodeSet& support);
 
   // Return bit-blasted form for the overflow predicates BVUADDO, BVSADDO,

--- a/lib/FloatBlaster/FloatBlast.cpp
+++ b/lib/FloatBlaster/FloatBlast.cpp
@@ -129,9 +129,10 @@ private:
     return ASTNode();
   }
 
-  // fp.gt/fp.lt over leaf operands skip SymFPU entirely: the source
-  // comparison survives to the bit-blaster, which compares the packed IEEE
-  // bits directly (BBcompareFP). Returns the surviving node -- `n` itself,
+  // The four ordering comparisons over leaf operands skip SymFPU entirely:
+  // the source comparison survives to the bit-blaster, which compares the
+  // packed IEEE bits directly (BBcompareFP). Returns the surviving node --
+  // `n` itself,
   // or the comparison rebuilt over resolved constant operands, both purely
   // float-sorted so no FP node is ever built over packed carriers -- or
   // null when the comparison has to take the SymFPU path.
@@ -551,9 +552,14 @@ private:
             formatOf(n[0]), asUnpacked(n[0]), asUnpacked(n[1]));
       }
       case FP_LEQ:
+      {
         requireSameFormat(n[0], n[1]);
+        const ASTNode survivor = nativeComparisonSurvivor(n);
+        if (!survivor.IsNull())
+          return survivor;
         return symbolic_fp::unpacked::lessThanOrEqual(
             formatOf(n[0]), asUnpacked(n[0]), asUnpacked(n[1]));
+      }
       case FP_GT:
       {
         requireSameFormat(n[0], n[1]);
@@ -564,9 +570,14 @@ private:
             formatOf(n[0]), asUnpacked(n[1]), asUnpacked(n[0]));
       }
       case FP_GEQ:
+      {
         requireSameFormat(n[0], n[1]);
+        const ASTNode survivor = nativeComparisonSurvivor(n);
+        if (!survivor.IsNull())
+          return survivor;
         return symbolic_fp::unpacked::lessThanOrEqual(
             formatOf(n[0]), asUnpacked(n[1]), asUnpacked(n[0]));
+      }
 
       case FP_ISNORMAL:
         return symbolic_fp::unpacked::isNormal(formatOf(n[0]),

--- a/lib/STPManager/STP.cpp
+++ b/lib/STPManager/STP.cpp
@@ -540,10 +540,11 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
   // Lower floating-point operations before the first pass that invokes the
   // bit-blaster. From here on the formula is a packed-bit circuit: float
   // symbols, constants and reads retain sort metadata for model
-  // reconstruction. The only FP operations that survive are fp.gt/fp.lt over
-  // leaf operands, which the bit-blaster encodes natively (see
-  // BBcompareFP); every downstream pass already has an FP_GT/FP_LT arm
-  // because these kinds used to reach them before lowering existed.
+  // reconstruction. The only FP operations that survive are the ordering
+  // comparisons (fp.gt/fp.lt/fp.geq/fp.leq) over leaf operands, which the
+  // bit-blaster encodes natively (see BBcompareFP); every downstream pass
+  // already has arms for these kinds because they used to reach it before
+  // lowering existed.
   //
   // This remains after all of the size-reducing passes above. In particular,
   // RemoveUnconstrained must see a float symbol rather than its exposed bits.

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -1325,13 +1325,13 @@ const BBNode BitBlaster::BBForm(const ASTNode& form,
     }
     case FP_GT:
     case FP_LT:
+    case FP_GEQ:
+    case FP_LEQ:
     {
       result = BBcompareFP(form, support);
       break;
     }
 
-    case FP_LEQ:
-    case FP_GEQ:
     case FP_EQ:
     case FP_ISNORMAL:
     case FP_ISSUBNORMAL:
@@ -3059,28 +3059,34 @@ BBNode BitBlaster::BBcompare(const ASTNode& form,
   }
 }
 
-// Bit-blasted form for FP_GT and FP_LT over packed IEEE-754 operands.
-// FloatBlast leaves these comparisons in place when both operands are leaves
-// (symbols, interned constants); their packed bits are compared directly,
-// with no unpacking. Sign-magnitude maps onto an unsigned total order with a
-// per-bit XOR against the sign:
+// Bit-blasted form for the four ordering comparisons (FP_GT, FP_LT, FP_GEQ,
+// FP_LEQ) over packed IEEE-754 operands. FloatBlast leaves these comparisons
+// in place when both operands are leaves (symbols, interned constants);
+// their packed bits are compared directly, with no unpacking. Sign-magnitude
+// maps onto an unsigned total order with a per-bit XOR against the sign:
 //
 //   key(f) = not(sign(f)) ++ (f[w-2:0] xor sign(f))
-//   a > b  = not(isNaN(a)) and not(isNaN(b))
-//            and not(isZero(a) and isZero(b)) and key(a) >u key(b)
+//   a >  b = not(isNaN(a)) and not(isNaN(b))
+//            and not(isZero(a) and isZero(b)) and key(a) >u  key(b)
+//   a >= b = not(isNaN(a)) and not(isNaN(b))
+//            and (   (isZero(a) and isZero(b)) or  key(a) >=u key(b))
 //
-// The keys order every pair correctly except (+0, -0): their keys are
-// adjacent with no other float's key between them, so the only misordered
-// pair is repaired by the both-zero conjunct. (A greater-or-equal variant
-// would need the correction ORed in instead.) isNaN tests the exponent and
-// significand fields, so operands with arbitrary NaN payloads compare as
-// NaN.
+// The keys order every pair correctly except the two zeros: key(-0) and
+// key(+0) are adjacent with no other float's key between them, and +0 and
+// -0 compare EQUAL. So exactly one pair is misordered per direction --
+// strictly, key(+0) > key(-0) must be suppressed (the both-zero conjunct);
+// non-strictly, key(-0) >= key(+0) must be granted (the both-zero
+// disjunct). isNaN tests the exponent and significand fields, so operands
+// with arbitrary NaN payloads compare as NaN.
 BBNode BitBlaster::BBcompareFP(const ASTNode& form, BBNodeSet& support)
 {
-  assert(form.GetKind() == FP_GT || form.GetKind() == FP_LT);
-  // fp.lt(a,b) is exactly fp.gt(b,a).
-  const ASTNode& a = form.GetKind() == FP_GT ? form[0] : form[1];
-  const ASTNode& b = form.GetKind() == FP_GT ? form[1] : form[0];
+  const Kind k = form.GetKind();
+  assert(k == FP_GT || k == FP_LT || k == FP_GEQ || k == FP_LEQ);
+  // fp.lt(a,b) is exactly fp.gt(b,a), and fp.leq(a,b) exactly fp.geq(b,a).
+  const bool mirrored = (k == FP_LT || k == FP_LEQ);
+  const bool strict = (k == FP_GT || k == FP_LT);
+  const ASTNode& a = mirrored ? form[1] : form[0];
+  const ASTNode& b = mirrored ? form[0] : form[1];
 
   const SourceSort sort = a.GetSourceSort();
   assert(sort.kind() == SourceSort::Kind::FloatingPoint);
@@ -3125,14 +3131,18 @@ BBNode BitBlaster::BBcompareFP(const ASTNode& form, BBNodeSet& support)
       nf->CreateNode(AND, isZero(aBits, w), isZero(bBits, w));
   const BBNodeVec aKey = key(aBits, w);
   const BBNodeVec bKey = key(bBits, w);
-  const BBNode greater = BBBVLE(bKey, aKey, false, true); // key(a) >u key(b)
+  // key(a) >u key(b) when strict, key(a) >=u key(b) otherwise.
+  const BBNode ordered = strict ? BBBVLE(bKey, aKey, false, true)
+                                : BBBVLE(bKey, aKey, false);
+  const BBNode zeroCorrected =
+      strict ? nf->CreateNode(AND, nf->CreateNode(NOT, bothZero), ordered)
+             : nf->CreateNode(OR, bothZero, ordered);
 
   BBNodeVec conjuncts;
-  conjuncts.reserve(4);
+  conjuncts.reserve(3);
   conjuncts.push_back(aNotNaN);
   conjuncts.push_back(bNotNaN);
-  conjuncts.push_back(nf->CreateNode(NOT, bothZero));
-  conjuncts.push_back(greater);
+  conjuncts.push_back(zeroCorrected);
   return nf->CreateNode(AND, conjuncts);
 }
 

--- a/tests/query-files/fp-tests/native-comparison-agrees-with-leq.smt2
+++ b/tests/query-files/fp-tests/native-comparison-agrees-with-leq.smt2
@@ -3,12 +3,14 @@
 ; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck %s
 ;
 ; For ordered (non-NaN) operands, fp.gt is exactly the negation of fp.leq.
-; fp.gt over symbols blasts natively (BBcompareFP) while fp.leq is not
-; migrated and lowers through SymFPU, so the SAT solver proves the native
-; and SymFPU encodings agree on every ordered binary32 pair -- +/-0,
-; infinities and subnormals included. (NaN operands, where gt and leq are
-; both false and the identity does not hold, are excluded here and covered
-; by native-comparison-nan-never-gt.smt2.)
+; Both blast natively (BBcompareFP) with the flag on -- gt through the
+; strict arm with the both-zero conjunct, leq through the non-strict arm
+; with the both-zero disjunct -- so the SAT solver proves the two arms are
+; complementary on every ordered binary32 pair, +/-0, infinities and
+; subnormals included; the flag-off run proves the same identity all-SymFPU.
+; (NaN operands, where gt and leq are both false and the identity does not
+; hold, are excluded here and covered by
+; native-comparison-nan-never-gt.smt2.)
 ;
 ; CHECK: ^unsat
 (set-logic QF_FP)

--- a/tests/query-files/fp-tests/native-comparison-geq-is-gt-or-eq.smt2
+++ b/tests/query-files/fp-tests/native-comparison-geq-is-gt-or-eq.smt2
@@ -1,0 +1,22 @@
+; RUN: %solver %s | %OutputCheck %s
+; RUN: %solver --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck %s
+;
+; For ordered (non-NaN) operands, fp.geq is exactly fp.gt-or-fp.eq. With
+; all four ordering comparisons native, fp.eq is the remaining SymFPU
+; encoding in this identity, so the SAT solver proves the native non-strict
+; arm agrees with SymFPU's equality on every ordered binary32 pair --
+; including the zeros, where fp.eq supplies the (+0 = -0) case that the
+; both-zero disjunct must match. The --disable-simplifications run keeps
+; fp.leq/fp.geq from being rewritten at parse (the factory mirrors leq onto
+; geq), and the flag-off run proves the identity all-SymFPU.
+;
+; CHECK: ^unsat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(declare-fun y () (_ FloatingPoint 8 24))
+(assert (not (fp.isNaN x)))
+(assert (not (fp.isNaN y)))
+(assert (xor (fp.geq x y) (or (fp.gt x y) (fp.eq x y))))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/native-comparison-zero-order-geq.smt2
+++ b/tests/query-files/fp-tests/native-comparison-zero-order-geq.smt2
@@ -1,0 +1,22 @@
+; RUN: %solver %s | %OutputCheck %s
+; RUN: %solver --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck %s
+;
+; Every zero is greater-or-equal to every other zero: +0 and -0 compare
+; EQUAL despite different packed bits. In the native encoding (BBcompareFP)
+; key(-0) < key(+0), so (fp.geq -0 +0) is the single pair the non-strict
+; key comparison misorders; the both-zero DISJUNCT repairs exactly it --
+; the mirror image of the strict case's conjunct, which
+; native-comparison-zero-order.smt2 pins. If the disjunct regresses (or the
+; strict conjunct is copied here by mistake), x = -0, y = +0 satisfies this
+; formula.
+;
+; CHECK: ^unsat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(declare-fun y () (_ FloatingPoint 8 24))
+(assert (fp.isZero x))
+(assert (fp.isZero y))
+(assert (not (fp.geq x y)))
+(check-sat)
+(exit)

--- a/tests/unit-tests/FloatBlast_Test.cpp
+++ b/tests/unit-tests/FloatBlast_Test.cpp
@@ -289,10 +289,10 @@ TEST(FloatBlast, every_floating_point_kind_is_lowered)
   }
 }
 
-// fp.gt/fp.lt over leaf operands are not expanded to SymFPU circuits: the
-// source node passes through lowering unchanged and the bit-blaster encodes
-// it natively over the packed bits (BBcompareFP). Everything else -- other
-// comparison kinds, operands that are FP operations, constant pairs, and
+// The four ordering comparisons over leaf operands are not expanded to
+// SymFPU circuits: the source node passes through lowering unchanged and
+// the bit-blaster encodes it natively over the packed bits (BBcompareFP).
+// Everything else -- operands that are FP operations, constant pairs, and
 // every comparison once the flag is off -- still lowers through SymFPU.
 TEST(FloatBlast, native_comparison_survives_for_leaf_operands)
 {
@@ -344,11 +344,13 @@ TEST(FloatBlast, native_comparison_survives_for_leaf_operands)
   EXPECT_FALSE(
       containsFloatingPointKind(lowered(mgr.CreateNode(FP_GT, one, two))));
 
-  // The other comparison kinds are not migrated.
+  // The non-strict comparisons survive under the same gate.
+  const ASTNode geq_symbols = mgr.CreateNode(FP_GEQ, x, y);
+  EXPECT_EQ(geq_symbols, lowered(geq_symbols));
+  const ASTNode leq_constant = mgr.CreateNode(FP_LEQ, x, one);
+  EXPECT_EQ(leq_constant, lowered(leq_constant));
   EXPECT_FALSE(
-      containsFloatingPointKind(lowered(mgr.CreateNode(FP_GEQ, x, y))));
-  EXPECT_FALSE(
-      containsFloatingPointKind(lowered(mgr.CreateNode(FP_LEQ, x, y))));
+      containsFloatingPointKind(lowered(mgr.CreateNode(FP_GEQ, sum, y))));
 
   // Flag off: the old behaviour, everything lowers.
   mgr.UserFlags.fp_native_cmp = false;
@@ -357,11 +359,11 @@ TEST(FloatBlast, native_comparison_survives_for_leaf_operands)
 
 // The native encoding and SymFPU must agree on every comparison. At the
 // smallest supported format, (3, 4), all 128 x 128 packed operand pairs are
-// checked for both fp.gt and fp.lt: the native verdict comes from
-// bit-blasting the comparison over constant operands (the AIG collapses to
-// a constant), the reference from SymFPU's fold-by-construction constant
-// evaluation. The sweep includes +/-0, +/-infinity, NaN and every subnormal
-// pair.
+// checked for each of the four ordering comparisons: the native verdict
+// comes from bit-blasting the comparison over constant operands (the AIG
+// collapses to a constant), the reference from SymFPU's
+// fold-by-construction constant evaluation. The sweep includes +/-0,
+// +/-infinity, NaN and every subnormal pair.
 TEST(FloatBlast, native_comparison_agrees_with_symfpu_exhaustively)
 {
   STPMgr mgr;
@@ -384,7 +386,7 @@ TEST(FloatBlast, native_comparison_agrees_with_symfpu_exhaustively)
   {
     for (unsigned j = 0; j < values; j++)
     {
-      for (const Kind kind : {FP_GT, FP_LT})
+      for (const Kind kind : {FP_GT, FP_LT, FP_GEQ, FP_LEQ})
       {
         const ASTNode comparison =
             mgr.CreateNode(kind, constants[i], constants[j]);
@@ -402,5 +404,5 @@ TEST(FloatBlast, native_comparison_agrees_with_symfpu_exhaustively)
       }
     }
   }
-  EXPECT_EQ(2 * values * values, checked);
+  EXPECT_EQ(4 * values * values, checked);
 }

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -374,7 +374,7 @@ void ExtraMain::create_options()
 
     ("bb.fp-native-cmp",
       BOOL_ARG(bm->UserFlags.fp_native_cmp),
-      "Bit-blast fp.gt/fp.lt over already-packed operands natively instead of via the SymFPU unpacking circuits"
+      "Bit-blast floating-point ordering comparisons over already-packed operands natively instead of via the SymFPU unpacking circuits"
       )
 
     ("bb.simplify-during-bb",


### PR DESCRIPTION
Follow-up to #757. The non-strict orderings reuse the sign-magnitude keys; the only semantic delta is the zero correction flipping direction. The two zeros compare equal but get adjacent distinct keys (`key(-0) < key(+0)`), so exactly one pair is misordered per direction:

- strict: `key(+0) > key(-0)` must be **suppressed** — the existing both-zero conjunct;
- non-strict: `key(-0) >= key(+0)` must be **granted** — a both-zero disjunct:

```
a >= b  =  !isNaN(a) & !isNaN(b) & (bothZero | key(a) >=u key(b))
```

`BBcompareFP` now handles all four ordering kinds (mirror swap for the less-thans, strict/non-strict `BBBVLE` and zero correction selected from the kind); the FloatBlast gate from #757 is kind-agnostic and just gained the `FP_GEQ`/`FP_LEQ` call sites. When a formula uses both strict and non-strict comparisons over the same operands, AIG hash-consing shares the key circuits.

Measured (binary64, `--disable-simplifications --exit-after-CNF`, same-binary flag A/B): `fp.geq x 1.3` drops 1617 vars / 4655 clauses → **381 / 947**, the same ~4-5x as fp.gt.

**Verification**

- The exhaustive differential now sweeps **all four kinds** over every constant pair at format (3, 4): 65536 checks against SymFPU's constant evaluation, 0 mismatches.
- `native-comparison-zero-order-geq.smt2`: `isZero x ∧ isZero y ∧ ¬(fp.geq x y)` is unsat — this dies if the disjunct regresses or the strict conjunct is copied by mistake.
- With all four orderings native, the cross-encoding identity moves to fp.eq (still SymFPU): `native-comparison-geq-is-gt-or-eq.smt2` SAT-proves `geq ≡ gt ∨ eq` on all ordered binary32 pairs, pinning the `+0 = -0` case against SymFPU equality. `agrees-with-leq` becomes a native-internal strict/non-strict complementarity check; its flag-off run keeps the all-SymFPU reference.
- Full suites green: FP build 101/101 (asserts on), non-FP build 74/74.