### PR TITLE
Copy CounterExampleMap entries before recursing on them

### DIFF
--- a/lib/AbsRefineCounterExample/CounterExample.cpp
+++ b/lib/AbsRefineCounterExample/CounterExample.cpp
@@ -301,7 +301,11 @@ AbsRefine_CounterExample::TermToConstTermUsingModel_inner(const ASTNode& term,
   ASTNodeMap::const_iterator it1;
   if ((it1 = CounterExampleMap.find(term)) != CounterExampleMap.end())
   {
-    const ASTNode& val = it1->second;
+    // A copy, never a reference into the map: the recursion below can reach
+    // an array equality, whose ModelQuery guard rolls CounterExampleMap back
+    // by whole-map assignment -- freeing every node, including the one a
+    // reference here would still be aliasing when the recursion returns.
+    const ASTNode val = it1->second;
     if (BVCONST != val.GetKind())
     {
       // CounterExampleMap has two maps rolled into
@@ -518,10 +522,10 @@ AbsRefine_CounterExample::TermToConstTermUsingModel_inner(const ASTNode& term,
       ASTNode modelentry;
       if (CounterExampleMap.find(index) != CounterExampleMap.end())
       {
-        // index has a const value in the CounterExampleMap
-        // ASTNode indexVal = CounterExampleMap[index];
-        ASTNode indexVal =
-            TermToConstTermUsingModel(CounterExampleMap[index], ArrayReadFlag);
+        // index has a const value in the CounterExampleMap. Copied out of the
+        // map for the reason given at the lookup at the top of this function.
+        const ASTNode indexEntry = CounterExampleMap[index];
+        ASTNode indexVal = TermToConstTermUsingModel(indexEntry, ArrayReadFlag);
         modelentry =
             bm->CreateTerm(READ, arrName.GetValueWidth(), arrName, indexVal);
       }
@@ -538,11 +542,13 @@ AbsRefine_CounterExample::TermToConstTermUsingModel_inner(const ASTNode& term,
       // modelentry is now an arrayread over a constant index
       BVTypeCheck(modelentry);
 
-      // if a value exists in the CounterExampleMap then return it
+      // if a value exists in the CounterExampleMap then return it. Copied out
+      // of the map for the reason given at the lookup at the top of this
+      // function.
       if (CounterExampleMap.find(modelentry) != CounterExampleMap.end())
       {
-        output = TermToConstTermUsingModel(CounterExampleMap[modelentry],
-                                           ArrayReadFlag);
+        const ASTNode modelentryValue = CounterExampleMap[modelentry];
+        output = TermToConstTermUsingModel(modelentryValue, ArrayReadFlag);
       }
       else if (ArrayReadFlag)
       {
@@ -688,7 +694,9 @@ AbsRefine_CounterExample::Expand_ReadOverWrite_UsingModel(const ASTNode& term,
   ASTNodeMap::iterator it1;
   if ((it1 = CounterExampleMap.find(term)) != CounterExampleMap.end())
   {
-    const ASTNode& val = it1->second;
+    // Copied out of the map for the reason given at the lookup at the top of
+    // TermToConstTermUsingModel_inner.
+    const ASTNode val = it1->second;
     if (BVCONST != val.GetKind())
     {
       // recursion is fine here. There are two maps that are checked

--- a/tests/query-files/array-extensionality-tests/76-equality-inside-substituted-definition.smt2
+++ b/tests/query-files/array-extensionality-tests/76-equality-inside-substituted-definition.smt2
@@ -1,0 +1,25 @@
+; RUN: %solver --array-equality -d %s | %OutputCheck %s
+; CHECK: ^sat
+; A whole-array disequality buried inside a definition of x, checked
+; against the model with -d.
+;
+; Counterexample evaluation memoises through CounterExampleMap, and
+; TermToConstTermUsingModel recursed on a looked-up definition by
+; reference into the map. Evaluating an array equality mid-walk enters
+; ArraysEqualUsingModel, whose ModelQuery guard restores the map by
+; whole-map assignment when it returns -- freeing every node, including
+; the one the suspended outer frame was still aliasing. The evaluator
+; now copies each entry out of the map before recursing on it.
+;
+; Today the equality below reaches the guard only after evaluation has
+; finished, via recheckCertifiedEqualities, where no frame is
+; suspended. Running PropagateEqualities before lowerArrayEqualities --
+; which the array-equality substitution work does -- moves x's whole
+; definition into the substitution map with the disequality still
+; inside it, and this query then segfaulted under the reference.
+(declare-fun x () (_ BitVec 8))
+(declare-fun i () (_ BitVec 4))
+(declare-fun A () (Array (_ BitVec 4) (_ BitVec 8)))
+(declare-fun B () (Array (_ BitVec 4) (_ BitVec 8)))
+(assert (= ((_ zero_extend 7) (ite (distinct (store A i (_ bv7 8)) B) (_ bv1 1) (_ bv0 1))) x))
+(check-sat)


### PR DESCRIPTION
Counterexample evaluation recursed on a looked-up definition **by reference into `CounterExampleMap`**. Evaluating a whole-array equality mid-walk enters `ArraysEqualUsingModel`, whose `ModelQuery` guard restores the map by whole-map assignment on return — freeing every node in it, including the one the suspended outer frame was still aliasing. Evaluation then resumed on freed memory.

No input is known to reach that window on master today: the guard runs from `recheckCertifiedEqualities` and from the model-query entry points, in both cases after or outside any suspended evaluation frame. But running `PropagateEqualities` before `lowerArrayEqualities` — which the in-flight array-equality substitution work does — moves a definition into the substitution map with a whole-array disequality still inside it, and the added test then segfaults deterministically under that ordering (caught by mimalloc's debug fill: the suspended frame's `_int_node_ptr` reads back as `0xdfdf…`). Found by fuzzing that branch (QF_ABV with `--array-equality` and `-d`).

The fix copies each entry out of the map before recursing on it, at the four sites that recursed on map storage (`TermToConstTermUsingModel_inner`'s memo lookup, the two READ-case `operator[]` uses, and `Expand_ReadOverWrite_UsingModel`'s lookup). An `ASTNode` is a refcounted pointer, so each copy is a refcount bump that keeps the node alive whatever happens to the map's own storage. `ComputeFormulaUsingModel`'s lookup already returns without recursing, so it is unchanged.

Verified:
- The full test suite passes (106 ctest targets, 458 lit query files).
- The originating fuzz batch — 2500 QF_ABV queries under `--array-equality -d` on the substitution branch — previously segfaulted at query 2135 and now answers all 2500 byte-identically to z3.
