### PR TITLE
Bit-blast fp.eq and = on floats over leaf operands natively

### DIFF
--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -126,9 +126,9 @@ public:
   bool bvplus_variant = true;
   bool conjoin_to_top = false;
 
-  // Bit-blast the floating-point ordering comparisons over already-packed
-  // operands natively (sign-magnitude comparison of the IEEE bits) instead
-  // of via the SymFPU unpacking circuits.
+  // Bit-blast the floating-point comparisons and equalities over
+  // already-packed operands natively (over the IEEE bits) instead of via the
+  // SymFPU unpacking circuits.
   bool fp_native_cmp = true;
 
   int64_t multiplication_variant = 1;

--- a/include/stp/ToSat/BitBlaster.h
+++ b/include/stp/ToSat/BitBlaster.h
@@ -197,6 +197,15 @@ class BitBlaster
   // FP_LEQ) over packed operands
   BBNode BBcompareFP(const ASTNode& form, BBNodeSet& support);
 
+  // bit blast a floating-point equality (FP_EQ, FP_SMT_EQ) over packed
+  // operands
+  BBNode BBeqFP(const ASTNode& form, BBNodeSet& support);
+
+  // Field tests on a packed IEEE-754 operand, shared by the comparison and
+  // equality encodings. `sb` is the significand width, `w` the total width.
+  BBNode BBfpIsNaN(const BBNodeVec& p, unsigned sb, unsigned w);
+  BBNode BBfpIsZero(const BBNodeVec& p, unsigned w);
+
   // Return bit-blasted form for the overflow predicates BVUADDO, BVSADDO,
   // BVUMULO, BVSMULO, BVUSUBO, BVSSUBO.
   BBNode BBOverflow(const ASTNode& form, BBNodeSet& support);

--- a/lib/FloatBlaster/FloatBlast.cpp
+++ b/lib/FloatBlaster/FloatBlast.cpp
@@ -129,10 +129,10 @@ private:
     return ASTNode();
   }
 
-  // The four ordering comparisons over leaf operands skip SymFPU entirely:
+  // The six comparison predicates over leaf operands skip SymFPU entirely:
   // the source comparison survives to the bit-blaster, which compares the
-  // packed IEEE bits directly (BBcompareFP). Returns the surviving node --
-  // `n` itself,
+  // packed IEEE bits directly (BBcompareFP, BBeqFP). Returns the surviving
+  // node -- `n` itself,
   // or the comparison rebuilt over resolved constant operands, both purely
   // float-sorted so no FP node is ever built over packed carriers -- or
   // null when the comparison has to take the SymFPU path.
@@ -155,7 +155,20 @@ private:
       return ASTNode();
     if (left == n[0] && right == n[1])
       return n;
-    return node_factory->CreateNode(n.GetKind(), left, right);
+    // The rebuild goes through the simplifying factory, which may fold the
+    // comparison into something the bit-blaster has no native arm for (it
+    // already turns fp.geq(x,x) into not(fp.isNaN(x))). Anything but a
+    // natively blasted comparison goes back to SymFPU.
+    const ASTNode rebuilt = node_factory->CreateNode(n.GetKind(), left, right);
+    if (!isNativelyBlasted(rebuilt.GetKind()))
+      return ASTNode();
+    return rebuilt;
+  }
+
+  static bool isNativelyBlasted(Kind k)
+  {
+    return k == FP_GT || k == FP_LT || k == FP_GEQ || k == FP_LEQ ||
+           k == FP_EQ || k == FP_SMT_EQ;
   }
 
   ASTNode rebuild(const ASTNode& n, const ASTVec& children)
@@ -534,14 +547,23 @@ private:
         return canonicalPacked(n[0]);
 
       case FP_SMT_EQ:
+      {
         requireSameFormat(n[0], n[1]);
+        const ASTNode survivor = nativeComparisonSurvivor(n);
+        if (!survivor.IsNull())
+          return survivor;
         return symbolic_fp::unpacked::smtEqual(
             formatOf(n[0]), asUnpacked(n[0]), asUnpacked(n[1]));
-
+      }
       case FP_EQ:
