### PR TITLE
Depth-2 floating-point rewrite search, and the rules it found

### DIFF
--- a/lib/NodeFactory/SimplifyingNodeFactory.cpp
+++ b/lib/NodeFactory/SimplifyingNodeFactory.cpp
@@ -223,6 +223,54 @@ static bool fpZeroIsAdditiveIdentity(int zeroSign, unsigned mode)
   return (zeroSign < 0) != rtn;
 }
 
+// Nonpositive constant: a zero of either sign, or sign bit set -- NaN
+// excluded. The strict variant excludes the zeros too.
+static bool fpConstIsNonpositive(const stp::ASTNode& c)
+{
+  if (!fpFormattedConst(c) || fpConstIsNaN(c))
+    return false;
+  return fpConstSign(c) < 0 || fpConstIsZero(c);
+}
+static bool fpConstIsNegativeNonzero(const stp::ASTNode& c)
+{
+  if (!fpFormattedConst(c) || fpConstIsNaN(c))
+    return false;
+  return fpConstSign(c) < 0 && !fpConstIsZero(c);
+}
+
+// A term whose value is never below zero -- at the very least -0, or NaN:
+// fp.abs of anything; fp.sqrt of anything (a negative operand gives NaN, and
+// sqrt(-0) is -0); and a self-product t*t (the operand's sign cancels with
+// itself, and the invalid 0*oo needs distinct operands). The comparison
+// rules below only rely on "never strictly below -0".
+static bool fpTermNeverNegative(const stp::ASTNode& n)
+{
+  const stp::Kind k = n.GetKind();
+  return (k == stp::FP_ABS && n.Degree() == 1) ||
+         (k == stp::FP_SQRT && n.Degree() == 2) ||
+         (k == stp::FP_MUL && n.Degree() == 3 && n[1] == n[2]);
+}
+
+// The shapes the classification predicates can look through (beyond the
+// abs/neg peel): t + t is NaN, zero, negative or positive exactly when t is
+// (equal signs cannot cancel, doubling cannot underflow, overflow keeps the
+// sign); t * t is NaN exactly when t is and never negative; fp.sqrt keeps
+// zeroness and positivity (a negative operand maps to NaN, which no
+// classification counts); fp.roundToIntegral keeps NaN, infinity and sign,
+// and its result -- integral, zero, infinite or NaN -- is never subnormal.
+static bool fpIsSelfSum(const stp::ASTNode& n)
+{
+  return n.GetKind() == stp::FP_ADD && n.Degree() == 3 && n[1] == n[2];
+}
+static bool fpIsSelfProduct(const stp::ASTNode& n)
+{
+  return n.GetKind() == stp::FP_MUL && n.Degree() == 3 && n[1] == n[2];
+}
+static bool fpIsRoundToIntegral(const stp::ASTNode& n)
+{
+  return n.GetKind() == stp::FP_ROUNDTOINTEGRAL && n.Degree() == 2;
+}
+
 bool SimplifyingNodeFactory::children_all_constants(
     const ASTVec& children) const
 {
@@ -738,18 +786,65 @@ ASTNode SimplifyingNodeFactory::CreateNode(Kind kind, const ASTVec& children)
     // the blaster, which is why the FP kinds bypass the constant-fold path
     // above.
 
-    // Classification ignores the sign, so a wrapping abs or neg can be peeled
-    // off. isPositive and isNegative are deliberately excluded: they are the
-    // two predicates that do depend on the sign.
+    // Classification ignores the sign, so a wrapping abs or neg is peeled
+    // off; past that, each predicate looks through the shapes that preserve
+    // what it tests (see the fpIsSelfSum group above). The recursive create
+    // re-simplifies, so the rules compose through nested wrappers.
     case stp::FP_ISNORMAL:
     case stp::FP_ISSUBNORMAL:
     case stp::FP_ISZERO:
     case stp::FP_ISINFINITE:
     case stp::FP_ISNAN:
-      if (children[0].GetKind() == stp::FP_ABS ||
-          children[0].GetKind() == stp::FP_NEG)
-        result = NodeFactory::CreateNode(kind, children[0][0]);
+    {
+      const ASTNode& t = children[0];
+      if (t.GetKind() == stp::FP_ABS || t.GetKind() == stp::FP_NEG)
+        result = NodeFactory::CreateNode(kind, t[0]);
+      else if (kind == stp::FP_ISNAN &&
+               (fpIsRoundToIntegral(t) || fpIsSelfSum(t) || fpIsSelfProduct(t)))
+        result = NodeFactory::CreateNode(kind, t[1]);
+      else if (kind == stp::FP_ISZERO &&
+               ((t.GetKind() == stp::FP_SQRT && t.Degree() == 2) ||
+                fpIsSelfSum(t)))
+        result = NodeFactory::CreateNode(kind, t[1]);
+      else if (kind == stp::FP_ISINFINITE && fpIsRoundToIntegral(t))
+        result = NodeFactory::CreateNode(kind, t[1]);
+      else if (kind == stp::FP_ISSUBNORMAL && fpIsRoundToIntegral(t))
+        result = ASTFalse;
       break;
+    }
+
+    // The sign predicates. An abs is never negative, and positive exactly
+    // when it is not NaN (both count the zeros: fp.isPositive(+0) holds); a
+    // neg swaps the two predicates (NaN stays NaN, failing both); t + t and
+    // fp.roundToIntegral keep the sign; sqrt keeps positivity (a negative
+    // operand gives NaN, counted by neither); t * t is an abs in disguise.
+    case stp::FP_ISNEGATIVE:
+    {
+      const ASTNode& t = children[0];
+      if (t.GetKind() == stp::FP_ABS || fpIsSelfProduct(t))
+        result = ASTFalse;
+      else if (t.GetKind() == stp::FP_NEG)
+        result = NodeFactory::CreateNode(stp::FP_ISPOSITIVE, t[0]);
+      else if (fpIsRoundToIntegral(t) || fpIsSelfSum(t))
+        result = NodeFactory::CreateNode(kind, t[1]);
+      break;
+    }
+    case stp::FP_ISPOSITIVE:
+    {
+      const ASTNode& t = children[0];
+      if (t.GetKind() == stp::FP_ABS)
+        result = NodeFactory::CreateNode(
+            stp::NOT, NodeFactory::CreateNode(stp::FP_ISNAN, t[0]));
+      else if (fpIsSelfProduct(t))
+        result = NodeFactory::CreateNode(
+            stp::NOT, NodeFactory::CreateNode(stp::FP_ISNAN, t[1]));
+      else if (t.GetKind() == stp::FP_NEG)
+        result = NodeFactory::CreateNode(stp::FP_ISNEGATIVE, t[0]);
+      else if ((t.GetKind() == stp::FP_SQRT && t.Degree() == 2) ||
+               fpIsRoundToIntegral(t) || fpIsSelfSum(t))
+        result = NodeFactory::CreateNode(kind, t[1]);
+      break;
+    }
 
     // Mirror the less-thans onto the greater-thans, as the bit-vector
     // comparisons are above (BVLT -> BVGT): fp.lt(a, b) is fp.gt(b, a)
@@ -774,18 +869,36 @@ ASTNode SimplifyingNodeFactory::CreateNode(Kind kind, const ASTVec& children)
     // constant (NaN is unordered against everything), and the two
     // impossible strict comparisons against the extremes: -oo > x and
     // x > +oo hold for no x. (The mirrored fp.lt forms arrive here already
-    // swapped, so these four cover all eight.)
+    // swapped, so these rules cover both spellings.) A term that is never
+    // below zero (abs, sqrt, a self-product) cannot be under a nonpositive
+    // constant, and is over a strictly negative one exactly when it is
+    // ordered; and t > |t| never holds, since t <= |t| whenever ordered.
     case stp::FP_GT:
-      if (children.size() == 2 &&
-          (children[0] == children[1] || fpConstIsNaN(children[0]) ||
-           fpConstIsNaN(children[1]) || fpConstInfSign(children[0]) == -1 ||
-           fpConstInfSign(children[1]) == 1))
-        result = ASTFalse;
+      if (children.size() == 2)
+      {
+        if (children[0] == children[1] || fpConstIsNaN(children[0]) ||
+            fpConstIsNaN(children[1]) || fpConstInfSign(children[0]) == -1 ||
+            fpConstInfSign(children[1]) == 1)
+          result = ASTFalse;
+        else if (children[1].GetKind() == stp::FP_ABS &&
+                 children[1][0] == children[0])
+          result = ASTFalse;
+        else if (fpTermNeverNegative(children[1]) &&
+                 fpConstIsNonpositive(children[0]))
+          result = ASTFalse;
+        else if (fpTermNeverNegative(children[0]) &&
+                 fpConstIsNegativeNonzero(children[1]))
+          result = NodeFactory::CreateNode(
+              stp::NOT, NodeFactory::CreateNode(stp::FP_ISNAN, children[0]));
+      }
       break;
 
     // x >= x holds exactly when x is not NaN -- and so do +oo >= x and
     // x >= -oo, since only a NaN is unordered against an extreme. Against a
-    // NaN constant the comparison is simply false.
+    // NaN constant the comparison is simply false. The never-below-zero
+    // terms compare against constants as in FP_GT (non-strict, so the zeros
+    // change sides: N >= any nonpositive constant whenever ordered, and a
+    // zero >= N squeezes N onto the zeros). |t| >= t whenever ordered.
     case stp::FP_GEQ:
       if (children.size() == 2)
       {
@@ -800,6 +913,21 @@ ASTNode SimplifyingNodeFactory::CreateNode(Kind kind, const ASTVec& children)
         else if (fpConstInfSign(children[1]) == -1)
           result = NodeFactory::CreateNode(
               stp::NOT, NodeFactory::CreateNode(stp::FP_ISNAN, children[0]));
+        else if (children[0].GetKind() == stp::FP_ABS &&
+                 children[0][0] == children[1])
+          result = NodeFactory::CreateNode(
+              stp::NOT, NodeFactory::CreateNode(stp::FP_ISNAN, children[1]));
+        else if (fpTermNeverNegative(children[0]) &&
+                 fpConstIsNonpositive(children[1]))
+          result = NodeFactory::CreateNode(
+              stp::NOT, NodeFactory::CreateNode(stp::FP_ISNAN, children[0]));
+        else if (fpTermNeverNegative(children[1]))
+        {
+          if (fpConstIsNegativeNonzero(children[0]))
+            result = ASTFalse;
+          else if (fpConstZeroSign(children[0]) != 0)
+            result = NodeFactory::CreateNode(stp::FP_ISZERO, children[1]);
+        }
       }
       break;
 
@@ -853,11 +981,24 @@ ASTNode SimplifyingNodeFactory::CreateNode(Kind kind, const ASTVec& children)
           }
         }
 
