### PR TITLE
Reject command lines whose options cancel each other out

### DIFF
--- a/tests/query-files/misc-tests/bad-cli-options-solvers.smt2
+++ b/tests/query-files/misc-tests/bad-cli-options-solvers.smt2
@@ -1,0 +1,28 @@
+; Two solver flags on one command line must be diagnosed, not resolved.
+;
+; parse_options() consults the solver flags in a fixed order rather than in
+; the order they were given, so 'stp --cadical --minisat' used to run CaDiCaL
+; without saying so. Only one can be meant.
+;
+; Separate from bad-cli-options.smt2 because this needs a pair of solver flags
+; that exist, and which solvers are compiled in varies. --minisat and
+; --simplifying-minisat come and go together, and neither is a default, so
+; they are the pair to test with.
+;
+; REQUIRES: minisat
+
+; RUN: not %solver --minisat --simplifying-minisat %s 2>&1 | %OutputCheck %s --check-prefix=TWOSOLVERS
+; RUN: not %solver --simplifying-minisat --minisat %s 2>&1 | %OutputCheck %s --check-prefix=TWOSOLVERS
+; TWOSOLVERS-NOT: terminate called
+; TWOSOLVERS: excludes
+
+; Either one on its own is how the flag is meant to be used.
+; RUN: %solver --minisat %s 2>&1 | %OutputCheck %s --check-prefix=SOLVE
+; RUN: %solver --simplifying-minisat %s 2>&1 | %OutputCheck %s --check-prefix=SOLVE
+; SOLVE: ^sat$
+
+(set-logic QF_BV)
+(declare-fun x () (_ BitVec 8))
+(assert (= x (_ bv1 8)))
+(check-sat)
+(exit)

--- a/tests/query-files/misc-tests/bad-cli-options.smt2
+++ b/tests/query-files/misc-tests/bad-cli-options.smt2
@@ -55,6 +55,60 @@
 ; BADPARSER-NOT: terminate called
 ; BADPARSER: more than one parsing option
 
