### PR TITLE
Guard the unencoded-SAT-variable sentinel on the array axiom path

### DIFF
--- a/lib/AbsRefineCounterExample/AbstractionRefinement.cpp
+++ b/lib/AbsRefineCounterExample/AbstractionRefinement.cpp
@@ -43,7 +43,28 @@ void getSatVariables(const ASTNode& a, vector<unsigned>& v_a,
 {
   ToSATBase::ASTNodeToSATVar::iterator it = satVar.find(a);
   if (it != satVar.end())
+  {
     v_a = it->second;
+
+    // ToCNFAIG::fill_node_to_var() writes ~0u for a bit of a symbol that
+    // reached no SAT variable, and the same value arrives from a CNF
+    // generator that left an object's variable number at -1. getEquals()
+    // indexes this vector straight into mkLit(), where the sentinel wraps
+    // into a variable far past the solver's range: MiniSat then indexes
+    // its assignment array out of bounds, and Cadical is handed a literal
+    // beyond max_var.
+    //
+    // There is no safe recovery. Allocating a fresh variable for the
+    // missing bit -- what the branch below does for a symbol that was
+    // never bit-blasted at all -- would carry no connection to the term
+    // the axiom is about, so the congruence clause could fail to rule out
+    // the candidate model it was built from. The array-equality encoder
+    // rejects the same shape for the same reason; see
+    // ExtensionalityContext::checkPreencodedBV().
+    for (size_t i = 0, size = v_a.size(); i < size; ++i)
+      if (v_a[i] == ~((unsigned)0))
+        FatalError("An array axiom leaf has a bit with no SAT variable: ", a);
+  }
   else if (!a.isConstant())
   {
     assert(a.GetKind() == SYMBOL);

--- a/lib/ToSat/ToSATAIG.cpp
+++ b/lib/ToSat/ToSATAIG.cpp
@@ -174,13 +174,18 @@ void ToSATAIG::mark_variables_as_frozen(SATSolver& satSolver)
     for (ArrayTransformer::arrTypeMap::const_iterator arr_it = atm.begin();
          arr_it != atm.end(); arr_it++)
     {
+      // A bit that reached no SAT variable is marked with ~0u rather than
+      // omitted, so freezing has to skip it: the sentinel is not a variable
+      // index, and a backend that acts on setFrozen() writes out of bounds
+      // when handed it. The extensionality loop below already guards this.
       const ArrayTransformer::ArrayRead& ar = arr_it->second;
       ASTNodeToSATVar::iterator it = nodeToSATVar.find(ar.index_symbol);
       if (it != nodeToSATVar.end())
       {
         const vector<unsigned>& v = it->second;
         for (size_t i = 0, size = v.size(); i < size; ++i)
-          satSolver.setFrozen(v[i]);
+          if (v[i] != ~((unsigned)0))
+            satSolver.setFrozen(v[i]);
       }
 
       ASTNodeToSATVar::iterator it2 = nodeToSATVar.find(ar.symbol);
@@ -188,7 +193,8 @@ void ToSATAIG::mark_variables_as_frozen(SATSolver& satSolver)
       {
         const vector<unsigned>& v = it2->second;
         for (size_t i = 0, size = v.size(); i < size; ++i)
-          satSolver.setFrozen(v[i]);
+          if (v[i] != ~((unsigned)0))
+            satSolver.setFrozen(v[i]);
       }
     }
   }


### PR DESCRIPTION
Defensive fix, no behaviour change on anything I could find. Found while reading how array congruence clauses handle bits whose value is already known.

## The sentinel

`ToCNFAIG::fill_node_to_var()` pre-fills each symbol's SAT-variable vector with `~0u` and overwrites only the bits that reached a variable, so `~0u` is an in-band marker for "this bit was not encoded". The same value also arrives from a CNF generator that left an object's variable number at `-1`, since that `int` is assigned into an `unsigned`.

Three consumers already know about it:

- `ConstructCounterExample()` skips such a bit.
- `ExtensionalityContext::checkPreencodedBV()` rejects a lemma leaf containing one, with a comment explaining why inventing a variable instead would be wrong.
- `mark_variables_as_frozen()` guards its extensionality loop.

The legacy array read-refinement path, which reads the same map, checks nowhere.

## What could go wrong

`getSatVariables()` copies the vector verbatim, and `getEquals()` validates only `v_a.size() == width` before indexing the contents into `mkLit()`. `mkLit(~0u, sign)` computes `var + var + sign`, which wraps to a variable of `0x7FFFFFFF`: MiniSat indexes its assignment array out of bounds, and Cadical is handed a literal far beyond `max_var`. The two unguarded `setFrozen()` calls in `mark_variables_as_frozen()` — twenty lines above the loop that does guard — have the same problem for backends that act on freezing, which is `SimplifyingMinisat` (Cadical's is deliberately a no-op).

## The change

Reject the sentinel in `getSatVariables()` rather than allocating a fresh variable for the missing bit. That is the same call `checkPreencodedBV()` makes, for the same reason: a variable invented mid-refinement carries no connection to the term the axiom is about, so the congruence clause could fail to rule out the candidate model it was built from. Silently continuing is the worse outcome here, not the better one. And skip the sentinel when freezing, matching the loop below.

## Reachability

I could not trigger it. Instrumenting `getSatVariables()` to report a copied sentinel produced no hit across the array queries in `tests/query-files` plus a local corpus of roughly 2500 generated array files, at every `--cnf-effort` setting.

Reasoning about the two sources: for a bit-vector symbol, `BBTerm()`'s `SYMBOL` case requests every bit from `CreateSymbol()`, so no bit is left null. Of the CNF generators, both `Cnf_Derive()` and `Cnf_DeriveFast()` assign a variable to every combinational input unconditionally. The Mf-based generator behind `--cnf-effort low` and `high` rebuilds the variable map from `-1` and fills only the inputs, and is the path this guards most directly.

So: latent rather than live. Worth closing because the value is an in-band sentinel that two other call sites consider serious enough to check, and the failure mode is silent memory corruption rather than an error.

## Testing

Full suite passes (101/101). The array corpus above reports unchanged results and no hit on the new check; the 91 fatal errors it does produce are all pre-existing intentional rejections (78 array-equality-without-the-flag, 13 syntax-error tests).