### PR TITLE
Make --ackermanize work with array equality

### DIFF
--- a/include/stp/Extensionality/ExtensionalityContext.h
+++ b/include/stp/Extensionality/ExtensionalityContext.h
@@ -228,6 +228,34 @@ public:
   // remain structural and are handled by the checker's T rules.
   ASTNode conjoinRecordConstraints(const ASTNode& root);
 
+  // Eager Ackermann reduction of the active equalities, the classical
+  // eager alternative to the refinement loop, taken when the user asked
+  // for --ackermanize. The negative direction of every equality is
+  // already eager -- conjoinRecordConstraints planted its witness
+  // clause -- and this pass makes the positive direction eager too: for
+  // every active record and every access-index term (read and write
+  // indexes) of the record's array shape in the solve, conjoin
+  //     proxy => read(left, i) = read(right, i).
+  // Once instantiated, the formula carries the complete equality
+  // semantics by itself, so the records are retired (the procedure
+  // reports inactive, every pass gate reopens) and the solve proceeds
+  // as an ordinary eager-Ackermannisation solve: reads expand into
+  // if-then-else chains and no refinement runs. Current lowerings stay,
+  // so the model surfaces still resolve opaque public handles -- to
+  // proxies that are now ordinary Boolean variables of the formula.
+  //
+  // Called between conjoinRecordConstraints and any simplification, on
+  // the exact root the former returned: the witness anchors must be in
+  // `root` (each record's lambda joins the index inventory through its
+  // anchor reads) and the construction operands must still be current.
+  //
+  // Returns the null node -- and changes nothing -- when a sort
+  // quotients its bit patterns (a float or RoundingMode cell or index):
+  // pointwise bit-equality is stronger than value equality there (NaN
+  // payloads, non-denoting patterns), so a packed instantiation could
+  // refuse a genuine model. Such solves stay on lemmas on demand.
+  ASTNode instantiateEagerAckermann(const ASTNode& root);
+
   // Final preparation, run after STP's simplifications and immediately
   // before its main array transformation:
   //  - recover each record's canonical operands from its anchors;

--- a/lib/Extensionality/ExtensionalityContext.cpp
+++ b/lib/Extensionality/ExtensionalityContext.cpp
@@ -771,6 +771,76 @@ ASTNode ExtensionalityContext::conjoinRecordConstraints(const ASTNode& root)
   return out;
 }
 
+ASTNode ExtensionalityContext::instantiateEagerAckermann(const ASTNode& root)
+{
+  assert(!activeRecordIds.empty());
+  assert(registrySealed); // the witness bundles are already in `root`
+
+  for (size_t i = 0; i < activeRecordIds.size(); i++)
+  {
+    const SourceSort sort =
+        records[activeRecordIds[i]].constructionLeft.GetSourceSort();
+    assert(sort.kind() == SourceSort::Kind::Array);
+    if (sort.usesFloatingPointTheory())
+      return ASTNode();
+  }
+
+  // Every distinct access-index term in the solve, grouped by the
+  // accessed array's shape. Writes are accesses exactly as they are for
+  // the lazy checker (paper section 11.4): equal stores at equal
+  // indices force equal values with no read anywhere near, so a write
+  // index is a point where an equality is observed and must be
+  // instantiated. One shared inventory per shape rather than one per
+  // equality-connected component: extra indexes only add valid
+  // implications of the guarding proxy, and sharing is what lets a
+  // chain a = b, b = c contradict a witness for a distinct (a, c) --
+  // the (a, c) record's lambda reaches the other two records' lemmas.
+  typedef std::pair<unsigned, unsigned> ArrayShape;
+  std::map<ArrayShape, std::set<ASTNode>> indexesByShape;
+  ASTNodeSet nodes;
+  collectDag(root, nodes);
+  for (ASTNodeSet::const_iterator it = nodes.begin(); it != nodes.end(); ++it)
+  {
+    const Kind k = it->GetKind();
+    if (k == READ)
+      indexesByShape[ArrayShape((*it)[0].GetIndexWidth(),
+                                (*it)[0].GetValueWidth())]
+          .insert((*it)[1]);
+    else if (k == WRITE)
+      indexesByShape[ArrayShape(it->GetIndexWidth(), it->GetValueWidth())]
+          .insert((*it)[1]);
+  }
+
+  // records-times-indexes lemmas, before the transform's own quadratic
+  // read expansion. That cost is what the user's --ackermanize opted
+  // into; it is the same trade the eager path makes without equalities.
+  NodeFactory* hf = bm->hashingNodeFactory;
+  ASTVec conjuncts;
+  conjuncts.push_back(root);
+  for (size_t i = 0; i < activeRecordIds.size(); i++)
+  {
+    const Record& r = records[activeRecordIds[i]];
+    const unsigned ew = r.constructionLeft.GetValueWidth();
+    const std::set<ASTNode>& indexes = indexesByShape[ArrayShape(
+        r.constructionLeft.GetIndexWidth(), ew)];
+    for (std::set<ASTNode>::const_iterator idx = indexes.begin();
+         idx != indexes.end(); ++idx)
+    {
+      const ASTNode readL = hf->CreateTerm(READ, ew, r.constructionLeft, *idx);
+      const ASTNode readR = hf->CreateTerm(READ, ew, r.constructionRight, *idx);
+      conjuncts.push_back(hf->CreateNode(OR, hf->CreateNode(NOT, r.proxy),
+                                         hf->CreateNode(EQ, readL, readR)));
+    }
+  }
+  const ASTNode out = bm->defaultNodeFactory->CreateNode(AND, conjuncts);
+
+  // Retire the records. Deliberately not beginSolve(): the current
+  // lowerings must survive for the model surfaces, and the protected-
+  // symbol set simply goes unconsulted once active() is false.
+  activeRecordIds.clear();
+  return out;
+}
+
 // Recover each record's canonical operands from its anchor equations
 // in the current formula. The anchors were conjoined before STP's
 // simplifications ran, so they were rewritten by exactly the passes

