### PR TITLE
Propagate definitional top-level array equalities

### DIFF
--- a/include/stp/AbsRefineCounterExample/AbsRefine_CounterExample.h
+++ b/include/stp/AbsRefineCounterExample/AbsRefine_CounterExample.h
@@ -141,7 +141,7 @@ private:
   // The array-valued nodes an array term is built from -- itself, the
   // base of every write, both branches of every array if-then-else.
   // These are the nodes the model can hold cells against.
-  void CollectArrayNodes(const ASTNode& arrayTerm, ASTNodeSet& out);
+  void CollectArrayNodes(const ASTNode& arrayTerm, ASTNodeSet& out) const;
 
   // counter_example. Always answers with a plain bitvector constant: a
   // float constant interns separately from the bitvector constant with

--- a/include/stp/AbsRefineCounterExample/AbsRefine_CounterExample.h
+++ b/include/stp/AbsRefineCounterExample/AbsRefine_CounterExample.h
@@ -141,7 +141,7 @@ private:
   // The array-valued nodes an array term is built from -- itself, the
   // base of every write, both branches of every array if-then-else.
   // These are the nodes the model can hold cells against.
-  static void CollectArrayNodes(const ASTNode& arrayTerm, ASTNodeSet& out);
+  void CollectArrayNodes(const ASTNode& arrayTerm, ASTNodeSet& out);
 
   // counter_example. Always answers with a plain bitvector constant: a
   // float constant interns separately from the bitvector constant with

--- a/lib/AbsRefineCounterExample/CounterExample.cpp
+++ b/lib/AbsRefineCounterExample/CounterExample.cpp
@@ -1096,7 +1096,7 @@ public:
 
 // See the header.
 void AbsRefine_CounterExample::CollectArrayNodes(const ASTNode& arrayTerm,
-                                                 ASTNodeSet& out)
+                                                 ASTNodeSet& out) const
 {
   ASTVec pending(1, arrayTerm);
   while (!pending.empty())

--- a/lib/AbsRefineCounterExample/CounterExample.cpp
+++ b/lib/AbsRefineCounterExample/CounterExample.cpp
@@ -298,8 +298,13 @@ AbsRefine_CounterExample::TermToConstTermUsingModel_inner(const ASTNode& term,
   assert(k != WRITE);
   assert(BOOLEAN_TYPE != term.GetType());
 
+  // An array-typed entry is a definitional alias installed by equality
+  // propagation (array symbol := array term), not a value; the READ case
+  // resolves through it. Recursing on it here would hand an array term to
+  // a walk that only understands element-typed values.
   ASTNodeMap::const_iterator it1;
-  if ((it1 = CounterExampleMap.find(term)) != CounterExampleMap.end())
+  if (ARRAY_TYPE != term.GetType() &&
+      (it1 = CounterExampleMap.find(term)) != CounterExampleMap.end())
   {
     const ASTNode& val = it1->second;
     if (BVCONST != val.GetKind())
@@ -399,6 +404,23 @@ AbsRefine_CounterExample::TermToConstTermUsingModel_inner(const ASTNode& term,
         FatalError("TermToConstTermUsingModel: "
                    "array has 0 index width: ",
                    arrName);
+      }
+
+      // An array symbol that equality propagation substituted away is
+      // defined by its (array-typed) entry in the counterexample map --
+      // the copied-in substitution map. The solve never bit-blasted a
+      // read of the vanished symbol, so no model entry can be keyed on
+      // it; read through the definition instead.
+      if (SYMBOL == arrName.GetKind())
+      {
+        ASTNodeMap::const_iterator sub = CounterExampleMap.find(arrName);
+        if (sub != CounterExampleMap.end() &&
+            ARRAY_TYPE == sub->second.GetType())
+        {
+          const ASTNode throughDefinition = bm->CreateTerm(
+              READ, term.GetValueWidth(), sub->second, index);
+          return TermToConstTermUsingModel(throughDefinition, ArrayReadFlag);
+        }
       }
 
       // With array equality active, every read in the solve is
@@ -1090,6 +1112,14 @@ void AbsRefine_CounterExample::CollectArrayNodes(const ASTNode& arrayTerm,
       pending.push_back(n[1]);
       pending.push_back(n[2]);
     }
+    else if (SYMBOL == n.GetKind())
+    {
+      // A substituted-away symbol's cells live against its definition.
+      const ASTNodeMap::const_iterator sub = CounterExampleMap.find(n);
+      if (sub != CounterExampleMap.end() &&
+          ARRAY_TYPE == sub->second.GetType())
+        pending.push_back(sub->second);
+    }
   }
 }
 
@@ -1167,6 +1197,19 @@ ASTNode AbsRefine_CounterExample::ReadUsingModel(const ASTNode& arrayTerm,
                    "truth value in the model",
                    level[0]);
       continue;
+    }
+
+    // A symbol equality propagation substituted away holds exactly what
+    // its definition holds.
+    if (SYMBOL == level.GetKind())
+    {
+      const ASTNodeMap::const_iterator sub = CounterExampleMap.find(level);
+      if (sub != CounterExampleMap.end() &&
+          ARRAY_TYPE == sub->second.GetType())
+      {
+        level = sub->second;
+        continue;
+      }
     }
 
     // A base array the model records nothing for at this index. It