-        // (= x NaN) is exactly (fp.isNaN x) -- SMT-LIB has a single NaN
-        // value -- but it is deliberately NOT rewritten: PropagateEqualities
-        // substitutes through a `=` with a constant side (x := NaN
-        // everywhere), which is strictly stronger than holding the smaller
-        // predicate.
+        // (= t NaN) is exactly (fp.isNaN t): SMT-LIB has a single NaN
+        // value. Rewritten only when t is NOT a bare symbol --
+        // PropagateEqualities substitutes through a `=` with a symbol on
+        // one side and a constant on the other (x := NaN everywhere), which
+        // is strictly stronger than holding the smaller predicate; a
+        // compound t offers no substitution to lose, and the isNaN may
+        // then simplify further (it peels abs/neg and looks through the
+        // NaN-transparent shapes).
+        if (kind == stp::FP_SMT_EQ)
+        {
+          for (unsigned k = 0; result.IsNull() && k <= 1; k++)
+            if (fpConstIsNaN(children[k]) &&
+                children[1 - k].GetKind() != stp::SYMBOL)
+              result =
+                  NodeFactory::CreateNode(stp::FP_ISNAN, children[1 - k]);
+          if (!result.IsNull())
+            break;
+        }
 
         // Both float equalities are symmetric. Order the operands so that
         // x ~ y and y ~ x become the same node and share their blasted
