### PR TITLE
Build NAND, NOR and XOR of a single operand

### DIFF
--- a/include/stp/ToSat/BBNodeManagerAIG.h
+++ b/include/stp/ToSat/BBNodeManagerAIG.h
@@ -217,7 +217,13 @@ public:
         break;
 
       case NAND:
-        if (children.size() == 2)
+        // The one-child cases mirror AND and OR above. makeTower needs at
+        // least two, and a single-bit field is not hypothetical: the
+        // significand of a two-bit format has exactly one stored bit, so
+        // NOR over it arrives here with one child.
+        if (children.size() == 1)
+          pNode = children[0].n;
+        else if (children.size() == 2)
           pNode = Aig_And(aigMgr, children[0].n, children[1].n);
         else
           pNode = makeTower(Aig_And, children);
@@ -230,7 +236,9 @@ public:
         break;
 
       case NOR:
-        if (children.size() == 2)
+        if (children.size() == 1)
+          pNode = children[0].n;
+        else if (children.size() == 2)
           pNode = Aig_Or(aigMgr, children[0].n, children[1].n);
         else
           pNode = makeTower(Aig_Or, children);
@@ -238,7 +246,9 @@ public:
         break;
 
       case XOR:
-        if (children.size() == 2)
+        if (children.size() == 1)
+          pNode = children[0].n;
+        else if (children.size() == 2)
           pNode = orderedAigExor(aigMgr, children[0].n, children[1].n);
         else
           pNode = makeTower(orderedAigExor, children);

--- a/tests/unit-tests/BBNodeManagerAIG_Test.cpp
+++ b/tests/unit-tests/BBNodeManagerAIG_Test.cpp
@@ -1,0 +1,121 @@
+/***********
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+**********************/
+
+/*
+ * The variadic gates of BBNodeManagerAIG at every arity that reaches them.
+ *
+ * An AIG node takes two inputs, so CreateNode folds longer child lists into a
+ * tower and special-cases the short ones. One child is the arity that gets
+ * forgotten: AND and OR handled it, the three gates built on top of them did
+ * not, and a one-element list fell through to makeTower -- which folds pairs
+ * until two remain and then asserts that it has two, so it aborted, or with
+ * assertions off read a deque it had already emptied.
+ *
+ * Checked structurally rather than by solving. ABC hash-conses as it builds,
+ * so the node for a gate over one input must be the very node that gate's
+ * definition names -- Aig_Not(x) for NAND and NOR, x itself for AND, OR and
+ * XOR -- and pointer equality says so exactly.
+ */
+
+#include "stp/ToSat/BBNodeManagerAIG.h"
+#include "stp/STPManager/STPManager.h"
+#include <gtest/gtest.h>
+
+using namespace stp;
+
+namespace
+{
+
+class AigGateArityTest : public ::testing::Test
+{
+protected:
+  STPMgr mgr;
+  BBNodeManagerAIG aig;
+  unsigned counter = 0;
+
+  // One fresh AIG input.
+  BBNodeAIG input()
+  {
+    const ASTNode s =
+        mgr.CreateSymbol(("b" + std::to_string(counter++)).c_str(), 0, 1);
+    return aig.CreateSymbol(s, 0);
+  }
+
+  // `n` fresh inputs. The count is laundered through a volatile read:
+  // CreateNode is inline, and given a length the optimiser can see it proves
+  // the wider branches dead and warns about the children[1] inside them
+  // (-Warray-bounds). Keeping the length opaque compiles every branch, which
+  // is also closer to how the blaster calls this -- with a field width it
+  // worked out at run time.
+  std::vector<BBNodeAIG> inputs(unsigned n)
+  {
+    static volatile unsigned opaque;
+    opaque = n;
+    std::vector<BBNodeAIG> v;
+    for (unsigned i = 0, size = opaque; i < size; i++)
+      v.push_back(input());
+    return v;
+  }
+};
+
+TEST_F(AigGateArityTest, OneChildIsTheGatesDefinition)
+{
+  std::vector<BBNodeAIG> one = inputs(1);
+  Aig_Obj_t* const x = one[0].n;
+
+  EXPECT_EQ(x, aig.CreateNode(AND, one).n);
+  EXPECT_EQ(x, aig.CreateNode(OR, one).n);
+  EXPECT_EQ(x, aig.CreateNode(XOR, one).n);
+  EXPECT_EQ(Aig_Not(x), aig.CreateNode(NAND, one).n);
+  EXPECT_EQ(Aig_Not(x), aig.CreateNode(NOR, one).n);
+}
+
+// The negating gates are exactly the negation of their positive counterparts,
+// at every arity -- which is what says the one-child case above was given the
+// right answer rather than merely a defined one.
+TEST_F(AigGateArityTest, NegatedGatesMatchTheirPositiveFormAtEveryArity)
+{
+  for (unsigned n = 1; n <= 5; n++)
+  {
+    std::vector<BBNodeAIG> children = inputs(n);
+    EXPECT_EQ(Aig_Not(aig.CreateNode(AND, children).n),
+              aig.CreateNode(NAND, children).n)
+        << "NAND with " << n << " children";
+    EXPECT_EQ(Aig_Not(aig.CreateNode(OR, children).n),
+              aig.CreateNode(NOR, children).n)
+        << "NOR with " << n << " children";
+  }
+}
+
+// Two children and up already worked; pin them so the short-list handling
+// cannot be "fixed" by changing what the general case builds.
+TEST_F(AigGateArityTest, TwoChildrenAreThePlainGate)
+{
+  std::vector<BBNodeAIG> two = inputs(2);
+  Aig_Obj_t* const x = two[0].n;
+  Aig_Obj_t* const y = two[1].n;
+
+  EXPECT_EQ(Aig_And(aig.aigMgr, x, y), aig.CreateNode(AND, two).n);
+  EXPECT_EQ(Aig_Or(aig.aigMgr, x, y), aig.CreateNode(OR, two).n);
+  EXPECT_EQ(Aig_Not(Aig_And(aig.aigMgr, x, y)), aig.CreateNode(NAND, two).n);
+  EXPECT_EQ(Aig_Not(Aig_Or(aig.aigMgr, x, y)), aig.CreateNode(NOR, two).n);
+}
+
+} // namespace

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -32,6 +32,13 @@ AddSTPGTest(SplitExtracts_Test.cpp)
 # index are AST machinery that floating point introduced but that every build
 # pays for, so both configurations have to cover them.
 AddSTPGTest(SourceSortMemo_Test.cpp)