@@ -1314,6 +1357,48 @@ vector<std::pair<ASTNode, ASTNode>>
 AbsRefine_CounterExample::GetSortedArrayModelEntries(const ASTNode& arraySym)
 {
   vector<std::pair<ASTNode, ASTNode>> entries;
+
+  // A symbol equality propagation substituted away has no reads of its
+  // own in the model; it holds exactly what its definition holds. Derive
+  // its entries from the definition: every cell the model records
+  // against the definition's base arrays, plus every index one of its
+  // writes covers. Equality propagation only substitutes plain
+  // bitvector-sorted arrays, so indexes and cells are plain constants
+  // here.
+  {
+    const ASTNodeMap::const_iterator sub = CounterExampleMap.find(arraySym);
+    if (sub != CounterExampleMap.end() &&
+        ARRAY_TYPE == sub->second.GetType())
+    {
+      const ASTNode definition = sub->second;
+      ASTNodeSet arrays;
+      CollectArrayNodes(definition, arrays);
+      ModelCells cells;
+      CollectModelCells(arrays, cells);
+
+      std::set<ASTNode> indexes;
+      for (ModelCells::const_iterator it = cells.begin(); it != cells.end();
+           ++it)
+        indexes.insert(it->first.second);
+      for (ASTNodeSet::const_iterator it = arrays.begin();
+           it != arrays.end(); ++it)
+        if (WRITE == it->GetKind())
+          indexes.insert(TermToConstTermUsingModel((*it)[1], false));
+
+      for (std::set<ASTNode>::const_iterator it = indexes.begin();
+           it != indexes.end(); ++it)
+        entries.push_back(
+            std::make_pair(*it, ReadUsingModel(definition, *it, cells)));
+
+      std::sort(entries.begin(), entries.end(),
+                [](const std::pair<ASTNode, ASTNode>& x,
+                   const std::pair<ASTNode, ASTNode>& y) {
+                  return CONSTANTBV::BitVector_Lexicompare(
+                             x.first.GetBVConst(), y.first.GetBVConst()) < 0;
+                });
+      return entries;
+    }
+  }
 
   // Take a copy of the counterexample map, 'cause TermToConstTermUsingModel
   // changes it. Which breaks the iterator otherwise.
@@ -1508,9 +1593,10 @@ void AbsRefine_CounterExample::outputLine(std::ostream& os, const ASTNode &f, AS
 {
     if (ARRAY_TYPE == se.GetType())
     {
-      FatalError("PrintCounterExampleSMTLIB2: "
-                 "entry in counterexample is an arraytype. bogus:",
-                 se);
+      // A definitional alias installed by equality propagation (array
+      // symbol := array term), not a cell of the model. The cells are
+      // recorded against the definition's base arrays and print there.
+      return;
     }
 
     // skip over introduced variables, and over the reads of an introduced
@@ -1907,9 +1993,10 @@ void AbsRefine_CounterExample::PrintCounterExample(bool t, std::ostream& os)
 
     if (ARRAY_TYPE == se.GetType())
     {
-      FatalError("TermToConstTermUsingModel: "
-                 "entry in counterexample is an arraytype. bogus:",
-                 se);
+      // A definitional alias installed by equality propagation (array
+      // symbol := array term), not a cell of the model. The cells are
+      // recorded against the definition's base arrays and print there.
+      continue;
     }
 
     // skip over introduced variables, and over the reads of an introduced

--- a/lib/STPManager/STP.cpp
+++ b/lib/STPManager/STP.cpp
@@ -312,11 +312,13 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
       new PropagateEqualities(simp, bm->defaultNodeFactory, bm));
 
   ASTNode semantic_input = original_input;
+  bool hadWholeArrayEquality = false;
   if (bm->UserFlags.enable_array_equality)
   {
     const bool hasOpaqueEquality =
         containsOpaqueArrayEquality(original_input) ||
         !arrayEqualityRewrites.empty();
+    hadWholeArrayEquality = hasOpaqueEquality;
 
     // A definitional equality -- a symbol equated with an array term at
     // the top level, (= A (store B i v)) -- substitutes the symbol away
@@ -464,8 +466,16 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
     }
   }
 
+  // A query with a whole-array equality always constructs the
+  // counterexample. Definitional substitution can leave so few reads
+  // that the eager removal above deletes every array operation, but the
+  // substituted symbols' interpretations still have to be reconstructed
+  // from their definitional aliases when the model surface is asked --
+  // and before substitution existed, every such query stayed on the
+  // lazy array path and constructed the counterexample anyway.
   if (bm->UserFlags.check_counterexample_flag ||
-      bm->UserFlags.print_counterexample_flag || (arrayops && !removed))
+      bm->UserFlags.print_counterexample_flag || (arrayops && !removed) ||
+      hadWholeArrayEquality)
     bm->UserFlags.construct_counterexample_flag = true;
   else
     bm->UserFlags.construct_counterexample_flag = false;

