### PR TITLE
Strength-reduce fp.eq against a constant to SMT equality

### DIFF
--- a/lib/NodeFactory/SimplifyingNodeFactory.cpp
+++ b/lib/NodeFactory/SimplifyingNodeFactory.cpp
@@ -109,6 +109,38 @@ static int fpConstPlusMinusOne(const stp::ASTNode& c)
   return CONSTANTBV::BitVector_bit_test(bits, eb + sb - 1) ? -1 : 1;
 }
 
+// True for a packed floating-point constant that is NaN: exponent field
+// (bits [sb-1 .. sb+eb-2]) all ones and stored significand (bits
+// [0 .. sb-2]) nonzero. Interning canonicalises every NaN literal to one
+// pattern, but classify from the bits rather than lean on that.
+static bool fpConstIsNaN(const stp::ASTNode& c)
+{
+  assert(c.GetKind() == stp::BVCONST);
+  const unsigned eb = c.GetExpWidth();
+  const unsigned sb = c.GetSigWidth();
+  assert(eb >= 2 && sb >= 2 && c.GetValueWidth() == eb + sb);
+  stp::CBV bits = c.GetBVConst();
+  for (unsigned i = sb - 1; i < sb + eb - 1; i++)
+    if (!CONSTANTBV::BitVector_bit_test(bits, i))
+      return false;
+  for (unsigned i = 0; i + 1 < sb; i++)
+    if (CONSTANTBV::BitVector_bit_test(bits, i))
+      return true;
+  return false;
+}
+
+// True for a packed floating-point constant that is +0 or -0: everything
+// below the sign bit is zero.
+static bool fpConstIsZero(const stp::ASTNode& c)
+{
+  assert(c.GetKind() == stp::BVCONST);
+  stp::CBV bits = c.GetBVConst();
+  for (unsigned i = 0; i + 1 < c.GetValueWidth(); i++)
+    if (CONSTANTBV::BitVector_bit_test(bits, i))
+      return false;
+  return true;
+}
+
 bool SimplifyingNodeFactory::children_all_constants(
     const ASTVec& children) const
 {
@@ -648,17 +680,66 @@ ASTNode SimplifyingNodeFactory::CreateNode(Kind kind, const ASTVec& children)
             stp::NOT, NodeFactory::CreateNode(stp::FP_ISNAN, children[0]));
       break;
 
-    // Both float equalities are symmetric. Order the operands so that x ~ y
-    // and y ~ x become the same node and share their blasted circuit.
     case stp::FP_EQ:
     case stp::FP_SMT_EQ:
-      if (children.size() == 2 &&
-          children[0].GetNodeNum() > children[1].GetNodeNum())
+      if (children.size() == 2)
       {
-        ASTVec swapped;
-        swapped.push_back(children[1]);
-        swapped.push_back(children[0]);
-        result = hashing.CreateNode(kind, swapped);
+        // x = x is reflexively true; fp.eq(x, x) fails exactly when x is NaN
+        // (the FP_GEQ rule above, restated for the other reflexive predicate).
+        if (children[0] == children[1])
+        {
+          if (kind == stp::FP_SMT_EQ)
+            result = bm.ASTTrue;
+          else
+            result = NodeFactory::CreateNode(
+                stp::NOT,
+                NodeFactory::CreateNode(stp::FP_ISNAN, children[0]));
+          break;
+        }
+
+        // fp.eq against a constant: fp.eq and = disagree only on pairs
+        // holding a NaN or two zeros, and inspecting the constant settles
+        // both. Nothing compares fp.eq-equal to NaN; the zeros compare
+        // fp.eq-equal to each other and to nothing else; any other value is
+        // the sole member of its fp.eq class, where IEEE equality *is*
+        // abstract equality. The prize is the = form: PropagateEqualities
+        // may substitute through it, which fp.eq must never do.
+        // (Both-constant instances folded before the switch.)
+        if (kind == stp::FP_EQ)
+        {
+          const int ci = children[0].GetKind() == stp::BVCONST   ? 0
+                         : children[1].GetKind() == stp::BVCONST ? 1
+                                                                 : -1;
+          // A constant operand of an fp.eq carries its format, but read the
+          // fields rather than assume: a packed carrier that has lost the
+          // stamp must fall through to the plain symmetric ordering.
+          const unsigned eb = ci < 0 ? 0 : children[ci].GetExpWidth();
+          const unsigned sb = ci < 0 ? 0 : children[ci].GetSigWidth();
+          if (ci >= 0 && eb >= 2 && sb >= 2 &&
+              children[ci].GetValueWidth() == eb + sb)
+          {
+            const ASTNode& c = children[ci];
+            const ASTNode& x = children[1 - ci];
+            if (fpConstIsNaN(c))
+              result = ASTFalse;
+            else if (fpConstIsZero(c))
+              result = NodeFactory::CreateNode(stp::FP_ISZERO, x);
+            else
+              result = NodeFactory::CreateNode(stp::FP_SMT_EQ, x, c);
+            break;
+          }
+        }
+
+        // Both float equalities are symmetric. Order the operands so that
+        // x ~ y and y ~ x become the same node and share their blasted
+        // circuit.
+        if (children[0].GetNodeNum() > children[1].GetNodeNum())
+        {
+          ASTVec swapped;
+          swapped.push_back(children[1]);
+          swapped.push_back(children[0]);
+          result = hashing.CreateNode(kind, swapped);
+        }
       }
       break;
 

