### PR TITLE
Gate the ackermanize float-array test on floating-point support

### DIFF
--- a/tests/query-files/array-extensionality-tests/75-ackermanize-float-stays-lazy.smt2
+++ b/tests/query-files/array-extensionality-tests/75-ackermanize-float-stays-lazy.smt2
@@ -1,3 +1,4 @@
+; REQUIRES: floating-point
 ; RUN: %solver --array-equality --ackermanize %s 2>&1 | %OutputCheck %s
 ; CHECK-L: Warning: --ackermanize is disabled for queries with array equality over floating-point sorts.
 ; CHECK: ^unsat


### PR DESCRIPTION
The `gcc (no-fp)` CI job on master fails since #801: the new test `array-extensionality-tests/75-ackermanize-float-stays-lazy.smt2` uses FloatingPoint sorts, but its directory is not excluded in builds without floating-point support, so the test runs and fails on the missing-support diagnostic.
Declare `; REQUIRES: floating-point` like the other float-element tests in that directory, so the no-fp configuration marks it unsupported instead.