### PR TITLE
Version-stamp linked worktrees with their own HEAD, not the main one

### DIFF
--- a/cmake/modules/GetGitRevisionDescription.cmake
+++ b/cmake/modules/GetGitRevisionDescription.cmake
@@ -75,20 +75,26 @@ function(get_git_head_revision _refspecvar _hashvar)
 	# 	get_filename_component(GIT_DIR ${SUBMODULE_DIR}/${GIT_DIR_RELATIVE} ABSOLUTE)
 	# endif()
 
+	# A linked worktree's .git is a file pointing at <common>/worktrees/<name>,
+	# which holds this worktree's HEAD; refs stay in the common dir, so HEAD
+	# must be read from the per-worktree dir and refs resolved against GIT_DIR.
+	set(GIT_HEAD_DIR "${GIT_DIR}")
 	if(NOT IS_DIRECTORY "${GIT_DIR}")
 		file(READ ${GIT_DIR} worktree)
- 		string(REGEX REPLACE "gitdir: (.*)worktrees(.*)\n$" "\\1" GIT_DIR ${worktree})
- 	endif()
+		string(STRIP "${worktree}" worktree)
+		string(REGEX REPLACE "^gitdir: *" "" GIT_HEAD_DIR "${worktree}")
+		string(REGEX REPLACE "/worktrees/.*$" "" GIT_DIR "${GIT_HEAD_DIR}")
+	endif()
 	set(GIT_DATA "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/git-data")
 	if(NOT EXISTS "${GIT_DATA}")
 		file(MAKE_DIRECTORY "${GIT_DATA}")
 	endif()
 
-	if(NOT EXISTS "${GIT_DIR}/HEAD")
+	if(NOT EXISTS "${GIT_HEAD_DIR}/HEAD")
 		return()
 	endif()
 	set(HEAD_FILE "${GIT_DATA}/HEAD")
-	configure_file("${GIT_DIR}/HEAD" "${HEAD_FILE}" COPYONLY)
+	configure_file("${GIT_HEAD_DIR}/HEAD" "${HEAD_FILE}" COPYONLY)
 
 	configure_file("${_gitdescmoddir}/GetGitRevisionDescription.cmake.in"
 		"${GIT_DATA}/grabRef.cmake"

--- a/cmake/modules/GetGitRevisionDescription.cmake.in
+++ b/cmake/modules/GetGitRevisionDescription.cmake.in
@@ -31,8 +31,9 @@ if(HEAD_CONTENTS MATCHES "ref")
 		endif()
 	endif()
 else()
-	# detached HEAD
-	configure_file("@GIT_DIR@/HEAD" "@GIT_DATA@/head-ref" COPYONLY)
+	# detached HEAD; @HEAD_FILE@ is the copy of this checkout's own HEAD --
+	# in a linked worktree @GIT_DIR@/HEAD belongs to another checkout
+	configure_file("@HEAD_FILE@" "@GIT_DATA@/head-ref" COPYONLY)
 endif()
 
 if(NOT HEAD_HASH)


### PR DESCRIPTION
`GetGitRevisionDescription.cmake` resolves the version SHA by parsing `.git` directly. In a linked worktree, `.git` is a file pointing at `<common>/worktrees/<name>`, which holds that worktree's `HEAD`, while refs stay in the common dir. The module stripped the `worktrees` suffix and read `HEAD` from the common dir, so every linked worktree was stamped with whatever the main checkout (or a bare repo's default `HEAD`) pointed at — a plausible-looking but wrong SHA, identical across all worktrees of the same repository. This makes binaries built from different worktrees indistinguishable, which is nasty when comparing builds of two branches.

The fix reads `HEAD` from the per-worktree dir and resolves refs against the common dir. The detached-HEAD branch of `grabRef` re-read `GIT_DIR/HEAD` directly and had the same bug; it now uses the already-copied `HEAD_FILE`. Plain checkouts are unaffected: there the two directories are the same.

Verified with a small harness that runs `get_git_head_revision()` and compares against `git rev-parse HEAD` in five layouts: linked worktree on a branch, linked worktree detached, plain clone on a branch, plain clone detached, and plain clone after `git pack-refs --all --prune` (the packed-refs fallback). All five match; the stock module fails the linked-worktree cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)