+; --- options that cannot both take effect --------------------------------
+;
+; One option discarding another's is a usage error rather than a silent
+; preference for whichever the code applies last. The solver flags are in
+; bad-cli-options-solvers.smt2, which which solvers are compiled in decides
+; whether to run at all.
+
+; A simplification requested alongside the flag that turns the whole suite
+; off. Rejected whichever way round they are given.
+; RUN: not %solver --disable-simplifications --flattening=true %s 2>&1 | %OutputCheck %s --check-prefix=DISABLEDSIMP
+; RUN: not %solver --flattening=true --disable-simplifications %s 2>&1 | %OutputCheck %s --check-prefix=DISABLEDSIMP
+; DISABLEDSIMP-NOT: terminate called
+; DISABLEDSIMP: excludes
+
+; ... and one it agrees with: the request still had no bearing on the run.
+; RUN: not %solver --disable-simplifications --disable-cbitp %s 2>&1 | %OutputCheck %s --check-prefix=DISABLEDSIMP
+
+; --size-reducing-only likewise overrides what it forces.
+; RUN: not %solver --size-reducing-only --difficulty-reversion=true %s 2>&1 | %OutputCheck %s --check-prefix=SIZEREDUCING
+; SIZEREDUCING-NOT: terminate called
+; SIZEREDUCING: excludes
+
+; --bb.simplify-during-bb needs the rewriting simplifier that these turn off.
+; RUN: not %solver --bb.simplify-during-bb=true --disable-opt-inc %s 2>&1 | %OutputCheck %s --check-prefix=SIMPDURINGBB
+; RUN: not %solver --bb.simplify-during-bb=true --disable-simplifications %s 2>&1 | %OutputCheck %s --check-prefix=SIMPDURINGBB
+; SIMPDURINGBB-NOT: terminate called
+; SIMPDURINGBB: excludes
+
+; --parse-only stops before any CNF exists to write out or exit after.
+; RUN: not %solver --parse-only --output-CNF %s 2>&1 | %OutputCheck %s --check-prefix=PARSEONLY
+; RUN: not %solver --parse-only --exit-after-CNF %s 2>&1 | %OutputCheck %s --check-prefix=PARSEONLY
+; PARSEONLY-NOT: terminate called
+; PARSEONLY: excludes
+
+; --interactive is read only on the SMT-LIB2 path.
+; RUN: not %solver --interactive=true --CVC %s 2>&1 | %OutputCheck %s --check-prefix=INTERACTIVE
+; RUN: not %solver --interactive=true --SMTLIB1 %s 2>&1 | %OutputCheck %s --check-prefix=INTERACTIVE
+; INTERACTIVE-NOT: terminate called
+; INTERACTIVE: excludes
+
+; --- combinations that are still accepted --------------------------------
+;
+; The exclusions above must not have caught anything that does take effect.
+
+; RUN: %solver --disable-simplifications %s 2>&1 | %OutputCheck %s --check-prefix=SOLVE
+; RUN: %solver --flattening=true %s 2>&1 | %OutputCheck %s --check-prefix=SOLVE
+; RUN: %solver --size-reducing-only %s 2>&1 | %OutputCheck %s --check-prefix=SOLVE
+; RUN: %solver --exit-after-CNF %s 2>&1 | %OutputCheck %s --check-prefix=SOLVE
+; RUN: %solver --disable-simplifications --size-reducing-only %s 2>&1 | %OutputCheck %s --check-prefix=SOLVE
+
+; --search-bias is documented as ignored by solvers without such a setting,
+; so it stays accepted next to any solver flag.
+; RUN: %solver --search-bias=unsat %s 2>&1 | %OutputCheck %s --check-prefix=SOLVE
+
 ; --- the diagnostics above go to stderr, not stdout ----------------------
 ;
 ; A caller that pipes stdout to a result parser should see nothing on a usage

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -26,8 +26,8 @@ THE SOFTWARE.
 
 #include <CLI/CLI.hpp>
 
-#include <cstddef>
 #include <initializer_list>
+#include <iterator>
 #include <string>
 #include <vector>
 
@@ -461,11 +461,12 @@ void ExtraMain::create_options()
   // parse_options() already rejects with a message of their own, and
   // --search-bias, documented as ignored by solvers that have no such setting
   // rather than as an error.
