### PR TITLE
Fold cheap whole-array equality shapes in the simplifying node factory

### DIFF
--- a/include/stp/NodeFactory/SimplifyingNodeFactory.h
+++ b/include/stp/NodeFactory/SimplifyingNodeFactory.h
@@ -94,6 +94,8 @@ private:
 
   ASTNode chaseRead(const ASTVec& children, unsigned int width);
 
+  ASTNode simplifyArrayEquality(const ASTNode& a, const ASTNode& b);
+
   ASTNode plusRules(const ASTNode& n0, const ASTNode& n1);
 
   //Helper functions

--- a/lib/NodeFactory/SimplifyingNodeFactory.cpp
+++ b/lib/NodeFactory/SimplifyingNodeFactory.cpp
@@ -554,23 +554,35 @@ ASTNode SimplifyingNodeFactory::CreateNode(Kind kind, const ASTVec& children)
       result = CreateSimpleFormITE(children);
       break;
     case EQ:
-      // Whole-array equality is opaque until the solve-boundary lowering
-      // pass. Do not run bit-vector equality rewrites over array operands.
+      // Whole-array equality is near-opaque until the solve-boundary
+      // lowering pass: reflexivity and the structural rules in
+      // simplifyArrayEquality apply, but no bit-vector equality rewrite
+      // may run over array operands. The hashing factory owns both the
+      // conversion to ARRAY_EQ and the rejection when --array-equality is
+      // off, so the rules only run once the node is legal to build.
       if (children.size() == 2 && children[0].GetIndexWidth() > 0)
-        result = children[0] == children[1]
-                     ? bm.ASTTrue
-                     : hashing.CreateNode(EQ, children);
+      {
+        if (children[0] == children[1])
+          result = bm.ASTTrue;
+        else if (bm.UserFlags.enable_array_equality)
+          result = simplifyArrayEquality(children[0], children[1]);
+        if (result.IsNull())
+          result = hashing.CreateNode(EQ, children);
+      }
       else
         result = CreateSimpleEQ(children);
       break;
     case ARRAY_EQ:
       assert(children.size() == 2);
