### PR TITLE
Floating-point rewrite-rule generator, and the constant-operand rules it found

### DIFF
--- a/include/stp/NodeFactory/SimplifyingNodeFactory.h
+++ b/include/stp/NodeFactory/SimplifyingNodeFactory.h
@@ -108,6 +108,11 @@ private:
   // sign bit, keeping the rest of the packed bits and the format.
   ASTNode foldFPSign(const ASTNode& fpConst, bool flip);
 
+  // The special constants of a format, for rules whose result is not one of
+  // the operands: interning canonicalises the NaN.
+  ASTNode makeFPNaN(unsigned eb, unsigned sb);
+  ASTNode makeFPZero(unsigned eb, unsigned sb, bool negative);
+
   ASTNode plusRules(const ASTVec& oldChildren);
 
 };

--- a/lib/NodeFactory/SimplifyingNodeFactory.cpp
+++ b/lib/NodeFactory/SimplifyingNodeFactory.cpp
@@ -26,6 +26,7 @@ THE SOFTWARE.
 #include "stp/AST/AST.h"
 #include "stp/AST/ASTKind.h"
 #include "stp/AbsRefineCounterExample/ArrayTransformer.h"
+#include "stp/FloatBlaster/rounding_modes.h"
 #include "stp/Simplifier/Simplifier.h"
 #include <cassert>
 #include <cmath>
@@ -109,16 +110,30 @@ static int fpConstPlusMinusOne(const stp::ASTNode& c)
   return CONSTANTBV::BitVector_bit_test(bits, eb + sb - 1) ? -1 : 1;
 }
 
+// True for a constant that carries a plausible packed floating-point format:
+// the guard every classifier below applies before reading fields. A real IEEE
+// format has eb, sb >= 2, and the packed width must be eb + sb for the bit
+// indices to be in range. (A rounding-mode constant is also kind BVCONST but
+// carries no format, so it fails here.)
+static bool fpFormattedConst(const stp::ASTNode& c)
+{
+  if (c.GetKind() != stp::BVCONST)
+    return false;
+  const unsigned eb = c.GetExpWidth();
+  const unsigned sb = c.GetSigWidth();
+  return eb >= 2 && sb >= 2 && c.GetValueWidth() == eb + sb;
+}
+
 // True for a packed floating-point constant that is NaN: exponent field
 // (bits [sb-1 .. sb+eb-2]) all ones and stored significand (bits
 // [0 .. sb-2]) nonzero. Interning canonicalises every NaN literal to one
 // pattern, but classify from the bits rather than lean on that.
 static bool fpConstIsNaN(const stp::ASTNode& c)
 {
-  assert(c.GetKind() == stp::BVCONST);
+  if (!fpFormattedConst(c))
+    return false;
   const unsigned eb = c.GetExpWidth();
   const unsigned sb = c.GetSigWidth();
-  assert(eb >= 2 && sb >= 2 && c.GetValueWidth() == eb + sb);
   stp::CBV bits = c.GetBVConst();
   for (unsigned i = sb - 1; i < sb + eb - 1; i++)
     if (!CONSTANTBV::BitVector_bit_test(bits, i))
@@ -127,6 +142,24 @@ static bool fpConstIsNaN(const stp::ASTNode& c)
     if (CONSTANTBV::BitVector_bit_test(bits, i))
       return true;
   return false;
+}
+
+// The infinities: exponent field all ones, stored significand zero. Returns
+// +1 for +oo, -1 for -oo, and 0 for everything else.
+static int fpConstInfSign(const stp::ASTNode& c)
+{
+  if (!fpFormattedConst(c))
+    return 0;
+  const unsigned eb = c.GetExpWidth();
+  const unsigned sb = c.GetSigWidth();
+  stp::CBV bits = c.GetBVConst();
+  for (unsigned i = sb - 1; i < sb + eb - 1; i++)
+    if (!CONSTANTBV::BitVector_bit_test(bits, i))
+      return 0;
+  for (unsigned i = 0; i + 1 < sb; i++)
+    if (CONSTANTBV::BitVector_bit_test(bits, i))
+      return 0;
+  return CONSTANTBV::BitVector_bit_test(bits, eb + sb - 1) ? -1 : 1;
 }
 
 // True for a packed floating-point constant that is +0 or -0: everything
@@ -139,6 +172,55 @@ static bool fpConstIsZero(const stp::ASTNode& c)
     if (CONSTANTBV::BitVector_bit_test(bits, i))
       return false;
   return true;
+}
+
+// The signed zeros: returns +1 for +0, -1 for -0, and 0 for everything else.
+static int fpConstZeroSign(const stp::ASTNode& c)
+{
+  if (!fpFormattedConst(c) || !fpConstIsZero(c))
+    return 0;
+  return CONSTANTBV::BitVector_bit_test(c.GetBVConst(), c.GetValueWidth() - 1)
+             ? -1
+             : 1;
+}
+
+// The sign bit of any formatted constant: +1 clear, -1 set, 0 not one.
+static int fpConstSign(const stp::ASTNode& c)
+{
+  if (!fpFormattedConst(c))
+    return 0;
+  return CONSTANTBV::BitVector_bit_test(c.GetBVConst(), c.GetValueWidth() - 1)
+             ? -1
+             : 1;
+}
+
+// The literal rounding mode in an arithmetic operation's first child, as a
+// symbolic_fp::rounding_modes value -- or 0 when the mode is symbolic or not
+// a legal one-hot encoding. (Both spellings of a literal mode -- the parser's
+// plain 5-bit constant and the API's ASTRMConst -- are kind BVCONST.)
+static unsigned fpConstRoundingMode(const stp::ASTNode& rm)
+{
+  if (rm.GetKind() != stp::BVCONST || rm.GetValueWidth() != 5)
+    return 0;
+  unsigned v = 0;
+  for (unsigned i = 0; i < 5; i++)
+    if (CONSTANTBV::BitVector_bit_test(rm.GetBVConst(), i))
+      v |= 1u << i;
+  return (v != 0 && (v & (v - 1)) == 0) ? v : 0;
+}
+
+// Whether adding the signed zero `zeroSign` (+1 for +0, -1 for -0) to any
+// float returns that float exactly, under the literal mode `mode` (0 = not
+// literal, never an identity). The sum of the two opposite zeros is the one
+// input that can see the zero operand: it is +0 under every mode except
+// round-toward-negative, where it is -0. So y + (-0) = y unless the mode is
+// RTN, and y + (+0) = y only there.
+static bool fpZeroIsAdditiveIdentity(int zeroSign, unsigned mode)
+{
+  if (mode == 0 || zeroSign == 0)
+    return false;
+  const bool rtn = (mode == stp::symbolic_fp::ROUND_TOWARD_NEGATIVE);
+  return (zeroSign < 0) != rtn;
 }
 
 bool SimplifyingNodeFactory::children_all_constants(
@@ -185,6 +267,27 @@ ASTNode SimplifyingNodeFactory::foldFPSign(const ASTNode& fpConst, bool flip)
 
   return bm.CreateFPConst(bm.CreateBVConst(bits, width),
                           fpConst.GetExpWidth(), fpConst.GetSigWidth());
+}
+
+ASTNode SimplifyingNodeFactory::makeFPNaN(unsigned eb, unsigned sb)
+{
+  const unsigned width = eb + sb;
+  stp::CBV bits = CONSTANTBV::BitVector_Create(width, true);
+  for (unsigned i = sb - 1; i < width - 1; i++) // exponent field all ones
+    CONSTANTBV::BitVector_Bit_On(bits, i);
+  // Any nonzero stored significand: CreateFPConst canonicalises the payload.
+  CONSTANTBV::BitVector_Bit_On(bits, 0);
+  return bm.CreateFPConst(bm.CreateBVConst(bits, width), eb, sb);
+}
+
+ASTNode SimplifyingNodeFactory::makeFPZero(unsigned eb, unsigned sb,
+                                           bool negative)
+{
+  const unsigned width = eb + sb;
+  stp::CBV bits = CONSTANTBV::BitVector_Create(width, true);
+  if (negative)
+    CONSTANTBV::BitVector_Bit_On(bits, width - 1);
+  return bm.CreateFPConst(bm.CreateBVConst(bits, width), eb, sb);
 }
 
 ASTNode SimplifyingNodeFactory::create_gt_node(const ASTVec& children)
