### PR TITLE
Stack safety (3/14): AST: flatten a same-kind chain and count reads without the call stack

### DIFF
--- a/include/stp/FloatBlaster/FpTotalise.h
+++ b/include/stp/FloatBlaster/FpTotalise.h
@@ -27,6 +27,7 @@ THE SOFTWARE.
 
 #include "stp/AST/AST.h"
 #include "stp/STPManager/STPManager.h"
+#include "stp/Util/DagWalk.h"
 
 namespace stp
 {
@@ -120,6 +121,11 @@ public:
 private:
   ASTNode visit(const ASTNode& n);
 
+  // The pass proper, for one node whose children visit() has already
+  // answered. Split out so that visit() can fill those answers from the
+  // bottom up rather than by calling itself once per level.
+  ASTNode totalise(const ASTNode& n, bool knownMissing = false);
+
   // The canonical form of an index over a float-indexed array whose index
   // format is (exp_width, sig_width): constants re-intern through the
   // canonicalising constant funnel, source FP expressions become an explicit
@@ -168,6 +174,9 @@ private:
 
   STPMgr* bm;
   NodeFactory* nf;
+
+  // Debug-only: verify that priming keeps visit's call depth bounded.
+  PrimeAudit memoAudit{"FpTotalise::visit", 8};
   // `traversal_cache` preserves DAG sharing only for one topLevel walk and is
   // released immediately afterwards. `persistent_cache` keeps just the
   // source FP/array nodes whose encoding changed and may be requested again

--- a/include/stp/Simplifier/Flatten.h
+++ b/include/stp/Simplifier/Flatten.h
@@ -54,6 +54,12 @@ class Flatten
 
   // sharecount is 1 if the node has one reference in the tree.
   void buildShareCount(const ASTNode& n);
+
+  // flatten() walks the DAG with its frames on the heap: the input decides
+  // how deep the walk goes, so a call per level exhausts the stack on the
+  // deeply nested formulas that exist. See DeepDag_Test.cpp.
+  struct Frame;
+  bool alreadyKnown(const ASTNode& n, ASTNode& answer);
   ASTNode flatten(const ASTNode& n, bool top=false);
 
 public:

--- a/include/stp/Simplifier/NodeDomainAnalysis.h
+++ b/include/stp/Simplifier/NodeDomainAnalysis.h
@@ -34,6 +34,7 @@ THE SOFTWARE.
 #include "stp/Simplifier/constantBitP/FixedBits.h"
 #include "stp/Simplifier/UnsignedIntervalAnalysis.h"
 #include "stp/Simplifier/ValueSetAnalysis.h"
+#include "stp/Util/DagWalk.h"
 #include <iostream>
 #include <unordered_map>
 
@@ -57,6 +58,18 @@ using NodeToValueSetMap =
 class NodeDomainAnalysis
 {
   STPMgr& bm;
+
+  // Shallow inputs keep buildMap's ordinary recursive path: walking the DAG
+  // once to prime a memo costs more than the stack it saves there. Once the
+  // prefix reaches this budget, primeMaps fills the suffix bottom-up and the
+  // bounded prefix unwinds normally.
+  static constexpr size_t unprimedDepthLimit = 512;
+  size_t unprimedDepth = 0;
+
+  // Debug-only: verify that the deliberately recursive prefix is bounded and
+  // priming answers every call made below it.
+  PrimeAudit mapAudit{"NodeDomainAnalysis::buildMap",
+                      unprimedDepthLimit + 8};
 
   // Cache read-only empty objects of different sizes.
   FixedBits* emptyBoolean;
@@ -92,6 +105,10 @@ public:
     ValueSet* set;
   };
 
+private:
+  DomainInfo buildMap(const ASTNode& n, bool knownMissing);
+
+public:
   NodeDomainAnalysis(STPMgr* _bm)
       : bm(*_bm), intervalAnalysis(*_bm), valueSetAnalysis(*_bm)
   {
@@ -141,6 +158,13 @@ public:
    }
 
   DomainInfo buildMap(const ASTNode& n);
+
+  // buildMap reaches a node's children by calling itself, so a deeply nested
+  // input exhausts the stack. Once the shallow recursion budget above is
+  // exhausted, fill the remaining maps from the bottom up, and those calls
+  // answer from the map instead. See DeepDag_Test.cpp.
+  void primeMaps(const ASTNode& n);
+  bool priming = false;
 
   void topLevel(const ASTNode& top)
   {

--- a/include/stp/Simplifier/PropagateEqualities.h
+++ b/include/stp/Simplifier/PropagateEqualities.h
@@ -72,6 +72,7 @@ private:
   IdSet alreadyVisited;
 
   void buildCandidateList(const ASTNode& a);
+  bool buildCandidateListNode(const ASTNode& a);
   void replaceIfPossible(int line, ASTNode& output, const ASTNode& lhs, const ASTNode& rhs);
   void buildXORCandidates(const ASTNode a, bool negated);
   

--- a/include/stp/Simplifier/Rewriting.h
+++ b/include/stp/Simplifier/Rewriting.h
@@ -49,6 +49,13 @@ class Rewriting
 
   // sharecount is 1 if the node has one reference in the tree.
   void buildShareCount(const ASTNode& n);
+  ASTNode applyRules(ASTNode c);
+
+  // rewrite() walks the DAG with its frames on the heap: the input decides
+  // how deep the walk goes, so a call per level exhausts the stack on the
+  // deeply nested formulas that exist. See DeepDag_Test.cpp.
+  struct Frame;
+  bool alreadyKnown(const ASTNode& n, ASTNode& answer);
   ASTNode rewrite(const ASTNode& n);
 
 public:

--- a/include/stp/Simplifier/VariablesInExpression.h
+++ b/include/stp/Simplifier/VariablesInExpression.h
@@ -28,6 +28,7 @@ THE SOFTWARE.
 #include "Symbols.h"
 #include "stp/AST/AST.h"
 #include "stp/Util/Attributes.h"
+#include "stp/Util/DagWalk.h"
 
 namespace stp
 {
@@ -36,9 +37,13 @@ class VariablesInExpression
 {
 private:
   void insert(const ASTNode& n, Symbols* s);
+  Symbols* getSymbol(const ASTNode& n, bool knownMissing);
 
   typedef std::unordered_map<uint64_t, Symbols*> ASTNodeToNodes;
   ASTNodeToNodes symbol_graph;
+
+  // Debug-only: verify that priming keeps getSymbol's call depth bounded.
+  PrimeAudit symbolAudit{"VariablesInExpression::getSymbol", 8};
 
 public:
   DLL_PUBLIC VariablesInExpression();
@@ -52,6 +57,12 @@ public:
   typedef std::unordered_set<Symbols*, SymbolPtrHasher> SymbolPtrSet;
 
   Symbols* getSymbol(const ASTNode& n);
+
+  // getSymbol reaches a node's children by calling itself, so a deeply
+  // nested input exhausts the stack. Fill symbol_graph from the bottom up
+  // first, and those calls answer from it instead. See DeepDag_Test.cpp.
+  void primeSymbols(const ASTNode& n);
+  bool priming = false;
 
   // this map is useful while traversing terms and uniquely
   // identifying variables in the those terms. Prevents double

--- a/include/stp/ToSat/BitBlaster.h
+++ b/include/stp/ToSat/BitBlaster.h
@@ -28,6 +28,7 @@ THE SOFTWARE.
 #include "stp/STPManager/STPManager.h"
 #include "stp/Simplifier/constantBitP/MultiplicationStats.h"
 #include "stp/ToSat/BBNodeManagerAIG.h"
+#include "stp/Util/DagWalk.h"
 #include <cassert>
 #include <cmath>
 #include <list>
@@ -282,6 +283,28 @@ class BitBlaster
   void updateForm(const ASTNode& n, BBNode& bb, BBNodeSet& support);
 
   const BBNode BBForm(const ASTNode& form, BBNodeSet& support);
+  const BBNode BBForm(const ASTNode& form, BBNodeSet& support,
+                      bool knownMissing);
+  const BBNodeVec BBTerm(const ASTNode& term, BBNodeSet& support,
+                         bool knownMissing);
+
+  // BBForm and BBTerm both blast a node's operands by calling themselves, so
+  // input nested deeply enough takes the stack with it. Shallow inputs keep
+  // the ordinary recursive path: starting an extra walk at their root costs
+  // more than the stack it saves. Once the shared formula/term recursion
+  // budget is exhausted, primeMemos fills both memos below that point and the
+  // bounded recursive prefix unwinds normally. One walk covers both memos
+  // because the two functions reach each other. See DeepDag_Test.cpp.
+  void primeMemos(const ASTNode& n, BBNodeSet& support);
+  static constexpr size_t unprimedDepthLimit = 512;
+  size_t unprimedDepth = 0;
+  bool priming = false;
+
+  // Debug-only: the deliberately recursive prefix plus the small amount of
+  // recursion used while processing nodes created during priming. Empty and
+  // free in a build with NDEBUG. The suffix itself must still answer from one
+  // of the two memos rather than nesting with the input.
+  PrimeAudit memoAudit{"BitBlaster", unprimedDepthLimit + 32};
 
   bool isConstant(const BBNodeVec& v);
   ASTNode getConstant(const BBNodeVec& v, const ASTNode& n);
@@ -308,7 +331,7 @@ public:
   // bitvector term.  Result is a ref to a vector of formula nodes
   // representing the boolean formula.
   const BBNodeVec BBTerm(const ASTNode& term, BBNodeSet& support);
-  
+
   std::unordered_map<ASTNode, BBNodeVec, ASTNode::ASTNodeHasher, ASTNode::ASTNodeEqual>::iterator
   simplify_during_bb(ASTNode& term, BBNodeSet& support);
 

--- a/include/stp/Util/DagWalk.h
+++ b/include/stp/Util/DagWalk.h
@@ -1,0 +1,208 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#ifndef DAGWALK_H_
+#define DAGWALK_H_
+
+#include "stp/AST/ASTNode.h"
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+namespace stp
+{
+
+// Visit an immutable AST in left-to-right pre-order. `enter` is called once
+// for each occurrence the walk reaches and returns whether that occurrence's
+// children should be traversed. This lets a caller apply its own DAG memo or
+// prune at a kind-specific boundary.
+//
+// Keep only the current node inline and suspended ancestors in `parents`.
+// A wide node whose children are leaves or pruned needs no allocation, and
+// the auxiliary memory of every other shape is O(depth), not O(frontier).
+template <class Enter>
+void walkPreOrder(const ASTNode& top, Enter enter)
+{
+  if (!enter(top) || top.Degree() == 0)
+    return;
+
+  struct Frame
+  {
+    const ASTNode* node;
+    size_t nextChild = 0;
+  };
+
+  Frame current{&top};
+  std::vector<Frame> parents;
+
+  while (true)
+  {
+    if (current.nextChild < current.node->Degree())
+    {
+      const ASTNode* child = &(*current.node)[current.nextChild++];
+      if (!enter(*child) || child->Degree() == 0)
+        continue;
+
+      parents.push_back(current);
+      current = Frame{child};
+      continue;
+    }
+
+    if (parents.empty())
+      return;
+    current = parents.back();
+    parents.pop_back();
+  }
+}
+
+// Rebuild a DAG bottom up, without putting the walk on the call stack.
+//
+// How deeply a formula nests is the input's choice, and inputs that nest
+// thousands deep exist, so a pass that recurses once per level dies on them.
+// This is the shape most of those passes have: visit a node's children, hand
+// the node and its rebuilt children to `combine`, and use what comes back in
+// place of the node. Frames live on the heap, so depth costs memory rather
+// than stack.
+//
+// `combine(node, children)` returns the replacement for `node`. It is called
+// once per node, after all of that node's children have been combined, and in
+// left-to-right order, so it sees exactly what the equivalent recursive
+// function saw and may call the node factory freely.
+//
+// `cache` maps a node to its replacement. A node reached twice is combined
+// once, and a cache that outlives the call carries answers between calls. It
+// needs find(), end() and insert(pair), which both ASTNodeMap and
+// DenseNodeMap provide. Leaves have nothing to rebuild: they are returned as
+// they are and are not cached.
+//
+// `combine` is a template parameter rather than a std::function so that it
+// inlines: this runs once per node, and an indirect call per node would be a
+// real cost on ordinary shallow input.
+template <class Cache, class Combine>
+ASTNode postOrderRebuild(const ASTNode& top, Cache& cache, Combine combine)
+{
+  // One node's progress: where its children begin in the shared LIFO arena,
+  // and how far along its own child list it has got. Keeping an ASTVec in
+  // every suspended frame allocated once per level on ordinary inputs.
+  struct Frame
+  {
+    ASTNode n;
+    size_t childrenBegin;
+    size_t i = 0;
+    bool waiting = false; // a child is being combined below.
+
+    Frame(const ASTNode& node, const size_t begin)
+        : n(node), childrenBegin(begin)
+    {
+    }
+  };
+
+  ASTNode result;
+
+  // Results already collected by every suspended frame. A child frame owns
+  // the suffix beginning at childrenBegin; when it completes, that suffix is
+  // moved through one reusable vector for combine and then replaced by the
+  // child's single result in its parent.
+  ASTVec activeChildren;
+  ASTVec combinedChildren;
+
+  // Answers that need no frame, which is what the recursive form answered
+  // without a call.
+  auto known = [&cache, &result](const ASTNode& n) -> bool {
+    if (n.Degree() == 0)
+    {
+      result = n;
+      return true;
+    }
+
+    const auto it = cache.find(n);
+    if (it != cache.end())
+    {
+      result = it->second;
+      return true;
+    }
+    return false;
+  };
+
+  if (known(top))
+    return result;
+
+  // A deque, so descending never moves the frames above it: `current` stays
+  // valid across a push.
+  std::deque<Frame> stack;
+  stack.emplace_back(top, activeChildren.size());
+
+  while (true)
+  {
+    Frame& current = stack.back();
+
+    if (current.waiting)
+    {
+      current.waiting = false;
+      activeChildren.push_back(result);
+      current.i++;
+    }
+
+    bool descended = false;
+    while (current.i < current.n.Degree())
+    {
+      if (known(current.n[current.i]))
+      {
+        activeChildren.push_back(result);
+        current.i++;
+        continue;
+      }
+
+      // Nothing above may be read after this push.
+      current.waiting = true;
+      stack.emplace_back(current.n[current.i], activeChildren.size());
+      descended = true;
+      break;
+    }
+
+    if (descended)
+      continue;
+
+    assert(activeChildren.size() - current.childrenBegin ==
+           current.n.Degree());
+    combinedChildren.clear();
+    combinedChildren.insert(
+        combinedChildren.end(),
+        std::make_move_iterator(activeChildren.begin() +
+                                current.childrenBegin),
+        std::make_move_iterator(activeChildren.end()));
+    activeChildren.resize(current.childrenBegin);
+
+    result = combine(current.n, combinedChildren);
+    combinedChildren.clear();
+    cache.insert({current.n, result});
+
+    stack.pop_back();
+    if (stack.empty())
+      return result;
+  }
+}
+}
+
+#endif /* DAGWALK_H_ */

--- a/include/stp/Util/DagWalk.h
+++ b/include/stp/Util/DagWalk.h
@@ -26,12 +26,27 @@ THE SOFTWARE.
 #define DAGWALK_H_
 
 #include "stp/AST/ASTNode.h"
-#include <cstddef>
+#include <cassert>
+#include <cstdint>
+#include <deque>
+#include <iostream>
+#include <iterator>
+#include <optional>
+#include <sstream>
+#include <string>
 #include <utility>
 #include <vector>
 
 namespace stp
 {
+
+// What primeMemo should do with a node it has reached.
+enum class Walk
+{
+  Descend, // walk this node's children, then hand it to visit
+  Visit,   // hand it to visit without walking its children
+  Skip     // ignore it: already done, or the pass never looks at it
+};
 
 // Visit an immutable AST in left-to-right pre-order. `enter` is called once
 // for each occurrence the walk reaches and returns whether that occurrence's
@@ -74,6 +89,373 @@ void walkPreOrder(const ASTNode& top, Enter enter)
     current = parents.back();
     parents.pop_back();
   }
+}
+
+// Whether a pass whose memo is primed still nests with its input.
+//
+// That is the whole of what priming buys: the pass's calls on its operands
+// answer from the memo, so its own recursion is a couple of levels whatever
+// the input nests to. It buys it only where the walk reaches the nodes the
+// pass reaches, and nothing in the type system says a pass qualifies -- the
+// preconditions live in a comment on primeMemo below and in whoever reads it.
+//
+// So the pass reports the nodes it runs, and the depth they reach is held
+// against what the pass claims. A classify() or an operands() that stops
+// short of a subtree does not stop the pass going there: it goes down its own
+// call stack for it, one frame per level, which is the crash priming exists
+// to prevent -- and which nothing in the output can show, because the answer
+// is the same. This is the check for that, and it runs on every query an
+// assertions build sees rather than on the ones somebody remembers to
+// measure.
+//
+// The depth a pass is allowed is its own claim, made where it declares its
+// audit. It is not one or two: a pass legitimately re-enters on nodes it has
+// just built -- a rewritten node, a pulled-up if-then-else -- and those calls
+// nest as deeply as the rewriting does, which is a property of the rules and
+// not of the input. What it may not do is nest in proportion to the input,
+// and the gap between those two is wide enough to sit a limit in.
+//
+// What this does not check is the other half: priming that reaches more than
+// the pass would have, which costs nodes that do not otherwise exist rather
+// than stack. That one is invisible from inside a primed run -- priming *is*
+// the pass running, so every node primed has, by then, been reached. What
+// catches it is the generated CNF: a manufactured node shifts every node
+// number after it, so the clauses move.
+#ifndef NDEBUG
+class PrimeAudit
+{
+  const char* pass;
+  size_t limit;
+
+  size_t running = 0; // how deep the pass's own calls are nested
+  size_t deepest = 0;
+
+public:
+  // `pass_` names the pass in a report, `limit_` is how deeply it says it
+  // nests once its memo is primed.
+  PrimeAudit(const char* pass_, const size_t limit_)
+      : pass(pass_), limit(limit_)
+  {
+  }
+
+  // The pass is running `n`, from whatever it was running before. One of
+  // these at the head of the pass's own entry point is the whole instrument.
+  class Running
+  {
+    PrimeAudit& audit;
+
+  public:
+    Running(PrimeAudit& audit_, const ASTNode&) : audit(audit_)
+    {
+      audit.running++;
+      if (audit.running > audit.deepest)
+        audit.deepest = audit.running;
+    }
+
+    Running(const Running&) = delete;
+    Running& operator=(const Running&) = delete;
+
+    ~Running()
+    {
+      audit.running--;
+      if (audit.running == 0)
+        audit.finished();
+    }
+  };
+
+  // Empty while the pass is within its claim. Public so that a test can drive
+  // the audit directly rather than by breaking a pass.
+  std::string disagreement() const
+  {
+    std::ostringstream out;
+
+    if (deepest > limit)
+      out << pass << " nested " << deepest << " deep, over its claim of "
+          << limit << ": priming is not answering the calls it makes on its "
+          << "operands, so the input's depth is back on the stack\n";
+
+    return out.str();
+  }
+
+  size_t depth() const { return deepest; }
+
+  void clear() { deepest = 0; }
+
+private:
+  void finished()
+  {
+    const std::string bad = disagreement();
+    if (!bad.empty())
+    {
+      std::cerr << "primeMemo preconditions violated (stp/Util/DagWalk.h):\n"
+                << bad;
+      assert(false && "a primed pass nests with its input after all");
+    }
+    clear();
+  }
+};
+#else
+// Release: the same shape, doing nothing, so the passes read the same in
+// both builds.
+class PrimeAudit
+{
+public:
+  PrimeAudit(const char*, size_t) {}
+  void clear() {}
+
+  class Running
+  {
+  public:
+    Running(PrimeAudit&, const ASTNode&) {}
+  };
+};
+#endif
+
+// Fill a memoised pass's table from the bottom up, so that the pass itself
+// stops recursing.
+//
+// The alternative to rewriting a pass as a state machine. A pass that
+// answers from a memo at its first line, and reaches other nodes only by
+// calling itself on their children, will find every child already answered
+// if the table is filled bottom up first -- so its recursion never goes more
+// than one level, whatever the input nests to, and not one line of it has to
+// change. That is worth having for the passes that are too large to restate:
+// BitBlaster::BBTerm dispatches on kind over 450 lines and calls itself from
+// 24 of them.
+//
+// It is only sound where the pass would have visited these nodes anyway, in
+// this order. Three things to check before using it:
+//
+//   * the memo is keyed on the node alone -- not on the node plus a flag,
+//     the way the Simplifier keys on pushNeg as well;
+//   * the pass has no early exit that skips children, or priming does work
+//     it would not have done, building nodes that do not otherwise exist and
+//     shifting every node number after them;
+//   * `classify` returns Descend for exactly the nodes whose children the
+//     pass looks at, and Skip for the ones it never passes down -- a
+//     constant index operand, say, that its kind ignores.
+//
+// Get those right and the pass sees the same nodes built by the same factory
+// calls in the same sequence. Check it with the generated CNF, which is
+// sensitive to all three.
+//
+// Self-calls on nodes the pass builds itself, rather than on children, get
+// nothing from this: those nodes do not exist when the walk runs. Usually
+// that costs nothing, because their operands are primed and the walk is one
+// level -- but it is an assumption about the pass's own rewriting and not
+// something priming secures, and it does not always hold. The simplifier's
+// float arm built a term thousands of levels deep and walked down it; the
+// depth check below is what found it, and that pass is now restated as an
+// explicit job stack (Simplifier::simplifyNode) rather than primed.
+// A pass normally recurses into all of a node's children, in order. The few
+// exceptions in STP recurse into a contiguous subrange, or into all children
+// in reverse order. WalkOperands describes those cases without copying an
+// ASTNode or allocating an operand vector. `operands(n)` returns the view for
+// n; the three-argument primeMemo below supplies WalkOperands::all(n).
+class WalkOperands
+{
+  uint32_t first_ = 0;
+  uint32_t count_ = 0;
+  bool reversed_ = false;
+
+  WalkOperands(const size_t first, const size_t count, const bool reversed)
+      : first_(static_cast<uint32_t>(first)),
+        count_(static_cast<uint32_t>(count)), reversed_(reversed)
+  {
+    assert(first == first_ && count == count_);
+  }
+
+public:
+  // An empty range. Needed so a suspended-parent slot can be held by value
+  // rather than in a std::optional -- see PrimeMemoParents below.
+  WalkOperands() = default;
+
+  static WalkOperands all(const ASTNode& n) { return range(0, n.Degree()); }
+
+  static WalkOperands range(const size_t first, const size_t pastLast)
+  {
+    assert(first <= pastLast);
+    return WalkOperands(first, pastLast - first, false);
+  }
+
+  static WalkOperands reversed(const ASTNode& n)
+  {
+    return reversedRange(0, n.Degree());
+  }
+
+  static WalkOperands reversedRange(const size_t first, const size_t pastLast)
+  {
+    assert(first <= pastLast);
+    return WalkOperands(first, pastLast - first, true);
+  }
+
+  size_t size() const { return count_; }
+
+  const ASTNode& at(const ASTNode& n, const size_t i) const
+  {
+    assert(i < count_ && static_cast<size_t>(first_) + count_ <= n.Degree());
+    return n[first_ + (reversed_ ? count_ - 1 - i : i)];
+  }
+};
+
+// Proof supplied to visit that classify admitted this node. A memoised pass
+// may use it as a known-miss token when (as all current primed passes do) its
+// classifier returns Visit or Descend only after finding no memo entry. That
+// removes the otherwise duplicate lookup at the pass's first line.
+//
+// The contract is deliberately explicit: processing descendants must not
+// memoise an ancestor as a side effect. A bottom-up pass over an acyclic AST
+// normally only records the node it was handed, which is exactly that case.
+struct PrimeMemoReady
+{
+};
+
+namespace detail
+{
+template <class Frame, bool InlineFirst> class PrimeMemoParents;
+
+template <class Frame> class PrimeMemoParents<Frame, false>
+{
+  std::vector<Frame> frames;
+
+public:
+  void push(Frame&& frame) { frames.push_back(std::move(frame)); }
+  bool empty() const { return frames.empty(); }
+
+  Frame pop()
+  {
+    Frame result = std::move(frames.back());
+    frames.pop_back();
+    return result;
+  }
+};
+
+template <class Frame> class PrimeMemoParents<Frame, true>
+{
+  // The first suspended parent is held by value, so the shallow walks that
+  // never nest twice touch no heap at all, and a pop leaves the slot holding
+  // a moved-from frame that the next descent assigns over.
+  //
+  // By value rather than in a std::optional deliberately: with an optional,
+  // whether the payload is engaged is a fact GCC cannot connect to the
+  // dereference in pop(), and it reports the ASTNode inside as possibly
+  // uninitialised -- fatal on the -Werror leg, on several GCC versions, and
+  // not fixable by rephrasing the guard. A default-constructed Frame is
+  // always initialised, so the question does not arise.
+  Frame first;
+  bool hasFirst = false;
+  std::vector<Frame> rest;
+
+public:
+  void push(Frame&& frame)
+  {
+    if (!hasFirst)
+    {
+      first = std::move(frame);
+      hasFirst = true;
+    }
+    else
+      rest.push_back(std::move(frame));
+  }
+
+  bool empty() const { return !hasFirst; }
+
+  Frame pop()
+  {
+    if (!rest.empty())
+    {
+      Frame result = std::move(rest.back());
+      rest.pop_back();
+      return result;
+    }
+
+    Frame result = std::move(first);
+    hasFirst = false;
+    return result;
+  }
+};
+} // namespace detail
+
+template <bool InlineFirstParent, class Classify, class Operands, class Visit>
+void primeMemoImpl(const ASTNode& top, Classify classify, Operands operands,
+                   Visit visit)
+{
+  if (classify(top) != Walk::Descend)
+    return; // the caller does it: there is nothing below to get ahead of.
+
+  struct Frame
+  {
+    ASTNode n;
+    WalkOperands operands;
+    uint32_t i = 0;
+
+    // An empty slot, for the by-value inline parent in PrimeMemoParents.
+    Frame() = default;
+
+    Frame(const ASTNode& node, const WalkOperands view)
+        : n(node), operands(view)
+    {
+    }
+  };
+
+  auto open = [&](const ASTNode& n) { return Frame(n, operands(n)); };
+
+  Frame current = open(top);
+  detail::PrimeMemoParents<Frame, InlineFirstParent> parents;
+
+  while (true)
+  {
+    if (current.i < current.operands.size())
+    {
+      const ASTNode& child = current.operands.at(current.n, current.i++);
+
+      switch (classify(child))
+      {
+        case Walk::Descend:
+          parents.push(std::move(current));
+          current = open(child);
+          break;
+        case Walk::Visit:
+          visit(child, PrimeMemoReady{});
+          break;
+        case Walk::Skip:
+          break;
+      }
+      continue;
+    }
+
+    visit(current.n, PrimeMemoReady{});
+    if (parents.empty())
+      return;
+
+    current = parents.pop();
+  }
+}
+
+template <class Classify, class Operands, class Visit>
+void primeMemo(const ASTNode& top, Classify classify, Operands operands,
+               Visit visit)
+{
+  primeMemoImpl<false>(top, classify, operands, visit);
+}
+
+// Metadata derivations commonly suspend exactly one parent. Keep that frame
+// inline for those hot accessors while leaving larger primed passes on the
+// compact vector-only implementation above.
+template <class Classify, class Operands, class Visit>
+void primeMemoInlineParent(const ASTNode& top, Classify classify,
+                           Operands operands, Visit visit)
+{
+  primeMemoImpl<true>(top, classify, operands, visit);
+}
+
+// The usual case: a pass recurses into a node's own children.
+template <class Classify, class Visit>
+void primeMemo(const ASTNode& top, Classify classify, Visit visit)
+{
+  primeMemo(
+      top, classify, [](const ASTNode& n) { return WalkOperands::all(n); },
+      visit);
 }
 
 // Rebuild a DAG bottom up, without putting the walk on the call stack.

--- a/lib/AST/ASTNode.cpp
+++ b/lib/AST/ASTNode.cpp
@@ -24,6 +24,7 @@ THE SOFTWARE.
 
 #include "stp/AST/AST.h"
 #include "stp/STPManager/STP.h"
+#include "stp/Util/DagWalk.h"
 #include <sstream>
 
 namespace stp
@@ -173,6 +174,61 @@ static bool deriveFPFormat(const ASTNode& n, unsigned int& e, unsigned int& s)
   }
 }
 
+// Which children a node's format derivation reads, as a half-open range of
+// child positions.
+//
+// This says what the switch above consults and has to keep agreeing with it:
+// the read and store arms take the format of the array under them, the
+// if-then-else arm takes a branch's, and the arithmetic arms take whichever
+// operand carries one. Every other kind decides from its own kind, or from
+// children it reads as constants rather than as floats, so an empty range is
+// also "the walk below stops here".
+//
+// The if-then-else and arithmetic arms stop at the first operand that answers,
+// where this names them all. Naming more than is read costs a derivation that
+// would have happened the moment anything asked that node its type, and can
+// cost nothing else: neither derivation builds a node, calls a factory or
+// reads anything but its subject's kind, children and widths.
+static void fpFormatOperands(const ASTNode& n, size_t& from, size_t& to)
+{
+  from = 0;
+  to = 0;
+
+  switch (n.GetKind())
+  {
+    case READ:
+    case WRITE:
+      to = (n.Degree() >= 1) ? 1 : 0;
+      break;
+
+    case ITE:
+      if (n.Degree() == 3)
+      {
+        from = 1;
+        to = 3;
+      }
+      break;
+
+    case FP_ABS:
+    case FP_NEG:
+    case FP_ADD:
+    case FP_SUB:
+    case FP_MUL:
+    case FP_DIV:
+    case FP_FMA:
+    case FP_SQRT:
+    case FP_REM:
+    case FP_ROUNDTOINTEGRAL:
+    case FP_MIN:
+    case FP_MAX:
+      to = n.Degree();
+      break;
+
+    default:
+      break;
+  }
+}
+
 // Sentinel cached in _exp_width once derivation has concluded "not a
 // float". Without it every format query on a formatless node re-walks its
 // children -- quadratic on store chains and ITE spines, since WRITE and ITE
@@ -183,29 +239,82 @@ static const uint32_t FP_NOT_A_FLOAT = 0xFFFFFFFFu;
 // Derive once and keep the answer -- positive or negative. The fields are
 // already mutable, and an interior node can hold them, so this costs one
 // walk per node rather than one per query.
+//
+// The derivation reads its operands' formats, and reading one derives it --
+// which was this function again, one call frame per level of a store chain or
+// an if-then-else spine. Nothing bounds those: they are as deep as the input
+// nests, and 20,000 is fatal. It is worse than a pass dying on its own input,
+// because this is not a pass. GetType asks for the format and everything asks
+// GetType, so a query deep enough could not be asked its type at all, from
+// anywhere.
+//
+// So primeMemo fills the dependency suffix bottom up, and the derivation then
+// finds every operand it reads already answered and stops one level down. See
+// DagWalk.h, and DeepDag_Test.cpp for the depths.
 void ASTNode::cacheFPFormat() const
 {
-  unsigned int e = 0;
-  unsigned int s = 0;
+#ifndef NDEBUG
+  static thread_local PrimeAudit audit{"ASTNode::cacheFPFormat", 8};
+  PrimeAudit::Running running(audit, *this);
+#endif
 
-  const bool is_float = deriveFPFormat(*this, e, s);
+  // One node, with its operands already answered.
+  auto store = [](const ASTNode& n) {
+    unsigned int e = 0;
+    unsigned int s = 0;
 
-  // A BVCONST has nowhere to put either answer (its setters reject it);
-  // float constants are made as ASTFPConst instead, and re-deriving on a
-  // childless node is cheap.
-  if (GetKind() == BVCONST ||
-      (Degree() == 0 &&
-       _int_node_ptr->getDeclaredSourceSort().isKnown()))
-    return;
+    const bool is_float = deriveFPFormat(n, e, s);
 
-  if (!is_float)
+    // A BVCONST has nowhere to put either answer (its setters reject it);
+    // float constants are made as ASTFPConst instead, and re-deriving on a
+    // childless node is cheap.
+    if (n.GetKind() == BVCONST ||
+        (n.Degree() == 0 &&
+         n._int_node_ptr->getDeclaredSourceSort().isKnown()))
+      return;
+
+    if (!is_float)
+    {
+      n._int_node_ptr->setExpWidth(FP_NOT_A_FLOAT);
+      return;
+    }
+
+    n._int_node_ptr->setExpWidth(e);
+    n._int_node_ptr->setSigWidth(s);
+  };
+
+  // Nothing below `n` needs filling: either its own derivation reads no
+  // operands, so asking it is already one level, or it has been asked
+  // before. The first case is why a node that cannot hold an answer -- a
+  // constant, a declared leaf -- never sends this walk into a loop over it.
+  auto settled = [](const ASTNode& n) {
+    size_t from, to;
+    fpFormatOperands(n, from, to);
+    return from == to || n._int_node_ptr->getExpWidth() != 0;
+  };
+
+  size_t from, to;
+  fpFormatOperands(*this, from, to);
+  bool fill = false;
+  for (size_t i = from; i < to && !fill; i++)
+    fill = !settled((*this)[i]);
+
+  if (!fill)
   {
-    _int_node_ptr->setExpWidth(FP_NOT_A_FLOAT);
+    store(*this);
     return;
   }
 
-  _int_node_ptr->setExpWidth(e);
-  _int_node_ptr->setSigWidth(s);
+  primeMemoInlineParent(
+      *this, [&](const ASTNode& child)
+      { return settled(child) ? Walk::Skip : Walk::Descend; },
+      [](const ASTNode& n)
+      {
+        size_t f, t;
+        fpFormatOperands(n, f, t);
+        return WalkOperands::range(f, t);
+      },
+      [&](const ASTNode& n, PrimeMemoReady) { store(n); });
 }
 
 unsigned int ASTNode::GetExpWidth() const
@@ -319,6 +428,44 @@ const char* ASTNode::GetName() const
 // (see cacheFPFormat): the derivation reads only the node's kind, children
 // and widths, and the first two are the hash-cons key. The widths are not, so
 // the setters drop the memo.
+// Which children a node's source-sort derivation reads, as a half-open range
+// of child positions, and the same bargain as fpFormatOperands above: it has
+// to keep agreeing with deriveSourceSort, and naming more than is read can
+// only cost a derivation that the next question would have caused anyway.
+//
+// Every other kind answers from its own kind, its declared sort, or its
+// widths -- and the widths route through GetType, which is the format
+// derivation and stops on its own.
+static void sourceSortOperands(const ASTNode& n, size_t& from, size_t& to)
+{
+  from = 0;
+  to = 0;
+
+  switch (n.GetKind())
+  {
+    case ARRAY:
+      if (n.Degree() == 2)
+        to = 2;
+      break;
+
+    case READ:
+    case WRITE:
+      to = (n.Degree() >= 1) ? 1 : 0;
+      break;
+
+    case ITE:
+      if (n.Degree() == 3)
+      {
+        from = 1;
+        to = 3;
+      }
+      break;
+
+    default:
+      break;
+  }
+}
+
 SourceSort ASTNode::GetSourceSort() const
 {
   if (IsNull())
@@ -327,11 +474,59 @@ SourceSort ASTNode::GetSourceSort() const
   if (const SourceSort* cached = _int_node_ptr->cachedSourceSort())
     return *cached;
 
-  _int_node_ptr->nodeManager->source_sort_derivations++;
-  const SourceSort derived = deriveSourceSort();
-  _int_node_ptr->setCachedSourceSort(
-      _int_node_ptr->nodeManager->internSourceSort(derived));
-  return derived;
+#ifndef NDEBUG
+  static thread_local PrimeAudit audit{"ASTNode::GetSourceSort", 8};
+  PrimeAudit::Running running(audit, *this);
+#endif
+
+  // One node, with its operands already answered. The answer goes on the node
+  // where a node can hold one -- a leaf cannot, only an interior node holds
+  // the memo -- and into `answer` either way, which is how the node this
+  // started from returns its own: the walk finishes with it, so the last
+  // answer recorded is that one.
+  SourceSort answer = SourceSort::unknown();
+  auto store = [&](const ASTNode& n) {
+    n._int_node_ptr->nodeManager->source_sort_derivations++;
+    answer = n.deriveSourceSort();
+    n._int_node_ptr->setCachedSourceSort(
+        n._int_node_ptr->nodeManager->internSourceSort(answer));
+  };
+
+  // As in cacheFPFormat, and for the same reason -- the derivation reads a
+  // child's sort by asking for it, which derived the child the same way, one
+  // call frame per level of a store chain or an if-then-else spine.
+  //
+  // A leaf is settled by having nothing to read, never by its memo: only an
+  // interior node can hold one. So the walk stops above every leaf and leaves
+  // it to be derived by whichever parent reads it, which is what kept the
+  // derivation count what it was.
+  auto settled = [](const ASTNode& n) {
+    size_t from, to;
+    sourceSortOperands(n, from, to);
+    return from == to || n._int_node_ptr->cachedSourceSort() != NULL;
+  };
+
+  size_t from, to;
+  sourceSortOperands(*this, from, to);
+  bool fill = false;
+  for (size_t i = from; i < to && !fill; i++)
+    fill = !settled((*this)[i]);
+
+  if (fill)
+    primeMemoInlineParent(
+        *this, [&](const ASTNode& child)
+        { return settled(child) ? Walk::Skip : Walk::Descend; },
+        [](const ASTNode& n)
+        {
+          size_t f, t;
+          sourceSortOperands(n, f, t);
+          return WalkOperands::range(f, t);
+        },
+        [&](const ASTNode& n, PrimeMemoReady) { store(n); });
+  else
+    store(*this);
+
+  return answer;
 }
 
 SourceSort ASTNode::deriveSourceSort() const

--- a/lib/AST/ASTmisc.cpp
+++ b/lib/AST/ASTmisc.cpp
@@ -89,35 +89,68 @@ bool arithless(const ASTNode& n1, const ASTNode& n2)
   }
 }
 
