### PR TITLE
Build pushes only on master, so a pull request runs CI once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,25 @@
-# workflow_dispatch adds a "Run workflow" button on the Actions tab, so a run
-# can be started by hand against any branch — useful for re-running against a
-# branch whose last push predates a fix elsewhere.
-on: [push, pull_request, workflow_dispatch]
+# Pushes are only built on master. An unfiltered push event fires a second,
+# identical run alongside the pull_request one whenever the branch lives in
+# this repository rather than in a fork. The pull_request run is the one
+# worth keeping: it builds the branch merged with master, which is what
+# actually lands. Tags do not match either, and release.yml builds and
+# smoke-tests the tagged tree itself.
+#
+# A branch is therefore covered from the moment a pull request is opened.
+# Before that, and for re-running against a branch whose last push predates
+# a fix elsewhere, workflow_dispatch adds a "Run workflow" button on the
+# Actions tab that works against any branch.
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
 name: CI
 
 # A newer commit makes the runs still going for the previous one pointless.
-# A push to a branch with an open pull request fires both a push and a
-# pull_request run, so those are grouped separately rather than cancelling
-# each other. Pushes to master are left running, so every commit there
-# keeps a result.
+# github.ref is refs/pull/N/merge on a pull_request event, so a superseded
+# run of a pull request is cancelled. Pushes to master are left running, so
+# every commit there keeps a result.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}


### PR DESCRIPTION
A pull request whose branch lives in this repository rather than in a fork
matched both the `push` and the `pull_request` trigger, and so started two
identical CI runs on the same commit. #773, #774 and #775 each got a pair,
seconds apart:

```
CI  pull_request  guard-unencoded-satvar-sentinel  40796ba1  04:56:21
CI  push          guard-unencoded-satvar-sentinel  40796ba1  04:55:58
CI  pull_request  fixedbits-unsigned-bit-positions de088663  04:36:21
CI  push          fixedbits-unsigned-bit-positions de088663  04:36:01
```

The concurrency group did not collapse them. It keys on
`pull_request.number || github.ref`, which is the number for one event and
the branch ref for the other, so the two runs landed in different groups by
construction. A pull request from a fork never doubled up, because a push to
the fork raises no event here. Filtering the push trigger to master is what
`codeql-analysis.yml` already does, and it is why CodeQL never doubled up
either.

The `pull_request` run is the one to keep. It builds the branch merged with
master, which is what actually lands, where the push run only builds the
branch tip. Keeping it also means a superseded run is now cancelled:
`github.ref` is `refs/pull/N/merge` on a `pull_request` event, so
`cancel-in-progress` is true and each pull request has a single group.
Before, the surviving push run kept a runner busy on a commit nobody was
waiting for.

Two gaps, both already covered. A branch has no CI until its pull request is
opened, and the "Run workflow" button that `workflow_dispatch` adds handles
the stretch before that. Tags no longer match the push trigger either, but a
tag is cut from a master commit that has already been built, and
`release.yml` builds and smoke-tests the tagged tree itself before publishing
anything.

This pull request is its own first test: it comes from a fork, so it should
show exactly one CI run, built from the workflow as changed here.