### PR TITLE
Add multiplication variant 16: choose 14 or 15 per multiply

### DIFF
--- a/include/stp/ToSat/BitBlaster.h
+++ b/include/stp/ToSat/BitBlaster.h
@@ -100,6 +100,8 @@ class BitBlaster
                   BBNodeSet& support, const stp::ASTNode& xN,
                   const stp::ASTNode& yN, vector<list<BBNode>>& products,
                   const ASTNode& n);
+  void mult_Booth_radix4(const BBNodeVec& x, const BBNodeVec& y,
+                         vector<list<BBNode>>& products, const ASTNode& n);
   BBNodeVec mult_normal(const BBNodeVec& x, const BBNodeVec& y,
                              BBNodeSet& support, const ASTNode& n);
 

--- a/include/stp/ToSat/BitBlaster.h
+++ b/include/stp/ToSat/BitBlaster.h
@@ -102,6 +102,9 @@ class BitBlaster
                   const ASTNode& n);
   void mult_Booth_radix4(const BBNodeVec& x, const BBNodeVec& y,
                          vector<list<BBNode>>& products, const ASTNode& n);
+  bool mult_Booth_constant(const BBNodeVec& x, const BBNodeVec& y,
+                           BBNodeSet& support, vector<list<BBNode>>& products,
+                           const ASTNode& n);
   BBNodeVec mult_normal(const BBNodeVec& x, const BBNodeVec& y,
                              BBNodeSet& support, const ASTNode& n);
 

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -1937,6 +1937,78 @@ void BitBlaster::mult_Booth(
   }
 }
 
+// Radix-4 modified Booth recoding.
+//
+// mult_Booth only rewrites runs of *constant* one bits, so a symbolic
+// multiplier still costs one partial-product row per bit. This groups the
+// multiplier into overlapping three-bit windows instead, halving the rows to
+// ceil(width/2). Each window picks a digit in {-2,-1,0,1,2}:
+//
+//   b(2i+1) b(2i) b(2i-1)   digit         b(-1) reads as zero
+//     0 0 0                   0
+//     0 0 1 / 0 1 0          +1
+//     0 1 1                  +2
+//     1 0 0                  -2
+//     1 0 1 / 1 1 0          -1
+//     1 1 1                   0
+//
+// which is carried as three signals: neg = b(2i+1), one = b(2i) xor b(2i-1),
+// and two = the pair of patterns that select twice y. Row bit j is then a
+// select between y[j] and y[j-1], conditionally inverted, and the inversion is
+// completed by adding neg itself into the row's lowest column -- the usual
+// two's complement identity -y = ~y + 1, made conditional. The all-ones window
+// falls out correctly: it selects nothing, inverts to all ones, and the added
+// one carries it back to zero.
+//
+// The trade is that halving the rows has to pay for a costlier row: a naive row
+// is one AND per bit, a radix-4 row is a select plus an XOR. Whether that is
+// worthwhile in CNF rather than in silicon is a question for measurement.
+//
+// Truncation keeps the negative digits honest: BVMULT is same-width, so bits
+// above the width are dropped and each row only needs to be right modulo
+// 2^width.
+void BitBlaster::mult_Booth_radix4(const BBNodeVec& x, const BBNodeVec& y,
+                                   vector<list<BBNode>>& products,
+                                   const ASTNode& n)
+{
+  const unsigned bitWidth = x.size();
+  const BBNode& BBFalse = nf->getFalse();
+
+  // The column bounds in MultiplicationStatsMap describe the un-recoded matrix
+  // of AND terms. This matrix holds conditionally negated selects instead, so
+  // those bounds do not apply to it -- mark the node so statsFound() keeps them
+  // away, exactly as mult_Booth does once it has recoded a run.
+  booth_recoded.insert(n);
+
+  for (unsigned base = 0; base < bitWidth; base += 2)
+  {
+    const BBNode& below = (base == 0) ? BBFalse : x[base - 1];
+    const BBNode& low = x[base];
+    const BBNode& high = (base + 1 < bitWidth) ? x[base + 1] : BBFalse;
+
+    const BBNode& neg = high;
+    const BBNode one = nf->CreateNode(XOR, low, below);
+    // twice y is selected by 011 and by 100, i.e. when low and below agree with
+    // each other and disagree with high.
+    const BBNode two = nf->CreateNode(
+        AND, nf->CreateNode(NOT, nf->CreateNode(XOR, low, below)),
+        nf->CreateNode(XOR, high, below));
+
+    for (unsigned j = 0; base + j < bitWidth; j++)
+    {
+      const BBNode single = nf->CreateNode(AND, one, y[j]);
+      const BBNode dbl =
+          (j == 0) ? BBFalse : nf->CreateNode(AND, two, y[j - 1]);
+      const BBNode selected = nf->CreateNode(OR, single, dbl);
+      products[base + j].push_back(nf->CreateNode(XOR, selected, neg));
+    }
+
+    // The +1 that completes a negated row, and nothing when the digit is
+    // positive.
+    products[base].push_back(neg);
+  }
+}
+
 void BitBlaster::mult_allPairs(
     const BBNodeVec& x, const BBNodeVec& y, BBNodeSet& /*support*/,
     vector<list<BBNode>>& products)