+      {
         requireSameFormat(n[0], n[1]);
+        const ASTNode survivor = nativeComparisonSurvivor(n);
+        if (!survivor.IsNull())
+          return survivor;
         return symbolic_fp::unpacked::ieeeEqual(
             formatOf(n[0]), asUnpacked(n[0]), asUnpacked(n[1]));
+      }
       case FP_LT:
       {
         requireSameFormat(n[0], n[1]);

--- a/lib/STPManager/STP.cpp
+++ b/lib/STPManager/STP.cpp
@@ -540,9 +540,10 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
   // Lower floating-point operations before the first pass that invokes the
   // bit-blaster. From here on the formula is a packed-bit circuit: float
   // symbols, constants and reads retain sort metadata for model
-  // reconstruction. The only FP operations that survive are the ordering
-  // comparisons (fp.gt/fp.lt/fp.geq/fp.leq) over leaf operands, which the
-  // bit-blaster encodes natively (see BBcompareFP); every downstream pass
+  // reconstruction. The only FP operations that survive are the six
+  // comparison predicates (fp.gt/fp.lt/fp.geq/fp.leq and the two
+  // equalities, fp.eq and = on floats) over leaf operands, which the
+  // bit-blaster encodes natively (BBcompareFP, BBeqFP); every downstream pass
   // already has arms for these kinds because they used to reach it before
   // lowering existed.
   //

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -1333,6 +1333,12 @@ const BBNode BitBlaster::BBForm(const ASTNode& form,
     }
 
     case FP_EQ:
+    case FP_SMT_EQ:
+    {
+      result = BBeqFP(form, support);
+      break;
+    }
+
     case FP_ISNORMAL:
     case FP_ISSUBNORMAL:
     case FP_ISZERO:
@@ -1340,7 +1346,6 @@ const BBNode BitBlaster::BBForm(const ASTNode& form,
     case FP_ISNAN:
     case FP_ISNEGATIVE:
     case FP_ISPOSITIVE:
-    case FP_SMT_EQ:
     {
       FatalError("BBForm: FP formulas should not reach the bit-blaster: ",
                  form);
@@ -3059,6 +3064,28 @@ BBNode BitBlaster::BBcompare(const ASTNode& form,
   }
 }
 
+// A packed IEEE-754 operand is NaN iff its exponent field is all ones and
+// its significand field is nonzero -- true of every NaN payload, so no
+// canonical pattern is assumed. Bit i is bit i of the IEEE encoding:
+// significand field in bits [0, sb-2], exponent field in bits [sb-1, w-2],
+// sign at w-1.
+BBNode BitBlaster::BBfpIsNaN(const BBNodeVec& p, unsigned sb, unsigned w)
+{
+  BBNodeVec expField(p.begin() + (sb - 1), p.begin() + (w - 1));
+  BBNodeVec sigField(p.begin(), p.begin() + (sb - 1));
+  const BBNode expAllOnes = nf->CreateNode(AND, expField);
+  const BBNode sigNonZero = nf->CreateNode(OR, sigField);
+  return nf->CreateNode(AND, expAllOnes, sigNonZero);
+}
+
+// Zero iff the whole magnitude (everything below the sign bit) is zero, so
+// both +0 and -0 satisfy it.
+BBNode BitBlaster::BBfpIsZero(const BBNodeVec& p, unsigned w)
+{
+  BBNodeVec magnitude(p.begin(), p.begin() + (w - 1));
+  return nf->CreateNode(NOR, magnitude);
+}
+
 // Bit-blasted form for the four ordering comparisons (FP_GT, FP_LT, FP_GEQ,
 // FP_LEQ) over packed IEEE-754 operands. FloatBlast leaves these comparisons
 // in place when both operands are leaves (symbols, interned constants);
@@ -3102,19 +3129,6 @@ BBNode BitBlaster::BBcompareFP(const ASTNode& form, BBNodeSet& support)
   const BBNodeVec aBits = BBTerm(a, support);
   const BBNodeVec bBits = BBTerm(b, support);
 
-  auto isNaN = [this](const BBNodeVec& p, unsigned sig, unsigned width) {
-    BBNodeVec expField(p.begin() + (sig - 1), p.begin() + (width - 1));
-    BBNodeVec sigField(p.begin(), p.begin() + (sig - 1));
-    const BBNode expAllOnes = nf->CreateNode(AND, expField);
-    const BBNode sigNonZero = nf->CreateNode(OR, sigField);
-    return nf->CreateNode(AND, expAllOnes, sigNonZero);
-  };
-
-  auto isZero = [this](const BBNodeVec& p, unsigned width) {
-    BBNodeVec magnitude(p.begin(), p.begin() + (width - 1));
-    return nf->CreateNode(NOR, magnitude);
-  };
-
   auto key = [this](const BBNodeVec& p, unsigned width) {
     const BBNode& sign = p[width - 1];
     BBNodeVec k;
@@ -3125,10 +3139,10 @@ BBNode BitBlaster::BBcompareFP(const ASTNode& form, BBNodeSet& support)
     return k;
   };
 
-  const BBNode aNotNaN = nf->CreateNode(NOT, isNaN(aBits, sb, w));
-  const BBNode bNotNaN = nf->CreateNode(NOT, isNaN(bBits, sb, w));
+  const BBNode aNotNaN = nf->CreateNode(NOT, BBfpIsNaN(aBits, sb, w));
+  const BBNode bNotNaN = nf->CreateNode(NOT, BBfpIsNaN(bBits, sb, w));
   const BBNode bothZero =
-      nf->CreateNode(AND, isZero(aBits, w), isZero(bBits, w));
+      nf->CreateNode(AND, BBfpIsZero(aBits, w), BBfpIsZero(bBits, w));
   const BBNodeVec aKey = key(aBits, w);
   const BBNodeVec bKey = key(bBits, w);
   // key(a) >u key(b) when strict, key(a) >=u key(b) otherwise.
@@ -3143,6 +3157,58 @@ BBNode BitBlaster::BBcompareFP(const ASTNode& form, BBNodeSet& support)
   conjuncts.push_back(aNotNaN);
   conjuncts.push_back(bNotNaN);
   conjuncts.push_back(zeroCorrected);
+  return nf->CreateNode(AND, conjuncts);
+}
+
+// Bit-blasted form for the two equalities (FP_EQ, FP_SMT_EQ) over packed
+// IEEE-754 operands; FloatBlast leaves them in place under the same gate as
+// the ordering comparisons (see BBcompareFP). No unpacking and no
+// comparator is needed: an IEEE interchange format encodes every value
+// exactly once, so equality is bit equality -- except at the two corners,
+// where the two kinds make opposite choices.
+//
+//   fp.eq: NaN equals nothing (whatever its payload), and +0 equals -0.
+//     fp.eq(a,b) = not(isNaN(a)) and not(isNaN(b))
+//                  and (bits(a) = bits(b) or (isZero(a) and isZero(b)))
+//
+//   SMT =: the SMT domain has one abstract NaN, so all NaN payloads are
+//   equal, and two distinct zeros, so +0 and -0 are not.
+//     a = b = (isNaN(a) and isNaN(b)) or bits(a) = bits(b)
+BBNode BitBlaster::BBeqFP(const ASTNode& form, BBNodeSet& support)
+{
+  const Kind k = form.GetKind();
+  assert(k == FP_EQ || k == FP_SMT_EQ);
+
+  const SourceSort sort = form[0].GetSourceSort();
+  assert(sort.kind() == SourceSort::Kind::FloatingPoint);
+  const unsigned sb = sort.significandWidth();
+  const unsigned w = sort.exponentWidth() + sb;
+  assert(form[0].GetValueWidth() == w);
+  assert(form[1].GetValueWidth() == w);
+  assert(sb >= 2 && w >= sb + 1);
+
+  const BBNodeVec aBits = BBTerm(form[0], support);
+  const BBNodeVec bBits = BBTerm(form[1], support);
+  const BBNode sameBits = BBEQ(aBits, bBits);
+
+  if (k == FP_SMT_EQ)
+  {
+    const BBNode bothNaN = nf->CreateNode(AND, BBfpIsNaN(aBits, sb, w),
+                                          BBfpIsNaN(bBits, sb, w));
+    return nf->CreateNode(OR, bothNaN, sameBits);
+  }
+
+  const BBNode aNotNaN = nf->CreateNode(NOT, BBfpIsNaN(aBits, sb, w));
+  const BBNode bNotNaN = nf->CreateNode(NOT, BBfpIsNaN(bBits, sb, w));
+  const BBNode bothZero =
+      nf->CreateNode(AND, BBfpIsZero(aBits, w), BBfpIsZero(bBits, w));
+  const BBNode sameValue = nf->CreateNode(OR, sameBits, bothZero);
+
+  BBNodeVec conjuncts;
+  conjuncts.reserve(3);
+  conjuncts.push_back(aNotNaN);
+  conjuncts.push_back(bNotNaN);
+  conjuncts.push_back(sameValue);
   return nf->CreateNode(AND, conjuncts);
 }
 

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -3198,18 +3198,23 @@ BBNode BitBlaster::BBeqFP(const ASTNode& form, BBNodeSet& support)
     return nf->CreateNode(OR, bothNaN, sameBits);
   }
 
