### PR TITLE
Check that the CNF does not depend on how STP was built

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,93 @@ jobs:
         python3 allocator_tests.py
       working-directory: build/tests/api/python
 
+    # The three legs of this matrix configure identically and differ only in
+    # compiler and optimisation level, which makes them the pairs worth
+    # comparing: the CNF is a function of the input, so nothing about how the
+    # binary was built should reach it. The cnf-determinism job below diffs
+    # the manifests. See scripts/cnf-manifest.sh for what a difference means.
+    # Not on the clang leg. STP's own code builds its operands in a fixed
+    # order, but SymFPU -- which only the floating-point path reaches -- does
+    # not, and C++ leaves the order of an overloaded operator's operands to
+    # the implementation. gcc and clang each choose consistently but
+    # differently, so their CNF differs on nine of the corpus's inputs, all
+    # floating-point. That is an encoding difference, not a wrong answer, and
+    # the fix is to replace SymFPU rather than to rewrite it; see
+    # bench-hard/reports/2026-08-10-cnf-build-determinism.md. Comparing the
+    # two gcc legs still covers optimisation level and assertions, and holds
+    # for every input with nothing excluded.
+    - name: CNF manifest
+      if: matrix.name != 'clang'
+      run: |
+        ./scripts/cnf-manifest.sh build/stp tests/query-files 120 \
+          > "cnf-${{ matrix.name }}.manifest"
+        wc -l < "cnf-${{ matrix.name }}.manifest"
+
+    - uses: actions/upload-artifact@v4
+      if: matrix.name != 'clang'
+      with:
+        name: cnf-manifest-${{ matrix.name }}
+        path: cnf-${{ matrix.name }}.manifest
+        if-no-files-found: error
+
+  # Whether the CNF STP writes depends on anything but its input. It should
+  # not: a build-dependent CNF means something upstream is reading an address
+  # rather than a value -- iteration over a pointer-keyed hash table, a sort
+  # tie broken on node identity, an uninitialised read -- and that class of
+  # bug makes measurements irreproducible and bug reports unrepeatable while
+  # staying invisible to a suite that only checks sat/unsat.
+  #
+  # This reuses the builds the matrix above already made, so it costs one
+  # short job rather than any extra compilation.
+  cnf-determinism:
+    name: CNF determinism
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+
+    - uses: actions/download-artifact@v4
+      with:
+        pattern: cnf-manifest-*
+        merge-multiple: true
+
+    - name: Compare the manifests
+      run: |
+        set -u
+        ls -l ./*.manifest
+
+        # Every input is compared; there is no exclusion list.
+        #
+        # Every manifest is compared against the first, so a difference is
+        # reported once per differing build rather than once per pair.
+        reference=$(find . -maxdepth 1 -name '*.manifest' | LC_ALL=C sort | head -1)
+        echo "reference: $reference ($(wc -l < "$reference") inputs compared)"
+
+        failed=0
+        for manifest in $(find . -maxdepth 1 -name '*.manifest' | LC_ALL=C sort | tail -n +2); do
+          if diff -u "$reference" "$manifest" > delta.txt; then
+            echo "OK       $manifest matches $reference"
+          else
+            failed=1
+            echo "::error::$manifest and $reference disagree on the CNF for $(grep -c '^-' delta.txt) input(s)"
+            echo "--- $reference vs $manifest ---"
+            cat delta.txt
+          fi
+        done
+
+        if [ "$failed" -ne 0 ]; then
+          echo
+          echo "The CNF STP generates differs between builds of the same source."
+          echo "The CNF is a function of the input; a build-dependent one means"
+          echo "something upstream depends on node creation order or on an"
+          echo "address. Each line above names the input that provokes it:"
+          echo "  stp --array-equality --output-CNF --exit-after-CNF <input>"
+          echo "under both builds, then diff output_0.cnf."
+          exit 1
+        fi
+
+        echo "All builds agree on the CNF for every input compared."
+
   build-cadical:
     name: gcc (cadical ${{ matrix.cadical_tag }})
     runs-on: ubuntu-latest

--- a/lib/Extensionality/ExtensionalityContext.cpp
+++ b/lib/Extensionality/ExtensionalityContext.cpp
@@ -65,17 +65,23 @@ bool nodeNumLess(const ASTNode& a, const ASTNode& b)
 ASTNode isPackedNaN(NodeFactory* hf, const ASTNode& x, unsigned eb,
                     unsigned sb)
 {
+  // Each sub-term is built in its own statement. C++ does not sequence a
+  // call's arguments against each other, so building two of them inside one
+  // call leaves the order to the compiler -- and node ids are handed out in
+  // creation order, which decides the numbering all the way out to the CNF.
   const unsigned w = eb + sb;
-  const ASTNode exponent =
-      hf->CreateTerm(BVEXTRACT, eb, x, hf->CreateBVConst(32, w - 2),
-                     hf->CreateBVConst(32, sb - 1));
+  const ASTNode expHigh = hf->CreateBVConst(32, w - 2);
+  const ASTNode expLow = hf->CreateBVConst(32, sb - 1);
+  const ASTNode exponent = hf->CreateTerm(BVEXTRACT, eb, x, expHigh, expLow);
+  const ASTNode sigHigh = hf->CreateBVConst(32, sb - 2);
+  const ASTNode sigLow = hf->CreateBVConst(32, 0);
   const ASTNode significand =
-      hf->CreateTerm(BVEXTRACT, sb - 1, x, hf->CreateBVConst(32, sb - 2),
-                     hf->CreateBVConst(32, 0));
-  return hf->CreateNode(
-      AND, hf->CreateNode(EQ, exponent, hf->CreateMaxConst(eb)),
-      hf->CreateNode(
-          NOT, hf->CreateNode(EQ, significand, hf->CreateZeroConst(sb - 1))));
+      hf->CreateTerm(BVEXTRACT, sb - 1, x, sigHigh, sigLow);
+  const ASTNode expAllOnes =
+      hf->CreateNode(EQ, exponent, hf->CreateMaxConst(eb));
+  const ASTNode sigZero =
+      hf->CreateNode(EQ, significand, hf->CreateZeroConst(sb - 1));
+  return hf->CreateNode(AND, expAllOnes, hf->CreateNode(NOT, sigZero));
 }
 
 // SMT-LIB's = between two packed floating-point cells of format (eb, sb).
@@ -87,9 +93,11 @@ ASTNode isPackedNaN(NodeFactory* hf, const ASTNode& x, unsigned eb,
 ASTNode packedFloatEq(NodeFactory* hf, const ASTNode& l, const ASTNode& r,
                       unsigned eb, unsigned sb)
 {
-  return hf->CreateNode(OR, hf->CreateNode(EQ, l, r),
-                        hf->CreateNode(AND, isPackedNaN(hf, l, eb, sb),
-                                       isPackedNaN(hf, r, eb, sb)));
+  // Sequenced deliberately; see the note in isPackedNaN.
+  const ASTNode sameBits = hf->CreateNode(EQ, l, r);
+  const ASTNode lNaN = isPackedNaN(hf, l, eb, sb);
+  const ASTNode rNaN = isPackedNaN(hf, r, eb, sb);
+  return hf->CreateNode(OR, sameBits, hf->CreateNode(AND, lNaN, rNaN));
 }
 
 // The packed bits of the one canonical quiet NaN of format (eb, sb):
@@ -458,11 +466,11 @@ ASTNode ExtensionalityContext::makeEquality(const ASTNode& a, const ASTNode& b)
   {
     const unsigned eb = elementSort.exponentWidth();
     const unsigned sb = elementSort.significandWidth();
+    // Sequenced deliberately; see the note in isPackedNaN.
+    const ASTNode lNaN = isPackedNaN(hf, r.nameL, eb, sb);
+    const ASTNode rNaN = isPackedNaN(hf, r.nameR, eb, sb);
     differ = hf->CreateNode(
-        AND, differ,
-        hf->CreateNode(NOT,
-                       hf->CreateNode(AND, isPackedNaN(hf, r.nameL, eb, sb),
-                                      isPackedNaN(hf, r.nameR, eb, sb))));
+        AND, differ, hf->CreateNode(NOT, hf->CreateNode(AND, lNaN, rNaN)));
   }
   else if (elementSort.kind() == SourceSort::Kind::RoundingMode)
   {
@@ -470,10 +478,11 @@ ASTNode ExtensionalityContext::makeEquality(const ASTNode& a, const ASTNode& b)
     // so a witness difference must be a difference of modes: both cells
     // are pinned valid. (The reads of the formula are pinned by
     // FpTotalise; these virtual reads enter the formula after it ran.)
-    differ = hf->CreateNode(
-        AND, differ,
-        hf->CreateNode(AND, bm->roundingModeValidConstraint(r.nameL),
-                       bm->roundingModeValidConstraint(r.nameR)));
+    // Sequenced deliberately; see the note in isPackedNaN.
+    const ASTNode lValid = bm->roundingModeValidConstraint(r.nameL);
+    const ASTNode rValid = bm->roundingModeValidConstraint(r.nameR);
+    differ = hf->CreateNode(AND, differ,
+                            hf->CreateNode(AND, lValid, rValid));
   }
   r.witnessClause = hf->CreateNode(OR, r.proxy, differ);
 
@@ -485,9 +494,12 @@ ASTNode ExtensionalityContext::makeEquality(const ASTNode& a, const ASTNode& b)
     {
       const unsigned ieb = indexSort.exponentWidth();
       const unsigned isb = indexSort.significandWidth();
-      r.indexSortClause = hf->CreateNode(
-          OR, hf->CreateNode(NOT, isPackedNaN(hf, r.lambda, ieb, isb)),
-          hf->CreateNode(EQ, r.lambda, canonicalQuietNaN(bm, ieb, isb)));
+      // Sequenced deliberately; see the note in isPackedNaN.
+      const ASTNode notNaN =
+          hf->CreateNode(NOT, isPackedNaN(hf, r.lambda, ieb, isb));
+      const ASTNode isCanonical =
+          hf->CreateNode(EQ, r.lambda, canonicalQuietNaN(bm, ieb, isb));
+      r.indexSortClause = hf->CreateNode(OR, notNaN, isCanonical);
     }
     else if (indexSort.kind() == SourceSort::Kind::RoundingMode)
     {

--- a/lib/FloatBlaster/FpTotalise.cpp
+++ b/lib/FloatBlaster/FpTotalise.cpp
@@ -275,10 +275,16 @@ ASTNode FpTotalise::zeroChoice(const char* tag, const ASTNode& left,
   const ASTNode left_positive = nf->CreateNode(EQ, signBit(left), zero);
   const ASTNode right_positive = nf->CreateNode(EQ, signBit(right), zero);
 
-  return nf->CreateTerm(
-      ITE, 1, left_positive,
-      nf->CreateTerm(ITE, 1, right_positive, bit[0], bit[1]),
-      nf->CreateTerm(ITE, 1, right_positive, bit[2], bit[3]));
+  // Sequenced deliberately: C++ does not order a call's arguments against
+  // each other, and node ids are handed out in creation order, so building
+  // both branches inside the one call lets the compiler decide the numbering
+  // that ends up in the CNF.
+  const ASTNode leftPositiveCase =
+      nf->CreateTerm(ITE, 1, right_positive, bit[0], bit[1]);
+  const ASTNode leftNegativeCase =
+      nf->CreateTerm(ITE, 1, right_positive, bit[2], bit[3]);
+  return nf->CreateTerm(ITE, 1, left_positive, leftPositiveCase,
+                        leftNegativeCase);
 }
 
 ASTNode FpTotalise::visit(const ASTNode& n)

--- a/lib/FloatBlaster/symbolic_fp.cpp
+++ b/lib/FloatBlaster/symbolic_fp.cpp
@@ -237,8 +237,12 @@ bitVector<isSigned>::bitVector(const bitVector<isSigned>& old)
 template <bool isSigned>
 ASTNode bitVector<isSigned>::fromProposition(const ASTNode& node) const
 {
-  return s_nf->CreateTerm(ITE, 1, node, s_bm->CreateOneConst(1),
-                          s_bm->CreateZeroConst(1));
+  // Sequenced deliberately: two constants built in one call expression are
+  // unordered against each other, and their node ids decide how commutative
+  // children later sort. See the note in FpTotalise::signSelect.
+  const ASTNode one = s_bm->CreateOneConst(1);
+  const ASTNode zero = s_bm->CreateZeroConst(1);
+  return s_nf->CreateTerm(ITE, 1, node, one, zero);
 }
 
 template <bool isSigned> bitWidthType bitVector<isSigned>::getWidth(void) const
@@ -603,10 +607,11 @@ bitVector<isSigned> bitVector<isSigned>::extract(bitWidthType upper,
                                                  bitWidthType lower) const
 {
   assert(upper >= lower);
+  // Sequenced deliberately; see the note in fromProposition.
+  const ASTNode hi = s_bm->CreateBVConst(32, upper);
+  const ASTNode lo = s_bm->CreateBVConst(32, lower);
   return bitVector<isSigned>(
-      s_nf->CreateTerm(BVEXTRACT, (upper - lower) + 1, *this,
-                       s_bm->CreateBVConst(32, upper),
-                       s_bm->CreateBVConst(32, lower)));
+      s_nf->CreateTerm(BVEXTRACT, (upper - lower) + 1, *this, hi, lo));
 }
 
 /****************************************************************

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -1990,9 +1990,10 @@ void BitBlaster::mult_Booth_radix4(const BBNodeVec& x, const BBNodeVec& y,
     const BBNode one = nf->CreateNode(XOR, low, below);
     // twice y is selected by 011 and by 100, i.e. when low and below agree with
     // each other and disagree with high.
-    const BBNode two = nf->CreateNode(
-        AND, nf->CreateNode(NOT, nf->CreateNode(XOR, low, below)),
-        nf->CreateNode(XOR, high, below));
+    // Sequenced deliberately; see the note in BBcompareFP.
+    const BBNode lowAgrees = nf->CreateNode(NOT, nf->CreateNode(XOR, low, below));
+    const BBNode highDiffers = nf->CreateNode(XOR, high, below);
+    const BBNode two = nf->CreateNode(AND, lowAgrees, highDiffers);
 
     for (unsigned j = 0; base + j < bitWidth; j++)
     {
@@ -3409,8 +3410,13 @@ BBNode BitBlaster::BBcompareFP(const ASTNode& form, BBNodeSet& support)
 
   const BBNode aNotNaN = nf->CreateNode(NOT, BBfpIsNaN(aBits, sb, w));
   const BBNode bNotNaN = nf->CreateNode(NOT, BBfpIsNaN(bBits, sb, w));
-  const BBNode bothZero =
-      nf->CreateNode(AND, BBfpIsZero(aBits, w), BBfpIsZero(bBits, w));
+  // Both operands' circuits are built before they are combined. Written as
+  // two statements because C++ does not sequence a call's arguments against
+  // each other: as one expression, which operand's AIG nodes get built first
+  // is the compiler's choice, and the numbering it decides reaches the CNF.
+  const BBNode aZero = BBfpIsZero(aBits, w);
+  const BBNode bZero = BBfpIsZero(bBits, w);
+  const BBNode bothZero = nf->CreateNode(AND, aZero, bZero);
   const BBNodeVec aKey = key(aBits, w);
   const BBNodeVec bKey = key(bBits, w);
   // key(a) >u key(b) when strict, key(a) >=u key(b) otherwise.
@@ -3461,8 +3467,10 @@ BBNode BitBlaster::BBeqFP(const ASTNode& form, BBNodeSet& support)
 
   if (k == FP_SMT_EQ)
   {
-    const BBNode bothNaN = nf->CreateNode(AND, BBfpIsNaN(aBits, sb, w),
-                                          BBfpIsNaN(bBits, sb, w));
+    // Sequenced deliberately; see the note in BBcompareFP.
+    const BBNode aNaN = BBfpIsNaN(aBits, sb, w);
+    const BBNode bNaN = BBfpIsNaN(bBits, sb, w);
+    const BBNode bothNaN = nf->CreateNode(AND, aNaN, bNaN);
     return nf->CreateNode(OR, bothNaN, sameBits);
   }
 
@@ -3478,8 +3486,10 @@ BBNode BitBlaster::BBeqFP(const ASTNode& form, BBNodeSet& support)
   // choice is per-node and deterministic.
   const BBNodeVec& nanSide = form[0].isConstant() ? aBits : bBits;
   const BBNode notNaN = nf->CreateNode(NOT, BBfpIsNaN(nanSide, sb, w));
-  const BBNode bothZero =
-      nf->CreateNode(AND, BBfpIsZero(aBits, w), BBfpIsZero(bBits, w));
+  // Sequenced deliberately; see the note in BBcompareFP.
+  const BBNode aZero = BBfpIsZero(aBits, w);
+  const BBNode bZero = BBfpIsZero(bBits, w);
+  const BBNode bothZero = nf->CreateNode(AND, aZero, bZero);
   const BBNode sameValue = nf->CreateNode(OR, sameBits, bothZero);
 
   return nf->CreateNode(AND, notNaN, sameValue);

--- a/scripts/cnf-manifest.sh
+++ b/scripts/cnf-manifest.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# Emit a manifest of the CNF an stp binary generates over a corpus: one line
+# per input file, sorted, of the form
+#
+#     <sha256 | none | timeout | error>  <path relative to the corpus root>
+#
+# The CNF STP produces is a function of the input alone. Nothing about how the
+# binary was built -- which compiler, which optimisation level, which
+# allocator, 32- or 64-bit, static or shared -- should reach it. Where it does,
+# the cause is something reading an address rather than a value: iteration over
+# a hash table keyed on pointers, a sort that ties on node identity, an
+# uninitialised read. Those are exactly the bugs that make a performance
+# measurement irreproducible and a bug report unrepeatable, and they are
+# invisible to a test suite that only checks sat/unsat.
+#
+# So: run this against two builds and diff the manifests. Identical means the
+# CNF is byte-identical across the pair for every input in the corpus.
+#
+#     scripts/cnf-manifest.sh build-gcc/stp tests/query-files > gcc.manifest
+#     scripts/cnf-manifest.sh build-clang/stp tests/query-files > clang.manifest
+#     diff -u gcc.manifest clang.manifest
+#
+# A differing line names the input that provokes it, which is the thing you
+# need to debug it.
+
+set -u -o pipefail
+
+if [ $# -lt 2 ]; then
+    echo "usage: $0 <stp binary> <corpus directory> [timeout seconds]" >&2
+    exit 2
+fi
+
+solver=$(readlink -f "$1")
+corpus=$(readlink -f "$2")
+per_file_timeout=${3:-60}
+
+if [ ! -x "$solver" ]; then
+    echo "$0: '$1' is not an executable" >&2
+    exit 2
+fi
+if [ ! -d "$corpus" ]; then
+    echo "$0: '$2' is not a directory" >&2
+    exit 2
+fi
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+# --output-CNF writes output_<n>.cnf into the working directory, so each input
+# gets a clean one. --exit-after-CNF stops at the first, which keeps the run
+# bounded on array problems whose refinement loop would otherwise emit one per
+# round; the first CNF is the one every build has to agree on anyway.
+#
+# --array-equality because STP refuses a whole-array equality outright without
+# it, and the corpus has 79 such inputs that would otherwise contribute an
+# identical "error" line from every build and test nothing. It is a semantic
+# option that only bites on formulas containing such an equality: measured
+# inert -- byte-identical CNF -- on all 111 corpus inputs that generate one
+# without it.
+#
+# find | sort rather than a glob: the manifest has to be in a stable order for
+# diff to be readable, and locale-independent so two machines agree.
+while IFS= read -r input; do
+    rel=${input#"$corpus"/}
+    rm -rf "$work/run"
+    mkdir -p "$work/run"
+
+    if ! (cd "$work/run" && timeout "$per_file_timeout" \
+              "$solver" --array-equality --output-CNF --exit-after-CNF "$input" \
+              >/dev/null 2>&1); then
+        status=$?
+        # 124 is timeout(1) killing it. Anything else is stp declining the
+        # input -- an unsupported logic, a deliberate error-path test. Both
+        # are recorded rather than skipped: a build that starts timing out, or
+        # starts rejecting an input the others accept, is itself a difference
+        # worth seeing.
+        if [ "$status" -eq 124 ]; then
+            printf '%-64s  %s\n' timeout "$rel"
+        else
+            printf '%-64s  %s\n' error "$rel"
+        fi
+        continue
+    fi
+
+    # Concatenated in name order, so a problem that emits several CNFs still
+    # hashes to one value. No CNF at all is the normal outcome for an input
+    # the preprocessing simplifier settles on its own, and is itself a fact
+    # the builds must agree on.
+    cnfs=$(find "$work/run" -maxdepth 1 -name 'output_*.cnf' | LC_ALL=C sort)
+    if [ -z "$cnfs" ]; then
+        printf '%-64s  %s\n' none "$rel"
+    else
+        # shellcheck disable=SC2086
+        printf '%-64s  %s\n' "$(cat $cnfs | sha256sum | cut -d' ' -f1)" "$rel"
+    fi
+done < <(find "$corpus" -type f \( -name '*.smt2' -o -name '*.cvc' \) \
+             | LC_ALL=C sort)


### PR DESCRIPTION
The CNF is a function of the input. Nothing about the binary that produced it — which optimisation level, which allocator, static or shared — should reach it. Where it does, something upstream depends on node creation order or on an address, and that class of bug makes a measurement irreproducible and a bug report unrepeatable while staying invisible to a suite that only checks sat/unsat.

## The tool

`scripts/cnf-manifest.sh` runs a binary over a corpus and prints one line per input: the sha256 of the CNF it generated, or `none`/`timeout`/`error`. Two builds agree exactly when their manifests are identical, and a differing line names the input — which is what makes a failure debuggable rather than just red.

```
scripts/cnf-manifest.sh build-a/stp tests/query-files > a.manifest
scripts/cnf-manifest.sh build-b/stp tests/query-files > b.manifest
diff -u a.manifest b.manifest
```

It passes `--array-equality`, because STP otherwise refuses a whole-array equality outright and 79 corpus inputs would contribute an identical `error` line from every build, testing nothing. The option is measured inert — byte-identical CNF — on all 111 inputs that produce one without it, and it raises the inputs that generate a CNF from 111 to 177.

## The CI wiring

A manifest step on the gcc legs of the existing `build` matrix, an artifact, and one short job that diffs them — no extra compilation. Those legs configure identically and differ in optimisation level and assertions.

**Every input is compared. There is no exclusion list.**

## Verification

Four builds of this commit — gcc -O3, gcc -O1, `STP_ALLOCATOR=system`, and `STATICCOMPILE=ON` — compared over the whole corpus:

| axis | result |
|---|---|
| gcc -O1 vs gcc -O3 | identical |
| mimalloc vs system allocator | identical |
| shared vs static | identical |

439 of 439 inputs, nothing excluded. The comparison was also run with a corrupted hash injected into one manifest, to confirm it fails and names the offending input rather than passing vacuously. Full `ctest`: 106/106.

## Why the clang leg is out

STP's own code now builds its operands in a fixed order, but SymFPU does not, and C++ leaves the order of an overloaded operator's operands to the implementation. gcc and clang each choose consistently but differently, so their CNF differs on nine floating-point inputs. The answers agree — identical variable and clause counts, the same problem numbered differently — so this is an encoding difference, not a soundness one.

Clearing it means rewriting SymFPU's expression style, not a contained fix: an experimental patch fixed 21 sites and moved the first differing construction from #1447 to #2151 of 10532 without eliminating it, at 406 lines and still converging, with ~84 candidate sites left. SymFPU is going to be replaced for bit-blasting, which removes the class, so that axis stays out until then rather than carrying a list of excluded inputs.

Measurements, the localisation method, and the structural alternative that was costed but not built are in `bench-hard/reports/2026-08-10-cnf-build-determinism.md`.

## The second commit

The unsequenced-operand fixes in STP's own code — the floating-point comparison and equality blasters plus a Booth-recoding step in `BitBlaster`, the packed-NaN and witness-clause helpers in `ExtensionalityContext`, the sign-select in `FpTotalise`, two constant pairs in the SymFPU adapter.

These are not what makes the check pass; the enforced axes were already clean. They are what stops a **compiler upgrade** silently changing the CNF, which comparing two builds of the same compiler cannot catch.

## Not measured

32-bit vs 64-bit. That leg runs inside a container and was not built here; it is the one axis of the original question left open.