@@ -3414,6 +3555,20 @@ ASTNode SimplifyingNodeFactory::CreateTerm(Kind kind, unsigned int width,
         result = NodeFactory::CreateTerm(stp::FP_ABS, width, children[0][0]);
       else if (children[0].GetKind() == stp::BVCONST)
         result = foldFPSign(children[0], /*flip=*/false);
+      // abs(t * t) = t * t: a self-product is never negative, and -0 (the
+      // one nonnegative value abs does change) cannot arise from it.
+      else if (fpIsSelfProduct(children[0]))
+        result = children[0];
+      break;
+
+    // Rounding an already-integral value -- and roundToIntegral yields
+    // nothing else: an integral, a zero, an infinity or NaN -- is exact
+    // under EVERY mode, so a second roundToIntegral is dropped whatever its
+    // own rounding mode.
+    case stp::FP_ROUNDTOINTEGRAL:
+      if (children.size() == 2 &&
+          children[1].GetKind() == stp::FP_ROUNDTOINTEGRAL)
+        result = children[1];
       break;
 
     // neg(neg x) = x.

--- a/tests/api/C/fp-printing.cpp
+++ b/tests/api/C/fp-printing.cpp
@@ -45,8 +45,11 @@ TEST(fp_printing, smtlib2_states_the_source_sorts)
   VC vc = vc_createValidityChecker();
 
   Expr x = vc_varExpr(vc, "x", vc_fpType(vc, 8, 24));
+  Expr y = vc_varExpr(vc, "y", vc_fpType(vc, 8, 24));
   Expr r = vc_varExpr(vc, "r", vc_fpRoundingModeType(vc));
-  Expr f = vc_fpIsNaNExpr(vc, vc_fpAddExpr(vc, r, x, x));
+  // Two DISTINCT floats: fp.isNaN(x + x) simplifies to fp.isNaN(x) at
+  // construction, which would drop the fp.add (and r) this test is about.
+  Expr f = vc_fpIsNaNExpr(vc, vc_fpAddExpr(vc, r, x, y));
 
   const std::string out = smtlib2(vc, f);
 

--- a/tools/fp_rewrite_gen/fp_rewrite_gen.cpp
+++ b/tools/fp_rewrite_gen/fp_rewrite_gen.cpp
@@ -36,6 +36,17 @@ THE SOFTWARE.
 // the SimplifyingNodeFactory to see whether it already knows the rule:
 // what remains is the list of candidate rules worth adding.
 //
+// Depth 2 nests ONE inner term -- from a small pool chosen to constrain the
+// value's class, sign or shape: (fp.abs x), (fp.neg x), (fp.sqrt rm x),
+// (fp.roundToIntegral rm x), x*x, x+x and x-x -- into one operand slot of
+// every outer operation (fp.fma excepted: its depth-1 space already
+// dominates the runtime), with the other slots drawn from {x, constants}.
+// The classification predicates join the outer operations, and the target
+// library gains "the inner term itself", which is what idempotence-style
+// rules (roundToIntegral of roundToIntegral) collapse to. When both the
+// inner and outer operation take a rounding mode they share the literal;
+// two DIFFERENT inner terms in one candidate are not searched.
+//
 // The oracle is the one test_fprewrites uses: blast the candidate once
 // through the *hashing* factory (so no rewrite fires on the way in), then
 // fold the resulting pure bitvector/Boolean circuit to a constant under each
@@ -55,6 +66,7 @@ THE SOFTWARE.
 
 #include <cstdint>
 #include <cstdio>
+#include <map>
 #include <string>
 #include <vector>
 
@@ -123,6 +135,30 @@ static const char* rmName[] = {"RNE", "RNA", "RTP", "RTN", "RTZ"};
 static const int NUM_RM = 5;
 
 // ---------------------------------------------------------------------------
+// The depth-2 inner terms, each chosen because it constrains its value's
+// class, sign or shape. The rm-bearing ones share the candidate's literal
+// mode.
+enum Inner
+{
+  I_ABS,
+  I_NEG,
+  I_SQRT,
+  I_RTI,
+  I_SQUARE, // x * x: nonnegative or NaN
+  I_DOUBLE, // x + x: NaN exactly when x is
+  I_SUBXX,  // x - x: a zero, or NaN for NaN and the infinities
+  I_COUNT
+};
+static const char* innerName[] = {
+    "(fp.abs x)",     "(fp.neg x)",     "(fp.sqrt rm x)",
+    "(fp.rti rm x)",  "(fp.mul rm x x)", "(fp.add rm x x)",
+    "(fp.sub rm x x)"};
+static bool innerUsesRm(int i)
+{
+  return i != I_ABS && i != I_NEG;
+}
+
+// ---------------------------------------------------------------------------
 // The cheap forms a candidate may collapse to.
 enum TargetKind
 {
@@ -132,6 +168,7 @@ enum TargetKind
   T_X,
   T_NEGX,
   T_ABSX,
+  T_INNER, // the candidate's own inner term (depth 2 only)
   T_TRUE,
   T_FALSE,
   T_ISNAN,
@@ -146,10 +183,12 @@ struct Target
   TargetKind k = T_NONE;
   Special sc = S_NAN; // for T_CONST
   uint64_t bits = 0;  // for T_CONST_ANY
+  int inner = -1;     // for T_INNER
   bool operator==(const Target& o) const
   {
     return k == o.k && (k != T_CONST || sc == o.sc) &&
-           (k != T_CONST_ANY || bits == o.bits);
+           (k != T_CONST_ANY || bits == o.bits) &&
+           (k != T_INNER || inner == o.inner);
   }
   bool operator!=(const Target& o) const { return !(*this == o); }
   std::string name(const char* var) const
@@ -161,6 +200,7 @@ struct Target
       case T_X: return var;
       case T_NEGX: return std::string("(fp.neg ") + var + ")";
       case T_ABSX: return std::string("(fp.abs ") + var + ")";
+      case T_INNER: return innerName[inner];
       case T_TRUE: return "true";
       case T_FALSE: return "false";
       case T_ISNAN: return std::string("(fp.isNaN ") + var + ")";
@@ -445,20 +485,53 @@ static const OpSig OPS[] = {
     {FP_SMT_EQ, "=", 2, false, true},
 };
 
-// An argument choice: 0 = the variable, 1 + s = pool constant s.
+// The classification predicates join the outer operations at depth 2 (at
+// depth 1 each IS its own target, so there is nothing to search).
+static const OpSig CLASSIFIERS[] = {
+    {FP_ISNAN, "fp.isNaN", 1, false, true},
+    {FP_ISZERO, "fp.isZero", 1, false, true},
+    {FP_ISINFINITE, "fp.isInfinite", 1, false, true},
+    {FP_ISNORMAL, "fp.isNormal", 1, false, true},
+    {FP_ISSUBNORMAL, "fp.isSubnormal", 1, false, true},
+    {FP_ISNEGATIVE, "fp.isNegative", 1, false, true},
+    {FP_ISPOSITIVE, "fp.isPositive", 1, false, true},
+};
+
+// An argument choice: 0 = the variable, 1 + s = pool constant s,
+// 1 + S_COUNT + i = inner term i (depth 2).
 static const int ARG_X = 0;
 static bool isX(int a) { return a == ARG_X; }
+static bool isConstArg(int a) { return a >= 1 && a <= S_COUNT; }
+static bool isInnerArg(int a) { return a > S_COUNT; }
+static int innerOf(int a) { return a - S_COUNT - 1; }
 
 struct Candidate
 {
   const OpSig* op;
   std::vector<int> args; // one per float operand
+
+  bool usesRm() const
+  {
+    if (op->rm)
+      return true;
+    for (const int a : args)
+      if (isInnerArg(a) && innerUsesRm(innerOf(a)))
+        return true;
+    return false;
+  }
+  int innerIdx() const // the (single) inner term, or -1 at depth 1
+  {
+    for (const int a : args)
+      if (isInnerArg(a))
+        return innerOf(a);
+    return -1;
+  }
 };
 
 static std::string describe(const Candidate& c, int modeMask)
 {
   std::string s = "(" + std::string(c.op->name);
-  if (c.op->rm)
+  if (c.usesRm())
   {
     bool all = (modeMask == (1 << NUM_RM) - 1);
     if (all)
@@ -479,7 +552,9 @@ static std::string describe(const Candidate& c, int modeMask)
     }
   }
   for (const int a : c.args)
-    s += std::string(" ") + (isX(a) ? "x" : specialName[a - 1]);
+    s += std::string(" ") + (isX(a) ? "x"
+                             : isConstArg(a) ? specialName[a - 1]
+                                             : innerName[innerOf(a)]);
   return s + ")";
 }
 
@@ -500,6 +575,44 @@ struct Generator
   Ctx c;
   int evaluated = 0;
 
+  // Value vectors of the inner terms, memoised per (inner, mode, format);
+  // the vector depends only on the structure, not on which symbol carries it.
+  std::map<uint64_t, std::vector<uint64_t>> innerCache;
+
+  ASTNode buildInner(NodeFactory* f, int i, int mode, const ASTNode& x,
+                     const Fmt& fmt)
+  {
+    const unsigned w = fmt.width();
+    const ASTNode r = c.rm(RM_MODES[mode]);
+    ASTNode n;
+    switch (i)
+    {
+      case I_ABS: n = f->CreateTerm(FP_ABS, w, x); break;
+      case I_NEG: n = f->CreateTerm(FP_NEG, w, x); break;
+      case I_SQRT: n = f->CreateTerm(FP_SQRT, w, r, x); break;
+      case I_RTI: n = f->CreateTerm(FP_ROUNDTOINTEGRAL, w, r, x); break;
+      case I_SQUARE: n = f->CreateTerm(FP_MUL, w, r, x, x); break;
+      case I_DOUBLE: n = f->CreateTerm(FP_ADD, w, r, x, x); break;
+      case I_SUBXX: n = f->CreateTerm(FP_SUB, w, r, x, x); break;
+    }
+    n.SetExpWidth(fmt.eb);
+    n.SetSigWidth(fmt.sb);
+    return n;
+  }
+
+  const std::vector<uint64_t>& innerVec(int i, int mode, const ASTNode& x,
+                                        const Fmt& fmt)
+  {
+    const int m = innerUsesRm(i) ? mode : 0;
+    const uint64_t key = ((uint64_t)fmt.eb << 40) | ((uint64_t)fmt.sb << 32) |
+                         ((uint64_t)i << 8) | (uint64_t)m;
+    const auto found = innerCache.find(key);
+    if (found != innerCache.end())
+      return found->second;
+    const ASTNode n = buildInner(c.hf, i, m, x, fmt);
+    return innerCache.emplace(key, c.valueVector(n, x, fmt, 0)).first->second;
+  }
+
   ASTNode build(NodeFactory* f, const Candidate& cand, int mode,
                 const ASTNode& x, const Fmt& fmt)
   {
@@ -507,13 +620,32 @@ struct Generator
     if (cand.op->rm)
       ch.push_back(c.rm(RM_MODES[mode]));
     for (const int a : cand.args)
-      ch.push_back(isX(a) ? x : c.fpConst(fmt, bitsOf((Special)(a - 1), fmt)));
+      ch.push_back(isX(a) ? x
+                   : isConstArg(a)
+                       ? c.fpConst(fmt, bitsOf((Special)(a - 1), fmt))
+                       : buildInner(f, innerOf(a), mode, x, fmt));
     if (cand.op->pred)
       return f->CreateNode(cand.op->k, ch);
     ASTNode n = f->CreateTerm(cand.op->k, fmt.width(), ch);
     n.SetExpWidth(fmt.eb);
     n.SetSigWidth(fmt.sb);
     return n;
+  }
+
+  // Match a candidate's vector: the named targets first, then -- for a term
+  // holding an inner -- the inner term itself (idempotence and absorption
+  // land there).
+  Target matchVec(const Candidate& cand, const std::vector<uint64_t>& vec,
+                  int mode, const ASTNode& x, const Fmt& fmt,
+                  const TargetSet& ts)
+  {
+    const Target t = ts.match(vec, cand.op->pred);
+    if (t.k != T_NONE)
+      return t;
+    const int ii = cand.innerIdx();
+    if (ii >= 0 && !cand.op->pred && innerVec(ii, mode, x, fmt) == vec)
+      return Target{T_INNER, S_NAN, 0, ii};
+    return t;
   }
 
   // The target the candidate collapses to at `fmt` under `mode`, or T_NONE.
@@ -523,12 +655,14 @@ struct Generator
   {
     evaluated++;
     const ASTNode n = build(c.hf, cand, mode, x, fmt);
-    const Target t0 = ts.match(c.valueVector(n, x, fmt, 0), cand.op->pred);
+    const Target t0 =
+        matchVec(cand, c.valueVector(n, x, fmt, 0), mode, x, fmt, ts);
     if (t0.k == T_NONE)
       return t0;
     if (cand.op->k == FP_MIN || cand.op->k == FP_MAX)
     {
-      const Target t1 = ts.match(c.valueVector(n, x, fmt, 1), cand.op->pred);
+      const Target t1 =
+          matchVec(cand, c.valueVector(n, x, fmt, 1), mode, x, fmt, ts);
       if (t1 != t0)
         return Target{T_NONE, S_NAN, 0};
     }
@@ -539,7 +673,7 @@ struct Generator
   void querySnf(Finding& f, const ASTNode& x, const Fmt& fmt)
   {
     int mode = 0;
-    while (f.cand.op->rm && !(f.modeMask & (1 << mode)))
+    while (f.cand.usesRm() && !(f.modeMask & (1 << mode)))
       mode++;
     const ASTNode plain = build(c.hf, f.cand, mode, x, fmt);
     const ASTNode simp = build(c.nf, f.cand, mode, x, fmt);
@@ -547,6 +681,11 @@ struct Generator
     ASTNode want;
     switch (f.target.k)
     {
+      case T_INNER:
+        // The factory sees already-simplified children, so the expected
+        // survivor is the inner term as the factory itself builds it.
+        want = buildInner(c.nf, f.target.inner, mode, x, fmt);
+        break;
       case T_CONST: want = c.fpConst(fmt, bitsOf(f.target.sc, fmt)); break;
       case T_CONST_ANY: want = c.fpConst(fmt, f.target.bits); break;
       case T_X: want = x; break;
@@ -582,7 +721,49 @@ struct Generator
       f.snfForm = std::string("rewritten to ") + _kind_names[simp.GetKind()];
   }
 
-  std::vector<Finding> run()
+  // Evaluate one candidate under every relevant mode, group the modes by
+  // the target they reach, confirm each group on the second format, and ask
+  // the factory what it does today.
+  void searchCandidate(const Candidate& cand, const ASTNode& x,
+                       const ASTNode& xc, const Fmt& fmt,
+                       const Fmt& confirmFmt, const TargetSet& ts,
+                       const TargetSet& tsConfirm,
+                       std::vector<Finding>& findings)
+  {
+    const int modes = cand.usesRm() ? NUM_RM : 1;
+    std::vector<Target> perMode(modes);
+    for (int m = 0; m < modes; m++)
+      perMode[m] = evalOne(cand, m, x, fmt, ts);
+
+    std::vector<std::pair<Target, int>> groups;
+    for (int m = 0; m < modes; m++)
+    {
+      if (perMode[m].k == T_NONE)
+        continue;
+      bool found = false;
+      for (auto& g : groups)
+        if (g.first == perMode[m])
+        {
+          g.second |= (1 << m);
+          found = true;
+        }
+      if (!found)
+        groups.push_back({perMode[m], 1 << m});
+    }
+
+    for (const auto& g : groups)
+    {
+      Finding f{cand, g.first, g.second, true, false, false, ""};
+      for (int m = 0; m < modes; m++)
+        if (g.second & (1 << m))
+          f.confirmed &=
+              (evalOne(cand, m, xc, confirmFmt, tsConfirm) == g.first);
+      querySnf(f, x, fmt);
+      findings.push_back(f);
+    }
+  }
+
+  std::vector<Finding> runDepth1()
   {
     std::vector<Finding> findings;
     for (const OpSig& op : OPS)
@@ -612,56 +793,80 @@ struct Generator
         }
         if (!hasX)
           continue;
-
-        // Per rounding mode (a single pass for rm-free ops), then group
-        // modes by the target they reach.
-        const int modes = op.rm ? NUM_RM : 1;
-        std::vector<Target> perMode(modes);
-        for (int m = 0; m < modes; m++)
-          perMode[m] = evalOne(cand, m, x, fmt, ts);
-
-        std::vector<std::pair<Target, int>> groups;
-        for (int m = 0; m < modes; m++)
-        {
-          if (perMode[m].k == T_NONE)
-            continue;
-          bool found = false;
-          for (auto& g : groups)
-            if (g.first == perMode[m])
-            {
-              g.second |= (1 << m);
-              found = true;
-            }
-          if (!found)
-            groups.push_back({perMode[m], 1 << m});
-        }
-
-        for (const auto& g : groups)
-        {
-          Finding f{cand, g.first, g.second, true, false, false, ""};
-          for (int m = 0; m < modes; m++)
-            if (g.second & (1 << m))
-              f.confirmed &= (evalOne(cand, m, xc, confirmFmt, tsConfirm) ==
-                              g.first);
-          querySnf(f, x, fmt);
-          findings.push_back(f);
-        }
+        searchCandidate(cand, x, xc, fmt, confirmFmt, ts, tsConfirm,
+                        findings);
       }
       printf("done %-20s (%d evaluations so far)\n", op.name, evaluated);
     }
     return findings;
   }