-// counts the number of reads. Shortcut when we get to the limit.
-void numberOfReadsLessThan(const ASTNode& n, std::unordered_set<uint64_t>& visited,
-                           int& soFar, const int limit)
-{
-  if (n.isAtom())
-    return;
-
-  if (visited.find(n.GetNodeNum()) != visited.end())
-    return;
-
-  if (n.GetKind() == READ)
-    soFar++;
-
-  if (soFar > limit)
-    return;
-
-  visited.insert(n.GetNodeNum());
-
-  for (size_t i = 0; i < n.Degree(); i++)
-    numberOfReadsLessThan(n[i], visited, soFar, limit);
-}
-
 // True if the number of reads in "n" is less than "limit"
 bool numberOfReadsLessThan(const ASTNode& n, int limit)
 {
+  if (limit <= 0)
+    return false;
+
   std::unordered_set<uint64_t> visited;
   int reads = 0;
-  numberOfReadsLessThan(n, visited, reads, limit);
-  return reads < limit;
+
+  // Admit a node once and say whether its children need walking. Atoms were
+  // deliberately absent from the old memo and remain so here.
+  auto descend = [&](const ASTNode& current) {
+    if (current.isAtom() || !visited.insert(current.GetNodeNum()).second)
+      return false;
+
+    if (current.GetKind() == READ)
+      reads++;
+    return current.Degree() != 0;
+  };
+
+  if (!descend(n))
+    return reads < limit;
+  if (reads >= limit)
+    return false;
+
+  struct Frame
+  {
+    const ASTNode* node;
+    size_t nextChild = 0;
+  };
+  static_assert(sizeof(Frame) <= 2 * sizeof(void*),
+                "read-count frames must contain only traversal state");
+
+  // Keep only suspended ancestors. More importantly, return globally as
+  // soon as the strict bound is reached: unwinding the rest of the walk is
+  // unnecessary, and may itself be a large untouched subtree.
+  Frame current{&n};
+  std::vector<Frame> parents;
+  while (true)
+  {
+    if (current.nextChild < current.node->Degree())
+    {
+      const ASTNode* child = &(*current.node)[current.nextChild++];
+      if (!descend(*child))
+      {
+        if (reads >= limit)
+          return false;
+        continue;
+      }
+      if (reads >= limit)
+        return false;
+
+      parents.push_back(current);
+      current = Frame{child};
+      continue;
+    }
+
+    if (parents.empty())
+      return true;
+    current = parents.back();
+    parents.pop_back();
+  }
 }
 
 // See the declaration for why this exists: constants of one value need
@@ -389,44 +422,98 @@ ASTVec toASTVec(const ASTChildren& c)
   return ASTVec(c.begin(), c.end());
 }
 
+// Where the walk of one node's children has got to. `depth` is how much
+// further the depth-limited form below may descend; the deduplicating one
+// ignores it, as it always has.
+//
+// The frames are on the heap. A nested same-kind chain is as deep as the
+// input nests, and a call per level exhausts the stack: measured to die
+// between 100,000 and 150,000 at 8 MiB. Reached from the simplifier, the BV
+// solver, PropagateEqualities, MergeSame and UseITEContext -- and while no
+// parsed query gets there today, because the simplifying factory flattens a
+// conjunction as it builds one, that is a property of the factory rather
+// than of these functions. A pass building through the hashing factory
+// reaches it. See DeepDag_Test.cpp.
+namespace
+{
+struct FlattenFrame
+{
+  ASTChildren children;
+  size_t i;
+  int depth;
+
+  FlattenFrame(const ASTChildren& c, int d) : children(c), i(0), depth(d) {}
+};
+}
+
 void FlattenKindNoDuplicates(const Kind k, const ASTChildren& children,
                              ASTVec& flat_children,
                              ASTNodeSet& alreadyFlattened)
 {
-  const auto ch_end = children.end();
-  for (auto it = children.begin(); it != ch_end; it++)
+  // Children left to right, and a same-kind one expanded where it is reached,
+  // so flat_children comes out in the order the recursion built it. The
+  // frames hold spans into each node's own child storage, which its parent
+  // keeps alive for the whole walk. Keep the current frame local so a flat
+  // input never allocates a traversal stack; parents are needed only after
+  // the first same-kind child is reached.
+  FlattenFrame current(children, 0);
+  std::vector<FlattenFrame> parents;
+
+  while (true)
   {
-    const Kind ck = it->GetKind();
-    if (k == ck)
+    if (current.i == current.children.size())
     {
-      if (alreadyFlattened.find(*it) == alreadyFlattened.end())
-      {
-        alreadyFlattened.insert(*it);
-        FlattenKindNoDuplicates(k, it->GetChildren(), flat_children,
-                                alreadyFlattened);
-      }
+      if (parents.empty())
+        break;
+      current = parents.back();
+      parents.pop_back();
+      continue;
     }
-    else
+
+    const ASTNode& child = current.children[current.i++];
+
+    if (k != child.GetKind())
     {
-      flat_children.push_back(*it);
+      flat_children.push_back(child);
+      continue;
     }
+
+    // A same-kind child seen before contributes nothing a second time: its
+    // operands are already in flat_children.
+    if (!alreadyFlattened.insert(child).second)
+      continue;
+
+    parents.push_back(current);
+    current = FlattenFrame(child.GetChildren(), 0);
   }
 }
 
 void FlattenKind(const Kind k, const ASTChildren& children, ASTVec& flat_children, int depth)
 {
-  auto ch_end = children.end();
-  for (auto it = children.begin(); it != ch_end; it++)
+  FlattenFrame current(children, depth);
+  std::vector<FlattenFrame> parents;
+
+  while (true)
   {
-    const Kind ck = it->GetKind();
-    if (k == ck && depth >= 0 )
+    if (current.i == current.children.size())
     {
-      FlattenKind(k, it->GetChildren(), flat_children, depth-1);
+      if (parents.empty())
+        break;
+      current = parents.back();
+      parents.pop_back();
+      continue;
+    }
+
+    const ASTNode& child = current.children[current.i++];
+    const int below = current.depth - 1;
+
+    if (k == child.GetKind() && current.depth >= 0)
+    {
+      parents.push_back(current);
+      current = FlattenFrame(child.GetChildren(), below);
     }
     else
-    {
-      flat_children.push_back(*it);
-    }
+      flat_children.push_back(child);
   }
 }
 
