### PR TITLE
Bit-blast the floating-point classifications over leaf operands

### DIFF
--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -126,9 +126,9 @@ public:
   bool bvplus_variant = true;
   bool conjoin_to_top = false;
 
-  // Bit-blast the floating-point comparisons and equalities over
-  // already-packed operands natively (over the IEEE bits) instead of via the
-  // SymFPU unpacking circuits.
+  // Bit-blast the floating-point predicates -- comparisons, equalities and
+  // classifications -- over already-packed operands natively (over the IEEE
+  // bits) instead of via the SymFPU unpacking circuits.
   bool fp_native_cmp = true;
 
   int64_t multiplication_variant = 1;

--- a/include/stp/ToSat/BitBlaster.h
+++ b/include/stp/ToSat/BitBlaster.h
@@ -201,6 +201,11 @@ class BitBlaster
   // operands
   BBNode BBeqFP(const ASTNode& form, BBNodeSet& support);
 
+  // bit blast a floating-point classification predicate (FP_ISNORMAL,
+  // FP_ISSUBNORMAL, FP_ISZERO, FP_ISINFINITE, FP_ISNAN, FP_ISNEGATIVE,
+  // FP_ISPOSITIVE) over a packed operand
+  BBNode BBclassifyFP(const ASTNode& form, BBNodeSet& support);
+
   // Field tests on a packed IEEE-754 operand, shared by the comparison and
   // equality encodings. `sb` is the significand width, `w` the total width.
   BBNode BBfpIsNaN(const BBNodeVec& p, unsigned sb, unsigned w);

--- a/lib/FloatBlaster/FloatBlast.cpp
+++ b/lib/FloatBlaster/FloatBlast.cpp
@@ -129,13 +129,14 @@ private:
     return ASTNode();
   }
 
-  // The six comparison predicates over leaf operands skip SymFPU entirely:
-  // the source comparison survives to the bit-blaster, which compares the
-  // packed IEEE bits directly (BBcompareFP, BBeqFP). Returns the surviving
-  // node -- `n` itself,
-  // or the comparison rebuilt over resolved constant operands, both purely
-  // float-sorted so no FP node is ever built over packed carriers -- or
-  // null when the comparison has to take the SymFPU path.
+  // The six binary comparison predicates over leaf operands skip SymFPU
+  // entirely: the source comparison survives to the bit-blaster, which
+  // compares the packed IEEE bits directly (BBcompareFP, BBeqFP). Returns
+  // the surviving node -- `n` itself, or the comparison rebuilt over
+  // resolved constant operands, both purely float-sorted so no FP node is
+  // ever built over packed carriers -- or null when the comparison has to
+  // take the SymFPU path. (nativeClassificationSurvivor is the unary
+  // sibling, for the classification predicates.)
   //
   // A comparison of two constants must not survive: constant folding and
   // model evaluation lower the node over its constant children and rely on
@@ -165,10 +166,33 @@ private:
     return rebuilt;
   }
 
+  // Unary sibling of nativeComparisonSurvivor for the classification
+  // predicates, which the bit-blaster reads straight off the packed fields
+  // (BBclassifyFP). Same three conditions, with the constant rule tightened:
+  // for a unary predicate a constant operand means the whole node is
+  // constant, and an all-constant node has to lower so that constant
+  // folding and model evaluation see it collapse.
+  ASTNode nativeClassificationSurvivor(const ASTNode& n) const
+  {
+    if (!bm->UserFlags.fp_native_cmp)
+      return ASTNode();
+    const ASTNode leaf = comparisonLeaf(n[0]);
+    if (leaf.IsNull() || leaf.isConstant())
+      return ASTNode();
+    if (leaf == n[0])
+      return n;
+    const ASTNode rebuilt = node_factory->CreateNode(n.GetKind(), leaf);
+    if (!isNativelyBlasted(rebuilt.GetKind()))
+      return ASTNode();
+    return rebuilt;
+  }
+
   static bool isNativelyBlasted(Kind k)
   {
     return k == FP_GT || k == FP_LT || k == FP_GEQ || k == FP_LEQ ||
-           k == FP_EQ || k == FP_SMT_EQ;
+           k == FP_EQ || k == FP_SMT_EQ || k == FP_ISNORMAL ||
+           k == FP_ISSUBNORMAL || k == FP_ISZERO || k == FP_ISINFINITE ||
+           k == FP_ISNAN || k == FP_ISNEGATIVE || k == FP_ISPOSITIVE;
   }
 
   ASTNode rebuild(const ASTNode& n, const ASTVec& children)
