### PR TITLE
Propagate SMT = equalities over floating-point symbols

### DIFF
--- a/include/stp/Simplifier/PropagateEqualities.h
+++ b/include/stp/Simplifier/PropagateEqualities.h
@@ -78,6 +78,7 @@ private:
   //ASTNode AndPropagate(const ASTNode& a, ArrayTransformer* at);
 
   void addCandidate(const ASTNode a, const ASTNode b);
+  ASTNode resolveFpLiteral(const ASTNode& n);
   bool isSymbol(ASTNode c);
 
   std::vector < std::pair<ASTNode, ASTNode> > candidates;

--- a/lib/Simplifier/PropagateEqualities.cpp
+++ b/lib/Simplifier/PropagateEqualities.cpp
@@ -346,7 +346,26 @@ void PropagateEqualities::addCandidate(const ASTNode a, const ASTNode b)
   candidates.push_back(std::make_pair(a,b));
 
   if (SYMBOL == b.GetKind())
-    candidates.push_back(std::make_pair(b,a));    
+    candidates.push_back(std::make_pair(b,a));
+}
+
+// FP constant folding is deferred solver-wide, so a float literal usually
+// arrives as to_fp's three-child reinterpret form over constant bits
+// rather than as an interned constant. Resolve that form through the
+// canonicalising funnel (CreateFPConst) -- the same lookthrough
+// RemoveUnconstrained's comparison rule and FloatBlast's native-comparison
+// gate use -- so the substitution installs an interned constant that folds
+// at every use site. Anything else is returned unchanged.
+ASTNode PropagateEqualities::resolveFpLiteral(const ASTNode& n)
+{
+  if (n.GetKind() == FP_TOFP && n.Degree() == 3 && n[2].GetKind() == BVCONST)
+  {
+    const SourceSort sort = n.GetSourceSort();
+    if (sort.kind() == SourceSort::Kind::FloatingPoint)
+      return bm->CreateFPConst(n[2], sort.exponentWidth(),
+                               sort.significandWidth());
+  }
+  return n;
 }
 
 void PropagateEqualities::buildXORCandidates(const ASTNode a, bool negated)
@@ -604,6 +623,21 @@ void PropagateEqualities::buildCandidateList(const ASTNode& a)
         //std::cerr << a;
     }
 