+
+  // Depth 2: exactly one operand slot holds an inner term, the rest come
+  // from {x, pool}. fp.fma is excluded as the outer operation (cost), and
+  // so are candidates with two inner terms -- both are logged, not silent.
+  std::vector<Finding> runDepth2()
+  {
+    std::vector<Finding> findings;
+    const TargetSet ts(FA);
+    const TargetSet tsConfirm(FB);
+
+    std::vector<const OpSig*> outer;
+    for (const OpSig& op : OPS)
+      if (op.k != FP_FMA)
+        outer.push_back(&op);
+    for (const OpSig& op : CLASSIFIERS)
+      outer.push_back(&op);
+    printf("depth 2: fp.fma outer and two-inner candidates excluded\n");
+
+    for (const OpSig* op : outer)
+    {
+      const ASTNode x = c.fp(FA);
+      const ASTNode xc = c.fp(FB);
+
+      const int options = 1 + S_COUNT + I_COUNT;
+      int tuples = 1;
+      for (unsigned i = 0; i < op->floats; i++)
+        tuples *= options;
+      for (int t = 0; t < tuples; t++)
+      {
+        Candidate cand{op, {}};
+        int rest = t;
+        int inners = 0;
+        for (unsigned i = 0; i < op->floats; i++)
+        {
+          cand.args.push_back(rest % options);
+          inners += isInnerArg(rest % options) ? 1 : 0;
+          rest /= options;
+        }
+        if (inners != 1)
+          continue;
+        searchCandidate(cand, x, xc, FA, FB, ts, tsConfirm, findings);
+      }
+      printf("done %-20s (%d evaluations so far)\n", op->name, evaluated);
+    }
+    return findings;
+  }
 };
 
