### PR TITLE
Fit the difficulty score to the AIG it estimates, and cover floating point

### DIFF
--- a/include/stp/Simplifier/DifficultyScore.h
+++ b/include/stp/Simplifier/DifficultyScore.h
@@ -26,6 +26,7 @@ THE SOFTWARE.
 #define DIFFICULTYSCORE_H_
 
 #include "stp/AST/AST.h"
+#include <cstdint>
 
 // Estimates how many AIG AND-nodes bit-blasting a formula would build,
 // without building them: the per-operation costs are measured, and summed
@@ -33,6 +34,11 @@ THE SOFTWARE.
 // left the problem harder than it found it. See DifficultyScore.cpp for what
 // the estimate does and does not model, and tools/difficulty_bench for the
 // measurement it is fitted to.
+//
+// int64_t rather than long: the estimate is a sum of quadratic (and, for
+// fp.sqrt, cubic) terms over every node of a formula, so it outgrows 32 bits
+// on inputs that are not especially large -- and `long` is 32 bits on Windows
+// and on i386.
 
 namespace stp
 {
@@ -40,11 +46,11 @@ class DifficultyScore // not copyable
 {
 private:
   // maps from nodeNumber to the previously calculated difficulty score..
-  std::map<uint64_t, long> cache;
-  long evalCount = 0;
+  std::map<uint64_t, int64_t> cache;
+  int64_t evalCount = 0;
 
 public:
-  long score(const ASTNode& top, STPMgr*);
+  int64_t score(const ASTNode& top, STPMgr*);
   auto getEvalCount() {return evalCount;}
 };
 }

--- a/include/stp/Simplifier/DifficultyScore.h
+++ b/include/stp/Simplifier/DifficultyScore.h
@@ -27,7 +27,12 @@ THE SOFTWARE.
 
 #include "stp/AST/AST.h"
 
-// estimate how difficult that input is to solve based on some simple rules.
+// Estimates how many AIG AND-nodes bit-blasting a formula would build,
+// without building them: the per-operation costs are measured, and summed
+// over the formula's distinct nodes. Used to decide whether a simplification
+// left the problem harder than it found it. See DifficultyScore.cpp for what
+// the estimate does and does not model, and tools/difficulty_bench for the
+// measurement it is fitted to.
 
 namespace stp
 {

--- a/lib/STPManager/STP.cpp
+++ b/lib/STPManager/STP.cpp
@@ -523,10 +523,10 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
 
   // Run size reducing just once.
   inputToSat = sizeReducing(inputToSat, bvSolver.get(), pe.get(), domain.get());
-  long initial_difficulty_score = difficulty.score(inputToSat, bm);
+  int64_t initial_difficulty_score = difficulty.score(inputToSat, bm);
 
   // It's helpful to know the initial node size. The difficulty scorer can easily get something similar:
-  const long initial_node_size = difficulty.getEvalCount();
+  const int64_t initial_node_size = difficulty.getEvalCount();
 
   // Fixed point it if it's not too difficult.
   // Currently we discards all the state each time sizeReducing is called,
@@ -570,7 +570,7 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
     initial_difficulty_score = difficulty.score(inputToSat, bm);
   }
 
-  long bitblasted_difficulty = -1;
+  int64_t bitblasted_difficulty = -1;
   // Expensive, so only want to do it once.
   // The AIG-equivalence/constant substitutions found here are not
   // recorded in the solver map, so they could silently strip a symbol
@@ -780,7 +780,7 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
 
   bm->TermsAlreadySeenMap_Clear();
 
-  long final_difficulty_score = difficulty.score(inputToSat, bm);
+  int64_t final_difficulty_score = difficulty.score(inputToSat, bm);
 
   bool worse = false;
   if (final_difficulty_score > .8 * initial_difficulty_score)

--- a/lib/Simplifier/DifficultyScore.cpp
+++ b/lib/Simplifier/DifficultyScore.cpp
@@ -27,6 +27,7 @@ THE SOFTWARE.
 #include "stp/AST/ASTKind.h"
 #include "stp/Util/NodeIterator.h"
 #include <algorithm>
