### PR TITLE
Add multiplication variant 15: radix-4 modified Booth

### DIFF
--- a/include/stp/ToSat/BitBlaster.h
+++ b/include/stp/ToSat/BitBlaster.h
@@ -100,6 +100,8 @@ class BitBlaster
                   BBNodeSet& support, const stp::ASTNode& xN,
                   const stp::ASTNode& yN, vector<list<BBNode>>& products,
                   const ASTNode& n);
+  void mult_Booth_radix4(const BBNodeVec& x, const BBNodeVec& y,
+                         vector<list<BBNode>>& products, const ASTNode& n);
   BBNodeVec mult_normal(const BBNodeVec& x, const BBNodeVec& y,
                              BBNodeSet& support, const ASTNode& n);
 

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -1937,6 +1937,78 @@ void BitBlaster::mult_Booth(
   }
 }
 
+// Radix-4 modified Booth recoding.
+//
+// mult_Booth only rewrites runs of *constant* one bits, so a symbolic
+// multiplier still costs one partial-product row per bit. This groups the
+// multiplier into overlapping three-bit windows instead, halving the rows to
+// ceil(width/2). Each window picks a digit in {-2,-1,0,1,2}:
+//
+//   b(2i+1) b(2i) b(2i-1)   digit         b(-1) reads as zero
+//     0 0 0                   0
+//     0 0 1 / 0 1 0          +1
+//     0 1 1                  +2
+//     1 0 0                  -2
+//     1 0 1 / 1 1 0          -1
+//     1 1 1                   0
+//
+// which is carried as three signals: neg = b(2i+1), one = b(2i) xor b(2i-1),
+// and two = the pair of patterns that select twice y. Row bit j is then a
+// select between y[j] and y[j-1], conditionally inverted, and the inversion is
+// completed by adding neg itself into the row's lowest column -- the usual
+// two's complement identity -y = ~y + 1, made conditional. The all-ones window
+// falls out correctly: it selects nothing, inverts to all ones, and the added
+// one carries it back to zero.
+//
+// The trade is that halving the rows has to pay for a costlier row: a naive row
+// is one AND per bit, a radix-4 row is a select plus an XOR. Whether that is
+// worthwhile in CNF rather than in silicon is a question for measurement.
+//
+// Truncation keeps the negative digits honest: BVMULT is same-width, so bits
+// above the width are dropped and each row only needs to be right modulo
+// 2^width.
+void BitBlaster::mult_Booth_radix4(const BBNodeVec& x, const BBNodeVec& y,
+                                   vector<list<BBNode>>& products,
+                                   const ASTNode& n)
+{
+  const unsigned bitWidth = x.size();
+  const BBNode& BBFalse = nf->getFalse();
+
+  // The column bounds in MultiplicationStatsMap describe the un-recoded matrix
+  // of AND terms. This matrix holds conditionally negated selects instead, so
+  // those bounds do not apply to it -- mark the node so statsFound() keeps them
+  // away, exactly as mult_Booth does once it has recoded a run.
+  booth_recoded.insert(n);
+
+  for (unsigned base = 0; base < bitWidth; base += 2)
+  {
+    const BBNode& below = (base == 0) ? BBFalse : x[base - 1];
+    const BBNode& low = x[base];
+    const BBNode& high = (base + 1 < bitWidth) ? x[base + 1] : BBFalse;
+
+    const BBNode& neg = high;
+    const BBNode one = nf->CreateNode(XOR, low, below);
+    // twice y is selected by 011 and by 100, i.e. when low and below agree with
+    // each other and disagree with high.
+    const BBNode two = nf->CreateNode(
+        AND, nf->CreateNode(NOT, nf->CreateNode(XOR, low, below)),
+        nf->CreateNode(XOR, high, below));
+
+    for (unsigned j = 0; base + j < bitWidth; j++)
+    {
+      const BBNode single = nf->CreateNode(AND, one, y[j]);
+      const BBNode dbl =
+          (j == 0) ? BBFalse : nf->CreateNode(AND, two, y[j - 1]);
+      const BBNode selected = nf->CreateNode(OR, single, dbl);
+      products[base + j].push_back(nf->CreateNode(XOR, selected, neg));
+    }
+
+    // The +1 that completes a negated row, and nothing when the digit is
+    // positive.
+    products[base].push_back(neg);
+  }
+}
+
 void BitBlaster::mult_allPairs(
     const BBNodeVec& x, const BBNodeVec& y, BBNodeSet& /*support*/,
     vector<list<BBNode>>& products)