@@ -436,11 +523,32 @@ ASTVec FlattenKind(Kind k, const ASTChildren& children, int maxDepth)
   ASTVec flat_children;
   if (k == OR || k == BVOR || k == BVAND || k == AND)
   {
+    bool nested = false;
+    for (const ASTNode& child : children)
+      if (child.GetKind() == k)
+      {
+        nested = true;
+        break;
+      }
+
+    // The overwhelmingly common flat case needs neither the traversal nor
+    // its deduplication set. Range assignment sizes the vector exactly once.
+    if (!nested)
+    {
+      flat_children.assign(children.begin(), children.end());
+      return flat_children;
+    }
+
     ASTNodeSet alreadyFlattened;
     FlattenKindNoDuplicates(k, children, flat_children, alreadyFlattened);
   }
   else
   {
+    // This form never discards repeated same-kind subtrees, so its output has
+    // at least the input's arity. The deduplicating form above can turn a
+    // very wide list of repeated edges into only a few operands; reserving
+    // the input's full width there retains memory for operands it discarded.
+    flat_children.reserve(children.size());
     FlattenKind(k, children, flat_children, maxDepth);
   }
 

--- a/lib/FloatBlaster/FpTotalise.cpp
+++ b/lib/FloatBlaster/FpTotalise.cpp
@@ -25,6 +25,7 @@ THE SOFTWARE.
 #include "stp/FloatBlaster/FpTotalise.h"
 
 #include "stp/FloatBlaster/FloatBlaster.h"
+#include "stp/Util/DagWalk.h"
 
 #include <string>
 
@@ -152,27 +153,31 @@ ASTNode FpTotalise::canonicalSourceBits(const ASTNode& value)
   return nf->CreateTerm(FP_TO_IEEE_BV, sort.packedWidth(), value);
 }
 
+// A continuation stack rather than a call per level: how deeply a float
+// expression nests is the input's choice, and this walks the whole of one.
+// It preserves the recursion's pre-order while retaining only ancestors, not
+// every sibling in a wide frontier. See DeepDag_Test.cpp.
 void FpTotalise::collectRoundingModeTerms(const ASTNode& n, ASTNodeSet& seen,
                                           ASTVec& constraints)
 {
-  if (!seen.insert(n).second)
-    return;
+  walkPreOrder(n, [&](const ASTNode& m) {
+    if (!seen.insert(m).second)
+      return false;
 
-  // Leaves are visited now, where they were skipped before: a declared
-  // RoundingMode symbol is a leaf, and it is exactly as much in need of
-  // pinning as a read is.
-  if (n.GetKind() == SYMBOL)
-  {
-    if (bm->isRoundingModeSymbol(n))
-      constraints.push_back(bm->roundingModeValidConstraint(n));
-    return;
-  }
+    // Leaves are visited now, where they were skipped before: a declared
+    // RoundingMode symbol is a leaf, and it is exactly as much in need of
+    // pinning as a read is.
+    if (m.GetKind() == SYMBOL)
+    {
+      if (bm->isRoundingModeSymbol(m))
+        constraints.push_back(bm->roundingModeValidConstraint(m));
+      return false;
+    }
 
-  if (n.GetKind() == READ && bm->arrayHasRmElement(n[0]))
-    constraints.push_back(bm->roundingModeValidConstraint(n));
-
-  for (size_t i = 0; i < n.Degree(); i++)
-    collectRoundingModeTerms(n[i], seen, constraints);
+    if (m.GetKind() == READ && bm->arrayHasRmElement(m[0]))
+      constraints.push_back(bm->roundingModeValidConstraint(m));
+    return true;
+  });
 }
 
 ASTNode FpTotalise::rebuild(const ASTNode& n, const ASTVec& children)
@@ -287,8 +292,25 @@ ASTNode FpTotalise::zeroChoice(const char* tag, const ASTNode& left,
                         leftNegativeCase);
 }
 
+// The pass is a call per level of a float expression, and how deeply one
+// nests is the input's choice: a query built from 30,000 nested fp.add
+// operations died here, and was the nearest wall left once the simplifier's
+// formula arms were converted. So the answers underneath are
+// filled from the bottom up first, and the pass then finds every child it
+// asks for already answered and stops one level down. See DagWalk.h, and
+// DeepDag_Test.cpp for the depth.
+//
+// Sound because the pass has no exit that skips a child: it answers from a
+// cache, or from having no children, or it visits all of them. So priming
+// reaches exactly the nodes the recursion reached, in the same post-order.
+// That matters more here than it usually would, because this pass mints fresh
+// variables -- see unspecified() and zeroChoice() -- and visiting in a
+// different order would number them differently and move every clause after
+// them. The CNF comparison is what checks it.
 ASTNode FpTotalise::visit(const ASTNode& n)
 {
+  PrimeAudit::Running running(memoAudit, n);
+
   if (n.Degree() == 0)
     return n;
 
@@ -298,6 +320,49 @@ ASTNode FpTotalise::visit(const ASTNode& n)
   const ASTNodeMap::const_iterator current = traversal_cache.find(n);
   if (current != traversal_cache.end())
     return current->second;
+
+  // Nothing below `m` needs filling: it is answered already, or it has no
+  // children to be answered from.
+  auto settled = [this](const ASTNode& m) {
+    return m.Degree() == 0 || persistent_cache.count(m) != 0 ||
+           traversal_cache.count(m) != 0;
+  };
+
+  bool fill = false;
+  for (size_t i = 0; i < n.Degree() && !fill; i++)
+    fill = !settled(n[i]);
+
+  if (!fill)
+    return totalise(n);
+
+  // The walk finishes with the node it started from, so the last answer it
+  // records is that one.
+  ASTNode answer;
+  primeMemo(
+      n, [&](const ASTNode& child)
+      { return settled(child) ? Walk::Skip : Walk::Descend; },
+      [&](const ASTNode& m, PrimeMemoReady) { answer = totalise(m, true); });
+  return answer;
+}
+
+// One node, with its children already totalised -- which is what the walk
+// below arranges, and what its own calls on those children then find.
+ASTNode FpTotalise::totalise(const ASTNode& n, const bool knownMissing)
+{
+  if (n.Degree() == 0)
+    return n;
+
+  // visit's classifier already checked both caches for primed nodes. Neither
+  // totalising a descendant nor rebuilding it can cache its ancestor.
+  if (!knownMissing)
+  {
+    const ASTNodeMap::const_iterator persistent = persistent_cache.find(n);
+    if (persistent != persistent_cache.end())
+      return persistent->second;
+    const ASTNodeMap::const_iterator current = traversal_cache.find(n);
+    if (current != traversal_cache.end())
+      return current->second;
+  }
 
   ASTVec children;
   children.reserve(n.Degree() + 1);

--- a/lib/Simplifier/Flatten.cpp
+++ b/lib/Simplifier/Flatten.cpp
@@ -22,7 +22,11 @@ THE SOFTWARE.
 ********************************************************************/
 
 #include "stp/Simplifier/Flatten.h"
+#include "stp/Util/DagWalk.h"
+#include <deque>
+#include <limits>
 #include <list>
+#include <vector>
 
 namespace stp
 {
@@ -54,105 +58,250 @@ namespace stp
   }
 
   // counter is 1 if the node has one reference in the tree.
+  //
+  // Iterative for the same reason as Rewriting::buildShareCount, which this
+  // mirrors: the input decides the depth, so a call per level of the DAG
+  // exhausts the stack. The continuation walk holds only suspended ancestors
+  // rather than every sibling in a wide frontier.
   void Flatten::buildShareCount(const ASTNode& n)
   {
-    if (n.Degree() == 0)
-      return;
+    walkPreOrder(n, [&](const ASTNode& current) {
+      if (current.Degree() == 0)
+        return false;
 
-    if (shareCount[n.GetNodeNum()]++ > 0) // 0 first time, 1 second time.
-      return;
-  
-    for (const auto& c: n.GetChildren())
-        buildShareCount(c);
+      if (shareCount[current.GetNodeNum()]++ > 0) // 0 first time, 1 second.
+        return false;
+      return true;
+    });
   }
+
+  // A leaf, or a node already flattened: answered without a frame, exactly
+  // as the recursive version answered it without a call.
+  bool Flatten::alreadyKnown(const ASTNode& n, ASTNode& answer)
+  {
+    if (n.Degree() == 0)
+    {
+      answer = n;
+      return true;
+    }
+
+    const auto it = fromTo.find(n.GetNodeNum());
+    if (it != fromTo.end())
+    {
+      answer = it->second;
+      return true;
+    }
+    return false;
+  }
+
+  // The walk one node is part-way through. Everything here was a local of
+  // the recursive flatten(); it lives on the heap because the input decides
+  // how many of them are live at once.
+  struct Flatten::Frame
+  {
+    ASTNode n;
+    Kind k;
+    bool top;
+    bool flattenable;
+    bool changed = false;
+
+    ASTChildren children;
+    unsigned it0 = 0; // original children consumed
+    unsigned i = 0;   // position in nextChildren
+
+    // The vectors and set are only needed after this node changes. Keeping
+    // an index here makes the common unchanged frame small; flatten() lends
+    // the actual storage from a LIFO scratch pool.
+    static constexpr unsigned noScratch =
+        std::numeric_limits<unsigned>::max();
+    unsigned scratch = noScratch;
+
+    // Set while this node waits for a child's flatten() to come back.
+    ASTNode pending;
+    bool waiting = false;
+
+    Frame(const ASTNode& n_, bool top_)
+        : n(n_), k(n_.GetKind()), top(top_),
+          //TODO STP doesn't currerntly handle >2 arity BVMULT.
+          flattenable(OR == k || AND == k || XOR == k || BVXOR == k ||
+                      BVOR == k || BVAND == k || BVPLUS == k),
+          children(n_.GetChildren())
+    {
+    }
+  };
 
   ASTNode Flatten::flatten(const ASTNode& n, bool top)
   {
-    if (n.Degree() == 0)
-      return n;
+    static_assert(sizeof(Frame) <= 80,
+                  "Flatten frames must stay cheap at deep DAG depths");
 
-    if (fromTo.find(n.GetNodeNum()) != fromTo.end())
-      return fromTo[n.GetNodeNum()];
+    ASTNode result;
+    if (alreadyKnown(n, result))
+      return result;
 
-    const Kind k = n.GetKind();
+    // A deque, so that descending into a child never moves the frames
+    // above it: `current` below stays valid across a push.
+    std::deque<Frame> stack;
+    stack.emplace_back(n, top);
 
-    ASTNode result =n;
-
-    bool changed =false;
-    
-    //TODO STP doesn't currerntly handle >2 arity BVMULT.
-    const bool flattenable = (OR==k || AND==k || XOR==k || BVXOR==k ||  BVOR==k || BVAND==k || BVPLUS==k);
-
-    std::unordered_set<uint64_t> seen;
-
-    ASTVec newChildren;
-
-    const ASTChildren children = n.GetChildren();
-    auto it0 = children.begin();
-
-    ASTVec nextChildren;
-    unsigned i = 0;
-
-    // Copy on write.
-    auto fill = [&]
+    struct Scratch
     {
-      assert(0 ==i);
+      ASTVec newChildren;
+      ASTVec nextChildren;
+      std::unordered_set<uint64_t> seen;
 
-      newChildren.reserve(children.size());
-      newChildren.insert(newChildren.end(), children.begin(), it0-1);
-      changed=true;
+      void clear()
+      {
+        newChildren.clear();
+        nextChildren.clear();
+        seen.clear();
+      }
     };
 
-    while (it0 != children.end() || i < nextChildren.size())
+    // Scratch slots are acquired and released in traversal order: an active
+    // child's slot is always above its parent's. Reusing them retains vector
+    // and hash-table capacity without carrying that state in every frame.
+    std::vector<Scratch> scratches;
+    unsigned scratchesInUse = 0;
+
+    auto scratchFor = [&](Frame& f) -> Scratch&
     {
-      const ASTNode c = (it0 != children.end())? *it0++: nextChildren[i++];
-
-      if (flattenable && c.GetKind() == k && (top || shareCount[c.GetNodeNum()] == 1))
+      if (f.scratch == Frame::noScratch)
       {
-         assert(c.Degree() > 1);
-         if (!changed)
-            fill();
+        assert(scratchesInUse <= scratches.size());
+        assert(scratchesInUse < Frame::noScratch);
+        f.scratch = scratchesInUse++;
+        if (f.scratch == scratches.size())
+          scratches.emplace_back();
+      }
+      return scratches[f.scratch];
+    };
 
-         if (top)
+    auto releaseScratch = [&](Frame& f)
+    {
+      if (f.scratch == Frame::noScratch)
+        return;
+      assert(f.scratch + 1 == scratchesInUse);
+      scratches[f.scratch].clear();
+      --scratchesInUse;
+    };
+
+    // Copy on write.
+    auto fill = [&](Frame& f)
+    {
+      assert(0 == f.i);
+
+      Scratch& scratch = scratchFor(f);
+      scratch.newChildren.reserve(f.children.size());
+      scratch.newChildren.insert(scratch.newChildren.end(),
+                                 f.children.begin(),
+                                 f.children.begin() + (f.it0 - 1));
+      f.changed = true;
+    };
+
+    while (true)
+    {
+      Frame& current = stack.back();
+
+      // Pick up the child this frame descended for. `result` is what its
+      // flatten() returned.
+      if (current.waiting)
+      {
+        if (result != current.pending && !current.changed)
+          fill(current);
+        if (current.changed)
+          scratches[current.scratch].newChildren.push_back(result);
+        current.waiting = false;
+      }
+
+      bool descended = false;
+
+      while (current.it0 < current.children.size() ||
+             (current.scratch != Frame::noScratch &&
+              current.i < scratches[current.scratch].nextChildren.size()))
+      {
+        // By value: the flattening branch below appends to nextChildren,
+        // which can move what a reference into it points at.
+        const ASTNode c = (current.it0 < current.children.size())
+                              ? current.children[current.it0++]
+                              : scratches[current.scratch]
+                                    .nextChildren[current.i++];
+
+        if (current.flattenable && c.GetKind() == current.k &&
+            (current.top || shareCount[c.GetNodeNum()] == 1))
+        {
+          assert(c.Degree() > 1);
+          if (!current.changed)
+            fill(current);
+          Scratch& scratch = scratches[current.scratch];
+
+          if (current.top)
             top_removed++;
-         else
-           removed++;
+          else
+            removed++;
 
-         for (const auto&e: c.GetChildren())
-         {
-            if (BVAND == k || AND == k || BVOR == k || OR == k)
+          for (const auto& e : c.GetChildren())
+          {
+            if (BVAND == current.k || AND == current.k || BVOR == current.k ||
+                OR == current.k)
             {
-              if (!seen.insert(e.GetNodeNum()).second)
-                continue; 
+              if (!scratch.seen.insert(e.GetNodeNum()).second)
+                continue;
             }
-            nextChildren.push_back(e);
-         }
-        shareCount[c.GetNodeNum()]--;
+            scratch.nextChildren.push_back(e);
+          }
+          shareCount[c.GetNodeNum()]--;
+        }
+        else
+        {
+          ASTNode r;
+          if (alreadyKnown(c, r))
+          {
+            if (r != c && !current.changed)
+              fill(current);
+            if (current.changed)
+              scratches[current.scratch].newChildren.push_back(r);
+            continue;
+          }
+
+          // Where the recursive version called flatten(c). Nothing above
+          // may be read after the push.
+          current.pending = c;
+          current.waiting = true;
+          stack.emplace_back(c, false);
+          descended = true;
+          break;
+        }
       }
-      else
+
+      if (descended)
+        continue;
+
+      Frame& done = stack.back();
+      result = done.n;
+
+      if (done.changed)
       {
-        const auto r = flatten(c);
-        if (r!=c && !changed)
-          fill();
-        if (changed)   
-          newChildren.push_back(r);
+        Scratch& scratch = scratches[done.scratch];
+        assert(done.n.Degree() <= scratch.newChildren.size());
+
+        if (done.n.GetType() == BOOLEAN_TYPE)
+          result = nf->CreateNode(done.k, scratch.newChildren);
+        else
+          result = nf->CreateArrayTerm(done.k, done.n.GetIndexWidth(),
+                                       done.n.GetValueWidth(),
+                                       scratch.newChildren);
+
+        shareCount[result.GetNodeNum()]++; // I'm guessing it's unusal, but we might make a node we already have.
       }
-    }    
 
-    if (changed)
-    {
-      assert(n.Degree() <= newChildren.size());
+      if (shareCount[done.n.GetNodeNum()] > 1)
+        fromTo.insert({done.n.GetNodeNum(), result});
 
-      if (n.GetType() == BOOLEAN_TYPE)
-        result = nf->CreateNode(k, newChildren);
-      else
-        result = nf->CreateArrayTerm(k, n.GetIndexWidth(),n.GetValueWidth(), newChildren);
-
-      shareCount[result.GetNodeNum()]++; // I'm guessing it's unusal, but we might make a node we already have.
+      releaseScratch(done);
+      stack.pop_back();
+      if (stack.empty())
+        return result;
     }
-
-    if (shareCount[n.GetNodeNum()] > 1)
-      fromTo.insert({n.GetNodeNum(),result});
-    return result;
   }
 }

--- a/lib/Simplifier/NodeDomainAnalysis.cpp
+++ b/lib/Simplifier/NodeDomainAnalysis.cpp
@@ -25,9 +25,37 @@ THE SOFTWARE.
 
 #include "stp/Simplifier/NodeDomainAnalysis.h"
 #include "stp/Simplifier/constantBitP/ConstantBitPropagation.h"
+#include "stp/Util/DagWalk.h"
 
 namespace stp
 {
+  namespace
+  {
+    // Keep the recursion counter balanced across buildMap's early returns.
+    class UnprimedDepth
+    {
+      size_t& depth;
+      const bool active;
+
+    public:
+      UnprimedDepth(size_t& depth_, const bool active_)
+          : depth(depth_), active(active_)
+      {
+        if (active)
+          ++depth;
+      }
+
+      UnprimedDepth(const UnprimedDepth&) = delete;
+      UnprimedDepth& operator=(const UnprimedDepth&) = delete;
+
+      ~UnprimedDepth()
+      {
+        if (active)
+          --depth;
+      }
+    };
+  }
+
 
   // True if the two domains have an intersection, i.e. share >=1 value.
   bool intersects(FixedBits * bits, UnsignedInterval * interval)
@@ -410,8 +438,36 @@ namespace stp
     assert(intersects(interval, set));
   }
 
+  // Every node below `n` before `n` itself, in the order buildMap would have
+  // reached them: children left to right, the node last. It looks at every
+  // child of every node it visits and has no early exit, so nothing is
+  // computed here that it would not have computed anyway.
+  void NodeDomainAnalysis::primeMaps(const ASTNode& n)
+  {
+    primeMemo(
+        n,
+        [this](const ASTNode& node)
+        {
+          if (toFixedBits.find(node) != toFixedBits.end())
+            return Walk::Skip; // buildMap would answer from the map.
+          return node.Degree() == 0 ? Walk::Visit : Walk::Descend;
+        },
+        [this](const ASTNode& node, PrimeMemoReady) { buildMap(node, true); });
+  }
+
   NodeDomainAnalysis::DomainInfo NodeDomainAnalysis::buildMap(const ASTNode& n)
   {
+    return buildMap(n, false);
+  }
+
+  NodeDomainAnalysis::DomainInfo
+  NodeDomainAnalysis::buildMap(const ASTNode& n, const bool knownMissing)
+  {
+    PrimeAudit::Running running(mapAudit, n);
+
+    // primeMaps' classifier already established the miss. Domain analysis of
+    // a descendant only records that descendant, never an ancestor.
+    if (!knownMissing)
     {
       auto it = toFixedBits.find(n);
       if (it != toFixedBits.end())
@@ -423,6 +479,25 @@ namespace stp
     }
 
     const auto number_children = n.Degree();
+
+    if (!priming && number_children > 0 &&
+        unprimedDepth >= unprimedDepthLimit)
+    {
+      priming = true;
+      primeMaps(n);
+      priming = false;
+
+      auto it = toFixedBits.find(n);
+      if (it != toFixedBits.end())
+      {
+        auto it0 = toIntervals.find(n);
+        auto it1 = toValueSets.find(n);
+        return {it->second, it0->second, it1->second};
+      }
+    }
+
+    // Leaves do not recurse, so they consume no part of the depth budget.
+    UnprimedDepth depth(unprimedDepth, !priming && number_children > 0);
 
     vector<FixedBits*> children_bits;
     children_bits.reserve(number_children);

--- a/lib/Simplifier/PropagateEqualities.cpp
+++ b/lib/Simplifier/PropagateEqualities.cpp
@@ -22,6 +22,7 @@ THE SOFTWARE.
 ********************************************************************/
 
 #include "stp/Simplifier/PropagateEqualities.h"
+#include "stp/Util/DagWalk.h"
 #include <string>
 #include <utility>
 #include <queue>
@@ -537,11 +538,21 @@ void PropagateEqualities::countToDo(ASTNode n)
   }
 }
 
