### PR TITLE
Remove the optional bit-blast simplification

### DIFF
--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -72,7 +72,6 @@ public:
   bool enable_common_subsum = false;
 
   int64_t AIG_rewrites_iterations = 0; // Number of iterations of AIG rewrites.
-  int64_t bitblast_simplification = 0;
   int64_t size_reducing_fixed_point = 0;
   
 
@@ -246,7 +245,6 @@ public:
     enable_common_subsum = false;
     enable_ite_context = false;
 
-    bitblast_simplification = 0;
     simple_cnf=true;
   }
 

--- a/lib/STPManager/STP.cpp
+++ b/lib/STPManager/STP.cpp
@@ -51,7 +51,6 @@ namespace stp
 {
 
 const static string cb_message = "After Constant Bit Propagation. ";
-const static string bb_message = "After Bitblast simplification. ";
 const static string uc_message = "After Removing Unconstrained. ";
 const static string int_message = "After Unsigned Interval Analysis. ";
 const static string pl_message = "After Pure Literals. ";
@@ -495,9 +494,6 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
   //
   // This remains after all of the size-reducing passes above. In particular,
   // RemoveUnconstrained must see a float symbol rather than its exposed bits.
-  // The old location was just below the difficulty snapshot, but that let the
-  // optional bit-blast simplification here receive FP_EQ and other floating-
-  // point nodes when --bit-blast-simplification enabled it.
   //
   // See FloatBlast for why this is a pass of its own: doing it inside
   // simplification meant building floating-point nodes over bitvector
@@ -509,65 +505,17 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
     inputToSat = fpEncodingContext->lowerPrepared(inputToSat);
     bm->ASTNodeStats("After floating-point lowering: ", inputToSat);
 
-    // The threshold controls the cost of bit-blasting the formula in its
-    // lowered form, so compare it with that form's difficulty rather than the
-    // much smaller word-level FP syntax. The always setting (-1) is unchanged.
+    // Everything downstream works on the lowered form, so the snapshot that
+    // difficulty reversion later compares against has to describe that form
+    // rather than the much smaller word-level FP syntax. Retaken here because
+    // the recompute below is skipped for array problems.
     initial_difficulty_score = difficulty.score(inputToSat, bm);
   }
-
-  int64_t bitblasted_difficulty = -1;
-  // Expensive, so only want to do it once.
-  // The AIG-equivalence/constant substitutions found here are not
-  // recorded in the solver map, so they could silently strip a symbol
-  // the array-equality procedure depends on (an abstraction variable,
-  // witness name, or lemma-leaf name) out of the formula. They are an
-  // optimization; skip them when array equality is active.
-  if (!extActive &&
-      (bm->UserFlags.bitblast_simplification == -1 || initial_difficulty_score < bm->UserFlags.bitblast_simplification))
-  {
-    BBNodeManagerAIG bitblast_nodemgr;
-    BitBlaster bb(&bitblast_nodemgr, simp, bm->defaultNodeFactory,
-                  &(bm->UserFlags));
-    ASTNodeMap fromTo;
-    ASTNodeMap equivs;
-    bb.getConsts(inputToSat, fromTo, equivs);
-
-    if (equivs.size() > 0)
-    {
-      /* These nodes have equivalent AIG representations, so even though they
-       * have different
-       * word level expressions they are identical semantically. So we pick one
-       * of the ASTnodes
-       * and replace the others with it.
-       * TODO: I replace with the lower id node, sometimes though we replace
-       * with much more
-       * difficult looking ASTNodes.
-      */
-      ASTNodeMap cache;
-      inputToSat = SubstitutionMap::replace(
-          inputToSat, equivs, cache, bm->defaultNodeFactory, false, true);
-      bm->ASTNodeStats(bb_message.c_str(), inputToSat);
-    }
-
-    if (fromTo.size() > 0)
-    {
-      ASTNodeMap cache;
-      inputToSat = SubstitutionMap::replace(inputToSat, fromTo, cache,
-                                            bm->defaultNodeFactory);
-      bm->ASTNodeStats(bb_message.c_str(), inputToSat);
-    }
-    
-    bitblasted_difficulty = bitblast_nodemgr.totalNumberOfNodes();
-  }
-
 
   if (!arrayops || bm->UserFlags.array_difficulty_reversion)
   {
     initial_difficulty_score = difficulty.score(inputToSat, bm);
   }
-
-  if (bitblasted_difficulty != -1 && bm->UserFlags.stats_flag)
-    cout << "Initial Bitblasted size:" << bitblasted_difficulty << endl;
 
   if (bm->UserFlags.stats_flag)
     cout << "Difficulty After Size reducing:" << initial_difficulty_score
@@ -730,25 +678,6 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
   bool worse = false;
   if (final_difficulty_score > .8 * initial_difficulty_score)
     worse = true;
