### PR TITLE
Run common sub-sum extraction before constant-bit propagation

### DIFF
--- a/lib/STPManager/STP.cpp
+++ b/lib/STPManager/STP.cpp
@@ -805,6 +805,17 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
 
   const bool maybeRefinement = arrayops && !bm->UserFlags.ackermannisation;
 
+  // Must run before the ConstantBitPropagation object below is built: cb's
+  // fixed-point map has to describe the exact tree handed to ToSATAIG, and a
+  // rewrite between the two leaves nodes the propagator has never seen, which
+  // BitBlaster's checkAtFixedPoint assertion rejects.
+  if (bm->UserFlags.enable_common_subsum)
+  {
+    CommonSubSum css(bm, bm->defaultNodeFactory);
+    inputToSat = css.topLevel(inputToSat);
+    bm->ASTNodeStats("After Common Sub-sum Extraction: ", inputToSat);
+  }
+
   simplifier::constantBitP::ConstantBitPropagation* cb = NULL;
   std::unique_ptr<simplifier::constantBitP::ConstantBitPropagation> cleaner;
 
@@ -821,13 +832,6 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
 
     if (cb->isUnsatisfiable())
       inputToSat = bm->ASTFalse;
-  }
-
-  if (bm->UserFlags.enable_common_subsum)
-  {
-    CommonSubSum css(bm, bm->defaultNodeFactory);
-    inputToSat = css.topLevel(inputToSat);
-    bm->ASTNodeStats("After Common Sub-sum Extraction: ", inputToSat);
   }
 
   ToSATAIG toSATAIG(bm, cb, arrayTransformer);


### PR DESCRIPTION
The persistent `ConstantBitPropagation` object built in `TopLevelSTPAux` is handed to `ToSATAIG`, and `BitBlaster::BBForm` asserts that its fixed-point map is consistent for the formula being blasted (`checkAtFixedPoint`). The `CommonSubSum` pass ran between the two, so the map described the pre-rewrite tree, and on inputs where the rewrite created new nodes the assertion fired:

```
ConstantBitPropagation.cpp:513: checkAtFixedPoint(...): Assertion `false' failed  ("Not fixed point")
```

Found by `fuzz_single.sh` on QF_BV with `--common-subsum=1` — on some inputs only together with `--bb.conjoin-constant=1`, which additionally calls `setNodeToTrue`/`propagate` on the rewritten top node. Answers were unaffected (release builds and `--disable-cbitp` gave results matching z3); this was the debug assertion catching the stale map, though letting the bit-blaster consume fixed-bit information computed for a different tree seems best avoided regardless.

Fix: move the extraction pass above the propagator's construction, so the fixed-point map is computed over the tree that is actually bit-blasted.

Verified by re-running both saved 2500-query fuzz batches with their original option draws: previously they aborted after 332 and 939 queries; now both complete with all 5000 answers matching z3.