### PR TITLE
Bit-blast fp.mul and fp.add natively over packed operands, behind --bb.fp-native-arith

### DIFF
--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -131,6 +131,11 @@ public:
   // bits) instead of via the SymFPU unpacking circuits.
   bool fp_native_cmp = true;
 
+  // Bit-blast fp.mul under surviving native predicates with the hand-written
+  // packed-operand circuit (BBfpMul) instead of the SymFPU unpacking
+  // circuits. Experimental; off by default.
+  bool fp_native_arith = false;
+
   int64_t multiplication_variant = 1;
 
   // If the bit-blaster discovers new constants, should the term simplifier be

--- a/include/stp/ToSat/BitBlaster.h
+++ b/include/stp/ToSat/BitBlaster.h
@@ -211,6 +211,22 @@ class BitBlaster
   BBNode BBfpIsNaN(const BBNodeVec& p, unsigned sb, unsigned w);
   BBNode BBfpIsZero(const BBNodeVec& p, unsigned w);
 
+  // bit blast fp.mul over packed operands: a hand-written
+  // unpack/multiply/round/pack circuit, no SymFPU (--bb.fp-native-arith)
+  BBNodeVec BBfpMul(const ASTNode& term, BBNodeSet& support);
+
+  // Helpers for the native floating-point arithmetic circuits.
+  // Count of leading zeros of v (from the MSB down) as an unsigned binary
+  // vector of `countWidth` bits; an all-zero v counts v.size().
+  BBNodeVec BBfpCLZ(const BBNodeVec& v, unsigned countWidth);
+  // Left shift v by the unsigned binary amount `amt` (zero fill).
+  BBNodeVec BBfpShiftLeft(const BBNodeVec& v, const BBNodeVec& amt);
+  // Right shift v by `amt`, ORing every shifted-out bit into `sticky`.
+  BBNodeVec BBfpShiftRightSticky(const BBNodeVec& v, const BBNodeVec& amt,
+                                 BBNode& sticky);
+  // v + inc (a single carry-in bit), one bit wider than v.
+  BBNodeVec BBfpIncrement(const BBNodeVec& v, const BBNode& inc);
+
   // Return bit-blasted form for the overflow predicates BVUADDO, BVSADDO,
   // BVUMULO, BVSMULO, BVUSUBO, BVSSUBO.
   BBNode BBOverflow(const ASTNode& form, BBNodeSet& support);

--- a/include/stp/ToSat/BitBlaster.h
+++ b/include/stp/ToSat/BitBlaster.h
@@ -211,9 +211,38 @@ class BitBlaster
   BBNode BBfpIsNaN(const BBNodeVec& p, unsigned sb, unsigned w);
   BBNode BBfpIsZero(const BBNodeVec& p, unsigned w);
 
-  // bit blast fp.mul over packed operands: a hand-written
-  // unpack/multiply/round/pack circuit, no SymFPU (--bb.fp-native-arith)
+  // bit blast fp.mul / fp.add over packed operands: hand-written
+  // unpack/compute/round/pack circuits, no SymFPU (--bb.fp-native-arith)
   BBNodeVec BBfpMul(const ASTNode& term, BBNodeSet& support);
+  BBNodeVec BBfpAdd(const ASTNode& term, BBNodeSet& support);
+
+  // A packed operand split for the native arithmetic circuits: fields,
+  // classification, and the significand with its hidden bit made explicit
+  // but NOT normalised (0 for subnormals) -- normalisation is deferred to
+  // the operation's result, so consuming a packed operand is only wiring.
+  struct FpOperand
+  {
+    BBNode sign, isZero, isInf, isNaN;
+    BBNodeVec msig; // sb bits, hidden bit at msig[sb-1]
+    BBNodeVec eUnb; // E bits, signed, unbiased (subnormals read exp as 1)
+  };
+  FpOperand BBfpUnpack(const BBNodeVec& p, unsigned sb, unsigned w,
+                       unsigned E, BBNodeSet& support);
+
+  // The shared tail of the native arithmetic circuits: denormalise into
+  // the subnormal range when the biased exponent be is <= 0, round rsig
+  // (with its guard and sticky) per the one-hot mode rm, saturate
+  // overflow per mode, and pack the finite result. NaN/infinity/zero
+  // specials are the caller's to mux over the top.
+  BBNodeVec BBfpRoundPack(const BBNodeVec& rm, const BBNode& sgn,
+                          const BBNodeVec& rsig, const BBNode& guard,
+                          const BBNode& sticky, const BBNodeVec& be,
+                          unsigned sb, unsigned eb, BBNodeSet& support);
+
+  // Width of the internal signed exponent for format (eb, sb): eb+2
+  // widened until the subnormal shift distance (up to bias + 2sb + 3,
+  // counting fp.add's alignment headroom) cannot overflow it.
+  static unsigned BBfpExpWidth(unsigned eb, unsigned sb);
 
   // Helpers for the native floating-point arithmetic circuits.
   // Count of leading zeros of v (from the MSB down) as an unsigned binary

--- a/lib/FloatBlaster/FloatBlast.cpp
+++ b/lib/FloatBlaster/FloatBlast.cpp
@@ -151,16 +151,18 @@ private:
         return n;
       return node_factory->CreateTerm(n.GetKind(), n.GetValueWidth(), inner);
     }
-    // fp.mul under --bb.fp-native-arith: the bit-blaster's hand-written
-    // packed circuit (BBfpMul) takes over from SymFPU when both float
-    // operands resolve to packed views and the rounding mode is immediate
-    // (a constant, or a declared symbol -- whose one-hot validity is
-    // asserted at declaration). The rebuild goes through the factory, so
-    // constant operands fold (a fully constant multiply never survives,
-    // keeping the lowering-must-change invariant of constant folding and
-    // model evaluation) and the multiplicative-identity rules still fire.
-    if (n.GetKind() == FP_MUL && bm->UserFlags.fp_native_arith &&
-        n.Degree() == 3 &&
+    // fp.mul and fp.add under --bb.fp-native-arith: the bit-blaster's
+    // hand-written packed circuits (BBfpMul, BBfpAdd) take over from
+    // SymFPU when both float operands resolve to packed views and the
+    // rounding mode is immediate (a constant, or a declared symbol --
+    // whose one-hot validity is asserted at declaration). The rebuild
+    // goes through the factory, so constant operands fold (a fully
+    // constant operation never survives, keeping the lowering-must-change
+    // invariant of constant folding and model evaluation) and the
+    // identity rules still fire. fp.sub needs no arm: the factory already
+    // lowers it to fp.add of the negation.
+    if ((n.GetKind() == FP_MUL || n.GetKind() == FP_ADD) &&
+        bm->UserFlags.fp_native_arith && n.Degree() == 3 &&
         (n[0].GetKind() == SYMBOL || n[0].GetKind() == BVCONST))
     {
       const ASTNode left = comparisonLeaf(n[1]);
@@ -171,8 +173,8 @@ private:
         return ASTNode();
       if (left == n[1] && right == n[2])
         return n;
-      return node_factory->CreateTerm(FP_MUL, n.GetValueWidth(), n[0], left,
-                                      right);
+      return node_factory->CreateTerm(n.GetKind(), n.GetValueWidth(), n[0],
+                                      left, right);
     }
     // A select from a float-element array already IS the packed element
     // bits: asPacked's READ arm only rebuilds the array and index if they

--- a/lib/FloatBlaster/FloatBlast.cpp
+++ b/lib/FloatBlaster/FloatBlast.cpp
@@ -151,6 +151,29 @@ private:
         return n;
       return node_factory->CreateTerm(n.GetKind(), n.GetValueWidth(), inner);
     }
+    // fp.mul under --bb.fp-native-arith: the bit-blaster's hand-written
+    // packed circuit (BBfpMul) takes over from SymFPU when both float
+    // operands resolve to packed views and the rounding mode is immediate
+    // (a constant, or a declared symbol -- whose one-hot validity is
+    // asserted at declaration). The rebuild goes through the factory, so
+    // constant operands fold (a fully constant multiply never survives,
+    // keeping the lowering-must-change invariant of constant folding and
+    // model evaluation) and the multiplicative-identity rules still fire.
+    if (n.GetKind() == FP_MUL && bm->UserFlags.fp_native_arith &&
+        n.Degree() == 3 &&
+        (n[0].GetKind() == SYMBOL || n[0].GetKind() == BVCONST))
+    {
+      const ASTNode left = comparisonLeaf(n[1]);
+      if (left.IsNull())
+        return ASTNode();
+      const ASTNode right = comparisonLeaf(n[2]);
+      if (right.IsNull())
+        return ASTNode();
+      if (left == n[1] && right == n[2])
+        return n;
+      return node_factory->CreateTerm(FP_MUL, n.GetValueWidth(), n[0], left,
+                                      right);
+    }
     // A select from a float-element array already IS the packed element
     // bits: asPacked's READ arm only rebuilds the array and index if they
     // contain FP work, so it never builds a circuit for the element itself