-int main()
+int main(int argc, char** argv)
 {
   setbuf(stdout, nullptr);
+  // Optional argument: "1" or "2" restricts the search to that depth.
+  const bool depth1 = (argc < 2) || std::string(argv[1]) == "1";
+  const bool depth2 = (argc < 2) || std::string(argv[1]) == "2";
   printf("Floating-point rewrite-rule search\n");
   printf("search format (%u,%u); confirm format (%u,%u); FMA on (%u,%u)\n\n",
          FA.eb, FA.sb, FB.eb, FB.sb, FS.eb, FS.sb);
 
   Generator gen;
-  std::vector<Finding> findings = gen.run();
+  std::vector<Finding> findings;
+  if (depth1)
+    findings = gen.runDepth1();
+  if (depth2)
+  {
+    std::vector<Finding> d2 = gen.runDepth2();
+    findings.insert(findings.end(), d2.begin(), d2.end());
+  }
 
   auto show = [](const Finding& f) {
     printf("  %-44s -> %-22s %s\n", describe(f.cand, f.modeMask).c_str(),

--- a/tools/test_fprewrites/test_fprewrites.cpp
+++ b/tools/test_fprewrites/test_fprewrites.cpp
@@ -516,9 +516,17 @@ static void run(Ctx& c)
       report(std::string(nm[i]) + "(abs/neg x) = " + nm[i] + "(x)",
              fires && sound);
     }
-    // isPositive/isNegative DO depend on the sign: must not be rewritten.
-    c.checkUnchanged("isPositive keeps abs", FP_ISPOSITIVE, {absx});
-    c.checkUnchanged("isNegative keeps neg", FP_ISNEGATIVE, {negx});
+    // isPositive/isNegative DO depend on the sign, so the peel above must
+    // not apply -- instead each resolves against what abs/neg do to it:
+    // an abs is never negative and positive iff not NaN; a neg swaps them.
+    c.checkNodeIs("isPositive(abs x) -> not isNaN", FP_ISPOSITIVE, {absx},
+                  c.hf->CreateNode(NOT, {c.hf->CreateNode(FP_ISNAN, {x})}));
+    c.checkNodeIs("isNegative(abs x) -> false", FP_ISNEGATIVE, {absx},
+                  c.mgr.ASTFalse);
+    c.checkNodeIs("isNegative(neg x) -> isPositive x", FP_ISNEGATIVE, {negx},
+                  c.hf->CreateNode(FP_ISPOSITIVE, {x}));
+    c.checkNodeIs("isPositive(neg x) -> isNegative x", FP_ISPOSITIVE, {negx},
+                  c.hf->CreateNode(FP_ISNEGATIVE, {x}));
   }
 
   // Folding a *constant* classification used to stamp a float format on the
@@ -928,6 +936,127 @@ static void run(Ctx& c)
                     nan);
       c.checkTermIs("fma(rm, +0, -0, z) = -0 + z", FP_FMA, w, {r, pz, nz, z},
                     c.nf->CreateTerm(FP_ADD, w, {r, nz, z}));