@@ -2398,6 +2470,21 @@ BBNodeVec BitBlaster::BBMult(const BBNodeVec& _x,
         return buildAdditionNetworkResult(products, support, n);
       }
       return mult_normal(x, y, support, n);
+    }
+
+    case 15:
+    {
+      // Radix-4 modified Booth: half as many partial-product rows, at the cost
+      // of a costlier row. Unlike the other Booth variants this recodes
+      // symbolic multipliers too, so it applies to every multiply rather than
+      // only to those with a constant operand.
+      //
+      // No setColumnsToZero() here: mult_Booth_radix4 marks the node recoded,
+      // because the constant-bit column bounds describe the un-recoded matrix
+      // of AND terms and would be wrong applied to conditionally negated
+      // selects.
+      mult_Booth_radix4(x, y, products, n);
+      return buildAdditionNetworkResult(products, support, n);
     }
 
     default:

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -1607,6 +1607,55 @@ void convert(const BBNodeVec& v, BBNodeManagerAIG* nf, mult_type* result)
   }
 }
 
+// Cost of using v as the multiplier. mult_Booth emits one partial-product row
+// per symbolic bit and one per non-zero digit left after recoding, but the two
+// are not priced alike. A symbolic row is a fresh AND gate for every bit of the
+// other operand; a constant row costs no gates at all, since AND with true is
+// the bit itself and a negated bit is just a complemented AIG edge. What a
+// constant row does cost is the column height it adds, which is what the
+// addition network then has to reduce -- and reducing that count is exactly
+// what recoding a run achieves.
+//
+// So "symbolic" is the figure that dominates, and "rows" only separates
+// operands that tie on it. Constant zeros -- including the ones a zero-extend
+// leaves behind, and the ones recoding creates inside a run -- cost nothing
+// either way. "recoded" reports how many runs were rewritten into a
+// subtract/add pair; zero means mult_Booth would leave the vector alone, so
+// there is nothing to be gained by preferring it over mult_normal.
+//
+// This asks convert(), so it sees whatever the bit-blasted vector actually
+// holds -- bits that constant bit propagation or simplification fixed count
+// just as much as the bits of a BVCONST term.
+int boothRows(const BBNodeVec& v, BBNodeManagerAIG* nf, int& recoded,
+              int& symbolic)
+{
+  recoded = 0;
+  symbolic = 0;
+  if (v.size() == 0)
+    return 0;
+
+  mult_type* t = (mult_type*)alloca(sizeof(mult_type) * v.size());
+  convert(v, nf, t);
+
+  int rows = 0;
+  for (size_t i = 0; i < v.size(); i++)
+  {
+    if (t[i] == MINUS_ONE_MT)
+    {
+      recoded++;
+      rows++;
+    }
+    else if (t[i] == ONE_MT)
+      rows++;
+    else if (t[i] == SYMBOL_MT)
+    {
+      symbolic++;
+      rows++;
+    }
+  }
+  return rows;
+}
+
 // Multiply "multiplier" by y[start ... bitWidth].
 void pushP(vector<vector<BBNode>>& products, const int start,
            const BBNodeVec& y, const BBNode& multiplier, BBNodeManagerAIG* nf)
