### PR TITLE
Remove the optional bit-blast simplification

### DIFF
--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -72,7 +72,6 @@ public:
   bool enable_common_subsum = false;
 
   int64_t AIG_rewrites_iterations = 0; // Number of iterations of AIG rewrites.
-  int64_t bitblast_simplification = 0;
   int64_t size_reducing_fixed_point = 0;
   
 
@@ -246,7 +245,6 @@ public:
     enable_common_subsum = false;
     enable_ite_context = false;
 
-    bitblast_simplification = 0;
     simple_cnf=true;
   }
 

--- a/lib/STPManager/STP.cpp
+++ b/lib/STPManager/STP.cpp
@@ -51,7 +51,6 @@ namespace stp
 {
 
 const static string cb_message = "After Constant Bit Propagation. ";
-const static string bb_message = "After Bitblast simplification. ";
 const static string uc_message = "After Removing Unconstrained. ";
 const static string int_message = "After Unsigned Interval Analysis. ";
 const static string pl_message = "After Pure Literals. ";
@@ -495,9 +494,6 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
   //
   // This remains after all of the size-reducing passes above. In particular,
   // RemoveUnconstrained must see a float symbol rather than its exposed bits.
-  // The old location was just below the difficulty snapshot, but that let the
-  // optional bit-blast simplification here receive FP_EQ and other floating-
-  // point nodes when --bit-blast-simplification enabled it.
   //
   // See FloatBlast for why this is a pass of its own: doing it inside
   // simplification meant building floating-point nodes over bitvector
@@ -509,65 +505,17 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
     inputToSat = fpEncodingContext->lowerPrepared(inputToSat);
     bm->ASTNodeStats("After floating-point lowering: ", inputToSat);
 
-    // The threshold controls the cost of bit-blasting the formula in its
-    // lowered form, so compare it with that form's difficulty rather than the
-    // much smaller word-level FP syntax. The always setting (-1) is unchanged.
+    // Everything downstream works on the lowered form, so the snapshot that
+    // difficulty reversion later compares against has to describe that form
+    // rather than the much smaller word-level FP syntax. Retaken here because
+    // the recompute below is skipped for array problems.
     initial_difficulty_score = difficulty.score(inputToSat, bm);
   }
-
-  int64_t bitblasted_difficulty = -1;
-  // Expensive, so only want to do it once.
-  // The AIG-equivalence/constant substitutions found here are not
-  // recorded in the solver map, so they could silently strip a symbol
-  // the array-equality procedure depends on (an abstraction variable,
-  // witness name, or lemma-leaf name) out of the formula. They are an
-  // optimization; skip them when array equality is active.
-  if (!extActive &&
-      (bm->UserFlags.bitblast_simplification == -1 || initial_difficulty_score < bm->UserFlags.bitblast_simplification))
-  {
-    BBNodeManagerAIG bitblast_nodemgr;
-    BitBlaster bb(&bitblast_nodemgr, simp, bm->defaultNodeFactory,
-                  &(bm->UserFlags));
-    ASTNodeMap fromTo;
-    ASTNodeMap equivs;
-    bb.getConsts(inputToSat, fromTo, equivs);
-
-    if (equivs.size() > 0)
-    {
-      /* These nodes have equivalent AIG representations, so even though they
-       * have different
-       * word level expressions they are identical semantically. So we pick one
-       * of the ASTnodes
-       * and replace the others with it.
-       * TODO: I replace with the lower id node, sometimes though we replace
-       * with much more
-       * difficult looking ASTNodes.
-      */
-      ASTNodeMap cache;
-      inputToSat = SubstitutionMap::replace(
-          inputToSat, equivs, cache, bm->defaultNodeFactory, false, true);
-      bm->ASTNodeStats(bb_message.c_str(), inputToSat);
-    }
-
-    if (fromTo.size() > 0)
-    {
-      ASTNodeMap cache;
-      inputToSat = SubstitutionMap::replace(inputToSat, fromTo, cache,
-                                            bm->defaultNodeFactory);
-      bm->ASTNodeStats(bb_message.c_str(), inputToSat);
-    }
-    
-    bitblasted_difficulty = bitblast_nodemgr.totalNumberOfNodes();
-  }
-
 
   if (!arrayops || bm->UserFlags.array_difficulty_reversion)
   {
     initial_difficulty_score = difficulty.score(inputToSat, bm);
   }
-
-  if (bitblasted_difficulty != -1 && bm->UserFlags.stats_flag)
-    cout << "Initial Bitblasted size:" << bitblasted_difficulty << endl;
 
   if (bm->UserFlags.stats_flag)
     cout << "Difficulty After Size reducing:" << initial_difficulty_score
@@ -727,28 +675,10 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
 
   int64_t final_difficulty_score = difficulty.score(inputToSat, bm);
 