-  auto excludes_all = [this](const char* name,
+  auto excludes_all = [this](const std::string& name,
                              std::initializer_list<const char*> others) {
+    CLI::Option* const option = app.get_option(name);
     for (const char* other : others)
     {
-      app.get_option(name)->excludes(app.get_option(other));
+      option->excludes(app.get_option(other));
     }
   };
 
@@ -473,26 +474,27 @@ void ExtraMain::create_options()
   // consults them in a fixed sequence, so 'stp --cadical --minisat' quietly
   // ran CaDiCaL. Only one of them can be meant. Which ones exist depends on
   // what was compiled in.
-  std::vector<const char*> solver_flags;
+  std::vector<std::string> solver_flags;
 #ifdef USE_CADICAL
-  solver_flags.push_back("--cadical");
+  solver_flags.emplace_back("--cadical");
 #endif
 #ifdef USE_CRYPTOMINISAT
-  solver_flags.push_back("--cryptominisat");
+  solver_flags.emplace_back("--cryptominisat");
 #endif
 #ifdef USE_RISS
-  solver_flags.push_back("--riss");
+  solver_flags.emplace_back("--riss");
 #endif
 #ifdef USE_MINISAT
-  solver_flags.push_back("--simplifying-minisat");
-  solver_flags.push_back("--minisat");
+  solver_flags.emplace_back("--simplifying-minisat");
+  solver_flags.emplace_back("--minisat");
 #endif
 
-  for (size_t i = 0; i < solver_flags.size(); i++)
+  for (auto first = solver_flags.begin(); first != solver_flags.end(); ++first)
   {
-    for (size_t j = i + 1; j < solver_flags.size(); j++)
+    CLI::Option* const option = app.get_option(*first);
+    for (auto second = std::next(first); second != solver_flags.end(); ++second)
     {
-      app.get_option(solver_flags[i])->excludes(app.get_option(solver_flags[j]));
+      option->excludes(app.get_option(*second));
     }
   }
 
@@ -505,11 +507,12 @@ void ExtraMain::create_options()
   // must apply, and tests/query-files/CMakeLists.txt sweeps the whole corpus
   // with it appended to every invocation, so an exclusion would fail every
   // test in that run that names a solver.
-  for (const char* flag : solver_flags)
+  CLI::Option* const threads_option = app.get_option("--threads");
+  for (const std::string& flag : solver_flags)
   {
-    if (std::string(flag) != "--cryptominisat")
+    if (flag != "--cryptominisat")
     {
-      app.get_option("--threads")->excludes(app.get_option(flag));
+      threads_option->excludes(app.get_option(flag));
     }
   }
 #endif

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -26,6 +26,11 @@ THE SOFTWARE.
 
 #include <CLI/CLI.hpp>
 
+#include <cstddef>
+#include <initializer_list>
+#include <string>
+#include <vector>
+
 using namespace stp;
 using std::cout;
 using std::cerr;
@@ -71,6 +76,9 @@ public:
 #endif
 #ifdef USE_CADICAL
   bool use_cadical = false;
+#endif
+#ifdef USE_RISS
+  bool use_riss = false;
 #endif
 
   // Held as text until parse_options() turns it into UserFlags.search_bias.
@@ -247,7 +255,11 @@ void ExtraMain::create_options()
 #endif
 
 #ifdef USE_RISS
-  app.add_flag("--riss", "use Riss as the solver")->group(solver_group);
+  // Bound to a variable like the rest: without one the flag parsed and then
+  // selected nothing, so asking for Riss was silently ignored whenever
+  // another solver was compiled in to supply the default.
+  app.add_flag("--riss", use_riss, "use Riss as the solver")
+      ->group(solver_group);
 #endif
 
 #ifdef USE_MINISAT
@@ -321,9 +333,9 @@ void ExtraMain::create_options()
   bool_arg("--bb.simplify-during-bb", bm->UserFlags.simplify_during_BB_flag,
            "When bit-blasting discovers that a non-constant child of a term "
            "blasts to an all-constant vector, rebuild the term with that "
-           "constant and re-run the word-level term simplifier on it. Has no "
-           "effect unless the rewriting simplifier is also on, i.e. not with "
-           "--disable-opt-inc or --disable-simplifications",
+           "constant and re-run the word-level term simplifier on it. Needs "
+           "the rewriting simplifier, so not with --disable-opt-inc or "
+           "--disable-simplifications",
            bb_group);
 
   const char* const print_group = "Printing options";
@@ -425,6 +437,108 @@ void ExtraMain::create_options()
   app.add_flag("--check-sanity,-d", bm->UserFlags.check_counterexample_flag,
                "construct counterexample and check it")
       ->group(misc_group);
+
+  // ---------------------------------------------------------------------
+  // Combinations where one option discards another's effect
+  // ---------------------------------------------------------------------
+  // Each pair below is one STP cannot honour both halves of: whichever the
+  // code happens to apply last wins, and the other request never reaches the
+  // solver. Reporting that is more useful than obeying half a command line,
+  // most of all for the generated ones that option sweeps and build scripts
+  // produce, where a silently dropped flag reads as a measurement.
+  //
+  // The options are looked up by name so that the definitions above stay as
+  // they were; get_option() throws if a name here stops matching one, so
+  // renaming an option cannot quietly drop its relationships.
+  //
+  // CLI11 tests whether an option was given, not what it was set to, so
+  // '--disable-simplifications --flattening false' is refused as well, even
+  // though the two agree. That is the same mistake in a milder form -- the
+  // second option still had no bearing on the run -- and treating it the same
+  // way keeps the rule to one sentence.
+  //
+  // Deliberately not here: the CVC/SMT-LIB1/SMT-LIB2 parser flags, which
+  // parse_options() already rejects with a message of their own, and
+  // --search-bias, documented as ignored by solvers that have no such setting
+  // rather than as an error.
+  auto excludes_all = [this](const char* name,
+                             std::initializer_list<const char*> others) {
+    for (const char* other : others)
+    {
+      app.get_option(name)->excludes(app.get_option(other));
+    }
+  };
+
+  // The solver flags are not applied in the order given: parse_options()
+  // consults them in a fixed sequence, so 'stp --cadical --minisat' quietly
+  // ran CaDiCaL. Only one of them can be meant. Which ones exist depends on
+  // what was compiled in.
+  std::vector<const char*> solver_flags;
+#ifdef USE_CADICAL
+  solver_flags.push_back("--cadical");
+#endif
+#ifdef USE_CRYPTOMINISAT
+  solver_flags.push_back("--cryptominisat");
+#endif
+#ifdef USE_RISS
+  solver_flags.push_back("--riss");
+#endif
+#ifdef USE_MINISAT
+  solver_flags.push_back("--simplifying-minisat");
+  solver_flags.push_back("--minisat");
+#endif
+
+  for (size_t i = 0; i < solver_flags.size(); i++)
+  {
+    for (size_t j = i + 1; j < solver_flags.size(); j++)
+    {
+      app.get_option(solver_flags[i])->excludes(app.get_option(solver_flags[j]));
+    }
+  }
+
+#ifdef USE_CRYPTOMINISAT
+  // A thread count is read only by CryptoMiniSat, so asking for one while
+  // selecting a different solver gets neither threads nor a warning.
+  //
+  // --cadical-factor is deliberately not treated the same way: it is a
+  // request CaDiCaL may decline with a warning rather than a setting that
+  // must apply, and tests/query-files/CMakeLists.txt sweeps the whole corpus
+  // with it appended to every invocation, so an exclusion would fail every
+  // test in that run that names a solver.
+  for (const char* flag : solver_flags)
+  {
+    if (std::string(flag) != "--cryptominisat")
+    {
+      app.get_option("--threads")->excludes(app.get_option(flag));
+    }
+  }
+#endif
+
+  // disableSimplifications() clears each of these after the command line has
+  // been read, so a request for one alongside it never takes effect.
+  excludes_all("--disable-simplifications",
+               {"--switch-word", "--disable-opt-inc", "--disable-cbitp",
+                "--disable-equality", "--unconstrained-variable-elimination",
+                "--flattening", "--rewriting", "--split-extracts",
+                "--ite-context-simplifications", "--use-intervals",
+                "--pure-literals", "--common-subsum", "--pair-extract",
+                "--merge-same", "--bit-blast-simplification"});
+
+  // Likewise for what disableSizeIncreasingSimplifications() forces.
+  excludes_all("--size-reducing-only",
+               {"--simplify-to-constants-only",
+                "--ite-context-simplifications", "--difficulty-reversion"});
+
+  // The rewriting simplifier has to be on for this to do anything.
+  excludes_all("--bb.simplify-during-bb",
+               {"--disable-opt-inc", "--disable-simplifications"});
+
+  // --parse-only stops before the SAT solver is reached, so there is never a
+  // CNF for these two to write out or exit after.
+  excludes_all("--parse-only", {"--output-CNF", "--exit-after-CNF"});
+
+  // interactive_read is consulted only on the SMT-LIB2 path.
+  excludes_all("--interactive", {"--CVC", "--SMTLIB1"});
 }
 
 int ExtraMain::parse_options(int argc, char** argv)