+// The AND arm below is the only place this reaches another node. Walk its
+// spine with suspended ancestors so both deeply nested and very wide
+// conjunctions have bounded auxiliary memory. See DeepDag_Test.cpp.
 void PropagateEqualities::buildCandidateList(const ASTNode& a)
+{
+  walkPreOrder(a, [&](const ASTNode& current) {
+    return buildCandidateListNode(current);
+  });
+}
+
+bool PropagateEqualities::buildCandidateListNode(const ASTNode& a)
 {
 
   if (!alreadyVisited.insert(a.GetNodeNum()).second)
-    return;
+    return false;
 
   const Kind k = a.GetKind();
 
@@ -656,11 +667,7 @@ void PropagateEqualities::buildCandidateList(const ASTNode& a)
     else if (SYMBOL == a[1].GetKind())
       addCandidate(a[1], a[0]);
   }
-  else if (AND == k)
-  {
-    for (const auto& it : a)
-      buildCandidateList(it);
-  }
+  return AND == k;
 }
 
 

--- a/lib/Simplifier/Rewriting.cpp
+++ b/lib/Simplifier/Rewriting.cpp
@@ -45,7 +45,10 @@ THE SOFTWARE.
 #include "stp/Simplifier/Rewriting.h"
 #include "stp/Simplifier/Simplifier.h"
 #include "stp/Simplifier/SubstitutionMap.h"
+#include "stp/Util/DagWalk.h"
 #include <list>
+#include <deque>
+#include <vector>
 
 namespace stp
 {
@@ -72,50 +75,29 @@ namespace stp
   }
 
   // counter is 1 if the node has one reference in the tree.
+  //
+  // The walk is iterative because the input decides how deep it goes, and
+  // deep inputs exist: a call per level of the DAG exhausts the stack. The
+  // continuation stack holds pointers into each node's own child storage,
+  // which the node above keeps alive for the whole walk. It stores suspended
+  // ancestors, not every sibling in a wide frontier.
   void Rewriting::buildShareCount(const ASTNode& n)
   {
-    if (n.Degree() == 0)
-      return;
+    walkPreOrder(n, [&](const ASTNode& current) {
+      if (current.Degree() == 0)
+        return false;
 
-    if (shareCount[n.GetNodeNum()]++ > 0) // 0 first time, 1 second time.
-      return;
-  
-    for (const auto& c: n.GetChildren())
-        buildShareCount(c);
+      if (shareCount[current.GetNodeNum()]++ > 0) // 0 first time, 1 second.
+        return false;
+      return true;
+    });
   }
 
-  ASTNode Rewriting::rewrite(const ASTNode& n)
+  // Every sharing-aware rule, in order, applied to one node. Each rule
+  // sees what the rules before it produced. Nothing here descends into
+  // the DAG: the caller decides what to do with a node that changed.
+  ASTNode Rewriting::applyRules(ASTNode c)
   {
-    if (n.Degree() == 0)
-      return n;
-
-    if (fromTo.find(n.GetNodeNum()) != fromTo.end())
-      return fromTo[n.GetNodeNum()];
-
-    ASTNode result =n;
-
-    const ASTChildren children = n.GetChildren();
-    ASTVec newChildren;
-
-    // Copy on write.
-    bool changed =false;
-    auto fill = [&](const ASTNode& find)
-    {
-      newChildren.reserve(children.size());
-      const auto findIt = std::find(children.begin(), children.end(), find);
-      assert(findIt != children.end());
-      newChildren.insert(newChildren.end(), children.begin(), findIt);
-      changed=true;
-    };
-
-
-    for (auto c: children)
-    {
-     const ASTNode begin = c;
-     
-     c = rewrite(c);
-
-     const ASTNode start = c;
 
      if (
         c.GetKind() == EQ 
@@ -710,30 +692,173 @@ namespace stp
           c = nf->CreateNode(EQ, left,right);
         }
 
-       if (start != c)
-       {
-          c = rewrite(c);
-          removed++;
-       }
-       // TODO should probably update the sharecount.
-       if (begin!=c && !changed)
-          fill(begin);
-        if (changed)   
-          newChildren.push_back(c);
-    }    
+    return c;
+  }
 
-    if (newChildren.size() > 0)
+  // A leaf, or a node already rewritten: answered without a frame, exactly
+  // as the recursive version answered it without a call.
+  bool Rewriting::alreadyKnown(const ASTNode& n, ASTNode& answer)
+  {
+    if (n.Degree() == 0)
     {
-      assert(newChildren.size() == children.size());
-
-      if (n.GetType() == BOOLEAN_TYPE)
-        result = nf->CreateNode(n.GetKind(), newChildren);
-      else
-        result = nf->CreateArrayTerm(n.GetKind(), n.GetIndexWidth(),n.GetValueWidth(), newChildren);
+      answer = n;
+      return true;
     }
 
-    //TODO is this right? We've replaced the children, but never this node?
-    fromTo.insert({n.GetNodeNum(),result});
-    return result;
+    const auto it = fromTo.find(n.GetNodeNum());
+    if (it != fromTo.end())
+    {
+      answer = it->second;
+      return true;
+    }
+    return false;
+  }
+
+  // One node's progress through its children. `phase` says what a value
+  // arriving from below is: the recursive rewrite() had two call sites per
+  // child -- the child itself, and again on whatever the rules made of it
+  // -- and a frame has to know which one it is waiting for.
+  struct Rewriting::Frame
+  {
+    ASTNode n;
+    ASTChildren children;
+    ASTVec newChildren; // copy on write: empty until a child changes.
+    bool changed = false;
+    unsigned i = 0; // the child being worked on
+
+    ASTNode begin; // that child as it was before anything ran on it
+    ASTNode start; // and as it was after rewriting, before the rules
+
+    enum Phase
+    {
+      Fresh,
+      AwaitingChild,
+      AwaitingTransformed
+    };
+    Phase phase = Fresh;
+
+    Frame(const ASTNode& n_) : n(n_), children(n_.GetChildren()) {}
+  };
+
+  ASTNode Rewriting::rewrite(const ASTNode& n)
+  {
+    ASTNode result;
+    if (alreadyKnown(n, result))
+      return result;
+
+    // A deque, so descending into a child never moves the frames above it:
+    // `current` stays valid across a push.
+    std::deque<Frame> stack;
+    stack.emplace_back(n);
+
+    // Copy on write.
+    auto fill = [](Frame& f, const ASTNode& find)
+    {
+      f.newChildren.reserve(f.children.size());
+      const auto findIt =
+          std::find(f.children.begin(), f.children.end(), find);
+      assert(findIt != f.children.end());
+      f.newChildren.insert(f.newChildren.end(), f.children.begin(), findIt);
+      f.changed = true;
+    };
+
+    // The tail of the recursive version's loop body: `c` is the child in
+    // its final form.
+    auto finishChild = [&fill](Frame& f, const ASTNode& c)
+    {
+      // TODO should probably update the sharecount.
+      if (f.begin != c && !f.changed)
+        fill(f, f.begin);
+      if (f.changed)
+        f.newChildren.push_back(c);
+      f.i++;
+    };
+
+    // With the child rewritten, run the rules over it. A rule that fires
+    // sends its result back through the walk, which is the second of the
+    // two call sites; true means this frame has descended for that.
+    auto afterRewrite = [&](Frame& f, const ASTNode& rewritten) -> bool
+    {
+      f.start = rewritten;
+      const ASTNode c = applyRules(rewritten);
+
+      if (f.start == c)
+      {
+        finishChild(f, c);
+        return false;
+      }
+
+      ASTNode known;
+      if (alreadyKnown(c, known))
+      {
+        removed++;
+        finishChild(f, known);
+        return false;
+      }
+
+      f.phase = Frame::AwaitingTransformed;
+      stack.emplace_back(c);
+      return true;
+    };
+
+    while (true)
+    {
+      Frame& current = stack.back();
+      bool descended = false;
+
+      // Take delivery of the child this frame descended for.
+      if (current.phase == Frame::AwaitingChild)
+      {
+        current.phase = Frame::Fresh;
+        descended = afterRewrite(current, result);
+      }
+      else if (current.phase == Frame::AwaitingTransformed)
+      {
+        current.phase = Frame::Fresh;
+        removed++;
+        finishChild(current, result);
+      }
+
+      while (!descended && current.i < current.children.size())
+      {
+        current.begin = current.children[current.i];
+
+        ASTNode known;
+        if (alreadyKnown(current.begin, known))
+        {
+          descended = afterRewrite(current, known);
+          continue;
+        }
+
+        current.phase = Frame::AwaitingChild;
+        stack.emplace_back(current.begin);
+        descended = true;
+      }
+
+      if (descended)
+        continue;
+
+      Frame& done = stack.back();
+      result = done.n;
+
+      if (done.newChildren.size() > 0)
+      {
+        assert(done.newChildren.size() == done.children.size());
+
+        if (done.n.GetType() == BOOLEAN_TYPE)
+          result = nf->CreateNode(done.n.GetKind(), done.newChildren);
+        else
+          result = nf->CreateArrayTerm(done.n.GetKind(), done.n.GetIndexWidth(),
+                                       done.n.GetValueWidth(),
+                                       done.newChildren);
+      }
+
+      //TODO is this right? We've replaced the children, but never this node?
+      fromTo.insert({done.n.GetNodeNum(), result});
+
+      stack.pop_back();
+      if (stack.empty())
+        return result;
+    }
   }
 }

--- a/lib/Simplifier/StrengthReduction.cpp
+++ b/lib/Simplifier/StrengthReduction.cpp
@@ -26,6 +26,7 @@ THE SOFTWARE.
 #include "stp/Simplifier/StrengthReduction.h"
 #include "stp/Simplifier/constantBitP/FixedBits.h"
 #include "stp/Util/CBVOps.h"
+#include "stp/Util/DagWalk.h"
 #include <iostream>
 
 namespace stp
@@ -86,52 +87,42 @@ namespace stp
   }
 
   // visit each node apply strength reductions to it.
+  //
+  // postOrderRebuild does the walking, on the heap: how deeply the input
+  // nests is not this pass's choice, and a call per level exhausts the
+  // stack. What is left here is the reduction of a single node.
   ASTNode StrengthReduction::visit(const ASTNode& n, NodeDomainAnalysis& nda, ASTNodeMap& cache)
   {
-    if (n.Degree() == 0 )
-      return n;
+    return postOrderRebuild(
+        n, cache, [&](const ASTNode& node, const ASTVec& children) {
+          ASTNode newN;
+          if (node.GetType() == BOOLEAN_TYPE)
+            newN = nf->CreateNode(node.GetKind(), children);
+          else
+            newN = nf->CreateArrayTerm(node.GetKind(), node.GetIndexWidth(),
+                                       node.GetValueWidth(), children);
 
-    {
-      const ASTNodeMap::const_iterator it = cache.find(n);
-      if (it != cache.end())
-        return it->second;
-    }
+          // buildMap memoises on the node, so it only needs redoing when the
+          // preceding reduction actually replaced the node.
+          nda.buildMap(newN);
+          ASTNode reduced = strengthReduction(newN, *nda.getCbitMap());
 
-    ASTVec children;
-    children.reserve(n.Degree());
-    
-    for (const auto & c: n)
-    {
-      children.push_back(visit(c,nda,cache));
-    }
+          if (reduced != newN)
+          {
+            newN = reduced;
+            nda.buildMap(newN);
+          }
+          reduced = strengthReduction(newN, *nda.getIntervalMap());
 
-    ASTNode newN;
-    if (n.GetType() == BOOLEAN_TYPE)
-      newN = nf->CreateNode(n.GetKind(), children);
-    else
-      newN = nf->CreateArrayTerm(n.GetKind(), n.GetIndexWidth(),n.GetValueWidth(), children);
-   
-    // buildMap memoises on the node, so it only needs redoing when the
-    // preceding reduction actually replaced the node.
-    nda.buildMap(newN);
-    ASTNode reduced = strengthReduction(newN, *nda.getCbitMap());
+          if (reduced != newN)
+          {
+            newN = reduced;
+            nda.buildMap(newN);
+          }
+          newN = strengthReduction(newN, *nda.getValueSetMap());
 
-    if (reduced != newN)
-    {
-      newN = reduced;
-      nda.buildMap(newN);
-    }
-    reduced = strengthReduction(newN, *nda.getIntervalMap());
-
-    if (reduced != newN)
-    {
-      newN = reduced;
-      nda.buildMap(newN);
-    }
-    newN = strengthReduction(newN, *nda.getValueSetMap());
-
-    cache.insert({n,newN});
-    return newN;
+          return newN;
+        });
   }
 
   ASTNode StrengthReduction::topLevel(const ASTNode& top, NodeDomainAnalysis& nda)

--- a/lib/Simplifier/SubstitutionMap.cpp
+++ b/lib/Simplifier/SubstitutionMap.cpp
@@ -26,6 +26,7 @@ THE SOFTWARE.
 #include "stp/AbsRefineCounterExample/ArrayTransformer.h"
 #include "stp/Extensionality/ExtensionalityContext.h"
 #include "stp/Simplifier/Simplifier.h"
+#include <vector>
 
 namespace stp
 {
@@ -131,135 +132,297 @@ ASTNode SubstitutionMap::replace(const ASTNode& n, NodeMapType& fromTo,
 // NB: You can't use this to map from "5" to the symbol "x" say.
 // It's optimised for the symbol to something case.
 
+// The walk keeps its frames on the heap. Input decides how deeply a formula
+// nests, and deeply nested ones exist, so a call per level of the DAG
+// exhausts the stack. See DeepDag_Test.cpp.
 template <class NodeMapType>
 ASTNode SubstitutionMap::replace(const ASTNode& n, NodeMapType& fromTo,
                                  NodeMapType& cache, NodeFactory* nf,
                                  bool stopAtArrays, bool preventInfinite)
 {
-  const Kind k = n.GetKind();
-  if (k == BVCONST || k == TRUE || k == FALSE)
-    return n;
-
-  typename NodeMapType::const_iterator it;
-
-  if ((it = cache.find(n)) != cache.end())
-    return it->second;
-
-  if ((it = fromTo.find(n)) != fromTo.end())
+  // One node's progress. `phase` says what a value arriving from below is:
+  // the recursive version called itself from three places -- following a
+  // chain of substitutions, replacing a child, and running again over a
+  // node it had just rebuilt -- and a frame has to know which it awaits.
+  struct Frame
   {
-    // By value, not by reference: the recursive calls below can insert into
-    // and erase from fromTo, and a DenseNodeMap moves its elements when that
-    // happens -- a reference here would dangle.
-    const ASTNode r = it->second;
-    assert(r.GetIndexWidth() == n.GetIndexWidth());
+    ASTNode n;
+    Kind k;
+    unsigned int indexWidth;
+    unsigned int valueWidth;
 
-    if (preventInfinite)
-      cache.insert(make_pair(n, r));
-
-    ASTNode replaced =
-        replace(r, fromTo, cache, nf, stopAtArrays, preventInfinite);
-    if (replaced != r)
+    enum Phase
     {
-      fromTo.erase(n);
-      fromTo[n] = replaced;
-    }
+      AwaitingChain,
+      AwaitingChild,
+      AwaitingRemap
+    };
+    Phase phase;
 
-    if (preventInfinite)
-      cache.erase(n);
+    ASTNode chainTarget; // what n maps to, for AwaitingChain
+    ASTNode remapped;    // the rebuilt node, for AwaitingRemap
+    bool started = false;
 
-    cache.insert(make_pair(n, replaced));
-    return replaced;
-  }
-
-  // These can't be created like regular nodes are
-  if (k == SYMBOL)
-    return n;
-
-  const unsigned int indexWidth = n.GetIndexWidth();
-  if (stopAtArrays && indexWidth > 0) // is an array.
-  {
-    return n;
-  }
-
-  // Floating-point special constants (NaN, +/-oo, +/-zero) are nullary leaves
-  // that the BVCONST/TRUE/FALSE test above does not cover, so they reach here
-  // with no children. They are values: there is nothing to substitute into.
-  if (n.Degree() == 0)
-    return n;
-
-  const ASTChildren children = n.GetChildren();
-  assert(children.size() > 0);
-  // Should have no leaves left here.
-
-  ASTVec newChildren;
-  bool changed = false;
-
-  for (auto it = children.begin(); it != children.end(); it++)
-  {
-    ASTNode newNode = replace(*it, fromTo, cache, nf, stopAtArrays, preventInfinite);
-    if (!changed && newNode!=*it)
-    {
-        newChildren.reserve(children.size());
-        newChildren.insert(newChildren.end(), children.begin(), it);
-        changed=true;
-    }
-    if (changed)   
-      newChildren.push_back(newNode);
-  }
-
-  assert(newChildren.size() == 0 || (newChildren.size() == children.size()));
-
-  // This code short-cuts if the children are the same. Nodes with the same
-  // children,
-  // won't have necessarily given the same node if the simplifyingNodeFactory is
-  // enabled
-  // now, but wasn't enabled when the node was created. Shortcutting saves lots
-  // of time.
-  if (newChildren.size() ==0)
-  {
-    cache.insert(make_pair(n, n));
-    return n;
-  }
+    ASTChildren children;
+    ASTVec newChildren;
+    bool changed = false;
+    unsigned i = 0; // the child being worked on
+    bool waiting = false;
+  };
 
   ASTNode result;
-  const unsigned int valueWidth = n.GetValueWidth();
 
-  if (valueWidth == 0) // n.GetType() == BOOLEAN_TYPE
+  // The head of the recursive version, in its order -- in particular the
+  // fromTo test before the SYMBOL test, which is what makes substituting
+  // for a symbol work at all. Either the answer needs no frame and lands in
+  // `result`, or `frame` is prepared for the walk below it.
+  auto prepare = [&](const ASTNode& node, Frame& frame) -> bool
   {
-    result = nf->CreateNode(k, newChildren);
-  }
-  else
-  {
-    // If the index and value width aren't saved, they are reset sometimes (??)
-    result = nf->CreateArrayTerm(k, indexWidth, valueWidth, newChildren);
-  }
+    const Kind k = node.GetKind();
+    if (k == BVCONST || k == TRUE || k == FALSE)
+    {
+      result = node;
+      return false;
+    }
 
-  // We may have created something that should be mapped. For instance,
-  // if n is READ(A, x), and the fromTo is: {x==0, READ(A,0) == 1}, then
-  // by here the result will be READ(A,0). Which needs to be mapped again..
-  // I hope that this makes it idempotent.
+    typename NodeMapType::const_iterator it;
 
-  if (fromTo.find(result) != fromTo.end())
+    if ((it = cache.find(node)) != cache.end())
+    {
+      result = it->second;
+      return false;
+    }
+
+    if ((it = fromTo.find(node)) != fromTo.end())
+    {
+      // By value, not by reference: the walk below inserts into and erases
+      // from fromTo, and a DenseNodeMap moves its elements when that
+      // happens -- a reference here would dangle.
+      frame.chainTarget = it->second;
+      assert(frame.chainTarget.GetIndexWidth() == node.GetIndexWidth());
+      frame.phase = Frame::AwaitingChain;
+
+      if (preventInfinite)
+        cache.insert(make_pair(node, frame.chainTarget));
+    }
+    // These can't be created like regular nodes are
+    else if (k == SYMBOL)
+    {
+      result = node;
+      return false;
+    }
+    else if (stopAtArrays && node.GetIndexWidth() > 0) // is an array.
+    {
+      result = node;
+      return false;
+    }
+    // Floating-point special constants (NaN, +/-oo, +/-zero) are nullary
+    // leaves that the BVCONST/TRUE/FALSE test above does not cover, so they
+    // reach here with no children. They are values: there is nothing to
+    // substitute into.
+    else if (node.Degree() == 0)
+    {
+      result = node;
+      return false;
+    }
+    else
+    {
+      frame.phase = Frame::AwaitingChild;
+      frame.children = node.GetChildren();
+      assert(frame.children.size() > 0);
+      // Should have no leaves left here.
+    }
+
+    frame.n = node;
+    frame.k = k;
+    frame.indexWidth = node.GetIndexWidth();
+    frame.valueWidth = node.GetValueWidth();
+    return true;
+  };
+
+  // Answer settled roots before constructing the stack, so constants, leaves,
+  // stopped arrays and cache hits pay for no traversal storage.
+  Frame top;
+  if (!prepare(n, top))
+    return result;
+
+  // Most substitution walks are only a few frames deep. Keep those frames in
+  // one compact allocation instead of a deque's map and fixed-size blocks.
+  // A push may move every frame, so callers of descend must not retain or use
+  // a Frame reference after descend returns true.
+  std::vector<Frame> stack;
+  stack.push_back(std::move(top));
+
+  auto descend = [&](const ASTNode& node, Frame* waitingParent = nullptr) -> bool
   {
-    // map n->result, if running replace() on result gives us 'n', it will not
-    // infinite loop.
-    // This is only currently required for the bitblast equivalence stuff.
+    Frame frame;
+    if (!prepare(node, frame))
+      return false;
+    if (waitingParent != nullptr)
+      waitingParent->waiting = true;
+    stack.push_back(std::move(frame));
+    return true;
+  };
+
+  // Copy on write, one child at a time.
+  auto foldChild = [](Frame& f, const ASTNode& newNode)
+  {
+    const ASTNode& child = f.children[f.i];
+    if (!f.changed && newNode != child)
+    {
+      f.newChildren.reserve(f.children.size());
+      f.newChildren.insert(f.newChildren.end(), f.children.begin(),
+                           f.children.begin() + f.i);
+      f.changed = true;
+    }
+    if (f.changed)
+      f.newChildren.push_back(newNode);
+    f.i++;
+  };
+
+  // The answer for a rebuilt node, cached and handed back up.
+  auto finish = [&](Frame& f, const ASTNode& value)
+  {
+    assert(value.GetValueWidth() == f.valueWidth);
+    assert(value.GetIndexWidth() == f.indexWidth);
+
+    // If there is already an "n" element in the cache, the maps semantics
+    // are to ignore the next insertion.
     if (preventInfinite)
-      cache.insert(make_pair(n, result));
+      cache.erase(f.n);
 
-    result = replace(result, fromTo, cache, nf, stopAtArrays, preventInfinite);
+    cache.insert(make_pair(f.n, value));
+    result = value;
+    stack.pop_back();
+  };
+
+  while (true)
+  {
+    Frame& current = stack.back();
+
+    // We call replace on each of the things in the fromTo map aswell.
+    // This is in case we have a fromTo map: (x maps to y), (y maps to 5),
+    // and pass the replace() function the node "x" to replace, then it
+    // will return 5, rather than y.
+    if (current.phase == Frame::AwaitingChain)
+    {
+      if (!current.started)
+      {
+        current.started = true;
+        if (descend(current.chainTarget))
+          continue;
+      }
+
+      const ASTNode replaced = result; // replace(chainTarget)
+      if (replaced != current.chainTarget)
+      {
+        fromTo.erase(current.n);
+        fromTo[current.n] = replaced;
+      }
+
+      if (preventInfinite)
+        cache.erase(current.n);
+
+      cache.insert(make_pair(current.n, replaced));
+      result = replaced;
+      stack.pop_back();
+
+      if (stack.empty())
+        return result;
+      continue;
+    }
+
+    if (current.phase == Frame::AwaitingRemap)
+    {
+      if (!current.started)
+      {
+        current.started = true;
+        if (descend(current.remapped))
+          continue;
+      }
+
+      finish(current, result); // replace(remapped)
+      if (stack.empty())
+        return result;
+      continue;
+    }
+
+    if (current.waiting)
+    {
+      current.waiting = false;
+      foldChild(current, result);
+    }
+
+    bool descended = false;
+    while (current.i < current.children.size())
+    {
+      // descend installs the continuation only when it will push, and does
+      // so before vector growth can move `current`.
+      if (descend(current.children[current.i], &current))
+      {
+        descended = true;
+        break;
+      }
+      foldChild(current, result);
+    }
+    if (descended)
+      continue;
+
+    assert(current.newChildren.size() == 0 ||
+           (current.newChildren.size() == current.children.size()));
+
+    // This code short-cuts if the children are the same. Nodes with the same
+    // children,
+    // won't have necessarily given the same node if the simplifyingNodeFactory is
+    // enabled
+    // now, but wasn't enabled when the node was created. Shortcutting saves lots
+    // of time.
+    if (current.newChildren.size() == 0)
+    {
+      cache.insert(make_pair(current.n, current.n));
+      result = current.n;
+      stack.pop_back();
+
+      if (stack.empty())
+        return result;
+      continue;
+    }
+
+    ASTNode built;
+    if (current.valueWidth == 0) // n.GetType() == BOOLEAN_TYPE
+    {
+      built = nf->CreateNode(current.k, current.newChildren);
+    }
+    else
+    {
+      // If the index and value width aren't saved, they are reset sometimes (??)
+      built = nf->CreateArrayTerm(current.k, current.indexWidth,
+                                  current.valueWidth, current.newChildren);
+    }
+
+    // We may have created something that should be mapped. For instance,
+    // if n is READ(A, x), and the fromTo is: {x==0, READ(A,0) == 1}, then
+    // by here the result will be READ(A,0). Which needs to be mapped again..
+    // I hope that this makes it idempotent.
+
+    if (fromTo.find(built) != fromTo.end())
+    {
+      // map n->result, if running replace() on result gives us 'n', it will
+      // not infinite loop.
+      // This is only currently required for the bitblast equivalence stuff.
+      if (preventInfinite)
+        cache.insert(make_pair(current.n, built));
+
+      current.phase = Frame::AwaitingRemap;
+      current.remapped = built;
+      current.started = false;
+      continue;
+    }
+
+    finish(current, built);
+    if (stack.empty())
+      return result;
   }
