### PR TITLE
Independent cleanup (alongside stack safety): count the array reads once, not twice

### DIFF
--- a/lib/STPManager/STP.cpp
+++ b/lib/STPManager/STP.cpp
@@ -421,11 +421,10 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
   // introduced.
   // TODO: I chose the number of reads we perform this operation at randomly.
   bool removed = false;
+  const int arrayReadLimit = bm->UserFlags.ackermannisation ? 50 : 10;
   if (arrayops &&
       !extActive && // array equality needs the refinement loop
-      ((bm->UserFlags.ackermannisation &&
-        numberOfReadsLessThan(inputToSat, 50)) ||
-       numberOfReadsLessThan(inputToSat, 10)))
+      numberOfReadsLessThan(inputToSat, arrayReadLimit))
   {
     // If the number of axioms that would be added it small. Remove them.
     bm->UserFlags.ackermannisation = true;


### PR DESCRIPTION
# Independent cleanup (alongside stack safety): count the array reads once, not twice

One of four small changes found while making STP's AST traversals stack-safe, and one of the four that have nothing to do with traversals. It depends on nothing and nothing depends on it — review and merge it entirely on its own, in any order relative to the others.

## What it changes

`TopLevelSTPAux` decides whether to Ackermannise by asking how many array reads the input has. The condition read:

```cpp
((bm->UserFlags.ackermannisation && numberOfReadsLessThan(inputToSat, 50)) ||
 numberOfReadsLessThan(inputToSat, 10))
```

With `ackermannisation` on and 50 or more reads, the first call fails and the second one walks the entire input again to answer a strictly weaker question — if there are not fewer than 50, there are not fewer than 10 either, so the second walk can only fail too.

Pick the limit first, walk once:

```cpp
const int arrayReadLimit = bm->UserFlags.ackermannisation ? 50 : 10;
```

## Why this is exactly equivalent

`numberOfReadsLessThan` is monotone in its limit, so for `ackermannisation` on the disjunction is true iff the count is under 50, and with it off the first disjunct is false and the whole thing is the second. Both branches reduce to a single comparison against the limit chosen above. The `TODO` above the condition — that the numbers 50 and 10 were picked arbitrarily — still stands and is untouched.

## Testing

Full suite unchanged from master: **107/107 ctest**, which includes the lit query corpus as `query-files`. The array suites in that run are what exercise the Ackermannisation decision on both sides of the limit.

```
cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_ASSERTIONS=ON \
  -DENABLE_TESTING=ON -DPYTHON_EXECUTABLE=/usr/bin/python3 \
  -DLIT_TOOL=$(command -v lit)
cmake --build build -j$(nproc) && (cd build && ctest -j12)
```