@@ -667,17 +770,37 @@ ASTNode SimplifyingNodeFactory::CreateNode(Kind kind, const ASTVec& children)
             NodeFactory::CreateNode(stp::FP_GEQ, children[1], children[0]);
       break;
 
-    // x > x is false, NaN included.
+    // x > x is false, NaN included. So is any comparison against a NaN
+    // constant (NaN is unordered against everything), and the two
+    // impossible strict comparisons against the extremes: -oo > x and
+    // x > +oo hold for no x. (The mirrored fp.lt forms arrive here already
+    // swapped, so these four cover all eight.)
     case stp::FP_GT:
-      if (children.size() == 2 && children[0] == children[1])
+      if (children.size() == 2 &&
+          (children[0] == children[1] || fpConstIsNaN(children[0]) ||
+           fpConstIsNaN(children[1]) || fpConstInfSign(children[0]) == -1 ||
+           fpConstInfSign(children[1]) == 1))
         result = ASTFalse;
       break;
 
-    // x >= x holds exactly when x is not NaN.
+    // x >= x holds exactly when x is not NaN -- and so do +oo >= x and
+    // x >= -oo, since only a NaN is unordered against an extreme. Against a
+    // NaN constant the comparison is simply false.
     case stp::FP_GEQ:
-      if (children.size() == 2 && children[0] == children[1])
-        result = NodeFactory::CreateNode(
-            stp::NOT, NodeFactory::CreateNode(stp::FP_ISNAN, children[0]));
+      if (children.size() == 2)
+      {
+        if (fpConstIsNaN(children[0]) || fpConstIsNaN(children[1]))
+          result = ASTFalse;
+        else if (children[0] == children[1])
+          result = NodeFactory::CreateNode(
+              stp::NOT, NodeFactory::CreateNode(stp::FP_ISNAN, children[0]));
+        else if (fpConstInfSign(children[0]) == 1)
+          result = NodeFactory::CreateNode(
+              stp::NOT, NodeFactory::CreateNode(stp::FP_ISNAN, children[1]));
+        else if (fpConstInfSign(children[1]) == -1)
+          result = NodeFactory::CreateNode(
+              stp::NOT, NodeFactory::CreateNode(stp::FP_ISNAN, children[0]));
+      }
       break;
 
     case stp::FP_EQ:
@@ -729,6 +852,12 @@ ASTNode SimplifyingNodeFactory::CreateNode(Kind kind, const ASTVec& children)
             break;
           }
         }
+
+        // (= x NaN) is exactly (fp.isNaN x) -- SMT-LIB has a single NaN
+        // value -- but it is deliberately NOT rewritten: PropagateEqualities
+        // substitutes through a `=` with a constant side (x := NaN
+        // everywhere), which is strictly stronger than holding the smaller
+        // predicate.
 
         // Both float equalities are symmetric. Order the operands so that
         // x ~ y and y ~ x become the same node and share their blasted
