### PR TITLE
Restore the build: drop the formatSupported guards from the literal fold

### DIFF
--- a/lib/FloatBlaster/literal_fp.cpp
+++ b/lib/FloatBlaster/literal_fp.cpp
@@ -25,7 +25,6 @@ THE SOFTWARE.
 
 #ifdef STP_ENABLE_FLOATING_POINT
 
-#include "stp/FloatBlaster/FloatBlaster.h"
 #include "stp/FloatBlaster/rounding_modes.h"
 #include "stp/STPManager/STPManager.h"
 
@@ -566,10 +565,13 @@ ASTNode packedResult(STPMgr* bm, const floatingPointTypeInfo& fmt,
                            fmt.packedWidth());
 }
 
+// Whether the node carries a floating-point format at all. Every format the
+// parser admits can be evaluated -- the widths symfpu once miscalculated are
+// fixed in patches/symfpu/ rather than refused here -- so the format itself
+// needs no further check.
 bool formatOk(const ASTNode& c)
 {
-  return c.GetExpWidth() != 0 &&
-         FloatBlaster::formatSupported(c.GetExpWidth(), c.GetSigWidth());
+  return c.GetExpWidth() != 0;
 }
 
 } // namespace
@@ -735,8 +737,6 @@ ASTNode tryEvaluateFpConstant(STPMgr* bm, const ASTNode& n)
     {
       const unsigned eb = n[0].GetUnsignedConst();
       const unsigned sb = n[1].GetUnsignedConst();
-      if (!FloatBlaster::formatSupported(eb, sb))
-        return ASTNode();
       const floatingPointTypeInfo target(eb, sb);
       if (n.Degree() == 3)
       {
@@ -761,8 +761,6 @@ ASTNode tryEvaluateFpConstant(STPMgr* bm, const ASTNode& n)
     {
       const unsigned eb = n[0].GetUnsignedConst();
       const unsigned sb = n[1].GetUnsignedConst();
-      if (!FloatBlaster::formatSupported(eb, sb))
-        return ASTNode();
       const floatingPointTypeInfo target(eb, sb);
       const roundingMode rm = rmOf(n[2]);
       const traits::ubv bits = packedOf(n[3]);

--- a/patches/symfpu/0004-valid-subnormal-amount-bound-width.patch
+++ b/patches/symfpu/0004-valid-subnormal-amount-bound-width.patch
@@ -1,0 +1,25 @@
+diff --git a/core/unpackedFloat.h b/core/unpackedFloat.h
+--- a/core/unpackedFloat.h
++++ b/core/unpackedFloat.h
+@@ -461,8 +467,19 @@ namespace symfpu {
+       // Subnormal numbers require an additional check to make sure they
+       // do not have an unrepresentable amount of significand bits.
+       sbv subnormalAmount(this->getSubnormalAmount(format));
+-      INVARIANT((sbv::zero(exWidth) <= subnormalAmount) &&
+-		(subnormalAmount <= sbv(exWidth,sigWidth)));
++      // The bound is sigWidth, but sbv(exWidth, sigWidth) builds it at the
++      // *exponent's* width, which need not be wide enough to hold it: at
++      // format (2, 4) exWidth is 3, so the bound wraps round to -4 and the
++      // check fails for every value. It is the narrow formats -- eb 2, sb a
++      // power of two -- where the unpacked exponent stays that tight against
++      // the significand. Compare at a width that holds both instead.
++      bwt boundWidth(bitsToRepresent<bwt>(sigWidth) + 1); // +1 for the sign
++      if (boundWidth < exWidth) {
++	boundWidth = exWidth;
++      }
++      sbv widenedAmount(subnormalAmount.extend(boundWidth - exWidth));
++      INVARIANT((sbv::zero(boundWidth) <= widenedAmount) &&
++		(widenedAmount <= sbv(boundWidth,sigWidth)));
+ 
+       // Invariant implies this following steps do not loose data
+       ubv mask(orderEncode<t>((sigWidth >= exWidth) ?

--- a/tests/query-files/fp-tests/fold-below-symfpu-floor.smt2
+++ b/tests/query-files/fp-tests/fold-below-symfpu-floor.smt2
@@ -1,0 +1,45 @@
+; RUN: %solver %s | %OutputCheck %s
+; RUN: %solver --disable-simplifications %s | %OutputCheck %s
+;
+; Constant folding at the formats that used to be refused. The literal fold
+; backend gated every operation on FloatBlaster::formatSupported, which turned
+; away sb <= 3 so that its refusals matched the circuit path's; once
+; patches/symfpu/0002 gave those formats their headroom bit the circuit path
+; stopped refusing anything, and the gate was left refusing formats that work.
+;
+; Every fact below is an operation on constants, so the first run folds it in
+; the simplifier and the second builds the circuit instead. The two arms have
+; to agree, and both have to agree with IEEE-754.
+;
+; In (_ FloatingPoint 3 3) the bias is 3 and the largest finite is 14.0; in
+; (_ FloatingPoint 2 2), the narrowest format SMT-LIB admits, the bias is 1,
+; the largest finite is 3.0 and the only subnormal is 0.5.
+;
+; CHECK: ^unsat
+(set-logic QF_FP)
+
+(assert (not (and
+  ; 1.0 + 1.0 = 2.0
+  (= (fp.add RNE (fp #b0 #b011 #b00) (fp #b0 #b011 #b00)) (fp #b0 #b100 #b00))
+  ; 8.0 + 8.0 = 16.0, past the midpoint 15.0 between 14.0 and 16.0: +oo
+  (= (fp.add RNE (fp #b0 #b110 #b00) (fp #b0 #b110 #b00)) (fp #b0 #b111 #b00))
+  ; the subnormal is exact here: 1.0 + 0.5 = 1.5
+  (= (fp.add RNE (fp #b0 #b01 #b0) (fp #b0 #b00 #b1)) (fp #b0 #b01 #b1))
+  ; 2.0 + 2.0 = 4.0, past the midpoint 3.5 between 3.0 and 4.0: +oo
+  (= (fp.add RNE (fp #b0 #b10 #b0) (fp #b0 #b10 #b0)) (fp #b0 #b11 #b0))
+  ; 0.5 * 0.5 = 0.25, exactly halfway to the only subnormal: ties to even
+  (= (fp.mul RNE (fp #b0 #b00 #b1) (fp #b0 #b00 #b1)) (fp #b0 #b00 #b0))
+  ; (_ FloatingPoint 2 4): bias 1, largest finite 3.75, smallest subnormal
+  ; 0.125. Not a short significand, so the gate never meant to cover it, but
+  ; its unpacked exponent comes out narrower than its significand, which is
+  ; what unpackedFloat::valid used to build its bound at.
+  (= (fp.add RNE (fp #b0 #b01 #b000) (fp #b0 #b01 #b000)) (fp #b0 #b10 #b000))
+  (= (fp.add RNE (fp #b0 #b01 #b000) (fp #b0 #b00 #b001)) (fp #b0 #b01 #b001))
+  ; and the conversions into these formats, which carried the gate separately
+  (= ((_ to_fp 3 3) RNE ((_ to_fp 5 11) RNE (fp #b0 #b011 #b00)))
+     (fp #b0 #b011 #b00))
+  (= ((_ to_fp 3 3) RNE (_ bv2 8)) (fp #b0 #b100 #b00))
+  (= ((_ to_fp_unsigned 2 2) RNE (_ bv3 8)) (fp #b0 #b10 #b1))
+)))
+(check-sat)
+(exit)

--- a/tests/unit-tests/FpConstantFold_Test.cpp
+++ b/tests/unit-tests/FpConstantFold_Test.cpp
@@ -422,11 +422,10 @@ TEST(FpConstantFold, one_third_matches_known_values_under_every_mode)
 // then the same call hands back the whole symfpu circuit -- a deeply shared
 // DAG, which an evaluator that walks paths rather than nodes cannot finish.
 //
-// The format is deliberately tiny. Float(3,4) is about the smallest symfpu
-// will build (formatSupported refuses sb <= 3), and its fp.add circuit is a
-// few hundred nodes -- linear if each is visited once, and hopeless
-// otherwise. Nothing here checks the *value*; the tests above do that, and
-// against the hardware. This one checks only that it arrives.
+// The format is deliberately tiny. Float(3,4)'s fp.add circuit is a few
+// hundred nodes -- linear if each is visited once, and hopeless otherwise.
+// Nothing here checks the *value*; the tests above do that, and against the
+// hardware. This one checks only that it arrives.
 TEST(FpConstantFold, folds_under_a_non_simplifying_factory)
 {
   STPMgr mgr; // hashingNodeFactory, as the constructor leaves it
@@ -529,8 +528,8 @@ TEST(FpConstantFold, partial_operations_do_not_fold_at_creation)
 // The anti-drift gate for the literal backend. Both paths instantiate the
 // same symfpu core, but each has its own Kind-to-operation driver; this
 // pins them together mechanically -- every covered kind, exhaustively at
-// the smallest supported format -- and is also what keeps the circuit fold
-// path exercised now that the evaluator prefers the literal one.
+// the narrowest formats -- and is also what keeps the circuit fold path
+// exercised now that the evaluator prefers the literal one.
 #include "stp/FloatBlaster/FloatBlast.h"
 #include "stp/FloatBlaster/literal_fp.h"
 
@@ -571,12 +570,9 @@ struct Differential : Fixture
   }
 };
 
-} // namespace
-
-TEST(FpConstantFold, literal_backend_agrees_with_the_circuit_exhaustively)
+void runDifferential(Differential& d, const unsigned eb, const unsigned sb)
 {
-  Differential d;
-  const unsigned eb = 3, sb = 4, w = eb + sb, N = 1u << w;
+  const unsigned w = eb + sb, N = 1u << w;
   std::vector<ASTNode> c;
   for (unsigned i = 0; i < N; i++)
     c.push_back(d.fpConst(eb, sb, i));
@@ -657,6 +653,37 @@ TEST(FpConstantFold, literal_backend_agrees_with_the_circuit_exhaustively)
               true);
     }
   }
+}
 
+} // namespace
+
+TEST(FpConstantFold, literal_backend_agrees_with_the_circuit_exhaustively)
+{
+  Differential d;
+  runDifferential(d, 3, 4);
   EXPECT_GT(d.checked, 90000u);
+}
+
+// The same gate at the formats that used to be refused outright.
+// FloatBlaster::formatSupported turned away everything with sb <= 3, because
+// symfpu's own unpack aborted on INVARIANT(unpackedExWidth > exWidth) there;
+// patches/symfpu/0002 gives those formats the headroom bit instead, so they
+// are now ordinary formats and both fold paths have to handle them. SMT-LIB
+// admits every format from (2,2) up, so these are the narrowest inputs a
+// solver can be handed.
+//
+// (2,4) is here for a second reason. It is not a short significand, so the
+// refusal never covered it on purpose, but it is where the unpacked exponent
+// ends up narrower than the significand -- eb 2 with sb a power of two -- and
+// unpackedFloat::valid then built its own bound at the exponent's width and
+// wrapped it negative. Only the literal backend evaluates that INVARIANT (the
+// symbolic one cannot), so the assertion builds are what see it; it is fixed
+// in patches/symfpu/0004.
+TEST(FpConstantFold, literal_backend_agrees_at_the_narrowest_formats)
+{
+  Differential d;
+  runDifferential(d, 3, 3);
+  runDifferential(d, 2, 2);
+  runDifferential(d, 2, 4);
+  EXPECT_GT(d.checked, 56000u);
 }


### PR DESCRIPTION
`master` does not compile at `9094ef70`.

## The break

Two PRs, each green on its own base, broken together:

- **#784** removed `FloatBlaster::formatSupported` (and `roundToIntegralSupported`). It had fixed the widths symfpu miscalculated in `patches/symfpu/0002` rather than refusing those formats at the front door, so the refusal had nothing left to refuse.
- **#766**, branched before that landed, added `lib/FloatBlaster/literal_fp.cpp`, which calls `FloatBlaster::formatSupported` in three places.

The two touch disjoint files, so git merged them cleanly and CI saw each against its own base. Combined:

```
literal_fp.cpp:572: error: 'formatSupported' is not a member of 'stp::FloatBlaster'
```

## The fix

The guards were parity scaffolding — #766 kept the literal path refusing exactly what the circuit path refused. With the circuit path refusing nothing, parity means no guard, and nothing replaces them: the parser already applies SMT-LIB's `eb >= 2, sb >= 2` floor at every `to_fp` entry point (`checkFpFormatWidths`), and every format above it now works.

## The defect that uncovered

With the guards gone, an assertions build aborts inside `unpackedFloat::valid()`. It bounds the subnormal amount by the significand width, but builds that bound at the *exponent's* width:

```cpp
INVARIANT((sbv::zero(exWidth) <= subnormalAmount) &&
          (subnormalAmount <= sbv(exWidth, sigWidth)));
```

At format (2,4) `exWidth` is 3, so the bound `4` wraps round to `-4` and the check fails for every value. Sweeping `fp.isInfinite` over a constant across eb 2..8 × sb 2..9, plus eb 2 × sb 15..33, it is exactly **eb 2 with sb a power of two** — (2,4), (2,8), (2,16), (2,32) — where `unpackedExponentWidth` comes out as `bitsToRepresent(sb-1) + 1` and stays one bit too tight against the significand. A wider exponent contributes `2^(eb-1)` to that calculation and never reaches it.

The value is right; only the bound expression overflows. `patches/symfpu/0004` compares at a width that holds both.

That invariant had never fired because only the literal backend can evaluate it — on the symbolic backend `traits::invariant` takes a node and cannot assert, so the circuit path computes the bound and discards it. It also needs assertions on, and `CMAKE_BUILD_TYPE=Release` forces `ENABLE_ASSERTIONS=OFF`, so it is reachable only in assertion builds of the new fold path.

## Tests

- The exhaustive literal-vs-circuit differential is parameterised over formats and now also runs at (3,3), (2,2) and (2,4): **56,643 operation instances, all agreeing** — every predicate, classification, sign operation, conversion, and rem/add pair, plus strided sub/mul/div/fma under every rounding mode. That is what confirms the (2,4) values were always correct and the bound alone was wrong.
- A new query file folds constants at those formats end to end, with and without simplifications, so the fold path and the circuit path each have to answer, and both have to agree with IEEE-754. It covers the two `to_fp` conversion sites separately, since those carried their own copy of the guard.
- Full `ctest` (106 tests) and the query-file suite pass in a `RelWithDebInfo` + `ENABLE_ASSERTIONS=ON` build, which is the configuration that sees the invariant at all.