--- a/lib/STPManager/STP.cpp
+++ b/lib/STPManager/STP.cpp
@@ -356,7 +356,7 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
   // current form can be recovered. Array-valued ITEs remain structural and
   // are handled directly by the consistency checker's T rules. A query with
   // no active array equality stays on STP's ordinary array path.
-  const bool extActive = ext != NULL && ext->active();
+  bool extActive = ext != NULL && ext->active();
   // Releases the record-table seal on every exit from this function.
   ExtensionalityContext::SolveScope extScope(ext);
   if (extActive)
@@ -365,11 +365,26 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
     if (bm->UserFlags.ackermannisation)
     {
       // Eager Ackermannization expands reads into if-then-else chains,
-      // destroying the array structure the lazy procedure works on.
-      cerr << "Warning: --ackermanize is disabled for queries with "
-              "array equality."
-           << endl;
-      bm->UserFlags.ackermannisation = false;
+      // destroying the array structure the lazy procedure works on --
+      // so the equalities go the same way: instantiate them pointwise
+      // over the solve's read indexes and retire the records, leaving a
+      // self-contained formula on STP's ordinary eager path. Quotiented
+      // sorts (float or RoundingMode cells or indexes) have no sound
+      // pointwise bit instantiation and stay on lemmas on demand.
+      const ASTNode eager = ext->instantiateEagerAckermann(inputToSat);
+      if (!eager.IsNull())
+      {
+        inputToSat = eager;
+        extActive = false;
+        bm->ASTNodeStats("after eager equality instantiation: ", inputToSat);
+      }
+      else
+      {
+        cerr << "Warning: --ackermanize is disabled for queries with "
+                "array equality over floating-point sorts."
+             << endl;
+        bm->UserFlags.ackermannisation = false;
+      }
     }
   }
 

--- a/tests/query-files/array-extensionality-tests/70-ackermanize-positive-equality.smt2
+++ b/tests/query-files/array-extensionality-tests/70-ackermanize-positive-equality.smt2
@@ -1,0 +1,17 @@
+; RUN: %solver --array-equality --ackermanize %s 2>&1 | %OutputCheck %s
+; CHECK-NOT-L: Warning:
+; CHECK: ^unsat
+; --ackermanize used to be switched off (with a warning) whenever an
+; array equality was active. For plain bitvector array sorts the
+; equality is now instantiated pointwise over the solve's access
+; indexes and the solve stays on the eager path: no warning, and read
+; congruence still propagates across the equality.
+(set-logic QF_ABV)
+(declare-fun a () (Array (_ BitVec 2) (_ BitVec 2)))
+(declare-fun b () (Array (_ BitVec 2) (_ BitVec 2)))
+(declare-fun i () (_ BitVec 2))
+(declare-fun j () (_ BitVec 2))
+(assert (= a b))
+(assert (= i j))
+(assert (distinct (select a i) (select b j)))
+(check-sat)