-  const BBNode aNotNaN = nf->CreateNode(NOT, BBfpIsNaN(aBits, sb, w));
-  const BBNode bNotNaN = nf->CreateNode(NOT, BBfpIsNaN(bBits, sb, w));
+  // One not-NaN test suffices, not two: when the result can be true at
+  // all, either bits(a) = bits(b) -- identical patterns, so the operands
+  // are NaN or not together and one test implies the other -- or both
+  // operands are zeros, which are never NaN. Testing only one side
+  // computes the same Boolean function (the exhaustive differential
+  // passes with either or both tests; no test CAN distinguish them, so
+  // this comment is the argument that keeps the dropped test dropped).
+  // Test the constant side when there is one: its isNaN folds away
+  // entirely and the symbolic side's isNaN circuit is never built. The
+  // choice is per-node and deterministic.
+  const BBNodeVec& nanSide = form[0].isConstant() ? aBits : bBits;
+  const BBNode notNaN = nf->CreateNode(NOT, BBfpIsNaN(nanSide, sb, w));
   const BBNode bothZero =
       nf->CreateNode(AND, BBfpIsZero(aBits, w), BBfpIsZero(bBits, w));
   const BBNode sameValue = nf->CreateNode(OR, sameBits, bothZero);
 
-  BBNodeVec conjuncts;
-  conjuncts.reserve(3);
-  conjuncts.push_back(aNotNaN);
-  conjuncts.push_back(bNotNaN);
-  conjuncts.push_back(sameValue);
-  return nf->CreateNode(AND, conjuncts);
+  return nf->CreateNode(AND, notNaN, sameValue);
 }
 
 // Return bit-blasted form for the overflow predicates BVUADDO, BVSADDO,