-
-  assert(result.GetValueWidth() == valueWidth);
-  assert(result.GetIndexWidth() == indexWidth);
-
-  // If there is already an "n" element in the cache, the maps semantics are to
-  // ignore the next insertion.
-  if (preventInfinite)
-    cache.erase(n);
-
-  cache.insert(make_pair(n, result));
-  return result;
 }
 
 // The two map types replace() runs over: the SolverMap paths use

--- a/lib/Simplifier/VariablesInExpression.cpp
+++ b/lib/Simplifier/VariablesInExpression.cpp
@@ -23,6 +23,7 @@ THE SOFTWARE.
 ********************************************************************/
 
 #include "stp/Simplifier/VariablesInExpression.h"
+#include "stp/Util/DagWalk.h"
 
 namespace stp
 {
@@ -48,9 +49,49 @@ void VariablesInExpression::insert(const ASTNode& n, Symbols* s)
 // in the descendents changes. For example (EXTRACT 0 1 n)
 // will have the same "Symbols" node as n, because
 // no new symbols are introduced.
+// Every node below `n` before `n` itself, in the order getSymbol would have
+// reached them. It looks at every child of every node it visits, and its one
+// early return is for a symbol, which has no children, so nothing is built
+// here that it would not have built anyway.
+void VariablesInExpression::primeSymbols(const ASTNode& n)
+{
+  primeMemo(
+      n,
+      [this](const ASTNode& node)
+      {
+        if (symbol_graph.find(node.GetNodeNum()) != symbol_graph.end())
+          return Walk::Skip; // getSymbol would answer from the graph.
+        return node.Degree() == 0 ? Walk::Visit : Walk::Descend;
+      },
+      [this](const ASTNode& node, PrimeMemoReady) { getSymbol(node, true); });
+}
+
 Symbols* VariablesInExpression::getSymbol(const ASTNode& n)
 {
+  return getSymbol(n, false);
+}
+
+Symbols* VariablesInExpression::getSymbol(const ASTNode& n,
+                                          const bool knownMissing)
+{
+  PrimeAudit::Running running(symbolAudit, n);
+
+  // primeSymbols' classifier already made this lookup. Its ready token is a
+  // known miss because building a descendant cannot insert an ancestor into
+  // this bottom-up graph.
+  if (!knownMissing)
   {
+    const ASTNodeToNodes::const_iterator it = symbol_graph.find(n.GetNodeNum());
+    if (it != symbol_graph.end())
+      return it->second;
+  }
+
+  if (!priming)
+  {
+    priming = true;
+    primeSymbols(n);
+    priming = false;
+
     const ASTNodeToNodes::const_iterator it = symbol_graph.find(n.GetNodeNum());
     if (it != symbol_graph.end())
       return it->second;
@@ -95,39 +136,46 @@ void VariablesInExpression::VarSeenInTerm(Symbols* term, SymbolPtrSet& visited,
                                           ASTNodeSet& found,
                                           vector<Symbols*>& av)
 {
-  if (visited.find(term) != visited.end())
+  // Iterative: the Symbols tree is as deep as the expression it was built
+  // from, so a call per level exhausts the stack on the inputs that reach
+  // here. Children are pushed in reverse, so they are still visited left to
+  // right and the walk sees what the recursion saw. See DeepDag_Test.cpp.
+  vector<Symbols*> toVisit;
+  toVisit.push_back(term);
+
+  while (!toVisit.empty())
   {
-    return;
+    Symbols* const current = toVisit.back();
+    toVisit.pop_back();
+
+    if (visited.find(current) != visited.end())
+    {
+      continue;
+    }
+
+    if (current->isLeaf())
+    {
+      found.insert(current->found);
+      continue;
+    }
+
+    visited.insert(current);
+
+    SymbolPtrToNode::const_iterator it;
+    if ((it = TermsAlreadySeenMap.find(current)) != TermsAlreadySeenMap.end())
+    {
+      // We've previously built the set of variables below this "symbols".
+      // It's not added into "found" because its sometimes 70k variables
+      // big, and if there are no other symbols discovered it's a terrible
+      // waste to create a copy of the set. Instead we store (in effect)
+      // a pointer to the set.
+      av.push_back(current);
+      continue;
+    }
+
+    for (size_t i = current->children.size(); i > 0; i--)
+      toVisit.push_back(current->children[i - 1]);
   }
-
-  if (term->isLeaf())
-  {
-    found.insert(term->found);
-    return;
-  }
-
-  visited.insert(term);
-
-  SymbolPtrToNode::const_iterator it;
-  if ((it = TermsAlreadySeenMap.find(term)) != TermsAlreadySeenMap.end())
-  {
-    // We've previously built the set of variables below this "symbols".
-    // It's not added into "found" because its sometimes 70k variables
-    // big, and if there are no other symbols discovered it's a terrible
-    // waste to create a copy of the set. Instead we store (in effect)
-    // a pointer to the set.
-    av.push_back(term);
-    return;
-  }
-
-  for (vector<Symbols*>::const_iterator it = term->children.begin(),
-                                        itend = term->children.end();
-       it != itend; it++)
-  {
-    VarSeenInTerm(*it, visited, found, av);
-  }
-
-  return;
 }
 
 ASTNodeSet* VariablesInExpression::SetofVarsSeenInTerm(Symbols* symbol,

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -27,7 +27,9 @@ THE SOFTWARE.
 #include "stp/Simplifier/constantBitP/FixedBits.h"
 #include "stp/Simplifier/constantBitP/NodeToFixedBitsMap.h"
 #include "stp/ToSat/BBNodeManagerAIG.h"
+#include "stp/Util/DagWalk.h"
 #include <cassert>
+#include <deque>
 #include <cmath>
 
 namespace stp
@@ -66,6 +68,35 @@ vector<BBNodeAIG> _empty_BBNodeAIGVec;
 // that should have already been applied.
 const bool debug_do_check = false;
 const bool debug_bitblaster = false;
+
+namespace
+{
+// BBForm and BBTerm share one recursion budget because they call each other.
+// Keeping the counter in a scope guard makes all of their many early returns
+// release the budget without putting cleanup code on each path.
+class UnprimedDepth
+{
+  size_t& depth;
+  const bool active;
+
+public:
+  UnprimedDepth(size_t& depth_, const bool active_)
+      : depth(depth_), active(active_)
+  {
+    if (active)
+      ++depth;
+  }
+
+  UnprimedDepth(const UnprimedDepth&) = delete;
+  UnprimedDepth& operator=(const UnprimedDepth&) = delete;
+
+  ~UnprimedDepth()
+  {
+    if (active)
+      --depth;
+  }
+};
+} // namespace
 
 // Translates signed BVDIV,BVMOD and BVREM into unsigned variety
 static ASTNode TranslateSignedDivModRem(const ASTNode& in, NodeFactory* nf)
@@ -737,18 +768,48 @@ BitBlaster::simplify_during_bb(ASTNode& term,
   return BBTermMemo.end();
 }
 
-const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term,
-                                   BBNodeSet& support)
+const BBNodeVec BitBlaster::BBTerm(const ASTNode& term, BBNodeSet& support)
+{
+  return BBTerm(term, support, false);
+}
+
+const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term, BBNodeSet& support,
+                                   const bool knownMissing)
 {
   ASTNode term = _term; // mutable local copy.
 
-  auto it = BBTermMemo.find(term);
-  if (it != BBTermMemo.end())
+  // Debug-only, and the whole of what holds primeMemos to the blaster: every
+  // node reached from here is one the walk has to have offered, and every
+  // operand the walk primed is one that has to be reached from here.
+  PrimeAudit::Running running(memoAudit, term);
+
+  auto it = BBTermMemo.end();
+  if (!knownMissing)
   {
-    // Constant bit propagation may have updated something.
-    updateTerm(term, it->second, support);
-    return it->second;
+    it = BBTermMemo.find(term);
+    if (it != BBTermMemo.end())
+    {
+      // Constant bit propagation may have updated something.
+      updateTerm(term, it->second, support);
+      return it->second;
+    }
   }
+
+  if (!priming && unprimedDepth >= unprimedDepthLimit)
+  {
+    priming = true;
+    primeMemos(term, support);
+    priming = false;
+
+    it = BBTermMemo.find(term);
+    if (it != BBTermMemo.end())
+    {
+      updateTerm(term, it->second, support);
+      return it->second;
+    }
+  }
+
+  UnprimedDepth depth(unprimedDepth, !priming);
 
   if (uf != NULL && uf->optimize_flag && uf->simplify_during_BB_flag)
   {
@@ -1241,16 +1302,112 @@ const BBNode BitBlaster::BBForm(const ASTNode& form)
     return nf->CreateNode(AND, v);
 }
 
-// bit blast a formula (boolean term).  Result is one bit wide,
-const BBNode BitBlaster::BBForm(const ASTNode& form,
-                                BBNodeSet& support)
+// The operands of a node, in the order the blaster reaches them, where that
+// is not left to right. Only the mirrored floating-point comparisons: to
+// blast fp.lt(a,b) BBcompareFP treats it as fp.gt(b,a) and blasts b first.
+// A walk that primed them left to right would build the same nodes in the
+// other order, and the CNF with them.
+static WalkOperands bbOperands(const ASTNode& n)
 {
-  auto it = BBFormMemo.find(form);
-  if (it != BBFormMemo.end())
+  const Kind k = n.GetKind();
+  if (k != FP_LT && k != FP_LEQ)
+    return WalkOperands::all(n);
+
+  return WalkOperands::reversed(n);
+}
+
+// Blast everything below `n` before `n` itself, so that the calls the
+// blaster makes on its operands all land on a memo and its recursion never
+// goes more than one deep. BBForm reaches its operands by calling itself for
+// the connectives; BBTerm reaches its own from 24 places across a 450-line
+// switch. Neither is restated: filling their memos from the bottom is what
+// makes them stack-safe.
+//
+// One walk over both memos rather than one each. The two sides reach each
+// other freely -- an ITE's condition is a formula inside a term, an
+// equality's operands are terms inside a formula -- so a walk that stopped
+// at the type boundary and left the far side to "the other walk" only works
+// if the other walk is running. It is not: it is guarded against re-entering
+// while this one is in progress. That is how a term below a formula below a
+// term used to go down the stack, and a walk that crosses the boundary
+// itself has no such hole. See DeepDag_Test.cpp.
+//
+// It is sound because of what the blaster does not do. No arm of either
+// function stops before an operand, so every node primed is one that would
+// have been blasted anyway; the order is the order they would have been
+// blasted in, operands first and each finished before the next starts. That
+// is load-bearing -- the CNF must not depend on the order operands happen to
+// be evaluated in, which is why BBForm blasts an ITE's arms into named
+// variables -- and it is what `bbOperands` above exists for.
+void BitBlaster::primeMemos(const ASTNode& n, BBNodeSet& support)
+{
+  primeMemo(
+      n,
+      [this](const ASTNode& node)
+      {
+        if (node.GetType() == BOOLEAN_TYPE)
+        {
+          // Ahead of the constant test below, because BBForm memoises TRUE
+          // and FALSE: the walk hands them over rather than skipping them.
+          if (BBFormMemo.find(node) != BBFormMemo.end())
+            return Walk::Skip; // BBForm would take it from the memo.
+          return node.Degree() == 0 ? Walk::Visit : Walk::Descend;
+        }
+        // A constant operand is skipped: the kinds that carry one --
+        // BVEXTRACT's indices, BVSX's width -- never blast it, and blasting
+        // it here would put a node in the memo the pass never asked for.
+        if (node.isConstant())
+          return Walk::Skip;
+        if (BBTermMemo.find(node) != BBTermMemo.end())
+          return Walk::Skip;
+        return node.Degree() == 0 ? Walk::Visit : Walk::Descend;
+      },
+      bbOperands,
+      [this, &support](const ASTNode& node, PrimeMemoReady)
+      {
+        if (node.GetType() == BOOLEAN_TYPE)
+          BBForm(node, support, true);
+        else
+          BBTerm(node, support, true);
+      });
+}
+
+// bit blast a formula (boolean term).  Result is one bit wide,
+const BBNode BitBlaster::BBForm(const ASTNode& form, BBNodeSet& support)
+{
+  return BBForm(form, support, false);
+}
+
+const BBNode BitBlaster::BBForm(const ASTNode& form, BBNodeSet& support,
+                                const bool knownMissing)
+{
+  // The other half of the audit above: the two memos are primed by one walk,
+  // so the walk is held to both functions at once.
+  PrimeAudit::Running running(memoAudit, form);
+
+  auto it = BBFormMemo.end();
+  if (!knownMissing)
   {
-    // already there.  Just return it.
-    return it->second;
+    it = BBFormMemo.find(form);
+    if (it != BBFormMemo.end())
+    {
+      // already there.  Just return it.
+      return it->second;
+    }
   }
+
+  if (!priming && unprimedDepth >= unprimedDepthLimit)
+  {
+    priming = true;
+    primeMemos(form, support);
+    priming = false;
+
+    it = BBFormMemo.find(form);
+    if (it != BBFormMemo.end())
+      return it->second;
+  }
+
+  UnprimedDepth depth(unprimedDepth, !priming);
 
   const Kind k = form.GetKind();
   if (!is_Form_kind(k))

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -117,3 +117,11 @@ AddSTPGTest(ValueSet_Exhaustive_Test.cpp)
 AddSTPGTest(SearchBias_Test.cpp)
 AddSTPGTest(Bva_Test.cpp)
 AddSTPGTest(FdOStream_Test.cpp)
+# Deeply nested input must not put the AST-depth-recursive traversals through
+# the call stack. Each case runs in a forked child on a 1 MiB stack.
+AddSTPGTest(DeepDag_Test.cpp)
+# Instantiates BBNodeManagerAIG, whose inline members call ABC; a shared
+# libstp localises ABC's symbols, so this links its own copy the way
+# FloatBlast_Test does.
+target_link_libraries(DeepDag_TestTests $<TARGET_FILE:libabc-pic>)
+add_dependencies(DeepDag_TestTests libabc-pic)

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -125,3 +125,7 @@ AddSTPGTest(DeepDag_Test.cpp)
 # FloatBlast_Test does.
 target_link_libraries(DeepDag_TestTests $<TARGET_FILE:libabc-pic>)
 add_dependencies(DeepDag_TestTests libabc-pic)
+# The check that a primed pass still walks what its priming visits. Debug-only,
+# like the audit it drives: under NDEBUG the cases compile away and the binary
+# reports nothing to run.
+AddSTPGTest(PrimeMemo_Test.cpp)

--- a/tests/unit-tests/DeepDag_Test.cpp
+++ b/tests/unit-tests/DeepDag_Test.cpp
@@ -530,6 +530,37 @@ bool propagateEqualitiesOk(Context& c, unsigned depth)
   return pe.topLevel(f).GetKind() != UNDEFINED;
 }
 
+// FlattenKind, which every pass that wants an n-ary view of a nested
+// same-kind chain goes through: the simplifier, the BV solver,
+// PropagateEqualities, MergeSame and UseITEContext. Its two forms differ in
+// whether they dedup or take a depth limit, and a chain of the kind being
+// flattened reaches each of them one level at a time.
+//
+// The deduplicating form is the one AND, OR, BVAND and BVOR take, and it
+// ignores the depth limit entirely.
+bool flattenKindNoDuplicatesOk(Context& c, unsigned depth)
+{
+  const ASTNode top = c.chain(BVAND, depth);
+  c.roots.push_back(top);
+
+  // The chain is left-nested, so flattening the top node yields every symbol
+  // in it -- which is also how we know the walk reached the bottom.
+  const ASTVec flat = FlattenKind(BVAND, top.GetChildren(), 15);
+  return flat.size() == depth;
+}
+
+// The depth-limited form, which the arithmetic kinds take -- with no limit at
+// all from two of the simplifier's arms, which is where its own recursion is
+// as deep as the chain.
+bool flattenKindDepthOk(Context& c, unsigned depth)
+{
+  const ASTNode top = c.chain(BVPLUS, depth);
+  c.roots.push_back(top);
+
+  const ASTVec flat = FlattenKind(BVPLUS, top.GetChildren());
+  return flat.size() == depth;
+}
+
 // CommonSubSum::topLevel. Already stack-safe; here to keep it that way.
 bool commonSubSumOk(Context& c, unsigned depth)
 {
@@ -538,6 +569,24 @@ bool commonSubSumOk(Context& c, unsigned depth)
   CommonSubSum css(&c.mgr, c.nf);
   ASTNode g = f;
   return css.topLevel(g).GetKind() != UNDEFINED;
+}
+
+// The read-count heuristic must traverse a read-free deep term without C++
+// recursion. Once its strict limit is reached, it must also stop the whole
+// traversal rather than continuing into a later deep sibling.
+bool numberOfReadsWalkOk(Context& c, unsigned depth)
+{
+  const ASTNode deep = c.chain(BVXOR, depth);
+  c.roots.push_back(deep);
+  if (!numberOfReadsLessThan(deep, 1))
+    return false;
+
+  const ASTNode array = c.mgr.CreateSymbol("read-count-array", 8, 8);
+  const ASTNode index = c.mgr.CreateSymbol("read-count-index", 0, 8);
+  const ASTNode read = c.hf->CreateTerm(READ, 8, array, index);
+  const ASTNode earlyStop = c.hf->CreateTerm(BVCONCAT, 16, read, deep);
+  c.roots.push_back(earlyStop);
+  return !numberOfReadsLessThan(earlyStop, 1);
 }
 #ifdef STP_ENABLE_FLOATING_POINT
 
@@ -811,6 +860,47 @@ TEST(DeepDag, substitution_root_fast_paths_preserve_results)
                                             true, false));
 }
 
