### PR TITLE
Take FixedBits bit positions as unsigned

### DIFF
--- a/include/stp/Simplifier/constantBitP/FixedBits.h
+++ b/include/stp/Simplifier/constantBitP/FixedBits.h
@@ -219,7 +219,8 @@ private:
   }
 
 public:
-  // returns -1 if it's zero.
+  // returns -1 if it's zero. Signed for that sentinel: check for it before
+  // using the result as a bit position, which is unsigned.
   int topmostPossibleLeadingOne()
   {
     for (int w = (int)numWords() - 1; w >= 0; w--)
@@ -254,6 +255,8 @@ public:
     return lowestSet(&FixedBits::unfixedBits);
   }
 
+  // returns -1 if every bit is fixed. Signed for that sentinel: check for it
+  // before using the result as a bit position, which is unsigned.
   int mostUnfixed() const
   {
     for (int w = (int)numWords() - 1; w >= 0; w--)
@@ -266,10 +269,10 @@ public:
   }
 
   // is this bit fixed to zero?
-  bool isFixedToZero(int n) const { return isFixed(n) && !getValue(n); }
+  bool isFixedToZero(unsigned n) const { return isFixed(n) && !getValue(n); }
 
   // is this bit fixed to one?
-  bool isFixedToOne(int n) const { return isFixed(n) && getValue(n); }
+  bool isFixedToOne(unsigned n) const { return isFixed(n) && getValue(n); }
 
   // is this bit fixed to either zero or one?
   bool isFixed(unsigned n) const

--- a/lib/Simplifier/constantBitP/ConstantBitP_Boolean.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_Boolean.cpp
@@ -339,12 +339,12 @@ Result bvImpliesBothWays(vector<FixedBits*>& children, FixedBits& result)
   FixedBits& b = (*children[1]);
 
   assert(a.getWidth() == result.getWidth());
-  [[maybe_unused]] const int bitWidth = a.getWidth();
+  [[maybe_unused]] const unsigned bitWidth = a.getWidth();
   assert(bitWidth == 1);
 
   Result r = NO_CHANGE;
 
-  int i = 0;
+  const unsigned i = 0;
 
   //  (false -> something) is always true.
   //  (something -> true ) is always true.

--- a/lib/Simplifier/constantBitP/ConstantBitP_Division.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_Division.cpp
@@ -1327,14 +1327,15 @@ static Result bvSignedModulusStructural(vector<FixedBits*>& children,
   {
     if (!fixBitTo(output, sign, false))
       return CONFLICT;
-    int highest = -1; // highest divisor bit that might be one.
-    for (int i = (int)sign - 1; i >= 0; i--)
+    // highest divisor bit that might be one; `sign` means there is none.
+    unsigned highest = sign;
+    for (unsigned i = sign; i-- > 0;)
       if (!b.isFixedToZero(i))
       {
         highest = i;
         break;
       }
-    assert(highest >= 0); // b is non-zero with a zero sign bit.
+    assert(highest < sign); // b is non-zero with a zero sign bit.
     // divisor <= 2^(highest+1)-1, so result <= 2^(highest+1)-2: the bits
     // above `highest` are zero.
     for (unsigned i = highest + 1; i < sign; i++)


### PR DESCRIPTION
`FixedBits::isFixedToZero()` and `isFixedToOne()` took their bit position as an `int`, while `isFixed()`, `getValue()` and `setValue()` immediately below them take an `unsigned`. Because the conversion happened inside the accessor, a negative index was invisible at the call site, and in a build with assertions off it would index the fixedness words at `(unsigned)-1 >> 6`.

This spells both parameters `unsigned`, which is what the rest of the class uses. That moves the conversion out to the two callers that were relying on it, and both are cleaned up here rather than left as casts:

- `bvImpliesBothWays()` indexes a width-one domain with a literal zero.
- `bvSignedModulusStructural()` scanned down from the sign bit with an `int` counter and `-1` for "no bit found". It now counts down in `unsigned` and marks the empty result with `sign`. The scan covers the same positions in the same order.

There is one behavioural difference, in a state the code already asserts cannot arise: a divisor that is non-zero with a zero sign bit, yet with no bit below the sign that could be one. Previously a release build would compute `(unsigned)(-1 + 1) == 0` and go on to fix every bit below the sign to zero; now the follow-on loop simply does not execute.

The two functions that genuinely do return `-1` — `topmostPossibleLeadingOne()` and `mostUnfixed()` — have to stay signed for the sentinel. Their declarations now say so, since the result cannot be passed to the accessors above without being tested first.

## Testing

- Full test suite passes (103/103, assertions enabled), including the exhaustive `ConstantBitP_TransferFunctions` suite that covers signed modulus.
- Rebuilt with `-Wsign-compare -Wsign-conversion`: no new warnings, and the call-site warnings the signature change exposes are all addressed by the two changes above.
- Release build is clean.