@@ -543,6 +657,13 @@ int ExtraMain::parse_options(int argc, char** argv)
   if (use_cadical)
   {
     bm->UserFlags.solver_to_use = UserDefinedFlags::CADICAL_SOLVER;
+  }
+#endif
+
+#ifdef USE_RISS
+  if (use_riss)
+  {
+    bm->UserFlags.solver_to_use = UserDefinedFlags::RISS_SOLVER;
   }
 #endif
 


### PR DESCRIPTION
STP took several option combinations it cannot honour both halves of and resolved them silently, in favour of whichever the code happened to apply last:

- `stp --cadical --minisat` ran CaDiCaL, because `parse_options()` consults the solver flags in a fixed sequence rather than in the order given.
- `--disable-simplifications --flattening true` ran with flattening off, because `disableSimplifications()` clears the flag after the command line has been read.
- `--parse-only --output-CNF` wrote no CNF, because parse-only stops before one exists.

In each case the second request never reached the solver and nothing said so. That matters most for the generated command lines that option sweeps and build scripts produce, where a dropped flag reads as a measurement.

CLI11 has had `excludes()` for this the whole time and STP used none of it across its 42 options. The relationships are now declared in one block at the end of `create_options()`, looked up by name so the option definitions above are untouched — and `get_option()` throws if a name there stops matching one, so renaming an option cannot quietly drop its relationships.