--- a/lib/STPManager/STP.cpp
+++ b/lib/STPManager/STP.cpp
@@ -312,13 +312,11 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
       new PropagateEqualities(simp, bm->defaultNodeFactory, bm));
 
   ASTNode semantic_input = original_input;
-  bool hadWholeArrayEquality = false;
   if (bm->UserFlags.enable_array_equality)
   {
     const bool hasOpaqueEquality =
         containsOpaqueArrayEquality(original_input) ||
         !arrayEqualityRewrites.empty();
-    hadWholeArrayEquality = hasOpaqueEquality;
 
     // A definitional equality -- a symbol equated with an array term at
     // the top level, (= A (store B i v)) -- substitutes the symbol away
@@ -466,16 +464,8 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
     }
   }
 
-  // A query with a whole-array equality always constructs the
-  // counterexample. Definitional substitution can leave so few reads
-  // that the eager removal above deletes every array operation, but the
-  // substituted symbols' interpretations still have to be reconstructed
-  // from their definitional aliases when the model surface is asked --
-  // and before substitution existed, every such query stayed on the
-  // lazy array path and constructed the counterexample anyway.
   if (bm->UserFlags.check_counterexample_flag ||
-      bm->UserFlags.print_counterexample_flag || (arrayops && !removed) ||
-      hadWholeArrayEquality)
+      bm->UserFlags.print_counterexample_flag || (arrayops && !removed))
     bm->UserFlags.construct_counterexample_flag = true;
   else
     bm->UserFlags.construct_counterexample_flag = false;

--- a/lib/STPManager/STP.cpp
+++ b/lib/STPManager/STP.cpp
@@ -308,11 +308,32 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
   // preparation records an entry only for a node that was already an
   // ARRAY_EQ, so a non-empty map means one was built, which means the
   // option was on.
+  std::unique_ptr<PropagateEqualities> pe(
+      new PropagateEqualities(simp, bm->defaultNodeFactory, bm));
+
   ASTNode semantic_input = original_input;
   if (bm->UserFlags.enable_array_equality)
   {
-    if (ext == NULL && (containsOpaqueArrayEquality(original_input) ||
-                        !arrayEqualityRewrites.empty()))
+    const bool hasOpaqueEquality =
+        containsOpaqueArrayEquality(original_input) ||
+        !arrayEqualityRewrites.empty();
+
+    // A definitional equality -- a symbol equated with an array term at
+    // the top level, (= A (store B i v)) -- substitutes the symbol away
+    // outright, which is strictly cheaper than abstracting the equality
+    // and refining it with lemmas. Run the propagator once before
+    // lowering so those equalities never reach abstraction; whatever
+    // remains (negated, nested, or non-definitional equalities) lowers
+    // as before. This is the only point in the solve where the
+    // propagator can see an ARRAY_EQ at all.
+    if (hasOpaqueEquality && bm->UserFlags.optimize_flag &&
+        bm->UserFlags.propagate_equalities)
+    {
+      semantic_input = pe->topLevel(semantic_input);
+      bm->ASTNodeStats(pe_message.c_str(), semantic_input);
+    }
+
+    if (ext == NULL && hasOpaqueEquality)
     {
       ext = bm->getExtensionality();
       ext->beginSolve();
@@ -323,7 +344,7 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
     // no equality.
     if (ext != NULL)
       semantic_input =
-          ext->lowerArrayEqualities(original_input, arrayEqualityRewrites);
+          ext->lowerArrayEqualities(semantic_input, arrayEqualityRewrites);
   }
 
   bm->ASTNodeStats("input asserts and query: ", semantic_input);
@@ -342,8 +363,6 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
 
   // A heap object so I can easily control its lifetime.
   std::unique_ptr<BVSolver> bvSolver(new BVSolver(bm, simp));
-  std::unique_ptr<PropagateEqualities> pe(
-      new PropagateEqualities(simp, bm->defaultNodeFactory, bm));
 
   ASTNode inputToSat = semantic_input;
 

--- a/lib/Simplifier/PropagateEqualities.cpp
+++ b/lib/Simplifier/PropagateEqualities.cpp
@@ -639,6 +639,23 @@ void PropagateEqualities::buildCandidateList(const ASTNode& a)
     else if (SYMBOL == right.GetKind())
       addCandidate(right, left);
   }