@@ -602,26 +626,61 @@ private:
       }
 
       case FP_ISNORMAL:
+      {
+        const ASTNode survivor = nativeClassificationSurvivor(n);
+        if (!survivor.IsNull())
+          return survivor;
         return symbolic_fp::unpacked::isNormal(formatOf(n[0]),
                                                asUnpacked(n[0]));
+      }
       case FP_ISSUBNORMAL:
+      {
+        const ASTNode survivor = nativeClassificationSurvivor(n);
+        if (!survivor.IsNull())
+          return survivor;
         return symbolic_fp::unpacked::isSubnormal(formatOf(n[0]),
                                                   asUnpacked(n[0]));
+      }
       case FP_ISZERO:
+      {
+        const ASTNode survivor = nativeClassificationSurvivor(n);
+        if (!survivor.IsNull())
+          return survivor;
         return symbolic_fp::unpacked::isZero(formatOf(n[0]),
                                              asUnpacked(n[0]));
+      }
       case FP_ISINFINITE:
+      {
+        const ASTNode survivor = nativeClassificationSurvivor(n);
+        if (!survivor.IsNull())
+          return survivor;
         return symbolic_fp::unpacked::isInfinite(formatOf(n[0]),
                                                  asUnpacked(n[0]));
+      }
       case FP_ISNAN:
+      {
+        const ASTNode survivor = nativeClassificationSurvivor(n);
+        if (!survivor.IsNull())
+          return survivor;
         return symbolic_fp::unpacked::isNaN(formatOf(n[0]),
                                             asUnpacked(n[0]));
+      }
       case FP_ISNEGATIVE:
+      {
+        const ASTNode survivor = nativeClassificationSurvivor(n);
+        if (!survivor.IsNull())
+          return survivor;
         return symbolic_fp::unpacked::isNegative(formatOf(n[0]),
                                                  asUnpacked(n[0]));
+      }
       case FP_ISPOSITIVE:
+      {
+        const ASTNode survivor = nativeClassificationSurvivor(n);
+        if (!survivor.IsNull())
+          return survivor;
         return symbolic_fp::unpacked::isPositive(formatOf(n[0]),
                                                  asUnpacked(n[0]));
+      }
 
       default:
         FatalError("FloatBlast: unhandled target-valued floating-point kind: ",

--- a/lib/STPManager/STP.cpp
+++ b/lib/STPManager/STP.cpp
@@ -540,10 +540,11 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
   // Lower floating-point operations before the first pass that invokes the
   // bit-blaster. From here on the formula is a packed-bit circuit: float
   // symbols, constants and reads retain sort metadata for model
-  // reconstruction. The only FP operations that survive are the six
-  // comparison predicates (fp.gt/fp.lt/fp.geq/fp.leq and the two
-  // equalities, fp.eq and = on floats) over leaf operands, which the
-  // bit-blaster encodes natively (BBcompareFP, BBeqFP); every downstream pass
+  // reconstruction. The only FP operations that survive are the predicates
+  // over leaf operands -- the four ordering comparisons, the two equalities
+  // (fp.eq and = on floats) and the seven classifications -- which the
+  // bit-blaster encodes natively over the packed bits (BBcompareFP, BBeqFP,
+  // BBclassifyFP); every downstream pass
   // already has arms for these kinds because they used to reach it before
   // lowering existed.
   //

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -1347,8 +1347,7 @@ const BBNode BitBlaster::BBForm(const ASTNode& form,
     case FP_ISNEGATIVE:
     case FP_ISPOSITIVE:
     {
-      FatalError("BBForm: FP formulas should not reach the bit-blaster: ",
-                 form);
+      result = BBclassifyFP(form, support);
       break;
     }
     default:
@@ -3215,6 +3214,93 @@ BBNode BitBlaster::BBeqFP(const ASTNode& form, BBNodeSet& support)
   const BBNode sameValue = nf->CreateNode(OR, sameBits, bothZero);
 
   return nf->CreateNode(AND, notNaN, sameValue);
+}
+
+// Bit-blasted form for the seven classification predicates over a packed
+// IEEE-754 operand. Each is a test on the exponent field e and the stored
+// significand m, both directly visible in the packed encoding, so the
+// SymFPU route pays a full unpack to read flags that are already there:
+//
+//   isZero        e = 0        and m = 0    (either sign)
+//   isSubnormal   e = 0        and m != 0
+//   isNormal      e != 0       and e != all-ones
+//   isInfinite    e = all-ones and m = 0
+//   isNaN         e = all-ones and m != 0   (any payload)
+//   isNegative    sign set     and not NaN
+//   isPositive    sign clear   and not NaN
+//
+// The two sign predicates are the ones with corners: -0 IS negative and +0
+// IS positive (the sign bit alone decides among the finite values), while a
+// NaN is neither, because its sign bit carries no meaning. isNormal has to
+// exclude the all-ones exponent as well as the zero one, or infinities and
+// NaNs count as normal.
+BBNode BitBlaster::BBclassifyFP(const ASTNode& form, BBNodeSet& support)
+{
+  const Kind k = form.GetKind();
+
+  const SourceSort sort = form[0].GetSourceSort();
+  assert(sort.kind() == SourceSort::Kind::FloatingPoint);
+  const unsigned sb = sort.significandWidth();
+  const unsigned w = sort.exponentWidth() + sb;
+  assert(form[0].GetValueWidth() == w);
+  assert(sb >= 2 && w >= sb + 1);
+
+  const BBNodeVec p = BBTerm(form[0], support);
+
+  switch (k)
+  {
+    case FP_ISZERO:
+      return BBfpIsZero(p, w);
+
+    case FP_ISNAN:
+      return BBfpIsNaN(p, sb, w);
+
+    case FP_ISSUBNORMAL:
+    {
+      BBNodeVec expField(p.begin() + (sb - 1), p.begin() + (w - 1));
+      BBNodeVec sigField(p.begin(), p.begin() + (sb - 1));
+      const BBNode expZero = nf->CreateNode(NOR, expField);
+      const BBNode sigNonZero = nf->CreateNode(OR, sigField);
+      return nf->CreateNode(AND, expZero, sigNonZero);
+    }
+
+    case FP_ISNORMAL:
+    {
+      // Built as NOT(AND(e)) rather than NAND(e) so the all-ones test is
+      // the same AIG node isNaN and isInfinite build over this operand.
+      BBNodeVec expField(p.begin() + (sb - 1), p.begin() + (w - 1));
+      const BBNode expNonZero = nf->CreateNode(OR, expField);
+      const BBNode expAllOnes = nf->CreateNode(AND, expField);
+      const BBNode expNotOnes = nf->CreateNode(NOT, expAllOnes);
+      return nf->CreateNode(AND, expNonZero, expNotOnes);
+    }
+
+    case FP_ISINFINITE:
+    {
+      BBNodeVec expField(p.begin() + (sb - 1), p.begin() + (w - 1));
+      BBNodeVec sigField(p.begin(), p.begin() + (sb - 1));
+      const BBNode expAllOnes = nf->CreateNode(AND, expField);
+      const BBNode sigZero = nf->CreateNode(NOR, sigField);
+      return nf->CreateNode(AND, expAllOnes, sigZero);
+    }
+
+    case FP_ISNEGATIVE:
+    {
+      const BBNode notNaN = nf->CreateNode(NOT, BBfpIsNaN(p, sb, w));
+      return nf->CreateNode(AND, p[w - 1], notNaN);
+    }
+
+    case FP_ISPOSITIVE:
+    {
+      const BBNode notNaN = nf->CreateNode(NOT, BBfpIsNaN(p, sb, w));
+      const BBNode signClear = nf->CreateNode(NOT, p[w - 1]);
+      return nf->CreateNode(AND, signClear, notNaN);
+    }
+
+    default:
+      FatalError("BBclassifyFP: Illegal kind", form);
+      return BBNode();
+  }
 }
 
 // Return bit-blasted form for the overflow predicates BVUADDO, BVSADDO,

--- a/tests/query-files/fp-tests/native-classify-disjoint.smt2
+++ b/tests/query-files/fp-tests/native-classify-disjoint.smt2
@@ -1,0 +1,25 @@
+; RUN: %solver %s | %OutputCheck %s
+; RUN: %solver --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck %s
+;
+; The value classes are DISJOINT: no operand is both zero and subnormal, or
+; both NaN and infinite (the significand field is zero in one and nonzero in
+; the other), or both normal and infinite (the exponent field is all-ones in
+; one and not in the other). Fresh symbols per pair, ored together, so any
+; one overlap makes the formula sat. This is the half of the partition that
+; catches a class test that drops one of its two field conditions -- an
+; isNormal encoded as just "exponent nonzero", or an isInfinite that ignores
+; the significand and so swallows the NaNs
+; (native-classify-partition.smt2 is the cover half, and a cover test cannot
+; see either mistake).
+;
+; CHECK: ^unsat
+(set-logic QF_FP)
+(declare-fun y () (_ FloatingPoint 8 24))
+(declare-fun z () (_ FloatingPoint 8 24))
+(declare-fun w () (_ FloatingPoint 8 24))
+(assert (or (and (fp.isZero y) (fp.isSubnormal y))
+            (or (and (fp.isNormal z) (fp.isInfinite z))
+                (and (fp.isNaN w) (fp.isInfinite w)))))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/native-classify-model.smt2
+++ b/tests/query-files/fp-tests/native-classify-model.smt2
@@ -1,0 +1,20 @@
+; RUN: %solver %s | %OutputCheck %s
+; RUN: %solver --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck %s
+;
+; A satisfiable pair of native classifications: the negative subnormals.
+; Every sat answer is validated internally by substituting the model into
+; the ORIGINAL fp.isSubnormal/fp.isNegative nodes and folding them through
+; SymFPU (CheckCounterExample), so this test cross-checks a concrete native
+; model against the SymFPU semantics on every run -- the check that stays
+; genuinely cross-encoding now that the classifications blast natively. x
+; appears twice so RemoveUnconstrained cannot discharge the predicates
+; before they blast.
+;
+; CHECK: ^sat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(assert (fp.isSubnormal x))
+(assert (fp.isNegative x))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/native-classify-nan-sign.smt2
+++ b/tests/query-files/fp-tests/native-classify-nan-sign.smt2
@@ -1,0 +1,17 @@
+; RUN: %solver %s | %OutputCheck %s
+; RUN: %solver --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck %s
+;
+; A NaN is neither negative nor positive: its sign bit is meaningless, and
+; the SAT solver is free to pick either value for it (and any payload), so
+; this formula is unsatisfiable. Natively (BBclassifyFP) that is the not-NaN
+; conjunct in both sign predicates; encode isNegative as the bare sign bit
+; and a NaN with the sign set satisfies this.
+;
+; CHECK: ^unsat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(assert (fp.isNaN x))
+(assert (or (fp.isNegative x) (fp.isPositive x)))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/native-classify-neg-mirror.smt2
+++ b/tests/query-files/fp-tests/native-classify-neg-mirror.smt2
@@ -1,0 +1,21 @@
+; RUN: %solver %s | %OutputCheck %s
+; RUN: %solver --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck %s
+;
+; Cross-encoding check that survives this migration: fp.neg is an FP
+; OPERATION, so (fp.isPositive (fp.neg x)) fails the leaf gate and is built
+; entirely by SymFPU, while (fp.isNegative x) is native (BBclassifyFP). The
+; two are equal for every x -- NaN: both false, since neither sign predicate
+; holds of a NaN; zeros: -0 is negative and its negation +0 is positive --
+; so this formula is unsatisfiable. The classification predicates are native
+; now and can no longer serve as the SymFPU anchor for each other; routing
+; one side through an FP operation restores that. (The factory's peel rule
+; for a negated operand deliberately skips the two sign predicates, so
+; fp.neg really does survive to lowering here.)
+;
+; CHECK: ^unsat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(assert (xor (fp.isNegative x) (fp.isPositive (fp.neg x))))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/native-classify-partition.smt2
+++ b/tests/query-files/fp-tests/native-classify-partition.smt2
@@ -1,0 +1,20 @@
+; RUN: %solver %s | %OutputCheck %s
+; RUN: %solver --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck %s
+;
+; The five value classes COVER the format: every packed operand is a NaN, an
+; infinity, a zero, a subnormal or a normal, so no x escapes all five and
+; this formula is unsatisfiable. Natively (BBclassifyFP) the classes are
+; field tests on the exponent and significand, and the one easy to get wrong
+; is isNormal: testing only "exponent nonzero" would admit infinities and
+; NaNs, which passes this cover test but fails the disjointness one
+; (native-classify-disjoint.smt2) -- the two files are complementary and both
+; are needed.
+;
+; CHECK: ^unsat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(assert (not (or (fp.isNaN x) (fp.isInfinite x) (fp.isZero x)
+                 (fp.isSubnormal x) (fp.isNormal x))))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/native-classify-zero-signs.smt2
+++ b/tests/query-files/fp-tests/native-classify-zero-signs.smt2
@@ -1,0 +1,17 @@
+; RUN: %solver %s | %OutputCheck %s
+; RUN: %solver --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck %s
+;
+; A zero is signed: -0 is negative and +0 is positive, exactly one of the
+; two, so this formula is unsatisfiable. It pins the corner opposite to
+; native-classify-nan-sign.smt2 -- the sign predicates must ignore the sign
+; bit for NaN but honour it for zero. An isNegative that excluded zeros (a
+; natural reading of "negative") makes -0 satisfy neither and this sat.
+;
+; CHECK: ^unsat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(assert (fp.isZero x))
+(assert (not (xor (fp.isNegative x) (fp.isPositive x))))
+(check-sat)
+(exit)

--- a/tests/unit-tests/FloatBlast_Test.cpp
+++ b/tests/unit-tests/FloatBlast_Test.cpp
@@ -203,8 +203,8 @@ TEST(FloatBlast, totalisation_defers_canonical_boundaries_to_lowering)
 TEST(FloatBlast, every_floating_point_kind_is_lowered)
 {
   STPMgr mgr;
-  // fp.gt/fp.lt over leaves deliberately survive lowering when the native
-  // comparison is on (see native_comparison_survives_for_leaf_operands).
+  // The FP predicates over leaves deliberately survive lowering when the
+  // native encoding is on (see native_comparison_survives_for_leaf_operands).
   // This sweep checks that every kind has a SymFPU arm, so turn it off.
   mgr.UserFlags.fp_native_cmp = false;
   const SourceSort fp32 = SourceSort::floatingPoint(8, 24);
@@ -361,18 +361,36 @@ TEST(FloatBlast, native_comparison_survives_for_leaf_operands)
   EXPECT_FALSE(
       containsFloatingPointKind(lowered(mgr.CreateNode(FP_EQ, sum, y))));
 
+  // The classification predicates survive over a symbol operand. Their gate
+  // is stricter about constants than the binary one: a unary predicate over
+  // a constant is a constant node, which must lower and collapse -- so the
+  // to_fp-reinterpret literal that makes a comparison survive does not make
+  // a classification survive.
+  const ASTNode isnan_symbol = mgr.CreateNode(FP_ISNAN, x);
+  EXPECT_EQ(isnan_symbol, lowered(isnan_symbol));
+  const ASTNode ispositive_symbol = mgr.CreateNode(FP_ISPOSITIVE, x);
+  EXPECT_EQ(ispositive_symbol, lowered(ispositive_symbol));
+  EXPECT_FALSE(containsFloatingPointKind(
+      lowered(mgr.CreateNode(FP_ISNAN, one_reinterpreted))));
+  EXPECT_FALSE(
+      containsFloatingPointKind(lowered(mgr.CreateNode(FP_ISNAN, one))));
+  EXPECT_FALSE(
+      containsFloatingPointKind(lowered(mgr.CreateNode(FP_ISNORMAL, sum))));
+
   // Flag off: the old behaviour, everything lowers.
   mgr.UserFlags.fp_native_cmp = false;
   EXPECT_FALSE(containsFloatingPointKind(lowered(gt_symbols)));
+  EXPECT_FALSE(containsFloatingPointKind(lowered(isnan_symbol)));
 }
 
-// The native encoding and SymFPU must agree on every comparison. At the
+// The native encoding and SymFPU must agree on every predicate. At the
 // smallest supported format, (3, 4), all 128 x 128 packed operand pairs are
-// checked for each of the six comparison predicates: the native verdict
-// comes from bit-blasting the comparison over constant operands (the AIG
-// collapses to a constant), the reference from SymFPU's
-// fold-by-construction constant evaluation. The sweep includes +/-0,
-// +/-infinity, NaN and every subnormal pair.
+// checked for each of the six comparison predicates, and all 128 operands
+// for each of the seven classifications: the native verdict comes from
+// bit-blasting the predicate over constant operands (the AIG collapses to a
+// constant), the reference from SymFPU's fold-by-construction constant
+// evaluation. The sweep includes +/-0, +/-infinity, every NaN payload and
+// every subnormal.
 TEST(FloatBlast, native_comparison_agrees_with_symfpu_exhaustively)
 {
   STPMgr mgr;
@@ -414,4 +432,26 @@ TEST(FloatBlast, native_comparison_agrees_with_symfpu_exhaustively)
     }
   }
   EXPECT_EQ(6 * values * values, checked);
