### PR TITLE
Replace platform-dependent long with fixed-width integer types

### DIFF
--- a/bindings/python/stp/stp.py.in
+++ b/bindings/python/stp/stp.py.in
@@ -27,7 +27,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import ast
 from ctypes import cdll, POINTER, CFUNCTYPE, byref
-from ctypes import c_char, c_char_p, c_void_p, c_int32, c_uint32, c_uint64, c_ulong, c_bool
+from ctypes import c_char, c_char_p, c_void_p, c_int32, c_uint32, c_uint64, c_size_t, c_bool
 from ctypes import c_double, c_float
 import inspect
 import os.path
@@ -116,13 +116,13 @@ _set_func('vc_parseExpr', _Expr, _VC, c_char_p)
 _set_func('vc_printExpr', None, _VC, _Expr)
 _set_func('vc_printSMTLIB', c_char_p, _VC, _Expr)
 _set_func('vc_printExprFile', None, _VC, _Expr, c_int32)
-_set_func('vc_printExprToBuffer', None, _VC, _Expr, POINTER(c_char_p), POINTER(c_ulong))
+_set_func('vc_printExprToBuffer', None, _VC, _Expr, POINTER(c_char_p), POINTER(c_size_t))
 _set_func('vc_printCounterExample', None, _VC)
 _set_func('vc_printVarDecls', None, _VC)
 _set_func('vc_clearDecls', None, _VC)
 _set_func('vc_printAsserts', None, _VC, c_int32)
-_set_func('vc_printQueryStateToBuffer', None, _VC, _Expr, POINTER(c_char_p), POINTER(c_ulong), c_int32)
-_set_func('vc_printCounterExampleToBuffer', None, _VC, POINTER(c_char_p), POINTER(c_ulong))
+_set_func('vc_printQueryStateToBuffer', None, _VC, _Expr, POINTER(c_char_p), POINTER(c_size_t), c_int32)
+_set_func('vc_printCounterExampleToBuffer', None, _VC, POINTER(c_char_p), POINTER(c_size_t))
 _set_func('vc_printQuery', None, _VC)
 _set_func('vc_assertFormula', None, _VC, _Expr)
 _set_func('vc_simplify', _Expr, _VC, _Expr)

--- a/include/stp/AST/AST.h
+++ b/include/stp/AST/AST.h
@@ -151,8 +151,6 @@ int TermOrder(const ASTNode& a, const ASTNode& b);
 // NB: The boolean value is always true!
 bool BVTypeCheck(const ASTNode& n);
 
-long getCurrentTime();
-
 ASTVec FlattenKind(Kind k, const ASTChildren& children, int maxDepth = INT_MAX);
 
 // Checks recursively all the way down.

--- a/include/stp/NodeFactory/NodeFactory.h
+++ b/include/stp/NodeFactory/NodeFactory.h
@@ -27,6 +27,7 @@ THE SOFTWARE.
 
 #include "stp/AST/ASTKind.h"
 #include "stp/Util/Attributes.h"
+#include <cstdint>
 #include <vector>
 
 using std::vector;
@@ -107,7 +108,7 @@ public:
   ASTNode CreateMaxConst(unsigned width);
   ASTNode CreateSignedMinConst(unsigned width);
   
-  ASTNode CreateBVConst(unsigned int width, unsigned long long int bvconst);
+  ASTNode CreateBVConst(unsigned int width, uint64_t bvconst);
   ASTNode CreateFPConst(const stp::ASTNode& bvconst, unsigned exp_width,
                         unsigned sig_width);
 

--- a/include/stp/STPManager/STPManager.h
+++ b/include/stp/STPManager/STPManager.h
@@ -38,6 +38,7 @@ THE SOFTWARE.
 #include "stp/Sat/SATSolver.h"
 #include "stp/Util/Attributes.h"
 #include "extlib-unordered-dense/ankerl/unordered_dense.h"