-      // ARRAY_EQ is deliberately opaque to ordinary simplification. The one
-      // theory-independent reduction is reflexivity; every other instance
-      // must survive until the extensionality lowering pass.
-      result = children[0] == children[1]
-                   ? bm.ASTTrue
-                   : hashing.CreateNode(ARRAY_EQ, children);
+      // ARRAY_EQ is deliberately near-opaque to ordinary simplification:
+      // reflexivity and the structural rules apply; every other
+      // instance must survive until the extensionality lowering pass.
+      if (children[0] == children[1])
+        result = bm.ASTTrue;
+      else
+        result = simplifyArrayEquality(children[0], children[1]);
+      if (result.IsNull())
+        result = hashing.CreateNode(ARRAY_EQ, children);
       break;
     case stp::IFF:
     {
@@ -1452,6 +1464,85 @@ ASTNode SimplifyingNodeFactory::chaseRead(const ASTVec& children,
     write = write[0];
   }
   return hashing.CreateTerm(stp::READ, width, write, readIndex);
+}
+
+namespace
+{
+// The whole-array equality rules only fire over arrays whose cells and
+// indexes are plain bitvectors. Floating-point cells are equal modulo the
+// NaN quotient and rounding-mode cells only denote through the five one-hot
+// patterns, so for those element sorts a bit-level read equality is not
+// cell equality; non-bitvector index sorts additionally quotient their
+// index patterns. All of that belongs to the extensionality lowering's
+// witness machinery, which handles it explicitly.
+bool isPlainBitvectorArray(const ASTNode& n)
+{
+  const stp::SourceSort sort = n.GetSourceSort();
+  return sort.kind() == stp::SourceSort::Kind::Array &&
+         sort.index().kind() == stp::SourceSort::Kind::BitVector &&
+         sort.element().kind() == stp::SourceSort::Kind::BitVector;
+}
+}
+
+// Structural rules for whole-array equality, applied where the equality
+// has a complete quantifier-free meaning over the existing terms and the
+// rewrite cannot grow the formula: no rule here creates reads or expands
+// write chains. Everything else stays an opaque ARRAY_EQ for the
+// extensionality lowering, whose witness abstraction is the general
+// decision procedure -- in particular, eagerly reducing write chains to
+// read equalities is a decision-procedure choice that belongs at the
+// solve boundary, beside the machinery it would be trading against.
+// Returns null when no rule applies.
+ASTNode SimplifyingNodeFactory::simplifyArrayEquality(const ASTNode& a,
+                                                      const ASTNode& b)
+{
+  assert(a != b); // Callers fold reflexivity first.
+
+  if (!isPlainBitvectorArray(a) || !isPlainBitvectorArray(b))
+    return ASTNode();
+
+  // Both sides overwrite the same index of the same array: off that
+  // index both sides are that array, at it they hold the written
+  // values, so the equality is exactly the values' equality.
+  //   write(A,i,v) = write(A,i,w)  <=>  v = w
+  // Chains sharing a longer prefix are the same shape: hash-consing
+  // makes equal sub-chains one node, which appears here as A.
+  if (a.GetKind() == stp::WRITE && b.GetKind() == stp::WRITE &&
+      a[0] == b[0] && a[1] == b[1])
+  {
+    ASTVec values;
+    values.push_back(a[2]);
+    values.push_back(b[2]);
+    return CreateSimpleEQ(values);
+  }
+
+  // An array ITE equated with one of its own branches: the matching arm
+  // holds by reflexivity, leaving the choice of that arm or the other
+  // branch's equality.
+  //   ite(c,X,Y) = X  <=>  c OR (Y = X)
+  //   ite(c,X,Y) = Y  <=>  (NOT c) OR (X = Y)
+  for (int orientation = 0; orientation < 2; orientation++)
+  {
+    const ASTNode& iteNode = (orientation == 0) ? a : b;
+    const ASTNode& other = (orientation == 0) ? b : a;
+    if (iteNode.GetKind() != ITE)
+      continue;
+    const bool thenMatches = iteNode[1] == other;
+    const bool elseMatches = iteNode[2] == other;
+    if (!thenMatches && !elseMatches)
+      continue;
+    const ASTNode& residualBranch = thenMatches ? iteNode[2] : iteNode[1];
+    if (residualBranch.GetSourceSort() != other.GetSourceSort())
+      continue; // The hashing factory rejects mismatched-sort equalities.
+    ASTVec disjuncts;
+    disjuncts.push_back(thenMatches ? iteNode[0]
+                                    : CreateSimpleNot(iteNode[0]));
+    disjuncts.push_back(
+        NodeFactory::CreateNode(ARRAY_EQ, residualBranch, other));
+    return CreateSimpleAndOr(0, disjuncts);
+  }
+
+  return ASTNode();
 }
 
 // This gets called with the arguments swapped as well. So the rules don't need

--- a/tests/query-files/array-extensionality-tests/70-factory-same-index-values-forced.smt2
+++ b/tests/query-files/array-extensionality-tests/70-factory-same-index-values-forced.smt2
@@ -1,0 +1,13 @@
+; RUN: %solver --array-equality %s | %OutputCheck %s
+; CHECK-NEXT: ^unsat
+; Both sides overwrite the same index of the same base, so the equality
+; forces exactly the written values equal. The simplifying factory folds
+; this at construction into v = w; no witness machinery is involved.
+(set-logic QF_ABV)
+(declare-fun a () (Array (_ BitVec 8) (_ BitVec 8)))
+(declare-fun i () (_ BitVec 8))
+(declare-fun v () (_ BitVec 8))
+(declare-fun w () (_ BitVec 8))
+(assert (= (store a i v) (store a i w)))
+(assert (distinct v w))
+(check-sat)

--- a/tests/query-files/array-extensionality-tests/71-factory-commuted-symbolic-writes.smt2
+++ b/tests/query-files/array-extensionality-tests/71-factory-commuted-symbolic-writes.smt2
@@ -1,0 +1,16 @@
+; RUN: %solver --array-equality %s | %OutputCheck %s
+; CHECK-NEXT: ^unsat
+; The same two writes over one base in swapped order, with symbolic
+; indexes asserted distinct: extensionally equal, so denying the
+; equality is unsatisfiable. The chains share a base but not a common
+; write prefix, so the equality stays opaque and the witness
+; machinery's refinement decides it.
+(set-logic QF_ABV)
+(declare-fun a () (Array (_ BitVec 8) (_ BitVec 8)))
+(declare-fun i () (_ BitVec 8))
+(declare-fun j () (_ BitVec 8))
+(declare-fun v () (_ BitVec 8))
+(declare-fun w () (_ BitVec 8))
+(assert (distinct i j))
+(assert (distinct (store (store a i v) j w) (store (store a j w) i v)))
+(check-sat)

