### PR TITLE
Bit-blast float-to-float to_fp natively over packed operands

### DIFF
--- a/include/stp/ToSat/BitBlaster.h
+++ b/include/stp/ToSat/BitBlaster.h
@@ -211,10 +211,12 @@ class BitBlaster
   BBNode BBfpIsNaN(const BBNodeVec& p, unsigned sb, unsigned w);
   BBNode BBfpIsZero(const BBNodeVec& p, unsigned w);
 
-  // bit blast fp.mul / fp.add over packed operands: hand-written
-  // unpack/compute/round/pack circuits, no SymFPU (--bb.fp-native-arith)
+  // bit blast fp.mul / fp.add / float-to-float to_fp over packed operands:
+  // hand-written unpack/compute/round/pack circuits, no SymFPU
+  // (--bb.fp-native-arith)
   BBNodeVec BBfpMul(const ASTNode& term, BBNodeSet& support);
   BBNodeVec BBfpAdd(const ASTNode& term, BBNodeSet& support);
+  BBNodeVec BBfpToFp(const ASTNode& term, BBNodeSet& support);
 
   // A packed operand split for the native arithmetic circuits: fields,
   // classification, and the significand with its hidden bit made explicit

--- a/lib/FloatBlaster/FloatBlast.cpp
+++ b/lib/FloatBlaster/FloatBlast.cpp
@@ -176,6 +176,41 @@ private:
       return node_factory->CreateTerm(n.GetKind(), n.GetValueWidth(), n[0],
                                       left, right);
     }
+    // The float-to-float form of to_fp (four children: the two format
+    // constants, the rounding mode, the float operand), under the same
+    // flag: the bit-blaster re-rounds the packed source directly
+    // (BBfpToFp). Unlike the arithmetic arms there is no factory fold for
+    // a constant conversion, so a constant operand under a constant mode
+    // must NOT survive -- constant folding and model evaluation rely on
+    // the SymFPU lowering collapsing exactly that case.
+    //
+    // Targets with a 2-bit exponent stay on the SymFPU path: SymFPU's
+    // convertFloatToFloat mis-rounds into such formats (e.g. converting
+    // the (3, 4) value 3/32 to (2, 5) under RNE gives the odd neighbour
+    // where IEEE ties-to-even picks 4/32; its own (2, 5) ADDITION is
+    // clean, so this is specific to the conversion). The native circuit
+    // rounds correctly there, but a circuit that disagrees with the
+    // constant evaluator makes model validation reject its own models.
+    // Until the evaluator side is fixed, the gate keeps the two aligned.
+    if (n.GetKind() == FP_TOFP && bm->UserFlags.fp_native_arith &&
+        n.Degree() == 4 &&
+        (n[2].GetKind() == SYMBOL || n[2].GetKind() == BVCONST) &&
+        n[0].GetUnsignedConst() >= 3)
+    {
+      const ASTNode operand = comparisonLeaf(n[3]);
+      if (operand.IsNull())
+        return ASTNode();
+      if (operand.isConstant() && n[2].GetKind() == BVCONST)
+        return ASTNode();
+      if (operand == n[3])
+        return n;
+      ASTVec children;
+      children.push_back(n[0]);
+      children.push_back(n[1]);
+      children.push_back(n[2]);
+      children.push_back(operand);
+      return node_factory->CreateTerm(FP_TOFP, n.GetValueWidth(), children);
+    }
     // A select from a float-element array already IS the packed element
     // bits: asPacked's READ arm only rebuilds the array and index if they
     // contain FP work, so it never builds a circuit for the element itself

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -1161,6 +1161,14 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term,
       break;
     }
 
+    // Only the four-child float-to-float form survives (comparisonLeaf);
+    // the reinterpret form resolves to the operand's own bits there.
+    case FP_TOFP:
+    {
+      result = BBfpToFp(term, support);
+      break;
+    }
+
     case FP_SUB:
     case FP_DIV:
     case FP_FMA:
@@ -1169,7 +1177,6 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term,
     case FP_ROUNDTOINTEGRAL:
     case FP_MIN:
     case FP_MAX:
-    case FP_TOFP:
     case FP_TOFP_SIGNED:
     case FP_TOFP_UNSIGNED:
     case FP_TO_UBV:
@@ -3893,6 +3900,116 @@ BBNodeVec BitBlaster::BBfpAdd(const ASTNode& term, BBNodeSet& support)
 
   res = BBITE(anyInf, packSpecial(false, infSign), res);
   res = BBITE(anyNaN, packSpecial(true, nf->getFalse()), res);