+  }
+  else if (FP_SMT_EQ == k)
+  {
+    // SMT `=` on floats is true equality on the abstract domain (one NaN,
+    // two distinct zeros), so substituting one side for the other is sound
+    // in every context. fp.eq (FP_EQ) must NEVER be propagated: it
+    // identifies +0 with -0, which fp.isNegative, division etc.
+    // distinguish. Kept separate from the EQ arm above so the bitvector
+    // inverse rewrites (BVNOT/BVUMINUS/BVPLUS) can't see float operands.
+    const ASTNode left = resolveFpLiteral(a[0]);
+    const ASTNode right = resolveFpLiteral(a[1]);
+    if (SYMBOL == left.GetKind())
+      addCandidate(left, right);
+    else if (SYMBOL == right.GetKind())
+      addCandidate(right, left);
   }
   else if (AND == k)
   {

--- a/tests/query-files/fp-tests/propagate-fp-eq-must-not.smt2
+++ b/tests/query-files/fp-tests/propagate-fp-eq-must-not.smt2
@@ -1,0 +1,16 @@
+; RUN: %solver %s | %OutputCheck %s
+; RUN: %solver --disable-simplifications %s | %OutputCheck %s
+;
+; fp.eq must NEVER be propagated as a substitution: it identifies +0 with
+; -0, which fp.isNegative distinguishes. Here x = -0 is the only model --
+; fp.eq(-0, +0) is true and isNegative(-0) is true. If fp.eq ever feeds
+; the substitution map, x becomes +0 and this flips to unsat. (SMT = is
+; the propagatable equality; fp.eq is IEEE equality on the quotient.)
+;
+; CHECK: ^sat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(assert (fp.eq x (fp #b0 #b00000000 #b00000000000000000000000)))
+(assert (fp.isNegative x))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/propagate-smt-eq-fires.smt2
+++ b/tests/query-files/fp-tests/propagate-smt-eq-fires.smt2
@@ -1,0 +1,27 @@
+; RUN: %solver --exit-after-CNF %s | %OutputCheck %s
+; RUN: %solver %s | %OutputCheck %s
+; RUN: %solver --disable-simplifications %s | %OutputCheck %s
+;
+; SMT = over a float symbol propagates: x and y become constants, the
+; fp.mul folds by construction, and every assertion is decided at the word
+; level. The first RUN is the firing test -- the verdict is printed under
+; --exit-after-CNF only when nothing reaches CNF generation, so this fails
+; (no output) if FP_SMT_EQ propagation or the downstream constant fold
+; regresses; same convention as unconstrained-fp-gt.smt2. Both literal
+; spellings are covered: (fp ...) interns at parse, the to_fp reinterpret
+; form is resolved by the lookthrough. The default RUN checks the model
+; internally; --disable-simplifications answers through the ordinary
+; blasting path with no propagation at all.
+;
+; 1.5 * 1.5 = 2.25 > 2.0, and 1.5 > 1.0.
+;
+; CHECK: ^sat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 11 53))
+(declare-fun y () (_ FloatingPoint 11 53))
+(assert (= x (fp #b0 #b01111111111 #b1000000000000000000000000000000000000000000000000000)))
+(assert (= y ((_ to_fp 11 53) #x4000000000000000)))
+(assert (fp.gt (fp.mul RNE x x) y))
+(assert (fp.gt x (fp #b0 #b01111111111 #b0000000000000000000000000000000000000000000000000000)))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/propagate-smt-eq-model.smt2
+++ b/tests/query-files/fp-tests/propagate-smt-eq-model.smt2
@@ -1,0 +1,19 @@
+; RUN: %solver -p %s | %OutputCheck %s
+;
+; Variables eliminated by SMT-= propagation must reappear in the model
+; with the values they were pinned to: the substitution map completes the
+; model for symbols the formula no longer contains. (The internal
+; counterexample check also validates them against the original
+; assertions on every sat answer.)
+;
+; CHECK: ^sat
+; CHECK-L: (define-fun |y| () (_ FloatingPoint 8 24) (fp #b1 #b01111111 #b10000000000000000000000))
+; CHECK-L: (define-fun |x| () (_ FloatingPoint 8 24) (fp #b0 #b01111111 #b10000000000000000000000))
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(declare-fun y () (_ FloatingPoint 8 24))
+(assert (= x (fp #b0 #b01111111 #b10000000000000000000000)))
+(assert (= y (fp #b1 #b01111111 #b10000000000000000000000)))
+(assert (fp.gt x y))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/propagate-smt-eq-unsat.smt2
+++ b/tests/query-files/fp-tests/propagate-smt-eq-unsat.smt2
@@ -1,0 +1,21 @@
+; RUN: %solver --exit-after-CNF %s | %OutputCheck %s
+; RUN: %solver %s | %OutputCheck %s
+; RUN: %solver --disable-simplifications %s | %OutputCheck %s
+;
+; The wintersteiger "has-no-other-solution" shape: variables pinned to
+; literals by SMT =, and the operation's result asserted NOT equal to the
+; known answer. Propagation makes the operands constant, the fp.add folds,
+; and the negated equality is refuted before CNF (first RUN prints unsat
+; only if that whole chain fires). 1.5 + 1.5 = 3.0 exactly at binary32.
+;
+; CHECK: ^unsat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(declare-fun y () (_ FloatingPoint 8 24))
+(declare-fun r () (_ FloatingPoint 8 24))
+(assert (= x (fp #b0 #b01111111 #b10000000000000000000000)))
+(assert (= y (fp #b0 #b01111111 #b10000000000000000000000)))
+(assert (= r (fp #b0 #b10000000 #b10000000000000000000000)))
+(assert (not (= (fp.add RNE x y) r)))
+(check-sat)
+(exit)

--- a/tests/unit-tests/PropagateEqualities_Test.cpp
+++ b/tests/unit-tests/PropagateEqualities_Test.cpp
@@ -343,9 +343,12 @@ TEST(PropagateEquality_Test, g_Booleans)
 
 // SMT `=` on floats (FP_SMT_EQ) is true equality on the abstract domain,
 // so it propagates like EQ. fp.eq (FP_EQ) identifies +0 with -0 and must
-// never propagate. These parse their own QF_FP prelude and return the
-// propagated conjunction for inspection.
-static stp::ASTNode propagateFP(const std::string& input)
+// never propagate. These parse their own QF_FP prelude and hand the
+// propagated conjunction to a checker WHILE the manager is alive: an
+// ASTNode must not outlive the STPMgr that owns its storage (returning one
+// crashed on i386 and shows as an invalid access under valgrind on x86-64).
+template <typename Check>
+static void propagateFP(const std::string& input, Check check)
 {
   stp::STPMgr mgr;
   SimplifyingNodeFactory snf(*(mgr.hashingNodeFactory), mgr);
@@ -382,7 +385,7 @@ static stp::ASTNode propagateFP(const std::string& input)
     n = simp.applySubstitutionMap(n);
     simp.haveAppliedSubstitutionMap();
   }
-  return n;
+  check(n);
 }
 
 // The propagated conjunction is not fully constant-folded here (all-constant
@@ -401,51 +404,62 @@ static bool containsSymbolNamed(const stp::ASTNode& n, const std::string& s)
 
 TEST(PropagateEquality_Test, fp_smt_eq_constant)
 {
-  const stp::ASTNode n = propagateFP(R"(
+  propagateFP(R"(
    (assert (= x (fp #b0 #b01111111 #b10000000000000000000000)))
    (assert (fp.gt x (fp #b0 #b01111111 #b00000000000000000000000)))
-  )");
-  ASSERT_FALSE(containsSymbolNamed(n, "x"));
+  )",
+              [](const stp::ASTNode& n) {
+                ASSERT_FALSE(containsSymbolNamed(n, "x"));
+              });
 }
 
 TEST(PropagateEquality_Test, fp_smt_eq_tofp_literal)
 {
   // The literal arrives as to_fp's unfolded reinterpret form; the
   // lookthrough resolves it to an interned constant before substituting.
-  const stp::ASTNode n = propagateFP(R"(
+  propagateFP(R"(
    (assert (= x ((_ to_fp 8 24) #x3FC00000)))
    (assert (fp.lt x ((_ to_fp 8 24) #x40000000)))
-  )");
-  ASSERT_FALSE(containsSymbolNamed(n, "x"));
+  )",
+              [](const stp::ASTNode& n) {
+                ASSERT_FALSE(containsSymbolNamed(n, "x"));
+              });
 }
 
 TEST(PropagateEquality_Test, fp_smt_eq_symbols)
 {
   // One of the two symbols substitutes for the other.
-  const stp::ASTNode n = propagateFP(R"(
+  propagateFP(R"(
    (assert (= x y))
    (assert (fp.isNormal x))
    (assert (fp.isNormal y))
-  )");
-  ASSERT_TRUE(!containsSymbolNamed(n, "x") || !containsSymbolNamed(n, "y"));
+  )",
+              [](const stp::ASTNode& n) {
+                ASSERT_TRUE(!containsSymbolNamed(n, "x") ||
+                            !containsSymbolNamed(n, "y"));
+              });
 }
 
 TEST(PropagateEquality_Test, fp_eq_never_propagates)
 {
   // fp.eq's +0 = -0 makes substitution unsound; the node must survive.
-  const stp::ASTNode n = propagateFP(R"(
+  propagateFP(R"(
    (assert (fp.eq x (fp #b0 #b00000000 #b00000000000000000000000)))
-  )");
-  ASSERT_EQ(stp::FP_EQ, n.GetKind());
+  )",
+              [](const stp::ASTNode& n) {
+                ASSERT_EQ(stp::FP_EQ, n.GetKind());
+              });
 }
 
 TEST(PropagateEquality_Test, fp_smt_eq_occurs_check)
 {
   // x appears on both sides; the candidate must be rejected, not looped.
-  const stp::ASTNode n = propagateFP(R"(
+  propagateFP(R"(
    (assert (= x (fp.add RNE x y)))
-  )");
-  ASSERT_EQ(stp::FP_SMT_EQ, n.GetKind());
+  )",
+              [](const stp::ASTNode& n) {
+                ASSERT_EQ(stp::FP_SMT_EQ, n.GetKind());
+              });
 }
 
 #endif // STP_ENABLE_FLOATING_POINT

--- a/tests/unit-tests/PropagateEqualities_Test.cpp
+++ b/tests/unit-tests/PropagateEqualities_Test.cpp
@@ -338,3 +338,114 @@ TEST(PropagateEquality_Test, g_Booleans)
 
   verify(input);
 }
+
+#ifdef STP_ENABLE_FLOATING_POINT
+
+// SMT `=` on floats (FP_SMT_EQ) is true equality on the abstract domain,
+// so it propagates like EQ. fp.eq (FP_EQ) identifies +0 with -0 and must
+// never propagate. These parse their own QF_FP prelude and return the
+// propagated conjunction for inspection.
+static stp::ASTNode propagateFP(const std::string& input)
+{
+  stp::STPMgr mgr;
+  SimplifyingNodeFactory snf(*(mgr.hashingNodeFactory), mgr);
+  mgr.defaultNodeFactory = &snf;
+  stp::Cpp_interface interface(mgr, mgr.defaultNodeFactory);
+
+  interface.startup();
+  stp::GlobalParserBM = &mgr;
+  stp::GlobalParserInterface = &interface;
+
+  stp::SubstitutionMap sm(&mgr);
+  stp::Simplifier simp(&mgr, &sm);
+
+  const std::string prelude = R"(
+  (set-logic QF_FP)
+  (declare-fun x () (_ FloatingPoint 8 24))
+  (declare-fun y () (_ FloatingPoint 8 24))
+  )";
+
+  stp::SMT2ScanString((prelude + input).c_str());
+  stp::SMT2Parse();
+  smt2lex_destroy();
+
+  ASTVec values = mgr.GetAsserts();
+  stp::ASTNode n = values.size() == 1 ? values[0]
+                                      : mgr.CreateNode(stp::AND, values);
+
+  stp::PropagateEqualities propagate(&simp, mgr.defaultNodeFactory, &mgr);
+  propagate.setSpeculativeOn();
+  n = propagate.topLevel(n);
+
+  if (simp.hasUnappliedSubstitutions())
+  {
+    n = simp.applySubstitutionMap(n);
+    simp.haveAppliedSubstitutionMap();
+  }
+  return n;
+}
+
+// The propagated conjunction is not fully constant-folded here (all-constant
+// FP predicates fold in later passes, not at node creation), so the tests
+// assert the guarantee propagation itself makes: the substituted symbol is
+// gone from the formula.
+static bool containsSymbolNamed(const stp::ASTNode& n, const std::string& s)
+{
+  if (n.GetKind() == stp::SYMBOL)
+    return n.GetName() == s;
+  for (size_t i = 0; i < n.Degree(); i++)
+    if (containsSymbolNamed(n[i], s))
+      return true;
+  return false;
+}
+
+TEST(PropagateEquality_Test, fp_smt_eq_constant)
+{
+  const stp::ASTNode n = propagateFP(R"(
+   (assert (= x (fp #b0 #b01111111 #b10000000000000000000000)))
+   (assert (fp.gt x (fp #b0 #b01111111 #b00000000000000000000000)))
+  )");
+  ASSERT_FALSE(containsSymbolNamed(n, "x"));
+}
+
+TEST(PropagateEquality_Test, fp_smt_eq_tofp_literal)
+{
+  // The literal arrives as to_fp's unfolded reinterpret form; the
+  // lookthrough resolves it to an interned constant before substituting.
+  const stp::ASTNode n = propagateFP(R"(
+   (assert (= x ((_ to_fp 8 24) #x3FC00000)))
+   (assert (fp.lt x ((_ to_fp 8 24) #x40000000)))
+  )");
+  ASSERT_FALSE(containsSymbolNamed(n, "x"));
+}
+
+TEST(PropagateEquality_Test, fp_smt_eq_symbols)
+{
+  // One of the two symbols substitutes for the other.
+  const stp::ASTNode n = propagateFP(R"(
+   (assert (= x y))
+   (assert (fp.isNormal x))
+   (assert (fp.isNormal y))
+  )");
+  ASSERT_TRUE(!containsSymbolNamed(n, "x") || !containsSymbolNamed(n, "y"));
+}
+
+TEST(PropagateEquality_Test, fp_eq_never_propagates)
+{
+  // fp.eq's +0 = -0 makes substitution unsound; the node must survive.
+  const stp::ASTNode n = propagateFP(R"(
+   (assert (fp.eq x (fp #b0 #b00000000 #b00000000000000000000000)))
+  )");
+  ASSERT_EQ(stp::FP_EQ, n.GetKind());
+}
+
+TEST(PropagateEquality_Test, fp_smt_eq_occurs_check)
+{
+  // x appears on both sides; the candidate must be rejected, not looped.
+  const stp::ASTNode n = propagateFP(R"(
+   (assert (= x (fp.add RNE x y)))
+  )");
+  ASSERT_EQ(stp::FP_SMT_EQ, n.GetKind());
+}
+
+#endif // STP_ENABLE_FLOATING_POINT


### PR DESCRIPTION
`PropagateEqualities` collected candidates only from `EQ`/`IFF`, so the float form of a top-level equality — `FP_SMT_EQ`, which SMT `=` parses to on FloatingPoint operands — never substituted, and formulas that pin a float variable to a literal carried the variable into the bit-blasted circuit anyway.

SMT `=` is true equality on the abstract floating-point domain (one NaN, two distinct zeros), so replacing one side by the other is sound in every context. The new arm handles the symbol/term orientations and is kept separate from the EQ arm so the bitvector inverse rewrites (BVNOT/BVUMINUS/BVPLUS) never see float operands. Since literals usually arrive as to_fp's three-child reinterpret form over constant bits (FP constant folding is deferred solver-wide), the arm resolves that form through the canonicalising `CreateFPConst` funnel — the same lookthrough `RemoveUnconstrained`'s comparison rule and the native-comparison gate use. The candidate machinery downstream is kind-agnostic: occurs/cycle handling and the substitution map apply unchanged, and eliminated variables are reconstructed in models.

`fp.eq` is deliberately **not** propagated: it identifies +0 with −0, which `fp.isNegative` and friends distinguish. A lit test pins x = −0 as the model of `fp.eq(x, +0) ∧ fp.isNegative(x)`; it flips unsat if `fp.eq` ever feeds the substitution map.

**Why it matters**: 39,620 of the 39,994 wintersteiger QF_FP files have the shape `(= x lit)`, `(= y lit)`, `(= r lit)`, plus one operation over x, y, r. Once the operands are constant the operation folds at node creation and nothing reaches CNF. Measured (same binary, default vs `--disable-equality`, which reproduces master's behaviour on these files; 30s timeout; verdicts cross-checked between arms and against `:status` on all 190 sampled files — 0 disagreements):

| family (n) | before | after | per-file |
|---|---|---|---|
| wintersteiger/rem (40) | 461s | 0.5s | ~11.5s → 13ms |
| wintersteiger/div (60) | 34.5s | 0.3s | ~0.6s → 5ms |
| wintersteiger/sqrt (20) | 59.0s | 0.1s | ~3.0s → 6ms |
| wintersteiger/mul (30) | 4.5s | 0.1s | ~0.15s → 5ms |
| wintersteiger/fma (20) | 3.5s | 0.1s | ~0.17s → 5ms |
| griggio (10) | ~176s, 4 timeouts | ~175s, 4 timeouts | neutral |
| ramalho (10) | 63.2s, 1 timeout | 2.1s, 0 timeouts | one 30s-timeout now solves in 0.30s |

The motivating instance `div-has-solution-14987.smt2` goes from 0.58s (35,075-var / 193,425-clause CNF plus SAT) to 4ms, decided before CNF generation. The rem family is the one dominating STP's gap to bitwuzla on this logic.

**Verification**: five new unit tests (constant / to_fp-literal / symbol=symbol propagation, fp.eq never a candidate, occurs check — guarded for non-FP builds); four new lit tests including an `--exit-after-CNF` firing test (the verdict only prints when every assertion is decided before CNF, so the test fails if propagation or the downstream fold regresses) and a model test asserting eliminated variables reappear in `-p` output with their pinned values. Full suites green with `-DENABLE_FLOATING_POINT=ON` (101/101) and `=OFF` (74/74). `--disable-equality` restores the old behaviour.