--- a/tests/unit-tests/FPPrintBack_Test.cpp
+++ b/tests/unit-tests/FPPrintBack_Test.cpp
@@ -212,11 +212,16 @@ TEST(FPPrintBack, specials_equality_and_classifications)
     (declare-fun a () (Array (_ BitVec 4) (_ FloatingPoint 3 5)))
     (declare-fun i () (_ BitVec 4))
     (assert (= x (_ +oo 3 5)))
-    (assert (fp.eq y (_ -zero 3 5)))
+    (assert (= y (_ -zero 3 5)))
+    (assert (fp.eq x y))
     (assert (or (fp.isSubnormal x) (fp.isZero y) (fp.isInfinite x)))
     (assert (or (fp.isNegative y) (fp.isPositive (select a i))))
   )",
-             {"(fp #b0 #b111 #b0000)", "(fp #b1 #b000 #b0000)",
+             // The equalities keep their constants: `=` is the strong one, so
+             // the factory's fp.eq-against-a-constant reduction leaves it
+             // alone. fp.eq between two symbols has nothing to reduce to and
+             // survives for the printer to spell.
+             {"(fp #b0 #b111 #b0000)", "(fp #b1 #b000 #b0000)", "fp.eq",
               "fp.isSubnormal", "fp.isZero", "fp.isInfinite", "fp.isNegative",
               "fp.isPositive",
               // The float-element array declares with its element sort.

--- a/tests/unit-tests/PropagateEqualities_Test.cpp
+++ b/tests/unit-tests/PropagateEqualities_Test.cpp
@@ -442,12 +442,55 @@ TEST(PropagateEquality_Test, fp_smt_eq_symbols)
 
 TEST(PropagateEquality_Test, fp_eq_never_propagates)
 {
-  // fp.eq's +0 = -0 makes substitution unsound; the node must survive.
+  // fp.eq's +0 = -0 makes substitution unsound, so x must survive. The
+  // factory has already turned the comparison against a zero into the
+  // classification that says exactly this -- which is the point: isZero
+  // keeps both zeros available where `x := +0` would have lost -0.
   propagateFP(R"(
    (assert (fp.eq x (fp #b0 #b00000000 #b00000000000000000000000)))
   )",
               [](const stp::ASTNode& n) {
+                ASSERT_EQ(stp::FP_ISZERO, n.GetKind());
+                ASSERT_TRUE(containsSymbolNamed(n, "x"));
+              });
+}
+
+TEST(PropagateEquality_Test, fp_eq_symbols_never_propagates)
+{
+  // With no constant to classify against, fp.eq stays fp.eq: substituting
+  // one symbol for the other would identify +0 with -0.
+  propagateFP(R"(
+   (assert (fp.eq x y))
+  )",
+              [](const stp::ASTNode& n) {
                 ASSERT_EQ(stp::FP_EQ, n.GetKind());
+                ASSERT_TRUE(containsSymbolNamed(n, "x"));
+                ASSERT_TRUE(containsSymbolNamed(n, "y"));
+              });
+}
+
+TEST(PropagateEquality_Test, fp_eq_nonzero_constant_propagates)
+{
+  // Against a constant that is neither NaN nor a zero, fp.eq and `=` agree,
+  // so the factory hands PropagateEqualities the `=` form and x substitutes
+  // away -- the whole point of the strength reduction.
+  propagateFP(R"(
+   (assert (fp.eq x (fp #b0 #b01111111 #b10000000000000000000000)))
+   (assert (fp.gt x (fp #b0 #b01111111 #b00000000000000000000000)))
+  )",
+              [](const stp::ASTNode& n) {
+                ASSERT_FALSE(containsSymbolNamed(n, "x"));
+              });
+}
+
+TEST(PropagateEquality_Test, fp_eq_nan_constant_is_false)
+{
+  // Nothing is fp.eq-equal to NaN, itself included.
+  propagateFP(R"(
+   (assert (fp.eq x (_ NaN 8 24)))
+  )",
+              [](const stp::ASTNode& n) {
+                ASSERT_EQ(stp::FALSE, n.GetKind());
               });
 }
 

--- a/tools/test_fprewrites/test_fprewrites.cpp
+++ b/tools/test_fprewrites/test_fprewrites.cpp
@@ -556,6 +556,83 @@ static void run(Ctx& c)
                c.nf->CreateNode(FP_SMT_EQ, {y, x}));
   }
 
+  // The reflexive pair: `=` is reflexive on the abstract domain (one NaN
+  // value), fp.eq is not (NaN compares equal to nothing, itself included).
+  {
+    ASTNode x = c.fp(EB, SB);
+    report("x = x -> true",
+           c.nf->CreateNode(FP_SMT_EQ, {x, x}) == c.mgr.ASTTrue);
+    report("fp.eq(x, x) -> not isNaN(x)",
+           c.nf->CreateNode(FP_EQ, {x, x}) ==
+               c.hf->CreateNode(NOT, {c.hf->CreateNode(FP_ISNAN, {x})}));
+  }
+
+  // Strength reduction of fp.eq against a constant. The two equalities
+  // disagree only on pairs holding a NaN or two zeros, so the constant
+  // decides which of three forms is exact: false for a NaN, isZero for
+  // either zero, and `=` for everything else -- the one worth having, since
+  // `=` propagates as a substitution where fp.eq never may.
+  //
+  // Checked over EVERY constant of the format and both operand orders:
+  // structurally (the expected node came out) and semantically (the folded
+  // circuits agree on every value of the free operand, which is what makes
+  // the structural expectation worth asserting).
+  {
+    ASTNode x = c.fp(EB, SB);
+    const uint64_t N = 1ull << (EB + SB);
+    const uint64_t signBit = 1ull << (EB + SB - 1);
+    bool structOk = true, semOk = true;
+    std::string why;
+    for (uint64_t v = 0; v < N && semOk; v++)
+    {
+      const RefFp d = refDecode(EB, SB, v);
+      const ASTNode k = c.fpConst(EB, SB, v);
+      // Interning collapses every NaN pattern onto one; compare against the
+      // constant the factory actually saw, not the pattern asked for.
+      const ASTNode want =
+          d.nan ? c.mgr.ASTFalse
+          : d.zero
+              ? c.hf->CreateNode(FP_ISZERO, {x})
+              : c.nf->CreateNode(FP_SMT_EQ, {x, k});
+      for (int order = 0; order < 2 && semOk; order++)
+      {
+        const ASTVec kids = order ? ASTVec{k, x} : ASTVec{x, k};
+        const ASTNode got = c.nf->CreateNode(FP_EQ, kids);
+        if (got != want)
+        {
+          structOk = false;
+          why = "unexpected form at v=" + std::to_string(v);
+        }
+        const std::string bad =
+            c.firstDisagreement(c.hf->CreateNode(FP_EQ, kids), got);
+        if (!bad.empty())
+        {
+          semOk = false;
+          why = bad + " (constant v=" + std::to_string(v) + ")";
+        }
+      }
+    }
+    report("fp.eq(x, const) exact for every constant", semOk, why);
+    report("fp.eq(x, const) takes the expected form", structOk, why);
+
+    // The three forms really are distinguishable: a NaN constant must not
+    // become an equality, and a zero constant must catch the *other* zero.
+    // (Rewriting fp.eq(x, +0) to `= x +0` would be the classic unsoundness.)
+    const ASTNode posZero = c.fpConst(EB, SB, 0);
+    const ASTNode negZero = c.fpConst(EB, SB, signBit);
+    report("fp.eq(x, +0) and fp.eq(x, -0) agree",
+           c.nf->CreateNode(FP_EQ, {x, posZero}) ==
+               c.nf->CreateNode(FP_EQ, {x, negZero}));
+
+    // `=` against a constant must NOT pick up any of this: it is already the
+    // strong equality, and a zero constant there distinguishes the two zeros.
+    // (Only the operand order may change, so compare kinds, not nodes.)
+    report("smt = keeps its zero constant",
+           c.nf->CreateNode(FP_SMT_EQ, {x, posZero}).GetKind() == FP_SMT_EQ &&
+               c.nf->CreateNode(FP_SMT_EQ, {x, posZero}) !=
+                   c.nf->CreateNode(FP_SMT_EQ, {x, negZero}));
+  }
+
   // fp.add and fp.mul are commutative in their two float operands
   {
     ASTNode x = c.fp(EB, SB), y = c.fp(EB, SB);


### PR DESCRIPTION
`fp.eq` and `=` disagree on exactly two pair classes: **NaN**, where `=` is true (the abstract domain has one NaN) and `fp.eq` is false, and the **zeros**, where `fp.eq` identifies `+0` with `-0` and `=` keeps them apart. A constant operand excludes both, and inspecting it gives a complete case split — nothing is `fp.eq`-equal to NaN; the zeros are `fp.eq`-equal to each other and to nothing else; every other value is the sole member of its class, where IEEE equality *is* abstract equality:

```
fp.eq(x, NaN)    ->  false
fp.eq(x, +/-0)   ->  fp.isZero(x)
fp.eq(x, c)      ->  (= x c)
```

The third form is the one worth having. `PropagateEqualities` substitutes through `FP_SMT_EQ` but deliberately refuses `FP_EQ`, so this turns a dead-end predicate into an `x := c` substitution that fold-by-construction can then collapse. The zero case is not a lesser outcome either: `isZero` is a native classification, and it keeps both zeros available where a substitution would have lost one.

Two reflexive rules come along with it: `(= x x)` is true, and `fp.eq(x, x)` holds exactly when `x` is not NaN — the analogue of the `fp.geq(x, x)` rule the factory already had.

Constants carry their format since the constant-interning change, so the classification reads the packed exponent and significand fields directly — no unpacking and no `to_fp` lookthrough. The arm re-checks those fields and falls through to the plain symmetric ordering when they are absent, so a packed carrier that has lost its format stamp cannot be misclassified.

### Verification

`tools/test_fprewrites` gains an exhaustive check: for **every** constant of a small format — all 128 patterns, covering zeros, subnormals, normals, infinities and NaNs — and **both operand orders**, the rewritten node must both take the expected form and fold identically to the original on every value of the free operand. The oracle is the real `FloatBlast` lowering, so the test cannot drift from the blaster.

- 63 checks in `test_fprewrites`, 0 failures; 104/104 ctest pass.
- Differential sweep over 361 `fp.eq`-containing files from the QF_FP benchmarks, release build vs unmodified master: **0 answer mismatches** (200 sat / 161 unsat).

### Effect on CNF

Measured with `--output-CNF --exit-after-CNF` over every `fp.eq`-containing file outside wintersteiger (53 files producing a CNF): **−0.08%** clauses overall, 21 files changed, no file growing by more than 50 clauses on a 470k-clause base.

The aggregate is dominated by a few huge griggio files that this does not touch; the per-family picture is where it shows:

| family | n | base clauses | cand clauses | delta |
|---|---:|---:|---:|---:|
| 20210211-Vector | 14 | 2,676 | 2,118 | **−20.85%** |
| 20170501-Heizmann-UltimateAutomizer | 1 | 303,827 | 298,916 | −1.62% |
| ramalho | 8 | 98,365 | 97,553 | −0.83% |
| schanda | 14 | 378,469 | 375,550 | −0.77% |
| griggio | 11 | 10,087,967 | 10,088,053 | +0.00% |

Individual files roughly halve — `schanda/spark/cancel_1.smt2` 2,655 → 1,265 clauses, several Vector files 207 → 105 — and two Vector files stop producing a CNF at all, solved entirely by simplification (answers verified unchanged).

griggio is unmoved by design: its `fp.eq` uses are overwhelmingly variable-vs-variable, which has no constant to classify against and is correctly left alone.

### Test changes

`fp_eq_never_propagates` used `fp.eq x +0` and asserted the node kind stayed `FP_EQ`. That premise is now wrong at the surface but right in substance — the node becomes `FP_ISZERO(x)`, which refuses to substitute just as firmly and still keeps both zeros reachable — so it asserts that instead, and gains cases for the symbol-vs-symbol path (still `FP_EQ`), the nonzero constant (now propagates) and NaN (now `false`).

`FPPrintBack.specials_equality_and_classifications` lost its `-zero` literal from the printed output because `fp.eq y -zero` became `fp.isZero y`. The literal moves onto the `=` form, which keeps its constant, and the test now covers `fp.eq` between two symbols explicitly.