+# The AIG gate builders, which every build has. Instantiating
+# BBNodeManagerAIG calls ABC through its inline members, and a shared libstp
+# localises ABC's symbols (--exclude-libs), so this links its own copy the
+# way FloatBlast_Test does below.
+AddSTPGTest(BBNodeManagerAIG_Test.cpp)
+target_link_libraries(BBNodeManagerAIG_TestTests $<TARGET_FILE:libabc-pic>)
+add_dependencies(BBNodeManagerAIG_TestTests libabc-pic)
 if (ENABLE_FLOATING_POINT)
     AddSTPGTest(FPPrintBack_Test.cpp)
     AddSTPGTest(FloatBlast_Test.cpp)


### PR DESCRIPTION
`BBNodeManagerAIG::CreateNode` folds a child list into a tower of two-input AIG nodes, so it special-cases the short lists. One child is the arity that got forgotten: `AND` and `OR` handle it, `NAND`, `NOR` and `XOR` do not, and a one-element list falls through to `makeTower`.

`makeTower` cannot take it. It folds pairs until two remain and then asserts that it has two, so a single-child `NOR` aborts there — or, with assertions off (which `CMAKE_BUILD_TYPE=Release` forces), pops a deque it has already emptied.

The results are the ones the two existing cases already imply: `NAND` and `NOR` of one operand are its negation, which the shared `Aig_Not` below supplies, and `XOR` of one operand is the operand.

### Is it reachable?

Not today, which is why it has gone unnoticed: nothing in the current bit-blaster hands these gates a single child. It becomes reachable the moment the narrowest floating-point formats are accepted — a two-bit significand stores exactly one significand bit, and the classification predicates build `NOR` over that field, so `(_ FloatingPoint 2 2)` with `fp.isInfinite` is enough to abort. That is how it was found.

I have split it out here rather than leaving it in that work, because it is an ordinary bug in the AIG layer with nothing floating-point about it, and it stands on its own.

### Test

The new unit test pins the one-child case and the arities either side of it, so the short-list handling cannot be repaired by changing what the general case builds. It is structural rather than solved: ABC hash-conses as it builds, so a gate over one input must be *the very node* its definition names, and pointer equality says so exactly. Reverting the fix aborts the first test on `makeTower`'s assertion — checked, so this is a regression test rather than a passing description.

One wrinkle worth flagging for review: the child count is laundered through a volatile read. `CreateNode` is inline, and given a length the optimiser can see, it proves the wider branches dead and warns about the `children[1]` inside them, which `-Werror` rejects. Keeping the length opaque compiles every branch — and is closer to how the blaster calls this anyway, with a field width worked out at run time.

Full suite passes (107/107).