+#include <cstdint>
 #include <list>
 
 /* Estimates how many AIG AND-nodes the bit-blaster will build for a formula.
@@ -92,18 +93,18 @@ bool anyConstantChild(const ASTNode& b)
 // costs 4w-6, because a known addend fixes one input of every full adder.
 // Subtracting a constant is cheaper again -- the negation of a constant is
 // itself a constant, so no carry chain is built for it.
-long addCost(const ASTNode& b, long w, bool subtract)
+int64_t addCost(const ASTNode& b, int64_t w, bool subtract)
 {
   const unsigned degree = b.Degree();
   const unsigned constants = constantChildren(b);
   const unsigned symbolic = degree - constants;
 
-  long score = 0;
+  int64_t score = 0;
   if (symbolic >= 2)
-    score += (11L * w - 7) * (symbolic - 1);
+    score += (11 * w - 7) * static_cast<int64_t>(symbolic - 1);
   if (constants > 0 && symbolic > 0)
-    score += subtract ? (3L * w - 1) : (4L * w - 6);
-  return std::max(0L, score);
+    score += subtract ? (3 * w - 1) : (4 * w - 6);
+  return std::max<int64_t>(0, score);
 }
 
 // One binary multiply of width w.
@@ -116,7 +117,7 @@ long addCost(const ASTNode& b, long w, bool subtract)
 // a constant with few -- or high -- set bits is so much cheaper than the
 // symbolic case. Summing that series over every bit gives the symmetric
 // case, 6(w-1)^2+1, which the measurements reproduce exactly out to w=256.
-long multiplyCost(const ASTNode& b, long w)
+int64_t multiplyCost(const ASTNode& b, int64_t w)
 {
   const ASTNode* constant = NULL;
   if (b.Degree() == 2)
@@ -128,21 +129,21 @@ long multiplyCost(const ASTNode& b, long w)
   }
 
   if (constant == NULL)
-    return 6L * (w - 1) * (w - 1) + 1;
+    return 6 * (w - 1) * (w - 1) + 1;
 
   const CBV cbv = constant->GetBVConst();
-  long score = 0;
+  int64_t score = 0;
   bool seenLowestSetBit = false;
-  for (long i = 0; i < w; i++)
+  for (int64_t i = 0; i < w; i++)
   {
-    if (!CONSTANTBV::BitVector_bit_test(cbv, (unsigned)i))
+    if (!CONSTANTBV::BitVector_bit_test(cbv, static_cast<unsigned>(i)))
       continue;
     if (!seenLowestSetBit)
     {
       seenLowestSetBit = true;
       continue;
     }
-    score += 11L * (w - i) - 7;
+    score += 11 * (w - i) - 7;
   }
   return score;
 }
@@ -151,14 +152,15 @@ long multiplyCost(const ASTNode& b, long w)
 // prunes against whichever operand is fixed, and against both ends of it: the
 // highest set bit bounds how many quotient bits can be non-zero, the lowest
 // bounds how much of each subtract survives.
-void setBitRange(const ASTNode& constant, long w, long& lowest, long& highest)
+void setBitRange(const ASTNode& constant, int64_t w, int64_t& lowest,
+                 int64_t& highest)
 {
   const CBV cbv = constant.GetBVConst();
   lowest = 0;
   highest = 0;
   bool seen = false;
-  for (long i = w - 1; i >= 0; i--)
-    if (CONSTANTBV::BitVector_bit_test(cbv, (unsigned)i))
+  for (int64_t i = w - 1; i >= 0; i--)
+    if (CONSTANTBV::BitVector_bit_test(cbv, static_cast<unsigned>(i)))
     {
       if (!seen)
       {
@@ -178,18 +180,18 @@ void setBitRange(const ASTNode& constant, long w, long& lowest, long& highest)
 // w-highest bits wide and each subtract is only as wide as the divisor's own
 // span, so the cost tapers from both ends: at w=32, dividing by 1 costs 5752
 // nodes, by 2^31-1 costs 2357, and by 2^30 costs 181.
-long constantDivisionCost(bool dividendIsConstant, const ASTNode& constant,
-                          long w)
+int64_t constantDivisionCost(bool dividendIsConstant,
+                             const ASTNode& constant, int64_t w)
 {
-  long lowest = 0, highest = 0;
+  int64_t lowest = 0, highest = 0;
   setBitRange(constant, w, lowest, highest);
 
   if (dividendIsConstant)
-    return 16L * w * highest + 6L * w;
+    return 16 * w * highest + 6 * w;
 
   // Two independent taperings of the symmetric cost, applied in steps so
   // that a wide bit-vector cannot overflow the product.
-  long score = 3L * (w - 1) * (w - 1);
+  int64_t score = 3 * (w - 1) * (w - 1);
   score = score * (2 * w - highest) / w;
   score = score * (w - lowest) / w;
   return score;
@@ -229,7 +231,7 @@ unsigned fpWidth(const ASTNode& n)
   return eb + sb;
 }
 
-long fpEval(const ASTNode& b, const Kind k)
+int64_t fpEval(const ASTNode& b, const Kind k)
 {
   switch (k)
   {
@@ -245,30 +247,30 @@ long fpEval(const ASTNode& b, const Kind k)
     case FP_GEQ:
     case FP_GT:
     {
-      const unsigned w = fpWidth(b[0]);
-      return anyConstantChild(b) ? 5L * w : 15L * w;
+      const int64_t w = fpWidth(b[0]);
+      return anyConstantChild(b) ? 5 * w : 15 * w;
     }
     case FP_EQ:
     case FP_SMT_EQ:
     {
-      const unsigned w = fpWidth(b[0]);
-      return anyConstantChild(b) ? (3L * w) / 2 : 6L * w;
+      const int64_t w = fpWidth(b[0]);
+      return anyConstantChild(b) ? (3 * w) / 2 : 6 * w;
     }
     case FP_ISNORMAL:
     {
       // Two exponent field tests: all-ones and all-zeros.
       unsigned eb = 0, sb = 0;
       fpFormat(b[0], eb, sb);
-      return std::max(1L, 2L * eb - 1);
+      return std::max<int64_t>(1, 2 * static_cast<int64_t>(eb) - 1);
     }
     case FP_ISSUBNORMAL:
     case FP_ISZERO:
     case FP_ISINFINITE:
     case FP_ISNAN:
-      return std::max(1L, (long)fpWidth(b[0]) - 2);
+      return std::max<int64_t>(1, static_cast<int64_t>(fpWidth(b[0])) - 2);
     case FP_ISNEGATIVE:
     case FP_ISPOSITIVE:
-      return std::max(1L, (long)fpWidth(b[0]) - 1);
+      return std::max<int64_t>(1, static_cast<int64_t>(fpWidth(b[0])) - 1);
 
     default:
       break;
@@ -277,37 +279,37 @@ long fpEval(const ASTNode& b, const Kind k)
   // The terms. Every one of these is costed at the format of its *result*.
   unsigned eb = 0, sb = 0;
   fpFormat(b, eb, sb);
-  const long w = eb + sb;
-  const long sig = sb;
+  const int64_t w = eb + sb;
+  const int64_t sig = sb;
 
   switch (k)
   {
     // Unpacking an operand and packing a result.
     case FP_TO_IEEE_BV:
-      return 35L * b.GetValueWidth();
+      return 35 * static_cast<int64_t>(b.GetValueWidth());
 
     case FP_ADD:
     case FP_SUB:
       // Alignment and normalisation shifters over the significand, then one
       // round: linear in the format with a barrel-shifter term on top.
-      return 85L * w + 11L * w * log2ceil(w);
+      return 85 * w + 11 * w * static_cast<int64_t>(log2ceil(w));
 
     case FP_MUL:
-      return 12L * sig * sig + 50L * w;
+      return 12 * sig * sig + 50 * w;
 
     case FP_DIV:
-      return 53L * sig * sig + 100L * w;
+      return 53 * sig * sig + 100 * w;
 
     case FP_FMA:
-      return 12L * sig * sig + 260L * w;
+      return 12 * sig * sig + 260 * w;
 
     case FP_SQRT:
     {
       // A restoring square root: one subtract-and-select per result bit over
       // a growing remainder. Cubic, so the significand is clamped before it
       // is cubed rather than after.
-      const long s = std::min(sig, 1000000L);
-      return 4L * s * s * s + 25L * s * s;
+      const int64_t s = std::min<int64_t>(sig, 1000000);
+      return 4 * s * s * s + 25 * s * s;
     }
 
     case FP_REM:
@@ -316,50 +318,51 @@ long fpEval(const ASTNode& b, const Kind k)
       // exponential in the exponent width. Clamped so the estimate stays a
       // number rather than an overflow.
       const unsigned shift = std::min(eb, 40u);
-      return 25L * (1L << shift) * sig;
+      return 25 * (INT64_C(1) << shift) * sig;
     }
 
     case FP_ROUNDTOINTEGRAL:
-      return 6L * w * log2ceil(w);
+      return 6 * w * static_cast<int64_t>(log2ceil(w));
 
     case FP_MIN:
     case FP_MAX:
-      return 14L * w * log2ceil(w);
+      return 14 * w * static_cast<int64_t>(log2ceil(w));
 
     case FP_TOFP:
     {
       // Reformatting another float. Widening is exact -- the circuit is
       // wiring -- so only narrowing pays for a round.
-      const long src = fpWidth(b[b.Degree() - 1]);
-      return src <= w ? (5L * src) / 4 : 25L * (src + w);
+      const int64_t src = fpWidth(b[b.Degree() - 1]);
+      return src <= w ? (5 * src) / 4 : 25 * (src + w);
     }
 
     case FP_TOFP_SIGNED:
     case FP_TOFP_UNSIGNED:
     {
       // An integer narrower than the significand converts exactly.
-      const long src = std::max(1u, b[b.Degree() - 1].GetValueWidth());
-      const long perBit = (k == FP_TOFP_SIGNED) ? 35L : 20L;
-      const long exact = (k == FP_TOFP_SIGNED) ? 8L : 1L;
+      const int64_t src = std::max(1u, b[b.Degree() - 1].GetValueWidth());
+      const int64_t perBit = (k == FP_TOFP_SIGNED) ? 35 : 20;
+      const int64_t exact = (k == FP_TOFP_SIGNED) ? 8 : 1;
       return src <= sig ? exact * src : perBit * src;
     }
 
     case FP_TO_UBV:
     case FP_TO_SBV:
       // Children are (target width, rounding mode, operand [, default]).
-      return (k == FP_TO_SBV ? 26L : 23L) *
-             ((long)std::max(1u, b.GetValueWidth()) + (long)fpWidth(b[2]));
+      return (k == FP_TO_SBV ? 26 : 23) *
+             (static_cast<int64_t>(std::max(1u, b.GetValueWidth())) +
+              static_cast<int64_t>(fpWidth(b[2])));
 
     default:
       break;
   }
 
-  return std::max(1L, w) * b.Degree();
+  return std::max<int64_t>(1, w) * b.Degree();
 }
 
 } // namespace
 
-long eval(const ASTNode& b)
+int64_t eval(const ASTNode& b)
 {
   const Kind k = b.GetKind();
 
@@ -369,7 +372,7 @@ long eval(const ASTNode& b)
   const unsigned w = b.GetValueWidth();
   const unsigned degree = b.Degree();
   // Booleans report a width of zero; the arithmetic below wants one bit.
-  const long lw = std::max(1u, w);
+  const int64_t lw = std::max(1u, w);
 
   // An operation over constants alone is evaluated by the bit-blaster, not
   // built: every bit of it comes back as the AIG's true or false. That is
@@ -425,7 +428,7 @@ long eval(const ASTNode& b)
     {
       // A constant operand fixes each column, so it costs nothing.
       const unsigned symbolic = degree - constantChildren(b);
-      return symbolic < 2 ? 0 : lw * (symbolic - 1);
+      return symbolic < 2 ? 0 : lw * static_cast<int64_t>(symbolic - 1);
     }
 
     case BVXOR:
@@ -434,7 +437,7 @@ long eval(const ASTNode& b)
       // An AIG spends three nodes on an XOR, but XOR with a constant is a
       // conditional inversion, so it is free.
       const unsigned symbolic = degree - constantChildren(b);
-      return symbolic < 2 ? 0 : 3L * lw * (symbolic - 1);
+      return symbolic < 2 ? 0 : 3 * lw * static_cast<int64_t>(symbolic - 1);
     }
 
     case BVPLUS:
@@ -445,13 +448,13 @@ long eval(const ASTNode& b)
       return addCost(b, lw, true);
 
     case BVUMINUS:
-      return 4L * (lw - 1);
+      return 4 * (lw - 1);
 
     case BVMULT:
       if (degree == 2)
         return multiplyCost(b, lw);
       // Wider multiplies are binarised before the bit-blaster sees them.
-      return (long)(degree - 1) * multiplyCost(b, lw);
+      return static_cast<int64_t>(degree - 1) * multiplyCost(b, lw);
 
     case BVDIV:
     case BVMOD:
@@ -461,17 +464,17 @@ long eval(const ASTNode& b)
         return constantDivisionCost(true, b[0], lw);
       if (b[1].isConstant())
         return constantDivisionCost(false, b[1], lw);
-      return 20L * (lw - 1) * (lw - 1) + 29L * lw;
+      return 20 * (lw - 1) * (lw - 1) + 29 * lw;
 
     case SBVDIV:
     case SBVREM:
     case SBVMOD:
       // The unsigned circuit plus the sign fixups on either side of it.
       if (b[0].isConstant())
-        return constantDivisionCost(true, b[0], lw) + 12L * lw;
+        return constantDivisionCost(true, b[0], lw) + 12 * lw;
       if (b[1].isConstant())
-        return constantDivisionCost(false, b[1], lw) + 12L * lw;
-      return 20L * (lw - 1) * (lw - 1) + 50L * lw;
+        return constantDivisionCost(false, b[1], lw) + 12 * lw;
+      return 20 * (lw - 1) * (lw - 1) + 50 * lw;
 
     case BVLEFTSHIFT:
     case BVRIGHTSHIFT:
@@ -483,9 +486,9 @@ long eval(const ASTNode& b)
       if (b[1].isConstant())
         return 0;
       if (b[0].isConstant())
-        return (11L * lw) / 2;
-      const long stages = log2ceil(w);
-      return ((k == BVSRSHIFT) ? 7L : 6L) * lw * stages / 2;
+        return (11 * lw) / 2;
+      const int64_t stages = log2ceil(w);
+      return ((k == BVSRSHIFT) ? 7 : 6) * lw * stages / 2;
     }
 
     case ITE:
@@ -496,13 +499,13 @@ long eval(const ASTNode& b)
           (b[1].isConstant() ? 1u : 0u) + (b[2].isConstant() ? 1u : 0u);
       if (constantArms == 2)
         return 0;
-      return constantArms == 1 ? lw + 3 : 3L * lw;
+      return constantArms == 1 ? lw + 3 : 3 * lw;
     }
 
     case EQ:
     {
-      const unsigned ow = std::max(1u, b[0].GetValueWidth());
-      return anyConstantChild(b) ? std::max(1L, (long)ow - 1) : 4L * ow - 1;
+      const int64_t ow = std::max(1u, b[0].GetValueWidth());
+      return anyConstantChild(b) ? std::max<int64_t>(1, ow - 1) : 4 * ow - 1;
     }
 
     case BVLT:
@@ -514,36 +517,36 @@ long eval(const ASTNode& b)
     case BVSGT:
     case BVSGE:
     {
-      const unsigned ow = std::max(1u, b[0].GetValueWidth());
-      return anyConstantChild(b) ? (long)ow : 6L * ow - 1;
+      const int64_t ow = std::max(1u, b[0].GetValueWidth());
+      return anyConstantChild(b) ? ow : 6 * ow - 1;
     }
 
     case BVUADDO:
     case BVUSUBO:
     {
       // The adder, kept only for its carry out.
-      const unsigned ow = std::max(1u, b[0].GetValueWidth());
-      return 11L * ow - 7;
+      const int64_t ow = std::max(1u, b[0].GetValueWidth());
+      return 11 * ow - 7;
     }
 
     case BVSADDO:
     case BVSSUBO:
     {
       // As above, plus the sign comparison the signed predicate needs.
-      const unsigned ow = std::max(1u, b[0].GetValueWidth());
-      return 11L * ow + 3;
+      const int64_t ow = std::max(1u, b[0].GetValueWidth());
+      return 11 * ow + 3;
     }
 
     case BVUMULO:
     {
-      const unsigned ow = std::max(1u, b[0].GetValueWidth());
-      return 12L * (ow - 1) * (ow - 1) + 7L * ow;
+      const int64_t ow = std::max(1u, b[0].GetValueWidth());
+      return 12 * (ow - 1) * (ow - 1) + 7 * ow;
     }
 
     case BVSMULO:
     {
-      const unsigned ow = std::max(1u, b[0].GetValueWidth());
-      return 23L * (ow - 1) * (ow - 1) + 21L * ow;
+      const int64_t ow = std::max(1u, b[0].GetValueWidth());
+      return 23 * (ow - 1) * (ow - 1) + 21 * ow;
     }
 
     // Boolean connectives, one AIG node per binary combination.
@@ -551,11 +554,11 @@ long eval(const ASTNode& b)
     case OR:
     case NAND:
     case NOR:
-      return degree - 1;
+      return static_cast<int64_t>(degree) - 1;
 
     case XOR:
     case IFF:
-      return 3L * (degree - 1);
+      return 3 * (static_cast<int64_t>(degree) - 1);
 
     case IMPLIES:
       return 1;
@@ -564,11 +567,11 @@ long eval(const ASTNode& b)
       // READ and WRITE reach here, as does anything new. Arrays are removed
       // before the bit-blaster runs, so this only has to be a placeholder
       // that grows with the operand.
-      return std::max<long>(w, 1) * degree;
+      return std::max<int64_t>(w, 1) * degree;
   }
 }
 
-long DifficultyScore::score(const ASTNode& top, STPMgr* mgr)
+int64_t DifficultyScore::score(const ASTNode& top, STPMgr* mgr)
 {
 
   {
@@ -579,7 +582,7 @@ long DifficultyScore::score(const ASTNode& top, STPMgr* mgr)
 
   NonAtomIterator ni(top, mgr->ASTUndefined, *mgr);
   ASTNode current;
-  long result = 0;
+  int64_t result = 0;
   while ((current = ni.next()) != ni.end())
     {
       evalCount++;

--- a/lib/Simplifier/DifficultyScore.cpp
+++ b/lib/Simplifier/DifficultyScore.cpp
@@ -26,17 +26,338 @@ THE SOFTWARE.
 #include "stp/AST/AST.h"
 #include "stp/AST/ASTKind.h"
 #include "stp/Util/NodeIterator.h"
+#include <algorithm>
 #include <list>
+
+/* Estimates how many AIG AND-nodes the bit-blaster will build for a formula.
+ *
+ * Every number below was measured, not guessed: each operation was built over
+ * fresh symbols, bit-blasted on its own with BBNodeManagerAIG, and the
+ * resulting AND-node count fitted against the bit-width. See
+ * bench-hard/reports/2026-08-06-difficulty-scorer-vs-aig-size.md for the
+ * sweep, the fits and the residuals.
+ *
+ * Two properties of the estimate are deliberate.
+ *
+ * Standalone, with no sharing. A node is costed as though it were the only
+ * consumer of its children and nothing downstream re-used it. The real AIG is
+ * hash-consed, so a formula whose operations overlap builds fewer nodes than
+ * the sum of the per-node costs. Modelling that would need the share counts
+ * the score is used to compare, so the estimate is an upper bound that stays
+ * proportional as long as sharing does not change wildly between the two
+ * formulas being compared.
+ *
+ * Constant operands are recognised. A multiply, an add or a comparison
+ * against a constant is several times cheaper than the symmetric one -- a
+ * shift by a constant, and a bitwise operation with a constant, are free --
+ * and the old scorer costed them all at the symbolic price. That mattered:
+ * simplifications that fold a constant into an operation looked neutral.
+ *
+ * The costs model the default bit-blaster settings (in particular
+ * multiplication_variant 1, which is a shift-and-add array rather than a
+ * Booth-recoded one). UserDefinedFlags is not reachable from here, so a
+ * non-default backend configuration is scored as though it were the default.
+ */
 
 namespace stp
 {
-// Estimate the number of clauses that would generated if sent to CNF.
 
-static bool isLikeDivision(const Kind& k)
+namespace
 {
-  return k == BVMULT || k == BVDIV || k == BVMOD || k == SBVDIV ||
-         k == SBVREM || k == SBVMOD;
+
+// ceil(log2(w)), the number of stages in a barrel shifter over w bits.
+unsigned log2ceil(unsigned w)
+{
+  unsigned r = 0;
+  while (r < 31 && (1u << r) < w)
+    r++;
+  return r;
 }
+
+unsigned constantChildren(const ASTNode& b)
+{
+  unsigned count = 0;
+  for (unsigned i = 0, degree = b.Degree(); i < degree; i++)
+    if (b[i].isConstant())
+      count++;
+  return count;
+}
+
+bool anyConstantChild(const ASTNode& b)
+{
+  return constantChildren(b) > 0;
+}
+
+// A ripple-carry adder over w bits costs 11w-7; adding a constant instead
+// costs 4w-6, because a known addend fixes one input of every full adder.
+// Subtracting a constant is cheaper again -- the negation of a constant is
+// itself a constant, so no carry chain is built for it.
+long addCost(const ASTNode& b, long w, bool subtract)
+{
+  const unsigned degree = b.Degree();
+  const unsigned constants = constantChildren(b);
+  const unsigned symbolic = degree - constants;
+
+  long score = 0;
+  if (symbolic >= 2)
+    score += (11L * w - 7) * (symbolic - 1);
+  if (constants > 0 && symbolic > 0)
+    score += subtract ? (3L * w - 1) : (4L * w - 6);
+  return std::max(0L, score);
+}
+
+// One binary multiply of width w.
+//
+// The default bit-blaster walks the bits of the first operand, and for each
+// set bit adds the other operand shifted left by that bit's position. The
+// lowest set bit seeds the accumulator for free; every later set bit i pays
+// for an add over the (w-i) columns above it, 11(w-i)-7 nodes. With a
+// constant operand only its set bits are built, which is why multiplying by
+// a constant with few -- or high -- set bits is so much cheaper than the
+// symbolic case. Summing that series over every bit gives the symmetric
+// case, 6(w-1)^2+1, which the measurements reproduce exactly out to w=256.
+long multiplyCost(const ASTNode& b, long w)
+{
+  const ASTNode* constant = NULL;
+  if (b.Degree() == 2)
+  {
+    if (b[0].isConstant())
+      constant = &b[0];
+    else if (b[1].isConstant())
+      constant = &b[1];
+  }
+
+  if (constant == NULL)
+    return 6L * (w - 1) * (w - 1) + 1;
+
+  const CBV cbv = constant->GetBVConst();
+  long score = 0;
+  bool seenLowestSetBit = false;
+  for (long i = 0; i < w; i++)
+  {
+    if (!CONSTANTBV::BitVector_bit_test(cbv, (unsigned)i))
+      continue;
+    if (!seenLowestSetBit)
+    {
+      seenLowestSetBit = true;
+      continue;
+    }
+    score += 11L * (w - i) - 7;
+  }
+  return score;
+}
+
+// Where a constant's set bits start and stop, both 0 for zero. Long division
+// prunes against whichever operand is fixed, and against both ends of it: the
+// highest set bit bounds how many quotient bits can be non-zero, the lowest
+// bounds how much of each subtract survives.
+void setBitRange(const ASTNode& constant, long w, long& lowest, long& highest)
+{
+  const CBV cbv = constant.GetBVConst();
+  lowest = 0;
+  highest = 0;
+  bool seen = false;
+  for (long i = w - 1; i >= 0; i--)
+    if (CONSTANTBV::BitVector_bit_test(cbv, (unsigned)i))
+    {
+      if (!seen)
+      {
+        highest = i;
+        seen = true;
+      }
+      lowest = i;
+    }
+}
+
+// A division with one constant operand.
+//
+// Only the quotient bits that can be non-zero get built, so both cases turn
+// on the constant's magnitude -- but in opposite directions. When the
+// *dividend* is fixed it bounds the whole computation and the cost is linear
+// in its magnitude. When the *divisor* is fixed, the quotient is at most
+// w-highest bits wide and each subtract is only as wide as the divisor's own
+// span, so the cost tapers from both ends: at w=32, dividing by 1 costs 5752
+// nodes, by 2^31-1 costs 2357, and by 2^30 costs 181.
+long constantDivisionCost(bool dividendIsConstant, const ASTNode& constant,
+                          long w)
+{
+  long lowest = 0, highest = 0;
+  setBitRange(constant, w, lowest, highest);
+
+  if (dividendIsConstant)
+    return 16L * w * highest + 6L * w;
+
+  // Two independent taperings of the symmetric cost, applied in steps so
+  // that a wide bit-vector cannot overflow the product.
+  long score = 3L * (w - 1) * (w - 1);
+  score = score * (2 * w - highest) / w;
+  score = score * (w - lowest) / w;
+  return score;
+}
+
+// The exponent and significand widths of a floating-point node. Lowering
+// leaves the natively-encoded predicates over packed bit-vector operands, so
+// the source sort is not always still there to ask; fall back to the standard
+// interchange format for the packed width.
+void fpFormat(const ASTNode& n, unsigned& eb, unsigned& sb)
+{
+  const SourceSort sort = n.GetSourceSort();
+  if (sort.kind() == SourceSort::Kind::FloatingPoint)
+  {
+    eb = sort.exponentWidth();
+    sb = sort.significandWidth();
+    return;
+  }
+
+  const unsigned w = std::max(3u, n.GetValueWidth());
+  switch (w)
+  {
+    case 16: eb = 5; break;
+    case 32: eb = 8; break;
+    case 64: eb = 11; break;
+    case 128: eb = 15; break;
+    default: eb = std::min(w - 1, std::max(2u, log2ceil(w) + 1)); break;
+  }
+  sb = w - eb;
+}
+
+// The packed width a floating-point operand occupies.
+unsigned fpWidth(const ASTNode& n)
+{
+  unsigned eb = 0, sb = 0;
+  fpFormat(n, eb, sb);
+  return eb + sb;
+}
+
+long fpEval(const ASTNode& b, const Kind k)
+{
+  switch (k)
+  {
+    // Sign manipulation of an unpacked value is wiring.
+    case FP_ABS:
+    case FP_NEG:
+      return 0;
+
+    // The predicates. The four orderings and the two equalities are encoded
+    // natively over the packed bits; the classifications are field tests.
+    case FP_LEQ:
+    case FP_LT:
+    case FP_GEQ:
+    case FP_GT:
+    {
+      const unsigned w = fpWidth(b[0]);
+      return anyConstantChild(b) ? 5L * w : 15L * w;
+    }
+    case FP_EQ:
+    case FP_SMT_EQ:
+    {
+      const unsigned w = fpWidth(b[0]);
+      return anyConstantChild(b) ? (3L * w) / 2 : 6L * w;
+    }
+    case FP_ISNORMAL:
+    {
+      // Two exponent field tests: all-ones and all-zeros.
+      unsigned eb = 0, sb = 0;
+      fpFormat(b[0], eb, sb);
+      return std::max(1L, 2L * eb - 1);
+    }
+    case FP_ISSUBNORMAL:
+    case FP_ISZERO:
+    case FP_ISINFINITE:
+    case FP_ISNAN:
+      return std::max(1L, (long)fpWidth(b[0]) - 2);
+    case FP_ISNEGATIVE:
+    case FP_ISPOSITIVE:
+      return std::max(1L, (long)fpWidth(b[0]) - 1);
+
+    default:
+      break;
+  }
+
+  // The terms. Every one of these is costed at the format of its *result*.
+  unsigned eb = 0, sb = 0;
+  fpFormat(b, eb, sb);
+  const long w = eb + sb;
+  const long sig = sb;
+
+  switch (k)
+  {
+    // Unpacking an operand and packing a result.
+    case FP_TO_IEEE_BV:
+      return 35L * b.GetValueWidth();
+
+    case FP_ADD:
+    case FP_SUB:
+      // Alignment and normalisation shifters over the significand, then one
+      // round: linear in the format with a barrel-shifter term on top.
+      return 85L * w + 11L * w * log2ceil(w);
+
+    case FP_MUL:
+      return 12L * sig * sig + 50L * w;
+
+    case FP_DIV:
+      return 53L * sig * sig + 100L * w;
+
+    case FP_FMA:
+      return 12L * sig * sig + 260L * w;
+
+    case FP_SQRT:
+    {
+      // A restoring square root: one subtract-and-select per result bit over
+      // a growing remainder. Cubic, so the significand is clamped before it
+      // is cubed rather than after.
+      const long s = std::min(sig, 1000000L);
+      return 4L * s * s * s + 25L * s * s;
+    }
+
+    case FP_REM:
+    {
+      // Exact remainder needs the whole quotient, so the circuit is
+      // exponential in the exponent width. Clamped so the estimate stays a
+      // number rather than an overflow.
+      const unsigned shift = std::min(eb, 40u);
+      return 25L * (1L << shift) * sig;
+    }
+
+    case FP_ROUNDTOINTEGRAL:
+      return 6L * w * log2ceil(w);
+
+    case FP_MIN:
+    case FP_MAX:
+      return 14L * w * log2ceil(w);
+
+    case FP_TOFP:
+    {
+      // Reformatting another float. Widening is exact -- the circuit is
+      // wiring -- so only narrowing pays for a round.
+      const long src = fpWidth(b[b.Degree() - 1]);
+      return src <= w ? (5L * src) / 4 : 25L * (src + w);
+    }
+
+    case FP_TOFP_SIGNED:
+    case FP_TOFP_UNSIGNED:
+    {
+      // An integer narrower than the significand converts exactly.
+      const long src = std::max(1u, b[b.Degree() - 1].GetValueWidth());
+      const long perBit = (k == FP_TOFP_SIGNED) ? 35L : 20L;
+      const long exact = (k == FP_TOFP_SIGNED) ? 8L : 1L;
+      return src <= sig ? exact * src : perBit * src;
+    }
+
+    case FP_TO_UBV:
+    case FP_TO_SBV:
+      // Children are (target width, rounding mode, operand [, default]).
+      return (k == FP_TO_SBV ? 26L : 23L) *
+             ((long)std::max(1u, b.GetValueWidth()) + (long)fpWidth(b[2]));
+
+    default:
+      break;
+  }
+
+  return std::max(1L, w) * b.Degree();
+}
+
+} // namespace
 
 long eval(const ASTNode& b)
 {
@@ -45,75 +366,206 @@ long eval(const ASTNode& b)
   if (b.Degree() == 0)
     return 0; // consts & symbols don't count.
 
-  // These scores are approximately the number of clauses created when
-  // no input values are known.
-  long score = 0;
-  if (k == BVMULT&& b.Degree() == 2 && b[0].GetKind() == BVCONST)
+  const unsigned w = b.GetValueWidth();
+  const unsigned degree = b.Degree();
+  // Booleans report a width of zero; the arithmetic below wants one bit.
+  const long lw = std::max(1u, w);
+
+  // An operation over constants alone is evaluated by the bit-blaster, not
+  // built: every bit of it comes back as the AIG's true or false. That is
+  // worth testing for even though the simplifying node factory folds most of
+  // them on creation, because the floating-point operations are folded later
+  // -- during lowering -- and the score is taken before that.
+  if (constantChildren(b) == degree)
+    return 0;
+
+  // Likewise a comparison of a node with itself. This is not the dead branch
+  // it looks like: propagating an equality x = e substitutes e for x on both
+  // sides of it, and the reflexive float equality that leaves behind is only
+  // recognised as true when the operation is lowered.
+  switch (k)
   {
-    // because it's going to be booth encoded, it's about the number of runs.
-    const auto cbv = b[0].GetBVConst(); // cleanup?
-    bool last = CONSTANTBV::BitVector_bit_test(cbv,0);
-    int changes = 0;
-    for (unsigned int i = 1; i < b.GetValueWidth(); i++)
+    case EQ:
+    case FP_SMT_EQ:
+    case BVLT:
+    case BVLE:
+    case BVGT:
+    case BVGE:
+    case BVSLT:
+    case BVSLE:
+    case BVSGT:
+    case BVSGE:
+      if (b[0] == b[1])
+        return 0;
+      break;
+    default:
+      break;
+  }
+
+  if (is_FP_kind(k))
+    return fpEval(b, k);
+
+  switch (k)
+  {
+    // Selecting, permuting and inverting bits is wiring: no AND-node is
+    // built for any of these.
+    case BVNOT:
+    case NOT:
+    case BVCONCAT:
+    case BVEXTRACT:
+    case BVSX:
+    case BVZX:
+    case BOOLEXTRACT:
+      return 0;
+
+    case BVAND:
+    case BVOR:
+    case BVNAND:
+    case BVNOR:
     {
-        if (last != CONSTANTBV::BitVector_bit_test(cbv,i))
-          changes++;
-
-        last = CONSTANTBV::BitVector_bit_test(cbv,i);
+      // A constant operand fixes each column, so it costs nothing.
+      const unsigned symbolic = degree - constantChildren(b);
+      return symbolic < 2 ? 0 : lw * (symbolic - 1);
     }
-   //std::cerr << "C" <<changes;
-   score = (4L * b.GetValueWidth() * changes);
 
+    case BVXOR:
+    case BVXNOR:
+    {
+      // An AIG spends three nodes on an XOR, but XOR with a constant is a
+      // conditional inversion, so it is free.
+      const unsigned symbolic = degree - constantChildren(b);
+      return symbolic < 2 ? 0 : 3L * lw * (symbolic - 1);
+    }
+
+    case BVPLUS:
+      return addCost(b, lw, false);
+
+    case BVSUB:
+      // Blasted as a + (-b), and the negation folds into the adder.
+      return addCost(b, lw, true);
+
+    case BVUMINUS:
+      return 4L * (lw - 1);
+
+    case BVMULT:
+      if (degree == 2)
+        return multiplyCost(b, lw);
+      // Wider multiplies are binarised before the bit-blaster sees them.
+      return (long)(degree - 1) * multiplyCost(b, lw);
+
+    case BVDIV:
+    case BVMOD:
+      // Restoring long division: a subtract and a select per quotient bit,
+      // over a remainder as wide as the dividend.
+      if (b[0].isConstant())
+        return constantDivisionCost(true, b[0], lw);
+      if (b[1].isConstant())
+        return constantDivisionCost(false, b[1], lw);
+      return 20L * (lw - 1) * (lw - 1) + 29L * lw;
+
+    case SBVDIV:
+    case SBVREM:
+    case SBVMOD:
+      // The unsigned circuit plus the sign fixups on either side of it.
+      if (b[0].isConstant())
+        return constantDivisionCost(true, b[0], lw) + 12L * lw;
+      if (b[1].isConstant())
+        return constantDivisionCost(false, b[1], lw) + 12L * lw;
+      return 20L * (lw - 1) * (lw - 1) + 50L * lw;
+
+    case BVLEFTSHIFT:
+    case BVRIGHTSHIFT:
+    case BVSRSHIFT:
+    {
+      // A barrel shifter: log2(w) stages of w muxes, plus the sign fill for
+      // an arithmetic shift. A constant distance is wiring; shifting a
+      // constant leaves each stage with one known input.
+      if (b[1].isConstant())
+        return 0;
+      if (b[0].isConstant())
+        return (11L * lw) / 2;
+      const long stages = log2ceil(w);
+      return ((k == BVSRSHIFT) ? 7L : 6L) * lw * stages / 2;
+    }
+
+    case ITE:
+    {
+      if (w == 0)
+        return 3; // a Boolean ITE is one mux.
+      const unsigned constantArms =
+          (b[1].isConstant() ? 1u : 0u) + (b[2].isConstant() ? 1u : 0u);
+      if (constantArms == 2)
+        return 0;
+      return constantArms == 1 ? lw + 3 : 3L * lw;
+    }
+
+    case EQ:
+    {
+      const unsigned ow = std::max(1u, b[0].GetValueWidth());
+      return anyConstantChild(b) ? std::max(1L, (long)ow - 1) : 4L * ow - 1;
+    }
+
+    case BVLT:
+    case BVLE:
+    case BVGT:
+    case BVGE:
+    case BVSLT:
+    case BVSLE:
+    case BVSGT:
+    case BVSGE:
+    {
+      const unsigned ow = std::max(1u, b[0].GetValueWidth());
+      return anyConstantChild(b) ? (long)ow : 6L * ow - 1;
+    }
+
+    case BVUADDO:
+    case BVUSUBO:
+    {
+      // The adder, kept only for its carry out.
+      const unsigned ow = std::max(1u, b[0].GetValueWidth());
+      return 11L * ow - 7;
+    }
+
+    case BVSADDO:
+    case BVSSUBO:
+    {
+      // As above, plus the sign comparison the signed predicate needs.
+      const unsigned ow = std::max(1u, b[0].GetValueWidth());
+      return 11L * ow + 3;
+    }
+
+    case BVUMULO:
+    {
+      const unsigned ow = std::max(1u, b[0].GetValueWidth());
+      return 12L * (ow - 1) * (ow - 1) + 7L * ow;
+    }
+
+    case BVSMULO:
+    {
+      const unsigned ow = std::max(1u, b[0].GetValueWidth());
+      return 23L * (ow - 1) * (ow - 1) + 21L * ow;
+    }
+
+    // Boolean connectives, one AIG node per binary combination.
+    case AND:
+    case OR:
+    case NAND:
+    case NOR:
+      return degree - 1;
+
+    case XOR:
+    case IFF:
+      return 3L * (degree - 1);
+
+    case IMPLIES:
+      return 1;
+
+    default:
+      // READ and WRITE reach here, as does anything new. Arrays are removed
+      // before the bit-blaster runs, so this only has to be a placeholder
+      // that grows with the operand.
+      return std::max<long>(w, 1) * degree;
   }
-  else if (k == BVMULT)
-  {
-    score = (4L * b.GetValueWidth() * b.GetValueWidth() * b.Degree());
-  }
-  else if (isLikeDivision(k))
-    score = (16L * b.GetValueWidth() * b.GetValueWidth());
-  else if (k == BVCONCAT || k == BVEXTRACT || k == NOT || k == BVNOT)
-  {
-  } // no harder.
-  else if (k == EQ || k == BVGE || k == BVGT || k == BVSGE || k == BVSGT)
-  {
-    score = 6L * std::max(b[0].GetValueWidth(), 1u);
-  }
-  else if (k == BVSUB)
-  {
-    // We convert subtract to a + (-b), we want the difficulty scores to be
-    // same.
-    score = 20L * b.GetValueWidth();
-  }
-  else if (k == EQ)
-  {
-    score = 5L * b[0].GetValueWidth();
-  }
-  else if (k == BVUMINUS)
-  {
-    score = 6L * b.GetValueWidth();
-  }  
-  else if (k == BVPLUS)
-  {
-    score = 14L * b.GetValueWidth() * (b.Degree()-1);
-  }
-  else if (k == BVRIGHTSHIFT || k == BVLEFTSHIFT)
-  {
-    score = 29L * b.GetValueWidth();
-  }
-  else if (k == BVSRSHIFT)
-  {
-    score = 30L * b.GetValueWidth();
-  }  
-  else if (k == BVZX || k == BVSX)
-  {
-    score = 0;
-  }
-  else 
-  {
-    //std::cerr << k;
-    score = std::max<long>(b.GetValueWidth(), 1) * b.Degree();
-  }
-  return score;
 }
 
 long DifficultyScore::score(const ASTNode& top, STPMgr* mgr)

--- a/lib/Simplifier/Rewriting.cpp
+++ b/lib/Simplifier/Rewriting.cpp
@@ -259,7 +259,7 @@ namespace stp
          exception to never increasing the node count: they add one node (two
          comparisons and a connective replace one comparison), but eliminate
          a plus from under the comparison, which is a large win on the
-         difficulty score (a comparison costs 6*width, a plus 14*width). The
+         difficulty score (a comparison costs 6*width, a plus 11*width). The
          single-use guard on the plus is what secures that win: if the plus
          survived for another use, the extra comparison would be a pure loss.
       */

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -78,6 +78,12 @@ if (ENABLE_FLOATING_POINT)
     AddSTPGTest(BVSolver_Test.cpp)
 endif()
 AddSTPGTest(StrengthReduction_Test.cpp)
+# Bit-blasts each operation to check the difficulty score against what the
+# AIG really costs, so it instantiates BBNodeManagerAIG and needs its own
+# copy of ABC for the same reason FloatBlast_Test does.
+AddSTPGTest(DifficultyScore_Test.cpp)
+target_link_libraries(DifficultyScore_TestTests $<TARGET_FILE:libabc-pic>)
+add_dependencies(DifficultyScore_TestTests libabc-pic)
 AddSTPGTest(StrengthReduction_Exhaustive_Test.cpp)
 AddSTPGTest(RemoveUnconstrained_Exhaustive_Test.cpp)
 AddSTPGTest(AchievableImage_Exhaustive_Test.cpp)

--- a/tests/unit-tests/DifficultyScore_Test.cpp
+++ b/tests/unit-tests/DifficultyScore_Test.cpp
@@ -63,7 +63,7 @@ public:
     return nm.totalNumberOfNodes();
   }
 