+    }
+  }
+
+  // ---- Depth-2 rules (found by fp_rewrite_gen's nested search). ----
+  // Facts about the never-below-zero terms (abs, sqrt, a self-product),
+  // classification predicates looking through value-preserving shapes, `=`
+  // against NaN with a compound side, and roundToIntegral idempotence.
+
+  {
+    ASTNode x = c.fp(EB, SB);
+    const unsigned w = x.GetValueWidth();
+    ASTNode nan = c.fpConst(EB, SB, packNaN(EB, SB));
+    ASTNode pz = c.fpConst(EB, SB, packZero(EB, SB, false));
+    ASTNode nz = c.fpConst(EB, SB, packZero(EB, SB, true));
+    ASTNode negOne = c.fpConst(EB, SB, packOne(EB, SB, true));
+    ASTNode ninf = c.fpConst(EB, SB, packInf(EB, SB, true));
+    const ASTNode notNanX =
+        c.hf->CreateNode(NOT, {c.hf->CreateNode(FP_ISNAN, {x})});
+
+    // The inner terms, built unsimplified. Both a "round" and a "directed"
+    // mode for the ones that round.
+    auto mk = [&](Kind k, const ASTVec& ch) {
+      ASTNode n = c.hf->CreateTerm(k, w, ch);
+      n.SetExpWidth(EB);
+      n.SetSigWidth(SB);
+      return n;
+    };
+    for (unsigned mode : {(unsigned)ROUND_NEAREST_TIES_TO_EVEN,
+                          (unsigned)ROUND_TOWARD_NEGATIVE})
+    {
+      ASTNode r = c.rm(mode);
+      ASTNode absx = c.unary(c.hf, FP_ABS, x);
+      ASTNode sq = mk(FP_MUL, {r, x, x});
+      ASTNode sqrtx = mk(FP_SQRT, {r, x});
+      ASTNode dbl = mk(FP_ADD, {r, x, x});
+      ASTNode rti = mk(FP_ROUNDTOINTEGRAL, {r, x});
+
+      // Range facts: never-below-zero terms against sign-decided constants.
+      c.checkNodeIs("gt(-1, |x|) -> false", FP_GT, {negOne, absx},
+                    c.mgr.ASTFalse);
+      c.checkNodeIs("gt(+0, sqrt x) -> false", FP_GT, {pz, sqrtx},
+                    c.mgr.ASTFalse);
+      c.checkNodeIs("gt(-0, x*x) -> false", FP_GT, {nz, sq}, c.mgr.ASTFalse);
+      c.checkNodeIs("gt(|x|, -1) -> not isNaN x", FP_GT, {absx, negOne},
+                    notNanX);
+      c.checkNodeIs("gt(x*x, -oo) -> not isNaN x", FP_GT, {sq, ninf},
+                    notNanX);
+      c.checkNodeIs(
+          "gt(sqrt x, -1) -> not isNaN(sqrt x)", FP_GT, {sqrtx, negOne},
+          c.hf->CreateNode(NOT, {c.hf->CreateNode(FP_ISNAN, {sqrtx})}));
+      c.checkNodeIs("geq(|x|, -0) -> not isNaN x", FP_GEQ, {absx, nz},
+                    notNanX);
+      c.checkNodeIs("geq(-1, x*x) -> false", FP_GEQ, {negOne, sq},
+                    c.mgr.ASTFalse);
+      c.checkNodeIs("geq(+0, |x|) -> isZero x", FP_GEQ, {pz, absx},
+                    c.hf->CreateNode(FP_ISZERO, {x}));
+      // isZero(x*x) does NOT reduce to isZero(x) -- a tiny square
+      // underflows to +0 -- so the squeeze must stop at isZero(x*x).
+      c.checkNodeIs("geq(-0, x*x) -> isZero(x*x)", FP_GEQ, {nz, sq},
+                    c.hf->CreateNode(FP_ISZERO, {sq}));
+      // The lt/leq spellings arrive through the mirror.
+      c.checkNodeIs("lt(|x|, -1) -> false", FP_LT, {absx, negOne},
+                    c.mgr.ASTFalse);
+      c.checkNodeIs("leq(sqrt x, -0) -> isZero x", FP_LEQ, {sqrtx, nz},
+                    c.hf->CreateNode(FP_ISZERO, {x}));
+
+      // t against |t|, no constant involved.
+      c.checkNodeIs("gt(x, |x|) -> false", FP_GT, {x, absx}, c.mgr.ASTFalse);
+      c.checkNodeIs("lt(|x|, x) -> false", FP_LT, {absx, x}, c.mgr.ASTFalse);
+      c.checkNodeIs("geq(|x|, x) -> not isNaN x", FP_GEQ, {absx, x},
+                    notNanX);
+      c.checkNodeIs("leq(x, |x|) -> not isNaN x", FP_LEQ, {x, absx},
+                    notNanX);
+
+      // Classification predicates looking through value-preserving shapes.
+      const ASTNode isNanX = c.hf->CreateNode(FP_ISNAN, {x});
+      c.checkNodeIs("isNaN(rti x) -> isNaN x", FP_ISNAN, {rti}, isNanX);
+      c.checkNodeIs("isNaN(x+x) -> isNaN x", FP_ISNAN, {dbl}, isNanX);
+      c.checkNodeIs("isNaN(x*x) -> isNaN x", FP_ISNAN, {sq}, isNanX);
+      c.checkNodeIs("isZero(sqrt x) -> isZero x", FP_ISZERO, {sqrtx},
+                    c.hf->CreateNode(FP_ISZERO, {x}));
+      c.checkNodeIs("isZero(x+x) -> isZero x", FP_ISZERO, {dbl},
+                    c.hf->CreateNode(FP_ISZERO, {x}));
+      c.checkNodeIs("isInfinite(rti x) -> isInfinite x", FP_ISINFINITE,
+                    {rti}, c.hf->CreateNode(FP_ISINFINITE, {x}));
+      c.checkNodeIs("isSubnormal(rti x) -> false", FP_ISSUBNORMAL, {rti},
+                    c.mgr.ASTFalse);
+      c.checkNodeIs("isNegative(x*x) -> false", FP_ISNEGATIVE, {sq},
+                    c.mgr.ASTFalse);
+      c.checkNodeIs("isPositive(x*x) -> not isNaN x", FP_ISPOSITIVE, {sq},
+                    notNanX);
+      c.checkNodeIs("isNegative(rti x) -> isNegative x", FP_ISNEGATIVE,
+                    {rti}, c.hf->CreateNode(FP_ISNEGATIVE, {x}));
+      c.checkNodeIs("isPositive(sqrt x) -> isPositive x", FP_ISPOSITIVE,
+                    {sqrtx}, c.hf->CreateNode(FP_ISPOSITIVE, {x}));
+      c.checkNodeIs("isNegative(x+x) -> isNegative x", FP_ISNEGATIVE, {dbl},
+                    c.hf->CreateNode(FP_ISNEGATIVE, {x}));
+      c.checkNodeIs("isPositive(x+x) -> isPositive x", FP_ISPOSITIVE, {dbl},
+                    c.hf->CreateNode(FP_ISPOSITIVE, {x}));
+
+      // `=` against NaN with a compound side is the NaN test (the bare-x
+      // spelling keeps its `=`, checked above); the created isNaN then
+      // simplifies through the same rules.
+      c.checkNodeIs("(= |x| NaN) -> isNaN x", FP_SMT_EQ, {absx, nan},
+                    isNanX);
+      c.checkNodeIs("(= NaN x*x) -> isNaN x", FP_SMT_EQ, {nan, sq}, isNanX);
+
+      // abs of a self-product is a no-op.
+      c.checkTermIs("abs(x*x) = x*x", FP_ABS, w, {sq}, sq);
+    }
+
+    // roundToIntegral idempotence must hold across DIFFERENT modes: the
+    // inner result is integral (or a zero, infinity or NaN), and rounding
+    // such a value is exact under every mode. The generator only verified
+    // the shared-mode instances, so cross-mode is the case to pin here.
+    {
+      ASTNode inner = mk(FP_ROUNDTOINTEGRAL,
+                         {c.rm(ROUND_TOWARD_NEGATIVE), x});
+      c.checkTermIs("rti(RTP, rti(RTN, x)) = rti(RTN, x)",
+                    FP_ROUNDTOINTEGRAL, w,
+                    {c.rm(ROUND_TOWARD_POSITIVE), inner}, inner);
     }
   }
 }


