### PR TITLE
Pass fp.neg and fp.abs through the native predicate gate

### DIFF
--- a/lib/FloatBlaster/FloatBlast.cpp
+++ b/lib/FloatBlaster/FloatBlast.cpp
@@ -133,6 +133,24 @@ private:
       return bm->CreateFPConst(n[2], sort.exponentWidth(),
                                sort.significandWidth());
     }
+    // fp.neg and fp.abs are sign-bit edits on the packed encoding (IEEE-754
+    // 5.5.1 quiet operations: no rounding, NaN payload untouched), so either
+    // wrapped around a packed view is still a packed view: resolve the
+    // operand and keep the wrapper for the bit-blaster, whose FP_NEG/FP_ABS
+    // arms negate or clear the top bit of the operand's bits. Rebuilding
+    // through the factory matters when the operand resolved to something
+    // new: a constant folds (foldFPSign), so the survivor functions'
+    // constant rules see the folded form, and a collapsed mux re-enters the
+    // involution rules (neg(neg x) = x).
+    if (n.GetKind() == FP_NEG || n.GetKind() == FP_ABS)
+    {
+      const ASTNode inner = comparisonLeaf(n[0]);
+      if (inner.IsNull())
+        return ASTNode();
+      if (inner == n[0])
+        return n;
+      return node_factory->CreateTerm(n.GetKind(), n.GetValueWidth(), inner);
+    }
     // A select from a float-element array already IS the packed element
     // bits: asPacked's READ arm only rebuilds the array and index if they
     // contain FP work, so it never builds a circuit for the element itself

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -778,6 +778,27 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term,
       break;
     }
 
+    // fp.neg / fp.abs over a packed IEEE-754 operand: sign-bit edits (IEEE
+    // 5.5.1 quiet operations -- no rounding, NaN payload kept), so the
+    // operand's bits pass through with the top bit negated or cleared.
+    // FloatBlast only leaves these under a surviving native predicate,
+    // whose operands are packed views (comparisonLeaf).
+    case FP_NEG:
+    {
+      BBNodeVec bits = BBTerm(term[0], support);
+      bits[bits.size() - 1] = nf->CreateNode(NOT, bits[bits.size() - 1]);
+      result = bits;
+      break;
+    }
+
+    case FP_ABS:
+    {
+      BBNodeVec bits = BBTerm(term[0], support);
+      bits[bits.size() - 1] = nf->getFalse();
+      result = bits;
+      break;
+    }
+
     case BVRIGHTSHIFT:
     case BVSRSHIFT:
     case BVLEFTSHIFT:
@@ -1125,8 +1146,6 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term,
       result = tmp_res;
       break;
     }
-    case FP_ABS:
-    case FP_NEG:
     case FP_ADD:
     case FP_SUB:
     case FP_MUL:

--- a/tests/query-files/fp-tests/native-abs-not-below-zero.smt2
+++ b/tests/query-files/fp-tests/native-abs-not-below-zero.smt2
@@ -1,0 +1,17 @@
+; RUN: %solver %s | %OutputCheck %s
+; RUN: %solver --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck %s
+;
+; fp.abs clears the sign, so its result is never below +0: for NaN the
+; ordering is false outright, for -0 the cleared sign gives +0 and the
+; zeros compare equal, and everything else is non-negative. The comparison
+; operand is fp.abs over a symbol, so the native path keeps the comparison
+; and zeroes the packed sign bit (BBTerm's FP_ABS arm); to_fp over constant
+; bits is the interned +0, resolved by the gate's constant lookthrough.
+;
+; CHECK: ^unsat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(assert (fp.lt (fp.abs x) ((_ to_fp 8 24) #x00000000)))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/native-neg-antitone-compare.smt2
+++ b/tests/query-files/fp-tests/native-neg-antitone-compare.smt2
@@ -1,0 +1,19 @@
+; RUN: %solver %s | %OutputCheck %s
+; RUN: %solver --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck %s
+;
+; fp.neg is antitone: fp.lt(-x, -y) holds exactly when fp.lt(y, x), NaN
+; (both orderings false) and the zeros (-(+0) = -0, and +-0 compare equal)
+; included, so the two strict orderings below contradict. Both comparison
+; operands are fp.neg over a symbol, so the native path keeps the
+; comparison and negates the packed sign bit in place (BBTerm's FP_NEG
+; arm); the third run proves the SymFPU path agrees.
+;
+; CHECK: ^unsat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(declare-fun y () (_ FloatingPoint 8 24))
+(assert (fp.lt (fp.neg x) (fp.neg y)))
+(assert (fp.lt x y))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/native-neg-gt-self-sat.smt2
+++ b/tests/query-files/fp-tests/native-neg-gt-self-sat.smt2
@@ -1,0 +1,15 @@
+; RUN: %solver %s | %OutputCheck %s
+; RUN: %solver --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck %s
+;
+; fp.gt(-x, x) is satisfiable exactly by the strictly negative x (for NaN
+; both orderings are false, and for the zeros -x and x compare equal), so
+; this checks the native path can also find models through a surviving
+; fp.neg operand, not just refute.
+;
+; CHECK: ^sat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(assert (fp.gt (fp.neg x) x))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/native-neg-nan-not-negative.smt2
+++ b/tests/query-files/fp-tests/native-neg-nan-not-negative.smt2
@@ -1,0 +1,18 @@
+; RUN: %solver %s | %OutputCheck %s
+; RUN: %solver --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck %s
+;
+; fp.neg keeps a NaN a NaN (the payload sign bit flips, the value does
+; not leave the NaN class), and fp.isNegative is false on every NaN. The
+; classification operand is fp.neg over a symbol, so the native path keeps
+; the classification (isNegative is one of the two the factory's
+; sign-stripping rule deliberately leaves alone) and reads the flipped
+; sign bit -- the NaN conjunct in BBclassifyFP must still veto it.
+;
+; CHECK: ^unsat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(assert (fp.isNaN x))
+(assert (fp.isNegative (fp.neg x)))
+(check-sat)
+(exit)


### PR DESCRIPTION
fp.neg and fp.abs are sign-bit edits on the packed IEEE-754 encoding (quiet operations: no rounding, NaN payloads untouched), so either wrapped around a packed view is still a packed view. The predicate gate's operand resolution (`comparisonLeaf`) now looks through them, and the bit-blaster blasts the surviving wrapper by negating (`FP_NEG`) or clearing (`FP_ABS`) the top bit of the operand's bits in place.

Before this, a comparison like `fp.lt(fp.neg x, y)` fell off the native path entirely — the `fp.neg` operand disqualified the gate — and both operands went through SymFPU's unpack circuits, even though the negation itself is one bit. Since the factory already lowers `fp.sub` to `fp.add`-of-neg, negations under predicates are common in real formulas. On a small formula comparing through `fp.neg` and `fp.abs`, the CNF drops about 3x (2,444 → 798 lines).

Resolving the operand back through the factory keeps the existing constant story intact: a wrapped constant folds there (`foldFPSign`), so the survivor functions' constant rules see the folded form, and model evaluation still watches the fully-constant predicate collapse. `isNegative`/`isPositive` stay correct over a surviving `fp.neg` because `BBclassifyFP`'s sign test carries the `isNaN` veto — a flipped NaN payload sign must not make `isNegative` true; one of the new tests pins that.

Four new query-file tests cover the antitone double-neg contradiction, abs-below-zero (exercising the -0 → +0 corner), NaN through fp.neg under `isNegative`, and a sat instance so the native path also produces models through a wrapper. Each runs with defaults, with `--disable-simplifications`, and with `--bb.fp-native-cmp=false`, so the SymFPU path proves agreement. Full test suite passes.

On the 294 hard QF_FP files (the griggio/ramalho/schanda sets, 10s timeout), the two paths agree on every answer, and files where the gate newly fires speed up — e.g. sin2.c.5 goes 5.8s → 2.2s. One file (sin2.c.10) slows from 3.7s past the timeout despite a marginally smaller CNF — SAT search variance on the perturbed encoding rather than circuit growth; solved counts stay within the run-to-run noise band for that subset.