--- a/tests/query-files/array-extensionality-tests/72-factory-ite-branch-equality-unsat.smt2
+++ b/tests/query-files/array-extensionality-tests/72-factory-ite-branch-equality-unsat.smt2
@@ -1,0 +1,14 @@
+; RUN: %solver --array-equality %s | %OutputCheck %s
+; CHECK-NEXT: ^unsat
+; An array ITE equated with its own then-branch reduces to the condition
+; or the else-branch's equality. With the condition denied, the branches
+; must be pointwise equal, contradicting the differing cell.
+(set-logic QF_ABV)
+(declare-fun a () (Array (_ BitVec 8) (_ BitVec 8)))
+(declare-fun b () (Array (_ BitVec 8) (_ BitVec 8)))
+(declare-fun c () Bool)
+(declare-fun k () (_ BitVec 8))
+(assert (= (ite c a b) a))
+(assert (not c))
+(assert (distinct (select a k) (select b k)))
+(check-sat)

--- a/tests/query-files/array-extensionality-tests/73-factory-ite-branch-equality-sat.smt2
+++ b/tests/query-files/array-extensionality-tests/73-factory-ite-branch-equality-sat.smt2
@@ -1,0 +1,13 @@
+; RUN: %solver --array-equality %s | %OutputCheck %s
+; CHECK-NEXT: ^sat
+; The same shape is satisfiable when the condition may hold: choosing
+; the then-branch discharges the equality by reflexivity, leaving the
+; differing cell free to differ.
+(set-logic QF_ABV)
+(declare-fun a () (Array (_ BitVec 8) (_ BitVec 8)))
+(declare-fun b () (Array (_ BitVec 8) (_ BitVec 8)))
+(declare-fun c () Bool)
+(declare-fun k () (_ BitVec 8))
+(assert (= (ite c a b) a))
+(assert (distinct (select a k) (select b k)))
+(check-sat)

--- a/tests/query-files/array-extensionality-tests/74-factory-divergence-only-at-overwritten-index.smt2
+++ b/tests/query-files/array-extensionality-tests/74-factory-divergence-only-at-overwritten-index.smt2
@@ -1,0 +1,14 @@
+; RUN: %solver --array-equality %s | %OutputCheck %s
+; CHECK-NEXT: ^sat
+; Distinct bases stay with the witness machinery: the writes force the
+; arrays to agree everywhere except the overwritten index, so a model
+; must place the differing cell exactly there.
+(set-logic QF_ABV)
+(declare-fun a () (Array (_ BitVec 8) (_ BitVec 8)))
+(declare-fun b () (Array (_ BitVec 8) (_ BitVec 8)))
+(declare-fun i () (_ BitVec 8))
+(declare-fun j () (_ BitVec 8))
+(declare-fun v () (_ BitVec 8))
+(assert (= (store a i v) (store b i v)))
+(assert (distinct (select a j) (select b j)))
+(check-sat)


### PR DESCRIPTION
Two structural rules for whole-array equality, applied at node construction to both `EQ`-over-arrays (gated on `--array-equality`; the hashing factory keeps ownership of the flag rejection and the `ARRAY_EQ` conversion) and `ARRAY_EQ`. Both are restricted to arrays whose index and element sorts are plain bitvectors.

**Same array, same index:** `write(A,i,v) = write(A,i,w)` folds to `v = w`. Off the shared index both sides are `A`, so the equality holds exactly when the written values agree. Hash-consing folds equal longer write prefixes into one node, so chains that differ only in the outermost written value reduce the same way.

**Array ITE against its own branch:** `ite(c,X,Y) = X` folds to `c OR (Y = X)` (dually for the else branch). It fires only when a branch syntactically matches the other operand, so the matching arm discharges by reflexivity and the rewrite never duplicates an opaque equality.

Neither rule creates reads or grows the formula, and equalities they decide never mint an abstraction variable or witness bundle, so they skip the refinement loop entirely. Floating-point and rounding-mode element sorts are excluded because bit-level value equality is not cell equality there (the NaN quotient, one-hot rounding-mode denotation); those and every other shape continue to the extensionality lowering unchanged. In particular, eagerly reducing whole write chains to read equalities is deliberately *not* done here — that is an eager-vs-lazy decision-procedure trade that belongs at the solve boundary beside the existing machinery.

Five new tests in `tests/query-files/array-extensionality-tests` cover both folds (unsat and sat directions) and pin the shapes that must keep going through refinement: commuted write chains, and distinct-base equalities whose model must place the arrays' divergence exactly at the overwritten index. Full test suite passes (ctest and lit, debug build with assertions).