@@ -3248,13 +3377,29 @@ ASTNode SimplifyingNodeFactory::CreateTerm(Kind kind, unsigned int width,
     // ----- Cheap floating-point rewrites, applied before bit-blasting. -----
     // See the matching block in CreateNode.
 
-    // min(x, x) = max(x, x) = x. The two float operands are children 0 and 1;
-    // the totalising pass may append a choice-of-zero child, but it runs after
-    // this, and the identity holds whether or not it is present.
+    // min(x, x) = max(x, x) = x. A NaN operand is ignored -- fp.min/fp.max
+    // return the other operand -- and the matching order extreme absorbs:
+    // min(x, -oo) = -oo and max(x, +oo) = +oo for every x, NaN included.
+    // All three are sound for either of the totalising pass's zero choices:
+    // the choice only matters when the operands are the two opposite zeros,
+    // which an equal, NaN or infinite operand precludes. The two float
+    // operands are children 0 and 1; the choice child, if the pass has
+    // already appended one, is irrelevant to these.
     case stp::FP_MIN:
     case stp::FP_MAX:
-      if (children.size() >= 2 && children[0] == children[1])
-        result = children[0];
+      if (children.size() >= 2)
+      {
+        if (children[0] == children[1])
+          result = children[0];
+        for (unsigned k = 0; result.IsNull() && k <= 1; k++)
+        {
+          if (fpConstIsNaN(children[k]))
+            result = children[1 - k];
+          else if (fpConstInfSign(children[k]) ==
+                   (kind == stp::FP_MIN ? -1 : 1))
+            result = children[k];
+        }
+      }
       break;
 
     // abs(abs x) = abs(neg x) = abs x. On a constant, fold at construction --
@@ -3290,17 +3435,32 @@ ASTNode SimplifyingNodeFactory::CreateTerm(Kind kind, unsigned int width,
             NodeFactory::CreateTerm(stp::FP_NEG, width, children[2]));
       break;
 
-    // fp.add is commutative in its two float operands (child 0 is the rounding
-    // mode). Order them so x + y and y + x share a node.
+    // fp.add: a NaN operand absorbs -- NaN + x is NaN for every x and mode --
+    // and a signed-zero operand whose addition is exact for the literal
+    // rounding mode is dropped: x + (-0) = x under every mode except
+    // round-toward-negative, x + (+0) = x only there. Otherwise fp.add is
+    // commutative in its two float operands (child 0 is the rounding mode):
+    // order them so x + y and y + x share a node.
     case stp::FP_ADD:
-      if (children.size() == 3 &&
-          children[1].GetNodeNum() > children[2].GetNodeNum())
+      if (children.size() == 3)
       {
-        ASTVec reordered;
-        reordered.push_back(children[0]);
-        reordered.push_back(children[2]);
-        reordered.push_back(children[1]);
-        result = hashing.CreateTerm(stp::FP_ADD, width, reordered);
+        for (unsigned k = 1; result.IsNull() && k <= 2; k++)
+        {
+          if (fpConstIsNaN(children[k]))
+            result = children[k];
+          else if (fpZeroIsAdditiveIdentity(fpConstZeroSign(children[k]),
+                                            fpConstRoundingMode(children[0])))
+            result = children[3 - k];
+        }
+        if (result.IsNull() &&
+            children[1].GetNodeNum() > children[2].GetNodeNum())
+        {
+          ASTVec reordered;
+          reordered.push_back(children[0]);
+          reordered.push_back(children[2]);
+          reordered.push_back(children[1]);
+          result = hashing.CreateTerm(stp::FP_ADD, width, reordered);
+        }
       }
       break;
 
@@ -3308,13 +3468,19 @@ ASTNode SimplifyingNodeFactory::CreateTerm(Kind kind, unsigned int width,
     // and x * -1.0 = -x, for every value and every rounding mode. 1.0 is the
     // multiplicative identity and -1.0 its negation, so the product is exactly
     // x or -x and no rounding happens (NaN, the infinities and the signed zeros
-    // all carry through). Either float operand (child 1 or 2) may be the
-    // constant; child 0 is the rounding mode.
+    // all carry through). A NaN operand absorbs the whole product. Either
+    // float operand (child 1 or 2) may be the constant; child 0 is the
+    // rounding mode.
     case stp::FP_MUL:
       if (children.size() == 3)
       {
         for (unsigned k = 1; result.IsNull() && k <= 2; k++)
         {
+          if (fpConstIsNaN(children[k]))
+          {
+            result = children[k];
+            continue;
+          }
           const int pm = fpConstPlusMinusOne(children[k]);
           if (pm == 1)
             result = children[3 - k];
@@ -3335,27 +3501,76 @@ ASTNode SimplifyingNodeFactory::CreateTerm(Kind kind, unsigned int width,
       }
       break;
 
-    // fp.div by 1.0 is exact: x / 1.0 = x. Only the divisor (child 2) folds --
-    // 1.0 / x is not x -- so the dividend is left alone. (-1.0 is deliberately
-    // not handled here; x / -1.0 -> -x could be added the same way.)
+    // fp.div: a NaN operand absorbs, and the exact divisors fold -- x / 1.0
+    // = x and x / -1.0 = -x for every value and mode. Only the divisor
+    // (child 2) has identities: 1.0 / x is not x, so the dividend is
+    // otherwise left alone.
     case stp::FP_DIV:
-      if (children.size() == 3 && fpConstPlusMinusOne(children[2]) == 1)
-        result = children[1];
+      if (children.size() == 3)
+      {
+        if (fpConstIsNaN(children[1]))
+          result = children[1];
+        else if (fpConstIsNaN(children[2]))
+          result = children[2];
+        else if (fpConstPlusMinusOne(children[2]) == 1)
+          result = children[1];
+        else if (fpConstPlusMinusOne(children[2]) == -1)
+          result = NodeFactory::CreateTerm(stp::FP_NEG, width, children[1]);
+      }
       break;
 
-    // fp.fma(rm, x, y, z) computes round(x*y + z); the two multiplicands x
-    // and y (children 1 and 2) are symmetric, so order them, keeping the
-    // rounding mode (child 0) and the addend (child 3) in place.
+    // fp.fma(rm, x, y, z) computes round(x*y + z), rounding once. A NaN in
+    // any float operand absorbs. When the product x*y is exact the single
+    // rounding is the addition's, so the fma IS an fp.add of the product:
+    // a multiplicand of +-1.0 gives round(+-y + z), and two constant
+    // multiplicands with a zero among them give either the invalid 0 * oo
+    // (NaN) or the xor-signed zero. The created fp.add re-simplifies, so
+    // its own NaN and signed-zero rules finish the job. Otherwise the two
+    // multiplicands (children 1 and 2) are symmetric: order them, keeping
+    // the rounding mode (child 0) and the addend (child 3) in place.
     case stp::FP_FMA:
-      if (children.size() == 4 &&
-          children[1].GetNodeNum() > children[2].GetNodeNum())
+      if (children.size() == 4)
       {
-        ASTVec reordered;
-        reordered.push_back(children[0]);
-        reordered.push_back(children[2]);
-        reordered.push_back(children[1]);
-        reordered.push_back(children[3]);
-        result = hashing.CreateTerm(stp::FP_FMA, width, reordered);
+        for (unsigned k = 1; result.IsNull() && k <= 3; k++)
+          if (fpConstIsNaN(children[k]))
+            result = children[k];
+
+        for (unsigned k = 1; result.IsNull() && k <= 2; k++)
+        {
+          const ASTNode& other = children[3 - k];
+          const int pm = fpConstPlusMinusOne(children[k]);
+          const int zs = fpConstZeroSign(children[k]);
+          if (pm != 0)
+            result = NodeFactory::CreateTerm(
+                stp::FP_ADD, width, children[0],
+                pm == 1 ? other
+                        : NodeFactory::CreateTerm(stp::FP_NEG, width, other),
+                children[3]);
+          else if (zs != 0 && fpFormattedConst(other))
+          {
+            if (fpConstInfSign(other) != 0)
+              result = makeFPNaN(children[k].GetExpWidth(),
+                                 children[k].GetSigWidth());
+            else
+              result = NodeFactory::CreateTerm(
+                  stp::FP_ADD, width, children[0],
+                  makeFPZero(children[k].GetExpWidth(),
+                             children[k].GetSigWidth(),
+                             (zs < 0) != (fpConstSign(other) < 0)),
+                  children[3]);
+          }
+        }
+
+        if (result.IsNull() &&
+            children[1].GetNodeNum() > children[2].GetNodeNum())
+        {
+          ASTVec reordered;
+          reordered.push_back(children[0]);
+          reordered.push_back(children[2]);
+          reordered.push_back(children[1]);
+          reordered.push_back(children[3]);
+          result = hashing.CreateTerm(stp::FP_FMA, width, reordered);
+        }
       }
       break;
 
@@ -3384,6 +3599,19 @@ ASTNode SimplifyingNodeFactory::CreateTerm(Kind kind, unsigned int width,
               stp::FP_NEG, width,
               NodeFactory::CreateTerm(stp::FP_REM, width, children[0][0],
                                       children[1]));
+        // The invalid operands: rem is NaN whenever the dividend is NaN or
+        // infinite, or the divisor is NaN or zero -- whatever the other
+        // operand is.
+        else if (fpConstIsNaN(children[0]))
+          result = children[0];
+        else if (fpConstIsNaN(children[1]))
+          result = children[1];
+        else if (fpConstInfSign(children[0]) != 0)
+          result = makeFPNaN(children[0].GetExpWidth(),
+                             children[0].GetSigWidth());
+        else if (fpConstZeroSign(children[1]) != 0)
+          result = makeFPNaN(children[1].GetExpWidth(),
+                             children[1].GetSigWidth());
       }
       break;
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -47,3 +47,10 @@ if (ENABLE_FLOATING_POINT AND (ENABLE_TESTING OR BUILD_EXTRA_TOOLS))
     add_subdirectory(test_fprewrites)
 endif()
 
+# The floating-point rewrite-rule generator: enumerates small terms over a
+# float variable and special constants, looking for sound collapses the
+# SimplifyingNodeFactory is missing. A developer tool, not a test.
+if (ENABLE_FLOATING_POINT AND BUILD_EXTRA_TOOLS)
+    add_subdirectory(fp_rewrite_gen)
+endif()
+

--- a/tools/fp_rewrite_gen/CMakeLists.txt
+++ b/tools/fp_rewrite_gen/CMakeLists.txt
@@ -1,0 +1,24 @@
+# AUTHORS: Trevor Hansen
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+add_executable(fp_rewrite_gen fp_rewrite_gen.cpp)
+target_link_libraries(fp_rewrite_gen stp)
+
+# EOF

--- a/tools/fp_rewrite_gen/fp_rewrite_gen.cpp
+++ b/tools/fp_rewrite_gen/fp_rewrite_gen.cpp
@@ -1,0 +1,692 @@
+/********************************************************************
+ * AUTHORS: Trevor Hansen
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+// Rewrite-rule *generator* for the floating-point kinds: the FP counterpart
+// of tools/rewrite_rule_gen, built as a value-vector search (which proved
+// stronger than the syntactic generator for the bitvector rules).
+//
+// Every depth-1 floating-point term and predicate over ONE float variable,
+// the five rounding modes and a pool of special constants (NaN, +-oo, +-0,
+// +-1) is evaluated on EVERY float of a small format, giving a vector of
+// values. A vector equal to that of a trivially cheaper form -- a constant,
+// x, (fp.neg x), (fp.abs x), true/false, (fp.isNaN x), ... -- is a sound
+// rewrite rule at that format. Hits are re-confirmed on a second format
+// (a fact of one format need not generalise), and finally rebuilt through
+// the SimplifyingNodeFactory to see whether it already knows the rule:
+// what remains is the list of candidate rules worth adding.
+//
+// The oracle is the one test_fprewrites uses: blast the candidate once
+// through the *hashing* factory (so no rewrite fires on the way in), then
+// fold the resulting pure bitvector/Boolean circuit to a constant under each
+// assignment of the variable. Folding a pre-blasted circuit rather than
+// re-blasting per assignment is what makes exhaustive enumeration cheap.
+//
+// fp.min/fp.max get their (+0, -0) choice child pinned, as FpTotalise does;
+// a candidate rule on them is only reported when it holds under BOTH pinned
+// choices, since a factory rewrite must be sound for every choice.
+
+#include "stp/AST/AST.h"
+#include "stp/FloatBlaster/FloatBlast.h"
+#include "stp/FloatBlaster/symbolic_fp.h"
+#include "stp/NodeFactory/SimplifyingNodeFactory.h"
+#include "stp/STPManager/STPManager.h"
+#include "stp/Simplifier/Simplifier.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using namespace stp;
+
+// ---------------------------------------------------------------------------
+// Formats: (eb, sb), sb counting the hidden bit; packed width = eb + sb.
+// sb must be at least 4 (symfpu issue #14). The search runs on FA; hits are
+// confirmed on FB. FMA circuits are much larger, so FMA searches on the
+// smaller FS and confirms on FA.
+struct Fmt
+{
+  unsigned eb, sb;
+  unsigned width() const { return eb + sb; }
+  uint64_t values() const { return 1ull << width(); }
+  uint64_t signBit() const { return 1ull << (width() - 1); }
+};
+static const Fmt FA{3, 4};
+static const Fmt FB{3, 5};
+static const Fmt FS{2, 4};
+
+// ---------------------------------------------------------------------------
+// The constant pool, defined semantically so it can be re-encoded per format.
+enum Special
+{
+  S_NAN,
+  S_PINF,
+  S_NINF,
+  S_PZERO,
+  S_NZERO,
+  S_PONE,
+  S_NONE,
+  S_COUNT
+};
+static const char* specialName[] = {"NaN", "+oo", "-oo", "+0.0",
+                                    "-0.0", "1.0", "-1.0"};
+
+static uint64_t bitsOf(Special s, const Fmt& f)
+{
+  const unsigned storedSig = f.sb - 1;
+  const uint64_t expMask = ((1ull << f.eb) - 1) << storedSig;
+  const uint64_t one = ((1ull << (f.eb - 1)) - 1) << storedSig; // exponent=bias
+  switch (s)
+  {
+    case S_NAN: return expMask | 1;
+    case S_PINF: return expMask;
+    case S_NINF: return f.signBit() | expMask;
+    case S_PZERO: return 0;
+    case S_NZERO: return f.signBit();
+    case S_PONE: return one;
+    case S_NONE: return f.signBit() | one;
+    default: return 0;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The five rounding modes (their parser encodings, 5-bit one-hot).
+static const unsigned RM_MODES[] = {
+    symbolic_fp::ROUND_NEAREST_TIES_TO_EVEN,
+    symbolic_fp::ROUND_NEAREST_TIES_TO_AWAY,
+    symbolic_fp::ROUND_TOWARD_POSITIVE,
+    symbolic_fp::ROUND_TOWARD_NEGATIVE,
+    symbolic_fp::ROUND_TOWARD_ZERO,
+};
+static const char* rmName[] = {"RNE", "RNA", "RTP", "RTN", "RTZ"};
+static const int NUM_RM = 5;
+
+// ---------------------------------------------------------------------------
+// The cheap forms a candidate may collapse to.
+enum TargetKind
+{
+  T_NONE,
+  T_CONST,     // a pool constant
+  T_CONST_ANY, // constant, but not one of the pool (bits recorded)
+  T_X,
+  T_NEGX,
+  T_ABSX,
+  T_TRUE,
+  T_FALSE,
+  T_ISNAN,
+  T_NOT_ISNAN,
+  T_ISZERO,
+  T_ISINF,
+  T_ISNEG,
+  T_ISPOS
+};
+struct Target
+{
+  TargetKind k = T_NONE;
+  Special sc = S_NAN; // for T_CONST
+  uint64_t bits = 0;  // for T_CONST_ANY
+  bool operator==(const Target& o) const
+  {
+    return k == o.k && (k != T_CONST || sc == o.sc) &&
+           (k != T_CONST_ANY || bits == o.bits);
+  }
+  bool operator!=(const Target& o) const { return !(*this == o); }
+  std::string name(const char* var) const
+  {
+    switch (k)
+    {
+      case T_CONST: return specialName[sc];
+      case T_CONST_ANY: return "const<" + std::to_string(bits) + ">";
+      case T_X: return var;
+      case T_NEGX: return std::string("(fp.neg ") + var + ")";
+      case T_ABSX: return std::string("(fp.abs ") + var + ")";
+      case T_TRUE: return "true";
+      case T_FALSE: return "false";
+      case T_ISNAN: return std::string("(fp.isNaN ") + var + ")";
+      case T_NOT_ISNAN: return std::string("(not (fp.isNaN ") + var + "))";
+      case T_ISZERO: return std::string("(fp.isZero ") + var + ")";
+      case T_ISINF: return std::string("(fp.isInfinite ") + var + ")";
+      case T_ISNEG: return std::string("(fp.isNegative ") + var + ")";
+      case T_ISPOS: return std::string("(fp.isPositive ") + var + ")";
+      default: return "?";
+    }
+  }
+};
+
+// ---------------------------------------------------------------------------
+// A small independent decoder for building the predicate target vectors.
+struct RefFp
+{
+  bool sign, nan, inf, zero;
+};
+static RefFp refDecode(const Fmt& f, uint64_t v)
+{
+  const unsigned storedSig = f.sb - 1;
+  const uint64_t sig = v & ((1ull << storedSig) - 1);
+  const uint64_t exp = (v >> storedSig) & ((1ull << f.eb) - 1);
+  const bool allOnes = (exp == ((1ull << f.eb) - 1));
+  RefFp d;
+  d.sign = (v >> (f.width() - 1)) & 1;
+  d.nan = allOnes && sig != 0;
+  d.inf = allOnes && sig == 0;
+  d.zero = (exp == 0 && sig == 0);
+  return d;
+}
+
+// Sentinels for Boolean results, clear of any packed float value (as in
+// test_fprewrites).
+static const uint64_t K_TRUE = 1ull << 40;
+static const uint64_t K_FALSE = 1ull << 41;
+static const uint64_t K_NAN = 1ull << 42;
+
+// The comparable key of a packed constant: every NaN pattern is the one
+// SMT-LIB NaN; +0 and -0 stay distinct.
+static uint64_t keyBits(uint64_t v, const Fmt& f)
+{
+  const unsigned storedSig = f.sb - 1;
+  const uint64_t expMask = ((1ull << f.eb) - 1) << storedSig;
+  const uint64_t sigMask = (1ull << storedSig) - 1;
+  if ((v & expMask) == expMask && (v & sigMask) != 0)
+    return K_NAN;
+  return v;
+}
+
+// ---------------------------------------------------------------------------
+struct Ctx
+{
+  STPMgr mgr;
+  SimplifyingNodeFactory snf;
+  NodeFactory* nf; // simplifying factory: queried for "already handled"
+  NodeFactory* hf; // hashing factory: builds candidates without simplifying
+  unsigned counter = 0;
+
+  Ctx() : snf(*(mgr.hashingNodeFactory), mgr)
+  {
+    CONSTANTBV::BitVector_Boot();
+    nf = &snf;
+    hf = mgr.hashingNodeFactory;
+    // Keep the default factory the hashing one: the blaster and the constant
+    // evaluator build through it, and a simplifying factory folding the
+    // blaster's output as it is built miscarries float formats onto shared
+    // Booleans (see test_fprewrites for the full account).
+    mgr.defaultNodeFactory = hf;
+    GlobalParserBM = &mgr;
+    symbolic_fp::init(&mgr);
+  }
+
+  ASTNode fp(const Fmt& f)
+  {
+    ASTNode s = mgr.CreateSymbol(("x" + std::to_string(counter++)).c_str(), 0,
+                                 f.width());
+    s.SetExpWidth(f.eb);
+    s.SetSigWidth(f.sb);
+    return s;
+  }
+
+  ASTNode fpConst(const Fmt& f, uint64_t v)
+  {
+    ASTNode n = mgr.CreateBVConst(f.width(), v);
+    return mgr.CreateFPConst(n, f.eb, f.sb);
+  }
+
+  ASTNode rm(unsigned mode) { return mgr.CreateBVConst(5, mode); }
+
+  // Give bare fp.min/fp.max the (+0, -0) choice child the blaster expects,
+  // pinned to `choice` -- run with both, since a rewrite must hold for each.
+  ASTNode pinPartialOps(const ASTNode& n, int choice)
+  {
+    ASTVec children;
+    children.reserve(n.Degree());
+    bool changed = false;
+    for (const ASTNode& ch : n)
+    {
+      const ASTNode nc = pinPartialOps(ch, choice);
+      changed |= (nc != ch);
+      children.push_back(nc);
+    }
+    const Kind k = n.GetKind();
+    if ((k == FP_MIN || k == FP_MAX) && n.Degree() == 2)
+    {
+      children.push_back(choice ? mgr.CreateOneConst(1)
+                                : mgr.CreateZeroConst(1));
+      changed = true;
+    }
+    if (!changed)
+      return n;
+    ASTNode out = (n.GetType() == BOOLEAN_TYPE)
+                      ? hf->CreateNode(k, children)
+                      : hf->CreateTerm(k, n.GetValueWidth(), children);
+    if (n.GetExpWidth() != 0)
+    {
+      out.SetExpWidth(n.GetExpWidth());
+      out.SetSigWidth(n.GetSigWidth());
+    }
+    return out;
+  }
+
+  ASTNode blastOnce(const ASTNode& n, int choice)
+  {
+    const ASTNode s = pinPartialOps(n, choice);
+    if (s.isConstant())
+      return s;
+    return FloatBlast::lowerOperation(&mgr, s);
+  }
+
+  ASTNode foldBlasted(const ASTNode& n, ASTNodeMap& memo)
+  {
+    if (n.isConstant())
+      return n;
+    const auto found = memo.find(n);
+    if (found != memo.end())
+      return found->second;
+    ASTVec kids;
+    kids.reserve(n.Degree());
+    for (const ASTNode& ch : n)
+      kids.push_back(foldBlasted(ch, memo));
+    const ASTNode r =
+        NonMemberBVConstEvaluator(&mgr, n.GetKind(), kids, n.GetValueWidth());
+    memo.insert({n, r});
+    return r;
+  }
+
+  // The comparable key of a folded result.
+  static uint64_t key(const ASTNode& r, const Fmt& f, bool isFloat)
+  {
+    const Kind rk = r.GetKind();
+    if (rk == TRUE)
+      return K_TRUE;
+    if (rk == FALSE)
+      return K_FALSE;
+    if (rk != BVCONST)
+      return (1ull << 43) | (uint64_t)(unsigned)r.GetNodeNum();
+    uint64_t v = 0;
+    const unsigned w = r.GetValueWidth();
+    for (unsigned i = 0; i < w && i < 64; i++)
+      if (CONSTANTBV::BitVector_bit_test(r.GetBVConst(), i))
+        v |= (1ull << i);
+    return isFloat ? keyBits(v, f) : v;
+  }
+
+  // Evaluate candidate `n` (whose only symbol is `x`) on every float of `f`.
+  std::vector<uint64_t> valueVector(const ASTNode& n, const ASTNode& x,
+                                    const Fmt& f, int choice)
+  {
+    const bool isFloat = (n.GetType() != BOOLEAN_TYPE);
+    const ASTNode blasted = blastOnce(n, choice);
+    std::vector<uint64_t> out(f.values());
+    for (uint64_t v = 0; v < f.values(); v++)
+    {
+      ASTNodeMap memo;
+      memo.insert({x, fpConst(f, v)});
+      out[v] = key(foldBlasted(blasted, memo), f, isFloat);
+    }
+    return out;
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Target vectors for a format.
+struct TargetSet
+{
+  std::vector<std::pair<Target, std::vector<uint64_t>>> term, pred;
+
+  TargetSet(const Fmt& f)
+  {
+    const uint64_t n = f.values();
+    auto vec = [&](TargetKind k, uint64_t (*g)(uint64_t, const Fmt&)) {
+      std::vector<uint64_t> v(n);
+      for (uint64_t i = 0; i < n; i++)
+        v[i] = g(i, f);
+      return std::make_pair(Target{k, S_NAN, 0}, v);
+    };
+    term.push_back(vec(T_X, [](uint64_t v, const Fmt& f) {
+      return keyBits(v, f);
+    }));
+    term.push_back(vec(T_NEGX, [](uint64_t v, const Fmt& f) {
+      return keyBits(v ^ f.signBit(), f);
+    }));
+    term.push_back(vec(T_ABSX, [](uint64_t v, const Fmt& f) {
+      return keyBits(v & ~f.signBit(), f);
+    }));
+    for (int s = 0; s < S_COUNT; s++)
+    {
+      const uint64_t kb = keyBits(bitsOf((Special)s, f), f);
+      term.push_back({Target{T_CONST, (Special)s, 0},
+                      std::vector<uint64_t>(n, kb)});
+    }
+
+    auto pvec = [&](TargetKind k, bool (*g)(const RefFp&)) {
+      std::vector<uint64_t> v(n);
+      for (uint64_t i = 0; i < n; i++)
+        v[i] = g(refDecode(f, i)) ? K_TRUE : K_FALSE;
+      return std::make_pair(Target{k, S_NAN, 0}, v);
+    };
+    pred.push_back({Target{T_TRUE, S_NAN, 0},
+                    std::vector<uint64_t>(n, K_TRUE)});
+    pred.push_back({Target{T_FALSE, S_NAN, 0},
+                    std::vector<uint64_t>(n, K_FALSE)});
+    pred.push_back(pvec(T_ISNAN, [](const RefFp& d) { return d.nan; }));
+    pred.push_back(pvec(T_NOT_ISNAN, [](const RefFp& d) { return !d.nan; }));
+    pred.push_back(pvec(T_ISZERO, [](const RefFp& d) { return d.zero; }));
+    pred.push_back(pvec(T_ISINF, [](const RefFp& d) { return d.inf; }));
+    pred.push_back(
+        pvec(T_ISNEG, [](const RefFp& d) { return !d.nan && d.sign; }));
+    pred.push_back(
+        pvec(T_ISPOS, [](const RefFp& d) { return !d.nan && !d.sign; }));
+  }
+
+  Target match(const std::vector<uint64_t>& v, bool isPred) const
+  {
+    for (const auto& t : (isPred ? pred : term))
+      if (t.second == v)
+        return t.first;
+    if (!isPred)
+    {
+      // Constant, but not one of the pool.
+      bool allEq = true;
+      for (const uint64_t k : v)
+        allEq &= (k == v[0]);
+      if (allEq)
+        return Target{T_CONST_ANY, S_NAN, v[0]};
+    }
+    return Target{T_NONE, S_NAN, 0};
+  }
+};
+
+// ---------------------------------------------------------------------------
+// The candidate shapes.
+struct OpSig
+{
+  Kind k;
+  const char* name;
+  unsigned floats; // float operands
+  bool rm;         // leading rounding-mode operand
+  bool pred;       // Boolean result
+};
+static const OpSig OPS[] = {
+    {FP_ABS, "fp.abs", 1, false, false},
+    {FP_NEG, "fp.neg", 1, false, false},
+    {FP_SQRT, "fp.sqrt", 1, true, false},
+    {FP_ROUNDTOINTEGRAL, "fp.roundToIntegral", 1, true, false},
+    {FP_ADD, "fp.add", 2, true, false},
+    {FP_SUB, "fp.sub", 2, true, false},
+    {FP_MUL, "fp.mul", 2, true, false},
+    {FP_DIV, "fp.div", 2, true, false},
+    {FP_REM, "fp.rem", 2, false, false},
+    {FP_MIN, "fp.min", 2, false, false},
+    {FP_MAX, "fp.max", 2, false, false},
+    {FP_FMA, "fp.fma", 3, true, false},
+    {FP_LT, "fp.lt", 2, false, true},
+    {FP_GT, "fp.gt", 2, false, true},
+    {FP_LEQ, "fp.leq", 2, false, true},
+    {FP_GEQ, "fp.geq", 2, false, true},
+    {FP_EQ, "fp.eq", 2, false, true},
+    {FP_SMT_EQ, "=", 2, false, true},
+};
+
+// An argument choice: 0 = the variable, 1 + s = pool constant s.
+static const int ARG_X = 0;
+static bool isX(int a) { return a == ARG_X; }
+
+struct Candidate
+{
+  const OpSig* op;
+  std::vector<int> args; // one per float operand
+};
+
+static std::string describe(const Candidate& c, int modeMask)
+{
+  std::string s = "(" + std::string(c.op->name);
+  if (c.op->rm)
+  {
+    bool all = (modeMask == (1 << NUM_RM) - 1);
+    if (all)
+      s += " rm";
+    else
+    {
+      s += " {";
+      bool first = true;
+      for (int m = 0; m < NUM_RM; m++)
+        if (modeMask & (1 << m))
+        {
+          if (!first)
+            s += ",";
+          s += rmName[m];
+          first = false;
+        }
+      s += "}";
+    }
+  }
+  for (const int a : c.args)
+    s += std::string(" ") + (isX(a) ? "x" : specialName[a - 1]);
+  return s + ")";
+}
+
+// ---------------------------------------------------------------------------
+struct Finding
+{
+  Candidate cand;
+  Target target;
+  int modeMask;   // for rm ops: modes the rule holds under
+  bool confirmed; // held on the second format too
+  bool handled;   // the SimplifyingNodeFactory already produces the target
+  bool trivial;   // the candidate IS the target, e.g. (fp.abs x) -> (fp.abs x)
+  std::string snfForm;
+};
+
+struct Generator
+{
+  Ctx c;
+  int evaluated = 0;
+
+  ASTNode build(NodeFactory* f, const Candidate& cand, int mode,
+                const ASTNode& x, const Fmt& fmt)
+  {
+    ASTVec ch;
+    if (cand.op->rm)
+      ch.push_back(c.rm(RM_MODES[mode]));
+    for (const int a : cand.args)
+      ch.push_back(isX(a) ? x : c.fpConst(fmt, bitsOf((Special)(a - 1), fmt)));
+    if (cand.op->pred)
+      return f->CreateNode(cand.op->k, ch);
+    ASTNode n = f->CreateTerm(cand.op->k, fmt.width(), ch);
+    n.SetExpWidth(fmt.eb);
+    n.SetSigWidth(fmt.sb);
+    return n;
+  }
+
+  // The target the candidate collapses to at `fmt` under `mode`, or T_NONE.
+  // fp.min/fp.max must reach the same target under both pinned choices.
+  Target evalOne(const Candidate& cand, int mode, const ASTNode& x,
+                 const Fmt& fmt, const TargetSet& ts)
+  {
+    evaluated++;
+    const ASTNode n = build(c.hf, cand, mode, x, fmt);
+    const Target t0 = ts.match(c.valueVector(n, x, fmt, 0), cand.op->pred);
+    if (t0.k == T_NONE)
+      return t0;
+    if (cand.op->k == FP_MIN || cand.op->k == FP_MAX)
+    {
+      const Target t1 = ts.match(c.valueVector(n, x, fmt, 1), cand.op->pred);
+      if (t1 != t0)
+        return Target{T_NONE, S_NAN, 0};
+    }
+    return t0;
+  }
+
+  // What the simplifying factory says about the candidate today.
+  void querySnf(Finding& f, const ASTNode& x, const Fmt& fmt)
+  {
+    int mode = 0;
+    while (f.cand.op->rm && !(f.modeMask & (1 << mode)))
+      mode++;
+    const ASTNode plain = build(c.hf, f.cand, mode, x, fmt);
+    const ASTNode simp = build(c.nf, f.cand, mode, x, fmt);
+
+    ASTNode want;
+    switch (f.target.k)
+    {
+      case T_CONST: want = c.fpConst(fmt, bitsOf(f.target.sc, fmt)); break;
+      case T_CONST_ANY: want = c.fpConst(fmt, f.target.bits); break;
+      case T_X: want = x; break;
+      case T_NEGX:
+        want = c.hf->CreateTerm(FP_NEG, fmt.width(), x);
+        want.SetExpWidth(fmt.eb);
+        want.SetSigWidth(fmt.sb);
+        break;
+      case T_ABSX:
+        want = c.hf->CreateTerm(FP_ABS, fmt.width(), x);
+        want.SetExpWidth(fmt.eb);
+        want.SetSigWidth(fmt.sb);
+        break;
+      case T_TRUE: want = c.mgr.ASTTrue; break;
+      case T_FALSE: want = c.mgr.ASTFalse; break;
+      case T_ISNAN: want = c.hf->CreateNode(FP_ISNAN, x); break;
+      case T_NOT_ISNAN:
+        want = c.hf->CreateNode(NOT, c.hf->CreateNode(FP_ISNAN, x));
+        break;
+      case T_ISZERO: want = c.hf->CreateNode(FP_ISZERO, x); break;
+      case T_ISINF: want = c.hf->CreateNode(FP_ISINFINITE, x); break;
+      case T_ISNEG: want = c.hf->CreateNode(FP_ISNEGATIVE, x); break;
+      case T_ISPOS: want = c.hf->CreateNode(FP_ISPOSITIVE, x); break;
+      default: break;
+    }
+    f.handled = (simp == want);
+    f.trivial = (plain == want);
+    if (simp == plain)
+      f.snfForm = "unchanged";
+    else if (f.handled)
+      f.snfForm = "target";
+    else
+      f.snfForm = std::string("rewritten to ") + _kind_names[simp.GetKind()];
+  }
+
+  std::vector<Finding> run()
+  {
+    std::vector<Finding> findings;
+    for (const OpSig& op : OPS)
+    {
+      const Fmt fmt = (op.k == FP_FMA) ? FS : FA;
+      const Fmt confirmFmt = (op.k == FP_FMA) ? FA : FB;
+      const TargetSet ts(fmt);
+      const TargetSet tsConfirm(confirmFmt);
+      const ASTNode x = c.fp(fmt);
+      const ASTNode xc = c.fp(confirmFmt);
+
+      // Every assignment of {x, pool} to the float operands, at least one x.
+      const int options = 1 + S_COUNT;
+      int tuples = 1;
+      for (unsigned i = 0; i < op.floats; i++)
+        tuples *= options;
+      for (int t = 0; t < tuples; t++)
+      {
+        Candidate cand{&op, {}};
+        int rest = t;
+        bool hasX = false;
+        for (unsigned i = 0; i < op.floats; i++)
+        {
+          cand.args.push_back(rest % options);
+          hasX |= isX(rest % options);
+          rest /= options;
+        }
+        if (!hasX)
+          continue;
+
+        // Per rounding mode (a single pass for rm-free ops), then group
+        // modes by the target they reach.
+        const int modes = op.rm ? NUM_RM : 1;
+        std::vector<Target> perMode(modes);
+        for (int m = 0; m < modes; m++)
+          perMode[m] = evalOne(cand, m, x, fmt, ts);
+
+        std::vector<std::pair<Target, int>> groups;
+        for (int m = 0; m < modes; m++)
+        {
+          if (perMode[m].k == T_NONE)
+            continue;
+          bool found = false;
+          for (auto& g : groups)
+            if (g.first == perMode[m])
+            {
+              g.second |= (1 << m);
+              found = true;
+            }
+          if (!found)
+            groups.push_back({perMode[m], 1 << m});
+        }
+
+        for (const auto& g : groups)
+        {
+          Finding f{cand, g.first, g.second, true, false, false, ""};
+          for (int m = 0; m < modes; m++)
+            if (g.second & (1 << m))
+              f.confirmed &= (evalOne(cand, m, xc, confirmFmt, tsConfirm) ==
+                              g.first);
+          querySnf(f, x, fmt);
+          findings.push_back(f);
+        }
+      }
+      printf("done %-20s (%d evaluations so far)\n", op.name, evaluated);
+    }
+    return findings;
+  }
+};
+
+int main()
+{
+  setbuf(stdout, nullptr);
+  printf("Floating-point rewrite-rule search\n");
+  printf("search format (%u,%u); confirm format (%u,%u); FMA on (%u,%u)\n\n",
+         FA.eb, FA.sb, FB.eb, FB.sb, FS.eb, FS.sb);
+
+  Generator gen;
+  std::vector<Finding> findings = gen.run();
+
+  auto show = [](const Finding& f) {
+    printf("  %-44s -> %-22s %s\n", describe(f.cand, f.modeMask).c_str(),
+           f.target.name("x").c_str(),
+           f.confirmed ? "" : "  ** NOT CONFIRMED on 2nd format **");
+  };
+
+  printf("\n== Rules the SimplifyingNodeFactory does NOT have ==\n");
+  int missed = 0;
+  for (const Finding& f : findings)
+    if (!f.handled)
+    {
+      show(f);
+      if (f.snfForm != "unchanged")
+        printf("        (factory currently: %s)\n", f.snfForm.c_str());
+      missed++;
+    }
+
+  printf("\n== Already handled by the factory ==\n");
+  for (const Finding& f : findings)
+    if (f.handled && !f.trivial)
+      show(f);
+
+  printf("\n%d candidate evaluations, %zu rules found, %d missed by the "
+         "factory\n",
+         gen.evaluated, findings.size(), missed);
+  return 0;
+}

--- a/tools/test_fprewrites/test_fprewrites.cpp
+++ b/tools/test_fprewrites/test_fprewrites.cpp
@@ -58,8 +58,10 @@ THE SOFTWARE.
 #include <vector>
 
 using namespace stp;
+using stp::symbolic_fp::ROUND_NEAREST_TIES_TO_AWAY;
 using stp::symbolic_fp::ROUND_NEAREST_TIES_TO_EVEN;
 using stp::symbolic_fp::ROUND_TOWARD_NEGATIVE;
+using stp::symbolic_fp::ROUND_TOWARD_POSITIVE;
 using stp::symbolic_fp::ROUND_TOWARD_ZERO;
 
 static int g_checks = 0;
@@ -360,7 +362,58 @@ struct Ctx
     ASTNode simplified = nf->CreateNode(k, children);
     report(name, plain == simplified, "node was unexpectedly rewritten");
   }
+
+  // Build through both factories; require the simplified result to BE
+  // `expected`, and the plain original to agree with it on every assignment
+  // of the free floats.
+  void checkTermIs(const std::string& name, Kind k, unsigned width,
+                   const ASTVec& children, const ASTNode& expected)
+  {
+    ASTNode plain = hf->CreateTerm(k, width, children);
+    ASTNode simplified = nf->CreateTerm(k, width, children);
+    if (simplified != expected)
+    {
+      report(name, false, "did not take the expected form");
+      return;
+    }
+    const std::string why = firstDisagreement(plain, simplified);
+    report(name, why.empty(), why);
+  }
+
+  void checkNodeIs(const std::string& name, Kind k, const ASTVec& children,
+                   const ASTNode& expected)
+  {
+    ASTNode plain = hf->CreateNode(k, children);
+    ASTNode simplified = nf->CreateNode(k, children);
+    if (simplified != expected)
+    {
+      report(name, false, "did not take the expected form");
+      return;
+    }
+    const std::string why = firstDisagreement(plain, simplified);
+    report(name, why.empty(), why);
+  }
 };
+
+// The packed bit patterns of the special constants, per format.
+static uint64_t packNaN(unsigned eb, unsigned sb)
+{
+  return (((1ull << eb) - 1) << (sb - 1)) | 1;
+}
+static uint64_t packInf(unsigned eb, unsigned sb, bool neg)
+{
+  const uint64_t v = ((1ull << eb) - 1) << (sb - 1);
+  return neg ? v | (1ull << (eb + sb - 1)) : v;
+}
+static uint64_t packZero(unsigned eb, unsigned sb, bool neg)
+{
+  return neg ? (1ull << (eb + sb - 1)) : 0;
+}
+static uint64_t packOne(unsigned eb, unsigned sb, bool neg)
+{
+  const uint64_t v = ((1ull << (eb - 1)) - 1) << (sb - 1);
+  return neg ? v | (1ull << (eb + sb - 1)) : v;
+}
 
 // Small formats that still contain zeros, subnormals, normals, infinities and
 // NaNs. (eb, sb): sb counts the hidden bit, packed = eb + sb. sb must be at
@@ -722,9 +775,159 @@ static void run(Ctx& c)
       c.checkTerm("x * -1.0 = neg x", FP_MUL, w, {r, x, negOne});
       c.checkTerm("-1.0 * x = neg x", FP_MUL, w, {r, negOne, x});
       c.checkTerm("x / 1.0 = x", FP_DIV, w, {r, x, one});
+      c.checkTerm("x / -1.0 = neg x", FP_DIV, w, {r, x, negOne});
       // 1.0 / x is not x: the divisor-only rule must leave this unchanged (and
       // must not, in any case, change its meaning).
       c.checkTerm("1.0 / x unchanged", FP_DIV, w, {r, one, x}, false);
+    }
+  }
+
+  // ---- Constant-operand collapses (found by tools/fp_rewrite_gen). ----
+  // Each check requires the factory to produce exactly the expected node AND
+  // the unsimplified original to agree with it on every float of the format.
+
+  {
+    ASTNode x = c.fp(EB, SB);
+    const unsigned w = x.GetValueWidth();
+    ASTNode nan = c.fpConst(EB, SB, packNaN(EB, SB));
+    ASTNode pinf = c.fpConst(EB, SB, packInf(EB, SB, false));
+    ASTNode ninf = c.fpConst(EB, SB, packInf(EB, SB, true));
+    ASTNode pz = c.fpConst(EB, SB, packZero(EB, SB, false));
+    ASTNode nz = c.fpConst(EB, SB, packZero(EB, SB, true));
+
+    // NaN absorbs through the arithmetic: either operand, every mode
+    // (round-toward-negative is the usually-sensitive one).
+    for (unsigned mode : {(unsigned)ROUND_NEAREST_TIES_TO_EVEN,
+                          (unsigned)ROUND_TOWARD_NEGATIVE})
+    {
+      ASTNode r = c.rm(mode);
+      c.checkTermIs("x + NaN = NaN", FP_ADD, w, {r, x, nan}, nan);
+      c.checkTermIs("NaN + x = NaN", FP_ADD, w, {r, nan, x}, nan);
+      c.checkTermIs("x - NaN = NaN", FP_SUB, w, {r, x, nan}, nan);
+      c.checkTermIs("NaN - x = NaN", FP_SUB, w, {r, nan, x}, nan);
+      c.checkTermIs("x * NaN = NaN", FP_MUL, w, {r, x, nan}, nan);
+      c.checkTermIs("NaN * x = NaN", FP_MUL, w, {r, nan, x}, nan);
+      c.checkTermIs("x / NaN = NaN", FP_DIV, w, {r, x, nan}, nan);
+      c.checkTermIs("NaN / x = NaN", FP_DIV, w, {r, nan, x}, nan);
+    }
+
+    // The rm-guarded signed-zero identities: x + (-0) = x except under
+    // round-toward-negative, and x + (+0) = x only there -- the sum of the
+    // opposite zeros is the input that decides. Where the identity does not
+    // apply, the zero must survive (only equivalence is required).
+    {
+      const unsigned modes[] = {
+          (unsigned)ROUND_NEAREST_TIES_TO_EVEN,
+          (unsigned)ROUND_NEAREST_TIES_TO_AWAY,
+          (unsigned)ROUND_TOWARD_POSITIVE,
+          (unsigned)ROUND_TOWARD_NEGATIVE,
+          (unsigned)ROUND_TOWARD_ZERO,
+      };
+      const char* names[] = {"RNE", "RNA", "RTP", "RTN", "RTZ"};
+      for (int i = 0; i < 5; i++)
+      {
+        ASTNode r = c.rm(modes[i]);
+        const bool rtn = (modes[i] == (unsigned)ROUND_TOWARD_NEGATIVE);
+        const std::string sfx = std::string(" [") + names[i] + "]";
+        if (rtn)
+        {
+          c.checkTermIs("x + +0 = x" + sfx, FP_ADD, w, {r, x, pz}, x);
+          c.checkTerm("x + -0 keeps the zero" + sfx, FP_ADD, w, {r, x, nz},
+                      false);
+        }
+        else
+        {
+          c.checkTermIs("x + -0 = x" + sfx, FP_ADD, w, {r, x, nz}, x);
+          c.checkTerm("x + +0 keeps the zero" + sfx, FP_ADD, w, {r, x, pz},
+                      false);
+        }
+      }
+      // Via the sub-to-add lowering: x - (+0) adds -0.
+      ASTNode rne = c.rm(ROUND_NEAREST_TIES_TO_EVEN);
+      c.checkTermIs("x - +0 = x [RNE]", FP_SUB, w, {rne, x, pz}, x);
+    }
+
+    // fp.rem's invalid operands are NaN whatever the other operand is.
+    ASTNode b = c.fp(EB, SB);
+    c.checkTermIs("rem(NaN, b) = NaN", FP_REM, w, {nan, b}, nan);
+    c.checkTermIs("rem(a, NaN) = NaN", FP_REM, w, {x, nan}, nan);
+    c.checkTermIs("rem(+oo, b) = NaN", FP_REM, w, {pinf, b}, nan);
+    c.checkTermIs("rem(-oo, b) = NaN", FP_REM, w, {ninf, b}, nan);
+    c.checkTermIs("rem(a, +0) = NaN", FP_REM, w, {x, pz}, nan);
+    c.checkTermIs("rem(a, -0) = NaN", FP_REM, w, {x, nz}, nan);
+
+    // fp.min/fp.max ignore a NaN operand, and the matching extreme absorbs.
+    c.checkTermIs("min(x, NaN) = x", FP_MIN, w, {x, nan}, x);
+    c.checkTermIs("min(NaN, x) = x", FP_MIN, w, {nan, x}, x);
+    c.checkTermIs("max(x, NaN) = x", FP_MAX, w, {x, nan}, x);
+    c.checkTermIs("max(NaN, x) = x", FP_MAX, w, {nan, x}, x);
+    c.checkTermIs("min(x, -oo) = -oo", FP_MIN, w, {x, ninf}, ninf);
+    c.checkTermIs("max(x, +oo) = +oo", FP_MAX, w, {x, pinf}, pinf);
+    // The opposite extreme decides nothing (NaN breaks it): must survive.
+    c.checkTerm("min(x, +oo) keeps both", FP_MIN, w, {x, pinf}, false);
+    c.checkTerm("max(x, -oo) keeps both", FP_MAX, w, {x, ninf}, false);
+
+    // Comparisons against NaN and the extremes. The lt/leq forms arrive at
+    // the gt/geq rules through the mirroring, so both spellings are checked.
+    const ASTNode notNan =
+        c.hf->CreateNode(NOT, {c.hf->CreateNode(FP_ISNAN, {x})});
+    c.checkNodeIs("fp.gt(x, NaN) -> false", FP_GT, {x, nan}, c.mgr.ASTFalse);
+    c.checkNodeIs("fp.gt(NaN, x) -> false", FP_GT, {nan, x}, c.mgr.ASTFalse);
+    c.checkNodeIs("fp.gt(-oo, x) -> false", FP_GT, {ninf, x}, c.mgr.ASTFalse);
+    c.checkNodeIs("fp.gt(x, +oo) -> false", FP_GT, {x, pinf}, c.mgr.ASTFalse);
+    c.checkNodeIs("fp.lt(x, NaN) -> false", FP_LT, {x, nan}, c.mgr.ASTFalse);
+    c.checkNodeIs("fp.lt(x, -oo) -> false", FP_LT, {x, ninf}, c.mgr.ASTFalse);
+    c.checkNodeIs("fp.lt(+oo, x) -> false", FP_LT, {pinf, x}, c.mgr.ASTFalse);
+    c.checkNodeIs("fp.geq(NaN, x) -> false", FP_GEQ, {nan, x}, c.mgr.ASTFalse);
+    c.checkNodeIs("fp.geq(x, NaN) -> false", FP_GEQ, {x, nan}, c.mgr.ASTFalse);
+    c.checkNodeIs("fp.geq(+oo, x) -> not isNaN", FP_GEQ, {pinf, x}, notNan);
+    c.checkNodeIs("fp.geq(x, -oo) -> not isNaN", FP_GEQ, {x, ninf}, notNan);
+    c.checkNodeIs("fp.leq(-oo, x) -> not isNaN", FP_LEQ, {ninf, x}, notNan);
+    c.checkNodeIs("fp.leq(x, +oo) -> not isNaN", FP_LEQ, {x, pinf}, notNan);
+
+    // (= x NaN) is exactly (fp.isNaN x), but it is deliberately NOT
+    // rewritten: PropagateEqualities substitutes through a `=` with a
+    // constant side (x := NaN everywhere), which is strictly stronger than
+    // holding the smaller predicate.
+    report("= keeps its NaN constant",
+           c.nf->CreateNode(FP_SMT_EQ, {x, nan}).GetKind() == FP_SMT_EQ);
+  }
+
+  // fp.fma at the smaller format (its circuits are much larger): NaN in any
+  // operand absorbs, and an exact product -- a +-1.0 multiplicand, or two
+  // constant multiplicands holding a zero -- reduces the fma to the fp.add
+  // of the product, which then re-simplifies by the rules above. The
+  // expected nodes are built through the simplifying factory so they take
+  // the same post-rewrite form.
+  {
+    ASTNode y = c.fp(SEB, SSB), z = c.fp(SEB, SSB);
+    const unsigned w = y.GetValueWidth();
+    ASTNode nan = c.fpConst(SEB, SSB, packNaN(SEB, SSB));
+    ASTNode pinf = c.fpConst(SEB, SSB, packInf(SEB, SSB, false));
+    ASTNode pz = c.fpConst(SEB, SSB, packZero(SEB, SSB, false));
+    ASTNode nz = c.fpConst(SEB, SSB, packZero(SEB, SSB, true));
+    ASTNode one = c.fpConst(SEB, SSB, packOne(SEB, SSB, false));
+    ASTNode negOne = c.fpConst(SEB, SSB, packOne(SEB, SSB, true));
+    for (unsigned mode : {(unsigned)ROUND_NEAREST_TIES_TO_EVEN,
+                          (unsigned)ROUND_TOWARD_NEGATIVE})
+    {
+      ASTNode r = c.rm(mode);
+      c.checkTermIs("fma(rm, NaN, y, z) = NaN", FP_FMA, w, {r, nan, y, z},
+                    nan);
+      c.checkTermIs("fma(rm, y, NaN, z) = NaN", FP_FMA, w, {r, y, nan, z},
+                    nan);
+      c.checkTermIs("fma(rm, y, z, NaN) = NaN", FP_FMA, w, {r, y, z, nan},
+                    nan);
+      c.checkTermIs("fma(rm, 1, y, z) = y + z", FP_FMA, w, {r, one, y, z},
+                    c.nf->CreateTerm(FP_ADD, w, {r, y, z}));
+      c.checkTermIs("fma(rm, -1, y, z) = -y + z", FP_FMA, w,
+                    {r, negOne, y, z},
+                    c.nf->CreateTerm(FP_ADD, w,
+                                     {r, c.unary(c.hf, FP_NEG, y), z}));
+      c.checkTermIs("fma(rm, +0, +oo, z) = NaN", FP_FMA, w, {r, pz, pinf, z},
+                    nan);
+      c.checkTermIs("fma(rm, +0, -0, z) = -0 + z", FP_FMA, w, {r, pz, nz, z},
+                    c.nf->CreateTerm(FP_ADD, w, {r, nz, z}));
     }
   }
 }


### PR DESCRIPTION
The bitvector side has `tools/rewrite_rule_gen`; the floating-point kinds had nothing. This PR adds a floating-point rewrite-rule generator, and the rules it found missing from the `SimplifyingNodeFactory`.

## The generator (`tools/fp_rewrite_gen`)

A value-vector search rather than a syntactic enumerator: every depth-1 floating-point term and predicate over one float variable, the five rounding modes and a pool of special constants (NaN, ±oo, ±0, ±1) is blasted once through the hashing factory, and the resulting pure bitvector/Boolean circuit is folded to a constant under every assignment of a small format — the oracle `test_fprewrites` already uses. A candidate whose value vector equals that of a trivially cheaper form (a constant, `x`, `(fp.neg x)`, `true`/`false`, `(fp.isNaN x)`, …) is a sound rewrite at that format; hits are re-confirmed on a second format, and rebuilt through the `SimplifyingNodeFactory` to report whether it already knows the rule. `fp.min`/`fp.max` candidates must reach the same target under both pinned (+0, −0) choices. The whole space — 1730 candidate evaluations — runs in about 23 seconds, and found 140 sound rules of which 119 were missing.

## The rules

The 119 compress into six families, each a kind-plus-constant-operand check at construction, and each firing deletes an entire blasted symfpu circuit:

- **NaN absorbs through the arithmetic**: `fp.add`, `fp.mul`, `fp.div` and `fp.fma` with a NaN operand are that NaN. `fp.sub` and the mirrored comparisons inherit the rules through the existing normalisations.
- **Signed-zero addition identities**, guarded by a literal rounding mode: `x + (-0) = x` under every mode except round-toward-negative, and `x + (+0) = x` only there. The sum of the two opposite zeros is the one input that can see the zero operand — an unconditional version of either rule would be unsound, which the generator's per-mode grouping catches automatically.
- **`fp.fma` with an exact product is the `fp.add` of that product**: a ±1.0 multiplicand gives round(±y + z), and two constant multiplicands holding a zero give the xor-signed zero — or NaN for the invalid 0 · oo. The created add re-simplifies, so its own NaN and signed-zero rules finish the job.
- **`fp.rem`'s invalid operands**: a NaN or infinite dividend, or a NaN or zero divisor, make the remainder NaN whatever the other operand is. `fp.div` by −1.0 folds to `fp.neg`, alongside the existing 1.0 rule.
- **`fp.min`/`fp.max` ignore a NaN operand and absorb the matching extreme**: min(x, −oo) = −oo and max(x, +oo) = +oo for every x, NaN included. Sound for either choice of the totalising pass, which only matters on the two opposite zeros.
- **Comparisons against the extremes**: nothing is greater than +oo or less than −oo, nothing compares against NaN, and +oo ≥ x and x ≥ −oo hold exactly when x is not NaN.

One sound finding is deliberately **not** applied: `(= x NaN)` is exactly `(fp.isNaN x)`, but `PropagateEqualities` substitutes through a float `=` with a constant side (x := NaN everywhere), which is strictly stronger than holding the smaller predicate. A comment in the factory and a test pin the decision.

## Verification

- `test_fprewrites` grows from 60 to 135 checks: every new rule must produce the exact expected node, and the unsimplified original must agree with it on every float of the format, through the same lowering a real solve uses. The rm-guarded identities are checked under all five modes, including the modes where the rule must not fire.
- Re-running the generator against the patched factory reports every rule handled (the two `=`-against-NaN spellings excepted by design).
- Full test suite passes; on a 300-file sample of SMT-LIB QF_FP benchmarks the solver's answers agree with the benchmarks' `:status` annotations on all 294 files that carry one (10 s timeout, none hit).
