### PR TITLE
Independent cleanup (alongside stack safety): enter CaDiCaL's variable declaration only when one is pending

### DIFF
--- a/lib/Sat/Cadical.cpp
+++ b/lib/Sat/Cadical.cpp
@@ -78,7 +78,8 @@ bool Cadical::solveInternal(bool& timeout_expired)
     s->connect_terminator(&time_limit);
   }
 
-  declareNewVariables();
+  if (factor_enabled && ext_of_stp.size() <= next_variable)
+    declareNewVariables();
 
   auto ret = s->solve();
   if (ret == 0)
@@ -199,12 +200,14 @@ bool Cadical::enableBVA()
 // the extension variables factor invents. Declaration is batched here
 // (lazily, before clauses are added) rather than done in newVar because
 // declare_more_variables destroys a satisfying assignment, and newVar can
-// be called while the refinement loop is still reading the model.
+// be called while the refinement loop is still reading the model. Callers
+// check that a range is actually pending so the usual up-to-date clause path
+// does not enter this comparatively large routine.
 void Cadical::declareNewVariables()
 {
 #ifdef STP_CADICAL_HAS_FACTOR
-  if (!factor_enabled)
-    return;
+  assert(factor_enabled);
+  assert(ext_of_stp.size() <= next_variable);
   if (ext_of_stp.empty())
     ext_of_stp.push_back(0); // dummy: variables are 1-based
   while (ext_of_stp.size() <= next_variable)
@@ -219,7 +222,8 @@ void Cadical::declareNewVariables()
 
 bool Cadical::addClause(const vec_literals& ps) // Add a clause to the solver.
 {
-  declareNewVariables();
+  if (factor_enabled && ext_of_stp.size() <= next_variable)
+    declareNewVariables();
   for (int i=0; i < ps.size(); i++)
     {
       uint32_t var = ps[i].x >> 1;


### PR DESCRIPTION
# Independent cleanup (alongside stack safety): enter CaDiCaL's variable declaration only when one is pending

One of four small changes found while making STP's AST traversals stack-safe, and one of the four that have nothing to do with traversals. It depends on nothing and nothing depends on it — review and merge it entirely on its own, in any order relative to the others.

## What it changes

`Cadical::declareNewVariables()` is called from `addClause()` and again at the head of every `solveInternal()`. In the ordinary case it finds the extension range already up to date and returns without doing anything, so the common clause-adding path pays a call into a comparatively large routine to be told there is nothing to do.

The two conditions it tested for itself — that `factor` is enabled at all, and that a range is actually pending — move to the call sites, and become asserts inside the function. The routine is entered only when it has work.

## Why it is the way it is

Declaration is batched here, rather than done in `newVar()`, because `declare_more_variables()` destroys a satisfying assignment and `newVar()` can be called while the refinement loop is still reading the model. That is unchanged; the comment above the function now also says why the callers, not the callee, check the range.

Behaviourally this is a no-op: the same variables get declared at the same points.

## Testing

Full suite unchanged from master: **107/107 ctest**, which includes the lit query corpus as `query-files` and `query-files-cadical-factor` — the second of those is the leg that exercises this code, since the whole routine is `#ifdef STP_CADICAL_HAS_FACTOR`.

```
cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_ASSERTIONS=ON \
  -DENABLE_TESTING=ON -DPYTHON_EXECUTABLE=/usr/bin/python3 \
  -DLIT_TOOL=$(command -v lit) -DUSE_CADICAL=ON -DCADICAL_DIR=<cadical>
cmake --build build -j$(nproc) && (cd build && ctest -j12)
```

Assertions are on above deliberately: the two conditions this moves to the call sites are now asserts, so a build with `NDEBUG` would not check them.