--- a/tests/query-files/array-extensionality-tests/71-ackermanize-transitive-witness.smt2
+++ b/tests/query-files/array-extensionality-tests/71-ackermanize-transitive-witness.smt2
@@ -1,0 +1,14 @@
+; RUN: %solver --array-equality --ackermanize %s | %OutputCheck %s
+; CHECK-NEXT: ^unsat
+; The access-index inventory is shared across every record of one
+; array shape, not split per equality: the (a, c) record's witness
+; index reaches the (a, b) and (b, c) lemmas, which is what lets the
+; chain contradict the distinct witness. No formula read anywhere.
+(set-logic QF_ABV)
+(declare-fun a () (Array (_ BitVec 8) (_ BitVec 8)))
+(declare-fun b () (Array (_ BitVec 8) (_ BitVec 8)))
+(declare-fun c () (Array (_ BitVec 8) (_ BitVec 8)))
+(assert (= a b))
+(assert (= b c))
+(assert (not (= a c)))
+(check-sat)

--- a/tests/query-files/array-extensionality-tests/72-ackermanize-equal-writes-value.smt2
+++ b/tests/query-files/array-extensionality-tests/72-ackermanize-equal-writes-value.smt2
@@ -1,0 +1,18 @@
+; RUN: %solver --array-equality --ackermanize %s | %OutputCheck %s
+; CHECK-NEXT: ^unsat
+; Writes are accesses for the eager instantiation exactly as they are
+; for the lazy checker (test 02): no explicit read anywhere, yet equal
+; stores at equal indices force equal values. The write index has to be
+; in the pointwise instantiation's index inventory for the equality to
+; be observed at it.
+(set-logic QF_ABV)
+(declare-fun a () (Array (_ BitVec 2) (_ BitVec 2)))
+(declare-fun b () (Array (_ BitVec 2) (_ BitVec 2)))
+(declare-fun i () (_ BitVec 2))
+(declare-fun j () (_ BitVec 2))
+(declare-fun e1 () (_ BitVec 2))
+(declare-fun e2 () (_ BitVec 2))
+(assert (= (store a i e1) (store b j e2)))
+(assert (= i j))
+(assert (distinct e1 e2))
+(check-sat)