### PR DESCRIPTION
Follow-up to #797: the floating-point rewrite-rule generator now searches **depth 2**, and this PR implements the high-value rules it found. (Also posted as a comment on #797, which merged while this was in flight.)

## The search

`fp_rewrite_gen` nests one inner term — from a pool chosen to constrain the value's class, sign or shape: `(fp.abs x)`, `(fp.neg x)`, `(fp.sqrt rm x)`, `(fp.roundToIntegral rm x)`, `x*x`, `x+x`, `x-x` — into one operand slot of every outer operation, with the other slots drawn from the variable and the special-constant pool. The classification predicates join the outer operations (at depth 1 each is its own target, so there was nothing to search), and the target library gains "the inner term itself", which is what idempotence- and absorption-shaped rules collapse to. Excluded and logged rather than silently dropped: `fp.fma` as outer, two inner terms in one candidate, mismatched inner/outer rounding modes.

The depth-2 space is 8754 candidate evaluations in about three minutes: **626 sound rules, 290 missing from the factory, every one confirmed on a second format**. An optional argument (`1`/`2`) restricts a run to one depth.

## The rules implemented

- **Never-below-zero terms against sign-decided constants.** `fp.abs` of anything, `fp.sqrt` of anything, and a self-product `t*t` are never below zero (−0 at the most extreme, or NaN). Such a term is never under a nonpositive constant, is over a strictly negative one exactly when it is ordered, and a zero on the other side squeezes it onto `fp.isZero`. Constant-free pair: `t > |t| → false`, and `|t| ≥ t → ¬fp.isNaN t`. The mirrored `fp.lt`/`fp.leq` spellings arrive through the existing normalisation.
- **Classification predicates look through value-preserving shapes**, extending the existing abs/neg peel: `isNaN` through `roundToIntegral`, `t+t` and `t*t`; `isZero` through `sqrt` and `t+t`; `isInfinite` through `roundToIntegral`, whose result is also never subnormal; the sign predicates resolve against abs (never negative, positive iff not NaN), swap under neg, follow the sign through `roundToIntegral` and `t+t`, and see `t*t` as an abs in disguise. The families compose: the comparison rules emit `fp.isNaN`/`fp.isZero` terms that these then reduce.
- **`(= t NaN) → (fp.isNaN t)` when `t` is not a bare symbol.** The bare-symbol spelling deliberately keeps its `=`, which PropagateEqualities turns into the strictly stronger substitution `x := NaN` (the exception documented in #797).
- **`fp.roundToIntegral` idempotence across different rounding modes** — an already-integral value (and roundToIntegral yields nothing else: an integral, a zero, an infinity or NaN) rounds exactly under every mode. The generator only verified shared-mode instances; the cross-mode case is pinned in the tests. And **`abs(t*t) → t*t`**: −0, the one nonnegative value abs changes, cannot arise from a self-product.

Deliberately skipped, documented in the code: the `x−x` consequence cluster (syntactically rare), `fp.min`/`fp.max` against constants, `fp.eq`/`=` of compound terms against non-NaN constants, and the mode-guarded underflow/overflow squeezes the search surfaced — e.g. `fp.eq(x*x, ±0) → isZero(x)` is sound **only** under RTP, since a tiny square underflows to +0 in every other mode, and `x*x = +oo ↔ isInfinite(x)` only under RTZ/RTN, since a finite square overflows to +oo in the others. The per-mode grouping caught both traps automatically; unconditional versions would be unsound.

## Verification

- `test_fprewrites` grows from 135 to 202 checks: each rule must produce the exact expected node AND agree with the unsimplified original on every float of the format, through the same lowering a real solve uses. The two old "isPositive keeps abs" / "isNegative keeps neg" expectations flip to the new collapsed forms.
- Re-running the generator against the patched factory reports every implemented family handled; the 180 remaining are exactly the skipped families above.
- Full test suite passes. One printer-test fixture updated: its `fp.isNaN(x + x)` now simplifies at construction, so it uses two distinct floats to keep the `fp.add` it prints.
- A 300-file sample of SMT-LIB QF_FP benchmarks again answers 294/294 in agreement with their `:status` annotations (the remaining 6 carry none; 10 s timeout, none hit).