@@ -2276,6 +2325,79 @@ BBNodeVec BitBlaster::BBMult(const BBNodeVec& _x,
       mult_Booth(_x, _y, support, n[0], n[1], products, n);
       setColumnsToZero(products, support, n);
       return v13(products, support, n);
+    }
+
+    case 14:
+    {
+      // Variant 1, except that a constant multiplier is Booth recoded.
+      //
+      // mult_normal walks the set bits of the multiplier and pays for one
+      // ripple-carry adder per set bit, so a constant containing a run of ones
+      // costs far more than it needs to: multiplying by 4095 builds twelve
+      // adders where two suffice.  Booth recoding rewrites each run of ones
+      // into a subtract/add pair, which is where nearly all of the encoding
+      // cost of a constant multiply goes.
+      //
+      // The test is on the bit-blasted vectors rather than on BVCONST, because
+      // that is what convert() itself looks at: a run of ones that constant bit
+      // propagation established is worth just as much as one written down in
+      // the input.  Testing the term instead would both miss those and route
+      // constants with no run of ones -- which encode the same either way --
+      // down a path that only churns the encoding.
+      //
+      // Only the operand mult_Booth decomposes into partial products is worth
+      // recoding: the other one is added or subtracted whole, once per row, so
+      // its bit pattern does not change the row count, and its constant bits
+      // are already folded away inside each row by the AIG.  So the choice
+      // that matters is which operand to hand it first, and the cost to
+      // minimise is rows -- not runs.  An operand can recode more runs than
+      // the other and still be the more expensive multiplier, by carrying more
+      // symbolic bits alongside them.
+      //
+      // An operand that recodes nothing is not a candidate: handing it to
+      // mult_Booth would change only the summation strategy, which the
+      // existing Booth variants already offer.  When neither recodes -- the
+      // symbolic x symbolic case -- mult_normal is kept.
+      int xRecoded = 0, yRecoded = 0, xSymbolic = 0, ySymbolic = 0;
+      const int xRows = boothRows(x, nf, xRecoded, xSymbolic);
+      const int yRows = boothRows(y, nf, yRecoded, ySymbolic);
+
+      if (xRecoded > 0 || yRecoded > 0)
+      {
+        // BBMult swapped x to the constant side, so track which AST child each
+        // vector now names -- xN/yN are used only for debug output, but keeping
+        // them consistent costs nothing.
+        const bool swapped =
+            (BVCONST != n[0].GetKind()) && (BVCONST == n[1].GetKind());
+        const ASTNode& xN = swapped ? n[1] : n[0];
+        const ASTNode& yN = swapped ? n[0] : n[1];
+
+        // Prefer the cheaper multiplier, among those that actually recode:
+        // fewest symbolic rows first, then fewest rows overall.
+        const bool useY =
+            (yRecoded > 0) &&
+            (xRecoded == 0 || ySymbolic < xSymbolic ||
+             (ySymbolic == xSymbolic && yRows < xRows));
+
+        if (useY)
+          mult_Booth(y, x, support, yN, xN, products, n);
+        else
+          mult_Booth(x, y, support, xN, yN, products, n);
+
+        // No setColumnsToZero() here, unlike the other Booth variants. It
+        // would do nothing: it reaches the constant-bit multiplication bounds
+        // through statsFound(), which refuses any node mult_Booth has recoded
+        // -- the column sums it holds describe the un-recoded matrix and are
+        // wrong once a run has become a subtract/add pair. Those variants call
+        // mult_Booth unconditionally, so for them the node is often not
+        // recoded and the call still pays; this one only gets here when the
+        // multiplier did recode, so the bounds are never available. The
+        // all-false argument of buildAdditionNetworkResult() is unreachable
+        // for the same reason. Measured over 1276 multiplies: the bounds were
+        // live 0 times.
+        return buildAdditionNetworkResult(products, support, n);
+      }
+      return mult_normal(x, y, support, n);
     }
 
     default:

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -2291,6 +2291,68 @@ void BitBlaster::setColumnsToZero(
   }
 }
 