--- a/tests/query-files/array-extensionality-tests/73-ackermanize-disequality-small-domain.smt2
+++ b/tests/query-files/array-extensionality-tests/73-ackermanize-disequality-small-domain.smt2
@@ -1,0 +1,15 @@
+; RUN: %solver --array-equality --ackermanize %s | %OutputCheck %s
+; CHECK-NEXT: ^unsat
+; A distinct-arrays witness over an exhausted 2-bit index domain: the
+; witness index must alias one of the four constants, where the cells
+; are pinned equal. Exercises the witness clause surviving the eager
+; path and the Ackermann index-aliasing chains over it.
+(set-logic QF_ABV)
+(declare-fun a () (Array (_ BitVec 2) (_ BitVec 4)))
+(declare-fun b () (Array (_ BitVec 2) (_ BitVec 4)))
+(assert (= (select a #b00) (select b #b00)))
+(assert (= (select a #b01) (select b #b01)))
+(assert (= (select a #b10) (select b #b10)))
+(assert (= (select a #b11) (select b #b11)))
+(assert (not (= a b)))
+(check-sat)

--- a/tests/query-files/array-extensionality-tests/74-ackermanize-sat-model.smt2
+++ b/tests/query-files/array-extensionality-tests/74-ackermanize-sat-model.smt2
@@ -1,0 +1,13 @@
+; RUN: %solver --array-equality --ackermanize --check-sanity %s | %OutputCheck %s
+; CHECK: ^sat
+; CHECK-L: define-fun
+; A satisfiable disequality on the eager path still yields a model, the
+; retired records' lowerings still resolve the public equality handle,
+; and the sanity check agrees with the published cells.
+(set-logic QF_ABV)
+(declare-fun a () (Array (_ BitVec 2) (_ BitVec 8)))
+(declare-fun b () (Array (_ BitVec 2) (_ BitVec 8)))
+(assert (not (= a b)))
+(assert (= (select a #b00) (select b #b00)))
+(check-sat)
+(get-model)

--- a/tests/query-files/array-extensionality-tests/75-ackermanize-float-stays-lazy.smt2
+++ b/tests/query-files/array-extensionality-tests/75-ackermanize-float-stays-lazy.smt2
@@ -1,0 +1,15 @@
+; RUN: %solver --array-equality --ackermanize %s 2>&1 | %OutputCheck %s
+; CHECK-L: Warning: --ackermanize is disabled for queries with array equality over floating-point sorts.
+; CHECK: ^unsat
+; Float cells quotient their bit patterns (every NaN payload is one
+; value), so the pointwise bit instantiation of the eager path would be
+; stronger than value equality; such solves fall back to lemmas on
+; demand, with a warning, and still decide correctly.
+(set-logic QF_ABVFP)
+(declare-fun a () (Array (_ BitVec 2) (_ FloatingPoint 3 5)))
+(declare-fun b () (Array (_ BitVec 2) (_ FloatingPoint 3 5)))
+(declare-fun i () (_ BitVec 2))
+(assert (= a b))
+(assert (not (fp.eq (select a i) (select b i))))
+(assert (not (fp.isNaN (select a i))))
+(check-sat)


### PR DESCRIPTION
Previously `--ackermanize` was switched off (with a warning) whenever an array equality was active: the eager read transform expands reads into if-then-else chains, destroying the array structure the lemmas-on-demand procedure works on. This PR lowers the equalities the same eager way instead, so the two features compose.

## How

The negative direction of every equality is already eager: `conjoinRecordConstraints` plants the witness clause of preprocessing step 1 (a fresh index λ with `proxy ∨ read(a,λ) ≠ read(b,λ)`). The new `ExtensionalityContext::instantiateEagerAckermann` makes the positive direction eager too: for every active record and every access-index term of the record's array shape in the solve, it conjoins

```
proxy => read(left, i) = read(right, i)
```

and then retires the records. The instantiated formula carries the complete equality semantics by itself, so every pass gate reopens and the solve proceeds as an ordinary eager-Ackermannisation solve — reads expand into if-then-else chains, no refinement loop runs. The current lowerings survive, so the model surfaces still resolve opaque equality handles, through proxies that are now ordinary Boolean variables of the formula.

Two points carry the completeness argument:

- **Write indexes are accesses**, exactly as they are for the lazy checker (Brummayer & Biere §11.4): equal stores at equal indices force equal values with no read anywhere near, so WRITE indexes join the inventory alongside READ indexes. (Read indexes alone answered sat on four unsatisfiable files of the existing test corpus.)
- **The inventory is shared across all records of one array shape** rather than split per equality-connected component: extra indexes only add valid implications of the guarding proxy, and sharing is what lets `a = b ∧ b = c` contradict a distinct witness for `(a, c)` — that record's λ reaches the other two records' lemmas.

Sorts that quotient their bit patterns (float or RoundingMode cells or indexes) keep the previous behaviour: pointwise bit-equality is stronger than value equality there (NaN payloads, non-denoting patterns), so a packed instantiation could refuse a genuine model. Those solves stay on lemmas on demand, with a narrower warning.

Cost is records × inventory lemmas before the transform's own quadratic expansion — the same trade the eager path always makes, reached only when the user asks for `--ackermanize`. A possible follow-up is letting the small-read auto-Ackermannisation heuristic fire for active-equality solves too; the threshold would need to count records × inventory rather than raw reads.

## Verification

- Lazy-vs-eager differential over the whole extensionality test corpus: 87 files compared, 0 mismatches.
- 650 seeds of random differential fuzzing (small index/element widths, stores, array-ITEs, mixed-polarity equalities under boolean structure), with `--check-sanity` on the eager side: 0 disagreements, 0 sanity failures — the retired records' lowerings agree with the published array cells.
- Full test suite passes. Six new tests: congruence across an equality, transitivity against a distinct witness, the write-index observation case, an exhausted index domain, a sat model under the sanity check, and the floating-point fallback warning.