## What is now rejected

| Combination | Why |
|---|---|
| two solver flags | only one solver runs |
| `--threads` + a solver that is not CryptoMiniSat | nothing else reads a thread count |
| `--disable-simplifications` + a simplification it clears | 15 options, listed against `disableSimplifications()` |
| `--size-reducing-only` + one it forces | 3 options, against `disableSizeIncreasingSimplifications()` |
| `--bb.simplify-during-bb` + `--disable-opt-inc` / `--disable-simplifications` | needs the rewriting simplifier; its help text already said so |
| `--parse-only` + `--output-CNF` / `--exit-after-CNF` | no CNF is ever built |
| `--interactive` + `--CVC` / `--SMTLIB1` | `interactive_read` is read only on the SMT-LIB2 path |

CLI11 tests whether an option was given, not what it was set to, so `--disable-simplifications --flattening false` is refused as well even though the two agree. That is the same mistake in a milder form, and treating it the same way keeps the rule to one sentence.

## What is deliberately left alone

- **`--cadical-factor`** — a request CaDiCaL may decline with a warning rather than a setting that must apply, and `tests/query-files/CMakeLists.txt` sweeps the whole corpus with it appended to every invocation. An exclusion would fail every test in that run that named a solver. Verified: with another solver selected it still warns and solves.
- **`--search-bias`** — documented as ignored by solvers that have no such setting.
- **The parser flags** — `parse_options()` already rejects those with a message of their own, which the existing test covers.

## Fixed along the way

`--riss` was declared with no variable to bind to, and `parse_options()` never looked at it. Under a build with another solver compiled in, asking for Riss selected nothing and said nothing. It is now bound and applied like the others. Untested here — there is no Riss checkout to build against — but it follows the shape of the four flags beside it.

## Testing

`tests/query-files/misc-tests/bad-cli-options.smt2` gains the new rejections plus a set of combinations that must still be accepted, so an over-broad exclusion fails the suite. The solver-flag cases are in a new `bad-cli-options-solvers.smt2` carrying `REQUIRES: minisat`, since which solvers exist varies by build and `REQUIRES` is per file.

Built and exercised in three configurations, all with `-DWERROR=ON`: minisat-only, `+CaDiCaL`, and `+CryptoMiniSat` — the last two being where the `#ifdef`-ed `--threads` and solver-list code differs. Full `query-files` suite: 427 passed, 18 unsupported, 0 failed. Also checked by hand that appending `--cadical-factor=on` to the new tests' command lines, as the corpus sweep does, leaves both their pass and fail outcomes unchanged.