### PR TITLE
Cover the special-value matrix for both float equalities

### DIFF
--- a/tests/query-files/fp-tests/equality-specials-constant-matrix.smt2
+++ b/tests/query-files/fp-tests/equality-specials-constant-matrix.smt2
@@ -2,46 +2,103 @@
 ; RUN: %solver --disable-simplifications %s | %OutputCheck %s
 ; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck %s
 ;
-; The specials matrix again, but written as LITERALS, so it lands on the
-; constant path -- the node-creation folders and the constant evaluator --
-; rather than on a blasted circuit. Both operators, all pairs.
+; The specials matrix written as LITERALS, so it lands on the constant path
+; -- the node-creation folders and the constant evaluator -- rather than on a
+; blasted circuit. Both operators, one (check-sat) per fact.
 ;
-; The NaN rows are the reason this file exists as a separate test: three
-; different NaN bit patterns are used (canonical quiet, a payload-1 pattern
-; with the quiet bit clear, and one with the sign bit set and yet another
-; payload). All three denote the single SMT-LIB NaN, so `=` must hold
-; between any two of them and fp.eq between none. A constant path that
-; compared packed bits, or that let a payload survive interning, gets these
-; backwards -- and it cannot be caught by comparing two symbolic NaNs,
-; because the two spellings only ever meet as constants here.
+; The NaN rows are the reason this exists as a separate file: three different
+; NaN bit patterns are used (canonical quiet, a payload-1 pattern with the
+; quiet bit clear, and one with the sign bit set and another payload). All
+; three denote the single SMT-LIB NaN, so `=` must hold between any two and
+; fp.eq between none. A constant path that compared packed bits, or that let
+; a payload survive interning, gets these backwards -- and no symbolic test
+; can catch it, because the two spellings only ever meet as constants here.
 ;
-; CHECK: ^unsat
 (set-logic QF_FP)