+  return res;
+}
+
+// Bit-blasted float-to-float conversion (the four-child form of to_fp)
+// over a packed operand, under the same flag and gate as BBfpMul/BBfpAdd.
+// A conversion is re-rounding: normalise the source significand (one CLZ,
+// absorbing subnormals), map it onto the target width -- low zeros when
+// widening, guard and sticky when narrowing -- rebias, and let the shared
+// rounder/packer handle the rest. Widening (both fields no narrower) is
+// exact by construction: no guard, no sticky, and a target exponent range
+// covering the source's, so the rounder never fires. The internal
+// exponent covers BOTH formats' ranges: a double's subnormal scale is far
+// outside a half's eb+2 bits.
+BBNodeVec BitBlaster::BBfpToFp(const ASTNode& term, BBNodeSet& support)
+{
+  assert(term.GetKind() == FP_TOFP);
+  assert(term.Degree() == 4);
+
+  const SourceSort tsort = term.GetSourceSort();
+  const SourceSort ssort = term[3].GetSourceSort();
+  assert(tsort.kind() == SourceSort::Kind::FloatingPoint);
+  assert(ssort.kind() == SourceSort::Kind::FloatingPoint);
+  const unsigned sb1 = ssort.significandWidth();
+  const unsigned eb1 = ssort.exponentWidth();
+  const unsigned w1 = eb1 + sb1;
+  const unsigned sb2 = tsort.significandWidth();
+  const unsigned eb2 = tsort.exponentWidth();
+  const unsigned w2 = eb2 + sb2;
+  const unsigned bias1 = (1u << (eb1 - 1)) - 1;
+  const unsigned bias2 = (1u << (eb2 - 1)) - 1;
+  unsigned E = 2;
+  while ((1u << (E - 1)) <= bias1 + sb1 + bias2 + 2 * sb2 + 4)
+    E++;
+
+  const BBNodeVec rm = BBTerm(term[2], support);
+  const BBNodeVec p = BBTerm(term[3], support);
+  assert(p.size() == w1);
+
+  auto constVec = [&](unsigned value, unsigned width) {
+    BBNodeVec c(width);
+    for (unsigned i = 0; i < width; i++)
+      c[i] = ((value >> i) & 1) ? nf->getTrue() : nf->getFalse();
+    return c;
+  };
+  auto zext = [&](const BBNodeVec& v, unsigned width) {
+    BBNodeVec c = v;
+    while (c.size() < width)
+      c.push_back(nf->getFalse());
+    return c;
+  };
+
+  const FpOperand s = BBfpUnpack(p, sb1, w1, E, support);
+
+  // Normalise the source significand; the count also lets a subnormal
+  // source become normal in a wider target range.
+  const unsigned lw1 = [](unsigned x) {
+    unsigned bb = 1;
+    while ((1u << bb) <= x)
+      bb++;
+    return bb;
+  }(sb1);
+  const BBNodeVec clz = BBfpCLZ(s.msig, lw1);
+  const BBNodeVec sn = BBfpShiftLeft(s.msig, clz);
+
+  // Map onto the target significand width.
+  BBNodeVec rsig(sb2);
+  BBNode guard = nf->getFalse();
+  BBNode sticky = nf->getFalse();
+  if (sb2 >= sb1)
+  {
+    for (unsigned i = 0; i < sb2 - sb1; i++)
+      rsig[i] = nf->getFalse();
+    for (unsigned i = 0; i < sb1; i++)
+      rsig[sb2 - sb1 + i] = sn[i];
+  }
+  else
+  {
+    const unsigned cut = sb1 - sb2;
+    for (unsigned i = 0; i < sb2; i++)
+      rsig[i] = sn[cut + i];
+    guard = sn[cut - 1];
+    BBNodeVec low(sn.begin(), sn.begin() + (cut - 1));
+    sticky = low.empty() ? nf->getFalse() : nf->CreateNode(OR, low);
+  }
+
+  // Rebias: be = eUnb - leading zeros + bias2.
+  BBNodeVec be = s.eUnb;
+  BBNodeVec clzE = zext(clz, E);
+  BBSub(be, clzE, support);
+  BBPlus2(be, constVec(bias2, E), nf->getFalse());
+
+  BBNodeVec res =
+      BBfpRoundPack(rm, s.sign, rsig, guard, sticky, be, sb2, eb2, support);
+
+  // Specials map to the target format's; a zero operand must be muxed
+  // (its garbage leading-zero count would otherwise wander the exponent).
+  auto packSpecial = [&](bool isnan, bool isinf) {
+    BBNodeVec sp(w2, nf->getFalse());
+    if (isnan || isinf)
+      for (unsigned i = 0; i < eb2; i++)
+        sp[sb2 - 1 + i] = nf->getTrue();
+    if (isnan)
+      sp[sb2 - 2] = nf->getTrue(); // canonical quiet NaN, positive
+    else
+      sp[w2 - 1] = s.sign;
+    return sp;
+  };
+  res = BBITE(s.isZero, packSpecial(false, false), res);
+  res = BBITE(s.isInf, packSpecial(false, true), res);
+  res = BBITE(s.isNaN, packSpecial(true, false), res);
   return res;
 }
 