--- a/lib/FloatBlaster/FpEncodingContext.cpp
+++ b/lib/FloatBlaster/FpEncodingContext.cpp
@@ -3,6 +3,8 @@
  ********************************************************************/
 #include "stp/FloatBlaster/FpEncodingContext.h"
 
+#include <iostream>
+
 namespace stp
 {
 
@@ -35,7 +37,22 @@ void FpEncodingContext::copyArrayEqualityRewrites(ASTNodeMap& out) const
 ASTNode FpEncodingContext::lowerPrepared(const ASTNode& prepared)
 {
   requireOriginalNodeFactory();
-  return blast.topLevel(prepared);
+  const ASTNode out = blast.topLevel(prepared);
+  if (bm->UserFlags.stats_flag)
+  {
+    // All-zero counters mean no SymFPU circuit was built: every
+    // floating-point node passed through to the bit-blaster's native
+    // encodings and this lowering was an identity.
+    const FloatBlast::Statistics& s = blast.statistics();
+    const bool noop =
+        s.unpacked_operation_builds + s.unpack_builds + s.pack_builds == 0;
+    std::cerr << "FloatBlast: " << s.unpacked_operation_builds
+              << " SymFPU operations, " << s.unpack_builds << " unpacks, "
+              << s.pack_builds << " packs"
+              << (noop ? " (no-op: everything passed through natively)" : "")
+              << std::endl;
+  }
+  return out;
 }
 
 ASTNode FpEncodingContext::encodeForModel(const ASTNode& source)

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -1146,9 +1146,9 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term,
       result = tmp_res;
       break;
     }
-    // fp.mul survives to the bit-blaster under --bb.fp-native-arith, when
-    // FloatBlast left it beneath a surviving native predicate over packed
-    // views (comparisonLeaf).
+    // fp.mul and fp.add survive to the bit-blaster under
+    // --bb.fp-native-arith, when FloatBlast left them beneath a surviving
+    // native predicate over packed views (comparisonLeaf).
     case FP_MUL:
     {
       result = BBfpMul(term, support);
@@ -1156,6 +1156,11 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term,
     }
 
     case FP_ADD:
+    {
+      result = BBfpAdd(term, support);
+      break;
+    }
+
     case FP_SUB:
     case FP_DIV:
     case FP_FMA:
@@ -3421,64 +3426,66 @@ BBNodeVec BitBlaster::BBfpIncrement(const BBNodeVec& v, const BBNode& inc)
   return r;
 }
 
-// Bit-blasted fp.mul over packed IEEE-754 operands: a hand-written
-// unpack / multiply / round / pack circuit, no SymFPU. FloatBlast leaves
-// FP_MUL in place under a surviving native predicate when
-// --bb.fp-native-arith is on and both float operands are packed views.
-//
-// Shape (fields as in BBcompareFP: significand in bits [0, sb-2], exponent
-// in [sb-1, w-2], sign at w-1):
-//   1. Normalise each operand to a significand with an explicit leading 1
-//      (subnormals shift up by their leading-zero count) and an unbiased
-//      exponent in eb+2 signed bits -- wide enough for every intermediate
-//      sum this circuit forms.
-//   2. Multiply the sb-bit significands into 2sb bits (school multiplier;
-//      the partial-product array is the irreducible core).
-//   3. Normalise the product (top bit at 2sb-1 or 2sb-2), extracting
-//      guard and sticky.
-//   4. If the biased exponent fell to 0 or below, shift right into the
-//      subnormal range, accumulating sticky; a shift past the significand
-//      leaves all-sticky (which rounding may still pull up to the minimum
-//      subnormal, e.g. under RTP).
-//   5. Round per mode -- the increment's carry renormalises, and a
-//      subnormal that rounds up to the hidden bit becomes the smallest
-//      normal with the same biased exponent.
-//   6. Overflow saturates per mode: RNE/RNA to infinity, RTZ to the
-//      largest finite, RTP/RTN to whichever of the two matches the sign.
-//   7. Specials are muxed over the computed result: NaN (any NaN operand,
-//      or zero times infinity), then infinity, then zero. The NaN produced
-//      is the canonical quiet NaN (positive, significand MSB set), the
-//      same value the SymFPU path packs.
-BBNodeVec BitBlaster::BBfpMul(const ASTNode& term, BBNodeSet& support)
+unsigned BitBlaster::BBfpExpWidth(unsigned eb, unsigned sb)
 {
-  assert(term.GetKind() == FP_MUL);
-  assert(term.Degree() == 3);
-
-  const SourceSort sort = term.GetSourceSort();
-  assert(sort.kind() == SourceSort::Kind::FloatingPoint);
-  const unsigned sb = sort.significandWidth();
-  const unsigned w = sort.exponentWidth() + sb;
-  const unsigned eb = w - sb;
-  assert(sb >= 2 && eb >= 2);
   const unsigned bias = (1u << (eb - 1)) - 1;
-  const unsigned maxbe = (1u << eb) - 2; // largest finite biased exponent
-  // Internal signed exponent width. eb+2 covers every exponent SUM this
-  // circuit forms, but the subnormal shift distance 1 - be reaches
-  // bias + 2sb - 1, which overflows eb+2 bits when the significand is wide
-  // relative to the exponent (e.g. (2,5)); widen until it fits.
   unsigned E = eb + 2;
-  while ((1u << (E - 1)) <= bias + 2 * sb)
+  while ((1u << (E - 1)) <= bias + 2 * sb + 4)
     E++;
+  return E;
+}
 