--- a/tests/query-files/fp-tests/native-comparison-geq-is-gt-or-eq.smt2
+++ b/tests/query-files/fp-tests/native-comparison-geq-is-gt-or-eq.smt2
@@ -2,12 +2,12 @@
 ; RUN: %solver --disable-simplifications %s | %OutputCheck %s
 ; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck %s
 ;
-; For ordered (non-NaN) operands, fp.geq is exactly fp.gt-or-fp.eq. With
-; all four ordering comparisons native, fp.eq is the remaining SymFPU
-; encoding in this identity, so the SAT solver proves the native non-strict
-; arm agrees with SymFPU's equality on every ordered binary32 pair --
-; including the zeros, where fp.eq supplies the (+0 = -0) case that the
-; both-zero disjunct must match. The --disable-simplifications run keeps
+; For ordered (non-NaN) operands, fp.geq is exactly fp.gt-or-fp.eq, so the
+; SAT solver proves the non-strict arm agrees with equality on every ordered
+; binary32 pair -- including the zeros, where fp.eq supplies the (+0 = -0)
+; case that the both-zero disjunct must match. (fp.eq was still SymFPU when
+; this test was written; it is native now, which leaves the flag-off run as
+; the cross-encoding check.) The --disable-simplifications run keeps
 ; fp.leq/fp.geq from being rewritten at parse (the factory mirrors leq onto
 ; geq), and the flag-off run proves the identity all-SymFPU.
 ;