@@ -2398,6 +2470,21 @@ BBNodeVec BitBlaster::BBMult(const BBNodeVec& _x,
         return buildAdditionNetworkResult(products, support, n);
       }
       return mult_normal(x, y, support, n);
+    }
+
+    case 15:
+    {
+      // Radix-4 modified Booth: half as many partial-product rows, at the cost
+      // of a costlier row. Unlike the other Booth variants this recodes
+      // symbolic multipliers too, so it applies to every multiply rather than
+      // only to those with a constant operand.
+      //
+      // No setColumnsToZero() here: mult_Booth_radix4 marks the node recoded,
+      // because the constant-bit column bounds describe the un-recoded matrix
+      // of AND terms and would be wrong applied to conditionally negated
+      // selects.
+      mult_Booth_radix4(x, y, products, n);
+      return buildAdditionNetworkResult(products, support, n);
     }
 
     default:

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -1607,6 +1607,55 @@ void convert(const BBNodeVec& v, BBNodeManagerAIG* nf, mult_type* result)
   }
 }
 
+// Cost of using v as the multiplier. mult_Booth emits one partial-product row
+// per symbolic bit and one per non-zero digit left after recoding, but the two
+// are not priced alike. A symbolic row is a fresh AND gate for every bit of the
+// other operand; a constant row costs no gates at all, since AND with true is
+// the bit itself and a negated bit is just a complemented AIG edge. What a
+// constant row does cost is the column height it adds, which is what the
+// addition network then has to reduce -- and reducing that count is exactly
+// what recoding a run achieves.
+//
+// So "symbolic" is the figure that dominates, and "rows" only separates
+// operands that tie on it. Constant zeros -- including the ones a zero-extend
+// leaves behind, and the ones recoding creates inside a run -- cost nothing
+// either way. "recoded" reports how many runs were rewritten into a
+// subtract/add pair; zero means mult_Booth would leave the vector alone, so
+// there is nothing to be gained by preferring it over mult_normal.
+//
+// This asks convert(), so it sees whatever the bit-blasted vector actually
+// holds -- bits that constant bit propagation or simplification fixed count
+// just as much as the bits of a BVCONST term.
+int boothRows(const BBNodeVec& v, BBNodeManagerAIG* nf, int& recoded,
+              int& symbolic)
+{
+  recoded = 0;
+  symbolic = 0;
+  if (v.size() == 0)
+    return 0;
+
+  mult_type* t = (mult_type*)alloca(sizeof(mult_type) * v.size());
+  convert(v, nf, t);
+
+  int rows = 0;
+  for (size_t i = 0; i < v.size(); i++)
+  {
+    if (t[i] == MINUS_ONE_MT)
+    {
+      recoded++;
+      rows++;
+    }
+    else if (t[i] == ONE_MT)
+      rows++;
+    else if (t[i] == SYMBOL_MT)
+    {
+      symbolic++;
+      rows++;
+    }
+  }
+  return rows;
+}
+
 // Multiply "multiplier" by y[start ... bitWidth].
 void pushP(vector<vector<BBNode>>& products, const int start,
            const BBNodeVec& y, const BBNode& multiplier, BBNodeManagerAIG* nf)