+  else if (ARRAY_EQ == k &&
+           !a[0].GetSourceSort().usesFloatingPointTheory())
+  {
+    // Whole-array `=` asserted at the top level is true equality on the
+    // array domain, so a symbol operand substitutes away exactly like
+    // the bitvector EQ case (the occurs check in processCandidates
+    // rejects A = store(A, i, v)). Kept separate from the EQ arm above
+    // so the bitvector inverse rewrites (BVNOT/BVUMINUS/BVPLUS) can't
+    // see array operands. Float- or RoundingMode-sorted arrays are left
+    // to abstraction: the model machinery that reconstructs a
+    // substituted symbol's cells reads them as plain bits, which is
+    // wrong under NaN's many packings and float index canonicalisation.
+    if (SYMBOL == a[0].GetKind())
+      addCandidate(a[0], a[1]);
+    else if (SYMBOL == a[1].GetKind())
+      addCandidate(a[1], a[0]);
+  }
   else if (AND == k)
   {
     for (const auto& it : a)

--- a/tests/api/C/array-extensionality.cpp
+++ b/tests/api/C/array-extensionality.cpp
@@ -178,7 +178,7 @@ TEST(array_extensionality, repeated_queries_do_not_leak_ite_records)
   // term) now substitutes away before abstraction ever sees it. This
   // test pins the abstraction/checker path itself, so keep the
   // equality there.
-  ((stp::STP*)vc)->bm->UserFlags.propagate_equalities = false;
+  static_cast<stp::STP*>(vc)->bm->UserFlags.propagate_equalities = false;
 
   Type bv8 = vc_bvType(vc, 8);
   Type bv4 = vc_bvType(vc, 4);
@@ -231,7 +231,7 @@ TEST(array_extensionality, nested_ite_fixed_point_is_stable)
   // term) now substitutes away before abstraction ever sees it. This
   // test pins the abstraction/checker path itself, so keep the
   // equality there.
-  ((stp::STP*)vc)->bm->UserFlags.propagate_equalities = false;
+  static_cast<stp::STP*>(vc)->bm->UserFlags.propagate_equalities = false;
 
   Type bv8 = vc_bvType(vc, 8);
   Type bv4 = vc_bvType(vc, 4);
@@ -354,7 +354,7 @@ TEST(array_extensionality, asserted_ite_condition_folds_before_fe03)
   // term) now substitutes away before abstraction ever sees it. This
   // test pins the abstraction/checker path itself, so keep the
   // equality there.
-  ((stp::STP*)vc)->bm->UserFlags.propagate_equalities = false;
+  static_cast<stp::STP*>(vc)->bm->UserFlags.propagate_equalities = false;
 
   Type bv8 = vc_bvType(vc, 8);
   Type bv4 = vc_bvType(vc, 4);
@@ -678,7 +678,7 @@ TEST(array_extensionality, equality_under_push_pops_away)
   // term) now substitutes away before abstraction ever sees it. This
   // test pins the abstraction/checker path itself, so keep the
   // equality there.
-  ((stp::STP*)vc)->bm->UserFlags.propagate_equalities = false;
+  static_cast<stp::STP*>(vc)->bm->UserFlags.propagate_equalities = false;
 
   Type bv8 = vc_bvType(vc, 8);
   Type bv4 = vc_bvType(vc, 4);
@@ -1000,7 +1000,7 @@ TEST(array_extensionality, active_checker_owns_complete_array_graph)
   // term) now substitutes away before abstraction ever sees it. This
   // test pins the abstraction/checker path itself, so keep the
   // equality there.
-  ((stp::STP*)vc)->bm->UserFlags.propagate_equalities = false;
+  static_cast<stp::STP*>(vc)->bm->UserFlags.propagate_equalities = false;
 
   Type bv8 = vc_bvType(vc, 8);
   Type bv4 = vc_bvType(vc, 4);
@@ -1287,7 +1287,7 @@ TEST(array_extensionality,
   // term) now substitutes away before abstraction ever sees it. This
   // test pins the abstraction/checker path itself, so keep the
   // equality there.
-  ((stp::STP*)vc)->bm->UserFlags.propagate_equalities = false;
+  static_cast<stp::STP*>(vc)->bm->UserFlags.propagate_equalities = false;
 
   Type bv8 = vc_bvType(vc, 8);
   Type arrT = vc_arrayType(vc, bv8, bv8);
@@ -1446,7 +1446,7 @@ TEST(array_extensionality, ite_replacement_survives_a_rewritten_condition)
   // term) now substitutes away before abstraction ever sees it. This
   // test pins the abstraction/checker path itself, so keep the
   // equality there.
-  ((stp::STP*)vc)->bm->UserFlags.propagate_equalities = false;
+  static_cast<stp::STP*>(vc)->bm->UserFlags.propagate_equalities = false;
 
   Type bv8 = vc_bvType(vc, 8);
   Type bv4 = vc_bvType(vc, 4);

--- a/tests/api/C/array-extensionality.cpp
+++ b/tests/api/C/array-extensionality.cpp
@@ -174,6 +174,11 @@ TEST(array_extensionality, repeated_queries_do_not_leak_ite_records)
   // flip the verdict.
   VC vc = vc_createValidityChecker();
   vc_setFlag(vc, 'x');
+  // A definitional top-level equality (a symbol equated with an array
+  // term) now substitutes away before abstraction ever sees it. This
+  // test pins the abstraction/checker path itself, so keep the
+  // equality there.
+  ((stp::STP*)vc)->bm->UserFlags.propagate_equalities = false;
 
   Type bv8 = vc_bvType(vc, 8);
   Type bv4 = vc_bvType(vc, 4);
@@ -222,6 +227,11 @@ TEST(array_extensionality, nested_ite_fixed_point_is_stable)
   // state.
   VC vc = vc_createValidityChecker();
   vc_setFlag(vc, 'x');
+  // A definitional top-level equality (a symbol equated with an array
+  // term) now substitutes away before abstraction ever sees it. This
+  // test pins the abstraction/checker path itself, so keep the
+  // equality there.
+  ((stp::STP*)vc)->bm->UserFlags.propagate_equalities = false;
 
   Type bv8 = vc_bvType(vc, 8);
   Type bv4 = vc_bvType(vc, 4);
@@ -340,6 +350,11 @@ TEST(array_extensionality, asserted_ite_condition_folds_before_fe03)
   // fold happens or not.
   VC vc = vc_createValidityChecker();
   vc_setFlag(vc, 'x');
+  // A definitional top-level equality (a symbol equated with an array
+  // term) now substitutes away before abstraction ever sees it. This
+  // test pins the abstraction/checker path itself, so keep the
+  // equality there.
+  ((stp::STP*)vc)->bm->UserFlags.propagate_equalities = false;
 
   Type bv8 = vc_bvType(vc, 8);
   Type bv4 = vc_bvType(vc, 4);
@@ -659,6 +674,11 @@ TEST(array_extensionality, equality_under_push_pops_away)
   // durable opaque handle activates it again.
   VC vc = vc_createValidityChecker();
   vc_setFlag(vc, 'x');
+  // A definitional top-level equality (a symbol equated with an array
+  // term) now substitutes away before abstraction ever sees it. This
+  // test pins the abstraction/checker path itself, so keep the
+  // equality there.
+  ((stp::STP*)vc)->bm->UserFlags.propagate_equalities = false;
 
   Type bv8 = vc_bvType(vc, 8);
   Type bv4 = vc_bvType(vc, 4);
@@ -976,6 +996,11 @@ TEST(array_extensionality, active_checker_owns_complete_array_graph)
   // verdict must come through its lemma path, pinned by the counter.
   VC vc = vc_createValidityChecker();
   vc_setFlag(vc, 'x');
+  // A definitional top-level equality (a symbol equated with an array
+  // term) now substitutes away before abstraction ever sees it. This
+  // test pins the abstraction/checker path itself, so keep the
+  // equality there.
+  ((stp::STP*)vc)->bm->UserFlags.propagate_equalities = false;
 
   Type bv8 = vc_bvType(vc, 8);
   Type bv4 = vc_bvType(vc, 4);
@@ -1258,6 +1283,11 @@ TEST(array_extensionality,
   // the store just set to 1.
   VC vc = vc_createValidityChecker();
   vc_setFlag(vc, 'x');
+  // A definitional top-level equality (a symbol equated with an array
+  // term) now substitutes away before abstraction ever sees it. This
+  // test pins the abstraction/checker path itself, so keep the
+  // equality there.
+  ((stp::STP*)vc)->bm->UserFlags.propagate_equalities = false;
 
   Type bv8 = vc_bvType(vc, 8);
   Type arrT = vc_arrayType(vc, bv8, bv8);
@@ -1412,6 +1442,11 @@ TEST(array_extensionality, ite_replacement_survives_a_rewritten_condition)
   // on a re-reading of whatever the condition was normalised into.
   VC vc = vc_createValidityChecker();
   vc_setFlag(vc, 'x');
+  // A definitional top-level equality (a symbol equated with an array
+  // term) now substitutes away before abstraction ever sees it. This
+  // test pins the abstraction/checker path itself, so keep the
+  // equality there.
+  ((stp::STP*)vc)->bm->UserFlags.propagate_equalities = false;
 
   Type bv8 = vc_bvType(vc, 8);
   Type bv4 = vc_bvType(vc, 4);

--- a/tests/query-files/array-extensionality-tests/33-get-model-content.smt2
+++ b/tests/query-files/array-extensionality-tests/33-get-model-content.smt2
@@ -8,6 +8,7 @@
 ; observations arrived purely through propagation across the true
 ; equality.
 (set-logic QF_ABV)
+(set-option :produce-models true)
 (declare-fun a () (Array (_ BitVec 1) (_ BitVec 1)))
 (declare-fun b () (Array (_ BitVec 1) (_ BitVec 1)))
 (assert (= a b))

--- a/tests/query-files/array-extensionality-tests/34-get-value-array-rejected.smt2
+++ b/tests/query-files/array-extensionality-tests/34-get-value-array-rejected.smt2
@@ -6,6 +6,7 @@
 ; (get-model prints completed array interpretations instead); scalar
 ; get-value keeps working in the same session.
 (set-logic QF_ABV)
+(set-option :produce-models true)
 (declare-fun a () (Array (_ BitVec 2) (_ BitVec 2)))
 (declare-fun b () (Array (_ BitVec 2) (_ BitVec 2)))
 (declare-fun x () (_ BitVec 2))

--- a/tests/query-files/array-extensionality-tests/76-definitional-store-unsat.smt2
+++ b/tests/query-files/array-extensionality-tests/76-definitional-store-unsat.smt2
@@ -1,0 +1,12 @@
+; RUN: %solver --array-equality %s | %OutputCheck %s
+; CHECK-NEXT: ^unsat
+; A definitional equality (= A (store B i v)) substitutes A away before
+; abstraction; the read of A at i is then v by construction.
+(set-logic QF_ABV)
+(declare-fun A () (Array (_ BitVec 4) (_ BitVec 8)))
+(declare-fun B () (Array (_ BitVec 4) (_ BitVec 8)))
+(declare-fun x () (_ BitVec 4))
+(declare-fun y () (_ BitVec 8))
+(assert (= A (store B x y)))
+(assert (distinct (select A x) y))
+(check-sat)

--- a/tests/query-files/array-extensionality-tests/77-definitional-store-sanity-checked.smt2
+++ b/tests/query-files/array-extensionality-tests/77-definitional-store-sanity-checked.smt2
@@ -1,0 +1,16 @@
+; RUN: %solver --array-equality --check-sanity %s | %OutputCheck %s
+; CHECK-NEXT: ^sat
+; The sanity check re-evaluates the query as submitted, so reads of the
+; substituted symbol and the original whole-array equality must both
+; evaluate through the symbol's definition.
+(set-logic QF_ABV)
+(declare-fun A () (Array (_ BitVec 4) (_ BitVec 8)))
+(declare-fun B () (Array (_ BitVec 4) (_ BitVec 8)))
+(declare-fun x () (_ BitVec 4))
+(declare-fun i () (_ BitVec 4))
+(declare-fun y () (_ BitVec 8))
+(assert (= A (store B x y)))
+(assert (distinct x i))
+(assert (= (select A i) (_ bv7 8)))
+(assert (distinct (select B x) (select A x)))
+(check-sat)

--- a/tests/query-files/array-extensionality-tests/78-definitional-get-model.smt2
+++ b/tests/query-files/array-extensionality-tests/78-definitional-get-model.smt2
@@ -1,0 +1,14 @@
+; RUN: %solver --array-equality %s | %OutputCheck %s
+; CHECK-NEXT: ^sat
+; CHECK-NEXT: ^\($
+; CHECK: define-fun \|A\| \(\) \(Array \(_ BitVec 2\) \(_ BitVec 2\)\).*#b00 #b10\).*#b01 #b11\)
+; A substituted symbol holds exactly what its definition holds: its
+; printed interpretation carries the write's cell (1 -> 3) and the
+; base's observed cell (0 -> 2), in ascending index order.
+(set-logic QF_ABV)
+(declare-fun A () (Array (_ BitVec 2) (_ BitVec 2)))
+(declare-fun B () (Array (_ BitVec 2) (_ BitVec 2)))
+(assert (= A (store B (_ bv1 2) (_ bv3 2))))
+(assert (= (select B (_ bv0 2)) (_ bv2 2)))
+(check-sat)
+(get-model)

--- a/tests/query-files/array-extensionality-tests/78-definitional-get-model.smt2
+++ b/tests/query-files/array-extensionality-tests/78-definitional-get-model.smt2
@@ -6,6 +6,7 @@
 ; printed interpretation carries the write's cell (1 -> 3) and the
 ; base's observed cell (0 -> 2), in ascending index order.
 (set-logic QF_ABV)
+(set-option :produce-models true)
 (declare-fun A () (Array (_ BitVec 2) (_ BitVec 2)))
 (declare-fun B () (Array (_ BitVec 2) (_ BitVec 2)))
 (assert (= A (store B (_ bv1 2) (_ bv3 2))))

--- a/tests/query-files/array-extensionality-tests/79-definitional-chain-unsat.smt2
+++ b/tests/query-files/array-extensionality-tests/79-definitional-chain-unsat.smt2
@@ -1,0 +1,14 @@
+; RUN: %solver --array-equality %s | %OutputCheck %s
+; CHECK-NEXT: ^unsat
+; Chained definitions: A := B feeds C := store(A, x, y); both substitute
+; through, so the read of C at x is y by construction.
+(set-logic QF_ABV)
+(declare-fun A () (Array (_ BitVec 4) (_ BitVec 8)))
+(declare-fun B () (Array (_ BitVec 4) (_ BitVec 8)))
+(declare-fun C () (Array (_ BitVec 4) (_ BitVec 8)))
+(declare-fun x () (_ BitVec 4))
+(declare-fun y () (_ BitVec 8))
+(assert (= A B))
+(assert (= C (store A x y)))
+(assert (distinct (select C x) y))
+(check-sat)

--- a/tests/unit-tests/PropagateEqualities_Test.cpp
+++ b/tests/unit-tests/PropagateEqualities_Test.cpp
@@ -339,6 +339,152 @@ TEST(PropagateEquality_Test, g_Booleans)
   verify(input);
 }
 
+// The propagated conjunction is not always fully constant-folded here, so
+// tests assert the guarantee propagation itself makes: the substituted
+// symbol is gone from the formula.
+static bool containsSymbolNamed(const stp::ASTNode& n, const std::string& s)
+{
+  if (n.GetKind() == stp::SYMBOL)
+    return n.GetName() == s;
+  for (size_t i = 0; i < n.Degree(); i++)
+    if (containsSymbolNamed(n[i], s))
+      return true;
+  return false;
+}
+
+// Whole-array equalities parse to ARRAY_EQ (a kind of its own, gated on
+// enable_array_equality). A top-level asserted (= A (store B x y)) is an
+// equality on the abstract array domain, so substituting A away is sound
+// exactly like the bitvector EQ case. These parse their own QF_ABV
+// prelude and hand the propagated conjunction to a checker WHILE the
+// manager is alive: an ASTNode must not outlive the STPMgr that owns its
+// storage.
+template <typename Check>
+static void propagateArray(const std::string& input, Check check)
+{
+  stp::STPMgr mgr;
+  mgr.UserFlags.enable_array_equality = true;
+  SimplifyingNodeFactory snf(*(mgr.hashingNodeFactory), mgr);
+  mgr.defaultNodeFactory = &snf;
+  stp::Cpp_interface interface(mgr, mgr.defaultNodeFactory);
+
+  interface.startup();
+  stp::GlobalParserBM = &mgr;
+  stp::GlobalParserInterface = &interface;
+
+  stp::SubstitutionMap sm(&mgr);
+  stp::Simplifier simp(&mgr, &sm);
+
+  const std::string prelude = R"(
+  (set-logic QF_ABV)
+  (declare-fun A () (Array (_ BitVec 4) (_ BitVec 8)))
+  (declare-fun B () (Array (_ BitVec 4) (_ BitVec 8)))
+  (declare-fun C () (Array (_ BitVec 4) (_ BitVec 8)))
+  (declare-fun x () (_ BitVec 4))
+  (declare-fun y () (_ BitVec 8))
+  (declare-fun i () (_ BitVec 4))
+  )";
+
+  stp::SMT2ScanString((prelude + input).c_str());
+  stp::SMT2Parse();
+  smt2lex_destroy();
+
+  ASTVec values = mgr.GetAsserts();
+  stp::ASTNode n = values.size() == 1 ? values[0]
+                                      : mgr.CreateNode(stp::AND, values);
+
+  stp::PropagateEqualities propagate(&simp, mgr.defaultNodeFactory, &mgr);
+  propagate.setSpeculativeOn();
+  n = propagate.topLevel(n);
+
+  if (simp.hasUnappliedSubstitutions())
+  {
+    n = simp.applySubstitutionMap(n);
+    simp.haveAppliedSubstitutionMap();
+  }
+  check(n);
+}
+
+TEST(PropagateEquality_Test, array_symbol_eq_write)
+{
+  // (= A (store B x y)) at the top level: A substitutes away everywhere,
+  // including under the unrelated select.
+  propagateArray(R"(
+   (assert (= A (store B x y)))
+   (assert (= (select A i) (_ bv0 8)))
+  )",
+                 [](const stp::ASTNode& n) {
+                   ASSERT_FALSE(containsSymbolNamed(n, "A"));
+                   ASSERT_TRUE(containsSymbolNamed(n, "B"));
+                 });
+}
+
+TEST(PropagateEquality_Test, array_write_eq_symbol)
+{
+  // Same equality with the symbol on the right-hand side.
+  propagateArray(R"(
+   (assert (= (store B x y) A))
+   (assert (= (select A i) (_ bv0 8)))
+  )",
+                 [](const stp::ASTNode& n) {
+                   ASSERT_FALSE(containsSymbolNamed(n, "A"));
+                   ASSERT_TRUE(containsSymbolNamed(n, "B"));
+                 });
+}
+
+TEST(PropagateEquality_Test, array_symbol_eq_symbol)
+{
+  // One of the two array symbols substitutes for the other.
+  propagateArray(R"(
+   (assert (= A B))
+   (assert (= (select A i) (_ bv0 8)))
+   (assert (= (select B x) (_ bv1 8)))
+  )",
+                 [](const stp::ASTNode& n) {
+                   ASSERT_TRUE(!containsSymbolNamed(n, "A") ||
+                               !containsSymbolNamed(n, "B"));
+                 });
+}
+
+TEST(PropagateEquality_Test, array_eq_chain)
+{
+  // A := store(B,..) feeds C := store(A,..): both definitions propagate
+  // through, leaving only B (plus the indices/values).
+  propagateArray(R"(
+   (assert (= A (store B x y)))
+   (assert (= C (store A i y)))
+   (assert (= (select C x) (_ bv0 8)))
+  )",
+                 [](const stp::ASTNode& n) {
+                   ASSERT_FALSE(containsSymbolNamed(n, "A"));
+                   ASSERT_FALSE(containsSymbolNamed(n, "C"));
+                   ASSERT_TRUE(containsSymbolNamed(n, "B"));
+                 });
+}
+
+TEST(PropagateEquality_Test, array_eq_occurs_check)
+{
+  // A appears on both sides; the candidate must be rejected, not looped.
+  propagateArray(R"(
+   (assert (= A (store A x y)))
+  )",
+                 [](const stp::ASTNode& n) {
+                   ASSERT_TRUE(containsSymbolNamed(n, "A"));
+                 });
+}
+
+TEST(PropagateEquality_Test, array_eq_negated_never_propagates)
+{
+  // A disequality asserts nothing substitutable; both symbols survive.
+  propagateArray(R"(
+   (assert (not (= A B)))
+  )",
+                 [](const stp::ASTNode& n) {
+                   ASSERT_TRUE(containsSymbolNamed(n, "A"));
+                   ASSERT_TRUE(containsSymbolNamed(n, "B"));
+                 });
+}
+
 #ifdef STP_ENABLE_FLOATING_POINT
 
 // SMT `=` on floats (FP_SMT_EQ) is true equality on the abstract domain,