--- a/tests/query-files/fp-tests/native-eq-is-geq-and-leq.smt2
+++ b/tests/query-files/fp-tests/native-eq-is-geq-and-leq.smt2
@@ -1,0 +1,20 @@
+; RUN: %solver %s | %OutputCheck %s
+; RUN: %solver --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck %s
+;
+; For ordered (non-NaN) operands, fp.eq is exactly fp.geq-and-fp.leq, so
+; this formula is unsatisfiable. All three predicates are now bit-blasted
+; natively, which makes this an internal-consistency check: the equality's
+; both-zero disjunct and the orderings' both-zero correction have to agree
+; on the (+0, -0) pair, the only place where equal values have different
+; packed bits. The flag-off run proves the identity all-SymFPU.
+;
+; CHECK: ^unsat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(declare-fun y () (_ FloatingPoint 8 24))
+(assert (not (fp.isNaN x)))
+(assert (not (fp.isNaN y)))
+(assert (xor (fp.eq x y) (and (fp.geq x y) (fp.leq x y))))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/native-eq-nan.smt2
+++ b/tests/query-files/fp-tests/native-eq-nan.smt2
@@ -1,0 +1,22 @@
+; RUN: %solver %s | %OutputCheck %s
+; RUN: %solver --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck %s
+;
+; fp.eq is IEEE equality, so a NaN operand -- on either side, with ANY
+; payload the SAT solver can pick -- makes it false, and this formula is
+; unsatisfiable. In the native encoding (BBeqFP) that is the pair of
+; not-NaN conjuncts, and NaN is recognised by its exponent and significand
+; fields rather than a canonical bit pattern; a payload-sensitive test, or a
+; not-NaN conjunct dropped from one side, makes this sat. fp.isNaN still
+; lowers through SymFPU, and the third run proves that path agrees.
+;
+; CHECK: ^unsat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(declare-fun y () (_ FloatingPoint 8 24))
+(declare-fun z () (_ FloatingPoint 8 24))
+(declare-fun w () (_ FloatingPoint 8 24))
+(assert (or (and (fp.eq x y) (fp.isNaN x))
+            (and (fp.eq z w) (fp.isNaN w))))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/native-eq-zero.smt2
+++ b/tests/query-files/fp-tests/native-eq-zero.smt2
@@ -1,0 +1,20 @@
+; RUN: %solver %s | %OutputCheck %s
+; RUN: %solver --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck %s
+;
+; fp.eq identifies the two zeros: +0 and -0 have different packed bits but
+; are IEEE-equal, so every pair of zeros satisfies fp.eq and this formula is
+; unsatisfiable. The native encoding (BBeqFP) gets this from the both-zero
+; disjunct that sits beside plain bit equality; drop it and x = -0, y = +0
+; makes the formula sat. fp.isZero still lowers through SymFPU, so the two
+; encodings are checked against each other.
+;
+; CHECK: ^unsat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(declare-fun y () (_ FloatingPoint 8 24))
+(assert (fp.isZero x))
+(assert (fp.isZero y))
+(assert (not (fp.eq x y)))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/native-smt-eq-implies-eq.smt2
+++ b/tests/query-files/fp-tests/native-smt-eq-implies-eq.smt2
@@ -1,0 +1,20 @@
+; RUN: %solver %s | %OutputCheck %s
+; RUN: %solver --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck %s
+;
+; The two equalities differ only at NaN and at the zeros, and in one
+; direction only: for a non-NaN operand, x = y implies fp.eq x y (the
+; converse fails at +0 = -0). So this formula is unsatisfiable. It ties the
+; two native encodings (BBeqFP) to each other -- they share their bit
+; equality but flip both corner cases, so a corner handled in the wrong kind
+; shows up here as sat.
+;
+; CHECK: ^unsat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(declare-fun y () (_ FloatingPoint 8 24))
+(assert (not (fp.isNaN x)))
+(assert (= x y))
+(assert (not (fp.eq x y)))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/native-smt-eq-nan-payloads.smt2
+++ b/tests/query-files/fp-tests/native-smt-eq-nan-payloads.smt2
@@ -1,0 +1,21 @@
+; RUN: %solver %s | %OutputCheck %s
+; RUN: %solver --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck %s
+;
+; The SMT domain has ONE NaN: payloads are a detail of the encoding, so all
+; NaNs are = to each other and this formula is unsatisfiable. This is the
+; test for the both-NaN disjunct in the native encoding (BBeqFP) -- plain
+; equality of the packed bits fails it, because the SAT solver simply picks
+; two different payloads (or two different NaN signs) for x and y.
+; fp.isNaN still lowers through SymFPU, and the third run proves that path
+; agrees.
+;
+; CHECK: ^unsat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(declare-fun y () (_ FloatingPoint 8 24))
+(assert (fp.isNaN x))
+(assert (fp.isNaN y))
+(assert (not (= x y)))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/native-smt-eq-zeros-distinct.smt2
+++ b/tests/query-files/fp-tests/native-smt-eq-zeros-distinct.smt2
@@ -1,0 +1,21 @@
+; RUN: %solver %s | %OutputCheck %s
+; RUN: %solver --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck %s
+;
+; SMT's = on the FloatingPoint sort separates the zeros -- the domain has
+; two of them, and they are different values even though fp.eq identifies
+; them. So x = -0 forces y to -0 as well, contradicting fp.isPositive y, and
+; this formula is unsatisfiable. The native encoding (BBeqFP) gets this for
+; free from bit equality; copy fp.eq's both-zero disjunct into the SMT
+; equality by mistake and x = -0, y = +0 makes it sat.
+;
+; CHECK: ^unsat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(declare-fun y () (_ FloatingPoint 8 24))
+(assert (= x y))
+(assert (fp.isZero x))
+(assert (fp.isNegative x))
+(assert (fp.isPositive y))
+(check-sat)
+(exit)