@@ -2276,6 +2325,79 @@ BBNodeVec BitBlaster::BBMult(const BBNodeVec& _x,
       mult_Booth(_x, _y, support, n[0], n[1], products, n);
       setColumnsToZero(products, support, n);
       return v13(products, support, n);
+    }
+
+    case 14:
+    {
+      // Variant 1, except that a constant multiplier is Booth recoded.
+      //
+      // mult_normal walks the set bits of the multiplier and pays for one
+      // ripple-carry adder per set bit, so a constant containing a run of ones
+      // costs far more than it needs to: multiplying by 4095 builds twelve
+      // adders where two suffice.  Booth recoding rewrites each run of ones
+      // into a subtract/add pair, which is where nearly all of the encoding
+      // cost of a constant multiply goes.
+      //
+      // The test is on the bit-blasted vectors rather than on BVCONST, because
+      // that is what convert() itself looks at: a run of ones that constant bit
+      // propagation established is worth just as much as one written down in
+      // the input.  Testing the term instead would both miss those and route
+      // constants with no run of ones -- which encode the same either way --
+      // down a path that only churns the encoding.
+      //
+      // Only the operand mult_Booth decomposes into partial products is worth
+      // recoding: the other one is added or subtracted whole, once per row, so
+      // its bit pattern does not change the row count, and its constant bits
+      // are already folded away inside each row by the AIG.  So the choice
+      // that matters is which operand to hand it first, and the cost to
+      // minimise is rows -- not runs.  An operand can recode more runs than
+      // the other and still be the more expensive multiplier, by carrying more
+      // symbolic bits alongside them.
+      //
+      // An operand that recodes nothing is not a candidate: handing it to
+      // mult_Booth would change only the summation strategy, which the
+      // existing Booth variants already offer.  When neither recodes -- the
+      // symbolic x symbolic case -- mult_normal is kept.
+      int xRecoded = 0, yRecoded = 0, xSymbolic = 0, ySymbolic = 0;
+      const int xRows = boothRows(x, nf, xRecoded, xSymbolic);
+      const int yRows = boothRows(y, nf, yRecoded, ySymbolic);
+
+      if (xRecoded > 0 || yRecoded > 0)
+      {
+        // BBMult swapped x to the constant side, so track which AST child each
+        // vector now names -- xN/yN are used only for debug output, but keeping
+        // them consistent costs nothing.
+        const bool swapped =
+            (BVCONST != n[0].GetKind()) && (BVCONST == n[1].GetKind());
+        const ASTNode& xN = swapped ? n[1] : n[0];
+        const ASTNode& yN = swapped ? n[0] : n[1];
+
+        // Prefer the cheaper multiplier, among those that actually recode:
+        // fewest symbolic rows first, then fewest rows overall.
+        const bool useY =
+            (yRecoded > 0) &&
+            (xRecoded == 0 || ySymbolic < xSymbolic ||
+             (ySymbolic == xSymbolic && yRows < xRows));
+
+        if (useY)
+          mult_Booth(y, x, support, yN, xN, products, n);
+        else
+          mult_Booth(x, y, support, xN, yN, products, n);
+
+        // No setColumnsToZero() here, unlike the other Booth variants. It
+        // would do nothing: it reaches the constant-bit multiplication bounds
+        // through statsFound(), which refuses any node mult_Booth has recoded
+        // -- the column sums it holds describe the un-recoded matrix and are
+        // wrong once a run has become a subtract/add pair. Those variants call
+        // mult_Booth unconditionally, so for them the node is often not
+        // recoded and the call still pays; this one only gets here when the
+        // multiplier did recode, so the bounds are never available. The
+        // all-false argument of buildAdditionNetworkResult() is unreachable
+        // for the same reason. Measured over 1276 multiplies: the bounds were
+        // live 0 times.
+        return buildAdditionNetworkResult(products, support, n);
+      }
+      return mult_normal(x, y, support, n);
     }
 
     default:

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -295,7 +295,14 @@ void ExtraMain::create_options()
            "comparison encoding variant 1", bb_group);
 
   int64_arg("--bb.mult-variant", bm->UserFlags.multiplication_variant,
-            "unsigned multiplication variant", bb_group);
+            "unsigned multiplication encoding. 1 (default) shifts and adds. "
+            "14 is 1, except that a multiplier holding a run of constant one "
+            "bits is Booth recoded. "
+            "3, 4, 6, 7, 8, 9 and 13 Booth recode and differ in how the "
+            "partial-product columns are summed. 5 uses the constant-bit "
+            "multiplication bounds, and needs --bb.mult-v2. Any other value "
+            "is an error, reported once bit-blasting reaches a multiply",
+            bb_group);
 
   bool_arg("--bb.mult-v2", bm->UserFlags.upper_multiplication_bound,
            "unsigned multiplication variant 2", bb_group);

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -297,7 +297,8 @@ void ExtraMain::create_options()
   int64_arg("--bb.mult-variant", bm->UserFlags.multiplication_variant,
             "unsigned multiplication encoding. 1 (default) shifts and adds. "
             "14 is 1, except that a multiplier holding a run of constant one "
-            "bits is Booth recoded. "
+            "bits is Booth recoded. 15 is radix-4 modified Booth, which halves "
+            "the partial-product rows and recodes symbolic multipliers too. "
             "3, 4, 6, 7, 8, 9 and 13 Booth recode and differ in how the "
             "partial-product columns are summed. 5 uses the constant-bit "
             "multiplication bounds, and needs --bb.mult-v2. Any other value "


### PR DESCRIPTION
**Stacked on #787** — the base of this PR is `mult-variant-14-constant-booth`, not master, because both add a case to the same switch and edit the same help text. Review #787 first; this diff on its own is the radix-4 encoding.

## What it does

`mult_Booth` only rewrites runs of *constant* one bits, so a symbolic multiplier still costs one partial-product row per bit. Radix-4 modified Booth groups the multiplier into overlapping three-bit windows instead, halving the rows to `ceil(width/2)`.

Each window selects a digit in {-2,-1,0,1,2}:

| b(2i+1) b(2i) b(2i-1) | digit |
|---|---|
| 000 | 0 |
| 001, 010 | +1 |
| 011 | +2 |
| 100 | -2 |
| 101, 110 | -1 |
| 111 | 0 |

carried as three signals — `neg = b(2i+1)`, `one = b(2i) xor b(2i-1)`, and `two` for the two patterns selecting twice y. A row bit is a select between `y[j]` and `y[j-1]`, conditionally inverted, and the inversion is completed by adding `neg` itself into the row's lowest column, which is the usual `-y = ~y + 1` made conditional. The all-ones window needs no special case: it selects nothing, inverts to all ones, and the added one carries it back to zero.

`BVMULT` is same-width, so each row only has to be correct modulo 2^width and the negative digits need no sign extension.

The node is marked recoded, exactly as `mult_Booth` marks a recoded run: the constant-bit column bounds describe the un-recoded matrix of AND terms, and would be wrong applied to conditionally negated selects. So `setColumnsToZero()` is deliberately not called here.

## Correctness

Rather than only differential-testing it, the encoding is checked against an **independent formulation** of the same product — a shift-and-add expansion written in SMT-LIB:

```
(assert (not (= (bvmul x y) <sum of (ite y[i] (bvshl x i) 0)>)))
```

This is `unsat` under variant 15 for every width from 1 to 12, i.e. the two agree for all x and y. On top of that: no answer disagreements over 800 fuzzer-generated files, 80 regression queries, the 198-file hard corpus, or 120 multiply-by-constant files.

## Where it helps, and where it does not

| corpus | budget | variant 1 | variant 15 | note |
|---|---|---|---|---|
| equivalence checks above, width 11 | — | 102 s | **17 s** | ~6x; width 12 solves where variant 1 times out at 300 s |
| 120 multiply-by-constant files | 100k | 11 | **108** | variant 14 gets 114 |
| 198 hard QF_BV files, 32 families | 60k | 105 | **103** | 5 gained, 7 lost |

The first row is the case radix-4 is for: a formula dominated by a symbolic multiplier. The last row is the honest one — halving the rows has to pay for a costlier row, a select plus an XOR per bit rather than a single AND, and across a general hard corpus it does not. That net −2 is inside the ±4 noise floor for this corpus and budget, so the fair summary is "no gain here", not "a regression".

So this is worth having for multiplier-dominated work and is **not** a candidate for the default. The default is unchanged.

It also does not trip the stack overflow in ABC's recursive CNF scan that `--bb.mult-variant 3` hits on deep AIGs.

## Follow-ups this does not do

- Radix-8, which would cut rows again but needs a 3y multiple that is not a shift.
- Choosing the encoding per multiply — radix-4 for symbolic operands, radix-2 constant recoding for constant ones — which the two measurements above suggest would beat either alone. That wants its own measurement rather than being assumed.