+TEST(DeepDag, shallow_flatten_kind_no_duplicates)
+{
+  Context c;
+  EXPECT_TRUE(flattenKindNoDuplicatesOk(c, SHALLOW));
+}
+
+TEST(DeepDag, shallow_flatten_kind_depth)
+{
+  Context c;
+  EXPECT_TRUE(flattenKindDepthOk(c, SHALLOW));
+}
+
+TEST(DeepDag, flat_flatten_kind_preserves_children)
+{
+  Context c;
+  ASTVec children;
+  for (unsigned i = 0; i < 4; ++i)
+  {
+    const std::string name = "flat" + std::to_string(i);
+    children.push_back(c.mgr.CreateSymbol(name.c_str(), 0, 8));
+  }
+  const ASTNode holder = c.hf->CreateTerm(BVXOR, 8, children);
+  const ASTVec expected = toASTVec(holder.GetChildren());
+
+  EXPECT_EQ(expected, FlattenKind(BVAND, holder.GetChildren()));
+  EXPECT_EQ(expected, FlattenKind(BVPLUS, holder.GetChildren()));
+}
+
+TEST(DeepDag, duplicate_flatten_kind_does_not_reserve_discarded_edges)
+{
+  Context c;
+  const ASTNode a = c.mgr.CreateSymbol("flat-shared-a", 0, 8);
+  const ASTNode b = c.mgr.CreateSymbol("flat-shared-b", 0, 8);
+  const ASTNode shared = c.hf->CreateTerm(BVAND, 8, a, b);
+  const ASTNode holder = c.hf->CreateTerm(BVXOR, 8, ASTVec(4096, shared));
+
+  const ASTVec flat = FlattenKind(BVAND, holder.GetChildren());
+  EXPECT_EQ(toASTVec(shared.GetChildren()), flat);
+  EXPECT_LT(flat.capacity(), holder.Degree());
+}
+
 TEST(DeepDag, shallow_strength_reduction)
 {
   Context c;
@@ -880,6 +970,31 @@ TEST(DeepDag, shallow_source_sort_store)
 #endif // STP_ENABLE_FLOATING_POINT
 
 
+TEST(DeepDag, array_read_count_is_strict_and_deduplicates_the_dag)
+{
+  Context c;
+  const ASTNode array = c.mgr.CreateSymbol("read-count-shared-array", 8, 8);
+  const ASTNode i = c.mgr.CreateSymbol("read-count-shared-i", 0, 8);
+  const ASTNode j = c.mgr.CreateSymbol("read-count-shared-j", 0, 8);
+  const ASTNode first = c.hf->CreateTerm(READ, 8, array, i);
+  const ASTNode second = c.hf->CreateTerm(READ, 8, array, j);
+  const ASTNode top =
+      c.hf->CreateTerm(BVXOR, 8, ASTVec{first, first, second});
+  c.roots.push_back(top);
+
+  EXPECT_TRUE(numberOfReadsLessThan(top, 3));
+  EXPECT_FALSE(numberOfReadsLessThan(top, 2));
+  EXPECT_FALSE(numberOfReadsLessThan(first, 1));
+  EXPECT_TRUE(numberOfReadsLessThan(first, 2));
+  EXPECT_FALSE(numberOfReadsLessThan(top, 0));
+}
+
+TEST(DeepDag, shallow_array_read_count_walk)
+{
+  Context c;
+  EXPECT_TRUE(numberOfReadsWalkOk(c, SHALLOW));
+}
+
 TEST(DeepDag, deep_rewriting_share_count)
 {
   EXPECT_STACK_SAFE(rewritingIdentityOk, 200000);
@@ -910,6 +1025,16 @@ TEST(DeepDag, deep_substitution)
   EXPECT_STACK_SAFE(substitutionOk, 20000);
 }
 
+TEST(DeepDag, deep_flatten_kind_no_duplicates)
+{
+  EXPECT_STACK_SAFE(flattenKindNoDuplicatesOk, 20000);
+}
+
+TEST(DeepDag, deep_flatten_kind_depth)
+{
+  EXPECT_STACK_SAFE(flattenKindDepthOk, 20000);
+}
+
 TEST(DeepDag, deep_strength_reduction)
 {
   EXPECT_STACK_SAFE(strengthReductionOk, 20000);
@@ -935,6 +1060,10 @@ TEST(DeepDag, deep_node_domain)        { EXPECT_STACK_SAFE(nodeDomainOk, 20000);
 TEST(DeepDag, deep_node_iterator)      { EXPECT_STACK_SAFE(nodeIteratorOk, 20000); }
 TEST(DeepDag, deep_vars_in_expression) { EXPECT_STACK_SAFE(varsInExpressionOk, 20000); }
 TEST(DeepDag, deep_propagate_equalities) { EXPECT_STACK_SAFE(propagateEqualitiesOk, 20000); }
+TEST(DeepDag, deep_array_read_count_walk)
+{
+  EXPECT_STACK_SAFE(numberOfReadsWalkOk, 20000);
+}
 #ifdef STP_ENABLE_FLOATING_POINT
 TEST(DeepDag, deep_fp_totalise)        { EXPECT_STACK_SAFE(fpTotaliseChainOk, 20000); }
 TEST(DeepDag, deep_fp_format_ite)      { EXPECT_STACK_SAFE(fpFormatIteChainOk, 20000); }

--- a/tests/unit-tests/DeepDag_Test.cpp
+++ b/tests/unit-tests/DeepDag_Test.cpp
@@ -200,6 +200,42 @@ struct Context
     return n;
   }
 };
+#ifdef STP_ENABLE_FLOATING_POINT
+
+// A chain of if-then-else terms, nested in the else-branch: a boolean symbol
+// the model says nothing about takes false, so evaluating one descends the
+// chain rather than stopping at the first level.
+ASTNode iteChain(Context& c, unsigned depth)
+{
+  const ASTNode cond = c.mgr.CreateSymbol("p", 0, 0);
+  const ASTNode zero = c.mgr.CreateZeroConst(8);
+  ASTNode t = c.mgr.CreateSymbol("x", 0, 8);
+  for (unsigned i = 0; i < depth; i++)
+    t = c.hf->CreateTerm(ITE, 8, cond, zero, t);
+  return t;
+}
+
+// A chain of stores over one array symbol, whose elements are `width` bits.
+ASTNode storeChain(Context& c, unsigned depth, const ASTNode& base,
+                   unsigned width = 8)
+{
+  ASTNode a = base;
+  for (unsigned i = 0; i < depth; i++)
+  {
+    const std::string nm = "w" + std::to_string(i);
+    a = c.hf->CreateArrayTerm(WRITE, 8, width, a,
+                              c.mgr.CreateSymbol(nm.c_str(), 0, 8),
+                              c.mgr.CreateZeroConst(width));
+  }
+  return a;
+}
+
+ASTNode storeChain(Context& c, unsigned depth)
+{
+  return storeChain(c, depth, c.mgr.CreateSymbol("A", 8, 8));
+}
+#endif // STP_ENABLE_FLOATING_POINT
+
 
 // Rewriting::rewrite (19 of the 21 known corpus crashes, ~9,300 nested
 // frames deep) and, ahead of it in the same pass, the equally unbounded
@@ -318,6 +354,93 @@ bool strengthReductionOk(Context& c, unsigned depth)
   return result == top;
 }
 
+// BitBlaster::BBTerm, which reaches its operands by calling itself from 24
+// places across its kind switch. The blaster uses ordinary recursion for a
+// bounded prefix, then fills the remaining suffix of its memo from the bottom
+// first. This depth is well beyond that boundary.
+bool bitBlastTermOk(Context& c, unsigned depth)
+{
+  const ASTNode f = c.formula(c.chain(BVXOR, depth));
+  c.roots.push_back(f);
+
+  SubstitutionMap sm(&c.mgr);
+  Simplifier simp(&c.mgr, &sm);
+  BBNodeManagerAIG nm;
+  BitBlaster bb(&nm, &simp, c.nf, &c.mgr.UserFlags);
+  bb.BBForm(f);
+
+  // Every xor in the chain is 8 bits of AIG, so this cannot pass without
+  // the whole chain having been blasted.
+  return nm.totalNumberOfNodes() >= static_cast<int>(depth);
+}
+
+// A deep term that is only reachable through a formula that is only
+// reachable through a term: the chain is an equality's operand, the equality
+// is an ITE's condition, and the ITE is a term. Priming each memo on its own
+// left this to the recursion -- the walk over terms handed the condition to
+// BBForm and stopped, and the walk over formulas was suppressed while the
+// first was running, so nothing primed the chain and BBTerm descended it a
+// frame at a time.
+ASTNode termUnderFormulaUnderTerm(Context& c, unsigned depth)
+{
+  const ASTNode chain = c.chain(BVXOR, depth);
+  const ASTNode cond = c.hf->CreateNode(EQ, chain, c.mgr.CreateZeroConst(8));
+  const ASTNode y0 = c.mgr.CreateSymbol("y0", 0, 8);
+  const ASTNode y1 = c.mgr.CreateSymbol("y1", 0, 8);
+  const ASTNode ite = c.hf->CreateTerm(ITE, 8, cond, y0, y1);
+  return c.hf->CreateTerm(BVMULT, 8, ite, y0);
+}
+
+bool bitBlastNestedOk(Context& c, unsigned depth)
+{
+  const ASTNode f = c.formula(termUnderFormulaUnderTerm(c, depth));
+  c.roots.push_back(f);
+
+  SubstitutionMap sm(&c.mgr);
+  Simplifier simp(&c.mgr, &sm);
+  BBNodeManagerAIG nm;
+  BitBlaster bb(&nm, &simp, c.nf, &c.mgr.UserFlags);
+  bb.BBForm(f);
+
+  // The chain is under the condition, so it cannot have been blasted
+  // without the walk having crossed into it.
+  return nm.totalNumberOfNodes() >= static_cast<int>(depth);
+}
+
+// BitBlaster::BBForm, which blasts a formula's operands by calling itself.
+bool bitBlastOk(Context& c, unsigned depth)
+{
+  ASTNode f = c.hf->CreateNode(EQ, c.mgr.CreateSymbol("b0", 0, 8),
+                               c.mgr.CreateZeroConst(8));
+  for (unsigned i = 1; i < depth; i++)
+  {
+    const std::string name = "b" + std::to_string(i);
+    const ASTNode leaf = c.hf->CreateNode(
+        EQ, c.mgr.CreateSymbol(name.c_str(), 0, 8), c.mgr.CreateZeroConst(8));
+    f = c.hf->CreateNode(AND, leaf, f);
+  }
+  c.roots.push_back(f);
+
+  SubstitutionMap sm(&c.mgr);
+  Simplifier simp(&c.mgr, &sm);
+  BBNodeManagerAIG nm;
+  BitBlaster bb(&nm, &simp, c.nf, &c.mgr.UserFlags);
+  bb.BBForm(f);
+
+  // One AIG node per conjunct at the very least.
+  return nm.totalNumberOfNodes() >= static_cast<int>(depth);
+}
+
+// NodeDomainAnalysis::buildMap.
+bool nodeDomainOk(Context& c, unsigned depth)
+{
+  const ASTNode f = c.formula(c.chain(BVXOR, depth));
+  c.roots.push_back(f);
+  NodeDomainAnalysis nda(&c.mgr);
+  nda.buildMap(f);
+  return true;
+}
+
 // NodeIterator historically visits children right-to-left. Put the deep
 // child last so a pending-node implementation retains one unvisited sibling
 // at every level; a continuation iterator retains just the active path.
@@ -375,6 +498,19 @@ bool nonAtomIteratorOrderOk(Context& c)
   return actual == expected;
 }
 
+// VariablesInExpression::getSymbol.
+bool varsInExpressionOk(Context& c, unsigned depth)
+{
+  const ASTNode f = c.formula(c.chain(BVXOR, depth));
+  c.roots.push_back(f);
+  VariablesInExpression vie;
+  bool destruct = false;
+  ASTNodeSet* v = vie.SetofVarsSeenInTerm(f, destruct);
+  const bool ok = v != nullptr;
+  if (destruct) delete v;
+  return ok;
+}
+
 // PropagateEqualities::buildCandidateList -- a void pre-order walk with a
 // visited set, so a worklist is enough.
 bool propagateEqualitiesOk(Context& c, unsigned depth)
@@ -403,6 +539,99 @@ bool commonSubSumOk(Context& c, unsigned depth)
   ASTNode g = f;
   return css.topLevel(g).GetKind() != UNDEFINED;
 }
+#ifdef STP_ENABLE_FLOATING_POINT
+
+/* A node's floating-point format and its source sort are both derived from
+   its children and memoised on it, and both derivations read a child's answer
+   by asking for it -- which derives the child the same way. So each ran one
+   call frame per level of whatever it walked: a store chain for both of them,
+   an if-then-else spine for both of them.
+
+   Neither is a pass, so neither has an input of its own: they are reached by
+   asking an ordinary question about a node. GetType() asks for the format,
+   and everything asks GetType(). That is what makes these worth converting --
+   a query deep enough cannot be asked its type at all, from anywhere. */
+
+// deriveFPFormat's if-then-else arm, which takes a branch's format and so
+// walks the spine. Reached here through GetType, the way almost everything
+// reaches it.
+bool fpFormatIteChainOk(Context& c, unsigned depth)
+{
+  const ASTNode t = iteChain(c, depth);
+  c.roots.push_back(t);
+  return t.GetType() == BITVECTOR_TYPE;
+}
+
+// deriveFPFormat's read and store arms: an array of floats keeps its element
+// format on the array node, so a read over a store chain derives through
+// every store in it.
+//
+// The one case here that answers with a format rather than with "not a
+// float", so it checks that the walk carried an answer up rather than only
+// that it finished: the format found at the top is the one declared at the
+// bottom, 20,000 stores below.
+bool fpFormatStoreChainOk(Context& c, unsigned depth)
+{
+  const ASTNode a = c.mgr.CreateSymbol("A", 8, 16);
+  a.SetExpWidth(5);
+  a.SetSigWidth(11);
+
+  const ASTNode chain = storeChain(c, depth, a, 16);
+  const ASTNode r =
+      c.hf->CreateTerm(READ, 16, chain, c.mgr.CreateSymbol("j", 0, 8));
+  c.roots.push_back(r);
+  return r.GetExpWidth() == 5 && r.GetSigWidth() == 11;
+}
+
+// deriveSourceSort's if-then-else arm, which asks both branches and walks the
+// same spine.
+bool sourceSortIteChainOk(Context& c, unsigned depth)
+{
+  const ASTNode t = iteChain(c, depth);
+  c.roots.push_back(t);
+  return t.GetSourceSort().kind() == SourceSort::Kind::BitVector;
+}
+
+// deriveSourceSort's store arm: a store has the sort of the array under it.
+bool sourceSortStoreChainOk(Context& c, unsigned depth)
+{
+  const ASTNode a = storeChain(c, depth);
+  c.roots.push_back(a);
+  return a.GetSourceSort().kind() == SourceSort::Kind::Array;
+}
+
+// FpTotalise, which replaces every partial floating-point operation with its
+// total form before the blaster sees it. How deeply a float expression nests
+// is the input's choice, and both of this pass's walks -- the totalising one
+// and the rounding-mode collector that runs over its output -- went down it a
+// frame at a time. A query built from 30,000 nested fp.add operations found
+// it, once the simplifier stopped dying in front of it.
+//
+// The chain is fp.add over one float symbol, which is what that query is.
+// Constructing it needs the format on the leaf: a symbol's is declared, and
+// every operation above derives its own from it.
+bool fpTotaliseChainOk(Context& c, unsigned depth)
+{
+  const unsigned eb = 8, sb = 24;
+  const ASTNode x = c.mgr.CreateSymbol("x", 0, eb + sb);
+  x.SetExpWidth(eb);
+  x.SetSigWidth(sb);
+  const ASTNode rm = c.mgr.CreateBVConst(5, symbolic_fp::ROUND_NEAREST_TIES_TO_EVEN);
+
+  ASTNode t = x;
+  for (unsigned i = 0; i < depth; i++)
+    t = c.hf->CreateTerm(FP_ADD, eb + sb, rm, t, x);
+
+  const ASTNode f = c.hf->CreateNode(FP_ISNAN, t);
+  c.roots.push_back(f);
+
+  FpTotalise fpt(&c.mgr);
+  const ASTNode result = fpt.topLevel(f);
+  c.roots.push_back(result);
+  return result.GetKind() != UNDEFINED;
+}
+#endif // STP_ENABLE_FLOATING_POINT
+
 
 TEST(DeepDag, shallow_rewriting)
 {
@@ -426,6 +655,12 @@ TEST(DeepDag, shallow_flatten_share_count)
 {
   Context c;
   EXPECT_TRUE(flattenShareCountOk(c, SHALLOW));
+}
+
+TEST(DeepDag, shallow_node_domain)
+{
+  Context c;
+  EXPECT_TRUE(nodeDomainOk(c, SHALLOW));
 }
 
 TEST(DeepDag, flatten_lazy_scratch_preserves_rebuild_and_dedup)
@@ -506,6 +741,41 @@ TEST(DeepDag, wide_propagate_equalities_visits_every_conjunct)
   PropagateEqualities propagate(&simplifier, c.nf, &c.mgr);
   EXPECT_EQ(c.mgr.ASTTrue, propagate.topLevel(input));
 }
+#ifdef STP_ENABLE_FLOATING_POINT
+
+TEST(DeepDag, wide_fp_rounding_mode_walk_adds_every_constraint)
+{
+  Context c;
+  const ASTNode rne = c.mgr.CreateRMConst(
+      symbolic_fp::ROUND_NEAREST_TIES_TO_EVEN);
+  ASTVec clauses;
+  clauses.reserve(256);
+  for (unsigned i = 0; i < 256; ++i)
+  {
+    const std::string name = "wide-rounding-mode" + std::to_string(i);
+    const ASTNode rm =
+        c.mgr.CreateSourceSymbol(name.c_str(), SourceSort::roundingMode());
+    clauses.push_back(c.hf->CreateNode(EQ, rm, rne));
+  }
+  const ASTNode input = c.hf->CreateNode(AND, clauses);
+  c.roots.push_back(input);
+
+  FpTotalise totalise(&c.mgr);
+  const ASTNode result = totalise.topLevel(input);
+  c.roots.push_back(result);
+
+  size_t validityConstraints = 0;
+  ASTNodeSet seen;
+  walkPreOrder(result, [&](const ASTNode& n) {
+    if (!seen.insert(n).second)
+      return false;
+    validityConstraints += n.GetKind() == OR && n.Degree() == 5;
+    return true;
+  });
+  EXPECT_EQ(clauses.size(), validityConstraints);
+}
+#endif // STP_ENABLE_FLOATING_POINT
+
 
 TEST(DeepDag, shallow_substitution)
 {
@@ -547,6 +817,24 @@ TEST(DeepDag, shallow_strength_reduction)
   EXPECT_TRUE(strengthReductionOk(c, SHALLOW));
 }
 
+TEST(DeepDag, shallow_bit_blast)
+{
+  Context c;
+  EXPECT_TRUE(bitBlastOk(c, SHALLOW));
+}
+
+TEST(DeepDag, shallow_bit_blast_term)
+{
+  Context c;
+  EXPECT_TRUE(bitBlastTermOk(c, SHALLOW));
+}
+
+TEST(DeepDag, shallow_bit_blast_nested)
+{
+  Context c;
+  EXPECT_TRUE(bitBlastNestedOk(c, SHALLOW));
+}
+
 TEST(DeepDag, node_iterator_preserves_lifo_dag_order)
 {
   Context c;
@@ -564,6 +852,33 @@ TEST(DeepDag, shallow_node_iterator)
   Context c;
   EXPECT_TRUE(nodeIteratorOk(c, SHALLOW));
 }
