### PR TITLE
Fold constant floating-point nodes at the simplifying factory

### DIFF
--- a/lib/NodeFactory/SimplifyingNodeFactory.cpp
+++ b/lib/NodeFactory/SimplifyingNodeFactory.cpp
@@ -342,20 +342,22 @@ ASTNode SimplifyingNodeFactory::CreateNode(Kind kind, const ASTVec& children)
   // These are created specially.
   //
 
-  /* we need to bypass the constant evaluation if we're creating an FP term
-   * (a table lookup: the FP category comes from ASTKind.kinds) */
-  const bool is_fp_operation = is_FP_kind(kind);
-
   // If all the parameters are constant, return the constant value.
   // The bitblaster calls CreateNode with a boolean vector. We don't try to
   // simplify those.
   // The type kinds (BOOLEAN..ROUNDINGMODE, API-only nodes) are exempt: a
   // childless one has "all children constant" vacuously, and the constant
   // evaluator has no business seeing a type.
+  //
+  // Floating-point predicates fold here too: the constant evaluator's FP
+  // arm evaluates them by lowering over the constant operands and returns
+  // TRUE/FALSE, so constant floating-point comparisons and classifications
+  // never outlive their creation. (The FP *term* fold, with its
+  // format-carrying subtleties, is in CreateTerm.)
   if (kind != stp::UNDEFINED && kind != stp::BOOLEAN &&
       kind != stp::BITVECTOR && kind != stp::ARRAY &&
       kind != stp::FLOATINGPOINT && kind != stp::ROUNDINGMODE &&
-      !is_fp_operation && children_all_constants(children))
+      children_all_constants(children))
   {
     const ASTNode& hash = hashing.CreateNode(kind, children);
     const ASTNode& c = NonMemberBVConstEvaluator(&bm, hash);
@@ -2017,12 +2019,21 @@ ASTNode SimplifyingNodeFactory::CreateTerm(Kind kind, unsigned int width,
 
   assert(bm.hashingNodeFactory == &hashing);
 
-  /* we need to bypass the constant evaluation if we're creating an FP term
-   * (a table lookup: the FP category comes from ASTKind.kinds) */
-  const bool is_fp_operation = is_FP_kind(kind);
+  // The partial floating-point operations cannot be constant-folded here:
+  // their unspecified cases (fp.min/fp.max on opposite zeros, out-of-range
+  // fp.to_ubv/fp.to_sbv) only get an answer when FpTotalise adds its
+  // never-constant unspecified-value child, and lowering requires that
+  // totalised arity. Every other floating-point term folds through the
+  // constant evaluator's FP arm, which re-interns the result with its
+  // format via the CreateFPConst funnel -- so both literal spellings,
+  // ((_ to_fp e s) bits) and (fp s e m), intern to the same ASTFPConst,
+  // and constant arithmetic collapses at creation.
+  const bool is_partial_fp_operation =
+      kind == stp::FP_MIN || kind == stp::FP_MAX || kind == stp::FP_TO_UBV ||
+      kind == stp::FP_TO_SBV;
 
   // If all the parameters are constant, return the constant value.
-  if (children_all_constants(children) && !is_fp_operation)
+  if (children_all_constants(children) && !is_partial_fp_operation)
   {
     const ASTNode& hash = hashing.CreateTerm(kind, width, children);
     const ASTNode& c = NonMemberBVConstEvaluator(&bm, hash);

--- a/lib/Simplifier/consteval.cpp
+++ b/lib/Simplifier/consteval.cpp
@@ -1046,8 +1046,18 @@ ASTNode NonMemberBVConstEvaluator(STPMgr* _bm, const Kind k,
           k == FP_ISSUBNORMAL || k == FP_ISZERO || k == FP_ISINFINITE ||
           k == FP_ISNAN || k == FP_ISNEGATIVE || k == FP_ISPOSITIVE;
 
-      ASTNode temp(boolean_result ? _bm->CreateNode(k, formatted)
-                                  : _bm->CreateTerm(k, inputwidth, formatted));
+      // Build the normalisation copy through the HASHING factory, never the
+      // default one: the simplifying factory folds all-constant
+      // floating-point nodes by calling back into this evaluator, so
+      // rebuilding the same kind over the same constant children through it
+      // would recurse without bound. Nothing is lost -- the factory
+      // shortcuts this skips (abs of a constant, x*1.0, same-operand
+      // comparisons) are all handled by lowering below, and the evaluation
+      // of `blasted` already supports an unfolded circuit.
+      ASTNode temp(boolean_result
+                       ? _bm->hashingNodeFactory->CreateNode(k, formatted)
+                       : _bm->hashingNodeFactory->CreateTerm(k, inputwidth,
+                                                             formatted));
 
       // Only a floating-point *result* carries a floating-point format. The
       // classifications and comparisons return a Boolean and to_ubv/to_sbv

--- a/tests/query-files/fp-tests/const-fold-at-parse.smt2
+++ b/tests/query-files/fp-tests/const-fold-at-parse.smt2
@@ -1,0 +1,27 @@
+; RUN: %solver --exit-after-CNF %s | %OutputCheck %s
+; RUN: %solver %s | %OutputCheck %s
+; RUN: %solver --disable-simplifications %s | %OutputCheck %s
+;
+; All-constant floating-point nodes fold at node creation under the
+; simplifying factory, so BOTH literal spellings -- (fp ...) which interns
+; at parse, and ((_ to_fp e s) bits) which used to stay an unfolded
+; reinterpret term solver-wide -- intern to the same ASTFPConst, and the
+; constant comparison and arithmetic below never survive parsing. The
+; first RUN prints its verdict only if every assertion is decided before
+; CNF generation, so it fails if creation-time folding regresses. The
+; --disable-simplifications run keeps the hashing factory, where nothing
+; folds at creation and the ordinary blasting path answers.
+;
+; 1.3 > 1.0 both ways of spelling 1.3; 1.5 + 2.5 = 4.0 exactly.
+;
+; CHECK: ^sat
+(set-logic QF_FP)
+(assert (fp.gt ((_ to_fp 11 53) #x3FF4CCCCCCCCCCCD)
+               (fp #b0 #b01111111111 #b0000000000000000000000000000000000000000000000000000)))
+(assert (fp.gt (fp #b0 #b01111111111 #b0100110011001100110011001100110011001100110011001101)
+               (fp #b0 #b01111111111 #b0000000000000000000000000000000000000000000000000000)))
+(assert (= (fp.add RNE ((_ to_fp 11 53) #x3FF8000000000000)
+                       ((_ to_fp 11 53) #x4004000000000000))
+           ((_ to_fp 11 53) #x4010000000000000)))
+(check-sat)
+(exit)

--- a/tests/unit-tests/FpConstantFold_Test.cpp
+++ b/tests/unit-tests/FpConstantFold_Test.cpp
@@ -440,3 +440,86 @@ TEST(FpConstantFold, folds_under_a_non_simplifying_factory)
   EXPECT_TRUE(folded.isConstant());
   EXPECT_EQ(eb + sb, folded.GetValueWidth());
 }
+
+// The simplifying factory folds all-constant floating-point nodes at
+// creation (the constant evaluator's FP arm re-interns results through the
+// CreateFPConst funnel), so a constant has ONE representation regardless of
+// how it was spelled, and constant operations never outlive their creation.
+TEST(FpConstantFold, both_literal_spellings_intern_to_the_same_node)
+{
+  Fixture f;
+  const uint64_t bits = 0x3FF4CCCCCCCCCCCDull; // 1.3, binary64
+
+  // ((_ to_fp 11 53) #x3FF4CCCCCCCCCCCD), as the parser builds it.
+  const ASTNode viaToFp = f.snf.CreateTerm(
+      FP_TOFP, 64,
+      ASTVec{f.mgr.CreateBVConst(32, 11), f.mgr.CreateBVConst(32, 53),
+             f.mgr.CreateBVConst(64, bits)});
+
+  // (fp #b0 #b01111111111 #b0100...) interns through CreateFPConst.
+  const ASTNode viaLiteral = f.fpConst(11, 53, bits);
+
+  EXPECT_TRUE(viaToFp.isConstant());
+  EXPECT_EQ(viaLiteral, viaToFp); // the same hash-consed node
+  EXPECT_EQ(11u, viaToFp.GetExpWidth());
+  EXPECT_EQ(53u, viaToFp.GetSigWidth());
+}
+
+TEST(FpConstantFold, constant_predicates_fold_at_creation)
+{
+  Fixture f;
+  const ASTNode onePointFive = f.fpConst(8, 24, 0x3FC00000u);
+  const ASTNode one = f.fpConst(8, 24, 0x3F800000u);
+
+  EXPECT_EQ(f.mgr.ASTTrue,
+            f.snf.CreateNode(FP_GT, ASTVec{onePointFive, one}));
+  EXPECT_EQ(f.mgr.ASTFalse,
+            f.snf.CreateNode(FP_LT, ASTVec{onePointFive, one}));
+  EXPECT_EQ(f.mgr.ASTFalse, f.snf.CreateNode(FP_ISNAN, ASTVec{one}));
+}
+
+TEST(FpConstantFold, constant_arithmetic_folds_at_creation)
+{
+  Fixture f;
+  const ASTNode sum = f.snf.CreateTerm(
+      FP_ADD, 64,
+      ASTVec{f.rm(symbolic_fp::ROUND_NEAREST_TIES_TO_EVEN),
+             f.fpConst(11, 53, bitsOf(1.5)), f.fpConst(11, 53, bitsOf(2.5))});
+
+  EXPECT_TRUE(sum.isConstant());
+  EXPECT_EQ(f.fpConst(11, 53, bitsOf(4.0)), sum);
+  EXPECT_EQ(11u, sum.GetExpWidth());
+}
+
+TEST(FpConstantFold, nan_payloads_intern_canonically)
+{
+  Fixture f;
+  auto reinterpret = [&f](uint32_t bits) {
+    return f.snf.CreateTerm(
+        FP_TOFP, 32,
+        ASTVec{f.mgr.CreateBVConst(32, 8), f.mgr.CreateBVConst(32, 24),
+               f.mgr.CreateBVConst(32, bits)});
+  };
+  // Two different NaN payloads (and signs) intern to the one canonical NaN,
+  // matching what every FP-observable path (unpack, fp.to_ieee_bv) already
+  // does with payloads.
+  const ASTNode a = reinterpret(0x7F800001u);
+  const ASTNode b = reinterpret(0xFFC12345u);
+  EXPECT_TRUE(a.isConstant());
+  EXPECT_EQ(a, b);
+  EXPECT_EQ(f.mgr.ASTTrue, f.snf.CreateNode(FP_ISNAN, ASTVec{a}));
+}
+
+// fp.min/fp.max (opposite zeros) and fp.to_ubv/fp.to_sbv (out of range)
+// have unspecified cases that only get an answer once FpTotalise adds its
+// unspecified-value child, so their pre-totalise constant forms must NOT
+// fold at creation.
+TEST(FpConstantFold, partial_operations_do_not_fold_at_creation)
+{
+  Fixture f;
+  const ASTNode minimum = f.snf.CreateTerm(
+      FP_MIN, 32,
+      ASTVec{f.fpConst(8, 24, 0x80000000u), f.fpConst(8, 24, 0x00000000u)});
+  EXPECT_EQ(FP_MIN, minimum.GetKind());
+  EXPECT_FALSE(minimum.isConstant());
+}


### PR DESCRIPTION
The simplifying factory bypassed the all-constant fold for every floating-point kind. The bypass was protective where it stood — the generic fold path returns a bare BVCONST that cannot carry a format — but the constant evaluator's FP arm already solves that (it re-interns results through the `CreateFPConst` funnel), so the factory now routes floating-point kinds through it like everything else.

**What changes**

- `((_ to_fp e s) bits)` and `(fp s e m)` intern to the **same hash-consed ASTFPConst**. Previously the reinterpret spelling stayed an unfolded three-child FP_TOFP term solver-wide, so the same constant had two permanently different ASTs depending on how the benchmark spelled it — the trap that separately forced `CreateFPConst` lookthroughs into RemoveUnconstrained (#753), the native-comparison gate (#757), and PropagateEqualities (#763). Under the default factory those lookthroughs are now unreachable; they stay because `--disable-simplifications` keeps the hashing factory, where nothing folds at creation.
- Constant predicates fold to TRUE/FALSE and constant arithmetic to interned, formatted constants at node creation, instead of surviving ~eight word-level passes per simplification iteration until `SimplifyAtomicFormula` reached them.
- NaN payloads intern canonically — observation-equivalent to before, since unpacking already drops payloads at every FP-observable boundary. Refusals (unsupported formats, wide fp.rem) move from lowering time to node-creation time: same error, earlier.
- Excluded from folding: fp.min/fp.max and fp.to_ubv/fp.to_sbv, whose unspecified cases (opposite zeros, out-of-range) only get an answer once FpTotalise adds its never-constant unspecified-value child.

**The load-bearing detail** is re-entrancy: the evaluator's FP arm rebuilds the node through a factory before lowering it, and rebuilding the same kind over the same constant children through the *simplifying* factory would now recurse without bound. The rebuild goes through the hashing factory instead; the shortcuts this skips (abs of a constant, x·1.0, same-operand comparisons) are all handled by lowering, whose result was already evaluated explicitly for exactly the unfolded case. The two halves of this PR are therefore inseparable.

**Neutrality where it doesn't fire, proven deterministically**: against a master-baseline binary, `--output-CNF` output is **byte-identical** on representatives of griggio, ramalho, and Heizmann-UltimateAutomizer (9.6k–72k vars) — the pipeline already folded these constants by blast time, so this is an invariant-and-robustness change, not an encoding change. Verdicts agree across a 41-file interleaved A/B; the only wall-clock differences were on instances sitting at the timeout cap, with identical CNF.

**Verification**: unit tests pin the headline identity (both spellings → one node, by node identity), creation-time folding of predicates and arithmetic, canonical NaN interning, and the fp.min exclusion; a lit firing test proves an all-constant file is decided before CNF generation under the default factory and still answers under `--disable-simplifications`. Full suites green: FP 102/102 (including the exhaustive native-vs-SymFPU differentials and the hardware-oracle constant-folding tests), non-FP 74/74.