+
+  unsigned classified = 0;
+  for (unsigned i = 0; i < values; i++)
+  {
+    for (const Kind kind : {FP_ISNORMAL, FP_ISSUBNORMAL, FP_ISZERO,
+                            FP_ISINFINITE, FP_ISNAN, FP_ISNEGATIVE,
+                            FP_ISPOSITIVE})
+    {
+      const ASTNode classification = mgr.CreateNode(kind, constants[i]);
+
+      const ASTNode reference = NonMemberBVConstEvaluator(&mgr, classification);
+      ASSERT_TRUE(reference == mgr.ASTTrue || reference == mgr.ASTFalse);
+
+      const BBNode native = bb.BBForm(classification);
+      ASSERT_TRUE(native == aig.getTrue() || native == aig.getFalse());
+
+      ASSERT_EQ(reference == mgr.ASTTrue, native == aig.getTrue())
+          << _kind_names[kind] << " disagrees on operand " << i;
+      ++classified;
+    }
+  }
+  EXPECT_EQ(7 * values, classified);
 }

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -374,7 +374,7 @@ void ExtraMain::create_options()
 
     ("bb.fp-native-cmp",
       BOOL_ARG(bm->UserFlags.fp_native_cmp),
-      "Bit-blast floating-point comparisons and equalities over already-packed operands natively instead of via the SymFPU unpacking circuits"
+      "Bit-blast floating-point predicates (comparisons, equalities, classifications) over already-packed operands natively instead of via the SymFPU unpacking circuits"
       )
 
     ("bb.simplify-during-bb",


### PR DESCRIPTION
Stacked on #760, which is stacked on #759 — merge those first and the base retargets automatically. The diff here is the seven unary predicates.

Each classification is a test on the exponent field `e` and the stored significand `m`, both plainly visible in the packed IEEE encoding, so lowering them through SymFPU asks for a full unpack (count-leading-zeros plus barrel shifter) in order to read a flag that is already there. `BBclassifyFP` reads them off the packed bits, and FloatBlast's gate gains a unary sibling that lets the source node survive when its operand is a leaf.

```
isZero       e = 0        and m = 0      (either sign)
isSubnormal  e = 0        and m != 0
isNormal     e != 0       and e != all-ones
isInfinite   e = all-ones and m = 0
isNaN        e = all-ones and m != 0     (any payload)
isNegative   sign set     and not NaN
isPositive   sign clear   and not NaN
```

The corners are in the two sign predicates: -0 is negative and +0 is positive, but a NaN is neither, because its sign bit carries no meaning. `isNormal` has to exclude the all-ones exponent as well as the zero one, or infinities and NaNs count as normal. The unary gate's constant rule is stricter than the binary one: for a unary predicate a constant operand means the whole node is constant, and an all-constant node has to lower so that constant folding and model evaluation see it collapse. With this, all thirteen FP predicate kinds are natively blasted and the "FP formulas should not reach the bit-blaster" group in `BBForm` is empty; the FP terms still fail closed on the default arm.

## Measurements — a narrower win than the comparisons

binary64, one predicate over a symbol, `--disable-simplifications --exit-after-CNF --output-CNF`, vars/clauses native vs `--bb.fp-native-cmp=false`:

| predicate | native | SymFPU | |
|---|---|---|---|
| `fp.isNormal` | 87 / 65 | 510 / 1334 | 20x fewer clauses |
| `fp.isSubnormal` | 128 / 188 | 510 / 1334 | 7x |
| `fp.isZero` | 128 / 188 | 139 / 221 | 1.2x |
| `fp.isInfinite` | 128 / 188 | 128 / 188 | CNF byte-identical |
| `fp.isNaN` | 128 / 188 | 128 / 188 | CNF byte-identical |
| `fp.isNegative` | 129 / 191 | 129 / 191 | CNF byte-identical |
| `fp.isPositive` | 129 / 191 | 129 / 191 | CNF byte-identical |

Four of the seven are exactly neutral, byte for byte, and it is worth saying why rather than quoting the two good rows alone: SymFPU derives the NaN, infinity and sign flags from the packed bits as well, and for a predicate that reads only a flag the rest of the unpack is outside the cone of influence, so ABC's AIG-to-CNF conversion had already dropped it. Only `isNormal` and `isSubnormal`, whose SymFPU definitions go through the normalised exponent, were paying for the unpack. I checked the byte-identical rows for a silent fallback rather than assuming: with the NaN helper and the isInfinite arm deliberately broken, the isNaN, isInfinite and isNegative probes all change, so those baselines really are the native encoder's output.

The standing caveat: when the operand also feeds SymFPU arithmetic elsewhere, the unpack is paid anyway and SymFPU's classification is nearly free. The leaf-only gate already restricts this to formulas where predicates are the only FP consumers of the operand.

## Verification

The exhaustive differential unit test gains a unary sweep: each of the seven kinds over all 128 constants at format (3,4), native AIG blast versus SymFPU constant evaluation, 0 mismatches. That covers every row of the table, both zeros and every NaN payload.

Six new lit tests, each under default, `--disable-simplifications` and flag-off: the five classes cover the format and are pairwise disjoint, a NaN is neither negative nor positive whatever its sign bit, a zero is exactly one of the two, `fp.isNegative x` agrees with `fp.isPositive (fp.neg x)` for every x, and a sat model (the negative subnormals) validated through CheckCounterExample.

I mutation-tested the suite: isNormal as bare exponent-nonzero, isNegative as the bare sign bit, isNegative excluding the zeros, isSubnormal and isInfinite ignoring the significand, isZero ignoring the exponent, isPositive as the bare clear sign bit, and a sign-sensitive isNaN. Each is caught. The first pass found a real gap — an isInfinite that swallows the NaNs was caught by nothing, since a cover test cannot see an over-broad class and the disjointness file did not pair isNaN with isInfinite. That pair is now in the file and the mutation is caught.

Two things worth flagging for review. First, the classifications can no longer serve as the SymFPU cross-encoding anchor that the earlier `native-comparison-*` tests leaned on; what remains genuinely cross-encoding is the exhaustive differential, every file's flag-off run, CheckCounterExample on every sat answer, and identities routed through an FP operation such as the fp.neg mirror. Second, that mirror test does not behave as designed but is still sound: both flag settings produce the same trivial CNF, because SymFPU's isPositive-of-a-negated-operand builds structurally the same AIG node as the native isNegative, so hash-consing collapses the xor before SAT. That is a circuit-level proof of the identity rather than a SAT-level one, and the mutation runs confirm the file still fails when the native encoding is wrong.

Full suites green: 101/101 with floating-point support, 74/74 with `-DENABLE_FLOATING_POINT=OFF`.