-  const BBNodeVec rm = BBTerm(term[0], support); // one-hot, see
-  const BBNode& rne = rm[0];                     // rounding_modes.h
+BitBlaster::FpOperand BitBlaster::BBfpUnpack(const BBNodeVec& p, unsigned sb,
+                                             unsigned w, unsigned E,
+                                             BBNodeSet& support)
+{
+  const unsigned eb = w - sb;
+  const unsigned bias = (1u << (eb - 1)) - 1;
+  FpOperand o;
+  o.sign = p[w - 1];
+  BBNodeVec exp(p.begin() + (sb - 1), p.begin() + (w - 1));
+  BBNodeVec sig(p.begin(), p.begin() + (sb - 1));
+  const BBNode expZero = nf->CreateNode(NOR, exp);
+  const BBNode expOnes = nf->CreateNode(AND, exp);
+  const BBNode sigZero = nf->CreateNode(NOR, sig);
+  const BBNode sigNonzero = nf->CreateNode(OR, sig);
+  o.isZero = nf->CreateNode(AND, expZero, sigZero);
+  o.isInf = nf->CreateNode(AND, expOnes, sigZero);
+  o.isNaN = nf->CreateNode(AND, expOnes, sigNonzero);
+  const BBNode hidden = nf->CreateNode(NOT, expZero);
+  o.msig = sig;
+  o.msig.push_back(hidden);
+  // Unbiased exponent, with subnormals reading their exponent field as 1
+  // (the scale the field's zero encoding shares).
+  BBNodeVec one(eb, nf->getFalse());
+  one[0] = nf->getTrue();
+  BBNodeVec e = BBITE(hidden, exp, one);
+  while (e.size() < E)
+    e.push_back(nf->getFalse());
+  BBNodeVec biasV(E, nf->getFalse());
+  for (unsigned i = 0; i < E; i++)
+    if ((bias >> i) & 1)
+      biasV[i] = nf->getTrue();
+  BBSub(e, biasV, support);
+  o.eUnb = e;
+  return o;
+}
+
+BBNodeVec BitBlaster::BBfpRoundPack(const BBNodeVec& rm, const BBNode& sgn,
+                                    const BBNodeVec& rsigIn,
+                                    const BBNode& guardIn,
+                                    const BBNode& stickyIn,
+                                    const BBNodeVec& beIn, unsigned sb,
+                                    unsigned eb, BBNodeSet& support)
+{
+  const unsigned w = eb + sb;
+  const unsigned bias = (1u << (eb - 1)) - 1;
+  const unsigned maxbe = (1u << eb) - 2;
+  const unsigned E = beIn.size();
+  const BBNode& rne = rm[0];
   const BBNode& rtp = rm[1];
   const BBNode& rtn = rm[2];
   const BBNode& rna = rm[4];
-
-  const BBNodeVec pa = BBTerm(term[1], support);
-  const BBNodeVec pb = BBTerm(term[2], support);
-  assert(pa.size() == w && pb.size() == w);
 
   auto constVec = [&](unsigned value, unsigned width) {
     BBNodeVec c(width);
@@ -3486,90 +3493,11 @@ BBNodeVec BitBlaster::BBfpMul(const ASTNode& term, BBNodeSet& support)
       c[i] = ((value >> i) & 1) ? nf->getTrue() : nf->getFalse();
     return c;
   };
-  auto zext = [&](const BBNodeVec& v, unsigned width) {
-    BBNodeVec c = v;
-    while (c.size() < width)
-      c.push_back(nf->getFalse());
-    return c;
-  };
 
-  // Field split and classification of one packed operand. The significand
-  // keeps its hidden bit UN-normalised (0 for subnormals): normalisation
-  // is deferred to the product, so consuming a packed operand costs only
-  // wiring and four classification gates -- nothing is shifted. That is
-  // what keeps chained native operations (whose intermediate results are
-  // packed) from paying an unpack circuit at every step.
-  struct Operand
-  {
-    BBNode sign, isZero, isInf, isNaN;
-    BBNodeVec msig; // sb bits, hidden bit at msig[sb-1], NOT normalised
-    BBNodeVec eUnb; // E bits, signed, unbiased (subnormals read exp as 1)
-  };
-  auto unpack = [&](const BBNodeVec& p) {
-    Operand o;
-    o.sign = p[w - 1];
-    BBNodeVec exp(p.begin() + (sb - 1), p.begin() + (w - 1));
-    BBNodeVec sig(p.begin(), p.begin() + (sb - 1));
-    const BBNode expZero = nf->CreateNode(NOR, exp);
-    const BBNode expOnes = nf->CreateNode(AND, exp);
-    const BBNode sigZero = nf->CreateNode(NOR, sig);
-    const BBNode sigNonzero = nf->CreateNode(OR, sig);
-    o.isZero = nf->CreateNode(AND, expZero, sigZero);
-    o.isInf = nf->CreateNode(AND, expOnes, sigZero);
-    o.isNaN = nf->CreateNode(AND, expOnes, sigNonzero);
-    const BBNode hidden = nf->CreateNode(NOT, expZero);
-    o.msig = sig;
-    o.msig.push_back(hidden);
-    BBNodeVec e = zext(BBITE(hidden, exp, constVec(1, eb)), E);
-    BBNodeVec biasV = constVec(bias, E);
-    BBSub(e, biasV, support);
-    o.eUnb = e;
-    return o;
-  };
-  const Operand a = unpack(pa);
-  const Operand b = unpack(pb);
-
-  const BBNode sgn = nf->CreateNode(XOR, a.sign, b.sign);
-
-  // Significand product, 2sb bits, of the raw hidden-bit significands --
-  // in [0, 4) counting subnormal fractions.
-  BBNodeVec prod = BBfill(2 * sb, nf->getFalse());
-  for (unsigned i = 0; i < sb; i++)
-  {
-    const BBNodeVec row = BBAndBit(b.msig, a.msig[i]);
-    BBNodeVec addend = BBfill(2 * sb, nf->getFalse());
-    for (unsigned j = 0; j < sb; j++)
-      addend[i + j] = row[j];
-    BBPlus2(prod, addend, nf->getFalse());
-  }
-
-  // One normalisation for the whole product: shift its leading 1 to the
-  // top and fold the shift count into the exponent. This also absorbs the
-  // subnormal operands' missing normalisation (their leading zeros simply
-  // appear here). A zero product leaves garbage, muxed out by the
-  // specials below (zero operands) or rounded from all-sticky=0 to zero.
-  const unsigned lw2 = [](unsigned x) { // bits to count up to x
-    unsigned bb = 1;
-    while ((1u << bb) <= x)
-      bb++;
-    return bb;
-  }(2 * sb);
-  const BBNodeVec ell = BBfpCLZ(prod, lw2);
-  const BBNodeVec pn = BBfpShiftLeft(prod, ell);
-  BBNodeVec rsig(pn.begin() + sb, pn.end()); // top sb bits: 1.frac
-  BBNode guard = pn[sb - 1];
-  auto orVec = [&](BBNodeVec v) {
-    return v.empty() ? nf->getFalse() : nf->CreateNode(OR, v);
-  };
-  BBNodeVec lowBits(pn.begin(), pn.begin() + (sb - 1));
-  BBNode sticky = orVec(lowBits);
-
-  // Biased result exponent: eUnbA + eUnbB + bias + 1 - leading zeros.
-  BBNodeVec be = a.eUnb;
-  BBPlus2(be, b.eUnb, nf->getFalse());
-  BBPlus2(be, constVec(bias, E), nf->getTrue());
-  BBNodeVec ellE = zext(ell, E);
-  BBSub(be, ellE, support);
+  BBNodeVec rsig = rsigIn;
+  BBNode guard = guardIn;
+  BBNode sticky = stickyIn;
+  BBNodeVec be = beIn;
 
   // Subnormal range: biased exponent <= 0 needs a right shift of 1 - be,
   // clamped -- anything past guard is pure sticky.
@@ -3624,7 +3552,8 @@ BBNodeVec BitBlaster::BBfpMul(const ASTNode& term, BBNodeSet& support)
   BBPlus2(beF, BBfill(E, nf->getFalse()), carry);
 
   // Overflow, checked after rounding; saturation is mode- and sign-
-  // dependent.
+  // dependent: to infinity for the nearest modes, to the largest finite
+  // value for RTZ and for the directed mode pointing away from the sign.
   const BBNode ovf =
       nf->CreateNode(NOT, BBBVLE(beF, constVec(maxbe, E), true /*signed*/));
   BBNodeVec infCases;
@@ -3634,8 +3563,8 @@ BBNodeVec BitBlaster::BBfpMul(const ASTNode& term, BBNodeSet& support)
   infCases.push_back(nf->CreateNode(AND, rtn, sgn));
   const BBNode roundsToInf = nf->CreateNode(OR, infCases);
 
-  // Pack the finite computed result. A significand without its leading 1
-  // is subnormal: exponent field 0 (beAfter is 1 there, the same scale).
+  // Pack the finite result. A significand without its leading 1 is
+  // subnormal: exponent field 0 (beAfter is 1 there, the same scale).
   const BBNode isNormRes = rsigF[sb - 1];
   BBNodeVec res(w);
   for (unsigned i = 0; i < sb - 1; i++)
@@ -3644,20 +3573,144 @@ BBNodeVec BitBlaster::BBfpMul(const ASTNode& term, BBNodeSet& support)
     res[sb - 1 + i] = nf->CreateNode(AND, isNormRes, beF[i]);
   res[w - 1] = sgn;
 
-  // Specials, outermost first: NaN, then infinity, then zero, then
-  // overflow saturation.
-  auto packSpecial = [&](bool nan, bool inf, bool maxFinite) {
+  BBNodeVec inf(w, nf->getFalse());
+  BBNodeVec maxFin(w, nf->getFalse());
+  for (unsigned i = 0; i < eb; i++)
+    inf[sb - 1 + i] = nf->getTrue();
+  for (unsigned i = 0; i < sb - 1; i++)
+    maxFin[i] = nf->getTrue();
+  for (unsigned i = 1; i < eb; i++)
+    maxFin[sb - 1 + i] = nf->getTrue(); // maxbe = 2^eb - 2: LSB clear
+  inf[w - 1] = sgn;
+  maxFin[w - 1] = sgn;
+
+  return BBITE(ovf, BBITE(roundsToInf, inf, maxFin), res);
+}
+
+// Bit-blasted fp.mul over packed IEEE-754 operands: a hand-written
+// unpack / multiply / round / pack circuit, no SymFPU. FloatBlast leaves
+// FP_MUL in place under a surviving native predicate when
+// --bb.fp-native-arith is on and both float operands are packed views.
+//
+// Shape (fields as in BBcompareFP: significand in bits [0, sb-2], exponent
+// in [sb-1, w-2], sign at w-1):
+//   1. Normalise each operand to a significand with an explicit leading 1
+//      (subnormals shift up by their leading-zero count) and an unbiased
+//      exponent in eb+2 signed bits -- wide enough for every intermediate
+//      sum this circuit forms.
+//   2. Multiply the sb-bit significands into 2sb bits (school multiplier;
+//      the partial-product array is the irreducible core).
+//   3. Normalise the product (top bit at 2sb-1 or 2sb-2), extracting
+//      guard and sticky.
+//   4. If the biased exponent fell to 0 or below, shift right into the
+//      subnormal range, accumulating sticky; a shift past the significand
+//      leaves all-sticky (which rounding may still pull up to the minimum
+//      subnormal, e.g. under RTP).
+//   5. Round per mode -- the increment's carry renormalises, and a
+//      subnormal that rounds up to the hidden bit becomes the smallest
+//      normal with the same biased exponent.
+//   6. Overflow saturates per mode: RNE/RNA to infinity, RTZ to the
+//      largest finite, RTP/RTN to whichever of the two matches the sign.
+//   7. Specials are muxed over the computed result: NaN (any NaN operand,
+//      or zero times infinity), then infinity, then zero. The NaN produced
+//      is the canonical quiet NaN (positive, significand MSB set), the
+//      same value the SymFPU path packs.
+BBNodeVec BitBlaster::BBfpMul(const ASTNode& term, BBNodeSet& support)
+{
+  assert(term.GetKind() == FP_MUL);
+  assert(term.Degree() == 3);
+
+  const SourceSort sort = term.GetSourceSort();
+  assert(sort.kind() == SourceSort::Kind::FloatingPoint);
+  const unsigned sb = sort.significandWidth();
+  const unsigned w = sort.exponentWidth() + sb;
+  const unsigned eb = w - sb;
+  assert(sb >= 2 && eb >= 2);
+  const unsigned bias = (1u << (eb - 1)) - 1;
+  const unsigned E = BBfpExpWidth(eb, sb);
+
+  const BBNodeVec rm = BBTerm(term[0], support); // one-hot, see
+  const BBNode& rne = rm[0];                     // rounding_modes.h
+  const BBNode& rtp = rm[1];
+  const BBNode& rtn = rm[2];
+  const BBNode& rna = rm[4];
+
+  const BBNodeVec pa = BBTerm(term[1], support);
+  const BBNodeVec pb = BBTerm(term[2], support);
+  assert(pa.size() == w && pb.size() == w);
+
+  auto constVec = [&](unsigned value, unsigned width) {
+    BBNodeVec c(width);
+    for (unsigned i = 0; i < width; i++)
+      c[i] = ((value >> i) & 1) ? nf->getTrue() : nf->getFalse();
+    return c;
+  };
+  auto zext = [&](const BBNodeVec& v, unsigned width) {
+    BBNodeVec c = v;
+    while (c.size() < width)
+      c.push_back(nf->getFalse());
+    return c;
+  };
+
+  // The un-normalised field split (see BBfpUnpack): consuming a packed
+  // operand -- a leaf or a chained native result -- is only wiring and
+  // four classification gates; normalisation is deferred to the product.
+  const FpOperand a = BBfpUnpack(pa, sb, w, E, support);
+  const FpOperand b = BBfpUnpack(pb, sb, w, E, support);
+
+  const BBNode sgn = nf->CreateNode(XOR, a.sign, b.sign);
+
+  // Significand product, 2sb bits, of the raw hidden-bit significands --
+  // in [0, 4) counting subnormal fractions.
+  BBNodeVec prod = BBfill(2 * sb, nf->getFalse());
+  for (unsigned i = 0; i < sb; i++)
+  {
+    const BBNodeVec row = BBAndBit(b.msig, a.msig[i]);
+    BBNodeVec addend = BBfill(2 * sb, nf->getFalse());
+    for (unsigned j = 0; j < sb; j++)
+      addend[i + j] = row[j];
+    BBPlus2(prod, addend, nf->getFalse());
+  }
+
+  // One normalisation for the whole product: shift its leading 1 to the
+  // top and fold the shift count into the exponent. This also absorbs the
+  // subnormal operands' missing normalisation (their leading zeros simply
+  // appear here). A zero product leaves garbage, muxed out by the
+  // specials below (zero operands) or rounded from all-sticky=0 to zero.
+  const unsigned lw2 = [](unsigned x) { // bits to count up to x
+    unsigned bb = 1;
+    while ((1u << bb) <= x)
+      bb++;
+    return bb;
+  }(2 * sb);
+  const BBNodeVec ell = BBfpCLZ(prod, lw2);
+  const BBNodeVec pn = BBfpShiftLeft(prod, ell);
+  BBNodeVec rsig(pn.begin() + sb, pn.end()); // top sb bits: 1.frac
+  BBNode guard = pn[sb - 1];
+  auto orVec = [&](BBNodeVec v) {
+    return v.empty() ? nf->getFalse() : nf->CreateNode(OR, v);
+  };
+  BBNodeVec lowBits(pn.begin(), pn.begin() + (sb - 1));
+  BBNode sticky = orVec(lowBits);
+
+  // Biased result exponent: eUnbA + eUnbB + bias + 1 - leading zeros.
+  BBNodeVec be = a.eUnb;
+  BBPlus2(be, b.eUnb, nf->getFalse());
+  BBPlus2(be, constVec(bias, E), nf->getTrue());
+  BBNodeVec ellE = zext(ell, E);
+  BBSub(be, ellE, support);
+
+  BBNodeVec res = BBfpRoundPack(rm, sgn, rsig, guard, sticky, be, sb, eb,
+                                support);
+
+  // Specials, outermost first: NaN (any NaN operand, or zero times
+  // infinity), then infinity, then zero.
+  auto packSpecial = [&](bool isnan, bool isinf) {
     BBNodeVec s(w, nf->getFalse());
-    if (nan || inf || maxFinite)
+    if (isnan || isinf)
       for (unsigned i = 0; i < eb; i++)
         s[sb - 1 + i] = nf->getTrue();
-    if (maxFinite)
-    {
-      s[sb - 1] = nf->getFalse(); // maxbe = 2^eb - 2: all ones but the LSB
-      for (unsigned i = 0; i < sb - 1; i++)
-        s[i] = nf->getTrue();
-    }
-    if (nan)
+    if (isnan)
       s[sb - 2] = nf->getTrue(); // canonical quiet NaN, positive
     else
       s[w - 1] = sgn;
@@ -3672,12 +3725,179 @@ BBNodeVec BitBlaster::BBfpMul(const ASTNode& term, BBNodeSet& support)
   const BBNode anyInf = nf->CreateNode(OR, a.isInf, b.isInf);
   const BBNode anyZero = nf->CreateNode(OR, a.isZero, b.isZero);
 
-  res = BBITE(ovf, BBITE(roundsToInf, packSpecial(false, true, false),
-                         packSpecial(false, false, true)),
-              res);
-  res = BBITE(anyZero, packSpecial(false, false, false), res);
-  res = BBITE(anyInf, packSpecial(false, true, false), res);
-  res = BBITE(anyNaN, packSpecial(true, false, false), res);
+  res = BBITE(anyZero, packSpecial(false, false), res);
+  res = BBITE(anyInf, packSpecial(false, true), res);
+  res = BBITE(anyNaN, packSpecial(true, false), res);
+  return res;
+}
+
+// Bit-blasted fp.add over packed IEEE-754 operands, under the same flag
+// and gate as BBfpMul. Single wide exact datapath:
+//   1. Split both operands un-normalised (BBfpUnpack) and order them by
+//      (exponent, significand) -- with un-normalised significands that
+//      lexicographic order IS magnitude order, because any operand whose
+//      exponent exceeds the minimum is normal.
+//   2. Align the smaller significand by the exponent difference in a
+//      W = 2sb+4 bit frame, wide enough that alignment down to the clamp
+//      loses only bits below the frame, collected as a sticky flag.
+//   3. One adder does both effective operations: adding the aligned
+//      significand, or its complement with a borrow that also accounts
+//      for the sticky tail (the true difference is then the computed
+//      integer plus a nonzero fraction, which the final sticky keeps).
+//      The swap guarantees the difference is non-negative.
+//   4. One leading-zero normalisation covers both the 1-bit carry of an
+//      addition and arbitrary cancellation of a subtraction; the shift
+//      count folds into the exponent exactly as in the multiplier.
+//   5. The shared rounder/packer finishes; zero operands need no special
+//      case (adding a zero significand is exact), only the sign of an
+//      EXACT zero result is mode-dependent: -0 under RTN, else +0.
+//   6. Specials: NaN operands and infinity minus infinity give NaN;
+//      otherwise any infinite operand's infinity wins, keeping its sign.
+BBNodeVec BitBlaster::BBfpAdd(const ASTNode& term, BBNodeSet& support)
+{
+  assert(term.GetKind() == FP_ADD);
+  assert(term.Degree() == 3);
+
+  const SourceSort sort = term.GetSourceSort();
+  assert(sort.kind() == SourceSort::Kind::FloatingPoint);
+  const unsigned sb = sort.significandWidth();
+  const unsigned w = sort.exponentWidth() + sb;
+  const unsigned eb = w - sb;
+  assert(sb >= 2 && eb >= 2);
+  const unsigned bias = (1u << (eb - 1)) - 1;
+  const unsigned E = BBfpExpWidth(eb, sb);
+
+  const BBNodeVec rm = BBTerm(term[0], support);
+  const BBNodeVec pa = BBTerm(term[1], support);
+  const BBNodeVec pb = BBTerm(term[2], support);
+  assert(pa.size() == w && pb.size() == w);
+
+  auto constVec = [&](unsigned value, unsigned width) {
+    BBNodeVec c(width);
+    for (unsigned i = 0; i < width; i++)
+      c[i] = ((value >> i) & 1) ? nf->getTrue() : nf->getFalse();
+    return c;
+  };
+  auto zext = [&](const BBNodeVec& v, unsigned width) {
+    BBNodeVec c = v;
+    while (c.size() < width)
+      c.push_back(nf->getFalse());
+    return c;
+  };
+
+  const FpOperand a = BBfpUnpack(pa, sb, w, E, support);
+  const FpOperand b = BBfpUnpack(pb, sb, w, E, support);
+  const BBNode effSub = nf->CreateNode(XOR, a.sign, b.sign);
+
+  // Order by magnitude: (eUnb, msig) lexicographically.
+  const BBNode eLess = BBBVLE(a.eUnb, b.eUnb, true /*signed*/, true);
+  const BBNode eEq = BBEQ(a.eUnb, b.eUnb);
+  const BBNode mLess = BBBVLE(a.msig, b.msig, false, true);
+  const BBNode swap =
+      nf->CreateNode(OR, eLess, nf->CreateNode(AND, eEq, mLess));
+  const BBNodeVec msigBig = BBITE(swap, b.msig, a.msig);
+  const BBNodeVec msigSmall = BBITE(swap, a.msig, b.msig);
+  const BBNodeVec eBig = BBITE(swap, b.eUnb, a.eUnb);
+  const BBNodeVec eSmall = BBITE(swap, a.eUnb, b.eUnb);
+  const BBNode signBig = nf->CreateNode(ITE, swap, b.sign, a.sign);
+
+  // Alignment distance, clamped into the frame.
+  const unsigned dmaxA = sb + 3;
+  const unsigned W = sb + dmaxA + 1; // headroom bit for the addition carry
+  BBNodeVec dist = eBig;
+  BBSub(dist, eSmall, support); // >= 0
+  const BBNode distFar = nf->CreateNode(
+      NOT, BBBVLE(dist, constVec(dmaxA, E), true /*signed*/));
+  const unsigned dwA = [](unsigned x) {
+    unsigned bb = 1;
+    while ((1u << bb) <= x)
+      bb++;
+    return bb;
+  }(dmaxA);
+  BBNodeVec dv(dwA);
+  for (unsigned i = 0; i < dwA; i++)
+    dv[i] = nf->CreateNode(ITE, distFar,
+                           ((dmaxA >> i) & 1) ? nf->getTrue()
+                                              : nf->getFalse(),
+                           dist[i]);
+
+  // Big at [dmaxA, W-2]; small likewise, then shifted right, everything
+  // below the frame ORed into stickyTail.
+  BBNodeVec big(W, nf->getFalse());
+  BBNodeVec small(W, nf->getFalse());
+  for (unsigned i = 0; i < sb; i++)
+  {
+    big[dmaxA + i] = msigBig[i];
+    small[dmaxA + i] = msigSmall[i];
+  }
+  BBNode stickyTail = nf->getFalse();
+  small = BBfpShiftRightSticky(small, dv, stickyTail);
+
+  // One adder for both effective operations. Subtracting also owes the
+  // sticky tail: the true small operand is (aligned + fraction), so the
+  // true difference is (big - aligned - 1) plus a nonzero fraction; the
+  // borrowed carry-in and the kept sticky express exactly that.
+  BBNodeVec addend(W);
+  for (unsigned i = 0; i < W; i++)
+    addend[i] = nf->CreateNode(XOR, small[i], effSub);
+  const BBNode cin =
+      nf->CreateNode(AND, effSub, nf->CreateNode(NOT, stickyTail));
+  BBNodeVec sum = big;
+  BBPlus2(sum, addend, cin);
+
+  // One normalisation for carry and cancellation alike.
+  const unsigned lwA = [](unsigned x) {
+    unsigned bb = 1;
+    while ((1u << bb) <= x)
+      bb++;
+    return bb;
+  }(W);
+  const BBNodeVec ell = BBfpCLZ(sum, lwA);
+  const BBNodeVec sn = BBfpShiftLeft(sum, ell);
+  BBNodeVec rsig(sn.begin() + (W - sb), sn.end());
+  const BBNode guard = sn[W - sb - 1];
+  BBNodeVec lowBits(sn.begin(), sn.begin() + (W - sb - 1));
+  BBNode sticky = nf->CreateNode(OR, nf->CreateNode(OR, lowBits), stickyTail);
+
+  // be = eBig + bias + 1 - leading zeros, exactly as the multiplier.
+  BBNodeVec be = eBig;
+  BBPlus2(be, constVec(bias, E), nf->getTrue());
+  BBNodeVec ellE = zext(ell, E);
+  BBSub(be, ellE, support);
+
+  // An EXACT zero result (cancellation of equal values -- only possible
+  // unshifted, so the sticky tail is clear) is +0 in every mode but RTN.
+  const BBNode sumZero = nf->CreateNode(NOR, sum);
+  const BBNode exactZero = nf->CreateNode(
+      AND, effSub, sumZero, nf->CreateNode(NOT, stickyTail));
+  const BBNode& rtn = rm[2];
+  const BBNode sgn = nf->CreateNode(ITE, exactZero, rtn, signBig);
+
+  BBNodeVec res =
+      BBfpRoundPack(rm, sgn, rsig, guard, sticky, be, sb, eb, support);
+
+  // Specials: NaN operands, or subtracting infinities; otherwise an
+  // infinite operand's infinity, keeping that operand's sign.
+  auto packSpecial = [&](bool isnan, const BBNode& sign) {
+    BBNodeVec s(w, nf->getFalse());
+    for (unsigned i = 0; i < eb; i++)
+      s[sb - 1 + i] = nf->getTrue();
+    if (isnan)
+      s[sb - 2] = nf->getTrue(); // canonical quiet NaN, positive
+    else
+      s[w - 1] = sign;
+    return s;
+  };
+  BBNodeVec nanCases;
+  nanCases.push_back(a.isNaN);
+  nanCases.push_back(b.isNaN);
+  nanCases.push_back(nf->CreateNode(AND, a.isInf, b.isInf, effSub));
+  const BBNode anyNaN = nf->CreateNode(OR, nanCases);
+  const BBNode anyInf = nf->CreateNode(OR, a.isInf, b.isInf);
+  const BBNode infSign = nf->CreateNode(ITE, a.isInf, a.sign, b.sign);
+
+  res = BBITE(anyInf, packSpecial(false, infSign), res);
+  res = BBITE(anyNaN, packSpecial(true, nf->getFalse()), res);
   return res;
 }
 

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -3479,7 +3479,6 @@ BBNodeVec BitBlaster::BBfpRoundPack(const BBNodeVec& rm, const BBNode& sgn,
                                     unsigned eb, BBNodeSet& support)
 {
   const unsigned w = eb + sb;
-  const unsigned bias = (1u << (eb - 1)) - 1;
   const unsigned maxbe = (1u << eb) - 2;
   const unsigned E = beIn.size();
   const BBNode& rne = rm[0];
@@ -3630,11 +3629,7 @@ BBNodeVec BitBlaster::BBfpMul(const ASTNode& term, BBNodeSet& support)
   const unsigned E = BBfpExpWidth(eb, sb);
 
   const BBNodeVec rm = BBTerm(term[0], support); // one-hot, see
-  const BBNode& rne = rm[0];                     // rounding_modes.h
-  const BBNode& rtp = rm[1];
-  const BBNode& rtn = rm[2];
-  const BBNode& rna = rm[4];
-
+                                                 // rounding_modes.h
   const BBNodeVec pa = BBTerm(term[1], support);
   const BBNodeVec pb = BBTerm(term[2], support);
   assert(pa.size() == w && pb.size() == w);

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -1146,9 +1146,17 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term,
       result = tmp_res;
       break;
     }
+    // fp.mul survives to the bit-blaster under --bb.fp-native-arith, when
+    // FloatBlast left it beneath a surviving native predicate over packed
+    // views (comparisonLeaf).
+    case FP_MUL:
+    {
+      result = BBfpMul(term, support);
+      break;
+    }
+
     case FP_ADD:
     case FP_SUB:
-    case FP_MUL:
     case FP_DIV:
     case FP_FMA:
     case FP_SQRT:
@@ -3321,6 +3329,356 @@ BBNode BitBlaster::BBclassifyFP(const ASTNode& form, BBNodeSet& support)
       FatalError("BBclassifyFP: Illegal kind", form);
       return BBNode();
   }
+}
+
+/****************************************************************
+ * Native fp.mul (--bb.fp-native-arith)                         *
+ ****************************************************************/
+
+// Count of leading zeros of v (scanning from the MSB down), as an unsigned
+// binary vector of countWidth bits. An all-zero v counts v.size(). Built as
+// a priority chain: scanning positions from the LSB up, each set bit
+// overrides the count implied by the lower ones, so the MSB wins.
+BBNodeVec BitBlaster::BBfpCLZ(const BBNodeVec& v, unsigned countWidth)
+{
+  const unsigned n = v.size();
+  auto constVec = [&](unsigned value) {
+    BBNodeVec c(countWidth);
+    for (unsigned i = 0; i < countWidth; i++)
+      c[i] = ((value >> i) & 1) ? nf->getTrue() : nf->getFalse();
+    return c;
+  };
+  BBNodeVec count = constVec(n);
+  for (unsigned i = 0; i < n; i++)
+    count = BBITE(v[i], constVec(n - 1 - i), count);
+  return count;
+}
+
+// Logarithmic left shifter, zero fill. The amount is unsigned binary; any
+// amount >= v.size() shifts everything out.
+BBNodeVec BitBlaster::BBfpShiftLeft(const BBNodeVec& v, const BBNodeVec& amt)
+{
+  BBNodeVec r = v;
+  for (unsigned s = 0; s < amt.size(); s++)
+  {
+    const unsigned k = 1u << s;
+    if (k >= r.size())
+    {
+      const BBNodeVec zeros = BBfill(r.size(), nf->getFalse());
+      r = BBITE(amt[s], zeros, r);
+      continue;
+    }
+    BBNodeVec shifted(r.size());
+    for (unsigned i = 0; i < r.size(); i++)
+      shifted[i] = (i >= k) ? r[i - k] : nf->getFalse();
+    r = BBITE(amt[s], shifted, r);
+  }
+  return r;
+}
+
+// Logarithmic right shifter that ORs every shifted-out bit into sticky --
+// the rounding circuits must not lose shifted-out precision.
+BBNodeVec BitBlaster::BBfpShiftRightSticky(const BBNodeVec& v,
+                                           const BBNodeVec& amt,
+                                           BBNode& sticky)
+{
+  BBNodeVec r = v;
+  for (unsigned s = 0; s < amt.size(); s++)
+  {
+    const unsigned k = 1u << s;
+    if (k >= r.size())
+    {
+      const BBNode all = nf->CreateNode(OR, r);
+      sticky = nf->CreateNode(OR, sticky, nf->CreateNode(AND, amt[s], all));
+      const BBNodeVec zeros = BBfill(r.size(), nf->getFalse());
+      r = BBITE(amt[s], zeros, r);
+      continue;
+    }
+    BBNodeVec dropped(r.begin(), r.begin() + k);
+    const BBNode droppedAny = nf->CreateNode(OR, dropped);
+    sticky =
+        nf->CreateNode(OR, sticky, nf->CreateNode(AND, amt[s], droppedAny));
+    BBNodeVec shifted(r.size());
+    for (unsigned i = 0; i < r.size(); i++)
+      shifted[i] = (i + k < r.size()) ? r[i + k] : nf->getFalse();
+    r = BBITE(amt[s], shifted, r);
+  }
+  return r;
+}
+
+// v + inc (a single carry-in bit), one bit wider than v -- the rounding
+// increment, whose carry-out is the significand overflowing to 10...0.
+BBNodeVec BitBlaster::BBfpIncrement(const BBNodeVec& v, const BBNode& inc)
+{
+  BBNodeVec r(v.size() + 1);
+  BBNode carry = inc;
+  for (unsigned i = 0; i < v.size(); i++)
+  {
+    r[i] = nf->CreateNode(XOR, v[i], carry);
+    carry = nf->CreateNode(AND, v[i], carry);
+  }
+  r[v.size()] = carry;
+  return r;
+}
+
+// Bit-blasted fp.mul over packed IEEE-754 operands: a hand-written
+// unpack / multiply / round / pack circuit, no SymFPU. FloatBlast leaves
+// FP_MUL in place under a surviving native predicate when
+// --bb.fp-native-arith is on and both float operands are packed views.
+//
+// Shape (fields as in BBcompareFP: significand in bits [0, sb-2], exponent
+// in [sb-1, w-2], sign at w-1):
+//   1. Normalise each operand to a significand with an explicit leading 1
+//      (subnormals shift up by their leading-zero count) and an unbiased
+//      exponent in eb+2 signed bits -- wide enough for every intermediate
+//      sum this circuit forms.
+//   2. Multiply the sb-bit significands into 2sb bits (school multiplier;
+//      the partial-product array is the irreducible core).
+//   3. Normalise the product (top bit at 2sb-1 or 2sb-2), extracting
+//      guard and sticky.
+//   4. If the biased exponent fell to 0 or below, shift right into the
+//      subnormal range, accumulating sticky; a shift past the significand
+//      leaves all-sticky (which rounding may still pull up to the minimum
+//      subnormal, e.g. under RTP).
+//   5. Round per mode -- the increment's carry renormalises, and a
+//      subnormal that rounds up to the hidden bit becomes the smallest
+//      normal with the same biased exponent.
+//   6. Overflow saturates per mode: RNE/RNA to infinity, RTZ to the
+//      largest finite, RTP/RTN to whichever of the two matches the sign.
+//   7. Specials are muxed over the computed result: NaN (any NaN operand,
+//      or zero times infinity), then infinity, then zero. The NaN produced
+//      is the canonical quiet NaN (positive, significand MSB set), the
+//      same value the SymFPU path packs.
+BBNodeVec BitBlaster::BBfpMul(const ASTNode& term, BBNodeSet& support)
+{
+  assert(term.GetKind() == FP_MUL);
+  assert(term.Degree() == 3);
+
+  const SourceSort sort = term.GetSourceSort();
+  assert(sort.kind() == SourceSort::Kind::FloatingPoint);
+  const unsigned sb = sort.significandWidth();
+  const unsigned w = sort.exponentWidth() + sb;
+  const unsigned eb = w - sb;
+  assert(sb >= 2 && eb >= 2);
+  const unsigned bias = (1u << (eb - 1)) - 1;
+  const unsigned maxbe = (1u << eb) - 2; // largest finite biased exponent
+  // Internal signed exponent width. eb+2 covers every exponent SUM this
+  // circuit forms, but the subnormal shift distance 1 - be reaches
+  // bias + 2sb - 1, which overflows eb+2 bits when the significand is wide
+  // relative to the exponent (e.g. (2,5)); widen until it fits.
+  unsigned E = eb + 2;
+  while ((1u << (E - 1)) <= bias + 2 * sb)
+    E++;
+
+  const BBNodeVec rm = BBTerm(term[0], support); // one-hot, see
+  const BBNode& rne = rm[0];                     // rounding_modes.h
+  const BBNode& rtp = rm[1];
+  const BBNode& rtn = rm[2];
+  const BBNode& rna = rm[4];
+
+  const BBNodeVec pa = BBTerm(term[1], support);
+  const BBNodeVec pb = BBTerm(term[2], support);
+  assert(pa.size() == w && pb.size() == w);
+
+  auto constVec = [&](unsigned value, unsigned width) {
+    BBNodeVec c(width);
+    for (unsigned i = 0; i < width; i++)
+      c[i] = ((value >> i) & 1) ? nf->getTrue() : nf->getFalse();
+    return c;
+  };
+  auto zext = [&](const BBNodeVec& v, unsigned width) {
+    BBNodeVec c = v;
+    while (c.size() < width)
+      c.push_back(nf->getFalse());
+    return c;
+  };
+
+  // Field split and classification of one packed operand. The significand
+  // keeps its hidden bit UN-normalised (0 for subnormals): normalisation
+  // is deferred to the product, so consuming a packed operand costs only
+  // wiring and four classification gates -- nothing is shifted. That is
+  // what keeps chained native operations (whose intermediate results are
+  // packed) from paying an unpack circuit at every step.
+  struct Operand
+  {
+    BBNode sign, isZero, isInf, isNaN;
+    BBNodeVec msig; // sb bits, hidden bit at msig[sb-1], NOT normalised
+    BBNodeVec eUnb; // E bits, signed, unbiased (subnormals read exp as 1)
+  };
+  auto unpack = [&](const BBNodeVec& p) {
+    Operand o;
+    o.sign = p[w - 1];
+    BBNodeVec exp(p.begin() + (sb - 1), p.begin() + (w - 1));
+    BBNodeVec sig(p.begin(), p.begin() + (sb - 1));
+    const BBNode expZero = nf->CreateNode(NOR, exp);
+    const BBNode expOnes = nf->CreateNode(AND, exp);
+    const BBNode sigZero = nf->CreateNode(NOR, sig);
+    const BBNode sigNonzero = nf->CreateNode(OR, sig);
+    o.isZero = nf->CreateNode(AND, expZero, sigZero);
+    o.isInf = nf->CreateNode(AND, expOnes, sigZero);
+    o.isNaN = nf->CreateNode(AND, expOnes, sigNonzero);
+    const BBNode hidden = nf->CreateNode(NOT, expZero);
+    o.msig = sig;
+    o.msig.push_back(hidden);
+    BBNodeVec e = zext(BBITE(hidden, exp, constVec(1, eb)), E);
+    BBNodeVec biasV = constVec(bias, E);
+    BBSub(e, biasV, support);
+    o.eUnb = e;
+    return o;
+  };
+  const Operand a = unpack(pa);
+  const Operand b = unpack(pb);
+
+  const BBNode sgn = nf->CreateNode(XOR, a.sign, b.sign);
+
+  // Significand product, 2sb bits, of the raw hidden-bit significands --
+  // in [0, 4) counting subnormal fractions.
+  BBNodeVec prod = BBfill(2 * sb, nf->getFalse());
+  for (unsigned i = 0; i < sb; i++)
+  {
+    const BBNodeVec row = BBAndBit(b.msig, a.msig[i]);
+    BBNodeVec addend = BBfill(2 * sb, nf->getFalse());
+    for (unsigned j = 0; j < sb; j++)
+      addend[i + j] = row[j];
+    BBPlus2(prod, addend, nf->getFalse());
+  }
+
+  // One normalisation for the whole product: shift its leading 1 to the
+  // top and fold the shift count into the exponent. This also absorbs the
+  // subnormal operands' missing normalisation (their leading zeros simply
+  // appear here). A zero product leaves garbage, muxed out by the
+  // specials below (zero operands) or rounded from all-sticky=0 to zero.
+  const unsigned lw2 = [](unsigned x) { // bits to count up to x
+    unsigned bb = 1;
+    while ((1u << bb) <= x)
+      bb++;
+    return bb;
+  }(2 * sb);
+  const BBNodeVec ell = BBfpCLZ(prod, lw2);
+  const BBNodeVec pn = BBfpShiftLeft(prod, ell);
+  BBNodeVec rsig(pn.begin() + sb, pn.end()); // top sb bits: 1.frac
+  BBNode guard = pn[sb - 1];
+  auto orVec = [&](BBNodeVec v) {
+    return v.empty() ? nf->getFalse() : nf->CreateNode(OR, v);
+  };
+  BBNodeVec lowBits(pn.begin(), pn.begin() + (sb - 1));
+  BBNode sticky = orVec(lowBits);
+
+  // Biased result exponent: eUnbA + eUnbB + bias + 1 - leading zeros.
+  BBNodeVec be = a.eUnb;
+  BBPlus2(be, b.eUnb, nf->getFalse());
+  BBPlus2(be, constVec(bias, E), nf->getTrue());
+  BBNodeVec ellE = zext(ell, E);
+  BBSub(be, ellE, support);
+
+  // Subnormal range: biased exponent <= 0 needs a right shift of 1 - be,
+  // clamped -- anything past guard is pure sticky.
+  const unsigned dmax = sb + 2;
+  const BBNode beNonPos =
+      nf->CreateNode(OR, be[E - 1], nf->CreateNode(NOR, be));
+  BBNodeVec shiftFull = constVec(1, E);
+  BBSub(shiftFull, be, support); // 1 - be, signed
+  const BBNode tooFar = nf->CreateNode(
+      NOT, BBBVLE(shiftFull, constVec(dmax, E), true /*signed*/));
+  const unsigned dw = [](unsigned x) {
+    unsigned bb = 1;
+    while ((1u << bb) <= x)
+      bb++;
+    return bb;
+  }(dmax);
+  BBNodeVec d(dw);
+  for (unsigned i = 0; i < dw; i++)
+  {
+    const BBNode inRange = nf->CreateNode(ITE, tooFar,
+                                          ((dmax >> i) & 1) ? nf->getTrue()
+                                                            : nf->getFalse(),
+                                          shiftFull[i]);
+    d[i] = nf->CreateNode(AND, beNonPos, inRange);
+  }
+  BBNodeVec vg = rsig;
+  vg.insert(vg.begin(), guard); // [guard, rsig...]
+  vg = BBfpShiftRightSticky(vg, d, sticky);
+  guard = vg[0];
+  for (unsigned i = 0; i < sb; i++)
+    rsig[i] = vg[i + 1];
+  // After a subnormal shift the value sits at the exp=1 scale (the encoding
+  // with exponent field 0 shares it).
+  BBNodeVec beAfter = BBITE(beNonPos, constVec(1, E), be);
+
+  // Round.
+  const BBNode gs = nf->CreateNode(OR, guard, sticky);
+  BBNodeVec upCases;
+  upCases.push_back(nf->CreateNode(
+      AND, rne, guard, nf->CreateNode(OR, sticky, rsig[0])));
+  upCases.push_back(nf->CreateNode(AND, rna, guard));
+  upCases.push_back(
+      nf->CreateNode(AND, rtp, nf->CreateNode(NOT, sgn), gs));
+  upCases.push_back(nf->CreateNode(AND, rtn, sgn, gs));
+  const BBNode roundUp = nf->CreateNode(OR, upCases);
+  const BBNodeVec rr = BBfpIncrement(rsig, roundUp);
+  const BBNode carry = rr[sb];
+  BBNodeVec rsigF(sb);
+  for (unsigned i = 0; i < sb; i++)
+    rsigF[i] = nf->CreateNode(ITE, carry, rr[i + 1], rr[i]);
+  BBNodeVec beF = beAfter;
+  BBPlus2(beF, BBfill(E, nf->getFalse()), carry);
+
+  // Overflow, checked after rounding; saturation is mode- and sign-
+  // dependent.
+  const BBNode ovf =
+      nf->CreateNode(NOT, BBBVLE(beF, constVec(maxbe, E), true /*signed*/));
+  BBNodeVec infCases;
+  infCases.push_back(rne);
+  infCases.push_back(rna);
+  infCases.push_back(nf->CreateNode(AND, rtp, nf->CreateNode(NOT, sgn)));
+  infCases.push_back(nf->CreateNode(AND, rtn, sgn));
+  const BBNode roundsToInf = nf->CreateNode(OR, infCases);
+
+  // Pack the finite computed result. A significand without its leading 1
+  // is subnormal: exponent field 0 (beAfter is 1 there, the same scale).
+  const BBNode isNormRes = rsigF[sb - 1];
+  BBNodeVec res(w);
+  for (unsigned i = 0; i < sb - 1; i++)
+    res[i] = rsigF[i];
+  for (unsigned i = 0; i < eb; i++)
+    res[sb - 1 + i] = nf->CreateNode(AND, isNormRes, beF[i]);
+  res[w - 1] = sgn;
+
+  // Specials, outermost first: NaN, then infinity, then zero, then
+  // overflow saturation.
+  auto packSpecial = [&](bool nan, bool inf, bool maxFinite) {
+    BBNodeVec s(w, nf->getFalse());
+    if (nan || inf || maxFinite)
+      for (unsigned i = 0; i < eb; i++)
+        s[sb - 1 + i] = nf->getTrue();
+    if (maxFinite)
+    {
+      s[sb - 1] = nf->getFalse(); // maxbe = 2^eb - 2: all ones but the LSB
+      for (unsigned i = 0; i < sb - 1; i++)
+        s[i] = nf->getTrue();
+    }
+    if (nan)
+      s[sb - 2] = nf->getTrue(); // canonical quiet NaN, positive
+    else
+      s[w - 1] = sgn;
+    return s;
+  };
+  BBNodeVec nanCases;
+  nanCases.push_back(a.isNaN);
+  nanCases.push_back(b.isNaN);
+  nanCases.push_back(nf->CreateNode(AND, a.isZero, b.isInf));
+  nanCases.push_back(nf->CreateNode(AND, a.isInf, b.isZero));
+  const BBNode anyNaN = nf->CreateNode(OR, nanCases);
+  const BBNode anyInf = nf->CreateNode(OR, a.isInf, b.isInf);
+  const BBNode anyZero = nf->CreateNode(OR, a.isZero, b.isZero);
+
+  res = BBITE(ovf, BBITE(roundsToInf, packSpecial(false, true, false),
+                         packSpecial(false, false, true)),
+              res);
+  res = BBITE(anyZero, packSpecial(false, false, false), res);
+  res = BBITE(anyInf, packSpecial(false, true, false), res);
+  res = BBITE(anyNaN, packSpecial(true, false, false), res);
+  return res;
 }
 
 // Return bit-blasted form for the overflow predicates BVUADDO, BVSADDO,