-  bool worse = false;
-  if (final_difficulty_score > .8 * initial_difficulty_score)
-    worse = true;
-
-  // It's of course very wasteful to do this! Later I'll make it reuse the
-  // work..We bit-blast again, in order to throw it away, so that we can
-  // measure whether the number of AIG nodes is smaller. The difficulty score
-  // is sometimes completelywrong, the sage-app7 are the motivating examples.
-  // The other way to improve it would be to fix the difficulty scorer!
-  if (!worse && (bitblasted_difficulty != -1))
-  {
-    BBNodeManagerAIG bitblast_nodemgr;
-    BitBlaster bb(&bitblast_nodemgr, simp, bm->defaultNodeFactory,
-                  &(bm->UserFlags));
-    bb.BBForm(inputToSat);
-    int newBB = bitblast_nodemgr.totalNumberOfNodes();
-    if (bm->UserFlags.stats_flag)
-      cerr << "Final BB Size:" << newBB << endl;
-
-    if (bitblasted_difficulty < newBB)
-      worse = true;
-  }
+  // Simplification has to have taken a fifth off the score to count as having
+  // helped. Written as an assignment now that the AIG node count is gone: it
+  // was the second of the two things that could set this.
+  const bool worse = final_difficulty_score > .8 * initial_difficulty_score;
 
   if (bm->UserFlags.stats_flag)
   {

--- a/tests/query-files/fp-tests/roundtointegral-rm-variable.smt2
+++ b/tests/query-files/fp-tests/roundtointegral-rm-variable.smt2
@@ -1,11 +1,8 @@
 ; RUN: %solver %s | %OutputCheck %s
-; RUN: %solver --bit-blast-simplification=-1 %s | %OutputCheck %s
 ;
 ; fp.roundToIntegral must accept a RoundingMode variable, not only the five
 ; literal modes. Regression test: its grammar rule used to demand a literal,
 ; unlike every other rounded operation.
-; The forced bit-blast simplification run also pins the pipeline invariant that
-; floating-point operations are lowered before any optional bit-blaster pass.
 (set-logic QF_FP)
 (declare-const r RoundingMode)
 (declare-fun x () (_ FloatingPoint 3 5))

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -204,13 +204,6 @@ void ExtraMain::create_options()
            "level",
            simp_group);
 
-  int64_arg("--bit-blast-simplification", bm->UserFlags.bitblast_simplification,
-            "Part-way through simplifying, convert to AIGs and look for bits "
-            "that the AIGs figure out are true/false or the same as another "
-            "node. If the difficulty is less than this number. -1 means "
-            "always.",
-            simp_group);
-
   int64_arg("--size-reducing-fixed-point-limit",
             bm->UserFlags.size_reducing_fixed_point,
             "If the number of non-leaf nodes is fewer than this number, run "
@@ -534,7 +527,7 @@ void ExtraMain::create_options()
                 "--flattening", "--rewriting", "--split-extracts",
                 "--ite-context-simplifications", "--use-intervals",
                 "--pure-literals", "--common-subsum", "--pair-extract",
-                "--merge-same", "--bit-blast-simplification"});
+                "--merge-same"});
 
   // Likewise for what disableSizeIncreasingSimplifications() forces.
   excludes_all("--size-reducing-only",


### PR DESCRIPTION
Re-raises #792 against `master`. That PR was based on `cli-option-conflicts`, and was merged into it after that branch's own PR (#789) had already landed, so the change never reached master. The content is unchanged apart from the commit message; it cherry-picks onto master cleanly.

## What is being removed

The pass bit-blasted the whole formula into a throwaway AIG part-way through preprocessing, read back the nodes ABC had proved constant or structurally equal, substituted those at the word level, and discarded the AIG. It was gated on `--bit-blast-simplification`, a difficulty threshold defaulting to `0` — which makes the guard `initial_difficulty_score < 0` false, since the score is clamped non-negative. Nothing else writes the field, so **the pass was unreachable in every default run**.

What the flag did reach was a crash. `BBTerm` has no arm for `READ`, and arrays are only rewritten away above it by `numberOfReadsLessThan(10)` (50 under `--ackermanize`), so any query with ten or more surviving reads walked the scratch bit-blast into a `READ` and hit `BBTerm: Illegal kind to BBTerm`. Four lines are enough:

```smt2
(set-logic QF_ABV)
(declare-fun a () (Array (_ BitVec 4) (_ BitVec 1)))
(assert (= (_ bv1 1) (bvadd (select a (_ bv0 4)) (select a (_ bv1 4)) (select a (_ bv2 4)) (select a (_ bv3 4)) (select a (_ bv4 4)) (select a (_ bv5 4)) (select a (_ bv6 4)) (select a (_ bv7 4)) (select a (_ bv8 4)) (select a (_ bv9 4)))))
(check-sat)
```

Exactly at the boundary: nine reads answers `sat`, ten exits 255. The pass already carried a guard of that shape for array equality — its substitutions bypass the solver map and could strip a symbol the extensionality procedure depends on — so this was the second array assumption it made without checking.

Rather than add the missing guard, the pass goes. It has been off by default for its whole life, so no measurement says it pays for the full bit-blast it costs, and the one configuration that enabled it was broken.

## What goes with it

The AIG-node-count second opinion on difficulty reversion. It re-blasted the final formula and compared the count against the one this pass left behind, had no other source for that baseline, and was therefore equally unreachable by default. Its reversion test collapses to a plain assignment.

The difficulty snapshot retaken after floating-point lowering stays, for the reason that outlives the threshold: everything downstream works on the lowered form, so the value reversion later compares against has to describe that form.

`BitBlaster::getConsts` stays — `tools/rewrite_rule_gen` is now its only caller.

The floating-point regression test loses the second RUN line that forced the pass on. What that line pinned — FP lowering preceding any bit-blaster pass — is what the remaining line exercises anyway.

`--bit-blast-simplification` was also named in the `excludes_all("--disable-simplifications", …)` list added by #789, and that block resolves options by name and throws if one stops matching, so the name is dropped there too.

## Testing

Full suite green (106/106) on a build with assertions and testing enabled. The reproducer above answers `sat`; the removed flag is now rejected by the option parser; the #789 exclusion list still resolves, with `--disable-simplifications --flattening=1` still refused as before.

The crash was originally found by differential fuzzing, which hit it three times in the first fifteen minutes of a six-worker run once the fuzzer was drawing this option again.

Depends on nothing; #795 removes the fuzzer's entry for the flag and can land in either order.