--- a/tests/unit-tests/FloatBlast_Test.cpp
+++ b/tests/unit-tests/FloatBlast_Test.cpp
@@ -289,9 +289,10 @@ TEST(FloatBlast, every_floating_point_kind_is_lowered)
   }
 }
 
-// The four ordering comparisons over leaf operands are not expanded to
-// SymFPU circuits: the source node passes through lowering unchanged and
-// the bit-blaster encodes it natively over the packed bits (BBcompareFP).
+// The six comparison predicates over leaf operands are not expanded to
+// SymFPU circuits: the source node passes through lowering unchanged and the
+// bit-blaster encodes it natively over the packed bits (BBcompareFP,
+// BBeqFP).
 // Everything else -- operands that are FP operations, constant pairs, and
 // every comparison once the flag is off -- still lowers through SymFPU.
 TEST(FloatBlast, native_comparison_survives_for_leaf_operands)
@@ -352,6 +353,14 @@ TEST(FloatBlast, native_comparison_survives_for_leaf_operands)
   EXPECT_FALSE(
       containsFloatingPointKind(lowered(mgr.CreateNode(FP_GEQ, sum, y))));
 
+  // ... and so do the two equalities.
+  const ASTNode eq_symbols = mgr.CreateNode(FP_EQ, x, y);
+  EXPECT_EQ(eq_symbols, lowered(eq_symbols));
+  const ASTNode smt_eq_constant = mgr.CreateNode(FP_SMT_EQ, x, one);
+  EXPECT_EQ(smt_eq_constant, lowered(smt_eq_constant));
+  EXPECT_FALSE(
+      containsFloatingPointKind(lowered(mgr.CreateNode(FP_EQ, sum, y))));
+
   // Flag off: the old behaviour, everything lowers.
   mgr.UserFlags.fp_native_cmp = false;
   EXPECT_FALSE(containsFloatingPointKind(lowered(gt_symbols)));
@@ -359,7 +368,7 @@ TEST(FloatBlast, native_comparison_survives_for_leaf_operands)
 
 // The native encoding and SymFPU must agree on every comparison. At the
 // smallest supported format, (3, 4), all 128 x 128 packed operand pairs are
-// checked for each of the four ordering comparisons: the native verdict
+// checked for each of the six comparison predicates: the native verdict
 // comes from bit-blasting the comparison over constant operands (the AIG
 // collapses to a constant), the reference from SymFPU's
 // fold-by-construction constant evaluation. The sweep includes +/-0,
@@ -386,7 +395,7 @@ TEST(FloatBlast, native_comparison_agrees_with_symfpu_exhaustively)
   {
     for (unsigned j = 0; j < values; j++)
     {
-      for (const Kind kind : {FP_GT, FP_LT, FP_GEQ, FP_LEQ})
+      for (const Kind kind : {FP_GT, FP_LT, FP_GEQ, FP_LEQ, FP_EQ, FP_SMT_EQ})
       {
         const ASTNode comparison =
             mgr.CreateNode(kind, constants[i], constants[j]);
@@ -404,5 +413,5 @@ TEST(FloatBlast, native_comparison_agrees_with_symfpu_exhaustively)
       }
     }
   }