--- a/tests/query-files/fp-tests/native-add-inf-minus-inf.smt2
+++ b/tests/query-files/fp-tests/native-add-inf-minus-inf.smt2
@@ -1,0 +1,14 @@
+; RUN: %solver --bb.fp-native-arith=true %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-arith=true --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver %s | %OutputCheck %s
+;
+; Subtracting infinities is the invalid operation: infinity plus its own
+; negation must be NaN, whichever infinity it is.
+;
+; CHECK: ^unsat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(assert (fp.isInfinite x))
+(assert (not (fp.isNaN (fp.add RNE x (fp.neg x)))))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/native-add-rtn-zero-sign.smt2
+++ b/tests/query-files/fp-tests/native-add-rtn-zero-sign.smt2
@@ -1,0 +1,17 @@
+; RUN: %solver --bb.fp-native-arith=true %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-arith=true --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver %s | %OutputCheck %s
+;
+; Exact cancellation gives the mode-dependent zero: x + (-x) is -0 under
+; RTN and +0 under every other mode, so under RTN its fp.isNegative holds
+; for every finite x. This pins the one place fp.add's result sign is not
+; simply inherited from the larger operand.
+;
+; CHECK: ^unsat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(assert (not (fp.isNaN x)))
+(assert (not (fp.isInfinite x)))
+(assert (not (fp.isNegative (fp.add RTN x (fp.neg x)))))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/native-add-zero-identity.smt2
+++ b/tests/query-files/fp-tests/native-add-zero-identity.smt2
@@ -1,0 +1,17 @@
+; RUN: %solver --bb.fp-native-arith=true %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-arith=true --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver %s | %OutputCheck %s
+;
+; Adding +0 is exact for every non-NaN operand -- fp.eq-exact, not
+; bit-exact: -0 + +0 is +0, which fp.eq still identifies with -0. In the
+; native adder this exercises the zero operand flowing through the general
+; datapath (a zero significand adds exactly); there is no zero special
+; case to hide behind.
+;
+; CHECK: ^unsat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(assert (not (fp.isNaN x)))
+(assert (not (fp.eq (fp.add RNE x ((_ to_fp 8 24) #x00000000)) x)))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/native-arith-floatblast-noop.smt2
+++ b/tests/query-files/fp-tests/native-arith-floatblast-noop.smt2
@@ -1,0 +1,18 @@
+; RUN: %solver --bb.fp-native-arith=true -s %s 2>&1 | %OutputCheck %s
+;
+; With the native arithmetic flag, a formula whose floating-point content
+; is entirely additions, multiplications, sign operations and predicates
+; over symbols reaches the bit-blaster untouched: FloatBlast builds no
+; SymFPU circuit at all, and its statistics line says so.
+;
+; CHECK: FloatBlast: 0 SymFPU operations, 0 unpacks, 0 packs
+; CHECK: ^sat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(declare-fun y () (_ FloatingPoint 8 24))
+(declare-fun z () (_ FloatingPoint 8 24))
+(assert (fp.lt (fp.add RNE (fp.mul RNE x y) (fp.neg z)) (fp.abs y)))
+(assert (fp.gt (fp.mul RNE x x) z))
+(assert (not (fp.isNaN x)))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/native-mul-inf-times-finite.smt2
+++ b/tests/query-files/fp-tests/native-mul-inf-times-finite.smt2
@@ -1,0 +1,20 @@
+; RUN: %solver --bb.fp-native-arith=true %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-arith=true --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver %s | %OutputCheck %s
+;
+; Infinity times a finite nonzero value is infinite (the sign may flip but
+; the class cannot): with y neither NaN nor zero, the product of an infinite
+; x is infinite, so demanding it finite is unsatisfiable. With the native
+; arithmetic flag the multiply blasts through BBfpMul's special-case muxing;
+; the third run is the SymFPU path agreeing.
+;
+; CHECK: ^unsat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(declare-fun y () (_ FloatingPoint 8 24))
+(assert (fp.isInfinite x))
+(assert (not (fp.isNaN y)))
+(assert (not (fp.isZero y)))
+(assert (not (fp.isInfinite (fp.mul RNE x y))))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/native-mul-model-search.smt2
+++ b/tests/query-files/fp-tests/native-mul-model-search.smt2
@@ -1,0 +1,23 @@
+; RUN: %solver --bb.fp-native-arith=true %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-arith=true --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver %s | %OutputCheck %s
+;
+; The native multiply must also be able to FIND models, not just refute:
+; a product strictly greater than both (finite, above-one) operands exists,
+; so the solver has to drive the whole unpack/multiply/round/pack circuit
+; forwards to a witness.
+;
+; CHECK: ^sat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(declare-fun y () (_ FloatingPoint 8 24))
+(declare-fun one () (_ FloatingPoint 8 24))
+(assert (= one ((_ to_fp 8 24) #x3F800000)))
+(assert (fp.lt one x))
+(assert (fp.lt one y))
+(assert (not (fp.isInfinite x)))
+(assert (not (fp.isInfinite y)))
+(assert (fp.gt (fp.mul RNE x y) x))
+(assert (fp.gt (fp.mul RNE x y) y))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/native-mul-rtp-subnormal-halving.smt2
+++ b/tests/query-files/fp-tests/native-mul-rtp-subnormal-halving.smt2
@@ -1,0 +1,21 @@
+; RUN: %solver --bb.fp-native-arith=true --disable-equality %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-arith=true --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver %s | %OutputCheck %s
+;
+; Halving the smallest positive subnormal under RTP rounds back UP to that
+; same subnormal: the exact product is below every representable positive
+; value, and rounding toward positive infinity may not cross zero. This
+; pins the interaction the hand-written circuit gets wrong most easily --
+; the sticky bits surviving the subnormal right shift and still driving the
+; rounding increment. --disable-equality keeps the pins as constraints so
+; the circuit (not constant folding) decides the first run.
+;
+; CHECK: ^unsat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(declare-fun y () (_ FloatingPoint 8 24))
+(assert (= x ((_ to_fp 8 24) #x00000001)))
+(assert (= y ((_ to_fp 8 24) #x3F000000)))
+(assert (not (fp.eq (fp.mul RTP x y) x)))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/native-mul-sign-of-product.smt2
+++ b/tests/query-files/fp-tests/native-mul-sign-of-product.smt2
@@ -1,0 +1,19 @@
+; RUN: %solver --bb.fp-native-arith=true %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-arith=true --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver %s | %OutputCheck %s
+;
+; A strictly negative times a strictly positive value cannot be strictly
+; positive: the product's sign is the XOR of the operand signs, so the
+; result is negative, a negative zero (underflow), or negative infinity
+; (overflow) -- never above +0. Exercises BBfpMul's sign wire against the
+; native comparisons on both sides of it.
+;
+; CHECK: ^unsat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(declare-fun y () (_ FloatingPoint 8 24))
+(assert (fp.lt x ((_ to_fp 8 24) #x00000000)))
+(assert (fp.lt ((_ to_fp 8 24) #x00000000) y))
+(assert (fp.gt (fp.mul RNE x y) ((_ to_fp 8 24) #x00000000)))
+(check-sat)
+(exit)

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -298,6 +298,12 @@ void ExtraMain::create_options()
            "via the SymFPU unpacking circuits",
            bb_group);
 
+  bool_arg("--bb.fp-native-arith", bm->UserFlags.fp_native_arith,
+           "Bit-blast fp.mul under surviving native predicates with the "
+           "hand-written packed-operand circuit instead of the SymFPU "
+           "unpacking circuits (experimental)",
+           bb_group);
+
   bool_arg("--bb.simplify-during-bb", bm->UserFlags.simplify_during_BB_flag,
            "When bit-blasting discovers that a non-constant child of a term "
            "blasts to an all-constant vector, rebuild the term with that "

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -299,9 +299,9 @@ void ExtraMain::create_options()
            bb_group);
 
   bool_arg("--bb.fp-native-arith", bm->UserFlags.fp_native_arith,
-           "Bit-blast fp.mul under surviving native predicates with the "
-           "hand-written packed-operand circuit instead of the SymFPU "
-           "unpacking circuits (experimental)",
+           "Bit-blast fp.add and fp.mul under surviving native predicates "
+           "with the hand-written packed-operand circuits instead of the "
+           "SymFPU unpacking circuits (experimental)",
            bb_group);
 
   bool_arg("--bb.simplify-during-bb", bm->UserFlags.simplify_during_BB_flag,


### PR DESCRIPTION
Stacked on #767 (the first commit is that branch).

Hand-written unpack/compute/round/pack circuits for `fp.mul` and `fp.add` in the bit-blaster, no SymFPU involvement, behind the new `--bb.fp-native-arith` flag (default off). The predicate gate's operand resolution learns arms for both, so the operations chain and compose with the existing lookthroughs; `fp.sub` needs no arm because the factory already lowers it to add-of-neg. A fully-constant operation never survives, keeping the lowering-must-change invariant of constant folding and model evaluation.

Both circuits defer normalisation to the result: operands are consumed un-normalised (a field split plus four classification gates -- so chained operations pay no unpack), and one leading-zero normalisation per operation covers subnormal operands, the multiplier's product range, the adder's carry, and arbitrary cancellation alike. The rounder/denormaliser/packer is shared (`BBfpRoundPack`); overflow saturates per mode, underflow collects sticky through the subnormal shift, and the adder's only special-cased sign is the exact zero of cancellation (-0 under RTN). The internal exponent widens beyond eb+2 where the significand is wide relative to the exponent range -- an overflow of the subnormal shift distance on formats like (2, 5) that exhaustive testing caught as wrong tiny-subnormal products.

**Verification**: each operation checked exhaustively against the constant-evaluation path at (3, 4) and (2, 5) -- 81,920 input/mode combinations per format per op, bit-for-bit (NaN by class) -- plus per-op random float32 batteries biased toward specials/subnormals/cancellation and 2,000 random mixed add/mul/neg chains. Eleven new query-file tests pin the classic corners. Full suite passes with the flag off and on.

FloatBlast's dormant statistics now print under `--stats`, and all-zero counters certify the lowering was an identity; a test pins that a formula of additions, multiplications, sign operations and predicates over symbols reaches the bit-blaster with zero SymFPU constructions.

**Measured honestly, the flag stays off**: per isolated operation the native circuits are ~10% smaller than SymFPU's, but on real formulas the SymFPU path's output benefits from the word-level simplification pipeline (a uniform ~2.2x clause reduction on these circuits) which the native path bypasses by construction -- on a representative hard instance the native CNF is ~1.7x larger net. The experiment's value is the framework (packed pass-through, the gate arms, the pass-through certificate) and the measurement itself; making the native path competitive would require either simplifying over the native circuits or a demonstrated AIG-level rewriting win, both future work. Real formulas also still fall back where no native arm exists (float-to-float conversions, notably).