@@ -386,20 +532,6 @@ static void propagateFP(const std::string& input, Check check)
     simp.haveAppliedSubstitutionMap();
   }
   check(n);
-}
-
-// The propagated conjunction is not fully constant-folded here (all-constant
-// FP predicates fold in later passes, not at node creation), so the tests
-// assert the guarantee propagation itself makes: the substituted symbol is
-// gone from the formula.
-static bool containsSymbolNamed(const stp::ASTNode& n, const std::string& s)
-{
-  if (n.GetKind() == stp::SYMBOL)
-    return n.GetName() == s;
-  for (size_t i = 0; i < n.Degree(); i++)
-    if (containsSymbolNamed(n[i], s))
-      return true;
-  return false;
 }
 
 TEST(PropagateEquality_Test, fp_smt_eq_constant)


### PR DESCRIPTION
A whole-array equality asserted at the top level with a symbol on either side — `(= A (store B i v))`, `(= A B)` — is a definition. Until now every such equality took the extensionality path: abstraction to a fresh Boolean, witness bundle construction, and lemmas-on-demand refinement. This PR substitutes the symbol away instead, exactly like the bitvector `EQ` case, so the definition costs nothing and the rest of the pipeline (including the plain array path when nothing else needs the checker) sees the smaller formula.

**What changed**

