### PR TITLE
Speed up SMT-LIB2 parsing of hard inputs, again (6 changes)

### DIFF
--- a/include/stp/Parser/LetMgr.h
+++ b/include/stp/Parser/LetMgr.h
@@ -26,6 +26,8 @@ THE SOFTWARE.
 #define LETMGR_H
 
 #include "stp/AST/AST.h"
+#include "stp/cpp_interface.h"
+#include <string_view>
 
 namespace stp
 {
@@ -37,7 +39,9 @@ class LetMgr
 private:
   const ASTNode ASTUndefined;
 
-  typedef std::unordered_map<string, ASTNode> MapType;
+  typedef ankerl::unordered_dense::map<string, ASTNode, TransparentStringHash,
+                                       std::equal_to<>>
+      MapType;
 
   // This maps from bound IDs that occur in LETs to
   // expressions. It's used to replace the IDs
@@ -48,7 +52,11 @@ private:
   // Each name maps to the stack of bindings that shadow each other,
   // innermost last, tagged with the index of the frame they belong to.
   // A single hash lookup resolves a name however deeply lets are nested.
-  std::unordered_map<string, std::vector<std::pair<size_t, ASTNode>>> bindings;
+  // A dense hash map probed via string_view: the lexer asks about every
+  // identifier it sees, so the probe must not copy the name.
+  ankerl::unordered_dense::map<string, std::vector<std::pair<size_t, ASTNode>>,
+                               TransparentStringHash, std::equal_to<>>
+      bindings;
 
   // The names bound in each open frame, so pop() can undo them.
   // Initally empty because we expect push() to be called before any bindings are added.
@@ -86,7 +94,7 @@ public:
 
   // The expression the innermost binding of s maps to, or nullptr.
   // The pointer is invalidated by any change to the bindings.
-  const ASTNode* lookupLet(const string& s) const;
+  const ASTNode* lookupLet(std::string_view s) const;
 
   ASTNode resolveLet(const string& s) const;
   ASTNode ResolveID(const ASTNode& var);

--- a/include/stp/cpp_interface.h
+++ b/include/stp/cpp_interface.h
@@ -122,12 +122,17 @@ class Cpp_interface
   };
   vector<Entry> cache;
 
+public:
+  // A stored define-fun. Public because the SMT-LIB2 parser carries a
+  // pointer to one through a token (see lookupFunction).
   struct Function
   {
     ASTVec params;
     ASTNode function;
     std::string name;
   };
+
+private:
   ankerl::unordered_dense::map<std::string, Function> functions;
 
   // Nested helper class to encapsulate a frame (i.e., between push a pop)
@@ -261,6 +266,16 @@ public:
 
   DLL_PUBLIC ASTNode applyFunction(const std::string& name,
                                    const ASTVec& params);
+
+  // Resolve a name to its stored function in a single map probe, or NULL if
+  // no such function exists. The pointer is into `functions`, which only
+  // mutates between commands (define-fun stores, frame pops erase), never
+  // while a term is being parsed -- so a pointer handed to the parser via a
+  // token is valid for the lifetime of that token.
+  DLL_PUBLIC const Function* lookupFunction(const std::string& name) const;
+
+  // Apply an already-resolved function, skipping the by-name map probe.
+  DLL_PUBLIC ASTNode applyFunction(const Function& f, const ASTVec& params);
 
   // Classify a name by its carrier return type in a single map probe:
   // BITVECTOR_TYPE or BOOLEAN_TYPE, or UNKNOWN_TYPE when the name is not a

--- a/include/stp/cpp_interface.h
+++ b/include/stp/cpp_interface.h
@@ -33,6 +33,7 @@ THE SOFTWARE.
 #include <map>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace stp
@@ -98,6 +99,19 @@ struct array_sort
   }
 };
 
