### PR TITLE
Widen the native FP gate to mux and array-read operands

### DIFF
--- a/lib/AbsRefineCounterExample/ArrayTransformer.cpp
+++ b/lib/AbsRefineCounterExample/ArrayTransformer.cpp
@@ -487,6 +487,15 @@ ASTNode ArrayTransformer::TransformArrayRead(const ASTNode& term)
 
       ASTNode CurrentSymbol = bm->CreateFreshVariable(
           term.GetIndexWidth(), term.GetValueWidth(), "ext_read");
+
+      // Same reason as the read-refinement path below: this variable stands
+      // in for the read from here on and is a leaf, so the element format
+      // has to travel with it or the element reaches the blaster as a
+      // formatless bitvector. Setting a zero width (a non-float array) is a
+      // no-op.
+      CurrentSymbol.SetExpWidth(term.GetExpWidth());
+      CurrentSymbol.SetSigWidth(term.GetSigWidth());
+
       result = CurrentSymbol;
       arrayToIndexToRead[arrName].insert(
           make_pair(readIndex, ArrayRead(result, CurrentSymbol)));

--- a/lib/FloatBlaster/FloatBlast.cpp
+++ b/lib/FloatBlaster/FloatBlast.cpp
@@ -107,15 +107,22 @@ private:
                  "source sorts");
   }
 
-  // A comparison operand that is (or resolves to) a leaf the lowering
-  // leaves untouched: a symbol or an interned constant. FP constant folding
-  // is deferred solver-wide, so a literal usually arrives as to_fp's
-  // three-child reinterpret form over constant bits; resolve it through the
-  // canonicalising funnel (CreateFPConst), the same lookthrough
-  // RemoveUnconstrained's comparison rule uses. Returns null for anything
-  // else -- in particular for FP operations, whose values are cached
-  // unpacked and belong on the SymFPU path.
-  ASTNode comparisonLeaf(const ASTNode& n) const
+  // A predicate operand that is (or resolves to) a packed view the lowering
+  // leaves in the formula: a symbol or an interned constant, and structural
+  // nodes built out of those. FP constant folding is deferred solver-wide,
+  // so a literal usually arrives as to_fp's three-child reinterpret form
+  // over constant bits; resolve it through the canonicalising funnel
+  // (CreateFPConst), the same lookthrough RemoveUnconstrained's comparison
+  // rule uses. Returns null for anything else -- in particular for FP
+  // operations, whose values are cached unpacked and belong on the SymFPU
+  // path.
+  //
+  // Everything returned here ends up as a child of a surviving predicate,
+  // so it must be what lowering would have left in the formula anyway: each
+  // case returns the node unchanged, or a node of the same kind whose
+  // children are themselves resolved this way (or lowered, for the parts
+  // that are not float-sorted).
+  ASTNode comparisonLeaf(const ASTNode& n)
   {
     if (n.Degree() == 0)
       return n;
@@ -126,23 +133,51 @@ private:
       return bm->CreateFPConst(n[2], sort.exponentWidth(),
                                sort.significandWidth());
     }
+    // A float-sorted ITE is a mux over packed bits once its branches are
+    // packed views, and the bit-blaster muxes them for free (BBITE) -- while
+    // SymFPU's ITE arm unpacks BOTH branches and muxes the unpacked records.
+    // The branches recurse through here rather than through asPacked,
+    // because asPacked would happily build an encode() circuit for an
+    // FP-operation branch, which is exactly the case that belongs on the
+    // SymFPU path.
+    if (n.GetKind() == ITE && n.Degree() == 3)
+    {
+      const ASTNode thenLeaf = comparisonLeaf(n[1]);
+      if (thenLeaf.IsNull())
+        return ASTNode();
+      const ASTNode elseLeaf = comparisonLeaf(n[2]);
+      if (elseLeaf.IsNull())
+        return ASTNode();
+      // The condition is Boolean, so lower() is the right treatment: any FP
+      // work inside it is lowered (possibly into further surviving native
+      // predicates) exactly as it would be anywhere else.
+      const ASTNode cond = lower(n[0]);
+      if (cond == n[0] && thenLeaf == n[1] && elseLeaf == n[2])
+        return n;
+      // Through the factory, so a folded condition collapses the mux to one
+      // branch here rather than leaving a dead one under the predicate. The
+      // constant rules in the two survivor functions run after this and
+      // still see the collapsed operand.
+      return node_factory->CreateTerm(ITE, n.GetValueWidth(), cond, thenLeaf,
+                                      elseLeaf);
+    }
     return ASTNode();
   }
 
