### PR TITLE
Independent cleanup (alongside stack safety): give NodeIterator a contiguous frontier and an inlinable filter

### DIFF
--- a/include/stp/Util/NodeIterator.h
+++ b/include/stp/Util/NodeIterator.h
@@ -27,7 +27,7 @@ THE SOFTWARE.
 
 #include "stp/AST/ASTNode.h"
 #include "stp/STPManager/STPManager.h"
-#include <stack>
+#include <vector>
 
 namespace stp
 {
@@ -36,52 +36,55 @@ namespace stp
 // wrong.
 class NodeIterator // not copyable
 {
-  std::stack<ASTNode> toVisit;
+  // A contiguous LIFO frontier retains the historical traversal order while
+  // avoiding std::stack's deque blocks. It stores one AST handle per pending
+  // edge; the path-frame representation stored two words per active ancestor
+  // and repeatedly re-entered ancestors to discover their next child.
+  std::vector<ASTNode> toVisit;
 
   const ASTNode& sentinel;
   uint8_t iteration;
+
+protected:
+  // The generic iterator retains its historical virtual `ok` hook. Known
+  // built-in filters call this templated core directly, letting their
+  // predicate inline into the walk instead of paying an indirect call for
+  // every node.
+  template <typename Accept>
+  ASTNode nextIf(Accept&& accept)
+  {
+    while (!toVisit.empty())
+    {
+      ASTNode result = toVisit.back();
+      toVisit.pop_back();
+      if (!accept(result) || result.getIteration() == iteration)
+        continue;
+
+      if (result == sentinel)
+        return result;
+
+      result.setIteration(iteration);
+      for (const ASTNode& child : result.GetChildren())
+      {
+        if (child.getIteration() != iteration)
+          toVisit.push_back(child);
+      }
+      return result;
+    }
+
+    return sentinel;
+  }
 
 public:
   NodeIterator(const ASTNode& n, const ASTNode& _sentinel, STPMgr& stpMgr)
       : sentinel(_sentinel), iteration(stpMgr.getNextIteration())
   {
-    toVisit.push(n);
+    toVisit.push_back(n);
   }
 
   ASTNode next()
   {
-    ASTNode result = sentinel;
-
-    while (true)
-    {
-      if (toVisit.empty())
-        return sentinel;
-
-      result = toVisit.top();
-      toVisit.pop();
-
-      if (!ok(result))
-        continue; // Not OK to investigate.
-
-      if (result.getIteration() != iteration)
-        break; // not visited, DONE!
-    }
-
-    if (result == sentinel)
-      return result;
-
-    result.setIteration(iteration);
-
-    const ASTChildren c = result.GetChildren();
-    auto itC = c.begin();
-    auto itendC = c.end();
-    for (; itC != itendC; itC++)
-    {
-      if (itC->getIteration() == iteration)
-        continue; // already examined.
-      toVisit.push(*itC);
-    }
-    return result;
+    return nextIf([this](const ASTNode& n) { return ok(n); });
   }
 
   ASTNode end() { return sentinel; }
@@ -90,14 +93,19 @@ public:
 };
 
 // Iterator that omits return atoms.
-class NonAtomIterator : public NodeIterator
+class NonAtomIterator final : public NodeIterator
 {
-  virtual bool ok(const ASTNode& n) { return !n.isAtom(); }
+  bool ok(const ASTNode& n) override { return !n.isAtom(); }
 
 public:
   NonAtomIterator(const ASTNode& n, const ASTNode& uf, STPMgr& stpMgr)
       : NodeIterator(n, uf, stpMgr)
   {
+  }
+
+  ASTNode next()
+  {
+    return nextIf([](const ASTNode& n) { return !n.isAtom(); });
   }
 };
 }


### PR DESCRIPTION
# Independent cleanup (alongside stack safety): give NodeIterator a contiguous frontier and an inlinable filter

One of four small changes found while making STP's AST traversals stack-safe, and one of the four that have nothing to do with traversals — `NodeIterator` was already iterative, so nothing here is about stack depth. It depends on nothing and nothing depends on it; review and merge it on its own, in any order relative to the others.

## What it changes

Two costs, both paid once per node visited.

**The frontier was a `std::stack`, so a `std::deque`** — a fresh block allocated per chunk of pending edges, and an indirection to reach the back. A `std::vector` holds the same last-in-first-out order, which is the order these iterators are specified to have and which callers depend on.

**The filter was a virtual call per node.** `next()` asked `ok(n)` through the vtable for every node it popped. The walk moves into a templated `nextIf(Accept&&)` in the protected section; `NonAtomIterator` calls it with its own predicate so `!n.isAtom()` inlines into the loop, and becomes `final`. The generic `NodeIterator::next()` keeps the historical virtual `ok` hook by calling the same core with a lambda that forwards to it, so an out-of-tree subclass overriding `ok` still works.

## What to check during review

The traversal order is load-bearing — `nodeIteratorOrderOk` in the stack-safety series covers it, but that series is not this PR, so it is worth reading directly. Popping the back of a vector that was pushed in child order gives the same sequence as popping the top of a stack pushed the same way, and the `iteration` stamp is still tested both when an edge is queued and when it is popped, which is what keeps a node visited once when several parents queue it before any of them is processed.

## Testing

Full suite unchanged from master: **107/107 ctest**, which includes the lit query corpus as `query-files`. `NodeIterator` is used by the printers, `Flatten`, and the bitvector solver, so the corpus exercises it broadly rather than through one suite.

```
cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_ASSERTIONS=ON \
  -DENABLE_TESTING=ON -DPYTHON_EXECUTABLE=/usr/bin/python3 \
  -DLIT_TOOL=$(command -v lit)
cmake --build build -j$(nproc) && (cd build && ctest -j12)
```