-  long score(const ASTNode& n)
+  int64_t score(const ASTNode& n)
   {
     DifficultyScore d;
     return d.score(n, &mgr);
@@ -86,10 +86,10 @@ public:
 void expectClose(DifficultyFixture& f, const ASTNode& n, const char* what)
 {
   const int aig = f.aigNodes(n);
-  const long predicted = f.score(n);
-  EXPECT_LE(predicted, 2 * (long)aig + 8)
+  const int64_t predicted = f.score(n);
+  EXPECT_LE(predicted, 2 * static_cast<int64_t>(aig) + 8)
       << what << ": predicted " << predicted << ", built " << aig;
-  EXPECT_GE(2 * predicted + 8, (long)aig)
+  EXPECT_GE(2 * predicted + 8, static_cast<int64_t>(aig))
       << what << ": predicted " << predicted << ", built " << aig;
 }
 
@@ -184,14 +184,14 @@ TEST(DifficultyScore, n_ary_scales_with_one_fewer_than_the_degree)
 
   for (const Kind k : {BVPLUS, BVAND, BVXOR})
   {
-    const long binary =
+    const int64_t binary =
         f.score(f.mgr.CreateTerm(k, w, f.fresh(w), f.fresh(w)));
     for (unsigned degree = 3; degree <= 8; degree++)
     {
       ASTVec kids;
       for (unsigned i = 0; i < degree; i++)
         kids.push_back(f.fresh(w));
-      EXPECT_EQ(binary * (long)(degree - 1),
+      EXPECT_EQ(binary * static_cast<int64_t>(degree - 1),
                 f.score(f.mgr.CreateTerm(k, w, kids)))
           << _kind_names[k] << " at degree " << degree;
     }
@@ -226,7 +226,7 @@ TEST(DifficultyScore, sharing_is_counted_once)
   const ASTNode twice =
       f.mgr.CreateNode(AND, once, f.mgr.CreateNode(EQ, product, f.fresh(w)));
 
-  const long multiply = f.score(product);
+  const int64_t multiply = f.score(product);
   ASSERT_GT(multiply, 0);
   // The second use adds an equality and a conjunction, not another multiply.
   EXPECT_LT(f.score(twice) - f.score(once), multiply / 2);

--- a/tests/unit-tests/DifficultyScore_Test.cpp
+++ b/tests/unit-tests/DifficultyScore_Test.cpp
@@ -1,0 +1,235 @@
+/********************************************************************
+ * The difficulty score against the AIG it is estimating.
+ *
+ * DifficultyScore predicts how many AIG AND-nodes the bit-blaster will build,
+ * and STP reverts a simplification when that prediction says the formula got
+ * harder. The prediction's coefficients were fitted to measurements; these
+ * tests bit-blast the same operations and check the fit still holds, so that
+ * a change to the bit-blaster which invalidates it fails here rather than
+ * silently degrading the revert decision.
+ *
+ * tools/difficulty_bench does the same measurement across every operation and
+ * width; this covers the load-bearing cases and the structural properties
+ * (constant operands are cheaper, n-ary scales with degree-1) that the
+ * coefficients alone do not capture.
+ ********************************************************************/
+
+#include "stp/AST/AST.h"
+#include "stp/STPManager/STPManager.h"
+#include "stp/Simplifier/DifficultyScore.h"
+#include "stp/Simplifier/Simplifier.h"
+#include "stp/ToSat/BBNodeManagerAIG.h"
+#include "stp/ToSat/BitBlaster.h"
+
+#include <gtest/gtest.h>
+
+using namespace stp;
+
+namespace
+{
+
+class DifficultyFixture
+{
+public:
+  STPMgr mgr;
+  SubstitutionMap substitutions;
+  Simplifier simp;
+  unsigned counter = 0;
+
+  DifficultyFixture() : substitutions(&mgr), simp(&mgr, &substitutions) {}
+
+  ASTNode fresh(unsigned width)
+  {
+    return mgr.CreateSymbol(("s" + std::to_string(counter++)).c_str(), 0,
+                            width);
+  }
+
+  ASTNode freshBool() { return fresh(0); }
+
+  // Bit-blasts n on its own and returns the AIG AND-node count. The children
+  // are fresh symbols, which cost nothing to blast, so this is the marginal
+  // cost of n itself.
+  int aigNodes(const ASTNode& n)
+  {
+    BBNodeManagerAIG nm;
+    BitBlaster bb(&nm, &simp, mgr.defaultNodeFactory, &mgr.UserFlags);
+    if (n.GetType() == BOOLEAN_TYPE)
+      bb.BBForm(n);
+    else
+    {
+      std::unordered_set<BBNodeAIG> support;
+      bb.BBTerm(n, support);
+    }
+    return nm.totalNumberOfNodes();
+  }
+
+  long score(const ASTNode& n)
+  {
+    DifficultyScore d;
+    return d.score(n, &mgr);
+  }
+
+  // A constant whose set bits are exactly `bits`.
+  ASTNode constant(unsigned width, const std::vector<unsigned>& bits)
+  {
+    CBV cbv = CONSTANTBV::BitVector_Create(width, true);
+    for (unsigned b : bits)
+      if (b < width)
+        CONSTANTBV::BitVector_Bit_On(cbv, b);
+    return mgr.CreateBVConst(cbv, width);
+  }
+};
+
+// The estimate deliberately assumes no sharing, so it is an upper bound and a
+// little high is right; a factor of two either way is the tolerance the
+// revert decision needs.
+void expectClose(DifficultyFixture& f, const ASTNode& n, const char* what)
+{
+  const int aig = f.aigNodes(n);
+  const long predicted = f.score(n);
+  EXPECT_LE(predicted, 2 * (long)aig + 8)
+      << what << ": predicted " << predicted << ", built " << aig;
+  EXPECT_GE(2 * predicted + 8, (long)aig)
+      << what << ": predicted " << predicted << ", built " << aig;
+}
+
+TEST(DifficultyScore, bitvector_operations_are_within_a_factor_of_two)
+{
+  DifficultyFixture f;
+
+  for (unsigned w : {8u, 16u, 32u, 64u})
+  {
+    for (const Kind k : {BVAND, BVOR, BVXOR, BVNAND, BVNOR, BVXNOR, BVPLUS,
+                         BVMULT})
+      expectClose(f, f.mgr.CreateTerm(k, w, f.fresh(w), f.fresh(w)), "n-ary");
+
+    for (const Kind k : {BVSUB, BVDIV, BVMOD, SBVDIV, SBVREM, SBVMOD,
+                         BVLEFTSHIFT, BVRIGHTSHIFT, BVSRSHIFT})
+      expectClose(f, f.mgr.CreateTerm(k, w, f.fresh(w), f.fresh(w)), "binary");
+
+    for (const Kind k : {EQ, BVLT, BVLE, BVGT, BVGE, BVSLT, BVSLE, BVSGT,
+                         BVSGE, BVUADDO, BVSADDO, BVUMULO, BVSMULO, BVUSUBO,
+                         BVSSUBO})
+      expectClose(f, f.mgr.CreateNode(k, f.fresh(w), f.fresh(w)), "predicate");
+
+    expectClose(f, f.mgr.CreateTerm(BVUMINUS, w, f.fresh(w)), "bvneg");
+    expectClose(f, f.mgr.CreateTerm(ITE, w, f.freshBool(), f.fresh(w),
+                                    f.fresh(w)),
+                "ite");
+  }
+}
+
+TEST(DifficultyScore, operations_with_a_constant_operand_are_within_a_factor_of_two)
+{
+  DifficultyFixture f;
+
+  for (unsigned w : {8u, 16u, 32u, 64u})
+  {
+    const ASTNode small = f.constant(w, {0, 2, 5});
+    const ASTNode large = f.constant(w, {w - 2, w - 8, 3});
+
+    expectClose(f, f.mgr.CreateTerm(BVAND, w, small, f.fresh(w)), "bvand-c");
+    expectClose(f, f.mgr.CreateTerm(BVXOR, w, small, f.fresh(w)), "bvxor-c");
+    expectClose(f, f.mgr.CreateTerm(BVPLUS, w, small, f.fresh(w)), "bvadd-c");
+    expectClose(f, f.mgr.CreateTerm(BVSUB, w, f.fresh(w), small), "bvsub-c");
+    expectClose(f, f.mgr.CreateTerm(BVMULT, w, small, f.fresh(w)), "bvmul-c");
+    expectClose(f, f.mgr.CreateTerm(BVMULT, w, large, f.fresh(w)), "bvmul-C");
+    expectClose(f, f.mgr.CreateTerm(BVDIV, w, f.fresh(w), small), "bvudiv-c");
+    expectClose(f, f.mgr.CreateTerm(BVDIV, w, small, f.fresh(w)), "c-bvudiv");
+    expectClose(f, f.mgr.CreateTerm(BVDIV, w, large, f.fresh(w)), "C-bvudiv");
+    expectClose(f, f.mgr.CreateTerm(BVLEFTSHIFT, w, f.fresh(w), small),
+                "bvshl-c");
+    expectClose(f, f.mgr.CreateNode(EQ, f.fresh(w), small), "=-c");
+    expectClose(f, f.mgr.CreateNode(BVGT, f.fresh(w), small), "bvugt-c");
+    expectClose(f, f.mgr.CreateTerm(ITE, w, f.freshBool(), small, f.fresh(w)),
+                "ite-c");
+  }
+}
+
+// Selecting and permuting bits builds no AIG node at all, and the score has
+// to agree exactly: these are what a simplification that rewrites an
+// operation into extracts and concats trades against.
+TEST(DifficultyScore, wiring_is_free)
+{
+  DifficultyFixture f;
+  const unsigned w = 32;
+
+  const ASTNode x = f.fresh(w);
+  const ASTNode cases[] = {
+      f.mgr.CreateTerm(BVNOT, w, x),
+      f.mgr.CreateTerm(BVCONCAT, 2 * w, x, f.fresh(w)),
+      f.mgr.CreateTerm(BVEXTRACT, w / 2, x, f.mgr.CreateBVConst(32, w / 2 - 1),
+                       f.mgr.CreateBVConst(32, 0)),
+      f.mgr.CreateTerm(BVSX, 2 * w, x, f.mgr.CreateBVConst(32, 2 * w)),
+      f.mgr.CreateTerm(BVZX, 2 * w, x, f.mgr.CreateBVConst(32, 2 * w)),
+      f.mgr.CreateNode(NOT, f.freshBool()),
+      f.mgr.CreateTerm(BVLEFTSHIFT, w, x, f.mgr.CreateBVConst(w, 3)),
+      f.mgr.CreateTerm(BVAND, w, x, f.constant(w, {0, 1, 2})),
+  };
+
+  for (const ASTNode& n : cases)
+  {
+    EXPECT_EQ(0, f.aigNodes(n)) << n;
+    EXPECT_EQ(0, f.score(n)) << n;
+  }
+}
+
+// An n-ary operation is blasted as degree-1 binary ones, and the score has to
+// scale the same way -- costing it `degree` times over is what made the old
+// scorer prefer splitting an add into a chain.
+TEST(DifficultyScore, n_ary_scales_with_one_fewer_than_the_degree)
+{
+  DifficultyFixture f;
+  const unsigned w = 32;
+
+  for (const Kind k : {BVPLUS, BVAND, BVXOR})
+  {
+    const long binary =
+        f.score(f.mgr.CreateTerm(k, w, f.fresh(w), f.fresh(w)));
+    for (unsigned degree = 3; degree <= 8; degree++)
+    {
+      ASTVec kids;
+      for (unsigned i = 0; i < degree; i++)
+        kids.push_back(f.fresh(w));
+      EXPECT_EQ(binary * (long)(degree - 1),
+                f.score(f.mgr.CreateTerm(k, w, kids)))
+          << _kind_names[k] << " at degree " << degree;
+    }
+  }
+}
+
+// Everything an operation is applied to being constant means the bit-blaster
+// evaluates it rather than building it.
+TEST(DifficultyScore, constant_folding_costs_nothing)
+{
+  DifficultyFixture f;
+  const unsigned w = 32;
+  const ASTNode a = f.constant(w, {0, 3, 9});
+  const ASTNode b = f.constant(w, {1, 4, 30});
+
+  for (const Kind k : {BVPLUS, BVMULT, BVDIV, BVAND})
+    EXPECT_EQ(0, f.score(f.mgr.CreateTerm(k, w, a, b))) << _kind_names[k];
+  EXPECT_EQ(0, f.score(f.mgr.CreateNode(BVGT, a, b)));
+}
+
+// The score of a whole formula is the sum over its distinct nodes: a shared
+// subterm is charged once, not once per use. That is what makes the estimate
+// track the hash-consed AIG at all.
+TEST(DifficultyScore, sharing_is_counted_once)
+{
+  DifficultyFixture f;
+  const unsigned w = 32;
+
+  const ASTNode product =
+      f.mgr.CreateTerm(BVMULT, w, f.fresh(w), f.fresh(w));
+  const ASTNode once = f.mgr.CreateNode(EQ, product, f.fresh(w));
+  const ASTNode twice =
+      f.mgr.CreateNode(AND, once, f.mgr.CreateNode(EQ, product, f.fresh(w)));
+
+  const long multiply = f.score(product);
+  ASSERT_GT(multiply, 0);
+  // The second use adds an equality and a conjunction, not another multiply.
+  EXPECT_LT(f.score(twice) - f.score(once), multiply / 2);
+}
+
+} // namespace

--- a/tools/difficulty_bench/CMakeLists.txt
+++ b/tools/difficulty_bench/CMakeLists.txt
@@ -1,4 +1,4 @@
-# AUTHORS: Dan Liew, Ryan Govostes, Mate Soos
+# AUTHORS: Trevor Hansen
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -18,23 +18,19 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-add_subdirectory(stp)
-add_subdirectory(extdiff)
+add_executable(difficulty_bench
+    main.cpp
+)
 
-option(BUILD_EXTRA_TOOLS "Build extra tools" OFF)
-if (BUILD_EXTRA_TOOLS)
-  add_subdirectory(rewrite_rule_gen)
-  add_subdirectory(propagator_bench)
-  add_subdirectory(difficulty_bench)
-endif()
-
-# The floating-point self-test tools: ordinary executables that exit
-# non-zero on failure. Built when testing needs them or when the extra
-# tools are asked for -- not in a default build. They are registered with
-# CTest from tests/CMakeLists.txt, which is processed after
-# enable_testing() and after the checks that can turn ENABLE_TESTING off.
-if (ENABLE_FLOATING_POINT AND (ENABLE_TESTING OR BUILD_EXTRA_TOOLS))
-    add_subdirectory(test_fpbackend)
-    add_subdirectory(test_fprewrites)
-endif()
-
+# difficulty_bench builds the AIG itself rather than reaching it through
+# libstp: BBNodeManagerAIG's inline constructor and destructor call
+# Aig_ManStart and Aig_ManStop. libstp localises the ABC symbols it links
+# (--exclude-libs, see lib/CMakeLists.txt), so a direct user of ABC has to
+# link it directly.
+target_link_libraries(difficulty_bench
+    stp
+    $<TARGET_FILE:libabc-pic>
+)
+# $<TARGET_FILE:...> names a file rather than a target, so the build order has
+# to be spelled out, exactly as lib/CMakeLists.txt does for libstp.
+add_dependencies(difficulty_bench libabc-pic)

--- a/tools/difficulty_bench/README.md
+++ b/tools/difficulty_bench/README.md
@@ -1,0 +1,76 @@
+# difficulty_bench
+
+Is `DifficultyScore` a good estimate of the bit-blasted AIG size?
+
+`DifficultyScore` predicts how many AIG AND-nodes the bit-blaster would build
+for a formula, without building them. STP uses that prediction to decide
+whether the size-increasing simplifications made the problem harder, and
+reverts them if so. Every constant in `lib/Simplifier/DifficultyScore.cpp` was
+fitted to the numbers this tool prints; re-run it after changing the
+bit-blaster, and the estimate can be re-fitted rather than guessed at.
+
+## What it measures
+
+One operation at a time, built over *fresh symbols*, bit-blasted on its own
+with `BBNodeManagerAIG`, and reported as `aigMgr->nObjs[AIG_OBJ_AND]`. Symbols
+cost nothing to blast, so with fresh children the count is the marginal cost of
+that one node — exactly what a per-node scorer has to charge for it.
+
+Three things the numbers make visible that a reading of the bit-blaster does
+not:
+
+* **Operations are not symmetric in their operands.** `bvudiv c x` is linear in
+  the width where `bvudiv x c` is quadratic; `bvand x c` is free.
+* **The default multiplier is not Booth-recoded.** `multiplication_variant`
+  defaults to 1, which is a plain shift-and-add array, so a multiply by a
+  constant costs one add per *set bit*, not per run of set bits.
+* **Floating point is dominated by a few operations.** `fp.sqrt` is cubic in
+  the significand and `fp.rem` is exponential in the exponent width, so one of
+  either can outweigh the rest of a benchmark.
+
+Floating-point operations are lowered (`FpTotalise` then `FloatBlast`) before
+being blasted, which is what the solver does. Each one runs in a forked child,
+because an operation with no circuit at the format asked for — `fp.rem` at
+binary128, `fp.roundToIntegral` at the smallest formats — calls `FatalError`.
+Those rows report `n/a`.
+
+The floating-point arithmetic is reported as the *marginal* cost of one more
+operation in a chain: the tool prints a depth-2 chain and the depth-1 chain
+under it, and the difference is what one operation costs. Measuring a lone
+operation instead would fold in packing its result, which belongs to
+`fp.to_ieee_bv`.
+
+## Building and running
+
+It is one of the extra tools:
+
+```sh
+cmake -DBUILD_EXTRA_TOOLS=ON -DCMAKE_BUILD_TYPE=Release ..
+make difficulty_bench
+```
+
+```sh
+./difficulty_bench                          # everything, at 8..128 bits
+./difficulty_bench --widths 32 --no-fp      # just the bit-vector operations
+./difficulty_bench --arity 4                # n-ary operands
+./difficulty_bench --csv > measured.csv     # for re-fitting
+```
+
+Sample output:
+
+```
+operation                 width          aig        score    ratio
+bvadd                        32          345          345    1.00x
+bvmul                        32         5767         5767    1.00x
+bvudiv                       32        20136        21532    1.07x
+bvmul-const                  32         2105         2156    1.02x
+const-bvudiv                 32         2696         2720    1.01x
+bvult                        32          191          191    1.00x
+fp.mul                       32         8843         9632    1.09x
+  (depth 1) fp.mul           32         4636         4816    1.04x
+```
+
+The trailing summary line gives the geomean of score/aig, the spread of that
+ratio, and the fraction of operations predicted within a factor of two. The
+estimate is deliberately an upper bound — it assumes no sharing, and the real
+AIG is hash-consed — so a geomean slightly above 1 is expected and correct.

--- a/tools/difficulty_bench/main.cpp
+++ b/tools/difficulty_bench/main.cpp
@@ -40,7 +40,9 @@ THE SOFTWARE.
 #endif
 
 #include <algorithm>
+#include <cstdint>
 #include <cmath>
+#include <cinttypes>
 #include <cstdio>
 #include <cstring>
 #include <string>
@@ -91,7 +93,7 @@ int aigNodes(const ASTNode& n)
   return nm.totalNumberOfNodes();
 }
 
-long scoreOf(const ASTNode& n)
+int64_t scoreOf(const ASTNode& n)
 {
   DifficultyScore d;
   return d.score(n, mgr);
@@ -105,19 +107,20 @@ struct Totals
   unsigned within2x = 0;
 } totals;
 
-void report(const string& label, unsigned width, int aig, long score)
+void report(const string& label, unsigned width, int aig, int64_t score)
 {
   if (aig < 0)
   {
     if (csv)
-      printf("%s,%u,,%ld\n", label.c_str(), width, score);
+      printf("%s,%u,,%" PRId64 "\n", label.c_str(), width, score);
     else
-      printf("%-24s %6u %12s %12ld %8s\n", label.c_str(), width, "n/a", score,
-             "-");
+      printf("%-24s %6u %12s %12" PRId64 " %8s\n", label.c_str(), width,
+             "n/a", score, "-");
     return;
   }
 
-  const double ratio = (double)std::max(1L, score) / std::max(1, aig);
+  const double ratio =
+      static_cast<double>(std::max<int64_t>(1, score)) / std::max(1, aig);
   totals.logSum += std::log(ratio);
   totals.logSqSum += std::log(ratio) * std::log(ratio);
   totals.count++;
@@ -125,10 +128,10 @@ void report(const string& label, unsigned width, int aig, long score)
     totals.within2x++;
 
   if (csv)
-    printf("%s,%u,%d,%ld\n", label.c_str(), width, aig, score);
+    printf("%s,%u,%d,%" PRId64 "\n", label.c_str(), width, aig, score);
   else
-    printf("%-24s %6u %12d %12ld %7.2fx\n", label.c_str(), width, aig, score,
-           ratio);
+    printf("%-24s %6u %12d %12" PRId64 " %7.2fx\n", label.c_str(), width, aig,
+           score, ratio);
 }
 
 // Bit-vector operations are measured in-process.
@@ -144,7 +147,7 @@ void measure(const string& label, unsigned width, const ASTNode& n)
 void measureFp(const string& label, unsigned width, const ASTNode& measured,
                const ASTNode& scored)
 {
-  const long score = scoreOf(scored);
+  const int64_t score = scoreOf(scored);
 
   int fds[2];
   if (pipe(fds) != 0)

--- a/tools/difficulty_bench/main.cpp
+++ b/tools/difficulty_bench/main.cpp
@@ -1,0 +1,471 @@
+/********************************************************************
+ * AUTHORS: Trevor Hansen
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+// Is the difficulty score a good estimate of the bit-blasted AIG size?
+// See README.md.
+
+#include "stp/AST/AST.h"
+#include "stp/AST/ASTKind.h"
+#include "stp/STPManager/STPManager.h"
+#include "stp/Simplifier/DifficultyScore.h"
+#include "stp/Simplifier/Simplifier.h"
+#include "stp/ToSat/BBNodeManagerAIG.h"
+#include "stp/ToSat/BitBlaster.h"
+
+#ifdef STP_ENABLE_FLOATING_POINT
+#include "stp/FloatBlaster/FloatBlast.h"
+#include "stp/FloatBlaster/FpTotalise.h"
+#include "stp/FloatBlaster/rounding_modes.h"
+#endif
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <vector>
+
+using namespace stp;
+using std::string;
+using std::vector;
+
+namespace
+{
+
+STPMgr* mgr = NULL;
+Simplifier* simp = NULL;
+unsigned counter = 0;
+bool csv = false;
+
+ASTNode fresh(unsigned width)
+{
+  char buf[32];
+  snprintf(buf, sizeof(buf), "s%u", counter++);
+  return mgr->CreateSymbol(buf, 0, width);
+}
+
+ASTNode freshBool()
+{
+  char buf[32];
+  snprintf(buf, sizeof(buf), "b%u", counter++);
+  return mgr->CreateSymbol(buf, 0, 0);
+}
+
+// The AIG AND-node count of bit-blasting `n` on its own. Children that are
+// symbols cost nothing, so with fresh children this is the marginal cost of
+// the top node.
+int aigNodes(const ASTNode& n)
+{
+  BBNodeManagerAIG nm;
+  BitBlaster bb(&nm, simp, mgr->defaultNodeFactory, &mgr->UserFlags);
+  if (n.GetType() == BOOLEAN_TYPE)
+    bb.BBForm(n);
+  else
+  {
+    std::unordered_set<BBNodeAIG> support;
+    bb.BBTerm(n, support);
+  }
+  return nm.totalNumberOfNodes();
+}
+
+long scoreOf(const ASTNode& n)
+{
+  DifficultyScore d;
+  return d.score(n, mgr);
+}
+
+struct Totals
+{
+  double logSum = 0;
+  double logSqSum = 0;
+  unsigned count = 0;
+  unsigned within2x = 0;
+} totals;
+
+void report(const string& label, unsigned width, int aig, long score)
+{
+  if (aig < 0)
+  {
+    if (csv)
+      printf("%s,%u,,%ld\n", label.c_str(), width, score);
+    else
+      printf("%-24s %6u %12s %12ld %8s\n", label.c_str(), width, "n/a", score,
+             "-");
+    return;
+  }
+
+  const double ratio = (double)std::max(1L, score) / std::max(1, aig);
+  totals.logSum += std::log(ratio);
+  totals.logSqSum += std::log(ratio) * std::log(ratio);
+  totals.count++;
+  if (ratio > 0.5 && ratio < 2.0)
+    totals.within2x++;
+
+  if (csv)
+    printf("%s,%u,%d,%ld\n", label.c_str(), width, aig, score);
+  else
+    printf("%-24s %6u %12d %12ld %7.2fx\n", label.c_str(), width, aig, score,
+           ratio);
+}
+
+// Bit-vector operations are measured in-process.
+void measure(const string& label, unsigned width, const ASTNode& n)
+{
+  report(label, width, aigNodes(n), scoreOf(n));
+}
+
+#ifdef STP_ENABLE_FLOATING_POINT
+// Floating point is lowered first, in a forked child: an operation that has no
+// circuit at the format asked for (fp.rem at binary128, fp.roundToIntegral at
+// the smallest formats) calls FatalError, which aborts the process.
+void measureFp(const string& label, unsigned width, const ASTNode& measured,
+               const ASTNode& scored)
+{
+  const long score = scoreOf(scored);
+
+  int fds[2];
+  if (pipe(fds) != 0)
+    return;
+  const pid_t pid = fork();
+  if (pid == 0)
+  {
+    close(fds[0]);
+    int aig = -1;
+    {
+      FpTotalise totalise(mgr);
+      FloatBlast blast(mgr);
+      aig = aigNodes(blast.topLevel(totalise.topLevel(measured)));
+    }
+    const ssize_t ignored = write(fds[1], &aig, sizeof(aig));
+    (void)ignored;
+    close(fds[1]);
+    _exit(0);
+  }
+  close(fds[1]);
+  int aig = -1;
+  if (read(fds[0], &aig, sizeof(aig)) != (ssize_t)sizeof(aig))
+    aig = -1;
+  close(fds[0]);
+  int status = 0;
+  waitpid(pid, &status, 0);
+  report(label, width, aig, score);
+}
+#endif
+
+void header()
+{
+  if (csv)
+    printf("operation,width,aig,score\n");
+  else
+    printf("%-24s %6s %12s %12s %8s\n", "operation", "width", "aig", "score",
+           "ratio");
+}
+
+ASTNode constantWithBits(unsigned w, unsigned stride)
+{
+  CBV cbv = CONSTANTBV::BitVector_Create(w, true);
+  for (unsigned i = 0; i < w; i += stride)
+    CONSTANTBV::BitVector_Bit_On(cbv, i);
+  return mgr->CreateBVConst(cbv, w);
+}
+
+void bitvectorSweep(const vector<unsigned>& widths, unsigned arity)
+{
+  struct NAry { const char* name; Kind kind; };
+  const vector<NAry> nary = {{"bvand", BVAND},   {"bvor", BVOR},
+                             {"bvxor", BVXOR},   {"bvnand", BVNAND},
+                             {"bvnor", BVNOR},   {"bvxnor", BVXNOR},
+                             {"bvadd", BVPLUS},  {"bvmul", BVMULT}};
+  const vector<NAry> binary = {
+      {"bvsub", BVSUB},         {"bvudiv", BVDIV},
+      {"bvurem", BVMOD},        {"bvsdiv", SBVDIV},
+      {"bvsrem", SBVREM},       {"bvsmod", SBVMOD},
+      {"bvshl", BVLEFTSHIFT},   {"bvlshr", BVRIGHTSHIFT},
+      {"bvashr", BVSRSHIFT}};
+  const vector<NAry> predicates = {
+      {"=", EQ},                {"bvult", BVLT},
+      {"bvule", BVLE},          {"bvugt", BVGT},
+      {"bvuge", BVGE},          {"bvslt", BVSLT},
+      {"bvsle", BVSLE},         {"bvsgt", BVSGT},
+      {"bvsge", BVSGE},         {"bvuaddo", BVUADDO},
+      {"bvsaddo", BVSADDO},     {"bvumulo", BVUMULO},
+      {"bvsmulo", BVSMULO},     {"bvusubo", BVUSUBO},
+      {"bvssubo", BVSSUBO}};
+
+  for (unsigned w : widths)
+  {
+    for (const NAry& op : nary)
+    {
+      ASTVec kids;
+      for (unsigned i = 0; i < arity; i++)
+        kids.push_back(fresh(w));
+      measure(op.name, w, mgr->CreateTerm(op.kind, w, kids));
+    }
+    for (const NAry& op : binary)
+      measure(op.name, w, mgr->CreateTerm(op.kind, w, fresh(w), fresh(w)));
+    for (const NAry& op : predicates)
+      measure(op.name, w, mgr->CreateNode(op.kind, fresh(w), fresh(w)));
+
+    measure("bvneg", w, mgr->CreateTerm(BVUMINUS, w, fresh(w)));
+    measure("bvnot", w, mgr->CreateTerm(BVNOT, w, fresh(w)));
+    measure("concat", 2 * w, mgr->CreateTerm(BVCONCAT, 2 * w, fresh(w),
+                                             fresh(w)));
+    measure("ite", w, mgr->CreateTerm(ITE, w, freshBool(), fresh(w),
+                                      fresh(w)));
+
+    // The same operations with one operand fixed. These are several times
+    // cheaper, which is the whole reason the scorer looks at its children.
+    const ASTNode c = constantWithBits(w, std::max(1u, w / 3));
+    measure("bvand-const", w, mgr->CreateTerm(BVAND, w, c, fresh(w)));
+    measure("bvadd-const", w, mgr->CreateTerm(BVPLUS, w, c, fresh(w)));
+    measure("bvsub-const", w, mgr->CreateTerm(BVSUB, w, fresh(w), c));
+    measure("bvmul-const", w, mgr->CreateTerm(BVMULT, w, c, fresh(w)));
+    measure("bvudiv-const", w, mgr->CreateTerm(BVDIV, w, fresh(w), c));
+    measure("const-bvudiv", w, mgr->CreateTerm(BVDIV, w, c, fresh(w)));
+    measure("bvshl-const", w, mgr->CreateTerm(BVLEFTSHIFT, w, fresh(w), c));
+    measure("=-const", w, mgr->CreateNode(EQ, fresh(w), c));
+    measure("bvugt-const", w, mgr->CreateNode(BVGT, fresh(w), c));
+    measure("ite-const", w, mgr->CreateTerm(ITE, w, freshBool(), c, fresh(w)));
+  }
+}
+
+#ifdef STP_ENABLE_FLOATING_POINT
+ASTNode freshFp(unsigned eb, unsigned sb)
+{
+  char buf[32];
+  snprintf(buf, sizeof(buf), "f%u", counter++);
+  return mgr->CreateSourceSymbol(buf, SourceSort::floatingPoint(eb, sb));
+}
+
+void floatingPointSweep(const vector<std::pair<unsigned, unsigned>>& formats)
+{
+  const ASTNode rne =
+      mgr->CreateRMConst(symbolic_fp::ROUND_NEAREST_TIES_TO_EVEN);
+
+  for (const auto& format : formats)
+  {
+    const unsigned eb = format.first, sb = format.second, w = eb + sb;
+
+    // The arithmetic is measured as the *marginal* cost of one more operation
+    // in a chain, which is what a per-node estimate has to charge: a chain of
+    // two, minus a chain of one. Both are consumed by a classification so that
+    // the result is never packed.
+    struct Arith { const char* name; Kind kind; };
+    for (const Arith& op : vector<Arith>{{"fp.add", FP_ADD},
+                                         {"fp.sub", FP_SUB},
+                                         {"fp.mul", FP_MUL},
+                                         {"fp.div", FP_DIV}})
+    {
+      const ASTNode one =
+          mgr->CreateTerm(op.kind, w, rne, freshFp(eb, sb), freshFp(eb, sb));
+      const ASTNode two = mgr->CreateTerm(op.kind, w, rne, one,
+                                          freshFp(eb, sb));
+      measureFp(op.name, w, mgr->CreateNode(FP_ISZERO, two),
+                mgr->CreateNode(FP_ISZERO, two));
+      measureFp(string("  (depth 1) ") + op.name, w,
+                mgr->CreateNode(FP_ISZERO, one),
+                mgr->CreateNode(FP_ISZERO, one));
+    }
+
+    // These are measured as one operation whose result is packed, so the
+    // score has to include the pack -- score and measure the same node.
+    const ASTNode fma =
+        mgr->CreateTerm(FP_TO_IEEE_BV, w,
+                        mgr->CreateTerm(FP_FMA, w,
+                                        ASTVec{rne, freshFp(eb, sb),
+                                               freshFp(eb, sb),
+                                               freshFp(eb, sb)}));
+    measureFp("fp.fma (+pack)", w, fma, fma);
+
+    struct Un { const char* name; Kind kind; bool rounded; };
+    for (const Un& op : vector<Un>{{"fp.sqrt", FP_SQRT, true},
+                                   {"fp.roundToIntegral", FP_ROUNDTOINTEGRAL,
+                                    true},
+                                   {"fp.abs", FP_ABS, false},
+                                   {"fp.neg", FP_NEG, false}})
+    {
+      const ASTNode t =
+          op.rounded ? mgr->CreateTerm(op.kind, w, rne, freshFp(eb, sb))
+                     : mgr->CreateTerm(op.kind, w, freshFp(eb, sb));
+      const ASTNode packed = mgr->CreateTerm(FP_TO_IEEE_BV, w, t);
+      measureFp(string(op.name) + " (+pack)", w, packed, packed);
+    }
+
+    for (const Un& op : vector<Un>{{"fp.rem", FP_REM, false},
+                                   {"fp.min", FP_MIN, false},
+                                   {"fp.max", FP_MAX, false}})
+    {
+      const ASTNode t =
+          mgr->CreateTerm(op.kind, w, freshFp(eb, sb), freshFp(eb, sb));
+      const ASTNode packed = mgr->CreateTerm(FP_TO_IEEE_BV, w, t);
+      measureFp(string(op.name) + " (+pack)", w, packed, packed);
+    }
+
+    measureFp("fp.to_ieee_bv", w,
+              mgr->CreateTerm(FP_TO_IEEE_BV, w, freshFp(eb, sb)),
+              mgr->CreateTerm(FP_TO_IEEE_BV, w, freshFp(eb, sb)));
+
+    for (const Un& op : vector<Un>{{"fp.leq", FP_LEQ, false},
+                                   {"fp.lt", FP_LT, false},
+                                   {"fp.geq", FP_GEQ, false},
+                                   {"fp.gt", FP_GT, false},
+                                   {"fp.eq", FP_EQ, false},
+                                   {"= (float)", FP_SMT_EQ, false}})
+    {
+      const ASTNode p =
+          mgr->CreateNode(op.kind, freshFp(eb, sb), freshFp(eb, sb));
+      measureFp(op.name, w, p, p);
+    }
+
+    for (const Un& op : vector<Un>{{"fp.isNormal", FP_ISNORMAL, false},
+                                   {"fp.isSubnormal", FP_ISSUBNORMAL, false},
+                                   {"fp.isZero", FP_ISZERO, false},
+                                   {"fp.isInfinite", FP_ISINFINITE, false},
+                                   {"fp.isNaN", FP_ISNAN, false},
+                                   {"fp.isNegative", FP_ISNEGATIVE, false},
+                                   {"fp.isPositive", FP_ISPOSITIVE, false}})
+    {
+      const ASTNode p = mgr->CreateNode(op.kind, freshFp(eb, sb));
+      measureFp(op.name, w, p, p);
+    }
+
+    // Conversions, from and to binary32 and a 32-bit integer.
+    const ASTNode toFp = mgr->CreateTerm(
+        FP_TOFP, w,
+        ASTVec{mgr->CreateBVConst(32, eb), mgr->CreateBVConst(32, sb), rne,
+               freshFp(8, 24)});
+    measureFp("to_fp (float)", w, mgr->CreateNode(FP_ISZERO, toFp), toFp);
+
+    const ASTNode fromSigned = mgr->CreateTerm(
+        FP_TOFP_SIGNED, w,
+        ASTVec{mgr->CreateBVConst(32, eb), mgr->CreateBVConst(32, sb), rne,
+               fresh(32)});
+    measureFp("to_fp (signed bv32)", w, mgr->CreateNode(FP_ISZERO, fromSigned),
+              fromSigned);
+
+    const ASTNode fromUnsigned = mgr->CreateTerm(
+        FP_TOFP_UNSIGNED, w,
+        ASTVec{mgr->CreateBVConst(32, eb), mgr->CreateBVConst(32, sb), rne,
+               fresh(32)});
+    measureFp("to_fp_unsigned (bv32)", w,
+              mgr->CreateNode(FP_ISZERO, fromUnsigned), fromUnsigned);
+  }
+}
+#endif
+
+vector<unsigned> parseWidths(const char* s)
+{
+  vector<unsigned> out;
+  const char* p = s;
+  while (*p != '\0')
+  {
+    out.push_back((unsigned)strtoul(p, NULL, 10));
+    while (*p != '\0' && *p != ',')
+      p++;
+    if (*p == ',')
+      p++;
+  }
+  return out;
+}
+
+void usage()
+{
+  printf("usage: difficulty_bench [options]\n\n"
+         "Compares DifficultyScore's estimate with the number of AIG AND\n"
+         "nodes the bit-blaster really builds for one operation.\n\n"
+         "  --widths LIST   bit-vector widths (default 8,16,32,64,128)\n"
+         "  --arity N       operands for the n-ary operations (default 2)\n"
+         "  --no-bv         skip the bit-vector operations\n"
+         "  --no-fp         skip the floating-point operations\n"
+         "  --csv           machine-readable output\n"
+         "  --help\n");
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+  vector<unsigned> widths = {8, 16, 32, 64, 128};
+  unsigned arity = 2;
+  bool doBv = true, doFp = true;
+
+  for (int i = 1; i < argc; i++)
+  {
+    const string a = argv[i];
+    if (a == "--help")
+    {
+      usage();
+      return 0;
+    }
+    else if (a == "--csv")
+      csv = true;
+    else if (a == "--no-bv")
+      doBv = false;
+    else if (a == "--no-fp")
+      doFp = false;
+    else if (a == "--widths" && i + 1 < argc)
+      widths = parseWidths(argv[++i]);
+    else if (a == "--arity" && i + 1 < argc)
+      arity = (unsigned)strtoul(argv[++i], NULL, 10);
+    else
+    {
+      printf("unrecognised argument: %s\n", a.c_str());
+      usage();
+      return 1;
+    }
+  }
+
+  STPMgr localMgr;
+  mgr = &localMgr;
+  SubstitutionMap substitutions(mgr);
+  Simplifier localSimp(mgr, &substitutions);
+  simp = &localSimp;
+
+  header();
+
+  if (doBv)
+    bitvectorSweep(widths, arity);
+
+#ifdef STP_ENABLE_FLOATING_POINT
+  if (doFp)
+    floatingPointSweep({{5, 11}, {8, 24}, {11, 53}, {15, 113}});
+#else
+  (void)doFp;
+#endif
+
+  if (!csv && totals.count > 0)
+  {
+    const double mean = totals.logSum / totals.count;
+    const double variance =
+        std::max(0.0, totals.logSqSum / totals.count - mean * mean);
+    printf("\n%u measurements: geomean score/aig %.3f, typical error x%.2f, "
+           "%.1f%% within 2x\n",
+           totals.count, std::exp(mean), std::exp(std::sqrt(variance)),
+           100.0 * totals.within2x / totals.count);
+  }
+
+  return 0;
+}


### PR DESCRIPTION
`DifficultyScore` predicts how many AIG AND-nodes bit-blasting a formula would build, without building them. STP uses that prediction for one decision: whether the size-increasing simplifications left the problem harder than they found it, and should be reverted. There is a comment in `STP.cpp` saying the score "is sometimes completely wrong ... The other way to improve it would be to fix the difficulty scorer!" — this is that.

## Measuring it

Each operation is built over fresh symbols, bit-blasted on its own with `BBNodeManagerAIG`, and the AND-node count read off. Symbols cost nothing to blast, so with fresh children that count *is* the marginal cost of the one node, which is exactly what a per-node estimate has to charge for it. Floating-point operations go through `FpTotalise` + `FloatBlast` first, as the solver does.

The harness is checked in as `tools/difficulty_bench`, so the calibration can be re-derived after a change to the bit-blaster rather than trusted.

## What was wrong

- **Eight predicates were not in the table at all.** `BVLT`, `BVLE`, `BVSLT`, `BVSLE` and the six overflow predicates fell through to the default `width * degree`. A 32-bit `bvult` scored 64 against a true cost of 191; a 32-bit `bvumulo` scored 64 against 11743.
- **Constant operands were charged the symbolic price.** At 32 bits, `x & c`, `x ^ c` and `x << c` cost *nothing* and scored 64, 64 and 928; `x = c` costs 31 and scored 192; `x + c` costs 122 and scored 448. Roughly a third of the nodes in a typical QF_BV benchmark have a constant operand, so this is not a corner case — it made every simplification that folds a constant into an operation look neutral.
- **The multiply-by-a-constant rule modelled a code path that is not the default.** It counted Booth *runs*, but `multiplication_variant` defaults to a plain shift-and-add array that never calls `mult_Booth`. `bvmul x 0xFFFFFFFF` has no bit transitions and therefore scored **0**, against a real cost of 5237 nodes.
- **Shifts were linear (`29w`)**; a barrel shifter is `w log w`.
- **n-ary operations were charged `Degree()` times** where the bit-blaster builds `Degree()-1` binary ones.
- **Division was one quadratic for all of `x/y`, `x/c` and `c/x`**, which really span 32x: dividing a constant by something is linear in the constant's magnitude, dividing by a constant tapers with where the divisor's bits sit.
- **Floating point was absent.** The predicates that survive lowering reach the scorer as Boolean-valued nodes, whose `GetValueWidth()` is zero, so `fp.leq` on two binary32 values scored **2** against a true cost of 465.

## What is here

Every coefficient is fitted to a measurement rather than guessed, and several come out exact — a symbolic multiply is `6(w-1)^2+1` AND-nodes, reproduced to the node out to `w=256`. The estimate stays deliberately sharing-free: it is an upper bound, since the AIG is hash-consed, and every use of the score is a ratio against another score.

Floating point is covered end to end: the arithmetic (`fp.add` linear in the format, `fp.mul`/`fp.div` quadratic in the significand, `fp.sqrt` **cubic**, `fp.rem` exponential in the exponent width), the natively-encoded predicates and classifications, and the conversion family.

## Results

Score against the AIG built from the identical formula:

| | old | new |
|---|---|---|
| QF_BV, 734 files: typical error | x1.96 | **x1.55** |
| within 2x | 77% | **94%** |
| Spearman rho | 0.973 | **0.987** |
| QF_FP, 197 files: typical error | x6.84 | **x1.59** |
| within 2x | 27% | **91%** |
| Spearman rho | 0.961 | **0.990** |

Per operation, over 1574 measured points: typical multiplicative error x13.0 -> **x1.35**, 41% -> **95%** within a factor of two.

## Behaviour and cost

The score gates one decision, so the change is small and safe: of 923 benchmarks that reach the SAT solver, **911 produce a byte-identical CNF** and 12 take a different revert decision — eight of those smaller, three larger, 7% fewer clauses in total, and the only solve time to move outside the noise improves (2.91s -> 2.53s). The twelve are exactly the families whose scores were furthest off.

Computing the score now inspects its children, which costs **+0.07% median, +0.17% worst** in retired instructions to the end of CNF generation over twelve pre-CNF benchmarks (measured with `perf`, since wall clock on the test box has a ±4% noise floor and cannot resolve that).

`--bit-blast-simplification N` compares against an absolute score, so its threshold is on a new scale; its default (0, off) is unaffected.

`DifficultyScore_Test` bit-blasts each operation and asserts the estimate is within a factor of two — it fails on eleven cases against the old coefficients.