- `PropagateEqualities::buildCandidateList` gets an `ARRAY_EQ` arm. A symbol operand on either side becomes a substitution candidate; the existing occurs check rejects `(= A (store A i v))`. The arm is gated to plain bitvector-sorted arrays: float- and RoundingMode-sorted arrays stay on the abstraction path, because the model-reconstruction code reads cells as plain bits, which is wrong under NaN's many packings and float index canonicalisation.
- `TopLevelSTPAux` runs PropagateEqualities once *before* `lowerArrayEqualities`. That is the only point in a solve where an `ARRAY_EQ` is visible to simplification — lowering abstracts every one immediately afterwards. Negated, nested, and non-definitional equalities lower exactly as before, and eager Ackermann instantiation (#801) then sees only the records that survive.
- The substituted symbol lands in the counterexample map as an array-typed definitional alias (via the solver-map copy). The READ evaluator, `ReadUsingModel`, `CollectArrayNodes` and `GetSortedArrayModelEntries` now follow the alias, and the two counterexample printers skip the alias entry itself. Without this, `--check-sanity` reports a bogus counterexample (the re-checked original query still names the vanished symbol) and `(get-model)` prints the substituted array as all-default.
- Seven API tests in `tests/api/C/array-extensionality.cpp` pin checker internals (record and lemma counters) using definitional equalities; they now set `propagate_equalities = false` so they keep exercising the abstraction path they exist to pin.

**Testing**

- New unit tests in `PropagateEqualities_Test.cpp`: both orientations of symbol = store, symbol = symbol, chained definitions, plus live soundness tests for the occurs check and negated equalities.
- New lit tests `76`–`79` in `array-extensionality-tests`: end-to-end unsat, a `--check-sanity` sat model, exact `(get-model)` cell contents for a substituted array, and chained definitions.
- Full unit + lit suites pass; release build is clean.
- A randomized differential over several hundred generated QF_ABV queries (stores, array ITEs, chains, negated equalities): the substitution path, `--disable-equality` (abstraction path), `--ackermanize`, and `--check-sanity` runs agree on every query, and fuzzed `(get-model)` printing produced no failures.