-  EXPECT_EQ(4 * values * values, checked);
+  EXPECT_EQ(6 * values * values, checked);
 }

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -374,7 +374,7 @@ void ExtraMain::create_options()
 
     ("bb.fp-native-cmp",
       BOOL_ARG(bm->UserFlags.fp_native_cmp),
-      "Bit-blast floating-point ordering comparisons over already-packed operands natively instead of via the SymFPU unpacking circuits"
+      "Bit-blast floating-point comparisons and equalities over already-packed operands natively instead of via the SymFPU unpacking circuits"
       )
 
     ("bb.simplify-during-bb",


### PR DESCRIPTION
Stacked on #759 (fp.geq/fp.leq) — please merge that one first; the base will retarget to master automatically. The diff here is the last two of the six comparison predicates.

`fp.eq` and SMT `=` on the FloatingPoint sort now survive FloatBlast under the same gate as the four ordering comparisons (both operands leaves, not both constant, `--bb.fp-native-cmp` on) and are bit-blasted directly over the packed IEEE bits. They are the cheapest of the six: an interchange format encodes every value exactly once, so equality is bit equality — no unpacking circuits and, unlike the orderings, no sign-magnitude key and no comparator.

The subtlety is the two corners, where the two kinds make the opposite choice. `fp.eq` is IEEE equality: NaN equals nothing whatever payload it carries, and +0 equals -0. SMT `=` is equality of abstract domain values, and that domain has ONE NaN (payloads are a representation detail, so every NaN bit pattern is the same value) and TWO zeros (so +0 and -0 are different values). So:

```
fp.eq(a,b) = !isNaN(a) & !isNaN(b) & (bits(a)=bits(b) | (isZero(a) & isZero(b)))
a = b      = (isNaN(a) & isNaN(b)) | bits(a)=bits(b)
```

`BBcompareFP`'s `isNaN`/`isZero` lambdas are hoisted to `BBfpIsNaN`/`BBfpIsZero` members and shared with the new `BBeqFP`; the ordering encoding is bit-identical. The FloatBlast gate is kind-agnostic and just gained two call sites, plus one guard: a comparison rebuilt through the simplifying factory is rejected if the factory folded it into a kind the bit-blaster has no native arm for. That is unreachable today, but the factory does turn `fp.geq(x,x)` into `not(fp.isNaN(x))`, which would leak an FP node past lowering if a similar rule ever applied after the to_fp lookthrough resolves an operand.

## Measurements

binary64, `--disable-simplifications --exit-after-CNF --output-CNF`, same binary, `p cnf` header, native vs `--bb.fp-native-cmp=false`:

| probe | native vars/clauses | SymFPU vars/clauses | ratio |
|---|---|---|---|
| `(fp.eq x 1.3)` | 175 / 329 | 1534 / 4406 | 8.8x / 13.4x |
| `(= x 1.3)` | 129 / 191 | 1532 / 4400 | 11.9x / 23.0x |
| `(fp.eq x y)` | 585 / 1367 | 3231 / 9305 | 5.5x / 6.8x |
| `(= x y)` | 511 / 1145 | 3233 / 9311 | 6.3x / 8.1x |

Better than the orderings' 4-5x, as expected with the comparator gone; against a constant operand nearly everything folds, and SMT `=` against a literal reduces to a 64-bit constant compare. All four probes give the same verdict under default, `--disable-simplifications` and `--bb.fp-native-cmp=false`.

## Verification

The exhaustive differential unit test now covers all six kinds: every packed operand pair at format (3,4), native AIG blast versus SymFPU's constant evaluation — 6 × 128 × 128 = 98304 checks, 0 mismatches, ~14s.

Six new lit tests, each run under default, `--disable-simplifications` and `--bb.fp-native-cmp=false`: the zeros are identified by `fp.eq` and separated by `=`, NaN of any payload on either side falsifies `fp.eq` while all NaN payloads are `=`-equal, `fp.eq` agrees with `fp.geq`-and-`fp.leq` on ordered operands, and `=` implies `fp.eq` for a non-NaN operand. The classification predicates they use (`fp.isNaN`, `fp.isZero`, `fp.isNegative`, `fp.isPositive`) still lower through SymFPU, so the first four are genuine cross-encoding checks rather than the native code checking itself.

Rather than trust the new tests, I mutation-tested them: dropping the both-zero disjunct from `fp.eq`, dropping the both-NaN disjunct from `=`, and copying `fp.eq`'s both-zero disjunct into `=` each fail exactly the test written for that mistake, and no other new test. One mutation is invisible — deleting one of `fp.eq`'s two not-NaN conjuncts — because it is logically redundant: bit equality with the other operand known non-NaN already implies this one is non-NaN. Keeping only one test would shrink `(fp.eq x 1.3)` further to 129/191, but which operand it should be depends on the factory's operand ordering, so I have left the encoding symmetric with the documented semantics and noted it as a follow-up.

Full suites green in both configurations: 101/101 with floating-point support, 74/74 with `-DENABLE_FLOATING_POINT=OFF` (the new bit-blaster code touches only BBNode operations and `SourceSort`, so it needs no SymFPU header and no `#ifdef`).