+// Fill the partial-product matrix by Booth recoding a constant multiplier,
+// choosing whichever operand is the cheaper one to decompose.
+//
+// Only the operand mult_Booth decomposes into partial products is worth
+// recoding: the other is added whole once per row, so its bit pattern does not
+// change the row count, and its constant bits are folded inside each row by the
+// AIG. The choice is therefore which operand to hand it first, and the cost
+// that dominates is the number of symbolic rows -- each is a fresh AND gate per
+// bit of the other operand, whereas a constant row costs no gates and only adds
+// column height. Rows overall break a tie.
+//
+// The test is on the bit-blasted vectors rather than on BVCONST, because that
+// is what convert() itself looks at: a run of ones that constant bit
+// propagation established is worth just as much as one written down in the
+// input. Testing the term instead would both miss those and route constants
+// with no run of ones -- which encode the same either way -- down a path that
+// only churns the encoding.
+//
+// Returns false, leaving products untouched, when neither operand recodes.
+// That is the symbolic x symbolic case, and the caller picks the fallback.
+bool BitBlaster::mult_Booth_constant(const BBNodeVec& x, const BBNodeVec& y,
+                                     BBNodeSet& support,
+                                     vector<list<BBNode>>& products,
+                                     const ASTNode& n)
+{
+  int xRecoded = 0, yRecoded = 0, xSymbolic = 0, ySymbolic = 0;
+  const int xRows = boothRows(x, nf, xRecoded, xSymbolic);
+  const int yRows = boothRows(y, nf, yRecoded, ySymbolic);
+
+  if (xRecoded == 0 && yRecoded == 0)
+    return false;
+
+  // BBMult swapped x to the constant side, so track which AST child each vector
+  // now names -- xN/yN are used only for debug output, but keeping them
+  // consistent costs nothing.
+  const bool swapped =
+      (BVCONST != n[0].GetKind()) && (BVCONST == n[1].GetKind());
+  const ASTNode& xN = swapped ? n[1] : n[0];
+  const ASTNode& yN = swapped ? n[0] : n[1];
+
+  const bool useY = (yRecoded > 0) &&
+                    (xRecoded == 0 || ySymbolic < xSymbolic ||
+                     (ySymbolic == xSymbolic && yRows < xRows));
+
+  if (useY)
+    mult_Booth(y, x, support, yN, xN, products, n);
+  else
+    mult_Booth(x, y, support, xN, yN, products, n);
+
+  // No setColumnsToZero() by the callers, unlike the other Booth variants. It
+  // would do nothing: it reaches the constant-bit multiplication bounds through
+  // statsFound(), which refuses any node mult_Booth has recoded -- the column
+  // sums it holds describe the un-recoded matrix and are wrong once a run has
+  // become a subtract/add pair. Those variants call mult_Booth
+  // unconditionally, so for them the node is often not recoded and the call
+  // still pays; this path is only taken when the multiplier did recode, so the
+  // bounds are never available. The all-false argument of
+  // buildAdditionNetworkResult() is unreachable for the same reason. Measured
+  // over 1276 multiplies: the bounds were live 0 times.
+  return true;
+}
+
 // Multiply two bitblasted numbers
 BBNodeVec BitBlaster::BBMult(const BBNodeVec& _x,
                              const BBNodeVec& _y,
@@ -2401,7 +2463,8 @@ BBNodeVec BitBlaster::BBMult(const BBNodeVec& _x,
 
     case 14:
     {
-      // Variant 1, except that a constant multiplier is Booth recoded.
+      // Variant 1, except that a multiplier holding a run of constant one bits
+      // is Booth recoded.
       //
       // mult_normal walks the set bits of the multiplier and pays for one
       // ripple-carry adder per set bit, so a constant containing a run of ones
@@ -2410,65 +2473,11 @@ BBNodeVec BitBlaster::BBMult(const BBNodeVec& _x,
       // into a subtract/add pair, which is where nearly all of the encoding
       // cost of a constant multiply goes.
       //
-      // The test is on the bit-blasted vectors rather than on BVCONST, because
-      // that is what convert() itself looks at: a run of ones that constant bit
-      // propagation established is worth just as much as one written down in
-      // the input.  Testing the term instead would both miss those and route
-      // constants with no run of ones -- which encode the same either way --
-      // down a path that only churns the encoding.
-      //
-      // Only the operand mult_Booth decomposes into partial products is worth
-      // recoding: the other one is added or subtracted whole, once per row, so
-      // its bit pattern does not change the row count, and its constant bits
-      // are already folded away inside each row by the AIG.  So the choice
-      // that matters is which operand to hand it first, and the cost to
-      // minimise is rows -- not runs.  An operand can recode more runs than
-      // the other and still be the more expensive multiplier, by carrying more
-      // symbolic bits alongside them.
-      //
-      // An operand that recodes nothing is not a candidate: handing it to
-      // mult_Booth would change only the summation strategy, which the
-      // existing Booth variants already offer.  When neither recodes -- the
-      // symbolic x symbolic case -- mult_normal is kept.
-      int xRecoded = 0, yRecoded = 0, xSymbolic = 0, ySymbolic = 0;
-      const int xRows = boothRows(x, nf, xRecoded, xSymbolic);
-      const int yRows = boothRows(y, nf, yRecoded, ySymbolic);
-
-      if (xRecoded > 0 || yRecoded > 0)
-      {
-        // BBMult swapped x to the constant side, so track which AST child each
-        // vector now names -- xN/yN are used only for debug output, but keeping
-        // them consistent costs nothing.
-        const bool swapped =
-            (BVCONST != n[0].GetKind()) && (BVCONST == n[1].GetKind());
-        const ASTNode& xN = swapped ? n[1] : n[0];
-        const ASTNode& yN = swapped ? n[0] : n[1];
-
-        // Prefer the cheaper multiplier, among those that actually recode:
-        // fewest symbolic rows first, then fewest rows overall.
-        const bool useY =
-            (yRecoded > 0) &&
-            (xRecoded == 0 || ySymbolic < xSymbolic ||
-             (ySymbolic == xSymbolic && yRows < xRows));
-
-        if (useY)
-          mult_Booth(y, x, support, yN, xN, products, n);
-        else
-          mult_Booth(x, y, support, xN, yN, products, n);
-
-        // No setColumnsToZero() here, unlike the other Booth variants. It
-        // would do nothing: it reaches the constant-bit multiplication bounds
-        // through statsFound(), which refuses any node mult_Booth has recoded
-        // -- the column sums it holds describe the un-recoded matrix and are
-        // wrong once a run has become a subtract/add pair. Those variants call
-        // mult_Booth unconditionally, so for them the node is often not
-        // recoded and the call still pays; this one only gets here when the
-        // multiplier did recode, so the bounds are never available. The
-        // all-false argument of buildAdditionNetworkResult() is unreachable
-        // for the same reason. Measured over 1276 multiplies: the bounds were
-        // live 0 times.
+      // Symbolic x symbolic keeps mult_normal: routing it through mult_Booth
+      // would recode nothing and only change the summation strategy, which the
+      // existing Booth variants already offer.
+      if (mult_Booth_constant(x, y, support, products, n))
         return buildAdditionNetworkResult(products, support, n);
-      }
       return mult_normal(x, y, support, n);
     }
 
@@ -2484,6 +2493,17 @@ BBNodeVec BitBlaster::BBMult(const BBNodeVec& _x,
       // of AND terms and would be wrong applied to conditionally negated
       // selects.
       mult_Booth_radix4(x, y, products, n);
+      return buildAdditionNetworkResult(products, support, n);
+    }
+
+    case 16:
+    {
+      // 14 and 15 win on different multiplies: 14's radix-2 constant recoding
+      // is the better encoding when the multiplier is constant, and 15's
+      // radix-4 is the only one of the two that does anything at all when it is
+      // symbolic. This picks between them per multiply rather than per query.
+      if (!mult_Booth_constant(x, y, support, products, n))
+        mult_Booth_radix4(x, y, products, n);
       return buildAdditionNetworkResult(products, support, n);
     }
 

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -295,7 +295,14 @@ void ExtraMain::create_options()
            "comparison encoding variant 1", bb_group);
 
   int64_arg("--bb.mult-variant", bm->UserFlags.multiplication_variant,
-            "unsigned multiplication variant", bb_group);
+            "unsigned multiplication encoding. 1 (default) shifts and adds. "
+            "14 is 1, except that a multiplier holding a run of constant one "
+            "bits is Booth recoded. "
+            "3, 4, 6, 7, 8, 9 and 13 Booth recode and differ in how the "
+            "partial-product columns are summed. 5 uses the constant-bit "
+            "multiplication bounds, and needs --bb.mult-v2. Any other value "
+            "is an error, reported once bit-blasting reaches a multiply",
+            bb_group);
 
   bool_arg("--bb.mult-v2", bm->UserFlags.upper_multiplication_bound,
            "unsigned multiplication variant 2", bb_group);

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -297,7 +297,8 @@ void ExtraMain::create_options()
   int64_arg("--bb.mult-variant", bm->UserFlags.multiplication_variant,
             "unsigned multiplication encoding. 1 (default) shifts and adds. "
             "14 is 1, except that a multiplier holding a run of constant one "
-            "bits is Booth recoded. "
+            "bits is Booth recoded. 15 is radix-4 modified Booth, which halves "
+            "the partial-product rows and recodes symbolic multipliers too. "
             "3, 4, 6, 7, 8, 9 and 13 Booth recode and differ in how the "
             "partial-product columns are summed. 5 uses the constant-bit "
             "multiplication bounds, and needs --bb.mult-v2. Any other value "

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -299,6 +299,7 @@ void ExtraMain::create_options()
             "14 is 1, except that a multiplier holding a run of constant one "
             "bits is Booth recoded. 15 is radix-4 modified Booth, which halves "
             "the partial-product rows and recodes symbolic multipliers too. "
+            "16 chooses between 14 and 15 for each multiply. "
             "3, 4, 6, 7, 8, 9 and 13 Booth recode and differ in how the "
             "partial-product columns are summed. 5 uses the constant-bit "
             "multiplication bounds, and needs --bb.mult-v2. Any other value "


### PR DESCRIPTION
**Stacked on #790, which is stacked on #787.** Review those first. The stack is now three deep on one area of code; happy to squash the three into a single PR if that reads better.

## What it does

Variants 14 and 15 win on different multiplies. 14's radix-2 constant recoding is the better encoding when the multiplier is constant; 15's radix-4 is the only one of the two that does anything at all when the multiplier is symbolic, since `convert()` recodes runs of constant one bits only.

Variant 16 picks between them per multiply rather than per query: recode a constant multiplier as 14 does, and fall back to radix-4 rather than to `mult_normal`.

Variant 14's operand choice moves into `mult_Booth_constant()`, which returns false when neither operand recodes so the caller can choose its own fallback. **Variant 14 is unchanged by that refactor** — CNF byte-identical on all 36 multiply-dense files measured.

## Result: it does what it was designed to do, and that is not enough

Solved counts at a fixed conflict budget, same binary throughout:

| corpus | budget | v1 | v14 | v15 | **v16** |
|---|---|---|---|---|---|
| 198 hard QF_BV files, 32 families | 60k | 105 | **110** | 103 | 103 |
| 120 multiply-by-constant files | 100k | 11 | 114 | 108 | **114** |

Variant 16 recovers all of 14's advantage on constant multipliers, which 15 gave up, and keeps radix-4 for the symbolic ones. So the mechanism works.

But the general hard corpus is dominated by multiplies that do not recode — **3,645 of 5,121** measured — so on that corpus 16 takes the radix-4 path almost everywhere, inherits its losses, and lands exactly where 15 does, seven files behind 14.

The hypothesis that pairing the two would beat either alone therefore holds only where constant *and* symbolic multipliers both matter. Where neither dominates, variant 14 is still the one to use. The default is unchanged.

## Correctness

Equivalent to an independent shift-and-add expansion of the same product — `unsat`, so they agree for all x and y — at every width from 1 to 12. No answer disagreements over 800 fuzzer-generated files, the 198-file hard corpus, or the 120 multiply-by-constant files.

## Caveat on the numbers

Every figure here comes from one machine and one corpus construction, and the constant-multiplier row rests on a single family. The v15/v16 difference from v14 on the hard corpus (−7) is larger than that corpus's ±4 noise floor, so it is probably real, but it has not been reproduced independently.