+#include <cstdint>
 
 namespace stp
 {
@@ -335,7 +336,7 @@ public:
   DLL_PUBLIC ASTNode CreateBVConst(CBV bv, unsigned width);
   ASTNode CreateBVConst(const char* strval, int base);
   ASTNode CreateBVConst(std::string strval, int base, int bit_width);
-  ASTNode CreateBVConst(unsigned int width, unsigned long long int bvconst);
+  ASTNode CreateBVConst(unsigned int width, uint64_t bvconst);
   ASTNode charToASTNode(unsigned char* strval, int base, int bit_width);
 
   DLL_PUBLIC ASTNode CreateFPConst(const stp::ASTNode& bvconst,

--- a/include/stp/Sat/Cadical.h
+++ b/include/stp/Sat/Cadical.h
@@ -97,7 +97,7 @@ public:
 
   void setVerbosity(int v) override;
 
-  unsigned long nVars() const override;
+  uint32_t nVars() const override;
 
   void printStats() const override;
 

--- a/include/stp/Sat/CryptoMinisat5.h
+++ b/include/stp/Sat/CryptoMinisat5.h
@@ -66,7 +66,7 @@ public:
 
   void setVerbosity(int v) override;
 
-  unsigned long nVars() const override;
+  uint32_t nVars() const override;
 
   void printStats() const override;
 

--- a/include/stp/Sat/MinisatCore.h
+++ b/include/stp/Sat/MinisatCore.h
@@ -71,7 +71,7 @@ public:
 
   void setVerbosity(int v) override;
 
-  unsigned long nVars() const override;
+  uint32_t nVars() const override;
 
   void printStats() const override;
 

--- a/include/stp/Sat/Riss.h
+++ b/include/stp/Sat/Riss.h
@@ -72,7 +72,7 @@ public:
 
   void setVerbosity(int v) override;
 
-  unsigned long nVars() const override;
+  uint32_t nVars() const override;
 
   void printStats() const override;
 

--- a/include/stp/Sat/SATSolver.h
+++ b/include/stp/Sat/SATSolver.h
@@ -172,7 +172,7 @@ public:
 
   virtual uint32_t newVar() = 0;
 
-  virtual unsigned long nVars() const = 0;
+  virtual uint32_t nVars() const = 0;
 
   virtual void printStats() const = 0;
 

--- a/include/stp/Sat/SimplifyingMinisat.h
+++ b/include/stp/Sat/SimplifyingMinisat.h
@@ -56,7 +56,7 @@ public:
 
   uint32_t newVar() override;
 
-  unsigned long nVars() const override;
+  uint32_t nVars() const override;
 
   void printStats() const override;
 

--- a/include/stp/Simplifier/constantBitP/MersenneTwister.h
+++ b/include/stp/Simplifier/constantBitP/MersenneTwister.h
@@ -61,6 +61,7 @@
 // Not thread safe (unless auto-initialization is avoided and each thread has
 // its own MTRand object)
 
+#include <cstdint>
 #include <iostream>
 #include <limits.h>
 #include <math.h>
@@ -71,7 +72,11 @@ class MTRand
 {
   // Data
 public:
-  typedef unsigned long uint32; // unsigned integer type, at least 32 bits
+  // Exactly 32 bits, not "unsigned long", which is 64 on LP64. The algorithm
+  // masks every state update to 32 bits, so the generated sequence is the
+  // same either way, but a 64-bit word doubled the state array and made
+  // the /dev/urandom seed read 8 bytes per word to then discard 4.
+  typedef uint32_t uint32;
 
   enum
   {

--- a/include/stp/Util/RunTimes.h
+++ b/include/stp/Util/RunTimes.h
@@ -26,6 +26,7 @@ THE SOFTWARE.
 #define RUNTIMES_H
 
 #include "stp/Util/Attributes.h"
+#include <cstdint>
 #include <iomanip>
 #include <iostream>
 #include <map>
@@ -33,6 +34,13 @@ THE SOFTWARE.
 #include <stack>
 #include <string>
 #include <vector>
+
+namespace stp
+{
+// Milliseconds since the epoch. Fixed width, because a millisecond count
+// does not fit the 32-bit "long" of an ILP32 or LLP64 target.
+DLL_PUBLIC int64_t getCurrentTime();
+}
 
 class RunTimes // not copyable
 {
@@ -94,21 +102,19 @@ public:
                                           };
 
 
-  typedef std::pair<Category, long> Element;
+  typedef std::pair<Category, int64_t> Element;
 
 private:
   RunTimes& operator=(const RunTimes&);
   RunTimes(const RunTimes& other);
 
   std::map<Category, int> counts;
-  std::map<Category, long> times;
+  std::map<Category, int64_t> times;
   std::stack<Element> category_stack;
 
-  // millisecond precision timer.
-  DLL_PUBLIC long getCurrentTime();
-  void addTime(Category c, long milliseconds);
+  void addTime(Category c, int64_t milliseconds);
 
-  long lastTime;
+  int64_t lastTime;
 
 public:
   DLL_PUBLIC void addCount(Category c);
@@ -122,7 +128,7 @@ public:
 
   void difference() { std::cout << getDifference() << std::endl << std::endl; }
 
-  RunTimes() { lastTime = getCurrentTime(); }
+  RunTimes() { lastTime = stp::getCurrentTime(); }
 
   void clear()
   {

--- a/include/stp/c_interface.h
+++ b/include/stp/c_interface.h
@@ -36,6 +36,7 @@ extern "C" {
 #endif
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 /////////////////////////////////////////////////////////////////////////////
@@ -488,7 +489,7 @@ DLL_PUBLIC void vc_printExprFile(VC vc, Expr e, int fd);
 //! The buffer is returned via output parameter 'buf' alongside its length 'len'.
 //! It is the responsibility of the caller to free the memory afterwards.
 DLL_PUBLIC void vc_printExprToBuffer(VC vc, Expr e, char** buf,
-                                     unsigned long* len);
+                                     size_t* len);
 
 //! \brief Prints the counter example after an invalid query to stdout, in the
 //!        presentation language.
@@ -544,7 +545,7 @@ DLL_PUBLIC void vc_printAsserts(VC vc, int simplify_print _CVCL_DEFAULT_ARG(0));
 //! to enable simplifications of the query state during printing.
 //!
 DLL_PUBLIC void vc_printQueryStateToBuffer(VC vc, Expr e, char** buf,
-                                           unsigned long* len,
+                                           size_t* len,
                                            int simplify_print);
 
 //! \brief Prints the found counter example to a buffer allocated by STP
@@ -557,7 +558,7 @@ DLL_PUBLIC void vc_printQueryStateToBuffer(VC vc, Expr e, char** buf,
 //! to enable simplifications of the counter example during printing.
 //!
 DLL_PUBLIC void vc_printCounterExampleToBuffer(VC vc, char** buf,
-                                               unsigned long* len);
+                                               size_t* len);
 
 //! \brief Prints the query to stdout in presentation language.
 //!
@@ -693,7 +694,7 @@ DLL_PUBLIC uint64_t getBVUnsignedLongLong(Expr e);
 //!
 //! It is the callers responsibility to free the buffer's memory.
 //!
-DLL_PUBLIC void vc_printBVBitStringToBuffer(Expr e, char** buf, unsigned long* len);
+DLL_PUBLIC void vc_printBVBitStringToBuffer(Expr e, char** buf, size_t* len);
 
 /////////////////////////////////////////////////////////////////////////////
 /// BITVECTOR OPERATIONS

--- a/include/stp/cpp_interface.h
+++ b/include/stp/cpp_interface.h
@@ -29,6 +29,7 @@ THE SOFTWARE.
 #include "stp/NodeFactory/NodeFactory.h"
 #include "stp/Util/Attributes.h"
 #include "extlib-unordered-dense/ankerl/unordered_dense.h"
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <string>
@@ -236,7 +237,7 @@ public:
                                    int bit_width);
   DLL_PUBLIC ASTNode CreateBVConst(const char* const strval, int base);
   DLL_PUBLIC ASTNode CreateBVConst(unsigned int width,
-                                   unsigned long long int bvconst);
+                                   uint64_t bvconst);
   DLL_PUBLIC ASTNode CreateRMConst(unsigned mode);
   DLL_PUBLIC ASTNode CreateSourceSymbol(const char* name,
                                         const SourceSort& source_sort);

--- a/lib/AST/ASTmisc.cpp
+++ b/lib/AST/ASTmisc.cpp
@@ -31,8 +31,6 @@ THE SOFTWARE.
 #include <unistd.h>
 #endif
 
-#include <sys/time.h>
-
 namespace stp
 {
 using std::cout;
@@ -1177,13 +1175,6 @@ bool BVTypeCheck(const ASTNode& n)
   {
     return BVTypeCheck_nonterm_kind(n, k);
   }
-}
-
-long getCurrentTime()
-{
-  timeval t;
-  gettimeofday(&t, NULL);
-  return (1000 * t.tv_sec) + (t.tv_usec / 1000);
 }
 
 } // end of namespace

--- a/lib/Interface/c_interface.cpp
+++ b/lib/Interface/c_interface.cpp
@@ -428,7 +428,7 @@ void vc_printAsserts(VC vc, int simplify_print)
   vc_printAssertsToStream(vc, cout, simplify_print);
 }
 
-void vc_printQueryStateToBuffer(VC vc, Expr e, char** buf, unsigned long* len,
+void vc_printQueryStateToBuffer(VC vc, Expr e, char** buf, size_t* len,
                                 int simplify_print)
 {
   stp::STPMgr* b = mgr(vc);
@@ -457,18 +457,18 @@ void vc_printQueryStateToBuffer(VC vc, Expr e, char** buf, unsigned long* len,
   // convert to a c buffer
   string s = os.str();
   const char* cstr = s.c_str();
-  unsigned long size = s.size() + 1; // number of chars + terminating null
+  size_t size = s.size() + 1; // number of chars + terminating null
   *buf = (char*)malloc(size);
   if (!(*buf))
   {
-    fprintf(stderr, "malloc(%lu) failed.", size);
+    fprintf(stderr, "malloc(%zu) failed.", size);
     assert(*buf);
   }
   *len = size;
   memcpy(*buf, cstr, size);
 }
 
-void vc_printCounterExampleToBuffer(VC vc, char** buf, unsigned long* len)
+void vc_printCounterExampleToBuffer(VC vc, char** buf, size_t* len)
 {
   assert(vc);
   assert(buf);
@@ -491,18 +491,18 @@ void vc_printCounterExampleToBuffer(VC vc, char** buf, unsigned long* len)
   // convert to a c buffer
   string s = os.str();
   const char* cstr = s.c_str();
-  unsigned long size = s.size() + 1; // number of chars + terminating null
+  size_t size = s.size() + 1; // number of chars + terminating null
   *buf = (char*)malloc(size);
   if (!(*buf))
   {
-    fprintf(stderr, "malloc(%lu) failed.", size);
+    fprintf(stderr, "malloc(%zu) failed.", size);
     assert(*buf);
   }
   *len = size;
   memcpy(*buf, cstr, size);
 }
 
-void vc_printExprToBuffer(VC vc, Expr e, char** buf, unsigned long* len)
+void vc_printExprToBuffer(VC vc, Expr e, char** buf, size_t* len)
 {
   stp::STPMgr* b = mgr(vc);
   stp::ASTNode q = *((stp::ASTNode*)e);
@@ -511,7 +511,7 @@ void vc_printExprToBuffer(VC vc, Expr e, char** buf, unsigned long* len)
   q.PL_Print(os, b);
   string s = os.str();
   const char* cstr = s.c_str();
-  unsigned long size = s.size() + 1; // number of chars + terminating null
+  size_t size = s.size() + 1; // number of chars + terminating null
   *buf = (char*)malloc(size);
   *len = size;
   memcpy(*buf, cstr, size);
@@ -2706,7 +2706,7 @@ uint64_t getBVUnsignedLongLong(Expr e)
   return tmp;
 }
 
-void vc_printBVBitStringToBuffer(Expr e, char** buf, unsigned long* len)
+void vc_printBVBitStringToBuffer(Expr e, char** buf, size_t* len)
 {
   assert(buf);
   assert(len);
@@ -2734,11 +2734,11 @@ void vc_printBVBitStringToBuffer(Expr e, char** buf, unsigned long* len)
 
   // convert to a c buffer
   const char* cstr = string_bv.c_str();
-  unsigned long size = string_bv.size() + 1; // number of chars + terminating null
+  size_t size = string_bv.size() + 1; // number of chars + terminating null
   *buf = (char*)malloc(size);
   if (!(*buf))
   {
-    fprintf(stderr, "malloc(%lu) failed.", size);
+    fprintf(stderr, "malloc(%zu) failed.", size);
     assert(*buf);
   }
   *len = size;

--- a/lib/Interface/cpp_interface.cpp
+++ b/lib/Interface/cpp_interface.cpp
@@ -218,7 +218,7 @@ ASTNode Cpp_interface::CreateBVConst(const char* const strval, int base)
 
 // FIXME: unsigned long long int is wong. Use intN_t from cstdint
 ASTNode Cpp_interface::CreateBVConst(unsigned int width,
-                                     unsigned long long int bvconst)
+                                     uint64_t bvconst)
 {
   return bm.CreateBVConst(width, bvconst);
 }

--- a/lib/NodeFactory/NodeFactory.cpp
+++ b/lib/NodeFactory/NodeFactory.cpp
@@ -187,7 +187,7 @@ ASTNode NodeFactory::CreateSignedMinConst(unsigned width)
 
 
 ASTNode NodeFactory::CreateBVConst(unsigned int width,
-                                   unsigned long long int bvconst)
+                                   uint64_t bvconst)
 {
   return bm.CreateBVConst(width, bvconst);
 }

--- a/lib/Printer/SMTLIBPrinter.cpp
+++ b/lib/Printer/SMTLIBPrinter.cpp
@@ -301,7 +301,7 @@ void SMTLIB_Print1(ostream& os, const ASTNode n, int indentation, bool letize,
       {
         string close = "";
 
-        for (long int i = 0; i < (long int)c.size() - 1; i++)
+        for (size_t i = 0; i + 1 < c.size(); i++)
         {
           os << "(" << functionToSMTLIBName(kind, smtlib1);
           os << " ";

--- a/lib/STPManager/STPManager.cpp
+++ b/lib/STPManager/STPManager.cpp
@@ -307,39 +307,24 @@ ASTNode STPMgr::CreateBVConst(unsigned int width,
   CreateBVConstVal = CONSTANTBV::BitVector_Resize(CreateBVConstVal, width);
   CONSTANTBV::BitVector_Empty(CreateBVConstVal);
 
-  unsigned long c_val = (~((unsigned long)0)) & bvconst;
-  unsigned int copied = 0;
-
-  // sizeof(unsigned long) returns the number of bytes in unsigned
-  // long. In order to convert it to bits, we need to shift left by
-  // 3. Hence, sizeof(unsigned long)*8
-
-  // The algo below works as follows: It starts by copying the
-  // lower-order bits of the input "bvconst" in chunks of size =
-  // number of bits in unsigned long. The variable "copied" keeps
-  // track of the number of chunks copied so far
-
-  const int shift_amount = sizeof(unsigned long) * 8;
-  while (copied + shift_amount < width)
+  // Copy the value into the bitvector 32 bits at a time, low chunk first.
+  //
+  // 32 rather than the width of a machine word: Chunk_Store takes its value
+  // as an "unsigned long", which is 32 bits on i386 and on 64-bit Windows,
+  // so a wider chunk would be silently truncated there. This loop stores the
+  // same chunks on every target, and needs no shift by the word size -- which
+  // is what the old version suppressed -Wshift-count-overflow for.
+  //
+  // Any width above 64 keeps the zeroes BitVector_Empty just wrote, because
+  // the source value has no bits up there.
+  const unsigned chunk = 32;
+  for (unsigned offset = 0; offset < width && offset < 64; offset += chunk)
   {
-    CONSTANTBV::BitVector_Chunk_Store(CreateBVConstVal, shift_amount, copied,
-                                      c_val);
-    if (shift_amount < (sizeof(bvconst) * 8))
-    {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshift-count-overflow"
-      bvconst >>= shift_amount;
-#pragma GCC diagnostic pop
-    }
-    else
-    {
-      bvconst = 0;
-    }
-    c_val = (~((unsigned long)0)) & bvconst;
-    copied += shift_amount;
+    const unsigned size = (width - offset < chunk) ? (width - offset) : chunk;
+    const unsigned long c_val =
+        static_cast<uint32_t>(bvconst >> offset);
+    CONSTANTBV::BitVector_Chunk_Store(CreateBVConstVal, size, offset, c_val);
   }
-  CONSTANTBV::BitVector_Chunk_Store(CreateBVConstVal, width - copied, copied,
-                                    c_val);
 
   ASTBVConst temp_bvconst(this, CreateBVConstVal, width, true);
   return ASTNode(LookupOrCreateBVConst(temp_bvconst));

--- a/lib/STPManager/STPManager.cpp
+++ b/lib/STPManager/STPManager.cpp
@@ -293,12 +293,12 @@ bool STPMgr::LookupSymbol(const char* const name, ASTNode& output)
 
 // Create a ASTBVConst node
 ASTNode STPMgr::CreateBVConst(unsigned int width,
-                              unsigned long long int bvconst)
+                              uint64_t bvconst)
 {
   if (width == 0)
     FatalError("CreateBVConst: "
                "trying to create bvconst using "
-               "unsigned long long of width: ",
+               "uint64_t of width: ",
                ASTUndefined, width);
 
   // We create a single bvconst that gets reused.

--- a/lib/Sat/Cadical.cpp
+++ b/lib/Sat/Cadical.cpp
@@ -29,7 +29,7 @@ using std::vector;
 
 namespace stp
 {
-unsigned long Cadical::nVars() const
+uint32_t Cadical::nVars() const
 {
   // Unlike other solvers Cadical doesn't need to be told about the variable in advance.
   return next_variable;

--- a/lib/Sat/CryptoMinisat5.cpp
+++ b/lib/Sat/CryptoMinisat5.cpp
@@ -179,7 +179,7 @@ void CryptoMiniSat5::setVerbosity(int v)
   s->set_verbosity(v);
 }
 
-unsigned long CryptoMiniSat5::nVars() const
+uint32_t CryptoMiniSat5::nVars() const
 {
   return s->nVars();
 }

--- a/lib/Sat/MinisatCore.cpp
+++ b/lib/Sat/MinisatCore.cpp
@@ -112,7 +112,7 @@ void MinisatCore::setVerbosity(int v)
   s->verbosity = v;
 }
 
-unsigned long MinisatCore::nVars() const
+uint32_t MinisatCore::nVars() const
 {
   return s->nVars();
 }

--- a/lib/Sat/RissCore.cpp
+++ b/lib/Sat/RissCore.cpp
@@ -131,7 +131,7 @@ void RissCore::setVerbosity(int v)
   s->verbosity = v;
 }
 
-unsigned long RissCore::nVars() const
+uint32_t RissCore::nVars() const
 {
   return s->nVars();
 }

--- a/lib/Sat/SimplifyingMinisat.cpp
+++ b/lib/Sat/SimplifyingMinisat.cpp
@@ -101,7 +101,7 @@ uint32_t SimplifyingMinisat::newVar()
   return s->newVar();
 }
 
-unsigned long SimplifyingMinisat::nVars() const
+uint32_t SimplifyingMinisat::nVars() const
 {
   return s->nVars();
 }

--- a/lib/Simplifier/RemoveUnconstrained.cpp
+++ b/lib/Simplifier/RemoveUnconstrained.cpp
@@ -1060,7 +1060,7 @@ ASTNode RemoveUnconstrained::topLevel_other(const ASTNode& n,
           newWidth += rhsSize;
         }
 
-        assert(newWidth == (long int)operandWidth);
+        assert(newWidth == (int)operandWidth);
         replace(var, current);
       }
       break;

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -896,8 +896,8 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term,
       // Replicate high-order bit as many times as necessary.
       // Arg 0 is expression to be sign extended.
       const ASTNode& arg = term[0];
-      const unsigned long result_width = term.GetValueWidth();
-      const unsigned long arg_width = arg.GetValueWidth();
+      const unsigned result_width = term.GetValueWidth();
+      const unsigned arg_width = arg.GetValueWidth();
       const BBNodeVec& bbarg = BBTerm(arg, support);
 
       if (result_width == arg_width)

--- a/lib/Util/RunTimes.cpp
+++ b/lib/Util/RunTimes.cpp
@@ -43,13 +43,20 @@ THE SOFTWARE.
 namespace stp
 {
 ATTR_NORETURN void FatalError(const char* str);
-}
 
-long RunTimes::getCurrentTime()
+// The only definition of the millisecond clock; declared in RunTimes.h and
+// used both here and by the rewrite-rule tools.
+//
+// tv_sec is widened before the multiply on purpose. Where time_t is 32 bits
+// -- the default on i386 -- "1000 * t.tv_sec" is a signed overflow, and the
+// millisecond result does not fit a 32-bit long either.
+int64_t getCurrentTime()
 {
   timeval t;
   gettimeofday(&t, NULL);
-  return (1000 * t.tv_sec) + (t.tv_usec / 1000);
+  return (1000 * static_cast<int64_t>(t.tv_sec)) +
+         (static_cast<int64_t>(t.tv_usec) / 1000);
+}
 }
 
 void RunTimes::print()
@@ -65,13 +72,13 @@ void RunTimes::print()
   std::ostringstream result;
   result << "statistics\n";
   std::map<Category, int>::const_iterator it1 = counts.begin();
-  std::map<Category, long>::const_iterator it2 = times.begin();
+  std::map<Category, int64_t>::const_iterator it2 = times.begin();
 
-  int cummulative_ms = 0;
+  int64_t cummulative_ms = 0;
 
   while (it1 != counts.end())
   {
-    int time_ms = 0;
+    int64_t time_ms = 0;
     if ((it2 = times.find(it1->first)) != times.end())
       time_ms = it2->second;
 
@@ -103,7 +110,7 @@ void RunTimes::print()
 std::string RunTimes::getDifference()
 {
   std::stringstream s;
-  long val = getCurrentTime();
+  int64_t val = stp::getCurrentTime();
   s << (val - lastTime) << "ms";
   lastTime = val;
   s << ":" << std::fixed << std::setprecision(0)
@@ -111,9 +118,9 @@ std::string RunTimes::getDifference()
   return s.str();
 }
 
-void RunTimes::addTime(Category c, long milliseconds)
+void RunTimes::addTime(Category c, int64_t milliseconds)
 {
-  std::map<Category, long>::iterator it;
+  std::map<Category, int64_t>::iterator it;
   if ((it = times.find(c)) == times.end())
   {
     times[c] = milliseconds;
@@ -147,11 +154,11 @@ void RunTimes::stop(Category c)
     std::cerr << c;
     stp::FatalError("Don't match");
   }
-  addTime(c, getCurrentTime() - e.second);
+  addTime(c, stp::getCurrentTime() - e.second);
   addCount(c);
 }
 
 void RunTimes::start(Category c)
 {
-  category_stack.push(std::make_pair(c, getCurrentTime()));
+  category_stack.push(std::make_pair(c, stp::getCurrentTime()));
 }

--- a/tests/api/C/b4-c2.cpp
+++ b/tests/api/C/b4-c2.cpp
@@ -2553,7 +2553,7 @@ TEST(b4_c2, one)
 #if 0
   {
     char* cc;
-    unsigned long len;
+    size_t len;
     vc_printQueryStateToBuffer(vc, e5286031, &cc, &len, 1);
     std::cout << cc << std::endl;
   }

--- a/tests/api/C/bit_string.cpp
+++ b/tests/api/C/bit_string.cpp
@@ -38,7 +38,7 @@ TEST(bit_string, one)
 
   // Convert it back to a bit string
   char* buf;
-  unsigned long len;
+  size_t len;
   vc_printBVBitStringToBuffer(e, &buf, &len);
 
   // 'buf' should now be allocated

--- a/tests/api/C/fp-multi-checker.cpp
+++ b/tests/api/C/fp-multi-checker.cpp
@@ -227,7 +227,7 @@ TEST(fp_multi_checker, print_counterexample_across_checkers)
 
   // Print v1's counterexample into a buffer; it must not touch v2's manager.
   char* buf = NULL;
-  unsigned long len = 0;
+  size_t len = 0;
   vc_printCounterExampleToBuffer(v1, &buf, &len);
   EXPECT_TRUE(buf != NULL);
   EXPECT_TRUE(len > 0);

--- a/tests/unit-tests/RemoveUnconstrained_Exhaustive_Test.cpp
+++ b/tests/unit-tests/RemoveUnconstrained_Exhaustive_Test.cpp
@@ -190,17 +190,17 @@ struct Context
     std::vector<ASTNode> syms(symSet.begin(), symSet.end());
 
     // Guard against an accidental combinatorial explosion.
-    unsigned long combos = 1;
+    uint64_t combos = 1;
     for (const auto& s : syms)
       combos *= domainSize(s);
     ASSERT_LE(combos, 1u << 16)
         << "too many assignments (" << combos << ") -- lower the width";
 
     std::vector<unsigned> idx(syms.size(), 0);
-    for (unsigned long c = 0; c < combos; c++)
+    for (uint64_t c = 0; c < combos; c++)
     {
       ASTNodeMap assignment;
-      unsigned long rest = c;
+      uint64_t rest = c;
       for (size_t i = 0; i < syms.size(); i++)
       {
         const unsigned size = domainSize(syms[i]);

--- a/tests/unit-tests/Rewriting_Exhaustive_Test.cpp
+++ b/tests/unit-tests/Rewriting_Exhaustive_Test.cpp
@@ -142,16 +142,16 @@ struct Context
     collectSymbols(after, symSet);
     std::vector<ASTNode> syms(symSet.begin(), symSet.end());
 
-    unsigned long combos = 1;
+    uint64_t combos = 1;
     for (const auto& s : syms)
       combos *= domainSize(s);
     ASSERT_LE(combos, 1u << 16)
         << "too many assignments (" << combos << ") -- lower the width";
 
-    for (unsigned long c = 0; c < combos; c++)
+    for (uint64_t c = 0; c < combos; c++)
     {
       ASTNodeMap assignment;
-      unsigned long rest = c;
+      uint64_t rest = c;
       for (size_t i = 0; i < syms.size(); i++)
       {
         const unsigned size = domainSize(syms[i]);

--- a/tests/unit-tests/SimplifyFormula_Test.cpp
+++ b/tests/unit-tests/SimplifyFormula_Test.cpp
@@ -164,8 +164,8 @@ struct Context
     std::vector<ASTNode> syms(symSet.begin(), symSet.end());
     ASSERT_LE(syms.size(), 16u) << "too many variables to enumerate";
 
-    const unsigned long combos = 1UL << syms.size();
-    for (unsigned long c = 0; c < combos; c++)
+    const uint64_t combos = UINT64_C(1) << syms.size();
+    for (uint64_t c = 0; c < combos; c++)
     {
       std::map<ASTNode, bool> asgn;
       for (size_t i = 0; i < syms.size(); i++)

--- a/tests/unit-tests/SimplifyingNodeFactory_Exhaustive_Test.cpp
+++ b/tests/unit-tests/SimplifyingNodeFactory_Exhaustive_Test.cpp
@@ -119,16 +119,16 @@ struct Context
     collectSymbols(after, symSet);
     std::vector<ASTNode> syms(symSet.begin(), symSet.end());
 
-    unsigned long combos = 1;
+    uint64_t combos = 1;
     for (const auto& s : syms)
       combos *= domainSize(s);
     ASSERT_LE(combos, 1u << 16)
         << "too many assignments (" << combos << ") -- lower the width";
 
-    for (unsigned long c = 0; c < combos; c++)
+    for (uint64_t c = 0; c < combos; c++)
     {
       ASTNodeMap assignment;
-      unsigned long rest = c;
+      uint64_t rest = c;
       for (size_t i = 0; i < syms.size(); i++)
       {
         const unsigned size = domainSize(syms[i]);

--- a/tests/unit-tests/SplitExtracts_Test.cpp
+++ b/tests/unit-tests/SplitExtracts_Test.cpp
@@ -141,7 +141,7 @@ struct Context
      collectSymbols(post, symSet);
      std::vector<ASTNode> syms(symSet.begin(), symSet.end());
 
-     unsigned long combos = 1;
+     uint64_t combos = 1;
      for (const auto& s : syms)
        combos *= (s.GetType() == stp::BOOLEAN_TYPE)
                      ? 2u
@@ -149,10 +149,10 @@ struct Context
      ASSERT_LE(combos, 1u << 16)
          << "too many assignments (" << combos << ") -- lower the width";
 
-     for (unsigned long c = 0; c < combos; c++)
+     for (uint64_t c = 0; c < combos; c++)
      {
        stp::ASTNodeMap assignment;
-       unsigned long rest = c;
+       uint64_t rest = c;
        for (const auto& s : syms)
        {
          if (s.GetType() == stp::BOOLEAN_TYPE)

--- a/tools/rewrite_rule_gen/rewrite_rule.h
+++ b/tools/rewrite_rule_gen/rewrite_rule.h
@@ -137,7 +137,7 @@ public:
   {
     mgr->soft_timeout_expired = false;
 
-    const long st = stp::getCurrentTime();
+    const int64_t st = stp::getCurrentTime();
     int checked_to = 0;
 
     // Start it verifying where we left off..
@@ -176,7 +176,8 @@ public:
     }
 
     if (getVerifiedToBits() <= checked_to)
-      setVerified(checked_to, getTime() + (stp::getCurrentTime() - st));
+      setVerified(checked_to,
+                  getTime() + static_cast<int>(stp::getCurrentTime() - st));
 
     // The timer might not have expired yet.
     setitimer(ITIMER_VIRTUAL, NULL, NULL);

--- a/tools/rewrite_rule_gen/rewrite_rule_gen.cpp
+++ b/tools/rewrite_rule_gen/rewrite_rule_gen.cpp
@@ -1135,11 +1135,11 @@ void findRewrites(ASTVec& expressions, const vector<VariableAssignment>& values,
 
       VariableAssignment different;
       bool bad = false;
-      const long st = getCurrentTime();
+      const int64_t st = getCurrentTime();
 
       if (checkRule(from, to, different, bad))
       {
-        const long checktime = getCurrentTime() - st;
+        const int64_t checktime = getCurrentTime() - st;
 
         equiv[i] = rewriteThroughWithAIGS(equiv[i]);
         equiv[j] = rewriteThroughWithAIGS(equiv[j]);

--- a/tools/rewrite_rule_gen/rewrite_system.h
+++ b/tools/rewrite_rule_gen/rewrite_system.h
@@ -292,7 +292,7 @@ public:
     {
       VariableAssignment assignment;
       bool bad = false;
-      const long st = stp::getCurrentTime();
+      const int64_t st = stp::getCurrentTime();
       bool r = checkRule(it->getFrom(), it->getTo(), assignment, bad);
       if (!r || bad)
       {
@@ -303,7 +303,7 @@ public:
         assert(!bad);
       }
       if (bits >= it->getVerifiedToBits())
-        it->setVerified(bits, stp::getCurrentTime() - st);
+        it->setVerified(bits, static_cast<int>(stp::getCurrentTime() - st));
     }
   }
 

--- a/tools/test_fprewrites/test_fprewrites.cpp
+++ b/tools/test_fprewrites/test_fprewrites.cpp
@@ -120,7 +120,7 @@ struct Ctx
   // The float of format (eb, sb) whose packed IEEE bits are `v`.
   ASTNode fpConst(unsigned eb, unsigned sb, uint64_t v)
   {
-    ASTNode n = mgr.CreateBVConst(eb + sb, (unsigned long long)v);
+    ASTNode n = mgr.CreateBVConst(eb + sb, v);
     return mgr.CreateFPConst(n, eb, sb);
   }
 

--- a/tools/test_fprewrites/test_fprewrites.cpp
+++ b/tools/test_fprewrites/test_fprewrites.cpp
@@ -261,16 +261,21 @@ struct Ctx
       collectSymbols(c, out);
   }
 
-  unsigned long domain(const ASTNode& s)
+  // Number of values the symbol can take, saturated rather than shifted past
+  // the width of the result: "1ul << 32" is fine on LP64 but undefined where
+  // long is 32 bits, and the caller only needs to know that a wide symbol
+  // exceeds its enumeration limit.
+  uint64_t domain(const ASTNode& s)
   {
     if (s.GetType() == BOOLEAN_TYPE)
       return 2;
-    if (s.GetType() == FLOATINGPOINT_TYPE)
-      return 1ul << (s.GetExpWidth() + s.GetSigWidth());
-    return 1ul << s.GetValueWidth();
+    const unsigned bits = (s.GetType() == FLOATINGPOINT_TYPE)
+                              ? s.GetExpWidth() + s.GetSigWidth()
+                              : s.GetValueWidth();
+    return bits >= 64 ? UINT64_MAX : (UINT64_C(1) << bits);
   }
 
-  ASTNode valueFor(const ASTNode& s, unsigned long v)
+  ASTNode valueFor(const ASTNode& s, uint64_t v)
   {
     if (s.GetType() == BOOLEAN_TYPE)
       return (v & 1) ? mgr.ASTTrue : mgr.ASTFalse;
@@ -294,11 +299,16 @@ struct Ctx
     collectSymbols(after, symSet);
     std::vector<ASTNode> syms(symSet.begin(), symSet.end());
 
-    unsigned long combos = 1;
+    // Tested before each multiply, so the product cannot itself overflow.
+    const uint64_t maxCombos = UINT64_C(1) << 18;
+    uint64_t combos = 1;
     for (const auto& s : syms)
-      combos *= domain(s);
-    if (combos > (1ul << 18))
-      return "too many assignments (" + std::to_string(combos) + ")";
+    {
+      const uint64_t d = domain(s);
+      if (d > maxCombos || combos > maxCombos / d)
+        return "too many assignments (over " + std::to_string(maxCombos) + ")";
+      combos *= d;
+    }
 
     const ASTNode blastedBefore = blastOnce(before);
     const ASTNode blastedAfter = blastOnce(after);
@@ -307,13 +317,13 @@ struct Ctx
     // if need be); a Boolean check reads 0s and collapses nothing.
     const unsigned eb = before.GetExpWidth(), sb = before.GetSigWidth();
 
-    for (unsigned long c = 0; c < combos; c++)
+    for (uint64_t c = 0; c < combos; c++)
     {
       ASTNodeMap assignment;
-      unsigned long rest = c;
+      uint64_t rest = c;
       for (size_t i = 0; i < syms.size(); i++)
       {
-        const unsigned long size = domain(syms[i]);
+        const uint64_t size = domain(syms[i]);
         assignment.insert({syms[i], valueFor(syms[i], rest % size)});
         rest /= size;
       }


### PR DESCRIPTION
`long` is 64 bits on LP64 (Linux, macOS) but 32 bits on ILP32 (i386) and LLP64 (64-bit Windows). Several interfaces used it for values that are conceptually fixed-width, so they described something different depending on the target. This replaces those with `int64_t`, `uint32_t`, `uint64_t` or `size_t` as appropriate.

Two were real defects rather than inconsistencies.

**`getCurrentTime()`** returned a millisecond count in a `long`. Where `time_t` is 32 bits — the default on i386 — `1000 * t.tv_sec` overflowed before the return type was even reached, which is undefined, and the millisecond result did not fit a 32-bit `long` anyway. It survived only because every caller takes differences, and the wraparound cancels for short intervals. `tv_sec` is now widened before the multiply and the function returns `int64_t`. It also had two byte-identical definitions, which are now one.

**`CreateBVConst`** chopped its 64-bit argument into chunks the width of a machine word. That happened to be correct on both word sizes, but only because `BitVector_Chunk_Store` also takes an `unsigned long`, and it needed a `-Wshift-count-overflow` suppression for a shift that is dead on 64-bit and live on 32-bit. It now stores 32 bits at a time, which is what `CBVOps` already does for the same reason, and both the coupling and the pragma go away.

The rest are consistency changes: `SATSolver::nVars()` (every underlying solver returns `int` or `uint32_t`, and the one caller assigned straight back to an `int`), `MersenneTwister`'s state word, the assignment-enumeration loops in the exhaustive tests, and assorted loop counters and widths.

## ABI changes

Two of these touch installed API and are deliberate breaks.

The four print-to-buffer entry points in `c_interface.h` now take their length as `size_t*` rather than `unsigned long*`. That is what they always were — every implementation stores `s.size() + 1` into it — and it is the least disruptive of the consistent choices: identical to the previous type on Linux, macOS and i386, with only 64-bit Windows callers seeing a width change. The ctypes bindings declared the same parameter as `c_ulong` and had the matching bug; they now use `c_size_t`.

The three `CreateBVConst` value overloads now take `uint64_t` rather than `unsigned long long int`. Unlike everything else here this was never a portability bug, since `unsigned long long` is 64 bits everywhere. But on LP64 `uint64_t` is `unsigned long`, a distinct type despite the identical width, so the mangled names change on Linux and macOS:

```
_ZN3stp6STPMgr13CreateBVConstEjy  ->  _ZN3stp6STPMgr13CreateBVConstEjm
```

and likewise for `Cpp_interface` and `NodeFactory`. On i386 and Windows, where `long` is 32 bits, `uint64_t` already is `unsigned long long` and the symbols are unchanged.

Both still want a release note, which I have not written.

## Verification

The full test suite passes, 103/103, and the build is warning-clean under the project's flags including `-Wsign-compare`.

`CreateBVConst` is the riskiest change, so it was checked against an independent oracle rather than left to the suite: 10400 cases across widths 1 to 130 — either side of both chunk boundaries — covering boundary values and every single-bit value, all agreeing. Deliberately mis-chunking the loop fails 3294 of them, so the check is not vacuous.

`c_interface.h` still compiles as pure C99 and C11 under `-Wall -Wextra -pedantic`.

The `MersenneTwister` change is behaviour-preserving: the algorithm masks every state update to 32 bits, in both `initialize()` and `twist()`, so the generated sequence is identical and only the storage shrinks. The seeded exhaustive tests confirm it.

## Left alone

`BitOps.h`'s two `unsigned long index` declarations are required by the MSVC `_BitScanForward64` and `_BitScanReverse64` signatures. The `signed long` casts in `ASTNode.cpp`, `consteval.cpp` and `UnsignedIntervalAnalysis.cpp` correctly match `CONSTANTBV::Set_Max`'s return type, and changing them without changing constbv would make them wrong rather than right. The Bison union's `unsigned long long` member converts implicitly and works unchanged.
