### PR TITLE
Add LibBF's licence, and ship the notices with the binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,6 +125,12 @@ jobs:
         cp "${{ steps.build.outputs.binary }}" \
            "assets/stp-${{ needs.check-version.outputs.version }}-linux-amd64"
         strip "assets/stp-${{ needs.check-version.outputs.version }}-linux-amd64"
+        # The asset is one static binary rather than an archive, so there is
+        # nothing inside it to carry the notices of the third-party code it was
+        # linked from. Several of those licences (MIT, BSD) require the notice to
+        # accompany a binary distribution, so the two files go up as assets of
+        # their own, next to it on the release page.
+        cp LICENSE LICENSE_COMPONENTS assets/
         ls -l assets/
 
     - uses: actions/upload-artifact@v4
@@ -238,7 +244,7 @@ jobs:
       shell: bash
       working-directory: assets
       run: |
-        sha256sum stp-* > SHA256SUMS
+        sha256sum stp-* LICENSE LICENSE_COMPONENTS > SHA256SUMS
         cat SHA256SUMS
         sha256sum --check SHA256SUMS
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1143,6 +1143,22 @@ export(PACKAGE STP)
 
 
 # -----------------------------------------------------------------------------
+# Install the licences
+# -----------------------------------------------------------------------------
+# STP's own licence, and the notices of the third-party code compiled into it.
+# Several of those -- ABC, mimalloc, ankerl::unordered_dense, LibBF -- are MIT
+# or BSD, whose one condition is that the notice travels with the binary, so an
+# install that left these behind would not meet it. Which components are
+# actually linked in varies with the configuration, and the file says which
+# ones are conditional, so it is installed whole rather than assembled per
+# build.
+install(FILES
+  "${PROJECT_SOURCE_DIR}/LICENSE"
+  "${PROJECT_SOURCE_DIR}/LICENSE_COMPONENTS"
+  DESTINATION "${CMAKE_INSTALL_DOCDIR}"
+)
+
+# -----------------------------------------------------------------------------
 # Export our targets so that other CMake based projects can interface with
 # the build of STP that is installed.
 # -----------------------------------------------------------------------------

--- a/Docker.ubuntu22
+++ b/Docker.ubuntu22
@@ -59,4 +59,8 @@ RUN cmake .. \
 # Set up to run in a minimal container
 FROM scratch
 COPY --from=builder /usr/local/bin/stp /stp
+# The image is a single static binary on scratch, so these are the only place
+# the notices of the code linked into it can live. MIT and BSD components
+# require them to accompany the binary; `cmake --install` put them here.
+COPY --from=builder /usr/local/share/doc/STP/ /share/doc/STP/
 ENTRYPOINT ["/stp", "--SMTLIB2"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,4 +59,8 @@ RUN cmake .. \
 # Set up to run in a minimal container
 FROM scratch
 COPY --from=builder /usr/local/bin/stp /stp
+# The image is a single static binary on scratch, so these are the only place
+# the notices of the code linked into it can live. MIT and BSD components
+# require them to accompany the binary; `cmake --install` put them here.
+COPY --from=builder /usr/local/share/doc/STP/ /share/doc/STP/
 ENTRYPOINT ["/stp", "--SMTLIB2"]

--- a/LICENSE_COMPONENTS
+++ b/LICENSE_COMPONENTS
@@ -6,6 +6,9 @@ STP imports code from the following libraries:
 	* mimalloc Copyright (c) 2018-2025 Microsoft Corporation, Daan Leijen.
 	* SymFPU copyright (C) by the authors from 2018 (only compiled in when
 		floating-point support is enabled).
+	* LibBF Copyright (c) 2017-2025 Fabrice Bellard (only compiled in when
+		built with USE_LIBBF, which folds the real literals in
+		floating-point input).
 	* ankerl::unordered_dense Copyright (c) 2022-2024 Martin Leitner-Ankerl.
 	* CLI11 Copyright (c) 2017-2026 University of Cincinnati (only compiled
 		into the stp command-line tool, not into the library).
@@ -143,6 +146,33 @@ SymFPU
 	STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
 	IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 	POSSIBILITY OF SUCH DAMAGE.
+
+LibBF
+	MIT License
+
+	STP builds the library proper out of the upstream release tarball, which
+	is two pairs of files, carrying a copyright line each:
+
+	libbf.c and libbf.h: Copyright (c) 2017-2025 Fabrice Bellard
+	cutils.c and cutils.h: Copyright (c) 2017 Fabrice Bellard
+
+	Permission is hereby granted, free of charge, to any person obtaining a copy
+	of this software and associated documentation files (the "Software"), to deal
+	in the Software without restriction, including without limitation the rights
+	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+	copies of the Software, and to permit persons to whom the Software is
+	furnished to do so, subject to the following conditions:
+
+	The above copyright notice and this permission notice shall be included in all
+	copies or substantial portions of the Software.
+
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+	SOFTWARE.
 
 ankerl::unordered_dense
 	Licensed under the MIT License <http://opensource.org/licenses/MIT>.


### PR DESCRIPTION
LibBF landed four days ago as the real-literal folder for floating-point input, and `LICENSE_COMPONENTS` was never updated for it. `libbf.a` is linked into `libstp.so`, so the code is distributed rather than merely used at build time, and its MIT terms ask for the notice to travel with it. The entry goes next to SymFPU — the other floating-point dependency compiled in only under a flag — and records both copyright lines, since the two file pairs taken out of the upstream tarball differ: `libbf.{c,h}` is 2017-2025 Fabrice Bellard, `cutils.{c,h}` is 2017. The MIT body is upstream's verbatim, rewrapped to match the neighbouring entries.

Adding it showed the file was reaching no one. Nothing installed it, the release workflow uploads a bare stripped binary, and the Docker image is that binary alone on `scratch` — so every route by which STP reaches someone who did not build it dropped the notices of its MIT and BSD components (ABC, mimalloc, ankerl::unordered_dense, SymFPU, and now LibBF), whose one condition is that they accompany the binary.

So this distributes them by all three routes:

- **Install tree** — `LICENSE` and `LICENSE_COMPONENTS` into `CMAKE_INSTALL_DOCDIR`, i.e. `share/doc/STP`.
- **Docker** — copied out of the builder stage into the scratch image, which is where the `cmake --install` above puts them.
- **Releases** — staged as assets of their own, because a single-binary asset has nothing to carry them inside. They join `SHA256SUMS` by name rather than by widening its glob, which is what keeps that file a description of exactly what is uploaded.

Which components are actually linked in varies with the configuration, and the file already marks the conditional ones, so it is installed whole rather than assembled per build.

## Testing

Configured, built and installed from this branch: both files land in `share/doc/STP`, and the installed `LICENSE_COMPONENTS` carries the LibBF section. The MIT text was compared against the header in the upstream tarball and matches once whitespace is normalised.

Not exercised here: the release workflow only runs on a tag, so the new assets first appear on the next release; a `workflow_dispatch` dry run exercises everything except the publish step if you want it checked before then.

## Note

`cmake --install` with a custom `CMAKE_INSTALL_PREFIX` still escapes that prefix for the Python bindings, which install to the detected system `dist-packages` unless `PYTHON_LIB_INSTALL_DIR` is set. That is pre-existing and untouched here, but it is why the install above needed that variable set.