### PR TITLE
Disable sub-sum extraction, pair extraction and flattening by default

### DIFF
--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -60,7 +60,7 @@ public:
   bool propagate_equalities = true; // Remove equalities.
   bool bitConstantProp_flag = true; // Constant bit propagation enabled.
   bool enable_unconstrained = true;
-  bool enable_flatten = true;
+  bool enable_flatten = false;
   bool enable_ite_context = false;
   bool enable_aig_core_simplify = false;
   bool enable_use_intervals = true;
@@ -68,8 +68,8 @@ public:
   bool enable_split_extracts = true;
   bool enable_sharing_aware_rewriting = true;
   bool enable_merge_same = false;
-  bool enable_pair_extract = true;
-  bool enable_common_subsum = true;
+  bool enable_pair_extract = false;
+  bool enable_common_subsum = false;
 
   int64_t AIG_rewrites_iterations = 0; // Number of iterations of AIG rewrites.
   int64_t bitblast_simplification = 0;

--- a/tests/query-files/misc-tests/common-subsum-repeated-operand-sat.smt2
+++ b/tests/query-files/misc-tests/common-subsum-repeated-operand-sat.smt2
@@ -1,4 +1,4 @@
-; RUN: %solver -d %s | %OutputCheck %s
+; RUN: %solver --flattening=true --common-subsum=true -d %s | %OutputCheck %s
 ; CHECK-NEXT: ^sat
 ; The satisfiable companion, run with -d so the counterexample is built and
 ; checked against the original query: if the extraction alters an addition's

--- a/tests/query-files/misc-tests/common-subsum-repeated-operand.smt2
+++ b/tests/query-files/misc-tests/common-subsum-repeated-operand.smt2
@@ -1,4 +1,4 @@
-; RUN: %solver %s | %OutputCheck %s
+; RUN: %solver --flattening=true --common-subsum=true %s | %OutputCheck %s
 ; CHECK-NEXT: ^unsat
 ; Common sub-sum extraction must handle an addition whose operands repeat.
 ; An operand appearing k times yields the same candidate pair C(k,2) times;


### PR DESCRIPTION
Common sub-sum extraction, pair extraction and sharing-aware flattening are currently on for every query. This turns all three off by default, so they run only when explicitly requested with `--common-subsum`, `--pair-extract` or `--flattening`. Flattening returns to the default it had before those passes landed.

The two sub-sum regression tests were relying on the passes being enabled by default, so they now name the flags they need on their RUN lines. Both still exercise the extraction (`--print-functionstat` shows the "After Common Sub-sum Extraction" pass running) and give the same unsat/sat answers as before.