+#ifdef STP_ENABLE_FLOATING_POINT
+
+TEST(DeepDag, shallow_fp_format_ite)
+{
+  Context c;
+  EXPECT_TRUE(fpFormatIteChainOk(c, SHALLOW));
+}
+
+TEST(DeepDag, shallow_fp_format_store)
+{
+  Context c;
+  EXPECT_TRUE(fpFormatStoreChainOk(c, SHALLOW));
+}
+
+TEST(DeepDag, shallow_source_sort_ite)
+{
+  Context c;
+  EXPECT_TRUE(sourceSortIteChainOk(c, SHALLOW));
+}
+
+TEST(DeepDag, shallow_source_sort_store)
+{
+  Context c;
+  EXPECT_TRUE(sourceSortStoreChainOk(c, SHALLOW));
+}
+#endif // STP_ENABLE_FLOATING_POINT
+
 
 TEST(DeepDag, deep_rewriting_share_count)
 {
@@ -600,7 +915,32 @@ TEST(DeepDag, deep_strength_reduction)
   EXPECT_STACK_SAFE(strengthReductionOk, 20000);
 }
 
+TEST(DeepDag, deep_bit_blast)
+{
+  EXPECT_STACK_SAFE(bitBlastOk, 20000);
+}
+
+TEST(DeepDag, deep_bit_blast_term)
+{
+  EXPECT_STACK_SAFE(bitBlastTermOk, 20000);
+}
+
+TEST(DeepDag, deep_bit_blast_nested)
+{
+  EXPECT_STACK_SAFE(bitBlastNestedOk, 20000);
+}
+
 TEST(DeepDag, deep_common_sub_sum)              { EXPECT_STACK_SAFE(commonSubSumOk, 20000); }
+TEST(DeepDag, deep_node_domain)        { EXPECT_STACK_SAFE(nodeDomainOk, 20000); }
 TEST(DeepDag, deep_node_iterator)      { EXPECT_STACK_SAFE(nodeIteratorOk, 20000); }
+TEST(DeepDag, deep_vars_in_expression) { EXPECT_STACK_SAFE(varsInExpressionOk, 20000); }
 TEST(DeepDag, deep_propagate_equalities) { EXPECT_STACK_SAFE(propagateEqualitiesOk, 20000); }
+#ifdef STP_ENABLE_FLOATING_POINT
+TEST(DeepDag, deep_fp_totalise)        { EXPECT_STACK_SAFE(fpTotaliseChainOk, 20000); }
+TEST(DeepDag, deep_fp_format_ite)      { EXPECT_STACK_SAFE(fpFormatIteChainOk, 20000); }
+TEST(DeepDag, deep_fp_format_store)    { EXPECT_STACK_SAFE(fpFormatStoreChainOk, 20000); }
+TEST(DeepDag, deep_source_sort_ite)    { EXPECT_STACK_SAFE(sourceSortIteChainOk, 20000); }
+TEST(DeepDag, deep_source_sort_store)  { EXPECT_STACK_SAFE(sourceSortStoreChainOk, 20000); }
+#endif // STP_ENABLE_FLOATING_POINT
+
 } // namespace

--- a/tests/unit-tests/DeepDag_Test.cpp
+++ b/tests/unit-tests/DeepDag_Test.cpp
@@ -1,0 +1,606 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+// AST-depth-recursive traversals: no pass may consume call stack in
+// proportion to the depth of the input DAG.
+//
+// Deeply nested formulas (CPAchecker k-induction traces, ~9,300 nested
+// nodes) deterministically segfault STP: Rewriting::rewrite and
+// Dependencies::build recurse once per level of the input, so an input
+// deep enough to exhaust the stack kills the process. The depth is chosen
+// by whoever wrote the input, so no fixed stack size is a fix -- these
+// traversals have to keep their working state on the heap.
+//
+// Each property below is checked twice: once on a shallow chain, which
+// says the property itself holds, and once on a chain far deeper than the
+// recursive frames fit in, which is what fails today. Two things make the
+// deep result a property of STP rather than of the machine it runs on:
+//
+//   * it runs under a stack rlimit the test sets itself, so the ambient
+//     `ulimit -s` (8 MiB here, unlimited on some CI runners) cannot
+//     decide the outcome; and
+//   * it runs in a forked child, so a stack overflow is one failing test
+//     rather than a segfault that takes the rest of the binary with it.
+//
+// The chains are built with the hashing factory: the simplifying factory
+// would fold or reassociate them, and the DAG under test would no longer
+// be the deep one the test means to build.
+
+#include "stp/AST/MutableASTNode.h"
+#include "stp/NodeFactory/SimplifyingNodeFactory.h"
+#include "stp/STPManager/STPManager.h"
+#include "stp/Simplifier/Flatten.h"
+#include "stp/Simplifier/Rewriting.h"
+#include "stp/Simplifier/NodeDomainAnalysis.h"
+#include "stp/AbsRefineCounterExample/ArrayTransformer.h"
+#include "stp/AbsRefineCounterExample/AbsRefine_CounterExample.h"
+#include "stp/FloatBlaster/FpEncodingContext.h"
+#include "stp/FloatBlaster/FpTotalise.h"
+#include "stp/Extensionality/ExtensionalityContext.h"
+#include "stp/Printer/printers.h"
+#include "stp/Simplifier/CommonSubSum.h"
+#include "stp/Simplifier/PropagateEqualities.h"
+#include "stp/Simplifier/RemoveUnconstrained.h"
+#include "stp/Simplifier/Simplifier.h"
+#include "stp/Simplifier/UseITEContext.h"
+#include "stp/Simplifier/VariablesInExpression.h"
+#include "stp/ToSat/BBNodeManagerAIG.h"
+#include "stp/ToSat/BitBlaster.h"
+#include "stp/Util/NodeIterator.h"
+#include "stp/Simplifier/StrengthReduction.h"
+#include "stp/Simplifier/SubstitutionMap.h"
+#include "stp/Simplifier/constantBitP/Dependencies.h"
+#include "stp/Simplifier/constantBitP/WorkList.h"
+#include <algorithm>
+#include <cstdlib>
+#include <gtest/gtest.h>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+
+#ifndef _WIN32
+#include <sys/resource.h>
+#endif
+
+using namespace stp;
+
+namespace
+{
+
+// Small enough that a per-level call frame cannot fit these depths, large
+// enough for anything a stack-safe traversal legitimately does.
+const size_t STACK_BYTES = 1024 * 1024;
+
+// Exit codes of the forked child. Anything else -- in particular a signal
+// -- is the failure this file exists to catch.
+const int EXIT_OK = 0;
+const int EXIT_BAD_RESULT = 2;
+
+// Shallow enough to recurse safely: what the control cases run on.
+const unsigned SHALLOW = 50;
+
+// Cap how far this process's stack may grow. Linux applies a lowered
+// RLIMIT_STACK to further growth of the main stack, so the check runs
+// against a stack of exactly this size whatever the ambient `ulimit -s`
+// is -- 8 MiB on a developer box, sometimes unlimited on a CI runner.
+// Bounding it is what makes a passing deep case mean "the traversal does
+// not use the stack for depth" rather than "this machine had room".
+void capStack()
+{
+#ifndef _WIN32
+  struct rlimit rl;
+  if (getrlimit(RLIMIT_STACK, &rl) == 0)
+  {
+    rl.rlim_cur = STACK_BYTES;
+    setrlimit(RLIMIT_STACK, &rl);
+  }
+#else
+  // No setrlimit; MSVC's default main-thread stack is 1 MiB already, which
+  // is the size this wants.
+#endif
+}
+
+// Runs one of the checks below in a child process on a bounded stack.
+// `check` returning false -- the pass ran but got the wrong answer -- is
+// reported as an exit code distinct from a crash.
+//
+// The manager is deliberately not destroyed. Releasing a deep DAG used to
+// be depth-recursive itself (~ASTInterior -> CleanUp -> ~ASTInterior, one
+// level per node), so tearing these chains down would overflow the stack
+// after the traversal under test had already returned, and every case here
+// would report the destructor's limit instead of the pass's. CleanUp drains
+// a queue now and deep_teardown below covers it, but keeping the roots alive
+// still isolates each case from the others: the child exits immediately, so
+// leaving the DAG alive costs nothing.
+#define EXPECT_STACK_SAFE(check, depth)                                     \
+  EXPECT_EXIT(                                                              \
+      {                                                                     \
+        capStack();                                                         \
+        Context* c = new Context();                                         \
+        std::exit(check(*c, depth) ? EXIT_OK : EXIT_BAD_RESULT);            \
+      },                                                                    \
+      ::testing::ExitedWithCode(EXIT_OK), "")
+
+struct Context
+{
+  STPMgr mgr;
+  SimplifyingNodeFactory snf;
+  NodeFactory* nf; // simplifying factory: what the passes themselves use.
+  NodeFactory* hf; // hashing factory: builds the input without folding it.
+
+  // Roots each check hands over, so that returning from it does not drop
+  // the last handle on a deep DAG and start the recursive teardown
+  // described at EXPECT_STACK_SAFE.
+  ASTVec roots;
+
+  Context() : snf(*(mgr.hashingNodeFactory), mgr)
+  {
+    static const bool booted = []() {
+      CONSTANTBV::BitVector_Boot();
+      return true;
+    }();
+    (void)booted;
+
+    mgr.defaultNodeFactory = &snf;
+    nf = &snf;
+    hf = mgr.hashingNodeFactory;
+  }
+
+  // A chain `depth` symbols long, so `depth`-1 operator nodes nested one
+  // inside the next. No rewrite or flattening rule matches a chain of
+  // BVXORs or BVMULTs over symbols, so what the passes do here is exactly
+  // the traversal.
+  ASTNode chain(Kind k, unsigned depth, unsigned width = 8)
+  {
+    ASTNode n = mgr.CreateSymbol("x0", 0, width);
+    for (unsigned i = 1; i < depth; i++)
+    {
+      const std::string name = "x" + std::to_string(i);
+      n = hf->CreateTerm(k, width, n,
+                         mgr.CreateSymbol(name.c_str(), 0, width));
+    }
+    return n;
+  }
+
+  // The passes take a formula, and rewrite rules fire on the children of a
+  // visited node rather than on the root, so put the chain under one.
+  ASTNode formula(const ASTNode& term)
+  {
+    return hf->CreateNode(EQ, term, mgr.CreateZeroConst(term.GetValueWidth()));
+  }
+
+  // The factories order commutative children (constants first, then
+  // symbols), so which index holds the chain is not fixed.
+  static ASTNode childOfKind(const ASTNode& n, Kind k)
+  {
+    for (const auto& c : n.GetChildren())
+      if (c.GetKind() == k)
+        return c;
+    return n;
+  }
+};
+
+// Rewriting::rewrite (19 of the 21 known corpus crashes, ~9,300 nested
+// frames deep) and, ahead of it in the same pass, the equally unbounded
+// Rewriting::buildShareCount.
+bool rewritingIdentityOk(Context& c, unsigned depth)
+{
+  const ASTNode top = c.formula(c.chain(BVXOR, depth));
+  c.roots.push_back(top);
+
+  Rewriting r(&c.mgr, c.nf);
+  ASTNode f = top;
+  // No rule matches a BVXOR chain, so the pass is an identity here; any
+  // other answer means the traversal lost part of the DAG.
+  return r.topLevel(f) == top;
+}
+
+// The second recursion point: when a rule rewrites a child, the result is
+// fed back through rewrite(). The rule is `0 = (a + b)` -->
+// `(bvuminus a) = b`, placed beside a deep chain so the re-entry happens
+// in a traversal that is already deep.
+bool rewritingRuleFiresOk(Context& c, unsigned depth)
+{
+  const unsigned width = 8;
+  // The hashing factory orders a node's children by node number, and the
+  // rule matches EQ(const, plus): the constant has to exist before the
+  // operands do, or the equality comes out as EQ(plus, const) and nothing
+  // fires.
+  const ASTNode zero = c.mgr.CreateZeroConst(width);
+  const ASTNode a = c.mgr.CreateSymbol("a", 0, width);
+  const ASTNode b = c.mgr.CreateSymbol("b", 0, width);
+  const ASTNode plus = c.hf->CreateTerm(BVPLUS, width, a, b);
+  const ASTNode fires = c.hf->CreateNode(EQ, zero, plus);
+  if (fires[0].GetKind() != BVCONST || fires[1].GetKind() != BVPLUS)
+    return false; // not the shape the rule matches: prove nothing quietly.
+
+  const ASTNode top =
+      c.hf->CreateNode(AND, fires, c.formula(c.chain(BVXOR, depth, width)));
+  c.roots.push_back(top);
+
+  Rewriting r(&c.mgr, c.nf);
+  ASTNode f = top;
+  // The equality is rewritten, so the pass must not be an identity.
+  return r.topLevel(f) != top;
+}
+
+// Flatten::buildShareCount on its own. A chain of same-kind flattenable
+// nodes is the one shape flatten() does not recurse on: it appends the
+// grandchildren to its own worklist and keeps looping, so the only
+// depth-recursive walk this input reaches is the share count built ahead
+// of it.
+bool flattenShareCountOk(Context& c, unsigned depth)
+{
+  const ASTNode top = c.formula(c.chain(BVPLUS, depth));
+  c.roots.push_back(top);
+
+  Flatten flattener(&c.mgr, c.nf);
+  ASTNode f = top;
+  const ASTNode result = flattener.topLevel(f);
+  c.roots.push_back(result);
+
+  // The whole chain collapses into one BVPLUS over every symbol in it.
+  const ASTNode plus = Context::childOfKind(result, BVPLUS);
+  return plus.GetKind() == BVPLUS && plus.Degree() == depth;
+}
+
+// Flatten carries its own copy of both traversals: an identical
+// buildShareCount, and flatten() with the same recursive shape as
+// rewrite(). Flattening is off by default since #786, so it is not on the
+// observed crash path -- but --flatten puts it back. BVMULT is not a
+// flattenable kind, which keeps this a test of the traversal rather than
+// of flattening.
+bool flattenIdentityOk(Context& c, unsigned depth)
+{
+  const ASTNode top = c.formula(c.chain(BVMULT, depth));
+  c.roots.push_back(top);
+
+  Flatten flattener(&c.mgr, c.nf);
+  ASTNode f = top;
+  return flattener.topLevel(f) == top;
+}
+
+// SubstitutionMap::replace, which rebuilds a DAG with some nodes swapped
+// out. Reached from every pass that applies a substitution, and the walk
+// is over the whole input.
+bool substitutionOk(Context& c, unsigned depth)
+{
+  const ASTNode top = c.formula(c.chain(BVXOR, depth));
+  c.roots.push_back(top);
+
+  // The symbol at the far end of the chain maps to a constant, so the walk
+  // has to reach the bottom and every node above it is rebuilt on the way
+  // back up.
+  ASTNodeMap fromTo, cache;
+  fromTo[c.mgr.CreateSymbol("x0", 0, 8)] = c.mgr.CreateBVConst(8, 1);
+
+  const ASTNode result =
+      SubstitutionMap::replace(top, fromTo, cache, c.nf);
+  c.roots.push_back(result);
+  return result != top;
+}
+
+// StrengthReduction::visit, which rebuilds the DAG applying whatever the
+// domain analyses prove about each node.
+bool strengthReductionOk(Context& c, unsigned depth)
+{
+  const ASTNode top = c.formula(c.chain(BVXOR, depth));
+  c.roots.push_back(top);
+
+  StrengthReduction sr(c.nf, &c.mgr.UserFlags);
+  NodeDomainAnalysis nda(&c.mgr);
+  const ASTNode result = sr.topLevel(top, nda);
+  c.roots.push_back(result);
+
+  // Nothing about a chain of unconstrained symbols is reducible, so the
+  // pass has to hand back what it was given.
+  return result == top;
+}
+
+// NodeIterator historically visits children right-to-left. Put the deep
+// child last so a pending-node implementation retains one unvisited sibling
+// at every level; a continuation iterator retains just the active path.
+bool nodeIteratorOk(Context& c, unsigned depth)
+{
+  ASTNode n = c.mgr.CreateSymbol("iterator-x0", 0, 8);
+  for (unsigned i = 1; i < depth; ++i)
+  {
+    const std::string name = "iterator-x" + std::to_string(i);
+    n = c.hf->CreateTerm(BVXOR, 8,
+                         c.mgr.CreateSymbol(name.c_str(), 0, 8), n);
+  }
+  c.roots.push_back(n);
+  return c.mgr.NodeSize(n) == 2 * depth - 1;
+}
+
+bool nodeIteratorOrderOk(Context& c)
+{
+  const ASTNode condition =
+      c.mgr.CreateSymbol("iterator-order-condition", 0, 0);
+  const ASTNode a = c.mgr.CreateSymbol("iterator-order-a", 0, 8);
+  const ASTNode b = c.mgr.CreateSymbol("iterator-order-b", 0, 8);
+  const ASTNode d = c.mgr.CreateSymbol("iterator-order-d", 0, 8);
+  const ASTNode left = c.hf->CreateTerm(BVCONCAT, 16, a, b);
+  const ASTNode right = c.hf->CreateTerm(BVCONCAT, 16, b, d);
+  const ASTNode top =
+      c.hf->CreateTerm(ITE, 16, condition, left, right);
+  c.roots.push_back(top);
+
+  const ASTVec expected{top, right, d, b, left, a, condition};
+  ASTVec actual;
+  NodeIterator nodes(top, c.mgr.ASTUndefined, c.mgr);
+  for (ASTNode n = nodes.next(); n != nodes.end(); n = nodes.next())
+    actual.push_back(n);
+  return actual == expected;
+}
+
+bool nonAtomIteratorOrderOk(Context& c)
+{
+  const ASTNode condition =
+      c.mgr.CreateSymbol("non-atom-order-condition", 0, 0);
+  const ASTNode a = c.mgr.CreateSymbol("non-atom-order-a", 0, 8);
+  const ASTNode b = c.mgr.CreateSymbol("non-atom-order-b", 0, 8);
+  const ASTNode d = c.mgr.CreateSymbol("non-atom-order-d", 0, 8);
+  const ASTNode left = c.hf->CreateTerm(BVCONCAT, 16, a, b);
+  const ASTNode right = c.hf->CreateTerm(BVCONCAT, 16, b, d);
+  const ASTNode top = c.hf->CreateTerm(ITE, 16, condition, left, right);
+  c.roots.push_back(top);
+
+  const ASTVec expected{top, right, left};
+  ASTVec actual;
+  NonAtomIterator nodes(top, c.mgr.ASTUndefined, c.mgr);
+  for (ASTNode n = nodes.next(); n != nodes.end(); n = nodes.next())
+    actual.push_back(n);
+  return actual == expected;
+}
+
+// PropagateEqualities::buildCandidateList -- a void pre-order walk with a
+// visited set, so a worklist is enough.
+bool propagateEqualitiesOk(Context& c, unsigned depth)
+{
+  ASTNode f = c.hf->CreateNode(EQ, c.mgr.CreateSymbol("q0", 0, 8),
+                               c.mgr.CreateZeroConst(8));
+  for (unsigned i = 1; i < depth; i++)
+  {
+    const std::string nm = "q" + std::to_string(i);
+    f = c.hf->CreateNode(AND, c.hf->CreateNode(EQ, c.mgr.CreateSymbol(nm.c_str(), 0, 8),
+                                               c.mgr.CreateZeroConst(8)), f);
+  }
+  c.roots.push_back(f);
+  SubstitutionMap sm(&c.mgr);
+  Simplifier simp(&c.mgr, &sm);
+  PropagateEqualities pe(&simp, c.nf, &c.mgr);
+  return pe.topLevel(f).GetKind() != UNDEFINED;
+}
+
+// CommonSubSum::topLevel. Already stack-safe; here to keep it that way.
+bool commonSubSumOk(Context& c, unsigned depth)
+{
+  const ASTNode f = c.formula(c.chain(BVPLUS, depth));
+  c.roots.push_back(f);
+  CommonSubSum css(&c.mgr, c.nf);
+  ASTNode g = f;
+  return css.topLevel(g).GetKind() != UNDEFINED;
+}
+
+TEST(DeepDag, shallow_rewriting)
+{
+  Context c;
+  EXPECT_TRUE(rewritingIdentityOk(c, SHALLOW));
+}
+
+TEST(DeepDag, shallow_rewriting_rule_fires)
+{
+  Context c;
+  EXPECT_TRUE(rewritingRuleFiresOk(c, SHALLOW));
+}
+
+TEST(DeepDag, shallow_flatten)
+{
+  Context c;
+  EXPECT_TRUE(flattenIdentityOk(c, SHALLOW));
+}
+
+TEST(DeepDag, shallow_flatten_share_count)
+{
+  Context c;
+  EXPECT_TRUE(flattenShareCountOk(c, SHALLOW));
+}
+
+TEST(DeepDag, flatten_lazy_scratch_preserves_rebuild_and_dedup)
+{
+  Context c;
+  const ASTNode a = c.mgr.CreateSymbol("flatten-scratch-a", 0, 8);
+  const ASTNode b = c.mgr.CreateSymbol("flatten-scratch-b", 0, 8);
+  const ASTNode d = c.mgr.CreateSymbol("flatten-scratch-d", 0, 8);
+  const ASTNode other = c.mgr.CreateSymbol("flatten-scratch-other", 0, 8);
+  const ASTNode left = c.hf->CreateTerm(BVAND, 8, a, b);
+  const ASTNode right = c.hf->CreateTerm(BVAND, 8, b, d);
+  const ASTNode nested = c.hf->CreateTerm(BVAND, 8, left, right);
+  ASTNode input = c.hf->CreateNode(EQ, nested, other);
+  c.roots.push_back(input);
+
+  Flatten flattener(&c.mgr, c.nf);
+  const ASTNode result = flattener.topLevel(input);
+  c.roots.push_back(result);
+  const ASTNode flat = Context::childOfKind(result, BVAND);
+
+  ASSERT_EQ(EQ, result.GetKind());
+  ASSERT_EQ(BVAND, flat.GetKind());
+  EXPECT_EQ(3U, flat.Degree());
+  ASTNodeSet children(flat.begin(), flat.end());
+  EXPECT_EQ(3U, children.size());
+  EXPECT_EQ(1U, children.count(a));
+  EXPECT_EQ(1U, children.count(b));
+  EXPECT_EQ(1U, children.count(d));
+}
+
+TEST(DeepDag, wide_share_count_walks_preserve_shared_rewrite_guards)
+{
+  Context c;
+  const ASTNode three = c.mgr.CreateBVConst(3, 3);
+  const ASTNode two = c.mgr.CreateBVConst(3, 2);
+  const ASTNode x = c.mgr.CreateSymbol("wide-share-x", 0, 3);
+  const ASTNode y = c.mgr.CreateSymbol("wide-share-y", 0, 3);
+  const ASTNode plus = c.hf->CreateTerm(BVPLUS, 3, three, x);
+  const ASTNode guarded = c.hf->CreateNode(
+      NOT, c.hf->CreateNode(BVGT, two, plus));
+  const ASTNode otherUse = c.hf->CreateNode(EQ, y, plus);
+
+  ASTVec children{guarded, otherUse};
+  children.reserve(4098);
+  for (unsigned i = 0; i < 4096; ++i)
+  {
+    const std::string name = "wide-share-b" + std::to_string(i);
+    children.push_back(c.mgr.CreateSymbol(name.c_str(), 0, 0));
+  }
+  ASTNode input = c.hf->CreateNode(AND, children);
+  c.roots.push_back(input);
+
+  Rewriting rewriting(&c.mgr, c.nf);
+  ASTNode rewriteInput = input;
+  EXPECT_EQ(input, rewriting.topLevel(rewriteInput));
+
+  Flatten flattening(&c.mgr, c.nf);
+  ASTNode flattenInput = input;
+  EXPECT_EQ(input, flattening.topLevel(flattenInput));
+}
+
+TEST(DeepDag, wide_propagate_equalities_visits_every_conjunct)
+{
+  Context c;
+  c.mgr.UserFlags.propagate_equalities = true;
+  ASTVec symbols;
+  symbols.reserve(2048);
+  for (unsigned i = 0; i < 2048; ++i)
+  {
+    const std::string name = "wide-propagate-b" + std::to_string(i);
+    symbols.push_back(c.mgr.CreateSymbol(name.c_str(), 0, 0));
+  }
+  const ASTNode input = c.hf->CreateNode(AND, symbols);
+  c.roots.push_back(input);
+
+  SubstitutionMap substitutions(&c.mgr);
+  Simplifier simplifier(&c.mgr, &substitutions);
+  PropagateEqualities propagate(&simplifier, c.nf, &c.mgr);
+  EXPECT_EQ(c.mgr.ASTTrue, propagate.topLevel(input));
+}
+
+TEST(DeepDag, shallow_substitution)
+{
+  Context c;
+  EXPECT_TRUE(substitutionOk(c, SHALLOW));
+}
+
+TEST(DeepDag, substitution_root_fast_paths_preserve_results)
+{
+  Context c;
+  const ASTNode x = c.mgr.CreateSymbol("subst-x", 0, 8);
+  const ASTNode y = c.mgr.CreateSymbol("subst-y", 0, 8);
+  const ASTNode free = c.mgr.CreateSymbol("subst-free", 0, 8);
+  const ASTNode cached = c.mgr.CreateSymbol("subst-cached", 0, 8);
+  const ASTNode one = c.mgr.CreateOneConst(8);
+  const ASTNode zero = c.mgr.CreateZeroConst(8);
+
+  ASTNodeMap fromTo, cache;
+  fromTo[x] = y;
+  fromTo[y] = one;
+  cache[cached] = zero;
+
+  EXPECT_EQ(zero, SubstitutionMap::replace(zero, fromTo, cache, c.nf));
+  EXPECT_EQ(free, SubstitutionMap::replace(free, fromTo, cache, c.nf));
+  EXPECT_EQ(zero, SubstitutionMap::replace(cached, fromTo, cache, c.nf));
+  EXPECT_EQ(one, SubstitutionMap::replace(x, fromTo, cache, c.nf));
+  EXPECT_EQ(one, fromTo.at(x));
+
+  const ASTNode array = c.mgr.CreateSymbol("subst-array", 8, 8);
+  const ASTNode write = c.hf->CreateArrayTerm(
+      WRITE, 8, 8, array, c.mgr.CreateZeroConst(8), one);
+  EXPECT_EQ(write, SubstitutionMap::replace(write, fromTo, cache, c.nf,
+                                            true, false));
+}
+
+TEST(DeepDag, shallow_strength_reduction)
+{
+  Context c;
+  EXPECT_TRUE(strengthReductionOk(c, SHALLOW));
+}
+
+TEST(DeepDag, node_iterator_preserves_lifo_dag_order)
+{
+  Context c;
+  EXPECT_TRUE(nodeIteratorOrderOk(c));
+}
+
+TEST(DeepDag, non_atom_iterator_preserves_filtered_lifo_order)
+{
+  Context c;
+  EXPECT_TRUE(nonAtomIteratorOrderOk(c));
+}
+
+TEST(DeepDag, shallow_node_iterator)
+{
+  Context c;
+  EXPECT_TRUE(nodeIteratorOk(c, SHALLOW));
+}
+
+TEST(DeepDag, deep_rewriting_share_count)
+{
+  EXPECT_STACK_SAFE(rewritingIdentityOk, 200000);
+}
+
+TEST(DeepDag, deep_rewriting_rewrite)
+{
+  EXPECT_STACK_SAFE(rewritingIdentityOk, 10000);
+}
+
+TEST(DeepDag, deep_rewriting_rule_fires)
+{
+  EXPECT_STACK_SAFE(rewritingRuleFiresOk, 10000);
+}
+
+TEST(DeepDag, deep_flatten_share_count)
+{
+  EXPECT_STACK_SAFE(flattenShareCountOk, 100000);
+}
+
+TEST(DeepDag, deep_flatten)
+{
+  EXPECT_STACK_SAFE(flattenIdentityOk, 10000);
+}
+
+TEST(DeepDag, deep_substitution)
+{
+  EXPECT_STACK_SAFE(substitutionOk, 20000);
+}
+
+TEST(DeepDag, deep_strength_reduction)
+{
+  EXPECT_STACK_SAFE(strengthReductionOk, 20000);
+}
+
+TEST(DeepDag, deep_common_sub_sum)              { EXPECT_STACK_SAFE(commonSubSumOk, 20000); }
+TEST(DeepDag, deep_node_iterator)      { EXPECT_STACK_SAFE(nodeIteratorOk, 20000); }
+TEST(DeepDag, deep_propagate_equalities) { EXPECT_STACK_SAFE(propagateEqualitiesOk, 20000); }
+} // namespace