+// Heterogeneous string hash: lets a string-keyed table be probed with a
+// string_view (e.g. straight from a lexer buffer) without materialising a
+// std::string first.
+struct TransparentStringHash
+{
+  using is_transparent = void;
+  using is_avalanching = void;
+  uint64_t operator()(std::string_view s) const noexcept
+  {
+    return ankerl::unordered_dense::hash<std::string_view>{}(s);
+  }
+};
+
 class Cpp_interface
 {
   STPMgr& bm;
@@ -156,13 +170,18 @@ private:
     void addSortAlias(const std::string& name);
     void addSymbol(const ASTNode& symbol);
     bool removeSymbol(const ASTNode& symbol);
-    bool lookupSymbol(const std::string& name, ASTNode& output) const;
+    bool lookupSymbol(std::string_view name, ASTNode& output) const;
 
   private:
     vector<std::string> _scoped_functions;
     vector<std::string> _scoped_sort_aliases;
     ASTVec _scoped_symbols;
-    std::map<std::string, std::vector<ASTNode>> _symbol_bindings;
+    // Hash map, not std::map: files declare tens of thousands of symbols
+    // with long common prefixes, and a tree walk memcmps the prefix at
+    // every level. Nothing iterates this in order.
+    ankerl::unordered_dense::map<std::string, std::vector<ASTNode>,
+                                 TransparentStringHash, std::equal_to<>>
+        _symbol_bindings;
     ankerl::unordered_dense::map<std::string, Function>*
         _global_function_context;
     std::map<std::string, std::pair<unsigned, unsigned>>*

--- a/lib/Interface/cpp_interface.cpp
+++ b/lib/Interface/cpp_interface.cpp
@@ -296,12 +296,21 @@ void Cpp_interface::storeFunction(const string& name, const ASTVec& params,
 
 ASTNode Cpp_interface::applyFunction(const string& name, const ASTVec& params)
 {
-  const auto found = functions.find(name);
-  if (found == functions.end())
+  const Function* f = lookupFunction(name);
+  if (f == NULL)
     FatalError("Trying to apply function which has not been defined.");
+  return applyFunction(*f, params);
+}
 
-  const Function& f = found->second;
+const Cpp_interface::Function*
+Cpp_interface::lookupFunction(const string& name) const
+{
+  const auto found = functions.find(name);
+  return found == functions.end() ? NULL : &found->second;
+}
 
+ASTNode Cpp_interface::applyFunction(const Function& f, const ASTVec& params)
+{
   if (f.params.size() != params.size())
     FatalError("Actual parameters differ in number from formal");
 

--- a/lib/Interface/cpp_interface.cpp
+++ b/lib/Interface/cpp_interface.cpp
@@ -358,9 +358,11 @@ ASTNode Cpp_interface::LookupOrCreateSymbol(string name)
 
 bool Cpp_interface::LookupSymbol(const char* const name, ASTNode& output)
 {
+  // One strlen for the whole search, not one per frame.
+  const std::string_view sv(name);
   for (auto it = frames.rbegin(); it != frames.rend(); ++it)
   {
-    if ((*it)->lookupSymbol(name, output))
+    if ((*it)->lookupSymbol(sv, output))
       return true;
   }
   return false;
@@ -951,12 +953,12 @@ void Cpp_interface::SolverFrame::addSortAlias(const std::string& name)
 void Cpp_interface::SolverFrame::addSymbol(const ASTNode& symbol)
 {
   _scoped_symbols.push_back(symbol);
-  _symbol_bindings[symbol.GetName()].push_back(symbol);
+  _symbol_bindings[std::string(symbol.GetName())].push_back(symbol);
 }
 
 bool Cpp_interface::SolverFrame::removeSymbol(const ASTNode& symbol)
 {
-  const auto binding = _symbol_bindings.find(symbol.GetName());
+  const auto binding = _symbol_bindings.find(std::string_view(symbol.GetName()));
   if (binding == _symbol_bindings.end() || binding->second.empty() ||
       binding->second.back() != symbol)
     return false;
@@ -976,7 +978,7 @@ bool Cpp_interface::SolverFrame::removeSymbol(const ASTNode& symbol)
   return false;
 }
 
-bool Cpp_interface::SolverFrame::lookupSymbol(const std::string& name,
+bool Cpp_interface::SolverFrame::lookupSymbol(std::string_view name,
                                               ASTNode& output) const
 {
   const auto found = _symbol_bindings.find(name);

--- a/lib/Parser/LetMgr.cpp
+++ b/lib/Parser/LetMgr.cpp
@@ -127,8 +127,13 @@ ASTNode LetMgr::ResolveID(const ASTNode& v)
   return v;
 }
 
-const ASTNode* LetMgr::lookupLet(const string& s) const
+const ASTNode* LetMgr::lookupLet(std::string_view s) const
 {
+  // The lexer asks about every identifier, including on files with no lets
+  // at all; skip the string hash entirely when there is nothing to find.
+  if (bindings.empty())
+    return nullptr;
+
   const auto found = bindings.find(s);
   if (found == bindings.end())
     return nullptr;

--- a/lib/Parser/smt2.lex
+++ b/lib/Parser/smt2.lex
@@ -3,7 +3,6 @@
 %option noyywrap
 %option noreject
 %option noyymore
-%option yylineno
 %option full
 
 /* %option debug */
@@ -45,6 +44,22 @@
   extern char *smt2text;
   extern int smt2error (const char *msg);
   bool stringOnly = false;
+
+  // Line counting for syntax-error messages, maintained by hand (in the
+  // flex-provided smt2lineno) in the few rules whose matches can contain a
+  // newline. '%option yylineno' made flex check a can-this-rule-match-eol
+  // table on every token instead, which cost a load and a branch per match
+  // across the whole input.
+  static void countNewlines(const char* s, size_t len)
+  {
+    const char* p = s;
+    const char* const end = s + len;
+    while ((p = (const char*)memchr(p, '\n', end - p)) != NULL)
+    {
+      smt2lineno++;
+      p++;
+    }
+  }
 
   // Whether the floating-point keywords are live. Off until the parser sees
   // an FP set-logic: SMT-LIB reserves theory names per-logic, and QF_BV
@@ -217,7 +232,7 @@ OPCHAR  ([~!@$%^&*\_\-+=<>\.?/])
 ANYTHING  ({LETTER}|{DIGIT}|{OPCHAR})
 
 %%
-[ \n\t\r\f] { /* skip whitespace */ }
+[ \n\t\r\f] { if (*smt2text == '\n') smt2lineno++; /* skip whitespace */ }
 
  /* We limit numerals to maxint, in the specification they are arbitary precision.*/
 {DIGIT}+               { smt2lval.uintval = strtoul(smt2text, NULL, 10); return NUMERAL_TOK; }
@@ -227,7 +242,7 @@ bv{DIGIT}+             { smt2lval.str = new std::string(smt2text+2); return BVCO
 {DIGIT}+"."{DIGIT}+    { smt2lval.str = new std::string(smt2text); return DECIMAL_TOK;}
 
 ";" { BEGIN COMMENT; }
-<COMMENT>"\n" { BEGIN INITIAL; /* return to normal mode */}
+<COMMENT>"\n" { smt2lineno++; BEGIN INITIAL; /* return to normal mode */}
 <COMMENT>.    { /* stay in comment mode */ }
 
 <INITIAL>"\""   { BEGIN STRING_LITERAL;
@@ -239,7 +254,8 @@ bv{DIGIT}+             { smt2lval.str = new std::string(smt2text+2); return BVCO
           smt2lval.str = new std::string(_string_lit);
           return STRING_TOK; }
 <STRING_LITERAL>.     { _string_lit.insert(_string_lit.end(),*smt2text); }
-<STRING_LITERAL>"\n"  { _string_lit.insert(_string_lit.end(),*smt2text); }
+<STRING_LITERAL>"\n"  { smt2lineno++;
+                        _string_lit.insert(_string_lit.end(),*smt2text); }
 
  /* Valid character are: ~ ! @ # $ % ^ & * _ - + = | \ : ; " < > . ? / ( )     */
 "("             { return LPAREN_TOK; }
@@ -306,8 +322,10 @@ bv{DIGIT}+             { smt2lval.str = new std::string(smt2text+2); return BVCO
   * so that the parenthesis returned is the one that closes the command
   * itself. String literals and quoted symbols are matched as units, since
   * either may contain an unbalanced parenthesis. */
-<SKIP_SEXPR>"\""([^"]|"\"\"")*"\""  { skippedText += yytext; /* string literal */ }
-<SKIP_SEXPR>"|"[^|]*"|"             { skippedText += yytext; /* quoted symbol */ }
+<SKIP_SEXPR>"\""([^"]|"\"\"")*"\""  { countNewlines(yytext, yyleng);
+                                      skippedText += yytext; /* string literal */ }
+<SKIP_SEXPR>"|"[^|]*"|"             { countNewlines(yytext, yyleng);
+                                      skippedText += yytext; /* quoted symbol */ }
 <SKIP_SEXPR>";"[^\n]*               { /* comment: not captured */ }
 <SKIP_SEXPR>"("                     { skippedDepth++; skippedText += '('; }
 <SKIP_SEXPR>")"                     { if (skippedDepth == 0)
@@ -324,7 +342,8 @@ bv{DIGIT}+             { smt2lval.str = new std::string(smt2text+2); return BVCO
                                           return RPAREN_TOK;
                                         }
                                       skippedDepth--; skippedText += ')'; }
-<SKIP_SEXPR>[^()|;\"]+              { skippedText += yytext; }
+<SKIP_SEXPR>[^()|;\"]+              { countNewlines(yytext, yyleng);
+                                      skippedText += yytext; }
 <SKIP_SEXPR>.                       { skippedText += yytext; }
 <SKIP_SEXPR><<EOF>>                 { BEGIN INITIAL; deferredDefineSort = false;
                                       return 0; }
@@ -475,7 +494,7 @@ bv{DIGIT}+             { smt2lval.str = new std::string(smt2text+2); return BVCO
 
 
 ({LETTER}|{OPCHAR})({ANYTHING})*  {return lookup(smt2text);}
-\|([^\|]|\n)*\| {return lookup(smt2text);}
+\|([^\|]|\n)*\| { countNewlines(smt2text, smt2leng); return lookup(smt2text); }
 
 . { smt2error("Illegal input character."); }
 %%

--- a/lib/Parser/smt2.lex
+++ b/lib/Parser/smt2.lex
@@ -42,6 +42,7 @@
 #include "parsesmt2.tab.h"
 
   extern char *smt2text;
+  extern int smt2leng;
   extern int smt2error (const char *msg);
   bool stringOnly = false;
 
@@ -107,27 +108,24 @@ namespace stp
 
   static int lookup(char* s)
   {
-    char * cleaned = NULL;
-
     // The SMTLIB2 specifications sez that the outter bars aren't part of the
     // name. This means that we can create an empty string symbol name.
+    // Strip them in place: s is always yytext (writable, and dead once the
+    // action returns), so overwriting the closing bar saves a malloc+copy
+    // per occurrence.
     if (s[0] == '|') {
-      size_t len = strlen(s);
+      const size_t len = smt2leng;
       assert(len >= 2);
       if (s[len-1] == '|')
       {
-        cleaned = (char*) malloc(len);
-        strncpy(cleaned,s+1,len-2); // chop off first and last characters.
-        cleaned[len-2] = '\0';
-        s = cleaned;
+        s[len-1] = '\0'; // chop off first and last characters.
+        s++;
       }
     }
 
     if (stringOnly)
     {
       smt2lval.str = new std::string(s);
-      if (cleaned)
-        free (cleaned);
       return STRING_TOK;
     }
 
@@ -151,8 +149,6 @@ namespace stp
           stp::GlobalParserInterface->lookupFunction(s);
       if (fn != NULL)
       {
-        if (cleaned)
-          free(cleaned);
         smt2lval.fn = fn;
         switch (fn->function.GetSourceSort().kind())
         {
@@ -187,9 +183,6 @@ namespace stp
 
     if (found)
     {
-       if (cleaned)
-         free (cleaned);
-
       // Check valuesize to see if it's a prop var.  I don't like doing
       // type determination in the lexer, but it's easier than rewriting
       // the whole grammar to eliminate the term/formula distinction.
@@ -203,8 +196,6 @@ namespace stp
     {
       // it has not been seen before.
       smt2lval.str = new std::string(s);
-      if (cleaned)
-        free (cleaned);
       return STRING_TOK;
     }
   }

--- a/lib/Parser/smt2.lex
+++ b/lib/Parser/smt2.lex
@@ -126,56 +126,49 @@ namespace stp
     }
     // Checking the functions before the symbols saves a symbol-table
     // probe in files built almost entirely from define-funs. A name can't
-    // legally be both, so the order isn't observable on valid input. A
-    // single functionReturnType probe classifies the name, so a boolean-
-    // function reference costs one map lookup rather than two.
+    // legally be both, so the order isn't observable on valid input. The
+    // return SourceSort classifies the name completely, so a function
+    // reference costs one map lookup rather than two.
     else if (stp::GlobalParserInterface->hasFunctions())
     {
       const stp::SourceSort source_sort =
           stp::GlobalParserInterface->functionReturnSourceSort(s);
-      if (source_sort.kind() == stp::SourceSort::Kind::RoundingMode)
+      switch (source_sort.kind())
       {
-        smt2lval.str = new std::string(s);
-        if (cleaned)
-          free(cleaned);
-        return ROUNDINGMODE_FUNCTIONID_TOK;
-      }
-      const stp::types ft = stp::GlobalParserInterface->functionReturnType(s);
-      if (ft == stp::BITVECTOR_TYPE)
-      {
-        smt2lval.str = new std::string(s);
-        if (cleaned)
-          free (cleaned);
-        return  BITVECTOR_FUNCTIONID_TOK;
-      }
-      else if (ft == stp::BOOLEAN_TYPE)
-      {
-        smt2lval.str = new std::string(s);
-        if (cleaned)
-          free (cleaned);
-        return  BOOLEAN_FUNCTIONID_TOK;
-      }
-      else if (ft == stp::FLOATINGPOINT_TYPE)
-      {
-        smt2lval.str = new std::string(s);
-        if (cleaned)
-          free (cleaned);
-        return  FLOATINGPOINT_FUNCTIONID_TOK;
-      }
-      // A nullary define-fun whose body has array type is a pure name for
-      // that body, so it is accepted whether or not --array-equality is on
-      // (QF_ABVFP benchmarks use them with no whole-array equalities in
-      // sight). Uses of the name expand to the body in the grammar.
-      else if (ft == stp::ARRAY_TYPE)
-      {
-        smt2lval.str = new std::string(s);
-        if (cleaned)
-          free (cleaned);
-        return  ARRAY_FUNCTIONID_TOK;
-      }
-      else if (stp::GlobalParserInterface->LookupSymbol(s,nptr)) // it's a symbol.
-      {
-        found = true;
+        case stp::SourceSort::Kind::RoundingMode:
+          smt2lval.str = new std::string(s);
+          if (cleaned)
+            free(cleaned);
+          return ROUNDINGMODE_FUNCTIONID_TOK;
+        case stp::SourceSort::Kind::BitVector:
+          smt2lval.str = new std::string(s);
+          if (cleaned)
+            free(cleaned);
+          return BITVECTOR_FUNCTIONID_TOK;
+        case stp::SourceSort::Kind::Bool:
+          smt2lval.str = new std::string(s);
+          if (cleaned)
+            free(cleaned);
+          return BOOLEAN_FUNCTIONID_TOK;
+        case stp::SourceSort::Kind::FloatingPoint:
+          smt2lval.str = new std::string(s);
+          if (cleaned)
+            free(cleaned);
+          return FLOATINGPOINT_FUNCTIONID_TOK;
+        // A nullary define-fun whose body has array type is a pure name for
+        // that body, so it is accepted whether or not --array-equality is on
+        // (QF_ABVFP benchmarks use them with no whole-array equalities in
+        // sight). Uses of the name expand to the body in the grammar.
+        case stp::SourceSort::Kind::Array:
+          smt2lval.str = new std::string(s);
+          if (cleaned)
+            free(cleaned);
+          return ARRAY_FUNCTIONID_TOK;
+        case stp::SourceSort::Kind::Unknown:
+          // Not a function after all.
+          if (stp::GlobalParserInterface->LookupSymbol(s,nptr)) // it's a symbol.
+            found = true;
+          break;
       }
     }
     else if (stp::GlobalParserInterface->LookupSymbol(s,nptr)) // it's a symbol.

--- a/lib/Parser/smt2.lex
+++ b/lib/Parser/smt2.lex
@@ -126,49 +126,43 @@ namespace stp
     }
     // Checking the functions before the symbols saves a symbol-table
     // probe in files built almost entirely from define-funs. A name can't
-    // legally be both, so the order isn't observable on valid input. The
-    // return SourceSort classifies the name completely, so a function
-    // reference costs one map lookup rather than two.
+    // legally be both, so the order isn't observable on valid input. One
+    // map probe resolves the name; the token carries the resolved function
+    // so the grammar never probes again, and the sort of the stored body
+    // (memoised on the node) classifies the token.
     else if (stp::GlobalParserInterface->hasFunctions())
     {
-      const stp::SourceSort source_sort =
-          stp::GlobalParserInterface->functionReturnSourceSort(s);
-      switch (source_sort.kind())
+      const stp::Cpp_interface::Function* fn =
+          stp::GlobalParserInterface->lookupFunction(s);
+      if (fn != NULL)
       {
-        case stp::SourceSort::Kind::RoundingMode:
-          smt2lval.str = new std::string(s);
-          if (cleaned)
-            free(cleaned);
-          return ROUNDINGMODE_FUNCTIONID_TOK;
-        case stp::SourceSort::Kind::BitVector:
-          smt2lval.str = new std::string(s);
-          if (cleaned)
-            free(cleaned);
-          return BITVECTOR_FUNCTIONID_TOK;
-        case stp::SourceSort::Kind::Bool:
-          smt2lval.str = new std::string(s);
-          if (cleaned)
-            free(cleaned);
-          return BOOLEAN_FUNCTIONID_TOK;
-        case stp::SourceSort::Kind::FloatingPoint:
-          smt2lval.str = new std::string(s);
-          if (cleaned)
-            free(cleaned);
-          return FLOATINGPOINT_FUNCTIONID_TOK;
-        // A nullary define-fun whose body has array type is a pure name for
-        // that body, so it is accepted whether or not --array-equality is on
-        // (QF_ABVFP benchmarks use them with no whole-array equalities in
-        // sight). Uses of the name expand to the body in the grammar.
-        case stp::SourceSort::Kind::Array:
-          smt2lval.str = new std::string(s);
-          if (cleaned)
-            free(cleaned);
-          return ARRAY_FUNCTIONID_TOK;
-        case stp::SourceSort::Kind::Unknown:
-          // Not a function after all.
-          if (stp::GlobalParserInterface->LookupSymbol(s,nptr)) // it's a symbol.
-            found = true;
-          break;
+        if (cleaned)
+          free(cleaned);
+        smt2lval.fn = fn;
+        switch (fn->function.GetSourceSort().kind())
+        {
+          case stp::SourceSort::Kind::RoundingMode:
+            return ROUNDINGMODE_FUNCTIONID_TOK;
+          case stp::SourceSort::Kind::BitVector:
+            return BITVECTOR_FUNCTIONID_TOK;
+          case stp::SourceSort::Kind::Bool:
+            return BOOLEAN_FUNCTIONID_TOK;
+          case stp::SourceSort::Kind::FloatingPoint:
+            return FLOATINGPOINT_FUNCTIONID_TOK;
+          // A nullary define-fun whose body has array type is a pure name
+          // for that body, so it is accepted whether or not --array-equality
+          // is on (QF_ABVFP benchmarks use them with no whole-array
+          // equalities in sight). Uses of the name expand to the body in
+          // the grammar.
+          case stp::SourceSort::Kind::Array:
+            return ARRAY_FUNCTIONID_TOK;
+          case stp::SourceSort::Kind::Unknown:
+            smt2error("Function with underivable return sort.");
+        }
+      }
+      else if (stp::GlobalParserInterface->LookupSymbol(s,nptr)) // it's a symbol.
+      {
+        found = true;
       }
     }
     else if (stp::GlobalParserInterface->LookupSymbol(s,nptr)) // it's a symbol.

--- a/lib/Parser/smt2.y
+++ b/lib/Parser/smt2.y
@@ -1252,6 +1252,11 @@ namespace stp
   stp::ASTVec *vec;
 
   std::string *str;
+
+  /* A resolved define-fun, pointing into Cpp_interface::functions. The map
+     only mutates between commands, never inside a term, so the pointer
+     outlives the token that carries it. */
+  const stp::Cpp_interface::Function *fn;
 };
 
 %start cmd
@@ -1280,7 +1285,8 @@ namespace stp
 %type <realc> an_real_constant
 
 %token <node> FORMID_TOK TERMID_TOK
-%token <str> STRING_TOK BITVECTOR_FUNCTIONID_TOK BOOLEAN_FUNCTIONID_TOK FLOATINGPOINT_FUNCTIONID_TOK ARRAY_FUNCTIONID_TOK
+%token <str> STRING_TOK
+%token <fn> BITVECTOR_FUNCTIONID_TOK BOOLEAN_FUNCTIONID_TOK FLOATINGPOINT_FUNCTIONID_TOK ARRAY_FUNCTIONID_TOK
 
 
  /* set-info tokens */
@@ -1358,7 +1364,7 @@ namespace stp
 /* Types for QF_FP and QF_BVFP. */
 %token FLOATINGPOINT_TOK
 %token ROUNDINGMODE_TOK
-%token <str> ROUNDINGMODE_FUNCTIONID_TOK
+%token <fn> ROUNDINGMODE_FUNCTIONID_TOK
 %token FLOAT16_TOK
 %token FLOAT32_TOK
 %token FLOAT64_TOK
@@ -2578,14 +2584,12 @@ FORMID_TOK
 | LPAREN_TOK BOOLEAN_FUNCTIONID_TOK an_mixed RPAREN_TOK
 {
   $$ = stp::GlobalParserInterface->newNode(stp::GlobalParserInterface->applyFunction(*$2,*$3));
-  delete $2;
   delete $3;
 }
 | BOOLEAN_FUNCTIONID_TOK
 {
   ASTVec empty;
   $$ = stp::GlobalParserInterface->newNode(stp::GlobalParserInterface->applyFunction(*$1,empty));
-  delete $1;
 }
 | LPAREN_TOK EXCLAIMATION_MARK_TOK an_formula NAMED_ATTRIBUTE_TOK STRING_TOK RPAREN_TOK
 {
@@ -2953,7 +2957,6 @@ TERMID_TOK
   // A use of a nullary array-sorted define-fun expands to its body.
   ASTVec empty;
   $$ = stp::GlobalParserInterface->newNode(stp::GlobalParserInterface->applyFunction(*$1,empty));
-  delete $1;
 }
 | LPAREN_TOK an_term RPAREN_TOK
 {
@@ -3252,7 +3255,6 @@ TERMID_TOK
   if ($$->GetType() != BITVECTOR_TYPE)
       yyerror("Must be bitvector type");
 
-  delete $2;
   delete $3;
 }
 | LPAREN_TOK FLOATINGPOINT_FUNCTIONID_TOK an_mixed RPAREN_TOK
@@ -3262,7 +3264,6 @@ TERMID_TOK
   if ($$->GetType() != FLOATINGPOINT_TYPE)
       yyerror("Must be floating-point type");
 
-  delete $2;
   delete $3;
 }
 | FLOATINGPOINT_FUNCTIONID_TOK
@@ -3272,8 +3273,6 @@ TERMID_TOK
 
   if ($$->GetType() != FLOATINGPOINT_TYPE)
     yyerror("Must be floating-point type");
-
-  delete $1;
 }
 | BITVECTOR_FUNCTIONID_TOK
 {
@@ -3282,8 +3281,6 @@ TERMID_TOK
 
   if ($$->GetType() != BITVECTOR_TYPE)
     yyerror("Must be bitvector type");
-
-  delete $1;
 }
 | LPAREN_TOK ROUNDINGMODE_FUNCTIONID_TOK an_mixed RPAREN_TOK
 {
@@ -3291,7 +3288,6 @@ TERMID_TOK
       stp::GlobalParserInterface->applyFunction(*$2, *$3));
   if ($$->GetSourceSort().kind() != stp::SourceSort::Kind::RoundingMode)
     yyerror("Must be RoundingMode type");
-  delete $2;
   delete $3;
 }
 | ROUNDINGMODE_FUNCTIONID_TOK
@@ -3301,7 +3297,6 @@ TERMID_TOK
       stp::GlobalParserInterface->applyFunction(*$1, empty));
   if ($$->GetSourceSort().kind() != stp::SourceSort::Kind::RoundingMode)
     yyerror("Must be RoundingMode type");
-  delete $1;
 }
 | LPAREN_TOK EXCLAIMATION_MARK_TOK an_term NAMED_ATTRIBUTE_TOK STRING_TOK RPAREN_TOK
 {


### PR DESCRIPTION
Parsing was profiled on the ~4,700 hardest QF_BV files of the SMT-LIB non-incremental benchmarks (16.6 GB of input). The flat profile splits into two shapes: CBMC-style files (no lets, millions of nullary define-funs and long `|quoted|` symbols) spend their time in identifier resolution — repeated map probes, string temporaries and a `std::map` symbol table — while let-heavy files (Sage2, asp) add the let-manager to that. Each commit below removes one of those costs, was measured individually, and leaves the CNF byte-identical.

Method: every commit was A/B'd against its predecessor with retired-instruction counts (`--parse-only`, median of repeated runs) and interleaved wall clock on a stratified 43-file subset of the hard set, plus a CNF byte-comparison over a stratified sample. The combined stack was then swept over all 4,661 hard files.

Per-commit results (mean instruction-count delta over the subset; wall delta is the subset total):

| commit | instructions | wall |
|---|---:|---:|
| Classify function references from one map probe during lexing | −1.3% | −3.2% |
| Carry the resolved function in FUNCTIONID tokens | −0.3% | ~0 |
| Store frame symbol bindings in a hash map probed without copies | −7.1% | −10.2% |
| Probe let bindings without copying the name, and not at all when empty | −1.5% | −5.8% |
| Count lines by hand instead of with %option yylineno | −2.6% | −3.3% |
| Strip quoted-symbol bars in place | −0.9% | −0.9% |

Combined, parsing the full hard set: **−15.5% wall** (462 s → 390 s, every benchmark family improved, −6.6% to −23.4%), **−12.8% mean instruction count** on the subset with every file negative (best −24.5% on the largest CBMC files).

Notes for review:

- The first commit restores the single-probe property #585 introduced: the floating-point work had added a `functionReturnSourceSort` probe ahead of the `functionReturnType` probe, so every function reference paid two `functions.find` calls again. The return `SourceSort` distinguishes every token class on its own.
- The second commit removes the third probe: the grammar's `applyFunction` re-found by name a function the lexer had just resolved, via a freshly allocated `std::string` it then deleted. The token now carries a `const Function*`. The pointer is into `Cpp_interface::functions`, which mutates only between commands, never while a term is being parsed, so it outlives the token.
- The symbol-table commit is the largest win. `SolverFrame::_symbol_bindings` was a `std::map`; CBMC files declare tens of thousands of symbols with long common prefixes, so each lookup walked ~15 tree levels memcmp-ing the shared prefix at every level. It is now an `unordered_dense` map with a transparent string_view hash, so lookups also stop materialising a `std::string` per frame. Nothing iterated the map in order.
- The line-counting commit: with `%option yylineno`, flex consults a can-this-rule-match-eol table and branches on every token match. The line number's only consumer is the syntax-error message, so the count is now maintained directly in the five rules whose matches can contain a newline. Error messages are unchanged, line numbers included — verified on errors that follow multi-line `|...|` blocks and comments.
- One further lever was tried and rejected: batching the single-character whitespace/comment/string-literal rules regressed instruction counts by +1.7% across the board (larger `%option full` tables plus a call per whitespace run outweigh the per-match dispatch it saves), so it is not part of this PR.

Correctness: byte-identical CNF on 101/101 sampled hard files (per-commit checks 41/41 each), identical sat/unsat answers and exit codes across the corpus sweep, unit and query-file test suites pass, and syntax-error output is byte-identical.

The measurements above were taken on a tree that also carried #589; the two change sets touch disjoint code and this branch applies to master independently.