-  // The six binary comparison predicates over leaf operands skip SymFPU
-  // entirely: the source comparison survives to the bit-blaster, which
-  // compares the packed IEEE bits directly (BBcompareFP, BBeqFP). Returns
-  // the surviving node -- `n` itself, or the comparison rebuilt over
-  // resolved constant operands, both purely float-sorted so no FP node is
-  // ever built over packed carriers -- or null when the comparison has to
-  // take the SymFPU path. (nativeClassificationSurvivor is the unary
+  // The six binary comparison predicates over packed-view operands skip
+  // SymFPU entirely: the source comparison survives to the bit-blaster,
+  // which compares the packed IEEE bits directly (BBcompareFP, BBeqFP).
+  // Returns the surviving node -- `n` itself, or the comparison rebuilt
+  // over resolved operands, both purely float-sorted so no FP node is ever
+  // built over packed carriers -- or null when the comparison has to take
+  // the SymFPU path. (nativeClassificationSurvivor is the unary
   // sibling, for the classification predicates.)
   //
   // A comparison of two constants must not survive: constant folding and
   // model evaluation lower the node over its constant children and rely on
   // the result collapsing to TRUE/FALSE through the simplifying factory
   // (ComputeFormulaUsingModel asserts lowering changed the node).
-  ASTNode nativeComparisonSurvivor(const ASTNode& n) const
+  ASTNode nativeComparisonSurvivor(const ASTNode& n)
   {
     if (!bm->UserFlags.fp_native_cmp)
       return ASTNode();
@@ -172,7 +207,7 @@ private:
   // for a unary predicate a constant operand means the whole node is
   // constant, and an all-constant node has to lower so that constant
   // folding and model evaluation see it collapse.
-  ASTNode nativeClassificationSurvivor(const ASTNode& n) const
+  ASTNode nativeClassificationSurvivor(const ASTNode& n)
   {
     if (!bm->UserFlags.fp_native_cmp)
       return ASTNode();

--- a/lib/FloatBlaster/FloatBlast.cpp
+++ b/lib/FloatBlaster/FloatBlast.cpp
@@ -133,6 +133,21 @@ private:
       return bm->CreateFPConst(n[2], sort.exponentWidth(),
                                sort.significandWidth());
     }
+    // A select from a float-element array already IS the packed element
+    // bits: asPacked's READ arm only rebuilds the array and index if they
+    // contain FP work, so it never builds a circuit for the element itself
+    // and the predicate can consume those bits directly. The element format
+    // lives on the array node and the read derives it (deriveFPFormat), so
+    // it survives the array transform's rewriting of this operand -- every
+    // stand-in it mints for a read carries the format (ArrayTransformer),
+    // which is what the bit-blaster reads back here.
+    if (n.GetKind() == READ)
+    {
+      const ASTNode packed = asPacked(n);
+      assert(packed.GetKind() == READ);
+      assert(packed.GetSourceSort().kind() == SourceSort::Kind::FloatingPoint);
+      return packed;
+    }
     // A float-sorted ITE is a mux over packed bits once its branches are
     // packed views, and the bit-blaster muxes them for free (BBITE) -- while
     // SymFPU's ITE arm unpacks BOTH branches and muxes the unpacked records.

--- a/lib/STPManager/STP.cpp
+++ b/lib/STPManager/STP.cpp
@@ -541,12 +541,12 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
   // bit-blaster. From here on the formula is a packed-bit circuit: float
   // symbols, constants and reads retain sort metadata for model
   // reconstruction. The only FP operations that survive are the predicates
-  // over leaf operands -- the four ordering comparisons, the two equalities
-  // (fp.eq and = on floats) and the seven classifications -- which the
-  // bit-blaster encodes natively over the packed bits (BBcompareFP, BBeqFP,
-  // BBclassifyFP); every downstream pass
-  // already has arms for these kinds because they used to reach it before
-  // lowering existed.
+  // over packed-view operands -- the four ordering comparisons, the two
+  // equalities (fp.eq and = on floats) and the seven classifications --
+  // which the bit-blaster encodes natively over the packed bits
+  // (BBcompareFP, BBeqFP, BBclassifyFP); every downstream pass already has
+  // arms for these kinds because they used to reach it before lowering
+  // existed.
   //
   // This remains after all of the size-reducing passes above. In particular,
   // RemoveUnconstrained must see a float symbol rather than its exposed bits.

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -3087,7 +3087,8 @@ BBNode BitBlaster::BBfpIsZero(const BBNodeVec& p, unsigned w)
 
 // Bit-blasted form for the four ordering comparisons (FP_GT, FP_LT, FP_GEQ,
 // FP_LEQ) over packed IEEE-754 operands. FloatBlast leaves these comparisons
-// in place when both operands are leaves (symbols, interned constants);
+// in place when both operands are packed views (symbols, interned
+// constants, muxes over those);
 // their packed bits are compared directly, with no unpacking. Sign-magnitude
 // maps onto an unsigned total order with a per-bit XOR against the sign:
 //

--- a/tests/query-files/fp-tests/native-ite-distributes.smt2
+++ b/tests/query-files/fp-tests/native-ite-distributes.smt2
@@ -1,0 +1,23 @@
+; RUN: %solver %s | %OutputCheck %s
+; RUN: %solver --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck %s
+;
+; A comparison of a mux is the mux of the comparisons, so this formula is
+; unsatisfiable. The two sides take different routes to the bit-blaster: the
+; left operand is a float-sorted ITE, which the widened gate admits as a
+; packed view (the bit-blaster muxes the branches), while the right side is
+; two comparisons of plain symbols. If the mux ever selected the wrong
+; branch -- or the branches were packed in the wrong order -- the two sides
+; would disagree and this would be sat. The flag-off run proves the identity
+; with both sides on SymFPU, whose ITE arm unpacks both branches instead.
+;
+; CHECK: ^unsat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(declare-fun y () (_ FloatingPoint 8 24))
+(declare-fun z () (_ FloatingPoint 8 24))
+(declare-fun c () Bool)
+(assert (xor (fp.gt (ite c x y) z)
+             (ite c (fp.gt x z) (fp.gt y z))))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/native-ite-model.smt2
+++ b/tests/query-files/fp-tests/native-ite-model.smt2
@@ -1,0 +1,22 @@
+; RUN: %solver %s | %OutputCheck %s
+; RUN: %solver --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck %s
+;
+; A satisfiable pair of comparisons over the SAME mux, pinning whichever
+; branch the condition selects into (1.0, 2.0). Every sat answer is
+; validated internally by substituting the model into the original nodes and
+; folding them through SymFPU (CheckCounterExample), so this covers model
+; evaluation over a surviving comparison whose operand is an ITE rather than
+; a symbol -- the path a widened gate is most likely to break. The mux is
+; used twice so RemoveUnconstrained cannot discharge the comparisons before
+; they blast.
+;
+; CHECK: ^sat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(declare-fun y () (_ FloatingPoint 8 24))
+(declare-fun c () Bool)
+(assert (fp.gt (ite c x y) (fp #b0 #b01111111 #b00000000000000000000000)))
+(assert (fp.lt (ite c x y) (fp #b0 #b10000000 #b00000000000000000000000)))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/native-ite-nan-branch.smt2
+++ b/tests/query-files/fp-tests/native-ite-nan-branch.smt2
@@ -1,0 +1,21 @@
+; RUN: %solver %s | %OutputCheck %s
+; RUN: %solver --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck %s
+;
+; When the condition holds, the mux is a NaN, and nothing is greater than a
+; NaN -- so this formula is unsatisfiable. It pins the branch a true
+; condition selects (swap the branches in the mux and it becomes sat, since
+; the solver is then free to pick a large x), and it does so with a value
+; the comparison itself treats specially. The NaN branch is spelled as a
+; to_fp reinterpret of constant bits, the form literals actually arrive in,
+; so the branch also exercises the constant lookthrough inside a mux.
+;
+; CHECK: ^unsat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(declare-fun z () (_ FloatingPoint 8 24))
+(declare-fun c () Bool)
+(assert c)
+(assert (fp.gt (ite c ((_ to_fp 8 24) #x7fc00001) x) z))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/native-read-array-equality.smt2
+++ b/tests/query-files/fp-tests/native-read-array-equality.smt2
@@ -1,0 +1,26 @@
+; RUN: %solver --array-equality %s | %OutputCheck %s
+; RUN: %solver --array-equality --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver --array-equality --bb.fp-native-cmp=false %s | %OutputCheck %s
+;
+; Equal arrays have equal cells, so a non-NaN cell is greater-or-equal to
+; itself and this formula is unsatisfiable -- with whole-array equality
+; deciding the array reasoning and a native comparison over the reads.
+;
+; With array equality active every read is abstracted to a fresh variable
+; (ArrayTransformer, "ext_read") rather than expanded, and that variable is
+; the comparison's operand from then on. It therefore has to carry the
+; element format, exactly as the read-refinement path's stand-in does: both
+; operands here are abstracted at once, so there is no other side to take the
+; format from, and without it this query aborts on the blaster's source-sort
+; assertion instead of answering.
+;
+; CHECK: ^unsat
+(set-logic QF_ABVFP)
+(declare-fun A () (Array (_ BitVec 4) (_ FloatingPoint 8 24)))
+(declare-fun B () (Array (_ BitVec 4) (_ FloatingPoint 8 24)))
+(declare-fun i () (_ BitVec 4))
+(assert (= A B))
+(assert (not (fp.isNaN (select A i))))
+(assert (not (fp.geq (select A i) (select B i))))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/native-read-compare-sat.smt2
+++ b/tests/query-files/fp-tests/native-read-compare-sat.smt2
@@ -1,0 +1,21 @@
+; RUN: %solver %s | %OutputCheck %s
+; RUN: %solver --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck %s
+; RUN: %solver -r %s | %OutputCheck %s
+;
+; A satisfiable pair of native comparisons over a select, pinning the cell
+; into (1.0, 2.0). Every sat answer is validated internally by substituting
+; the model into the original nodes and folding them through SymFPU
+; (CheckCounterExample), so this covers model evaluation over a surviving
+; comparison whose operand is an array read -- the counterexample path runs
+; after the array machinery has rewritten that operand. The same select is
+; used twice so RemoveUnconstrained cannot discharge the comparisons.
+;
+; CHECK: ^sat
+(set-logic QF_ABVFP)
+(declare-fun A () (Array (_ BitVec 4) (_ FloatingPoint 8 24)))
+(declare-fun i () (_ BitVec 4))
+(assert (fp.gt (select A i) (fp #b0 #b01111111 #b00000000000000000000000)))
+(assert (fp.lt (select A i) (fp #b0 #b10000000 #b00000000000000000000000)))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/native-read-congruence.smt2
+++ b/tests/query-files/fp-tests/native-read-congruence.smt2
@@ -1,0 +1,28 @@
+; RUN: %solver %s | %OutputCheck %s
+; RUN: %solver --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck %s
+; RUN: %solver -r %s | %OutputCheck %s
+;
+; Read congruence underneath a surviving native comparison: equal indices
+; select the same cell, so a non-NaN cell is greater-or-equal to itself and
+; this formula is unsatisfiable, under read refinement and under eager
+; Ackermannization (-r).
+;
+; A select from a float-element array is already the packed element bits, so
+; the gate admits it and the comparison consumes them directly -- which means
+; the array machinery rewrites the operand UNDERNEATH a surviving
+; floating-point node. Every stand-in it mints for a read has to keep the
+; element format; if one does not, the comparison arrives at the blaster with
+; no format to compare in (see native-read-array-equality.smt2, which is the
+; case where that was true).
+;
+; CHECK: ^unsat
+(set-logic QF_ABVFP)
+(declare-fun A () (Array (_ BitVec 4) (_ FloatingPoint 8 24)))
+(declare-fun i () (_ BitVec 4))
+(declare-fun j () (_ BitVec 4))
+(assert (= i j))
+(assert (not (fp.isNaN (select A i))))
+(assert (not (fp.geq (select A i) (select A j))))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/native-read-nan-cell.smt2
+++ b/tests/query-files/fp-tests/native-read-nan-cell.smt2
@@ -1,0 +1,20 @@
+; RUN: %solver %s | %OutputCheck %s
+; RUN: %solver --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck %s
+; RUN: %solver -r %s | %OutputCheck %s
+;
+; A cell holding a NaN is greater than nothing, so this formula is
+; unsatisfiable. Array cells are unconstrained bits, so the solver is free to
+; choose any NaN payload for the cell -- the native isNaN test is field-based
+; and does not care. fp.isNaN and fp.gt both blast natively over the same
+; select here, and the -r run puts an if-then-else chain underneath them.
+;
+; CHECK: ^unsat
+(set-logic QF_ABVFP)
+(declare-fun A () (Array (_ BitVec 4) (_ FloatingPoint 8 24)))
+(declare-fun i () (_ BitVec 4))
+(declare-fun x () (_ FloatingPoint 8 24))
+(assert (fp.isNaN (select A i)))
+(assert (fp.gt (select A i) x))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/native-read-store.smt2
+++ b/tests/query-files/fp-tests/native-read-store.smt2
@@ -1,0 +1,21 @@
+; RUN: %solver %s | %OutputCheck %s
+; RUN: %solver --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck %s
+; RUN: %solver -r %s | %OutputCheck %s
+;
+; Read-over-write underneath a surviving native comparison: selecting the
+; cell just stored gives back the stored value, so a non-NaN v equals itself
+; and this formula is unsatisfiable. The array transform expands the write
+; chain into an if-then-else over the stored value and a fresh read variable,
+; so the comparison's operand is rebuilt as a mux underneath it and both arms
+; have to keep the element format.
+;
+; CHECK: ^unsat
+(set-logic QF_ABVFP)
+(declare-fun A () (Array (_ BitVec 4) (_ FloatingPoint 8 24)))
+(declare-fun i () (_ BitVec 4))
+(declare-fun v () (_ FloatingPoint 8 24))
+(assert (not (fp.isNaN v)))
+(assert (not (fp.eq (select (store A i v) i) v)))
+(check-sat)
+(exit)

--- a/tests/unit-tests/FloatBlast_Test.cpp
+++ b/tests/unit-tests/FloatBlast_Test.cpp
@@ -450,6 +450,72 @@ TEST(FloatBlast, native_comparison_survives_for_ite_operands)
   EXPECT_FALSE(containsFloatingPointKind(lowered(isnan_mux)));
 }
 
+// A select from a float-element array is the packed element bits already,
+// so a predicate over one survives lowering as well. The array and the index
+// are lowered like any other children -- what must not happen is the element
+// itself being unpacked and re-encoded.
+TEST(FloatBlast, native_comparison_survives_for_read_operands)
+{
+  STPMgr mgr;
+  ASSERT_TRUE(mgr.UserFlags.fp_native_cmp); // on by default
+  const SourceSort fp32 = SourceSort::floatingPoint(8, 24);
+  const SourceSort index = SourceSort::bitVector(4);
+  const ASTNode array =
+      mgr.CreateSourceSymbol("A", SourceSort::array(index, fp32));
+  const ASTNode i = mgr.CreateSourceSymbol("i", index);
+  const ASTNode y = mgr.CreateSourceSymbol("y", fp32);
+  const ASTNode x = mgr.CreateSourceSymbol("x", fp32);
+  const ASTNode sum = mgr.CreateTerm(FP_ADD, 32, ASTVec{rne(mgr), x, y});
+
+  auto lowered = [&mgr](const ASTNode& n) {
+    FloatBlast lower(&mgr);
+    return lower.topLevel(n);
+  };
+
+  const ASTNode read = mgr.CreateTerm(READ, 32, array, i);
+  ASSERT_EQ(SourceSort::Kind::FloatingPoint, read.GetSourceSort().kind());
+
+  // Array and index carry no FP work: the whole comparison survives as is.
+  const ASTNode gt_read = mgr.CreateNode(FP_GT, read, y);
+  EXPECT_EQ(gt_read, lowered(gt_read));
+
+  // The classifications and equalities share the gate.
+  const ASTNode isnan_read = mgr.CreateNode(FP_ISNAN, read);
+  EXPECT_EQ(isnan_read, lowered(isnan_read));
+
+  // An index containing FP work is lowered like any other child, so the
+  // comparison survives REBUILT over a read with the lowered index -- the
+  // element bits are still read directly. The index here compares an
+  // fp.add, which cannot survive, so nothing floating-point is left in it.
+  const ASTNode fp_index = mgr.CreateTerm(
+      ITE, 4,
+      ASTVec{mgr.CreateNode(FP_GT, sum, y), i, mgr.CreateBVConst(4, 3)});
+  const ASTNode gt_fp_index =
+      mgr.CreateNode(FP_GT, mgr.CreateTerm(READ, 32, array, fp_index), y);
+  const ASTNode gt_fp_index_lowered = lowered(gt_fp_index);
+  EXPECT_NE(gt_fp_index, gt_fp_index_lowered);
+  EXPECT_EQ(FP_GT, gt_fp_index_lowered.GetKind());
+  ASSERT_EQ(READ, gt_fp_index_lowered[0].GetKind());
+  EXPECT_EQ(array, gt_fp_index_lowered[0][0]);
+  EXPECT_FALSE(containsFloatingPointKind(gt_fp_index_lowered[0][1]));
+
+  // A comparison in the index that CAN survive is left alone there, exactly
+  // as it would be anywhere else in the formula.
+  const ASTNode native_index = mgr.CreateTerm(
+      ITE, 4, ASTVec{mgr.CreateNode(FP_GT, x, y), i, mgr.CreateBVConst(4, 3)});
+  const ASTNode gt_native_index =
+      mgr.CreateNode(FP_GT, mgr.CreateTerm(READ, 32, array, native_index), y);
+  EXPECT_EQ(gt_native_index, lowered(gt_native_index));
+
+  // The other operand still has to pass the gate.
+  EXPECT_FALSE(
+      containsFloatingPointKind(lowered(mgr.CreateNode(FP_GT, read, sum))));
+
+  // Flag off: the old behaviour, everything lowers.
+  mgr.UserFlags.fp_native_cmp = false;
+  EXPECT_FALSE(containsFloatingPointKind(lowered(gt_read)));
+}
+
 // The native encoding and SymFPU must agree on every predicate. At the
 // smallest supported format, (3, 4), all 128 x 128 packed operand pairs are
 // checked for each of the six comparison predicates, and all 128 operands

--- a/tests/unit-tests/FloatBlast_Test.cpp
+++ b/tests/unit-tests/FloatBlast_Test.cpp
@@ -289,7 +289,7 @@ TEST(FloatBlast, every_floating_point_kind_is_lowered)
   }
 }
 
-// The six comparison predicates over leaf operands are not expanded to
+// The six comparison predicates over packed-view operands are not expanded to
 // SymFPU circuits: the source node passes through lowering unchanged and the
 // bit-blaster encodes it natively over the packed bits (BBcompareFP,
 // BBeqFP).
@@ -383,6 +383,73 @@ TEST(FloatBlast, native_comparison_survives_for_leaf_operands)
   EXPECT_FALSE(containsFloatingPointKind(lowered(isnan_symbol)));
 }
 
+// A float-sorted ITE is a mux over packed bits, so a predicate over one can
+// survive lowering too: the bit-blaster muxes the branches (BBITE) instead
+// of SymFPU unpacking both of them and muxing the unpacked records. The
+// branches have to pass the same test the top-level operands do.
+TEST(FloatBlast, native_comparison_survives_for_ite_operands)
+{
+  STPMgr mgr;
+  ASSERT_TRUE(mgr.UserFlags.fp_native_cmp); // on by default
+  const SourceSort fp32 = SourceSort::floatingPoint(8, 24);
+  const ASTNode x = mgr.CreateSourceSymbol("x", fp32);
+  const ASTNode y = mgr.CreateSourceSymbol("y", fp32);
+  const ASTNode z = mgr.CreateSourceSymbol("z", fp32);
+  const ASTNode c = mgr.CreateSymbol("c", 0, 0);
+  const ASTNode d = mgr.CreateSymbol("d", 0, 0);
+  const ASTNode one =
+      mgr.CreateFPConst(mgr.CreateBVConst(32, 0x3f800000u), 8, 24);
+  const ASTNode sum = mgr.CreateTerm(FP_ADD, 32, ASTVec{rne(mgr), x, y});
+
+  auto lowered = [&mgr](const ASTNode& n) {
+    FloatBlast lower(&mgr);
+    return lower.topLevel(n);
+  };
+
+  // Both branches are symbols: the whole comparison survives unchanged.
+  const ASTNode mux = mgr.CreateTerm(ITE, 32, ASTVec{c, x, y});
+  const ASTNode gt_mux = mgr.CreateNode(FP_GT, mux, z);
+  EXPECT_EQ(gt_mux, lowered(gt_mux));
+
+  // Nested muxes are just more of the same.
+  const ASTNode nested = mgr.CreateTerm(
+      ITE, 32, ASTVec{d, x, mgr.CreateTerm(ITE, 32, ASTVec{c, y, z})});
+  const ASTNode gt_nested = mgr.CreateNode(FP_GT, nested, z);
+  EXPECT_EQ(gt_nested, lowered(gt_nested));
+
+  // A to_fp-spelled literal inside a branch resolves to the interned
+  // constant, so the comparison survives rebuilt over the resolved mux.
+  const ASTNode one_reinterpreted = mgr.CreateTerm(
+      FP_TOFP, 32,
+      ASTVec{mgr.CreateBVConst(32, 8), mgr.CreateBVConst(32, 24),
+             mgr.CreateBVConst(32, 0x3f800000u)});
+  const ASTNode gt_resolved = mgr.CreateNode(
+      FP_GT, mgr.CreateTerm(ITE, 32, ASTVec{c, x, one}), z);
+  EXPECT_EQ(gt_resolved,
+            lowered(mgr.CreateNode(
+                FP_GT, mgr.CreateTerm(ITE, 32, ASTVec{c, x, one_reinterpreted}),
+                z)));
+
+  // An FP operation in either branch keeps the whole comparison on the
+  // SymFPU path -- the branch has no packed view that lowering would leave
+  // in the formula.
+  EXPECT_FALSE(containsFloatingPointKind(lowered(mgr.CreateNode(
+      FP_GT, mgr.CreateTerm(ITE, 32, ASTVec{c, x, sum}), z))));
+  EXPECT_FALSE(containsFloatingPointKind(lowered(mgr.CreateNode(
+      FP_GT, mgr.CreateTerm(ITE, 32, ASTVec{c, sum, x}), z))));
+
+  // The equalities and the classifications share the gate.
+  const ASTNode eq_mux = mgr.CreateNode(FP_EQ, mux, z);
+  EXPECT_EQ(eq_mux, lowered(eq_mux));
+  const ASTNode isnan_mux = mgr.CreateNode(FP_ISNAN, mux);
+  EXPECT_EQ(isnan_mux, lowered(isnan_mux));
+
+  // Flag off: the old behaviour, everything lowers.
+  mgr.UserFlags.fp_native_cmp = false;
+  EXPECT_FALSE(containsFloatingPointKind(lowered(gt_mux)));
+  EXPECT_FALSE(containsFloatingPointKind(lowered(isnan_mux)));
+}
+
 // The native encoding and SymFPU must agree on every predicate. At the
 // smallest supported format, (3, 4), all 128 x 128 packed operand pairs are
 // checked for each of the six comparison predicates, and all 128 operands
@@ -454,4 +521,45 @@ TEST(FloatBlast, native_comparison_agrees_with_symfpu_exhaustively)
     }
   }
   EXPECT_EQ(7 * values, classified);
+
+  // Muxed operands: the same sweep through a float-sorted ITE. The mux is
+  // structural, so what needs checking is that the surviving comparison
+  // reads the branch the condition selects -- against every constant, with
+  // a NaN in the other branch so a mux that leaked the wrong branch shows
+  // up as a comparison that is false when it should not be. (The unit tests
+  // build nodes through the hashing factory, so the constant condition does
+  // not fold the ITE away before it is blasted.)
+  unsigned nanIndex = values;
+  for (unsigned i = 0; i < values && nanIndex == values; i++)
+    if (NonMemberBVConstEvaluator(&mgr, mgr.CreateNode(FP_ISNAN, constants[i]))
+        == mgr.ASTTrue)
+      nanIndex = i;
+  ASSERT_LT(nanIndex, values);
+
+  unsigned muxed = 0;
+  for (const ASTNode& cond : {mgr.ASTTrue, mgr.ASTFalse})
+  {
+    for (unsigned i = 0; i < values; i++)
+    {
+      const ASTNode mux = mgr.CreateTerm(
+          ITE, width, ASTVec{cond, constants[i], constants[nanIndex]});
+      const ASTNode& selected =
+          cond == mgr.ASTTrue ? constants[i] : constants[nanIndex];
+      for (unsigned j = 0; j < values; j++)
+      {
+        const ASTNode comparison = mgr.CreateNode(FP_GT, mux, constants[j]);
+        const ASTNode reference = NonMemberBVConstEvaluator(
+            &mgr, mgr.CreateNode(FP_GT, selected, constants[j]));
+        ASSERT_TRUE(reference == mgr.ASTTrue || reference == mgr.ASTFalse);
+
+        const BBNode native = bb.BBForm(comparison);
+        ASSERT_TRUE(native == aig.getTrue() || native == aig.getFalse());
+
+        ASSERT_EQ(reference == mgr.ASTTrue, native == aig.getTrue())
+            << "muxed fp.gt disagrees on branch " << i << ", operand " << j;
+        ++muxed;
+      }
+    }
+  }
+  EXPECT_EQ(2 * values * values, muxed);
 }


### PR DESCRIPTION
Stacked on #761, which is stacked on #760 — merge those first and the base retargets automatically.

Three commits: ITE operands, a missing format stamp in the array transform, and array-read operands on top of it.

## Mux operands

The gate that keeps a floating-point predicate out of SymFPU admitted only symbols, interned constants and to_fp-spelled literals. A float-sorted ITE belongs there too: once its branches are packed views it is a mux over packed bits, which the bit-blaster already builds for free (BBITE), whereas SymFPU's ITE arm unpacks BOTH branches and muxes the unpacked records.

`comparisonLeaf` recurses into the branches through itself rather than through `asPacked` — `asPacked` would happily build an `encode()` circuit for an FP-operation branch, which is exactly the operand that belongs on the SymFPU path, so recursing through the gate refuses it instead and gets to_fp-literal resolution inside branches for free. The condition is Boolean and goes through `lower()`. All thirteen predicates share the gate, so the equalities and classifications pick this up too.

## The format stamp

A read from an array of floats yields a float, and the element format lives on the array node for the read to derive. Once the array transform replaces that read with a fresh variable, the variable is a leaf and derives nothing, so the format has to be stamped onto it — which the read-refinement path does, with a comment explaining why. The whole-array-equality read abstraction minted its own stand-in and did not.

Nothing needed it until now, because floating-point lowering ran before the array transform and left only bitvectors behind. The moment a float-sorted node survives lowering over a read, the element reaches the blaster as a formatless bitvector with no format to interpret its bits with. Setting a zero width is a no-op, so arrays of ordinary bitvectors are unaffected.

## Array read operands

A select from a float-element array is the packed element bits already — `asPacked`'s READ arm rebuilds only the array and the index if they contain FP work, and never builds a circuit for the element. So the gate admits it and the predicate consumes those bits directly.

This is the widening that travels furthest: the comparison now survives into the array machinery, which rewrites its operand underneath it — a fresh read variable under refinement, an if-then-else chain under eager Ackermannization, a mux over the stored value under a write chain, an abstraction variable under whole-array equality. Each of those keeps the element format after the stamp above, and the asserts on the way into the native encoders will say so immediately if a new path appears that does not.

Array cells are unconstrained bits, so a cell can hold any NaN payload; the native NaN test is field-based rather than a canonical pattern, so this needs nothing extra, and `native-read-nan-cell.smt2` pins it.

## Measurements

binary64, `--disable-simplifications --exit-after-CNF --output-CNF`, vars/clauses native vs `--bb.fp-native-cmp=false`:

| probe | native | SymFPU | ratio |
|---|---|---|---|
| `fp.gt(ite c x y, z)` and `fp.lt` over the same mux | 1539 / 4034 | 5307 / 15338 | 3.4x / 3.8x |
| `fp.eq(ite c x y, z)` and `fp.isNormal` of the mux | 810 / 1847 | 4944 / 14249 | 6.1x / 7.7x |
| two comparisons over the same select | 379 / 941 | 1589 / 4571 | 4.2x / 4.9x |

The select probe measures identically under default flags, `-r` and `--array-equality`, which is the expected shape: the read is abstracted to a variable before anything blasts, so what differs between the array strategies is the array reasoning, not the comparison circuit.

## Verification

The exhaustive differential gains a muxed sweep — both constant conditions against all 128 branch values and all 128 other operands, with a NaN in the far branch so a mux that selected the wrong side shows up. It costs no measurable runtime, because BBForm memoises.

Unit tests cover nested muxes, a to_fp literal inside a branch, non-survival when either branch is an FP operation, survival over a plain select, a rebuilt select when the index contains lowered FP work, and a surviving comparison left alone inside an index. Lit tests cover the distribution identity `fp.gt(ite c x y, z) = ite(c, fp.gt(x,z), fp.gt(y,z))`, the branch a true condition selects, model evaluation over a mux operand, read congruence, read over write, a NaN-payload cell, a sat model over a select, and the array-equality query — the array ones also under `-r`.

The stamp was verified causally in both directions: remove it and exactly `native-read-array-equality.smt2` fails on the source-sort assertion; remove the READ case instead and that file passes vacuously. 92 existing test files exercise `--array-equality`, all green.

Full suites green: 101/101 with floating-point support, 74/74 with `-DENABLE_FLOATING_POINT=OFF`.