-(assert (not (and
-  ; --- fp.eq: zeros equal, NaN never, infinities by sign ---
-  (fp.eq ((_ to_fp 8 24) #x00000000) ((_ to_fp 8 24) #x80000000))
-  (fp.eq ((_ to_fp 8 24) #x80000000) ((_ to_fp 8 24) #x00000000))
-  (fp.eq ((_ to_fp 8 24) #x7F800000) ((_ to_fp 8 24) #x7F800000))
-  (fp.eq ((_ to_fp 8 24) #xFF800000) ((_ to_fp 8 24) #xFF800000))
-  (not (fp.eq ((_ to_fp 8 24) #x7F800000) ((_ to_fp 8 24) #xFF800000)))
-  (not (fp.eq ((_ to_fp 8 24) #x7FC00000) ((_ to_fp 8 24) #x7FC00000)))
-  (not (fp.eq ((_ to_fp 8 24) #x7FC00000) ((_ to_fp 8 24) #x7F800001)))
-  (not (fp.eq ((_ to_fp 8 24) #x7F800001) ((_ to_fp 8 24) #xFFC12345)))
-  (not (fp.eq ((_ to_fp 8 24) #x7FC00000) ((_ to_fp 8 24) #x00000000)))
-  (not (fp.eq ((_ to_fp 8 24) #x7F800000) ((_ to_fp 8 24) #x3F800000)))
+(declare-fun unused () Bool)
 
-  ; --- = : zeros distinct, all NaNs identified, infinities by sign ---
-  (not (= ((_ to_fp 8 24) #x00000000) ((_ to_fp 8 24) #x80000000)))
-  (not (= ((_ to_fp 8 24) #x80000000) ((_ to_fp 8 24) #x00000000)))
-  (= ((_ to_fp 8 24) #x7F800000) ((_ to_fp 8 24) #x7F800000))
-  (= ((_ to_fp 8 24) #xFF800000) ((_ to_fp 8 24) #xFF800000))
-  (not (= ((_ to_fp 8 24) #x7F800000) ((_ to_fp 8 24) #xFF800000)))
-  (= ((_ to_fp 8 24) #x7FC00000) ((_ to_fp 8 24) #x7FC00000))
-  (= ((_ to_fp 8 24) #x7FC00000) ((_ to_fp 8 24) #x7F800001))
-  (= ((_ to_fp 8 24) #x7F800001) ((_ to_fp 8 24) #xFFC12345))
-  (= ((_ to_fp 8 24) #xFFC12345) ((_ to_fp 8 24) #x7FC00000))
-  (not (= ((_ to_fp 8 24) #x7FC00000) ((_ to_fp 8 24) #x00000000)))
-  (not (= ((_ to_fp 8 24) #x7F800000) ((_ to_fp 8 24) #x3F800000)))
-)))
-(check-sat)
+; fp.eq: the zero literals are numerically equal
+; CHECK: ^unsat
+(push 1) (assert (not (fp.eq ((_ to_fp 8 24) #x00000000) ((_ to_fp 8 24) #x80000000)))) (check-sat) (pop 1)
+
+; fp.eq: and in the other operand order
+; CHECK-NEXT: ^unsat
+(push 1) (assert (not (fp.eq ((_ to_fp 8 24) #x80000000) ((_ to_fp 8 24) #x00000000)))) (check-sat) (pop 1)
+
+; fp.eq: +oo literal against itself
+; CHECK-NEXT: ^unsat
+(push 1) (assert (not (fp.eq ((_ to_fp 8 24) #x7F800000) ((_ to_fp 8 24) #x7F800000)))) (check-sat) (pop 1)
+
+; fp.eq: -oo literal against itself
+; CHECK-NEXT: ^unsat
+(push 1) (assert (not (fp.eq ((_ to_fp 8 24) #xFF800000) ((_ to_fp 8 24) #xFF800000)))) (check-sat) (pop 1)
+
+; fp.eq: the infinity literals differ by sign
+; CHECK-NEXT: ^unsat
+(push 1) (assert (fp.eq ((_ to_fp 8 24) #x7F800000) ((_ to_fp 8 24) #xFF800000))) (check-sat) (pop 1)
+
+; fp.eq: a NaN literal is not equal to itself
+; CHECK-NEXT: ^unsat
+(push 1) (assert (fp.eq ((_ to_fp 8 24) #x7FC00000) ((_ to_fp 8 24) #x7FC00000))) (check-sat) (pop 1)
+
+; fp.eq: nor to a different NaN bit pattern
+; CHECK-NEXT: ^unsat
+(push 1) (assert (fp.eq ((_ to_fp 8 24) #x7FC00000) ((_ to_fp 8 24) #x7F800001))) (check-sat) (pop 1)
+
+; fp.eq: nor across payload AND sign
+; CHECK-NEXT: ^unsat
+(push 1) (assert (fp.eq ((_ to_fp 8 24) #x7F800001) ((_ to_fp 8 24) #xFFC12345))) (check-sat) (pop 1)
+
+; fp.eq: NaN literal against a zero literal
+; CHECK-NEXT: ^unsat
+(push 1) (assert (fp.eq ((_ to_fp 8 24) #x7FC00000) ((_ to_fp 8 24) #x00000000))) (check-sat) (pop 1)
+
+; fp.eq: infinity literal against a finite one
+; CHECK-NEXT: ^unsat
+(push 1) (assert (fp.eq ((_ to_fp 8 24) #x7F800000) ((_ to_fp 8 24) #x3F800000))) (check-sat) (pop 1)
+
+; =: the zero literals are two different values
+; CHECK-NEXT: ^unsat
+(push 1) (assert (= ((_ to_fp 8 24) #x00000000) ((_ to_fp 8 24) #x80000000))) (check-sat) (pop 1)
+
+; =: and in the other operand order
+; CHECK-NEXT: ^unsat
+(push 1) (assert (= ((_ to_fp 8 24) #x80000000) ((_ to_fp 8 24) #x00000000))) (check-sat) (pop 1)
+
+; =: +oo literal against itself
+; CHECK-NEXT: ^unsat
+(push 1) (assert (not (= ((_ to_fp 8 24) #x7F800000) ((_ to_fp 8 24) #x7F800000)))) (check-sat) (pop 1)
+
+; =: -oo literal against itself
+; CHECK-NEXT: ^unsat
+(push 1) (assert (not (= ((_ to_fp 8 24) #xFF800000) ((_ to_fp 8 24) #xFF800000)))) (check-sat) (pop 1)
+
+; =: the infinity literals differ by sign
+; CHECK-NEXT: ^unsat
+(push 1) (assert (= ((_ to_fp 8 24) #x7F800000) ((_ to_fp 8 24) #xFF800000))) (check-sat) (pop 1)
+
+; =: a NaN literal equals itself
+; CHECK-NEXT: ^unsat
+(push 1) (assert (not (= ((_ to_fp 8 24) #x7FC00000) ((_ to_fp 8 24) #x7FC00000)))) (check-sat) (pop 1)
+
+; =: and a different NaN bit pattern (interning)
+; CHECK-NEXT: ^unsat
+(push 1) (assert (not (= ((_ to_fp 8 24) #x7FC00000) ((_ to_fp 8 24) #x7F800001)))) (check-sat) (pop 1)
+
+; =: and across payload AND sign
+; CHECK-NEXT: ^unsat
+(push 1) (assert (not (= ((_ to_fp 8 24) #x7F800001) ((_ to_fp 8 24) #xFFC12345)))) (check-sat) (pop 1)
+
+; =: and in the other operand order
+; CHECK-NEXT: ^unsat
+(push 1) (assert (not (= ((_ to_fp 8 24) #xFFC12345) ((_ to_fp 8 24) #x7FC00000)))) (check-sat) (pop 1)
+
+; =: NaN literal against a zero literal
+; CHECK-NEXT: ^unsat
+(push 1) (assert (= ((_ to_fp 8 24) #x7FC00000) ((_ to_fp 8 24) #x00000000))) (check-sat) (pop 1)
+
+; =: infinity literal against a finite one
+; CHECK-NEXT: ^unsat
+(push 1) (assert (= ((_ to_fp 8 24) #x7F800000) ((_ to_fp 8 24) #x3F800000))) (check-sat) (pop 1)
+
 (exit)

--- a/tests/query-files/fp-tests/equality-specials-constant-matrix.smt2
+++ b/tests/query-files/fp-tests/equality-specials-constant-matrix.smt2
@@ -1,0 +1,47 @@
+; RUN: %solver %s | %OutputCheck %s
+; RUN: %solver --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck %s
+;
+; The specials matrix again, but written as LITERALS, so it lands on the
+; constant path -- the node-creation folders and the constant evaluator --
+; rather than on a blasted circuit. Both operators, all pairs.
+;
+; The NaN rows are the reason this file exists as a separate test: three
+; different NaN bit patterns are used (canonical quiet, a payload-1 pattern
+; with the quiet bit clear, and one with the sign bit set and yet another
+; payload). All three denote the single SMT-LIB NaN, so `=` must hold
+; between any two of them and fp.eq between none. A constant path that
+; compared packed bits, or that let a payload survive interning, gets these
+; backwards -- and it cannot be caught by comparing two symbolic NaNs,
+; because the two spellings only ever meet as constants here.
+;
+; CHECK: ^unsat
+(set-logic QF_FP)
+(assert (not (and
+  ; --- fp.eq: zeros equal, NaN never, infinities by sign ---
+  (fp.eq ((_ to_fp 8 24) #x00000000) ((_ to_fp 8 24) #x80000000))
+  (fp.eq ((_ to_fp 8 24) #x80000000) ((_ to_fp 8 24) #x00000000))
+  (fp.eq ((_ to_fp 8 24) #x7F800000) ((_ to_fp 8 24) #x7F800000))
+  (fp.eq ((_ to_fp 8 24) #xFF800000) ((_ to_fp 8 24) #xFF800000))
+  (not (fp.eq ((_ to_fp 8 24) #x7F800000) ((_ to_fp 8 24) #xFF800000)))
+  (not (fp.eq ((_ to_fp 8 24) #x7FC00000) ((_ to_fp 8 24) #x7FC00000)))
+  (not (fp.eq ((_ to_fp 8 24) #x7FC00000) ((_ to_fp 8 24) #x7F800001)))
+  (not (fp.eq ((_ to_fp 8 24) #x7F800001) ((_ to_fp 8 24) #xFFC12345)))
+  (not (fp.eq ((_ to_fp 8 24) #x7FC00000) ((_ to_fp 8 24) #x00000000)))
+  (not (fp.eq ((_ to_fp 8 24) #x7F800000) ((_ to_fp 8 24) #x3F800000)))
+
+  ; --- = : zeros distinct, all NaNs identified, infinities by sign ---
+  (not (= ((_ to_fp 8 24) #x00000000) ((_ to_fp 8 24) #x80000000)))
+  (not (= ((_ to_fp 8 24) #x80000000) ((_ to_fp 8 24) #x00000000)))
+  (= ((_ to_fp 8 24) #x7F800000) ((_ to_fp 8 24) #x7F800000))
+  (= ((_ to_fp 8 24) #xFF800000) ((_ to_fp 8 24) #xFF800000))
+  (not (= ((_ to_fp 8 24) #x7F800000) ((_ to_fp 8 24) #xFF800000)))
+  (= ((_ to_fp 8 24) #x7FC00000) ((_ to_fp 8 24) #x7FC00000))
+  (= ((_ to_fp 8 24) #x7FC00000) ((_ to_fp 8 24) #x7F800001))
+  (= ((_ to_fp 8 24) #x7F800001) ((_ to_fp 8 24) #xFFC12345))
+  (= ((_ to_fp 8 24) #xFFC12345) ((_ to_fp 8 24) #x7FC00000))
+  (not (= ((_ to_fp 8 24) #x7FC00000) ((_ to_fp 8 24) #x00000000)))
+  (not (= ((_ to_fp 8 24) #x7F800000) ((_ to_fp 8 24) #x3F800000)))
+)))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/equality-specials-symbolic-vs-constant.smt2
+++ b/tests/query-files/fp-tests/equality-specials-symbolic-vs-constant.smt2
@@ -3,70 +3,136 @@
 ; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck %s
 ;
 ; The specials matrix with ONE symbolic operand and one literal -- the shape
-; the factory strength-reduces, and the only one of the three arrangements
-; that reaches it. (Two literals fold before the rule; two symbols have no
-; constant to classify against.) Each arm of the reduction is exercised
-; against every class of symbolic operand:
+; the factory strength-reduces, and the only arrangement that reaches it.
+; (Two literals fold before the rule; two symbols have no constant to
+; classify against.) One (check-sat) per fact, so a failure names the arm.
 ;
+; Each arm of the reduction is exercised against every class of symbolic
+; operand:
 ;   fp.eq(x, NaN literal)  -> false          the NaN arm
 ;   fp.eq(x, +/-0 literal) -> fp.isZero(x)   the zero arm; must catch BOTH
 ;                                            zeros whichever zero is written
 ;   fp.eq(x, c)            -> (= x c)        the arm that lets equalities
 ;                                            propagate
-;
 ; The three NaN literals differ in payload and sign, so the NaN arm is
 ; checked against each spelling. The zero rows are the ones that would break
 ; if the zero arm were ever "simplified" to a plain equality: a -0 literal
 ; against a +0 variable has to stay true.
 ;
-; The required truth values are conjoined and negated, so any one of them
-; going the wrong way makes this satisfiable.
-;
-; CHECK: ^unsat
 (set-logic QF_FP)
 (declare-fun pz () (_ FloatingPoint 8 24))
 (declare-fun mz () (_ FloatingPoint 8 24))
 (declare-fun pi () (_ FloatingPoint 8 24))
 (declare-fun mi () (_ FloatingPoint 8 24))
-(declare-fun nn () (_ FloatingPoint 8 24))
-
+(declare-fun n1 () (_ FloatingPoint 8 24))
+(declare-fun n2 () (_ FloatingPoint 8 24))
+(declare-fun one () (_ FloatingPoint 8 24))
 (assert (and (fp.isZero pz) (fp.isPositive pz)))
 (assert (and (fp.isZero mz) (fp.isNegative mz)))
 (assert (and (fp.isInfinite pi) (fp.isPositive pi)))
 (assert (and (fp.isInfinite mi) (fp.isNegative mi)))
-(assert (fp.isNaN nn))
+(assert (fp.isNaN n1))
+(assert (fp.isNaN n2))
+(assert (= one ((_ to_fp 8 24) #x3F800000)))
 
-(assert (not (and
-  ; --- fp.eq, zero arm: either zero literal matches either zero variable ---
-  (fp.eq pz ((_ to_fp 8 24) #x00000000))
-  (fp.eq pz ((_ to_fp 8 24) #x80000000))
-  (fp.eq mz ((_ to_fp 8 24) #x00000000))
-  (fp.eq mz ((_ to_fp 8 24) #x80000000))
-  ; --- fp.eq, NaN arm: false for every NaN spelling and every operand ---
-  (not (fp.eq nn ((_ to_fp 8 24) #x7FC00000)))
-  (not (fp.eq nn ((_ to_fp 8 24) #x7F800001)))
-  (not (fp.eq nn ((_ to_fp 8 24) #xFFC12345)))
-  (not (fp.eq pz ((_ to_fp 8 24) #x7FC00000)))
-  (not (fp.eq pi ((_ to_fp 8 24) #x7F800001)))
-  ; --- fp.eq, equality arm: infinities by sign, finite by value ---
-  (fp.eq pi ((_ to_fp 8 24) #x7F800000))
-  (fp.eq mi ((_ to_fp 8 24) #xFF800000))
-  (not (fp.eq pi ((_ to_fp 8 24) #xFF800000)))
-  (not (fp.eq mi ((_ to_fp 8 24) #x7F800000)))
-  (not (fp.eq pi ((_ to_fp 8 24) #x3F800000)))
-  (not (fp.eq pz ((_ to_fp 8 24) #x3F800000)))
-  ; --- `=` against the same literals keeps the zeros apart and the NaNs
-  ;     together, and must NOT pick up the fp.eq behaviour above ---
-  (= pz ((_ to_fp 8 24) #x00000000))
-  (not (= pz ((_ to_fp 8 24) #x80000000)))
-  (not (= mz ((_ to_fp 8 24) #x00000000)))
-  (= mz ((_ to_fp 8 24) #x80000000))
-  (= nn ((_ to_fp 8 24) #x7FC00000))
-  (= nn ((_ to_fp 8 24) #x7F800001))
-  (= nn ((_ to_fp 8 24) #xFFC12345))
-  (= pi ((_ to_fp 8 24) #x7F800000))
-  (not (= pi ((_ to_fp 8 24) #xFF800000)))
-  (not (= pz ((_ to_fp 8 24) #x7FC00000)))
-)))
-(check-sat)
+; zero arm: +0 variable against the +0 literal
+; CHECK: ^unsat
+(push 1) (assert (not (fp.eq pz ((_ to_fp 8 24) #x00000000)))) (check-sat) (pop 1)
+
+; zero arm: +0 variable against the -0 literal
+; CHECK-NEXT: ^unsat
+(push 1) (assert (not (fp.eq pz ((_ to_fp 8 24) #x80000000)))) (check-sat) (pop 1)
+
+; zero arm: -0 variable against the +0 literal
+; CHECK-NEXT: ^unsat
+(push 1) (assert (not (fp.eq mz ((_ to_fp 8 24) #x00000000)))) (check-sat) (pop 1)
+
+; zero arm: -0 variable against the -0 literal
+; CHECK-NEXT: ^unsat
+(push 1) (assert (not (fp.eq mz ((_ to_fp 8 24) #x80000000)))) (check-sat) (pop 1)
+
+; NaN arm: canonical quiet NaN literal
+; CHECK-NEXT: ^unsat
+(push 1) (assert (fp.eq n1 ((_ to_fp 8 24) #x7FC00000))) (check-sat) (pop 1)
+
+; NaN arm: payload-1 NaN literal
+; CHECK-NEXT: ^unsat
+(push 1) (assert (fp.eq n1 ((_ to_fp 8 24) #x7F800001))) (check-sat) (pop 1)
+
+; NaN arm: sign-set NaN literal
+; CHECK-NEXT: ^unsat
+(push 1) (assert (fp.eq n1 ((_ to_fp 8 24) #xFFC12345))) (check-sat) (pop 1)
+
+; NaN arm: a zero variable against a NaN literal
+; CHECK-NEXT: ^unsat
+(push 1) (assert (fp.eq pz ((_ to_fp 8 24) #x7FC00000))) (check-sat) (pop 1)
+
+; NaN arm: an infinity variable against a NaN literal
+; CHECK-NEXT: ^unsat
+(push 1) (assert (fp.eq pi ((_ to_fp 8 24) #x7F800001))) (check-sat) (pop 1)
+
+; equality arm: +oo variable against the +oo literal
+; CHECK-NEXT: ^unsat
+(push 1) (assert (not (fp.eq pi ((_ to_fp 8 24) #x7F800000)))) (check-sat) (pop 1)
+
+; equality arm: -oo variable against the -oo literal
+; CHECK-NEXT: ^unsat
+(push 1) (assert (not (fp.eq mi ((_ to_fp 8 24) #xFF800000)))) (check-sat) (pop 1)
+
+; equality arm: infinities differ by sign
+; CHECK-NEXT: ^unsat
+(push 1) (assert (fp.eq pi ((_ to_fp 8 24) #xFF800000))) (check-sat) (pop 1)
+
+; equality arm: and in the other direction
+; CHECK-NEXT: ^unsat
+(push 1) (assert (fp.eq mi ((_ to_fp 8 24) #x7F800000))) (check-sat) (pop 1)
+
+; equality arm: infinity variable, finite literal
+; CHECK-NEXT: ^unsat
+(push 1) (assert (fp.eq pi ((_ to_fp 8 24) #x3F800000))) (check-sat) (pop 1)
+
+; equality arm: zero variable, finite literal
+; CHECK-NEXT: ^unsat
+(push 1) (assert (fp.eq pz ((_ to_fp 8 24) #x3F800000))) (check-sat) (pop 1)
+
+; = keeps the zeros apart: +0 variable, +0 literal
+; CHECK-NEXT: ^unsat
+(push 1) (assert (not (= pz ((_ to_fp 8 24) #x00000000)))) (check-sat) (pop 1)
+
+; = keeps the zeros apart: +0 variable, -0 literal
+; CHECK-NEXT: ^unsat
+(push 1) (assert (= pz ((_ to_fp 8 24) #x80000000))) (check-sat) (pop 1)
+
+; = keeps the zeros apart: -0 variable, +0 literal
+; CHECK-NEXT: ^unsat
+(push 1) (assert (= mz ((_ to_fp 8 24) #x00000000))) (check-sat) (pop 1)
+
+; = keeps the zeros apart: -0 variable, -0 literal
+; CHECK-NEXT: ^unsat
+(push 1) (assert (not (= mz ((_ to_fp 8 24) #x80000000)))) (check-sat) (pop 1)
+
+; = identifies the NaNs: canonical quiet literal
+; CHECK-NEXT: ^unsat
+(push 1) (assert (not (= n1 ((_ to_fp 8 24) #x7FC00000)))) (check-sat) (pop 1)
+
+; = identifies the NaNs: payload-1 literal
+; CHECK-NEXT: ^unsat
+(push 1) (assert (not (= n1 ((_ to_fp 8 24) #x7F800001)))) (check-sat) (pop 1)
+
+; = identifies the NaNs: sign-set literal
+; CHECK-NEXT: ^unsat
+(push 1) (assert (not (= n1 ((_ to_fp 8 24) #xFFC12345)))) (check-sat) (pop 1)
+
+; = on infinities: +oo variable, +oo literal
+; CHECK-NEXT: ^unsat
+(push 1) (assert (not (= pi ((_ to_fp 8 24) #x7F800000)))) (check-sat) (pop 1)
+
+; = on infinities: +oo variable, -oo literal
+; CHECK-NEXT: ^unsat
+(push 1) (assert (= pi ((_ to_fp 8 24) #xFF800000))) (check-sat) (pop 1)
+
+; = cross-class: zero variable, NaN literal
+; CHECK-NEXT: ^unsat
+(push 1) (assert (= pz ((_ to_fp 8 24) #x7FC00000))) (check-sat) (pop 1)
+
 (exit)

--- a/tests/query-files/fp-tests/equality-specials-symbolic-vs-constant.smt2
+++ b/tests/query-files/fp-tests/equality-specials-symbolic-vs-constant.smt2
@@ -1,0 +1,72 @@
+; RUN: %solver %s | %OutputCheck %s
+; RUN: %solver --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck %s
+;
+; The specials matrix with ONE symbolic operand and one literal -- the shape
+; the factory strength-reduces, and the only one of the three arrangements
+; that reaches it. (Two literals fold before the rule; two symbols have no
+; constant to classify against.) Each arm of the reduction is exercised
+; against every class of symbolic operand:
+;
+;   fp.eq(x, NaN literal)  -> false          the NaN arm
+;   fp.eq(x, +/-0 literal) -> fp.isZero(x)   the zero arm; must catch BOTH
+;                                            zeros whichever zero is written
+;   fp.eq(x, c)            -> (= x c)        the arm that lets equalities
+;                                            propagate
+;
+; The three NaN literals differ in payload and sign, so the NaN arm is
+; checked against each spelling. The zero rows are the ones that would break
+; if the zero arm were ever "simplified" to a plain equality: a -0 literal
+; against a +0 variable has to stay true.
+;
+; The required truth values are conjoined and negated, so any one of them
+; going the wrong way makes this satisfiable.
+;
+; CHECK: ^unsat
+(set-logic QF_FP)
+(declare-fun pz () (_ FloatingPoint 8 24))
+(declare-fun mz () (_ FloatingPoint 8 24))
+(declare-fun pi () (_ FloatingPoint 8 24))
+(declare-fun mi () (_ FloatingPoint 8 24))
+(declare-fun nn () (_ FloatingPoint 8 24))
+
+(assert (and (fp.isZero pz) (fp.isPositive pz)))
+(assert (and (fp.isZero mz) (fp.isNegative mz)))
+(assert (and (fp.isInfinite pi) (fp.isPositive pi)))
+(assert (and (fp.isInfinite mi) (fp.isNegative mi)))
+(assert (fp.isNaN nn))
+
+(assert (not (and
+  ; --- fp.eq, zero arm: either zero literal matches either zero variable ---
+  (fp.eq pz ((_ to_fp 8 24) #x00000000))
+  (fp.eq pz ((_ to_fp 8 24) #x80000000))
+  (fp.eq mz ((_ to_fp 8 24) #x00000000))
+  (fp.eq mz ((_ to_fp 8 24) #x80000000))
+  ; --- fp.eq, NaN arm: false for every NaN spelling and every operand ---
+  (not (fp.eq nn ((_ to_fp 8 24) #x7FC00000)))
+  (not (fp.eq nn ((_ to_fp 8 24) #x7F800001)))
+  (not (fp.eq nn ((_ to_fp 8 24) #xFFC12345)))
+  (not (fp.eq pz ((_ to_fp 8 24) #x7FC00000)))
+  (not (fp.eq pi ((_ to_fp 8 24) #x7F800001)))
+  ; --- fp.eq, equality arm: infinities by sign, finite by value ---
+  (fp.eq pi ((_ to_fp 8 24) #x7F800000))
+  (fp.eq mi ((_ to_fp 8 24) #xFF800000))
+  (not (fp.eq pi ((_ to_fp 8 24) #xFF800000)))
+  (not (fp.eq mi ((_ to_fp 8 24) #x7F800000)))
+  (not (fp.eq pi ((_ to_fp 8 24) #x3F800000)))
+  (not (fp.eq pz ((_ to_fp 8 24) #x3F800000)))
+  ; --- `=` against the same literals keeps the zeros apart and the NaNs
+  ;     together, and must NOT pick up the fp.eq behaviour above ---
+  (= pz ((_ to_fp 8 24) #x00000000))
+  (not (= pz ((_ to_fp 8 24) #x80000000)))
+  (not (= mz ((_ to_fp 8 24) #x00000000)))
+  (= mz ((_ to_fp 8 24) #x80000000))
+  (= nn ((_ to_fp 8 24) #x7FC00000))
+  (= nn ((_ to_fp 8 24) #x7F800001))
+  (= nn ((_ to_fp 8 24) #xFFC12345))
+  (= pi ((_ to_fp 8 24) #x7F800000))
+  (not (= pi ((_ to_fp 8 24) #xFF800000)))
+  (not (= pz ((_ to_fp 8 24) #x7FC00000)))
+)))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/fp-eq-specials-matrix.smt2
+++ b/tests/query-files/fp-tests/fp-eq-specials-matrix.smt2
@@ -1,0 +1,50 @@
+; RUN: %solver %s | %OutputCheck %s
+; RUN: %solver --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck %s
+;
+; fp.eq over the whole matrix of special values, pairwise. The operands are
+; symbolic and pinned by classification, so each is free to be any witness of
+; its class -- in particular the two NaNs may take different payloads and
+; different signs -- and the whole matrix has to hold for every choice.
+;
+; fp.eq is IEEE numeric equality:
+;   * the two zeros are numerically equal, so every zero pair is true;
+;   * NaN is equal to nothing, itself included;
+;   * infinities are equal exactly when their signs agree.
+; The required truth values are conjoined and negated, so any one of them
+; going the wrong way makes this satisfiable.
+;
+; CHECK: ^unsat
+(set-logic QF_FP)
+(declare-fun pz () (_ FloatingPoint 8 24))
+(declare-fun mz () (_ FloatingPoint 8 24))
+(declare-fun pi () (_ FloatingPoint 8 24))
+(declare-fun mi () (_ FloatingPoint 8 24))
+(declare-fun n1 () (_ FloatingPoint 8 24))
+(declare-fun n2 () (_ FloatingPoint 8 24))
+(declare-fun one () (_ FloatingPoint 8 24))
+
+(assert (and (fp.isZero pz) (fp.isPositive pz)))
+(assert (and (fp.isZero mz) (fp.isNegative mz)))
+(assert (and (fp.isInfinite pi) (fp.isPositive pi)))
+(assert (and (fp.isInfinite mi) (fp.isNegative mi)))
+(assert (fp.isNaN n1))
+(assert (fp.isNaN n2))
+(assert (= one ((_ to_fp 8 24) #x3F800000)))
+
+(assert (not (and
+  ; zero vs zero: all three pairs true, signs irrelevant to fp.eq
+  (fp.eq pz pz) (fp.eq pz mz) (fp.eq mz mz)
+  ; NaN vs NaN: false even for the same variable, and across payloads
+  (not (fp.eq n1 n1)) (not (fp.eq n1 n2)) (not (fp.eq n2 n2))
+  ; infinity vs infinity: by sign
+  (fp.eq pi pi) (fp.eq mi mi) (not (fp.eq pi mi))
+  ; cross-class
+  (not (fp.eq n1 pz)) (not (fp.eq n1 pi)) (not (fp.eq n1 one))
+  (not (fp.eq pi pz)) (not (fp.eq pi one)) (not (fp.eq mi one))
+  (not (fp.eq pz one)) (not (fp.eq mz one))
+  ; symmetric in both operand orders
+  (fp.eq mz pz) (not (fp.eq mi pi)) (not (fp.eq one pi))
+)))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/fp-eq-specials-matrix.smt2
+++ b/tests/query-files/fp-tests/fp-eq-specials-matrix.smt2
@@ -2,19 +2,17 @@
 ; RUN: %solver --disable-simplifications %s | %OutputCheck %s
 ; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck %s
 ;
-; fp.eq over the whole matrix of special values, pairwise. The operands are
-; symbolic and pinned by classification, so each is free to be any witness of
-; its class -- in particular the two NaNs may take different payloads and
-; different signs -- and the whole matrix has to hold for every choice.
+; fp.eq over the matrix of special values, pairwise, one (check-sat) per
+; fact so that a failure names the row rather than the file. The operands
+; are symbolic and pinned by classification, so each is free to be any
+; witness of its class -- in particular the two NaNs may take different
+; payloads and different signs -- and every row has to hold for every
+; choice.
 ;
-; fp.eq is IEEE numeric equality:
-;   * the two zeros are numerically equal, so every zero pair is true;
-;   * NaN is equal to nothing, itself included;
-;   * infinities are equal exactly when their signs agree.
-; The required truth values are conjoined and negated, so any one of them
-; going the wrong way makes this satisfiable.
+; fp.eq is IEEE numeric equality: the two zeros are numerically equal, NaN
+; is equal to nothing, and infinities agree exactly when their signs do.
+; Each row is probed on its own, in the polarity that makes it unsat.
 ;
-; CHECK: ^unsat
 (set-logic QF_FP)
 (declare-fun pz () (_ FloatingPoint 8 24))
 (declare-fun mz () (_ FloatingPoint 8 24))
@@ -23,7 +21,6 @@
 (declare-fun n1 () (_ FloatingPoint 8 24))
 (declare-fun n2 () (_ FloatingPoint 8 24))
 (declare-fun one () (_ FloatingPoint 8 24))
-
 (assert (and (fp.isZero pz) (fp.isPositive pz)))
 (assert (and (fp.isZero mz) (fp.isNegative mz)))
 (assert (and (fp.isInfinite pi) (fp.isPositive pi)))
@@ -32,19 +29,72 @@
 (assert (fp.isNaN n2))
 (assert (= one ((_ to_fp 8 24) #x3F800000)))
 
-(assert (not (and
-  ; zero vs zero: all three pairs true, signs irrelevant to fp.eq
-  (fp.eq pz pz) (fp.eq pz mz) (fp.eq mz mz)
-  ; NaN vs NaN: false even for the same variable, and across payloads
-  (not (fp.eq n1 n1)) (not (fp.eq n1 n2)) (not (fp.eq n2 n2))
-  ; infinity vs infinity: by sign
-  (fp.eq pi pi) (fp.eq mi mi) (not (fp.eq pi mi))
-  ; cross-class
-  (not (fp.eq n1 pz)) (not (fp.eq n1 pi)) (not (fp.eq n1 one))
-  (not (fp.eq pi pz)) (not (fp.eq pi one)) (not (fp.eq mi one))
-  (not (fp.eq pz one)) (not (fp.eq mz one))
-  ; symmetric in both operand orders
-  (fp.eq mz pz) (not (fp.eq mi pi)) (not (fp.eq one pi))
-)))
-(check-sat)
+; the two zeros are numerically equal
+; CHECK: ^unsat
+(push 1) (assert (not (fp.eq pz mz))) (check-sat) (pop 1)
+
+; +0 against itself
+; CHECK-NEXT: ^unsat
+(push 1) (assert (not (fp.eq pz pz))) (check-sat) (pop 1)
+
+; -0 against itself
+; CHECK-NEXT: ^unsat
+(push 1) (assert (not (fp.eq mz mz))) (check-sat) (pop 1)
+
+; and in the other operand order
+; CHECK-NEXT: ^unsat
+(push 1) (assert (not (fp.eq mz pz))) (check-sat) (pop 1)
+
+; NaN is equal to nothing, itself included
+; CHECK-NEXT: ^unsat
+(push 1) (assert (fp.eq n1 n1)) (check-sat) (pop 1)
+
+; nor to a second NaN, of any payload or sign
+; CHECK-NEXT: ^unsat
+(push 1) (assert (fp.eq n1 n2)) (check-sat) (pop 1)
+
+; nor in the other operand order
+; CHECK-NEXT: ^unsat
+(push 1) (assert (fp.eq n2 n1)) (check-sat) (pop 1)
+
+; +oo equals +oo
+; CHECK-NEXT: ^unsat
+(push 1) (assert (not (fp.eq pi pi))) (check-sat) (pop 1)
+
+; -oo equals -oo
+; CHECK-NEXT: ^unsat
+(push 1) (assert (not (fp.eq mi mi))) (check-sat) (pop 1)
+
+; but the infinities differ by sign
+; CHECK-NEXT: ^unsat
+(push 1) (assert (fp.eq pi mi)) (check-sat) (pop 1)
+
+; and in the other operand order
+; CHECK-NEXT: ^unsat
+(push 1) (assert (fp.eq mi pi)) (check-sat) (pop 1)
+
+; NaN against a zero
+; CHECK-NEXT: ^unsat
+(push 1) (assert (fp.eq n1 pz)) (check-sat) (pop 1)
+
+; NaN against an infinity
+; CHECK-NEXT: ^unsat
+(push 1) (assert (fp.eq n1 pi)) (check-sat) (pop 1)
+
+; NaN against a finite value
+; CHECK-NEXT: ^unsat
+(push 1) (assert (fp.eq n1 one)) (check-sat) (pop 1)
+
+; an infinity against a zero
+; CHECK-NEXT: ^unsat
+(push 1) (assert (fp.eq pi pz)) (check-sat) (pop 1)
+
+; an infinity against a finite value
+; CHECK-NEXT: ^unsat
+(push 1) (assert (fp.eq pi one)) (check-sat) (pop 1)
+
+; a zero against a finite value
+; CHECK-NEXT: ^unsat
+(push 1) (assert (fp.eq pz one)) (check-sat) (pop 1)
+
 (exit)

--- a/tests/query-files/fp-tests/smt-eq-specials-matrix.smt2
+++ b/tests/query-files/fp-tests/smt-eq-specials-matrix.smt2
@@ -2,21 +2,17 @@
 ; RUN: %solver --disable-simplifications %s | %OutputCheck %s
 ; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck %s
 ;
-; SMT-LIB `=` over the whole matrix of special values, pairwise, as the
-; companion to fp-eq-specials-matrix.smt2 -- the two operators disagree on
-; exactly the zero and NaN rows, and running the same matrix through both is
-; what pins that difference down.
+; SMT-LIB `=` over the matrix of special values, pairwise, one (check-sat)
+; per fact -- the companion to fp-eq-specials-matrix.smt2. The two operators
+; disagree on exactly the zero and NaN rows, and running the same matrix
+; through both is what pins that difference down.
 ;
-; `=` is equality on the abstract FloatingPoint domain:
-;   * +0 and -0 are DISTINCT values, so the mixed zero pair is false;
-;   * there is ONE NaN, so any two NaNs are equal whatever payloads and signs
-;     the solver picks for them (the both-NaN disjunct of the native BBeqFP
-;     encoding -- comparing packed bits alone fails this);
-;   * infinities are equal exactly when their signs agree.
-; The required truth values are conjoined and negated, so any one of them
-; going the wrong way makes this satisfiable.
+; `=` is equality on the abstract FloatingPoint domain: +0 and -0 are
+; DISTINCT values, there is ONE NaN so any two NaNs are equal whatever
+; payloads and signs the solver picks (the both-NaN disjunct of the native
+; BBeqFP encoding -- comparing packed bits alone fails this), and infinities
+; agree exactly when their signs do.
 ;
-; CHECK: ^unsat
 (set-logic QF_FP)
 (declare-fun pz () (_ FloatingPoint 8 24))
 (declare-fun mz () (_ FloatingPoint 8 24))
@@ -25,7 +21,6 @@
 (declare-fun n1 () (_ FloatingPoint 8 24))
 (declare-fun n2 () (_ FloatingPoint 8 24))
 (declare-fun one () (_ FloatingPoint 8 24))
-
 (assert (and (fp.isZero pz) (fp.isPositive pz)))
 (assert (and (fp.isZero mz) (fp.isNegative mz)))
 (assert (and (fp.isInfinite pi) (fp.isPositive pi)))
@@ -34,19 +29,72 @@
 (assert (fp.isNaN n2))
 (assert (= one ((_ to_fp 8 24) #x3F800000)))
 
-(assert (not (and
-  ; zero vs zero: the signed zeros are two different values
-  (= pz pz) (= mz mz) (not (= pz mz))
-  ; NaN vs NaN: one NaN value, so true across payloads and signs
-  (= n1 n1) (= n2 n2) (= n1 n2)
-  ; infinity vs infinity: by sign
-  (= pi pi) (= mi mi) (not (= pi mi))
-  ; cross-class
-  (not (= n1 pz)) (not (= n1 pi)) (not (= n1 one))
-  (not (= pi pz)) (not (= pi one)) (not (= mi one))
-  (not (= pz one)) (not (= mz one))
-  ; symmetric in both operand orders
-  (not (= mz pz)) (= n2 n1) (not (= mi pi))
-)))
-(check-sat)
+; +0 against itself
+; CHECK: ^unsat
+(push 1) (assert (not (= pz pz))) (check-sat) (pop 1)
+
+; -0 against itself
+; CHECK-NEXT: ^unsat
+(push 1) (assert (not (= mz mz))) (check-sat) (pop 1)
+
+; the signed zeros are two DIFFERENT values
+; CHECK-NEXT: ^unsat
+(push 1) (assert (= pz mz)) (check-sat) (pop 1)
+
+; and in the other operand order
+; CHECK-NEXT: ^unsat
+(push 1) (assert (= mz pz)) (check-sat) (pop 1)
+
+; one NaN value: a NaN equals itself
+; CHECK-NEXT: ^unsat
+(push 1) (assert (not (= n1 n1))) (check-sat) (pop 1)
+
+; and a second NaN, whatever payload and sign
+; CHECK-NEXT: ^unsat
+(push 1) (assert (not (= n1 n2))) (check-sat) (pop 1)
+
+; and in the other operand order
+; CHECK-NEXT: ^unsat
+(push 1) (assert (not (= n2 n1))) (check-sat) (pop 1)
+
+; +oo equals +oo
+; CHECK-NEXT: ^unsat
+(push 1) (assert (not (= pi pi))) (check-sat) (pop 1)
+
+; -oo equals -oo
+; CHECK-NEXT: ^unsat
+(push 1) (assert (not (= mi mi))) (check-sat) (pop 1)
+
+; but the infinities differ by sign
+; CHECK-NEXT: ^unsat
+(push 1) (assert (= pi mi)) (check-sat) (pop 1)
+
+; and in the other operand order
+; CHECK-NEXT: ^unsat
+(push 1) (assert (= mi pi)) (check-sat) (pop 1)
+
+; NaN against a zero
+; CHECK-NEXT: ^unsat
+(push 1) (assert (= n1 pz)) (check-sat) (pop 1)
+
+; NaN against an infinity
+; CHECK-NEXT: ^unsat
+(push 1) (assert (= n1 pi)) (check-sat) (pop 1)
+
+; NaN against a finite value
+; CHECK-NEXT: ^unsat
+(push 1) (assert (= n1 one)) (check-sat) (pop 1)
+
+; an infinity against a zero
+; CHECK-NEXT: ^unsat
+(push 1) (assert (= pi pz)) (check-sat) (pop 1)
+
+; an infinity against a finite value
+; CHECK-NEXT: ^unsat
+(push 1) (assert (= pi one)) (check-sat) (pop 1)
+
+; a zero against a finite value
+; CHECK-NEXT: ^unsat
+(push 1) (assert (= pz one)) (check-sat) (pop 1)
+
 (exit)

--- a/tests/query-files/fp-tests/smt-eq-specials-matrix.smt2
+++ b/tests/query-files/fp-tests/smt-eq-specials-matrix.smt2
@@ -1,0 +1,52 @@
+; RUN: %solver %s | %OutputCheck %s
+; RUN: %solver --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck %s
+;
+; SMT-LIB `=` over the whole matrix of special values, pairwise, as the
+; companion to fp-eq-specials-matrix.smt2 -- the two operators disagree on
+; exactly the zero and NaN rows, and running the same matrix through both is
+; what pins that difference down.
+;
+; `=` is equality on the abstract FloatingPoint domain:
+;   * +0 and -0 are DISTINCT values, so the mixed zero pair is false;
+;   * there is ONE NaN, so any two NaNs are equal whatever payloads and signs
+;     the solver picks for them (the both-NaN disjunct of the native BBeqFP
+;     encoding -- comparing packed bits alone fails this);
+;   * infinities are equal exactly when their signs agree.
+; The required truth values are conjoined and negated, so any one of them
+; going the wrong way makes this satisfiable.
+;
+; CHECK: ^unsat
+(set-logic QF_FP)
+(declare-fun pz () (_ FloatingPoint 8 24))
+(declare-fun mz () (_ FloatingPoint 8 24))
+(declare-fun pi () (_ FloatingPoint 8 24))
+(declare-fun mi () (_ FloatingPoint 8 24))
+(declare-fun n1 () (_ FloatingPoint 8 24))
+(declare-fun n2 () (_ FloatingPoint 8 24))
+(declare-fun one () (_ FloatingPoint 8 24))
+
+(assert (and (fp.isZero pz) (fp.isPositive pz)))
+(assert (and (fp.isZero mz) (fp.isNegative mz)))
+(assert (and (fp.isInfinite pi) (fp.isPositive pi)))
+(assert (and (fp.isInfinite mi) (fp.isNegative mi)))
+(assert (fp.isNaN n1))
+(assert (fp.isNaN n2))
+(assert (= one ((_ to_fp 8 24) #x3F800000)))
+
+(assert (not (and
+  ; zero vs zero: the signed zeros are two different values
+  (= pz pz) (= mz mz) (not (= pz mz))
+  ; NaN vs NaN: one NaN value, so true across payloads and signs
+  (= n1 n1) (= n2 n2) (= n1 n2)
+  ; infinity vs infinity: by sign
+  (= pi pi) (= mi mi) (not (= pi mi))
+  ; cross-class
+  (not (= n1 pz)) (not (= n1 pi)) (not (= n1 one))
+  (not (= pi pz)) (not (= pi one)) (not (= mi one))
+  (not (= pz one)) (not (= mz one))
+  ; symmetric in both operand orders
+  (not (= mz pz)) (= n2 n1) (not (= mi pi))
+)))
+(check-sat)
+(exit)

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -44,6 +44,9 @@ if (ENABLE_FLOATING_POINT)
     target_link_libraries(FloatBlast_TestTests $<TARGET_FILE:libabc-pic>)
     add_dependencies(FloatBlast_TestTests libabc-pic)
     AddSTPGTest(FpTotalise_Test.cpp)
+    # Truth values the model-formula evaluator gives the two float
+    # equalities; the circuit's answers are covered elsewhere.
+    AddSTPGTest(FpModelEquality_Test.cpp)
     AddSTPGTest(SourceSort_Test.cpp)
     # Builds float/rounding-mode constants, which is the whole point.
     AddSTPGTest(ConstantIdentity_Test.cpp)

--- a/tests/unit-tests/FpModelEquality_Test.cpp
+++ b/tests/unit-tests/FpModelEquality_Test.cpp
@@ -1,0 +1,240 @@
+/***********
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+**********************/
+
+/*
+ * Truth values the model-formula evaluator
+ * (AbsRefine_CounterExample::ComputeFormulaUsingModel) gives the two float
+ * equalities on the special values.
+ *
+ * The evaluator is a second, independent implementation of the semantics:
+ * the circuit decides satisfiability, and then this walk re-derives the
+ * formula's value over the model to check the counterexample. Disagreement
+ * between the two is how a satisfiable query gets killed with "counterexample
+ * bogus", so the special values -- the only place the two equalities differ
+ * from each other -- need pinning here as well as in the circuit.
+ *
+ * fp-model-eval-predicates.cpp already drives every predicate kind through
+ * this walk, but by construction its query is satisfiable "independent of the
+ * predicate's own truth value" (its words): it proves the kinds are
+ * implemented, not that they are right. These tests ask the evaluator
+ * directly, through QueryFormulaAgainstModel, and assert the value.
+ *
+ * The model values are bound as PLAIN bitvector constants, which is how the
+ * solver publishes them -- the format is stamped on by the evaluator from the
+ * node, not carried by the value. That is what makes the NaN cases here real:
+ * the raw payload survives into the model and reaches the operator.
+ *
+ * Two independent mechanisms then give `=` the right answer across payloads,
+ * and this was measured rather than assumed: the stamping funnel
+ * (withFormat -> CreateFPConst) interns every NaN pattern to one node, and
+ * the lowered circuit recognises NaN by its exponent and significand fields.
+ * Disabling either one alone leaves these tests passing; disabling both
+ * fails them. So the NaN rows below are a check on the pair, not on one
+ * chosen implementation -- which is the useful thing to assert, since a
+ * rewrite is free to drop either mechanism but not both.
+ */
+
+#include "stp/AbsRefineCounterExample/AbsRefine_CounterExample.h"
+#include "stp/AbsRefineCounterExample/ArrayTransformer.h"
+#include "stp/STPManager/STPManager.h"
+#include "stp/Simplifier/Simplifier.h"
+#include <gtest/gtest.h>
+
+#ifdef STP_ENABLE_FLOATING_POINT
+
+using namespace stp;
+
+namespace
+{
+
+// Packed binary32 patterns. Three NaNs that differ in payload and in sign:
+// all denote the one SMT-LIB NaN.
+const uint32_t PZERO = 0x00000000;
+const uint32_t MZERO = 0x80000000;
+const uint32_t PINF = 0x7F800000;
+const uint32_t MINF = 0xFF800000;
+const uint32_t NAN_QUIET = 0x7FC00000;
+const uint32_t NAN_PAYLOAD = 0x7F800001; // quiet bit clear, payload 1
+const uint32_t NAN_NEG = 0xFFC12345;     // sign set, another payload
+const uint32_t ONE = 0x3F800000;
+const uint32_t SUBNORMAL = 0x00000001;
+
+class FpModelEqualityTest : public ::testing::Test
+{
+protected:
+  STPMgr mgr;
+  SubstitutionMap substitutions;
+  Simplifier simplifier;
+  ArrayTransformer transformer;
+  AbsRefine_CounterExample ce;
+  unsigned counter = 0;
+
+  FpModelEqualityTest()
+      : substitutions(&mgr), simplifier(&mgr, &substitutions),
+        transformer(&mgr, &simplifier), ce(&mgr, &simplifier, &transformer)
+  {
+  }
+
+  // A Float32 variable already bound to `bits` in the model. The binding is a
+  // plain 32-bit constant: the solver's model carries bits, and the evaluator
+  // is what attaches the format.
+  ASTNode bound(uint32_t bits)
+  {
+    ASTNode v =
+        mgr.CreateSymbol(("f" + std::to_string(counter++)).c_str(), 0, 32);
+    v.SetExpWidth(8);
+    v.SetSigWidth(24);
+    ce.InsertIntoCounterExampleMap(v, mgr.CreateBVConst(32, bits));
+    return v;
+  }
+
+  // The evaluator's verdict on `kind` over two model-bound variables. Built
+  // with the hashing factory so that the node reaching the evaluator is the
+  // one asked for, with no rewrite standing in for it.
+  bool eval(Kind kind, uint32_t a, uint32_t b)
+  {
+    const ASTVec operands = {bound(a), bound(b)};
+    const ASTNode form = mgr.hashingNodeFactory->CreateNode(kind, operands);
+    const ASTNode value = ce.QueryFormulaAgainstModel(form);
+    EXPECT_TRUE(value == mgr.ASTTrue || value == mgr.ASTFalse)
+        << "evaluator did not reduce the predicate to a Boolean";
+    return value == mgr.ASTTrue;
+  }
+};
+
+// fp.eq is IEEE numeric equality: the two zeros are equal, NaN is equal to
+// nothing, infinities agree only with the same sign.
+TEST_F(FpModelEqualityTest, FpEqSpecials)
+{
+  // Zeros: sign is not part of the numeric value.
+  EXPECT_TRUE(eval(FP_EQ, PZERO, PZERO));
+  EXPECT_TRUE(eval(FP_EQ, PZERO, MZERO));
+  EXPECT_TRUE(eval(FP_EQ, MZERO, PZERO));
+  EXPECT_TRUE(eval(FP_EQ, MZERO, MZERO));
+
+  // NaN, whatever payload or sign the model happens to hold, and in either
+  // operand position.
+  const uint32_t nans[] = {NAN_QUIET, NAN_PAYLOAD, NAN_NEG};
+  for (uint32_t n : nans)
+  {
+    for (uint32_t m : nans)
+      EXPECT_FALSE(eval(FP_EQ, n, m)) << std::hex << n << " vs " << m;
+    EXPECT_FALSE(eval(FP_EQ, n, PZERO));
+    EXPECT_FALSE(eval(FP_EQ, PZERO, n));
+    EXPECT_FALSE(eval(FP_EQ, n, PINF));
+    EXPECT_FALSE(eval(FP_EQ, n, ONE));
+  }
+
+  // Infinities.
+  EXPECT_TRUE(eval(FP_EQ, PINF, PINF));
+  EXPECT_TRUE(eval(FP_EQ, MINF, MINF));
+  EXPECT_FALSE(eval(FP_EQ, PINF, MINF));
+  EXPECT_FALSE(eval(FP_EQ, MINF, PINF));
+
+  // Cross-class, including the subnormal that a zero-vs-finite mix-up
+  // would swallow.
+  EXPECT_FALSE(eval(FP_EQ, PINF, ONE));
+  EXPECT_FALSE(eval(FP_EQ, PZERO, ONE));
+  EXPECT_FALSE(eval(FP_EQ, PZERO, SUBNORMAL));
+  EXPECT_TRUE(eval(FP_EQ, ONE, ONE));
+  EXPECT_TRUE(eval(FP_EQ, SUBNORMAL, SUBNORMAL));
+}
+
+// `=` is equality on the abstract domain: the signed zeros are two values,
+// and every NaN pattern is the one NaN.
+TEST_F(FpModelEqualityTest, SmtEqSpecials)
+{
+  // Zeros are distinguishable here, which is the whole difference from fp.eq.
+  EXPECT_TRUE(eval(FP_SMT_EQ, PZERO, PZERO));
+  EXPECT_TRUE(eval(FP_SMT_EQ, MZERO, MZERO));
+  EXPECT_FALSE(eval(FP_SMT_EQ, PZERO, MZERO));
+  EXPECT_FALSE(eval(FP_SMT_EQ, MZERO, PZERO));
+
+  // One NaN value: true between any two spellings, in either order. A model
+  // that published the raw payloads, reaching an evaluator that both skipped
+  // the interning funnel and compared packed bits, fails exactly here.
+  const uint32_t nans[] = {NAN_QUIET, NAN_PAYLOAD, NAN_NEG};
+  for (uint32_t n : nans)
+    for (uint32_t m : nans)
+      EXPECT_TRUE(eval(FP_SMT_EQ, n, m)) << std::hex << n << " vs " << m;
+
+  // ... and false against everything that is not a NaN.
+  for (uint32_t n : nans)
+  {
+    EXPECT_FALSE(eval(FP_SMT_EQ, n, PZERO));
+    EXPECT_FALSE(eval(FP_SMT_EQ, PZERO, n));
+    EXPECT_FALSE(eval(FP_SMT_EQ, n, PINF));
+    EXPECT_FALSE(eval(FP_SMT_EQ, n, ONE));
+  }
+
+  // Infinities.
+  EXPECT_TRUE(eval(FP_SMT_EQ, PINF, PINF));
+  EXPECT_TRUE(eval(FP_SMT_EQ, MINF, MINF));
+  EXPECT_FALSE(eval(FP_SMT_EQ, PINF, MINF));
+  EXPECT_FALSE(eval(FP_SMT_EQ, MINF, PINF));
+
+  // Cross-class.
+  EXPECT_FALSE(eval(FP_SMT_EQ, PINF, ONE));
+  EXPECT_FALSE(eval(FP_SMT_EQ, PZERO, ONE));
+  EXPECT_FALSE(eval(FP_SMT_EQ, PZERO, SUBNORMAL));
+  EXPECT_TRUE(eval(FP_SMT_EQ, ONE, ONE));
+  EXPECT_TRUE(eval(FP_SMT_EQ, SUBNORMAL, SUBNORMAL));
+}
+
+// The two operators must actually differ where the semantics say they do,
+// and agree everywhere else. Stated as a relation between the two verdicts
+// so that an evaluator which quietly routed one kind to the other -- the
+// plausible failure, given they share an arm -- cannot pass.
+TEST_F(FpModelEqualityTest, TheTwoEqualitiesDifferExactlyOnZerosAndNaN)
+{
+  const uint32_t values[] = {PZERO, MZERO,       PINF, MINF,     NAN_QUIET,
+                             NAN_PAYLOAD, NAN_NEG, ONE,  SUBNORMAL};
+  for (uint32_t a : values)
+    for (uint32_t b : values)
+    {
+      const bool ieee = eval(FP_EQ, a, b);
+      const bool abstract = eval(FP_SMT_EQ, a, b);
+      const bool bothNaN = (a & 0x7FFFFFFF) > 0x7F800000 &&
+                           (b & 0x7FFFFFFF) > 0x7F800000;
+      const bool bothZero = (a & 0x7FFFFFFF) == 0 && (b & 0x7FFFFFFF) == 0;
+      const bool mixedZero = bothZero && a != b;
+
+      if (bothNaN)
+      {
+        EXPECT_FALSE(ieee);
+        EXPECT_TRUE(abstract);
+      }
+      else if (mixedZero)
+      {
+        EXPECT_TRUE(ieee);
+        EXPECT_FALSE(abstract);
+      }
+      else
+      {
+        EXPECT_EQ(ieee, abstract)
+            << "the operators must agree away from zeros and NaN: " << std::hex
+            << a << " vs " << b;
+      }
+    }
+}
+
+} // namespace
+
+#endif // STP_ENABLE_FLOATING_POINT


### PR DESCRIPTION
The two float equality operators differ on exactly two rows — the **zeros**, which `fp.eq` identifies and `=` keeps apart, and **NaN**, which `=` identifies with itself and `fp.eq` with nothing — and the suite tested those rows only in scattered pieces. Auditing it turned up four gaps:

- **Infinities appeared in no equality test at all**, symbolic or otherwise, outside the anonymous entries of the exhaustive Float(3,4) sweep in `FloatBlast_Test`. Nothing asserted `fp.eq(+oo,-oo)` false or `(= -oo -oo)` true.
- **No positive symbolic case for `=` on zeros** — every symbolic zero test was a refutation, so nothing forced `(= x y)` true for two same-signed zeros.
- **The both-NaN disjunct of the native `BBeqFP` encoding had a single test**, and it cannot be reached from a constant at all: `CreateFPConst` canonicalises every NaN pattern at interning time, so two NaN literals with different payloads arrive at the operator as *one node*. Only symbolic operands can actually differ, which makes that one test load-bearing for the whole encoding.
- **The model-formula evaluator had no truth-value coverage for either operator.** `ComputeFormulaUsingModel` re-derives a formula's value over the model to check the counterexample — a second implementation of the semantics, and where disagreement with the circuit turns a satisfiable query into `counterexample bogus`. The existing `fp-model-eval-predicates.cpp` drives every predicate kind through that walk, but its query is satisfiable "independent of the predicate's own truth value" (its own words): it pins that the kinds are implemented, not that they are right.

### Query files: the specials matrix, one fact at a time

Four files covering the pairwise matrix — zeros, infinities, three NaN spellings (canonical quiet, a payload-1 pattern with the quiet bit clear, one with the sign bit set and another payload) and a finite value, in both operand orders — run under the default, no-simplification and SymFPU-comparison configurations.

Each of the 80 facts gets its own `(check-sat)` inside a `push`/`pop`, probed in the polarity that makes it unsat, with a `CHECK-NEXT` and a sentence naming it directly above. Breaking one row mid-file reports `Could not find a match for CheckNext Directive (...:69)`, and line 68 is the sentence describing that row. The pins stay at top level, so the split costs nothing in setup.

They cover the three operand arrangements as separate files because each lands on different code:

| file | arrangement | what it reaches |
|---|---|---|
| `equality-specials-constant-matrix.smt2` | two literals | the folders and constant evaluator |
| `fp-eq-specials-matrix.smt2`, `smt-eq-specials-matrix.smt2` | two symbols, classification-pinned | the blasted circuit, both encodings |
| `equality-specials-symbolic-vs-constant.smt2` | one of each | the factory's strength reduction |

The symbolic operands are pinned by classification rather than by bits. That matters: a `to_fp` of a constrained bitvector folds back to a constant under default flags, so it never reaches the circuit, whereas a classification pin stays symbolic and leaves the solver free to pick any witness of the class — in particular different payloads and signs for two NaNs.

### Unit test: the model evaluator

`FpModelEquality_Test` asks the evaluator directly, through `QueryFormulaAgainstModel`, over the same matrix. Model values are bound as plain bitvector constants, the way the solver publishes them, so the raw NaN payload reaches the operator. The last test states the relation between the two operators rather than their values one at a time, so an evaluator that quietly routed one kind to the other — the plausible failure, since they share an arm — cannot pass it.

The comment on its NaN rows records a measurement rather than a guess: two mechanisms make `=` hold across payloads, the interning funnel and the circuit's field-based NaN test, and disabling either one alone leaves the tests passing. It takes both to fail them, so what those rows pin is the pair.

### Validation

The matrix was derived from the SMT-LIB semantics and then checked fact by fact against an independent solver, across the constant, symbolic and mixed arrangements and four solver configurations — no disagreements. The model of every satisfiable case was pinned back into its formula and re-checked independently as well.

Every fact is load-bearing: flipping the polarity of any one of the 80 makes its file fail, on both solvers. Mutating the evaluator likewise fails the unit tests — conflating `FP_EQ` with `FP_SMT_EQ` is caught by two of the three.

These document pre-existing correct behaviour and pass on master unchanged; they are coverage fills, not regression fixes.