-
-  // It's of course very wasteful to do this! Later I'll make it reuse the
-  // work..We bit-blast again, in order to throw it away, so that we can
-  // measure whether the number of AIG nodes is smaller. The difficulty score
-  // is sometimes completelywrong, the sage-app7 are the motivating examples.
-  // The other way to improve it would be to fix the difficulty scorer!
-  if (!worse && (bitblasted_difficulty != -1))
-  {
-    BBNodeManagerAIG bitblast_nodemgr;
-    BitBlaster bb(&bitblast_nodemgr, simp, bm->defaultNodeFactory,
-                  &(bm->UserFlags));
-    bb.BBForm(inputToSat);
-    int newBB = bitblast_nodemgr.totalNumberOfNodes();
-    if (bm->UserFlags.stats_flag)
-      cerr << "Final BB Size:" << newBB << endl;
-
-    if (bitblasted_difficulty < newBB)
-      worse = true;
-  }
 
   if (bm->UserFlags.stats_flag)
   {

--- a/lib/STPManager/STP.cpp
+++ b/lib/STPManager/STP.cpp
@@ -675,9 +675,10 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
 
   int64_t final_difficulty_score = difficulty.score(inputToSat, bm);
 
-  bool worse = false;
-  if (final_difficulty_score > .8 * initial_difficulty_score)
-    worse = true;
+  // Simplification has to have taken a fifth off the score to count as having
+  // helped. Written as an assignment now that the AIG node count is gone: it
+  // was the second of the two things that could set this.
+  const bool worse = final_difficulty_score > .8 * initial_difficulty_score;
 
   if (bm->UserFlags.stats_flag)
   {

--- a/tests/query-files/fp-tests/roundtointegral-rm-variable.smt2
+++ b/tests/query-files/fp-tests/roundtointegral-rm-variable.smt2
@@ -1,11 +1,8 @@
 ; RUN: %solver %s | %OutputCheck %s
-; RUN: %solver --bit-blast-simplification=-1 %s | %OutputCheck %s
 ;
 ; fp.roundToIntegral must accept a RoundingMode variable, not only the five
 ; literal modes. Regression test: its grammar rule used to demand a literal,
 ; unlike every other rounded operation.
-; The forced bit-blast simplification run also pins the pipeline invariant that
-; floating-point operations are lowered before any optional bit-blaster pass.
 (set-logic QF_FP)
 (declare-const r RoundingMode)
 (declare-fun x () (_ FloatingPoint 3 5))

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -204,13 +204,6 @@ void ExtraMain::create_options()
            "level",
            simp_group);
 
-  int64_arg("--bit-blast-simplification", bm->UserFlags.bitblast_simplification,
-            "Part-way through simplifying, convert to AIGs and look for bits "
-            "that the AIGs figure out are true/false or the same as another "
-            "node. If the difficulty is less than this number. -1 means "
-            "always.",
-            simp_group);
-
   int64_arg("--size-reducing-fixed-point-limit",
             bm->UserFlags.size_reducing_fixed_point,
             "If the number of non-leaf nodes is fewer than this number, run "
@@ -525,7 +518,7 @@ void ExtraMain::create_options()
                 "--flattening", "--rewriting", "--split-extracts",
                 "--ite-context-simplifications", "--use-intervals",
                 "--pure-literals", "--common-subsum", "--pair-extract",
-                "--merge-same", "--bit-blast-simplification"});
+                "--merge-same"});
 
   // Likewise for what disableSizeIncreasingSimplifications() forces.
   excludes_all("--size-reducing-only",


### PR DESCRIPTION
> Stacked on #789, which must merge first. That PR registers `--bit-blast-simplification` in an exclusion list looked up by name, so if these two landed independently `get_option()` would throw at startup on the missing option. Base changes to `master` once #789 is in.

The pass bit-blasted the whole formula into a throwaway AIG part-way through preprocessing, read back the nodes ABC had proved constant or structurally equal, substituted those at the word level, and discarded the AIG. It was gated on `--bit-blast-simplification`, a difficulty threshold whose default of `0` makes the guard `initial_difficulty_score < 0` false — so only an explicit `-1` (or a positive bound) ever ran it, and nothing outside `main.cpp` writes the field. It was unreachable in every default run.

What the flag did reach was a crash. `BBTerm` has no arm for `READ`, and arrays are only rewritten away above by `numberOfReadsLessThan(10)` — 50 with `--ackermanize` — so any query with ten or more surviving reads walked the scratch bit-blast into a `READ` and hit `BBTerm: Illegal kind to BBTerm`. The pass already carried a guard of exactly this shape for array equality, whose substitutions bypass the solver map and could strip a symbol the extensionality procedure depends on; this was a second array assumption made without checking.

Rather than add the missing guard, drop the pass. It has been off by default for its whole life, so there is no measurement saying it repays the full bit-blast it costs, and the one configuration that switched it on was broken.

## What goes with it

**The AIG-size second opinion on difficulty reversion.** A later block re-blasted the final formula and marked the simplification "worse" if the AIG had grown, comparing against the node count this pass left behind — its comment notes the difficulty score "is sometimes completely wrong, the sage-app7 are the motivating examples". That baseline had no other source, so the check was equally unreachable by default and goes too. It is a discarded idea rather than a lost feature: reinstating it needs its own flag and its own baseline.

**Not removed:** `BitBlaster::getConsts`, which `tools/rewrite_rule_gen` still calls. That leaves the AIG-equivalence harvesting in the core library serving one extra tool; retiring that tool would let it go as well.

The difficulty snapshot retaken after floating-point lowering stays, but its comment now gives the reason that outlives the threshold: everything downstream works on the lowered form, so the value reversion later compares against must describe that form, and the recompute below it is skipped for array problems.

## Testing

The crash reproducer now solves. Full `ctest`: 106/106. Builds clean under `-DWERROR=ON` with CaDiCaL and with CryptoMiniSat.

Behaviour neutrality is argued above from the default flag value, and confirmed by measurement. Two statically linked binaries were built from this commit and its parent — static because a build-tree RUNPATH would make a copied binary load the rebuilt `libstp` and the comparison pass vacuously — and run over 1197 files (the whole `query-files` corpus plus 900 from a fuzz corpus), byte-comparing every generated CNF as well as the answers:

| | |
|---|---|
| identical CNF and answer | 1196 |
| CNF differs | 0 |
| answer differs | 0 |

The 1197th, a 2500-query file, first showed an answer difference that turned out to be the harness: it needs longer than the per-file cap, so the two runs truncated at different points. Uncapped, both binaries produce byte-identical 2500-line output. A sweep of the remaining ~1600 corpus files is running and I will report it here.