### PR TITLE
Evaluate constant floating-point operations with a literal symfpu backend

### DIFF
--- a/include/stp/FloatBlaster/literal_fp.h
+++ b/include/stp/FloatBlaster/literal_fp.h
@@ -1,0 +1,68 @@
+/********************************************************************
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#ifndef STP_LITERAL_FP_H
+#define STP_LITERAL_FP_H
+
+// A *literal* symfpu backend: the same IEEE semantics as the circuit
+// backend (symbolic_fp), instantiated over concrete CBV arithmetic instead
+// of ASTNode construction. Constant folding through this backend computes
+// the answer directly -- microseconds and no node churn -- where the
+// circuit backend builds and collapses thousands of interned gates.
+//
+// The semantics source is shared by construction: both backends
+// instantiate the identical symfpu::core templates. The Kind-to-operation
+// driver (tryEvaluateFpConstant) is the only per-kind code, and it is
+// pinned to the circuit path by an exhaustive per-kind differential in
+// FpConstantFold_Test.
+
+#include "stp/AST/AST.h"
+
+namespace stp
+{
+class STPMgr;
+
+namespace literal_fp
+{
+
+// Evaluate one all-constant floating-point operation directly.
+//
+// `n` is the node the constant evaluator built for the fold: every child
+// is a constant (FP constants carry their formats). Returns the folded
+// value -- ASTTrue/ASTFalse for predicates, a bare BVCONST for bit-vector
+// and float results (the caller re-stamps float formats, as it already
+// does for the circuit path) -- or a null ASTNode when this backend does
+// not cover the kind or format, in which case the caller falls back to
+// building and collapsing the circuit.
+//
+// Deliberately not covered: fp.min/fp.max/fp.to_ubv/fp.to_sbv (their
+// unspecified cases route through FpTotalise's machinery) and
+// fp.roundToIntegral (kept on the circuit path so its symfpu guard-bug
+// refusals stay identical). Unsupported formats return null for the same
+// refusal-parity reason.
+ASTNode tryEvaluateFpConstant(STPMgr* bm, const ASTNode& n);
+
+} // namespace literal_fp
+} // namespace stp
+
+#endif

--- a/lib/FloatBlaster/CMakeLists.txt
+++ b/lib/FloatBlaster/CMakeLists.txt
@@ -32,6 +32,7 @@ set(floatblaster_sources
     FloatBlast.cpp
     FpEncodingContext.cpp
     FpTotalise.cpp
+    literal_fp.cpp
 )
 if (ENABLE_FLOATING_POINT)
     list(APPEND floatblaster_sources symbolic_fp.cpp)

--- a/lib/FloatBlaster/literal_fp.cpp
+++ b/lib/FloatBlaster/literal_fp.cpp
@@ -1,0 +1,800 @@
+/********************************************************************
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#include "stp/FloatBlaster/literal_fp.h"
+
+#ifdef STP_ENABLE_FLOATING_POINT
+
+#include "stp/FloatBlaster/FloatBlaster.h"
+#include "stp/FloatBlaster/rounding_modes.h"
+#include "stp/STPManager/STPManager.h"
+
+#include <cassert>
+
+#include "extlib-constbv/constantbv.h"
+
+namespace stp
+{
+namespace literal_fp
+{
+
+typedef uint32_t bitWidthType;
+typedef bitWidthType bwt;
+typedef bool proposition;
+
+// The value classes symfpu computes with, over concrete CBV arithmetic.
+// This mirrors symfpu's own baseTypes/cvc4_literal.h, with CONSTANTBV as
+// the bignum. Everything is by-value with RAII around the heap CBV; these
+// live only for the duration of one constant fold.
+
+class roundingMode
+{
+  unsigned mode;
+
+public:
+  roundingMode(unsigned m) : mode(m) {}
+  roundingMode(const roundingMode& old) : mode(old.mode) {}
+  roundingMode& operator=(const roundingMode& old)
+  {
+    mode = old.mode;
+    return *this;
+  }
+  proposition operator==(const roundingMode& op) const
+  {
+    return mode == op.mode;
+  }
+};
+
+class floatingPointTypeInfo
+{
+  bitWidthType eb, sb;
+
+public:
+  floatingPointTypeInfo(unsigned e, unsigned s) : eb(e), sb(s) {}
+  floatingPointTypeInfo(const floatingPointTypeInfo& old)
+      : eb(old.eb), sb(old.sb)
+  {
+  }
+  floatingPointTypeInfo& operator=(const floatingPointTypeInfo& old)
+  {
+    eb = old.eb;
+    sb = old.sb;
+    return *this;
+  }
+  bitWidthType exponentWidth(void) const { return eb; }
+  bitWidthType significandWidth(void) const { return sb; }
+  bitWidthType packedWidth(void) const { return eb + sb; }
+  bitWidthType packedExponentWidth(void) const { return eb; }
+  bitWidthType packedSignificandWidth(void) const { return sb - 1; }
+};
+
+template <bool isSigned> class bitVector;
+
+class traits
+{
+public:
+  typedef bitWidthType bwt;
+  typedef roundingMode rm;
+  typedef floatingPointTypeInfo fpt;
+  typedef proposition prop;
+  typedef bitVector<true> sbv;
+  typedef bitVector<false> ubv;
+
+  static roundingMode RNE(void)
+  {
+    return roundingMode(symbolic_fp::ROUND_NEAREST_TIES_TO_EVEN);
+  }
+  static roundingMode RNA(void)
+  {
+    return roundingMode(symbolic_fp::ROUND_NEAREST_TIES_TO_AWAY);
+  }
+  static roundingMode RTP(void)
+  {
+    return roundingMode(symbolic_fp::ROUND_TOWARD_POSITIVE);
+  }
+  static roundingMode RTN(void)
+  {
+    return roundingMode(symbolic_fp::ROUND_TOWARD_NEGATIVE);
+  }
+  static roundingMode RTZ(void)
+  {
+    return roundingMode(symbolic_fp::ROUND_TOWARD_ZERO);
+  }
+
+  static void precondition(const bool b)
+  {
+    assert(b);
+    (void)b;
+  }
+  static void postcondition(const bool b)
+  {
+    assert(b);
+    (void)b;
+  }
+  static void invariant(const bool b)
+  {
+    assert(b);
+    (void)b;
+  }
+};
+
+template <bool isSigned> class bitVector
+{
+  bitWidthType width;
+  CBV bits; // owned
+
+  friend class bitVector<!isSigned>;
+
+  bitVector(CBV owned_bits, bitWidthType w) : width(w), bits(owned_bits) {}
+
+  static CBV mk(bitWidthType w) { return CONSTANTBV::BitVector_Create(w, true); }
+
+  // Shift amounts arrive as same-width vectors; saturate to the width,
+  // which is total and matches what the circuit's shifters produce for
+  // oversized amounts (all bits shifted out).
+  bitWidthType shiftAmount(const bitVector<isSigned>& op) const
+  {
+    bitWidthType amount = 0;
+    for (bitWidthType i = 0; i < op.width; i++)
+      if (CONSTANTBV::BitVector_bit_test(op.bits, i))
+      {
+        if (i >= 32 || (amount | (1u << i)) >= width)
+          return width;
+        amount |= (1u << i);
+      }
+    return amount >= width ? width : amount;
+  }
+
+public:
+  bitVector(const bwt w, const unsigned v) : width(w), bits(mk(w))
+  {
+    assert(w > 0);
+    for (unsigned i = 0; i < 32 && i < w; i++)
+      if (v & (1u << i))
+        CONSTANTBV::BitVector_Bit_On(bits, i);
+    // The literal must fit; symfpu constructs small constants only.
+    assert(w >= 32 || (v >> w) == 0);
+  }
+  bitVector(const proposition& p) : bitVector(1, p ? 1u : 0u) {}
+  bitVector(const bitVector<isSigned>& old)
+      : width(old.width), bits(CONSTANTBV::BitVector_Clone(old.bits))
+  {
+  }
+  // Adopt a clone of an existing CBV (used by the driver / conversions).
+  static bitVector<isSigned> fromCBV(bitWidthType w, const CBV source)
+  {
+    assert(bits_(source) == w);
+    return bitVector<isSigned>(CONSTANTBV::BitVector_Clone(source), w);
+  }
+  CBV rawBits() const { return bits; }
+
+  bitVector<isSigned>& operator=(const bitVector<isSigned>& old)
+  {
+    if (this != &old)
+    {
+      CONSTANTBV::BitVector_Destroy(bits);
+      width = old.width;
+      bits = CONSTANTBV::BitVector_Clone(old.bits);
+    }
+    return *this;
+  }
+  ~bitVector() { CONSTANTBV::BitVector_Destroy(bits); }
+
+  bwt getWidth(void) const { return width; }
+
+  static bitVector<isSigned> one(const bwt& w) { return bitVector(w, 1); }
+  static bitVector<isSigned> zero(const bwt& w) { return bitVector(w, 0); }
+  static bitVector<isSigned> allOnes(const bwt& w)
+  {
+    bitVector<isSigned> r(w, 0);
+    CONSTANTBV::BitVector_Fill(r.bits);
+    return r;
+  }
+
+  proposition isAllOnes() const { return CONSTANTBV::BitVector_is_full(bits); }
+  proposition isAllZeros() const { return CONSTANTBV::BitVector_is_empty(bits); }
+
+  static bitVector<isSigned> maxValue(const bwt& w)
+  {
+    bitVector<isSigned> r(allOnes(w));
+    if (isSigned)
+      CONSTANTBV::BitVector_Bit_Off(r.bits, w - 1);
+    return r;
+  }
+  static bitVector<isSigned> minValue(const bwt& w)
+  {
+    bitVector<isSigned> r(w, 0);
+    if (isSigned)
+      CONSTANTBV::BitVector_Bit_On(r.bits, w - 1);
+    return r;
+  }
+
+  bitVector<isSigned> operator<<(const bitVector<isSigned>& op) const
+  {
+    bitVector<isSigned> r(*this);
+    CONSTANTBV::BitVector_Move_Left(r.bits, shiftAmount(op));
+    return r;
+  }
+  bitVector<isSigned> operator>>(const bitVector<isSigned>& op) const
+  {
+    bitVector<isSigned> r(*this);
+    const bitWidthType amount = shiftAmount(op);
+    CONSTANTBV::BitVector_Move_Right(r.bits, amount);
+    if (isSigned && CONSTANTBV::BitVector_msb_(bits))
+      for (bitWidthType i = (amount > width) ? 0 : width - amount; i < width;
+           i++)
+        CONSTANTBV::BitVector_Bit_On(r.bits, i);
+    return r;
+  }
+
+  bitVector<isSigned> operator|(const bitVector<isSigned>& op) const
+  {
+    bitVector<isSigned> r(*this);
+    CONSTANTBV::Set_Union(r.bits, r.bits, op.bits);
+    return r;
+  }
+  bitVector<isSigned> operator&(const bitVector<isSigned>& op) const
+  {
+    bitVector<isSigned> r(*this);
+    CONSTANTBV::Set_Intersection(r.bits, r.bits, op.bits);
+    return r;
+  }
+  bitVector<isSigned> operator+(const bitVector<isSigned>& op) const
+  {
+    bitVector<isSigned> r(width, 0);
+    CONSTANTBV::boolean carry = false;
+    CONSTANTBV::BitVector_add(r.bits, bits, op.bits, &carry);
+    return r;
+  }
+  bitVector<isSigned> operator-(const bitVector<isSigned>& op) const
+  {
+    bitVector<isSigned> r(width, 0);
+    CONSTANTBV::boolean carry = false;
+    CONSTANTBV::BitVector_sub(r.bits, bits, op.bits, &carry);
+    return r;
+  }
+  bitVector<isSigned> operator*(const bitVector<isSigned>& op) const
+  {
+    // Multiply demands room for the full product; compute wide, then take
+    // the low half (symfpu widens its operands itself when it needs the
+    // exact product, so truncation here matches the circuit).
+    const bitWidthType wide = 2 * width;
+    CBV a = mk(wide);
+    CBV b = mk(wide);
+    CONSTANTBV::BitVector_Interval_Copy(a, bits, 0, 0, width);
+    CONSTANTBV::BitVector_Interval_Copy(b, op.bits, 0, 0, width);
+    if (isSigned)
+    {
+      if (CONSTANTBV::BitVector_bit_test(bits, width - 1))
+        for (bitWidthType i = width; i < wide; i++)
+          CONSTANTBV::BitVector_Bit_On(a, i);
+      if (CONSTANTBV::BitVector_bit_test(op.bits, width - 1))
+        for (bitWidthType i = width; i < wide; i++)
+          CONSTANTBV::BitVector_Bit_On(b, i);
+    }
+    CBV product = mk(wide);
+    CONSTANTBV::ErrCode e = CONSTANTBV::BitVector_Multiply(product, a, b);
+    assert(0 == e);
+    (void)e;
+    CONSTANTBV::BitVector_Destroy(a);
+    CONSTANTBV::BitVector_Destroy(b);
+    CBV low = mk(width);
+    CONSTANTBV::BitVector_Interval_Copy(low, product, 0, 0, width);
+    CONSTANTBV::BitVector_Destroy(product);
+    return bitVector<isSigned>(low, width);
+  }
+
+  // Total division, SMT-LIB conventions (x/0 = all ones, x%0 = x), the
+  // same choices cvc4_literal's *Total operations make. symfpu's uses are
+  // guarded so the zero cases should be unreachable; total keeps them
+  // defined rather than undefined behaviour if a guard is ever wrong.
+  bitVector<isSigned> operator/(const bitVector<isSigned>& op) const
+  {
+    assert(!isSigned); // symfpu only divides unsigned significands
+    if (CONSTANTBV::BitVector_is_empty(op.bits))
+      return allOnes(width);
+    bitVector<isSigned> quotient(width, 0);
+    bitVector<isSigned> remainder(width, 0);
+    CBV dividend = CONSTANTBV::BitVector_Clone(bits);
+    CONSTANTBV::ErrCode e = CONSTANTBV::BitVector_Div_Pos(
+        quotient.bits, dividend, op.bits, remainder.bits);
+    assert(0 == e);
+    (void)e;
+    CONSTANTBV::BitVector_Destroy(dividend);
+    return quotient;
+  }
+  bitVector<isSigned> operator%(const bitVector<isSigned>& op) const
+  {
+    assert(!isSigned);
+    if (CONSTANTBV::BitVector_is_empty(op.bits))
+      return *this;
+    bitVector<isSigned> quotient(width, 0);
+    bitVector<isSigned> remainder(width, 0);
+    CBV dividend = CONSTANTBV::BitVector_Clone(bits);
+    CONSTANTBV::ErrCode e = CONSTANTBV::BitVector_Div_Pos(
+        quotient.bits, dividend, op.bits, remainder.bits);
+    assert(0 == e);
+    (void)e;
+    CONSTANTBV::BitVector_Destroy(dividend);
+    return remainder;
+  }
+
+  bitVector<isSigned> operator-(void) const
+  {
+    bitVector<isSigned> r(width, 0);
+    CONSTANTBV::BitVector_Negate(r.bits, bits);
+    return r;
+  }
+  bitVector<isSigned> operator~(void) const
+  {
+    bitVector<isSigned> r(*this);
+    CONSTANTBV::Set_Complement(r.bits, r.bits);
+    return r;
+  }
+  bitVector<isSigned> increment() const
+  {
+    return *this + bitVector<isSigned>::one(width);
+  }
+  bitVector<isSigned> decrement() const
+  {
+    return *this - bitVector<isSigned>::one(width);
+  }
+  bitVector<isSigned> signExtendRightShift(const bitVector<isSigned>& op) const
+  {
+    bitVector<isSigned> r(*this);
+    const bitWidthType amount = shiftAmount(op);
+    CONSTANTBV::BitVector_Move_Right(r.bits, amount);
+    if (CONSTANTBV::BitVector_msb_(bits))
+      for (bitWidthType i = (amount > width) ? 0 : width - amount; i < width;
+           i++)
+        CONSTANTBV::BitVector_Bit_On(r.bits, i);
+    return r;
+  }
+
+  // Modular operations are the plain ones: overflow wraps in CBV exactly
+  // as it wraps in the circuit.
+  bitVector<isSigned> modularLeftShift(const bitVector<isSigned>& op) const
+  {
+    return *this << op;
+  }
+  bitVector<isSigned> modularRightShift(const bitVector<isSigned>& op) const
+  {
+    return *this >> op;
+  }
+  bitVector<isSigned> modularIncrement() const { return increment(); }
+  bitVector<isSigned> modularDecrement() const { return decrement(); }
+  bitVector<isSigned> modularAdd(const bitVector<isSigned>& op) const
+  {
+    return *this + op;
+  }
+  bitVector<isSigned> modularSubtract(const bitVector<isSigned>& op) const
+  {
+    return *this - op;
+  }
+  bitVector<isSigned> modularNegate() const { return -(*this); }
+
+  proposition operator==(const bitVector<isSigned>& op) const
+  {
+    return CONSTANTBV::BitVector_equal(bits, op.bits);
+  }
+  proposition operator<=(const bitVector<isSigned>& op) const
+  {
+    return compare(op) <= 0;
+  }
+  proposition operator>=(const bitVector<isSigned>& op) const
+  {
+    return compare(op) >= 0;
+  }
+  proposition operator<(const bitVector<isSigned>& op) const
+  {
+    return compare(op) < 0;
+  }
+  proposition operator>(const bitVector<isSigned>& op) const
+  {
+    return compare(op) > 0;
+  }
+
+  bitVector<true> toSigned(void) const
+  {
+    return bitVector<true>(CONSTANTBV::BitVector_Clone(bits), width);
+  }
+  bitVector<false> toUnsigned(void) const
+  {
+    return bitVector<false>(CONSTANTBV::BitVector_Clone(bits), width);
+  }
+
+  bitVector<isSigned> extend(bwt extension) const
+  {
+    const bitWidthType w = width + extension;
+    CBV out = mk(w);
+    if (isSigned && CONSTANTBV::BitVector_msb_(bits))
+      CONSTANTBV::BitVector_Fill(out);
+    CONSTANTBV::BitVector_Interval_Copy(out, bits, 0, 0, width);
+    return bitVector<isSigned>(out, w);
+  }
+  bitVector<isSigned> contract(bwt reduction) const
+  {
+    assert(width > reduction);
+    const bitWidthType w = width - reduction;
+    CBV out = mk(w);
+    CONSTANTBV::BitVector_Interval_Copy(out, bits, 0, 0, w);
+    return bitVector<isSigned>(out, w);
+  }
+  bitVector<isSigned> resize(bwt newSize) const
+  {
+    if (newSize > width)
+      return extend(newSize - width);
+    if (newSize < width)
+      return contract(width - newSize);
+    return *this;
+  }
+  bitVector<isSigned> matchWidth(const bitVector<isSigned>& op) const
+  {
+    assert(width <= op.width);
+    return extend(op.width - width);
+  }
+  bitVector<isSigned> append(const bitVector<isSigned>& op) const
+  {
+    // *this becomes the high bits, matching the symbolic backend.
+    const bitWidthType w = width + op.width;
+    CBV out = mk(w);
+    CONSTANTBV::BitVector_Interval_Copy(out, op.bits, 0, 0, op.width);
+    CONSTANTBV::BitVector_Interval_Copy(out, bits, op.width, 0, width);
+    return bitVector<isSigned>(out, w);
+  }
+  bitVector<isSigned> extract(bwt upper, bwt lower) const
+  {
+    assert(upper >= lower);
+    const bitWidthType w = upper - lower + 1;
+    CBV out = mk(w);
+    CONSTANTBV::BitVector_Interval_Copy(out, bits, 0, lower, w);
+    return bitVector<isSigned>(out, w);
+  }
+
+private:
+  int compare(const bitVector<isSigned>& op) const
+  {
+    assert(width == op.width);
+    if (isSigned)
+      return CONSTANTBV::BitVector_Compare(bits, op.bits);
+    return CONSTANTBV::BitVector_Lexicompare(bits, op.bits);
+  }
+};
+
+} // namespace literal_fp
+} // namespace stp
+
+// symfpu constructs ITEs through this template; over concrete booleans it
+// is just selection. The primary template must be visible before the
+// specializations.
+#include "symfpu/core/ite.h"
+
+namespace symfpu
+{
+#define STP_LITERAL_ITE(T)                                                     \
+  template <> struct ite<stp::literal_fp::proposition, T>                      \
+  {                                                                            \
+    static T iteOp(const stp::literal_fp::proposition& cond,                   \
+                         const T& l, const T& r)                               \
+    {                                                                          \
+      return cond ? l : r;                                                     \
+    }                                                                          \
+  };
+
+STP_LITERAL_ITE(stp::literal_fp::traits::rm)
+STP_LITERAL_ITE(stp::literal_fp::traits::prop)
+STP_LITERAL_ITE(stp::literal_fp::traits::sbv)
+STP_LITERAL_ITE(stp::literal_fp::traits::ubv)
+#undef STP_LITERAL_ITE
+} // namespace symfpu
+
+#include "symfpu/core/add.h"
+#include "symfpu/core/classify.h"
+#include "symfpu/core/compare.h"
+#include "symfpu/core/convert.h"
+#include "symfpu/core/divide.h"
+#include "symfpu/core/fma.h"
+#include "symfpu/core/multiply.h"
+#include "symfpu/core/packing.h"
+#include "symfpu/core/remainder.h"
+#include "symfpu/core/sign.h"
+#include "symfpu/core/sqrt.h"
+#include "symfpu/core/unpackedFloat.h"
+
+namespace stp
+{
+namespace literal_fp
+{
+
+typedef symfpu::unpackedFloat<traits> uf;
+
+namespace
+{
+
+traits::ubv packedOf(const ASTNode& c)
+{
+  assert(c.isConstant());
+  return traits::ubv::fromCBV(c.GetValueWidth(), c.GetBVConst());
+}
+
+floatingPointTypeInfo formatOf(const ASTNode& c)
+{
+  assert(c.GetExpWidth() != 0);
+  return floatingPointTypeInfo(c.GetExpWidth(), c.GetSigWidth());
+}
+
+uf unpackChild(const ASTNode& c)
+{
+  return symfpu::unpack<traits>(formatOf(c), packedOf(c));
+}
+
+roundingMode rmOf(const ASTNode& c)
+{
+  return roundingMode(c.GetUnsignedConst());
+}
+
+ASTNode boolResult(STPMgr* bm, bool v)
+{
+  return v ? bm->ASTTrue : bm->ASTFalse;
+}
+
+ASTNode packedResult(STPMgr* bm, const floatingPointTypeInfo& fmt,
+                     const uf& value)
+{
+  const traits::ubv packed(symfpu::pack<traits>(fmt, value));
+  return bm->CreateBVConst(CONSTANTBV::BitVector_Clone(packed.rawBits()),
+                           fmt.packedWidth());
+}
+
+bool formatOk(const ASTNode& c)
+{
+  return c.GetExpWidth() != 0 &&
+         FloatBlaster::formatSupported(c.GetExpWidth(), c.GetSigWidth());
+}
+
+} // namespace
+
+ASTNode tryEvaluateFpConstant(STPMgr* bm, const ASTNode& n)
+{
+  const Kind k = n.GetKind();
+
+  switch (k)
+  {
+    // Binary predicates over same-format operands.
+    case FP_LEQ:
+    case FP_LT:
+    case FP_GEQ:
+    case FP_GT:
+    case FP_EQ:
+    case FP_SMT_EQ:
+    {
+      if (!formatOk(n[0]) || !formatOk(n[1]))
+        return ASTNode();
+      const floatingPointTypeInfo fmt = formatOf(n[0]);
+      const uf a = unpackChild(n[0]);
+      const uf b = unpackChild(n[1]);
+      bool v;
+      switch (k)
+      {
+        case FP_LEQ:
+          v = symfpu::lessThanOrEqual<traits>(fmt, a, b);
+          break;
+        case FP_LT:
+          v = symfpu::lessThan<traits>(fmt, a, b);
+          break;
+        case FP_GEQ:
+          v = symfpu::lessThanOrEqual<traits>(fmt, b, a);
+          break;
+        case FP_GT:
+          v = symfpu::lessThan<traits>(fmt, b, a);
+          break;
+        case FP_EQ:
+          v = symfpu::ieee754Equal<traits>(fmt, a, b);
+          break;
+        default:
+          v = symfpu::smtlibEqual<traits>(fmt, a, b);
+          break;
+      }
+      return boolResult(bm, v);
+    }
+
+    // Unary classifications.
+    case FP_ISNORMAL:
+    case FP_ISSUBNORMAL:
+    case FP_ISZERO:
+    case FP_ISINFINITE:
+    case FP_ISNAN:
+    case FP_ISNEGATIVE:
+    case FP_ISPOSITIVE:
+    {
+      if (!formatOk(n[0]))
+        return ASTNode();
+      const floatingPointTypeInfo fmt = formatOf(n[0]);
+      const uf a = unpackChild(n[0]);
+      bool v;
+      switch (k)
+      {
+        case FP_ISNORMAL:
+          v = symfpu::isNormal<traits>(fmt, a);
+          break;
+        case FP_ISSUBNORMAL:
+          v = symfpu::isSubnormal<traits>(fmt, a);
+          break;
+        case FP_ISZERO:
+          v = symfpu::isZero<traits>(fmt, a);
+          break;
+        case FP_ISINFINITE:
+          v = symfpu::isInfinite<traits>(fmt, a);
+          break;
+        case FP_ISNAN:
+          v = symfpu::isNaN<traits>(fmt, a);
+          break;
+        case FP_ISNEGATIVE:
+          v = symfpu::isNegative<traits>(fmt, a);
+          break;
+        default:
+          v = symfpu::isPositive<traits>(fmt, a);
+          break;
+      }
+      return boolResult(bm, v);
+    }
+
+    case FP_ABS:
+    case FP_NEG:
+    {
+      if (!formatOk(n[0]))
+        return ASTNode();
+      const floatingPointTypeInfo fmt = formatOf(n[0]);
+      const uf a = unpackChild(n[0]);
+      return packedResult(bm, fmt,
+                          k == FP_ABS ? symfpu::absolute<traits>(fmt, a)
+                                      : symfpu::negate<traits>(fmt, a));
+    }
+
+    // Rounded binary arithmetic: children are (rm, x, y).
+    case FP_ADD:
+    case FP_SUB:
+    case FP_MUL:
+    case FP_DIV:
+    {
+      if (!formatOk(n[1]) || !formatOk(n[2]))
+        return ASTNode();
+      const floatingPointTypeInfo fmt = formatOf(n[1]);
+      const roundingMode rm = rmOf(n[0]);
+      const uf a = unpackChild(n[1]);
+      const uf b = unpackChild(n[2]);
+      uf r = (k == FP_ADD)   ? symfpu::add<traits>(fmt, rm, a, b, true)
+             : (k == FP_SUB) ? symfpu::add<traits>(fmt, rm, a, b, false)
+             : (k == FP_MUL) ? symfpu::multiply<traits>(fmt, rm, a, b)
+                             : symfpu::divide<traits>(fmt, rm, a, b);
+      return packedResult(bm, fmt, r);
+    }
+
+    case FP_FMA:
+    {
+      if (!formatOk(n[1]) || !formatOk(n[2]) || !formatOk(n[3]))
+        return ASTNode();
+      const floatingPointTypeInfo fmt = formatOf(n[1]);
+      const roundingMode rm = rmOf(n[0]);
+      const uf x = unpackChild(n[1]);
+      const uf y = unpackChild(n[2]);
+      const uf z = unpackChild(n[3]);
+      return packedResult(bm, fmt, symfpu::fma<traits>(fmt, rm, x, y, z));
+    }
+
+    case FP_SQRT:
+    {
+      if (!formatOk(n[1]))
+        return ASTNode();
+      const floatingPointTypeInfo fmt = formatOf(n[1]);
+      return packedResult(
+          bm, fmt, symfpu::sqrt<traits>(fmt, rmOf(n[0]), unpackChild(n[1])));
+    }
+
+    case FP_REM:
+    {
+      if (!formatOk(n[0]) || !formatOk(n[1]))
+        return ASTNode();
+      const floatingPointTypeInfo fmt = formatOf(n[0]);
+      return packedResult(bm, fmt,
+                          symfpu::remainder<traits>(fmt, unpackChild(n[0]),
+                                                    unpackChild(n[1])));
+    }
+
+    case FP_TO_IEEE_BV:
+    {
+      // The circuit path canonicalises payloads at this boundary; packing
+      // the unpacked value does the same (payloads do not survive unpack).
+      if (!formatOk(n[0]))
+        return ASTNode();
+      const floatingPointTypeInfo fmt = formatOf(n[0]);
+      return packedResult(bm, fmt, unpackChild(n[0]));
+    }
+
+    case FP_TOFP:
+    {
+      const unsigned eb = n[0].GetUnsignedConst();
+      const unsigned sb = n[1].GetUnsignedConst();
+      if (!FloatBlaster::formatSupported(eb, sb))
+        return ASTNode();
+      const floatingPointTypeInfo target(eb, sb);
+      if (n.Degree() == 3)
+      {
+        // Reinterpret constant bits.
+        if (n[2].GetValueWidth() != eb + sb)
+          return ASTNode();
+        return packedResult(
+            bm, target,
+            symfpu::unpack<traits>(target, packedOf(n[2])));
+      }
+      // (eb, sb, rm, float): round between formats.
+      if (n.Degree() != 4 || !formatOk(n[3]))
+        return ASTNode();
+      return packedResult(bm, target,
+                          symfpu::convertFloatToFloat<traits>(
+                              formatOf(n[3]), target, rmOf(n[2]),
+                              unpackChild(n[3])));
+    }
+
+    case FP_TOFP_SIGNED:
+    case FP_TOFP_UNSIGNED:
+    {
+      const unsigned eb = n[0].GetUnsignedConst();
+      const unsigned sb = n[1].GetUnsignedConst();
+      if (!FloatBlaster::formatSupported(eb, sb))
+        return ASTNode();
+      const floatingPointTypeInfo target(eb, sb);
+      const roundingMode rm = rmOf(n[2]);
+      const traits::ubv bits = packedOf(n[3]);
+      const uf r =
+          (k == FP_TOFP_SIGNED)
+              ? symfpu::convertSBVToFloat<traits>(target, rm, bits.toSigned())
+              : symfpu::convertUBVToFloat<traits>(target, rm, bits);
+      return packedResult(bm, target, r);
+    }
+
+    // fp.min/fp.max/fp.to_ubv/fp.to_sbv route their unspecified cases
+    // through FpTotalise; fp.roundToIntegral keeps the circuit path so its
+    // guard-bug refusals stay identical. All fall back.
+    default:
+      return ASTNode();
+  }
+}
+
+} // namespace literal_fp
+} // namespace stp
+
+#else // !STP_ENABLE_FLOATING_POINT
+
+namespace stp
+{
+namespace literal_fp
+{
+ASTNode tryEvaluateFpConstant(STPMgr*, const ASTNode&)
+{
+  return ASTNode();
+}
+} // namespace literal_fp
+} // namespace stp
+
+#endif

--- a/lib/Simplifier/consteval.cpp
+++ b/lib/Simplifier/consteval.cpp
@@ -24,6 +24,7 @@ THE SOFTWARE.
 
 #include "stp/FloatBlaster/FloatBlast.h"
 #include "stp/FloatBlaster/FloatBlaster.h"
+#include "stp/FloatBlaster/literal_fp.h"
 #include "stp/Simplifier/Simplifier.h"
 #include "stp/Util/CBVOps.h"
 #include <cassert>
@@ -1089,6 +1090,24 @@ ASTNode NonMemberBVConstEvaluator(STPMgr* _bm, const Kind k,
           OutputNode =
               FloatBlaster::withFormat(_bm, OutputNode, exp_width, sig_width);
         break;
+      }
+
+      // Evaluate directly when the literal backend covers the operation:
+      // the same symfpu semantics as the circuit, instantiated over
+      // concrete CBV arithmetic -- microseconds instead of building and
+      // collapsing thousands of interned gates. The per-kind agreement of
+      // the two paths is machine-checked exhaustively at a small format
+      // (FpConstantFold_Test) and against the hardware oracle.
+      {
+        const ASTNode literal = literal_fp::tryEvaluateFpConstant(_bm, temp);
+        if (!literal.IsNull())
+        {
+          OutputNode = literal;
+          if (float_result)
+            OutputNode =
+                FloatBlaster::withFormat(_bm, OutputNode, exp_width, sig_width);
+          break;
+        }
       }
 
       // One table, the same one the solver's lowering pass uses, reached with

--- a/tests/unit-tests/FpConstantFold_Test.cpp
+++ b/tests/unit-tests/FpConstantFold_Test.cpp
@@ -42,8 +42,10 @@ THE SOFTWARE.
 // These tests are the gate for it. IEEE-754 requires +, -, *, / and sqrt to
 // be correctly rounded, so the hardware is an exact oracle for the two
 // native formats under the four native rounding modes, independent of
-// anything in STP. They pass against the circuit path today; a literal
-// backend has to keep them passing.
+// anything in STP. That backend now exists (lib/FloatBlaster/literal_fp.cpp)
+// and the constant evaluator prefers it, so these oracle tests exercise the
+// literal path; the exhaustive differential at the bottom of this file pins
+// it to the circuit path per kind and keeps the circuit fold reachable.
 
 #include "stp/AST/AST.h"
 #include "stp/FloatBlaster/rounding_modes.h"
@@ -522,4 +524,139 @@ TEST(FpConstantFold, partial_operations_do_not_fold_at_creation)
       ASTVec{f.fpConst(8, 24, 0x80000000u), f.fpConst(8, 24, 0x00000000u)});
   EXPECT_EQ(FP_MIN, minimum.GetKind());
   EXPECT_FALSE(minimum.isConstant());
+}
+
+// The anti-drift gate for the literal backend. Both paths instantiate the
+// same symfpu core, but each has its own Kind-to-operation driver; this
+// pins them together mechanically -- every covered kind, exhaustively at
+// the smallest supported format -- and is also what keeps the circuit fold
+// path exercised now that the evaluator prefers the literal one.
+#include "stp/FloatBlaster/FloatBlast.h"
+#include "stp/FloatBlaster/literal_fp.h"
+
+namespace
+{
+
+struct Differential : Fixture
+{
+  unsigned checked = 0;
+
+  ASTNode temp(Kind k, const ASTVec& kids, unsigned width, unsigned eb,
+               unsigned sb, bool float_result)
+  {
+    ASTNode t = (width == 0)
+                    ? mgr.hashingNodeFactory->CreateNode(k, kids)
+                    : mgr.hashingNodeFactory->CreateTerm(k, width, kids);
+    if (float_result)
+    {
+      t.SetExpWidth(eb);
+      t.SetSigWidth(sb);
+    }
+    return t;
+  }
+
+  void agree(Kind k, const ASTVec& kids, unsigned width, unsigned eb,
+             unsigned sb, bool float_result)
+  {
+    const ASTNode t = temp(k, kids, width, eb, sb, float_result);
+
+    const ASTNode viaLiteral = literal_fp::tryEvaluateFpConstant(&mgr, t);
+    ASSERT_FALSE(viaLiteral.IsNull()) << _kind_names[k];
+
+    const ASTNode blasted = FloatBlast::lowerOperation(&mgr, t);
+    const ASTNode viaCircuit = NonMemberBVConstEvaluator(&mgr, blasted);
+
+    ASSERT_EQ(viaCircuit, viaLiteral) << _kind_names[k];
+    ++checked;
+  }
+};
+
+} // namespace
+
+TEST(FpConstantFold, literal_backend_agrees_with_the_circuit_exhaustively)
+{
+  Differential d;
+  const unsigned eb = 3, sb = 4, w = eb + sb, N = 1u << w;
+  std::vector<ASTNode> c;
+  for (unsigned i = 0; i < N; i++)
+    c.push_back(d.fpConst(eb, sb, i));
+  const std::vector<unsigned> modes = {
+      symbolic_fp::ROUND_NEAREST_TIES_TO_EVEN,
+      symbolic_fp::ROUND_NEAREST_TIES_TO_AWAY,
+      symbolic_fp::ROUND_TOWARD_POSITIVE,
+      symbolic_fp::ROUND_TOWARD_NEGATIVE,
+      symbolic_fp::ROUND_TOWARD_ZERO};
+
+  // Binary predicates: every pair.
+  for (const Kind k : {FP_LEQ, FP_LT, FP_GEQ, FP_GT, FP_EQ, FP_SMT_EQ})
+    for (unsigned i = 0; i < N; i++)
+      for (unsigned j = i % 2; j < N; j += 2)
+        d.agree(k, ASTVec{c[i], c[j]}, 0, eb, sb, false);
+
+  // Classifications and sign ops: every value.
+  for (unsigned i = 0; i < N; i++)
+  {
+    for (const Kind k : {FP_ISNORMAL, FP_ISSUBNORMAL, FP_ISZERO,
+                         FP_ISINFINITE, FP_ISNAN, FP_ISNEGATIVE,
+                         FP_ISPOSITIVE})
+      d.agree(k, ASTVec{c[i]}, 0, eb, sb, false);
+    d.agree(FP_ABS, ASTVec{c[i]}, w, eb, sb, true);
+    d.agree(FP_NEG, ASTVec{c[i]}, w, eb, sb, true);
+    d.agree(FP_TO_IEEE_BV, ASTVec{c[i]}, w, eb, sb, false);
+  }
+
+  // Rounded binary arithmetic: every pair under RNE, and every mode over a
+  // coarser grid. fp.rem takes no mode; every pair.
+  // fp.add exhaustively; the others on strides that still hit every value
+  // on each side (odd strides are coprime with the space).
+  for (unsigned i = 0; i < N; i++)
+    for (unsigned j = 0; j < N; j++)
+      d.agree(FP_ADD, ASTVec{d.rm(modes[0]), c[i], c[j]}, w, eb, sb, true);
+  for (const Kind k : {FP_SUB, FP_MUL, FP_DIV})
+    for (unsigned i = 0; i < N; i++)
+      for (unsigned j = i % 3; j < N; j += 3)
+        d.agree(k, ASTVec{d.rm(modes[0]), c[i], c[j]}, w, eb, sb, true);
+  for (const Kind k : {FP_ADD, FP_SUB, FP_MUL, FP_DIV})
+    for (size_t m = 1; m < modes.size(); m++)
+      for (unsigned i = 0; i < N; i += 5)
+        for (unsigned j = 0; j < N; j += 5)
+          d.agree(k, ASTVec{d.rm(modes[m]), c[i], c[j]}, w, eb, sb, true);
+  for (unsigned i = 0; i < N; i++)
+    for (unsigned j = i % 3; j < N; j += 3)
+      d.agree(FP_REM, ASTVec{c[i], c[j]}, w, eb, sb, true);
+
+  // sqrt under every mode; fma over a coarse grid under RNE.
+  for (const unsigned m : modes)
+    for (unsigned i = 0; i < N; i++)
+      d.agree(FP_SQRT, ASTVec{d.rm(m), c[i]}, w, eb, sb, true);
+  for (unsigned i = 0; i < N; i += 7)
+    for (unsigned j = 0; j < N; j += 7)
+      for (unsigned l = 0; l < N; l += 7)
+        d.agree(FP_FMA, ASTVec{d.rm(modes[0]), c[i], c[j], c[l]}, w, eb, sb,
+                true);
+
+  // Conversions: reinterpret every pattern; float->float both directions;
+  // bv->float signed/unsigned under every mode.
+  const ASTNode ebc = d.mgr.CreateBVConst(32, eb);
+  const ASTNode sbc = d.mgr.CreateBVConst(32, sb);
+  const ASTNode eb2 = d.mgr.CreateBVConst(32, 4);
+  const ASTNode sb2 = d.mgr.CreateBVConst(32, 5);
+  for (unsigned i = 0; i < N; i++)
+  {
+    d.agree(FP_TOFP, ASTVec{ebc, sbc, d.mgr.CreateBVConst(w, i)}, w, eb, sb,
+            true);
+    d.agree(FP_TOFP, ASTVec{eb2, sb2, d.rm(modes[i % 5]), c[i]}, 9, 4, 5,
+            true);
+    for (const unsigned m : modes)
+    {
+      d.agree(FP_TOFP_SIGNED,
+              ASTVec{ebc, sbc, d.rm(m), d.mgr.CreateBVConst(w, i)}, w, eb, sb,
+              true);
+      d.agree(FP_TOFP_UNSIGNED,
+              ASTVec{ebc, sbc, d.rm(m), d.mgr.CreateBVConst(w, i)}, w, eb, sb,
+              true);
+    }
+  }
+
+  EXPECT_GT(d.checked, 90000u);
 }


### PR DESCRIPTION
Folding an all-constant floating-point operation used to build its full SymFPU circuit through the node factory and collapse it gate by gate — thousands of interned nodes, ~0.5ms for a binary64 `fp.add` and ~10ms for `fp.rem` — because STP's only SymFPU backend was the symbolic one, whose bit-vectors *are* nodes. Since #763 feeds whole wintersteiger files into the constant evaluator and #765 folds at parse time, fold speed now bounds constant-heavy workloads.

This adds the literal backend SymFPU was designed to admit (`lib/FloatBlaster/literal_fp.cpp`, modeled on the library's own `cvc4_literal`): the **same core templates — the identical IEEE semantics that build the solver's circuits — instantiated over concrete CBV arithmetic**. `bitVector` wraps a CONSTANTBV vector with RAII; `proposition` is `bool`; primitives follow the conventions the constant evaluator's bit-vector arms already use (total division, wrapping modular ops, saturating shift amounts). The constant evaluator's FP arm tries the literal backend first and falls back to build-and-collapse for what it deliberately does not cover: fp.min/fp.max/fp.to_ubv/fp.to_sbv (unspecified cases route through FpTotalise) and fp.roundToIntegral plus unsupported formats (so the existing refusals stay byte-for-byte identical).

**One semantics source, two drivers, machine-pinned**: both paths instantiate the same SymFPU core. Each path has a small Kind→operation driver, and the drivers are pinned together by an exhaustive differential at format (3,4) — over 90,000 operation instances (every predicate, classification, sign op, conversion, and rem/add pair; strided sub/mul/div/fma under all five rounding modes), circuit vs literal. That test is also what keeps the circuit fold path exercised now that the evaluator prefers the literal one. The hardware-oracle tests — written in advance as the gate for exactly this change — now run through the literal path unchanged.

**Verification**: full suites green in FP (102/102) and non-FP (74/74, the new file compiles to a stub) builds; valgrind clean over the new CBV code; the 90k-case circuit-vs-literal differential; hardware oracle for binary32/64 under four rounding modes.