--- a/tests/query-files/fp-tests/native-tofp-floatblast-noop.smt2
+++ b/tests/query-files/fp-tests/native-tofp-floatblast-noop.smt2
@@ -1,0 +1,19 @@
+; RUN: %solver --bb.fp-native-arith=true -s %s 2>&1 | %OutputCheck %s
+;
+; With the conversion arm, the fmcad12 shape -- narrow symbols widened,
+; multiplied, added and compared in the wide format -- reaches the
+; bit-blaster whole: FloatBlast builds no SymFPU circuit at all.
+;
+; CHECK: FloatBlast: 0 SymFPU operations, 0 unpacks, 0 packs
+; CHECK: ^sat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(declare-fun y () (_ FloatingPoint 8 24))
+(declare-fun b () (_ FloatingPoint 11 53))
+(assert (fp.lt (fp.add RNE (fp.mul RNE ((_ to_fp 11 53) RNE x)
+                                       ((_ to_fp 11 53) RNE y))
+                           (fp.neg b))
+               b))
+(assert (not (fp.isNaN b)))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/native-tofp-roundtrip-exact.smt2
+++ b/tests/query-files/fp-tests/native-tofp-roundtrip-exact.smt2
@@ -1,0 +1,16 @@
+; RUN: %solver --bb.fp-native-arith=true %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-arith=true --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver %s | %OutputCheck %s
+;
+; Widening is exact and narrowing an exactly-representable value is exact,
+; so converting a float up and back down returns it: fp.eq-equal for every
+; non-NaN operand, whatever the rounding modes. Exercises both directions
+; of the native conversion around a single symbol.
+;
+; CHECK: ^unsat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(assert (not (fp.isNaN x)))
+(assert (not (fp.eq ((_ to_fp 8 24) RTZ ((_ to_fp 11 53) RNE x)) x)))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/native-tofp-rtz-never-makes-infinity.smt2
+++ b/tests/query-files/fp-tests/native-tofp-rtz-never-makes-infinity.smt2
@@ -1,0 +1,16 @@
+; RUN: %solver --bb.fp-native-arith=true %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-arith=true --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver %s | %OutputCheck %s
+;
+; Narrowing under RTZ saturates to the largest finite value, never to
+; infinity: a finite double cannot become an infinite float. Pins the
+; mode-dependent overflow saturation inside the conversion's rounder.
+;
+; CHECK: ^unsat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 11 53))
+(assert (not (fp.isNaN x)))
+(assert (not (fp.isInfinite x)))
+(assert (fp.isInfinite ((_ to_fp 8 24) RTZ x)))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/native-tofp-widen-preserves-order.smt2
+++ b/tests/query-files/fp-tests/native-tofp-widen-preserves-order.smt2
@@ -1,0 +1,17 @@
+; RUN: %solver --bb.fp-native-arith=true %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-arith=true --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver %s | %OutputCheck %s
+;
+; Widening embeds the source values exactly, so it preserves the strict
+; order: the narrow and wide comparisons must agree on every pair. This is
+; the shape the fmcad12 benchmarks use everywhere -- float32 symbols
+; widened to float64 before comparing.
+;
+; CHECK: ^unsat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(declare-fun y () (_ FloatingPoint 8 24))
+(assert (distinct (fp.lt x y)
+                  (fp.lt ((_ to_fp 11 53) RNE x) ((_ to_fp 11 53) RNE y))))
+(check-sat)
+(exit)


### PR DESCRIPTION
Stacked on #768 (its commits appear here; review the top commit, f15eb7cb).

The four-child form of `to_fp` joins `fp.mul` and `fp.add` under `--bb.fp-native-arith`. A conversion is re-rounding: normalise the source significand (one CLZ, absorbing subnormal sources), map it onto the target width — low zeros when widening, guard and sticky when narrowing — rebias, and let the shared rounder/packer finish. Widening both fields is exact by construction: no guard, no sticky, and a target exponent range covering the source's, so the rounder never fires. The internal exponent covers both formats' ranges, since a double's subnormal scale sits far outside a half's eb+2 bits. Specials map across; a zero source is muxed, as its garbage leading-zero count would otherwise wander the exponent.

**A pre-existing evaluator divergence, and how the gate handles it**: conversions into 2-bit-exponent targets stay on the SymFPU path. On master, with no native flags involved, the constant evaluator mis-rounds those — converting the (3, 4) value 3/32 into (2, 5) under RNE yields the odd neighbour where ties-to-even picks the even one, checked against exact rational arithmetic — and the SymFPU circuit for the same conversion flips a satisfiable formula to unsat under `--disable-equality` (a one-formula sat/unsat flip on master). The native circuit rounds these cases correctly, but a circuit that disagrees with the evaluator makes model validation reject its own models, so the gate keeps the two aligned until the evaluator side is settled. The likely underlying issue is the same unpacked-exponent-width invariant for which the parser already refuses significands of 3 bits or fewer; refusing 2-bit exponents the same way may be the right fix, and I can open a separate issue with the minimal reproducer.

**Verification**: exhaustive against the constant-evaluation path for (2,5)→(3,4), (3,4)→(8,24), and (3,4)→(3,4) — every input under all five rounding modes — plus 2,000 random float64→float32 narrowings biased toward specials and the subnormal boundary; all agree bit-for-bit. Four new query-file tests pin the round-trip exactness, order preservation under widening, RTZ's saturate-to-finite overflow, and — with this arm — that the fmcad12 shape (narrow symbols widened, multiplied, added, and compared wide) reaches the bit-blaster whole: the FloatBlast statistics line certifies the lowering was a no-op. Full test suite passes with the flag off and on.