--- a/tests/unit-tests/PrimeMemo_Test.cpp
+++ b/tests/unit-tests/PrimeMemo_Test.cpp
@@ -1,0 +1,344 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+// Whether PrimeAudit catches a pass and its priming walk disagreeing.
+//
+// Six memoised computations fill their tables from the bottom up so their
+// own recursion stops one level down, which is sound only where the walk
+// reaches the nodes the pass would have reached anyway. Comparing the
+// generated CNF catches a violation only when the violation changes the
+// output, and a walk that stops short of a subtree does not: the pass goes
+// down its own call stack for that subtree and answers exactly as before.
+//
+// So the walk and the pass are compared directly (stp/Util/DagWalk.h),
+// and this is the test of the comparison rather than of any pass: a walk and
+// a pass are played against each other by hand, agreeing and then failing to,
+// so that the check is known to report what it exists to report. A check
+// nobody has seen fail is a check nobody has.
+//
+// The audit is debug-only, so all of this compiles away under NDEBUG.
+
+#include "stp/NodeFactory/SimplifyingNodeFactory.h"
+#include "stp/STPManager/STPManager.h"
+#include "stp/Util/DagWalk.h"
+#include <gtest/gtest.h>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+
+using namespace stp;
+
+namespace
+{
+
+using WalkOperandResult = decltype(std::declval<const WalkOperands&>().at(
+    std::declval<const ASTNode&>(), size_t{0}));
+static_assert(std::is_same<WalkOperandResult, const ASTNode&>::value,
+              "operand views must not increment AST reference counts");
+
+struct Context
+{
+  STPMgr mgr;
+  SimplifyingNodeFactory snf;
+  NodeFactory* hf; // hashing factory: builds the input without folding it.
+
+  Context() : snf(*(mgr.hashingNodeFactory), mgr)
+  {
+    static const bool booted = []() {
+      CONSTANTBV::BitVector_Boot();
+      return true;
+    }();
+    (void)booted;
+
+    mgr.defaultNodeFactory = &snf;
+    hf = mgr.hashingNodeFactory;
+  }
+
+  // BVXOR(BVXOR(x0, x1), x2): two interior nodes, three leaves, and no rule
+  // in any factory that rewrites it.
+  ASTNode chain() { return chain(3); }
+
+  // The same nested `levels` deep.
+  ASTNode chain(unsigned levels)
+  {
+    ASTNode n = mgr.CreateSymbol(("x" + std::to_string(counter++)).c_str(), 0, 8);
+    for (unsigned i = 1; i < levels; i++)
+      n = hf->CreateTerm(
+          BVXOR, 8, n,
+          mgr.CreateSymbol(("x" + std::to_string(counter++)).c_str(), 0, 8));
+    return n;
+  }
+
+  unsigned counter = 0;
+
+  // The factory orders a commutative node's children, so which index holds
+  // the nested one is not fixed.
+  static ASTNode interiorChild(const ASTNode& n)
+  {
+    for (const ASTNode& c : n.GetChildren())
+      if (c.Degree() > 0)
+        return c;
+    return n;
+  }
+
+  static ASTNode leafChild(const ASTNode& n)
+  {
+    for (const ASTNode& c : n.GetChildren())
+      if (c.Degree() == 0)
+        return c;
+    return n;
+  }
+};
+
+// The manager is deliberately not destroyed, as in DeepDag_Test.cpp: what
+// tearing one down does while its nodes are still held is not what these
+// cases are about, and the process is about to exit anyway.
+Context& fresh()
+{
+  return *(new Context());
+}
+
+TEST(DagWalk, preorder_is_left_to_right_and_honours_pruning)
+{
+  Context& c = fresh();
+  const ASTNode a = c.mgr.CreateSymbol("preorder-a", 0, 4);
+  const ASTNode b = c.mgr.CreateSymbol("preorder-b", 0, 4);
+  const ASTNode d = c.mgr.CreateSymbol("preorder-d", 0, 4);
+  const ASTNode e = c.mgr.CreateSymbol("preorder-e", 0, 4);
+  const ASTNode left = c.hf->CreateTerm(BVCONCAT, 8, a, b);
+  const ASTNode pruned = c.hf->CreateTerm(BVCONCAT, 8, d, e);
+  const ASTNode top = c.hf->CreateTerm(BVCONCAT, 16, left, pruned);
+
+  ASTVec visited;
+  walkPreOrder(top, [&](const ASTNode& n) {
+    visited.push_back(n);
+    return n != pruned;
+  });
+
+  EXPECT_EQ((ASTVec{top, left, a, b, pruned}), visited);
+}
+
+TEST(DagWalk, postorder_rebuild_preserves_child_ranges_and_sharing)
+{
+  Context& c = fresh();
+  const ASTNode a = c.mgr.CreateSymbol("rebuild-a", 0, 4);
+  const ASTNode b = c.mgr.CreateSymbol("rebuild-b", 0, 4);
+  const ASTNode d = c.mgr.CreateSymbol("rebuild-d", 0, 4);
+  const ASTNode shared = c.hf->CreateTerm(BVXOR, 4, a, b);
+  const ASTNode left = c.hf->CreateTerm(BVPLUS, 4, shared, d);
+  const ASTNode top = c.hf->CreateTerm(BVAND, 4, left, shared);
+
+  ASTNodeMap cache;
+  std::vector<std::pair<ASTNode, ASTVec>> combined;
+  const ASTNode result = postOrderRebuild(
+      top, cache, [&](const ASTNode& n, const ASTVec& children) {
+        combined.push_back({n, children});
+        return n;
+      });
+
+  ASSERT_EQ(top, result);
+  ASSERT_EQ(3U, combined.size());
+  EXPECT_EQ(shared, combined[0].first);
+  EXPECT_EQ(toASTVec(shared.GetChildren()), combined[0].second);
+  EXPECT_EQ(left, combined[1].first);
+  EXPECT_EQ(toASTVec(left.GetChildren()), combined[1].second);
+  EXPECT_EQ(top, combined[2].first);
+  EXPECT_EQ(toASTVec(top.GetChildren()), combined[2].second);
+  EXPECT_EQ(3U, cache.size());
+}
+
+TEST(PrimeMemo, non_owning_operand_views_preserve_postorder)
+{
+  Context& c = fresh();
+  const ASTNode a = c.mgr.CreateSymbol("view-a", 0, 0);
+  const ASTNode b = c.mgr.CreateSymbol("view-b", 0, 0);
+  const ASTNode d = c.mgr.CreateSymbol("view-d", 0, 0);
+  const ASTNode e = c.mgr.CreateSymbol("view-e", 0, 0);
+  const ASTNode inner = c.hf->CreateNode(OR, ASTVec{a, b, d});
+  const ASTNode top = c.hf->CreateNode(AND, ASTVec{inner, e});
+
+  ASTVec visited;
+  primeMemo(
+      top, [](const ASTNode& n)
+      { return n.Degree() == 0 ? Walk::Visit : Walk::Descend; },
+      [&](const ASTNode& n)
+      {
+        if (n == top)
+          return WalkOperands::reversed(n);
+        if (n == inner)
+          return WalkOperands::range(1, n.Degree());
+        return WalkOperands::all(n);
+      },
+      [&](const ASTNode& n, PrimeMemoReady) { visited.push_back(n); });
+
+  ASTVec expected;
+  for (size_t i = top.Degree(); i != 0; --i)
+  {
+    const ASTNode child = top[i - 1];
+    if (child == inner)
+    {
+      for (size_t j = 1; j < inner.Degree(); ++j)
+        expected.push_back(inner[j]);
+      expected.push_back(inner);
+    }
+    else
+      expected.push_back(child);
+  }
+  expected.push_back(top);
+
+  EXPECT_EQ(expected, visited);
+}
+
+#ifndef NDEBUG
+
+// A pass, played by hand: it runs a node, asks for the nodes the test says it
+// asks for, and reports both to the audit exactly as a real pass does.
+void run(PrimeAudit& audit, const ASTNode& n, const ASTVec& asks)
+{
+  PrimeAudit::Running running(audit, n);
+  for (const ASTNode& child : asks)
+  {
+    PrimeAudit::Running below(audit, child);
+  }
+}
+
+// A pass that was not primed: it runs a node and, from inside it, the node
+// below -- one level of its own call stack per level of the input, which is
+// what priming exists to stop and what the depth claim is about.
+void runUnprimed(PrimeAudit& audit, const ASTNode& n)
+{
+  PrimeAudit::Running running(audit, n);
+
+  const ASTNode below = Context::interiorChild(n);
+  if (below != n) // the bottom of the chain answers with itself.
+    runUnprimed(audit, below);
+}
+
+// Holds the audit open while a case reads its verdict. The check runs when
+// the pass's outermost call returns, and where the pass is past its claim it
+// stops the process -- which is what it is for, and is checked below by a case
+// that lets it happen, but is not a thing to read a string out of.
+struct Held
+{
+  PrimeAudit& audit;
+  PrimeAudit::Running running;
+
+  Held(PrimeAudit& audit_, const ASTNode& sentinel)
+      : audit(audit_), running(audit_, sentinel)
+  {
+  }
+
+  // Cleared before the sentinel is dropped, so the comparison it triggers
+  // has nothing left to disagree about.
+  ~Held() { audit.clear(); }
+};
+
+// A primed pass: it runs a node, its operands answer from the memo, and its
+// own calls go one level. Whatever the input nests to.
+TEST(PrimeAudit, a_pass_within_its_claim_is_silent)
+{
+  Context& c = fresh();
+  const ASTNode top = c.chain(12);
+  const ASTNode inner = Context::interiorChild(top);
+  const ASTNode leaf = Context::leafChild(top);
+
+  PrimeAudit audit("test", 8);
+
+  {
+    PrimeAudit::Running running(audit, top);
+    run(audit, inner, ASTVec{inner[0], inner[1]});
+    PrimeAudit::Running below(audit, leaf);
+  }
+
+  EXPECT_EQ(audit.disagreement(), "");
+}
+
+// What priming getting it wrong looks like from here: the walk misses a
+// subtree, the pass reaches it anyway -- down its own call stack, one frame
+// per level, which is the crash priming exists to prevent. Nothing in the
+// output moves, so the CNF comparison cannot see it; the depth can.
+TEST(PrimeAudit, a_pass_that_nests_past_its_claim_is_reported)
+{
+  Context& c = fresh();
+  const ASTNode top = c.chain(12);
+
+  PrimeAudit audit("test", 4);
+
+  std::string bad;
+  {
+    Held held(audit, c.mgr.CreateSymbol("sentinel", 0, 8));
+    runUnprimed(audit, top); // nothing was primed, so it goes all the way.
+    bad = audit.disagreement();
+  }
+
+  EXPECT_NE(bad.find("nested 12 deep"), std::string::npos)
+      << "audit said: " << bad;
+  EXPECT_NE(bad.find("over its claim of 4"), std::string::npos)
+      << "audit said: " << bad;
+}
+
+// ... and it stops the process rather than reporting quietly, which is the
+// only way an assertions build has of insisting.
+TEST(PrimeAuditDeath, nesting_past_the_claim_stops_the_process)
+{
+  EXPECT_DEATH(
+      {
+        Context& c = fresh();
+        PrimeAudit audit("test", 4);
+        runUnprimed(audit, c.chain(12));
+      },
+      "nested 11 deep");
+}
+
+
+// Re-entering on a node the pass has just built is allowed, and is why the
+// claim is a small number rather than one or two: the operands of such a node
+// are already primed, so the nesting is a property of the rewriting and not
+// of the input.
+TEST(PrimeAudit, re_entering_on_a_built_node_is_within_the_claim)
+{
+  Context& c = fresh();
+  const ASTNode top = c.chain();
+  const ASTNode inner = Context::interiorChild(top);
+  const ASTNode leaf = Context::leafChild(top);
+
+  PrimeAudit audit("test", 8);
+
+  const ASTNode built = c.hf->CreateTerm(BVNOT, 8, top);
+
+  {
+    PrimeAudit::Running running(audit, top);
+    run(audit, inner, ASTVec{inner[0], inner[1]});
+    PrimeAudit::Running below(audit, leaf);
+    PrimeAudit::Running newer(audit, built); // asked for, never primed.
+  }
+
+  EXPECT_EQ(audit.disagreement(), "");
+}
+
+
+#endif // NDEBUG
+
+} // namespace


### PR DESCRIPTION
# Stack safety 3/14 — AST: flatten a same-kind chain and count reads without the call stack

**This PR builds on top of #807** (stack safety 2/14). Please review and merge that one first; this branch contains its commits.

Three free functions in `lib/AST/ASTmisc.cpp`. They do not fit either tool from 1/14 and 2/14 — they are not memoised and they do not rebuild a node — so each gets an explicit stack shaped to what it actually needs.

## FlattenKind and FlattenKindNoDuplicates

Both expand a child of the same kind where they reach it, by calling themselves. A nested conjunction is as deep as the input nests, and one call per level was measured to die between 100,000 and 150,000 at 8 MiB.

**No parsed query reaches that today**, and the reason is worth stating plainly: the simplifying factory flattens a conjunction as it builds one, so nothing that deep survives to be handed to these. That is a property of the factory, not of these functions — a pass building through the hashing factory reaches them directly, and the reachable ones are covered by 1/14 and 11/14. This is the conversion done because the function is on the list, not because a crash was found in it.

Both now keep frames on the heap, holding spans into each node's own child storage, which its parent keeps alive for the whole walk. The current frame stays local, so a flat input — the overwhelmingly common case — never allocates a traversal stack at all. `flat_children` comes out in the order the recursion built it, and the deduplicating variant still records a same-kind child in `alreadyFlattened` before descending, so a second occurrence contributes nothing.

## numberOfReadsLessThan

Same treatment, plus a shortcut it did not have. The recursive version kept unwinding after the limit was reached; it now returns as soon as the strict bound is passed, rather than walking what may be a large untouched subtree to reach an answer already decided. Atoms are still deliberately absent from the visited set, as before.

## What to check during review

`FlattenKind` carries a depth limit and the deduplicating one does not — the shared frame holds a `depth` field that the deduplicating walk ignores, exactly as the recursive pair did. `duplicate_flatten_kind_does_not_reserve_discarded_edges` and `flat_flatten_kind_preserves_children` cover the two behaviours that differ between them.

## Testing

**109/109 ctest**, which includes the lit query corpus as `query-files`; **51 deep-DAG cases**, up from 42.

```
cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_ASSERTIONS=ON \
  -DENABLE_TESTING=ON -DPYTHON_EXECUTABLE=/usr/bin/python3 \
  -DLIT_TOOL=$(command -v lit)
cmake --build build -j$(nproc) && (cd build && ctest -j12)
```
