### PR TITLE
Stack safety (14/14): Make the continuation drivers explicit

### DIFF
--- a/include/stp/AST/ASTInterior.h
+++ b/include/stp/AST/ASTInterior.h
@@ -46,9 +46,8 @@ class ASTInterior : public ASTInternal
   friend class STPMgr;
   friend class ASTNodeHasher;
   friend class ASTNodeEqual;
-  friend stp::ASTNode
-  HashingNodeFactory::CreateNode(const Kind kind,
-                                 const stp::ASTVec& back_children);
+  friend stp::ASTNode HashingNodeFactory::CreateNode(
+      Kind kind, stp::ASTChildren back_children);
 
   // The children are stored in a flexible array immediately after this
   // object -- node and children are one allocation, made by create(). This

--- a/include/stp/AST/ASTNode.h
+++ b/include/stp/AST/ASTNode.h
@@ -46,8 +46,8 @@ class ASTNode
   friend class STPMgr;
   friend class ASTInterior;
   friend class vector<ASTNode>;
-  friend ASTNode HashingNodeFactory::CreateNode(const stp::Kind kind,
-                                                const ASTVec& back_children);
+  friend ASTNode HashingNodeFactory::CreateNode(
+      stp::Kind kind, stp::ASTChildren back_children);
   friend bool exprless(const ASTNode& n1, const ASTNode& n2);
   friend bool arithless(const ASTNode& n1, const ASTNode& n2);
 

--- a/include/stp/AST/MutableASTNode.h
+++ b/include/stp/AST/MutableASTNode.h
@@ -32,6 +32,7 @@ THE SOFTWARE.
 #include "stp/AST/AST.h"
 #include "stp/STPManager/STPManager.h"
 #include "stp/Simplifier/Simplifier.h"
+#include <deque>
 
 namespace stp
 {
@@ -88,35 +89,102 @@ private:
    * node of a sub-tree will be created after its children.
    */
 
+  // The walk keeps its frames on the heap. How deeply a formula nests is the
+  // input's choice, and deeply nested ones exist, so a call per level of the
+  // DAG exhausts the stack: unconstrained-variable elimination builds this
+  // graph for every query, and a 30,000-deep alternation of NOT and AND died
+  // here. See DeepDag_Test.cpp.
+  //
+  // A node is answered from `visited` or it is built. A parent waiting for a
+  // new child consumes the returned pointer directly; shared children that
+  // were already built are still answered from `visited`.
+  struct Frame
+  {
+    ASTNode n;
+    size_t i = 0;
+    bool waiting = false;
+    vector<MutableASTNode*> tempChildren;
+
+    Frame(const ASTNode& node) : n(node)
+    {
+      tempChildren.reserve(node.Degree());
+    }
+  };
+
 public:
   static MutableASTNode* build(const ASTNode& n,
                                std::unordered_map<uint64_t, MutableASTNode*>& visited)
   {
+    MutableASTNode* result = NULL;
+
+    // What the recursive version answered without a call.
+    auto known = [&visited, &result](const ASTNode& node) {
+      const auto it = visited.find(node.GetNodeNum());
+      if (it == visited.end())
+        return false;
+      result = it->second;
+      return true;
+    };
+
+    if (known(n))
+      return result;
+
+    // A deque, so descending never moves the frames above it: `current`
+    // stays valid across a push.
+    std::deque<Frame> stack;
+    stack.emplace_back(n);
+
+    while (true)
     {
-      const auto it = visited.find(n.GetNodeNum());
-      if (it != visited.end())
-        return it->second;
+      Frame& current = stack.back();
+
+      if (current.waiting)
+      {
+        current.waiting = false;
+        current.tempChildren.push_back(result);
+        current.i++;
+      }
+
+      bool descended = false;
+      while (current.i < current.n.Degree())
+      {
+        if (known(current.n[current.i]))
+        {
+          current.tempChildren.push_back(result);
+          current.i++;
+          continue;
+        }
+
+        // Nothing above may be read after this push.
+        current.waiting = true;
+        stack.emplace_back(current.n[current.i]);
+        descended = true;
+        break;
+      }
+
+      if (descended)
+        continue;
+
+      // Same order as the recursion: every child built, then the node, then
+      // the parent links, then the entry that makes it answerable.
+      MutableASTNode* mut = createNode(current.n);
+
+      for (size_t i = 0; i < current.tempChildren.size(); i++)
+      {
+        current.tempChildren[i]->parents.insert(mut);
+      }
+
+      // The temporary already has exactly the representation the mutable
+      // node needs. Transfer its allocation instead of allocating a second
+      // pointer array and copying every child into it.
+      mut->children = std::move(current.tempChildren);
+      visited.insert(std::make_pair(current.n.GetNodeNum(), mut));
+
+      result = mut;
+      stack.pop_back();
+      if (stack.empty())
+        return result;
     }
-
-    vector<MutableASTNode*> tempChildren;
-    tempChildren.reserve(n.Degree());
-
-    for (size_t i = 0; i < n.Degree(); i++)
-    {
-      tempChildren.push_back(build(n[i], visited));
-    }
-
-    MutableASTNode* mut = createNode(n);
-
-    for (size_t i = 0; i < n.Degree(); i++)
-    {
-      tempChildren[i]->parents.insert(mut);
-    }
-
-    mut->children.insert(mut->children.end(), tempChildren.begin(),
-                         tempChildren.end());
-    visited.insert(std::make_pair(n.GetNodeNum(), mut));
-    return mut;
   }
 
 private:
@@ -125,34 +193,61 @@ private:
 public:
   bool checkInvariant()
   {
-    // Symbols have no children.
-    if (n.GetKind() == SYMBOL)
+    struct CheckFrame
     {
-      assert(children.size() == 0);
-    }
+      MutableASTNode* node;
+      size_t nextChild = 0;
+      bool entered = false;
+      bool waitingForChild = false;
+    };
 
-    // all my parents have me as a child.
-    for (ParentsType::iterator it = parents.begin(); it != parents.end(); it++)
+    std::deque<CheckFrame> stack;
+    stack.push_back({this});
+    while (!stack.empty())
     {
-      vector<MutableASTNode*>::iterator it2 = (*it)->children.begin();
-      // Only consumed by the assert, which an NDEBUG build compiles out.
-      [[maybe_unused]] bool found = false;
-      for (; it2 != (*it)->children.end(); it2++)
+      CheckFrame& frame = stack.back();
+      MutableASTNode* current = frame.node;
+
+      if (!frame.entered)
       {
-        assert(*it2 != NULL);
-        if (*it2 == this)
-          found = true;
+        // Symbols have no children.
+        if (current->n.GetKind() == SYMBOL)
+          assert(current->children.empty());
+
+        // All my parents have me as a child.
+        for (MutableASTNode* parent : current->parents)
+        {
+          // Only consumed by the assert, which an NDEBUG build compiles out.
+          [[maybe_unused]] bool found = false;
+          for (MutableASTNode* child : parent->children)
+          {
+            assert(child != NULL);
+            if (child == current)
+              found = true;
+          }
+          assert(found);
+        }
+        frame.entered = true;
       }
-      assert(found);
-    }
 
-    for (size_t i = 0; i < children.size(); i++)
-    {
-      // call check on all the children.
-      children[i]->checkInvariant();
+      if (frame.waitingForChild)
+      {
+        [[maybe_unused]] MutableASTNode* child =
+            current->children[frame.nextChild];
+        assert(child->parents.find(current) != child->parents.end());
+        frame.nextChild++;
+        frame.waitingForChild = false;
+        continue;
+      }
 
-      // all my children have me as a parent.
-      assert(children[i]->parents.find(this) != children[i]->parents.end());
+      if (frame.nextChild < current->children.size())
+      {
+        frame.waitingForChild = true;
+        stack.push_back({current->children[frame.nextChild]});
+        continue;
+      }
+
+      stack.pop_back();
     }
 
     return true; // ignored.
@@ -169,37 +264,70 @@ public:
     if (!dirty)
       return n;
 
-    if (children.size() == 0)
+    if (children.empty())
       return n;
 
+    struct RebuildFrame
+    {
+      MutableASTNode* node;
+      size_t nextChild = 0;
+    };
+    static_assert(sizeof(RebuildFrame) <= 2 * sizeof(void*),
+                  "mutable rebuild frames must not own child buffers");
+
+    std::vector<RebuildFrame> stack;
+    stack.push_back({this});
     ASTVec newChildren;
-    for (size_t i = 0; i < children.size(); i++)
-      newChildren.push_back(children[i]->toASTNode(stpMgr));
 
-    // Don't use the simplifying node factory here. Imagine CreateNode simplified
-    // down,
-    // from (= 1 ite( x , 1,0)) to x (say). Then this node will become a symbol,
-    // but, this object will still have the equal's children. i.e. 1, and the
-    // ITE.
-    // So it becomes a SYMBOL with children...
+    while (true)
+    {
+      RebuildFrame& frame = stack.back();
+      MutableASTNode* current = frame.node;
 
-    if (n.GetType() == BOOLEAN_TYPE)
-    {
-      n = stpMgr->hashingNodeFactory->CreateNode(n.GetKind(), newChildren);
-    }
-    else if (n.GetType() == BITVECTOR_TYPE)
-    {
-      n = stpMgr->hashingNodeFactory->CreateTerm(n.GetKind(), n.GetValueWidth(),
-                                                 newChildren);
-    }
-    else
-    {
-      n = stpMgr->hashingNodeFactory->CreateArrayTerm(
-          n.GetKind(), n.GetIndexWidth(), n.GetValueWidth(), newChildren);
-    }
+      if (frame.nextChild < current->children.size())
+      {
+        MutableASTNode* child = current->children[frame.nextChild++];
+        if (!child->dirty || child->children.empty())
+          continue;
 
-    dirty = false;
-    return n;
+        stack.push_back({child});
+        continue;
+      }
+
+      // Every child owns its rebuilt AST answer, so only the node currently
+      // being recreated needs a child-handle buffer. Reuse one allocation
+      // across the whole post-order walk instead of one vector per depth.
+      newChildren.clear();
+      newChildren.reserve(current->children.size());
+      for (MutableASTNode* child : current->children)
+        newChildren.push_back(child->n);
+
+      // Don't use the simplifying node factory here. Imagine CreateNode
+      // simplified (= 1 (ite x 1 0)) down to x. This object would become a
+      // symbol while retaining the equality's children.
+      if (current->n.GetType() == BOOLEAN_TYPE)
+      {
+        current->n = stpMgr->hashingNodeFactory->CreateNode(
+            current->n.GetKind(), newChildren);
+      }
+      else if (current->n.GetType() == BITVECTOR_TYPE)
+      {
+        current->n = stpMgr->hashingNodeFactory->CreateTerm(
+            current->n.GetKind(), current->n.GetValueWidth(),
+            newChildren);
+      }
+      else
+      {
+        current->n = stpMgr->hashingNodeFactory->CreateArrayTerm(
+            current->n.GetKind(), current->n.GetIndexWidth(),
+            current->n.GetValueWidth(), newChildren);
+      }
+
+      current->dirty = false;
+      stack.pop_back();
+      if (stack.empty())
+        return current->n;
+    }
   }
 
   ASTNode n;
@@ -233,9 +361,44 @@ public:
     if (dirty)
       return;
 
+    struct ParentFrame
+    {
+      MutableASTNode* node;
+      ParentsType::const_iterator next;
+
+      explicit ParentFrame(MutableASTNode* n)
+          : node(n), next(n->parents.begin())
+      {
+      }
+    };
+    static_assert(sizeof(ParentFrame) <= 2 * sizeof(void*),
+                  "dirty-walk frames must contain only traversal state");
+
     dirty = true;
-    for (ParentsType::iterator it = parents.begin(); it != parents.end(); it++)
-      (*it)->propagateUpDirty();
+    if (parents.empty())
+      return;
+
+    // Retain the parent-set continuation at each active level rather than
+    // enqueueing every parent on the traversal frontier at once.
+    vector<ParentFrame> path;
+    path.emplace_back(this);
+    while (!path.empty())
+    {
+      ParentFrame& frame = path.back();
+      if (frame.next == frame.node->parents.end())
+      {
+        path.pop_back();
+        continue;
+      }
+
+      MutableASTNode* parent = *frame.next++;
+      if (parent->dirty)
+        continue;
+
+      parent->dirty = true;
+      if (!parent->parents.empty())
+        path.emplace_back(parent);
+    }
   }
 
   void replaceWithAnotherNode(MutableASTNode* newN)
@@ -268,21 +431,48 @@ public:
 
   void removeChildren(vector<MutableASTNode*>& variables)
   {
-    for (unsigned i = 0; i < children.size(); i++)
+    if (children.empty())
+      return;
+
+    struct RemoveFrame
     {
-      MutableASTNode* child = children[i];
-      ParentsType& children_parents = child->parents;
-      children_parents.erase(this);
+      MutableASTNode* node;
+      size_t nextChild = 0;
+      MutableASTNode* returningChild = NULL;
+    };
 
-      if (children_parents.size() == 0)
+    std::deque<RemoveFrame> stack;
+    stack.push_back({this});
+    while (!stack.empty())
+    {
+      RemoveFrame& frame = stack.back();
+      if (frame.returningChild != NULL)
       {
-        child->removeChildren(variables);
+        if (frame.returningChild->isUnconstrained())
+          variables.push_back(frame.returningChild);
+        frame.returningChild = NULL;
+        continue;
       }
 
-      if (child->isUnconstrained())
+      if (frame.nextChild == frame.node->children.size())
       {
-        variables.push_back(child);
+        stack.pop_back();
+        continue;
       }
+
+      MutableASTNode* child = frame.node->children[frame.nextChild++];
+      // `parents` records unique parents, not edge multiplicity. If this
+      // parent names the same child more than once, the first edge removes
+      // the whole parent relationship. Following a later duplicate merely
+      // because the child's parent set is already empty would tear the same
+      // orphaned DAG down once per path -- exponentially for a layered DAG
+      // whose nodes use the same child twice.
+      if (child->parents.erase(frame.node) == 0)
+        continue;
+
+      frame.returningChild = child;
+      if (child->parents.empty())
+        stack.push_back({child});
     }
   }
 
@@ -305,12 +495,43 @@ public:
   {
     if (!visited.insert(this).second)
       return;
+
     if (isSymbol())
       result.push_back(this);
-    const int size = children.size();
-    for (int i = 0; i < size; i++)
+
+    if (children.empty())
+      return;
+
+    struct ChildFrame
     {
-      children[i]->getAllVariablesRecursively(result, visited);
+      MutableASTNode* node;
+      size_t nextChild = 0;
+    };
+    static_assert(sizeof(ChildFrame) <= 2 * sizeof(void*),
+                  "variable-walk frames must contain only traversal state");
+
+    // A continuation per active ancestor retains the old left-to-right DFS
+    // result order without retaining all unvisited siblings on the frontier.
+    vector<ChildFrame> path;
+    path.push_back({this});
+    while (!path.empty())
+    {
+      ChildFrame& frame = path.back();
+      if (frame.nextChild == frame.node->children.size())
+      {
+        path.pop_back();
+        continue;
+      }
+
+      MutableASTNode* current = frame.node->children[frame.nextChild++];
+      if (!visited.insert(current).second)
+        continue;
+
+      if (current->isSymbol())
+        result.push_back(current);
+
+      if (!current->children.empty())
+        path.push_back({current});
     }
   }
 

--- a/include/stp/AbsRefineCounterExample/AbsRefine_CounterExample.h
+++ b/include/stp/AbsRefineCounterExample/AbsRefine_CounterExample.h
@@ -166,7 +166,7 @@ private:
   // choice and can be deeper than the stack holds. So the three are one walk
   // with its frames on the heap rather than three sets of call frames. See
   // DeepDag_Test.cpp.
-  struct Frame;
+  class EvaluationDriver;
   ASTNode evaluate(Job job, const ASTNode& n, bool topArrayReadFlag);
 
 public:

--- a/include/stp/AbsRefineCounterExample/AbsRefine_CounterExample.h
+++ b/include/stp/AbsRefineCounterExample/AbsRefine_CounterExample.h
@@ -152,8 +152,22 @@ private:
                                     bool ArrayReadFlag = true);
 
 private:
-  ASTNode TermToConstTermUsingModel_inner(const ASTNode& term,
-                                           bool ArrayReadFlag);
+  // Which of the three evaluations below a frame of the walk is running.
+  enum Job
+  {
+    EvalFormula,
+    EvalTerm,
+    EvalExpand
+  };
+
+  // Evaluating a formula evaluates its terms, a term its if-then-else
+  // condition, and a read over a write the expansion of that write chain and
+  // then the terms in it -- once per level of the input, which is the input's
+  // choice and can be deeper than the stack holds. So the three are one walk
+  // with its frames on the heap rather than three sets of call frames. See
+  // DeepDag_Test.cpp.
+  struct Frame;
+  ASTNode evaluate(Job job, const ASTNode& n, bool topArrayReadFlag);
 
 public:
 

--- a/include/stp/AbsRefineCounterExample/ArrayTransformer.h
+++ b/include/stp/AbsRefineCounterExample/ArrayTransformer.h
@@ -108,7 +108,7 @@ private:
   // input, which is the input's choice and can be deeper than the stack
   // holds. So the three are one walk with its frames on the heap rather
   // than three sets of call frames. See DeepDag_Test.cpp.
-  struct Frame;
+  class TransformDriver;
   ASTNode transform(bool asFormula, const ASTNode& n);
 
 public:

--- a/include/stp/AbsRefineCounterExample/ArrayTransformer.h
+++ b/include/stp/AbsRefineCounterExample/ArrayTransformer.h
@@ -98,11 +98,18 @@ private:
    ****************************************************************/
 
   ASTNode TransformTerm(const ASTNode& inputterm);
+  ASTNode finishTransformTerm(const ASTNode& term, const ASTNode& result);
   void assertTransformPostConditions(const ASTNode& term, ASTNodeSet& visited);
 
-  ASTNode TransformArrayRead(const ASTNode& term);
-
   ASTNode TransformFormula(const ASTNode& form);
+
+  // Transforming a formula transforms its terms, a term its condition and
+  // its children, and a read the array under it -- once per level of the
+  // input, which is the input's choice and can be deeper than the stack
+  // holds. So the three are one walk with its frames on the heap rather
+  // than three sets of call frames. See DeepDag_Test.cpp.
+  struct Frame;
+  ASTNode transform(bool asFormula, const ASTNode& n);
 
 public:
   // fill the arrayname_readindices vector if e0 is a READ(Arr,index)

--- a/include/stp/FloatBlaster/FpTotalise.h
+++ b/include/stp/FloatBlaster/FpTotalise.h
@@ -27,6 +27,7 @@ THE SOFTWARE.
 
 #include "stp/AST/AST.h"
 #include "stp/STPManager/STPManager.h"
+#include "stp/Util/DagWalk.h"
 
 namespace stp
 {
@@ -120,6 +121,11 @@ public:
 private:
   ASTNode visit(const ASTNode& n);
 
+  // The pass proper, for one node whose children visit() has already
+  // answered. Split out so that visit() can fill those answers from the
+  // bottom up rather than by calling itself once per level.
+  ASTNode totalise(const ASTNode& n, bool knownMissing = false);
+
   // The canonical form of an index over a float-indexed array whose index
   // format is (exp_width, sig_width): constants re-intern through the
   // canonicalising constant funnel, source FP expressions become an explicit
@@ -168,6 +174,9 @@ private:
 
   STPMgr* bm;
   NodeFactory* nf;
+
+  // Debug-only: verify that priming keeps visit's call depth bounded.
+  PrimeAudit memoAudit{"FpTotalise::visit", 8};
   // `traversal_cache` preserves DAG sharing only for one topLevel walk and is
   // released immediately afterwards. `persistent_cache` keeps just the
   // source FP/array nodes whose encoding changed and may be requested again

--- a/include/stp/NodeFactory/HashingNodeFactory.h
+++ b/include/stp/NodeFactory/HashingNodeFactory.h
@@ -35,11 +35,15 @@ public:
   HashingNodeFactory(STPMgr& bm_) : NodeFactory(bm_) {}
   virtual ~HashingNodeFactory();
 
-  ASTNode CreateNode(const Kind kind, const ASTVec& back_children);
-  ASTNode CreateTerm(Kind kind, unsigned int width,
-                                const ASTVec& children);
+  using NodeFactory::CreateArrayTerm;
+  using NodeFactory::CreateNode;
+  using NodeFactory::CreateTerm;
 
-  virtual std::string getName() { return "hashing"; }
+  ASTNode CreateNode(Kind kind, ASTChildren back_children) override;
+  ASTNode CreateTerm(Kind kind, unsigned int width,
+                     ASTChildren children) override;
+
+  std::string getName() override { return "hashing"; }
 };
 
 #endif /* HASHINGNODEFACTORY_H_ */

--- a/include/stp/NodeFactory/NodeFactory.h
+++ b/include/stp/NodeFactory/NodeFactory.h
@@ -28,6 +28,7 @@ THE SOFTWARE.
 #include "stp/AST/ASTKind.h"
 #include "stp/Util/Attributes.h"
 #include <cstdint>
+#include <initializer_list>
 #include <vector>
 
 using std::vector;
@@ -35,6 +36,8 @@ namespace stp
 {
 class ASTNode;
 typedef vector<ASTNode> ASTVec;
+template <class T> class Span;
+typedef Span<const ASTNode> ASTChildren;
 DLL_PUBLIC extern ASTVec _empty_ASTVec;
 class STPMgr;
 typedef unsigned int* CBV;
@@ -43,6 +46,7 @@ typedef unsigned int* CBV;
 using stp::ASTNode;
 using stp::Kind;
 using stp::ASTVec;
+using stp::ASTChildren;
 using stp::_empty_ASTVec;
 using stp::STPMgr;
 
@@ -56,14 +60,25 @@ public:
   NodeFactory(STPMgr& bm_) : bm(bm_) {}
   virtual ~NodeFactory() {}
 
+  // A non-owning contiguous child range. ASTVec converts to this view, while
+  // callers which already own another contiguous arena avoid materialising
+  // a vector merely to cross the factory boundary.
   virtual ASTNode CreateTerm(Kind kind, unsigned int width,
-                                        const ASTVec& children) = 0;
+                             ASTChildren children) = 0;
 
   virtual ASTNode CreateArrayTerm(Kind kind, unsigned int index,
-                                             unsigned int width,
-                                             const ASTVec& children);
+                                  unsigned int width, ASTChildren children);
 
-  virtual ASTNode CreateNode(Kind kind, const ASTVec& children) = 0;
+  virtual ASTNode CreateNode(Kind kind, ASTChildren children) = 0;
+
+  // Preserve the convenient braced-child API without allocating a temporary
+  // ASTVec. The initializer-list storage remains alive for the duration of
+  // these calls.
+  ASTNode CreateTerm(Kind kind, unsigned int width,
+                     std::initializer_list<ASTNode> children);
+  ASTNode CreateArrayTerm(Kind kind, unsigned int index, unsigned int width,
+                          std::initializer_list<ASTNode> children);
+  ASTNode CreateNode(Kind kind, std::initializer_list<ASTNode> children);
 
   ASTNode CreateSymbol(const char* const name, unsigned indexWidth,
                        unsigned valueWidth);

--- a/include/stp/NodeFactory/SimplifyingNodeFactory.h
+++ b/include/stp/NodeFactory/SimplifyingNodeFactory.h
@@ -95,7 +95,8 @@ private:
   ASTNode CreateSimpleNot(ASTChildren children);
 
   ASTNode CreateSimpleEQ(ASTChildren children);
-
+  ASTNode CreateSimpleEQConstConcat(const ASTNode& constant,
+                                    const ASTNode& concat);
 
   ASTNode chaseRead(ASTChildren children, unsigned int width);
 

--- a/include/stp/NodeFactory/SimplifyingNodeFactory.h
+++ b/include/stp/NodeFactory/SimplifyingNodeFactory.h
@@ -57,8 +57,13 @@ class DLL_PUBLIC SimplifyingNodeFactory : public NodeFactory
 {
 
 public:
-  virtual ASTNode CreateNode(const Kind kind, const ASTVec& children) override;
-  virtual ASTNode CreateTerm(const Kind kind, const unsigned int width, const ASTVec& children) override;
+  using NodeFactory::CreateArrayTerm;
+  using NodeFactory::CreateNode;
+  using NodeFactory::CreateTerm;
+
+  virtual ASTNode CreateNode(Kind kind, ASTChildren children) override;
+  virtual ASTNode CreateTerm(Kind kind, unsigned int width,
+                             ASTChildren children) override;
   virtual std::string getName() override { return "simplifying"; }
 
   SimplifyingNodeFactory(NodeFactory& raw_, STPMgr& bm_)
@@ -70,8 +75,8 @@ public:
   SimplifyingNodeFactory& operator=(const SimplifyingNodeFactory&) = delete;
 
   static ASTNode convertKnownShiftAmount(const Kind k,
-                                            const ASTVec& children, STPMgr& bm,
-                                            NodeFactory* nf);
+                                         ASTChildren children, STPMgr& bm,
+                                         NodeFactory* nf);
 private:
   NodeFactory& hashing;
 
@@ -79,32 +84,32 @@ private:
   const ASTNode& ASTFalse;
   const ASTNode& ASTUndefined;
 
-  ASTNode CreateSimpleFormITE(const ASTVec& children);
-  ASTNode CreateSimpleXor(const ASTVec& children);
+  ASTNode CreateSimpleFormITE(ASTChildren children);
+  ASTNode CreateSimpleXor(ASTChildren children);
 
-  ASTNode CreateSimpleAndOr(bool IsAnd, const ASTVec& children);
+  ASTNode CreateSimpleAndOr(bool IsAnd, ASTChildren children);
   ASTNode CreateSimpleAndOr(bool IsAnd, const ASTNode& form1, const ASTNode& form2);
-  ASTNode handle_2_children(bool IsAnd, const ASTVec& children);
+  ASTNode handle_2_children(bool IsAnd, ASTChildren children);
 
   ASTNode CreateSimpleNot(const ASTNode& form);
-  ASTNode CreateSimpleNot(const ASTVec& children);
+  ASTNode CreateSimpleNot(ASTChildren children);
 
-  ASTNode CreateSimpleEQ(const ASTVec& children);
+  ASTNode CreateSimpleEQ(ASTChildren children);
 
 
-  ASTNode chaseRead(const ASTVec& children, unsigned int width);
+  ASTNode chaseRead(ASTChildren children, unsigned int width);
 
   ASTNode simplifyArrayEquality(const ASTNode& a, const ASTNode& b);
 
   ASTNode plusRules(const ASTNode& n0, const ASTNode& n1);
 
   //Helper functions
-  bool children_all_constants(const ASTVec& children) const;
+  bool children_all_constants(ASTChildren children) const;
   ASTNode get_smallest_number(const unsigned width);
   ASTNode get_largest_number(const unsigned width);
-  ASTNode handle_bvxor(unsigned int width, const ASTVec& input_children);
-  ASTNode handle_bvand(unsigned int width, const ASTVec& children);
-  ASTNode create_gt_node(const ASTVec& children);
+  ASTNode handle_bvxor(unsigned int width, ASTChildren input_children);
+  ASTNode handle_bvand(unsigned int width, ASTChildren children);
+  ASTNode create_gt_node(ASTChildren children);
 
   // abs/neg of a constant float: clear (flip=false) or flip (flip=true) the
   // sign bit, keeping the rest of the packed bits and the format.
@@ -115,7 +120,7 @@ private:
   ASTNode makeFPNaN(unsigned eb, unsigned sb);
   ASTNode makeFPZero(unsigned eb, unsigned sb, bool negative);
 
-  ASTNode plusRules(const ASTVec& oldChildren);
+  ASTNode plusRules(ASTChildren oldChildren);
 
 };
 

--- a/include/stp/NodeFactory/TypeChecker.h
+++ b/include/stp/NodeFactory/TypeChecker.h
@@ -42,13 +42,19 @@ public:
   }
   virtual ~TypeChecker(){};
 
-  stp::ASTNode CreateTerm(stp::Kind kind, unsigned int width,
-                          const stp::ASTVec& children);
-  stp::ASTNode CreateNode(stp::Kind kind, const stp::ASTVec& children);
-  stp::ASTNode CreateArrayTerm(Kind kind, unsigned int index,
-                               unsigned int width, const ASTVec& children);
+  using NodeFactory::CreateArrayTerm;
+  using NodeFactory::CreateNode;
+  using NodeFactory::CreateTerm;
 
-  virtual std::string getName() { return "type checking"; }
+  stp::ASTNode CreateTerm(stp::Kind kind, unsigned int width,
+                          stp::ASTChildren children) override;
+  stp::ASTNode CreateNode(stp::Kind kind,
+                          stp::ASTChildren children) override;
+  stp::ASTNode CreateArrayTerm(Kind kind, unsigned int index,
+                               unsigned int width,
+                               stp::ASTChildren children) override;
+
+  std::string getName() override { return "type checking"; }
 };
 
 #endif /* TYPECHECKER_H_ */

--- a/include/stp/STPManager/STPManager.h
+++ b/include/stp/STPManager/STPManager.h
@@ -65,8 +65,8 @@ class STPMgr
   friend class ASTInterior;
   friend class ASTBVConst;
   friend class ASTSymbol;
-  friend ASTNode HashingNodeFactory::CreateNode(const Kind kind,
-                                                const ASTVec& back_children);
+  friend ASTNode HashingNodeFactory::CreateNode(
+      Kind kind, ASTChildren back_children);
 
 private:
   // Typedef for unique Interior node table.

--- a/include/stp/STPManager/STPManager.h
+++ b/include/stp/STPManager/STPManager.h
@@ -90,6 +90,14 @@ private:
   // Unique node tables that enables common subexpression sharing
   ASTInteriorSet _interior_unique_table;
 
+  // Interior nodes whose last reference has gone while another one was
+  // already being deleted. Releasing a node releases its children, so
+  // deleting the root of a deeply nested DAG would otherwise nest one
+  // destructor per level and run off the stack; ASTInterior::CleanUp drains
+  // this instead. See DeepDag_Test.cpp.
+  std::vector<ASTInterior*> _pending_deletion;
+  uint8_t _interior_deletion_depth = 0;
+
   // Table for variable names, let names etc.
   ASTSymbolSet _symbol_unique_table;
 

--- a/include/stp/Simplifier/Flatten.h
+++ b/include/stp/Simplifier/Flatten.h
@@ -54,6 +54,12 @@ class Flatten
 
   // sharecount is 1 if the node has one reference in the tree.
   void buildShareCount(const ASTNode& n);
+
+  // flatten() walks the DAG with its frames on the heap: the input decides
+  // how deep the walk goes, so a call per level exhausts the stack on the
+  // deeply nested formulas that exist. See DeepDag_Test.cpp.
+  struct Frame;
+  bool alreadyKnown(const ASTNode& n, ASTNode& answer);
   ASTNode flatten(const ASTNode& n, bool top=false);
 
 public:

--- a/include/stp/Simplifier/NodeDomainAnalysis.h
+++ b/include/stp/Simplifier/NodeDomainAnalysis.h
@@ -34,6 +34,7 @@ THE SOFTWARE.
 #include "stp/Simplifier/constantBitP/FixedBits.h"
 #include "stp/Simplifier/UnsignedIntervalAnalysis.h"
 #include "stp/Simplifier/ValueSetAnalysis.h"
+#include "stp/Util/DagWalk.h"
 #include <iostream>
 #include <unordered_map>
 
@@ -57,6 +58,18 @@ using NodeToValueSetMap =
 class NodeDomainAnalysis
 {
   STPMgr& bm;
+
+  // Shallow inputs keep buildMap's ordinary recursive path: walking the DAG
+  // once to prime a memo costs more than the stack it saves there. Once the
+  // prefix reaches this budget, primeMaps fills the suffix bottom-up and the
+  // bounded prefix unwinds normally.
+  static constexpr size_t unprimedDepthLimit = 512;
+  size_t unprimedDepth = 0;
+
+  // Debug-only: verify that the deliberately recursive prefix is bounded and
+  // priming answers every call made below it.
+  PrimeAudit mapAudit{"NodeDomainAnalysis::buildMap",
+                      unprimedDepthLimit + 8};
 
   // Cache read-only empty objects of different sizes.
   FixedBits* emptyBoolean;
@@ -92,6 +105,10 @@ public:
     ValueSet* set;
   };
 
+private:
+  DomainInfo buildMap(const ASTNode& n, bool knownMissing);
+
+public:
   NodeDomainAnalysis(STPMgr* _bm)
       : bm(*_bm), intervalAnalysis(*_bm), valueSetAnalysis(*_bm)
   {
@@ -141,6 +158,13 @@ public:
    }
 
   DomainInfo buildMap(const ASTNode& n);
+
+  // buildMap reaches a node's children by calling itself, so a deeply nested
+  // input exhausts the stack. Once the shallow recursion budget above is
+  // exhausted, fill the remaining maps from the bottom up, and those calls
+  // answer from the map instead. See DeepDag_Test.cpp.
+  void primeMaps(const ASTNode& n);
+  bool priming = false;
 
   void topLevel(const ASTNode& top)
   {

--- a/include/stp/Simplifier/PropagateEqualities.h
+++ b/include/stp/Simplifier/PropagateEqualities.h
@@ -72,6 +72,7 @@ private:
   IdSet alreadyVisited;
 
   void buildCandidateList(const ASTNode& a);
+  bool buildCandidateListNode(const ASTNode& a);
   void replaceIfPossible(int line, ASTNode& output, const ASTNode& lhs, const ASTNode& rhs);
   void buildXORCandidates(const ASTNode a, bool negated);
   

--- a/include/stp/Simplifier/Rewriting.h
+++ b/include/stp/Simplifier/Rewriting.h
@@ -49,6 +49,13 @@ class Rewriting
 
   // sharecount is 1 if the node has one reference in the tree.
   void buildShareCount(const ASTNode& n);
+  ASTNode applyRules(ASTNode c);
+
+  // rewrite() walks the DAG with its frames on the heap: the input decides
+  // how deep the walk goes, so a call per level exhausts the stack on the
+  // deeply nested formulas that exist. See DeepDag_Test.cpp.
+  struct Frame;
+  bool alreadyKnown(const ASTNode& n, ASTNode& answer);
   ASTNode rewrite(const ASTNode& n);
 
 public:

--- a/include/stp/Simplifier/Simplifier.h
+++ b/include/stp/Simplifier/Simplifier.h
@@ -211,6 +211,18 @@ public:
   }
 
 private:
+  enum class SimplifyJob
+  {
+    Formula,
+    Term,
+    Array
+  };
+
+  // Formulae, bit-vector/floating-point terms, and the array terms reached by
+  // READ all share one continuation stack. A generated rewrite is scheduled
+  // on that stack just like an input child, so neither input depth nor rewrite
+  // depth becomes C++ call depth.
+  ASTNode simplifyNode(const ASTNode& n, bool pushNeg, SimplifyJob job);
 
   void checkIfInSimplifyMap(const ASTNode& n, ASTNodeSet visited);
 
@@ -228,9 +240,7 @@ private:
 
   ASTNode SimplifyFormula_NoRemoveWrites(const ASTNode& a, bool pushNeg);
 
-  ASTNode SimplifyAtomicFormula(const ASTNode& a, bool pushNeg);
-
-  ASTNode ITEOpt_InEqs(const ASTNode& in1);
+  ASTNode ITEOpt_InEqs(const ASTNode& in1, ASTNode& conditionToNegate);
 
   ASTNode PullUpITE(const ASTNode& in);
 
@@ -240,26 +250,17 @@ private:
   ASTNode CreateSimplifiedINEQ(const Kind k, const ASTNode& a0,
                                const ASTNode& a1, bool pushNeg);
 
-  ASTNode SimplifyNotFormula(const ASTNode& a, bool pushNeg);
-
-  ASTNode SimplifyAndOrFormula(const ASTNode& a, bool pushNeg);
-
-  ASTNode SimplifyXorFormula(const ASTNode& a, bool pushNeg);
-
-  ASTNode SimplifyNandFormula(const ASTNode& a, bool pushNeg);
-
-  ASTNode SimplifyNorFormula(const ASTNode& a, bool pushNeg);
-
-  ASTNode SimplifyImpliesFormula(const ASTNode& a, bool pushNeg);
-
-  ASTNode SimplifyIffFormula(const ASTNode& a, bool pushNeg);
-
-  ASTNode SimplifyIteFormula(const ASTNode& a, bool pushNeg);
+  // SimplifyFormula's head: the answers it gives without dispatching at all,
+  // plus the PullUpITE'd node the dispatch would run on. True when `out` is
+  // the answer.
+  bool formulaShortcut(const ASTNode& b, bool pushNeg, ASTNode& a,
+                       ASTNode& out);
 
   ASTNode CombineLikeTerms(const ASTNode& a);
   ASTNode CombineLikeTerms(const ASTVec& a);
 
-  ASTNode LhsMinusRhs(const ASTNode& eq);
+  ASTNode LhsMinusRhsTerm(const ASTNode& eq,
+                          const ASTNode& simplifiedNegatedRhs);
 
   ASTNode DistributeMultOverPlus(const ASTNode& a,
                                  bool startdistribution = false);

--- a/include/stp/Simplifier/Simplifier.h
+++ b/include/stp/Simplifier/Simplifier.h
@@ -211,6 +211,8 @@ public:
   }
 
 private:
+  class SimplifyDriver;
+
   enum class SimplifyJob
   {
     Formula,

--- a/include/stp/Simplifier/VariablesInExpression.h
+++ b/include/stp/Simplifier/VariablesInExpression.h
@@ -28,6 +28,7 @@ THE SOFTWARE.
 #include "Symbols.h"
 #include "stp/AST/AST.h"
 #include "stp/Util/Attributes.h"
+#include "stp/Util/DagWalk.h"
 
 namespace stp
 {
@@ -36,9 +37,13 @@ class VariablesInExpression
 {
 private:
   void insert(const ASTNode& n, Symbols* s);
+  Symbols* getSymbol(const ASTNode& n, bool knownMissing);
 
   typedef std::unordered_map<uint64_t, Symbols*> ASTNodeToNodes;
   ASTNodeToNodes symbol_graph;
+
+  // Debug-only: verify that priming keeps getSymbol's call depth bounded.
+  PrimeAudit symbolAudit{"VariablesInExpression::getSymbol", 8};
 
 public:
   DLL_PUBLIC VariablesInExpression();
@@ -52,6 +57,12 @@ public:
   typedef std::unordered_set<Symbols*, SymbolPtrHasher> SymbolPtrSet;
 
   Symbols* getSymbol(const ASTNode& n);
+
+  // getSymbol reaches a node's children by calling itself, so a deeply
+  // nested input exhausts the stack. Fill symbol_graph from the bottom up
+  // first, and those calls answer from it instead. See DeepDag_Test.cpp.
+  void primeSymbols(const ASTNode& n);
+  bool priming = false;
 
   // this map is useful while traversing terms and uniquely
   // identifying variables in the those terms. Prevents double

--- a/include/stp/Simplifier/constantBitP/Dependencies.h
+++ b/include/stp/Simplifier/constantBitP/Dependencies.h
@@ -27,6 +27,7 @@ THE SOFTWARE.
 
 #include "stp/AST/AST.h"
 #include "extlib-unordered-dense/ankerl/unordered_dense.h"
+#include <cstdint>
 #include <utility>
 #include <vector>
 
@@ -49,6 +50,11 @@ using stp::ASTNode;
 // contiguous memory. Parents appear in each slice in the order the DFS
 // first saw the edge, which is the same order the previous per-node
 // insertion-ordered sets iterated in.
+//
+// The DFS keeps its frames on the heap. Nesting depth is whatever the input
+// formula nests to, and deep inputs exist -- CPAchecker k-induction traces
+// nest ~9,300 deep -- so one call frame per level exhausts the stack and
+// kills the process. See DeepDag_Test.cpp.
 class Dependencies
 {
 private:
@@ -63,6 +69,21 @@ private:
   // (childIdx, parentIdx) in DFS discovery order; cleared after compaction.
   typedef std::vector<std::pair<uint32_t, uint32_t>> EdgeList;
 
+  typedef ankerl::unordered_dense::set<uint64_t> WideSeen;
+
+  // Where the walk of one node has got to. `wide` is that node's slot in
+  // the duplicate-child sets, or NO_WIDE for the usual narrow node, which
+  // dedups by scanning instead and so needs no set at all.
+  struct Frame
+  {
+    uint32_t idx;
+    uint32_t degree;
+    uint32_t next;
+    uint32_t wide;
+  };
+
+  static constexpr uint32_t NO_WIDE = UINT32_MAX;
+
   uint32_t discover(const ASTNode& n)
   {
     const auto it = index.try_emplace(n.GetNodeNum(), (uint32_t)nodes.size());
@@ -71,28 +92,69 @@ private:
     return it.first->second;
   }
 
+  // Wide nodes are rare, so their sets are handed out from a pool that only
+  // ever grows to the deepest nesting of wide nodes, rather than sitting in
+  // every frame.
+  Frame enter(const uint32_t idx, std::vector<WideSeen>& wideSeen,
+              uint32_t& wideInUse) const
+  {
+    Frame f;
+    f.idx = idx;
+    f.degree = (uint32_t)nodes[idx].Degree();
+    f.next = 0;
+    f.wide = NO_WIDE;
+
+    if (f.degree > 32) // where the quadratic scan starts to bite.
+    {
+      if (wideInUse == wideSeen.size())
+        wideSeen.emplace_back();
+      else
+        wideSeen[wideInUse].clear(); // keeps the buckets it already has.
+      f.wide = wideInUse++;
+    }
+    return f;
+  }
+
   // A (parent -> child) edge repeats only when a node lists the same child
   // more than once (e.g. BVPLUS(x,x)); dedup by scanning the earlier
   // children, or through a set once the quadratic scan would bite.
-  void build(const ASTNode& current, const uint32_t currentIdx,
-             EdgeList& edges)
+  void build(const uint32_t topIdx, EdgeList& edges)
   {
-    const unsigned degree = current.Degree();
+    std::vector<Frame> stack;
+    std::vector<WideSeen> wideSeen;
+    uint32_t wideInUse = 0;
 
-    ankerl::unordered_dense::set<uint64_t> seenWide;
-    const bool wide = degree > 32;
+    stack.push_back(enter(topIdx, wideSeen, wideInUse));
 
-    for (unsigned i = 0; i < degree; i++)
+    while (!stack.empty())
     {
+      Frame& f = stack.back();
+
+      if (f.next == f.degree)
+      {
+        if (f.wide != NO_WIDE)
+          wideInUse--;
+        stack.pop_back();
+        continue;
+      }
+
+      const uint32_t currentIdx = f.idx;
+      const unsigned i = f.next++;
+
+      // Discovering a child can move `nodes`, so neither of these may be
+      // read across one. The child itself is stored in the node that lists
+      // it rather than in `nodes`, so that reference does survive.
+      const ASTNode& current = nodes[currentIdx];
       const ASTNode& child = current[i];
+
       if (child.isConstant()) // don't care about what depends on constants.
         continue;
 
       const uint64_t childId = child.GetNodeNum();
 
-      if (wide)
+      if (f.wide != NO_WIDE)
       {
-        if (!seenWide.insert(childId).second)
+        if (!wideSeen[f.wide].insert(childId).second)
           continue;
       }
       else
@@ -108,8 +170,8 @@ private:
           continue;
       }
 
-      // By value: the recursive call inserts into `index`, which can move
-      // the entry the iterator points at.
+      // By value: this inserts into `index`, which can move the entry the
+      // iterator points at.
       const auto r = index.try_emplace(childId, (uint32_t)nodes.size());
       const uint32_t childIdx = r.first->second;
       const bool firstVisit = r.second;
@@ -118,9 +180,10 @@ private:
       edges.emplace_back(childIdx, currentIdx);
 
       // On a repeat visit through a new parent, the edges to the children
-      // are already recorded.
+      // are already recorded. Descending invalidates `f`, so nothing above
+      // may be read after this point.
       if (firstVisit)
-        build(child, childIdx, edges);
+        stack.push_back(enter(childIdx, wideSeen, wideInUse));
     }
   }
 
@@ -148,7 +211,7 @@ public:
       return;
 
     EdgeList edges;
-    build(top, discover(top), edges);
+    build(discover(top), edges);
     compact(edges);
   }
 

--- a/include/stp/Simplifier/constantBitP/WorkList.h
+++ b/include/stp/Simplifier/constantBitP/WorkList.h
@@ -28,6 +28,7 @@ THE SOFTWARE.
 #include "stp/AST/AST.h"
 #include "stp/AST/ASTNode.h"
 #include "extlib-unordered-dense/ankerl/unordered_dense.h"
+#include <vector>
 
 namespace simplifier
 {
@@ -50,27 +51,70 @@ private:
   WorkList(const WorkList&); // Shouldn't needed to copy or assign.
   WorkList& operator=(const WorkList&);
 
-  // We add to the worklist any node that immediately depends on a constant.
-  void addToWorklist(const stp::ASTNode& n, stp::ASTNodeSet& visited)
+  // Where the walk of one node has got to. `addedParent` is that node's
+  // `alreadyAdded`: it is pushed once, at its first constant child.
+  struct Frame
   {
-    if (n.isConstant())
-      return;
+    const stp::ASTNode* n;
+    unsigned i = 0;
+    bool addedParent = false;
 
-    if (visited.find(n) != visited.end())
-      return;
+    Frame(const stp::ASTNode& node) : n(&node) {}
+  };
 
-    visited.insert(n);
+  // We add to the worklist any node that immediately depends on a constant.
+  //
+  // Iterative: this seeds constant-bit propagation by descending the whole
+  // input DAG, and how deeply that nests is the input's choice. A call per
+  // level exhausts the stack on the deeply nested formulas that exist -- a
+  // chain under an if-then-else condition reached here once the passes ahead
+  // of it stopped crashing. See DeepDag_Test.cpp.
+  //
+  // The order is the recursion's, which matters: `push` inserts into a set
+  // whose iteration order is its insertion order, and `pop` takes the front,
+  // so the order nodes are added is the order propagation visits them. A
+  // node is therefore still pushed at its first constant child and before
+  // the walk descends into that child. The stack holds pointers into each
+  // node's own child storage, which the node above keeps alive for the whole
+  // walk.
+  void addToWorklist(const stp::ASTNode& top, stp::ASTNodeSet& visited)
+  {
+    std::vector<Frame> stack;
 
-    bool alreadyAdded = false;
+    // The head of the recursive version: what it answered without a call.
+    auto enter = [&](const stp::ASTNode& n) {
+      if (n.isConstant())
+        return;
+      if (!visited.insert(n).second)
+        return;
+      stack.push_back(Frame(n));
+    };
 
-    for (unsigned i = 0; i < n.GetChildren().size(); i++)
+    enter(top);
+
+    while (!stack.empty())
     {
-      if (!alreadyAdded && n[i].isConstant())
+      Frame& f = stack.back();
+
+      if (f.i == f.n->Degree())
       {
-        alreadyAdded = true;
-        push(n);
+        stack.pop_back();
+        continue;
       }
-      addToWorklist(n[i], visited);
+
+      // Held through the push below, which can move `f` but not these: the
+      // child is stored in the node that lists it.
+      const stp::ASTNode& parent = *f.n;
+      const stp::ASTNode& child = parent[f.i++];
+
+      if (!f.addedParent && child.isConstant())
+      {
+        f.addedParent = true;
+        push(parent);
+      }
+
+      // Nothing above may be read after this.
+      enter(child);
     }
   }
 

--- a/include/stp/ToSat/BitBlaster.h
+++ b/include/stp/ToSat/BitBlaster.h
@@ -28,6 +28,7 @@ THE SOFTWARE.
 #include "stp/STPManager/STPManager.h"
 #include "stp/Simplifier/constantBitP/MultiplicationStats.h"
 #include "stp/ToSat/BBNodeManagerAIG.h"
+#include "stp/Util/DagWalk.h"
 #include <cassert>
 #include <cmath>
 #include <list>
@@ -282,6 +283,28 @@ class BitBlaster
   void updateForm(const ASTNode& n, BBNode& bb, BBNodeSet& support);
 
   const BBNode BBForm(const ASTNode& form, BBNodeSet& support);
+  const BBNode BBForm(const ASTNode& form, BBNodeSet& support,
+                      bool knownMissing);
+  const BBNodeVec BBTerm(const ASTNode& term, BBNodeSet& support,
+                         bool knownMissing);
+
+  // BBForm and BBTerm both blast a node's operands by calling themselves, so
+  // input nested deeply enough takes the stack with it. Shallow inputs keep
+  // the ordinary recursive path: starting an extra walk at their root costs
+  // more than the stack it saves. Once the shared formula/term recursion
+  // budget is exhausted, primeMemos fills both memos below that point and the
+  // bounded recursive prefix unwinds normally. One walk covers both memos
+  // because the two functions reach each other. See DeepDag_Test.cpp.
+  void primeMemos(const ASTNode& n, BBNodeSet& support);
+  static constexpr size_t unprimedDepthLimit = 512;
+  size_t unprimedDepth = 0;
+  bool priming = false;
+
+  // Debug-only: the deliberately recursive prefix plus the small amount of
+  // recursion used while processing nodes created during priming. Empty and
+  // free in a build with NDEBUG. The suffix itself must still answer from one
+  // of the two memos rather than nesting with the input.
+  PrimeAudit memoAudit{"BitBlaster", unprimedDepthLimit + 32};
 
   bool isConstant(const BBNodeVec& v);
   ASTNode getConstant(const BBNodeVec& v, const ASTNode& n);
@@ -308,7 +331,7 @@ public:
   // bitvector term.  Result is a ref to a vector of formula nodes
   // representing the boolean formula.
   const BBNodeVec BBTerm(const ASTNode& term, BBNodeSet& support);
-  
+
   std::unordered_map<ASTNode, BBNodeVec, ASTNode::ASTNodeHasher, ASTNode::ASTNodeEqual>::iterator
   simplify_during_bb(ASTNode& term, BBNodeSet& support);
 

--- a/include/stp/Util/DagWalk.h
+++ b/include/stp/Util/DagWalk.h
@@ -1,0 +1,208 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#ifndef DAGWALK_H_
+#define DAGWALK_H_
+
+#include "stp/AST/ASTNode.h"
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+namespace stp
+{
+
+// Visit an immutable AST in left-to-right pre-order. `enter` is called once
+// for each occurrence the walk reaches and returns whether that occurrence's
+// children should be traversed. This lets a caller apply its own DAG memo or
+// prune at a kind-specific boundary.
+//
+// Keep only the current node inline and suspended ancestors in `parents`.
+// A wide node whose children are leaves or pruned needs no allocation, and
+// the auxiliary memory of every other shape is O(depth), not O(frontier).
+template <class Enter>
+void walkPreOrder(const ASTNode& top, Enter enter)
+{
+  if (!enter(top) || top.Degree() == 0)
+    return;
+
+  struct Frame
+  {
+    const ASTNode* node;
+    size_t nextChild = 0;
+  };
+
+  Frame current{&top};
+  std::vector<Frame> parents;
+
+  while (true)
+  {
+    if (current.nextChild < current.node->Degree())
+    {
+      const ASTNode* child = &(*current.node)[current.nextChild++];
+      if (!enter(*child) || child->Degree() == 0)
+        continue;
+
+      parents.push_back(current);
+      current = Frame{child};
+      continue;
+    }
+
+    if (parents.empty())
+      return;
+    current = parents.back();
+    parents.pop_back();
+  }
+}
+
+// Rebuild a DAG bottom up, without putting the walk on the call stack.
+//
+// How deeply a formula nests is the input's choice, and inputs that nest
+// thousands deep exist, so a pass that recurses once per level dies on them.
+// This is the shape most of those passes have: visit a node's children, hand
+// the node and its rebuilt children to `combine`, and use what comes back in
+// place of the node. Frames live on the heap, so depth costs memory rather
+// than stack.
+//
+// `combine(node, children)` returns the replacement for `node`. It is called
+// once per node, after all of that node's children have been combined, and in
+// left-to-right order, so it sees exactly what the equivalent recursive
+// function saw and may call the node factory freely.
+//
+// `cache` maps a node to its replacement. A node reached twice is combined
+// once, and a cache that outlives the call carries answers between calls. It
+// needs find(), end() and insert(pair), which both ASTNodeMap and
+// DenseNodeMap provide. Leaves have nothing to rebuild: they are returned as
+// they are and are not cached.
+//
+// `combine` is a template parameter rather than a std::function so that it
+// inlines: this runs once per node, and an indirect call per node would be a
+// real cost on ordinary shallow input.
+template <class Cache, class Combine>
+ASTNode postOrderRebuild(const ASTNode& top, Cache& cache, Combine combine)
+{
+  // One node's progress: where its children begin in the shared LIFO arena,
+  // and how far along its own child list it has got. Keeping an ASTVec in
+  // every suspended frame allocated once per level on ordinary inputs.
+  struct Frame
+  {
+    ASTNode n;
+    size_t childrenBegin;
+    size_t i = 0;
+    bool waiting = false; // a child is being combined below.
+
+    Frame(const ASTNode& node, const size_t begin)
+        : n(node), childrenBegin(begin)
+    {
+    }
+  };
+
+  ASTNode result;
+
+  // Results already collected by every suspended frame. A child frame owns
+  // the suffix beginning at childrenBegin; when it completes, that suffix is
+  // moved through one reusable vector for combine and then replaced by the
+  // child's single result in its parent.
+  ASTVec activeChildren;
+  ASTVec combinedChildren;
+
+  // Answers that need no frame, which is what the recursive form answered
+  // without a call.
+  auto known = [&cache, &result](const ASTNode& n) -> bool {
+    if (n.Degree() == 0)
+    {
+      result = n;
+      return true;
+    }
+
+    const auto it = cache.find(n);
+    if (it != cache.end())
+    {
+      result = it->second;
+      return true;
+    }
+    return false;
+  };
+
+  if (known(top))
+    return result;
+
+  // A deque, so descending never moves the frames above it: `current` stays
+  // valid across a push.
+  std::deque<Frame> stack;
+  stack.emplace_back(top, activeChildren.size());
+
+  while (true)
+  {
+    Frame& current = stack.back();
+
+    if (current.waiting)
+    {
+      current.waiting = false;
+      activeChildren.push_back(result);
+      current.i++;
+    }
+
+    bool descended = false;
+    while (current.i < current.n.Degree())
+    {
+      if (known(current.n[current.i]))
+      {
+        activeChildren.push_back(result);
+        current.i++;
+        continue;
+      }
+
+      // Nothing above may be read after this push.
+      current.waiting = true;
+      stack.emplace_back(current.n[current.i], activeChildren.size());
+      descended = true;
+      break;
+    }
+
+    if (descended)
+      continue;
+
+    assert(activeChildren.size() - current.childrenBegin ==
+           current.n.Degree());
+    combinedChildren.clear();
+    combinedChildren.insert(
+        combinedChildren.end(),
+        std::make_move_iterator(activeChildren.begin() +
+                                current.childrenBegin),
+        std::make_move_iterator(activeChildren.end()));
+    activeChildren.resize(current.childrenBegin);
+
+    result = combine(current.n, combinedChildren);
+    combinedChildren.clear();
+    cache.insert({current.n, result});
+
+    stack.pop_back();
+    if (stack.empty())
+      return result;
+  }
+}
+}
+
+#endif /* DAGWALK_H_ */

--- a/include/stp/Util/DagWalk.h
+++ b/include/stp/Util/DagWalk.h
@@ -26,12 +26,27 @@ THE SOFTWARE.
 #define DAGWALK_H_
 
 #include "stp/AST/ASTNode.h"
-#include <cstddef>
+#include <cassert>
+#include <cstdint>
+#include <deque>
+#include <iostream>
+#include <iterator>
+#include <optional>
+#include <sstream>
+#include <string>
 #include <utility>
 #include <vector>
 
 namespace stp
 {
+
+// What primeMemo should do with a node it has reached.
+enum class Walk
+{
+  Descend, // walk this node's children, then hand it to visit
+  Visit,   // hand it to visit without walking its children
+  Skip     // ignore it: already done, or the pass never looks at it
+};
 
 // Visit an immutable AST in left-to-right pre-order. `enter` is called once
 // for each occurrence the walk reaches and returns whether that occurrence's
@@ -74,6 +89,373 @@ void walkPreOrder(const ASTNode& top, Enter enter)
     current = parents.back();
     parents.pop_back();
   }
+}
+
+// Whether a pass whose memo is primed still nests with its input.
+//
+// That is the whole of what priming buys: the pass's calls on its operands
+// answer from the memo, so its own recursion is a couple of levels whatever
+// the input nests to. It buys it only where the walk reaches the nodes the
+// pass reaches, and nothing in the type system says a pass qualifies -- the
+// preconditions live in a comment on primeMemo below and in whoever reads it.
+//
+// So the pass reports the nodes it runs, and the depth they reach is held
+// against what the pass claims. A classify() or an operands() that stops
+// short of a subtree does not stop the pass going there: it goes down its own
+// call stack for it, one frame per level, which is the crash priming exists
+// to prevent -- and which nothing in the output can show, because the answer
+// is the same. This is the check for that, and it runs on every query an
+// assertions build sees rather than on the ones somebody remembers to
+// measure.
+//
+// The depth a pass is allowed is its own claim, made where it declares its
+// audit. It is not one or two: a pass legitimately re-enters on nodes it has
+// just built -- a rewritten node, a pulled-up if-then-else -- and those calls
+// nest as deeply as the rewriting does, which is a property of the rules and
+// not of the input. What it may not do is nest in proportion to the input,
+// and the gap between those two is wide enough to sit a limit in.
+//
+// What this does not check is the other half: priming that reaches more than
+// the pass would have, which costs nodes that do not otherwise exist rather
+// than stack. That one is invisible from inside a primed run -- priming *is*
+// the pass running, so every node primed has, by then, been reached. What
+// catches it is the generated CNF: a manufactured node shifts every node
+// number after it, so the clauses move.
+#ifndef NDEBUG
+class PrimeAudit
+{
+  const char* pass;
+  size_t limit;
+
+  size_t running = 0; // how deep the pass's own calls are nested
+  size_t deepest = 0;
+
+public:
+  // `pass_` names the pass in a report, `limit_` is how deeply it says it
+  // nests once its memo is primed.
+  PrimeAudit(const char* pass_, const size_t limit_)
+      : pass(pass_), limit(limit_)
+  {
+  }
+
+  // The pass is running `n`, from whatever it was running before. One of
+  // these at the head of the pass's own entry point is the whole instrument.
+  class Running
+  {
+    PrimeAudit& audit;
+
+  public:
+    Running(PrimeAudit& audit_, const ASTNode&) : audit(audit_)
+    {
+      audit.running++;
+      if (audit.running > audit.deepest)
+        audit.deepest = audit.running;
+    }
+
+    Running(const Running&) = delete;
+    Running& operator=(const Running&) = delete;
+
+    ~Running()
+    {
+      audit.running--;
+      if (audit.running == 0)
+        audit.finished();
+    }
+  };
+
+  // Empty while the pass is within its claim. Public so that a test can drive
+  // the audit directly rather than by breaking a pass.
+  std::string disagreement() const
+  {
+    std::ostringstream out;
+
+    if (deepest > limit)
+      out << pass << " nested " << deepest << " deep, over its claim of "
+          << limit << ": priming is not answering the calls it makes on its "
+          << "operands, so the input's depth is back on the stack\n";
+
+    return out.str();
+  }
+
+  size_t depth() const { return deepest; }
+
+  void clear() { deepest = 0; }
+
+private:
+  void finished()
+  {
+    const std::string bad = disagreement();
+    if (!bad.empty())
+    {
+      std::cerr << "primeMemo preconditions violated (stp/Util/DagWalk.h):\n"
+                << bad;
+      assert(false && "a primed pass nests with its input after all");
+    }
+    clear();
+  }
+};
+#else
+// Release: the same shape, doing nothing, so the passes read the same in
+// both builds.
+class PrimeAudit
+{
+public:
+  PrimeAudit(const char*, size_t) {}
+  void clear() {}
+
+  class Running
+  {
+  public:
+    Running(PrimeAudit&, const ASTNode&) {}
+  };
+};
+#endif
+
+// Fill a memoised pass's table from the bottom up, so that the pass itself
+// stops recursing.
+//
+// The alternative to rewriting a pass as a state machine. A pass that
+// answers from a memo at its first line, and reaches other nodes only by
+// calling itself on their children, will find every child already answered
+// if the table is filled bottom up first -- so its recursion never goes more
+// than one level, whatever the input nests to, and not one line of it has to
+// change. That is worth having for the passes that are too large to restate:
+// BitBlaster::BBTerm dispatches on kind over 450 lines and calls itself from
+// 24 of them.
+//
+// It is only sound where the pass would have visited these nodes anyway, in
+// this order. Three things to check before using it:
+//
+//   * the memo is keyed on the node alone -- not on the node plus a flag,
+//     the way the Simplifier keys on pushNeg as well;
+//   * the pass has no early exit that skips children, or priming does work
+//     it would not have done, building nodes that do not otherwise exist and
+//     shifting every node number after them;
+//   * `classify` returns Descend for exactly the nodes whose children the
+//     pass looks at, and Skip for the ones it never passes down -- a
+//     constant index operand, say, that its kind ignores.
+//
+// Get those right and the pass sees the same nodes built by the same factory
+// calls in the same sequence. Check it with the generated CNF, which is
+// sensitive to all three.
+//
+// Self-calls on nodes the pass builds itself, rather than on children, get
+// nothing from this: those nodes do not exist when the walk runs. Usually
+// that costs nothing, because their operands are primed and the walk is one
+// level -- but it is an assumption about the pass's own rewriting and not
+// something priming secures, and it does not always hold. The simplifier's
+// float arm built a term thousands of levels deep and walked down it; the
+// depth check below is what found it, and that pass is now restated as an
+// explicit job stack (Simplifier::simplifyNode) rather than primed.
+// A pass normally recurses into all of a node's children, in order. The few
+// exceptions in STP recurse into a contiguous subrange, or into all children
+// in reverse order. WalkOperands describes those cases without copying an
+// ASTNode or allocating an operand vector. `operands(n)` returns the view for
+// n; the three-argument primeMemo below supplies WalkOperands::all(n).
+class WalkOperands
+{
+  uint32_t first_ = 0;
+  uint32_t count_ = 0;
+  bool reversed_ = false;
+
+  WalkOperands(const size_t first, const size_t count, const bool reversed)
+      : first_(static_cast<uint32_t>(first)),
+        count_(static_cast<uint32_t>(count)), reversed_(reversed)
+  {
+    assert(first == first_ && count == count_);
+  }
+
+public:
+  // An empty range. Needed so a suspended-parent slot can be held by value
+  // rather than in a std::optional -- see PrimeMemoParents below.
+  WalkOperands() = default;
+
+  static WalkOperands all(const ASTNode& n) { return range(0, n.Degree()); }
+
+  static WalkOperands range(const size_t first, const size_t pastLast)
+  {
+    assert(first <= pastLast);
+    return WalkOperands(first, pastLast - first, false);
+  }
+
+  static WalkOperands reversed(const ASTNode& n)
+  {
+    return reversedRange(0, n.Degree());
+  }
+
+  static WalkOperands reversedRange(const size_t first, const size_t pastLast)
+  {
+    assert(first <= pastLast);
+    return WalkOperands(first, pastLast - first, true);
+  }
+
+  size_t size() const { return count_; }
+
+  const ASTNode& at(const ASTNode& n, const size_t i) const
+  {
+    assert(i < count_ && static_cast<size_t>(first_) + count_ <= n.Degree());
+    return n[first_ + (reversed_ ? count_ - 1 - i : i)];
+  }
+};
+
+// Proof supplied to visit that classify admitted this node. A memoised pass
+// may use it as a known-miss token when (as all current primed passes do) its
+// classifier returns Visit or Descend only after finding no memo entry. That
+// removes the otherwise duplicate lookup at the pass's first line.
+//
+// The contract is deliberately explicit: processing descendants must not
+// memoise an ancestor as a side effect. A bottom-up pass over an acyclic AST
+// normally only records the node it was handed, which is exactly that case.
+struct PrimeMemoReady
+{
+};
+
+namespace detail
+{
+template <class Frame, bool InlineFirst> class PrimeMemoParents;
+
+template <class Frame> class PrimeMemoParents<Frame, false>
+{
+  std::vector<Frame> frames;
+
+public:
+  void push(Frame&& frame) { frames.push_back(std::move(frame)); }
+  bool empty() const { return frames.empty(); }
+
+  Frame pop()
+  {
+    Frame result = std::move(frames.back());
+    frames.pop_back();
+    return result;
+  }
+};
+
+template <class Frame> class PrimeMemoParents<Frame, true>
+{
+  // The first suspended parent is held by value, so the shallow walks that
+  // never nest twice touch no heap at all, and a pop leaves the slot holding
+  // a moved-from frame that the next descent assigns over.
+  //
+  // By value rather than in a std::optional deliberately: with an optional,
+  // whether the payload is engaged is a fact GCC cannot connect to the
+  // dereference in pop(), and it reports the ASTNode inside as possibly
+  // uninitialised -- fatal on the -Werror leg, on several GCC versions, and
+  // not fixable by rephrasing the guard. A default-constructed Frame is
+  // always initialised, so the question does not arise.
+  Frame first;
+  bool hasFirst = false;
+  std::vector<Frame> rest;
+
+public:
+  void push(Frame&& frame)
+  {
+    if (!hasFirst)
+    {
+      first = std::move(frame);
+      hasFirst = true;
+    }
+    else
+      rest.push_back(std::move(frame));
+  }
+
+  bool empty() const { return !hasFirst; }
+
+  Frame pop()
+  {
+    if (!rest.empty())
+    {
+      Frame result = std::move(rest.back());
+      rest.pop_back();
+      return result;
+    }
+
+    Frame result = std::move(first);
+    hasFirst = false;
+    return result;
+  }
+};
+} // namespace detail
+
+template <bool InlineFirstParent, class Classify, class Operands, class Visit>
+void primeMemoImpl(const ASTNode& top, Classify classify, Operands operands,
+                   Visit visit)
+{
+  if (classify(top) != Walk::Descend)
+    return; // the caller does it: there is nothing below to get ahead of.
+
+  struct Frame
+  {
+    ASTNode n;
+    WalkOperands operands;
+    uint32_t i = 0;
+
+    // An empty slot, for the by-value inline parent in PrimeMemoParents.
+    Frame() = default;
+
+    Frame(const ASTNode& node, const WalkOperands view)
+        : n(node), operands(view)
+    {
+    }
+  };
+
+  auto open = [&](const ASTNode& n) { return Frame(n, operands(n)); };
+
+  Frame current = open(top);
+  detail::PrimeMemoParents<Frame, InlineFirstParent> parents;
+
+  while (true)
+  {
+    if (current.i < current.operands.size())
+    {
+      const ASTNode& child = current.operands.at(current.n, current.i++);
+
+      switch (classify(child))
+      {
+        case Walk::Descend:
+          parents.push(std::move(current));
+          current = open(child);
+          break;
+        case Walk::Visit:
+          visit(child, PrimeMemoReady{});
+          break;
+        case Walk::Skip:
+          break;
+      }
+      continue;
+    }
+
+    visit(current.n, PrimeMemoReady{});
+    if (parents.empty())
+      return;
+
+    current = parents.pop();
+  }
+}
+
+template <class Classify, class Operands, class Visit>
+void primeMemo(const ASTNode& top, Classify classify, Operands operands,
+               Visit visit)
+{
+  primeMemoImpl<false>(top, classify, operands, visit);
+}
+
+// Metadata derivations commonly suspend exactly one parent. Keep that frame
+// inline for those hot accessors while leaving larger primed passes on the
+// compact vector-only implementation above.
+template <class Classify, class Operands, class Visit>
+void primeMemoInlineParent(const ASTNode& top, Classify classify,
+                           Operands operands, Visit visit)
+{
+  primeMemoImpl<true>(top, classify, operands, visit);
+}
+
+// The usual case: a pass recurses into a node's own children.
+template <class Classify, class Visit>
+void primeMemo(const ASTNode& top, Classify classify, Visit visit)
+{
+  primeMemo(
+      top, classify, [](const ASTNode& n) { return WalkOperands::all(n); },
+      visit);
 }
 
 // Rebuild a DAG bottom up, without putting the walk on the call stack.

--- a/lib/AST/ASTInterior.cpp
+++ b/lib/AST/ASTInterior.cpp
@@ -64,10 +64,56 @@ ASTInterior::~ASTInterior()
 
 // Call this when deleting a node that has been stored in the
 // the unique table
+//
+// Deleting an interior node releases its children, and a child that loses
+// its last reference is deleted in turn. Left to nest, that is one set of
+// destructor frames per level of the DAG, so releasing a deeply nested
+// formula runs off the stack -- the depth is the input's, not ours. A short,
+// fixed prefix is still cheaper to release directly. Once that bound is
+// reached, anything else that dies is queued on the manager; the outermost
+// cleanup drains that queue with the same bounded prefix for each entry.
 void ASTInterior::CleanUp()
 {
   nodeManager->_interior_unique_table.erase(this);
+
+  // Thirty-two nested deletes are small even on the test suite's 1 MiB stack
+  // and cover ordinary shallow ASTs without one queue push and pop per node.
+  static constexpr uint8_t directDeletionDepth = 32;
+  if (nodeManager->_interior_deletion_depth >= directDeletionDepth)
+  {
+    nodeManager->_pending_deletion.push_back(this);
+    return;
+  }
+
+  // Held separately: the first delete below is `this`, and nodeManager is
+  // one of its members.
+  STPMgr* const mgr = nodeManager;
+
+  const bool outermost = mgr->_interior_deletion_depth == 0;
+
+  // Restored by the guard rather than by the line after delete. A destructor
+  // that threw would otherwise leave later cleanups starting at the wrong
+  // depth and queueing nodes on a drain that may never run again.
+  struct DeletionDepth
+  {
+    STPMgr* mgr;
+    DeletionDepth(STPMgr* m) : mgr(m) { ++mgr->_interior_deletion_depth; }
+    ~DeletionDepth() { --mgr->_interior_deletion_depth; }
+  } deletionDepth(mgr);
+
   delete this;
+
+  // A nested direct deletion returns to the destructor which released it.
+  // The outermost cleanup alone owns the spill queue.
+  if (!outermost)
+    return;
+
+  while (!mgr->_pending_deletion.empty())
+  {
+    ASTInterior* const node = mgr->_pending_deletion.back();
+    mgr->_pending_deletion.pop_back();
+    delete node; // releases up to another bounded prefix of descendants.
+  }
 }
 
 // Returns kinds.  "lispprinter" handles printing of parenthesis

--- a/lib/AST/ASTNode.cpp
+++ b/lib/AST/ASTNode.cpp
@@ -24,6 +24,7 @@ THE SOFTWARE.
 
 #include "stp/AST/AST.h"
 #include "stp/STPManager/STP.h"
+#include "stp/Util/DagWalk.h"
 #include <sstream>
 
 namespace stp
@@ -173,6 +174,61 @@ static bool deriveFPFormat(const ASTNode& n, unsigned int& e, unsigned int& s)
   }
 }
 
+// Which children a node's format derivation reads, as a half-open range of
+// child positions.
+//
+// This says what the switch above consults and has to keep agreeing with it:
+// the read and store arms take the format of the array under them, the
+// if-then-else arm takes a branch's, and the arithmetic arms take whichever
+// operand carries one. Every other kind decides from its own kind, or from
+// children it reads as constants rather than as floats, so an empty range is
+// also "the walk below stops here".
+//
+// The if-then-else and arithmetic arms stop at the first operand that answers,
+// where this names them all. Naming more than is read costs a derivation that
+// would have happened the moment anything asked that node its type, and can
+// cost nothing else: neither derivation builds a node, calls a factory or
+// reads anything but its subject's kind, children and widths.
+static void fpFormatOperands(const ASTNode& n, size_t& from, size_t& to)
+{
+  from = 0;
+  to = 0;
+
+  switch (n.GetKind())
+  {
+    case READ:
+    case WRITE:
+      to = (n.Degree() >= 1) ? 1 : 0;
+      break;
+
+    case ITE:
+      if (n.Degree() == 3)
+      {
+        from = 1;
+        to = 3;
+      }
+      break;
+
+    case FP_ABS:
+    case FP_NEG:
+    case FP_ADD:
+    case FP_SUB:
+    case FP_MUL:
+    case FP_DIV:
+    case FP_FMA:
+    case FP_SQRT:
+    case FP_REM:
+    case FP_ROUNDTOINTEGRAL:
+    case FP_MIN:
+    case FP_MAX:
+      to = n.Degree();
+      break;
+
+    default:
+      break;
+  }
+}
+
 // Sentinel cached in _exp_width once derivation has concluded "not a
 // float". Without it every format query on a formatless node re-walks its
 // children -- quadratic on store chains and ITE spines, since WRITE and ITE
@@ -183,29 +239,82 @@ static const uint32_t FP_NOT_A_FLOAT = 0xFFFFFFFFu;
 // Derive once and keep the answer -- positive or negative. The fields are
 // already mutable, and an interior node can hold them, so this costs one
 // walk per node rather than one per query.
+//
+// The derivation reads its operands' formats, and reading one derives it --
+// which was this function again, one call frame per level of a store chain or
+// an if-then-else spine. Nothing bounds those: they are as deep as the input
+// nests, and 20,000 is fatal. It is worse than a pass dying on its own input,
+// because this is not a pass. GetType asks for the format and everything asks
+// GetType, so a query deep enough could not be asked its type at all, from
+// anywhere.
+//
+// So primeMemo fills the dependency suffix bottom up, and the derivation then
+// finds every operand it reads already answered and stops one level down. See
+// DagWalk.h, and DeepDag_Test.cpp for the depths.
 void ASTNode::cacheFPFormat() const
 {
-  unsigned int e = 0;
-  unsigned int s = 0;
+#ifndef NDEBUG
+  static thread_local PrimeAudit audit{"ASTNode::cacheFPFormat", 8};
+  PrimeAudit::Running running(audit, *this);
+#endif
 
-  const bool is_float = deriveFPFormat(*this, e, s);
+  // One node, with its operands already answered.
+  auto store = [](const ASTNode& n) {
+    unsigned int e = 0;
+    unsigned int s = 0;
 
-  // A BVCONST has nowhere to put either answer (its setters reject it);
-  // float constants are made as ASTFPConst instead, and re-deriving on a
-  // childless node is cheap.
-  if (GetKind() == BVCONST ||
-      (Degree() == 0 &&
-       _int_node_ptr->getDeclaredSourceSort().isKnown()))
-    return;
+    const bool is_float = deriveFPFormat(n, e, s);
 
-  if (!is_float)
+    // A BVCONST has nowhere to put either answer (its setters reject it);
+    // float constants are made as ASTFPConst instead, and re-deriving on a
+    // childless node is cheap.
+    if (n.GetKind() == BVCONST ||
+        (n.Degree() == 0 &&
+         n._int_node_ptr->getDeclaredSourceSort().isKnown()))
+      return;
+
+    if (!is_float)
+    {
+      n._int_node_ptr->setExpWidth(FP_NOT_A_FLOAT);
+      return;
+    }
+
+    n._int_node_ptr->setExpWidth(e);
+    n._int_node_ptr->setSigWidth(s);
+  };
+
+  // Nothing below `n` needs filling: either its own derivation reads no
+  // operands, so asking it is already one level, or it has been asked
+  // before. The first case is why a node that cannot hold an answer -- a
+  // constant, a declared leaf -- never sends this walk into a loop over it.
+  auto settled = [](const ASTNode& n) {
+    size_t from, to;
+    fpFormatOperands(n, from, to);
+    return from == to || n._int_node_ptr->getExpWidth() != 0;
+  };
+
+  size_t from, to;
+  fpFormatOperands(*this, from, to);
+  bool fill = false;
+  for (size_t i = from; i < to && !fill; i++)
+    fill = !settled((*this)[i]);
+
+  if (!fill)
   {
-    _int_node_ptr->setExpWidth(FP_NOT_A_FLOAT);
+    store(*this);
     return;
   }
 
-  _int_node_ptr->setExpWidth(e);
-  _int_node_ptr->setSigWidth(s);
+  primeMemoInlineParent(
+      *this, [&](const ASTNode& child)
+      { return settled(child) ? Walk::Skip : Walk::Descend; },
+      [](const ASTNode& n)
+      {
+        size_t f, t;
+        fpFormatOperands(n, f, t);
+        return WalkOperands::range(f, t);
+      },
+      [&](const ASTNode& n, PrimeMemoReady) { store(n); });
 }
 
 unsigned int ASTNode::GetExpWidth() const
@@ -319,6 +428,44 @@ const char* ASTNode::GetName() const
 // (see cacheFPFormat): the derivation reads only the node's kind, children
 // and widths, and the first two are the hash-cons key. The widths are not, so
 // the setters drop the memo.
+// Which children a node's source-sort derivation reads, as a half-open range
+// of child positions, and the same bargain as fpFormatOperands above: it has
+// to keep agreeing with deriveSourceSort, and naming more than is read can
+// only cost a derivation that the next question would have caused anyway.
+//
+// Every other kind answers from its own kind, its declared sort, or its
+// widths -- and the widths route through GetType, which is the format
+// derivation and stops on its own.
+static void sourceSortOperands(const ASTNode& n, size_t& from, size_t& to)
+{
+  from = 0;
+  to = 0;
+
+  switch (n.GetKind())
+  {
+    case ARRAY:
+      if (n.Degree() == 2)
+        to = 2;
+      break;
+
+    case READ:
+    case WRITE:
+      to = (n.Degree() >= 1) ? 1 : 0;
+      break;
+
+    case ITE:
+      if (n.Degree() == 3)
+      {
+        from = 1;
+        to = 3;
+      }
+      break;
+
+    default:
+      break;
+  }
+}
+
 SourceSort ASTNode::GetSourceSort() const
 {
   if (IsNull())
@@ -327,11 +474,59 @@ SourceSort ASTNode::GetSourceSort() const
   if (const SourceSort* cached = _int_node_ptr->cachedSourceSort())
     return *cached;
 
-  _int_node_ptr->nodeManager->source_sort_derivations++;
-  const SourceSort derived = deriveSourceSort();
-  _int_node_ptr->setCachedSourceSort(
-      _int_node_ptr->nodeManager->internSourceSort(derived));
-  return derived;
+#ifndef NDEBUG
+  static thread_local PrimeAudit audit{"ASTNode::GetSourceSort", 8};
+  PrimeAudit::Running running(audit, *this);
+#endif
+
+  // One node, with its operands already answered. The answer goes on the node
+  // where a node can hold one -- a leaf cannot, only an interior node holds
+  // the memo -- and into `answer` either way, which is how the node this
+  // started from returns its own: the walk finishes with it, so the last
+  // answer recorded is that one.
+  SourceSort answer = SourceSort::unknown();
+  auto store = [&](const ASTNode& n) {
+    n._int_node_ptr->nodeManager->source_sort_derivations++;
+    answer = n.deriveSourceSort();
+    n._int_node_ptr->setCachedSourceSort(
+        n._int_node_ptr->nodeManager->internSourceSort(answer));
+  };
+
+  // As in cacheFPFormat, and for the same reason -- the derivation reads a
+  // child's sort by asking for it, which derived the child the same way, one
+  // call frame per level of a store chain or an if-then-else spine.
+  //
+  // A leaf is settled by having nothing to read, never by its memo: only an
+  // interior node can hold one. So the walk stops above every leaf and leaves
+  // it to be derived by whichever parent reads it, which is what kept the
+  // derivation count what it was.
+  auto settled = [](const ASTNode& n) {
+    size_t from, to;
+    sourceSortOperands(n, from, to);
+    return from == to || n._int_node_ptr->cachedSourceSort() != NULL;
+  };
+
+  size_t from, to;
+  sourceSortOperands(*this, from, to);
+  bool fill = false;
+  for (size_t i = from; i < to && !fill; i++)
+    fill = !settled((*this)[i]);
+
+  if (fill)
+    primeMemoInlineParent(
+        *this, [&](const ASTNode& child)
+        { return settled(child) ? Walk::Skip : Walk::Descend; },
+        [](const ASTNode& n)
+        {
+          size_t f, t;
+          sourceSortOperands(n, f, t);
+          return WalkOperands::range(f, t);
+        },
+        [&](const ASTNode& n, PrimeMemoReady) { store(n); });
+  else
+    store(*this);
+
+  return answer;
 }
 
 SourceSort ASTNode::deriveSourceSort() const

--- a/lib/AST/ASTmisc.cpp
+++ b/lib/AST/ASTmisc.cpp
@@ -89,35 +89,68 @@ bool arithless(const ASTNode& n1, const ASTNode& n2)
   }
 }
 
-// counts the number of reads. Shortcut when we get to the limit.
-void numberOfReadsLessThan(const ASTNode& n, std::unordered_set<uint64_t>& visited,
-                           int& soFar, const int limit)
-{
-  if (n.isAtom())
-    return;
-
-  if (visited.find(n.GetNodeNum()) != visited.end())
-    return;
-
-  if (n.GetKind() == READ)
-    soFar++;
-
-  if (soFar > limit)
-    return;
-
-  visited.insert(n.GetNodeNum());
-
-  for (size_t i = 0; i < n.Degree(); i++)
-    numberOfReadsLessThan(n[i], visited, soFar, limit);
-}
-
 // True if the number of reads in "n" is less than "limit"
 bool numberOfReadsLessThan(const ASTNode& n, int limit)
 {
+  if (limit <= 0)
+    return false;
+
   std::unordered_set<uint64_t> visited;
   int reads = 0;
-  numberOfReadsLessThan(n, visited, reads, limit);
-  return reads < limit;
+
+  // Admit a node once and say whether its children need walking. Atoms were
+  // deliberately absent from the old memo and remain so here.
+  auto descend = [&](const ASTNode& current) {
+    if (current.isAtom() || !visited.insert(current.GetNodeNum()).second)
+      return false;
+
+    if (current.GetKind() == READ)
+      reads++;
+    return current.Degree() != 0;
+  };
+
+  if (!descend(n))
+    return reads < limit;
+  if (reads >= limit)
+    return false;
+
+  struct Frame
+  {
+    const ASTNode* node;
+    size_t nextChild = 0;
+  };
+  static_assert(sizeof(Frame) <= 2 * sizeof(void*),
+                "read-count frames must contain only traversal state");
+
+  // Keep only suspended ancestors. More importantly, return globally as
+  // soon as the strict bound is reached: unwinding the rest of the walk is
+  // unnecessary, and may itself be a large untouched subtree.
+  Frame current{&n};
+  std::vector<Frame> parents;
+  while (true)
+  {
+    if (current.nextChild < current.node->Degree())
+    {
+      const ASTNode* child = &(*current.node)[current.nextChild++];
+      if (!descend(*child))
+      {
+        if (reads >= limit)
+          return false;
+        continue;
+      }
+      if (reads >= limit)
+        return false;
+
+      parents.push_back(current);
+      current = Frame{child};
+      continue;
+    }
+
+    if (parents.empty())
+      return true;
+    current = parents.back();
+    parents.pop_back();
+  }
 }
 
 // See the declaration for why this exists: constants of one value need
@@ -389,44 +422,98 @@ ASTVec toASTVec(const ASTChildren& c)
   return ASTVec(c.begin(), c.end());
 }
 
+// Where the walk of one node's children has got to. `depth` is how much
+// further the depth-limited form below may descend; the deduplicating one
+// ignores it, as it always has.
+//
+// The frames are on the heap. A nested same-kind chain is as deep as the
+// input nests, and a call per level exhausts the stack: measured to die
+// between 100,000 and 150,000 at 8 MiB. Reached from the simplifier, the BV
+// solver, PropagateEqualities, MergeSame and UseITEContext -- and while no
+// parsed query gets there today, because the simplifying factory flattens a
+// conjunction as it builds one, that is a property of the factory rather
+// than of these functions. A pass building through the hashing factory
+// reaches it. See DeepDag_Test.cpp.
+namespace
+{
+struct FlattenFrame
+{
+  ASTChildren children;
+  size_t i;
+  int depth;
+
+  FlattenFrame(const ASTChildren& c, int d) : children(c), i(0), depth(d) {}
+};
+}
+
 void FlattenKindNoDuplicates(const Kind k, const ASTChildren& children,
                              ASTVec& flat_children,
                              ASTNodeSet& alreadyFlattened)
 {
-  const auto ch_end = children.end();
-  for (auto it = children.begin(); it != ch_end; it++)
+  // Children left to right, and a same-kind one expanded where it is reached,
+  // so flat_children comes out in the order the recursion built it. The
+  // frames hold spans into each node's own child storage, which its parent
+  // keeps alive for the whole walk. Keep the current frame local so a flat
+  // input never allocates a traversal stack; parents are needed only after
+  // the first same-kind child is reached.
+  FlattenFrame current(children, 0);
+  std::vector<FlattenFrame> parents;
+
+  while (true)
   {
-    const Kind ck = it->GetKind();
-    if (k == ck)
+    if (current.i == current.children.size())
     {
-      if (alreadyFlattened.find(*it) == alreadyFlattened.end())
-      {
-        alreadyFlattened.insert(*it);
-        FlattenKindNoDuplicates(k, it->GetChildren(), flat_children,
-                                alreadyFlattened);
-      }
+      if (parents.empty())
+        break;
+      current = parents.back();
+      parents.pop_back();
+      continue;
     }
-    else
+
+    const ASTNode& child = current.children[current.i++];
+
+    if (k != child.GetKind())
     {
-      flat_children.push_back(*it);
+      flat_children.push_back(child);
+      continue;
     }
+
+    // A same-kind child seen before contributes nothing a second time: its
+    // operands are already in flat_children.
+    if (!alreadyFlattened.insert(child).second)
+      continue;
+
+    parents.push_back(current);
+    current = FlattenFrame(child.GetChildren(), 0);
   }
 }
 
 void FlattenKind(const Kind k, const ASTChildren& children, ASTVec& flat_children, int depth)
 {
-  auto ch_end = children.end();
-  for (auto it = children.begin(); it != ch_end; it++)
+  FlattenFrame current(children, depth);
+  std::vector<FlattenFrame> parents;
+
+  while (true)
   {
-    const Kind ck = it->GetKind();
-    if (k == ck && depth >= 0 )
+    if (current.i == current.children.size())
     {
-      FlattenKind(k, it->GetChildren(), flat_children, depth-1);
+      if (parents.empty())
+        break;
+      current = parents.back();
+      parents.pop_back();
+      continue;
+    }
+
+    const ASTNode& child = current.children[current.i++];
+    const int below = current.depth - 1;
+
+    if (k == child.GetKind() && current.depth >= 0)
+    {
+      parents.push_back(current);
+      current = FlattenFrame(child.GetChildren(), below);
     }
     else
-    {
-      flat_children.push_back(*it);
-    }
+      flat_children.push_back(child);
   }
 }
 
@@ -436,11 +523,32 @@ ASTVec FlattenKind(Kind k, const ASTChildren& children, int maxDepth)
   ASTVec flat_children;
   if (k == OR || k == BVOR || k == BVAND || k == AND)
   {
+    bool nested = false;
+    for (const ASTNode& child : children)
+      if (child.GetKind() == k)
+      {
+        nested = true;
+        break;
+      }
+
+    // The overwhelmingly common flat case needs neither the traversal nor
+    // its deduplication set. Range assignment sizes the vector exactly once.
+    if (!nested)
+    {
+      flat_children.assign(children.begin(), children.end());
+      return flat_children;
+    }
+
     ASTNodeSet alreadyFlattened;
     FlattenKindNoDuplicates(k, children, flat_children, alreadyFlattened);
   }
   else
   {
+    // This form never discards repeated same-kind subtrees, so its output has
+    // at least the input's arity. The deduplicating form above can turn a
+    // very wide list of repeated edges into only a few operands; reserving
+    // the input's full width there retains memory for operands it discarded.
+    flat_children.reserve(children.size());
     FlattenKind(k, children, flat_children, maxDepth);
   }
 

--- a/lib/AbsRefineCounterExample/ArrayTransformer.cpp
+++ b/lib/AbsRefineCounterExample/ArrayTransformer.cpp
@@ -284,79 +284,163 @@ static FormulaOperand formulaOperand(const Kind k, const size_t i)
 // through both -- so they are one walk with its frames on the heap rather
 // than three sets of call frames. See DeepDag_Test.cpp.
 //
-// `job` says which of the three a frame is running and `phase` where in it,
-// because most of them suspend at more than one point. Everything else here
-// was a local of the function it came from, kept because it has to survive
-// the suspension.
-struct ArrayTransformer::Frame
+// Each job has its own resume-point type, so a request cannot accidentally
+// resume a term as a formula or a read as a term.
+class ArrayTransformer::TransformDriver
 {
-  enum Job
+  ArrayTransformer& owner;
+  ASTNodeMap*& TransformMap;
+  Simplifier* const simp;
+  STPMgr* const bm;
+  NodeFactory* const nf;
+  ASTNode& ASTTrue;
+  ASTNode& ASTFalse;
+  ASTNode& ASTUndefined;
+  ArrType& arrayToIndexToRead;
+  std::map<ASTNode, vector<std::pair<ASTNode, ASTNode>>>& ack_pair;
+
+  ASTNode finishTransformTerm(const ASTNode& term, const ASTNode& result)
   {
-    Formula,
-    Term,
-    Read
-  };
-
-  enum Phase
-  {
-    Start,
-    Operands,       // a formula's operands, or a term's own children
-    TermIteCond,    // ITE term: waiting for the condition
-    TermIteOnly,    // ... for the one branch the condition left
-    TermIteThen,    // ... for the then-branch, both surviving
-    TermIteElse,    // ... for the else-branch
-    TermRead,       // READ term: waiting for the array-read transform
-    ReadIndex,      // array read: waiting for the read index
-    ReadWriteIndex, // read over write: waiting for the write index
-    ReadWriteVal,   // ... for the written value
-    ReadPushedIn,   // ... for the read pushed under the write
-    ReadIteCond,    // read over ITE: waiting for the condition
-    ReadIteOnly,    // ... for the one branch the condition left
-    ReadIteThen,    // ... for the then-read, both surviving
-    ReadIteElse     // ... for the else-read
-  };
-
-  Job job;
-  Phase phase = Start;
-  ASTNode n;
-
-  // Formula and ordinary-term frames use storage for the beginning of their
-  // operands in the shared arena. Read frames use it for their state slots in
-  // that same arena; those jobs never need both meanings.
-  size_t storage = 0;
-  size_t i = 0;         // the operand being worked on
-  bool waiting = false; // an operand is being transformed below
-
-  // Term ITEs and reads share these. The rest of a slow-path read's
-  // continuation lives in the shared arena so every formula and ordinary
-  // term does not carry it.
-  ASTNode cond;
-  ASTNode thn;
-
-  Frame(Job j, ASTNode node) : job(j), n(std::move(node))
-  {
+    return owner.finishTransformTerm(term, result);
   }
-};
 
-// TransformFormula, TransformTerm and TransformArrayRead, walked together
-// with their frames on the heap. Everything the three did is here in the
-// order they did it: the same memo reads and writes, the same node-factory
-// calls, and the same decisions about which operand is transformed at all --
-// which matters most in the two places that transform only the branch of an
-// if-then-else that its condition leaves alive, and tell the extensionality
-// context about the one they dropped.
-ASTNode ArrayTransformer::transform(const bool asFormula, const ASTNode& top)
-{
-  assert(TransformMap != NULL);
+  struct Frame
+  {
+    enum Job
+    {
+      Formula,
+      Term,
+      Read
+    };
+
+    enum class FormulaPhase : uint8_t
+    {
+      Start,
+      CollectOperands,
+      AfterOperand
+    };
+
+    enum class TermPhase : uint8_t
+    {
+      Start,
+      CollectOperands,
+      AfterOperand,
+      AfterRead,
+      AfterIteCondition,
+      AfterIteSelectedBranch,
+      AfterIteThen,
+      AfterIteElse
+    };
+
+    enum class ReadPhase : uint8_t
+    {
+      Start,
+      AfterIndex,
+      AfterWriteIndex,
+      AfterWriteValue,
+      AfterPushedRead,
+      AfterIteCondition,
+      AfterIteSelectedBranch,
+      AfterIteThen,
+      AfterIteElse
+    };
+
+    Job job;
+    union
+    {
+      FormulaPhase formulaPhase;
+      TermPhase termPhase;
+      ReadPhase readPhase;
+    };
+    ASTNode n;
+
+    // Formula and ordinary-term frames use storage for the beginning of their
+    // operands in the shared arena. Read frames use it for their state slots in
+    // that same arena; those jobs never need both meanings.
+    size_t storage = 0;
+    size_t i = 0; // the operand being worked on
+
+    // Term ITEs and reads share these. The rest of a slow-path read's
+    // continuation lives in the shared arena so every formula and ordinary
+    // term does not carry it.
+    ASTNode cond;
+    ASTNode thn;
+
+    explicit Frame(ASTNode node, const FormulaPhase phase = FormulaPhase::Start)
+        : job(Formula), formulaPhase(phase), n(std::move(node))
+    {
+    }
+
+    Frame(ASTNode node, const TermPhase phase)
+        : job(Term), termPhase(phase), n(std::move(node))
+    {
+    }
+
+    Frame(ASTNode node, const ReadPhase phase)
+        : job(Read), readPhase(phase), n(std::move(node))
+    {
+    }
+
+    void resumeAt(const FormulaPhase phase)
+    {
+      assert(job == Formula);
+      formulaPhase = phase;
+    }
+    void resumeAt(const TermPhase phase)
+    {
+      assert(job == Term);
+      termPhase = phase;
+    }
+    void resumeAt(const ReadPhase phase)
+    {
+      assert(job == Read);
+      readPhase = phase;
+    }
+
+    bool ownsReadState() const
+    {
+      assert(job == Read);
+      return readPhase != ReadPhase::Start &&
+             readPhase != ReadPhase::AfterIndex;
+    }
+  };
+
+  // TransformFormula, TransformTerm and TransformArrayRead, walked together
+  // with their frames on the heap. Everything the three did is here in the
+  // order they did it: the same memo reads and writes, the same node-factory
+  // calls, and the same decisions about which operand is transformed at all --
+  // which matters most in the two places that transform only the branch of an
+  // if-then-else that its condition leaves alive, and tell the extensionality
+  // context about the one they dropped.
+  ASTNode result;
+  std::vector<Frame> stack;
+  ASTVec activeParts;
+
+  enum ReadStateSlot : size_t
+  {
+    ReadIndexSlot,
+    WriteIndexSlot,
+    WriteValueSlot,
+    ElseReadSlot,
+    ReadStateSlots
+  };
+
   static_assert(sizeof(Frame) <= 56,
                 "common array-transform frames must remain compact");
 
-  ASTNode result;
+  ASTChildren partsFor(const Frame& f) const
+  {
+    assert(f.n.Degree() > 0);
+    assert(activeParts.size() - f.storage == f.n.Degree());
+    return ASTChildren(activeParts.data() + f.storage,
+                       activeParts.size() - f.storage);
+  }
 
   // Decide whether transforming `n` needs a frame. A root which is already
   // answered returns before the stack is constructed; descendant callers
   // use the same checks before pushing a frame.
-  auto prepare = [&](const Frame::Job job, const ASTNode& n) -> bool {
+  bool prepare(const Frame::Job job, const ASTNode& n)
+  {
     if (job == Frame::Read)
     {
       if (READ != n.GetKind())
@@ -432,94 +516,62 @@ ASTNode ArrayTransformer::transform(const bool asFormula, const ASTNode& top)
       FatalError("TransformTerm: this kind is not supported", n);
 
     return true;
-  };
-
-  const Frame::Job rootJob = asFormula ? Frame::Formula : Frame::Term;
-  if (!prepare(rootJob, top))
-    return result;
-
-  // Most transforms are shallow. Keep their continuations in one compact
-  // allocation instead of a deque's map and fixed-size blocks. A push may
-  // move every frame, so a step must return without touching its Frame after
-  // a request helper descends.
-  std::vector<Frame> stack;
-  // One allocation covers the common formula -> term -> read alternation and
-  // avoids moving these comparatively large frames while it remains shallow.
-  stack.reserve(8);
-  stack.emplace_back(rootJob, top);
-
-  // Continuation storage shared by every suspended job. Formula and term
-  // frames append their operands; a Read frame reserves four ASTNode slots.
-  // Each child owns the suffix beginning at storage and removes it before
-  // its result is appended to its parent.
-  ASTVec activeParts;
-
-  enum ReadStateSlot : size_t
-  {
-    ReadIndexSlot,
-    WriteIndexSlot,
-    WriteValueSlot,
-    ElseReadSlot,
-    ReadStateSlots
-  };
-  auto partsFor = [&](const Frame& f) -> ASTChildren {
-    // prepare() resolves every leaf without pushing a frame, so a frame
-    // reaching reconstruction always owns at least one arena element.
-    assert(f.n.Degree() > 0);
-    assert(activeParts.size() - f.storage == f.n.Degree());
-    return ASTChildren(activeParts.data() + f.storage,
-                       activeParts.size() - f.storage);
-  };
+  }
 
   // Ask for a formula descendant. Either `prepare` leaves its immediate
   // answer in `result`, or the walk goes below a new frame. Formula and term
   // requests stay separate so their hot paths do not redispatch on Job.
-  auto wantFormula = [&](const ASTNode& n,
-                         Frame* waitingParent = nullptr) -> bool {
+  template <typename ResumePhase>
+  bool requestFormula(Frame& parent, const ResumePhase resume, const ASTNode& n)
+  {
+    parent.resumeAt(resume);
     if (!prepare(Frame::Formula, n))
       return false;
     ASTNode owned = n;
-    if (waitingParent != nullptr)
-      waitingParent->waiting = true;
-    stack.emplace_back(Frame::Formula, std::move(owned));
+    stack.emplace_back(std::move(owned), Frame::FormulaPhase::Start);
     return true;
-  };
+  }
 
   // The term counterpart. Own the requested node before vector growth
   // invalidates a reference which may point into the current frame.
-  auto wantTerm = [&](const ASTNode& n,
-                      Frame* waitingParent = nullptr) -> bool {
+  template <typename ResumePhase>
+  bool requestTerm(Frame& parent, const ResumePhase resume, const ASTNode& n)
+  {
+    parent.resumeAt(resume);
     if (!prepare(Frame::Term, n))
       return false;
     ASTNode owned = n;
-    if (waitingParent != nullptr)
-      waitingParent->waiting = true;
-    stack.emplace_back(Frame::Term, std::move(owned));
+    stack.emplace_back(std::move(owned), Frame::TermPhase::Start);
     return true;
-  };
+  }
 
   // Read is requested from one place only. Keep its uncommon state-allocation
   // path out of the formula and term helpers used for every operand.
-  auto wantRead = [&](const ASTNode& n) -> bool {
+  bool requestRead(Frame& parent, const Frame::TermPhase resume,
+                   const ASTNode& n)
+  {
+    parent.resumeAt(resume);
     if (!prepare(Frame::Read, n))
       return false;
     ASTNode owned = n;
-    stack.emplace_back(Frame::Read, std::move(owned));
+    stack.emplace_back(std::move(owned), Frame::ReadPhase::Start);
     return true;
-  };
+  }
 
   // One step of TransformFormula: collect the operands, then rebuild.
-  auto stepFormula = [&](Frame& f) -> bool {
-    if (f.phase == Frame::Start)
+  bool stepFormula(Frame& f)
+  {
+    assert(f.job == Frame::Formula);
+    if (f.formulaPhase == Frame::FormulaPhase::Start)
     {
-      f.phase = Frame::Operands;
+      f.formulaPhase = Frame::FormulaPhase::CollectOperands;
       f.storage = activeParts.size();
     }
 
-    if (f.waiting)
+    if (f.formulaPhase == Frame::FormulaPhase::AfterOperand)
     {
-      f.waiting = false;
       activeParts.push_back(result);
+      f.formulaPhase = Frame::FormulaPhase::CollectOperands;
     }
 
     const Kind k = f.n.GetKind();
@@ -537,9 +589,10 @@ ASTNode ArrayTransformer::transform(const bool asFormula, const ASTNode& top)
 
       // The request helper installs the continuation only when it will push,
       // and does so before vector growth can move `f`.
-      const bool descended = op == OperandFormula
-                                 ? wantFormula(f.n[i], &f)
-                                 : wantTerm(f.n[i], &f);
+      const bool descended =
+          op == OperandFormula
+              ? requestFormula(f, Frame::FormulaPhase::AfterOperand, f.n[i])
+              : requestTerm(f, Frame::FormulaPhase::AfterOperand, f.n[i]);
       if (descended)
         return true;
       activeParts.push_back(result);
@@ -556,20 +609,21 @@ ASTNode ArrayTransformer::transform(const bool asFormula, const ASTNode& top)
     if (f.n.Degree() > 0)
       (*TransformMap)[f.n] = result;
     return false;
-  };
+  }
 
   // One step of TransformTerm. READ hands over to the array-read job, ITE
   // transforms its condition and then only the branch that survives it, and
   // everything else transforms its own children and rebuilds.
-  auto stepTerm = [&](Frame& f) -> bool {
+  bool stepTerm(Frame& f)
+  {
+    assert(f.job == Frame::Term);
     const Kind k = f.n.GetKind();
 
     if (k == READ)
     {
-      if (f.phase == Frame::Start)
+      if (f.termPhase == Frame::TermPhase::Start)
       {
-        f.phase = Frame::TermRead;
-        if (wantRead(f.n))
+        if (requestRead(f, Frame::TermPhase::AfterRead, f.n))
           return true;
       }
       result = finishTransformTerm(f.n, result);
@@ -578,14 +632,13 @@ ASTNode ArrayTransformer::transform(const bool asFormula, const ASTNode& top)
 
     if (k == ITE)
     {
-      if (f.phase == Frame::Start)
+      if (f.termPhase == Frame::TermPhase::Start)
       {
-        f.phase = Frame::TermIteCond;
-        if (wantFormula(f.n[0]))
+        if (requestFormula(f, Frame::TermPhase::AfterIteCondition, f.n[0]))
           return true;
       }
 
-      if (f.phase == Frame::TermIteCond)
+      if (f.termPhase == Frame::TermPhase::AfterIteCondition)
       {
         f.cond = result;
         ExtensionalityContext* ext = bm->getExtensionalityIfAny();
@@ -596,30 +649,28 @@ ASTNode ArrayTransformer::transform(const bool asFormula, const ASTNode& top)
           if (ext != NULL && ext->activeInSolve())
             ext->noteEliminatedReadSubtree(takeThen ? f.n[2] : f.n[1]);
 
-          f.phase = Frame::TermIteOnly;
-          if (wantTerm(takeThen ? f.n[1] : f.n[2]))
+          if (requestTerm(f, Frame::TermPhase::AfterIteSelectedBranch,
+                          takeThen ? f.n[1] : f.n[2]))
             return true;
         }
         else
         {
-          f.phase = Frame::TermIteThen;
-          if (wantTerm(f.n[1]))
+          if (requestTerm(f, Frame::TermPhase::AfterIteThen, f.n[1]))
             return true;
         }
       }
 
-      if (f.phase == Frame::TermIteOnly)
+      if (f.termPhase == Frame::TermPhase::AfterIteSelectedBranch)
       {
         assert(result.GetIndexWidth() == f.n.GetIndexWidth());
         result = finishTransformTerm(f.n, result);
         return false;
       }
 
-      if (f.phase == Frame::TermIteThen)
+      if (f.termPhase == Frame::TermPhase::AfterIteThen)
       {
         f.thn = result;
-        f.phase = Frame::TermIteElse;
-        if (wantTerm(f.n[2]))
+        if (requestTerm(f, Frame::TermPhase::AfterIteElse, f.n[2]))
           return true;
       }
 
@@ -634,16 +685,16 @@ ASTNode ArrayTransformer::transform(const bool asFormula, const ASTNode& top)
       return false;
     }
 
-    if (f.phase == Frame::Start)
+    if (f.termPhase == Frame::TermPhase::Start)
     {
-      f.phase = Frame::Operands;
+      f.termPhase = Frame::TermPhase::CollectOperands;
       f.storage = activeParts.size();
     }
 
-    if (f.waiting)
+    if (f.termPhase == Frame::TermPhase::AfterOperand)
     {
-      f.waiting = false;
       activeParts.push_back(result);
+      f.termPhase = Frame::TermPhase::CollectOperands;
     }
 
     while (f.i < f.n.Degree())
@@ -652,7 +703,7 @@ ASTNode ArrayTransformer::transform(const bool asFormula, const ASTNode& top)
 
       // The request helper installs the continuation only when it will push,
       // and does so before vector growth can move `f`.
-      if (wantTerm(child, &f))
+      if (requestTerm(f, Frame::TermPhase::AfterOperand, child))
         return true;
       activeParts.push_back(result);
     }
@@ -668,7 +719,7 @@ ASTNode ArrayTransformer::transform(const bool asFormula, const ASTNode& top)
 
     result = finishTransformTerm(f.n, result);
     return false;
-  };
+  }
 
   /* One step of TransformArrayRead, which transforms Array Reads, Read over
    * Writes, Read over ITEs into flattened form.
@@ -681,12 +732,14 @@ ASTNode ArrayTransformer::transform(const bool asFormula, const ASTNode& top)
    * ITE(i=j,v1,v2)
    *
   */
-  auto stepRead = [&](Frame& f) -> bool {
+  bool stepRead(Frame& f)
+  {
+    assert(f.job == Frame::Read);
     ASTNode* state = nullptr;
     // A Read allocates persistent slots only when it advances beyond the
     // index phase into a WRITE or ITE continuation. The phase therefore
     // records the presence of state without another flag or sentinel store.
-    if (f.phase > Frame::ReadIndex)
+    if (f.ownsReadState())
     {
       assert(f.storage + ReadStateSlots <= activeParts.size());
       state = activeParts.data() + f.storage;
@@ -698,7 +751,8 @@ ASTNode ArrayTransformer::transform(const bool asFormula, const ASTNode& top)
     const ASTNode& arrName = term[0];
 
     // The tail every path below this point shares.
-    auto finishRead = [&](const ASTNode& value) {
+    auto finishRead = [&](const ASTNode& value)
+    {
       assert(BVTypeCheck(value));
       assert(!value.IsNull());
       (*TransformMap)[term] = value;
@@ -706,14 +760,13 @@ ASTNode ArrayTransformer::transform(const bool asFormula, const ASTNode& top)
       return false;
     };
 
-    if (f.phase == Frame::Start)
+    if (f.readPhase == Frame::ReadPhase::Start)
     {
-      f.phase = Frame::ReadIndex;
-      if (wantTerm(term[1]))
+      if (requestTerm(f, Frame::ReadPhase::AfterIndex, term[1]))
         return true;
     }
 
-    if (f.phase == Frame::ReadIndex)
+    if (f.readPhase == Frame::ReadPhase::AfterIndex)
     {
       // SYMBOL reads and the whole-graph array-equality path finish in this
       // phase, so keep their index local. Allocate persistent Read state only
@@ -843,8 +896,7 @@ ASTNode ArrayTransformer::transform(const bool asFormula, const ASTNode& top)
                 p.rend();
             for (; it2 != it2end; it2++)
             {
-              ASTNode cond =
-                  simp->CreateSimplifiedEQ(readIndex, it2->first);
+              ASTNode cond = simp->CreateSimplifiedEQ(readIndex, it2->first);
               if (ASTFalse == cond)
                 continue;
 
@@ -857,8 +909,7 @@ ASTNode ArrayTransformer::transform(const bool asFormula, const ASTNode& top)
                                                              symbolResult);
             }
 
-            ack_pair[arrName].push_back(
-                make_pair(readIndex, CurrentSymbol));
+            ack_pair[arrName].push_back(make_pair(readIndex, CurrentSymbol));
           }
 
           assert(arrName.GetType() == ARRAY_TYPE);
@@ -889,8 +940,7 @@ ASTNode ArrayTransformer::transform(const bool asFormula, const ASTNode& top)
           activeParts.resize(f.storage + ReadStateSlots);
           state = activeParts.data() + f.storage;
           state[ReadIndexSlot] = readIndex;
-          f.phase = Frame::ReadWriteIndex;
-          if (wantTerm(arrName[1]))
+          if (requestTerm(f, Frame::ReadPhase::AfterWriteIndex, arrName[1]))
             return true;
           break;
         }
@@ -910,8 +960,8 @@ ASTNode ArrayTransformer::transform(const bool asFormula, const ASTNode& top)
           activeParts.resize(f.storage + ReadStateSlots);
           state = activeParts.data() + f.storage;
           state[ReadIndexSlot] = readIndex;
-          f.phase = Frame::ReadIteCond;
-          if (wantFormula(arrName[0]))
+          if (requestFormula(f, Frame::ReadPhase::AfterIteCondition,
+                             arrName[0]))
             return true;
           break;
         }
@@ -924,17 +974,16 @@ ASTNode ArrayTransformer::transform(const bool asFormula, const ASTNode& top)
     }
 
     assert(state != nullptr);
-    if (f.phase == Frame::ReadWriteIndex)
+    if (f.readPhase == Frame::ReadPhase::AfterWriteIndex)
     {
       // Both operands are transformed before the condition is built, as
       // they were: the factory sees them in that order.
       state[WriteIndexSlot] = result;
-      f.phase = Frame::ReadWriteVal;
-      if (wantTerm(arrName[2]))
+      if (requestTerm(f, Frame::ReadPhase::AfterWriteValue, arrName[2]))
         return true;
     }
 
-    if (f.phase == Frame::ReadWriteVal)
+    if (f.readPhase == Frame::ReadPhase::AfterWriteValue)
     {
       state[WriteValueSlot] = result;
 
@@ -943,8 +992,8 @@ ASTNode ArrayTransformer::transform(const bool asFormula, const ASTNode& top)
                    "An array write is being attempted on a non-array:",
                    term);
 
-      f.cond = simp->CreateSimplifiedEQ(state[WriteIndexSlot],
-                                        state[ReadIndexSlot]);
+      f.cond =
+          simp->CreateSimplifiedEQ(state[WriteIndexSlot], state[ReadIndexSlot]);
       assert(BVTypeCheck(f.cond));
 
       // If the condition is true, it saves iteratively transforming through
@@ -958,12 +1007,11 @@ ASTNode ArrayTransformer::transform(const bool asFormula, const ASTNode& top)
 
       // The simplifying node factory may have produced
       // something that's not a READ.
-      f.phase = Frame::ReadPushedIn;
-      if (wantTerm(readTerm))
+      if (requestTerm(f, Frame::ReadPhase::AfterPushedRead, readTerm))
         return true;
     }
 
-    if (f.phase == Frame::ReadPushedIn)
+    if (f.readPhase == Frame::ReadPhase::AfterPushedRead)
     {
       const ASTNode readPushedIn = result;
       assert(BVTypeCheck(const_cast<ASTNode&>(readPushedIn)));
@@ -971,7 +1019,7 @@ ASTNode ArrayTransformer::transform(const bool asFormula, const ASTNode& top)
           f.cond, state[WriteValueSlot], readPushedIn));
     }
 
-    if (f.phase == Frame::ReadIteCond)
+    if (f.readPhase == Frame::ReadPhase::AfterIteCondition)
     {
       f.cond = result;
 
@@ -979,13 +1027,11 @@ ASTNode ArrayTransformer::transform(const bool asFormula, const ASTNode& top)
       const ASTNode& els = arrName[2];
 
       //(READ thn j)
-      ASTNode thnRead =
-          nf->CreateTerm(READ, width, thn, state[ReadIndexSlot]);
+      ASTNode thnRead = nf->CreateTerm(READ, width, thn, state[ReadIndexSlot]);
       assert(BVTypeCheck(thnRead));
 
       //(READ els j)
-      ASTNode elsRead =
-          nf->CreateTerm(READ, width, els, state[ReadIndexSlot]);
+      ASTNode elsRead = nf->CreateTerm(READ, width, els, state[ReadIndexSlot]);
       assert(BVTypeCheck(elsRead));
 
       /* We try to call TransformTerm only if necessary, because it
@@ -994,69 +1040,99 @@ ASTNode ArrayTransformer::transform(const bool asFormula, const ASTNode& top)
        */
       if (ASTTrue == f.cond || ASTFalse == f.cond)
       {
-        f.phase = Frame::ReadIteOnly;
-        if (wantTerm((ASTTrue == f.cond) ? thnRead : elsRead))
+        if (requestTerm(f, Frame::ReadPhase::AfterIteSelectedBranch,
+                        (ASTTrue == f.cond) ? thnRead : elsRead))
           return true;
       }
       else
       {
         // Built now, transformed after the then-read.
         state[ElseReadSlot] = elsRead;
-        f.phase = Frame::ReadIteThen;
-        if (wantTerm(thnRead))
+        if (requestTerm(f, Frame::ReadPhase::AfterIteThen, thnRead))
           return true;
       }
     }
 
-    if (f.phase == Frame::ReadIteOnly)
+    if (f.readPhase == Frame::ReadPhase::AfterIteSelectedBranch)
       return finishRead(result);
 
-    if (f.phase == Frame::ReadIteThen)
+    if (f.readPhase == Frame::ReadPhase::AfterIteThen)
     {
       f.thn = result;
-      f.phase = Frame::ReadIteElse;
-      if (wantTerm(state[ElseReadSlot]))
+      if (requestTerm(f, Frame::ReadPhase::AfterIteElse, state[ElseReadSlot]))
         return true;
     }
 
     //(ITE cond (READ thn j) (READ els j))
-    return finishRead(
-        simp->CreateSimplifiedTermITE(f.cond, f.thn, result));
-  };
-
-  while (true)
-  {
-    Frame& current = stack.back();
-
-    bool descended = false;
-    switch (current.job)
-    {
-      case Frame::Formula:
-        descended = stepFormula(current);
-        break;
-      case Frame::Term:
-        descended = stepTerm(current);
-        break;
-      case Frame::Read:
-        descended = stepRead(current);
-        break;
-    }
-
-    if (descended)
-      continue;
-
-    if (current.job == Frame::Read)
-    {
-      if (current.phase > Frame::ReadIndex)
-      {
-        assert(current.storage + ReadStateSlots == activeParts.size());
-        activeParts.resize(current.storage);
-      }
-    }
-    stack.pop_back();
-    if (stack.empty())
-      return result;
+    return finishRead(simp->CreateSimplifiedTermITE(f.cond, f.thn, result));
   }
+
+public:
+  explicit TransformDriver(ArrayTransformer& owner)
+      : owner(owner), TransformMap(owner.TransformMap), simp(owner.simp),
+        bm(owner.bm), nf(owner.nf), ASTTrue(owner.ASTTrue),
+        ASTFalse(owner.ASTFalse), ASTUndefined(owner.ASTUndefined),
+        arrayToIndexToRead(owner.arrayToIndexToRead), ack_pair(owner.ack_pair)
+  {
+  }
+
+  ASTNode run(const bool asFormula, const ASTNode& top)
+  {
+    assert(TransformMap != NULL);
+    result = ASTNode();
+    stack.clear();
+    activeParts.clear();
+
+    const Frame::Job rootJob = asFormula ? Frame::Formula : Frame::Term;
+    if (!prepare(rootJob, top))
+      return result;
+
+    // One allocation covers the common formula -> term -> read alternation.
+    stack.reserve(8);
+    if (asFormula)
+      stack.emplace_back(top, Frame::FormulaPhase::Start);
+    else
+      stack.emplace_back(top, Frame::TermPhase::Start);
+
+    while (true)
+    {
+      Frame& current = stack.back();
+
+      bool descended = false;
+      switch (current.job)
+      {
+        case Frame::Formula:
+          descended = stepFormula(current);
+          break;
+        case Frame::Term:
+          descended = stepTerm(current);
+          break;
+        case Frame::Read:
+          descended = stepRead(current);
+          break;
+      }
+
+      if (descended)
+        continue;
+
+      if (current.job == Frame::Read)
+      {
+        if (current.ownsReadState())
+        {
+          assert(current.storage + ReadStateSlots == activeParts.size());
+          activeParts.resize(current.storage);
+        }
+      }
+      stack.pop_back();
+      if (stack.empty())
+        return result;
+    }
+  }
+};
+
+ASTNode ArrayTransformer::transform(const bool asFormula, const ASTNode& top)
+{
+  return TransformDriver(*this).run(asFormula, top);
 }
 
 /********************************************************

--- a/lib/AbsRefineCounterExample/ArrayTransformer.cpp
+++ b/lib/AbsRefineCounterExample/ArrayTransformer.cpp
@@ -35,6 +35,8 @@ THE SOFTWARE.
 #include <cstdlib>
 #include <iostream>
 #include <sstream>
+#include <utility>
+#include <vector>
 
 namespace stp
 {
@@ -170,234 +172,10 @@ void ArrayTransformer::assertTransformPostConditions(const ASTNode& term,
   }
 }
 
-/********************************************************
- * TransformFormula()
- *
- * Get rid of ARRAY read/writes
- ********************************************************/
-ASTNode ArrayTransformer::TransformFormula(const ASTNode& simpleForm)
+// The tail every arm of TransformTerm shares.
+ASTNode ArrayTransformer::finishTransformTerm(const ASTNode& term,
+                                              const ASTNode& result)
 {
-  assert(TransformMap != NULL);
-
-  const Kind k = simpleForm.GetKind();
-  if (!(is_Form_kind(k) && BOOLEAN_TYPE == simpleForm.GetType()))
-  {
-    // FIXME: "You have inputted a NON-formula"?
-    FatalError("TransformFormula:"
-               "You have input a NON-formula",
-               simpleForm);
-  }
-
-  ASTNodeMap::const_iterator iter;
-  if ((iter = TransformMap->find(simpleForm)) != TransformMap->end())
-    return iter->second;
-
-  ASTNode result;
-
-  switch (k)
-  {
-    case TRUE:
-    case FALSE:
-    {
-      result = simpleForm;
-      break;
-    }
-    case NOT:
-    {
-      ASTVec c;
-      c.push_back(TransformFormula(simpleForm[0]));
-      result = nf->CreateNode(NOT, c);
-      break;
-    }
-    case BOOLEXTRACT:
-    {
-      ASTVec c;
-      c.push_back(TransformTerm(simpleForm[0]));
-      c.push_back(simpleForm[1]);
-      result = nf->CreateNode(BOOLEXTRACT, c);
-      break;
-    }
-    case BVLT:
-    case BVLE:
-    case BVGT:
-    case BVGE:
-    case BVSLT:
-    case BVSLE:
-    case BVSGT:
-    case BVSGE:
-    case BVUADDO:
-    case BVSADDO:
-    case BVUMULO:
-    case BVSMULO:
-    case BVUSUBO:
-    case BVSSUBO:
-    {
-      ASTVec c;
-      c.push_back(TransformTerm(simpleForm[0]));
-      c.push_back(TransformTerm(simpleForm[1]));
-      result = nf->CreateNode(k, c);
-      break;
-    }
-    case EQ:
-    {
-      ASTNode term1 = TransformTerm(simpleForm[0]);
-      ASTNode term2 = TransformTerm(simpleForm[1]);
-      if (bm->UserFlags.optimize_flag)
-        result = simp->CreateSimplifiedEQ(term1, term2);
-      else
-        result = nf->CreateNode(EQ, term1, term2);
-      break;
-    }
-    case AND: // These could shortcut. Not sure if the extra effort is
-              // justified.
-    case OR:
-    case NAND:
-    case NOR:
-    case IFF:
-    case XOR:
-    case ITE:
-    case IMPLIES:
-    {
-      ASTVec vec;
-      vec.reserve(simpleForm.Degree());
-
-      for (auto it = simpleForm.begin(),
-                                  itend = simpleForm.end();
-           it != itend; it++)
-      {
-        vec.push_back(TransformFormula(*it));
-      }
-
-      result = nf->CreateNode(k, vec);
-      break;
-    }
-    case FP_LEQ:
-    case FP_LT:
-    case FP_GEQ:
-    case FP_GT:
-    case FP_EQ:
-    case FP_ISNORMAL:
-    case FP_ISSUBNORMAL:
-    case FP_ISZERO:
-    case FP_ISINFINITE:
-    case FP_ISNAN:
-    case FP_ISNEGATIVE:
-    case FP_ISPOSITIVE:
-    case FP_SMT_EQ:
-    {
-      ASTVec vec;
-      vec.reserve(simpleForm.Degree());
-
-      for (auto it = simpleForm.begin(), itend = simpleForm.end(); it != itend;
-           it++)
-      {
-        vec.push_back(TransformTerm(*it));
-      }
-
-      result = nf->CreateNode(k, vec);
-      break;
-    }
-    default:
-    {
-      if (k == SYMBOL && BOOLEAN_TYPE == simpleForm.GetType())
-        result = simpleForm;
-      else
-      {
-        FatalError("TransformFormula: Illegal kind: ", ASTUndefined, k);
-      }
-      break;
-    }
-  }
-
-  assert(!result.IsNull());
-  if (simpleForm.Degree() > 0)
-    (*TransformMap)[simpleForm] = result;
-  return result;
-}
-
-ASTNode ArrayTransformer::TransformTerm(const ASTNode& term)
-{
-  assert(TransformMap != NULL);
-
-  const Kind k = term.GetKind();
-  if (!is_Term_kind(k))
-    FatalError("TransformTerm: Illegal kind: You have input a nonterm:", term,
-               k);
-  ASTNodeMap::const_iterator iter;
-  if ((iter = TransformMap->find(term)) != TransformMap->end())
-    return iter->second;
-
-  ASTNode result;
-  switch (k)
-  {
-    case SYMBOL:
-    case BVCONST:
-    {
-      result = term;
-      break;
-    }
-    case WRITE:
-      FatalError("TransformTerm: this kind is not supported", term);
-      break;
-    case READ:
-      result = TransformArrayRead(term);
-      break;
-    case ITE:
-    {
-      ASTNode cond = term[0];
-      ASTNode thn = term[1];
-      ASTNode els = term[2];
-      cond = TransformFormula(cond);
-      if (ASTTrue == cond)
-      {
-        ExtensionalityContext* ext = bm->getExtensionalityIfAny();
-        if (ext != NULL && ext->activeInSolve())
-          ext->noteEliminatedReadSubtree(els);
-        result = TransformTerm(thn);
-      }
-      else if (ASTFalse == cond)
-      {
-        ExtensionalityContext* ext = bm->getExtensionalityIfAny();
-        if (ext != NULL && ext->activeInSolve())
-          ext->noteEliminatedReadSubtree(thn);
-        result = TransformTerm(els);
-      }
-      else
-      {
-        thn = TransformTerm(thn);
-        els = TransformTerm(els);
-        if (bm->UserFlags.optimize_flag)
-          result = simp->CreateSimplifiedTermITE(cond, thn, els);
-        else
-          result = nf->CreateTerm(ITE, thn.GetValueWidth(), cond, thn, els);
-      }
-      assert(result.GetIndexWidth() == term.GetIndexWidth());
-      break;
-    }
-    default:
-    {
-      const ASTChildren c = term.GetChildren();
-      auto it = c.begin();
-      auto itend = c.end();
-      const unsigned width = term.GetValueWidth();
-      const unsigned indexwidth = term.GetIndexWidth();
-      ASTVec o;
-      o.reserve(c.size());
-      for (; it != itend; it++)
-      {
-        o.push_back(TransformTerm(*it));
-      }
-
-      if (c != o)
-      {
-        result = nf->CreateArrayTerm(k, indexwidth, width, o);
-      }
-      else
-        result = term;
-    }
-    break;
-  }
-
   if (term.Degree() > 0)
     (*TransformMap)[term] = result;
   if (term.GetValueWidth() != result.GetValueWidth())
@@ -414,334 +192,886 @@ ASTNode ArrayTransformer::TransformTerm(const ASTNode& term)
   return result;
 }
 
-/* This function transforms Array Reads, Read over Writes, Read over
- * ITEs into flattened form.
- *
- * Transform1: Suppose there are two array reads in the input
- * Read(A,i) and Read(A,j) over the same array. Then Read(A,i) is
- * replaced with a symbolic constant, say v1, and Read(A,j) is
- * replaced with the following ITE:
- *
- * ITE(i=j,v1,v2)
- *
- */
-ASTNode ArrayTransformer::TransformArrayRead(const ASTNode& term)
+// The formula kinds TransformFormula has an arm for. Anything else boolean
+// that is not TRUE, FALSE or a symbol reaches its default and dies there, so
+// the test happens here, in the same place: after the memo lookup and before
+// any operand is touched.
+static bool transformableFormula(const Kind k)
+{
+  switch (k)
+  {
+    case NOT:
+    case BOOLEXTRACT:
+    case BVLT:
+    case BVLE:
+    case BVGT:
+    case BVGE:
+    case BVSLT:
+    case BVSLE:
+    case BVSGT:
+    case BVSGE:
+    case BVUADDO:
+    case BVSADDO:
+    case BVUMULO:
+    case BVSMULO:
+    case BVUSUBO:
+    case BVSSUBO:
+    case EQ:
+    case AND:
+    case OR:
+    case NAND:
+    case NOR:
+    case IFF:
+    case XOR:
+    case ITE:
+    case IMPLIES:
+    case FP_LEQ:
+    case FP_LT:
+    case FP_GEQ:
+    case FP_GT:
+    case FP_EQ:
+    case FP_ISNORMAL:
+    case FP_ISSUBNORMAL:
+    case FP_ISZERO:
+    case FP_ISINFINITE:
+    case FP_ISNAN:
+    case FP_ISNEGATIVE:
+    case FP_ISPOSITIVE:
+    case FP_SMT_EQ:
+      return true;
+    default:
+      return false;
+  }
+}
+
+// What a formula's operand is transformed as. The connectives take formulas,
+// the comparisons and the floating-point predicates take terms, and
+// BOOLEXTRACT is the one kind that carries an operand through untouched --
+// its bit index.
+enum FormulaOperand
+{
+  OperandFormula,
+  OperandTerm,
+  OperandAsIs
+};
+
+static FormulaOperand formulaOperand(const Kind k, const size_t i)
+{
+  switch (k)
+  {
+    case NOT:
+    case AND:
+    case OR:
+    case NAND:
+    case NOR:
+    case IFF:
+    case XOR:
+    case ITE:
+    case IMPLIES:
+      return OperandFormula;
+    case BOOLEXTRACT:
+      return i == 0 ? OperandTerm : OperandAsIs;
+    default:
+      return OperandTerm;
+  }
+}
+
+// Where one node's transform has got to.
+//
+// The three functions this replaces called each other once per level of the
+// input -- a formula's operands through TransformTerm, a term's condition
+// back through TransformFormula, a read's index and the array under it
+// through both -- so they are one walk with its frames on the heap rather
+// than three sets of call frames. See DeepDag_Test.cpp.
+//
+// `job` says which of the three a frame is running and `phase` where in it,
+// because most of them suspend at more than one point. Everything else here
+// was a local of the function it came from, kept because it has to survive
+// the suspension.
+struct ArrayTransformer::Frame
+{
+  enum Job
+  {
+    Formula,
+    Term,
+    Read
+  };
+
+  enum Phase
+  {
+    Start,
+    Operands,       // a formula's operands, or a term's own children
+    TermIteCond,    // ITE term: waiting for the condition
+    TermIteOnly,    // ... for the one branch the condition left
+    TermIteThen,    // ... for the then-branch, both surviving
+    TermIteElse,    // ... for the else-branch
+    TermRead,       // READ term: waiting for the array-read transform
+    ReadIndex,      // array read: waiting for the read index
+    ReadWriteIndex, // read over write: waiting for the write index
+    ReadWriteVal,   // ... for the written value
+    ReadPushedIn,   // ... for the read pushed under the write
+    ReadIteCond,    // read over ITE: waiting for the condition
+    ReadIteOnly,    // ... for the one branch the condition left
+    ReadIteThen,    // ... for the then-read, both surviving
+    ReadIteElse     // ... for the else-read
+  };
+
+  Job job;
+  Phase phase = Start;
+  ASTNode n;
+
+  // Formula and ordinary-term frames use storage for the beginning of their
+  // operands in the shared arena. Read frames use it for their state slots in
+  // that same arena; those jobs never need both meanings.
+  size_t storage = 0;
+  size_t i = 0;         // the operand being worked on
+  bool waiting = false; // an operand is being transformed below
+
+  // Term ITEs and reads share these. The rest of a slow-path read's
+  // continuation lives in the shared arena so every formula and ordinary
+  // term does not carry it.
+  ASTNode cond;
+  ASTNode thn;
+
+  Frame(Job j, ASTNode node) : job(j), n(std::move(node))
+  {
+  }
+};
+
+// TransformFormula, TransformTerm and TransformArrayRead, walked together
+// with their frames on the heap. Everything the three did is here in the
+// order they did it: the same memo reads and writes, the same node-factory
+// calls, and the same decisions about which operand is transformed at all --
+// which matters most in the two places that transform only the branch of an
+// if-then-else that its condition leaves alive, and tell the extensionality
+// context about the one they dropped.
+ASTNode ArrayTransformer::transform(const bool asFormula, const ASTNode& top)
 {
   assert(TransformMap != NULL);
-
-  const unsigned int width = term.GetValueWidth();
-
-  if (READ != term.GetKind())
-    return term;
-
-  ASTNodeMap::const_iterator iter;
-  if ((iter = TransformMap->find(term)) != TransformMap->end())
-    return iter->second;
-
-  //'term' is of the form READ(arrName, readIndex)
-  const ASTNode& arrName = term[0];
-  const ASTNode& readIndex = TransformTerm(term[1]);
+  static_assert(sizeof(Frame) <= 56,
+                "common array-transform frames must remain compact");
 
   ASTNode result;
 
-  // With array equality active, every read takes the direct
-  // read-abstraction path: mint or reuse the fresh variable for the
-  // (array, index) pair, whatever the array
-  // term is: variable, write, or if-then-else. Neither its write chain
-  // nor its if-then-else structure is expanded here. The lemmas-on-
-  // demand consistency checker owns read-over-write and read-over-
-  // if-then-else reasoning for these arrays (rules D/U and T-down/T-up),
-  // and it needs the structure and the abstraction variables intact.
-  {
-    ExtensionalityContext* ext = bm->getExtensionalityIfAny();
-    if (ext != NULL && ext->activeInSolve())
+  // Decide whether transforming `n` needs a frame. A root which is already
+  // answered returns before the stack is constructed; descendant callers
+  // use the same checks before pushing a frame.
+  auto prepare = [&](const Frame::Job job, const ASTNode& n) -> bool {
+    if (job == Frame::Read)
     {
-      if (!ext->arrayGraphFrozen())
-        FatalError("array-equality: the array transform ran before the "
-                   "complete array graph was frozen",
-                   term);
-      if (!ext->ownsArray(arrName))
-        FatalError("array-equality: a transformed read is absent from the "
-                   "complete owned array graph",
-                   term);
-      if (bm->UserFlags.ackermannisation)
-        FatalError("array-equality: eager Ackermannization reached the "
-                   "whole-graph read transform");
-
-      ArrType::const_iterator it;
-      if ((it = arrayToIndexToRead.find(arrName)) != arrayToIndexToRead.end())
+      if (READ != n.GetKind())
       {
-        std::map<ASTNode, ArrayRead>::const_iterator it2;
-        if ((it2 = it->second.find(readIndex)) != it->second.end())
-        {
-          if (it2->second.ite != it2->second.symbol)
-            FatalError("array-equality: a whole-graph read reused a legacy "
-                       "nested-ITE transformer row",
-                       term);
-          result = it2->second.ite;
-          ext->noteAbstractedRead(term, readIndex, it2->second.symbol);
-          (*TransformMap)[term] = result;
-          return result;
-        }
+        result = n;
+        return false;
       }
 
-      ASTNode CurrentSymbol = bm->CreateFreshVariable(
-          term.GetIndexWidth(), term.GetValueWidth(), "ext_read");
+      const ASTNodeMap::const_iterator it = TransformMap->find(n);
+      if (it != TransformMap->end())
+      {
+        result = it->second;
+        return false;
+      }
 
-      // Same reason as the read-refinement path below: this variable stands
-      // in for the read from here on and is a leaf, so the element format
-      // has to travel with it or the element reaches the blaster as a
-      // formatless bitvector. Setting a zero width (a non-float array) is a
-      // no-op.
-      CurrentSymbol.SetExpWidth(term.GetExpWidth());
-      CurrentSymbol.SetSigWidth(term.GetSigWidth());
-
-      result = CurrentSymbol;
-      arrayToIndexToRead[arrName].insert(
-          make_pair(readIndex, ArrayRead(result, CurrentSymbol)));
-      ext->noteAbstractedRead(term, readIndex, CurrentSymbol);
-      (*TransformMap)[term] = result;
-      return result;
+      return true;
     }
-  }
 
-  switch (arrName.GetKind())
-  {
-    case SYMBOL:
+    const Kind k = n.GetKind();
+
+    if (job == Frame::Formula)
     {
-      /* input is of the form: READ(A, readIndex)
-       *
-       * output is of the from: A1, if this is the first READ over A
-       *
-       *                        ITE(previous_readIndex=readIndex,A1,A2)
-       *
-       *                        .....
-       */
-
+      if (!(is_Form_kind(k) && BOOLEAN_TYPE == n.GetType()))
       {
-        ArrType::const_iterator it;
-        if ((it = arrayToIndexToRead.find(arrName)) != arrayToIndexToRead.end())
+        // FIXME: "You have inputted a NON-formula"?
+        FatalError("TransformFormula:"
+                   "You have input a NON-formula",
+                   n);
+      }
+
+      const ASTNodeMap::const_iterator it = TransformMap->find(n);
+      if (it != TransformMap->end())
+      {
+        result = it->second;
+        return false;
+      }
+
+      // TRUE, FALSE and a boolean symbol transform to themselves, and are
+      // not recorded: the map was only ever written for a node with
+      // children.
+      if (k == TRUE || k == FALSE || k == SYMBOL)
+      {
+        result = n;
+        return false;
+      }
+
+      if (!transformableFormula(k))
+        FatalError("TransformFormula: Illegal kind: ", ASTUndefined, k);
+
+      return true;
+    }
+
+    if (!is_Term_kind(k))
+      FatalError("TransformTerm: Illegal kind: You have input a nonterm:", n,
+                 k);
+
+    const ASTNodeMap::const_iterator it = TransformMap->find(n);
+    if (it != TransformMap->end())
+    {
+      result = it->second;
+      return false;
+    }
+
+    if (k == SYMBOL || k == BVCONST)
+    {
+      // Leaves are not memoized, and their width checks are true by
+      // construction because the result is the input itself.
+      result = n;
+      return false;
+    }
+
+    if (k == WRITE)
+      FatalError("TransformTerm: this kind is not supported", n);
+
+    return true;
+  };
+
+  const Frame::Job rootJob = asFormula ? Frame::Formula : Frame::Term;
+  if (!prepare(rootJob, top))
+    return result;
+
+  // Most transforms are shallow. Keep their continuations in one compact
+  // allocation instead of a deque's map and fixed-size blocks. A push may
+  // move every frame, so a step must return without touching its Frame after
+  // a request helper descends.
+  std::vector<Frame> stack;
+  // One allocation covers the common formula -> term -> read alternation and
+  // avoids moving these comparatively large frames while it remains shallow.
+  stack.reserve(8);
+  stack.emplace_back(rootJob, top);
+
+  // Continuation storage shared by every suspended job. Formula and term
+  // frames append their operands; a Read frame reserves four ASTNode slots.
+  // Each child owns the suffix beginning at storage and removes it before
+  // its result is appended to its parent.
+  ASTVec activeParts;
+
+  enum ReadStateSlot : size_t
+  {
+    ReadIndexSlot,
+    WriteIndexSlot,
+    WriteValueSlot,
+    ElseReadSlot,
+    ReadStateSlots
+  };
+  auto partsFor = [&](const Frame& f) -> ASTChildren {
+    // prepare() resolves every leaf without pushing a frame, so a frame
+    // reaching reconstruction always owns at least one arena element.
+    assert(f.n.Degree() > 0);
+    assert(activeParts.size() - f.storage == f.n.Degree());
+    return ASTChildren(activeParts.data() + f.storage,
+                       activeParts.size() - f.storage);
+  };
+
+  // Ask for a formula descendant. Either `prepare` leaves its immediate
+  // answer in `result`, or the walk goes below a new frame. Formula and term
+  // requests stay separate so their hot paths do not redispatch on Job.
+  auto wantFormula = [&](const ASTNode& n,
+                         Frame* waitingParent = nullptr) -> bool {
+    if (!prepare(Frame::Formula, n))
+      return false;
+    ASTNode owned = n;
+    if (waitingParent != nullptr)
+      waitingParent->waiting = true;
+    stack.emplace_back(Frame::Formula, std::move(owned));
+    return true;
+  };
+
+  // The term counterpart. Own the requested node before vector growth
+  // invalidates a reference which may point into the current frame.
+  auto wantTerm = [&](const ASTNode& n,
+                      Frame* waitingParent = nullptr) -> bool {
+    if (!prepare(Frame::Term, n))
+      return false;
+    ASTNode owned = n;
+    if (waitingParent != nullptr)
+      waitingParent->waiting = true;
+    stack.emplace_back(Frame::Term, std::move(owned));
+    return true;
+  };
+
+  // Read is requested from one place only. Keep its uncommon state-allocation
+  // path out of the formula and term helpers used for every operand.
+  auto wantRead = [&](const ASTNode& n) -> bool {
+    if (!prepare(Frame::Read, n))
+      return false;
+    ASTNode owned = n;
+    stack.emplace_back(Frame::Read, std::move(owned));
+    return true;
+  };
+
+  // One step of TransformFormula: collect the operands, then rebuild.
+  auto stepFormula = [&](Frame& f) -> bool {
+    if (f.phase == Frame::Start)
+    {
+      f.phase = Frame::Operands;
+      f.storage = activeParts.size();
+    }
+
+    if (f.waiting)
+    {
+      f.waiting = false;
+      activeParts.push_back(result);
+    }
+
+    const Kind k = f.n.GetKind();
+
+    while (f.i < f.n.Degree())
+    {
+      const size_t i = f.i++;
+      const FormulaOperand op = formulaOperand(k, i);
+
+      if (op == OperandAsIs)
+      {
+        activeParts.push_back(f.n[i]);
+        continue;
+      }
+
+      // The request helper installs the continuation only when it will push,
+      // and does so before vector growth can move `f`.
+      const bool descended = op == OperandFormula
+                                 ? wantFormula(f.n[i], &f)
+                                 : wantTerm(f.n[i], &f);
+      if (descended)
+        return true;
+      activeParts.push_back(result);
+    }
+
+    const ASTChildren parts = partsFor(f);
+    if (k == EQ && bm->UserFlags.optimize_flag)
+      result = simp->CreateSimplifiedEQ(parts[0], parts[1]);
+    else
+      result = nf->CreateNode(k, parts);
+    activeParts.resize(f.storage);
+
+    assert(!result.IsNull());
+    if (f.n.Degree() > 0)
+      (*TransformMap)[f.n] = result;
+    return false;
+  };
+
+  // One step of TransformTerm. READ hands over to the array-read job, ITE
+  // transforms its condition and then only the branch that survives it, and
+  // everything else transforms its own children and rebuilds.
+  auto stepTerm = [&](Frame& f) -> bool {
+    const Kind k = f.n.GetKind();
+
+    if (k == READ)
+    {
+      if (f.phase == Frame::Start)
+      {
+        f.phase = Frame::TermRead;
+        if (wantRead(f.n))
+          return true;
+      }
+      result = finishTransformTerm(f.n, result);
+      return false;
+    }
+
+    if (k == ITE)
+    {
+      if (f.phase == Frame::Start)
+      {
+        f.phase = Frame::TermIteCond;
+        if (wantFormula(f.n[0]))
+          return true;
+      }
+
+      if (f.phase == Frame::TermIteCond)
+      {
+        f.cond = result;
+        ExtensionalityContext* ext = bm->getExtensionalityIfAny();
+
+        if (ASTTrue == f.cond || ASTFalse == f.cond)
         {
-          std::map<ASTNode, ArrayRead>::const_iterator it2;
-          if ((it2 = it->second.find(readIndex)) != it->second.end())
-          {
-            result = it2->second.ite;
-            break;
-          }
+          const bool takeThen = (ASTTrue == f.cond);
+          if (ext != NULL && ext->activeInSolve())
+            ext->noteEliminatedReadSubtree(takeThen ? f.n[2] : f.n[1]);
+
+          f.phase = Frame::TermIteOnly;
+          if (wantTerm(takeThen ? f.n[1] : f.n[2]))
+            return true;
+        }
+        else
+        {
+          f.phase = Frame::TermIteThen;
+          if (wantTerm(f.n[1]))
+            return true;
         }
       }
 
-      // Make up a new abstract variable. Build symbolic name
-      // corresponding to array read. The symbolic name has 2
-      // components: stringname, and a count
-
-      ASTNode CurrentSymbol =
-          bm->CreateFreshVariable(term.GetIndexWidth(), term.GetValueWidth(),
-                                  "array_" + std::string(arrName.GetName()));
-
-      // Reading an array of floats yields a float. The read node derived its
-      // format from the array, but this fresh variable stands in for the read
-      // from here on and is a leaf, so it has to carry the format itself --
-      // otherwise the element arrives at the blaster as a formatless
-      // bitvector.
-      CurrentSymbol.SetExpWidth(term.GetExpWidth());
-      CurrentSymbol.SetSigWidth(term.GetSigWidth());
-
-      result = CurrentSymbol;
-
-      if (!bm->UserFlags.ackermannisation)
+      if (f.phase == Frame::TermIteOnly)
       {
-        // result is a variable here; it is an ite in the
-        // else-branch
+        assert(result.GetIndexWidth() == f.n.GetIndexWidth());
+        result = finishTransformTerm(f.n, result);
+        return false;
       }
-      else
+
+      if (f.phase == Frame::TermIteThen)
       {
-        // Full Array transform if we're not doing read refinement.
+        f.thn = result;
+        f.phase = Frame::TermIteElse;
+        if (wantTerm(f.n[2]))
+          return true;
+      }
 
-        // list of array-read indices corresponding to arrName, seen while
-        // traversing the AST tree. we need this list to construct the ITEs
-        vector<std::pair<ASTNode, ASTNode>> p = ack_pair[arrName];
+      const ASTNode els = result;
+      if (bm->UserFlags.optimize_flag)
+        result = simp->CreateSimplifiedTermITE(f.cond, f.thn, els);
+      else
+        result = nf->CreateTerm(ITE, f.thn.GetValueWidth(), f.cond, f.thn, els);
 
-        vector<std::pair<ASTNode, ASTNode>>::const_reverse_iterator it2 =
-            p.rbegin();
-        vector<std::pair<ASTNode, ASTNode>>::const_reverse_iterator it2end =
-            p.rend();
-        for (; it2 != it2end; it2++)
+      assert(result.GetIndexWidth() == f.n.GetIndexWidth());
+      result = finishTransformTerm(f.n, result);
+      return false;
+    }
+
+    if (f.phase == Frame::Start)
+    {
+      f.phase = Frame::Operands;
+      f.storage = activeParts.size();
+    }
+
+    if (f.waiting)
+    {
+      f.waiting = false;
+      activeParts.push_back(result);
+    }
+
+    while (f.i < f.n.Degree())
+    {
+      const ASTNode& child = f.n[f.i++];
+
+      // The request helper installs the continuation only when it will push,
+      // and does so before vector growth can move `f`.
+      if (wantTerm(child, &f))
+        return true;
+      activeParts.push_back(result);
+    }
+
+    const ASTChildren parts = partsFor(f);
+    const ASTChildren c = f.n.GetChildren();
+    if (c != parts)
+      result = nf->CreateArrayTerm(k, f.n.GetIndexWidth(), f.n.GetValueWidth(),
+                                   parts);
+    else
+      result = f.n;
+    activeParts.resize(f.storage);
+
+    result = finishTransformTerm(f.n, result);
+    return false;
+  };
+
+  /* One step of TransformArrayRead, which transforms Array Reads, Read over
+   * Writes, Read over ITEs into flattened form.
+   *
+   * Transform1: Suppose there are two array reads in the input
+   * Read(A,i) and Read(A,j) over the same array. Then Read(A,i) is
+   * replaced with a symbolic constant, say v1, and Read(A,j) is
+   * replaced with the following ITE:
+   *
+   * ITE(i=j,v1,v2)
+   *
+  */
+  auto stepRead = [&](Frame& f) -> bool {
+    ASTNode* state = nullptr;
+    // A Read allocates persistent slots only when it advances beyond the
+    // index phase into a WRITE or ITE continuation. The phase therefore
+    // records the presence of state without another flag or sentinel store.
+    if (f.phase > Frame::ReadIndex)
+    {
+      assert(f.storage + ReadStateSlots <= activeParts.size());
+      state = activeParts.data() + f.storage;
+    }
+    const ASTNode& term = f.n;
+    const unsigned int width = term.GetValueWidth();
+
+    //'term' is of the form READ(arrName, readIndex)
+    const ASTNode& arrName = term[0];
+
+    // The tail every path below this point shares.
+    auto finishRead = [&](const ASTNode& value) {
+      assert(BVTypeCheck(value));
+      assert(!value.IsNull());
+      (*TransformMap)[term] = value;
+      result = value;
+      return false;
+    };
+
+    if (f.phase == Frame::Start)
+    {
+      f.phase = Frame::ReadIndex;
+      if (wantTerm(term[1]))
+        return true;
+    }
+
+    if (f.phase == Frame::ReadIndex)
+    {
+      // SYMBOL reads and the whole-graph array-equality path finish in this
+      // phase, so keep their index local. Allocate persistent Read state only
+      // for the WRITE/ITE paths which actually suspend again.
+      const ASTNode readIndex = result;
+
+      // With array equality active, every read takes the direct
+      // read-abstraction path: mint or reuse the fresh variable for the
+      // (array, index) pair, whatever the array
+      // term is: variable, write, or if-then-else. Neither its write chain
+      // nor its if-then-else structure is expanded here. The lemmas-on-
+      // demand consistency checker owns read-over-write and read-over-
+      // if-then-else reasoning for these arrays (rules D/U and T-down/T-up),
+      // and it needs the structure and the abstraction variables intact.
+      {
+        ExtensionalityContext* ext = bm->getExtensionalityIfAny();
+        if (ext != NULL && ext->activeInSolve())
         {
-          ASTNode cond = simp->CreateSimplifiedEQ(readIndex, it2->first);
-          if (ASTFalse == cond)
-            continue;
+          if (!ext->arrayGraphFrozen())
+            FatalError("array-equality: the array transform ran before the "
+                       "complete array graph was frozen",
+                       term);
+          if (!ext->ownsArray(arrName))
+            FatalError("array-equality: a transformed read is absent from the "
+                       "complete owned array graph",
+                       term);
+          if (bm->UserFlags.ackermannisation)
+            FatalError("array-equality: eager Ackermannization reached the "
+                       "whole-graph read transform");
 
-          if (ASTTrue == cond)
+          ArrType::const_iterator it;
+          if ((it = arrayToIndexToRead.find(arrName)) !=
+              arrayToIndexToRead.end())
           {
-            result = it2->second;
+            std::map<ASTNode, ArrayRead>::const_iterator it2;
+            if ((it2 = it->second.find(readIndex)) != it->second.end())
+            {
+              if (it2->second.ite != it2->second.symbol)
+                FatalError("array-equality: a whole-graph read reused a legacy "
+                           "nested-ITE transformer row",
+                           term);
+              result = it2->second.ite;
+              ext->noteAbstractedRead(term, readIndex, it2->second.symbol);
+              (*TransformMap)[term] = result;
+              return false;
+            }
+          }
+
+          ASTNode CurrentSymbol = bm->CreateFreshVariable(
+              term.GetIndexWidth(), term.GetValueWidth(), "ext_read");
+
+          // Same reason as the read-refinement path below: this variable
+          // stands in for the read from here on and is a leaf, so the element
+          // format has to travel with it or the element reaches the blaster
+          // as a formatless bitvector. Setting a zero width (a non-float
+          // array) is a no-op.
+          CurrentSymbol.SetExpWidth(term.GetExpWidth());
+          CurrentSymbol.SetSigWidth(term.GetSigWidth());
+
+          result = CurrentSymbol;
+          arrayToIndexToRead[arrName].insert(
+              make_pair(readIndex, ArrayRead(result, CurrentSymbol)));
+          ext->noteAbstractedRead(term, readIndex, CurrentSymbol);
+          (*TransformMap)[term] = result;
+          return false;
+        }
+      }
+
+      switch (arrName.GetKind())
+      {
+        case SYMBOL:
+        {
+          /* input is of the form: READ(A, readIndex)
+           *
+           * output is of the from: A1, if this is the first READ over A
+           *
+           *                        ITE(previous_readIndex=readIndex,A1,A2)
+           *
+           *                        .....
+           */
+
+          {
+            ArrType::const_iterator it;
+            if ((it = arrayToIndexToRead.find(arrName)) !=
+                arrayToIndexToRead.end())
+            {
+              std::map<ASTNode, ArrayRead>::const_iterator it2;
+              if ((it2 = it->second.find(readIndex)) != it->second.end())
+                return finishRead(it2->second.ite);
+            }
+          }
+
+          // Make up a new abstract variable. Build symbolic name
+          // corresponding to array read. The symbolic name has 2
+          // components: stringname, and a count
+
+          ASTNode CurrentSymbol = bm->CreateFreshVariable(
+              term.GetIndexWidth(), term.GetValueWidth(),
+              "array_" + std::string(arrName.GetName()));
+
+          // Reading an array of floats yields a float. The read node derived
+          // its format from the array, but this fresh variable stands in for
+          // the read from here on and is a leaf, so it has to carry the
+          // format itself -- otherwise the element arrives at the blaster as
+          // a formatless bitvector.
+          CurrentSymbol.SetExpWidth(term.GetExpWidth());
+          CurrentSymbol.SetSigWidth(term.GetSigWidth());
+
+          ASTNode symbolResult = CurrentSymbol;
+
+          if (!bm->UserFlags.ackermannisation)
+          {
+            // result is a variable here; it is an ite in the
+            // else-branch
           }
           else
-            result = simp->CreateSimplifiedTermITE(cond, it2->second, result);
+          {
+            // Full Array transform if we're not doing read refinement.
+
+            // list of array-read indices corresponding to arrName, seen while
+            // traversing the AST tree. we need this list to construct the ITEs
+            vector<std::pair<ASTNode, ASTNode>> p = ack_pair[arrName];
+
+            vector<std::pair<ASTNode, ASTNode>>::const_reverse_iterator it2 =
+                p.rbegin();
+            vector<std::pair<ASTNode, ASTNode>>::const_reverse_iterator it2end =
+                p.rend();
+            for (; it2 != it2end; it2++)
+            {
+              ASTNode cond =
+                  simp->CreateSimplifiedEQ(readIndex, it2->first);
+              if (ASTFalse == cond)
+                continue;
+
+              if (ASTTrue == cond)
+              {
+                symbolResult = it2->second;
+              }
+              else
+                symbolResult = simp->CreateSimplifiedTermITE(cond, it2->second,
+                                                             symbolResult);
+            }
+
+            ack_pair[arrName].push_back(
+                make_pair(readIndex, CurrentSymbol));
+          }
+
+          assert(arrName.GetType() == ARRAY_TYPE);
+          arrayToIndexToRead[arrName].insert(
+              make_pair(readIndex, ArrayRead(symbolResult, CurrentSymbol)));
+          return finishRead(symbolResult);
         }
+        case WRITE:
+        {
+          /* The input to this case is: READ((WRITE A i val) j)
+           *
+           * The output of this case is: ITE( (= i j) val (READ A j))
+           */
 
-        ack_pair[arrName].push_back(make_pair(readIndex, CurrentSymbol));
+          /* 1. arrName or term[0] is infact a WRITE(A,i,val) expression
+           *
+           * 2. term[1] is the read-index j
+           *
+           * 3. arrName[0] is the new arrName i.e. A. A can be either a
+           SYMBOL or a nested WRITE. no other possibility
+           *
+           * 4. arrName[1] is the WRITE index i.e. i
+           *
+           * 5. arrName[2] is the WRITE value i.e. val (val can inturn
+           *    be an array read)
+           */
+          f.storage = activeParts.size();
+          activeParts.resize(f.storage + ReadStateSlots);
+          state = activeParts.data() + f.storage;
+          state[ReadIndexSlot] = readIndex;
+          f.phase = Frame::ReadWriteIndex;
+          if (wantTerm(arrName[1]))
+            return true;
+          break;
+        }
+        case ITE:
+        {
+          /* READ((ITE cond thn els) j)
+           *
+           * is transformed into
+           *
+           * (ITE cond (READ thn j) (READ els j))
+           */
+
+          // pull out the ite from the read // pushes the read through.
+
+          //(ITE cond thn els)
+          f.storage = activeParts.size();
+          activeParts.resize(f.storage + ReadStateSlots);
+          state = activeParts.data() + f.storage;
+          state[ReadIndexSlot] = readIndex;
+          f.phase = Frame::ReadIteCond;
+          if (wantFormula(arrName[0]))
+            return true;
+          break;
+        }
+        default:
+          FatalError("TransformArray: "
+                     "The READ is NOT over SYMBOL/WRITE/ITE",
+                     term);
+          break;
       }
-
-      assert(arrName.GetType() == ARRAY_TYPE);
-      arrayToIndexToRead[arrName].insert(
-          make_pair(readIndex, ArrayRead(result, CurrentSymbol)));
-      break;
     }
-    case WRITE:
+
+    assert(state != nullptr);
+    if (f.phase == Frame::ReadWriteIndex)
     {
-      /* The input to this case is: READ((WRITE A i val) j)
-       *
-       * The output of this case is: ITE( (= i j) val (READ A j))
-       */
+      // Both operands are transformed before the condition is built, as
+      // they were: the factory sees them in that order.
+      state[WriteIndexSlot] = result;
+      f.phase = Frame::ReadWriteVal;
+      if (wantTerm(arrName[2]))
+        return true;
+    }
 
-      /* 1. arrName or term[0] is infact a WRITE(A,i,val) expression
-       *
-       * 2. term[1] is the read-index j
-       *
-       * 3. arrName[0] is the new arrName i.e. A. A can be either a
-       SYMBOL or a nested WRITE. no other possibility
-       *
-       * 4. arrName[1] is the WRITE index i.e. i
-       *
-       * 5. arrName[2] is the WRITE value i.e. val (val can inturn
-       *    be an array read)
-       */
-
-      ASTNode writeIndex = TransformTerm(arrName[1]);
-      ASTNode writeVal = TransformTerm(arrName[2]);
+    if (f.phase == Frame::ReadWriteVal)
+    {
+      state[WriteValueSlot] = result;
 
       if (ARRAY_TYPE != arrName[0].GetType())
         FatalError("TransformArray: "
                    "An array write is being attempted on a non-array:",
                    term);
 
-      // if ((SYMBOL == arrName[0].GetKind()
-      //|| WRITE == arrName[0].GetKind()))
-      {
-        ASTNode cond = simp->CreateSimplifiedEQ(writeIndex, readIndex);
-        assert(BVTypeCheck(cond));
+      f.cond = simp->CreateSimplifiedEQ(state[WriteIndexSlot],
+                                        state[ReadIndexSlot]);
+      assert(BVTypeCheck(f.cond));
 
-        // If the condition is true, it saves iteratively transforming through
-        // all the (possibly nested) arrays.
-        if (ASTTrue == cond)
-        {
-          result = writeVal;
-        }
-        else
-        {
-          ASTNode readTerm = nf->CreateTerm(READ, width, arrName[0], readIndex);
-          assert(BVTypeCheck(readTerm));
+      // If the condition is true, it saves iteratively transforming through
+      // all the (possibly nested) arrays.
+      if (ASTTrue == f.cond)
+        return finishRead(state[WriteValueSlot]);
 
-          // The simplifying node factory may have produced
-          // something that's not a READ.
-          ASTNode readPushedIn = TransformTerm(readTerm);
-          assert(BVTypeCheck(readPushedIn));
+      ASTNode readTerm =
+          nf->CreateTerm(READ, width, arrName[0], state[ReadIndexSlot]);
+      assert(BVTypeCheck(readTerm));
 
-          result = simp->CreateSimplifiedTermITE(cond, writeVal, readPushedIn);
-        }
-      }
-
-// Trevor: I've removed this code because I don't see the advantage in working
-// inside out. i.e. transforming read(write(ite(p,A,B),i,j),k), into
-// read(ite(p,write(A,i,j),write(B,i,j),k). That is bringing up the ite.
-// Without this code it will become: ite(i=k, j, read(ite(p,A,B),k))
-
-#if 0
-          else if (ITE == arrName[0].GetKind())
-            {
-              // pull out the ite from the write // pushes the write
-              // through.
-              ASTNode writeTrue =
-                nf->CreateNode(WRITE, (arrName[0][1]), writeIndex, writeVal);
-              writeTrue.SetIndexWidth(writeIndex.GetValueWidth());
-              writeTrue.SetValueWidth(writeVal.GetValueWidth());
-              assert(ARRAY_TYPE == writeTrue.GetType());
-
-              ASTNode writeFalse = 
-                nf->CreateNode(WRITE, (arrName[0][2]), writeIndex, writeVal);
-              writeFalse.SetIndexWidth(writeIndex.GetValueWidth());
-              writeFalse.SetValueWidth(writeVal.GetValueWidth());
-              assert(ARRAY_TYPE == writeFalse.GetType());
-
-              result =  (writeTrue == writeFalse) ?
-                writeTrue : simp->CreateSimplifiedTermITE(TransformFormula(arrName[0][0]),
-                                              writeTrue, writeFalse);
-              result.SetIndexWidth(writeIndex.GetValueWidth());
-              result.SetValueWidth(writeVal.GetValueWidth());
-              assert(ARRAY_TYPE == result.GetType());
-
-              result = 
-                nf->CreateTerm(READ, writeVal.GetValueWidth(),
-                               result, readIndex);
-              BVTypeCheck(result);
-              result = TransformArrayRead(result);
-            }
-          else
-            FatalError("TransformArray: Write over bad type.");
-#endif
-      break;
+      // The simplifying node factory may have produced
+      // something that's not a READ.
+      f.phase = Frame::ReadPushedIn;
+      if (wantTerm(readTerm))
+        return true;
     }
-    case ITE:
+
+    if (f.phase == Frame::ReadPushedIn)
     {
-      /* READ((ITE cond thn els) j)
-       *
-       * is transformed into
-       *
-       * (ITE cond (READ thn j) (READ els j))
-       */
+      const ASTNode readPushedIn = result;
+      assert(BVTypeCheck(const_cast<ASTNode&>(readPushedIn)));
+      return finishRead(simp->CreateSimplifiedTermITE(
+          f.cond, state[WriteValueSlot], readPushedIn));
+    }
 
-      // pull out the ite from the read // pushes the read through.
-
-      //(ITE cond thn els)
-
-      ASTNode cond = arrName[0];
-      cond = TransformFormula(cond);
+    if (f.phase == Frame::ReadIteCond)
+    {
+      f.cond = result;
 
       const ASTNode& thn = arrName[1];
       const ASTNode& els = arrName[2];
 
       //(READ thn j)
-      ASTNode thnRead = nf->CreateTerm(READ, width, thn, readIndex);
+      ASTNode thnRead =
+          nf->CreateTerm(READ, width, thn, state[ReadIndexSlot]);
       assert(BVTypeCheck(thnRead));
 
       //(READ els j)
-      ASTNode elsRead = nf->CreateTerm(READ, width, els, readIndex);
+      ASTNode elsRead =
+          nf->CreateTerm(READ, width, els, state[ReadIndexSlot]);
       assert(BVTypeCheck(elsRead));
 
       /* We try to call TransformTerm only if necessary, because it
        * introduces a new symbol for each read. The amount of work we
        * need to do later is based on the square of the number of symbols.
        */
-      if (ASTTrue == cond)
+      if (ASTTrue == f.cond || ASTFalse == f.cond)
       {
-        result = TransformTerm(thnRead);
-      }
-      else if (ASTFalse == cond)
-      {
-        result = TransformTerm(elsRead);
+        f.phase = Frame::ReadIteOnly;
+        if (wantTerm((ASTTrue == f.cond) ? thnRead : elsRead))
+          return true;
       }
       else
       {
-        thnRead = TransformTerm(thnRead);
-        elsRead = TransformTerm(elsRead);
-
-        //(ITE cond (READ thn j) (READ els j))
-        result = simp->CreateSimplifiedTermITE(cond, thnRead, elsRead);
+        // Built now, transformed after the then-read.
+        state[ElseReadSlot] = elsRead;
+        f.phase = Frame::ReadIteThen;
+        if (wantTerm(thnRead))
+          return true;
       }
-      break;
     }
-    default:
-      FatalError("TransformArray: "
-                 "The READ is NOT over SYMBOL/WRITE/ITE",
-                 term);
-      break;
-  }
 
-  assert(BVTypeCheck(result));
-  assert(!result.IsNull());
-  (*TransformMap)[term] = result;
-  return result;
+    if (f.phase == Frame::ReadIteOnly)
+      return finishRead(result);
+
+    if (f.phase == Frame::ReadIteThen)
+    {
+      f.thn = result;
+      f.phase = Frame::ReadIteElse;
+      if (wantTerm(state[ElseReadSlot]))
+        return true;
+    }
+
+    //(ITE cond (READ thn j) (READ els j))
+    return finishRead(
+        simp->CreateSimplifiedTermITE(f.cond, f.thn, result));
+  };
+
+  while (true)
+  {
+    Frame& current = stack.back();
+
+    bool descended = false;
+    switch (current.job)
+    {
+      case Frame::Formula:
+        descended = stepFormula(current);
+        break;
+      case Frame::Term:
+        descended = stepTerm(current);
+        break;
+      case Frame::Read:
+        descended = stepRead(current);
+        break;
+    }
+
+    if (descended)
+      continue;
+
+    if (current.job == Frame::Read)
+    {
+      if (current.phase > Frame::ReadIndex)
+      {
+        assert(current.storage + ReadStateSlots == activeParts.size());
+        activeParts.resize(current.storage);
+      }
+    }
+    stack.pop_back();
+    if (stack.empty())
+      return result;
+  }
+}
+
+/********************************************************
+ * TransformFormula()
+ *
+ * Get rid of ARRAY read/writes
+ ********************************************************/
+ASTNode ArrayTransformer::TransformFormula(const ASTNode& simpleForm)
+{
+  return transform(true, simpleForm);
+}
+
+ASTNode ArrayTransformer::TransformTerm(const ASTNode& term)
+{
+  return transform(false, term);
 }
 
 // Since these arrayreads are being nuked and recorded in the

--- a/lib/AbsRefineCounterExample/CounterExample.cpp
+++ b/lib/AbsRefineCounterExample/CounterExample.cpp
@@ -298,119 +298,192 @@ void AbsRefine_CounterExample::ConstructCounterExample(
 // the term evaluator -- so they are one walk with its frames on the heap
 // rather than three sets of call frames. See DeepDag_Test.cpp.
 //
-// `job` says which of the three a frame is running and `phase` where in it,
-// because most of them suspend at more than one point. Everything else here
-// was a local of the function it came from, kept because it has to survive
-// the suspension.
-struct AbsRefine_CounterExample::Frame
+// The evaluator owns the explicit continuation stack and keeps all of its
+// suspension machinery out of AbsRefine_CounterExample's ordinary methods.
+class AbsRefine_CounterExample::EvaluationDriver
 {
-  enum Phase
+  AbsRefine_CounterExample& owner;
+  ASTNode& ASTTrue;
+  ASTNode& ASTFalse;
+  ASTNode& ASTUndefined;
+  ASTNodeMap& CounterExampleMap;
+  ASTNodeMap& ComputeFormulaMap;
+  STPMgr* const bm;
+  Simplifier* const simp;
+  unsigned int& fpEncodedEvaluationDepth;
+
+  FpEncodingContext& requireFpEncodingContext() const
   {
-    Start,
+    return owner.requireFpEncodingContext();
+  }
 
-    // ComputeFormulaUsingModel.
-    FormSymbolValue,     // boolean symbol: waiting for its recorded value
-    FormArrayEqLowered,  // array equality: for the lowering that decided it
-    FormBoolExtract,     // bit extract: for the term underneath
-    FormOperand,         // connective or comparison: for operand `i`
-    FormIteCond,         // if-then-else: for the condition
-    FormIteBranch,       // ... for the branch the condition left alive
-    FormFpOperand,       // float predicate: for operand `i`
-    FormFpOperandStrict, // ... for it again, this time refusing a bare read
-    FormFpRewritten,     // ... for what the factory returned instead
-    FormFpBlasted,       // ... for the lowering of the predicate
+  bool arrayEqualityIsModelDecidable(const ASTNode& arrayTerm) const
+  {
+    return owner.arrayEqualityIsModelDecidable(arrayTerm);
+  }
 
-    // TermToConstTermUsingModel.
-    TermRecordedValueStart, // recorded non-constant: about to evaluate its value
-    TermRecordedValue,  // for the value the model already records for this term
-    TermEncoded,        // float source term: for its encoding
-    TermDefinition,     // substituted array read: for the read through its definition
-    TermCellIndex,      // owned array read: for the index
-    TermCellValue,      // ... for a recorded cell value that is not constant
-    TermCellWriteIndex, // ... for the index the write at this level stores at
-    TermCellWritten,    // ... for the value it stores, the index having hit
-    TermCellIteCond,    // ... for an array if-then-else's condition
-    TermExpand,         // read over a write: for the expansion
-    TermExpanded,       // ... for the value of the expansion
-    TermReadIteIndex,   // read over an if-then-else: for the index
-    TermReadIteCond,    // ... for the condition
-    TermReadIteBranch,  // ... for the read over the branch it left alive
-    TermReadIndex,      // plain read: for the index, however it is spelled
-    TermReadValue,      // ... for the value the model records at that index
-    TermIteCond,        // if-then-else term: for the condition
-    TermIteBranch,      // ... for the branch the condition left alive
-    TermOperand,        // any other operation: for child `i`
-    TermOperandStrict,  // ... for it again, this time refusing a bare read
+  bool ArraysEqualUsingModel(const ASTNode& left, const ASTNode& right)
+  {
+    return owner.ArraysEqualUsingModel(left, right);
+  }
 
-    // Expand_ReadOverWrite_UsingModel.
-    ExpandRecordedValueStart, // recorded non-constant: about to evaluate its value
-    ExpandRecordedValue, // for the value the model already records for the read
-    ExpandReadIndex,     // for the read index
-    ExpandWriteIndex,    // for the index the write at this level stores at
-    ExpandWritten,       // ... for the value it stores, the index having hit
-    ExpandPushedIn       // for the read under everything the chain did not hit
+  ASTNode defaultCellValue(const ASTNode& arrayTerm) const
+  {
+    return owner.defaultCellValue(arrayTerm);
+  }
+
+  struct Frame
+  {
+    enum class FormulaPhase : uint8_t
+    {
+      Start,
+      AfterSymbolValue,
+      AfterArrayEqualityLowering,
+      AfterBoolExtractOperand,
+      AfterOperand,
+      AfterIteCondition,
+      AfterIteSelectedBranch,
+      AfterFpOperand,
+      AfterFpOperandStrict,
+      AfterFpRewrite,
+      AfterFpBlast
+    };
+
+    enum class TermPhase : uint8_t
+    {
+      Start,
+      PreparedRecordedValue,
+      AfterRecordedValue,
+      AfterEncodedValue,
+      AfterDefinition,
+      AfterCellIndex,
+      AfterCellValue,
+      AfterCellWriteIndex,
+      AfterCellWrittenValue,
+      AfterCellIteCondition,
+      AfterExpansion,
+      AfterExpandedValue,
+      AfterReadIteIndex,
+      AfterReadIteCondition,
+      AfterReadIteSelectedBranch,
+      AfterReadIndex,
+      AfterReadValue,
+      AfterIteCondition,
+      AfterIteSelectedBranch,
+      AfterOperand,
+      AfterOperandStrict
+    };
+
+    enum class ExpansionPhase : uint8_t
+    {
+      Start,
+      PreparedRecordedValue,
+      AfterRecordedValue,
+      AfterReadIndex,
+      AfterWriteIndex,
+      AfterWrittenValue,
+      AfterPushedRead
+    };
+
+    Job job;
+    union
+    {
+      FormulaPhase formulaPhase;
+      TermPhase termPhase;
+      ExpansionPhase expansionPhase;
+    };
+    ASTNode n;
+    bool ArrayReadFlag;
+
+    ASTVec parts; // operands evaluated so far
+    size_t i = 0; // the operand being worked on
+
+    // Locals that outlive one of their function's suspension points. Each is
+    // one role, under whichever of the three names its function gave it: the
+    // evaluated read index (`idxVal`, `indexVal`, `readIndex`), the array node
+    // a walk down a chain has reached (`level`, `write`), and the read
+    // renormalised over a constant index (`modelentry`).
+    ASTNode index;
+    ASTNode cursor;
+    ASTNode entry;
+
+    // Raised while an already-lowered float expression is evaluated and
+    // lowered when this frame is dropped, which is where the scope guard the
+    // recursive version held across the sub-evaluation used to end. Getting
+    // this wrong changes float model values rather than crashing.
+    ScopedFpEncodedEvaluation fpScope;
+
+    Frame(const ASTNode& node, const bool flag, const FormulaPhase phase)
+        : job(EvalFormula), formulaPhase(phase), n(node), ArrayReadFlag(flag)
+    {
+    }
+
+    Frame(const ASTNode& node, const bool flag, const TermPhase phase)
+        : job(EvalTerm), termPhase(phase), n(node), ArrayReadFlag(flag)
+    {
+    }
+
+    Frame(const ASTNode& node, const bool flag, const ExpansionPhase phase)
+        : job(EvalExpand), expansionPhase(phase), n(node), ArrayReadFlag(flag)
+    {
+    }
+
+    void resumeAt(const FormulaPhase phase)
+    {
+      assert(job == EvalFormula);
+      formulaPhase = phase;
+    }
+    void resumeAt(const TermPhase phase)
+    {
+      assert(job == EvalTerm);
+      termPhase = phase;
+    }
+    void resumeAt(const ExpansionPhase phase)
+    {
+      assert(job == EvalExpand);
+      expansionPhase = phase;
+    }
   };
 
-  Job job;
-  Phase phase = Start;
-  ASTNode n;
-  bool ArrayReadFlag;
+  // ComputeFormulaUsingModel, TermToConstTermUsingModel and
+  // Expand_ReadOverWrite_UsingModel, walked together with their frames on the
+  // heap. Everything the three did is here in the order they did it: the same
+  // map reads and writes, the same node-factory calls, the same asserts, and
+  // the same decisions about which operand is evaluated at all.
+  //
+  // That last one is why this is a state machine rather than a priming pass.
+  // Three arms evaluate an if-then-else's condition and then only the branch it
+  // leaves alive, and a dropped branch here is not merely wasted work: it can
+  // be genuinely unevaluable against the model, and all three call FatalError
+  // when it is.
+  //
+  // Two things a reader should check for, because both change the model
+  // silently rather than crashing. The map writes are not uniform -- a term's
+  // value is recorded by the tail its arm reaches, and five of the arms return
+  // before that tail, three of them writing the map themselves on the way past.
+  // And a term's answer is put into the plain bit-vector spelling once per
+  // frame, where the wrapper around the old recursive evaluator did it once per
+  // call.
+  static_assert(sizeof(Frame) <= 88,
+                "counterexample continuation frame unexpectedly grew");
 
-  ASTVec parts; // operands evaluated so far
-  size_t i = 0; // the operand being worked on
-
-  // Locals that outlive one of their function's suspension points. Each is
-  // one role, under whichever of the three names its function gave it: the
-  // evaluated read index (`idxVal`, `indexVal`, `readIndex`), the array node
-  // a walk down a chain has reached (`level`, `write`), and the read
-  // renormalised over a constant index (`modelentry`).
-  ASTNode index;
-  ASTNode cursor;
-  ASTNode entry;
-
-  // Raised while an already-lowered float expression is evaluated and
-  // lowered when this frame is dropped, which is where the scope guard the
-  // recursive version held across the sub-evaluation used to end. Getting
-  // this wrong changes float model values rather than crashing.
-  ScopedFpEncodedEvaluation fpScope;
-
-  Frame(Job j, const ASTNode& node, bool flag)
-      : job(j), n(node), ArrayReadFlag(flag)
-  {
-  }
-};
-
-// ComputeFormulaUsingModel, TermToConstTermUsingModel and
-// Expand_ReadOverWrite_UsingModel, walked together with their frames on the
-// heap. Everything the three did is here in the order they did it: the same
-// map reads and writes, the same node-factory calls, the same asserts, and
-// the same decisions about which operand is evaluated at all.
-//
-// That last one is why this is a state machine rather than a priming pass.
-// Three arms evaluate an if-then-else's condition and then only the branch it
-// leaves alive, and a dropped branch here is not merely wasted work: it can
-// be genuinely unevaluable against the model, and all three call FatalError
-// when it is.
-//
-// Two things a reader should check for, because both change the model
-// silently rather than crashing. The map writes are not uniform -- a term's
-// value is recorded by the tail its arm reaches, and five of the arms return
-// before that tail, three of them writing the map themselves on the way past.
-// And a term's answer is put into the plain bit-vector spelling once per
-// frame, where the wrapper around the old recursive evaluator did it once per
-// call.
-ASTNode AbsRefine_CounterExample::evaluate(const Job job, const ASTNode& top,
-                                           const bool topArrayReadFlag)
-{
   // The value the frame that finished last returned, which is what the frame
   // below it resumes with.
   ASTNode result;
+  std::vector<Frame> stack;
+
+  enum class StepResult
+  {
+    Finished,
+    Pushed,
+    Redispatch
+  };
 
   // Run the non-recursive head of one of the three former functions. An
   // immediate answer lands in `result` and needs no frame. Otherwise `frame`
   // carries everything learned by the head into the walk below it, so a memo
   // miss is never probed for a second time when the frame starts.
-  auto prepare = [&](const Job j, const ASTNode& n, Frame& frame) -> bool
+  bool prepare(const Job j, const ASTNode& n, Frame& frame)
   {
     assert(frame.job == j && frame.n == n);
     if (j == EvalFormula)
@@ -485,7 +558,7 @@ ASTNode AbsRefine_CounterExample::evaluate(const Job job, const ASTNode& top,
         }
 
         frame.entry = it->second;
-        frame.phase = Frame::TermRecordedValueStart;
+        frame.termPhase = Frame::TermPhase::PreparedRecordedValue;
         return true;
       }
 
@@ -514,56 +587,66 @@ ASTNode AbsRefine_CounterExample::evaluate(const Job job, const ASTNode& top,
       }
 
       frame.entry = it->second;
-      frame.phase = Frame::ExpandRecordedValueStart;
+      frame.expansionPhase = Frame::ExpansionPhase::PreparedRecordedValue;
       return true;
     }
 
     return true;
-  };
-
-  Frame first(job, top, topArrayReadFlag);
-  if (!prepare(job, top, first))
-    return result;
-
-  // Most model expressions are shallow. Keep their frontier contiguous and
-  // preallocate the common case; a push may move the current frame, so every
-  // step returns immediately after one.
-  std::vector<Frame> stack;
-  stack.reserve(8);
-  stack.push_back(std::move(first));
-
-  enum class StepResult
-  {
-    Finished,
-    Pushed,
-    Redispatch
-  };
+  }
 
   // Ask for the value of `n`, and suspend this frame until it is known: it
   // picks up at `resume` with the answer in `result`. An immediate head answer
   // is redispatched within the same job; only a real child reaches the outer
   // worklist loop.
-  auto want = [&](Frame& f, const Frame::Phase resume, const Job j,
-                  const ASTNode& n,
-                  const bool flag = true) -> StepResult {
-    f.phase = resume;
-    Frame below(j, n, flag);
-    if (!prepare(j, n, below))
+  template <typename ResumePhase>
+  StepResult requestFormula(Frame& f, const ResumePhase resume,
+                            const ASTNode& n, const bool flag = true)
+  {
+    f.resumeAt(resume);
+    Frame below(n, flag, Frame::FormulaPhase::Start);
+    if (!prepare(EvalFormula, n, below))
       return StepResult::Redispatch;
     stack.push_back(std::move(below));
     return StepResult::Pushed;
-  };
+  }
+
+  template <typename ResumePhase>
+  StepResult requestTerm(Frame& f, const ResumePhase resume, const ASTNode& n,
+                         const bool flag = true)
+  {
+    f.resumeAt(resume);
+    Frame below(n, flag, Frame::TermPhase::Start);
+    if (!prepare(EvalTerm, n, below))
+      return StepResult::Redispatch;
+    stack.push_back(std::move(below));
+    return StepResult::Pushed;
+  }
+
+  template <typename ResumePhase>
+  StepResult requestExpansion(Frame& f, const ResumePhase resume,
+                              const ASTNode& n, const bool flag = true)
+  {
+    f.resumeAt(resume);
+    Frame below(n, flag, Frame::ExpansionPhase::Start);
+    if (!prepare(EvalExpand, n, below))
+      return StepResult::Redispatch;
+    stack.push_back(std::move(below));
+    return StepResult::Pushed;
+  }
 
   /* One step of ComputeFormulaUsingModel, which accepts a non-constant
    * formula and checks if the formula is ASTTrue or ASTFalse w.r.t to a
    * model.
    */
-  auto stepFormula = [&](Frame& f) -> StepResult {
+  StepResult stepFormula(Frame& f)
+  {
+    assert(f.job == EvalFormula);
     const ASTNode& form = f.n;
     const Kind k = form.GetKind();
 
     // The tail every path but the memo hit shares.
-    auto finish = [&](const ASTNode& output) {
+    auto finish = [&](const ASTNode& output)
+    {
       assert(ASTUndefined != output);
       assert(output.isConstant());
       ComputeFormulaMap[form] = output;
@@ -588,7 +671,7 @@ ASTNode AbsRefine_CounterExample::evaluate(const Job job, const ASTNode& top,
         return finish(form);
       case SYMBOL:
       {
-        if (f.phase == Frame::FormSymbolValue)
+        if (f.formulaPhase == Frame::FormulaPhase::AfterSymbolValue)
           return finish(result);
 
         if (BOOLEAN_TYPE != form.GetType())
@@ -601,8 +684,8 @@ ASTNode AbsRefine_CounterExample::evaluate(const Job job, const ASTNode& top,
         {
           const ASTNode counterexample_val = recorded->second;
           if (!bm->VarSeenInTerm(form, counterexample_val))
-            return want(f, Frame::FormSymbolValue, EvalFormula,
-                        counterexample_val);
+            return requestFormula(f, Frame::FormulaPhase::AfterSymbolValue,
+                                  counterexample_val);
           return finish(counterexample_val);
         }
         // Has been simplified out. Can take any value.
@@ -610,7 +693,7 @@ ASTNode AbsRefine_CounterExample::evaluate(const Job job, const ASTNode& top,
       }
       case ARRAY_EQ:
       {
-        if (f.phase == Frame::FormArrayEqLowered)
+        if (f.formulaPhase == Frame::FormulaPhase::AfterArrayEqualityLowering)
           return finish(result);
 
         ExtensionalityContext* ext = bm->getExtensionalityIfAny();
@@ -618,7 +701,8 @@ ASTNode AbsRefine_CounterExample::evaluate(const Job job, const ASTNode& top,
         if (ext != NULL && ext->getCurrentLowering(form, lowered))
         {
           // This solve decided the equality; its lowering is the answer.
-          return want(f, Frame::FormArrayEqLowered, EvalFormula, lowered);
+          return requestFormula(
+              f, Frame::FormulaPhase::AfterArrayEqualityLowering, lowered);
         }
 
         // It did not: either the equality belongs to an earlier query,
@@ -644,12 +728,12 @@ ASTNode AbsRefine_CounterExample::evaluate(const Job job, const ASTNode& top,
       }
       case BOOLEXTRACT:
       {
-        if (f.phase == Frame::Start)
-          return want(f, Frame::FormBoolExtract, EvalTerm, form[0]);
+        if (f.formulaPhase == Frame::FormulaPhase::Start)
+          return requestTerm(f, Frame::FormulaPhase::AfterBoolExtractOperand,
+                             form[0]);
 
-        return finish(
-            simp->BVConstEvaluator(bm->CreateNode(BOOLEXTRACT, result,
-                                                  form[1])));
+        return finish(simp->BVConstEvaluator(
+            bm->CreateNode(BOOLEXTRACT, result, form[1])));
       }
       case EQ:
       case BVLT:
@@ -667,13 +751,14 @@ ASTNode AbsRefine_CounterExample::evaluate(const Job job, const ASTNode& top,
       case BVUSUBO:
       case BVSSUBO:
       {
-        if (f.phase == Frame::FormOperand)
+        if (f.formulaPhase == Frame::FormulaPhase::AfterOperand)
           f.parts.push_back(result);
         else
           f.parts.reserve(form.Degree());
 
         if (f.i < form.Degree())
-          return want(f, Frame::FormOperand, EvalTerm, form[f.i++], false);
+          return requestTerm(f, Frame::FormulaPhase::AfterOperand, form[f.i++],
+                             false);
 
         return finish(
             NonMemberBVConstEvaluator(bm, k, f.parts, form.GetValueWidth()));
@@ -688,13 +773,14 @@ ASTNode AbsRefine_CounterExample::evaluate(const Job job, const ASTNode& top,
       case IMPLIES:
       case OR:
       {
-        if (f.phase == Frame::FormOperand)
+        if (f.formulaPhase == Frame::FormulaPhase::AfterOperand)
           f.parts.push_back(result);
         else
           f.parts.reserve(form.Degree());
 
         if (f.i < form.Degree())
-          return want(f, Frame::FormOperand, EvalFormula, form[f.i++]);
+          return requestFormula(f, Frame::FormulaPhase::AfterOperand,
+                                form[f.i++]);
 
         return finish(
             NonMemberBVConstEvaluator(bm, k, f.parts, form.GetValueWidth()));
@@ -702,15 +788,18 @@ ASTNode AbsRefine_CounterExample::evaluate(const Job job, const ASTNode& top,
 
       case ITE:
       {
-        if (f.phase == Frame::Start)
-          return want(f, Frame::FormIteCond, EvalFormula, form[0]);
+        if (f.formulaPhase == Frame::FormulaPhase::Start)
+          return requestFormula(f, Frame::FormulaPhase::AfterIteCondition,
+                                form[0]);
 
-        if (f.phase == Frame::FormIteCond)
+        if (f.formulaPhase == Frame::FormulaPhase::AfterIteCondition)
         {
           if (ASTTrue == result)
-            return want(f, Frame::FormIteBranch, EvalFormula, form[1]);
+            return requestFormula(
+                f, Frame::FormulaPhase::AfterIteSelectedBranch, form[1]);
           else if (ASTFalse == result)
-            return want(f, Frame::FormIteBranch, EvalFormula, form[2]);
+            return requestFormula(
+                f, Frame::FormulaPhase::AfterIteSelectedBranch, form[2]);
           else
             FatalError("ComputeFormulaUsingModel: ITE: "
                        "something is wrong with the formula: ",
@@ -733,8 +822,8 @@ ASTNode AbsRefine_CounterExample::evaluate(const Job job, const ASTNode& top,
       case FP_ISPOSITIVE:
       case FP_SMT_EQ:
       {
-        if (f.phase == Frame::FormFpRewritten ||
-            f.phase == Frame::FormFpBlasted)
+        if (f.formulaPhase == Frame::FormulaPhase::AfterFpRewrite ||
+            f.formulaPhase == Frame::FormulaPhase::AfterFpBlast)
           return finish(result);
 
         // An operand must resolve to a constant, as in the float arm of
@@ -745,12 +834,13 @@ ASTNode AbsRefine_CounterExample::evaluate(const Job job, const ASTNode& top,
         // blaster would carry the read along, and the same-operand folds
         // below can hand the bare READ back. The read is genuinely
         // unconstrained here, so resolve it to a concrete value.
-        if (f.phase == Frame::FormFpOperand && BVCONST != result.GetKind())
-          return want(f, Frame::FormFpOperandStrict, EvalTerm, form[f.i],
-                      false);
+        if (f.formulaPhase == Frame::FormulaPhase::AfterFpOperand &&
+            BVCONST != result.GetKind())
+          return requestTerm(f, Frame::FormulaPhase::AfterFpOperandStrict,
+                             form[f.i], false);
 
-        if (f.phase == Frame::FormFpOperand ||
-            f.phase == Frame::FormFpOperandStrict)
+        if (f.formulaPhase == Frame::FormulaPhase::AfterFpOperand ||
+            f.formulaPhase == Frame::FormulaPhase::AfterFpOperandStrict)
         {
           assert(result.GetKind() == BVCONST);
           f.parts.push_back(FloatBlaster::withFormat(
@@ -765,7 +855,7 @@ ASTNode AbsRefine_CounterExample::evaluate(const Job job, const ASTNode& top,
         }
 
         if (f.i < form.Degree())
-          return want(f, Frame::FormFpOperand, EvalTerm, form[f.i]);
+          return requestTerm(f, Frame::FormulaPhase::AfterFpOperand, form[f.i]);
 
         ASTNode temp(bm->CreateNode(k, f.parts));
 
@@ -776,7 +866,7 @@ ASTNode AbsRefine_CounterExample::evaluate(const Job job, const ASTNode& top,
         // (not (fp.isNaN ...)). Whatever came back that is not this operation
         // is a formula; evaluate it, never blast it.
         if (temp.GetKind() != k)
-          return want(f, Frame::FormFpRewritten, EvalFormula, temp);
+          return requestFormula(f, Frame::FormulaPhase::AfterFpRewrite, temp);
 
         // One table, the same one the solver's lowering pass uses. temp's
         // operands were re-stamped with their formats above, so it is a
@@ -786,7 +876,7 @@ ASTNode AbsRefine_CounterExample::evaluate(const Job job, const ASTNode& top,
         assert(blasted != temp);
         assert(blasted != form);
 
-        return want(f, Frame::FormFpBlasted, EvalFormula, blasted);
+        return requestFormula(f, Frame::FormulaPhase::AfterFpBlast, blasted);
       }
       default:
         cerr << _kind_names[k];
@@ -794,19 +884,22 @@ ASTNode AbsRefine_CounterExample::evaluate(const Job job, const ASTNode& top,
                    "the kind has not been implemented",
                    ASTUndefined);
     }
-  };
+  }
 
   /* One step of TermToConstTermUsingModel, which accepts a non-constant term
    * and returns the corresponding constant term with respect to a model.
    */
-  auto stepTerm = [&](Frame& f) -> StepResult {
+  StepResult stepTerm(Frame& f)
+  {
+    assert(f.job == EvalTerm);
     const ASTNode& term = f.n;
     const Kind k = term.GetKind();
     const bool ArrayReadFlag = f.ArrayReadFlag;
 
     // The tail the arms that run to their end share. Five arms return before
     // reaching it, and three of those record the term's value themselves.
-    auto finish = [&](const ASTNode& output) {
+    auto finish = [&](const ASTNode& output)
+    {
       assert(ArrayReadFlag || (BVCONST == output.GetKind()));
 
       // when this flag is false, we should compute the arrayread to a
@@ -832,11 +925,12 @@ ASTNode AbsRefine_CounterExample::evaluate(const Job job, const ASTNode& top,
       return StepResult::Finished;
     };
 
-    if (f.phase == Frame::TermRecordedValueStart)
-      return want(f, Frame::TermRecordedValue, EvalTerm, f.entry,
-                  ArrayReadFlag);
+    if (f.termPhase == Frame::TermPhase::PreparedRecordedValue)
+      return requestTerm(f, Frame::TermPhase::AfterRecordedValue, f.entry,
+                         ArrayReadFlag);
 
-    if (f.phase == Frame::Start && fpEncodedEvaluationDepth == 0 &&
+    if (f.termPhase == Frame::TermPhase::Start &&
+        fpEncodedEvaluationDepth == 0 &&
         (is_FP_kind(k) || isFpIndexedArrayAccess(term)))
     {
       // FP source operations are evaluated through the solve-owned lowering
@@ -867,16 +961,17 @@ ASTNode AbsRefine_CounterExample::evaluate(const Job job, const ASTNode& top,
         // when this frame is dropped, which is where the guard the recursive
         // version held across the call to itself ended.
         f.fpScope.activate(fpEncodedEvaluationDepth);
-        return want(f, Frame::TermEncoded, EvalTerm, encoded, ArrayReadFlag);
+        return requestTerm(f, Frame::TermPhase::AfterEncodedValue, encoded,
+                           ArrayReadFlag);
       }
     }
 
     // The value the model already records for this term is the answer, and
     // the map already holds it.
-    if (f.phase == Frame::TermRecordedValue)
+    if (f.termPhase == Frame::TermPhase::AfterRecordedValue)
       return StepResult::Finished;
 
-    if (f.phase == Frame::TermEncoded)
+    if (f.termPhase == Frame::TermPhase::AfterEncodedValue)
     {
       const ASTNode value = result;
       if (term != value)
@@ -885,7 +980,7 @@ ASTNode AbsRefine_CounterExample::evaluate(const Job job, const ASTNode& top,
       return StepResult::Finished;
     }
 
-    if (f.phase == Frame::TermDefinition)
+    if (f.termPhase == Frame::TermPhase::AfterDefinition)
       return StepResult::Finished;
 
     switch (k)
@@ -902,10 +997,10 @@ ASTNode AbsRefine_CounterExample::evaluate(const Job job, const ASTNode& top,
         // Has been simplified out and can take any value. A RoundingMode's
         // 5-bit representation has 27 junk patterns, though, so complete that
         // sort with a real value rather than the ordinary all-zero default.
-        return finish(bm->isRoundingModeSortedTerm(term)
-                          ? bm->CreateBVConst(
-                                5, symbolic_fp::ROUND_NEAREST_TIES_TO_EVEN)
-                          : bm->CreateZeroConst(term.GetValueWidth()));
+        return finish(
+            bm->isRoundingModeSortedTerm(term)
+                ? bm->CreateBVConst(5, symbolic_fp::ROUND_NEAREST_TIES_TO_EVEN)
+                : bm->CreateZeroConst(term.GetValueWidth()));
       }
       case READ:
       {
@@ -915,7 +1010,7 @@ ASTNode AbsRefine_CounterExample::evaluate(const Job job, const ASTNode& top,
         // Which of the four shapes of read this frame is walking is settled
         // when it starts, and its phase says which from then on -- so each
         // gate below is asked exactly once, as it was.
-        if (f.phase == Frame::Start)
+        if (f.termPhase == Frame::TermPhase::Start)
         {
           if (0 == arrName.GetIndexWidth())
           {
@@ -937,10 +1032,10 @@ ASTNode AbsRefine_CounterExample::evaluate(const Job job, const ASTNode& top,
                 ARRAY_TYPE == sub->second.GetType())
             {
               const ASTNode definition = sub->second;
-              const ASTNode throughDefinition = bm->CreateTerm(
-                  READ, term.GetValueWidth(), definition, index);
-              return want(f, Frame::TermDefinition, EvalTerm,
-                          throughDefinition, ArrayReadFlag);
+              const ASTNode throughDefinition =
+                  bm->CreateTerm(READ, term.GetValueWidth(), definition, index);
+              return requestTerm(f, Frame::TermPhase::AfterDefinition,
+                                 throughDefinition, ArrayReadFlag);
             }
           }
 
@@ -962,15 +1057,16 @@ ASTNode AbsRefine_CounterExample::evaluate(const Job job, const ASTNode& top,
           ExtensionalityContext* ext = bm->getExtensionalityIfAny();
           if (ext != NULL && ext->active() && ext->arrayGraphFrozen() &&
               ext->ownsArray(arrName))
-            return want(f, Frame::TermCellIndex, EvalTerm, index, false);
+            return requestTerm(f, Frame::TermPhase::AfterCellIndex, index,
+                               false);
 
           if (WRITE == arrName.GetKind()) // READ over a WRITE
-            return want(f, Frame::TermExpand, EvalExpand, term,
-                        ArrayReadFlag);
+            return requestExpansion(f, Frame::TermPhase::AfterExpansion, term,
+                                    ArrayReadFlag);
 
           if (ITE == arrName.GetKind()) // READ over an ITE
-            return want(f, Frame::TermReadIteIndex, EvalTerm, index,
-                        ArrayReadFlag);
+            return requestTerm(f, Frame::TermPhase::AfterReadIteIndex, index,
+                               ArrayReadFlag);
 
           const ASTNodeMap::const_iterator recorded =
               CounterExampleMap.find(index);
@@ -979,39 +1075,39 @@ ASTNode AbsRefine_CounterExample::evaluate(const Job job, const ASTNode& top,
             // Copy out of the map before the nested evaluation, which may
             // restore the map by whole-map assignment.
             const ASTNode indexEntry = recorded->second;
-            return want(f, Frame::TermReadIndex, EvalTerm, indexEntry,
-                        ArrayReadFlag);
+            return requestTerm(f, Frame::TermPhase::AfterReadIndex, indexEntry,
+                               ArrayReadFlag);
           }
           // index does not have a const value in the
           // CounterExampleMap. compute it.
-          return want(f, Frame::TermReadIndex, EvalTerm, index,
-                      ArrayReadFlag);
+          return requestTerm(f, Frame::TermPhase::AfterReadIndex, index,
+                             ArrayReadFlag);
         }
 
         // The walk down an owned array for the cell the model gives it. Every
         // turn of it but the last suspends, so what was a loop is the
         // sequence of resumes into the turn below.
-        if (f.phase == Frame::TermCellValue ||
-            f.phase == Frame::TermCellWritten)
+        if (f.termPhase == Frame::TermPhase::AfterCellValue ||
+            f.termPhase == Frame::TermPhase::AfterCellWrittenValue)
         {
           CounterExampleMap[term] = result;
           return StepResult::Finished;
         }
 
-        if (f.phase == Frame::TermCellIndex ||
-            f.phase == Frame::TermCellWriteIndex ||
-            f.phase == Frame::TermCellIteCond)
+        if (f.termPhase == Frame::TermPhase::AfterCellIndex ||
+            f.termPhase == Frame::TermPhase::AfterCellWriteIndex ||
+            f.termPhase == Frame::TermPhase::AfterCellIteCondition)
         {
-          if (f.phase == Frame::TermCellIndex)
+          if (f.termPhase == Frame::TermPhase::AfterCellIndex)
           {
             f.index = result;
             f.cursor = arrName;
           }
-          else if (f.phase == Frame::TermCellWriteIndex)
+          else if (f.termPhase == Frame::TermPhase::AfterCellWriteIndex)
           {
             if (result == f.index)
-              return want(f, Frame::TermCellWritten, EvalTerm, f.cursor[2],
-                          false);
+              return requestTerm(f, Frame::TermPhase::AfterCellWrittenValue,
+                                 f.cursor[2], false);
             f.cursor = f.cursor[0];
           }
           else
@@ -1027,23 +1123,25 @@ ASTNode AbsRefine_CounterExample::evaluate(const Job job, const ASTNode& top,
           }
 
           NodeFactory* hf = bm->hashingNodeFactory;
-          const ASTNode key = hf->CreateTerm(READ, f.cursor.GetValueWidth(),
-                                             f.cursor, f.index);
+          const ASTNode key =
+              hf->CreateTerm(READ, f.cursor.GetValueWidth(), f.cursor, f.index);
           ASTNodeMap::const_iterator cit = CounterExampleMap.find(key);
           if (cit != CounterExampleMap.end())
           {
             const ASTNode val = cit->second;
             if (BVCONST != val.GetKind())
-              return want(f, Frame::TermCellValue, EvalTerm, val, false);
+              return requestTerm(f, Frame::TermPhase::AfterCellValue, val,
+                                 false);
             CounterExampleMap[term] = val;
             result = val;
             return StepResult::Finished;
           }
           if (WRITE == f.cursor.GetKind())
-            return want(f, Frame::TermCellWriteIndex, EvalTerm, f.cursor[1],
-                        false);
+            return requestTerm(f, Frame::TermPhase::AfterCellWriteIndex,
+                               f.cursor[1], false);
           if (ITE == f.cursor.GetKind() && f.cursor.GetType() == ARRAY_TYPE)
-            return want(f, Frame::TermCellIteCond, EvalFormula, f.cursor[0]);
+            return requestFormula(f, Frame::TermPhase::AfterCellIteCondition,
+                                  f.cursor[0]);
 
           // base array with no observation
           const ASTNode val = defaultCellValue(f.cursor);
@@ -1052,7 +1150,7 @@ ASTNode AbsRefine_CounterExample::evaluate(const Job job, const ASTNode& top,
           return StepResult::Finished;
         }
 
-        if (f.phase == Frame::TermExpand)
+        if (f.termPhase == Frame::TermPhase::AfterExpansion)
         {
           if (result == term)
           {
@@ -1061,35 +1159,36 @@ ASTNode AbsRefine_CounterExample::evaluate(const Job job, const ASTNode& top,
                        "into an ITE",
                        term);
           }
-          return want(f, Frame::TermExpanded, EvalTerm, result,
-                      ArrayReadFlag);
+          return requestTerm(f, Frame::TermPhase::AfterExpandedValue, result,
+                             ArrayReadFlag);
         }
 
-        if (f.phase == Frame::TermExpanded)
+        if (f.termPhase == Frame::TermPhase::AfterExpandedValue)
         {
           assert(ArrayReadFlag || (BVCONST == result.GetKind()));
           return StepResult::Finished;
         }
 
-        if (f.phase == Frame::TermReadIteIndex)
+        if (f.termPhase == Frame::TermPhase::AfterReadIteIndex)
         {
           // The "then" and "else" branch are arrays.
           f.index = result;
           // Get the truth value.
-          return want(f, Frame::TermReadIteCond, EvalFormula, arrName[0]);
+          return requestFormula(f, Frame::TermPhase::AfterReadIteCondition,
+                                arrName[0]);
         }
 
-        if (f.phase == Frame::TermReadIteCond)
+        if (f.termPhase == Frame::TermPhase::AfterReadIteCondition)
         {
           const unsigned int wid = arrName.GetValueWidth();
           if (ASTTrue == result)
-            return want(f, Frame::TermReadIteBranch, EvalTerm,
-                        bm->CreateTerm(READ, wid, arrName[1], f.index),
-                        ArrayReadFlag);
+            return requestTerm(f, Frame::TermPhase::AfterReadIteSelectedBranch,
+                               bm->CreateTerm(READ, wid, arrName[1], f.index),
+                               ArrayReadFlag);
           else if (ASTFalse == result)
-            return want(f, Frame::TermReadIteBranch, EvalTerm,
-                        bm->CreateTerm(READ, wid, arrName[2], f.index),
-                        ArrayReadFlag);
+            return requestTerm(f, Frame::TermPhase::AfterReadIteSelectedBranch,
+                               bm->CreateTerm(READ, wid, arrName[2], f.index),
+                               ArrayReadFlag);
           else
           {
             FatalError(" TermToConstTermUsingModel: termITE: "
@@ -1098,13 +1197,13 @@ ASTNode AbsRefine_CounterExample::evaluate(const Job job, const ASTNode& top,
           }
         }
 
-        if (f.phase == Frame::TermReadIteBranch)
+        if (f.termPhase == Frame::TermPhase::AfterReadIteSelectedBranch)
         {
           assert(ArrayReadFlag || (BVCONST == result.GetKind()));
           return StepResult::Finished;
         }
 
-        if (f.phase == Frame::TermReadIndex)
+        if (f.termPhase == Frame::TermPhase::AfterReadIndex)
         {
           f.entry =
               bm->CreateTerm(READ, arrName.GetValueWidth(), arrName, result);
@@ -1117,8 +1216,8 @@ ASTNode AbsRefine_CounterExample::evaluate(const Job job, const ASTNode& top,
           if (recorded != CounterExampleMap.end())
           {
             const ASTNode modelentryValue = recorded->second;
-            return want(f, Frame::TermReadValue, EvalTerm, modelentryValue,
-                        ArrayReadFlag);
+            return requestTerm(f, Frame::TermPhase::AfterReadValue,
+                               modelentryValue, ArrayReadFlag);
           }
 
           if (ArrayReadFlag)
@@ -1166,21 +1265,22 @@ ASTNode AbsRefine_CounterExample::evaluate(const Job job, const ASTNode& top,
                             : bm->CreateMaxConst(f.entry.GetValueWidth()));
         }
 
-        return finish(result); // Frame::TermReadValue
+        return finish(result); // Frame::TermPhase::AfterReadValue
       }
       case ITE:
       {
-        if (f.phase == Frame::Start)
-          return want(f, Frame::TermIteCond, EvalFormula, term[0]);
+        if (f.termPhase == Frame::TermPhase::Start)
+          return requestFormula(f, Frame::TermPhase::AfterIteCondition,
+                                term[0]);
 
-        if (f.phase == Frame::TermIteCond)
+        if (f.termPhase == Frame::TermPhase::AfterIteCondition)
         {
           if (ASTTrue == result)
-            return want(f, Frame::TermIteBranch, EvalTerm, term[1],
-                        ArrayReadFlag);
+            return requestTerm(f, Frame::TermPhase::AfterIteSelectedBranch,
+                               term[1], ArrayReadFlag);
           else if (ASTFalse == result)
-            return want(f, Frame::TermIteBranch, EvalTerm, term[2],
-                        ArrayReadFlag);
+            return requestTerm(f, Frame::TermPhase::AfterIteSelectedBranch,
+                               term[2], ArrayReadFlag);
           else
           {
             FatalError(" TermToConstTermUsingModel: termITE: cannot "
@@ -1203,12 +1303,13 @@ ASTNode AbsRefine_CounterExample::evaluate(const Job job, const ASTNode& top,
         // to a concrete constant rather than hand a non-constant to the
         // evaluator (which cannot read arrays and would abort on the array
         // symbol).
-        if (f.phase == Frame::TermOperand && BVCONST != result.GetKind())
-          return want(f, Frame::TermOperandStrict, EvalTerm, term[f.i],
-                      false);
+        if (f.termPhase == Frame::TermPhase::AfterOperand &&
+            BVCONST != result.GetKind())
+          return requestTerm(f, Frame::TermPhase::AfterOperandStrict, term[f.i],
+                             false);
 
-        if (f.phase == Frame::TermOperand ||
-            f.phase == Frame::TermOperandStrict)
+        if (f.termPhase == Frame::TermPhase::AfterOperand ||
+            f.termPhase == Frame::TermPhase::AfterOperandStrict)
         {
           ASTNode ff = result;
           // A floating-point operand comes back as a bare bit-vector:
@@ -1229,114 +1330,172 @@ ASTNode AbsRefine_CounterExample::evaluate(const Job job, const ASTNode& top,
           f.parts.reserve(term.Degree());
 
         if (f.i < term.Degree())
-          return want(f, Frame::TermOperand, EvalTerm, term[f.i],
-                      ArrayReadFlag);
+          return requestTerm(f, Frame::TermPhase::AfterOperand, term[f.i],
+                             ArrayReadFlag);
 
         return finish(
             NonMemberBVConstEvaluator(bm, k, f.parts, term.GetValueWidth()));
       }
     }
-  };
+  }
 
   // One step of Expand_ReadOverWrite_UsingModel, which expands
   // read-over-write by evaluating (readIndex=writeIndex) for every writeindex
   // until, either it evaluates to TRUE or all (readIndex=writeIndex) evaluate
   // to FALSE.
-  auto stepExpand = [&](Frame& f) -> StepResult {
+  StepResult stepExpand(Frame& f)
+  {
+    assert(f.job == EvalExpand);
     const ASTNode& term = f.n;
     const bool arrayread_flag = f.ArrayReadFlag;
 
     // memoize
-    auto finish = [&](const ASTNode& output) {
+    auto finish = [&](const ASTNode& output)
+    {
       CounterExampleMap[term] = output;
       result = output;
       return StepResult::Finished;
     };
 
-    if (f.phase == Frame::ExpandRecordedValueStart)
-      return want(f, Frame::ExpandRecordedValue, EvalTerm, f.entry,
-                  arrayread_flag);
+    if (f.expansionPhase == Frame::ExpansionPhase::PreparedRecordedValue)
+      return requestTerm(f, Frame::ExpansionPhase::AfterRecordedValue, f.entry,
+                         arrayread_flag);
 
-    if (f.phase == Frame::Start)
-      return want(f, Frame::ExpandReadIndex, EvalTerm, term[1], false);
+    if (f.expansionPhase == Frame::ExpansionPhase::Start)
+      return requestTerm(f, Frame::ExpansionPhase::AfterReadIndex, term[1],
+                         false);
 
     // The value the model already records for this read is the answer, and
     // the map already holds it.
-    if (f.phase == Frame::ExpandRecordedValue)
+    if (f.expansionPhase == Frame::ExpansionPhase::AfterRecordedValue)
       return StepResult::Finished;
 
-    if (f.phase == Frame::ExpandWritten || f.phase == Frame::ExpandPushedIn)
+    if (f.expansionPhase == Frame::ExpansionPhase::AfterWrittenValue ||
+        f.expansionPhase == Frame::ExpansionPhase::AfterPushedRead)
       return finish(result);
 
     // iteratively expand read-over-write, and evaluate against the
     // model at every iteration
-    if (f.phase == Frame::ExpandReadIndex)
+    if (f.expansionPhase == Frame::ExpansionPhase::AfterReadIndex)
     {
       f.index = result;
       f.cursor = term[0];
     }
-    else // Frame::ExpandWriteIndex
+    else // Frame::ExpansionPhase::AfterWriteIndex
     {
       if (result == f.index)
       {
         // found the write-value. return it
-        return want(f, Frame::ExpandWritten, EvalTerm, f.cursor[2], false);
+        return requestTerm(f, Frame::ExpansionPhase::AfterWrittenValue,
+                           f.cursor[2], false);
       }
 
       f.cursor = f.cursor[0];
       if (WRITE != f.cursor.GetKind())
       {
         const unsigned int width = term.GetValueWidth();
-        return want(f, Frame::ExpandPushedIn, EvalTerm,
-                    bm->CreateTerm(READ, width, f.cursor, f.index),
-                    arrayread_flag);
+        return requestTerm(f, Frame::ExpansionPhase::AfterPushedRead,
+                           bm->CreateTerm(READ, width, f.cursor, f.index),
+                           arrayread_flag);
       }
     }
 
-    return want(f, Frame::ExpandWriteIndex, EvalTerm, f.cursor[1], false);
-  };
+    return requestTerm(f, Frame::ExpansionPhase::AfterWriteIndex, f.cursor[1],
+                       false);
+  }
 
-  while (true)
+public:
+  explicit EvaluationDriver(AbsRefine_CounterExample& owner)
+      : owner(owner), ASTTrue(owner.ASTTrue), ASTFalse(owner.ASTFalse),
+        ASTUndefined(owner.ASTUndefined),
+        CounterExampleMap(owner.CounterExampleMap),
+        ComputeFormulaMap(owner.ComputeFormulaMap), bm(owner.bm),
+        simp(owner.simp),
+        fpEncodedEvaluationDepth(owner.fpEncodedEvaluationDepth)
   {
-    Frame& current = stack.back();
+  }
 
-    StepResult stepResult = StepResult::Finished;
-    switch (current.job)
+  ASTNode run(const Job job, const ASTNode& top, const bool topArrayReadFlag)
+  {
+    result = ASTNode();
+    stack.clear();
+
+    // Most model expressions are shallow. Keep their frontier contiguous and
+    // preallocate the common case; a request may move the current frame, so
+    // every step returns immediately after one.
+    if (job == EvalFormula)
     {
-      case EvalFormula:
-        do
-          stepResult = stepFormula(current);
-        while (stepResult == StepResult::Redispatch);
-        break;
-      case EvalTerm:
-        do
-          stepResult = stepTerm(current);
-        while (stepResult == StepResult::Redispatch);
-        break;
-      case EvalExpand:
-        do
-          stepResult = stepExpand(current);
-        while (stepResult == StepResult::Redispatch);
-        break;
+      Frame first(top, topArrayReadFlag, Frame::FormulaPhase::Start);
+      if (!prepare(EvalFormula, top, first))
+        return result;
+      stack.reserve(8);
+      stack.push_back(std::move(first));
+    }
+    else if (job == EvalTerm)
+    {
+      Frame first(top, topArrayReadFlag, Frame::TermPhase::Start);
+      if (!prepare(EvalTerm, top, first))
+        return result;
+      stack.reserve(8);
+      stack.push_back(std::move(first));
+    }
+    else
+    {
+      Frame first(top, topArrayReadFlag, Frame::ExpansionPhase::Start);
+      if (!prepare(EvalExpand, top, first))
+        return result;
+      stack.reserve(8);
+      stack.push_back(std::move(first));
     }
 
-    if (stepResult == StepResult::Pushed)
-      continue;
-    assert(stepResult == StepResult::Finished);
+    while (true)
+    {
+      Frame& current = stack.back();
 
-    // Dropping the frame is what lowers a float encoding's evaluation depth,
-    // so it happens before the answer is handed up -- exactly where the scope
-    // guard used to end. A term's answer is then put into the plain
-    // bit-vector spelling, which is what the wrapper around the recursive
-    // evaluator did to everything it returned.
-    const bool wasTerm = (current.job == EvalTerm);
-    stack.pop_back();
-    if (wasTerm)
-      result = plainModelCarrier(bm, result);
+      StepResult stepResult = StepResult::Finished;
+      switch (current.job)
+      {
+        case EvalFormula:
+          do
+            stepResult = stepFormula(current);
+          while (stepResult == StepResult::Redispatch);
+          break;
+        case EvalTerm:
+          do
+            stepResult = stepTerm(current);
+          while (stepResult == StepResult::Redispatch);
+          break;
+        case EvalExpand:
+          do
+            stepResult = stepExpand(current);
+          while (stepResult == StepResult::Redispatch);
+          break;
+      }
 
-    if (stack.empty())
-      return result;
+      if (stepResult == StepResult::Pushed)
+        continue;
+      assert(stepResult == StepResult::Finished);
+
+      // Dropping the frame is what lowers a float encoding's evaluation depth,
+      // so it happens before the answer is handed up -- exactly where the scope
+      // guard used to end. A term's answer is then put into the plain
+      // bit-vector spelling, which is what the wrapper around the recursive
+      // evaluator did to everything it returned.
+      const bool wasTerm = (current.job == EvalTerm);
+      stack.pop_back();
+      if (wasTerm)
+        result = plainModelCarrier(bm, result);
+
+      if (stack.empty())
+        return result;
+    }
   }
+};
+
+ASTNode AbsRefine_CounterExample::evaluate(const Job job, const ASTNode& top,
+                                           const bool topArrayReadFlag)
+{
+  return EvaluationDriver(*this).run(job, top, topArrayReadFlag);
 }
 
 // FUNCTION: accepts a non-constant term, and returns the

--- a/lib/AbsRefineCounterExample/CounterExample.cpp
+++ b/lib/AbsRefineCounterExample/CounterExample.cpp
@@ -29,7 +29,7 @@ THE SOFTWARE.
 #include "stp/FloatBlaster/FpEncodingContext.h"
 #include "stp/Printer/printers.h"
 #include "stp/ToSat/ToSATAIG.h"
-#include <memory>
+#include <vector>
 
 const bool debug_counterexample = false;
 
@@ -81,19 +81,52 @@ static ASTNode plainModelCarrier(STPMgr* bm, const ASTNode& value)
 class ScopedFpEncodedEvaluation final
 {
 public:
-  explicit ScopedFpEncodedEvaluation(unsigned int& depth_) : depth(depth_)
+  ScopedFpEncodedEvaluation() = default;
+
+  explicit ScopedFpEncodedEvaluation(unsigned int& depth_) { activate(depth_); }
+
+  ScopedFpEncodedEvaluation(const ScopedFpEncodedEvaluation&) = delete;
+  ScopedFpEncodedEvaluation&
+  operator=(const ScopedFpEncodedEvaluation&) = delete;
+
+  ScopedFpEncodedEvaluation(ScopedFpEncodedEvaluation&& other) noexcept
+      : depth(other.depth)
   {
-    ++depth;
+    other.depth = NULL;
   }
 
-  ~ScopedFpEncodedEvaluation()
+  ScopedFpEncodedEvaluation&
+  operator=(ScopedFpEncodedEvaluation&& other) noexcept
   {
-    assert(depth > 0);
-    --depth;
+    if (this != &other)
+    {
+      deactivate();
+      depth = other.depth;
+      other.depth = NULL;
+    }
+    return *this;
+  }
+
+  ~ScopedFpEncodedEvaluation() { deactivate(); }
+
+  void activate(unsigned int& depth_)
+  {
+    assert(depth == NULL);
+    depth = &depth_;
+    ++*depth;
   }
 
 private:
-  unsigned int& depth;
+  void deactivate()
+  {
+    if (depth == NULL)
+      return;
+    assert(*depth > 0);
+    --*depth;
+    depth = NULL;
+  }
+
+  unsigned int* depth = NULL;
 };
 
 FpEncodingContext&
@@ -256,6 +289,1056 @@ void AbsRefine_CounterExample::ConstructCounterExample(
   }
 }
 
+// Where one evaluation has got to.
+//
+// The three functions this replaces called each other once per level of the
+// input -- a formula's operands through the term evaluator, a term's
+// if-then-else condition back through the formula evaluator, a read over a
+// write through the expander and every term in the write chain back through
+// the term evaluator -- so they are one walk with its frames on the heap
+// rather than three sets of call frames. See DeepDag_Test.cpp.
+//
+// `job` says which of the three a frame is running and `phase` where in it,
+// because most of them suspend at more than one point. Everything else here
+// was a local of the function it came from, kept because it has to survive
+// the suspension.
+struct AbsRefine_CounterExample::Frame
+{
+  enum Phase
+  {
+    Start,
+
+    // ComputeFormulaUsingModel.
+    FormSymbolValue,     // boolean symbol: waiting for its recorded value
+    FormArrayEqLowered,  // array equality: for the lowering that decided it
+    FormBoolExtract,     // bit extract: for the term underneath
+    FormOperand,         // connective or comparison: for operand `i`
+    FormIteCond,         // if-then-else: for the condition
+    FormIteBranch,       // ... for the branch the condition left alive
+    FormFpOperand,       // float predicate: for operand `i`
+    FormFpOperandStrict, // ... for it again, this time refusing a bare read
+    FormFpRewritten,     // ... for what the factory returned instead
+    FormFpBlasted,       // ... for the lowering of the predicate
+
+    // TermToConstTermUsingModel.
+    TermRecordedValueStart, // recorded non-constant: about to evaluate its value
+    TermRecordedValue,  // for the value the model already records for this term
+    TermEncoded,        // float source term: for its encoding
+    TermDefinition,     // substituted array read: for the read through its definition
+    TermCellIndex,      // owned array read: for the index
+    TermCellValue,      // ... for a recorded cell value that is not constant
+    TermCellWriteIndex, // ... for the index the write at this level stores at
+    TermCellWritten,    // ... for the value it stores, the index having hit
+    TermCellIteCond,    // ... for an array if-then-else's condition
+    TermExpand,         // read over a write: for the expansion
+    TermExpanded,       // ... for the value of the expansion
+    TermReadIteIndex,   // read over an if-then-else: for the index
+    TermReadIteCond,    // ... for the condition
+    TermReadIteBranch,  // ... for the read over the branch it left alive
+    TermReadIndex,      // plain read: for the index, however it is spelled
+    TermReadValue,      // ... for the value the model records at that index
+    TermIteCond,        // if-then-else term: for the condition
+    TermIteBranch,      // ... for the branch the condition left alive
+    TermOperand,        // any other operation: for child `i`
+    TermOperandStrict,  // ... for it again, this time refusing a bare read
+
+    // Expand_ReadOverWrite_UsingModel.
+    ExpandRecordedValueStart, // recorded non-constant: about to evaluate its value
+    ExpandRecordedValue, // for the value the model already records for the read
+    ExpandReadIndex,     // for the read index
+    ExpandWriteIndex,    // for the index the write at this level stores at
+    ExpandWritten,       // ... for the value it stores, the index having hit
+    ExpandPushedIn       // for the read under everything the chain did not hit
+  };
+
+  Job job;
+  Phase phase = Start;
+  ASTNode n;
+  bool ArrayReadFlag;
+
+  ASTVec parts; // operands evaluated so far
+  size_t i = 0; // the operand being worked on
+
+  // Locals that outlive one of their function's suspension points. Each is
+  // one role, under whichever of the three names its function gave it: the
+  // evaluated read index (`idxVal`, `indexVal`, `readIndex`), the array node
+  // a walk down a chain has reached (`level`, `write`), and the read
+  // renormalised over a constant index (`modelentry`).
+  ASTNode index;
+  ASTNode cursor;
+  ASTNode entry;
+
+  // Raised while an already-lowered float expression is evaluated and
+  // lowered when this frame is dropped, which is where the scope guard the
+  // recursive version held across the sub-evaluation used to end. Getting
+  // this wrong changes float model values rather than crashing.
+  ScopedFpEncodedEvaluation fpScope;
+
+  Frame(Job j, const ASTNode& node, bool flag)
+      : job(j), n(node), ArrayReadFlag(flag)
+  {
+  }
+};
+
+// ComputeFormulaUsingModel, TermToConstTermUsingModel and
+// Expand_ReadOverWrite_UsingModel, walked together with their frames on the
+// heap. Everything the three did is here in the order they did it: the same
+// map reads and writes, the same node-factory calls, the same asserts, and
+// the same decisions about which operand is evaluated at all.
+//
+// That last one is why this is a state machine rather than a priming pass.
+// Three arms evaluate an if-then-else's condition and then only the branch it
+// leaves alive, and a dropped branch here is not merely wasted work: it can
+// be genuinely unevaluable against the model, and all three call FatalError
+// when it is.
+//
+// Two things a reader should check for, because both change the model
+// silently rather than crashing. The map writes are not uniform -- a term's
+// value is recorded by the tail its arm reaches, and five of the arms return
+// before that tail, three of them writing the map themselves on the way past.
+// And a term's answer is put into the plain bit-vector spelling once per
+// frame, where the wrapper around the old recursive evaluator did it once per
+// call.
+ASTNode AbsRefine_CounterExample::evaluate(const Job job, const ASTNode& top,
+                                           const bool topArrayReadFlag)
+{
+  // The value the frame that finished last returned, which is what the frame
+  // below it resumes with.
+  ASTNode result;
+
+  // Run the non-recursive head of one of the three former functions. An
+  // immediate answer lands in `result` and needs no frame. Otherwise `frame`
+  // carries everything learned by the head into the walk below it, so a memo
+  // miss is never probed for a second time when the frame starts.
+  auto prepare = [&](const Job j, const ASTNode& n, Frame& frame) -> bool
+  {
+    assert(frame.job == j && frame.n == n);
+    if (j == EvalFormula)
+    {
+      if (!(is_Form_kind(n.GetKind()) && BOOLEAN_TYPE == n.GetType()))
+      {
+        FatalError(" ComputeConstFormUsingModel: "
+                   "The input is a non-formula: ",
+                   n);
+      }
+
+      const ASTNodeMap::const_iterator it = ComputeFormulaMap.find(n);
+      if (it != ComputeFormulaMap.end())
+      {
+        if (ASTTrue != it->second && ASTFalse != it->second)
+        {
+          FatalError("ComputeFormulaUsingModel: "
+                     "The value of a formula must be TRUE or FALSE:",
+                     n);
+        }
+
+        result = it->second;
+        return false;
+      }
+
+      // These are the formula equivalent of a term constant: the switch only
+      // records and returns them, so do that without allocating a worklist.
+      if (n.GetKind() == TRUE || n.GetKind() == FALSE)
+      {
+        ComputeFormulaMap[n] = n;
+        result = n;
+        return false;
+      }
+
+      return true;
+    }
+
+    if (j == EvalTerm)
+    {
+      // The recursive term evaluator returned constants before consulting the
+      // model. Keeping that in the head matters here: constants are never
+      // memoised, so otherwise every occurrence would allocate a frame.
+      if (n.GetKind() == BVCONST)
+      {
+        result = plainModelCarrier(bm, n);
+        return false;
+      }
+
+      assert(is_Term_kind(n.GetKind()));
+      assert(WRITE != n.GetKind());
+      assert(BOOLEAN_TYPE != n.GetType());
+
+      // An array-typed entry is a definitional alias installed by equality
+      // propagation (array symbol := array term), not a value. The READ arm
+      // below resolves through it; evaluating it here would hand an array
+      // term to a walk that only understands element-typed values.
+      const ASTNodeMap::const_iterator it = CounterExampleMap.find(n);
+      if (n.GetType() != ARRAY_TYPE && it != CounterExampleMap.end())
+      {
+        if (BVCONST == it->second.GetKind())
+        {
+          result = plainModelCarrier(bm, it->second);
+          return false;
+        }
+
+        if (n == it->second)
+        {
+          FatalError("TermToConstTermUsingModel: "
+                     "The input term is stored as-is "
+                     "in the CounterExample: Not ok: ",
+                     n);
+        }
+
+        frame.entry = it->second;
+        frame.phase = Frame::TermRecordedValueStart;
+        return true;
+      }
+
+      return true;
+    }
+
+    assert(j == EvalExpand);
+    if (READ != n.GetKind() || WRITE != n[0].GetKind())
+      FatalError("RemovesWrites: Input must be a READ over a WRITE", n);
+
+    const ASTNodeMap::const_iterator it = CounterExampleMap.find(n);
+    if (it != CounterExampleMap.end())
+    {
+      if (BVCONST == it->second.GetKind())
+      {
+        result = it->second;
+        return false;
+      }
+
+      if (n == it->second)
+      {
+        FatalError("TermToConstTermUsingModel: The input term is "
+                   "stored as-is "
+                   "in the CounterExample: Not ok: ",
+                   n);
+      }
+
+      frame.entry = it->second;
+      frame.phase = Frame::ExpandRecordedValueStart;
+      return true;
+    }
+
+    return true;
+  };
+
+  Frame first(job, top, topArrayReadFlag);
+  if (!prepare(job, top, first))
+    return result;
+
+  // Most model expressions are shallow. Keep their frontier contiguous and
+  // preallocate the common case; a push may move the current frame, so every
+  // step returns immediately after one.
+  std::vector<Frame> stack;
+  stack.reserve(8);
+  stack.push_back(std::move(first));
+
+  enum class StepResult
+  {
+    Finished,
+    Pushed,
+    Redispatch
+  };
+
+  // Ask for the value of `n`, and suspend this frame until it is known: it
+  // picks up at `resume` with the answer in `result`. An immediate head answer
+  // is redispatched within the same job; only a real child reaches the outer
+  // worklist loop.
+  auto want = [&](Frame& f, const Frame::Phase resume, const Job j,
+                  const ASTNode& n,
+                  const bool flag = true) -> StepResult {
+    f.phase = resume;
+    Frame below(j, n, flag);
+    if (!prepare(j, n, below))
+      return StepResult::Redispatch;
+    stack.push_back(std::move(below));
+    return StepResult::Pushed;
+  };
+
+  /* One step of ComputeFormulaUsingModel, which accepts a non-constant
+   * formula and checks if the formula is ASTTrue or ASTFalse w.r.t to a
+   * model.
+   */
+  auto stepFormula = [&](Frame& f) -> StepResult {
+    const ASTNode& form = f.n;
+    const Kind k = form.GetKind();
+
+    // The tail every path but the memo hit shares.
+    auto finish = [&](const ASTNode& output) {
+      assert(ASTUndefined != output);
+      assert(output.isConstant());
+      ComputeFormulaMap[form] = output;
+      result = output;
+      return StepResult::Finished;
+    };
+
+    // Unlike the term arm (TermToConstTermUsingModel), floating-point
+    // *predicates* are not routed through encodeForModel. Encoding the whole
+    // predicate and re-entering the evaluator runs the walk at
+    // fpEncodedEvaluationDepth > 0, where the term arm's own encode step is
+    // switched off -- so any float operand reached inside the encoded
+    // predicate would fall through to the term switch's default. Instead the
+    // FP_* predicate cases below resolve each operand to a constant at depth
+    // 0 (where the term arm does encode floats correctly) and fold the
+    // predicate over those constants.
+
+    switch (k)
+    {
+      case TRUE:
+      case FALSE:
+        return finish(form);
+      case SYMBOL:
+      {
+        if (f.phase == Frame::FormSymbolValue)
+          return finish(result);
+
+        if (BOOLEAN_TYPE != form.GetType())
+          FatalError(" ComputeFormulaUsingModel: "
+                     "Non-Boolean variables are not formulas",
+                     form);
+        const ASTNodeMap::const_iterator recorded =
+            CounterExampleMap.find(form);
+        if (recorded != CounterExampleMap.end())
+        {
+          const ASTNode counterexample_val = recorded->second;
+          if (!bm->VarSeenInTerm(form, counterexample_val))
+            return want(f, Frame::FormSymbolValue, EvalFormula,
+                        counterexample_val);
+          return finish(counterexample_val);
+        }
+        // Has been simplified out. Can take any value.
+        return finish(ASTFalse);
+      }
+      case ARRAY_EQ:
+      {
+        if (f.phase == Frame::FormArrayEqLowered)
+          return finish(result);
+
+        ExtensionalityContext* ext = bm->getExtensionalityIfAny();
+        ASTNode lowered;
+        if (ext != NULL && ext->getCurrentLowering(form, lowered))
+        {
+          // This solve decided the equality; its lowering is the answer.
+          return want(f, Frame::FormArrayEqLowered, EvalFormula, lowered);
+        }
+
+        // It did not: either the equality belongs to an earlier query,
+        // or lowering discarded it -- an equality nested in a conjunct
+        // that solving a write chain against its own base dropped as
+        // shadowed. There is no abstraction variable to consult, and
+        // the one that used to be consulted here had never been
+        // assigned, so it read false while the model gave the two
+        // arrays identical contents.
+        //
+        // Ask the model instead. It is the same model the caller is
+        // about to print, so the answer agrees with it by construction,
+        // which is the property the abstraction variable could not
+        // offer.
+        if (!arrayEqualityIsModelDecidable(form[0]) ||
+            !arrayEqualityIsModelDecidable(form[1]))
+          FatalError("array-equality: cannot evaluate an opaque equality "
+                     "over float-indexed arrays that was not reachable in "
+                     "the most recent solve",
+                     form);
+        return finish(ArraysEqualUsingModel(form[0], form[1]) ? ASTTrue
+                                                              : ASTFalse);
+      }
+      case BOOLEXTRACT:
+      {
+        if (f.phase == Frame::Start)
+          return want(f, Frame::FormBoolExtract, EvalTerm, form[0]);
+
+        return finish(
+            simp->BVConstEvaluator(bm->CreateNode(BOOLEXTRACT, result,
+                                                  form[1])));
+      }
+      case EQ:
+      case BVLT:
+      case BVLE:
+      case BVGT:
+      case BVGE:
+      case BVSLT:
+      case BVSLE:
+      case BVSGT:
+      case BVSGE:
+      case BVUADDO:
+      case BVSADDO:
+      case BVUMULO:
+      case BVSMULO:
+      case BVUSUBO:
+      case BVSSUBO:
+      {
+        if (f.phase == Frame::FormOperand)
+          f.parts.push_back(result);
+        else
+          f.parts.reserve(form.Degree());
+
+        if (f.i < form.Degree())
+          return want(f, Frame::FormOperand, EvalTerm, form[f.i++], false);
+
+        return finish(
+            NonMemberBVConstEvaluator(bm, k, f.parts, form.GetValueWidth()));
+      }
+
+      case NAND:
+      case NOR:
+      case NOT:
+      case AND:
+      case XOR:
+      case IFF:
+      case IMPLIES:
+      case OR:
+      {
+        if (f.phase == Frame::FormOperand)
+          f.parts.push_back(result);
+        else
+          f.parts.reserve(form.Degree());
+
+        if (f.i < form.Degree())
+          return want(f, Frame::FormOperand, EvalFormula, form[f.i++]);
+
+        return finish(
+            NonMemberBVConstEvaluator(bm, k, f.parts, form.GetValueWidth()));
+      }
+
+      case ITE:
+      {
+        if (f.phase == Frame::Start)
+          return want(f, Frame::FormIteCond, EvalFormula, form[0]);
+
+        if (f.phase == Frame::FormIteCond)
+        {
+          if (ASTTrue == result)
+            return want(f, Frame::FormIteBranch, EvalFormula, form[1]);
+          else if (ASTFalse == result)
+            return want(f, Frame::FormIteBranch, EvalFormula, form[2]);
+          else
+            FatalError("ComputeFormulaUsingModel: ITE: "
+                       "something is wrong with the formula: ",
+                       form);
+        }
+
+        return finish(result);
+      }
+      case FP_LEQ:
+      case FP_LT:
+      case FP_GEQ:
+      case FP_GT:
+      case FP_EQ:
+      case FP_ISNORMAL:
+      case FP_ISSUBNORMAL:
+      case FP_ISZERO:
+      case FP_ISINFINITE:
+      case FP_ISNAN:
+      case FP_ISNEGATIVE:
+      case FP_ISPOSITIVE:
+      case FP_SMT_EQ:
+      {
+        if (f.phase == Frame::FormFpRewritten ||
+            f.phase == Frame::FormFpBlasted)
+          return finish(result);
+
+        // An operand must resolve to a constant, as in the float arm of
+        // TermToConstTermUsingModel: the read-tolerant flag is on inside the
+        // walk, so a float-element array read the solve never constrained
+        // comes back as the symbolic READ (case 2 there) rather than a
+        // value. Rebuilding the predicate over it is not evaluation -- the
+        // blaster would carry the read along, and the same-operand folds
+        // below can hand the bare READ back. The read is genuinely
+        // unconstrained here, so resolve it to a concrete value.
+        if (f.phase == Frame::FormFpOperand && BVCONST != result.GetKind())
+          return want(f, Frame::FormFpOperandStrict, EvalTerm, form[f.i],
+                      false);
+
+        if (f.phase == Frame::FormFpOperand ||
+            f.phase == Frame::FormFpOperandStrict)
+        {
+          assert(result.GetKind() == BVCONST);
+          f.parts.push_back(FloatBlaster::withFormat(
+              bm, result, form[f.i].GetExpWidth(), form[f.i].GetSigWidth()));
+          f.i++;
+        }
+        else
+        {
+          // Rebuild at the node's real arity: the comparisons are binary but
+          // the classification predicates are unary.
+          f.parts.reserve(form.Degree());
+        }
+
+        if (f.i < form.Degree())
+          return want(f, Frame::FormFpOperand, EvalTerm, form[f.i]);
+
+        ASTNode temp(bm->CreateNode(k, f.parts));
+
+        // Rebuilding through the simplifying factory may rewrite the predicate
+        // rather than return it: constant operands fold to true/false outright,
+        // and the same-operand rules fire here because interned constants
+        // compare pointer-equal -- fp.leq of a value with itself comes back as
+        // (not (fp.isNaN ...)). Whatever came back that is not this operation
+        // is a formula; evaluate it, never blast it.
+        if (temp.GetKind() != k)
+          return want(f, Frame::FormFpRewritten, EvalFormula, temp);
+
+        // One table, the same one the solver's lowering pass uses. temp's
+        // operands were re-stamped with their formats above, so it is a
+        // well-formed source node and its own sorts say what the formats are.
+        ASTNode blasted(FloatBlast::lowerOperation(bm, temp));
+
+        assert(blasted != temp);
+        assert(blasted != form);
+
+        return want(f, Frame::FormFpBlasted, EvalFormula, blasted);
+      }
+      default:
+        cerr << _kind_names[k];
+        FatalError(" ComputeFormulaUsingModel: "
+                   "the kind has not been implemented",
+                   ASTUndefined);
+    }
+  };
+
+  /* One step of TermToConstTermUsingModel, which accepts a non-constant term
+   * and returns the corresponding constant term with respect to a model.
+   */
+  auto stepTerm = [&](Frame& f) -> StepResult {
+    const ASTNode& term = f.n;
+    const Kind k = term.GetKind();
+    const bool ArrayReadFlag = f.ArrayReadFlag;
+
+    // The tail the arms that run to their end share. Five arms return before
+    // reaching it, and three of those record the term's value themselves.
+    auto finish = [&](const ASTNode& output) {
+      assert(ArrayReadFlag || (BVCONST == output.GetKind()));
+
+      // when this flag is false, we should compute the arrayread to a
+      // constant. this constant is stored in the counter_example
+      // datastructure
+      // if (!ArrayReadFlag)
+      {
+        // Don't memoise a read as its own value. With ArrayReadFlag true, a
+        // read with no value in the model is returned unchanged (case 2 above)
+        // -- this happens for an unconstrained read, such as the array that
+        // totalising introduces for an out-of-range to_ubv/to_sbv. Caching
+        // term -> term would put the term in its own value slot, violating the
+        // invariant the lookups rely on: a later lookup then trips the "stored
+        // as-is" fatal error, or leaves the read unresolved and non-constant.
+        // Skipping the self-entry lets that later lookup fall through to the
+        // documented arbitrary completion.
+        if (term != output)
+          CounterExampleMap[term] = output;
+      }
+
+      // cerr << "Output to TermToConstTermUsingModel: " << output << endl;
+      result = output;
+      return StepResult::Finished;
+    };
+
+    if (f.phase == Frame::TermRecordedValueStart)
+      return want(f, Frame::TermRecordedValue, EvalTerm, f.entry,
+                  ArrayReadFlag);
+
+    if (f.phase == Frame::Start && fpEncodedEvaluationDepth == 0 &&
+        (is_FP_kind(k) || isFpIndexedArrayAccess(term)))
+    {
+      // FP source operations are evaluated through the solve-owned lowering
+      // context. This is deliberately before the target-language switch below:
+      // counterexample evaluation must not maintain a second implementation of
+      // totalisation, operand reconstruction, and SymFPU lowering.
+      const ASTNode encoded = requireFpEncodingContext().encodeForModel(term);
+      if (encoded == term && is_FP_kind(k))
+        FatalError("floating-point model encoding made no progress: ", term);
+
+      // The invariant this arm exists to hold: *a float's model value is its
+      // canonical carrier*. A float symbol's raw model bits are whichever NaN
+      // payload the SAT solver happened to pick, and the solve compared
+      // pack(unpack(x)); the two agree on everything except the payload, which
+      // is exactly what an array index distinguishes. So any node the encoding
+      // pass rewrote must be evaluated through that rewrite and never through
+      // its raw bits.
+      //
+      // Whether a rewrite was needed is the pass's answer to give, not ours:
+      // an access whose indexes are all already canonical comes back unchanged
+      // and falls through to the ordinary switch below.
+      if (encoded != term)
+      {
+        // The lowered DAG retains source-sort metadata on carrier reads and
+        // leaves. Keep the entire evaluation below here in target mode so a
+        // nested read-over-write cannot mistake that metadata for a fresh
+        // source boundary and canonicalise it repeatedly. The scope ends
+        // when this frame is dropped, which is where the guard the recursive
+        // version held across the call to itself ended.
+        f.fpScope.activate(fpEncodedEvaluationDepth);
+        return want(f, Frame::TermEncoded, EvalTerm, encoded, ArrayReadFlag);
+      }
+    }
+
+    // The value the model already records for this term is the answer, and
+    // the map already holds it.
+    if (f.phase == Frame::TermRecordedValue)
+      return StepResult::Finished;
+
+    if (f.phase == Frame::TermEncoded)
+    {
+      const ASTNode value = result;
+      if (term != value)
+        CounterExampleMap[term] = value;
+      result = value;
+      return StepResult::Finished;
+    }
+
+    if (f.phase == Frame::TermDefinition)
+      return StepResult::Finished;
+
+    switch (k)
+    {
+      case BVCONST:
+        return finish(term);
+      case SYMBOL:
+      {
+        if (term.GetType() == ARRAY_TYPE)
+        {
+          result = term;
+          return StepResult::Finished;
+        }
+        // Has been simplified out and can take any value. A RoundingMode's
+        // 5-bit representation has 27 junk patterns, though, so complete that
+        // sort with a real value rather than the ordinary all-zero default.
+        return finish(bm->isRoundingModeSortedTerm(term)
+                          ? bm->CreateBVConst(
+                                5, symbolic_fp::ROUND_NEAREST_TIES_TO_EVEN)
+                          : bm->CreateZeroConst(term.GetValueWidth()));
+      }
+      case READ:
+      {
+        const ASTNode& arrName = term[0];
+        const ASTNode& index = term[1];
+
+        // Which of the four shapes of read this frame is walking is settled
+        // when it starts, and its phase says which from then on -- so each
+        // gate below is asked exactly once, as it was.
+        if (f.phase == Frame::Start)
+        {
+          if (0 == arrName.GetIndexWidth())
+          {
+            FatalError("TermToConstTermUsingModel: "
+                       "array has 0 index width: ",
+                       arrName);
+          }
+
+          // An array symbol that equality propagation substituted away is
+          // defined by its array-typed counterexample entry. The vanished
+          // symbol has no read abstraction in the solve, so evaluate a read
+          // through its definition instead. Copy the definition before the
+          // nested evaluation, which may restore the whole map.
+          if (SYMBOL == arrName.GetKind())
+          {
+            const ASTNodeMap::const_iterator sub =
+                CounterExampleMap.find(arrName);
+            if (sub != CounterExampleMap.end() &&
+                ARRAY_TYPE == sub->second.GetType())
+            {
+              const ASTNode definition = sub->second;
+              const ASTNode throughDefinition = bm->CreateTerm(
+                  READ, term.GetValueWidth(), definition, index);
+              return want(f, Frame::TermDefinition, EvalTerm,
+                          throughDefinition, ArrayReadFlag);
+            }
+          }
+
+          // With array equality active, every read in the solve is
+          // evaluated through its read-abstraction variable -- never by
+          // expanding its write chain against the model. The consistency
+          // checker, not the model-side expander, is the authority for
+          // these reads: the abstraction variable holds whatever the SAT
+          // solver assigned, and any disagreement with the array axioms is
+          // exactly what the checker turns into a lemma.
+          //
+          // An owned read with no recorded abstraction variable was
+          // simplified out of the formula before solving; it is evaluated
+          // from the certified array contents instead: the recorded
+          // observation at the concrete index if one exists at this level,
+          // else the concrete write-hit value, else descend into the base
+          // array, defaulting to zero. This agrees with every recorded
+          // access whenever the checker certifies the candidate.
+          ExtensionalityContext* ext = bm->getExtensionalityIfAny();
+          if (ext != NULL && ext->active() && ext->arrayGraphFrozen() &&
+              ext->ownsArray(arrName))
+            return want(f, Frame::TermCellIndex, EvalTerm, index, false);
+
+          if (WRITE == arrName.GetKind()) // READ over a WRITE
+            return want(f, Frame::TermExpand, EvalExpand, term,
+                        ArrayReadFlag);
+
+          if (ITE == arrName.GetKind()) // READ over an ITE
+            return want(f, Frame::TermReadIteIndex, EvalTerm, index,
+                        ArrayReadFlag);
+
+          const ASTNodeMap::const_iterator recorded =
+              CounterExampleMap.find(index);
+          if (recorded != CounterExampleMap.end())
+          {
+            // Copy out of the map before the nested evaluation, which may
+            // restore the map by whole-map assignment.
+            const ASTNode indexEntry = recorded->second;
+            return want(f, Frame::TermReadIndex, EvalTerm, indexEntry,
+                        ArrayReadFlag);
+          }
+          // index does not have a const value in the
+          // CounterExampleMap. compute it.
+          return want(f, Frame::TermReadIndex, EvalTerm, index,
+                      ArrayReadFlag);
+        }
+
+        // The walk down an owned array for the cell the model gives it. Every
+        // turn of it but the last suspends, so what was a loop is the
+        // sequence of resumes into the turn below.
+        if (f.phase == Frame::TermCellValue ||
+            f.phase == Frame::TermCellWritten)
+        {
+          CounterExampleMap[term] = result;
+          return StepResult::Finished;
+        }
+
+        if (f.phase == Frame::TermCellIndex ||
+            f.phase == Frame::TermCellWriteIndex ||
+            f.phase == Frame::TermCellIteCond)
+        {
+          if (f.phase == Frame::TermCellIndex)
+          {
+            f.index = result;
+            f.cursor = arrName;
+          }
+          else if (f.phase == Frame::TermCellWriteIndex)
+          {
+            if (result == f.index)
+              return want(f, Frame::TermCellWritten, EvalTerm, f.cursor[2],
+                          false);
+            f.cursor = f.cursor[0];
+          }
+          else
+          {
+            if (result == ASTTrue)
+              f.cursor = f.cursor[1];
+            else if (result == ASTFalse)
+              f.cursor = f.cursor[2];
+            else
+              FatalError("array-equality: an owned array if-then-else "
+                         "condition has no concrete model value",
+                         f.cursor[0]);
+          }
+
+          NodeFactory* hf = bm->hashingNodeFactory;
+          const ASTNode key = hf->CreateTerm(READ, f.cursor.GetValueWidth(),
+                                             f.cursor, f.index);
+          ASTNodeMap::const_iterator cit = CounterExampleMap.find(key);
+          if (cit != CounterExampleMap.end())
+          {
+            const ASTNode val = cit->second;
+            if (BVCONST != val.GetKind())
+              return want(f, Frame::TermCellValue, EvalTerm, val, false);
+            CounterExampleMap[term] = val;
+            result = val;
+            return StepResult::Finished;
+          }
+          if (WRITE == f.cursor.GetKind())
+            return want(f, Frame::TermCellWriteIndex, EvalTerm, f.cursor[1],
+                        false);
+          if (ITE == f.cursor.GetKind() && f.cursor.GetType() == ARRAY_TYPE)
+            return want(f, Frame::TermCellIteCond, EvalFormula, f.cursor[0]);
+
+          // base array with no observation
+          const ASTNode val = defaultCellValue(f.cursor);
+          CounterExampleMap[term] = val;
+          result = val;
+          return StepResult::Finished;
+        }
+
+        if (f.phase == Frame::TermExpand)
+        {
+          if (result == term)
+          {
+            FatalError("TermToConstTermUsingModel: "
+                       "Read_Over_Write term must be expanded "
+                       "into an ITE",
+                       term);
+          }
+          return want(f, Frame::TermExpanded, EvalTerm, result,
+                      ArrayReadFlag);
+        }
+
+        if (f.phase == Frame::TermExpanded)
+        {
+          assert(ArrayReadFlag || (BVCONST == result.GetKind()));
+          return StepResult::Finished;
+        }
+
+        if (f.phase == Frame::TermReadIteIndex)
+        {
+          // The "then" and "else" branch are arrays.
+          f.index = result;
+          // Get the truth value.
+          return want(f, Frame::TermReadIteCond, EvalFormula, arrName[0]);
+        }
+
+        if (f.phase == Frame::TermReadIteCond)
+        {
+          const unsigned int wid = arrName.GetValueWidth();
+          if (ASTTrue == result)
+            return want(f, Frame::TermReadIteBranch, EvalTerm,
+                        bm->CreateTerm(READ, wid, arrName[1], f.index),
+                        ArrayReadFlag);
+          else if (ASTFalse == result)
+            return want(f, Frame::TermReadIteBranch, EvalTerm,
+                        bm->CreateTerm(READ, wid, arrName[2], f.index),
+                        ArrayReadFlag);
+          else
+          {
+            FatalError(" TermToConstTermUsingModel: termITE: "
+                       "cannot compute ITE conditional against model: ",
+                       term);
+          }
+        }
+
+        if (f.phase == Frame::TermReadIteBranch)
+        {
+          assert(ArrayReadFlag || (BVCONST == result.GetKind()));
+          return StepResult::Finished;
+        }
+
+        if (f.phase == Frame::TermReadIndex)
+        {
+          f.entry =
+              bm->CreateTerm(READ, arrName.GetValueWidth(), arrName, result);
+          // modelentry is now an arrayread over a constant index
+          BVTypeCheck(f.entry);
+
+          // if a value exists in the CounterExampleMap then return it
+          const ASTNodeMap::const_iterator recorded =
+              CounterExampleMap.find(f.entry);
+          if (recorded != CounterExampleMap.end())
+          {
+            const ASTNode modelentryValue = recorded->second;
+            return want(f, Frame::TermReadValue, EvalTerm, modelentryValue,
+                        ArrayReadFlag);
+          }
+
+          if (ArrayReadFlag)
+          {
+            // return the array read over a constantindex
+            return finish(f.entry);
+          }
+
+          if (bm->UserFlags.enable_array_equality)
+          {
+            // Has been simplified out, so any value will do -- but only one
+            // value agrees with the model that is published. With array
+            // equality enabled the model surface prints a total
+            // interpretation per array, and this is a cell of it that no
+            // observation covers, so it is the completion or nothing.
+            // Inventing something else makes evaluation disagree with every
+            // other reader: an array equality evaluates false through its
+            // lowering's reads while the printed arrays are identical, which
+            // is the disagreement the post-solve audit trips on -- and,
+            // unaudited, a (get-model) that falsifies the query it answered
+            // sat. Both of this arm's former answers were such an invention:
+            // all-ones for a bitvector cell the printer filled with zero,
+            // and RNE for a RoundingMode cell that ReadUsingModel and the
+            // checker were still completing with all-zero bits.
+            //
+            // Memoising the invented value instead cannot close that gap.
+            // Model queries run inside a scope that restores the
+            // counterexample map afterwards, so the entry is rolled back
+            // and the next reader invents the value again against a model
+            // that never recorded it. Agreeing with the completion the rest
+            // of the model already uses needs no bookkeeping at all.
+            //
+            // Gated on the option: with it off the counterexample map, and
+            // so vc_getCounterExampleArray, must stay exactly as before.
+            return finish(defaultCellValue(arrName));
+          }
+
+          // Has been simplified out and can take any value. Keep the historical
+          // all-one completion for ordinary bitvectors, but not for
+          // RoundingMode: 0b11111 is not one of that sort's five values and can
+          // make SymFPU exhibit a non-IEEE sixth rounding behaviour.
+          return finish(bm->isRoundingModeSortedTerm(f.entry)
+                            ? bm->CreateBVConst(
+                                  5, symbolic_fp::ROUND_NEAREST_TIES_TO_EVEN)
+                            : bm->CreateMaxConst(f.entry.GetValueWidth()));
+        }
+
+        return finish(result); // Frame::TermReadValue
+      }
+      case ITE:
+      {
+        if (f.phase == Frame::Start)
+          return want(f, Frame::TermIteCond, EvalFormula, term[0]);
+
+        if (f.phase == Frame::TermIteCond)
+        {
+          if (ASTTrue == result)
+            return want(f, Frame::TermIteBranch, EvalTerm, term[1],
+                        ArrayReadFlag);
+          else if (ASTFalse == result)
+            return want(f, Frame::TermIteBranch, EvalTerm, term[2],
+                        ArrayReadFlag);
+          else
+          {
+            FatalError(" TermToConstTermUsingModel: termITE: cannot "
+                       "compute ITE conditional against model: ",
+                       term);
+          }
+        }
+
+        return finish(result);
+      }
+      default:
+      {
+        // NonMemberBVConstEvaluator below needs every child to be a constant.
+        // With ArrayReadFlag set, a read with no value in the model comes back
+        // as a symbolic READ over the array (case 2 above) rather than a
+        // constant -- this happens for the unconstrained array that totalising
+        // introduces for an out-of-range to_ubv/to_sbv, reached here when the
+        // enclosing ITE selects the unspecified branch and it feeds an ordinary
+        // bit-vector operation. Its value is genuinely arbitrary, so resolve it
+        // to a concrete constant rather than hand a non-constant to the
+        // evaluator (which cannot read arrays and would abort on the array
+        // symbol).
+        if (f.phase == Frame::TermOperand && BVCONST != result.GetKind())
+          return want(f, Frame::TermOperandStrict, EvalTerm, term[f.i],
+                      false);
+
+        if (f.phase == Frame::TermOperand ||
+            f.phase == Frame::TermOperandStrict)
+        {
+          ASTNode ff = result;
+          // A floating-point operand comes back as a bare bit-vector:
+          // TermToConstTermUsingModel strips the format off every result it
+          // returns. NonMemberBVConstEvaluator lowers through FloatBlast,
+          // which reads each operand's format off its source sort, so restore
+          // each float operand's own format here -- the same reattachment the
+          // FP-predicate arm of ComputeFormulaUsingModel makes before rebuilding
+          // a predicate. Non-float operands (bit-vectors, rounding modes) keep
+          // their bare form.
+          if (term[f.i].GetType() == FLOATINGPOINT_TYPE)
+            ff = FloatBlaster::withFormat(bm, ff, term[f.i].GetExpWidth(),
+                                          term[f.i].GetSigWidth());
+          f.parts.push_back(ff);
+          f.i++;
+        }
+        else
+          f.parts.reserve(term.Degree());
+
+        if (f.i < term.Degree())
+          return want(f, Frame::TermOperand, EvalTerm, term[f.i],
+                      ArrayReadFlag);
+
+        return finish(
+            NonMemberBVConstEvaluator(bm, k, f.parts, term.GetValueWidth()));
+      }
+    }
+  };
+
+  // One step of Expand_ReadOverWrite_UsingModel, which expands
+  // read-over-write by evaluating (readIndex=writeIndex) for every writeindex
+  // until, either it evaluates to TRUE or all (readIndex=writeIndex) evaluate
+  // to FALSE.
+  auto stepExpand = [&](Frame& f) -> StepResult {
+    const ASTNode& term = f.n;
+    const bool arrayread_flag = f.ArrayReadFlag;
+
+    // memoize
+    auto finish = [&](const ASTNode& output) {
+      CounterExampleMap[term] = output;
+      result = output;
+      return StepResult::Finished;
+    };
+
+    if (f.phase == Frame::ExpandRecordedValueStart)
+      return want(f, Frame::ExpandRecordedValue, EvalTerm, f.entry,
+                  arrayread_flag);
+
+    if (f.phase == Frame::Start)
+      return want(f, Frame::ExpandReadIndex, EvalTerm, term[1], false);
+
+    // The value the model already records for this read is the answer, and
+    // the map already holds it.
+    if (f.phase == Frame::ExpandRecordedValue)
+      return StepResult::Finished;
+
+    if (f.phase == Frame::ExpandWritten || f.phase == Frame::ExpandPushedIn)
+      return finish(result);
+
+    // iteratively expand read-over-write, and evaluate against the
+    // model at every iteration
+    if (f.phase == Frame::ExpandReadIndex)
+    {
+      f.index = result;
+      f.cursor = term[0];
+    }
+    else // Frame::ExpandWriteIndex
+    {
+      if (result == f.index)
+      {
+        // found the write-value. return it
+        return want(f, Frame::ExpandWritten, EvalTerm, f.cursor[2], false);
+      }
+
+      f.cursor = f.cursor[0];
+      if (WRITE != f.cursor.GetKind())
+      {
+        const unsigned int width = term.GetValueWidth();
+        return want(f, Frame::ExpandPushedIn, EvalTerm,
+                    bm->CreateTerm(READ, width, f.cursor, f.index),
+                    arrayread_flag);
+      }
+    }
+
+    return want(f, Frame::ExpandWriteIndex, EvalTerm, f.cursor[1], false);
+  };
+
+  while (true)
+  {
+    Frame& current = stack.back();
+
+    StepResult stepResult = StepResult::Finished;
+    switch (current.job)
+    {
+      case EvalFormula:
+        do
+          stepResult = stepFormula(current);
+        while (stepResult == StepResult::Redispatch);
+        break;
+      case EvalTerm:
+        do
+          stepResult = stepTerm(current);
+        while (stepResult == StepResult::Redispatch);
+        break;
+      case EvalExpand:
+        do
+          stepResult = stepExpand(current);
+        while (stepResult == StepResult::Redispatch);
+        break;
+    }
+
+    if (stepResult == StepResult::Pushed)
+      continue;
+    assert(stepResult == StepResult::Finished);
+
+    // Dropping the frame is what lowers a float encoding's evaluation depth,
+    // so it happens before the answer is handed up -- exactly where the scope
+    // guard used to end. A term's answer is then put into the plain
+    // bit-vector spelling, which is what the wrapper around the recursive
+    // evaluator did to everything it returned.
+    const bool wasTerm = (current.job == EvalTerm);
+    stack.pop_back();
+    if (wasTerm)
+      result = plainModelCarrier(bm, result);
+
+    if (stack.empty())
+      return result;
+  }
+}
+
 // FUNCTION: accepts a non-constant term, and returns the
 // corresponding constant term with respect to a model.
 //
@@ -281,423 +1364,7 @@ void AbsRefine_CounterExample::ConstructCounterExample(
 ASTNode AbsRefine_CounterExample::TermToConstTermUsingModel(const ASTNode& term,
                                                             bool ArrayReadFlag)
 {
-  return plainModelCarrier(
-      bm, TermToConstTermUsingModel_inner(term, ArrayReadFlag));
-}
-
-ASTNode
-AbsRefine_CounterExample::TermToConstTermUsingModel_inner(const ASTNode& term,
-                                                          bool ArrayReadFlag)
-{
-  if (term.GetKind() == BVCONST)
-    return term;
-
-  const Kind k = term.GetKind();
-
-  assert(is_Term_kind(k));
-  assert(k != WRITE);
-  assert(BOOLEAN_TYPE != term.GetType());
-
-  // An array-typed entry is a definitional alias installed by equality
-  // propagation (array symbol := array term), not a value; the READ case
-  // resolves through it. Recursing on it here would hand an array term to
-  // a walk that only understands element-typed values.
-  ASTNodeMap::const_iterator it1;
-  if (ARRAY_TYPE != term.GetType() &&
-      (it1 = CounterExampleMap.find(term)) != CounterExampleMap.end())
-  {
-    // A copy, never a reference into the map: the recursion below can reach
-    // an array equality, whose ModelQuery guard rolls CounterExampleMap back
-    // by whole-map assignment -- freeing every node, including the one a
-    // reference here would still be aliasing when the recursion returns.
-    const ASTNode val = it1->second;
-    if (BVCONST != val.GetKind())
-    {
-      // CounterExampleMap has two maps rolled into
-      // one. SubstitutionMap and SolverMap.
-      //
-      // recursion is fine here. There are two maps that are checked
-      // here. One is the substitutionmap. We garuntee that the value
-      // of a key in the substitutionmap is always a constant.
-      //
-      // in the SolverMap we garuntee that "term" does not occur in
-      // the value part of the map
-      if (term == val)
-      {
-        FatalError("TermToConstTermUsingModel: "
-                   "The input term is stored as-is "
-                   "in the CounterExample: Not ok: ",
-                   term);
-      }
-      return TermToConstTermUsingModel(val, ArrayReadFlag);
-    }
-    else
-    {
-      return val;
-    }
-  }
-
-  // FP source operations are evaluated through the solve-owned lowering
-  // context. This is deliberately before the target-language switch below:
-  // counterexample evaluation must not maintain a second implementation of
-  // totalisation, operand reconstruction, and SymFPU lowering.
-  if (fpEncodedEvaluationDepth == 0 &&
-      (is_FP_kind(k) || isFpIndexedArrayAccess(term)))
-  {
-    const ASTNode encoded =
-        requireFpEncodingContext().encodeForModel(term);
-    if (encoded == term && is_FP_kind(k))
-      FatalError("floating-point model encoding made no progress: ", term);
-
-    // The invariant this arm exists to hold: *a float's model value is its
-    // canonical carrier*. A float symbol's raw model bits are whichever NaN
-    // payload the SAT solver happened to pick, and the solve compared
-    // pack(unpack(x)); the two agree on everything except the payload, which
-    // is exactly what an array index distinguishes. So any node the encoding
-    // pass rewrote must be evaluated through that rewrite and never through
-    // its raw bits.
-    //
-    // Whether a rewrite was needed is the pass's answer to give, not ours:
-    // an access whose indexes are all already canonical comes back unchanged
-    // and falls through to the ordinary switch below.
-    if (encoded != term)
-    {
-      // The lowered DAG retains source-sort metadata on carrier reads and
-      // leaves. Keep the entire recursive evaluation in target mode so a
-      // nested read-over-write cannot mistake that metadata for a fresh
-      // source boundary and canonicalise it repeatedly.
-      const ScopedFpEncodedEvaluation evaluating(fpEncodedEvaluationDepth);
-      const ASTNode value =
-          TermToConstTermUsingModel(encoded, ArrayReadFlag);
-      if (term != value)
-        CounterExampleMap[term] = value;
-      return value;
-    }
-  }
-
-  ASTNode output;
-  switch (k)
-  {
-    case BVCONST:
-      output = term;
-      break;
-    case SYMBOL:
-    {
-      if (term.GetType() == ARRAY_TYPE)
-      {
-        return term;
-      }
-      else
-      {
-        // Has been simplified out and can take any value. A RoundingMode's
-        // 5-bit representation has 27 junk patterns, though, so complete that
-        // sort with a real value rather than the ordinary all-zero default.
-        output = bm->isRoundingModeSortedTerm(term)
-                     ? bm->CreateBVConst(
-                           5, symbolic_fp::ROUND_NEAREST_TIES_TO_EVEN)
-                     : bm->CreateZeroConst(term.GetValueWidth());
-      }
-      break;
-    }
-    case READ:
-    {
-      ASTNode arrName = term[0];
-      ASTNode index = term[1];
-      if (0 == arrName.GetIndexWidth())
-      {
-        FatalError("TermToConstTermUsingModel: "
-                   "array has 0 index width: ",
-                   arrName);
-      }
-
-      // An array symbol that equality propagation substituted away is
-      // defined by its (array-typed) entry in the counterexample map --
-      // the copied-in substitution map. The solve never bit-blasted a
-      // read of the vanished symbol, so no model entry can be keyed on
-      // it; read through the definition instead.
-      if (SYMBOL == arrName.GetKind())
-      {
-        ASTNodeMap::const_iterator sub = CounterExampleMap.find(arrName);
-        if (sub != CounterExampleMap.end() &&
-            ARRAY_TYPE == sub->second.GetType())
-        {
-          const ASTNode throughDefinition = bm->CreateTerm(
-              READ, term.GetValueWidth(), sub->second, index);
-          return TermToConstTermUsingModel(throughDefinition, ArrayReadFlag);
-        }
-      }
-
-      // With array equality active, every read in the solve is
-      // evaluated through its read-abstraction variable -- never by
-      // expanding its write chain against the model. The consistency
-      // checker, not the model-side expander, is the authority for
-      // these reads: the abstraction variable holds whatever the SAT
-      // solver assigned, and any disagreement with the array axioms is
-      // exactly what the checker turns into a lemma.
-      //
-      // An owned read with no recorded abstraction variable was
-      // simplified out of the formula before solving; it is evaluated
-      // from the certified array contents instead: the recorded
-      // observation at the concrete index if one exists at this level,
-      // else the concrete write-hit value, else recurse into the base
-      // array, defaulting to zero. This agrees with every recorded
-      // access whenever the checker certifies the candidate.
-      {
-        ExtensionalityContext* ext = bm->getExtensionalityIfAny();
-        if (ext != NULL && ext->active() && ext->arrayGraphFrozen() &&
-            ext->ownsArray(arrName))
-        {
-          const ASTNode idxVal = TermToConstTermUsingModel(index, false);
-          NodeFactory* hf = bm->hashingNodeFactory;
-          ASTNode level = arrName;
-          ASTNode val;
-          while (true)
-          {
-            const ASTNode key = hf->CreateTerm(READ, level.GetValueWidth(),
-                                               level, idxVal);
-            ASTNodeMap::const_iterator cit = CounterExampleMap.find(key);
-            if (cit != CounterExampleMap.end())
-            {
-              val = cit->second;
-              if (BVCONST != val.GetKind())
-                val = TermToConstTermUsingModel(val, false);
-              break;
-            }
-            if (WRITE == level.GetKind())
-            {
-              const ASTNode writeIdx = TermToConstTermUsingModel(level[1],
-                                                                 false);
-              if (writeIdx == idxVal)
-              {
-                val = TermToConstTermUsingModel(level[2], false);
-                break;
-              }
-              level = level[0];
-              continue;
-            }
-            if (ITE == level.GetKind() && level.GetType() == ARRAY_TYPE)
-            {
-              const ASTNode cond = ComputeFormulaUsingModel(level[0]);
-              if (cond == ASTTrue)
-                level = level[1];
-              else if (cond == ASTFalse)
-                level = level[2];
-              else
-                FatalError("array-equality: an owned array if-then-else "
-                           "condition has no concrete model value",
-                           level[0]);
-              continue;
-            }
-            // base array with no observation
-            val = defaultCellValue(level);
-            break;
-          }
-          CounterExampleMap[term] = val;
-          return val;
-        }
-      }
-
-      if (WRITE == arrName.GetKind()) // READ over a WRITE
-      {
-        ASTNode wrtterm = Expand_ReadOverWrite_UsingModel(term, ArrayReadFlag);
-        if (wrtterm == term)
-        {
-          FatalError("TermToConstTermUsingModel: "
-                     "Read_Over_Write term must be expanded "
-                     "into an ITE",
-                     term);
-        }
-        ASTNode rtterm = TermToConstTermUsingModel(wrtterm, ArrayReadFlag);
-        assert(ArrayReadFlag || (BVCONST == rtterm.GetKind()));
-        return rtterm;
-      }
-      else if (ITE == arrName.GetKind()) // READ over an ITE
-      {
-        // The "then" and "else" branch are arrays.
-        ASTNode indexVal = TermToConstTermUsingModel(index, ArrayReadFlag);
-
-        ASTNode condcompute =
-            ComputeFormulaUsingModel(arrName[0]); // Get the truth value.
-        unsigned int wid = arrName.GetValueWidth();
-        if (ASTTrue == condcompute)
-        {
-          const ASTNode& result = TermToConstTermUsingModel(
-              bm->CreateTerm(READ, wid, arrName[1], indexVal), ArrayReadFlag);
-          assert(ArrayReadFlag || (BVCONST == result.GetKind()));
-          return result;
-        }
-        else if (ASTFalse == condcompute)
-        {
-          const ASTNode& result = TermToConstTermUsingModel(
-              bm->CreateTerm(READ, wid, arrName[2], indexVal), ArrayReadFlag);
-          assert(ArrayReadFlag || (BVCONST == result.GetKind()));
-          return result;
-        }
-        else
-        {
-          FatalError(" TermToConstTermUsingModel: termITE: "
-                     "cannot compute ITE conditional against model: ",
-                     term);
-        }
-      }
-
-      ASTNode modelentry;
-      if (CounterExampleMap.find(index) != CounterExampleMap.end())
-      {
-        // index has a const value in the CounterExampleMap. Copied out of the
-        // map for the reason given at the lookup at the top of this function.
-        const ASTNode indexEntry = CounterExampleMap[index];
-        ASTNode indexVal = TermToConstTermUsingModel(indexEntry, ArrayReadFlag);
-        modelentry =
-            bm->CreateTerm(READ, arrName.GetValueWidth(), arrName, indexVal);
-      }
-      else
-      {
-        // index does not have a const value in the
-        // CounterExampleMap. compute it.
-        ASTNode indexconstval = TermToConstTermUsingModel(index, ArrayReadFlag);
-        // update model with value of the index
-        // CounterExampleMap[index] = indexconstval;
-        modelentry = bm->CreateTerm(READ, arrName.GetValueWidth(), arrName,
-                                    indexconstval);
-      }
-      // modelentry is now an arrayread over a constant index
-      BVTypeCheck(modelentry);
-
-      // if a value exists in the CounterExampleMap then return it. Copied out
-      // of the map for the reason given at the lookup at the top of this
-      // function.
-      if (CounterExampleMap.find(modelentry) != CounterExampleMap.end())
-      {
-        const ASTNode modelentryValue = CounterExampleMap[modelentry];
-        output = TermToConstTermUsingModel(modelentryValue, ArrayReadFlag);
-      }
-      else if (ArrayReadFlag)
-      {
-        // return the array read over a constantindex
-        output = modelentry;
-      }
-      else if (bm->UserFlags.enable_array_equality)
-      {
-        // Has been simplified out, so any value will do -- but only one
-        // value agrees with the model that is published. With array
-        // equality enabled the model surface prints a total
-        // interpretation per array, and this is a cell of it that no
-        // observation covers, so it is the completion or nothing.
-        // Inventing something else makes evaluation disagree with every
-        // other reader: an array equality evaluates false through its
-        // lowering's reads while the printed arrays are identical, which
-        // is the disagreement the post-solve audit trips on -- and,
-        // unaudited, a (get-model) that falsifies the query it answered
-        // sat. Both of this arm's former answers were such an invention:
-        // all-ones for a bitvector cell the printer filled with zero,
-        // and RNE for a RoundingMode cell that ReadUsingModel and the
-        // checker were still completing with all-zero bits.
-        //
-        // Memoising the invented value instead cannot close that gap.
-        // Model queries run inside a scope that restores the
-        // counterexample map afterwards, so the entry is rolled back
-        // and the next reader invents the value again against a model
-        // that never recorded it. Agreeing with the completion the rest
-        // of the model already uses needs no bookkeeping at all.
-        //
-        // Gated on the option: with it off the counterexample map, and
-        // so vc_getCounterExampleArray, must stay exactly as before.
-        output = defaultCellValue(arrName);
-      }
-      else
-      {
-        // Has been simplified out and can take any value. Keep the historical
-        // all-one completion for ordinary bitvectors, but not for
-        // RoundingMode: 0b11111 is not one of that sort's five values and can
-        // make SymFPU exhibit a non-IEEE sixth rounding behaviour.
-        output = bm->isRoundingModeSortedTerm(modelentry)
-                     ? bm->CreateBVConst(
-                           5, symbolic_fp::ROUND_NEAREST_TIES_TO_EVEN)
-                     : bm->CreateMaxConst(modelentry.GetValueWidth());
-      }
-      break;
-    }
-    case ITE:
-    {
-      ASTNode condcompute = ComputeFormulaUsingModel(term[0]);
-      if (ASTTrue == condcompute)
-      {
-        output = TermToConstTermUsingModel(term[1], ArrayReadFlag);
-      }
-      else if (ASTFalse == condcompute)
-      {
-        output = TermToConstTermUsingModel(term[2], ArrayReadFlag);
-      }
-      else
-      {
-        FatalError(" TermToConstTermUsingModel: termITE: cannot "
-                   "compute ITE conditional against model: ",
-                   term);
-      }
-      break;
-    }
-    default:
-    {
-      const ASTChildren c = term.GetChildren();
-      ASTVec o;
-      o.reserve(c.size());
-      for (auto it = c.begin(), itend = c.end(); it != itend;
-           it++)
-      {
-        ASTNode ff = TermToConstTermUsingModel(*it, ArrayReadFlag);
-        // NonMemberBVConstEvaluator below needs every child to be a constant.
-        // With ArrayReadFlag set, a read with no value in the model comes back
-        // as a symbolic READ over the array (case 2 above) rather than a
-        // constant -- this happens for the unconstrained array that totalising
-        // introduces for an out-of-range to_ubv/to_sbv, reached here when the
-        // enclosing ITE selects the unspecified branch and it feeds an ordinary
-        // bit-vector operation. Its value is genuinely arbitrary, so resolve it
-        // to a concrete constant rather than hand a non-constant to the
-        // evaluator (which cannot read arrays and would abort on the array
-        // symbol).
-        if (BVCONST != ff.GetKind())
-          ff = TermToConstTermUsingModel(*it, false);
-        // A floating-point operand comes back as a bare bit-vector:
-        // TermToConstTermUsingModel strips the format off every result it
-        // returns. NonMemberBVConstEvaluator lowers through FloatBlast,
-        // which reads each operand's format off its source sort, so restore
-        // each float operand's own format here -- the same reattachment the
-        // FP-predicate arm of ComputeFormulaUsingModel makes before rebuilding
-        // a predicate. Non-float operands (bit-vectors, rounding modes) keep
-        // their bare form.
-        if (it->GetType() == FLOATINGPOINT_TYPE)
-          ff = FloatBlaster::withFormat(bm, ff, it->GetExpWidth(),
-                                        it->GetSigWidth());
-        o.push_back(ff);
-      }
-
-      output = NonMemberBVConstEvaluator(bm, k, o, term.GetValueWidth());
-      break;
-    }
-  }
-
-  assert(ArrayReadFlag || (BVCONST == output.GetKind()));
-
-  // when this flag is false, we should compute the arrayread to a
-  // constant. this constant is stored in the counter_example
-  // datastructure
-  // if (!ArrayReadFlag)
-  {
-    // Don't memoise a read as its own value. With ArrayReadFlag true, a read
-    // with no value in the model is returned unchanged (case 2 above) -- this
-    // happens for an unconstrained read, such as the array that totalising
-    // introduces for an out-of-range to_ubv/to_sbv. Caching term -> term would
-    // put the term in its own value slot, violating the invariant the lookups
-    // rely on: a later lookup then trips the "stored as-is" fatal error, or
-    // leaves the read unresolved and non-constant. Skipping the self-entry lets
-    // that later lookup fall through to the documented arbitrary completion.
-    if (term != output)
-      CounterExampleMap[term] = output;
-  }
-
-  // cerr << "Output to TermToConstTermUsingModel: " << output << endl;
-  return output;
+  return evaluate(EvalTerm, term, ArrayReadFlag);
 }
 
 // Expands read-over-write by evaluating (readIndex=writeIndex) for
@@ -707,313 +1374,15 @@ ASTNode
 AbsRefine_CounterExample::Expand_ReadOverWrite_UsingModel(const ASTNode& term,
                                                           bool arrayread_flag)
 {
-  if (READ != term.GetKind() || WRITE != term[0].GetKind())
-  {
-    FatalError("RemovesWrites: Input must be a READ over a WRITE", term);
-  }
-
-  ASTNode output;
-  ASTNodeMap::iterator it1;
-  if ((it1 = CounterExampleMap.find(term)) != CounterExampleMap.end())
-  {
-    // Copied out of the map for the reason given at the lookup at the top of
-    // TermToConstTermUsingModel_inner.
-    const ASTNode val = it1->second;
-    if (BVCONST != val.GetKind())
-    {
-      // recursion is fine here. There are two maps that are checked
-      // here. One is the substitutionmap. We garuntee that the value
-      // of a key in the substitutionmap is always a constant.
-      if (term == val)
-      {
-        FatalError("TermToConstTermUsingModel: The input term is "
-                   "stored as-is "
-                   "in the CounterExample: Not ok: ",
-                   term);
-      }
-      return TermToConstTermUsingModel(val, arrayread_flag);
-    }
-    else
-    {
-      return val;
-    }
-  }
-
-  ASTNode newRead = term;
-  const ASTNode readIndex = TermToConstTermUsingModel(newRead[1], false);
-  // iteratively expand read-over-write, and evaluate against the
-  // model at every iteration
-  ASTNode write = newRead[0];
-  do
-  {
-    ASTNode writeIndex = TermToConstTermUsingModel(write[1], false);
-
-    if (writeIndex == readIndex)
-    {
-      // found the write-value. return it
-      output = TermToConstTermUsingModel(write[2], false);
-      CounterExampleMap[term] = output;
-      return output;
-    }
-
-    write = write[0];
-  } while (WRITE == write.GetKind());
-
-  const unsigned int width = term.GetValueWidth();
-  newRead = bm->CreateTerm(READ, width, write, readIndex);
-  output = TermToConstTermUsingModel(newRead, arrayread_flag);
-
-  // memoize
-  CounterExampleMap[term] = output;
-  return output;
-} // Expand_ReadOverWrite_UsingModel()
+  return evaluate(EvalExpand, term, arrayread_flag);
+}
 
 /* FUNCTION: accepts a non-constant formula, and checks if the
  * formula is ASTTrue or ASTFalse w.r.t to a model
  */
 ASTNode AbsRefine_CounterExample::ComputeFormulaUsingModel(const ASTNode& form)
 {
-  const Kind k = form.GetKind();
-  if (!(is_Form_kind(k) && BOOLEAN_TYPE == form.GetType()))
-  {
-    FatalError(" ComputeConstFormUsingModel: "
-               "The input is a non-formula: ",
-               form);
-  }
-
-  // cerr << "Input to ComputeFormulaUsingModel:" << form << endl;
-  ASTNodeMap::const_iterator it1;
-  if ((it1 = ComputeFormulaMap.find(form)) != ComputeFormulaMap.end())
-  {
-    const ASTNode& res = it1->second;
-    if (ASTTrue == res || ASTFalse == res)
-    {
-      return res;
-    }
-    else
-    {
-      FatalError("ComputeFormulaUsingModel: "
-                 "The value of a formula must be TRUE or FALSE:",
-                 form);
-    }
-  }
-
-  // Unlike the term arm (TermToConstTermUsingModel), floating-point *predicates*
-  // are not routed through encodeForModel. Encoding the whole predicate and
-  // re-entering the evaluator runs the recursion at fpEncodedEvaluationDepth > 0,
-  // where the term arm's own encode step is switched off -- so any float operand
-  // reached inside the encoded predicate would fall through to the term switch's
-  // default. Instead the FP_* predicate cases below resolve each operand to a
-  // constant at depth 0 (where the term arm does encode floats correctly) and
-  // fold the predicate over those constants.
-
-  ASTNode output = ASTUndefined;
-  switch (k)
-  {
-    case TRUE:
-    case FALSE:
-      output = form;
-      break;
-    case SYMBOL:
-      if (BOOLEAN_TYPE != form.GetType())
-        FatalError(" ComputeFormulaUsingModel: "
-                   "Non-Boolean variables are not formulas",
-                   form);
-      if (CounterExampleMap.find(form) != CounterExampleMap.end())
-      {
-        ASTNode counterexample_val = CounterExampleMap[form];
-        if (!bm->VarSeenInTerm(form, counterexample_val))
-        {
-          output = ComputeFormulaUsingModel(counterexample_val);
-        }
-        else
-        {
-          output = counterexample_val;
-        }
-      }
-      else
-      {
-        // Has been simplified out. Can take any value.
-        output = ASTFalse;
-      }
-      break;
-    case ARRAY_EQ:
-    {
-      ExtensionalityContext* ext = bm->getExtensionalityIfAny();
-      ASTNode lowered;
-      if (ext != NULL && ext->getCurrentLowering(form, lowered))
-      {
-        // This solve decided the equality; its lowering is the answer.
-        output = ComputeFormulaUsingModel(lowered);
-      }
-      else
-      {
-        // It did not: either the equality belongs to an earlier query,
-        // or lowering discarded it -- an equality nested in a conjunct
-        // that solving a write chain against its own base dropped as
-        // shadowed. There is no abstraction variable to consult, and
-        // the one that used to be consulted here had never been
-        // assigned, so it read false while the model gave the two
-        // arrays identical contents.
-        //
-        // Ask the model instead. It is the same model the caller is
-        // about to print, so the answer agrees with it by construction,
-        // which is the property the abstraction variable could not
-        // offer.
-        if (!arrayEqualityIsModelDecidable(form[0]) ||
-            !arrayEqualityIsModelDecidable(form[1]))
-          FatalError("array-equality: cannot evaluate an opaque equality "
-                     "over float-indexed arrays that was not reachable in "
-                     "the most recent solve",
-                     form);
-        output = ArraysEqualUsingModel(form[0], form[1]) ? ASTTrue : ASTFalse;
-      }
-      break;
-    }
-    case BOOLEXTRACT:
-    {
-      ASTNode t0 = TermToConstTermUsingModel(form[0]);
-      output = simp->BVConstEvaluator(bm->CreateNode(BOOLEXTRACT, t0, form[1]));
-      break;
-    }
-    case EQ:
-    case BVLT:
-    case BVLE:
-    case BVGT:
-    case BVGE:
-    case BVSLT:
-    case BVSLE:
-    case BVSGT:
-    case BVSGE:
-    case BVUADDO:
-    case BVSADDO:
-    case BVUMULO:
-    case BVSMULO:
-    case BVUSUBO:
-    case BVSSUBO:
-    {
-      ASTVec children;
-      children.reserve(form.Degree());
-
-      for (auto it = form.begin(), itend = form.end();
-           it != itend; it++)
-      {
-        children.push_back(TermToConstTermUsingModel(*it, false));
-      }
-
-      output = NonMemberBVConstEvaluator(bm, k, children, form.GetValueWidth());
-    }
-    break;
-
-    case NAND:
-    case NOR:
-    case NOT:
-    case AND:
-    case XOR:
-    case IFF:
-    case IMPLIES:
-    case OR:
-    {
-      ASTVec children;
-      children.reserve(form.Degree());
-
-      for (auto it = form.begin(), itend = form.end();
-           it != itend; it++)
-      {
-        children.push_back(ComputeFormulaUsingModel(*it));
-      }
-
-      output = NonMemberBVConstEvaluator(bm, k, children, form.GetValueWidth());
-    }
-    break;
-
-    case ITE:
-    {
-      ASTNode t0 = ComputeFormulaUsingModel(form[0]);
-      if (ASTTrue == t0)
-        output = ComputeFormulaUsingModel(form[1]);
-      else if (ASTFalse == t0)
-        output = ComputeFormulaUsingModel(form[2]);
-      else
-        FatalError("ComputeFormulaUsingModel: ITE: "
-                   "something is wrong with the formula: ",
-                   form);
-    }
-    break;
-    case FP_LEQ:
-    case FP_LT:
-    case FP_GEQ:
-    case FP_GT:
-    case FP_EQ:
-    case FP_ISNORMAL:
-    case FP_ISSUBNORMAL:
-    case FP_ISZERO:
-    case FP_ISINFINITE:
-    case FP_ISNAN:
-    case FP_ISNEGATIVE:
-    case FP_ISPOSITIVE:
-    case FP_SMT_EQ:
-    {
-      // Rebuild at the node's real arity: the comparisons are binary but the
-      // classification predicates are unary.
-      ASTVec operands;
-      operands.reserve(form.Degree());
-
-      for (unsigned int i = 0; i < form.Degree(); i++)
-      {
-        ASTNode simp(TermToConstTermUsingModel(form[i]));
-        // An operand must resolve to a constant, as in the float arm of
-        // TermToConstTermUsingModel: the read-tolerant flag is on inside the
-        // walk, so a float-element array read the solve never constrained
-        // comes back as the symbolic READ (case 2 there) rather than a
-        // value. Rebuilding the predicate over it is not evaluation -- the
-        // blaster would carry the read along, and the same-operand folds
-        // below can hand the bare READ back. The read is genuinely
-        // unconstrained here, so resolve it to a concrete value.
-        if (BVCONST != simp.GetKind())
-          simp = TermToConstTermUsingModel(form[i], false);
-        assert(simp.GetKind() == BVCONST);
-        operands.push_back(FloatBlaster::withFormat(
-            bm, simp, form[i].GetExpWidth(), form[i].GetSigWidth()));
-      }
-
-      ASTNode temp(bm->CreateNode(k, operands));
-
-      // Rebuilding through the simplifying factory may rewrite the predicate
-      // rather than return it: constant operands fold to true/false outright,
-      // and the same-operand rules fire here because interned constants
-      // compare pointer-equal -- fp.leq of a value with itself comes back as
-      // (not (fp.isNaN ...)). Whatever came back that is not this operation
-      // is a formula; evaluate it, never blast it.
-      if (temp.GetKind() != k)
-      {
-        output = ComputeFormulaUsingModel(temp);
-        break;
-      }
-
-      // One table, the same one the solver's lowering pass uses. temp's
-      // operands were re-stamped with their formats above, so it is a
-      // well-formed source node and its own sorts say what the formats are.
-      ASTNode blasted(FloatBlast::lowerOperation(bm, temp));
-
-      assert(blasted != temp);
-      assert(blasted != form);
-
-      output = ComputeFormulaUsingModel(blasted);
-      break;
-    }
-    default:
-      cerr << _kind_names[k];
-      FatalError(" ComputeFormulaUsingModel: "
-                 "the kind has not been implemented",
-                 ASTUndefined);
-      break;
-  }
-
-  assert(ASTUndefined != output);
-  assert(output.isConstant());
-  ComputeFormulaMap[form] = output;
-  return output;
+  return evaluate(EvalFormula, form, true);
 }
 
 void AbsRefine_CounterExample::CheckCounterExample(
@@ -1280,9 +1649,9 @@ bool AbsRefine_CounterExample::ArraysEqualUsingModel(const ASTNode& left,
       encode ? requireFpEncodingContext().encodeForModel(left) : left;
   const ASTNode lowered_right =
       encode ? requireFpEncodingContext().encodeForModel(right) : right;
-  std::unique_ptr<ScopedFpEncodedEvaluation> evaluating;
+  ScopedFpEncodedEvaluation evaluating;
   if (encode)
-    evaluating.reset(new ScopedFpEncodedEvaluation(fpEncodedEvaluationDepth));
+    evaluating.activate(fpEncodedEvaluationDepth);
   if (lowered_left == lowered_right)
     return true;
 

--- a/lib/Extensionality/ExtensionalityContext.cpp
+++ b/lib/Extensionality/ExtensionalityContext.cpp
@@ -28,10 +28,11 @@ THE SOFTWARE.
 #include "stp/STPManager/STPManager.h"
 #include "stp/Simplifier/SubstitutionMap.h"
 #include "stp/ToSat/ToSATBase.h"
+#include "stp/Util/DagWalk.h"
 #include <algorithm>
 #include <cstdio>
 #include <cstdlib>
-#include <functional>
+#include <limits>
 
 namespace stp
 {
@@ -116,13 +117,14 @@ ASTNode canonicalQuietNaN(STPMgr* bm, unsigned eb, unsigned sb)
   return bm->CreateBVConst(bits, w);
 }
 
-// Postorder DAG collection of every node beneath (and including) n.
+// Collect every node beneath (and including) n. The input chooses the DAG's
+// depth, so retain suspended ancestors on the heap rather than recursing once
+// per level.
 void collectDag(const ASTNode& n, ASTNodeSet& visited)
 {
-  if (!visited.insert(n).second)
-    return;
-  for (unsigned k = 0; k < n.Degree(); k++)
-    collectDag(n[k], visited);
+  walkPreOrder(n, [&](const ASTNode& current) {
+    return visited.insert(current).second;
+  });
 }
 
 // The current form of an equality operand, read back from its witness
@@ -152,39 +154,6 @@ void collectDag(const ASTNode& n, ASTNodeSet& visited)
 //
 // Anything else means an anchor was rewritten beyond recognition:
 // refuse loudly rather than guess.
-// Does any node of this DAG belong to `needles`? Iterative post-order,
-// because the terms it is asked about are as deep as the user's write
-// chains and if-then-else nests.
-bool subtreeMentions(const ASTNode& root, const std::set<ASTNode>& needles)
-{
-  std::map<ASTNode, bool> found;
-  std::vector<std::pair<ASTNode, bool>> stack;
-  stack.push_back(std::make_pair(root, false));
-  while (!stack.empty())
-  {
-    const ASTNode n = stack.back().first;
-    const bool expanded = stack.back().second;
-    stack.pop_back();
-    if (found.find(n) != found.end())
-      continue;
-    if (!expanded)
-    {
-      // Children are pushed after this node's second visit, so they are
-      // all answered before it is.
-      stack.push_back(std::make_pair(n, true));
-      for (unsigned k = 0; k < n.Degree(); k++)
-        if (found.find(n[k]) == found.end())
-          stack.push_back(std::make_pair(n[k], false));
-      continue;
-    }
-    bool here = needles.find(n) != needles.end();
-    for (unsigned k = 0; !here && k < n.Degree(); k++)
-      here = found[n[k]];
-    found[n] = here;
-  }
-  return found[root];
-}
-
 ASTNode recoverAnchoredOperand(const ASTNode& rhs, const ASTNode& lambda,
                                const ASTNode& proxy)
 {
@@ -532,52 +501,173 @@ ASTNode ExtensionalityContext::lowerArrayEqualities(
 
   ASTNodeMap cache;
   NodeFactory* hf = bm->hashingNodeFactory;
-  std::function<ASTNode(const ASTNode&)> lower = [&](const ASTNode& n) {
-    ASTNodeMap::const_iterator found = cache.find(n);
+
+  // Lower the DAG in the same left-to-right post-order as the former
+  // recursive std::function. That function consumed one native call frame
+  // per input level (and made a type-erased call per edge); a sufficiently
+  // deep write operand therefore exhausted the stack before ordinary STP
+  // preprocessing began.
+  //
+  // Most nodes do not contain ARRAY_EQ and come back unchanged. Keep the
+  // current node's original children in its immutable storage and acquire an
+  // owned vector only after one child changes. Scratch slots are nested and
+  // released in traversal order, so unchanged frames stay compact while a
+  // changed ancestor can retain its prefix across a changed descendant.
+  struct Frame
+  {
+    enum : unsigned
+    {
+      noScratch = std::numeric_limits<unsigned>::max()
+    };
+
+    const ASTNode* node;
+    size_t nextChild = 0;
+    unsigned scratch = noScratch;
+    bool waiting = false;
+
+    explicit Frame(const ASTNode* n) : node(n) {}
+  };
+  static_assert(sizeof(Frame) <= 32,
+                "array-equality lowering frames must stay compact");
+
+  ASTNode result;
+
+  // The recursive form cached leaves too. Settle them without allocating a
+  // frame, at the same point in the traversal at which their call returned.
+  auto settled = [&](const ASTNode& n) -> bool {
+    const ASTNodeMap::const_iterator found = cache.find(n);
     if (found != cache.end())
-      return found->second;
-
-    const ASTChildren children = n.GetChildren();
-    ASTVec loweredChildren;
-    bool changed = false;
-    loweredChildren.reserve(children.size());
-    for (const ASTNode& originalChild : children)
     {
-      const ASTNode child = lower(originalChild);
-      loweredChildren.push_back(child);
-      changed = changed || child != originalChild;
+      result = found->second;
+      return true;
     }
-
-    ASTNode result;
-    if (n.GetKind() == ARRAY_EQ)
-    {
-      assert(loweredChildren.size() == 2);
-      result = makeEquality(loweredChildren[0], loweredChildren[1]);
-      currentLowerings[n] = result;
-    }
-    else if (!changed)
-    {
-      result = n;
-    }
-    else if (n.GetValueWidth() == 0)
-    {
-      result = hf->CreateNode(n.GetKind(), loweredChildren);
-    }
-    else if (n.GetIndexWidth() > 0)
-    {
-      result = hf->CreateArrayTerm(n.GetKind(), n.GetIndexWidth(),
-                                   n.GetValueWidth(), loweredChildren);
-    }
-    else
-    {
-      result = hf->CreateTerm(n.GetKind(), n.GetValueWidth(), loweredChildren);
-    }
-
+    if (n.Degree() != 0)
+      return false;
+    result = n;
     cache.insert(std::make_pair(n, result));
-    return result;
+    return true;
   };
 
-  const ASTNode lowered = lower(root);
+  ASTNode lowered;
+  if (settled(root))
+  {
+    lowered = result;
+  }
+  else
+  {
+    std::vector<Frame> stack;
+    stack.emplace_back(&root);
+
+    std::vector<ASTVec> scratches;
+    unsigned scratchesInUse = 0;
+
+    auto scratchFor = [&](Frame& frame) -> ASTVec& {
+      if (frame.scratch == Frame::noScratch)
+      {
+        assert(scratchesInUse < Frame::noScratch);
+        frame.scratch = scratchesInUse++;
+        if (frame.scratch == scratches.size())
+          scratches.emplace_back();
+      }
+      return scratches[frame.scratch];
+    };
+
+    auto releaseScratch = [&](Frame& frame) {
+      if (frame.scratch == Frame::noScratch)
+        return;
+      assert(frame.scratch + 1 == scratchesInUse);
+      scratches[frame.scratch].clear();
+      --scratchesInUse;
+    };
+
+    // Consume the answer for frame.nextChild, copying the original prefix
+    // only when this is the first child that changed.
+    auto acceptChild = [&](Frame& frame) {
+      const ASTChildren original = frame.node->GetChildren();
+      assert(frame.nextChild < original.size());
+      if (result != original[frame.nextChild] &&
+          frame.scratch == Frame::noScratch)
+      {
+        ASTVec& changed = scratchFor(frame);
+        changed.reserve(original.size());
+        changed.insert(changed.end(), original.begin(),
+                       original.begin() + frame.nextChild);
+      }
+      if (frame.scratch != Frame::noScratch)
+        scratches[frame.scratch].push_back(result);
+      ++frame.nextChild;
+    };
+
+    while (true)
+    {
+      Frame& current = stack.back();
+
+      if (current.waiting)
+      {
+        current.waiting = false;
+        acceptChild(current);
+      }
+
+      bool descended = false;
+      while (current.nextChild < current.node->Degree())
+      {
+        const ASTNode* child = &(*current.node)[current.nextChild];
+        if (settled(*child))
+        {
+          acceptChild(current);
+          continue;
+        }
+
+        current.waiting = true;
+        stack.emplace_back(child);
+        descended = true;
+        break;
+      }
+      if (descended)
+        continue;
+
+      const ASTNode& n = *current.node;
+      const ASTVec* changed =
+          current.scratch == Frame::noScratch
+              ? NULL
+              : &scratches[current.scratch];
+
+      if (n.GetKind() == ARRAY_EQ)
+      {
+        assert(n.Degree() == 2);
+        const ASTNode& left = changed == NULL ? n[0] : (*changed)[0];
+        const ASTNode& right = changed == NULL ? n[1] : (*changed)[1];
+        result = makeEquality(left, right);
+        currentLowerings[n] = result;
+      }
+      else if (changed == NULL)
+      {
+        result = n;
+      }
+      else if (n.GetValueWidth() == 0)
+      {
+        result = hf->CreateNode(n.GetKind(), *changed);
+      }
+      else if (n.GetIndexWidth() > 0)
+      {
+        result = hf->CreateArrayTerm(n.GetKind(), n.GetIndexWidth(),
+                                     n.GetValueWidth(), *changed);
+      }
+      else
+      {
+        result = hf->CreateTerm(n.GetKind(), n.GetValueWidth(), *changed);
+      }
+
+      cache.insert(std::make_pair(n, result));
+      releaseScratch(current);
+      stack.pop_back();
+      if (stack.empty())
+      {
+        lowered = result;
+        break;
+      }
+    }
+  }
 
   // FpTotalise runs before this pass. If it changed an operand of an opaque
   // equality, the public expression handle still names the original node
@@ -605,14 +695,9 @@ ASTNode ExtensionalityContext::lowerArrayEqualities(
       currentLowerings[it->first] = loweredRewrite->second;
   }
 
-  // ARRAY_EQ is legal only in the user-facing AST. Ordinary simplification,
-  // array transformation and bit-blasting intentionally have no case for it.
-  ASTNodeSet nodes;
-  collectDag(lowered, nodes);
-  for (ASTNodeSet::const_iterator it = nodes.begin(); it != nodes.end(); ++it)
-    if (it->GetKind() == ARRAY_EQ)
-      FatalError("array-equality: query lowering left an opaque equality", *it);
-
+  // Activation walks this exact root next and checks the lowering
+  // postcondition while it does so; do not inventory the whole DAG once
+  // merely to traverse it again immediately afterwards.
   activateReachableRecords(lowered);
 
   return lowered;
@@ -633,13 +718,25 @@ void ExtensionalityContext::activateReachableRecords(
 {
   std::set<size_t> activeIds;
   ASTNodeSet visited;
+  visited.insert(loweredRoot);
   ASTVec pending(1, loweredRoot);
   while (!pending.empty())
   {
     const ASTNode node = pending.back();
     pending.pop_back();
-    if (!visited.insert(node).second)
-      continue;
+
+    // ARRAY_EQ is legal only in the user-facing AST. Ordinary
+    // simplification, array transformation and bit-blasting intentionally
+    // have no case for it. This used to be a separate complete walk just
+    // before activation.
+    if (node.GetKind() == ARRAY_EQ)
+      FatalError("array-equality: query lowering left an opaque equality",
+                 node);
+
+    auto enqueue = [&](const ASTNode& next) {
+      if (visited.insert(next).second)
+        pending.push_back(next);
+    };
 
     const std::map<ASTNode, size_t>::const_iterator proxy =
         proxyToRecord.find(node);
@@ -650,12 +747,12 @@ void ExtensionalityContext::activateReachableRecords(
       // condition or another operand subterm. Follow cached operands so that
       // activation is the transitive closure, not merely the proxies still
       // visible at the Boolean root.
-      pending.push_back(r.constructionLeft);
-      pending.push_back(r.constructionRight);
+      enqueue(r.constructionLeft);
+      enqueue(r.constructionRight);
     }
 
     for (unsigned i = 0; i < node.Degree(); ++i)
-      pending.push_back(node[i]);
+      enqueue(node[i]);
   }
 
   activeRecordIds.assign(activeIds.begin(), activeIds.end());
@@ -855,7 +952,7 @@ void ExtensionalityContext::locateCanonicalOperands(const ASTNode& root)
   // collected: a protected lambda or proxy turning up in an equation of
   // the same shape is none of this function's business.
   std::set<ASTNode> witnessNames;
-  std::set<ASTNode> witnessIndexes;
+  ASTNodeSet witnessIndexes;
   for (size_t i = 0; i < activeRecordIds.size(); i++)
   {
     const Record& r = records[activeRecordIds[i]];
@@ -888,6 +985,35 @@ void ExtensionalityContext::locateCanonicalOperands(const ASTNode& root)
   std::map<ASTNode, ASTNode> anchorRhs;
   ASTNodeSet visited;
   collectDag(root, visited);
+
+  // The question is existential and every write asks it against the same set
+  // of witness indexes. Once a node's complete subtree has been checked and
+  // found safe, every later write which shares that node is safe without a
+  // fresh post-order map. Across all writes this visits each unique index-DAG
+  // node once rather than once per write.
+  //
+  // The set is marked in pre-order, so a walk that finds a witness stops
+  // with the subtrees of already-marked nodes unexamined. That never leaks
+  // into a later answer only because a hit is fatal below: every call that
+  // returns false ran to completion, and only completed walks leave nodes
+  // behind for a later walk to trust. If the FatalError ever becomes a soft
+  // skip, this memo must go back to per-walk state.
+  ASTNodeSet checkedWriteIndexNodes;
+  auto writeIndexMentionsWitness = [&](const ASTNode& index) {
+    bool mentions = false;
+    walkPreOrder(index, [&](const ASTNode& current) {
+      if (mentions || !checkedWriteIndexNodes.insert(current).second)
+        return false;
+      if (witnessIndexes.find(current) != witnessIndexes.end())
+      {
+        mentions = true;
+        return false;
+      }
+      return true;
+    });
+    return mentions;
+  };
+
   for (ASTNodeSet::const_iterator it = visited.begin(); it != visited.end();
        ++it)
   {
@@ -907,7 +1033,7 @@ void ExtensionalityContext::locateCanonicalOperands(const ASTNode& root)
     // and a sort whose values are not all denoting needs exactly that --
     // and no such position gives a rewrite anything to work with. Only a
     // write index does.
-    if (n.GetKind() == WRITE && subtreeMentions(n[1], witnessIndexes))
+    if (n.GetKind() == WRITE && writeIndexMentionsWitness(n[1]))
       FatalError("array-equality: a write index mentions a witness index, "
                  "so a rewrite could decide that write against an anchor "
                  "read and move the operand recovery reads",

--- a/lib/FloatBlaster/FpTotalise.cpp
+++ b/lib/FloatBlaster/FpTotalise.cpp
@@ -25,6 +25,7 @@ THE SOFTWARE.
 #include "stp/FloatBlaster/FpTotalise.h"
 
 #include "stp/FloatBlaster/FloatBlaster.h"
+#include "stp/Util/DagWalk.h"
 
 #include <string>
 
@@ -152,27 +153,31 @@ ASTNode FpTotalise::canonicalSourceBits(const ASTNode& value)
   return nf->CreateTerm(FP_TO_IEEE_BV, sort.packedWidth(), value);
 }
 
+// A continuation stack rather than a call per level: how deeply a float
+// expression nests is the input's choice, and this walks the whole of one.
+// It preserves the recursion's pre-order while retaining only ancestors, not
+// every sibling in a wide frontier. See DeepDag_Test.cpp.
 void FpTotalise::collectRoundingModeTerms(const ASTNode& n, ASTNodeSet& seen,
                                           ASTVec& constraints)
 {
-  if (!seen.insert(n).second)
-    return;
+  walkPreOrder(n, [&](const ASTNode& m) {
+    if (!seen.insert(m).second)
+      return false;
 
-  // Leaves are visited now, where they were skipped before: a declared
-  // RoundingMode symbol is a leaf, and it is exactly as much in need of
-  // pinning as a read is.
-  if (n.GetKind() == SYMBOL)
-  {
-    if (bm->isRoundingModeSymbol(n))
-      constraints.push_back(bm->roundingModeValidConstraint(n));
-    return;
-  }
+    // Leaves are visited now, where they were skipped before: a declared
+    // RoundingMode symbol is a leaf, and it is exactly as much in need of
+    // pinning as a read is.
+    if (m.GetKind() == SYMBOL)
+    {
+      if (bm->isRoundingModeSymbol(m))
+        constraints.push_back(bm->roundingModeValidConstraint(m));
+      return false;
+    }
 
-  if (n.GetKind() == READ && bm->arrayHasRmElement(n[0]))
-    constraints.push_back(bm->roundingModeValidConstraint(n));
-
-  for (size_t i = 0; i < n.Degree(); i++)
-    collectRoundingModeTerms(n[i], seen, constraints);
+    if (m.GetKind() == READ && bm->arrayHasRmElement(m[0]))
+      constraints.push_back(bm->roundingModeValidConstraint(m));
+    return true;
+  });
 }
 
 ASTNode FpTotalise::rebuild(const ASTNode& n, const ASTVec& children)
@@ -287,8 +292,25 @@ ASTNode FpTotalise::zeroChoice(const char* tag, const ASTNode& left,
                         leftNegativeCase);
 }
 
+// The pass is a call per level of a float expression, and how deeply one
+// nests is the input's choice: a query built from 30,000 nested fp.add
+// operations died here, and was the nearest wall left once the simplifier's
+// formula arms were converted. So the answers underneath are
+// filled from the bottom up first, and the pass then finds every child it
+// asks for already answered and stops one level down. See DagWalk.h, and
+// DeepDag_Test.cpp for the depth.
+//
+// Sound because the pass has no exit that skips a child: it answers from a
+// cache, or from having no children, or it visits all of them. So priming
+// reaches exactly the nodes the recursion reached, in the same post-order.
+// That matters more here than it usually would, because this pass mints fresh
+// variables -- see unspecified() and zeroChoice() -- and visiting in a
+// different order would number them differently and move every clause after
+// them. The CNF comparison is what checks it.
 ASTNode FpTotalise::visit(const ASTNode& n)
 {
+  PrimeAudit::Running running(memoAudit, n);
+
   if (n.Degree() == 0)
     return n;
 
@@ -298,6 +320,49 @@ ASTNode FpTotalise::visit(const ASTNode& n)
   const ASTNodeMap::const_iterator current = traversal_cache.find(n);
   if (current != traversal_cache.end())
     return current->second;
+
+  // Nothing below `m` needs filling: it is answered already, or it has no
+  // children to be answered from.
+  auto settled = [this](const ASTNode& m) {
+    return m.Degree() == 0 || persistent_cache.count(m) != 0 ||
+           traversal_cache.count(m) != 0;
+  };
+
+  bool fill = false;
+  for (size_t i = 0; i < n.Degree() && !fill; i++)
+    fill = !settled(n[i]);
+
+  if (!fill)
+    return totalise(n);
+
+  // The walk finishes with the node it started from, so the last answer it
+  // records is that one.
+  ASTNode answer;
+  primeMemo(
+      n, [&](const ASTNode& child)
+      { return settled(child) ? Walk::Skip : Walk::Descend; },
+      [&](const ASTNode& m, PrimeMemoReady) { answer = totalise(m, true); });
+  return answer;
+}
+
+// One node, with its children already totalised -- which is what the walk
+// below arranges, and what its own calls on those children then find.
+ASTNode FpTotalise::totalise(const ASTNode& n, const bool knownMissing)
+{
+  if (n.Degree() == 0)
+    return n;
+
+  // visit's classifier already checked both caches for primed nodes. Neither
+  // totalising a descendant nor rebuilding it can cache its ancestor.
+  if (!knownMissing)
+  {
+    const ASTNodeMap::const_iterator persistent = persistent_cache.find(n);
+    if (persistent != persistent_cache.end())
+      return persistent->second;
+    const ASTNodeMap::const_iterator current = traversal_cache.find(n);
+    if (current != traversal_cache.end())
+      return current->second;
+  }
 
   ASTVec children;
   children.reserve(n.Degree() + 1);

--- a/lib/NodeFactory/HashingNodeFactory.cpp
+++ b/lib/NodeFactory/HashingNodeFactory.cpp
@@ -35,7 +35,7 @@ HashingNodeFactory::~HashingNodeFactory()
 
 // Get structurally hashed version of the node.
 ASTNode HashingNodeFactory::CreateNode(const Kind kind,
-                                       const ASTVec& back_children)
+                                       const ASTChildren back_children)
 {
   // We can't create NOT(NOT (..)) nodes because of how the numbering scheme we
   // use works. So you can't trust the hashing node factory even to return
@@ -95,9 +95,9 @@ ASTNode HashingNodeFactory::CreateNode(const Kind kind,
       return ASTNode(bm.LookupOrCreateInterior(kind, back_children));
     }
 
-    ASTVec sorted_children = back_children;
+    ASTVec sorted_children(back_children.begin(), back_children.end());
     SortByExprNum(sorted_children);
-    return ASTNode(bm.LookupOrCreateInterior(kind, std::move(sorted_children)));
+    return ASTNode(bm.LookupOrCreateInterior(kind, sorted_children));
   }
   else
   {
@@ -108,18 +108,18 @@ ASTNode HashingNodeFactory::CreateNode(const Kind kind,
       return ASTNode(bm.LookupOrCreateInterior(kind, back_children));
     }
 
-    ASTVec children(back_children);
+    ASTVec children(back_children.begin(), back_children.end());
     // The Bitvector solver seems to expect constants on the RHS, variables on the
     // LHS.
     SortByArith(children);
 
-    return ASTNode(bm.LookupOrCreateInterior(kind, std::move(children)));
+    return ASTNode(bm.LookupOrCreateInterior(kind, children));
   }
 }
 
 // Create and return an ASTNode for a term
 ASTNode HashingNodeFactory::CreateTerm(Kind kind, unsigned int width,
-                                       const ASTVec& children)
+                                       const ASTChildren children)
 {
   ASTNode n = CreateNode(kind, children);
   n.SetValueWidth(width);

--- a/lib/NodeFactory/NodeFactory.cpp
+++ b/lib/NodeFactory/NodeFactory.cpp
@@ -27,9 +27,30 @@ THE SOFTWARE.
 #include "stp/STPManager/STPManager.h"
 
 stp::ASTNode NodeFactory::CreateTerm(stp::Kind kind, unsigned int width,
-                                     const stp::ASTVec& children)
+                                     stp::ASTChildren children)
 {
   return CreateTerm(kind, width, children);
+}
+
+ASTNode NodeFactory::CreateTerm(Kind kind, unsigned int width,
+                                std::initializer_list<ASTNode> children)
+{
+  return CreateTerm(kind, width,
+                    ASTChildren(children.begin(), children.size()));
+}
+
+ASTNode NodeFactory::CreateArrayTerm(
+    Kind kind, unsigned int index, unsigned int width,
+    std::initializer_list<ASTNode> children)
+{
+  return CreateArrayTerm(kind, index, width,
+                         ASTChildren(children.begin(), children.size()));
+}
+
+ASTNode NodeFactory::CreateNode(Kind kind,
+                                std::initializer_list<ASTNode> children)
+{
+  return CreateNode(kind, ASTChildren(children.begin(), children.size()));
 }
 
 ASTNode NodeFactory::CreateTerm(Kind kind, unsigned int width,
@@ -122,7 +143,7 @@ ASTNode NodeFactory::CreateArrayTerm(Kind kind, unsigned int index,
 
 stp::ASTNode NodeFactory::CreateArrayTerm(Kind kind, unsigned int index,
                                           unsigned int width,
-                                          const stp::ASTVec& children)
+                                          stp::ASTChildren children)
 {
   ASTNode result = CreateTerm(kind, width, children);
   result.SetIndexWidth(index);

--- a/lib/NodeFactory/SimplifyingNodeFactory.cpp
+++ b/lib/NodeFactory/SimplifyingNodeFactory.cpp
@@ -272,7 +272,7 @@ static bool fpIsRoundToIntegral(const stp::ASTNode& n)
 }
 
 bool SimplifyingNodeFactory::children_all_constants(
-    const ASTVec& children) const
+    const ASTChildren children) const
 {
   for (unsigned i = 0; i < children.size(); i++)
   {
@@ -338,7 +338,7 @@ ASTNode SimplifyingNodeFactory::makeFPZero(unsigned eb, unsigned sb,
   return bm.CreateFPConst(bm.CreateBVConst(bits, width), eb, sb);
 }
 
-ASTNode SimplifyingNodeFactory::create_gt_node(const ASTVec& children)
+ASTNode SimplifyingNodeFactory::create_gt_node(const ASTChildren children)
 {
   if (children[0] == children[1])
   {
@@ -519,7 +519,8 @@ ASTNode SimplifyingNodeFactory::create_gt_node(const ASTVec& children)
   return ASTNode();
 }
 
-ASTNode SimplifyingNodeFactory::CreateNode(Kind kind, const ASTVec& children)
+ASTNode SimplifyingNodeFactory::CreateNode(Kind kind,
+                                           const ASTChildren children)
 {
   assert(kind != SYMBOL);
   // These are created specially.
@@ -1062,7 +1063,7 @@ ASTNode SimplifyingNodeFactory::CreateSimpleNot(const ASTNode& form)
   }
 }
 
-ASTNode SimplifyingNodeFactory::CreateSimpleNot(const ASTVec& children)
+ASTNode SimplifyingNodeFactory::CreateSimpleNot(const ASTChildren children)
 {
   assert(children.size() == 1);
   const Kind k = children[0].GetKind();
@@ -1099,7 +1100,7 @@ ASTNode SimplifyingNodeFactory::CreateSimpleAndOr(bool IsAnd,
 }
 
 ASTNode SimplifyingNodeFactory::handle_2_children(bool IsAnd,
-                                                  const ASTVec& children)
+                                                  const ASTChildren children)
 {
   if (children.size() == 2)
   {
@@ -1151,7 +1152,7 @@ ASTNode SimplifyingNodeFactory::handle_2_children(bool IsAnd,
 }
 
 ASTNode SimplifyingNodeFactory::CreateSimpleAndOr(bool IsAnd,
-                                                  const ASTVec& c)
+                                                  const ASTChildren c)
 {
   ASTNode retval = handle_2_children(IsAnd, c);
   if (retval != ASTUndefined)
@@ -1163,12 +1164,13 @@ ASTNode SimplifyingNodeFactory::CreateSimpleAndOr(bool IsAnd,
   // Sorting these can be expensive, so we only sort it if it's not already sorted.
   bool isSorted =  std::is_sorted(c.begin(),c.end(),stp::ExprLess{});
   ASTVec sorted_children;
-  const ASTVec& children = isSorted ? c: sorted_children;
   if (!isSorted)
   {
-    sorted_children = c;
+    sorted_children.assign(c.begin(), c.end());
     SortByExprNum(sorted_children);  
   }
+  const ASTChildren children =
+      isSorted ? c : ASTChildren(sorted_children);
 
   // Copy on write. Usually nothing is dropped, so we only build up
   // "new_children" once the first element is actually discarded; until then
@@ -1216,7 +1218,8 @@ ASTNode SimplifyingNodeFactory::CreateSimpleAndOr(bool IsAnd,
     }
   }
 
-  const ASTVec& out = materialised ? new_children : children;
+  const ASTChildren out =
+      materialised ? ASTChildren(new_children) : children;
 
   // A child of the same kind contributes its own children conjunctively
   // (resp. disjunctively), so a literal here and its negation one level
@@ -1267,7 +1270,7 @@ ASTNode SimplifyingNodeFactory::CreateSimpleAndOr(bool IsAnd,
 
 // Tries to simplify the input to TRUE/FALSE. if it fails, then
 // return the constructed equality
-ASTNode SimplifyingNodeFactory::CreateSimpleEQ(const ASTVec& children)
+ASTNode SimplifyingNodeFactory::CreateSimpleEQ(const ASTChildren children)
 {
   assert(children.size() == 2);
 
@@ -1545,13 +1548,13 @@ ASTNode SimplifyingNodeFactory::CreateSimpleEQ(const ASTVec& children)
 }
 
 // Constant children are accumulated in "accumconst".
-ASTNode SimplifyingNodeFactory::CreateSimpleXor(const ASTVec& children)
+ASTNode SimplifyingNodeFactory::CreateSimpleXor(const ASTChildren children)
 {
   if (debug_simplifyingNodeFactory)
   {
     cout << "========" << endl << "CreateSimpXor ";
 
-    lpvec(children);
+    lpvec(toASTVec(children));
     cout << endl;
   }
 
@@ -1580,8 +1583,7 @@ ASTNode SimplifyingNodeFactory::CreateSimpleXor(const ASTVec& children)
     }
   }
 
-  ASTVec flat_children; // empty vector
-  flat_children = children;
+  ASTVec flat_children(children.begin(), children.end());
 
   // sort so that identical nodes occur in sequential runs, followed by
   // their negations.
@@ -1685,7 +1687,8 @@ ASTNode SimplifyingNodeFactory::CreateSimpleXor(const ASTVec& children)
   return retval;
 }
 
-ASTNode SimplifyingNodeFactory::CreateSimpleFormITE(const ASTVec& children)
+ASTNode SimplifyingNodeFactory::CreateSimpleFormITE(
+    const ASTChildren children)
 {
   const ASTNode& child0 = children[0];
   const ASTNode& child1 = children[1];
@@ -1758,7 +1761,7 @@ ASTNode SimplifyingNodeFactory::CreateSimpleFormITE(const ASTVec& children)
 // simplify things like:
 // read(write(write(A,1,2),2,3),4) cheaply.
 // The "children" that are passed should be the children of a READ.
-ASTNode SimplifyingNodeFactory::chaseRead(const ASTVec& children,
+ASTNode SimplifyingNodeFactory::chaseRead(const ASTChildren children,
                                           unsigned int width)
 {
   assert(children[0].GetKind() == stp::WRITE);
@@ -1959,7 +1962,8 @@ ASTNode SimplifyingNodeFactory::plusRules(const ASTNode& n0, const ASTNode& n1)
   return result;
 }
 
-ASTNode SimplifyingNodeFactory::handle_bvxor(unsigned int width, const ASTVec& input_children)
+ASTNode SimplifyingNodeFactory::handle_bvxor(
+    unsigned int width, const ASTChildren input_children)
 {
   // a ^ (a ^ b ^ ...) -> (b ^ ...): cancel an operand shared with a nested
   // xor. Children aren't flattened, so the duplicate-removal below can't see
@@ -1999,7 +2003,7 @@ ASTNode SimplifyingNodeFactory::handle_bvxor(unsigned int width, const ASTVec& i
 
   const ASTNode zero = bm.CreateZeroConst(width);
 
-  ASTVec flat_children(input_children);
+  ASTVec flat_children(input_children.begin(), input_children.end());
 
   // Expression numbers don't place BVNOT(t) next to (t), so strip BVNOTS first..
   for (size_t i = 0; i < flat_children.size();i++)
@@ -2134,7 +2138,8 @@ static void collectConjuncts(const ASTNode& n, uint64_t* out, size_t& count)
       collectConjuncts(n[i], out, count);
 }
 
-ASTNode SimplifyingNodeFactory::handle_bvand(unsigned int width, const ASTVec& new_children) 
+ASTNode SimplifyingNodeFactory::handle_bvand(
+    unsigned int width, const ASTChildren new_children)
 {
 
 
@@ -2171,7 +2176,7 @@ ASTNode SimplifyingNodeFactory::handle_bvand(unsigned int width, const ASTVec& n
     }
   }
 
-  ASTVec flat_children(new_children);
+  ASTVec flat_children(new_children.begin(), new_children.end());
   SortByExprNum(flat_children); // We want duplicates to be adjacent.
 
   const ASTNode annihilator = bm.CreateZeroConst(width);
@@ -2349,7 +2354,7 @@ ASTNode SimplifyingNodeFactory::handle_bvand(unsigned int width, const ASTVec& n
   return hashing.CreateTerm(stp::BVAND,width,children);
 }
 
-ASTNode SimplifyingNodeFactory::plusRules(const ASTVec& oldChildren)
+ASTNode SimplifyingNodeFactory::plusRules(const ASTChildren oldChildren)
 {
   assert(oldChildren.size() > 2);
   const unsigned width = oldChildren[0].GetValueWidth();
@@ -2431,9 +2436,8 @@ ASTNode SimplifyingNodeFactory::plusRules(const ASTVec& oldChildren)
 
 // If the shift is bigger than the bitwidth, replace by an extract.
 ASTNode convertArithmeticKnownShiftAmount([[maybe_unused]] const Kind k,
-                                                      const ASTVec& children,
-                                                      STPMgr& bm,
-                                                      NodeFactory* nf)
+                                          const ASTChildren children,
+                                          STPMgr& bm, NodeFactory* nf)
 {
   const ASTNode a = children[0];
   const ASTNode b = children[1];
@@ -2477,8 +2481,9 @@ ASTNode convertArithmeticKnownShiftAmount([[maybe_unused]] const Kind k,
 
 // If the rhs of a left or right shift is known.
 ASTNode SimplifyingNodeFactory::convertKnownShiftAmount(const Kind k,
-                                            const ASTVec& children, STPMgr& bm,
-                                            NodeFactory* nf)
+                                                        ASTChildren children,
+                                                        STPMgr& bm,
+                                                        NodeFactory* nf)
 {
   const ASTNode a = children[0];
   const ASTNode b = children[1];
@@ -2535,7 +2540,7 @@ ASTNode SimplifyingNodeFactory::convertKnownShiftAmount(const Kind k,
 }
 
 ASTNode SimplifyingNodeFactory::CreateTerm(Kind kind, unsigned int width,
-                                           const ASTVec& children)
+                                           const ASTChildren children)
 {
   if (!is_Term_kind(kind))
     FatalError("CreateTerm:  Illegal kind to CreateTerm:", ASTUndefined, kind);

--- a/lib/NodeFactory/SimplifyingNodeFactory.cpp
+++ b/lib/NodeFactory/SimplifyingNodeFactory.cpp
@@ -30,6 +30,7 @@ THE SOFTWARE.
 #include "stp/Simplifier/Simplifier.h"
 #include <cassert>
 #include <cmath>
+#include <deque>
 
 using stp::Kind;
 
@@ -1342,33 +1343,38 @@ ASTNode SimplifyingNodeFactory::CreateSimpleEQ(const ASTChildren children)
       (in2 == bm.CreateZeroConst(width)))
     return NodeFactory::CreateNode(stp::BVGT, in1[1], in1[0]);
 
-  // split the constant to equal each part of the concat.
+  // Split the constant to equal each part of the concat. A concat can itself
+  // be one of those parts, so the old pair of CreateNode(EQ, ...) calls made
+  // this recurse once per concat level.
   if (BVCONCAT == k2 && stp::BVCONST == k1)
-  {
-    int low_b = 0;
-    int high_b = (int)in2[1].GetValueWidth() - 1;
-    int low_t = in2[1].GetValueWidth();
-    int high_t = width - 1;
-
-    ASTNode c0 = NodeFactory::CreateTerm(BVEXTRACT, in2[1].GetValueWidth(), in1,
-                                         bm.CreateBVConst(32, high_b),
-                                         bm.CreateBVConst(32, low_b));
-    ASTNode c1 = NodeFactory::CreateTerm(BVEXTRACT, in2[0].GetValueWidth(), in1,
-                                         bm.CreateBVConst(32, high_t),
-                                         bm.CreateBVConst(32, low_t));
-
-    ASTNode a = NodeFactory::CreateNode(EQ, in2[1], c0);
-    ASTNode b = NodeFactory::CreateNode(EQ, in2[0], c1);
-    return NodeFactory::CreateNode(stp::AND, a, b);
-  }
+    return CreateSimpleEQConstConcat(in1, in2);
 
   // (a ++ b) = (a ++ c) <=> b = c, and (a ++ c) = (b ++ c) <=> a = b.
-  // Sharing a side pins the widths of the other sides to match.
-  if (BVCONCAT == k1 && BVCONCAT == k2 && in1[0] == in2[0])
-    return NodeFactory::CreateNode(EQ, in1[1], in2[1]);
-
-  if (BVCONCAT == k1 && BVCONCAT == k2 && in1[1] == in2[1])
-    return NodeFactory::CreateNode(EQ, in1[0], in2[0]);
+  // Sharing a side pins the widths of the other sides to match. Peel an
+  // entire run here before re-entering the factory, so a nested concat chain
+  // consumes one C++ frame rather than one frame per equality rewrite.
+  if (BVCONCAT == k1 && BVCONCAT == k2 &&
+      (in1[0] == in2[0] || in1[1] == in2[1]))
+  {
+    ASTNode lhs = in1;
+    ASTNode rhs = in2;
+    while (lhs.GetKind() == BVCONCAT && rhs.GetKind() == BVCONCAT)
+    {
+      if (lhs[0] == rhs[0])
+      {
+        lhs = lhs[1];
+        rhs = rhs[1];
+      }
+      else if (lhs[1] == rhs[1])
+      {
+        lhs = lhs[0];
+        rhs = rhs[0];
+      }
+      else
+        break;
+    }
+    return NodeFactory::CreateNode(EQ, lhs, rhs);
+  }
 
   // Sign extension keeps the value, so the equality only needs the wider
   // of the two originals' widths: drop the extension of the wider side,
@@ -1545,6 +1551,95 @@ ASTNode SimplifyingNodeFactory::CreateSimpleEQ(const ASTChildren children)
 
   // last resort is to CreateNode
   return hashing.CreateNode(EQ, children);
+}
+
+ASTNode SimplifyingNodeFactory::CreateSimpleEQConstConcat(
+    const ASTNode& constant, const ASTNode& concat)
+{
+  auto splitConstant = [&](const ASTNode& c, const ASTNode& term,
+                           ASTNode& low, ASTNode& high) {
+    const unsigned lowWidth = term[1].GetValueWidth();
+    const unsigned width = term.GetValueWidth();
+    low = NodeFactory::CreateTerm(
+        BVEXTRACT, lowWidth, c, bm.CreateBVConst(32, lowWidth - 1),
+        bm.CreateZeroConst(32));
+    high = NodeFactory::CreateTerm(
+        BVEXTRACT, term[0].GetValueWidth(), c,
+        bm.CreateBVConst(32, width - 1), bm.CreateBVConst(32, lowWidth));
+  };
+
+  // Most concat equalities split only once. Keep that case out of the
+  // continuation machine so it does not construct a deque for two leaf
+  // equalities.
+  if (concat[0].GetKind() != BVCONCAT && concat[1].GetKind() != BVCONCAT)
+  {
+    ASTNode lowConstant, highConstant;
+    splitConstant(constant, concat, lowConstant, highConstant);
+    const ASTNode lowEquality =
+        NodeFactory::CreateNode(EQ, concat[1], lowConstant);
+    const ASTNode highEquality =
+        NodeFactory::CreateNode(EQ, concat[0], highConstant);
+    return NodeFactory::CreateNode(stp::AND, lowEquality, highEquality);
+  }
+
+  struct Frame
+  {
+    enum Phase
+    {
+      Start,
+      LowDone,
+      HighDone
+    };
+
+    ASTNode constant;
+    ASTNode term;
+    ASTNode lowConstant;
+    ASTNode highConstant;
+    ASTNode lowEquality;
+    Phase phase = Start;
+
+    Frame(const ASTNode& c, const ASTNode& t) : constant(c), term(t) {}
+  };
+
+  std::deque<Frame> stack;
+  stack.emplace_back(constant, concat);
+  ASTNode result;
+
+  while (true)
+  {
+    Frame& frame = stack.back();
+    if (frame.phase == Frame::Start)
+    {
+      if (frame.term.GetKind() != BVCONCAT)
+      {
+        result = NodeFactory::CreateNode(EQ, frame.term, frame.constant);
+        stack.pop_back();
+        if (stack.empty())
+          return result;
+        continue;
+      }
+
+      splitConstant(frame.constant, frame.term, frame.lowConstant,
+                    frame.highConstant);
+
+      frame.phase = Frame::LowDone;
+      stack.emplace_back(frame.lowConstant, frame.term[1]);
+      continue;
+    }
+
+    if (frame.phase == Frame::LowDone)
+    {
+      frame.lowEquality = result;
+      frame.phase = Frame::HighDone;
+      stack.emplace_back(frame.highConstant, frame.term[0]);
+      continue;
+    }
+
+    result = NodeFactory::CreateNode(stp::AND, frame.lowEquality, result);
+    stack.pop_back();
+    if (stack.empty())
+      return result;
+  }
 }
 
 // Constant children are accumulated in "accumconst".
@@ -2118,9 +2213,8 @@ ASTNode SimplifyingNodeFactory::handle_bvxor(
 // nesting itself reaches sixty. A depth limit would have to be set at eight
 // to lose nothing, and eight is not a number with any meaning -- it is just
 // the deepest pair this corpus happens to contain. Bounding the conjuncts
-// bounds the cost directly instead, and since every BVAND has at least two
-// children it bounds the recursion too; sixty-four is comfortably past every
-// pair seen.
+// bounds the cost directly, and therefore also bounds the fixed traversal
+// path below; sixty-four is comfortably past every pair seen.
 //
 // Stopping early costs a rewrite that does not fire, never a wrong answer.
 static const size_t MAX_CONJUNCTS = 64;
@@ -2130,12 +2224,52 @@ static void collectConjuncts(const ASTNode& n, uint64_t* out, size_t& count)
   if (count >= MAX_CONJUNCTS)
     return;
 
-  out[count++] = (n.GetKind() == BVNOT) ? n[0].GetNodeNum() + 1
-                                        : n.GetNodeNum();
+  struct Frame
+  {
+    const ASTNode* node;
+    size_t nextChild;
+  };
 
-  if (n.GetKind() == stp::BVAND)
-    for (size_t i = 0; i < n.Degree(); i++)
-      collectConjuncts(n[i], out, count);
+  // A fixed path preserves the recursive depth-first, left-to-right order
+  // without allocating on the 1.9M common shallow calls. Every descent first
+  // records a conjunct, so count < MAX_CONJUNCTS also proves that the next
+  // suspended-parent slot exists.
+  Frame path[MAX_CONJUNCTS];
+  size_t depth = 0;
+  const ASTNode* current = &n;
+
+  while (true)
+  {
+    out[count++] = (current->GetKind() == BVNOT)
+                       ? (*current)[0].GetNodeNum() + 1
+                       : current->GetNodeNum();
+    if (count >= MAX_CONJUNCTS)
+      return;
+
+    if (current->GetKind() == stp::BVAND && current->Degree() != 0)
+    {
+      assert(depth < MAX_CONJUNCTS);
+      path[depth++] = {current, 1};
+      current = &(*current)[0];
+      continue;
+    }
+
+    bool advanced = false;
+    while (depth != 0)
+    {
+      Frame& parent = path[depth - 1];
+      if (parent.nextChild < parent.node->Degree())
+      {
+        current = &(*parent.node)[parent.nextChild++];
+        advanced = true;
+        break;
+      }
+      --depth;
+    }
+
+    if (!advanced)
+      return;
+  }
 }
 
 ASTNode SimplifyingNodeFactory::handle_bvand(

--- a/lib/NodeFactory/TypeChecker.cpp
+++ b/lib/NodeFactory/TypeChecker.cpp
@@ -26,17 +26,15 @@ THE SOFTWARE.
 #include "stp/AST/AST.h"
 
 stp::ASTNode TypeChecker::CreateTerm(stp::Kind kind, unsigned int width,
-                                     const stp::ASTVec& children)
+                                     stp::ASTChildren children)
 {
   stp::ASTNode r = f.CreateTerm(kind, width, children);
   BVTypeCheck(r);
   return r;
 }
 
-// virtual stp::ASTNode CreateNode(stp::Kind kind, const stp::ASTVec&
-// children);
 stp::ASTNode TypeChecker::CreateNode(stp::Kind kind,
-                                     const stp::ASTVec& children)
+                                     stp::ASTChildren children)
 {
   stp::ASTNode r = f.CreateNode(kind, children);
   BVTypeCheck(r);
@@ -45,7 +43,7 @@ stp::ASTNode TypeChecker::CreateNode(stp::Kind kind,
 
 stp::ASTNode TypeChecker::CreateArrayTerm(Kind kind, unsigned int index,
                                           unsigned int width,
-                                          const stp::ASTVec& children)
+                                          stp::ASTChildren children)
 {
   ASTNode r = f.CreateTerm(kind, width, children);
   r.SetIndexWidth(index);

--- a/lib/Printer/LispPrinter.cpp
+++ b/lib/Printer/LispPrinter.cpp
@@ -23,6 +23,8 @@ THE SOFTWARE.
 ********************************************************************/
 
 #include "stp/Printer/printers.h"
+#include <deque>
+#include <utility>
 
 namespace printer
 {
@@ -36,69 +38,100 @@ ostream& Lisp_Print_indent(ostream& os, const ASTNode& n, int indentation);
 /** Internal function to print in lisp format.  Assume newline
     and indentation printed already before first line.  Recursive
     calls will have newline & indent, though */
+/* The walk is iterative. How deeply a node nests is the input's choice, and
+   printing is on the path an error message takes -- operator<< on a node
+   comes through here -- so a formula too deep to print is a formula too deep
+   to report on. Text that the recursion emitted after returning from a child
+   is queued as a literal instead, so the output is unchanged.
+   See DeepDag_Test.cpp. */
 ostream& Lisp_Print1(ostream& os, const ASTNode& n, int indentation)
 {
-  if (!n.IsDefined())
+  // Either a node still to print, or text to emit once the nodes queued
+  // after it are done. `indented` marks the children that the recursion
+  // reached through Lisp_Print_indent, which puts them on their own line.
+  struct Item
   {
-    os << "<undefined>";
-    return os;
-  }
-  Kind kind = n.GetKind();
-  // FIXME: figure out how to avoid symbols with same names as kinds.
-  //    if (kind == READ) {
-  //      const ASTChildren children = GetChildren();
-  //      children[0].LispPrint1(os, indentation);
-  //  os << "[" << children[1] << "]";
-  //    } else
-  if (kind == BOOLEXTRACT)
-  {
-    const ASTChildren children = n.GetChildren();
-    // child 0 is a symbol.  Print without the NodeNum.
-    os << n.GetNodeNum() << ":";
+    ASTNode n;
+    int indentation = 0;
+    bool indented = false;
+    const char* literal = nullptr;
+  };
 
-    children[0].nodeprint(os, true);
-    os << "{";
-    children[1].nodeprint(os, true);
-    os << "}";
-  }
-  else if (kind == NOT)
+  // A deque, so pushing never moves what is already queued.
+  std::deque<Item> stack;
+  stack.push_back(Item{n, indentation, false, nullptr});
+
+  while (!stack.empty())
   {
-    const ASTChildren children = n.GetChildren();
-    os << n.GetNodeNum() << ":";
-    os << "(NOT ";
-    Lisp_Print1(os, children[0], indentation);
-    os << ")";
-  }
-  else if (n.Degree() == 0)
-  {
-    // Symbol or a kind with no children print as index:NAME if shared,
-    // even if they have been printed before.
-    os << n.GetNodeNum() << ":";
-    n.nodeprint(os, true);
-    // os << "(" << _int_node_ptr->_ref_count << ")";
-    // os << "{" << GetValueWidth() << "}";
-  }
-  else if (Lisp_AlreadyPrintedSet.find(n) != Lisp_AlreadyPrintedSet.end())
-  {
-    // print non-symbols as "[index]" if seen before.
-    os << "[" << n.GetNodeNum() << "]";
-    //         << "(" << _int_node_ptr->_ref_count << ")";
-  }
-  else
-  {
-    Lisp_AlreadyPrintedSet.insert(n);
-    const ASTChildren children = n.GetChildren();
-    os << n.GetNodeNum() << ":"
-       //<< "(" << _int_node_ptr->_ref_count << ")"
-       << "(" << kind << " ";
-    // os << "{" << GetValueWidth() << "}";
-    auto iend = children.end();
-    for (auto i = children.begin(); i != iend; i++)
+    const Item item = std::move(stack.back());
+    stack.pop_back();
+
+    if (item.literal != nullptr)
     {
-      Lisp_Print_indent(os, *i, indentation + 2);
+      os << item.literal;
+      continue;
     }
-    os << ")";
+
+    if (item.indented)
+      os << std::endl << spaces(item.indentation);
+
+    const ASTNode& current = item.n;
+
+    if (!current.IsDefined())
+    {
+      os << "<undefined>";
+      continue;
+    }
+
+    const Kind kind = current.GetKind();
+    // FIXME: figure out how to avoid symbols with same names as kinds.
+    if (kind == BOOLEXTRACT)
+    {
+      const ASTChildren children = current.GetChildren();
+      // child 0 is a symbol.  Print without the NodeNum.
+      os << current.GetNodeNum() << ":";
+
+      children[0].nodeprint(os, true);
+      os << "{";
+      children[1].nodeprint(os, true);
+      os << "}";
+    }
+    else if (kind == NOT)
+    {
+      const ASTChildren children = current.GetChildren();
+      os << current.GetNodeNum() << ":";
+      os << "(NOT ";
+      stack.push_back(Item{ASTNode(), 0, false, ")"});
+      stack.push_back(Item{children[0], item.indentation, false, nullptr});
+    }
+    else if (current.Degree() == 0)
+    {
+      // Symbol or a kind with no children print as index:NAME if shared,
+      // even if they have been printed before.
+      os << current.GetNodeNum() << ":";
+      current.nodeprint(os, true);
+    }
+    else if (Lisp_AlreadyPrintedSet.find(current) !=
+             Lisp_AlreadyPrintedSet.end())
+    {
+      // print non-symbols as "[index]" if seen before.
+      os << "[" << current.GetNodeNum() << "]";
+    }
+    else
+    {
+      Lisp_AlreadyPrintedSet.insert(current);
+      const ASTChildren children = current.GetChildren();
+      os << current.GetNodeNum() << ":"
+         << "(" << kind << " ";
+
+      // Closing bracket first, so it comes off after every child.
+      stack.push_back(Item{ASTNode(), 0, false, ")"});
+      for (size_t i = children.size(); i > 0; i--)
+        stack.push_back(
+            Item{children[i - 1], item.indentation + 2, true, nullptr});
+    }
   }
+
   return os;
 }
 

--- a/lib/Simplifier/Flatten.cpp
+++ b/lib/Simplifier/Flatten.cpp
@@ -22,7 +22,11 @@ THE SOFTWARE.
 ********************************************************************/
 
 #include "stp/Simplifier/Flatten.h"
+#include "stp/Util/DagWalk.h"
+#include <deque>
+#include <limits>
 #include <list>
+#include <vector>
 
 namespace stp
 {
@@ -54,105 +58,250 @@ namespace stp
   }
 
   // counter is 1 if the node has one reference in the tree.
+  //
+  // Iterative for the same reason as Rewriting::buildShareCount, which this
+  // mirrors: the input decides the depth, so a call per level of the DAG
+  // exhausts the stack. The continuation walk holds only suspended ancestors
+  // rather than every sibling in a wide frontier.
   void Flatten::buildShareCount(const ASTNode& n)
   {
-    if (n.Degree() == 0)
-      return;
+    walkPreOrder(n, [&](const ASTNode& current) {
+      if (current.Degree() == 0)
+        return false;
 
-    if (shareCount[n.GetNodeNum()]++ > 0) // 0 first time, 1 second time.
-      return;
-  
-    for (const auto& c: n.GetChildren())
-        buildShareCount(c);
+      if (shareCount[current.GetNodeNum()]++ > 0) // 0 first time, 1 second.
+        return false;
+      return true;
+    });
   }
+
+  // A leaf, or a node already flattened: answered without a frame, exactly
+  // as the recursive version answered it without a call.
+  bool Flatten::alreadyKnown(const ASTNode& n, ASTNode& answer)
+  {
+    if (n.Degree() == 0)
+    {
+      answer = n;
+      return true;
+    }
+
+    const auto it = fromTo.find(n.GetNodeNum());
+    if (it != fromTo.end())
+    {
+      answer = it->second;
+      return true;
+    }
+    return false;
+  }
+
+  // The walk one node is part-way through. Everything here was a local of
+  // the recursive flatten(); it lives on the heap because the input decides
+  // how many of them are live at once.
+  struct Flatten::Frame
+  {
+    ASTNode n;
+    Kind k;
+    bool top;
+    bool flattenable;
+    bool changed = false;
+
+    ASTChildren children;
+    unsigned it0 = 0; // original children consumed
+    unsigned i = 0;   // position in nextChildren
+
+    // The vectors and set are only needed after this node changes. Keeping
+    // an index here makes the common unchanged frame small; flatten() lends
+    // the actual storage from a LIFO scratch pool.
+    static constexpr unsigned noScratch =
+        std::numeric_limits<unsigned>::max();
+    unsigned scratch = noScratch;
+
+    // Set while this node waits for a child's flatten() to come back.
+    ASTNode pending;
+    bool waiting = false;
+
+    Frame(const ASTNode& n_, bool top_)
+        : n(n_), k(n_.GetKind()), top(top_),
+          //TODO STP doesn't currerntly handle >2 arity BVMULT.
+          flattenable(OR == k || AND == k || XOR == k || BVXOR == k ||
+                      BVOR == k || BVAND == k || BVPLUS == k),
+          children(n_.GetChildren())
+    {
+    }
+  };
 
   ASTNode Flatten::flatten(const ASTNode& n, bool top)
   {
-    if (n.Degree() == 0)
-      return n;
+    static_assert(sizeof(Frame) <= 80,
+                  "Flatten frames must stay cheap at deep DAG depths");
 
-    if (fromTo.find(n.GetNodeNum()) != fromTo.end())
-      return fromTo[n.GetNodeNum()];
+    ASTNode result;
+    if (alreadyKnown(n, result))
+      return result;
 
-    const Kind k = n.GetKind();
+    // A deque, so that descending into a child never moves the frames
+    // above it: `current` below stays valid across a push.
+    std::deque<Frame> stack;
+    stack.emplace_back(n, top);
 
-    ASTNode result =n;
-
-    bool changed =false;
-    
-    //TODO STP doesn't currerntly handle >2 arity BVMULT.
-    const bool flattenable = (OR==k || AND==k || XOR==k || BVXOR==k ||  BVOR==k || BVAND==k || BVPLUS==k);
-
-    std::unordered_set<uint64_t> seen;
-
-    ASTVec newChildren;
-
-    const ASTChildren children = n.GetChildren();
-    auto it0 = children.begin();
-
-    ASTVec nextChildren;
-    unsigned i = 0;
-
-    // Copy on write.
-    auto fill = [&]
+    struct Scratch
     {
-      assert(0 ==i);
+      ASTVec newChildren;
+      ASTVec nextChildren;
+      std::unordered_set<uint64_t> seen;
 
-      newChildren.reserve(children.size());
-      newChildren.insert(newChildren.end(), children.begin(), it0-1);
-      changed=true;
+      void clear()
+      {
+        newChildren.clear();
+        nextChildren.clear();
+        seen.clear();
+      }
     };
 
-    while (it0 != children.end() || i < nextChildren.size())
+    // Scratch slots are acquired and released in traversal order: an active
+    // child's slot is always above its parent's. Reusing them retains vector
+    // and hash-table capacity without carrying that state in every frame.
+    std::vector<Scratch> scratches;
+    unsigned scratchesInUse = 0;
+
+    auto scratchFor = [&](Frame& f) -> Scratch&
     {
-      const ASTNode c = (it0 != children.end())? *it0++: nextChildren[i++];
-
-      if (flattenable && c.GetKind() == k && (top || shareCount[c.GetNodeNum()] == 1))
+      if (f.scratch == Frame::noScratch)
       {
-         assert(c.Degree() > 1);
-         if (!changed)
-            fill();
+        assert(scratchesInUse <= scratches.size());
+        assert(scratchesInUse < Frame::noScratch);
+        f.scratch = scratchesInUse++;
+        if (f.scratch == scratches.size())
+          scratches.emplace_back();
+      }
+      return scratches[f.scratch];
+    };
 
-         if (top)
+    auto releaseScratch = [&](Frame& f)
+    {
+      if (f.scratch == Frame::noScratch)
+        return;
+      assert(f.scratch + 1 == scratchesInUse);
+      scratches[f.scratch].clear();
+      --scratchesInUse;
+    };
+
+    // Copy on write.
+    auto fill = [&](Frame& f)
+    {
+      assert(0 == f.i);
+
+      Scratch& scratch = scratchFor(f);
+      scratch.newChildren.reserve(f.children.size());
+      scratch.newChildren.insert(scratch.newChildren.end(),
+                                 f.children.begin(),
+                                 f.children.begin() + (f.it0 - 1));
+      f.changed = true;
+    };
+
+    while (true)
+    {
+      Frame& current = stack.back();
+
+      // Pick up the child this frame descended for. `result` is what its
+      // flatten() returned.
+      if (current.waiting)
+      {
+        if (result != current.pending && !current.changed)
+          fill(current);
+        if (current.changed)
+          scratches[current.scratch].newChildren.push_back(result);
+        current.waiting = false;
+      }
+
+      bool descended = false;
+
+      while (current.it0 < current.children.size() ||
+             (current.scratch != Frame::noScratch &&
+              current.i < scratches[current.scratch].nextChildren.size()))
+      {
+        // By value: the flattening branch below appends to nextChildren,
+        // which can move what a reference into it points at.
+        const ASTNode c = (current.it0 < current.children.size())
+                              ? current.children[current.it0++]
+                              : scratches[current.scratch]
+                                    .nextChildren[current.i++];
+
+        if (current.flattenable && c.GetKind() == current.k &&
+            (current.top || shareCount[c.GetNodeNum()] == 1))
+        {
+          assert(c.Degree() > 1);
+          if (!current.changed)
+            fill(current);
+          Scratch& scratch = scratches[current.scratch];
+
+          if (current.top)
             top_removed++;
-         else
-           removed++;
+          else
+            removed++;
 
-         for (const auto&e: c.GetChildren())
-         {
-            if (BVAND == k || AND == k || BVOR == k || OR == k)
+          for (const auto& e : c.GetChildren())
+          {
+            if (BVAND == current.k || AND == current.k || BVOR == current.k ||
+                OR == current.k)
             {
-              if (!seen.insert(e.GetNodeNum()).second)
-                continue; 
+              if (!scratch.seen.insert(e.GetNodeNum()).second)
+                continue;
             }
-            nextChildren.push_back(e);
-         }
-        shareCount[c.GetNodeNum()]--;
+            scratch.nextChildren.push_back(e);
+          }
+          shareCount[c.GetNodeNum()]--;
+        }
+        else
+        {
+          ASTNode r;
+          if (alreadyKnown(c, r))
+          {
+            if (r != c && !current.changed)
+              fill(current);
+            if (current.changed)
+              scratches[current.scratch].newChildren.push_back(r);
+            continue;
+          }
+
+          // Where the recursive version called flatten(c). Nothing above
+          // may be read after the push.
+          current.pending = c;
+          current.waiting = true;
+          stack.emplace_back(c, false);
+          descended = true;
+          break;
+        }
       }
-      else
+
+      if (descended)
+        continue;
+
+      Frame& done = stack.back();
+      result = done.n;
+
+      if (done.changed)
       {
-        const auto r = flatten(c);
-        if (r!=c && !changed)
-          fill();
-        if (changed)   
-          newChildren.push_back(r);
+        Scratch& scratch = scratches[done.scratch];
+        assert(done.n.Degree() <= scratch.newChildren.size());
+
+        if (done.n.GetType() == BOOLEAN_TYPE)
+          result = nf->CreateNode(done.k, scratch.newChildren);
+        else
+          result = nf->CreateArrayTerm(done.k, done.n.GetIndexWidth(),
+                                       done.n.GetValueWidth(),
+                                       scratch.newChildren);
+
+        shareCount[result.GetNodeNum()]++; // I'm guessing it's unusal, but we might make a node we already have.
       }
-    }    
 
-    if (changed)
-    {
-      assert(n.Degree() <= newChildren.size());
+      if (shareCount[done.n.GetNodeNum()] > 1)
+        fromTo.insert({done.n.GetNodeNum(), result});
 
-      if (n.GetType() == BOOLEAN_TYPE)
-        result = nf->CreateNode(k, newChildren);
-      else
-        result = nf->CreateArrayTerm(k, n.GetIndexWidth(),n.GetValueWidth(), newChildren);
-
-      shareCount[result.GetNodeNum()]++; // I'm guessing it's unusal, but we might make a node we already have.
+      releaseScratch(done);
+      stack.pop_back();
+      if (stack.empty())
+        return result;
     }
-
-    if (shareCount[n.GetNodeNum()] > 1)
-      fromTo.insert({n.GetNodeNum(),result});
-    return result;
   }
 }

--- a/lib/Simplifier/NodeDomainAnalysis.cpp
+++ b/lib/Simplifier/NodeDomainAnalysis.cpp
@@ -25,9 +25,37 @@ THE SOFTWARE.
 
 #include "stp/Simplifier/NodeDomainAnalysis.h"
 #include "stp/Simplifier/constantBitP/ConstantBitPropagation.h"
+#include "stp/Util/DagWalk.h"
 
 namespace stp
 {
+  namespace
+  {
+    // Keep the recursion counter balanced across buildMap's early returns.
+    class UnprimedDepth
+    {
+      size_t& depth;
+      const bool active;
+
+    public:
+      UnprimedDepth(size_t& depth_, const bool active_)
+          : depth(depth_), active(active_)
+      {
+        if (active)
+          ++depth;
+      }
+
+      UnprimedDepth(const UnprimedDepth&) = delete;
+      UnprimedDepth& operator=(const UnprimedDepth&) = delete;
+
+      ~UnprimedDepth()
+      {
+        if (active)
+          --depth;
+      }
+    };
+  }
+
 
   // True if the two domains have an intersection, i.e. share >=1 value.
   bool intersects(FixedBits * bits, UnsignedInterval * interval)
@@ -410,8 +438,36 @@ namespace stp
     assert(intersects(interval, set));
   }
 
+  // Every node below `n` before `n` itself, in the order buildMap would have
+  // reached them: children left to right, the node last. It looks at every
+  // child of every node it visits and has no early exit, so nothing is
+  // computed here that it would not have computed anyway.
+  void NodeDomainAnalysis::primeMaps(const ASTNode& n)
+  {
+    primeMemo(
+        n,
+        [this](const ASTNode& node)
+        {
+          if (toFixedBits.find(node) != toFixedBits.end())
+            return Walk::Skip; // buildMap would answer from the map.
+          return node.Degree() == 0 ? Walk::Visit : Walk::Descend;
+        },
+        [this](const ASTNode& node, PrimeMemoReady) { buildMap(node, true); });
+  }
+
   NodeDomainAnalysis::DomainInfo NodeDomainAnalysis::buildMap(const ASTNode& n)
   {
+    return buildMap(n, false);
+  }
+
+  NodeDomainAnalysis::DomainInfo
+  NodeDomainAnalysis::buildMap(const ASTNode& n, const bool knownMissing)
+  {
+    PrimeAudit::Running running(mapAudit, n);
+
+    // primeMaps' classifier already established the miss. Domain analysis of
+    // a descendant only records that descendant, never an ancestor.
+    if (!knownMissing)
     {
       auto it = toFixedBits.find(n);
       if (it != toFixedBits.end())
@@ -423,6 +479,25 @@ namespace stp
     }
 
     const auto number_children = n.Degree();
+
+    if (!priming && number_children > 0 &&
+        unprimedDepth >= unprimedDepthLimit)
+    {
+      priming = true;
+      primeMaps(n);
+      priming = false;
+
+      auto it = toFixedBits.find(n);
+      if (it != toFixedBits.end())
+      {
+        auto it0 = toIntervals.find(n);
+        auto it1 = toValueSets.find(n);
+        return {it->second, it0->second, it1->second};
+      }
+    }
+
+    // Leaves do not recurse, so they consume no part of the depth budget.
+    UnprimedDepth depth(unprimedDepth, !priming && number_children > 0);
 
     vector<FixedBits*> children_bits;
     children_bits.reserve(number_children);

--- a/lib/Simplifier/PropagateEqualities.cpp
+++ b/lib/Simplifier/PropagateEqualities.cpp
@@ -22,6 +22,7 @@ THE SOFTWARE.
 ********************************************************************/
 
 #include "stp/Simplifier/PropagateEqualities.h"
+#include "stp/Util/DagWalk.h"
 #include <string>
 #include <utility>
 #include <queue>
@@ -537,11 +538,21 @@ void PropagateEqualities::countToDo(ASTNode n)
   }
 }
 
+// The AND arm below is the only place this reaches another node. Walk its
+// spine with suspended ancestors so both deeply nested and very wide
+// conjunctions have bounded auxiliary memory. See DeepDag_Test.cpp.
 void PropagateEqualities::buildCandidateList(const ASTNode& a)
+{
+  walkPreOrder(a, [&](const ASTNode& current) {
+    return buildCandidateListNode(current);
+  });
+}
+
+bool PropagateEqualities::buildCandidateListNode(const ASTNode& a)
 {
 
   if (!alreadyVisited.insert(a.GetNodeNum()).second)
-    return;
+    return false;
 
   const Kind k = a.GetKind();
 
@@ -656,11 +667,7 @@ void PropagateEqualities::buildCandidateList(const ASTNode& a)
     else if (SYMBOL == a[1].GetKind())
       addCandidate(a[1], a[0]);
   }
-  else if (AND == k)
-  {
-    for (const auto& it : a)
-      buildCandidateList(it);
-  }
+  return AND == k;
 }
 
 

--- a/lib/Simplifier/Rewriting.cpp
+++ b/lib/Simplifier/Rewriting.cpp
@@ -45,7 +45,10 @@ THE SOFTWARE.
 #include "stp/Simplifier/Rewriting.h"
 #include "stp/Simplifier/Simplifier.h"
 #include "stp/Simplifier/SubstitutionMap.h"
+#include "stp/Util/DagWalk.h"
 #include <list>
+#include <deque>
+#include <vector>
 
 namespace stp
 {
@@ -72,50 +75,29 @@ namespace stp
   }
 
   // counter is 1 if the node has one reference in the tree.
+  //
+  // The walk is iterative because the input decides how deep it goes, and
+  // deep inputs exist: a call per level of the DAG exhausts the stack. The
+  // continuation stack holds pointers into each node's own child storage,
+  // which the node above keeps alive for the whole walk. It stores suspended
+  // ancestors, not every sibling in a wide frontier.
   void Rewriting::buildShareCount(const ASTNode& n)
   {
-    if (n.Degree() == 0)
-      return;
+    walkPreOrder(n, [&](const ASTNode& current) {
+      if (current.Degree() == 0)
+        return false;
 
-    if (shareCount[n.GetNodeNum()]++ > 0) // 0 first time, 1 second time.
-      return;
-  
-    for (const auto& c: n.GetChildren())
-        buildShareCount(c);
+      if (shareCount[current.GetNodeNum()]++ > 0) // 0 first time, 1 second.
+        return false;
+      return true;
+    });
   }
 
-  ASTNode Rewriting::rewrite(const ASTNode& n)
+  // Every sharing-aware rule, in order, applied to one node. Each rule
+  // sees what the rules before it produced. Nothing here descends into
+  // the DAG: the caller decides what to do with a node that changed.
+  ASTNode Rewriting::applyRules(ASTNode c)
   {
-    if (n.Degree() == 0)
-      return n;
-
-    if (fromTo.find(n.GetNodeNum()) != fromTo.end())
-      return fromTo[n.GetNodeNum()];
-
-    ASTNode result =n;
-
-    const ASTChildren children = n.GetChildren();
-    ASTVec newChildren;
-
-    // Copy on write.
-    bool changed =false;
-    auto fill = [&](const ASTNode& find)
-    {
-      newChildren.reserve(children.size());
-      const auto findIt = std::find(children.begin(), children.end(), find);
-      assert(findIt != children.end());
-      newChildren.insert(newChildren.end(), children.begin(), findIt);
-      changed=true;
-    };
-
-
-    for (auto c: children)
-    {
-     const ASTNode begin = c;
-     
-     c = rewrite(c);
-
-     const ASTNode start = c;
 
      if (
         c.GetKind() == EQ 
@@ -710,30 +692,173 @@ namespace stp
           c = nf->CreateNode(EQ, left,right);
         }
 
-       if (start != c)
-       {
-          c = rewrite(c);
-          removed++;
-       }
-       // TODO should probably update the sharecount.
-       if (begin!=c && !changed)
-          fill(begin);
-        if (changed)   
-          newChildren.push_back(c);
-    }    
+    return c;
+  }
 
-    if (newChildren.size() > 0)
+  // A leaf, or a node already rewritten: answered without a frame, exactly
+  // as the recursive version answered it without a call.
+  bool Rewriting::alreadyKnown(const ASTNode& n, ASTNode& answer)
+  {
+    if (n.Degree() == 0)
     {
-      assert(newChildren.size() == children.size());
-
-      if (n.GetType() == BOOLEAN_TYPE)
-        result = nf->CreateNode(n.GetKind(), newChildren);
-      else
-        result = nf->CreateArrayTerm(n.GetKind(), n.GetIndexWidth(),n.GetValueWidth(), newChildren);
+      answer = n;
+      return true;
     }
 
-    //TODO is this right? We've replaced the children, but never this node?
-    fromTo.insert({n.GetNodeNum(),result});
-    return result;
+    const auto it = fromTo.find(n.GetNodeNum());
+    if (it != fromTo.end())
+    {
+      answer = it->second;
+      return true;
+    }
+    return false;
+  }
+
+  // One node's progress through its children. `phase` says what a value
+  // arriving from below is: the recursive rewrite() had two call sites per
+  // child -- the child itself, and again on whatever the rules made of it
+  // -- and a frame has to know which one it is waiting for.
+  struct Rewriting::Frame
+  {
+    ASTNode n;
+    ASTChildren children;
+    ASTVec newChildren; // copy on write: empty until a child changes.
+    bool changed = false;
+    unsigned i = 0; // the child being worked on
+
+    ASTNode begin; // that child as it was before anything ran on it
+    ASTNode start; // and as it was after rewriting, before the rules
+
+    enum Phase
+    {
+      Fresh,
+      AwaitingChild,
+      AwaitingTransformed
+    };
+    Phase phase = Fresh;
+
+    Frame(const ASTNode& n_) : n(n_), children(n_.GetChildren()) {}
+  };
+
+  ASTNode Rewriting::rewrite(const ASTNode& n)
+  {
+    ASTNode result;
+    if (alreadyKnown(n, result))
+      return result;
+
+    // A deque, so descending into a child never moves the frames above it:
+    // `current` stays valid across a push.
+    std::deque<Frame> stack;
+    stack.emplace_back(n);
+
+    // Copy on write.
+    auto fill = [](Frame& f, const ASTNode& find)
+    {
+      f.newChildren.reserve(f.children.size());
+      const auto findIt =
+          std::find(f.children.begin(), f.children.end(), find);
+      assert(findIt != f.children.end());
+      f.newChildren.insert(f.newChildren.end(), f.children.begin(), findIt);
+      f.changed = true;
+    };
+
+    // The tail of the recursive version's loop body: `c` is the child in
+    // its final form.
+    auto finishChild = [&fill](Frame& f, const ASTNode& c)
+    {
+      // TODO should probably update the sharecount.
+      if (f.begin != c && !f.changed)
+        fill(f, f.begin);
+      if (f.changed)
+        f.newChildren.push_back(c);
+      f.i++;
+    };
+
+    // With the child rewritten, run the rules over it. A rule that fires
+    // sends its result back through the walk, which is the second of the
+    // two call sites; true means this frame has descended for that.
+    auto afterRewrite = [&](Frame& f, const ASTNode& rewritten) -> bool
+    {
+      f.start = rewritten;
+      const ASTNode c = applyRules(rewritten);
+
+      if (f.start == c)
+      {
+        finishChild(f, c);
+        return false;
+      }
+
+      ASTNode known;
+      if (alreadyKnown(c, known))
+      {
+        removed++;
+        finishChild(f, known);
+        return false;
+      }
+
+      f.phase = Frame::AwaitingTransformed;
+      stack.emplace_back(c);
+      return true;
+    };
+
+    while (true)
+    {
+      Frame& current = stack.back();
+      bool descended = false;
+
+      // Take delivery of the child this frame descended for.
+      if (current.phase == Frame::AwaitingChild)
+      {
+        current.phase = Frame::Fresh;
+        descended = afterRewrite(current, result);
+      }
+      else if (current.phase == Frame::AwaitingTransformed)
+      {
+        current.phase = Frame::Fresh;
+        removed++;
+        finishChild(current, result);
+      }
+
+      while (!descended && current.i < current.children.size())
+      {
+        current.begin = current.children[current.i];
+
+        ASTNode known;
+        if (alreadyKnown(current.begin, known))
+        {
+          descended = afterRewrite(current, known);
+          continue;
+        }
+
+        current.phase = Frame::AwaitingChild;
+        stack.emplace_back(current.begin);
+        descended = true;
+      }
+
+      if (descended)
+        continue;
+
+      Frame& done = stack.back();
+      result = done.n;
+
+      if (done.newChildren.size() > 0)
+      {
+        assert(done.newChildren.size() == done.children.size());
+
+        if (done.n.GetType() == BOOLEAN_TYPE)
+          result = nf->CreateNode(done.n.GetKind(), done.newChildren);
+        else
+          result = nf->CreateArrayTerm(done.n.GetKind(), done.n.GetIndexWidth(),
+                                       done.n.GetValueWidth(),
+                                       done.newChildren);
+      }
+
+      //TODO is this right? We've replaced the children, but never this node?
+      fromTo.insert({done.n.GetNodeNum(), result});
+
+      stack.pop_back();
+      if (stack.empty())
+        return result;
+    }
   }
 }

--- a/lib/Simplifier/Simplifier.cpp
+++ b/lib/Simplifier/Simplifier.cpp
@@ -27,11 +27,13 @@ THE SOFTWARE.
 #include "stp/FloatBlaster/FloatBlaster.h"
 #include <cassert>
 #include <cmath>
+#include <cstdint>
+#include <deque>
 
 namespace stp
 {
-using std::endl;
 using std::cerr;
+using std::endl;
 
 
 // If enabled, simplifyTerm will simplify all the arguments to a function before
@@ -262,233 +264,56 @@ ASTNode Simplifier::SimplifyTerm_TopLevel(const ASTNode& b)
   return out;
 }
 
-ASTNode Simplifier::SimplifyFormula(const ASTNode& b, bool pushNeg)
+bool Simplifier::formulaShortcut(const ASTNode& b, bool pushNeg, ASTNode& a,
+                                 ASTNode& out)
 {
   assert(_bm->UserFlags.optimize_flag);
   assert(BOOLEAN_TYPE == b.GetType());
 
   if (b.isConstant())
   {
-    return pushNeg ? nf->CreateNode(NOT, b) : b;
+    out = pushNeg ? nf->CreateNode(NOT, b) : b;
+    return true;
   }
 
-  ASTNode output;
-  if (CheckSimplifyMap(b, output, pushNeg))
-    return output;
+  if (CheckSimplifyMap(b, out, pushNeg))
+    return true;
 
   // pullUpITE can change the Kind of the node.
-  ASTNode a = PullUpITE(b);
-
-  switch (a.GetKind())
-  {
-    case AND:
-    case OR:
-      output = SimplifyAndOrFormula(a, pushNeg);
-      break;
-    case NOT:
-      output = SimplifyNotFormula(a, pushNeg);
-      break;
-    case XOR:
-      output = SimplifyXorFormula(a, pushNeg);
-      break;
-    case NAND:
-      output = SimplifyNandFormula(a, pushNeg);
-      break;
-    case NOR:
-      output = SimplifyNorFormula(a, pushNeg);
-      break;
-    case IFF:
-      output = SimplifyIffFormula(a, pushNeg);
-      break;
-    case IMPLIES:
-      output = SimplifyImpliesFormula(a, pushNeg);
-      break;
-    case ITE:
-      output = SimplifyIteFormula(a, pushNeg);
-      break;
-    default:
-      // kind can be EQ,NEQ,BVLT,BVLE,... or a propositional variable
-      output = SimplifyAtomicFormula(a, pushNeg);
-      break;
-  }
-
-  UpdateSimplifyMap(b, output, pushNeg);
-  if (a != b) // PullUpITE often returns its input unchanged.
-    UpdateSimplifyMap(a, output, pushNeg);
-
-  return output;
+  a = PullUpITE(b);
+  return false;
 }
 
-ASTNode Simplifier::SimplifyAtomicFormula(const ASTNode& a, bool pushNeg)
+// A concat's leading constant, if it has one. Keep the answer itself rather
+// than only its width: callers inspect several bits, and chasing the first
+// child from the root again for every bit makes that quadratic in a deep
+// concat's depth and its constant prefix width.
+const ASTNode* mostSignificantConstant(const ASTNode& n)
 {
-  ASTNode output;
-  if (CheckSimplifyMap(a, output, pushNeg))
-  {
-    return output;
-  }
-
-  ASTNode left, right;
-  if (a.Degree() == 2)
-  {
-    left = SimplifyTerm(a[0]);
-    right = SimplifyTerm(a[1]);
-  }
-
-  Kind kind = a.GetKind();
-  switch (kind)
-  {
-    case TRUE:
-      output = pushNeg ? ASTFalse : ASTTrue;
-      break;
-    case FALSE:
-      output = pushNeg ? ASTTrue : ASTFalse;
-      break;
-    case SYMBOL:
-      if (!InsideSubstitutionMap(a, output))
-      {
-        output = a;
-      }
-      output = pushNeg ? nf->CreateNode(NOT, output) : output;
-      break;
-    case BOOLEXTRACT:
-    {
-      ASTNode term = SimplifyTerm(a[0]);
-      ASTNode thebit = a[1];
-      ASTNode zero = nf->CreateZeroConst(1);
-      ASTNode one = nf->CreateOneConst(1);
-      ASTNode getthebit = SimplifyTerm(
-          nf->CreateTerm(BVEXTRACT, 1, term, thebit, thebit));
-      if (getthebit == zero)
-        output = pushNeg ? ASTTrue : ASTFalse;
-      else if (getthebit == one)
-        output = pushNeg ? ASTFalse : ASTTrue;
-      else
-      {
-        output = nf->CreateNode(BOOLEXTRACT, term, thebit);
-        output = pushNeg ? nf->CreateNode(NOT, output) : output;
-      }
-      break;
-    }
-    case EQ:
-    {
-      output = CreateSimplifiedEQ(left, right);
-      output = LhsMinusRhs(output);
-      output = ITEOpt_InEqs(output);
-      if (output == ASTTrue)
-        output = pushNeg ? ASTFalse : ASTTrue;
-      else if (output == ASTFalse)
-        output = pushNeg ? ASTTrue : ASTFalse;
-      else
-        output = pushNeg ? nf->CreateNode(NOT, output) : output;
-      break;
-    }
-    case BVLT:
-    case BVLE:
-    case BVGT:
-    case BVGE:
-    case BVSLT:
-    case BVSLE:
-    case BVSGT:
-    case BVSGE:
-    {
-      output = CreateSimplifiedINEQ(kind, left, right, pushNeg);
-      break;
-    }
-    case BVUADDO:
-    case BVSADDO:
-    case BVUMULO:
-    case BVSMULO:
-    case BVUSUBO:
-    case BVSSUBO:
-    {
-      // Overflow predicates are not inequalities; just rebuild with the
-      // simplified children (constant children are folded by the node
-      // factory) and honour pushNeg.
-      output = nf->CreateNode(kind, left, right);
-      output = pushNeg ? nf->CreateNode(NOT, output) : output;
-      break;
-    }
-    case FP_LEQ:
-    case FP_LT:
-    case FP_GEQ:
-    case FP_GT:
-    case FP_EQ:
-    case FP_ISNORMAL:
-    case FP_ISSUBNORMAL:
-    case FP_ISZERO:
-    case FP_ISINFINITE:
-    case FP_ISNAN:
-    case FP_ISNEGATIVE:
-    case FP_ISPOSITIVE:
-    case FP_SMT_EQ:
-    {
-      // Rebuild at the node's real arity: the comparisons are binary but the
-      // classification predicates are unary. Nothing here lowers anything --
-      // see the floating-point arm of simplify_term_switch, and FloatBlast.
-      ASTVec simplified;
-      simplified.reserve(a.Degree());
-
-      for (unsigned int i = 0; i < a.Degree(); i++)
-        simplified.push_back(SimplifyTerm(a[i]));
-
-      // The factory may rewrite the predicate rather than build it: constant
-      // operands fold to true/false, and the same-operand rules fire (fp.leq
-      // of a term with itself comes back as (not (fp.isNaN ...))) -- interned
-      // constants compare pointer-equal, so equal values are the same
-      // operand.
-      output = nf->CreateNode(kind, simplified);
-      if (pushNeg)
-        output = nf->CreateNode(NOT, output);
-
-      break;
-    }
-    default:
-      FatalError("SimplifyAtomicFormula: "
-                 "NO atomic formula of the kind: ",
-                 ASTUndefined, kind);
-      break;
-  }
-
-  // memoize
-  UpdateSimplifyMap(a, output, pushNeg);
-  return output;
+  const ASTNode* current = &n;
+  while (current->GetKind() == BVCONCAT)
+    current = &(*current)[0];
+  return current->isConstant() ? current : NULL;
 }
 
-// number of constant bits in the most significant places.
-unsigned mostSignificantConstants(const ASTNode& n)
+unsigned getConstantBit(const ASTNode& constant, const unsigned i)
 {
-  if (n.isConstant())
-    return n.GetValueWidth();
-  if (n.GetKind() == BVCONCAT)
-    return mostSignificantConstants(n[0]);
-  return 0;
-}
-
-unsigned getConstantBit(const ASTNode& n, const int i)
-{
-  if (n.GetKind() == BVCONST)
-  {
-    assert((int)n.GetValueWidth() >= i + 1);
-    return CONSTANTBV::BitVector_bit_test(n.GetBVConst(),
-                                          n.GetValueWidth() - 1 - i)
-               ? 1
-               : 0;
-  }
-  if (n.GetKind() == BVCONCAT)
-    return getConstantBit(n[0], i);
-
-  assert(false);
-  abort();
+  assert(constant.GetKind() == BVCONST && i < constant.GetValueWidth());
+  return CONSTANTBV::BitVector_bit_test(
+             constant.GetBVConst(), constant.GetValueWidth() - 1 - i)
+             ? 1
+             : 0;
 }
 
 unsigned numberOfLeadingZeroes(const ASTNode& n)
 {
-  unsigned c = mostSignificantConstants(n);
-  if (c == 0)
+  const ASTNode* constant = mostSignificantConstant(n);
+  if (constant == NULL)
     return 0;
 
+  const unsigned c = constant->GetValueWidth();
   for (unsigned i = 0; i < c; i++)
-    if (getConstantBit(n, i) != 0)
+    if (getConstantBit(*constant, i) != 0)
       return i;
   return c;
 }
@@ -665,7 +490,7 @@ ASTNode Simplifier::PullUpITE(const ASTNode& in)
 }
 
 // takes care of some simple ITE Optimizations in the context of equations
-ASTNode Simplifier::ITEOpt_InEqs(const ASTNode& in)
+ASTNode Simplifier::ITEOpt_InEqs(const ASTNode& in, ASTNode& conditionToNegate)
 {
   CountersAndStats("ITEOpts_InEqs", _bm);
 
@@ -720,8 +545,8 @@ ASTNode Simplifier::ITEOpt_InEqs(const ASTNode& in)
     }
     else if (in1[2] == in2 && constantsDenoteDifferentValues(in2, in1[1]))
     {
-      cond = SimplifyFormula(cond, true);
-      output = cond;
+      conditionToNegate = cond;
+      return ASTUndefined;
     }
     else
     {
@@ -740,8 +565,8 @@ ASTNode Simplifier::ITEOpt_InEqs(const ASTNode& in)
     }
     else if (in2[2] == in1 && constantsDenoteDifferentValues(in1, in2[1]))
     {
-      cond = SimplifyFormula(cond, true);
-      output = cond;
+      conditionToNegate = cond;
+      return ASTUndefined;
     }
     else
     {
@@ -780,13 +605,17 @@ ASTNode Simplifier::CreateSimplifiedEQ(const ASTNode& in1, const ASTNode& in2)
   // Check if some of the leading constant bits are different. Fancier code
   // would check
   // each bit, not just the leading bits.
-  const int constStart =
-      std::min(mostSignificantConstants(in1), mostSignificantConstants(in2));
+  const ASTNode* leading1 = mostSignificantConstant(in1);
+  const ASTNode* leading2 = mostSignificantConstant(in2);
+  const unsigned constStart =
+      leading1 == NULL || leading2 == NULL
+          ? 0
+          : std::min(leading1->GetValueWidth(), leading2->GetValueWidth());
 
-  for (int i = 0; i < constStart; i++)
+  for (unsigned i = 0; i < constStart; i++)
   {
-    const int a = getConstantBit(in1, i);
-    const int b = getConstantBit(in2, i);
+    const unsigned a = getConstantBit(*leading1, i);
+    const unsigned b = getConstantBit(*leading2, i);
     assert(a == 1 || a == 0);
     assert(b == 1 || b == 0);
 
@@ -797,7 +626,7 @@ ASTNode Simplifier::CreateSimplifiedEQ(const ASTNode& in1, const ASTNode& in2)
   // The above loop has determined that the leading bits are the same.
   if (constStart > 0)
   {
-    int newWidth = in1.GetValueWidth() - constStart;
+    const unsigned newWidth = in1.GetValueWidth() - constStart;
     ASTNode zero = nf->CreateZeroConst(32);
 
     ASTNode lhs = nf->CreateTerm(BVEXTRACT, newWidth, in1,
@@ -926,355 +755,1164 @@ ASTNode Simplifier::CreateSimplifiedFormulaITE(const ASTNode& in0,
   return result;
 }
 
-ASTNode Simplifier::SimplifyAndOrFormula(const ASTNode& a, bool pushNeg)
+// Every connective is where a formula nests: each operand is simplified by
+// coming back through here, so a formula nested as deeply as the input runs
+// the stack out. The frames live on the heap instead.
+//
+// The AND/OR spine was walked this way already, on the argument that the
+// other kinds "nest through each other rather than through a spine, and
+// nothing has been seen to reach a depth that matters". Something has: a
+// query built from 8,000 nested fp.add operations lowers to NOT and
+// if-then-else nested that deeply, and it died in exactly those two arms --
+// below the ~9,300 of the deepest input we have. So all of them are one walk
+// now. See DeepDag_Test.cpp.
+ASTNode Simplifier::SimplifyFormula(const ASTNode& b, bool pushNeg)
 {
-  ASTNode output;
-
-  if (CheckSimplifyMap(a, output, pushNeg))
-    return output;
-
-  const Kind k = a.GetKind();
-  const bool isAnd = (k == AND);
-
-  // Under pushNeg we are simplifying NOT(a): De Morgan flips the connective,
-  // and a child that simplifies to the annihilator collapses the whole node.
-  const ASTNode annihilator =
-      isAnd ? (pushNeg ? ASTTrue : ASTFalse) : (pushNeg ? ASTFalse : ASTTrue);
-  const Kind outKind = (isAnd == !pushNeg) ? AND : OR;
-
-  // Recursively simplify each child; short-circuit as soon as one is the
-  // annihilator. We do NOT pre-flatten nested same-kind operands: simplifying
-  // such a child yields an outKind node, which the splice below flattens
-  // anyway, so a separate FlattenKind pass would be redundant work.
-  ASTVec outvec;
-  outvec.reserve(a.Degree());
-  for (const ASTNode& child : a.GetChildren())
-  {
-    const ASTNode aaa = SimplifyFormula(child, pushNeg);
-    if (aaa == annihilator)
-    {
-      UpdateSimplifyMap(a, annihilator, pushNeg);
-      return annihilator;
-    }
-    // A child that simplified to the output connective (typically via De
-    // Morgan) would otherwise leave a nested same-kind node, which the factory
-    // does not flatten. Splice its already-simplified operands in so the
-    // result stays flat -- without this SimplifyFormula is not idempotent.
-    if (aaa.GetKind() == outKind)
-      outvec.insert(outvec.end(), aaa.begin(), aaa.end());
-    else
-      outvec.push_back(aaa);
-  }
-
-  // Hand the simplified children to the node factory. CreateSimpleAndOr
-  // sorts them, drops identities, removes duplicates, detects complements
-  // and unwraps singletons -- so none of that is repeated here.
-  output = nf->CreateNode(outKind, outvec);
-
-  UpdateSimplifyMap(a, output, pushNeg);
-  return output;
+  return simplifyNode(b, pushNeg, SimplifyJob::Formula);
 }
 
-ASTNode Simplifier::SimplifyNotFormula(const ASTNode& a, bool pushNeg)
+ASTNode Simplifier::simplifyNode(const ASTNode& b, bool pushNeg,
+                                 const SimplifyJob rootJob)
 {
-  ASTNode output;
-  if (CheckSimplifyMap(a, output, pushNeg))
-    return output;
-
-  if (!(a.Degree() == 1 && NOT == a.GetKind()))
-    FatalError("SimplifyNotFormula: input vector with more than 1 node",
-               ASTUndefined);
-
-  // if pushNeg is set then there is NOT on top
-  unsigned int NotCount = pushNeg ? 1 : 0;
-  ASTNode o = a;
-  // count the number of NOTs in 'a'
-  while (NOT == o.GetKind())
+  // What one node is part-way through. `b` is the node as it arrived and `a`
+  // as PullUpITE left it; both are recorded against the answer, as
+  // SimplifyFormula and simplifyNonAndOr each did.
+  //
+  // `pushNeg` is per frame, where the AND/OR-only driver took one for the
+  // whole walk. That arm does hand its own negation to every operand, but the
+  // others choose per operand: NAND and NOR push it into both, IMPLIES and
+  // IFF into one, and a NOT counts the run of NOTs above it and starts again
+  // from the parity of that count.
+  //
+  // Each arm of the switch below is one of the functions this replaced, and
+  // each phase is a point where that function called SimplifyFormula and has
+  // to be able to stop:
+  //
+  //     AND, OR              SimplifyAndOrFormula
+  //     NOT                  SimplifyNotFormula
+  //     XOR                  SimplifyXorFormula
+  //     NAND, NOR, IMPLIES   SimplifyNandFormula, SimplifyNorFormula,
+  //                          SimplifyImpliesFormula
+  //     IFF                  SimplifyIffFormula
+  //     ITE                  SimplifyIteFormula
+  //     default              SimplifyAtomicFormula
+  //
+  // An arm reads the same way as the function did if `finish` is read as its
+  // `return`, and `want` as the call it made just above one. Nothing else of
+  // those functions moved: the head each shared is formulaShortcut plus the
+  // map test in Frame::Start, and the tail each shared is `finish`.
+  struct Frame
   {
-    o = o[0];
-    NotCount++;
-  }
-
-  // pushnegation if there are odd number of NOTs
-  bool pn = (NotCount % 2 == 0) ? false : true;
-
-  if (CheckSimplifyMap(o, output, pn))
-  {
-    return output;
-  }
-
-  if (ASTTrue == o)
-  {
-    output = pn ? ASTFalse : ASTTrue;
-  }
-  else if (ASTFalse == o)
-  {
-    output = pn ? ASTTrue : ASTFalse;
-  }
-  else
-  {
-    output = SimplifyFormula(o, pn);
-  }
-  // memoize
-  UpdateSimplifyMap(o, output, pn);
-  UpdateSimplifyMap(a, output, pushNeg);
-  return output;
-}
-
-ASTNode Simplifier::SimplifyXorFormula(const ASTNode& a, bool pushNeg)
-{
-  ASTNode output;
-  if (CheckSimplifyMap(a, output, pushNeg))
-    return output;
-
-  assert(a.GetChildren().size() > 0);
-
-  if (a.GetChildren().size() == 1)
-  {
-    output = a[0];
-  }
-  else if (a.GetChildren().size() == 2)
-  {
-    ASTNode a0 = SimplifyFormula(a[0], false);
-    ASTNode a1 = SimplifyFormula(a[1], false);
-    if (pushNeg)
-      a0 = nf->CreateNode(NOT, a0);
-    output = nf->CreateNode(XOR, a0, a1);
-
-    if (a0 == a1)
-      output = ASTFalse;
-    else if ((a0 == ASTTrue && a1 == ASTFalse) ||
-             (a0 == ASTFalse && a1 == ASTTrue))
-      output = ASTTrue;
-  }
-  else
-  {
-    ASTVec newC;
-    for (size_t i = 0; i < a.GetChildren().size(); i++)
+    enum Job : uint8_t
     {
-      newC.push_back(SimplifyFormula(a[i], false));
+      FormulaJob,
+      AtomicJob,
+      TermJob,
+      ArrayJob
+    };
+    enum Phase : uint8_t
+    {
+      Start,
+      PrecheckedStart,
+      AndOrOperand, // AND/OR: the operand at `i`
+      NotBody,      // NOT: whatever is under the run of NOTs
+      XorOperand,   // XOR: the operand at `i`
+      BinaryLeft,   // NAND, NOR, IMPLIES: the first operand
+      BinaryRight,  // ... and the second
+      IffRight,     // IFF: the second operand, which it simplifies first
+      IffLeft,      // ... then the first
+      IffFold,      // ... then one of the two again, negated
+      IteCond,      // ITE: the condition
+      IteThen,      // ... the then-branch
+      IteElse,      // ... the else-branch
+      IteFold,       // ... ITE(c, false, true): the condition again, negated
+      FormulaAtomic,
+
+      AtomicLeft,
+      AtomicRight,
+      AtomicBoolExtract,
+      AtomicFpOperand,
+      AtomicEqNegRhs,
+      AtomicEqCombined,
+      AtomicEqIteCondition,
+
+      TermSubstitutionPrechecked,
+      TermSubstitution,
+      TermOperand,
+      TermPulled,
+      TermRetry,
+      TermOutput,
+      TermReadArray,
+
+      ArrayCond,
+      ArrayThen,
+      ArrayElse,
+      ArrayBase,
+      ArrayIndex,
+      ArrayValue
+    };
+
+    struct Init
+    {
+      Job job;
+      ASTNode b;
+      ASTNode a;
+      bool pushNeg;
+      Phase phase;
+    };
+
+    // Put the reference-counted and aligned state first. The scalar state is
+    // packed at the tail so a frame does not acquire padding between every
+    // phase discriminator and node.
+    ASTNode b;
+    ASTNode a;
+
+    // AND, OR and XOR collect their operands.
+    ASTVec outvec;
+
+    // The operands an arm has to keep across a suspension: what a NOT has
+    // under it, the two sides of a binary connective, the three of an
+    // if-then-else.
+    ASTNode t0, t1, t2;
+
+    // Term jobs simplify their selected operands in `outvec` itself. `output`
+    // is also scratch storage for atomic jobs and for the AND/OR annihilator;
+    // those jobs are mutually exclusive, so carrying another ASTNode in every
+    // frame would only make the explicit stack larger.
+    ASTNode output;
+    size_t i = 0;
+
+    // Formula jobs use the kind while term jobs use the width. A frame can
+    // never be both, so keeping separate words only enlarged every frame.
+    union
+    {
+      Kind outKind;
+      unsigned valueWidth;
+    };
+
+    Job job = FormulaJob;
+    Phase phase = Start;
+    bool pushNeg = false;
+
+    Frame() : outKind(UNDEFINED) {}
+
+    explicit Frame(Init&& init)
+        : b(std::move(init.b)), a(std::move(init.a)), outKind(UNDEFINED),
+          job(init.job), phase(init.phase), pushNeg(init.pushNeg)
+    {
     }
-    if (pushNeg)
-      newC[0] = nf->CreateNode(NOT, newC[0]);
+  };
 
-    output = nf->CreateNode(XOR, newC);
-  }
+  static_assert(sizeof(Frame) <= 88,
+                "simplifier continuation frame unexpectedly grew");
 
-  // memoize
-  UpdateSimplifyMap(a, output, pushNeg);
-  return output;
-}
+  ASTNode result;
 
-ASTNode Simplifier::SimplifyNandFormula(const ASTNode& a, bool pushNeg)
-{
-  ASTNode output, a0, a1;
-  if (CheckSimplifyMap(a, output, pushNeg))
-    return output;
-
-  // the two NOTs cancel out
-  if (pushNeg)
-  {
-    a0 = SimplifyFormula(a[0], false);
-    a1 = SimplifyFormula(a[1], false);
-    output = nf->CreateNode(AND, a0, a1);
-  }
-  else
-  {
-    // push the NOT implicit in the NAND
-    a0 = SimplifyFormula(a[0], true);
-    a1 = SimplifyFormula(a[1], true);
-    output = nf->CreateNode(OR, a0, a1);
-  }
-
-  // memoize
-  UpdateSimplifyMap(a, output, pushNeg);
-  return output;
-}
-
-ASTNode Simplifier::SimplifyNorFormula(const ASTNode& a, bool pushNeg)
-{
-  ASTNode output, a0, a1;
-  if (CheckSimplifyMap(a, output, pushNeg))
-    return output;
-
-  // the two NOTs cancel out
-  if (pushNeg)
-  {
-    a0 = SimplifyFormula(a[0], false);
-    a1 = SimplifyFormula(a[1], false);
-    output = nf->CreateNode(OR, a0, a1);
-  }
-  else
-  {
-    // push the NOT implicit in the NAND
-    a0 = SimplifyFormula(a[0], true);
-    a1 = SimplifyFormula(a[1], true);
-    output = nf->CreateNode(AND, a0, a1);
-  }
-
-  // memoize
-  UpdateSimplifyMap(a, output, pushNeg);
-  return output;
-}
-
-ASTNode Simplifier::SimplifyImpliesFormula(const ASTNode& a, bool pushNeg)
-{
-  ASTNode output;
-  if (CheckSimplifyMap(a, output, pushNeg))
-    return output;
-
-  if (!(a.Degree() == 2 && IMPLIES == a.GetKind()))
-    FatalError("SimplifyImpliesFormula: vector with wrong num of nodes",
-               ASTUndefined);
-
-  ASTNode c0, c1;
-  if (pushNeg)
-  {
-    c0 = SimplifyFormula(a[0], false);
-    c1 = SimplifyFormula(a[1], true);
-    output = nf->CreateNode(AND, c0, c1);
-  }
-  else
-  {
-    c0 = SimplifyFormula(a[0], false);
-    c1 = SimplifyFormula(a[1], false);
-    if (ASTFalse == c0)
+  // The head of SimplifyFormula: the answers it gives before dispatching to
+  // an arm at all. `a` is left holding the node PullUpITE produced, which is
+  // what the arm runs on. True when `result` is the answer.
+  auto head = [&](const ASTNode& n, const bool neg, ASTNode& a) -> bool {
+    ASTNode out;
+    if (formulaShortcut(n, neg, a, out))
     {
-      output = ASTTrue;
+      result = out;
+      return true;
     }
-    else if (ASTTrue == c0)
+
+    // Every arm began by asking the map about the node PullUpITE produced.
+    // formulaShortcut already asked when PullUpITE left the node unchanged.
+    ASTNode cached;
+    if (a != n && CheckSimplifyMap(a, cached, neg))
     {
-      output = c1;
+      // `a` is the key that answered, so only the node as it arrived still
+      // needs recording.
+      UpdateSimplifyMap(n, cached, neg);
+      result = cached;
+      return true;
     }
-    else if (c0 == c1)
+    return false;
+  };
+
+  // Answer root-level leaves and memo hits before constructing the deque.
+  // A deque may allocate initial storage in its constructor (libstdc++ does),
+  // so returning after the first push can still make every shallow call pay
+  // for a traversal worklist it never used.
+  Frame top;
+  top.b = b;
+  top.pushNeg = pushNeg;
+  if (rootJob == SimplifyJob::Formula)
+  {
+    top.job = Frame::FormulaJob;
+    if (head(b, pushNeg, top.a))
+      return result;
+  }
+  else if (rootJob == SimplifyJob::Term)
+  {
+    assert(_bm->UserFlags.optimize_flag);
+    top.job = Frame::TermJob;
+
+    // A root substitution frame only returned the answer from its image and
+    // deliberately did not memoise the substituted key. Follow those
+    // transparent frames here, applying the same constant/substitution/memo
+    // head as `want`, until a real term frame is needed.
+    ASTNode root = b;
+    ASTNode substitutionImage;
+    while (true)
     {
-      output = ASTTrue;
-    }
-    else
-    {
-      if (NOT == c0.GetKind())
+      if (root.isConstant())
+        return root;
+      if (InsideSubstitutionMap(root, substitutionImage))
       {
-        output = nf->CreateNode(OR, c0[0], c1);
+        root = substitutionImage;
+        continue;
       }
-      else
-      {
-        output = nf->CreateNode(OR, nf->CreateNode(NOT, c0), c1);
-      }
+      if (CheckSimplifyMap(root, result, false))
+        return result;
+      break;
     }
+
+    top.b = root;
+    top.phase = Frame::PrecheckedStart;
+  }
+  else
+  {
+    assert(b.GetIndexWidth() > 0);
+    top.job = Frame::ArrayJob;
+    if (CheckSimplifyMap(b, result, false))
+      return result;
+    if (b.GetKind() == SYMBOL)
+      return b;
+    top.phase = Frame::PrecheckedStart;
   }
 
-  // memoize
-  UpdateSimplifyMap(a, output, pushNeg);
-  return output;
+  // Keep shallow walks in one contiguous allocation. `want` is the only
+  // operation that can grow the vector, and every caller returns from its
+  // step immediately afterwards, so no Frame reference survives a move.
+  // Unlike deque, vector also avoids allocating a block plus a block map for
+  // the overwhelmingly common one- and two-frame walks.
+  std::vector<Frame> stack;
+  stack.push_back(std::move(top));
+
+  enum class StepResult
+  {
+    Finished,
+    Pushed,
+    Redispatch,
+    Yield
+  };
+
+  // Ask for the simplification of `n` under `neg`, and set this frame's
+  // continuation to `resume`.
+  //
+  // The head runs here rather than in the frame below because most of the
+  // time it answers: the operands of a DAG are mostly nodes the walk has
+  // already simplified, and a memo hit does not need a frame to return
+  // through. Return Pushed only when a child frame was added. An immediate
+  // answer stays in `result` and returns Redispatch, which the job-local loop
+  // consumes without a control-flow jump or an outer worklist dispatch.
+  // `n` can name storage in the current frame (for example f.output or
+  // f.t0). Construct the child before growing the vector so it owns those
+  // references before a reallocation can move the parent.
+  auto pushChild = [&](const Frame::Job job, const ASTNode& n, ASTNode a,
+                       const bool neg,
+                       const Frame::Phase start) -> StepResult {
+    Frame::Init child{job, n, std::move(a), neg, start};
+    stack.emplace_back(std::move(child));
+    return StepResult::Pushed;
+  };
+
+  // Keep the four child heads separate. Their job is known at every request
+  // site; making it a run-time argument forced this hot path through a
+  // four-way discriminator even though only one arm could ever apply.
+  auto want = [&](Frame& f, const Frame::Phase resume, const ASTNode& n,
+                  const bool neg) -> StepResult {
+    f.phase = resume;
+    ASTNode a;
+    if (head(n, neg, a))
+      return StepResult::Redispatch;
+    return pushChild(Frame::FormulaJob, n, std::move(a), neg, Frame::Start);
+  };
+
+  auto wantTerm = [&](Frame& f, const Frame::Phase resume,
+                      const ASTNode& n) -> StepResult {
+    f.phase = resume;
+    if (n.isConstant())
+    {
+      result = n;
+      return StepResult::Redispatch;
+    }
+
+    ASTNode substitutionImage;
+    Frame::Phase start;
+    if (InsideSubstitutionMap(n, substitutionImage))
+      start = Frame::TermSubstitutionPrechecked;
+    else if (CheckSimplifyMap(n, result, false))
+      return StepResult::Redispatch;
+    else
+      start = Frame::PrecheckedStart;
+
+    const StepResult pushed =
+        pushChild(Frame::TermJob, n, ASTNode(), false, start);
+    if (start == Frame::TermSubstitutionPrechecked)
+      stack.back().output = std::move(substitutionImage);
+    return pushed;
+  };
+
+  auto wantArray = [&](Frame& f, const Frame::Phase resume,
+                       const ASTNode& n) -> StepResult {
+    f.phase = resume;
+    if (n.GetKind() == SYMBOL)
+    {
+      result = n;
+      return StepResult::Redispatch;
+    }
+    if (CheckSimplifyMap(n, result, false))
+      return StepResult::Redispatch;
+    return pushChild(Frame::ArrayJob, n, ASTNode(), false,
+                     Frame::PrecheckedStart);
+  };
+
+  auto wantAtomic = [&](Frame& f, const Frame::Phase resume,
+                        const ASTNode& n, const bool neg) -> StepResult {
+    f.phase = resume;
+    return pushChild(Frame::AtomicJob, n, ASTNode(), neg,
+                     Frame::PrecheckedStart);
+  };
+
+  // Keep each job's phase dispatcher in its own function. Formula and term
+  // jobs dominate ordinary simplification; folding the atomic and array
+  // state machines into the same large body evicts their hot code even when
+  // those jobs are not running.
+  auto stepAtomic = [&](Frame& f) -> StepResult {
+    assert(f.job == Frame::AtomicJob);
+    // The one request site, wantAtomic, always starts an atomic frame
+    // prechecked: the formula head that scheduled it has already probed the
+    // map for this node under this polarity.
+    assert(f.phase != Frame::Start);
+    {
+      auto finishAtomic = [&](const ASTNode& output)
+      {
+        UpdateSimplifyMap(f.b, output, f.pushNeg);
+        result = output;
+        return StepResult::Finished;
+      };
+
+      auto finishEquality = [&](ASTNode output)
+      {
+        if (output == ASTTrue)
+          output = f.pushNeg ? ASTFalse : ASTTrue;
+        else if (output == ASTFalse)
+          output = f.pushNeg ? ASTTrue : ASTFalse;
+        else if (f.pushNeg)
+          output = nf->CreateNode(NOT, output);
+        return finishAtomic(output);
+      };
+
+      auto optimizeAndFinishEquality = [&](ASTNode output)
+      {
+        const ASTNode input = output;
+        ASTNode conditionToNegate;
+        output = ITEOpt_InEqs(output, conditionToNegate);
+        if (!conditionToNegate.IsNull())
+        {
+          // ITEOpt_InEqs used to call SimplifyFormula before recording this
+          // intermediate equality. Keep the key across that suspension so
+          // the resumed job preserves the same memoisation edge.
+          f.output = input;
+          // This rare helper is itself a continuation boundary. Preserve its
+          // historical outer-loop resume for both an immediate answer and a
+          // pushed child; the common request sites below fuse their immediate
+          // answers directly.
+          const StepResult requested =
+              want(f, Frame::AtomicEqIteCondition, conditionToNegate, true);
+          return requested == StepResult::Redispatch ? StepResult::Yield
+                                                      : requested;
+        }
+        return finishEquality(output);
+      };
+
+      if (f.phase == Frame::PrecheckedStart)
+      {
+        // Keep the original atomic-formula order: every binary predicate
+        // simplifies both operands before dispatch, including BOOLEXTRACT.
+        if (f.b.Degree() == 2)
+          return wantTerm(f, Frame::AtomicLeft, f.b[0]);
+      }
+      else if (f.phase == Frame::AtomicLeft)
+      {
+        f.t0 = result;
+        return wantTerm(f, Frame::AtomicRight, f.b[1]);
+      }
+      else if (f.phase == Frame::AtomicRight)
+      {
+        f.t1 = result;
+      }
+      else if (f.phase == Frame::AtomicBoolExtract)
+      {
+        const ASTNode zero = nf->CreateZeroConst(1);
+        const ASTNode one = nf->CreateOneConst(1);
+        ASTNode output;
+        if (result == zero)
+          output = f.pushNeg ? ASTTrue : ASTFalse;
+        else if (result == one)
+          output = f.pushNeg ? ASTFalse : ASTTrue;
+        else
+        {
+          output = nf->CreateNode(BOOLEXTRACT, f.t0, f.b[1]);
+          if (f.pushNeg)
+            output = nf->CreateNode(NOT, output);
+        }
+        return finishAtomic(output);
+      }
+      else if (f.phase == Frame::AtomicFpOperand)
+      {
+        f.outvec.push_back(result);
+        ++f.i;
+      }
+
+      if (f.phase == Frame::AtomicEqNegRhs)
+      {
+        const ASTNode combined = LhsMinusRhsTerm(f.output, result);
+        return wantTerm(f, Frame::AtomicEqCombined, combined);
+      }
+
+      ASTNode output;
+      const Kind kind = f.b.GetKind();
+      if (f.phase == Frame::AtomicEqIteCondition)
+      {
+        UpdateSimplifyMap(f.output, result, false);
+        return finishEquality(result);
+      }
+      if (f.phase == Frame::AtomicEqCombined)
+      {
+        output = CreateSimplifiedEQ(
+            result, nf->CreateZeroConst(result.GetValueWidth()));
+        return optimizeAndFinishEquality(output);
+      }
+
+      switch (kind)
+      {
+        case TRUE:
+          output = f.pushNeg ? ASTFalse : ASTTrue;
+          break;
+        case FALSE:
+          output = f.pushNeg ? ASTTrue : ASTFalse;
+          break;
+        case SYMBOL:
+          if (!InsideSubstitutionMap(f.b, output))
+            output = f.b;
+          if (f.pushNeg)
+            output = nf->CreateNode(NOT, output);
+          break;
+        case BOOLEXTRACT:
+        {
+          const ASTNode getthebit =
+              nf->CreateTerm(BVEXTRACT, 1, f.t0, f.b[1], f.b[1]);
+          return wantTerm(f, Frame::AtomicBoolExtract, getthebit);
+        }
+        case EQ:
+        {
+          output = CreateSimplifiedEQ(f.t0, f.t1);
+          ASTNode cached;
+          if (CheckSimplifyMap(output, cached, false))
+            output = cached;
+          else if (output.GetKind() == EQ)
+          {
+            const Kind lhsKind = output[0].GetKind();
+            const Kind rhsKind = output[1].GetKind();
+            if (lhsKind == BVPLUS || rhsKind == BVPLUS ||
+                (lhsKind == BVMULT && rhsKind == BVMULT))
+            {
+              f.output = output;
+              const ASTNode rhs = (lhsKind != BVPLUS && rhsKind == BVPLUS)
+                                      ? output[0]
+                                      : output[1];
+              const ASTNode negated =
+                  nf->CreateTerm(BVUMINUS, rhs.GetValueWidth(), rhs);
+              return wantTerm(f, Frame::AtomicEqNegRhs, negated);
+            }
+          }
+          return optimizeAndFinishEquality(output);
+        }
+        case BVLT:
+        case BVLE:
+        case BVGT:
+        case BVGE:
+        case BVSLT:
+        case BVSLE:
+        case BVSGT:
+        case BVSGE:
+          output = CreateSimplifiedINEQ(kind, f.t0, f.t1, f.pushNeg);
+          break;
+        case BVUADDO:
+        case BVSADDO:
+        case BVUMULO:
+        case BVSMULO:
+        case BVUSUBO:
+        case BVSSUBO:
+          output = nf->CreateNode(kind, f.t0, f.t1);
+          if (f.pushNeg)
+            output = nf->CreateNode(NOT, output);
+          break;
+        case FP_LEQ:
+        case FP_LT:
+        case FP_GEQ:
+        case FP_GT:
+        case FP_EQ:
+        case FP_ISNORMAL:
+        case FP_ISSUBNORMAL:
+        case FP_ISZERO:
+        case FP_ISINFINITE:
+        case FP_ISNAN:
+        case FP_ISNEGATIVE:
+        case FP_ISPOSITIVE:
+        case FP_SMT_EQ:
+          if (f.outvec.empty())
+            f.outvec.reserve(f.b.Degree());
+          if (f.outvec.empty() && f.b.Degree() == 2)
+          {
+            f.outvec.push_back(f.t0);
+            f.outvec.push_back(f.t1);
+            f.i = 2;
+          }
+          while (f.i < f.b.Degree())
+          {
+            const StepResult requested =
+                wantTerm(f, Frame::AtomicFpOperand, f.b[f.i]);
+            if (requested == StepResult::Pushed)
+              return requested;
+            assert(requested == StepResult::Redispatch);
+            f.outvec.push_back(result);
+            ++f.i;
+          }
+          output = nf->CreateNode(kind, f.outvec);
+          if (f.pushNeg)
+            output = nf->CreateNode(NOT, output);
+          break;
+        default:
+          FatalError("SimplifyAtomicFormula: NO atomic formula of the kind: ",
+                     ASTUndefined, kind);
+      }
+
+      return finishAtomic(output);
+    }
+  };
+
+  auto stepArray = [&](Frame& f) -> StepResult {
+    assert(f.job == Frame::ArrayJob);
+    {
+      auto finishArray = [&](const ASTNode& output)
+      {
+        UpdateSimplifyMap(f.b, output, false);
+        assert(f.b.GetIndexWidth() == output.GetIndexWidth());
+        assert(BVTypeCheck(output));
+        result = output;
+        return StepResult::Finished;
+      };
+
+      const unsigned iw = f.b.GetIndexWidth();
+      assert(iw > 0);
+
+      if (f.phase == Frame::Start || f.phase == Frame::PrecheckedStart)
+      {
+        if (f.phase == Frame::Start)
+        {
+          if (CheckSimplifyMap(f.b, result, false))
+            return StepResult::Finished;
+
+          if (f.b.GetKind() == SYMBOL)
+          {
+            result = f.b;
+            return StepResult::Finished;
+          }
+        }
+
+        if (f.b.GetKind() == ITE)
+          return want(f, Frame::ArrayCond, f.b[0], false);
+        if (f.b.GetKind() == WRITE)
+          return wantArray(f, Frame::ArrayBase, f.b[0]);
+
+        FatalError("SimplifyArrayTerm: unexpected array term", f.b);
+      }
+
+      if (f.b.GetKind() == ITE)
+      {
+        if (f.phase == Frame::ArrayCond)
+        {
+          f.t0 = result;
+          return wantArray(f, Frame::ArrayThen, f.b[1]);
+        }
+        if (f.phase == Frame::ArrayThen)
+        {
+          f.t1 = result;
+          return wantArray(f, Frame::ArrayElse, f.b[2]);
+        }
+
+        f.t2 = result;
+        return finishArray(CreateSimplifiedTermITE(f.t0, f.t1, f.t2));
+      }
+
+      if (f.phase == Frame::ArrayBase)
+      {
+        f.t0 = result;
+        return wantTerm(f, Frame::ArrayIndex, f.b[1]);
+      }
+      if (f.phase == Frame::ArrayIndex)
+      {
+        f.t1 = result;
+        return wantTerm(f, Frame::ArrayValue, f.b[2]);
+      }
+
+      f.t2 = result;
+      return finishArray(nf->CreateArrayTerm(WRITE, iw, f.b.GetValueWidth(),
+                                             f.t0, f.t1, f.t2));
+    }
+  };
+
+  auto stepTerm = [&](Frame& f) -> StepResult {
+    assert(f.job == Frame::TermJob);
+    {
+      auto finishTerm = [&](const ASTNode& output)
+      {
+        result = output;
+        return StepResult::Finished;
+      };
+
+      auto finishTermTail = [&](const ASTNode& output)
+      {
+        if (!f.t2.IsNull())
+          UpdateSimplifyMap(f.t2, output, false);
+        if (f.a != f.t2)
+          UpdateSimplifyMap(f.a, output, false);
+        if (f.b != f.a && f.b != f.t2)
+          UpdateSimplifyMap(f.b, output, false);
+
+        assert(!output.IsNull());
+        assert(f.a.GetValueWidth() == output.GetValueWidth());
+        assert(f.a.GetIndexWidth() == output.GetIndexWidth());
+        assert(hasBeenSimplified(output));
+#ifndef NDEBUG
+        for (size_t i = 0; i < output.Degree(); ++i)
+        {
+          if (output[i].GetType() != ARRAY_TYPE &&
+              !hasBeenSimplified(output[i]))
+          {
+            std::cerr << output << i;
+            assert(false);
+          }
+        }
+#endif
+        result = output;
+        return StepResult::Finished;
+      };
+
+      if (f.phase == Frame::TermSubstitution)
+        return finishTerm(result);
+      if (f.phase == Frame::TermPulled || f.phase == Frame::TermRetry)
+      {
+        UpdateSimplifyMap(f.b, result, false);
+        if (f.a != f.b)
+          UpdateSimplifyMap(f.a, result, false);
+        return finishTerm(result);
+      }
+      if (f.phase == Frame::TermOutput)
+        return finishTermTail(result);
+
+      if (f.phase == Frame::Start ||
+          f.phase == Frame::PrecheckedStart ||
+          f.phase == Frame::TermSubstitutionPrechecked)
+      {
+        assert(_bm->UserFlags.optimize_flag);
+        if (f.phase == Frame::Start && f.b.isConstant())
+          return finishTerm(f.b);
+
+        f.a = f.b;
+        const ASTNode substitutionImage = f.output;
+        f.output = f.a;
+        assert(BVTypeCheck(f.a));
+
+        if (f.phase == Frame::TermSubstitutionPrechecked)
+          return wantTerm(f, Frame::TermSubstitution, substitutionImage);
+        if (f.phase == Frame::Start &&
+            InsideSubstitutionMap(f.a, f.output))
+          return wantTerm(f, Frame::TermSubstitution, f.output);
+        if (f.phase == Frame::Start &&
+            CheckSimplifyMap(f.a, result, false))
+          return StepResult::Finished;
+
+        const Kind k = f.a.GetKind();
+        if (!is_Term_kind(k))
+          FatalError("SimplifyTerm: You have input a Non-term", f.a);
+
+        f.valueWidth = f.a.GetValueWidth();
+        if (k != SYMBOL)
+        {
+          if (k == BVAND || k == BVOR || k == BVPLUS)
+            f.outvec = FlattenKind(k, f.b.GetChildren(), 15);
+          else
+            f.outvec = toASTVec(f.b.GetChildren());
+        }
+      }
+      else if (f.phase == Frame::TermOperand)
+      {
+        f.outvec[f.i] = result;
+        ++f.i;
+      }
+
+      // Simplify the selected operands left-to-right. Array operands are
+      // deliberately carried through here; READ schedules its array as an
+      // ArrayJob below, matching the old split between the two functions.
+      while (f.a.GetKind() != SYMBOL && f.i < f.outvec.size())
+      {
+        const ASTNode& operand = f.outvec[f.i];
+        if (operand.GetType() == BITVECTOR_TYPE ||
+            operand.GetType() == FLOATINGPOINT_TYPE)
+        {
+          const StepResult requested =
+              wantTerm(f, Frame::TermOperand, operand);
+          if (requested == StepResult::Pushed)
+            return requested;
+          assert(requested == StepResult::Redispatch);
+          f.outvec[f.i] = result;
+          ++f.i;
+          continue;
+        }
+        if (operand.GetType() == BOOLEAN_TYPE)
+        {
+          const StepResult requested =
+              want(f, Frame::TermOperand, operand, false);
+          if (requested == StepResult::Pushed)
+            return requested;
+          assert(requested == StepResult::Redispatch);
+          f.outvec[f.i] = result;
+          ++f.i;
+          continue;
+        }
+        ++f.i;
+      }
+
+      if (f.a.GetKind() != SYMBOL && f.phase != Frame::TermReadArray)
+      {
+        assert(!f.outvec.empty());
+        if (ASTChildren(f.outvec) != f.b.GetChildren())
+        {
+          f.output = nf->CreateArrayTerm(f.a.GetKind(), f.b.GetIndexWidth(),
+                                         f.valueWidth, f.outvec);
+          f.output = FloatBlaster::withFormat(_bm, f.output, f.b.GetExpWidth(),
+                                              f.b.GetSigWidth());
+        }
+        else
+          f.output = f.b;
+
+        if (f.a != f.output)
+        {
+          UpdateSimplifyMap(f.a, f.output, false);
+          f.a = f.output;
+        }
+
+        const ASTChildren children = f.a.GetChildren();
+        const Kind k = f.a.GetKind();
+        if (k != stp::UNDEFINED && k != stp::SYMBOL)
+        {
+          bool allConstant = true;
+          for (const ASTNode& child : children)
+          {
+            if (!child.isConstant())
+            {
+              allConstant = false;
+              break;
+            }
+          }
+          if (allConstant)
+          {
+            const ASTNode c = BVConstEvaluator(f.a);
+            assert(c.isConstant());
+            UpdateSimplifyMap(f.a, c, false);
+            return finishTerm(c);
+          }
+        }
+
+        const ASTNode pulledUp = PullUpITE(f.a);
+        if (pulledUp != f.a)
+          return wantTerm(f, Frame::TermPulled, pulledUp);
+
+        bool notSimplified = false;
+        for (size_t i = 0; i < f.a.Degree(); ++i)
+        {
+          if (f.a[i].GetType() != ARRAY_TYPE && !hasBeenSimplified(f.a[i]))
+          {
+            notSimplified = true;
+            break;
+          }
+        }
+        if (notSimplified)
+          return wantTerm(f, Frame::TermRetry, f.a);
+      }
+
+      if (f.a.GetKind() == READ && f.phase != Frame::TermReadArray)
+        return wantArray(f, Frame::TermReadArray, f.a[0]);
+
+      if (f.a.GetKind() == READ && f.phase == Frame::TermReadArray &&
+          result != f.a[0])
+      {
+        // Preserve the pre-rebuild READ as a memo key. The recursive version
+        // returned through that invocation after simplifying the array.
+        f.t2 = f.a;
+        ASTVec children = toASTVec(f.a.GetChildren());
+        children[0] = result;
+        f.a = nf->CreateArrayTerm(READ, f.a.GetIndexWidth(), f.valueWidth,
+                                  children);
+        f.output = f.a;
+      }
+
+      // The kind switch and its helpers perform one rewrite step. If that
+      // manufactures a different term, schedule the candidate as another
+      // term job below. This is the common replacement for every former
+      // helper-to-SimplifyTerm call, including terms that did not exist in
+      // the input DAG.
+      ASTNode ret =
+          simplify_term_switch(f.b, f.a, f.output, f.a.GetKind(), f.valueWidth);
+      if (ret != ASTUndefined)
+        return finishTerm(ret);
+
+      assert(!f.output.IsNull());
+      if (f.a != f.output)
+        return wantTerm(f, Frame::TermOutput, f.output);
+      return finishTermTail(f.output);
+    }
+  };
+
+  auto stepFormula = [&](Frame& f) -> StepResult {
+    assert(f.job == Frame::FormulaJob);
+    // The formula arms implemented in this frame share their memoisation
+    // tail: record the PullUpITE result and, when distinct, the input. The
+    // separately scheduled AtomicJob owns its own first entry and bypasses
+    // this tail when it returns below.
+    auto finish = [&](const ASTNode& output) {
+      UpdateSimplifyMap(f.a, output, f.pushNeg);
+      if (f.b != f.a)
+        UpdateSimplifyMap(f.b, output, f.pushNeg);
+      result = output;
+      return StepResult::Finished;
+    };
+
+    // `f.a` is set by the head, which ran before this frame was pushed.
+    const Kind k = f.a.GetKind();
+    switch (k)
+    {
+      case AND:
+      case OR:
+      {
+        auto takeChild = [&](const ASTNode& child) {
+          if (child == f.output)
+            return false;
+
+          // A child that simplified to the output connective (typically via
+          // De Morgan) would otherwise leave a nested same-kind node, which
+          // the factory does not flatten. Splice its already-simplified
+          // operands in so the result stays flat -- without this
+          // SimplifyFormula is not idempotent.
+          if (child.GetKind() == f.outKind)
+            f.outvec.insert(f.outvec.end(), child.begin(), child.end());
+          else
+            f.outvec.push_back(child);
+          ++f.i;
+          return true;
+        };
+
+        if (f.phase == Frame::Start)
+        {
+          const bool isAnd = (k == AND);
+          // Under pushNeg we are simplifying NOT(a): De Morgan flips the
+          // connective, and a child that simplifies to the annihilator
+          // collapses the whole node.
+          f.output = isAnd ? (f.pushNeg ? ASTTrue : ASTFalse)
+                           : (f.pushNeg ? ASTFalse : ASTTrue);
+          f.outKind = (isAnd == !f.pushNeg) ? AND : OR;
+          f.outvec.reserve(f.a.Degree());
+        }
+        else
+        {
+          if (!takeChild(result))
+            return finish(f.output);
+        }
+
+        while (f.i < f.a.Degree())
+        {
+          const StepResult requested =
+              want(f, Frame::AndOrOperand, f.a[f.i], f.pushNeg);
+          if (requested == StepResult::Pushed)
+            return requested;
+          assert(requested == StepResult::Redispatch);
+          if (!takeChild(result))
+            return finish(f.output);
+        }
+
+        // Hand the simplified children to the node factory. CreateSimpleAndOr
+        // sorts them, drops identities, removes duplicates, detects
+        // complements and unwraps singletons -- so none of that is repeated
+        // here.
+        return finish(nf->CreateNode(f.outKind, f.outvec));
+      }
+
+      case NOT:
+      {
+        if (f.phase == Frame::NotBody)
+          return finish(result);
+
+        if (!(f.a.Degree() == 1 && NOT == f.a.GetKind()))
+          FatalError("SimplifyNotFormula: input vector with more than 1 node",
+                     ASTUndefined);
+
+        // if pushNeg is set then there is NOT on top
+        unsigned int NotCount = f.pushNeg ? 1 : 0;
+        ASTNode o = f.a;
+        // count the number of NOTs in 'a'
+        while (NOT == o.GetKind())
+        {
+          o = o[0];
+          NotCount++;
+        }
+
+        // pushnegation if there are odd number of NOTs
+        const bool pn = (NotCount % 2 == 0) ? false : true;
+
+        // `want` owns the child shortcut and memo probe. If it schedules a
+        // child frame, that frame records `o`; if it answers immediately,
+        // the entry either already exists or `o` is a leaf that is never
+        // memoised. The returning NOT frame therefore only records itself.
+        return want(f, Frame::NotBody, o, pn);
+      }
+
+      case XOR:
+      {
+        assert(f.a.Degree() > 0);
+
+        if (f.a.Degree() == 1)
+          return finish(f.a[0]);
+
+        if (f.phase == Frame::Start)
+          f.outvec.reserve(f.a.Degree());
+
+        if (f.phase == Frame::XorOperand)
+        {
+          f.outvec.push_back(result);
+          ++f.i;
+        }
+
+        while (f.i < f.a.Degree())
+        {
+          const StepResult requested =
+              want(f, Frame::XorOperand, f.a[f.i], false);
+          if (requested == StepResult::Pushed)
+            return requested;
+          assert(requested == StepResult::Redispatch);
+          f.outvec.push_back(result);
+          ++f.i;
+        }
+
+        if (f.pushNeg)
+          f.outvec[0] = nf->CreateNode(NOT, f.outvec[0]);
+
+        if (f.a.Degree() == 2)
+        {
+          ASTNode output = nf->CreateNode(XOR, f.outvec[0], f.outvec[1]);
+          if (f.outvec[0] == f.outvec[1])
+            output = ASTFalse;
+          else if ((f.outvec[0] == ASTTrue && f.outvec[1] == ASTFalse) ||
+                   (f.outvec[0] == ASTFalse && f.outvec[1] == ASTTrue))
+            output = ASTTrue;
+          return finish(output);
+        }
+
+        return finish(nf->CreateNode(XOR, f.outvec));
+      }
+
+      case NAND:
+      case NOR:
+      case IMPLIES:
+      {
+        if (f.phase == Frame::Start)
+        {
+          if (k == IMPLIES && !(f.a.Degree() == 2))
+            FatalError("SimplifyImpliesFormula: vector with wrong num of nodes",
+                       ASTUndefined);
+
+          // NAND and NOR are a negated AND/OR, so the negation they carry
+          // goes into both operands and cancels with the caller's. IMPLIES
+          // negates only its consequent, and only when it is itself negated.
+          return want(f, Frame::BinaryLeft, f.a[0],
+                      (k == IMPLIES) ? false : !f.pushNeg);
+        }
+
+        if (f.phase == Frame::BinaryLeft)
+        {
+          f.t0 = result;
+          return want(f, Frame::BinaryRight, f.a[1],
+                      (k == IMPLIES) ? f.pushNeg : !f.pushNeg);
+        }
+
+        f.t1 = result;
+
+        if (k == NAND)
+          return finish(nf->CreateNode(f.pushNeg ? AND : OR, f.t0, f.t1));
+        if (k == NOR)
+          return finish(nf->CreateNode(f.pushNeg ? OR : AND, f.t0, f.t1));
+
+        if (f.pushNeg)
+          return finish(nf->CreateNode(AND, f.t0, f.t1));
+        if (ASTFalse == f.t0)
+          return finish(ASTTrue);
+        if (ASTTrue == f.t0)
+          return finish(f.t1);
+        if (f.t0 == f.t1)
+          return finish(ASTTrue);
+        if (NOT == f.t0.GetKind())
+          return finish(nf->CreateNode(OR, f.t0[0], f.t1));
+        return finish(nf->CreateNode(OR, nf->CreateNode(NOT, f.t0), f.t1));
+      }
+
+      case IFF:
+      {
+        if (f.phase == Frame::Start)
+        {
+          if (!(f.a.Degree() == 2))
+            FatalError("SimplifyIffFormula: vector with wrong num of nodes",
+                       ASTUndefined);
+
+          // The second operand first, as it was.
+          return want(f, Frame::IffRight, f.a[1], false);
+        }
+
+        if (f.phase == Frame::IffRight)
+        {
+          f.t1 = result;
+          return want(f, Frame::IffLeft, f.a[0], f.pushNeg);
+        }
+
+        if (f.phase == Frame::IffLeft)
+        {
+          f.t0 = result;
+
+          if (ASTTrue == f.t0)
+            return finish(f.t1);
+          if (ASTFalse == f.t0)
+            return want(f, Frame::IffFold, f.t1, true);
+          if (ASTTrue == f.t1)
+            return finish(f.t0);
+          if (ASTFalse == f.t1)
+            return want(f, Frame::IffFold, f.t0, true);
+          if (f.t0 == f.t1)
+            return finish(ASTTrue);
+          if ((NOT == f.t0.GetKind() && f.t0[0] == f.t1) ||
+              (NOT == f.t1.GetKind() && f.t0 == f.t1[0]))
+            return finish(ASTFalse);
+          return finish(nf->CreateNode(XOR, nf->CreateNode(NOT, f.t0), f.t1));
+        }
+
+        return finish(result); // Frame::IffFold
+      }
+
+      case ITE:
+      {
+        if (f.phase == Frame::Start)
+        {
+          if (!(f.a.Degree() == 3))
+            FatalError("SimplifyIteFormula: vector with wrong num of nodes",
+                       ASTUndefined);
+
+          return want(f, Frame::IteCond, f.a[0], false);
+        }
+
+        if (f.phase == Frame::IteCond)
+        {
+          f.t0 = result;
+          return want(f, Frame::IteThen, f.a[1], f.pushNeg);
+        }
+
+        if (f.phase == Frame::IteThen)
+        {
+          f.t1 = result;
+          return want(f, Frame::IteElse, f.a[2], f.pushNeg);
+        }
+
+        if (f.phase == Frame::IteElse)
+        {
+          f.t2 = result;
+
+          // Every structural fold here -- constant condition, equal branches,
+          // a constant branch collapsing to AND/OR -- is done by the
+          // simplifying node factory when the ITE node is (re)created, so we
+          // just hand it the simplified children. The one exception is
+          // ITE(c, false, true): the factory would only give a shallow
+          // NOT(c), whereas pushing the negation into c exposes more
+          // simplifications.
+          if (ASTTrue == f.t0)
+            return finish(f.t1);
+          if (ASTFalse == f.t0)
+            return finish(f.t2);
+          if (ASTFalse == f.t1 && ASTTrue == f.t2)
+            return want(f, Frame::IteFold, f.t0, true);
+          return finish(nf->CreateNode(ITE, f.t0, f.t1, f.t2));
+        }
+
+        return finish(result); // Frame::IteFold
+      }
+
+      default:
+        // Atomic predicates do not stop the walk: their term operands and any
+        // terms they manufacture are jobs on this same continuation stack.
+        if (f.phase == Frame::FormulaAtomic)
+        {
+          // AtomicJob has already recorded `f.a`. Only the pre-PullUpITE key
+          // can remain for this formula frame to record.
+          if (f.b != f.a)
+            UpdateSimplifyMap(f.b, result, f.pushNeg);
+          return StepResult::Finished;
+        }
+        return wantAtomic(f, Frame::FormulaAtomic, f.a, f.pushNeg);
+    }
+  };
+
+  while (true)
+  {
+    Frame& current = stack.back();
+    StepResult stepResult = StepResult::Finished;
+    switch (current.job)
+    {
+      case Frame::FormulaJob:
+        do
+          stepResult = stepFormula(current);
+        while (stepResult == StepResult::Redispatch);
+        break;
+      case Frame::AtomicJob:
+        do
+          stepResult = stepAtomic(current);
+        while (stepResult == StepResult::Redispatch);
+        break;
+      case Frame::TermJob:
+        do
+          stepResult = stepTerm(current);
+        while (stepResult == StepResult::Redispatch);
+        break;
+      case Frame::ArrayJob:
+        do
+          stepResult = stepArray(current);
+        while (stepResult == StepResult::Redispatch);
+        break;
+    }
+
+    if (stepResult == StepResult::Pushed ||
+        stepResult == StepResult::Yield)
+      continue;
+    assert(stepResult == StepResult::Finished);
+
+    stack.pop_back();
+    if (stack.empty())
+      return result;
+  }
 }
 
-ASTNode Simplifier::SimplifyIffFormula(const ASTNode& a, bool pushNeg)
-{
-  ASTNode output;
-  if (CheckSimplifyMap(a, output, pushNeg))
-    return output;
-
-  if (!(a.Degree() == 2 && IFF == a.GetKind()))
-    FatalError("SimplifyIffFormula: vector with wrong num of nodes",
-               ASTUndefined);
-
-  ASTNode c0 = a[0];
-  ASTNode c1 = SimplifyFormula(a[1], false);
-
-  if (pushNeg)
-    c0 = SimplifyFormula(c0, true);
-  else
-    c0 = SimplifyFormula(c0, false);
-
-  if (ASTTrue == c0)
-  {
-    output = c1;
-  }
-  else if (ASTFalse == c0)
-  {
-    output = SimplifyFormula(c1, true);
-  }
-  else if (ASTTrue == c1)
-  {
-    output = c0;
-  }
-  else if (ASTFalse == c1)
-  {
-    output = SimplifyFormula(c0, true);
-  }
-  else if (c0 == c1)
-  {
-    output = ASTTrue;
-  }
-  else if ((NOT == c0.GetKind() && c0[0] == c1) ||
-           (NOT == c1.GetKind() && c0 == c1[0]))
-  {
-    output = ASTFalse;
-  }
-  else
-  {
-    output = nf->CreateNode(XOR, nf->CreateNode(NOT, c0), c1);
-  }
-
-  // memoize
-  UpdateSimplifyMap(a, output, pushNeg);
-  return output;
-}
-
-ASTNode Simplifier::SimplifyIteFormula(const ASTNode& b, bool pushNeg)
-{
-  //    if (!optimize_flag)
-  //       return b;
-
-  ASTNode output;
-  if (CheckSimplifyMap(b, output, pushNeg))
-    return output;
-
-  if (!(b.Degree() == 3 && ITE == b.GetKind()))
-    FatalError("SimplifyIteFormula: vector with wrong num of nodes",
-               ASTUndefined);
-
-  ASTNode a = b;
-  ASTNode t0 = SimplifyFormula(a[0], false);
-  ASTNode t1, t2;
-  if (pushNeg)
-  {
-    t1 = SimplifyFormula(a[1], true);
-    t2 = SimplifyFormula(a[2], true);
-  }
-  else
-  {
-    t1 = SimplifyFormula(a[1], false);
-    t2 = SimplifyFormula(a[2], false);
-  }
-
-  // Every structural fold below - constant condition, equal branches, a
-  // constant branch collapsing to AND/OR - is done by the simplifying node
-  // factory when the ITE node is (re)created, so we just hand it the
-  // simplified children. The one exception is ITE(c, false, true): the factory
-  // would only give a shallow NOT(c), whereas pushing the negation into c
-  // exposes more simplifications.
-  if (ASTTrue == t0)
-  {
-    output = t1;
-  }
-  else if (ASTFalse == t0)
-  {
-    output = t2;
-  }
-  else if (ASTFalse == t1 && ASTTrue == t2)
-  {
-    output = SimplifyFormula(t0, true);
-  }
-  else
-  {
-    output = nf->CreateNode(ITE, t0, t1, t2);
-  }
-
-  // memoize
-  UpdateSimplifyMap(a, output, pushNeg);
-  return output;
-}
 
 ASTNode Simplifier::makeTower(const Kind k, const stp::ASTVec& children)
 {
@@ -1367,11 +2005,9 @@ ASTNode Simplifier::pullUpBVSX(ASTNode output)
     ASTNode newA = nf->CreateTerm(BVEXTRACT, maxLength, output.GetChildren()[0],
                                   nf->CreateBVConst(32, maxLength - 1),
                                   nf->CreateZeroConst(32));
-    newA = SimplifyTerm(newA);
     ASTNode newB = nf->CreateTerm(BVEXTRACT, maxLength, output.GetChildren()[1],
                                   nf->CreateBVConst(32, maxLength - 1),
                                   nf->CreateZeroConst(32));
-    newB = SimplifyTerm(newB);
 
     ASTNode mult = nf->CreateTerm(output.GetKind(), maxLength, newA, newB);
     output = nf->CreateTerm(BVSX, inputValueWidth, mult,
@@ -1380,209 +2016,9 @@ ASTNode Simplifier::pullUpBVSX(ASTNode output)
   return output;
 }
 
-// This function simplifies terms based on their kind
-ASTNode Simplifier::SimplifyTerm(const ASTNode& actualInputterm)
+ASTNode Simplifier::SimplifyTerm(const ASTNode& inputterm)
 {
-  assert(_bm->UserFlags.optimize_flag);
-
-  if (actualInputterm.isConstant())
-    return actualInputterm;
-
-  ASTNode inputterm(actualInputterm); // mutable local copy.
-
-  // cout << "SimplifyTerm: input: " << actualInputterm << endl;
-  // if (!optimize_flag)
-  //       {
-  //         return inputterm;
-  //       }
-
-  ASTNode output = inputterm;
-  assert(BVTypeCheck(inputterm));
-
-  //########################################
-  //########################################
-
-  if (InsideSubstitutionMap(inputterm, output))
-  {
-    // cout << "SolverMap:" << inputterm << " output: " << output << endl;
-    return SimplifyTerm(output);
-  }
-
-  if (CheckSimplifyMap(inputterm, output, false))
-  {
-    // cerr << "SimplifierMap:" << inputterm << " output: " <<
-    // output << endl;
-    return output;
-  }
-  //########################################
-  //########################################
-
-  Kind k = inputterm.GetKind();
-  if (!is_Term_kind(k))
-  {
-    FatalError("SimplifyTerm: You have input a Non-term", inputterm);
-  }
-
-  const unsigned int inputValueWidth = inputterm.GetValueWidth();
-
-  {
-    assert(k != BVCONST);
-    if (k != SYMBOL) // const and symbols need to be created specially.
-    {
-      ASTVec v;
-      ASTVec toProcess = toASTVec(actualInputterm.GetChildren());
-      if (actualInputterm.GetKind() == BVAND ||
-          actualInputterm.GetKind() == BVOR ||
-          actualInputterm.GetKind() == BVPLUS)
-      {
-        // If we didn't flatten these, then we'd start flattening each of these
-        // from the bottom up. Potentially creating tons of the nodes along the
-        // way.
-
-        toProcess = FlattenKind(actualInputterm.GetKind(), toProcess,15);
-      }
-
-      v.reserve(toProcess.size());
-      for (unsigned i = 0; i < toProcess.size(); i++)
-      {
-        if (toProcess[i].GetType() == BITVECTOR_TYPE)
-          v.push_back(SimplifyTerm(toProcess[i]));
-        else if (toProcess[i].GetType() == BOOLEAN_TYPE)
-          v.push_back(SimplifyFormula(toProcess[i], false));
-        // A floating-point child is a term like any other: simplify it, so
-        // the floating-point identities and constant folds fire (see the
-        // matching arm of simplify_term_switch -- which, like everything
-        // here, lowers nothing; lowering is FloatBlast's own pass). It
-        // needs an arm of its own only because its type is neither
-        // BITVECTOR nor BOOLEAN, and the catch-all below would carry it
-        // through unsimplified. Historically -- when lowering still
-        // happened inside simplification -- this same line made several
-        // satisfiable QF_ABVFP queries answer unsat; both causes (rebuilds
-        // dropping the per-node float format, and the operand sort
-        // inverting the floating-point comparisons) were fixed in
-        // fbb96cd8, and the nested-fp lit tests pin the behaviour.
-        else if (toProcess[i].GetType() == FLOATINGPOINT_TYPE)
-          v.push_back(SimplifyTerm(toProcess[i]));
-        else
-          v.push_back(toProcess[i]);
-      }
-
-      assert(v.size() > 0);
-      if (ASTChildren(v) != actualInputterm.GetChildren()) // short-cut.
-      {
-        output = nf->CreateArrayTerm(k, actualInputterm.GetIndexWidth(),
-                                     inputValueWidth, v);
-
-        // Rebuilding drops the floating-point format, which is per-node state
-        // rather than something the kind implies. Carry it over: the rebuilt
-        // node has the same kind and children, so it denotes a float of the
-        // same format, and everything downstream (the blaster in particular)
-        // reads the format off the node.
-        output = FloatBlaster::withFormat(_bm, output,
-                                          actualInputterm.GetExpWidth(),
-                                          actualInputterm.GetSigWidth());
-      }
-      else
-        output = actualInputterm;
-
-      if (inputterm != output)
-      {
-        UpdateSimplifyMap(inputterm, output, false);
-        inputterm = output;
-      }
-    }
-
-    const ASTChildren children = inputterm.GetChildren();
-    k = inputterm.GetKind();
-
-    // Perform constant propagation if possible.
-    // This should do nothing if the simplifyingnodefactory is used.
-    if (k != stp::UNDEFINED && k != stp::SYMBOL)
-    {
-      bool allConstant = true;
-
-      for (unsigned i = 0; i < children.size(); i++)
-        if (!children[i].isConstant())
-        {
-          allConstant = false;
-          break;
-        }
-
-      if (allConstant)
-      {
-        const ASTNode& c = BVConstEvaluator(inputterm);
-        assert(c.isConstant());
-        UpdateSimplifyMap(inputterm, c, false);
-        return c;
-      }
-    }
-  }
-
-  {
-    ASTNode pulledUp = PullUpITE(inputterm);
-    if (pulledUp != inputterm)
-    {
-      ASTNode r = SimplifyTerm(pulledUp);
-      UpdateSimplifyMap(actualInputterm, r, false);
-      UpdateSimplifyMap(inputterm, r, false);
-      return r;
-    }
-  }
-
-  // Check that each of the bit-vector operands is simplified.
-  // I haven't measured if this is worth the expense.
-  {
-    bool notSimplified = false;
-    for (size_t i = 0; i < inputterm.Degree(); i++)
-      if (inputterm[i].GetType() != ARRAY_TYPE)
-        if (!hasBeenSimplified(inputterm[i]))
-        {
-          notSimplified = true;
-          break;
-        }
-    if (notSimplified)
-    {
-      ASTNode r = SimplifyTerm(inputterm);
-      UpdateSimplifyMap(actualInputterm, r, false);
-      UpdateSimplifyMap(inputterm, r, false);
-      return r;
-    }
-  }
-
-  ASTNode ret = simplify_term_switch(actualInputterm, inputterm, output, k, inputValueWidth);
-  if (ret != ASTUndefined)
-  {
-    return ret;
-  }
-  assert(!output.IsNull());
-
-  if (inputterm != output)
-    output = SimplifyTerm(output);
-  // memoize
-  UpdateSimplifyMap(inputterm, output, false);
-  UpdateSimplifyMap(actualInputterm, output, false);
-
-  // cerr << "SimplifyTerm: output" << output << endl;
-
-  assert(!output.IsNull());
-  assert(inputterm.GetValueWidth() == output.GetValueWidth());
-  assert(inputterm.GetIndexWidth() == output.GetIndexWidth());
-  assert(hasBeenSimplified(output));
-
-#ifndef NDEBUG
-  for (size_t i = 0; i < output.Degree(); i++)
-  {
-    if (output[i].GetType() != ARRAY_TYPE)
-      if (!hasBeenSimplified(output[i]))
-      {
-        std::cerr << output;
-        std::cerr << i;
-        assert(false);
-      }
-  }
-#endif
-
-  return output;
+  return simplifyNode(inputterm, false, SimplifyJob::Term);
 }
 
 ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
@@ -1597,9 +2033,7 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
 
     case SYMBOL:
       if (InsideSubstitutionMap(inputterm, output))
-      {
-        return SimplifyTerm(output);
-      }
+        break;
       output = inputterm;
       break;
 
@@ -1612,8 +2046,8 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
     {
       if (BVPLUS == k && inputterm.Degree() == 2 && inputterm[1].GetKind() == BVLEFTSHIFT && inputterm[0] == inputterm[1][1])
       {
-        ASTNode replacement = nf->CreateTerm(BVOR, inputValueWidth, toASTVec(inputterm.GetChildren()));
-        return SimplifyTerm(replacement);
+        output = nf->CreateTerm(BVOR, inputValueWidth, toASTVec(inputterm.GetChildren()));
+        break;
       }
 
 
@@ -1806,8 +2240,7 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
             // process -3*x, but not -(3*x).
             if (BVCONST == a0[0].GetKind())
             {
-              ASTNode a00 =
-                  SimplifyTerm(nf->CreateTerm(BVUMINUS, inputValueWidth, a0[0]));
+              ASTNode a00 =nf->CreateTerm(BVUMINUS, inputValueWidth, a0[0]);
               output = nf->CreateTerm(BVMULT, inputValueWidth, a00, a0[1]);
             }
             else
@@ -1828,8 +2261,8 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
                it != itend; it++)
           {
             // Simplify(BVUMINUS(a1x1))
-            ASTNode aaa = SimplifyTerm(
-                nf->CreateTerm(BVUMINUS, inputValueWidth, *it));
+            ASTNode aaa =
+                nf->CreateTerm(BVUMINUS, inputValueWidth, *it);
             o.push_back(aaa);
           }
 
@@ -1851,10 +2284,10 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
         {
           // BVUMINUS(ITE(c,t1,t2)) <==> ITE(c,BVUMINUS(t1),BVUMINUS(t2))
           ASTNode c = a0[0];
-          ASTNode t1 = SimplifyTerm(
-              nf->CreateTerm(BVUMINUS, inputValueWidth, a0[1]));
-          ASTNode t2 = SimplifyTerm(
-              nf->CreateTerm(BVUMINUS, inputValueWidth, a0[2]));
+          ASTNode t1 =
+              nf->CreateTerm(BVUMINUS, inputValueWidth, a0[1]);
+          ASTNode t2 =
+              nf->CreateTerm(BVUMINUS, inputValueWidth, a0[2]);
           output = CreateSimplifiedTermITE(c, t1, t2);
           break;
         }
@@ -1934,9 +2367,9 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
             // (t@u)[i:j] <==> t[i-len_u:0] @ u[len_u-1:j]
             i = nf->CreateBVConst(32, i_val - len_u);
             ASTNode m = nf->CreateBVConst(32, len_u - 1);
-            t = SimplifyTerm(
-                nf->CreateTerm(BVEXTRACT, i_val - len_u + 1, t, i, zero));
-            u = SimplifyTerm(nf->CreateTerm(BVEXTRACT, len_u - j_val, u, m, j));
+            t =
+                nf->CreateTerm(BVEXTRACT, i_val - len_u + 1, t, i, zero);
+            u =nf->CreateTerm(BVEXTRACT, len_u - j_val, u, m, j);
             output = nf->CreateTerm(BVCONCAT, inputValueWidth, t, u);
           }
           break;
@@ -1952,8 +2385,7 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
                jt++)
           {
             ASTNode aaa = *jt;
-            aaa =
-                SimplifyTerm(nf->CreateTerm(BVEXTRACT, i_val + 1, aaa, i, zero));
+            aaa =nf->CreateTerm(BVEXTRACT, i_val + 1, aaa, i, zero);
             o.push_back(aaa);
           }
           output = nf->CreateTerm(a0.GetKind(), i_val + 1, o);
@@ -2050,10 +2482,8 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
         case ITE:
           if (a0[1].isConstant() && a0[2].isConstant())
           {
-            ASTNode t =
-                SimplifyTerm(nf->CreateTerm(BVNOT, inputValueWidth, a0[1]));
-            ASTNode f =
-                SimplifyTerm(nf->CreateTerm(BVNOT, inputValueWidth, a0[2]));
+            ASTNode t =nf->CreateTerm(BVNOT, inputValueWidth, a0[1]);
+            ASTNode f =nf->CreateTerm(BVNOT, inputValueWidth, a0[2]);
             output = nf->CreateTerm(ITE, inputValueWidth, a0[0],
                                     BVConstEvaluator(t), BVConstEvaluator(f));
             break;
@@ -2134,8 +2564,8 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
             for (auto it = c.begin(), itend = c.end();
                  it != itend; it++)
             {
-              ASTNode aaa = SimplifyTerm(
-                  nf->CreateTerm(BVSX, inputValueWidth, *it, a1));
+              ASTNode aaa =
+                  nf->CreateTerm(BVSX, inputValueWidth, *it, a1);
               o.push_back(aaa);
             }
             output = nf->CreateTerm(a0.GetKind(), inputValueWidth, o);
@@ -2147,10 +2577,10 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
         case ITE:
         {
           const ASTNode& cond = a0[0];
-          ASTNode thenpart = SimplifyTerm(
-              nf->CreateTerm(BVSX, inputValueWidth, a0[1], a1));
-          ASTNode elsepart = SimplifyTerm(
-              nf->CreateTerm(BVSX, inputValueWidth, a0[2], a1));
+          ASTNode thenpart =
+              nf->CreateTerm(BVSX, inputValueWidth, a0[1], a1);
+          ASTNode elsepart =
+              nf->CreateTerm(BVSX, inputValueWidth, a0[2], a1);
           output = CreateSimplifiedTermITE(cond, thenpart, elsepart);
           break;
         }
@@ -2207,7 +2637,8 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
           output = annihilator;
           // memoize
           UpdateSimplifyMap(inputterm, output, false);
-          UpdateSimplifyMap(actualInputterm, output, false);
+          if (actualInputterm != inputterm)
+            UpdateSimplifyMap(actualInputterm, output, false);
           // cerr << "output of SimplifyTerm: " << output << endl;
           return output;
         }
@@ -2223,7 +2654,8 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
         {
           output = annihilator;
           UpdateSimplifyMap(inputterm, output, false);
-          UpdateSimplifyMap(actualInputterm, output, false);
+          if (actualInputterm != inputterm)
+            UpdateSimplifyMap(actualInputterm, output, false);
           return output;
         }
 
@@ -2444,8 +2876,11 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
     {
       ASTNode out1;
 
-      ASTNode array_term = SimplifyArrayTerm(inputterm[0]);
-      ASTNode read_index = SimplifyTerm(inputterm[1]);
+      const
+
+      ASTNode array_term =inputterm[0];
+      const
+      ASTNode read_index =inputterm[1];
 
       if (SYMBOL == array_term.GetKind())
       {
@@ -2461,7 +2896,6 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
         {
           out1 = nf->CreateTerm(READ, inputterm.GetValueWidth(), array_term[0],
                                 read_index);
-          out1 = SimplifyTerm(out1);
         }
         else
         {
@@ -2478,13 +2912,11 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
         // array transformer is going to do this later anyway. So, we do it
         // here. But it's ugggglly.
 
-        ASTNode cond = SimplifyFormula(inputterm[0][0], false);
+        ASTNode cond = array_term[0];
         ASTNode read1 =
-            nf->CreateTerm(READ, inputValueWidth, inputterm[0][1], read_index);
+            nf->CreateTerm(READ, inputValueWidth, array_term[1], read_index);
         ASTNode read2 =
-            nf->CreateTerm(READ, inputValueWidth, inputterm[0][2], read_index);
-        read1 = SimplifyTerm(read1);
-        read2 = SimplifyTerm(read2);
+            nf->CreateTerm(READ, inputValueWidth, array_term[2], read_index);
         out1 = CreateSimplifiedTermITE(cond, read1, read2);
       }
       else if (ITE == array_term.GetKind())
@@ -2575,16 +3007,9 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
       // because a float format was stamped onto it and its blasted children.
       // Nodes are hash-consed, so that stamp landed on whatever else denoted
       // the same bits.
-      ASTVec simplified;
-      simplified.reserve(inputterm.Degree());
-
-      for (unsigned int i = 0; i < inputterm.Degree(); i++)
-      {
-        if (inputterm[i].GetType() != FLOATINGPOINT_TYPE)
-          simplified.push_back(inputterm[i]);
-        else
-          simplified.push_back(SimplifyTerm(inputterm[i]));
-      }
+      // The generic operand phase of the job already simplified every float
+      // child. Non-float metadata children were carried through unchanged.
+      ASTVec simplified = toASTVec(inputterm.GetChildren());
 
       // The factory may fold the operation as it rebuilds it (abs/neg of a
       // constant, x*1.0, x/1.0), which is the whole point of going back
@@ -2726,8 +3151,8 @@ ASTNode Simplifier::CombineLikeTerms(const ASTVec& c)
       monom = it->first;
     else
     {
-      monom = SimplifyTerm(nf->CreateTerm(BVMULT, constant.GetValueWidth(),
-                                          constant, it->first));
+      monom =nf->CreateTerm(BVMULT, constant.GetValueWidth(),
+                                          constant, it->first);
     }
     if (zero != monom)
     {
@@ -2770,88 +3195,43 @@ ASTNode Simplifier::CombineLikeTerms(const ASTVec& c)
 // assumes that lhs and rhs have already been simplified. although
 // this assumption is not needed for correctness, it is essential for
 // performance. The function also assumes that lhs is a BVPLUS
-ASTNode Simplifier::LhsMinusRhs(const ASTNode& eq)
+ASTNode Simplifier::LhsMinusRhsTerm(const ASTNode& eq,
+                                    const ASTNode& simplifiedNegatedRhs)
 {
-  // if input is not an equality, simply return it
-  if (EQ != eq.GetKind())
-    return eq;
+  assert ( eq.GetKind() == EQ);
 
   ASTNode lhs = eq[0];
-  ASTNode rhs = eq[1];
-  const Kind k_lhs = lhs.GetKind();
-  const Kind k_rhs = rhs.GetKind();
-  // either the lhs has to be a BVPLUS or the rhs has to be a
-  // BVPLUS
-  if (!(BVPLUS == k_lhs || BVPLUS == k_rhs ||
-        (BVMULT == k_lhs && BVMULT == k_rhs)))
-  {
-    return eq;
-  }
+  const Kind lhsKind = lhs.GetKind();
+  const Kind rhsKind = eq[1].GetKind();
+  if (lhsKind !=BVPLUS && rhsKind == BVPLUS)
+    lhs = eq[1];
 
-  ASTNode output;
-  if (CheckSimplifyMap(eq, output, false))
-  {
-    // check memo table
-    // cerr << "output of SimplifyTerm Cache: " << output << endl;
-    return output;
-  }
+  const ASTNode&
+    rhs = simplifiedNegatedRhs;
+  const
 
-  // if the lhs is not a BVPLUS, but the rhs is a BVPLUS, then swap
-  // the lhs and rhs
-  // bool swap_flag = false;
-  if (BVPLUS != k_lhs && BVPLUS == k_rhs)
-  {
-    ASTNode swap = lhs;
-    lhs = rhs;
-    rhs = swap;
-    // swap_flag = true;
-  }
+  unsigned len = lhs.GetValueWidth();
 
-  unsigned int len = lhs.GetValueWidth();
-  ASTNode zero = nf->CreateZeroConst(len);
-  // right is -1*(rhs): Simplify(-1*rhs)
-  rhs = SimplifyTerm(nf->CreateTerm(BVUMINUS, len, rhs));
-
-  ASTVec lvec = toASTVec(lhs.GetChildren());
-  const ASTChildren rvec = rhs.GetChildren();
-  ASTNode lhsplusrhs;
-  if (BVPLUS != lhs.GetKind() && BVPLUS != rhs.GetKind())
+  ASTVec lhsChildren = toASTVec(lhs.GetChildren());
+  const ASTChildren rhsChildren = rhs.GetChildren();
+  ASTNode sum;
+  if ( lhs.GetKind() != BVPLUS && rhs.GetKind() != BVPLUS)
+    sum = nf->CreateTerm(BVPLUS, len, lhs, rhs);
+  else if ( lhs.GetKind() == BVPLUS && rhs.GetKind() == BVPLUS)
   {
-    lhsplusrhs = nf->CreateTerm(BVPLUS, len, lhs, rhs);
+    lhsChildren.insert(lhsChildren.end(), rhsChildren.begin(),
+                       rhsChildren.end());
+    sum = nf->CreateTerm(BVPLUS, len, lhsChildren);
   }
-  else if (BVPLUS == lhs.GetKind() && BVPLUS == rhs.GetKind())
+  else if ( lhs.GetKind() == BVPLUS)
   {
-    // combine the childnodes of the left and the right
-    lvec.insert(lvec.end(), rvec.begin(), rvec.end());
-    lhsplusrhs = nf->CreateTerm(BVPLUS, len, lvec);
-  }
-  else if (BVPLUS == lhs.GetKind() && BVPLUS != rhs.GetKind())
-  {
-    lvec.push_back(rhs);
-    lhsplusrhs = nf->CreateTerm(BVPLUS, len, lvec);
+    lhsChildren.push_back(rhs);
+    sum = nf->CreateTerm(BVPLUS, len, lhsChildren);
   }
   else
-  {
-    lhsplusrhs = nf->CreateTerm(BVPLUS, len, lhs, rhs);
-  }
+    sum = nf->CreateTerm(BVPLUS, len, lhs, rhs);
 
-  // combine like terms
-  output = CombineLikeTerms(lhsplusrhs);
-  output = SimplifyTerm(output);
-  //
-  // Now make output into: lhs-rhs = 0
-  output = CreateSimplifiedEQ(output, zero);
-  // sort if BVPLUS
-  if (BVPLUS == output.GetKind())
-  {
-    ASTVec outv = toASTVec(output.GetChildren());
-    SortByArith(outv);
-    output = nf->CreateTerm(BVPLUS, len, outv);
-  }
-
-  // memoize
-  // UpdateSimplifyMap(eq,output,false);
-  return output;
+  return CombineLikeTerms(sum);
 }
 
 // THis function accepts a BVMULT(t1,t2) and distributes the mult
@@ -2948,7 +3328,7 @@ ASTNode Simplifier::DistributeMultOverPlus(const ASTNode& a,
       for (auto j = rightnodes.begin(), jend = rightnodes.end();
            j != jend; j++)
       {
-        ASTNode out = SimplifyTerm(nf->CreateTerm(BVMULT, len, left, *j));
+        ASTNode out =nf->CreateTerm(BVMULT, len, left, *j);
         outputvec.push_back(out);
       }
     }
@@ -2965,7 +3345,7 @@ ASTNode Simplifier::DistributeMultOverPlus(const ASTNode& a,
       for (auto j = rightnodes.begin(), jend = rightnodes.end();
            j != jend; j++)
       {
-        ASTNode out = SimplifyTerm(nf->CreateTerm(BVMULT, len, multiplier, *j));
+        ASTNode out =nf->CreateTerm(BVMULT, len, multiplier, *j);
         outputvec.push_back(out);
       }
     }
@@ -2975,10 +3355,9 @@ ASTNode Simplifier::DistributeMultOverPlus(const ASTNode& a,
   if (outputvec.size() > 1)
   {
     output = CombineLikeTerms(nf->CreateTerm(BVPLUS, len, outputvec));
-    output = SimplifyTerm(output);
   }
   else
-    output = SimplifyTerm(outputvec[0]);
+    output =outputvec[0];
 
   // memoize
   // UpdateSimplifyMap(a,output,false);
@@ -2988,47 +3367,7 @@ ASTNode Simplifier::DistributeMultOverPlus(const ASTNode& a,
 // recursively simplify things that are of type array.
 ASTNode Simplifier::SimplifyArrayTerm(const ASTNode& term)
 {
-
-  const unsigned iw = term.GetIndexWidth();
-  assert(iw > 0);
-
-  ASTNode output;
-  if (CheckSimplifyMap(term, output, false))
-  {
-    return output;
-  }
-
-  switch (term.GetKind())
-  {
-    case SYMBOL:
-      return term;
-    case ITE:
-    {
-      output = CreateSimplifiedTermITE(SimplifyFormula(term[0], false),
-                                       SimplifyArrayTerm(term[1]),
-                                       SimplifyArrayTerm(term[2]));
-      assert(output.GetIndexWidth() == iw);
-    }
-    break;
-    case WRITE:
-    {
-      ASTNode array = SimplifyArrayTerm(term[0]);
-      ASTNode idx = SimplifyTerm(term[1]);
-      ASTNode val = SimplifyTerm(term[2]);
-
-      output =
-          nf->CreateArrayTerm(WRITE, iw, term.GetValueWidth(), array, idx, val);
-    }
-
-    break;
-    default:
-      FatalError("2313456331");
-  }
-
-  UpdateSimplifyMap(term, output, false);
-  assert(term.GetIndexWidth() == output.GetIndexWidth());
-  assert(BVTypeCheck(output));
-  return output;
+  return simplifyNode(term, false, SimplifyJob::Array);
 }
 
 // compute the multiplicative inverse of the input
@@ -3203,4 +3542,4 @@ ASTNode Simplifier::BVConstEvaluator(const ASTNode& t)
 }
 
 
-} // end of namespace
+} // namespace stp

--- a/lib/Simplifier/Simplifier.cpp
+++ b/lib/Simplifier/Simplifier.cpp
@@ -771,9 +771,86 @@ ASTNode Simplifier::SimplifyFormula(const ASTNode& b, bool pushNeg)
   return simplifyNode(b, pushNeg, SimplifyJob::Formula);
 }
 
-ASTNode Simplifier::simplifyNode(const ASTNode& b, bool pushNeg,
-                                 const SimplifyJob rootJob)
+class Simplifier::SimplifyDriver
 {
+  Simplifier& owner;
+  NodeFactory* const nf;
+  STPMgr* const _bm;
+  ASTNode& ASTTrue;
+  ASTNode& ASTFalse;
+  ASTNode& ASTUndefined;
+
+  bool formulaShortcut(const ASTNode& b, const bool pushNeg, ASTNode& a,
+                       ASTNode& out)
+  {
+    return owner.formulaShortcut(b, pushNeg, a, out);
+  }
+
+  bool CheckSimplifyMap(const ASTNode& key, ASTNode& output, const bool pushNeg)
+  {
+    return owner.CheckSimplifyMap(key, output, pushNeg);
+  }
+
+  void UpdateSimplifyMap(const ASTNode& key, const ASTNode& value,
+                         const bool pushNeg)
+  {
+    owner.UpdateSimplifyMap(key, value, pushNeg);
+  }
+
+  bool InsideSubstitutionMap(const ASTNode& key, ASTNode& output)
+  {
+    return owner.InsideSubstitutionMap(key, output);
+  }
+
+  ASTNode ITEOpt_InEqs(const ASTNode& input, ASTNode& conditionToNegate)
+  {
+    return owner.ITEOpt_InEqs(input, conditionToNegate);
+  }
+
+  ASTNode LhsMinusRhsTerm(const ASTNode& equality,
+                          const ASTNode& simplifiedNegatedRhs)
+  {
+    return owner.LhsMinusRhsTerm(equality, simplifiedNegatedRhs);
+  }
+
+  ASTNode CreateSimplifiedEQ(const ASTNode& left, const ASTNode& right)
+  {
+    return owner.CreateSimplifiedEQ(left, right);
+  }
+
+  ASTNode CreateSimplifiedINEQ(const Kind kind, const ASTNode& left,
+                               const ASTNode& right, const bool pushNeg)
+  {
+    return owner.CreateSimplifiedINEQ(kind, left, right, pushNeg);
+  }
+
+  ASTNode CreateSimplifiedTermITE(const ASTNode& condition,
+                                  const ASTNode& thenValue,
+                                  const ASTNode& elseValue)
+  {
+    return owner.CreateSimplifiedTermITE(condition, thenValue, elseValue);
+  }
+
+  ASTNode BVConstEvaluator(const ASTNode& node)
+  {
+    return owner.BVConstEvaluator(node);
+  }
+
+  ASTNode PullUpITE(const ASTNode& node) { return owner.PullUpITE(node); }
+
+  bool hasBeenSimplified(const ASTNode& node)
+  {
+    return owner.hasBeenSimplified(node);
+  }
+
+  ASTNode simplify_term_switch(const ASTNode& actualInput, ASTNode& input,
+                               ASTNode& output, const Kind kind,
+                               const unsigned valueWidth)
+  {
+    return owner.simplify_term_switch(actualInput, input, output, kind,
+                                      valueWidth);
+  }
+
   // What one node is part-way through. `b` is the node as it arrived and `a`
   // as PullUpITE left it; both are recorded against the answer, as
   // SimplifyFormula and simplifyNonAndOr each did.
@@ -798,9 +875,10 @@ ASTNode Simplifier::simplifyNode(const ASTNode& b, bool pushNeg,
   //     default              SimplifyAtomicFormula
   //
   // An arm reads the same way as the function did if `finish` is read as its
-  // `return`, and `want` as the call it made just above one. Nothing else of
-  // those functions moved: the head each shared is formulaShortcut plus the
-  // map test in Frame::Start, and the tail each shared is `finish`.
+  // `return`, and `requestFormula` as the call it made just above one. Nothing
+  // else of those functions moved: the head each shared is formulaShortcut
+  // plus the map test before a frame is pushed, and the tail each shared is
+  // `finish`.
   struct Frame
   {
     enum Job : uint8_t
@@ -810,55 +888,61 @@ ASTNode Simplifier::simplifyNode(const ASTNode& b, bool pushNeg,
       TermJob,
       ArrayJob
     };
-    enum Phase : uint8_t
+
+    // A resume point belongs to exactly one job. Keeping these as distinct
+    // types makes it impossible to suspend (say) a term frame at a formula
+    // continuation by mistake.
+    enum class FormulaPhase : uint8_t
     {
       Start,
-      PrecheckedStart,
-      AndOrOperand, // AND/OR: the operand at `i`
-      NotBody,      // NOT: whatever is under the run of NOTs
-      XorOperand,   // XOR: the operand at `i`
-      BinaryLeft,   // NAND, NOR, IMPLIES: the first operand
-      BinaryRight,  // ... and the second
-      IffRight,     // IFF: the second operand, which it simplifies first
-      IffLeft,      // ... then the first
-      IffFold,      // ... then one of the two again, negated
-      IteCond,      // ITE: the condition
-      IteThen,      // ... the then-branch
-      IteElse,      // ... the else-branch
-      IteFold,       // ... ITE(c, false, true): the condition again, negated
-      FormulaAtomic,
-
-      AtomicLeft,
-      AtomicRight,
-      AtomicBoolExtract,
-      AtomicFpOperand,
-      AtomicEqNegRhs,
-      AtomicEqCombined,
-      AtomicEqIteCondition,
-
-      TermSubstitutionPrechecked,
-      TermSubstitution,
-      TermOperand,
-      TermPulled,
-      TermRetry,
-      TermOutput,
-      TermReadArray,
-
-      ArrayCond,
-      ArrayThen,
-      ArrayElse,
-      ArrayBase,
-      ArrayIndex,
-      ArrayValue
+      AfterAndOrOperand,
+      AfterNotBody,
+      AfterXorOperand,
+      AfterBinaryLeft,
+      AfterBinaryRight,
+      AfterIffRight,
+      AfterIffLeft,
+      AfterIffFold,
+      AfterIteCondition,
+      AfterIteThen,
+      AfterIteElse,
+      AfterIteFold,
+      AfterAtomic
     };
 
-    struct Init
+    enum class AtomicPhase : uint8_t
     {
-      Job job;
-      ASTNode b;
-      ASTNode a;
-      bool pushNeg;
-      Phase phase;
+      Prepared,
+      AfterLeftOperand,
+      AfterRightOperand,
+      AfterBoolExtract,
+      AfterFpOperand,
+      AfterNegatedEqualityRhs,
+      AfterCombinedEquality,
+      AfterIteCondition
+    };
+
+    enum class TermPhase : uint8_t
+    {
+      Prepared,
+      PreparedSubstitution,
+      AfterSubstitution,
+      AfterOperand,
+      AfterPullUpIte,
+      AfterRetry,
+      AfterOutput,
+      AfterReadArray
+    };
+
+    enum class ArrayPhase : uint8_t
+    {
+      Prepared,
+      AfterCondition,
+      AfterThen,
+      AfterElse,
+      AfterBase,
+      AfterIndex,
+      AfterValue
     };
 
     // Put the reference-counted and aligned state first. The scalar state is
@@ -891,15 +975,61 @@ ASTNode Simplifier::simplifyNode(const ASTNode& b, bool pushNeg,
     };
 
     Job job = FormulaJob;
-    Phase phase = Start;
+    union
+    {
+      FormulaPhase formulaPhase;
+      AtomicPhase atomicPhase;
+      TermPhase termPhase;
+      ArrayPhase arrayPhase;
+    };
     bool pushNeg = false;
 
-    Frame() : outKind(UNDEFINED) {}
+    Frame() : outKind(UNDEFINED), formulaPhase(FormulaPhase::Start) {}
 
-    explicit Frame(Init&& init)
-        : b(std::move(init.b)), a(std::move(init.a)), outKind(UNDEFINED),
-          job(init.job), phase(init.phase), pushNeg(init.pushNeg)
+    Frame(ASTNode input, ASTNode dispatch, const bool neg,
+          const FormulaPhase phase)
+        : b(std::move(input)), a(std::move(dispatch)), outKind(UNDEFINED),
+          job(FormulaJob), formulaPhase(phase), pushNeg(neg)
     {
+    }
+
+    Frame(ASTNode input, const bool neg, const AtomicPhase phase)
+        : b(std::move(input)), outKind(UNDEFINED), job(AtomicJob),
+          atomicPhase(phase), pushNeg(neg)
+    {
+    }
+
+    Frame(ASTNode input, const TermPhase phase)
+        : b(std::move(input)), outKind(UNDEFINED), job(TermJob),
+          termPhase(phase)
+    {
+    }
+
+    Frame(ASTNode input, const ArrayPhase phase)
+        : b(std::move(input)), outKind(UNDEFINED), job(ArrayJob),
+          arrayPhase(phase)
+    {
+    }
+
+    void resumeAt(const FormulaPhase phase)
+    {
+      assert(job == FormulaJob);
+      formulaPhase = phase;
+    }
+    void resumeAt(const AtomicPhase phase)
+    {
+      assert(job == AtomicJob);
+      atomicPhase = phase;
+    }
+    void resumeAt(const TermPhase phase)
+    {
+      assert(job == TermJob);
+      termPhase = phase;
+    }
+    void resumeAt(const ArrayPhase phase)
+    {
+      assert(job == ArrayJob);
+      arrayPhase = phase;
     }
   };
 
@@ -907,11 +1037,21 @@ ASTNode Simplifier::simplifyNode(const ASTNode& b, bool pushNeg,
                 "simplifier continuation frame unexpectedly grew");
 
   ASTNode result;
+  std::vector<Frame> stack;
+
+  enum class StepResult
+  {
+    Finished,
+    Pushed,
+    Redispatch,
+    Yield
+  };
 
   // The head of SimplifyFormula: the answers it gives before dispatching to
   // an arm at all. `a` is left holding the node PullUpITE produced, which is
   // what the arm runs on. True when `result` is the answer.
-  auto head = [&](const ASTNode& n, const bool neg, ASTNode& a) -> bool {
+  bool prepareFormula(const ASTNode& n, const bool neg, ASTNode& a)
+  {
     ASTNode out;
     if (formulaShortcut(n, neg, a, out))
     {
@@ -931,75 +1071,7 @@ ASTNode Simplifier::simplifyNode(const ASTNode& b, bool pushNeg,
       return true;
     }
     return false;
-  };
-
-  // Answer root-level leaves and memo hits before constructing the deque.
-  // A deque may allocate initial storage in its constructor (libstdc++ does),
-  // so returning after the first push can still make every shallow call pay
-  // for a traversal worklist it never used.
-  Frame top;
-  top.b = b;
-  top.pushNeg = pushNeg;
-  if (rootJob == SimplifyJob::Formula)
-  {
-    top.job = Frame::FormulaJob;
-    if (head(b, pushNeg, top.a))
-      return result;
   }
-  else if (rootJob == SimplifyJob::Term)
-  {
-    assert(_bm->UserFlags.optimize_flag);
-    top.job = Frame::TermJob;
-
-    // A root substitution frame only returned the answer from its image and
-    // deliberately did not memoise the substituted key. Follow those
-    // transparent frames here, applying the same constant/substitution/memo
-    // head as `want`, until a real term frame is needed.
-    ASTNode root = b;
-    ASTNode substitutionImage;
-    while (true)
-    {
-      if (root.isConstant())
-        return root;
-      if (InsideSubstitutionMap(root, substitutionImage))
-      {
-        root = substitutionImage;
-        continue;
-      }
-      if (CheckSimplifyMap(root, result, false))
-        return result;
-      break;
-    }
-
-    top.b = root;
-    top.phase = Frame::PrecheckedStart;
-  }
-  else
-  {
-    assert(b.GetIndexWidth() > 0);
-    top.job = Frame::ArrayJob;
-    if (CheckSimplifyMap(b, result, false))
-      return result;
-    if (b.GetKind() == SYMBOL)
-      return b;
-    top.phase = Frame::PrecheckedStart;
-  }
-
-  // Keep shallow walks in one contiguous allocation. `want` is the only
-  // operation that can grow the vector, and every caller returns from its
-  // step immediately afterwards, so no Frame reference survives a move.
-  // Unlike deque, vector also avoids allocating a block plus a block map for
-  // the overwhelmingly common one- and two-frame walks.
-  std::vector<Frame> stack;
-  stack.push_back(std::move(top));
-
-  enum class StepResult
-  {
-    Finished,
-    Pushed,
-    Redispatch,
-    Yield
-  };
 
   // Ask for the simplification of `n` under `neg`, and set this frame's
   // continuation to `resume`.
@@ -1013,29 +1085,25 @@ ASTNode Simplifier::simplifyNode(const ASTNode& b, bool pushNeg,
   // `n` can name storage in the current frame (for example f.output or
   // f.t0). Construct the child before growing the vector so it owns those
   // references before a reallocation can move the parent.
-  auto pushChild = [&](const Frame::Job job, const ASTNode& n, ASTNode a,
-                       const bool neg,
-                       const Frame::Phase start) -> StepResult {
-    Frame::Init child{job, n, std::move(a), neg, start};
-    stack.emplace_back(std::move(child));
-    return StepResult::Pushed;
-  };
-
   // Keep the four child heads separate. Their job is known at every request
   // site; making it a run-time argument forced this hot path through a
   // four-way discriminator even though only one arm could ever apply.
-  auto want = [&](Frame& f, const Frame::Phase resume, const ASTNode& n,
-                  const bool neg) -> StepResult {
-    f.phase = resume;
+  template <typename ResumePhase>
+  StepResult requestFormula(Frame& f, const ResumePhase resume,
+                            const ASTNode& n, const bool neg)
+  {
+    f.resumeAt(resume);
     ASTNode a;
-    if (head(n, neg, a))
+    if (prepareFormula(n, neg, a))
       return StepResult::Redispatch;
-    return pushChild(Frame::FormulaJob, n, std::move(a), neg, Frame::Start);
-  };
+    stack.emplace_back(n, std::move(a), neg, Frame::FormulaPhase::Start);
+    return StepResult::Pushed;
+  }
 
-  auto wantTerm = [&](Frame& f, const Frame::Phase resume,
-                      const ASTNode& n) -> StepResult {
-    f.phase = resume;
+  template <typename ResumePhase>
+  StepResult requestTerm(Frame& f, const ResumePhase resume, const ASTNode& n)
+  {
+    f.resumeAt(resume);
     if (n.isConstant())
     {
       result = n;
@@ -1043,24 +1111,24 @@ ASTNode Simplifier::simplifyNode(const ASTNode& b, bool pushNeg,
     }
 
     ASTNode substitutionImage;
-    Frame::Phase start;
+    Frame::TermPhase start;
     if (InsideSubstitutionMap(n, substitutionImage))
-      start = Frame::TermSubstitutionPrechecked;
+      start = Frame::TermPhase::PreparedSubstitution;
     else if (CheckSimplifyMap(n, result, false))
       return StepResult::Redispatch;
     else
-      start = Frame::PrecheckedStart;
+      start = Frame::TermPhase::Prepared;
 
-    const StepResult pushed =
-        pushChild(Frame::TermJob, n, ASTNode(), false, start);
-    if (start == Frame::TermSubstitutionPrechecked)
+    stack.emplace_back(n, start);
+    if (start == Frame::TermPhase::PreparedSubstitution)
       stack.back().output = std::move(substitutionImage);
-    return pushed;
-  };
+    return StepResult::Pushed;
+  }
 
-  auto wantArray = [&](Frame& f, const Frame::Phase resume,
-                       const ASTNode& n) -> StepResult {
-    f.phase = resume;
+  template <typename ResumePhase>
+  StepResult requestArray(Frame& f, const ResumePhase resume, const ASTNode& n)
+  {
+    f.resumeAt(resume);
     if (n.GetKind() == SYMBOL)
     {
       result = n;
@@ -1068,27 +1136,29 @@ ASTNode Simplifier::simplifyNode(const ASTNode& b, bool pushNeg,
     }
     if (CheckSimplifyMap(n, result, false))
       return StepResult::Redispatch;
-    return pushChild(Frame::ArrayJob, n, ASTNode(), false,
-                     Frame::PrecheckedStart);
-  };
+    stack.emplace_back(n, Frame::ArrayPhase::Prepared);
+    return StepResult::Pushed;
+  }
 
-  auto wantAtomic = [&](Frame& f, const Frame::Phase resume,
-                        const ASTNode& n, const bool neg) -> StepResult {
-    f.phase = resume;
-    return pushChild(Frame::AtomicJob, n, ASTNode(), neg,
-                     Frame::PrecheckedStart);
-  };
+  template <typename ResumePhase>
+  StepResult requestAtomic(Frame& f, const ResumePhase resume, const ASTNode& n,
+                           const bool neg)
+  {
+    f.resumeAt(resume);
+    stack.emplace_back(n, neg, Frame::AtomicPhase::Prepared);
+    return StepResult::Pushed;
+  }
 
   // Keep each job's phase dispatcher in its own function. Formula and term
   // jobs dominate ordinary simplification; folding the atomic and array
   // state machines into the same large body evicts their hot code even when
   // those jobs are not running.
-  auto stepAtomic = [&](Frame& f) -> StepResult {
+  StepResult stepAtomic(Frame& f)
+  {
     assert(f.job == Frame::AtomicJob);
-    // The one request site, wantAtomic, always starts an atomic frame
+    // The one request site, requestAtomic, always starts an atomic frame
     // prechecked: the formula head that scheduled it has already probed the
     // map for this node under this polarity.
-    assert(f.phase != Frame::Start);
     {
       auto finishAtomic = [&](const ASTNode& output)
       {
@@ -1124,30 +1194,31 @@ ASTNode Simplifier::simplifyNode(const ASTNode& b, bool pushNeg,
           // pushed child; the common request sites below fuse their immediate
           // answers directly.
           const StepResult requested =
-              want(f, Frame::AtomicEqIteCondition, conditionToNegate, true);
+              requestFormula(f, Frame::AtomicPhase::AfterIteCondition,
+                             conditionToNegate, true);
           return requested == StepResult::Redispatch ? StepResult::Yield
-                                                      : requested;
+                                                     : requested;
         }
         return finishEquality(output);
       };
 
-      if (f.phase == Frame::PrecheckedStart)
+      if (f.atomicPhase == Frame::AtomicPhase::Prepared)
       {
         // Keep the original atomic-formula order: every binary predicate
         // simplifies both operands before dispatch, including BOOLEXTRACT.
         if (f.b.Degree() == 2)
-          return wantTerm(f, Frame::AtomicLeft, f.b[0]);
+          return requestTerm(f, Frame::AtomicPhase::AfterLeftOperand, f.b[0]);
       }
-      else if (f.phase == Frame::AtomicLeft)
+      else if (f.atomicPhase == Frame::AtomicPhase::AfterLeftOperand)
       {
         f.t0 = result;
-        return wantTerm(f, Frame::AtomicRight, f.b[1]);
+        return requestTerm(f, Frame::AtomicPhase::AfterRightOperand, f.b[1]);
       }
-      else if (f.phase == Frame::AtomicRight)
+      else if (f.atomicPhase == Frame::AtomicPhase::AfterRightOperand)
       {
         f.t1 = result;
       }
-      else if (f.phase == Frame::AtomicBoolExtract)
+      else if (f.atomicPhase == Frame::AtomicPhase::AfterBoolExtract)
       {
         const ASTNode zero = nf->CreateZeroConst(1);
         const ASTNode one = nf->CreateOneConst(1);
@@ -1164,26 +1235,27 @@ ASTNode Simplifier::simplifyNode(const ASTNode& b, bool pushNeg,
         }
         return finishAtomic(output);
       }
-      else if (f.phase == Frame::AtomicFpOperand)
+      else if (f.atomicPhase == Frame::AtomicPhase::AfterFpOperand)
       {
         f.outvec.push_back(result);
         ++f.i;
       }
 
-      if (f.phase == Frame::AtomicEqNegRhs)
+      if (f.atomicPhase == Frame::AtomicPhase::AfterNegatedEqualityRhs)
       {
         const ASTNode combined = LhsMinusRhsTerm(f.output, result);
-        return wantTerm(f, Frame::AtomicEqCombined, combined);
+        return requestTerm(f, Frame::AtomicPhase::AfterCombinedEquality,
+                           combined);
       }
 
       ASTNode output;
       const Kind kind = f.b.GetKind();
-      if (f.phase == Frame::AtomicEqIteCondition)
+      if (f.atomicPhase == Frame::AtomicPhase::AfterIteCondition)
       {
         UpdateSimplifyMap(f.output, result, false);
         return finishEquality(result);
       }
-      if (f.phase == Frame::AtomicEqCombined)
+      if (f.atomicPhase == Frame::AtomicPhase::AfterCombinedEquality)
       {
         output = CreateSimplifiedEQ(
             result, nf->CreateZeroConst(result.GetValueWidth()));
@@ -1208,7 +1280,8 @@ ASTNode Simplifier::simplifyNode(const ASTNode& b, bool pushNeg,
         {
           const ASTNode getthebit =
               nf->CreateTerm(BVEXTRACT, 1, f.t0, f.b[1], f.b[1]);
-          return wantTerm(f, Frame::AtomicBoolExtract, getthebit);
+          return requestTerm(f, Frame::AtomicPhase::AfterBoolExtract,
+                             getthebit);
         }
         case EQ:
         {
@@ -1229,7 +1302,8 @@ ASTNode Simplifier::simplifyNode(const ASTNode& b, bool pushNeg,
                                       : output[1];
               const ASTNode negated =
                   nf->CreateTerm(BVUMINUS, rhs.GetValueWidth(), rhs);
-              return wantTerm(f, Frame::AtomicEqNegRhs, negated);
+              return requestTerm(f, Frame::AtomicPhase::AfterNegatedEqualityRhs,
+                                 negated);
             }
           }
           return optimizeAndFinishEquality(output);
@@ -1278,7 +1352,7 @@ ASTNode Simplifier::simplifyNode(const ASTNode& b, bool pushNeg,
           while (f.i < f.b.Degree())
           {
             const StepResult requested =
-                wantTerm(f, Frame::AtomicFpOperand, f.b[f.i]);
+                requestTerm(f, Frame::AtomicPhase::AfterFpOperand, f.b[f.i]);
             if (requested == StepResult::Pushed)
               return requested;
             assert(requested == StepResult::Redispatch);
@@ -1296,9 +1370,10 @@ ASTNode Simplifier::simplifyNode(const ASTNode& b, bool pushNeg,
 
       return finishAtomic(output);
     }
-  };
+  }
 
-  auto stepArray = [&](Frame& f) -> StepResult {
+  StepResult stepArray(Frame& f)
+  {
     assert(f.job == Frame::ArrayJob);
     {
       auto finishArray = [&](const ASTNode& output)
@@ -1313,63 +1388,53 @@ ASTNode Simplifier::simplifyNode(const ASTNode& b, bool pushNeg,
       const unsigned iw = f.b.GetIndexWidth();
       assert(iw > 0);
 
-      if (f.phase == Frame::Start || f.phase == Frame::PrecheckedStart)
+      if (f.arrayPhase == Frame::ArrayPhase::Prepared)
       {
-        if (f.phase == Frame::Start)
-        {
-          if (CheckSimplifyMap(f.b, result, false))
-            return StepResult::Finished;
-
-          if (f.b.GetKind() == SYMBOL)
-          {
-            result = f.b;
-            return StepResult::Finished;
-          }
-        }
-
         if (f.b.GetKind() == ITE)
-          return want(f, Frame::ArrayCond, f.b[0], false);
+          return requestFormula(f, Frame::ArrayPhase::AfterCondition, f.b[0],
+                                false);
         if (f.b.GetKind() == WRITE)
-          return wantArray(f, Frame::ArrayBase, f.b[0]);
+          return requestArray(f, Frame::ArrayPhase::AfterBase, f.b[0]);
 
         FatalError("SimplifyArrayTerm: unexpected array term", f.b);
       }
 
       if (f.b.GetKind() == ITE)
       {
-        if (f.phase == Frame::ArrayCond)
+        if (f.arrayPhase == Frame::ArrayPhase::AfterCondition)
         {
           f.t0 = result;
-          return wantArray(f, Frame::ArrayThen, f.b[1]);
+          return requestArray(f, Frame::ArrayPhase::AfterThen, f.b[1]);
         }
-        if (f.phase == Frame::ArrayThen)
+        if (f.arrayPhase == Frame::ArrayPhase::AfterThen)
         {
           f.t1 = result;
-          return wantArray(f, Frame::ArrayElse, f.b[2]);
+          return requestArray(f, Frame::ArrayPhase::AfterElse, f.b[2]);
         }
 
         f.t2 = result;
         return finishArray(CreateSimplifiedTermITE(f.t0, f.t1, f.t2));
       }
 
-      if (f.phase == Frame::ArrayBase)
+      if (f.arrayPhase == Frame::ArrayPhase::AfterBase)
       {
         f.t0 = result;
-        return wantTerm(f, Frame::ArrayIndex, f.b[1]);
+        return requestTerm(f, Frame::ArrayPhase::AfterIndex, f.b[1]);
       }
-      if (f.phase == Frame::ArrayIndex)
+      if (f.arrayPhase == Frame::ArrayPhase::AfterIndex)
       {
         f.t1 = result;
-        return wantTerm(f, Frame::ArrayValue, f.b[2]);
+        return requestTerm(f, Frame::ArrayPhase::AfterValue, f.b[2]);
       }
 
       f.t2 = result;
       return finishArray(nf->CreateArrayTerm(WRITE, iw, f.b.GetValueWidth(),
                                              f.t0, f.t1, f.t2));
     }
-  };
+  }
 
-  auto stepTerm = [&](Frame& f) -> StepResult {
+  StepResult stepTerm(Frame& f)
+  {
     assert(f.job == Frame::TermJob);
     {
       auto finishTerm = [&](const ASTNode& output)
@@ -1406,40 +1471,32 @@ ASTNode Simplifier::simplifyNode(const ASTNode& b, bool pushNeg,
         return StepResult::Finished;
       };
 
-      if (f.phase == Frame::TermSubstitution)
+      if (f.termPhase == Frame::TermPhase::AfterSubstitution)
         return finishTerm(result);
-      if (f.phase == Frame::TermPulled || f.phase == Frame::TermRetry)
+      if (f.termPhase == Frame::TermPhase::AfterPullUpIte ||
+          f.termPhase == Frame::TermPhase::AfterRetry)
       {
         UpdateSimplifyMap(f.b, result, false);
         if (f.a != f.b)
           UpdateSimplifyMap(f.a, result, false);
         return finishTerm(result);
       }
-      if (f.phase == Frame::TermOutput)
+      if (f.termPhase == Frame::TermPhase::AfterOutput)
         return finishTermTail(result);
 
-      if (f.phase == Frame::Start ||
-          f.phase == Frame::PrecheckedStart ||
-          f.phase == Frame::TermSubstitutionPrechecked)
+      if (f.termPhase == Frame::TermPhase::Prepared ||
+          f.termPhase == Frame::TermPhase::PreparedSubstitution)
       {
         assert(_bm->UserFlags.optimize_flag);
-        if (f.phase == Frame::Start && f.b.isConstant())
-          return finishTerm(f.b);
 
         f.a = f.b;
         const ASTNode substitutionImage = f.output;
         f.output = f.a;
         assert(BVTypeCheck(f.a));
 
-        if (f.phase == Frame::TermSubstitutionPrechecked)
-          return wantTerm(f, Frame::TermSubstitution, substitutionImage);
-        if (f.phase == Frame::Start &&
-            InsideSubstitutionMap(f.a, f.output))
-          return wantTerm(f, Frame::TermSubstitution, f.output);
-        if (f.phase == Frame::Start &&
-            CheckSimplifyMap(f.a, result, false))
-          return StepResult::Finished;
-
+        if (f.termPhase == Frame::TermPhase::PreparedSubstitution)
+          return requestTerm(f, Frame::TermPhase::AfterSubstitution,
+                             substitutionImage);
         const Kind k = f.a.GetKind();
         if (!is_Term_kind(k))
           FatalError("SimplifyTerm: You have input a Non-term", f.a);
@@ -1453,7 +1510,7 @@ ASTNode Simplifier::simplifyNode(const ASTNode& b, bool pushNeg,
             f.outvec = toASTVec(f.b.GetChildren());
         }
       }
-      else if (f.phase == Frame::TermOperand)
+      else if (f.termPhase == Frame::TermPhase::AfterOperand)
       {
         f.outvec[f.i] = result;
         ++f.i;
@@ -1469,7 +1526,7 @@ ASTNode Simplifier::simplifyNode(const ASTNode& b, bool pushNeg,
             operand.GetType() == FLOATINGPOINT_TYPE)
         {
           const StepResult requested =
-              wantTerm(f, Frame::TermOperand, operand);
+              requestTerm(f, Frame::TermPhase::AfterOperand, operand);
           if (requested == StepResult::Pushed)
             return requested;
           assert(requested == StepResult::Redispatch);
@@ -1480,7 +1537,7 @@ ASTNode Simplifier::simplifyNode(const ASTNode& b, bool pushNeg,
         if (operand.GetType() == BOOLEAN_TYPE)
         {
           const StepResult requested =
-              want(f, Frame::TermOperand, operand, false);
+              requestFormula(f, Frame::TermPhase::AfterOperand, operand, false);
           if (requested == StepResult::Pushed)
             return requested;
           assert(requested == StepResult::Redispatch);
@@ -1491,7 +1548,8 @@ ASTNode Simplifier::simplifyNode(const ASTNode& b, bool pushNeg,
         ++f.i;
       }
 
-      if (f.a.GetKind() != SYMBOL && f.phase != Frame::TermReadArray)
+      if (f.a.GetKind() != SYMBOL &&
+          f.termPhase != Frame::TermPhase::AfterReadArray)
       {
         assert(!f.outvec.empty());
         if (ASTChildren(f.outvec) != f.b.GetChildren())
@@ -1534,7 +1592,7 @@ ASTNode Simplifier::simplifyNode(const ASTNode& b, bool pushNeg,
 
         const ASTNode pulledUp = PullUpITE(f.a);
         if (pulledUp != f.a)
-          return wantTerm(f, Frame::TermPulled, pulledUp);
+          return requestTerm(f, Frame::TermPhase::AfterPullUpIte, pulledUp);
 
         bool notSimplified = false;
         for (size_t i = 0; i < f.a.Degree(); ++i)
@@ -1546,14 +1604,15 @@ ASTNode Simplifier::simplifyNode(const ASTNode& b, bool pushNeg,
           }
         }
         if (notSimplified)
-          return wantTerm(f, Frame::TermRetry, f.a);
+          return requestTerm(f, Frame::TermPhase::AfterRetry, f.a);
       }
 
-      if (f.a.GetKind() == READ && f.phase != Frame::TermReadArray)
-        return wantArray(f, Frame::TermReadArray, f.a[0]);
+      if (f.a.GetKind() == READ &&
+          f.termPhase != Frame::TermPhase::AfterReadArray)
+        return requestArray(f, Frame::TermPhase::AfterReadArray, f.a[0]);
 
-      if (f.a.GetKind() == READ && f.phase == Frame::TermReadArray &&
-          result != f.a[0])
+      if (f.a.GetKind() == READ &&
+          f.termPhase == Frame::TermPhase::AfterReadArray && result != f.a[0])
       {
         // Preserve the pre-rebuild READ as a memo key. The recursive version
         // returned through that invocation after simplifying the array.
@@ -1577,18 +1636,20 @@ ASTNode Simplifier::simplifyNode(const ASTNode& b, bool pushNeg,
 
       assert(!f.output.IsNull());
       if (f.a != f.output)
-        return wantTerm(f, Frame::TermOutput, f.output);
+        return requestTerm(f, Frame::TermPhase::AfterOutput, f.output);
       return finishTermTail(f.output);
     }
-  };
+  }
 
-  auto stepFormula = [&](Frame& f) -> StepResult {
+  StepResult stepFormula(Frame& f)
+  {
     assert(f.job == Frame::FormulaJob);
     // The formula arms implemented in this frame share their memoisation
     // tail: record the PullUpITE result and, when distinct, the input. The
     // separately scheduled AtomicJob owns its own first entry and bypasses
     // this tail when it returns below.
-    auto finish = [&](const ASTNode& output) {
+    auto finish = [&](const ASTNode& output)
+    {
       UpdateSimplifyMap(f.a, output, f.pushNeg);
       if (f.b != f.a)
         UpdateSimplifyMap(f.b, output, f.pushNeg);
@@ -1603,7 +1664,8 @@ ASTNode Simplifier::simplifyNode(const ASTNode& b, bool pushNeg,
       case AND:
       case OR:
       {
-        auto takeChild = [&](const ASTNode& child) {
+        auto takeChild = [&](const ASTNode& child)
+        {
           if (child == f.output)
             return false;
 
@@ -1620,7 +1682,7 @@ ASTNode Simplifier::simplifyNode(const ASTNode& b, bool pushNeg,
           return true;
         };
 
-        if (f.phase == Frame::Start)
+        if (f.formulaPhase == Frame::FormulaPhase::Start)
         {
           const bool isAnd = (k == AND);
           // Under pushNeg we are simplifying NOT(a): De Morgan flips the
@@ -1639,8 +1701,8 @@ ASTNode Simplifier::simplifyNode(const ASTNode& b, bool pushNeg,
 
         while (f.i < f.a.Degree())
         {
-          const StepResult requested =
-              want(f, Frame::AndOrOperand, f.a[f.i], f.pushNeg);
+          const StepResult requested = requestFormula(
+              f, Frame::FormulaPhase::AfterAndOrOperand, f.a[f.i], f.pushNeg);
           if (requested == StepResult::Pushed)
             return requested;
           assert(requested == StepResult::Redispatch);
@@ -1657,7 +1719,7 @@ ASTNode Simplifier::simplifyNode(const ASTNode& b, bool pushNeg,
 
       case NOT:
       {
-        if (f.phase == Frame::NotBody)
+        if (f.formulaPhase == Frame::FormulaPhase::AfterNotBody)
           return finish(result);
 
         if (!(f.a.Degree() == 1 && NOT == f.a.GetKind()))
@@ -1677,11 +1739,11 @@ ASTNode Simplifier::simplifyNode(const ASTNode& b, bool pushNeg,
         // pushnegation if there are odd number of NOTs
         const bool pn = (NotCount % 2 == 0) ? false : true;
 
-        // `want` owns the child shortcut and memo probe. If it schedules a
+        // `requestFormula` owns the child shortcut and memo probe. If it schedules a
         // child frame, that frame records `o`; if it answers immediately,
         // the entry either already exists or `o` is a leaf that is never
         // memoised. The returning NOT frame therefore only records itself.
-        return want(f, Frame::NotBody, o, pn);
+        return requestFormula(f, Frame::FormulaPhase::AfterNotBody, o, pn);
       }
 
       case XOR:
@@ -1691,10 +1753,10 @@ ASTNode Simplifier::simplifyNode(const ASTNode& b, bool pushNeg,
         if (f.a.Degree() == 1)
           return finish(f.a[0]);
 
-        if (f.phase == Frame::Start)
+        if (f.formulaPhase == Frame::FormulaPhase::Start)
           f.outvec.reserve(f.a.Degree());
 
-        if (f.phase == Frame::XorOperand)
+        if (f.formulaPhase == Frame::FormulaPhase::AfterXorOperand)
         {
           f.outvec.push_back(result);
           ++f.i;
@@ -1702,8 +1764,8 @@ ASTNode Simplifier::simplifyNode(const ASTNode& b, bool pushNeg,
 
         while (f.i < f.a.Degree())
         {
-          const StepResult requested =
-              want(f, Frame::XorOperand, f.a[f.i], false);
+          const StepResult requested = requestFormula(
+              f, Frame::FormulaPhase::AfterXorOperand, f.a[f.i], false);
           if (requested == StepResult::Pushed)
             return requested;
           assert(requested == StepResult::Redispatch);
@@ -1732,7 +1794,7 @@ ASTNode Simplifier::simplifyNode(const ASTNode& b, bool pushNeg,
       case NOR:
       case IMPLIES:
       {
-        if (f.phase == Frame::Start)
+        if (f.formulaPhase == Frame::FormulaPhase::Start)
         {
           if (k == IMPLIES && !(f.a.Degree() == 2))
             FatalError("SimplifyImpliesFormula: vector with wrong num of nodes",
@@ -1741,15 +1803,16 @@ ASTNode Simplifier::simplifyNode(const ASTNode& b, bool pushNeg,
           // NAND and NOR are a negated AND/OR, so the negation they carry
           // goes into both operands and cancels with the caller's. IMPLIES
           // negates only its consequent, and only when it is itself negated.
-          return want(f, Frame::BinaryLeft, f.a[0],
-                      (k == IMPLIES) ? false : !f.pushNeg);
+          return requestFormula(f, Frame::FormulaPhase::AfterBinaryLeft, f.a[0],
+                                (k == IMPLIES) ? false : !f.pushNeg);
         }
 
-        if (f.phase == Frame::BinaryLeft)
+        if (f.formulaPhase == Frame::FormulaPhase::AfterBinaryLeft)
         {
           f.t0 = result;
-          return want(f, Frame::BinaryRight, f.a[1],
-                      (k == IMPLIES) ? f.pushNeg : !f.pushNeg);
+          return requestFormula(f, Frame::FormulaPhase::AfterBinaryRight,
+                                f.a[1],
+                                (k == IMPLIES) ? f.pushNeg : !f.pushNeg);
         }
 
         f.t1 = result;
@@ -1774,34 +1837,38 @@ ASTNode Simplifier::simplifyNode(const ASTNode& b, bool pushNeg,
 
       case IFF:
       {
-        if (f.phase == Frame::Start)
+        if (f.formulaPhase == Frame::FormulaPhase::Start)
         {
           if (!(f.a.Degree() == 2))
             FatalError("SimplifyIffFormula: vector with wrong num of nodes",
                        ASTUndefined);
 
           // The second operand first, as it was.
-          return want(f, Frame::IffRight, f.a[1], false);
+          return requestFormula(f, Frame::FormulaPhase::AfterIffRight, f.a[1],
+                                false);
         }
 
-        if (f.phase == Frame::IffRight)
+        if (f.formulaPhase == Frame::FormulaPhase::AfterIffRight)
         {
           f.t1 = result;
-          return want(f, Frame::IffLeft, f.a[0], f.pushNeg);
+          return requestFormula(f, Frame::FormulaPhase::AfterIffLeft, f.a[0],
+                                f.pushNeg);
         }
 
-        if (f.phase == Frame::IffLeft)
+        if (f.formulaPhase == Frame::FormulaPhase::AfterIffLeft)
         {
           f.t0 = result;
 
           if (ASTTrue == f.t0)
             return finish(f.t1);
           if (ASTFalse == f.t0)
-            return want(f, Frame::IffFold, f.t1, true);
+            return requestFormula(f, Frame::FormulaPhase::AfterIffFold, f.t1,
+                                  true);
           if (ASTTrue == f.t1)
             return finish(f.t0);
           if (ASTFalse == f.t1)
-            return want(f, Frame::IffFold, f.t0, true);
+            return requestFormula(f, Frame::FormulaPhase::AfterIffFold, f.t0,
+                                  true);
           if (f.t0 == f.t1)
             return finish(ASTTrue);
           if ((NOT == f.t0.GetKind() && f.t0[0] == f.t1) ||
@@ -1810,33 +1877,36 @@ ASTNode Simplifier::simplifyNode(const ASTNode& b, bool pushNeg,
           return finish(nf->CreateNode(XOR, nf->CreateNode(NOT, f.t0), f.t1));
         }
 
-        return finish(result); // Frame::IffFold
+        return finish(result); // Frame::FormulaPhase::AfterIffFold
       }
 
       case ITE:
       {
-        if (f.phase == Frame::Start)
+        if (f.formulaPhase == Frame::FormulaPhase::Start)
         {
           if (!(f.a.Degree() == 3))
             FatalError("SimplifyIteFormula: vector with wrong num of nodes",
                        ASTUndefined);
 
-          return want(f, Frame::IteCond, f.a[0], false);
+          return requestFormula(f, Frame::FormulaPhase::AfterIteCondition,
+                                f.a[0], false);
         }
 
-        if (f.phase == Frame::IteCond)
+        if (f.formulaPhase == Frame::FormulaPhase::AfterIteCondition)
         {
           f.t0 = result;
-          return want(f, Frame::IteThen, f.a[1], f.pushNeg);
+          return requestFormula(f, Frame::FormulaPhase::AfterIteThen, f.a[1],
+                                f.pushNeg);
         }
 
-        if (f.phase == Frame::IteThen)
+        if (f.formulaPhase == Frame::FormulaPhase::AfterIteThen)
         {
           f.t1 = result;
-          return want(f, Frame::IteElse, f.a[2], f.pushNeg);
+          return requestFormula(f, Frame::FormulaPhase::AfterIteElse, f.a[2],
+                                f.pushNeg);
         }
 
-        if (f.phase == Frame::IteElse)
+        if (f.formulaPhase == Frame::FormulaPhase::AfterIteElse)
         {
           f.t2 = result;
 
@@ -1852,17 +1922,18 @@ ASTNode Simplifier::simplifyNode(const ASTNode& b, bool pushNeg,
           if (ASTFalse == f.t0)
             return finish(f.t2);
           if (ASTFalse == f.t1 && ASTTrue == f.t2)
-            return want(f, Frame::IteFold, f.t0, true);
+            return requestFormula(f, Frame::FormulaPhase::AfterIteFold, f.t0,
+                                  true);
           return finish(nf->CreateNode(ITE, f.t0, f.t1, f.t2));
         }
 
-        return finish(result); // Frame::IteFold
+        return finish(result); // Frame::FormulaPhase::AfterIteFold
       }
 
       default:
         // Atomic predicates do not stop the walk: their term operands and any
         // terms they manufacture are jobs on this same continuation stack.
-        if (f.phase == Frame::FormulaAtomic)
+        if (f.formulaPhase == Frame::FormulaPhase::AfterAtomic)
         {
           // AtomicJob has already recorded `f.a`. Only the pre-PullUpITE key
           // can remain for this formula frame to record.
@@ -1870,49 +1941,121 @@ ASTNode Simplifier::simplifyNode(const ASTNode& b, bool pushNeg,
             UpdateSimplifyMap(f.b, result, f.pushNeg);
           return StepResult::Finished;
         }
-        return wantAtomic(f, Frame::FormulaAtomic, f.a, f.pushNeg);
+        return requestAtomic(f, Frame::FormulaPhase::AfterAtomic, f.a,
+                             f.pushNeg);
     }
-  };
-
-  while (true)
-  {
-    Frame& current = stack.back();
-    StepResult stepResult = StepResult::Finished;
-    switch (current.job)
-    {
-      case Frame::FormulaJob:
-        do
-          stepResult = stepFormula(current);
-        while (stepResult == StepResult::Redispatch);
-        break;
-      case Frame::AtomicJob:
-        do
-          stepResult = stepAtomic(current);
-        while (stepResult == StepResult::Redispatch);
-        break;
-      case Frame::TermJob:
-        do
-          stepResult = stepTerm(current);
-        while (stepResult == StepResult::Redispatch);
-        break;
-      case Frame::ArrayJob:
-        do
-          stepResult = stepArray(current);
-        while (stepResult == StepResult::Redispatch);
-        break;
-    }
-
-    if (stepResult == StepResult::Pushed ||
-        stepResult == StepResult::Yield)
-      continue;
-    assert(stepResult == StepResult::Finished);
-
-    stack.pop_back();
-    if (stack.empty())
-      return result;
   }
-}
 
+public:
+  explicit SimplifyDriver(Simplifier& owner)
+      : owner(owner), nf(owner.nf), _bm(owner._bm), ASTTrue(owner.ASTTrue),
+        ASTFalse(owner.ASTFalse), ASTUndefined(owner.ASTUndefined)
+  {
+  }
+
+  ASTNode run(const ASTNode& b, const bool pushNeg, const SimplifyJob rootJob)
+  {
+    result = ASTNode();
+    stack.clear();
+
+    // Answer root-level leaves and memo hits before constructing the vector.
+    // A vector allocation is unnecessary for the overwhelmingly common leaf
+    // and memo-hit cases.
+    Frame top;
+    top.b = b;
+    top.pushNeg = pushNeg;
+    if (rootJob == SimplifyJob::Formula)
+    {
+      top.job = Frame::FormulaJob;
+      if (prepareFormula(b, pushNeg, top.a))
+        return result;
+    }
+    else if (rootJob == SimplifyJob::Term)
+    {
+      assert(_bm->UserFlags.optimize_flag);
+      top.job = Frame::TermJob;
+
+      // A substitution frame is transparent: follow its image without
+      // memoising the substituted key until a real term frame is needed.
+      ASTNode root = b;
+      ASTNode substitutionImage;
+      while (true)
+      {
+        if (root.isConstant())
+          return root;
+        if (InsideSubstitutionMap(root, substitutionImage))
+        {
+          root = substitutionImage;
+          continue;
+        }
+        if (CheckSimplifyMap(root, result, false))
+          return result;
+        break;
+      }
+
+      top.b = root;
+      top.termPhase = Frame::TermPhase::Prepared;
+    }
+    else
+    {
+      assert(b.GetIndexWidth() > 0);
+      top.job = Frame::ArrayJob;
+      if (CheckSimplifyMap(b, result, false))
+        return result;
+      if (b.GetKind() == SYMBOL)
+        return b;
+      top.arrayPhase = Frame::ArrayPhase::Prepared;
+    }
+
+    // A child request is the only operation that can grow the vector, and
+    // every caller returns from its step immediately afterwards, so no Frame
+    // reference survives a move.
+    stack.push_back(std::move(top));
+
+    while (true)
+    {
+      Frame& current = stack.back();
+      StepResult stepResult = StepResult::Finished;
+      switch (current.job)
+      {
+        case Frame::FormulaJob:
+          do
+            stepResult = stepFormula(current);
+          while (stepResult == StepResult::Redispatch);
+          break;
+        case Frame::AtomicJob:
+          do
+            stepResult = stepAtomic(current);
+          while (stepResult == StepResult::Redispatch);
+          break;
+        case Frame::TermJob:
+          do
+            stepResult = stepTerm(current);
+          while (stepResult == StepResult::Redispatch);
+          break;
+        case Frame::ArrayJob:
+          do
+            stepResult = stepArray(current);
+          while (stepResult == StepResult::Redispatch);
+          break;
+      }
+
+      if (stepResult == StepResult::Pushed || stepResult == StepResult::Yield)
+        continue;
+      assert(stepResult == StepResult::Finished);
+
+      stack.pop_back();
+      if (stack.empty())
+        return result;
+    }
+  }
+};
+
+ASTNode Simplifier::simplifyNode(const ASTNode& b, const bool pushNeg,
+                                 const SimplifyJob rootJob)
+{
+  return SimplifyDriver(*this).run(b, pushNeg, rootJob);
+}
 
 ASTNode Simplifier::makeTower(const Kind k, const stp::ASTVec& children)
 {

--- a/lib/Simplifier/StrengthReduction.cpp
+++ b/lib/Simplifier/StrengthReduction.cpp
@@ -26,6 +26,7 @@ THE SOFTWARE.
 #include "stp/Simplifier/StrengthReduction.h"
 #include "stp/Simplifier/constantBitP/FixedBits.h"
 #include "stp/Util/CBVOps.h"
+#include "stp/Util/DagWalk.h"
 #include <iostream>
 
 namespace stp
@@ -86,52 +87,42 @@ namespace stp
   }
 
   // visit each node apply strength reductions to it.
+  //
+  // postOrderRebuild does the walking, on the heap: how deeply the input
+  // nests is not this pass's choice, and a call per level exhausts the
+  // stack. What is left here is the reduction of a single node.
   ASTNode StrengthReduction::visit(const ASTNode& n, NodeDomainAnalysis& nda, ASTNodeMap& cache)
   {
-    if (n.Degree() == 0 )
-      return n;
+    return postOrderRebuild(
+        n, cache, [&](const ASTNode& node, const ASTVec& children) {
+          ASTNode newN;
+          if (node.GetType() == BOOLEAN_TYPE)
+            newN = nf->CreateNode(node.GetKind(), children);
+          else
+            newN = nf->CreateArrayTerm(node.GetKind(), node.GetIndexWidth(),
+                                       node.GetValueWidth(), children);
 
-    {
-      const ASTNodeMap::const_iterator it = cache.find(n);
-      if (it != cache.end())
-        return it->second;
-    }
+          // buildMap memoises on the node, so it only needs redoing when the
+          // preceding reduction actually replaced the node.
+          nda.buildMap(newN);
+          ASTNode reduced = strengthReduction(newN, *nda.getCbitMap());
 
-    ASTVec children;
-    children.reserve(n.Degree());
-    
-    for (const auto & c: n)
-    {
-      children.push_back(visit(c,nda,cache));
-    }
+          if (reduced != newN)
+          {
+            newN = reduced;
+            nda.buildMap(newN);
+          }
+          reduced = strengthReduction(newN, *nda.getIntervalMap());
 
-    ASTNode newN;
-    if (n.GetType() == BOOLEAN_TYPE)
-      newN = nf->CreateNode(n.GetKind(), children);
-    else
-      newN = nf->CreateArrayTerm(n.GetKind(), n.GetIndexWidth(),n.GetValueWidth(), children);
-   
-    // buildMap memoises on the node, so it only needs redoing when the
-    // preceding reduction actually replaced the node.
-    nda.buildMap(newN);
-    ASTNode reduced = strengthReduction(newN, *nda.getCbitMap());
+          if (reduced != newN)
+          {
+            newN = reduced;
+            nda.buildMap(newN);
+          }
+          newN = strengthReduction(newN, *nda.getValueSetMap());
 
-    if (reduced != newN)
-    {
-      newN = reduced;
-      nda.buildMap(newN);
-    }
-    reduced = strengthReduction(newN, *nda.getIntervalMap());
-
-    if (reduced != newN)
-    {
-      newN = reduced;
-      nda.buildMap(newN);
-    }
-    newN = strengthReduction(newN, *nda.getValueSetMap());
-
-    cache.insert({n,newN});
-    return newN;
+          return newN;
+        });
   }
 
   ASTNode StrengthReduction::topLevel(const ASTNode& top, NodeDomainAnalysis& nda)

--- a/lib/Simplifier/SubstitutionMap.cpp
+++ b/lib/Simplifier/SubstitutionMap.cpp
@@ -26,6 +26,7 @@ THE SOFTWARE.
 #include "stp/AbsRefineCounterExample/ArrayTransformer.h"
 #include "stp/Extensionality/ExtensionalityContext.h"
 #include "stp/Simplifier/Simplifier.h"
+#include <vector>
 
 namespace stp
 {
@@ -131,135 +132,297 @@ ASTNode SubstitutionMap::replace(const ASTNode& n, NodeMapType& fromTo,
 // NB: You can't use this to map from "5" to the symbol "x" say.
 // It's optimised for the symbol to something case.
 
+// The walk keeps its frames on the heap. Input decides how deeply a formula
+// nests, and deeply nested ones exist, so a call per level of the DAG
+// exhausts the stack. See DeepDag_Test.cpp.
 template <class NodeMapType>
 ASTNode SubstitutionMap::replace(const ASTNode& n, NodeMapType& fromTo,
                                  NodeMapType& cache, NodeFactory* nf,
                                  bool stopAtArrays, bool preventInfinite)
 {
-  const Kind k = n.GetKind();
-  if (k == BVCONST || k == TRUE || k == FALSE)
-    return n;
-
-  typename NodeMapType::const_iterator it;
-
-  if ((it = cache.find(n)) != cache.end())
-    return it->second;
-
-  if ((it = fromTo.find(n)) != fromTo.end())
+  // One node's progress. `phase` says what a value arriving from below is:
+  // the recursive version called itself from three places -- following a
+  // chain of substitutions, replacing a child, and running again over a
+  // node it had just rebuilt -- and a frame has to know which it awaits.
+  struct Frame
   {
-    // By value, not by reference: the recursive calls below can insert into
-    // and erase from fromTo, and a DenseNodeMap moves its elements when that
-    // happens -- a reference here would dangle.
-    const ASTNode r = it->second;
-    assert(r.GetIndexWidth() == n.GetIndexWidth());
+    ASTNode n;
+    Kind k;
+    unsigned int indexWidth;
+    unsigned int valueWidth;
 
-    if (preventInfinite)
-      cache.insert(make_pair(n, r));
-
-    ASTNode replaced =
-        replace(r, fromTo, cache, nf, stopAtArrays, preventInfinite);
-    if (replaced != r)
+    enum Phase
     {
-      fromTo.erase(n);
-      fromTo[n] = replaced;
-    }
+      AwaitingChain,
+      AwaitingChild,
+      AwaitingRemap
+    };
+    Phase phase;
 
-    if (preventInfinite)
-      cache.erase(n);
+    ASTNode chainTarget; // what n maps to, for AwaitingChain
+    ASTNode remapped;    // the rebuilt node, for AwaitingRemap
+    bool started = false;
 
-    cache.insert(make_pair(n, replaced));
-    return replaced;
-  }
-
-  // These can't be created like regular nodes are
-  if (k == SYMBOL)
-    return n;
-
-  const unsigned int indexWidth = n.GetIndexWidth();
-  if (stopAtArrays && indexWidth > 0) // is an array.
-  {
-    return n;
-  }
-
-  // Floating-point special constants (NaN, +/-oo, +/-zero) are nullary leaves
-  // that the BVCONST/TRUE/FALSE test above does not cover, so they reach here
-  // with no children. They are values: there is nothing to substitute into.
-  if (n.Degree() == 0)
-    return n;
-
-  const ASTChildren children = n.GetChildren();
-  assert(children.size() > 0);
-  // Should have no leaves left here.
-
-  ASTVec newChildren;
-  bool changed = false;
-
-  for (auto it = children.begin(); it != children.end(); it++)
-  {
-    ASTNode newNode = replace(*it, fromTo, cache, nf, stopAtArrays, preventInfinite);
-    if (!changed && newNode!=*it)
-    {
-        newChildren.reserve(children.size());
-        newChildren.insert(newChildren.end(), children.begin(), it);
-        changed=true;
-    }
-    if (changed)   
-      newChildren.push_back(newNode);
-  }
-
-  assert(newChildren.size() == 0 || (newChildren.size() == children.size()));
-
-  // This code short-cuts if the children are the same. Nodes with the same
-  // children,
-  // won't have necessarily given the same node if the simplifyingNodeFactory is
-  // enabled
-  // now, but wasn't enabled when the node was created. Shortcutting saves lots
-  // of time.
-  if (newChildren.size() ==0)
-  {
-    cache.insert(make_pair(n, n));
-    return n;
-  }
+    ASTChildren children;
+    ASTVec newChildren;
+    bool changed = false;
+    unsigned i = 0; // the child being worked on
+    bool waiting = false;
+  };
 
   ASTNode result;
-  const unsigned int valueWidth = n.GetValueWidth();
 
-  if (valueWidth == 0) // n.GetType() == BOOLEAN_TYPE
+  // The head of the recursive version, in its order -- in particular the
+  // fromTo test before the SYMBOL test, which is what makes substituting
+  // for a symbol work at all. Either the answer needs no frame and lands in
+  // `result`, or `frame` is prepared for the walk below it.
+  auto prepare = [&](const ASTNode& node, Frame& frame) -> bool
   {
-    result = nf->CreateNode(k, newChildren);
-  }
-  else
-  {
-    // If the index and value width aren't saved, they are reset sometimes (??)
-    result = nf->CreateArrayTerm(k, indexWidth, valueWidth, newChildren);
-  }
+    const Kind k = node.GetKind();
+    if (k == BVCONST || k == TRUE || k == FALSE)
+    {
+      result = node;
+      return false;
+    }
 
-  // We may have created something that should be mapped. For instance,
-  // if n is READ(A, x), and the fromTo is: {x==0, READ(A,0) == 1}, then
-  // by here the result will be READ(A,0). Which needs to be mapped again..
-  // I hope that this makes it idempotent.
+    typename NodeMapType::const_iterator it;
 
-  if (fromTo.find(result) != fromTo.end())
+    if ((it = cache.find(node)) != cache.end())
+    {
+      result = it->second;
+      return false;
+    }
+
+    if ((it = fromTo.find(node)) != fromTo.end())
+    {
+      // By value, not by reference: the walk below inserts into and erases
+      // from fromTo, and a DenseNodeMap moves its elements when that
+      // happens -- a reference here would dangle.
+      frame.chainTarget = it->second;
+      assert(frame.chainTarget.GetIndexWidth() == node.GetIndexWidth());
+      frame.phase = Frame::AwaitingChain;
+
+      if (preventInfinite)
+        cache.insert(make_pair(node, frame.chainTarget));
+    }
+    // These can't be created like regular nodes are
+    else if (k == SYMBOL)
+    {
+      result = node;
+      return false;
+    }
+    else if (stopAtArrays && node.GetIndexWidth() > 0) // is an array.
+    {
+      result = node;
+      return false;
+    }
+    // Floating-point special constants (NaN, +/-oo, +/-zero) are nullary
+    // leaves that the BVCONST/TRUE/FALSE test above does not cover, so they
+    // reach here with no children. They are values: there is nothing to
+    // substitute into.
+    else if (node.Degree() == 0)
+    {
+      result = node;
+      return false;
+    }
+    else
+    {
+      frame.phase = Frame::AwaitingChild;
+      frame.children = node.GetChildren();
+      assert(frame.children.size() > 0);
+      // Should have no leaves left here.
+    }
+
+    frame.n = node;
+    frame.k = k;
+    frame.indexWidth = node.GetIndexWidth();
+    frame.valueWidth = node.GetValueWidth();
+    return true;
+  };
+
+  // Answer settled roots before constructing the stack, so constants, leaves,
+  // stopped arrays and cache hits pay for no traversal storage.
+  Frame top;
+  if (!prepare(n, top))
+    return result;
+
+  // Most substitution walks are only a few frames deep. Keep those frames in
+  // one compact allocation instead of a deque's map and fixed-size blocks.
+  // A push may move every frame, so callers of descend must not retain or use
+  // a Frame reference after descend returns true.
+  std::vector<Frame> stack;
+  stack.push_back(std::move(top));
+
+  auto descend = [&](const ASTNode& node, Frame* waitingParent = nullptr) -> bool
   {
-    // map n->result, if running replace() on result gives us 'n', it will not
-    // infinite loop.
-    // This is only currently required for the bitblast equivalence stuff.
+    Frame frame;
+    if (!prepare(node, frame))
+      return false;
+    if (waitingParent != nullptr)
+      waitingParent->waiting = true;
+    stack.push_back(std::move(frame));
+    return true;
+  };
+
+  // Copy on write, one child at a time.
+  auto foldChild = [](Frame& f, const ASTNode& newNode)
+  {
+    const ASTNode& child = f.children[f.i];
+    if (!f.changed && newNode != child)
+    {
+      f.newChildren.reserve(f.children.size());
+      f.newChildren.insert(f.newChildren.end(), f.children.begin(),
+                           f.children.begin() + f.i);
+      f.changed = true;
+    }
+    if (f.changed)
+      f.newChildren.push_back(newNode);
+    f.i++;
+  };
+
+  // The answer for a rebuilt node, cached and handed back up.
+  auto finish = [&](Frame& f, const ASTNode& value)
+  {
+    assert(value.GetValueWidth() == f.valueWidth);
+    assert(value.GetIndexWidth() == f.indexWidth);
+
+    // If there is already an "n" element in the cache, the maps semantics
+    // are to ignore the next insertion.
     if (preventInfinite)
-      cache.insert(make_pair(n, result));
+      cache.erase(f.n);
 
-    result = replace(result, fromTo, cache, nf, stopAtArrays, preventInfinite);
+    cache.insert(make_pair(f.n, value));
+    result = value;
+    stack.pop_back();
+  };
+
+  while (true)
+  {
+    Frame& current = stack.back();
+
+    // We call replace on each of the things in the fromTo map aswell.
+    // This is in case we have a fromTo map: (x maps to y), (y maps to 5),
+    // and pass the replace() function the node "x" to replace, then it
+    // will return 5, rather than y.
+    if (current.phase == Frame::AwaitingChain)
+    {
+      if (!current.started)
+      {
+        current.started = true;
+        if (descend(current.chainTarget))
+          continue;
+      }
+
+      const ASTNode replaced = result; // replace(chainTarget)
+      if (replaced != current.chainTarget)
+      {
+        fromTo.erase(current.n);
+        fromTo[current.n] = replaced;
+      }
+
+      if (preventInfinite)
+        cache.erase(current.n);
+
+      cache.insert(make_pair(current.n, replaced));
+      result = replaced;
+      stack.pop_back();
+
+      if (stack.empty())
+        return result;
+      continue;
+    }
+
+    if (current.phase == Frame::AwaitingRemap)
+    {
+      if (!current.started)
+      {
+        current.started = true;
+        if (descend(current.remapped))
+          continue;
+      }
+
+      finish(current, result); // replace(remapped)
+      if (stack.empty())
+        return result;
+      continue;
+    }
+
+    if (current.waiting)
+    {
+      current.waiting = false;
+      foldChild(current, result);
+    }
+
+    bool descended = false;
+    while (current.i < current.children.size())
+    {
+      // descend installs the continuation only when it will push, and does
+      // so before vector growth can move `current`.
+      if (descend(current.children[current.i], &current))
+      {
+        descended = true;
+        break;
+      }
+      foldChild(current, result);
+    }
+    if (descended)
+      continue;
+
+    assert(current.newChildren.size() == 0 ||
+           (current.newChildren.size() == current.children.size()));
+
+    // This code short-cuts if the children are the same. Nodes with the same
+    // children,
+    // won't have necessarily given the same node if the simplifyingNodeFactory is
+    // enabled
+    // now, but wasn't enabled when the node was created. Shortcutting saves lots
+    // of time.
+    if (current.newChildren.size() == 0)
+    {
+      cache.insert(make_pair(current.n, current.n));
+      result = current.n;
+      stack.pop_back();
+
+      if (stack.empty())
+        return result;
+      continue;
+    }
+
+    ASTNode built;
+    if (current.valueWidth == 0) // n.GetType() == BOOLEAN_TYPE
+    {
+      built = nf->CreateNode(current.k, current.newChildren);
+    }
+    else
+    {
+      // If the index and value width aren't saved, they are reset sometimes (??)
+      built = nf->CreateArrayTerm(current.k, current.indexWidth,
+                                  current.valueWidth, current.newChildren);
+    }
+
+    // We may have created something that should be mapped. For instance,
+    // if n is READ(A, x), and the fromTo is: {x==0, READ(A,0) == 1}, then
+    // by here the result will be READ(A,0). Which needs to be mapped again..
+    // I hope that this makes it idempotent.
+
+    if (fromTo.find(built) != fromTo.end())
+    {
+      // map n->result, if running replace() on result gives us 'n', it will
+      // not infinite loop.
+      // This is only currently required for the bitblast equivalence stuff.
+      if (preventInfinite)
+        cache.insert(make_pair(current.n, built));
+
+      current.phase = Frame::AwaitingRemap;
+      current.remapped = built;
+      current.started = false;
+      continue;
+    }
+
+    finish(current, built);
+    if (stack.empty())
+      return result;
   }
-
-  assert(result.GetValueWidth() == valueWidth);
-  assert(result.GetIndexWidth() == indexWidth);
-
-  // If there is already an "n" element in the cache, the maps semantics are to
-  // ignore the next insertion.
-  if (preventInfinite)
-    cache.erase(n);
-
-  cache.insert(make_pair(n, result));
-  return result;
 }
 
 // The two map types replace() runs over: the SolverMap paths use

--- a/lib/Simplifier/VariablesInExpression.cpp
+++ b/lib/Simplifier/VariablesInExpression.cpp
@@ -23,6 +23,7 @@ THE SOFTWARE.
 ********************************************************************/
 
 #include "stp/Simplifier/VariablesInExpression.h"
+#include "stp/Util/DagWalk.h"
 
 namespace stp
 {
@@ -48,9 +49,49 @@ void VariablesInExpression::insert(const ASTNode& n, Symbols* s)
 // in the descendents changes. For example (EXTRACT 0 1 n)
 // will have the same "Symbols" node as n, because
 // no new symbols are introduced.
+// Every node below `n` before `n` itself, in the order getSymbol would have
+// reached them. It looks at every child of every node it visits, and its one
+// early return is for a symbol, which has no children, so nothing is built
+// here that it would not have built anyway.
+void VariablesInExpression::primeSymbols(const ASTNode& n)
+{
+  primeMemo(
+      n,
+      [this](const ASTNode& node)
+      {
+        if (symbol_graph.find(node.GetNodeNum()) != symbol_graph.end())
+          return Walk::Skip; // getSymbol would answer from the graph.
+        return node.Degree() == 0 ? Walk::Visit : Walk::Descend;
+      },
+      [this](const ASTNode& node, PrimeMemoReady) { getSymbol(node, true); });
+}
+
 Symbols* VariablesInExpression::getSymbol(const ASTNode& n)
 {
+  return getSymbol(n, false);
+}
+
+Symbols* VariablesInExpression::getSymbol(const ASTNode& n,
+                                          const bool knownMissing)
+{
+  PrimeAudit::Running running(symbolAudit, n);
+
+  // primeSymbols' classifier already made this lookup. Its ready token is a
+  // known miss because building a descendant cannot insert an ancestor into
+  // this bottom-up graph.
+  if (!knownMissing)
   {
+    const ASTNodeToNodes::const_iterator it = symbol_graph.find(n.GetNodeNum());
+    if (it != symbol_graph.end())
+      return it->second;
+  }
+
+  if (!priming)
+  {
+    priming = true;
+    primeSymbols(n);
+    priming = false;
+
     const ASTNodeToNodes::const_iterator it = symbol_graph.find(n.GetNodeNum());
     if (it != symbol_graph.end())
       return it->second;
@@ -95,39 +136,46 @@ void VariablesInExpression::VarSeenInTerm(Symbols* term, SymbolPtrSet& visited,
                                           ASTNodeSet& found,
                                           vector<Symbols*>& av)
 {
-  if (visited.find(term) != visited.end())
+  // Iterative: the Symbols tree is as deep as the expression it was built
+  // from, so a call per level exhausts the stack on the inputs that reach
+  // here. Children are pushed in reverse, so they are still visited left to
+  // right and the walk sees what the recursion saw. See DeepDag_Test.cpp.
+  vector<Symbols*> toVisit;
+  toVisit.push_back(term);
+
+  while (!toVisit.empty())
   {
-    return;
+    Symbols* const current = toVisit.back();
+    toVisit.pop_back();
+
+    if (visited.find(current) != visited.end())
+    {
+      continue;
+    }
+
+    if (current->isLeaf())
+    {
+      found.insert(current->found);
+      continue;
+    }
+
+    visited.insert(current);
+
+    SymbolPtrToNode::const_iterator it;
+    if ((it = TermsAlreadySeenMap.find(current)) != TermsAlreadySeenMap.end())
+    {
+      // We've previously built the set of variables below this "symbols".
+      // It's not added into "found" because its sometimes 70k variables
+      // big, and if there are no other symbols discovered it's a terrible
+      // waste to create a copy of the set. Instead we store (in effect)
+      // a pointer to the set.
+      av.push_back(current);
+      continue;
+    }
+
+    for (size_t i = current->children.size(); i > 0; i--)
+      toVisit.push_back(current->children[i - 1]);
   }
-
-  if (term->isLeaf())
-  {
-    found.insert(term->found);
-    return;
-  }
-
-  visited.insert(term);
-
-  SymbolPtrToNode::const_iterator it;
-  if ((it = TermsAlreadySeenMap.find(term)) != TermsAlreadySeenMap.end())
-  {
-    // We've previously built the set of variables below this "symbols".
-    // It's not added into "found" because its sometimes 70k variables
-    // big, and if there are no other symbols discovered it's a terrible
-    // waste to create a copy of the set. Instead we store (in effect)
-    // a pointer to the set.
-    av.push_back(term);
-    return;
-  }
-
-  for (vector<Symbols*>::const_iterator it = term->children.begin(),
-                                        itend = term->children.end();
-       it != itend; it++)
-  {
-    VarSeenInTerm(*it, visited, found, av);
-  }
-
-  return;
 }
 
 ASTNodeSet* VariablesInExpression::SetofVarsSeenInTerm(Symbols* symbol,

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -27,7 +27,9 @@ THE SOFTWARE.
 #include "stp/Simplifier/constantBitP/FixedBits.h"
 #include "stp/Simplifier/constantBitP/NodeToFixedBitsMap.h"
 #include "stp/ToSat/BBNodeManagerAIG.h"
+#include "stp/Util/DagWalk.h"
 #include <cassert>
+#include <deque>
 #include <cmath>
 
 namespace stp
@@ -66,6 +68,35 @@ vector<BBNodeAIG> _empty_BBNodeAIGVec;
 // that should have already been applied.
 const bool debug_do_check = false;
 const bool debug_bitblaster = false;
+
+namespace
+{
+// BBForm and BBTerm share one recursion budget because they call each other.
+// Keeping the counter in a scope guard makes all of their many early returns
+// release the budget without putting cleanup code on each path.
+class UnprimedDepth
+{
+  size_t& depth;
+  const bool active;
+
+public:
+  UnprimedDepth(size_t& depth_, const bool active_)
+      : depth(depth_), active(active_)
+  {
+    if (active)
+      ++depth;
+  }
+
+  UnprimedDepth(const UnprimedDepth&) = delete;
+  UnprimedDepth& operator=(const UnprimedDepth&) = delete;
+
+  ~UnprimedDepth()
+  {
+    if (active)
+      --depth;
+  }
+};
+} // namespace
 
 // Translates signed BVDIV,BVMOD and BVREM into unsigned variety
 static ASTNode TranslateSignedDivModRem(const ASTNode& in, NodeFactory* nf)
@@ -737,18 +768,48 @@ BitBlaster::simplify_during_bb(ASTNode& term,
   return BBTermMemo.end();
 }
 
-const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term,
-                                   BBNodeSet& support)
+const BBNodeVec BitBlaster::BBTerm(const ASTNode& term, BBNodeSet& support)
+{
+  return BBTerm(term, support, false);
+}
+
+const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term, BBNodeSet& support,
+                                   const bool knownMissing)
 {
   ASTNode term = _term; // mutable local copy.
 
-  auto it = BBTermMemo.find(term);
-  if (it != BBTermMemo.end())
+  // Debug-only, and the whole of what holds primeMemos to the blaster: every
+  // node reached from here is one the walk has to have offered, and every
+  // operand the walk primed is one that has to be reached from here.
+  PrimeAudit::Running running(memoAudit, term);
+
+  auto it = BBTermMemo.end();
+  if (!knownMissing)
   {
-    // Constant bit propagation may have updated something.
-    updateTerm(term, it->second, support);
-    return it->second;
+    it = BBTermMemo.find(term);
+    if (it != BBTermMemo.end())
+    {
+      // Constant bit propagation may have updated something.
+      updateTerm(term, it->second, support);
+      return it->second;
+    }
   }
+
+  if (!priming && unprimedDepth >= unprimedDepthLimit)
+  {
+    priming = true;
+    primeMemos(term, support);
+    priming = false;
+
+    it = BBTermMemo.find(term);
+    if (it != BBTermMemo.end())
+    {
+      updateTerm(term, it->second, support);
+      return it->second;
+    }
+  }
+
+  UnprimedDepth depth(unprimedDepth, !priming);
 
   if (uf != NULL && uf->optimize_flag && uf->simplify_during_BB_flag)
   {
@@ -1241,16 +1302,112 @@ const BBNode BitBlaster::BBForm(const ASTNode& form)
     return nf->CreateNode(AND, v);
 }
 
-// bit blast a formula (boolean term).  Result is one bit wide,
-const BBNode BitBlaster::BBForm(const ASTNode& form,
-                                BBNodeSet& support)
+// The operands of a node, in the order the blaster reaches them, where that
+// is not left to right. Only the mirrored floating-point comparisons: to
+// blast fp.lt(a,b) BBcompareFP treats it as fp.gt(b,a) and blasts b first.
+// A walk that primed them left to right would build the same nodes in the
+// other order, and the CNF with them.
+static WalkOperands bbOperands(const ASTNode& n)
 {
-  auto it = BBFormMemo.find(form);
-  if (it != BBFormMemo.end())
+  const Kind k = n.GetKind();
+  if (k != FP_LT && k != FP_LEQ)
+    return WalkOperands::all(n);
+
+  return WalkOperands::reversed(n);
+}
+
+// Blast everything below `n` before `n` itself, so that the calls the
+// blaster makes on its operands all land on a memo and its recursion never
+// goes more than one deep. BBForm reaches its operands by calling itself for
+// the connectives; BBTerm reaches its own from 24 places across a 450-line
+// switch. Neither is restated: filling their memos from the bottom is what
+// makes them stack-safe.
+//
+// One walk over both memos rather than one each. The two sides reach each
+// other freely -- an ITE's condition is a formula inside a term, an
+// equality's operands are terms inside a formula -- so a walk that stopped
+// at the type boundary and left the far side to "the other walk" only works
+// if the other walk is running. It is not: it is guarded against re-entering
+// while this one is in progress. That is how a term below a formula below a
+// term used to go down the stack, and a walk that crosses the boundary
+// itself has no such hole. See DeepDag_Test.cpp.
+//
+// It is sound because of what the blaster does not do. No arm of either
+// function stops before an operand, so every node primed is one that would
+// have been blasted anyway; the order is the order they would have been
+// blasted in, operands first and each finished before the next starts. That
+// is load-bearing -- the CNF must not depend on the order operands happen to
+// be evaluated in, which is why BBForm blasts an ITE's arms into named
+// variables -- and it is what `bbOperands` above exists for.
+void BitBlaster::primeMemos(const ASTNode& n, BBNodeSet& support)
+{
+  primeMemo(
+      n,
+      [this](const ASTNode& node)
+      {
+        if (node.GetType() == BOOLEAN_TYPE)
+        {
+          // Ahead of the constant test below, because BBForm memoises TRUE
+          // and FALSE: the walk hands them over rather than skipping them.
+          if (BBFormMemo.find(node) != BBFormMemo.end())
+            return Walk::Skip; // BBForm would take it from the memo.
+          return node.Degree() == 0 ? Walk::Visit : Walk::Descend;
+        }
+        // A constant operand is skipped: the kinds that carry one --
+        // BVEXTRACT's indices, BVSX's width -- never blast it, and blasting
+        // it here would put a node in the memo the pass never asked for.
+        if (node.isConstant())
+          return Walk::Skip;
+        if (BBTermMemo.find(node) != BBTermMemo.end())
+          return Walk::Skip;
+        return node.Degree() == 0 ? Walk::Visit : Walk::Descend;
+      },
+      bbOperands,
+      [this, &support](const ASTNode& node, PrimeMemoReady)
+      {
+        if (node.GetType() == BOOLEAN_TYPE)
+          BBForm(node, support, true);
+        else
+          BBTerm(node, support, true);
+      });
+}
+
+// bit blast a formula (boolean term).  Result is one bit wide,
+const BBNode BitBlaster::BBForm(const ASTNode& form, BBNodeSet& support)
+{
+  return BBForm(form, support, false);
+}
+
+const BBNode BitBlaster::BBForm(const ASTNode& form, BBNodeSet& support,
+                                const bool knownMissing)
+{
+  // The other half of the audit above: the two memos are primed by one walk,
+  // so the walk is held to both functions at once.
+  PrimeAudit::Running running(memoAudit, form);
+
+  auto it = BBFormMemo.end();
+  if (!knownMissing)
   {
-    // already there.  Just return it.
-    return it->second;
+    it = BBFormMemo.find(form);
+    if (it != BBFormMemo.end())
+    {
+      // already there.  Just return it.
+      return it->second;
+    }
   }
+
+  if (!priming && unprimedDepth >= unprimedDepthLimit)
+  {
+    priming = true;
+    primeMemos(form, support);
+    priming = false;
+
+    it = BBFormMemo.find(form);
+    if (it != BBFormMemo.end())
+      return it->second;
+  }
+
+  UnprimedDepth depth(unprimedDepth, !priming);
 
   const Kind k = form.GetKind();
   if (!is_Form_kind(k))

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -117,3 +117,11 @@ AddSTPGTest(ValueSet_Exhaustive_Test.cpp)
 AddSTPGTest(SearchBias_Test.cpp)
 AddSTPGTest(Bva_Test.cpp)
 AddSTPGTest(FdOStream_Test.cpp)
+# Deeply nested input must not put the AST-depth-recursive traversals through
+# the call stack. Each case runs in a forked child on a 1 MiB stack.
+AddSTPGTest(DeepDag_Test.cpp)
+# Instantiates BBNodeManagerAIG, whose inline members call ABC; a shared
+# libstp localises ABC's symbols, so this links its own copy the way
+# FloatBlast_Test does.
+target_link_libraries(DeepDag_TestTests $<TARGET_FILE:libabc-pic>)
+add_dependencies(DeepDag_TestTests libabc-pic)

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -125,3 +125,7 @@ AddSTPGTest(DeepDag_Test.cpp)
 # FloatBlast_Test does.
 target_link_libraries(DeepDag_TestTests $<TARGET_FILE:libabc-pic>)
 add_dependencies(DeepDag_TestTests libabc-pic)
+# The check that a primed pass still walks what its priming visits. Debug-only,
+# like the audit it drives: under NDEBUG the cases compile away and the binary
+# reports nothing to run.
+AddSTPGTest(PrimeMemo_Test.cpp)

--- a/tests/unit-tests/DeepDag_Test.cpp
+++ b/tests/unit-tests/DeepDag_Test.cpp
@@ -495,6 +495,51 @@ bool bitBlastOk(Context& c, unsigned depth)
   return nm.totalNumberOfNodes() >= static_cast<int>(depth);
 }
 
+// CreateSimpleEQ peels equal sides from two concat chains. Each peel used to
+// re-enter the simplifying node factory and consume another C++ frame.
+bool concatEqualityOk(Context& c, unsigned depth)
+{
+  ASTNode lhsBase = c.mgr.CreateSymbol("concat-lhs", 0, 1);
+  ASTNode rhsBase = c.mgr.CreateSymbol("concat-rhs", 0, 1);
+  ASTNode lhs = lhsBase;
+  ASTNode rhs = rhsBase;
+  for (unsigned i = 1; i < depth; ++i)
+  {
+    const std::string name = "concat-common-" + std::to_string(i);
+    const ASTNode common = c.mgr.CreateSymbol(name.c_str(), 0, 1);
+    lhs = c.hf->CreateTerm(BVCONCAT, i + 1, lhs, common);
+    rhs = c.hf->CreateTerm(BVCONCAT, i + 1, rhs, common);
+  }
+  c.roots.push_back(lhs);
+  c.roots.push_back(rhs);
+
+  const ASTNode expected = c.hf->CreateNode(EQ, lhsBase, rhsBase);
+  const ASTNode result = c.nf->CreateNode(EQ, lhs, rhs);
+  c.roots.push_back(result);
+  return result == expected;
+}
+
+// Constant equality takes both concat branches and rebuilds their two
+// equalities under AND, so it needs a real continuation frame rather than the
+// tail-peeling loop used by the shared-side case above.
+bool concatConstantEqualityOk(Context& c, unsigned depth)
+{
+  ASTNode concat = c.mgr.CreateSymbol("concat-constant-0", 0, 1);
+  for (unsigned i = 1; i < depth; ++i)
+  {
+    const std::string name = "concat-constant-" + std::to_string(i);
+    concat = c.hf->CreateTerm(
+        BVCONCAT, i + 1, concat,
+        c.mgr.CreateSymbol(name.c_str(), 0, 1));
+  }
+  c.roots.push_back(concat);
+
+  const ASTNode result =
+      c.nf->CreateNode(EQ, c.mgr.CreateZeroConst(depth), concat);
+  c.roots.push_back(result);
+  return result.GetType() == BOOLEAN_TYPE;
+}
+
 // NodeDomainAnalysis::buildMap.
 bool nodeDomainOk(Context& c, unsigned depth)
 {
@@ -1302,6 +1347,18 @@ TEST(DeepDag, shallow_bit_blast_nested)
   EXPECT_TRUE(bitBlastNestedOk(c, SHALLOW));
 }
 
+TEST(DeepDag, shallow_concat_equality)
+{
+  Context c;
+  EXPECT_TRUE(concatEqualityOk(c, SHALLOW));
+}
+
+TEST(DeepDag, shallow_concat_constant_equality)
+{
+  Context c;
+  EXPECT_TRUE(concatConstantEqualityOk(c, SHALLOW));
+}
+
 TEST(DeepDag, shallow_mutable_dag_walks)
 {
   Context c;
@@ -1485,6 +1542,14 @@ TEST(DeepDag, deep_bit_blast_nested)
 TEST(DeepDag, deep_common_sub_sum)              { EXPECT_STACK_SAFE(commonSubSumOk, 20000); }
 TEST(DeepDag, deep_work_list)          { EXPECT_STACK_SAFE(workListOk, 20000); }
 TEST(DeepDag, deep_remove_unconstrained) { EXPECT_STACK_SAFE(removeUnconstrainedOk, 20000); }
+TEST(DeepDag, deep_concat_equality)
+{
+  EXPECT_STACK_SAFE(concatEqualityOk, 20000);
+}
+TEST(DeepDag, deep_concat_constant_equality)
+{
+  EXPECT_STACK_SAFE(concatConstantEqualityOk, 4000);
+}
 TEST(DeepDag, deep_mutable_dag_walks)
 {
   EXPECT_STACK_SAFE(mutableDagWalksOk, 20000);

--- a/tests/unit-tests/DeepDag_Test.cpp
+++ b/tests/unit-tests/DeepDag_Test.cpp
@@ -568,6 +568,214 @@ bool propagateEqualitiesOk(Context& c, unsigned depth)
   return pe.topLevel(f).GetKind() != UNDEFINED;
 }
 
+// MutableASTNode::build, the up-and-down graph unconstrained-variable
+// elimination runs on. Not an AST walk by signature -- it hands back a
+// MutableASTNode, so the recursion checker's ASTNode test never saw it --
+// but it descends the input DAG all the same, and this is the shape that
+// found it: a formula that alternates NOT and AND has no flat spine for the
+// simplifier to collapse, so it reaches RemoveUnconstrained as deep as it
+// was written.
+bool removeUnconstrainedOk(Context& c, unsigned depth)
+{
+  ASTNode f = c.hf->CreateNode(EQ, c.mgr.CreateSymbol("u0", 0, 8),
+                               c.mgr.CreateZeroConst(8));
+  for (unsigned i = 1; i < depth; i++)
+  {
+    const std::string nm = "u" + std::to_string(i);
+    f = c.hf->CreateNode(
+        NOT, c.hf->CreateNode(
+                 AND, c.hf->CreateNode(EQ, c.mgr.CreateSymbol(nm.c_str(), 0, 8),
+                                       c.mgr.CreateZeroConst(8)),
+                 f));
+  }
+  c.roots.push_back(f);
+
+  c.mgr.UserFlags.optimize_flag = true;
+  SubstitutionMap sm(&c.mgr);
+  Simplifier simp(&c.mgr, &sm);
+  RemoveUnconstrained ru(c.mgr);
+  const ASTNode result = ru.topLevel(f, &simp);
+  c.roots.push_back(result);
+  return result.GetKind() != UNDEFINED;
+}
+
+// The mutable graph has walks in both directions: invariant/variable scans
+// and dirty rebuilding go down, dirty propagation goes up, and detaching an
+// orphaned subtree tears it down in post-order. Exercise all of them on the
+// same chain so none can hide behind MutableASTNode::build's iterative walk.
+bool mutableDagWalksOk(Context& c, unsigned depth)
+{
+  const ASTNode input = c.chain(BVXOR, depth);
+  c.roots.push_back(input);
+  MutableASTNode* root = MutableASTNode::build(input);
+
+  bool ok = root->checkInvariant();
+  vector<MutableASTNode*> symbols;
+  std::unordered_set<MutableASTNode*> visited;
+  root->getAllVariablesRecursively(symbols, visited);
+  ok = ok && symbols.size() == depth;
+
+  MutableASTNode* leaf = root;
+  unsigned pathDepth = 0;
+  while (!leaf->isSymbol())
+  {
+    MutableASTNode* next = NULL;
+    for (MutableASTNode* child : leaf->children)
+      if (!child->isSymbol())
+      {
+        next = child;
+        break;
+      }
+    leaf = next == NULL ? leaf->children[0] : next;
+    pathDepth++;
+  }
+  ok = ok && pathDepth == depth - 1;
+
+  vector<MutableASTNode*> variables;
+  leaf->replaceWithVar(c.mgr.CreateSymbol("mutable-leaf", 0, 8), variables);
+  const ASTNode rebuilt = root->toASTNode(&c.mgr);
+  c.roots.push_back(rebuilt);
+  ok = ok && rebuilt != input && !variables.empty();
+
+  // Replacing the root orphans the whole rebuilt chain. removeChildren must
+  // finish that teardown without using one call frame per level.
+  root->replaceWithVar(c.mgr.CreateSymbol("mutable-root", 0, 8), variables);
+  ok = ok && root->toASTNode(&c.mgr) == root->n && root->checkInvariant();
+  MutableASTNode::cleanup();
+  return ok;
+}
+
+// Root-level no-ops should not need a traversal worklist: a repeated variable
+// scan is already visited, a symbol has no children to remove, and propagating
+// from an already-dirty replacement has nowhere new to go.
+bool mutableDagRootFastPathsOk(Context& c)
+{
+  const ASTNode original = c.mgr.CreateSymbol("mutable-fast-original", 0, 8);
+  MutableASTNode* root = MutableASTNode::build(original);
+
+  vector<MutableASTNode*> symbols;
+  std::unordered_set<MutableASTNode*> visited;
+  root->getAllVariablesRecursively(symbols, visited);
+  root->getAllVariablesRecursively(symbols, visited);
+
+  vector<MutableASTNode*> variables;
+  root->removeChildren(variables);
+  const ASTNode replacement =
+      c.mgr.CreateSymbol("mutable-fast-replacement", 0, 8);
+  root->replaceWithVar(replacement, variables);
+  root->propagateUpDirty();
+
+  const bool ok = symbols.size() == 1 && symbols[0] == root &&
+                  variables.empty() && root->toASTNode(&c.mgr) == replacement;
+  MutableASTNode::cleanup();
+  return ok;
+}
+
+// A parent consumes a newly built child directly when its child frame
+// returns; it must not need to find that child in `visited` a second time.
+// Mix misses and a shared hit so the continuation is pinned to the right
+// child position as well as to the right mutable node.
+bool mutableDagBuildResumeOrderOk(Context& c)
+{
+  const ASTNode a = c.mgr.CreateSymbol("mutable-build-a", 0, 8);
+  const ASTNode b = c.mgr.CreateSymbol("mutable-build-b", 0, 8);
+  const ASTNode d = c.mgr.CreateSymbol("mutable-build-d", 0, 8);
+  const ASTNode left = c.hf->CreateTerm(BVXOR, 8, a, b);
+  const ASTNode right = c.hf->CreateTerm(BVAND, 8, b, d);
+  const ASTNode top = c.hf->CreateTerm(BVPLUS, 8, left, right, left);
+  c.roots.push_back(top);
+
+  std::unordered_map<uint64_t, MutableASTNode*> nodes;
+  MutableASTNode* root = MutableASTNode::build(top, nodes);
+  bool ok = root->children.size() == top.Degree() && nodes.size() == 6;
+  for (size_t i = 0; ok && i < top.Degree(); ++i)
+  {
+    const auto child = nodes.find(top[i].GetNodeNum());
+    ok = child != nodes.end() && root->children[i] == child->second;
+  }
+
+  const auto leftNode = nodes.find(left.GetNodeNum());
+  size_t leftEdges = 0;
+  if (leftNode != nodes.end())
+  {
+    for (MutableASTNode* child : root->children)
+      leftEdges += child == leftNode->second;
+  }
+  ok = ok && leftNode != nodes.end() && leftEdges == 2 &&
+       leftNode->second->parents.count(root) == 1;
+  MutableASTNode::cleanup();
+  return ok;
+}
+
+// Dirty rebuilding can reach the same mutable child through more than one
+// parent. The first route rebuilds it and later routes reuse the stored AST;
+// the parent must gather both answers in operand order even though rebuild
+// frames no longer retain their own child vectors.
+bool mutableDagSharedRebuildOk(Context& c)
+{
+  const ASTNode x = c.mgr.CreateSymbol("mutable-rebuild-x", 0, 8);
+  const ASTNode y = c.mgr.CreateSymbol("mutable-rebuild-y", 0, 8);
+  const ASTNode z = c.mgr.CreateSymbol("mutable-rebuild-z", 0, 8);
+  const ASTNode shared = c.hf->CreateTerm(BVXOR, 8, x, y);
+  const ASTNode left = c.hf->CreateTerm(BVPLUS, 8, shared, z);
+  const ASTNode right = c.hf->CreateTerm(BVAND, 8, z, shared);
+  const ASTNode top = c.hf->CreateTerm(BVPLUS, 8, left, right, z);
+  c.roots.push_back(top);
+
+  std::unordered_map<uint64_t, MutableASTNode*> nodes;
+  MutableASTNode* root = MutableASTNode::build(top, nodes);
+  vector<MutableASTNode*> variables;
+  const ASTNode replacement =
+      c.mgr.CreateSymbol("mutable-rebuild-replacement", 0, 8);
+  nodes.at(x.GetNodeNum())->replaceWithVar(replacement, variables);
+
+  const ASTNode expectedShared =
+      c.hf->CreateTerm(BVXOR, 8, replacement, y);
+  const ASTNode expectedLeft =
+      c.hf->CreateTerm(BVPLUS, 8, expectedShared, z);
+  const ASTNode expectedRight =
+      c.hf->CreateTerm(BVAND, 8, z, expectedShared);
+  const ASTNode expected =
+      c.hf->CreateTerm(BVPLUS, 8, expectedLeft, expectedRight, z);
+  const ASTNode rebuilt = root->toASTNode(&c.mgr);
+  c.roots.push_back(rebuilt);
+
+  const bool ok = rebuilt == expected && root->toASTNode(&c.mgr) == rebuilt &&
+                  variables.size() == 1 && root->checkInvariant();
+  MutableASTNode::cleanup();
+  return ok;
+}
+
+// Mutable parents are a set, so two edges from one parent represent one
+// parent relationship. Detaching such a DAG must likewise process that
+// relationship once. Otherwise every duplicate edge revisits an already
+// orphaned child: n[i] = xor(n[i-1], n[i-1]) takes 2^i work, and a symbol
+// retained by another parent is reported once per path.
+bool mutableDagRepeatedEdgesOk(Context& c)
+{
+  const ASTNode shared = c.mgr.CreateSymbol("mutable-shared", 0, 8);
+  ASTNode repeated = shared;
+  for (unsigned i = 0; i < 12; ++i)
+    repeated = c.hf->CreateTerm(BVXOR, 8, repeated, repeated);
+
+  const ASTNode keeper = c.hf->CreateTerm(
+      BVXOR, 8, shared,
+      c.mgr.CreateSymbol("mutable-keeper-child", 0, 8));
+  const ASTNode top = c.hf->CreateTerm(BVPLUS, 8, repeated, keeper);
+  c.roots.push_back(top);
+
+  std::unordered_map<uint64_t, MutableASTNode*> nodes;
+  MutableASTNode::build(top, nodes);
+  MutableASTNode* repeatedMutable = nodes.at(repeated.GetNodeNum());
+
+  vector<MutableASTNode*> variables;
+  repeatedMutable->removeChildren(variables);
+  const bool ok = variables.size() == 1 && variables[0]->n == shared &&
+                  variables[0]->parents.size() == 1;
+  MutableASTNode::cleanup();
+  return ok;
+}
+
 // FlattenKind, which every pass that wants an n-ary view of a nested
 // same-kind chain goes through: the simplifier, the BV solver,
 // PropagateEqualities, MergeSame and UseITEContext. Its two forms differ in
@@ -1000,6 +1208,12 @@ TEST(DeepDag, shallow_bit_blast_nested)
   EXPECT_TRUE(bitBlastNestedOk(c, SHALLOW));
 }
 
+TEST(DeepDag, shallow_mutable_dag_walks)
+{
+  Context c;
+  EXPECT_TRUE(mutableDagWalksOk(c, SHALLOW));
+}
+
 TEST(DeepDag, node_iterator_preserves_lifo_dag_order)
 {
   Context c;
@@ -1070,6 +1284,30 @@ TEST(DeepDag, shallow_array_read_count_walk)
   EXPECT_TRUE(numberOfReadsWalkOk(c, SHALLOW));
 }
 
+TEST(DeepDag, mutable_dag_root_fast_paths_preserve_no_ops)
+{
+  Context c;
+  EXPECT_TRUE(mutableDagRootFastPathsOk(c));
+}
+
+TEST(DeepDag, mutable_dag_repeated_edges_are_detached_once)
+{
+  Context c;
+  EXPECT_TRUE(mutableDagRepeatedEdgesOk(c));
+}
+
+TEST(DeepDag, mutable_dag_build_consumes_returned_children_in_order)
+{
+  Context c;
+  EXPECT_TRUE(mutableDagBuildResumeOrderOk(c));
+}
+
+TEST(DeepDag, mutable_dag_shared_children_rebuild_in_operand_order)
+{
+  Context c;
+  EXPECT_TRUE(mutableDagSharedRebuildOk(c));
+}
+
 TEST(DeepDag, deep_rewriting_share_count)
 {
   EXPECT_STACK_SAFE(rewritingIdentityOk, 200000);
@@ -1136,6 +1374,11 @@ TEST(DeepDag, deep_bit_blast_nested)
 }
 
 TEST(DeepDag, deep_common_sub_sum)              { EXPECT_STACK_SAFE(commonSubSumOk, 20000); }
+TEST(DeepDag, deep_remove_unconstrained) { EXPECT_STACK_SAFE(removeUnconstrainedOk, 20000); }
+TEST(DeepDag, deep_mutable_dag_walks)
+{
+  EXPECT_STACK_SAFE(mutableDagWalksOk, 20000);
+}
 TEST(DeepDag, deep_node_domain)        { EXPECT_STACK_SAFE(nodeDomainOk, 20000); }
 TEST(DeepDag, deep_node_iterator)      { EXPECT_STACK_SAFE(nodeIteratorOk, 20000); }
 TEST(DeepDag, deep_vars_in_expression) { EXPECT_STACK_SAFE(varsInExpressionOk, 20000); }

--- a/tests/unit-tests/DeepDag_Test.cpp
+++ b/tests/unit-tests/DeepDag_Test.cpp
@@ -245,6 +245,8 @@ size_t dagDepth(const ASTNode& top)
 
   return result;
 }
+#endif // STP_ENABLE_FLOATING_POINT
+
 
 // A chain of if-then-else terms, nested in the else-branch: a boolean symbol
 // the model says nothing about takes false, so evaluating one descends the
@@ -258,6 +260,7 @@ ASTNode iteChain(Context& c, unsigned depth)
     t = c.hf->CreateTerm(ITE, 8, cond, zero, t);
   return t;
 }
+#ifdef STP_ENABLE_FLOATING_POINT
 
 // A chain of stores over one array symbol, whose elements are `width` bits.
 ASTNode storeChain(Context& c, unsigned depth, const ASTNode& base,
@@ -1470,6 +1473,92 @@ bool transformFormulaSpineOk(Context& c, unsigned depth)
   c.roots.push_back(result);
   return result.GetKind() != UNDEFINED;
 }
+
+// Counterexample evaluation. TermToConstTermUsingModel and
+// ComputeFormulaUsingModel evaluate the ORIGINAL formula against the model a
+// sat answer produced, and reached each other once per level of it, so a term
+// nested deeply enough took the stack with them. Two frames per level: a
+// chain of 30,000 selects died here at the ordinary 8 MiB, and it was the
+// last thing on that input's path that did.
+//
+// Neither generic tool fits, which is why it is a state machine. The term
+// side has no memo to prime -- only CounterExampleMap, written for array
+// reads and float encodings -- and a memo could not be keyed on the node
+// alone anyway, since the answer depends on ArrayReadFlag and on whether the
+// walk is already inside an encoded evaluation. And both sides evaluate an
+// if-then-else's condition and then only the branch it leaves alive, where a
+// dropped branch is not merely wasted work: it can be genuinely unevaluable
+// against the model, and both call FatalError when it is. So priming would
+// turn a working query into an abort.
+//
+// No solve is needed to reach it: with an empty model every symbol takes its
+// default and the walk still descends the whole term.
+bool counterExampleEvalOk(Context& c, unsigned depth)
+{
+  const ASTNode a = c.mgr.CreateSymbol("A", 8, 8);
+  ASTNode t = c.mgr.CreateSymbol("i", 0, 8);
+  for (unsigned i = 0; i < depth; i++)
+    t = c.hf->CreateTerm(READ, 8, a, t);
+
+  const ASTNode f = c.formula(t);
+  c.roots.push_back(f);
+
+  SubstitutionMap sm(&c.mgr);
+  Simplifier simp(&c.mgr, &sm);
+  ArrayTransformer at(&c.mgr, &simp);
+  AbsRefine_CounterExample ce(&c.mgr, &simp, &at);
+
+  return ce.ComputeFormulaUsingModel(f).isConstant();
+}
+
+// The formula side's own spine, which is the arm nearly every query reaches:
+// a connective evaluates each operand and rebuilds over the answers.
+bool counterExampleFormulaOk(Context& c, unsigned depth)
+{
+  ASTNode f = c.hf->CreateNode(EQ, c.mgr.CreateSymbol("t0", 0, 8),
+                               c.mgr.CreateZeroConst(8));
+  for (unsigned i = 1; i < depth; i++)
+  {
+    const std::string nm = "t" + std::to_string(i);
+    f = c.hf->CreateNode(
+        NOT, c.hf->CreateNode(
+                 AND, c.hf->CreateNode(EQ, c.mgr.CreateSymbol(nm.c_str(), 0, 8),
+                                       c.mgr.CreateZeroConst(8)),
+                 f));
+  }
+  c.roots.push_back(f);
+
+  SubstitutionMap sm(&c.mgr);
+  Simplifier simp(&c.mgr, &sm);
+  ArrayTransformer at(&c.mgr, &simp);
+  AbsRefine_CounterExample ce(&c.mgr, &simp, &at);
+
+  return ce.ComputeFormulaUsingModel(f).isConstant();
+}
+
+// A chain of if-then-else terms, which is the shape the two functions are
+// mutually recursive for: each level evaluates a condition as a formula and
+// then descends into the branch it leaves alive as a term.
+//
+// This case wanted the float format of each level derived as the chain was
+// built, because asking a nested if-then-else its type used to overflow
+// deriving that format before this walk got a turn. deep_fp_format_ite below
+// is that recursion, converted and tested on its own, so the chain is left
+// cold here.
+bool counterExampleTermIteOk(Context& c, unsigned depth)
+{
+  const ASTNode t = iteChain(c, depth);
+  c.roots.push_back(t);
+
+  SubstitutionMap sm(&c.mgr);
+  Simplifier simp(&c.mgr, &sm);
+  ArrayTransformer at(&c.mgr, &simp);
+  AbsRefine_CounterExample ce(&c.mgr, &simp, &at);
+
+  // ModelValueOfTerm asks with the read-tolerant flag off, so every level has
+  // to come back a constant.
+  return ce.ModelValueOfTerm(t).GetKind() == BVCONST;
+}
 #ifdef STP_ENABLE_FLOATING_POINT
 
 /* A node's floating-point format and its source sort are both derived from
@@ -2040,6 +2129,84 @@ TEST(DeepDag, mutable_dag_shared_children_rebuild_in_operand_order)
   EXPECT_TRUE(mutableDagSharedRebuildOk(c));
 }
 
+TEST(DeepDag, counterexample_prechecked_heads_preserve_model_values)
+{
+  Context c;
+  SubstitutionMap sm(&c.mgr);
+  Simplifier simp(&c.mgr, &sm);
+  ArrayTransformer transformer(&c.mgr, &simp);
+  AbsRefine_CounterExample ce(&c.mgr, &simp, &transformer);
+
+  const ASTNode zero = c.mgr.CreateZeroConst(8);
+  const ASTNode one = c.mgr.CreateOneConst(8);
+
+  // Constants and Boolean constants are answered by the job head itself.
+  EXPECT_EQ(zero, ce.ModelValueOfTerm(zero));
+  EXPECT_EQ(c.mgr.ASTTrue, ce.ModelValueOfFormula(c.mgr.ASTTrue));
+  EXPECT_EQ(c.mgr.ASTFalse, ce.ModelValueOfFormula(c.mgr.ASTFalse));
+
+  // A recorded non-constant still needs a frame, but the map lookup that
+  // discovered its image must carry through to that frame rather than being
+  // repeated when it starts.
+  const ASTNode x = c.mgr.CreateSymbol("ce-head-x", 0, 8);
+  const ASTNode y = c.mgr.CreateSymbol("ce-head-y", 0, 8);
+  ce.InsertIntoCounterExampleMap(x, y);
+  ce.InsertIntoCounterExampleMap(y, one);
+  EXPECT_EQ(one, ce.ModelValueOfTerm(x));
+
+  const ASTNode p = c.mgr.CreateSymbol("ce-head-p", 0, 0);
+  ce.InsertIntoCounterExampleMap(p, c.mgr.ASTTrue);
+  EXPECT_EQ(c.mgr.ASTTrue, ce.ModelValueOfFormula(p));
+  // The second question is a ComputeFormulaMap root hit.
+  EXPECT_EQ(c.mgr.ASTTrue, ce.ModelValueOfFormula(p));
+
+  // Exercise the corresponding prechecked image path in the read-over-write
+  // expander, not merely the term and formula jobs.
+  const ASTNode array = c.mgr.CreateSymbol("ce-head-array", 8, 8);
+  const ASTNode write = c.hf->CreateArrayTerm(WRITE, 8, 8, array, zero, one);
+  const ASTNode read = c.hf->CreateTerm(READ, 8, write, zero);
+  const ASTNode recorded = c.mgr.CreateSymbol("ce-head-read", 0, 8);
+  ce.InsertIntoCounterExampleMap(read, recorded);
+  ce.InsertIntoCounterExampleMap(recorded, one);
+  EXPECT_EQ(one, ce.Expand_ReadOverWrite_UsingModel(read, false));
+}
+
+TEST(DeepDag, counterexample_consumes_ready_descendants_in_place)
+{
+  Context c;
+  SubstitutionMap sm(&c.mgr);
+  Simplifier simp(&c.mgr, &sm);
+  ArrayTransformer transformer(&c.mgr, &simp);
+  AbsRefine_CounterExample ce(&c.mgr, &simp, &transformer);
+
+  const ASTNode zero = c.mgr.CreateZeroConst(8);
+  const ASTNode one = c.mgr.CreateOneConst(8);
+  const ASTNode x = c.mgr.CreateSymbol("ce-ready-x", 0, 8);
+  const ASTNode y = c.mgr.CreateSymbol("ce-ready-y", 0, 8);
+  ce.InsertIntoCounterExampleMap(x, one);
+  ce.InsertIntoCounterExampleMap(y, zero);
+
+  // Both term operands are immediate model-map hits. The containing formula
+  // then consumes the completed term without suspending either job.
+  const ASTNode sum = c.hf->CreateTerm(BVPLUS, 8, x, y);
+  const ASTNode equality = c.hf->CreateNode(EQ, sum, one);
+  EXPECT_EQ(c.mgr.ASTTrue, ce.ModelValueOfFormula(equality));
+
+  // A formula memo hit follows the same continuation path.
+  const ASTNode p = c.mgr.CreateSymbol("ce-ready-p", 0, 0);
+  ce.InsertIntoCounterExampleMap(p, c.mgr.ASTTrue);
+  EXPECT_EQ(c.mgr.ASTTrue, ce.ModelValueOfFormula(p));
+  EXPECT_EQ(c.mgr.ASTTrue,
+            ce.ModelValueOfFormula(c.hf->CreateNode(AND, p, p)));
+
+  // The read-over-write expander consumes constant indexes and the selected
+  // value directly as well.
+  const ASTNode array = c.mgr.CreateSymbol("ce-ready-array", 8, 8);
+  const ASTNode write = c.hf->CreateArrayTerm(WRITE, 8, 8, array, zero, one);
+  const ASTNode read = c.hf->CreateTerm(READ, 8, write, zero);
+  EXPECT_EQ(one, ce.Expand_ReadOverWrite_UsingModel(read, false));
+}
+
 TEST(DeepDag, array_transformer_job_specific_operands_preserve_paths)
 {
   Context c;
@@ -2295,6 +2462,9 @@ TEST(DeepDag, deep_fp_totalise)        { EXPECT_STACK_SAFE(fpTotaliseChainOk, 20
 #endif // STP_ENABLE_FLOATING_POINT
 
 TEST(DeepDag, deep_printer_lisp)       { EXPECT_STACK_SAFE(printerLispOk, 20000); }
+TEST(DeepDag, deep_counterexample_eval) { EXPECT_STACK_SAFE(counterExampleEvalOk, 20000); }
+TEST(DeepDag, deep_counterexample_formula) { EXPECT_STACK_SAFE(counterExampleFormulaOk, 20000); }
+TEST(DeepDag, deep_counterexample_term_ite) { EXPECT_STACK_SAFE(counterExampleTermIteOk, 20000); }
 #ifdef STP_ENABLE_FLOATING_POINT
 TEST(DeepDag, deep_fp_format_ite)      { EXPECT_STACK_SAFE(fpFormatIteChainOk, 20000); }
 TEST(DeepDag, deep_fp_format_store)    { EXPECT_STACK_SAFE(fpFormatStoreChainOk, 20000); }
@@ -2303,4 +2473,5 @@ TEST(DeepDag, deep_source_sort_store)  { EXPECT_STACK_SAFE(sourceSortStoreChainO
 #endif // STP_ENABLE_FLOATING_POINT
 
 TEST(DeepDag, DISABLED_deep_printer_smtlib2)    { EXPECT_STACK_SAFE(printerSMTLIB2Ok, 20000); }
+
 } // namespace

--- a/tests/unit-tests/DeepDag_Test.cpp
+++ b/tests/unit-tests/DeepDag_Test.cpp
@@ -530,6 +530,37 @@ bool propagateEqualitiesOk(Context& c, unsigned depth)
   return pe.topLevel(f).GetKind() != UNDEFINED;
 }
 
+// FlattenKind, which every pass that wants an n-ary view of a nested
+// same-kind chain goes through: the simplifier, the BV solver,
+// PropagateEqualities, MergeSame and UseITEContext. Its two forms differ in
+// whether they dedup or take a depth limit, and a chain of the kind being
+// flattened reaches each of them one level at a time.
+//
+// The deduplicating form is the one AND, OR, BVAND and BVOR take, and it
+// ignores the depth limit entirely.
+bool flattenKindNoDuplicatesOk(Context& c, unsigned depth)
+{
+  const ASTNode top = c.chain(BVAND, depth);
+  c.roots.push_back(top);
+
+  // The chain is left-nested, so flattening the top node yields every symbol
+  // in it -- which is also how we know the walk reached the bottom.
+  const ASTVec flat = FlattenKind(BVAND, top.GetChildren(), 15);
+  return flat.size() == depth;
+}
+
+// The depth-limited form, which the arithmetic kinds take -- with no limit at
+// all from two of the simplifier's arms, which is where its own recursion is
+// as deep as the chain.
+bool flattenKindDepthOk(Context& c, unsigned depth)
+{
+  const ASTNode top = c.chain(BVPLUS, depth);
+  c.roots.push_back(top);
+
+  const ASTVec flat = FlattenKind(BVPLUS, top.GetChildren());
+  return flat.size() == depth;
+}
+
 // CommonSubSum::topLevel. Already stack-safe; here to keep it that way.
 bool commonSubSumOk(Context& c, unsigned depth)
 {
@@ -538,6 +569,24 @@ bool commonSubSumOk(Context& c, unsigned depth)
   CommonSubSum css(&c.mgr, c.nf);
   ASTNode g = f;
   return css.topLevel(g).GetKind() != UNDEFINED;
+}
+
+// The read-count heuristic must traverse a read-free deep term without C++
+// recursion. Once its strict limit is reached, it must also stop the whole
+// traversal rather than continuing into a later deep sibling.
+bool numberOfReadsWalkOk(Context& c, unsigned depth)
+{
+  const ASTNode deep = c.chain(BVXOR, depth);
+  c.roots.push_back(deep);
+  if (!numberOfReadsLessThan(deep, 1))
+    return false;
+
+  const ASTNode array = c.mgr.CreateSymbol("read-count-array", 8, 8);
+  const ASTNode index = c.mgr.CreateSymbol("read-count-index", 0, 8);
+  const ASTNode read = c.hf->CreateTerm(READ, 8, array, index);
+  const ASTNode earlyStop = c.hf->CreateTerm(BVCONCAT, 16, read, deep);
+  c.roots.push_back(earlyStop);
+  return !numberOfReadsLessThan(earlyStop, 1);
 }
 #ifdef STP_ENABLE_FLOATING_POINT
 
@@ -811,6 +860,47 @@ TEST(DeepDag, substitution_root_fast_paths_preserve_results)
                                             true, false));
 }
 
+TEST(DeepDag, shallow_flatten_kind_no_duplicates)
+{
+  Context c;
+  EXPECT_TRUE(flattenKindNoDuplicatesOk(c, SHALLOW));
+}
+
+TEST(DeepDag, shallow_flatten_kind_depth)
+{
+  Context c;
+  EXPECT_TRUE(flattenKindDepthOk(c, SHALLOW));
+}
+
+TEST(DeepDag, flat_flatten_kind_preserves_children)
+{
+  Context c;
+  ASTVec children;
+  for (unsigned i = 0; i < 4; ++i)
+  {
+    const std::string name = "flat" + std::to_string(i);
+    children.push_back(c.mgr.CreateSymbol(name.c_str(), 0, 8));
+  }
+  const ASTNode holder = c.hf->CreateTerm(BVXOR, 8, children);
+  const ASTVec expected = toASTVec(holder.GetChildren());
+
+  EXPECT_EQ(expected, FlattenKind(BVAND, holder.GetChildren()));
+  EXPECT_EQ(expected, FlattenKind(BVPLUS, holder.GetChildren()));
+}
+
+TEST(DeepDag, duplicate_flatten_kind_does_not_reserve_discarded_edges)
+{
+  Context c;
+  const ASTNode a = c.mgr.CreateSymbol("flat-shared-a", 0, 8);
+  const ASTNode b = c.mgr.CreateSymbol("flat-shared-b", 0, 8);
+  const ASTNode shared = c.hf->CreateTerm(BVAND, 8, a, b);
+  const ASTNode holder = c.hf->CreateTerm(BVXOR, 8, ASTVec(4096, shared));
+
+  const ASTVec flat = FlattenKind(BVAND, holder.GetChildren());
+  EXPECT_EQ(toASTVec(shared.GetChildren()), flat);
+  EXPECT_LT(flat.capacity(), holder.Degree());
+}
+
 TEST(DeepDag, shallow_strength_reduction)
 {
   Context c;
@@ -880,6 +970,31 @@ TEST(DeepDag, shallow_source_sort_store)
 #endif // STP_ENABLE_FLOATING_POINT
 
 
+TEST(DeepDag, array_read_count_is_strict_and_deduplicates_the_dag)
+{
+  Context c;
+  const ASTNode array = c.mgr.CreateSymbol("read-count-shared-array", 8, 8);
+  const ASTNode i = c.mgr.CreateSymbol("read-count-shared-i", 0, 8);
+  const ASTNode j = c.mgr.CreateSymbol("read-count-shared-j", 0, 8);
+  const ASTNode first = c.hf->CreateTerm(READ, 8, array, i);
+  const ASTNode second = c.hf->CreateTerm(READ, 8, array, j);
+  const ASTNode top =
+      c.hf->CreateTerm(BVXOR, 8, ASTVec{first, first, second});
+  c.roots.push_back(top);
+
+  EXPECT_TRUE(numberOfReadsLessThan(top, 3));
+  EXPECT_FALSE(numberOfReadsLessThan(top, 2));
+  EXPECT_FALSE(numberOfReadsLessThan(first, 1));
+  EXPECT_TRUE(numberOfReadsLessThan(first, 2));
+  EXPECT_FALSE(numberOfReadsLessThan(top, 0));
+}
+
+TEST(DeepDag, shallow_array_read_count_walk)
+{
+  Context c;
+  EXPECT_TRUE(numberOfReadsWalkOk(c, SHALLOW));
+}
+
 TEST(DeepDag, deep_rewriting_share_count)
 {
   EXPECT_STACK_SAFE(rewritingIdentityOk, 200000);
@@ -910,6 +1025,16 @@ TEST(DeepDag, deep_substitution)
   EXPECT_STACK_SAFE(substitutionOk, 20000);
 }
 
+TEST(DeepDag, deep_flatten_kind_no_duplicates)
+{
+  EXPECT_STACK_SAFE(flattenKindNoDuplicatesOk, 20000);
+}
+
+TEST(DeepDag, deep_flatten_kind_depth)
+{
+  EXPECT_STACK_SAFE(flattenKindDepthOk, 20000);
+}
+
 TEST(DeepDag, deep_strength_reduction)
 {
   EXPECT_STACK_SAFE(strengthReductionOk, 20000);
@@ -935,6 +1060,10 @@ TEST(DeepDag, deep_node_domain)        { EXPECT_STACK_SAFE(nodeDomainOk, 20000);
 TEST(DeepDag, deep_node_iterator)      { EXPECT_STACK_SAFE(nodeIteratorOk, 20000); }
 TEST(DeepDag, deep_vars_in_expression) { EXPECT_STACK_SAFE(varsInExpressionOk, 20000); }
 TEST(DeepDag, deep_propagate_equalities) { EXPECT_STACK_SAFE(propagateEqualitiesOk, 20000); }
+TEST(DeepDag, deep_array_read_count_walk)
+{
+  EXPECT_STACK_SAFE(numberOfReadsWalkOk, 20000);
+}
 #ifdef STP_ENABLE_FLOATING_POINT
 TEST(DeepDag, deep_fp_totalise)        { EXPECT_STACK_SAFE(fpTotaliseChainOk, 20000); }
 TEST(DeepDag, deep_fp_format_ite)      { EXPECT_STACK_SAFE(fpFormatIteChainOk, 20000); }

--- a/tests/unit-tests/DeepDag_Test.cpp
+++ b/tests/unit-tests/DeepDag_Test.cpp
@@ -200,6 +200,42 @@ struct Context
     return n;
   }
 };
+#ifdef STP_ENABLE_FLOATING_POINT
+
+// A chain of if-then-else terms, nested in the else-branch: a boolean symbol
+// the model says nothing about takes false, so evaluating one descends the
+// chain rather than stopping at the first level.
+ASTNode iteChain(Context& c, unsigned depth)
+{
+  const ASTNode cond = c.mgr.CreateSymbol("p", 0, 0);
+  const ASTNode zero = c.mgr.CreateZeroConst(8);
+  ASTNode t = c.mgr.CreateSymbol("x", 0, 8);
+  for (unsigned i = 0; i < depth; i++)
+    t = c.hf->CreateTerm(ITE, 8, cond, zero, t);
+  return t;
+}
+
+// A chain of stores over one array symbol, whose elements are `width` bits.
+ASTNode storeChain(Context& c, unsigned depth, const ASTNode& base,
+                   unsigned width = 8)
+{
+  ASTNode a = base;
+  for (unsigned i = 0; i < depth; i++)
+  {
+    const std::string nm = "w" + std::to_string(i);
+    a = c.hf->CreateArrayTerm(WRITE, 8, width, a,
+                              c.mgr.CreateSymbol(nm.c_str(), 0, 8),
+                              c.mgr.CreateZeroConst(width));
+  }
+  return a;
+}
+
+ASTNode storeChain(Context& c, unsigned depth)
+{
+  return storeChain(c, depth, c.mgr.CreateSymbol("A", 8, 8));
+}
+#endif // STP_ENABLE_FLOATING_POINT
+
 
 // Rewriting::rewrite (19 of the 21 known corpus crashes, ~9,300 nested
 // frames deep) and, ahead of it in the same pass, the equally unbounded
@@ -318,6 +354,93 @@ bool strengthReductionOk(Context& c, unsigned depth)
   return result == top;
 }
 
+// BitBlaster::BBTerm, which reaches its operands by calling itself from 24
+// places across its kind switch. The blaster uses ordinary recursion for a
+// bounded prefix, then fills the remaining suffix of its memo from the bottom
+// first. This depth is well beyond that boundary.
+bool bitBlastTermOk(Context& c, unsigned depth)
+{
+  const ASTNode f = c.formula(c.chain(BVXOR, depth));
+  c.roots.push_back(f);
+
+  SubstitutionMap sm(&c.mgr);
+  Simplifier simp(&c.mgr, &sm);
+  BBNodeManagerAIG nm;
+  BitBlaster bb(&nm, &simp, c.nf, &c.mgr.UserFlags);
+  bb.BBForm(f);
+
+  // Every xor in the chain is 8 bits of AIG, so this cannot pass without
+  // the whole chain having been blasted.
+  return nm.totalNumberOfNodes() >= static_cast<int>(depth);
+}
+
+// A deep term that is only reachable through a formula that is only
+// reachable through a term: the chain is an equality's operand, the equality
+// is an ITE's condition, and the ITE is a term. Priming each memo on its own
+// left this to the recursion -- the walk over terms handed the condition to
+// BBForm and stopped, and the walk over formulas was suppressed while the
+// first was running, so nothing primed the chain and BBTerm descended it a
+// frame at a time.
+ASTNode termUnderFormulaUnderTerm(Context& c, unsigned depth)
+{
+  const ASTNode chain = c.chain(BVXOR, depth);
+  const ASTNode cond = c.hf->CreateNode(EQ, chain, c.mgr.CreateZeroConst(8));
+  const ASTNode y0 = c.mgr.CreateSymbol("y0", 0, 8);
+  const ASTNode y1 = c.mgr.CreateSymbol("y1", 0, 8);
+  const ASTNode ite = c.hf->CreateTerm(ITE, 8, cond, y0, y1);
+  return c.hf->CreateTerm(BVMULT, 8, ite, y0);
+}
+
+bool bitBlastNestedOk(Context& c, unsigned depth)
+{
+  const ASTNode f = c.formula(termUnderFormulaUnderTerm(c, depth));
+  c.roots.push_back(f);
+
+  SubstitutionMap sm(&c.mgr);
+  Simplifier simp(&c.mgr, &sm);
+  BBNodeManagerAIG nm;
+  BitBlaster bb(&nm, &simp, c.nf, &c.mgr.UserFlags);
+  bb.BBForm(f);
+
+  // The chain is under the condition, so it cannot have been blasted
+  // without the walk having crossed into it.
+  return nm.totalNumberOfNodes() >= static_cast<int>(depth);
+}
+
+// BitBlaster::BBForm, which blasts a formula's operands by calling itself.
+bool bitBlastOk(Context& c, unsigned depth)
+{
+  ASTNode f = c.hf->CreateNode(EQ, c.mgr.CreateSymbol("b0", 0, 8),
+                               c.mgr.CreateZeroConst(8));
+  for (unsigned i = 1; i < depth; i++)
+  {
+    const std::string name = "b" + std::to_string(i);
+    const ASTNode leaf = c.hf->CreateNode(
+        EQ, c.mgr.CreateSymbol(name.c_str(), 0, 8), c.mgr.CreateZeroConst(8));
+    f = c.hf->CreateNode(AND, leaf, f);
+  }
+  c.roots.push_back(f);
+
+  SubstitutionMap sm(&c.mgr);
+  Simplifier simp(&c.mgr, &sm);
+  BBNodeManagerAIG nm;
+  BitBlaster bb(&nm, &simp, c.nf, &c.mgr.UserFlags);
+  bb.BBForm(f);
+
+  // One AIG node per conjunct at the very least.
+  return nm.totalNumberOfNodes() >= static_cast<int>(depth);
+}
+
+// NodeDomainAnalysis::buildMap.
+bool nodeDomainOk(Context& c, unsigned depth)
+{
+  const ASTNode f = c.formula(c.chain(BVXOR, depth));
+  c.roots.push_back(f);
+  NodeDomainAnalysis nda(&c.mgr);
+  nda.buildMap(f);
+  return true;
+}
+
 // NodeIterator historically visits children right-to-left. Put the deep
 // child last so a pending-node implementation retains one unvisited sibling
 // at every level; a continuation iterator retains just the active path.
@@ -375,6 +498,19 @@ bool nonAtomIteratorOrderOk(Context& c)
   return actual == expected;
 }
 
+// VariablesInExpression::getSymbol.
+bool varsInExpressionOk(Context& c, unsigned depth)
+{
+  const ASTNode f = c.formula(c.chain(BVXOR, depth));
+  c.roots.push_back(f);
+  VariablesInExpression vie;
+  bool destruct = false;
+  ASTNodeSet* v = vie.SetofVarsSeenInTerm(f, destruct);
+  const bool ok = v != nullptr;
+  if (destruct) delete v;
+  return ok;
+}
+
 // PropagateEqualities::buildCandidateList -- a void pre-order walk with a
 // visited set, so a worklist is enough.
 bool propagateEqualitiesOk(Context& c, unsigned depth)
@@ -403,6 +539,99 @@ bool commonSubSumOk(Context& c, unsigned depth)
   ASTNode g = f;
   return css.topLevel(g).GetKind() != UNDEFINED;
 }
+#ifdef STP_ENABLE_FLOATING_POINT
+
+/* A node's floating-point format and its source sort are both derived from
+   its children and memoised on it, and both derivations read a child's answer
+   by asking for it -- which derives the child the same way. So each ran one
+   call frame per level of whatever it walked: a store chain for both of them,
+   an if-then-else spine for both of them.
+
+   Neither is a pass, so neither has an input of its own: they are reached by
+   asking an ordinary question about a node. GetType() asks for the format,
+   and everything asks GetType(). That is what makes these worth converting --
+   a query deep enough cannot be asked its type at all, from anywhere. */
+
+// deriveFPFormat's if-then-else arm, which takes a branch's format and so
+// walks the spine. Reached here through GetType, the way almost everything
+// reaches it.
+bool fpFormatIteChainOk(Context& c, unsigned depth)
+{
+  const ASTNode t = iteChain(c, depth);
+  c.roots.push_back(t);
+  return t.GetType() == BITVECTOR_TYPE;
+}
+
+// deriveFPFormat's read and store arms: an array of floats keeps its element
+// format on the array node, so a read over a store chain derives through
+// every store in it.
+//
+// The one case here that answers with a format rather than with "not a
+// float", so it checks that the walk carried an answer up rather than only
+// that it finished: the format found at the top is the one declared at the
+// bottom, 20,000 stores below.
+bool fpFormatStoreChainOk(Context& c, unsigned depth)
+{
+  const ASTNode a = c.mgr.CreateSymbol("A", 8, 16);
+  a.SetExpWidth(5);
+  a.SetSigWidth(11);
+
+  const ASTNode chain = storeChain(c, depth, a, 16);
+  const ASTNode r =
+      c.hf->CreateTerm(READ, 16, chain, c.mgr.CreateSymbol("j", 0, 8));
+  c.roots.push_back(r);
+  return r.GetExpWidth() == 5 && r.GetSigWidth() == 11;
+}
+
+// deriveSourceSort's if-then-else arm, which asks both branches and walks the
+// same spine.
+bool sourceSortIteChainOk(Context& c, unsigned depth)
+{
+  const ASTNode t = iteChain(c, depth);
+  c.roots.push_back(t);
+  return t.GetSourceSort().kind() == SourceSort::Kind::BitVector;
+}
+
+// deriveSourceSort's store arm: a store has the sort of the array under it.
+bool sourceSortStoreChainOk(Context& c, unsigned depth)
+{
+  const ASTNode a = storeChain(c, depth);
+  c.roots.push_back(a);
+  return a.GetSourceSort().kind() == SourceSort::Kind::Array;
+}
+
+// FpTotalise, which replaces every partial floating-point operation with its
+// total form before the blaster sees it. How deeply a float expression nests
+// is the input's choice, and both of this pass's walks -- the totalising one
+// and the rounding-mode collector that runs over its output -- went down it a
+// frame at a time. A query built from 30,000 nested fp.add operations found
+// it, once the simplifier stopped dying in front of it.
+//
+// The chain is fp.add over one float symbol, which is what that query is.
+// Constructing it needs the format on the leaf: a symbol's is declared, and
+// every operation above derives its own from it.
+bool fpTotaliseChainOk(Context& c, unsigned depth)
+{
+  const unsigned eb = 8, sb = 24;
+  const ASTNode x = c.mgr.CreateSymbol("x", 0, eb + sb);
+  x.SetExpWidth(eb);
+  x.SetSigWidth(sb);
+  const ASTNode rm = c.mgr.CreateBVConst(5, symbolic_fp::ROUND_NEAREST_TIES_TO_EVEN);
+
+  ASTNode t = x;
+  for (unsigned i = 0; i < depth; i++)
+    t = c.hf->CreateTerm(FP_ADD, eb + sb, rm, t, x);
+
+  const ASTNode f = c.hf->CreateNode(FP_ISNAN, t);
+  c.roots.push_back(f);
+
+  FpTotalise fpt(&c.mgr);
+  const ASTNode result = fpt.topLevel(f);
+  c.roots.push_back(result);
+  return result.GetKind() != UNDEFINED;
+}
+#endif // STP_ENABLE_FLOATING_POINT
+
 
 TEST(DeepDag, shallow_rewriting)
 {
@@ -426,6 +655,12 @@ TEST(DeepDag, shallow_flatten_share_count)
 {
   Context c;
   EXPECT_TRUE(flattenShareCountOk(c, SHALLOW));
+}
+
+TEST(DeepDag, shallow_node_domain)
+{
+  Context c;
+  EXPECT_TRUE(nodeDomainOk(c, SHALLOW));
 }
 
 TEST(DeepDag, flatten_lazy_scratch_preserves_rebuild_and_dedup)
@@ -506,6 +741,41 @@ TEST(DeepDag, wide_propagate_equalities_visits_every_conjunct)
   PropagateEqualities propagate(&simplifier, c.nf, &c.mgr);
   EXPECT_EQ(c.mgr.ASTTrue, propagate.topLevel(input));
 }
+#ifdef STP_ENABLE_FLOATING_POINT
+
+TEST(DeepDag, wide_fp_rounding_mode_walk_adds_every_constraint)
+{
+  Context c;
+  const ASTNode rne = c.mgr.CreateRMConst(
+      symbolic_fp::ROUND_NEAREST_TIES_TO_EVEN);
+  ASTVec clauses;
+  clauses.reserve(256);
+  for (unsigned i = 0; i < 256; ++i)
+  {
+    const std::string name = "wide-rounding-mode" + std::to_string(i);
+    const ASTNode rm =
+        c.mgr.CreateSourceSymbol(name.c_str(), SourceSort::roundingMode());
+    clauses.push_back(c.hf->CreateNode(EQ, rm, rne));
+  }
+  const ASTNode input = c.hf->CreateNode(AND, clauses);
+  c.roots.push_back(input);
+
+  FpTotalise totalise(&c.mgr);
+  const ASTNode result = totalise.topLevel(input);
+  c.roots.push_back(result);
+
+  size_t validityConstraints = 0;
+  ASTNodeSet seen;
+  walkPreOrder(result, [&](const ASTNode& n) {
+    if (!seen.insert(n).second)
+      return false;
+    validityConstraints += n.GetKind() == OR && n.Degree() == 5;
+    return true;
+  });
+  EXPECT_EQ(clauses.size(), validityConstraints);
+}
+#endif // STP_ENABLE_FLOATING_POINT
+
 
 TEST(DeepDag, shallow_substitution)
 {
@@ -547,6 +817,24 @@ TEST(DeepDag, shallow_strength_reduction)
   EXPECT_TRUE(strengthReductionOk(c, SHALLOW));
 }
 
+TEST(DeepDag, shallow_bit_blast)
+{
+  Context c;
+  EXPECT_TRUE(bitBlastOk(c, SHALLOW));
+}
+
+TEST(DeepDag, shallow_bit_blast_term)
+{
+  Context c;
+  EXPECT_TRUE(bitBlastTermOk(c, SHALLOW));
+}
+
+TEST(DeepDag, shallow_bit_blast_nested)
+{
+  Context c;
+  EXPECT_TRUE(bitBlastNestedOk(c, SHALLOW));
+}
+
 TEST(DeepDag, node_iterator_preserves_lifo_dag_order)
 {
   Context c;
@@ -564,6 +852,33 @@ TEST(DeepDag, shallow_node_iterator)
   Context c;
   EXPECT_TRUE(nodeIteratorOk(c, SHALLOW));
 }
+#ifdef STP_ENABLE_FLOATING_POINT
+
+TEST(DeepDag, shallow_fp_format_ite)
+{
+  Context c;
+  EXPECT_TRUE(fpFormatIteChainOk(c, SHALLOW));
+}
+
+TEST(DeepDag, shallow_fp_format_store)
+{
+  Context c;
+  EXPECT_TRUE(fpFormatStoreChainOk(c, SHALLOW));
+}
+
+TEST(DeepDag, shallow_source_sort_ite)
+{
+  Context c;
+  EXPECT_TRUE(sourceSortIteChainOk(c, SHALLOW));
+}
+
+TEST(DeepDag, shallow_source_sort_store)
+{
+  Context c;
+  EXPECT_TRUE(sourceSortStoreChainOk(c, SHALLOW));
+}
+#endif // STP_ENABLE_FLOATING_POINT
+
 
 TEST(DeepDag, deep_rewriting_share_count)
 {
@@ -600,7 +915,32 @@ TEST(DeepDag, deep_strength_reduction)
   EXPECT_STACK_SAFE(strengthReductionOk, 20000);
 }
 
+TEST(DeepDag, deep_bit_blast)
+{
+  EXPECT_STACK_SAFE(bitBlastOk, 20000);
+}
+
+TEST(DeepDag, deep_bit_blast_term)
+{
+  EXPECT_STACK_SAFE(bitBlastTermOk, 20000);
+}
+
+TEST(DeepDag, deep_bit_blast_nested)
+{
+  EXPECT_STACK_SAFE(bitBlastNestedOk, 20000);
+}
+
 TEST(DeepDag, deep_common_sub_sum)              { EXPECT_STACK_SAFE(commonSubSumOk, 20000); }
+TEST(DeepDag, deep_node_domain)        { EXPECT_STACK_SAFE(nodeDomainOk, 20000); }
 TEST(DeepDag, deep_node_iterator)      { EXPECT_STACK_SAFE(nodeIteratorOk, 20000); }
+TEST(DeepDag, deep_vars_in_expression) { EXPECT_STACK_SAFE(varsInExpressionOk, 20000); }
 TEST(DeepDag, deep_propagate_equalities) { EXPECT_STACK_SAFE(propagateEqualitiesOk, 20000); }
+#ifdef STP_ENABLE_FLOATING_POINT
+TEST(DeepDag, deep_fp_totalise)        { EXPECT_STACK_SAFE(fpTotaliseChainOk, 20000); }
+TEST(DeepDag, deep_fp_format_ite)      { EXPECT_STACK_SAFE(fpFormatIteChainOk, 20000); }
+TEST(DeepDag, deep_fp_format_store)    { EXPECT_STACK_SAFE(fpFormatStoreChainOk, 20000); }
+TEST(DeepDag, deep_source_sort_ite)    { EXPECT_STACK_SAFE(sourceSortIteChainOk, 20000); }
+TEST(DeepDag, deep_source_sort_store)  { EXPECT_STACK_SAFE(sourceSortStoreChainOk, 20000); }
+#endif // STP_ENABLE_FLOATING_POINT
+
 } // namespace

--- a/tests/unit-tests/DeepDag_Test.cpp
+++ b/tests/unit-tests/DeepDag_Test.cpp
@@ -1333,6 +1333,48 @@ bool commonSubSumOk(Context& c, unsigned depth)
   return css.topLevel(g).GetKind() != UNDEFINED;
 }
 
+// ArrayTransformer, whose three functions -- TransformFormula,
+// TransformTerm and TransformArrayRead -- reach each other once per level of
+// the input, and are one walk on the heap.
+//
+// Priming would not have done here, which is why this one is a state
+// machine: the ITE arms transform the condition and then only the branch
+// that survives it, telling the extensionality context which branch they
+// dropped, and which that is cannot be known until the condition has been
+// transformed. Nor does the operands hook rescue it, as SimplifyTerm's
+// flattening was rescued: the hook would have to run the pass to answer.
+bool arrayTransformerOk(Context& c, unsigned depth)
+{
+  const ASTNode f = c.formula(c.chain(BVXOR, depth));
+  c.roots.push_back(f);
+  SubstitutionMap sm(&c.mgr);
+  Simplifier simp(&c.mgr, &sm);
+  ArrayTransformer at(&c.mgr, &simp);
+  return at.TransformFormula_TopLevel(f).GetKind() != UNDEFINED;
+}
+
+// A chain of reads, each indexing the array with the last one's result.
+// TransformArrayRead transforms a read's index by handing it back to
+// TransformTerm, so this is the input's nesting and not the pass's.
+bool arrayReadChainOk(Context& c, unsigned depth)
+{
+  const ASTNode a = c.mgr.CreateSymbol("A", 8, 8);
+  ASTNode t = c.mgr.CreateSymbol("i", 0, 8);
+  for (unsigned i = 0; i < depth; i++)
+    t = c.hf->CreateTerm(READ, 8, a, t);
+
+  const ASTNode f = c.formula(t);
+  c.roots.push_back(f);
+  SubstitutionMap sm(&c.mgr);
+  Simplifier simp(&c.mgr, &sm);
+  ArrayTransformer at(&c.mgr, &simp);
+  const ASTNode result = at.TransformFormula_TopLevel(f);
+  c.roots.push_back(result);
+  // Every read is abstracted to a fresh variable, so nothing of the chain
+  // may be left.
+  return result.GetKind() != UNDEFINED;
+}
+
 // The read-count heuristic must traverse a read-free deep term without C++
 // recursion. Once its strict limit is reached, it must also stop the whole
 // traversal rather than continuing into a later deep sibling.
@@ -1349,6 +1391,32 @@ bool numberOfReadsWalkOk(Context& c, unsigned depth)
   const ASTNode earlyStop = c.hf->CreateTerm(BVCONCAT, 16, read, deep);
   c.roots.push_back(earlyStop);
   return !numberOfReadsLessThan(earlyStop, 1);
+}
+
+// A chain of writes under one read. The read is pushed under the writes one
+// at a time, each step building a new read over the array below it and
+// transforming that -- so the walk descends the write chain, which is again
+// the input's nesting.
+bool arrayWriteChainOk(Context& c, unsigned depth)
+{
+  ASTNode a = c.mgr.CreateSymbol("A", 8, 8);
+  for (unsigned i = 0; i < depth; i++)
+  {
+    const std::string nm = "w" + std::to_string(i);
+    a = c.hf->CreateArrayTerm(WRITE, 8, 8, a,
+                              c.mgr.CreateSymbol(nm.c_str(), 0, 8),
+                              c.mgr.CreateZeroConst(8));
+  }
+  const ASTNode f =
+      c.formula(c.hf->CreateTerm(READ, 8, a, c.mgr.CreateSymbol("j", 0, 8)));
+  c.roots.push_back(f);
+
+  SubstitutionMap sm(&c.mgr);
+  Simplifier simp(&c.mgr, &sm);
+  ArrayTransformer at(&c.mgr, &simp);
+  const ASTNode result = at.TransformFormula_TopLevel(f);
+  c.roots.push_back(result);
+  return result.GetKind() != UNDEFINED;
 }
 
 // Solve-boundary array equality lowering used a recursive std::function for
@@ -1374,6 +1442,33 @@ bool arrayEqualityLoweringOk(Context& c, unsigned depth)
   c.roots.push_back(lowered);
   return lowered.GetKind() == SYMBOL && ext.getRecords().size() == 1 &&
          ext.getActiveRecordCount() == 1;
+}
+
+// TransformFormula's own spine. A conjunction reaches this pass flat in
+// ordinary use, because the simplifier collapses it first -- but that is the
+// simplifier's doing, not a property of this pass, and the pass is reachable
+// without it.
+bool transformFormulaSpineOk(Context& c, unsigned depth)
+{
+  ASTNode f = c.hf->CreateNode(EQ, c.mgr.CreateSymbol("t0", 0, 8),
+                               c.mgr.CreateZeroConst(8));
+  for (unsigned i = 1; i < depth; i++)
+  {
+    const std::string nm = "t" + std::to_string(i);
+    f = c.hf->CreateNode(
+        NOT, c.hf->CreateNode(
+                 AND, c.hf->CreateNode(EQ, c.mgr.CreateSymbol(nm.c_str(), 0, 8),
+                                       c.mgr.CreateZeroConst(8)),
+                 f));
+  }
+  c.roots.push_back(f);
+
+  SubstitutionMap sm(&c.mgr);
+  Simplifier simp(&c.mgr, &sm);
+  ArrayTransformer at(&c.mgr, &simp);
+  const ASTNode result = at.TransformFormula_TopLevel(f);
+  c.roots.push_back(result);
+  return result.GetKind() != UNDEFINED;
 }
 #ifdef STP_ENABLE_FLOATING_POINT
 
@@ -1945,6 +2040,117 @@ TEST(DeepDag, mutable_dag_shared_children_rebuild_in_operand_order)
   EXPECT_TRUE(mutableDagSharedRebuildOk(c));
 }
 
+TEST(DeepDag, array_transformer_job_specific_operands_preserve_paths)
+{
+  Context c;
+  const ASTNode guard = c.mgr.CreateSymbol("array-guard", 0, 0);
+  const ASTNode cond = c.mgr.CreateSymbol("array-cond", 0, 0);
+  const ASTNode array = c.mgr.CreateSymbol("array-buffer", 8, 8);
+  const ASTNode index = c.mgr.CreateSymbol("array-index", 0, 8);
+  const ASTNode read = c.hf->CreateTerm(READ, 8, array, index);
+  const ASTNode sum = c.hf->CreateTerm(
+      BVXOR, 8, read, c.mgr.CreateOneConst(8));
+  const ASTNode choice = c.hf->CreateTerm(
+      ITE, 8, cond, sum, c.mgr.CreateZeroConst(8));
+  const ASTNode equality = c.hf->CreateNode(
+      EQ, choice, c.mgr.CreateSymbol("array-rhs", 0, 8));
+  // Transforming equality suspends below an already completed guard. This
+  // pins the shared operand arena's nonzero child range: finishing the
+  // equality must remove only its suffix, leaving the parent's guard intact.
+  const ASTNode input = c.hf->CreateNode(AND, guard, equality);
+
+  SubstitutionMap sm(&c.mgr);
+  Simplifier simp(&c.mgr, &sm);
+  ArrayTransformer transformer(&c.mgr, &simp);
+  const ASTNode result = transformer.TransformFormula_TopLevel(input);
+
+  bool sawIte = false;
+  bool sawGenericTerm = false;
+  bool sawRead = false;
+  bool sawGuard = false;
+  ASTNodeSet visited;
+  ASTVec pending{result};
+  while (!pending.empty())
+  {
+    const ASTNode n = pending.back();
+    pending.pop_back();
+    if (!visited.insert(n).second)
+      continue;
+    sawIte |= n.GetKind() == ITE;
+    sawGenericTerm |= n.GetKind() == BVXOR;
+    sawRead |= n.GetKind() == READ;
+    sawGuard |= n == guard;
+    pending.insert(pending.end(), n.begin(), n.end());
+  }
+
+  EXPECT_EQ(AND, result.GetKind());
+  EXPECT_TRUE(sawIte);
+  EXPECT_TRUE(sawGenericTerm);
+  EXPECT_TRUE(sawGuard);
+  EXPECT_FALSE(sawRead);
+  ASSERT_EQ(1U, transformer.arrayToIndexToRead.count(array));
+  EXPECT_EQ(1U, transformer.arrayToIndexToRead.at(array).count(index));
+}
+
+TEST(DeepDag, array_transformer_read_state_survives_nested_arena_growth)
+{
+  Context c;
+  const ASTNode cond = c.mgr.CreateSymbol("read-state-cond", 0, 0);
+  const ASTNode thnArray = c.mgr.CreateSymbol("read-state-thn", 8, 8);
+  const ASTNode elsArray = c.mgr.CreateSymbol("read-state-els", 8, 8);
+  const ASTNode index = c.mgr.CreateSymbol("read-state-index", 0, 8);
+  const ASTNode arrayIte = c.hf->CreateArrayTerm(
+      ITE, 8, 8, cond, thnArray, elsArray);
+  const ASTNode read = c.hf->CreateTerm(READ, 8, arrayIte, index);
+  const ASTNode input = c.hf->CreateNode(
+      EQ, read, c.mgr.CreateSymbol("read-state-rhs", 0, 8));
+
+  SubstitutionMap sm(&c.mgr);
+  Simplifier simp(&c.mgr, &sm);
+  ArrayTransformer transformer(&c.mgr, &simp);
+  const ASTNode result = transformer.TransformFormula_TopLevel(input);
+
+  // Transforming each ITE arm pushes another Read frame. The outer frame's
+  // condition and pending else-read must survive growth of the shared
+  // continuation arena.
+  bool sawIte = false;
+  bool sawRead = false;
+  ASTNodeSet visited;
+  ASTVec pending{result};
+  while (!pending.empty())
+  {
+    const ASTNode n = pending.back();
+    pending.pop_back();
+    if (!visited.insert(n).second)
+      continue;
+    sawIte |= n.GetKind() == ITE;
+    sawRead |= n.GetKind() == READ;
+    pending.insert(pending.end(), n.begin(), n.end());
+  }
+
+  EXPECT_TRUE(sawIte);
+  EXPECT_FALSE(sawRead);
+  ASSERT_EQ(1U, transformer.arrayToIndexToRead.count(thnArray));
+  ASSERT_EQ(1U, transformer.arrayToIndexToRead.count(elsArray));
+  EXPECT_EQ(1U, transformer.arrayToIndexToRead.at(thnArray).count(index));
+  EXPECT_EQ(1U, transformer.arrayToIndexToRead.at(elsArray).count(index));
+}
+
+TEST(DeepDag, array_transformer_root_fast_paths_preserve_leaf_formulas)
+{
+  Context c;
+  SubstitutionMap sm(&c.mgr);
+  Simplifier simp(&c.mgr, &sm);
+  ArrayTransformer transformer(&c.mgr, &simp);
+  const ASTNode symbol = c.mgr.CreateSymbol("array-root-symbol", 0, 0);
+
+  EXPECT_EQ(c.mgr.ASTTrue,
+            transformer.TransformFormula_TopLevel(c.mgr.ASTTrue));
+  EXPECT_EQ(c.mgr.ASTFalse,
+            transformer.TransformFormula_TopLevel(c.mgr.ASTFalse));
+  EXPECT_EQ(symbol, transformer.TransformFormula_TopLevel(symbol));
+}
+
 /* The same properties on inputs deeper than the call stack can hold.
    Depths are picked so each case reaches the traversal it is named for:
    buildShareCount's frames are far smaller than rewrite's, so it only
@@ -2072,14 +2278,18 @@ TEST(DeepDag, deep_node_domain)        { EXPECT_STACK_SAFE(nodeDomainOk, 20000);
 TEST(DeepDag, deep_node_iterator)      { EXPECT_STACK_SAFE(nodeIteratorOk, 20000); }
 TEST(DeepDag, deep_vars_in_expression) { EXPECT_STACK_SAFE(varsInExpressionOk, 20000); }
 TEST(DeepDag, deep_propagate_equalities) { EXPECT_STACK_SAFE(propagateEqualitiesOk, 20000); }
+TEST(DeepDag, deep_array_transformer)  { EXPECT_STACK_SAFE(arrayTransformerOk, 20000); }
+TEST(DeepDag, deep_array_read_chain)   { EXPECT_STACK_SAFE(arrayReadChainOk, 20000); }
 TEST(DeepDag, deep_array_read_count_walk)
 {
   EXPECT_STACK_SAFE(numberOfReadsWalkOk, 20000);
 }
+TEST(DeepDag, deep_array_write_chain)  { EXPECT_STACK_SAFE(arrayWriteChainOk, 20000); }
 TEST(DeepDag, deep_array_equality_lowering)
 {
   EXPECT_STACK_SAFE(arrayEqualityLoweringOk, 20000);
 }
+TEST(DeepDag, deep_transform_formula_spine) { EXPECT_STACK_SAFE(transformFormulaSpineOk, 20000); }
 #ifdef STP_ENABLE_FLOATING_POINT
 TEST(DeepDag, deep_fp_totalise)        { EXPECT_STACK_SAFE(fpTotaliseChainOk, 20000); }
 #endif // STP_ENABLE_FLOATING_POINT

--- a/tests/unit-tests/DeepDag_Test.cpp
+++ b/tests/unit-tests/DeepDag_Test.cpp
@@ -1,0 +1,606 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+// AST-depth-recursive traversals: no pass may consume call stack in
+// proportion to the depth of the input DAG.
+//
+// Deeply nested formulas (CPAchecker k-induction traces, ~9,300 nested
+// nodes) deterministically segfault STP: Rewriting::rewrite and
+// Dependencies::build recurse once per level of the input, so an input
+// deep enough to exhaust the stack kills the process. The depth is chosen
+// by whoever wrote the input, so no fixed stack size is a fix -- these
+// traversals have to keep their working state on the heap.
+//
+// Each property below is checked twice: once on a shallow chain, which
+// says the property itself holds, and once on a chain far deeper than the
+// recursive frames fit in, which is what fails today. Two things make the
+// deep result a property of STP rather than of the machine it runs on:
+//
+//   * it runs under a stack rlimit the test sets itself, so the ambient
+//     `ulimit -s` (8 MiB here, unlimited on some CI runners) cannot
+//     decide the outcome; and
+//   * it runs in a forked child, so a stack overflow is one failing test
+//     rather than a segfault that takes the rest of the binary with it.
+//
+// The chains are built with the hashing factory: the simplifying factory
+// would fold or reassociate them, and the DAG under test would no longer
+// be the deep one the test means to build.
+
+#include "stp/AST/MutableASTNode.h"
+#include "stp/NodeFactory/SimplifyingNodeFactory.h"
+#include "stp/STPManager/STPManager.h"
+#include "stp/Simplifier/Flatten.h"
+#include "stp/Simplifier/Rewriting.h"
+#include "stp/Simplifier/NodeDomainAnalysis.h"
+#include "stp/AbsRefineCounterExample/ArrayTransformer.h"
+#include "stp/AbsRefineCounterExample/AbsRefine_CounterExample.h"
+#include "stp/FloatBlaster/FpEncodingContext.h"
+#include "stp/FloatBlaster/FpTotalise.h"
+#include "stp/Extensionality/ExtensionalityContext.h"
+#include "stp/Printer/printers.h"
+#include "stp/Simplifier/CommonSubSum.h"
+#include "stp/Simplifier/PropagateEqualities.h"
+#include "stp/Simplifier/RemoveUnconstrained.h"
+#include "stp/Simplifier/Simplifier.h"
+#include "stp/Simplifier/UseITEContext.h"
+#include "stp/Simplifier/VariablesInExpression.h"
+#include "stp/ToSat/BBNodeManagerAIG.h"
+#include "stp/ToSat/BitBlaster.h"
+#include "stp/Util/NodeIterator.h"
+#include "stp/Simplifier/StrengthReduction.h"
+#include "stp/Simplifier/SubstitutionMap.h"
+#include "stp/Simplifier/constantBitP/Dependencies.h"
+#include "stp/Simplifier/constantBitP/WorkList.h"
+#include <algorithm>
+#include <cstdlib>
+#include <gtest/gtest.h>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+
+#ifndef _WIN32
+#include <sys/resource.h>
+#endif
+
+using namespace stp;
+
+namespace
+{
+
+// Small enough that a per-level call frame cannot fit these depths, large
+// enough for anything a stack-safe traversal legitimately does.
+const size_t STACK_BYTES = 1024 * 1024;
+
+// Exit codes of the forked child. Anything else -- in particular a signal
+// -- is the failure this file exists to catch.
+const int EXIT_OK = 0;
+const int EXIT_BAD_RESULT = 2;
+
+// Shallow enough to recurse safely: what the control cases run on.
+const unsigned SHALLOW = 50;
+
+// Cap how far this process's stack may grow. Linux applies a lowered
+// RLIMIT_STACK to further growth of the main stack, so the check runs
+// against a stack of exactly this size whatever the ambient `ulimit -s`
+// is -- 8 MiB on a developer box, sometimes unlimited on a CI runner.
+// Bounding it is what makes a passing deep case mean "the traversal does
+// not use the stack for depth" rather than "this machine had room".
+void capStack()
+{
+#ifndef _WIN32
+  struct rlimit rl;
+  if (getrlimit(RLIMIT_STACK, &rl) == 0)
+  {
+    rl.rlim_cur = STACK_BYTES;
+    setrlimit(RLIMIT_STACK, &rl);
+  }
+#else
+  // No setrlimit; MSVC's default main-thread stack is 1 MiB already, which
+  // is the size this wants.
+#endif
+}
+
+// Runs one of the checks below in a child process on a bounded stack.
+// `check` returning false -- the pass ran but got the wrong answer -- is
+// reported as an exit code distinct from a crash.
+//
+// The manager is deliberately not destroyed. Releasing a deep DAG used to
+// be depth-recursive itself (~ASTInterior -> CleanUp -> ~ASTInterior, one
+// level per node), so tearing these chains down would overflow the stack
+// after the traversal under test had already returned, and every case here
+// would report the destructor's limit instead of the pass's. CleanUp drains
+// a queue now and deep_teardown below covers it, but keeping the roots alive
+// still isolates each case from the others: the child exits immediately, so
+// leaving the DAG alive costs nothing.
+#define EXPECT_STACK_SAFE(check, depth)                                     \
+  EXPECT_EXIT(                                                              \
+      {                                                                     \
+        capStack();                                                         \
+        Context* c = new Context();                                         \
+        std::exit(check(*c, depth) ? EXIT_OK : EXIT_BAD_RESULT);            \
+      },                                                                    \
+      ::testing::ExitedWithCode(EXIT_OK), "")
+
+struct Context
+{
+  STPMgr mgr;
+  SimplifyingNodeFactory snf;
+  NodeFactory* nf; // simplifying factory: what the passes themselves use.
+  NodeFactory* hf; // hashing factory: builds the input without folding it.
+
+  // Roots each check hands over, so that returning from it does not drop
+  // the last handle on a deep DAG and start the recursive teardown
+  // described at EXPECT_STACK_SAFE.
+  ASTVec roots;
+
+  Context() : snf(*(mgr.hashingNodeFactory), mgr)
+  {
+    static const bool booted = []() {
+      CONSTANTBV::BitVector_Boot();
+      return true;
+    }();
+    (void)booted;
+
+    mgr.defaultNodeFactory = &snf;
+    nf = &snf;
+    hf = mgr.hashingNodeFactory;
+  }
+
+  // A chain `depth` symbols long, so `depth`-1 operator nodes nested one
+  // inside the next. No rewrite or flattening rule matches a chain of
+  // BVXORs or BVMULTs over symbols, so what the passes do here is exactly
+  // the traversal.
+  ASTNode chain(Kind k, unsigned depth, unsigned width = 8)
+  {
+    ASTNode n = mgr.CreateSymbol("x0", 0, width);
+    for (unsigned i = 1; i < depth; i++)
+    {
+      const std::string name = "x" + std::to_string(i);
+      n = hf->CreateTerm(k, width, n,
+                         mgr.CreateSymbol(name.c_str(), 0, width));
+    }
+    return n;
+  }
+
+  // The passes take a formula, and rewrite rules fire on the children of a
+  // visited node rather than on the root, so put the chain under one.
+  ASTNode formula(const ASTNode& term)
+  {
+    return hf->CreateNode(EQ, term, mgr.CreateZeroConst(term.GetValueWidth()));
+  }
+
+  // The factories order commutative children (constants first, then
+  // symbols), so which index holds the chain is not fixed.
+  static ASTNode childOfKind(const ASTNode& n, Kind k)
+  {
+    for (const auto& c : n.GetChildren())
+      if (c.GetKind() == k)
+        return c;
+    return n;
+  }
+};
+
+// Rewriting::rewrite (19 of the 21 known corpus crashes, ~9,300 nested
+// frames deep) and, ahead of it in the same pass, the equally unbounded
+// Rewriting::buildShareCount.
+bool rewritingIdentityOk(Context& c, unsigned depth)
+{
+  const ASTNode top = c.formula(c.chain(BVXOR, depth));
+  c.roots.push_back(top);
+
+  Rewriting r(&c.mgr, c.nf);
+  ASTNode f = top;
+  // No rule matches a BVXOR chain, so the pass is an identity here; any
+  // other answer means the traversal lost part of the DAG.
+  return r.topLevel(f) == top;
+}
+
+// The second recursion point: when a rule rewrites a child, the result is
+// fed back through rewrite(). The rule is `0 = (a + b)` -->
+// `(bvuminus a) = b`, placed beside a deep chain so the re-entry happens
+// in a traversal that is already deep.
+bool rewritingRuleFiresOk(Context& c, unsigned depth)
+{
+  const unsigned width = 8;
+  // The hashing factory orders a node's children by node number, and the
+  // rule matches EQ(const, plus): the constant has to exist before the
+  // operands do, or the equality comes out as EQ(plus, const) and nothing
+  // fires.
+  const ASTNode zero = c.mgr.CreateZeroConst(width);
+  const ASTNode a = c.mgr.CreateSymbol("a", 0, width);
+  const ASTNode b = c.mgr.CreateSymbol("b", 0, width);
+  const ASTNode plus = c.hf->CreateTerm(BVPLUS, width, a, b);
+  const ASTNode fires = c.hf->CreateNode(EQ, zero, plus);
+  if (fires[0].GetKind() != BVCONST || fires[1].GetKind() != BVPLUS)
+    return false; // not the shape the rule matches: prove nothing quietly.
+
+  const ASTNode top =
+      c.hf->CreateNode(AND, fires, c.formula(c.chain(BVXOR, depth, width)));
+  c.roots.push_back(top);
+
+  Rewriting r(&c.mgr, c.nf);
+  ASTNode f = top;
+  // The equality is rewritten, so the pass must not be an identity.
+  return r.topLevel(f) != top;
+}
+
+// Flatten::buildShareCount on its own. A chain of same-kind flattenable
+// nodes is the one shape flatten() does not recurse on: it appends the
+// grandchildren to its own worklist and keeps looping, so the only
+// depth-recursive walk this input reaches is the share count built ahead
+// of it.
+bool flattenShareCountOk(Context& c, unsigned depth)
+{
+  const ASTNode top = c.formula(c.chain(BVPLUS, depth));
+  c.roots.push_back(top);
+
+  Flatten flattener(&c.mgr, c.nf);
+  ASTNode f = top;
+  const ASTNode result = flattener.topLevel(f);
+  c.roots.push_back(result);
+
+  // The whole chain collapses into one BVPLUS over every symbol in it.
+  const ASTNode plus = Context::childOfKind(result, BVPLUS);
+  return plus.GetKind() == BVPLUS && plus.Degree() == depth;
+}
+
+// Flatten carries its own copy of both traversals: an identical
+// buildShareCount, and flatten() with the same recursive shape as
+// rewrite(). Flattening is off by default since #786, so it is not on the
+// observed crash path -- but --flatten puts it back. BVMULT is not a
+// flattenable kind, which keeps this a test of the traversal rather than
+// of flattening.
+bool flattenIdentityOk(Context& c, unsigned depth)
+{
+  const ASTNode top = c.formula(c.chain(BVMULT, depth));
+  c.roots.push_back(top);
+
+  Flatten flattener(&c.mgr, c.nf);
+  ASTNode f = top;
+  return flattener.topLevel(f) == top;
+}
+
+// SubstitutionMap::replace, which rebuilds a DAG with some nodes swapped
+// out. Reached from every pass that applies a substitution, and the walk
+// is over the whole input.
+bool substitutionOk(Context& c, unsigned depth)
+{
+  const ASTNode top = c.formula(c.chain(BVXOR, depth));
+  c.roots.push_back(top);
+
+  // The symbol at the far end of the chain maps to a constant, so the walk
+  // has to reach the bottom and every node above it is rebuilt on the way
+  // back up.
+  ASTNodeMap fromTo, cache;
+  fromTo[c.mgr.CreateSymbol("x0", 0, 8)] = c.mgr.CreateBVConst(8, 1);
+
+  const ASTNode result =
+      SubstitutionMap::replace(top, fromTo, cache, c.nf);
+  c.roots.push_back(result);
+  return result != top;
+}
+
+// StrengthReduction::visit, which rebuilds the DAG applying whatever the
+// domain analyses prove about each node.
+bool strengthReductionOk(Context& c, unsigned depth)
+{
+  const ASTNode top = c.formula(c.chain(BVXOR, depth));
+  c.roots.push_back(top);
+
+  StrengthReduction sr(c.nf, &c.mgr.UserFlags);
+  NodeDomainAnalysis nda(&c.mgr);
+  const ASTNode result = sr.topLevel(top, nda);
+  c.roots.push_back(result);
+
+  // Nothing about a chain of unconstrained symbols is reducible, so the
+  // pass has to hand back what it was given.
+  return result == top;
+}
+
+// NodeIterator historically visits children right-to-left. Put the deep
+// child last so a pending-node implementation retains one unvisited sibling
+// at every level; a continuation iterator retains just the active path.
+bool nodeIteratorOk(Context& c, unsigned depth)
+{
+  ASTNode n = c.mgr.CreateSymbol("iterator-x0", 0, 8);
+  for (unsigned i = 1; i < depth; ++i)
+  {
+    const std::string name = "iterator-x" + std::to_string(i);
+    n = c.hf->CreateTerm(BVXOR, 8,
+                         c.mgr.CreateSymbol(name.c_str(), 0, 8), n);
+  }
+  c.roots.push_back(n);
+  return c.mgr.NodeSize(n) == 2 * depth - 1;
+}
+
+bool nodeIteratorOrderOk(Context& c)
+{
+  const ASTNode condition =
+      c.mgr.CreateSymbol("iterator-order-condition", 0, 0);
+  const ASTNode a = c.mgr.CreateSymbol("iterator-order-a", 0, 8);
+  const ASTNode b = c.mgr.CreateSymbol("iterator-order-b", 0, 8);
+  const ASTNode d = c.mgr.CreateSymbol("iterator-order-d", 0, 8);
+  const ASTNode left = c.hf->CreateTerm(BVCONCAT, 16, a, b);
+  const ASTNode right = c.hf->CreateTerm(BVCONCAT, 16, b, d);
+  const ASTNode top =
+      c.hf->CreateTerm(ITE, 16, condition, left, right);
+  c.roots.push_back(top);
+
+  const ASTVec expected{top, right, d, b, left, a, condition};
+  ASTVec actual;
+  NodeIterator nodes(top, c.mgr.ASTUndefined, c.mgr);
+  for (ASTNode n = nodes.next(); n != nodes.end(); n = nodes.next())
+    actual.push_back(n);
+  return actual == expected;
+}
+
+bool nonAtomIteratorOrderOk(Context& c)
+{
+  const ASTNode condition =
+      c.mgr.CreateSymbol("non-atom-order-condition", 0, 0);
+  const ASTNode a = c.mgr.CreateSymbol("non-atom-order-a", 0, 8);
+  const ASTNode b = c.mgr.CreateSymbol("non-atom-order-b", 0, 8);
+  const ASTNode d = c.mgr.CreateSymbol("non-atom-order-d", 0, 8);
+  const ASTNode left = c.hf->CreateTerm(BVCONCAT, 16, a, b);
+  const ASTNode right = c.hf->CreateTerm(BVCONCAT, 16, b, d);
+  const ASTNode top = c.hf->CreateTerm(ITE, 16, condition, left, right);
+  c.roots.push_back(top);
+
+  const ASTVec expected{top, right, left};
+  ASTVec actual;
+  NonAtomIterator nodes(top, c.mgr.ASTUndefined, c.mgr);
+  for (ASTNode n = nodes.next(); n != nodes.end(); n = nodes.next())
+    actual.push_back(n);
+  return actual == expected;
+}
+
+// PropagateEqualities::buildCandidateList -- a void pre-order walk with a
+// visited set, so a worklist is enough.
+bool propagateEqualitiesOk(Context& c, unsigned depth)
+{
+  ASTNode f = c.hf->CreateNode(EQ, c.mgr.CreateSymbol("q0", 0, 8),
+                               c.mgr.CreateZeroConst(8));
+  for (unsigned i = 1; i < depth; i++)
+  {
+    const std::string nm = "q" + std::to_string(i);
+    f = c.hf->CreateNode(AND, c.hf->CreateNode(EQ, c.mgr.CreateSymbol(nm.c_str(), 0, 8),
+                                               c.mgr.CreateZeroConst(8)), f);
+  }
+  c.roots.push_back(f);
+  SubstitutionMap sm(&c.mgr);
+  Simplifier simp(&c.mgr, &sm);
+  PropagateEqualities pe(&simp, c.nf, &c.mgr);
+  return pe.topLevel(f).GetKind() != UNDEFINED;
+}
+
+// CommonSubSum::topLevel. Already stack-safe; here to keep it that way.
+bool commonSubSumOk(Context& c, unsigned depth)
+{
+  const ASTNode f = c.formula(c.chain(BVPLUS, depth));
+  c.roots.push_back(f);
+  CommonSubSum css(&c.mgr, c.nf);
+  ASTNode g = f;
+  return css.topLevel(g).GetKind() != UNDEFINED;
+}
+
+TEST(DeepDag, shallow_rewriting)
+{
+  Context c;
+  EXPECT_TRUE(rewritingIdentityOk(c, SHALLOW));
+}
+
+TEST(DeepDag, shallow_rewriting_rule_fires)
+{
+  Context c;
+  EXPECT_TRUE(rewritingRuleFiresOk(c, SHALLOW));
+}
+
+TEST(DeepDag, shallow_flatten)
+{
+  Context c;
+  EXPECT_TRUE(flattenIdentityOk(c, SHALLOW));
+}
+
+TEST(DeepDag, shallow_flatten_share_count)
+{
+  Context c;
+  EXPECT_TRUE(flattenShareCountOk(c, SHALLOW));
+}
+
+TEST(DeepDag, flatten_lazy_scratch_preserves_rebuild_and_dedup)
+{
+  Context c;
+  const ASTNode a = c.mgr.CreateSymbol("flatten-scratch-a", 0, 8);
+  const ASTNode b = c.mgr.CreateSymbol("flatten-scratch-b", 0, 8);
+  const ASTNode d = c.mgr.CreateSymbol("flatten-scratch-d", 0, 8);
+  const ASTNode other = c.mgr.CreateSymbol("flatten-scratch-other", 0, 8);
+  const ASTNode left = c.hf->CreateTerm(BVAND, 8, a, b);
+  const ASTNode right = c.hf->CreateTerm(BVAND, 8, b, d);
+  const ASTNode nested = c.hf->CreateTerm(BVAND, 8, left, right);
+  ASTNode input = c.hf->CreateNode(EQ, nested, other);
+  c.roots.push_back(input);
+
+  Flatten flattener(&c.mgr, c.nf);
+  const ASTNode result = flattener.topLevel(input);
+  c.roots.push_back(result);
+  const ASTNode flat = Context::childOfKind(result, BVAND);
+
+  ASSERT_EQ(EQ, result.GetKind());
+  ASSERT_EQ(BVAND, flat.GetKind());
+  EXPECT_EQ(3U, flat.Degree());
+  ASTNodeSet children(flat.begin(), flat.end());
+  EXPECT_EQ(3U, children.size());
+  EXPECT_EQ(1U, children.count(a));
+  EXPECT_EQ(1U, children.count(b));
+  EXPECT_EQ(1U, children.count(d));
+}
+
+TEST(DeepDag, wide_share_count_walks_preserve_shared_rewrite_guards)
+{
+  Context c;
+  const ASTNode three = c.mgr.CreateBVConst(3, 3);
+  const ASTNode two = c.mgr.CreateBVConst(3, 2);
+  const ASTNode x = c.mgr.CreateSymbol("wide-share-x", 0, 3);
+  const ASTNode y = c.mgr.CreateSymbol("wide-share-y", 0, 3);
+  const ASTNode plus = c.hf->CreateTerm(BVPLUS, 3, three, x);
+  const ASTNode guarded = c.hf->CreateNode(
+      NOT, c.hf->CreateNode(BVGT, two, plus));
+  const ASTNode otherUse = c.hf->CreateNode(EQ, y, plus);
+
+  ASTVec children{guarded, otherUse};
+  children.reserve(4098);
+  for (unsigned i = 0; i < 4096; ++i)
+  {
+    const std::string name = "wide-share-b" + std::to_string(i);
+    children.push_back(c.mgr.CreateSymbol(name.c_str(), 0, 0));
+  }
+  ASTNode input = c.hf->CreateNode(AND, children);
+  c.roots.push_back(input);
+
+  Rewriting rewriting(&c.mgr, c.nf);
+  ASTNode rewriteInput = input;
+  EXPECT_EQ(input, rewriting.topLevel(rewriteInput));
+
+  Flatten flattening(&c.mgr, c.nf);
+  ASTNode flattenInput = input;
+  EXPECT_EQ(input, flattening.topLevel(flattenInput));
+}
+
+TEST(DeepDag, wide_propagate_equalities_visits_every_conjunct)
+{
+  Context c;
+  c.mgr.UserFlags.propagate_equalities = true;
+  ASTVec symbols;
+  symbols.reserve(2048);
+  for (unsigned i = 0; i < 2048; ++i)
+  {
+    const std::string name = "wide-propagate-b" + std::to_string(i);
+    symbols.push_back(c.mgr.CreateSymbol(name.c_str(), 0, 0));
+  }
+  const ASTNode input = c.hf->CreateNode(AND, symbols);
+  c.roots.push_back(input);
+
+  SubstitutionMap substitutions(&c.mgr);
+  Simplifier simplifier(&c.mgr, &substitutions);
+  PropagateEqualities propagate(&simplifier, c.nf, &c.mgr);
+  EXPECT_EQ(c.mgr.ASTTrue, propagate.topLevel(input));
+}
+
+TEST(DeepDag, shallow_substitution)
+{
+  Context c;
+  EXPECT_TRUE(substitutionOk(c, SHALLOW));
+}
+
+TEST(DeepDag, substitution_root_fast_paths_preserve_results)
+{
+  Context c;
+  const ASTNode x = c.mgr.CreateSymbol("subst-x", 0, 8);
+  const ASTNode y = c.mgr.CreateSymbol("subst-y", 0, 8);
+  const ASTNode free = c.mgr.CreateSymbol("subst-free", 0, 8);
+  const ASTNode cached = c.mgr.CreateSymbol("subst-cached", 0, 8);
+  const ASTNode one = c.mgr.CreateOneConst(8);
+  const ASTNode zero = c.mgr.CreateZeroConst(8);
+
+  ASTNodeMap fromTo, cache;
+  fromTo[x] = y;
+  fromTo[y] = one;
+  cache[cached] = zero;
+
+  EXPECT_EQ(zero, SubstitutionMap::replace(zero, fromTo, cache, c.nf));
+  EXPECT_EQ(free, SubstitutionMap::replace(free, fromTo, cache, c.nf));
+  EXPECT_EQ(zero, SubstitutionMap::replace(cached, fromTo, cache, c.nf));
+  EXPECT_EQ(one, SubstitutionMap::replace(x, fromTo, cache, c.nf));
+  EXPECT_EQ(one, fromTo.at(x));
+
+  const ASTNode array = c.mgr.CreateSymbol("subst-array", 8, 8);
+  const ASTNode write = c.hf->CreateArrayTerm(
+      WRITE, 8, 8, array, c.mgr.CreateZeroConst(8), one);
+  EXPECT_EQ(write, SubstitutionMap::replace(write, fromTo, cache, c.nf,
+                                            true, false));
+}
+
+TEST(DeepDag, shallow_strength_reduction)
+{
+  Context c;
+  EXPECT_TRUE(strengthReductionOk(c, SHALLOW));
+}
+
+TEST(DeepDag, node_iterator_preserves_lifo_dag_order)
+{
+  Context c;
+  EXPECT_TRUE(nodeIteratorOrderOk(c));
+}
+
+TEST(DeepDag, non_atom_iterator_preserves_filtered_lifo_order)
+{
+  Context c;
+  EXPECT_TRUE(nonAtomIteratorOrderOk(c));
+}
+
+TEST(DeepDag, shallow_node_iterator)
+{
+  Context c;
+  EXPECT_TRUE(nodeIteratorOk(c, SHALLOW));
+}
+
+TEST(DeepDag, deep_rewriting_share_count)
+{
+  EXPECT_STACK_SAFE(rewritingIdentityOk, 200000);
+}
+
+TEST(DeepDag, deep_rewriting_rewrite)
+{
+  EXPECT_STACK_SAFE(rewritingIdentityOk, 10000);
+}
+
+TEST(DeepDag, deep_rewriting_rule_fires)
+{
+  EXPECT_STACK_SAFE(rewritingRuleFiresOk, 10000);
+}
+
+TEST(DeepDag, deep_flatten_share_count)
+{
+  EXPECT_STACK_SAFE(flattenShareCountOk, 100000);
+}
+
+TEST(DeepDag, deep_flatten)
+{
+  EXPECT_STACK_SAFE(flattenIdentityOk, 10000);
+}
+
+TEST(DeepDag, deep_substitution)
+{
+  EXPECT_STACK_SAFE(substitutionOk, 20000);
+}
+
+TEST(DeepDag, deep_strength_reduction)
+{
+  EXPECT_STACK_SAFE(strengthReductionOk, 20000);
+}
+
+TEST(DeepDag, deep_common_sub_sum)              { EXPECT_STACK_SAFE(commonSubSumOk, 20000); }
+TEST(DeepDag, deep_node_iterator)      { EXPECT_STACK_SAFE(nodeIteratorOk, 20000); }
+TEST(DeepDag, deep_propagate_equalities) { EXPECT_STACK_SAFE(propagateEqualitiesOk, 20000); }
+} // namespace

--- a/tests/unit-tests/DeepDag_Test.cpp
+++ b/tests/unit-tests/DeepDag_Test.cpp
@@ -337,6 +337,44 @@ bool substitutionOk(Context& c, unsigned depth)
   return result != top;
 }
 
+// Releasing a DAG. A node that loses its last reference releases its
+// children, which can lose theirs: the teardown is as deep as the input,
+// and it runs wherever the last handle happens to be dropped.
+bool teardownOk(Context& c, unsigned depth)
+{
+  {
+    const ASTNode top = c.formula(c.chain(BVXOR, depth));
+    (void)top;
+  } // the only handle goes here, and the whole chain follows it.
+  return true;
+}
+
+// Two independently owned chains die under the same root. Both reach the
+// direct-deletion cap while that root is still being destroyed, so the
+// outermost cleanup has more than one spill frontier to drain.
+bool teardownSpillFrontiersOk(Context& c, unsigned depth)
+{
+  auto chain = [&](const char* side) {
+    const std::string first = std::string(side) + "0";
+    ASTNode n = c.mgr.CreateSymbol(first.c_str(), 0, 8);
+    for (unsigned i = 1; i < depth; ++i)
+    {
+      const std::string name = std::string(side) + std::to_string(i);
+      n = c.hf->CreateTerm(BVXOR, 8, n,
+                           c.mgr.CreateSymbol(name.c_str(), 0, 8));
+    }
+    return n;
+  };
+
+  {
+    const ASTNode top =
+        c.hf->CreateTerm(BVPLUS, 8, chain("delete-left-"),
+                         chain("delete-right-"));
+    (void)top;
+  }
+  return true;
+}
+
 // StrengthReduction::visit, which rebuilds the DAG applying whatever the
 // domain analyses prove about each node.
 bool strengthReductionOk(Context& c, unsigned depth)
@@ -860,6 +898,18 @@ TEST(DeepDag, substitution_root_fast_paths_preserve_results)
                                             true, false));
 }
 
+TEST(DeepDag, shallow_teardown)
+{
+  Context c;
+  EXPECT_TRUE(teardownOk(c, SHALLOW));
+}
+
+TEST(DeepDag, teardown_drains_multiple_spill_frontiers)
+{
+  Context c;
+  EXPECT_TRUE(teardownSpillFrontiersOk(c, SHALLOW));
+}
+
 TEST(DeepDag, shallow_flatten_kind_no_duplicates)
 {
   Context c;
@@ -1023,6 +1073,11 @@ TEST(DeepDag, deep_flatten)
 TEST(DeepDag, deep_substitution)
 {
   EXPECT_STACK_SAFE(substitutionOk, 20000);
+}
+
+TEST(DeepDag, deep_teardown)
+{
+  EXPECT_STACK_SAFE(teardownOk, 50000);
 }
 
 TEST(DeepDag, deep_flatten_kind_no_duplicates)

--- a/tests/unit-tests/DeepDag_Test.cpp
+++ b/tests/unit-tests/DeepDag_Test.cpp
@@ -2207,6 +2207,77 @@ TEST(DeepDag, counterexample_consumes_ready_descendants_in_place)
   EXPECT_EQ(one, ce.Expand_ReadOverWrite_UsingModel(read, false));
 }
 
+TEST(DeepDag, counterexample_continuation_paths_preserve_model_values)
+{
+  Context c;
+  SubstitutionMap sm(&c.mgr);
+  Simplifier simp(&c.mgr, &sm);
+  ArrayTransformer transformer(&c.mgr, &simp);
+  AbsRefine_CounterExample ce(&c.mgr, &simp, &transformer);
+
+  const ASTNode zero = c.mgr.CreateZeroConst(8);
+  const ASTNode one = c.mgr.CreateOneConst(8);
+  const ASTNode two = c.mgr.CreateBVConst(8, 2);
+  const ASTNode three = c.mgr.CreateBVConst(8, 3);
+  const ASTNode maximum = c.mgr.CreateMaxConst(8);
+  const ASTNode x = c.mgr.CreateSymbol("ce-path-x", 0, 8);
+  const ASTNode y = c.mgr.CreateSymbol("ce-path-y", 0, 8);
+  const ASTNode p = c.mgr.CreateSymbol("ce-path-p", 0, 0);
+  const ASTNode q = c.mgr.CreateSymbol("ce-path-q", 0, 0);
+  ce.InsertIntoCounterExampleMap(x, one);
+  ce.InsertIntoCounterExampleMap(y, two);
+  ce.InsertIntoCounterExampleMap(p, c.mgr.ASTTrue);
+  ce.InsertIntoCounterExampleMap(q, c.mgr.ASTFalse);
+
+  // Formula continuations: a term operand, formula operands, Boolean
+  // extraction, and conditionally evaluating just one ITE branch.
+  const ASTNode sum = c.hf->CreateTerm(BVPLUS, 8, x, y);
+  EXPECT_EQ(c.mgr.ASTTrue,
+            ce.ModelValueOfFormula(c.hf->CreateNode(EQ, sum, three)));
+  EXPECT_EQ(c.mgr.ASTTrue, ce.ModelValueOfFormula(c.hf->CreateNode(
+                               AND, p, c.hf->CreateNode(NOT, q))));
+  EXPECT_EQ(c.mgr.ASTTrue, ce.ModelValueOfFormula(c.hf->CreateNode(
+                               BOOLEXTRACT, x, c.mgr.CreateBVConst(32, 0))));
+  EXPECT_EQ(c.mgr.ASTFalse,
+            ce.ModelValueOfFormula(c.hf->CreateNode(ITE, p, q, c.mgr.ASTTrue)));
+
+  // Term continuations: ordinary operands and a selected ITE branch.
+  EXPECT_EQ(three, ce.ModelValueOfTerm(sum));
+  EXPECT_EQ(one, ce.ModelValueOfTerm(c.hf->CreateTerm(ITE, 8, p, x, y)));
+
+  const ASTNode base = c.mgr.CreateSymbol("ce-path-array", 8, 8);
+  const ASTNode other = c.mgr.CreateSymbol("ce-path-other", 8, 8);
+  const ASTNode symbolicIndex = c.mgr.CreateSymbol("ce-path-index", 0, 8);
+  const ASTNode plainRead = c.hf->CreateTerm(READ, 8, base, symbolicIndex);
+
+  // The formerly uncovered completion path: a read requested as a concrete
+  // value, with array equality disabled and no model entry, is all ones.
+  c.mgr.UserFlags.enable_array_equality = false;
+  EXPECT_EQ(maximum, ce.ModelValueOfTerm(plainRead));
+
+  // Expansion resumes both when a write hits and when it misses and pushes
+  // the read into the base array.
+  const ASTNode write = c.hf->CreateArrayTerm(WRITE, 8, 8, base, zero, one);
+  EXPECT_EQ(one, ce.Expand_ReadOverWrite_UsingModel(
+                     c.hf->CreateTerm(READ, 8, write, zero), false));
+  EXPECT_EQ(maximum, ce.Expand_ReadOverWrite_UsingModel(
+                         c.hf->CreateTerm(READ, 8, write, two), false));
+
+  // A read over an array ITE keeps its evaluated index while the condition
+  // and selected read are evaluated below it.
+  const ASTNode otherAtZero = c.mgr.CreateTerm(READ, 8, other, zero);
+  ce.InsertIntoCounterExampleMap(otherAtZero, two);
+  const ASTNode arrayChoice = c.hf->CreateArrayTerm(ITE, 8, 8, q, base, other);
+  EXPECT_EQ(two,
+            ce.ModelValueOfTerm(c.hf->CreateTerm(READ, 8, arrayChoice, zero)));
+
+  // Equality propagation can leave an array symbol as an alias for an array
+  // term. The definition continuation must evaluate the read through it.
+  const ASTNode alias = c.mgr.CreateSymbol("ce-path-alias", 8, 8);
+  ce.InsertIntoCounterExampleMap(alias, write);
+  EXPECT_EQ(one, ce.ModelValueOfTerm(c.hf->CreateTerm(READ, 8, alias, zero)));
+}
+
 TEST(DeepDag, array_transformer_job_specific_operands_preserve_paths)
 {
   Context c;
@@ -2301,6 +2372,59 @@ TEST(DeepDag, array_transformer_read_state_survives_nested_arena_growth)
   ASSERT_EQ(1U, transformer.arrayToIndexToRead.count(elsArray));
   EXPECT_EQ(1U, transformer.arrayToIndexToRead.at(thnArray).count(index));
   EXPECT_EQ(1U, transformer.arrayToIndexToRead.at(elsArray).count(index));
+}
+
+TEST(DeepDag, array_transformer_selected_and_write_continuations)
+{
+  Context c;
+  const ASTNode zero = c.mgr.CreateZeroConst(8);
+  const ASTNode one = c.mgr.CreateOneConst(8);
+  const ASTNode two = c.mgr.CreateBVConst(8, 2);
+  const ASTNode base = c.mgr.CreateSymbol("transform-path-base", 8, 8);
+  const ASTNode dropped = c.mgr.CreateSymbol("transform-path-dropped", 8, 8);
+  const ASTNode write = c.hf->CreateArrayTerm(WRITE, 8, 8, base, zero, one);
+  const ASTNode writeHit = c.hf->CreateTerm(READ, 8, write, zero);
+  const ASTNode writeMiss = c.hf->CreateTerm(READ, 8, write, two);
+  const ASTNode baseRead = c.hf->CreateTerm(READ, 8, base, zero);
+  const ASTNode droppedRead = c.hf->CreateTerm(READ, 8, dropped, zero);
+
+  // Both term ITE and read-over-array-ITE should transform only the branch
+  // selected by a constant condition. The write cases exercise both the
+  // direct hit and the read pushed into the base array after a miss.
+  const ASTNode termChoice =
+      c.hf->CreateTerm(ITE, 8, c.mgr.ASTTrue, baseRead, droppedRead);
+  const ASTNode arrayChoice =
+      c.hf->CreateArrayTerm(ITE, 8, 8, c.mgr.ASTTrue, base, dropped);
+  const ASTNode arrayChoiceRead = c.hf->CreateTerm(READ, 8, arrayChoice, zero);
+  const ASTNode input =
+      c.hf->CreateNode(AND, ASTVec{c.hf->CreateNode(EQ, writeHit, one),
+                                   c.hf->CreateNode(EQ, writeMiss, two),
+                                   c.hf->CreateNode(EQ, termChoice, one),
+                                   c.hf->CreateNode(EQ, arrayChoiceRead, one)});
+
+  SubstitutionMap sm(&c.mgr);
+  Simplifier simp(&c.mgr, &sm);
+  ArrayTransformer transformer(&c.mgr, &simp);
+  const ASTNode result = transformer.TransformFormula_TopLevel(input);
+
+  bool sawRead = false;
+  ASTNodeSet visited;
+  ASTVec pending{result};
+  while (!pending.empty())
+  {
+    const ASTNode n = pending.back();
+    pending.pop_back();
+    if (!visited.insert(n).second)
+      continue;
+    sawRead |= n.GetKind() == READ;
+    pending.insert(pending.end(), n.begin(), n.end());
+  }
+
+  EXPECT_FALSE(sawRead);
+  EXPECT_EQ(0U, transformer.arrayToIndexToRead.count(dropped));
+  ASSERT_EQ(1U, transformer.arrayToIndexToRead.count(base));
+  EXPECT_EQ(1U, transformer.arrayToIndexToRead.at(base).count(zero));
+  EXPECT_EQ(1U, transformer.arrayToIndexToRead.at(base).count(two));
 }
 
 TEST(DeepDag, array_transformer_root_fast_paths_preserve_leaf_formulas)

--- a/tests/unit-tests/DeepDag_Test.cpp
+++ b/tests/unit-tests/DeepDag_Test.cpp
@@ -720,6 +720,31 @@ bool fpTotaliseChainOk(Context& c, unsigned depth)
 #endif // STP_ENABLE_FLOATING_POINT
 
 
+// The LISP printer, which is what operator<< on a node uses -- so a deep
+// node cannot even be printed, including from an error path.
+bool printerLispOk(Context& c, unsigned depth)
+{
+  const ASTNode f = c.formula(c.chain(BVXOR, depth));
+  c.roots.push_back(f);
+  std::ostringstream os;
+  os << f;
+  return os.str().size() > 0;
+}
+
+// The SMT-LIB2 printer, behind --print-back-SMTLIB2. The same shape as the
+// LISP printer, which is done, but about thirty arms each interleaving
+// their own text with their operands, so it is a long mechanical
+// conversion rather than a subtle one. Its output is exactly checkable,
+// which is what makes it low risk.
+bool printerSMTLIB2Ok(Context& c, unsigned depth)
+{
+  const ASTNode f = c.formula(c.chain(BVXOR, depth));
+  c.roots.push_back(f);
+  std::ostringstream os;
+  printer::SMTLIB2_Print1(os, f, 0, false);
+  return os.str().size() > 0;
+}
+
 TEST(DeepDag, shallow_rewriting)
 {
   Context c;
@@ -1121,10 +1146,15 @@ TEST(DeepDag, deep_array_read_count_walk)
 }
 #ifdef STP_ENABLE_FLOATING_POINT
 TEST(DeepDag, deep_fp_totalise)        { EXPECT_STACK_SAFE(fpTotaliseChainOk, 20000); }
+#endif // STP_ENABLE_FLOATING_POINT
+
+TEST(DeepDag, deep_printer_lisp)       { EXPECT_STACK_SAFE(printerLispOk, 20000); }
+#ifdef STP_ENABLE_FLOATING_POINT
 TEST(DeepDag, deep_fp_format_ite)      { EXPECT_STACK_SAFE(fpFormatIteChainOk, 20000); }
 TEST(DeepDag, deep_fp_format_store)    { EXPECT_STACK_SAFE(fpFormatStoreChainOk, 20000); }
 TEST(DeepDag, deep_source_sort_ite)    { EXPECT_STACK_SAFE(sourceSortIteChainOk, 20000); }
 TEST(DeepDag, deep_source_sort_store)  { EXPECT_STACK_SAFE(sourceSortStoreChainOk, 20000); }
 #endif // STP_ENABLE_FLOATING_POINT
 
+TEST(DeepDag, DISABLED_deep_printer_smtlib2)    { EXPECT_STACK_SAFE(printerSMTLIB2Ok, 20000); }
 } // namespace

--- a/tests/unit-tests/DeepDag_Test.cpp
+++ b/tests/unit-tests/DeepDag_Test.cpp
@@ -237,6 +237,32 @@ ASTNode storeChain(Context& c, unsigned depth)
 #endif // STP_ENABLE_FLOATING_POINT
 
 
+// Dependencies::build, the parent map constant-bit propagation runs on.
+// Two of the 21 known corpus crashes land here.
+bool dependenciesChainOk(Context& c, unsigned depth)
+{
+  const ASTNode top = c.formula(c.chain(BVXOR, depth));
+  c.roots.push_back(top);
+
+  simplifier::constantBitP::Dependencies deps(top);
+
+  // Every link of the chain is read by exactly one parent, the link above
+  // it -- and the traversal has to have reached the bottom to know that.
+  ASTNode n = Context::childOfKind(top, BVXOR);
+  unsigned levels = 0;
+  while (n.GetKind() == BVXOR)
+  {
+    const ASTNode child = n[0].GetKind() == BVXOR ? n[0] : n[1];
+    if (deps.getDependents(child).size() != 1)
+      return false;
+    if (!deps.nodeDependsOn(n, child))
+      return false;
+    n = child;
+    levels++;
+  }
+  return levels == depth - 1;
+}
+
 // Rewriting::rewrite (19 of the 21 known corpus crashes, ~9,300 nested
 // frames deep) and, ahead of it in the same pass, the equally unbounded
 // Rewriting::buildShareCount.
@@ -776,6 +802,25 @@ bool mutableDagRepeatedEdgesOk(Context& c)
   return ok;
 }
 
+// WorkList::addToWorklist, which seeds constant-bit propagation by walking
+// the whole input. A constant somewhere in the chain is what puts nodes on
+// the worklist at all, so the chain is built with one.
+bool workListOk(Context& c, unsigned depth)
+{
+  ASTNode t = c.mgr.CreateSymbol("k0", 0, 8);
+  for (unsigned i = 1; i < depth; i++)
+  {
+    const std::string nm = "k" + std::to_string(i);
+    t = c.hf->CreateTerm(BVXOR, 8, t, c.mgr.CreateSymbol(nm.c_str(), 0, 8));
+    t = c.hf->CreateTerm(BVPLUS, 8, t, c.mgr.CreateOneConst(8));
+  }
+  const ASTNode f = c.formula(t);
+  c.roots.push_back(f);
+
+  simplifier::constantBitP::WorkList wl(f);
+  return wl.size() > 0;
+}
+
 // FlattenKind, which every pass that wants an n-ary view of a nested
 // same-kind chain goes through: the simplifier, the BV solver,
 // PropagateEqualities, MergeSame and UseITEContext. Its two forms differ in
@@ -951,6 +996,15 @@ bool printerSMTLIB2Ok(Context& c, unsigned depth)
   std::ostringstream os;
   printer::SMTLIB2_Print1(os, f, 0, false);
   return os.str().size() > 0;
+}
+
+/* Control cases: the same properties on a chain shallow enough for the
+   recursive implementations. These pass today, so a deep case failing is
+   about stack depth and nothing else. */
+TEST(DeepDag, shallow_dependencies_build)
+{
+  Context c;
+  EXPECT_TRUE(dependenciesChainOk(c, SHALLOW));
 }
 
 TEST(DeepDag, shallow_rewriting)
@@ -1184,6 +1238,21 @@ TEST(DeepDag, duplicate_flatten_kind_does_not_reserve_discarded_edges)
   EXPECT_LT(flat.capacity(), holder.Degree());
 }
 
+TEST(DeepDag, work_list_shared_edges_are_visited_once)
+{
+  Context c;
+  const ASTNode symbol = c.mgr.CreateSymbol("work-list-shared", 0, 8);
+  const ASTNode one = c.mgr.CreateOneConst(8);
+  const ASTNode dependsOnConstant = c.hf->CreateTerm(BVXOR, 8, symbol, one);
+  const ASTNode shared = c.hf->CreateTerm(BVNOT, 8, dependsOnConstant);
+  const ASTNode top = c.hf->CreateTerm(BVXOR, 8, shared, shared);
+
+  simplifier::constantBitP::WorkList workList(top);
+  ASSERT_EQ(1, workList.size());
+  EXPECT_EQ(dependsOnConstant, workList.pop());
+  EXPECT_TRUE(workList.isEmpty());
+}
+
 TEST(DeepDag, shallow_strength_reduction)
 {
   Context c;
@@ -1308,6 +1377,21 @@ TEST(DeepDag, mutable_dag_shared_children_rebuild_in_operand_order)
   EXPECT_TRUE(mutableDagSharedRebuildOk(c));
 }
 
+/* The same properties on inputs deeper than the call stack can hold.
+   Depths are picked so each case reaches the traversal it is named for:
+   buildShareCount's frames are far smaller than rewrite's, so it only
+   fails first on a much deeper input.
+
+   The cases still marked DISABLED_ are the traversals that have not been
+   converted yet; each is enabled by the commit that converts the traversal
+   it names. deep_rewriting_share_count needs both buildShareCount and
+   rewrite, since topLevel runs them back to back and there is no way in
+   from outside to run only the first. */
+TEST(DeepDag, deep_dependencies_build)
+{
+  EXPECT_STACK_SAFE(dependenciesChainOk, 50000);
+}
+
 TEST(DeepDag, deep_rewriting_share_count)
 {
   EXPECT_STACK_SAFE(rewritingIdentityOk, 200000);
@@ -1374,6 +1458,7 @@ TEST(DeepDag, deep_bit_blast_nested)
 }
 
 TEST(DeepDag, deep_common_sub_sum)              { EXPECT_STACK_SAFE(commonSubSumOk, 20000); }
+TEST(DeepDag, deep_work_list)          { EXPECT_STACK_SAFE(workListOk, 20000); }
 TEST(DeepDag, deep_remove_unconstrained) { EXPECT_STACK_SAFE(removeUnconstrainedOk, 20000); }
 TEST(DeepDag, deep_mutable_dag_walks)
 {

--- a/tests/unit-tests/DeepDag_Test.cpp
+++ b/tests/unit-tests/DeepDag_Test.cpp
@@ -879,6 +879,31 @@ bool numberOfReadsWalkOk(Context& c, unsigned depth)
   c.roots.push_back(earlyStop);
   return !numberOfReadsLessThan(earlyStop, 1);
 }
+
+// Solve-boundary array equality lowering used a recursive std::function for
+// this post-order rebuild. A write chain is unchanged below the equality but
+// still drove that function one native frame per write; at 5,000 writes it
+// dies under a 512 KiB stack before any ordinary preprocessing runs.
+bool arrayEqualityLoweringOk(Context& c, unsigned depth)
+{
+  c.mgr.UserFlags.enable_array_equality = true;
+  ASTNode chain = c.mgr.CreateSymbol("lower-array-a", 16, 8);
+  const ASTNode other = c.mgr.CreateSymbol("lower-array-b", 16, 8);
+  const ASTNode index = c.mgr.CreateSymbol("lower-array-i", 0, 16);
+  const ASTNode value = c.mgr.CreateSymbol("lower-array-v", 0, 8);
+  for (unsigned i = 0; i < depth; ++i)
+    chain = c.hf->CreateArrayTerm(WRITE, 16, 8, chain, index, value);
+
+  const ASTNode opaque = c.hf->CreateNode(EQ, chain, other);
+  c.roots.push_back(opaque);
+
+  ExtensionalityContext ext(&c.mgr);
+  ext.beginSolve();
+  const ASTNode lowered = ext.lowerArrayEqualities(opaque);
+  c.roots.push_back(lowered);
+  return lowered.GetKind() == SYMBOL && ext.getRecords().size() == 1 &&
+         ext.getActiveRecordCount() == 1;
+}
 #ifdef STP_ENABLE_FLOATING_POINT
 
 /* A node's floating-point format and its source sort are both derived from
@@ -1471,6 +1496,10 @@ TEST(DeepDag, deep_propagate_equalities) { EXPECT_STACK_SAFE(propagateEqualities
 TEST(DeepDag, deep_array_read_count_walk)
 {
   EXPECT_STACK_SAFE(numberOfReadsWalkOk, 20000);
+}
+TEST(DeepDag, deep_array_equality_lowering)
+{
+  EXPECT_STACK_SAFE(arrayEqualityLoweringOk, 20000);
 }
 #ifdef STP_ENABLE_FLOATING_POINT
 TEST(DeepDag, deep_fp_totalise)        { EXPECT_STACK_SAFE(fpTotaliseChainOk, 20000); }

--- a/tests/unit-tests/DeepDag_Test.cpp
+++ b/tests/unit-tests/DeepDag_Test.cpp
@@ -202,6 +202,50 @@ struct Context
 };
 #ifdef STP_ENABLE_FLOATING_POINT
 
+// Structural depth without putting the measurement itself on the call
+// stack. Memoisation matters for the generated FP circuits, which are DAGs
+// with extensive sharing rather than trees.
+size_t dagDepth(const ASTNode& top)
+{
+  struct Frame
+  {
+    ASTNode node;
+    size_t nextChild = 0;
+    size_t deepestChild = 0;
+
+    explicit Frame(const ASTNode& n) : node(n) {}
+  };
+
+  std::unordered_map<uint64_t, size_t> known;
+  std::vector<Frame> stack;
+  stack.emplace_back(top);
+  size_t result = 0;
+
+  while (!stack.empty())
+  {
+    Frame& frame = stack.back();
+    if (frame.nextChild < frame.node.Degree())
+    {
+      const ASTNode child = frame.node[frame.nextChild++];
+      const auto found = known.find(child.GetNodeNum());
+      if (found != known.end())
+        frame.deepestChild = std::max(frame.deepestChild, found->second);
+      else
+        stack.emplace_back(child);
+      continue;
+    }
+
+    result = frame.deepestChild + 1;
+    known[frame.node.GetNodeNum()] = result;
+    stack.pop_back();
+    if (!stack.empty())
+      stack.back().deepestChild =
+          std::max(stack.back().deepestChild, result);
+  }
+
+  return result;
+}
+
 // A chain of if-then-else terms, nested in the else-branch: a boolean symbol
 // the model says nothing about takes false, so evaluating one descends the
 // chain rather than stopping at the first level.
@@ -418,6 +462,57 @@ bool strengthReductionOk(Context& c, unsigned depth)
   return result == top;
 }
 
+// Simplifier::SimplifyFormula. The AND/OR spine it nests through is walked
+// on the heap; the other boolean kinds still recurse into each other.
+bool simplifyOk(Context& c, unsigned depth)
+{
+  // A chain of ANDs: each operand of each one is simplified by coming back
+  // through SimplifyFormula.
+  ASTNode f = c.hf->CreateNode(EQ, c.mgr.CreateSymbol("s0", 0, 8),
+                               c.mgr.CreateZeroConst(8));
+  for (unsigned i = 1; i < depth; i++)
+  {
+    const std::string name = "s" + std::to_string(i);
+    const ASTNode leaf = c.hf->CreateNode(
+        EQ, c.mgr.CreateSymbol(name.c_str(), 0, 8), c.mgr.CreateZeroConst(8));
+    f = c.hf->CreateNode(AND, leaf, f);
+  }
+  c.roots.push_back(f);
+
+  SubstitutionMap sm(&c.mgr);
+  Simplifier simp(&c.mgr, &sm);
+  const ASTNode result = simp.SimplifyFormula_TopLevel(f, false);
+  c.roots.push_back(result);
+  return result.GetKind() == AND || result.GetKind() == EQ;
+}
+
+// The formula arms that are not AND or OR. Those two were walked on the heap
+// first, on the argument that the rest "nest through each other rather than
+// through a spine, and nothing has been seen to reach a depth that matters".
+// A float chain's lowering nests NOT and if-then-else exactly that way: a
+// query built from 8,000 nested fp.add operations died in these two arms, at
+// a depth below the deepest input we have.
+bool simplifyFormulaSpineOk(Context& c, unsigned depth)
+{
+  const ASTNode p = c.mgr.CreateSymbol("p", 0, 0);
+  ASTNode f = c.hf->CreateNode(EQ, c.mgr.CreateSymbol("s0", 0, 8),
+                               c.mgr.CreateZeroConst(8));
+  for (unsigned i = 1; i < depth; i++)
+  {
+    const std::string name = "s" + std::to_string(i);
+    const ASTNode leaf = c.hf->CreateNode(
+        EQ, c.mgr.CreateSymbol(name.c_str(), 0, 8), c.mgr.CreateZeroConst(8));
+    f = c.hf->CreateNode(NOT, c.hf->CreateNode(ITE, p, leaf, f));
+  }
+  c.roots.push_back(f);
+
+  SubstitutionMap sm(&c.mgr);
+  Simplifier simp(&c.mgr, &sm);
+  const ASTNode result = simp.SimplifyFormula_TopLevel(f, false);
+  c.roots.push_back(result);
+  return result.GetKind() != UNDEFINED;
+}
+
 // BitBlaster::BBTerm, which reaches its operands by calling itself from 24
 // places across its kind switch. The blaster uses ordinary recursion for a
 // bounded prefix, then fills the remaining suffix of its memo from the bottom
@@ -495,6 +590,304 @@ bool bitBlastOk(Context& c, unsigned depth)
   return nm.totalNumberOfNodes() >= static_cast<int>(depth);
 }
 
+// Simplifier's term side. The job machine must use the same flattened operand
+// policy as the old recursive code; simplifying intermediate BVAND/BVOR/
+// BVPLUS nodes would change which nodes the pass constructs.
+bool simplifyTermOk(Context& c, unsigned depth)
+{
+  const ASTNode t = c.chain(BVXOR, depth);
+  c.roots.push_back(t);
+  c.mgr.UserFlags.optimize_flag = true;
+  SubstitutionMap sm(&c.mgr);
+  Simplifier simp(&c.mgr, &sm);
+  return simp.SimplifyTerm(t).GetValueWidth() == 8;
+}
+
+// SimplifyTerm again, for the deep term it reaches through the substitution
+// map rather than through a child. The term handed to the pass is shallow;
+// everything below it arrives from the map, which is not somewhere a walk
+// over children would look.
+bool simplifyTermSubstitutedOk(Context& c, unsigned depth)
+{
+  const ASTNode deep = c.chain(BVXOR, depth);
+  c.roots.push_back(deep);
+
+  c.mgr.UserFlags.optimize_flag = true;
+  SubstitutionMap sm(&c.mgr);
+  Simplifier simp(&c.mgr, &sm);
+
+  const ASTNode s = c.mgr.CreateSymbol("substituted", 0, 8);
+  if (!simp.UpdateSolverMap(s, deep))
+    return false; // the map refused it: prove nothing quietly.
+
+  const ASTNode t =
+      c.hf->CreateTerm(BVMULT, 8, s, c.mgr.CreateSymbol("y0", 0, 8));
+  c.roots.push_back(t);
+  return simp.SimplifyTerm(t).GetValueWidth() == 8;
+}
+
+// The term work frame uses one operand buffer for both the inputs and their
+// answers. Exercise every way an entry can be handled: a boolean operand is a
+// formula job, a bit-vector operand is a term job, and an array operand stays
+// in place until READ schedules its separate array job.
+bool simplifyMixedTermOperandsOk(Context& c)
+{
+  const ASTNode zero = c.mgr.CreateZeroConst(8);
+  const ASTNode one = c.mgr.CreateOneConst(8);
+  const ASTNode index = c.mgr.CreateBVConst(8, 3);
+  const ASTNode stored = c.mgr.CreateBVConst(8, 0x2a);
+  const ASTNode array = c.mgr.CreateSymbol("operand-array", 8, 8);
+
+  const ASTNode write =
+      c.hf->CreateArrayTerm(WRITE, 8, 8, array, index, stored);
+  const ASTNode read = c.hf->CreateTerm(READ, 8, write, index);
+  const ASTNode condition = c.hf->CreateNode(EQ, zero, one);
+  const ASTNode selected = c.hf->CreateTerm(ITE, 8, condition, one, zero);
+  const ASTNode input = c.hf->CreateTerm(BVXOR, 8, selected, read);
+  c.roots.push_back(input);
+
+  c.mgr.UserFlags.optimize_flag = true;
+  SubstitutionMap sm(&c.mgr);
+  Simplifier simp(&c.mgr, &sm);
+  const ASTNode output = simp.SimplifyTerm(input);
+  c.roots.push_back(output);
+  return output == stored;
+}
+
+// A descendant term is prechecked before its frame is pushed. Preserve a
+// substitution image found by that check so the frame neither probes the map
+// again nor accidentally simplifies the original symbol instead.
+bool simplifyPrecheckedSubstitutionOk(Context& c)
+{
+  const ASTNode one = c.mgr.CreateOneConst(8);
+  const ASTNode two = c.mgr.CreateBVConst(8, 2);
+  const ASTNode three = c.mgr.CreateBVConst(8, 3);
+  const ASTNode substituted = c.mgr.CreateSymbol("prechecked", 0, 8);
+  const ASTNode image = c.hf->CreateTerm(BVPLUS, 8, one, two);
+  const ASTNode input = c.hf->CreateTerm(BVXOR, 8, substituted,
+                                         c.mgr.CreateZeroConst(8));
+  c.roots.push_back(image);
+  c.roots.push_back(input);
+
+  c.mgr.UserFlags.optimize_flag = true;
+  SubstitutionMap sm(&c.mgr);
+  Simplifier simp(&c.mgr, &sm);
+  if (!simp.UpdateSolverMap(substituted, image))
+    return false;
+
+  const ASTNode output = simp.SimplifyTerm(input);
+  c.roots.push_back(output);
+  return output == three;
+}
+
+// The NOT frame delegates an atomic child to AtomicJob. The child job owns
+// the pushed-negation memo entry, while the returning NOT frame owns its
+// outer entry; removing duplicate probes and writes must preserve both keys.
+bool simplifyNotAtomicMemoOk(Context& c)
+{
+  const ASTNode zero = c.mgr.CreateZeroConst(8);
+  const ASTNode x = c.mgr.CreateSymbol("memo-not-atomic", 0, 8);
+  const ASTNode term = c.hf->CreateTerm(BVXOR, 8, x, zero);
+  const ASTNode atomic = c.hf->CreateNode(EQ, term, zero);
+  const ASTNode input = c.hf->CreateNode(NOT, atomic);
+  c.roots.push_back(input);
+
+  c.mgr.UserFlags.optimize_flag = true;
+  SubstitutionMap sm(&c.mgr);
+  Simplifier simp(&c.mgr, &sm);
+  const ASTNode output = simp.SimplifyFormula(input, false);
+  c.roots.push_back(output);
+
+  ASTNode atomicCached;
+  ASTNode inputCached;
+  return simp.CheckSimplifyMap(atomic, atomicCached, true) &&
+         simp.CheckSimplifyMap(input, inputCached, false) &&
+         atomicCached == output && inputCached == output &&
+         simp.SimplifyFormula(input, false) == output;
+}
+
+// Leaves, cached roots and transparent root substitutions are all answered
+// before the unified simplifier needs a continuation frame. Exercise each
+// shortcut and then a nontrivial substituted image, which must still enter
+// the job machine and produce the same result.
+bool simplifyRootFastPathsOk(Context& c)
+{
+  const ASTNode zero = c.mgr.CreateZeroConst(8);
+  const ASTNode one = c.mgr.CreateOneConst(8);
+  const ASTNode two = c.mgr.CreateBVConst(8, 2);
+  const ASTNode x = c.mgr.CreateSymbol("root-fast-x", 0, 8);
+  const ASTNode cachedTerm = c.hf->CreateTerm(BVXOR, 8, x, zero);
+  const ASTNode cachedFormula = c.hf->CreateNode(EQ, cachedTerm, zero);
+  const ASTNode substituted = c.mgr.CreateSymbol("root-fast-sub", 0, 8);
+  const ASTNode image = c.hf->CreateTerm(BVPLUS, 8, one, two);
+  c.roots.push_back(cachedFormula);
+  c.roots.push_back(image);
+
+  c.mgr.UserFlags.optimize_flag = true;
+  SubstitutionMap sm(&c.mgr);
+  Simplifier simp(&c.mgr, &sm);
+
+  if (simp.SimplifyTerm(zero) != zero ||
+      simp.SimplifyFormula(c.mgr.ASTTrue, false) != c.mgr.ASTTrue)
+    return false;
+
+  const ASTNode termOutput = simp.SimplifyTerm(cachedTerm);
+  const ASTNode formulaOutput = simp.SimplifyFormula(cachedFormula, false);
+  if (simp.SimplifyTerm(cachedTerm) != termOutput ||
+      simp.SimplifyFormula(cachedFormula, false) != formulaOutput)
+    return false;
+
+  if (!simp.UpdateSolverMap(substituted, image))
+    return false;
+  const ASTNode substitutedOutput = simp.SimplifyTerm(substituted);
+  c.roots.push_back(termOutput);
+  c.roots.push_back(formulaOutput);
+  c.roots.push_back(substitutedOutput);
+  return termOutput.GetType() == BITVECTOR_TYPE &&
+         formulaOutput.GetType() == BOOLEAN_TYPE &&
+         substitutedOutput == c.mgr.CreateBVConst(8, 3);
+}
+#ifdef STP_ENABLE_FLOATING_POINT
+
+// A descendant request normally answers from the simplification map rather
+// than by pushing another work frame. The parent must consume those ready
+// term and formula answers in place: yielding and re-dispatching is wasted
+// work, while treating a ready answer as a completed parent drops the rest of
+// the parent entirely.
+bool simplifyReadyDescendantsOk(Context& c)
+{
+  const ASTNode zero = c.mgr.CreateZeroConst(8);
+  const ASTNode x = c.mgr.CreateSymbol("ready-descendant-x", 0, 8);
+  const ASTNode y = c.mgr.CreateSymbol("ready-descendant-y", 0, 8);
+  const ASTNode z = c.mgr.CreateSymbol("ready-descendant-z", 0, 8);
+  const ASTNode left = c.hf->CreateTerm(BVXOR, 8, x, zero);
+  const ASTNode right = c.hf->CreateTerm(BVXOR, 8, y, zero);
+  const ASTNode third = c.hf->CreateTerm(BVXOR, 8, z, zero);
+  const ASTNode equality = c.hf->CreateNode(EQ, left, right);
+  const ASTNode top = c.hf->CreateNode(AND, equality, c.mgr.ASTTrue);
+  c.roots.push_back(top);
+
+  c.mgr.UserFlags.optimize_flag = true;
+  SubstitutionMap sm(&c.mgr);
+  Simplifier simp(&c.mgr, &sm);
+
+  // Prime both term continuations and then the formula continuation. Every
+  // child request made while simplifying `top` can now answer immediately.
+  const ASTNode simplifiedLeft = simp.SimplifyTerm(left);
+  const ASTNode simplifiedRight = simp.SimplifyTerm(right);
+  const ASTNode simplifiedThird = simp.SimplifyTerm(third);
+  const ASTNode simplifiedEquality = simp.SimplifyFormula(equality, false);
+  const ASTNode output = simp.SimplifyFormula(top, false);
+
+  // Pin the n-ary loops too: each answer is ready, but every position still
+  // has to be consumed exactly once before the parent is rebuilt.
+  const ASTNode wideTerm =
+      c.hf->CreateTerm(BVXOR, 8, ASTVec{left, right, third});
+  const ASTNode expectedTerm = c.nf->CreateTerm(
+      BVXOR, 8, ASTVec{simplifiedLeft, simplifiedRight, simplifiedThird});
+  const ASTNode termOutput = simp.SimplifyTerm(wideTerm);
+
+  const ASTNode p = c.mgr.CreateSymbol("ready-descendant-p", 0, 0);
+  const ASTNode q = c.mgr.CreateSymbol("ready-descendant-q", 0, 0);
+  const ASTNode r = c.mgr.CreateSymbol("ready-descendant-r", 0, 0);
+  const ASTNode wideAnd =
+      c.hf->CreateNode(AND, ASTVec{p, q, r, c.mgr.ASTTrue});
+  const ASTNode expectedAnd = c.nf->CreateNode(AND, ASTVec{p, q, r});
+  const ASTNode andOutput = simp.SimplifyFormula(wideAnd, false);
+
+  const ASTNode wideXor = c.hf->CreateNode(XOR, ASTVec{p, q, r});
+  const ASTNode expectedXor = c.nf->CreateNode(XOR, ASTVec{p, q, r});
+  const ASTNode xorOutput = simp.SimplifyFormula(wideXor, false);
+
+  // Unary floating-point predicates collect their term operands through the
+  // same ready-answer loop rather than the binary atomic-formula path.
+  const ASTNode fp = c.mgr.CreateSymbol("ready-descendant-fp", 0, 16);
+  fp.SetExpWidth(5);
+  fp.SetSigWidth(11);
+  simp.SimplifyTerm(fp);
+  const ASTNode fpPredicate = c.hf->CreateNode(FP_ISNAN, fp);
+  const ASTNode expectedFpPredicate = c.nf->CreateNode(FP_ISNAN, fp);
+  const ASTNode fpOutput = simp.SimplifyFormula(fpPredicate, false);
+
+  c.roots.push_back(simplifiedEquality);
+  c.roots.push_back(output);
+  c.roots.push_back(termOutput);
+  c.roots.push_back(andOutput);
+  c.roots.push_back(xorOutput);
+  c.roots.push_back(fpOutput);
+  return output == simplifiedEquality && termOutput == expectedTerm &&
+         andOutput == expectedAnd && xorOutput == expectedXor &&
+         fpOutput == expectedFpPredicate;
+}
+#endif // STP_ENABLE_FLOATING_POINT
+
+
+// A term contains a formula which contains the preceding term, at every
+// level. Separate iterative formula and term drivers are insufficient for
+// this shape: calling from one driver into the other still makes one C++
+// frame per alternation.
+bool simplifyAlternatingTermFormulaOk(Context& c, unsigned depth)
+{
+  const ASTNode zero = c.mgr.CreateZeroConst(8);
+  const ASTNode one = c.mgr.CreateOneConst(8);
+  ASTNode term = c.mgr.CreateSymbol("alternating", 0, 8);
+  for (unsigned i = 0; i < depth; ++i)
+  {
+    const ASTNode condition = c.hf->CreateNode(EQ, term, zero);
+    term = c.hf->CreateTerm(ITE, 8, condition, one, zero);
+  }
+  c.roots.push_back(term);
+
+  c.mgr.UserFlags.optimize_flag = true;
+  SubstitutionMap sm(&c.mgr);
+  Simplifier simp(&c.mgr, &sm);
+  const ASTNode output = simp.SimplifyTerm(term);
+  c.roots.push_back(output);
+  return output.GetValueWidth() == 8;
+}
+#ifdef STP_ENABLE_FLOATING_POINT
+
+// A source expression only three operations deep can lower to a bit-vector
+// circuit thousands of terms deep. This is the shape that made term priming
+// an incomplete fix: the generated nodes did not exist when the input was
+// primed, so SimplifyTerm still descended them recursively. Exponent width
+// 11 is the supported boundary for fp.rem and generates the 8,000-level case
+// from rem-exponent-width-boundary.smt2; width 5 is the shallow control.
+bool simplifyInternallyGeneratedFpTermOk(Context& c, unsigned exponentWidth)
+{
+  const unsigned significandWidth = 8;
+  const unsigned width = exponentWidth + significandWidth;
+  const ASTNode x = c.mgr.CreateSymbol("generated-fp", 0, width);
+  x.SetExpWidth(exponentWidth);
+  x.SetSigWidth(significandWidth);
+  const ASTNode rm = c.mgr.CreateBVConst(
+      5, symbolic_fp::ROUND_NEAREST_TIES_TO_EVEN);
+  const ASTNode rounded =
+      c.hf->CreateTerm(FP_ROUNDTOINTEGRAL, width, rm, x);
+  const ASTNode remainder = c.hf->CreateTerm(FP_REM, width, rounded, x);
+  const ASTNode source = c.hf->CreateNode(FP_ISNAN, remainder);
+  c.roots.push_back(source);
+
+  FpEncodingContext encoding(&c.mgr);
+  const ASTNode prepared = encoding.prepare(source);
+  const ASTNode lowered = encoding.lowerPrepared(prepared);
+  c.roots.push_back(prepared);
+  c.roots.push_back(lowered);
+  if (lowered == prepared)
+    return false; // no generated circuit means the intended path was missed.
+  if (exponentWidth == 11 && dagDepth(lowered) < 4000)
+    return false; // keep the low-stack case deep even if lowering changes.
+
+  c.mgr.UserFlags.optimize_flag = true;
+  SubstitutionMap sm(&c.mgr);
+  Simplifier simp(&c.mgr, &sm);
+  const ASTNode output = simp.SimplifyFormula_TopLevel(lowered, false);
+  c.roots.push_back(output);
+  return output.GetType() == BOOLEAN_TYPE && output.GetKind() != UNDEFINED;
+}
+#endif // STP_ENABLE_FLOATING_POINT
+
+
 // CreateSimpleEQ peels equal sides from two concat chains. Each peel used to
 // re-enter the simplifying node factory and consume another C++ frame.
 bool concatEqualityOk(Context& c, unsigned depth)
@@ -538,6 +931,39 @@ bool concatConstantEqualityOk(Context& c, unsigned depth)
       c.nf->CreateNode(EQ, c.mgr.CreateZeroConst(depth), concat);
   c.roots.push_back(result);
   return result.GetType() == BOOLEAN_TYPE;
+}
+
+// Simplifier::CreateSimplifiedEQ compares every bit of the leading constant
+// prefixes. Make the only difference their least-significant bit, so it must
+// inspect the whole prefix; each lookup must reuse the constant found by one
+// descent through these deep concat chains.
+bool leadingConcatConstantScanOk(Context& c, unsigned depth)
+{
+  ASTNode lhs = c.mgr.CreateZeroConst(depth);
+  ASTNode rhs = c.mgr.CreateOneConst(depth);
+  const ASTNode tail = c.mgr.CreateSymbol("leading-constant-tail", 0, 1);
+  for (unsigned i = 0; i < depth; ++i)
+  {
+    const unsigned width = depth + i + 1;
+    lhs = c.hf->CreateTerm(BVCONCAT, width, lhs, tail);
+    rhs = c.hf->CreateTerm(BVCONCAT, width, rhs, tail);
+  }
+  c.roots.push_back(lhs);
+  c.roots.push_back(rhs);
+
+  SubstitutionMap sm(&c.mgr);
+  Simplifier simp(&c.mgr, &sm);
+  return simp.CreateSimplifiedEQ(lhs, rhs) == c.mgr.ASTFalse;
+}
+
+// UseITEContext::visit. Carries a context set down, so neither the walker
+// nor priming fits: the same node under two contexts has two answers.
+bool useITEContextOk(Context& c, unsigned depth)
+{
+  const ASTNode f = c.formula(c.chain(BVXOR, depth));
+  c.roots.push_back(f);
+  UseITEContext u(&c.mgr);
+  return u.topLevel(f).GetKind() != UNDEFINED;
 }
 
 // NodeDomainAnalysis::buildMap.
@@ -1329,6 +1755,12 @@ TEST(DeepDag, shallow_strength_reduction)
   EXPECT_TRUE(strengthReductionOk(c, SHALLOW));
 }
 
+TEST(DeepDag, shallow_simplify)
+{
+  Context c;
+  EXPECT_TRUE(simplifyOk(c, SHALLOW));
+}
+
 TEST(DeepDag, shallow_bit_blast)
 {
   Context c;
@@ -1347,6 +1779,54 @@ TEST(DeepDag, shallow_bit_blast_nested)
   EXPECT_TRUE(bitBlastNestedOk(c, SHALLOW));
 }
 
+TEST(DeepDag, simplify_term_preserves_mixed_operand_positions)
+{
+  Context c;
+  EXPECT_TRUE(simplifyMixedTermOperandsOk(c));
+}
+
+TEST(DeepDag, simplify_term_preserves_prechecked_substitution)
+{
+  Context c;
+  EXPECT_TRUE(simplifyPrecheckedSubstitutionOk(c));
+}
+
+TEST(DeepDag, simplify_not_atomic_preserves_memo_edges)
+{
+  Context c;
+  EXPECT_TRUE(simplifyNotAtomicMemoOk(c));
+}
+
+TEST(DeepDag, simplifier_root_fast_paths_preserve_results)
+{
+  Context c;
+  EXPECT_TRUE(simplifyRootFastPathsOk(c));
+}
+#ifdef STP_ENABLE_FLOATING_POINT
+
+TEST(DeepDag, simplifier_consumes_ready_descendants_in_place)
+{
+  Context c;
+  EXPECT_TRUE(simplifyReadyDescendantsOk(c));
+}
+#endif // STP_ENABLE_FLOATING_POINT
+
+
+TEST(DeepDag, shallow_simplify_alternating_term_formula)
+{
+  Context c;
+  EXPECT_TRUE(simplifyAlternatingTermFormulaOk(c, SHALLOW));
+}
+#ifdef STP_ENABLE_FLOATING_POINT
+
+TEST(DeepDag, shallow_simplify_internally_generated_fp_term)
+{
+  Context c;
+  EXPECT_TRUE(simplifyInternallyGeneratedFpTermOk(c, 5));
+}
+#endif // STP_ENABLE_FLOATING_POINT
+
+
 TEST(DeepDag, shallow_concat_equality)
 {
   Context c;
@@ -1357,6 +1837,12 @@ TEST(DeepDag, shallow_concat_constant_equality)
 {
   Context c;
   EXPECT_TRUE(concatConstantEqualityOk(c, SHALLOW));
+}
+
+TEST(DeepDag, shallow_leading_concat_constant_scan)
+{
+  Context c;
+  EXPECT_TRUE(leadingConcatConstantScanOk(c, SHALLOW));
 }
 
 TEST(DeepDag, shallow_mutable_dag_walks)
@@ -1524,6 +2010,16 @@ TEST(DeepDag, deep_strength_reduction)
   EXPECT_STACK_SAFE(strengthReductionOk, 20000);
 }
 
+TEST(DeepDag, deep_simplify)
+{
+  EXPECT_STACK_SAFE(simplifyOk, 20000);
+}
+
+TEST(DeepDag, deep_simplify_formula_spine)
+{
+  EXPECT_STACK_SAFE(simplifyFormulaSpineOk, 20000);
+}
+
 TEST(DeepDag, deep_bit_blast)
 {
   EXPECT_STACK_SAFE(bitBlastOk, 20000);
@@ -1542,6 +2038,19 @@ TEST(DeepDag, deep_bit_blast_nested)
 TEST(DeepDag, deep_common_sub_sum)              { EXPECT_STACK_SAFE(commonSubSumOk, 20000); }
 TEST(DeepDag, deep_work_list)          { EXPECT_STACK_SAFE(workListOk, 20000); }
 TEST(DeepDag, deep_remove_unconstrained) { EXPECT_STACK_SAFE(removeUnconstrainedOk, 20000); }
+TEST(DeepDag, deep_simplify_term)      { EXPECT_STACK_SAFE(simplifyTermOk, 20000); }
+TEST(DeepDag, deep_simplify_term_substituted) { EXPECT_STACK_SAFE(simplifyTermSubstitutedOk, 20000); }
+TEST(DeepDag, deep_simplify_alternating_term_formula)
+{
+  EXPECT_STACK_SAFE(simplifyAlternatingTermFormulaOk, 20000);
+}
+#ifdef STP_ENABLE_FLOATING_POINT
+TEST(DeepDag, deep_simplify_internally_generated_fp_term)
+{
+  EXPECT_STACK_SAFE(simplifyInternallyGeneratedFpTermOk, 11);
+}
+#endif // STP_ENABLE_FLOATING_POINT
+
 TEST(DeepDag, deep_concat_equality)
 {
   EXPECT_STACK_SAFE(concatEqualityOk, 20000);
@@ -1550,10 +2059,15 @@ TEST(DeepDag, deep_concat_constant_equality)
 {
   EXPECT_STACK_SAFE(concatConstantEqualityOk, 4000);
 }
+TEST(DeepDag, deep_leading_concat_constant_scan)
+{
+  EXPECT_STACK_SAFE(leadingConcatConstantScanOk, 20000);
+}
 TEST(DeepDag, deep_mutable_dag_walks)
 {
   EXPECT_STACK_SAFE(mutableDagWalksOk, 20000);
 }
+TEST(DeepDag, DISABLED_deep_use_ite_context)    { EXPECT_STACK_SAFE(useITEContextOk, 20000); }
 TEST(DeepDag, deep_node_domain)        { EXPECT_STACK_SAFE(nodeDomainOk, 20000); }
 TEST(DeepDag, deep_node_iterator)      { EXPECT_STACK_SAFE(nodeIteratorOk, 20000); }
 TEST(DeepDag, deep_vars_in_expression) { EXPECT_STACK_SAFE(varsInExpressionOk, 20000); }

--- a/tests/unit-tests/Extensionality_Test.cpp
+++ b/tests/unit-tests/Extensionality_Test.cpp
@@ -2721,6 +2721,35 @@ TEST_F(ExtPrepareTest, WitnessIndexOverAWriteChainOperandIsAccepted)
       << " right=" << r.canonicalRight;
 }
 
+// Every write in this chain has the same deep index DAG. Witness-index
+// validation is a property of that DAG, not of an incoming write edge: the
+// shared index must be checked once and then reused rather than rebuilt into
+// a fresh post-order map for every write in the operand.
+TEST_F(ExtPrepareTest, SharedDeepWriteIndexDagIsAccepted)
+{
+  NodeFactory* hf = mgr.hashingNodeFactory;
+  ASTNode a = arr("shared-index-a"), b = arr("shared-index-b");
+  ASTNode index = bv("shared-index-i");
+  const ASTNode value = bv("shared-index-v");
+  for (unsigned i = 0; i < 1000; ++i)
+    index = hf->CreateTerm(BVNOT, 2, index);
+
+  ASTNode chain = a;
+  for (unsigned i = 0; i < 1000; ++i)
+    chain = hf->CreateArrayTerm(WRITE, 2, 2, {chain, index, value});
+
+  ext->beginSolve();
+  const ASTNode proxy =
+      ext->lowerArrayEqualities(hf->CreateNode(EQ, chain, b));
+  const ASTNode root = ext->conjoinRecordConstraints(proxy);
+  ext->prepare(root);
+
+  const ExtensionalityContext::Record& r = ext->getRecords()[0];
+  EXPECT_TRUE((r.canonicalLeft == chain && r.canonicalRight == b) ||
+              (r.canonicalLeft == b && r.canonicalRight == chain));
+  EXPECT_TRUE(ext->ownsArray(chain));
+}
+
 TEST_F(ExtPrepareTest, DuplicateAnchorFailsLoudly)
 {
   NodeFactory* hf = mgr.hashingNodeFactory;

--- a/tests/unit-tests/FpModelEquality_Test.cpp
+++ b/tests/unit-tests/FpModelEquality_Test.cpp
@@ -53,6 +53,7 @@ THE SOFTWARE.
 
 #include "stp/AbsRefineCounterExample/AbsRefine_CounterExample.h"
 #include "stp/AbsRefineCounterExample/ArrayTransformer.h"
+#include "stp/FloatBlaster/FpEncodingContext.h"
 #include "stp/STPManager/STPManager.h"
 #include "stp/Simplifier/Simplifier.h"
 #include <gtest/gtest.h>
@@ -83,13 +84,16 @@ protected:
   SubstitutionMap substitutions;
   Simplifier simplifier;
   ArrayTransformer transformer;
+  FpEncodingContext encoding;
   AbsRefine_CounterExample ce;
   unsigned counter = 0;
 
   FpModelEqualityTest()
       : substitutions(&mgr), simplifier(&mgr, &substitutions),
-        transformer(&mgr, &simplifier), ce(&mgr, &simplifier, &transformer)
+        transformer(&mgr, &simplifier), encoding(&mgr),
+        ce(&mgr, &simplifier, &transformer)
   {
+    ce.setFpEncodingContext(&encoding);
   }
 
   // A Float32 variable already bound to `bits` in the model. The binding is a
@@ -118,6 +122,22 @@ protected:
     return value == mgr.ASTTrue;
   }
 };
+
+TEST_F(FpModelEqualityTest, EncodedTermScopeEndsBetweenModelQueries)
+{
+  const ASTNode one = bound(ONE);
+  const ASTNode negated =
+      mgr.hashingNodeFactory->CreateTerm(FP_NEG, 32, ASTVec{one});
+  const ASTNode absolute =
+      mgr.hashingNodeFactory->CreateTerm(FP_ABS, 32, ASTVec{negated});
+
+  // Each source operation enters target-language evaluation while its lowered
+  // DAG is live. The next independent question must enter source mode again;
+  // otherwise it skips lowering and cannot interpret the FP operation.
+  EXPECT_EQ(mgr.CreateBVConst(32, 0xBF800000), ce.ModelValueOfTerm(negated));
+  EXPECT_EQ(mgr.CreateBVConst(32, ONE), ce.ModelValueOfTerm(absolute));
+  EXPECT_EQ(mgr.CreateBVConst(32, 0xBF800000), ce.ModelValueOfTerm(negated));
+}
 
 // fp.eq is IEEE numeric equality: the two zeros are equal, NaN is equal to
 // nothing, infinities agree only with the same sign.

--- a/tests/unit-tests/PrimeMemo_Test.cpp
+++ b/tests/unit-tests/PrimeMemo_Test.cpp
@@ -1,0 +1,344 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+// Whether PrimeAudit catches a pass and its priming walk disagreeing.
+//
+// Six memoised computations fill their tables from the bottom up so their
+// own recursion stops one level down, which is sound only where the walk
+// reaches the nodes the pass would have reached anyway. Comparing the
+// generated CNF catches a violation only when the violation changes the
+// output, and a walk that stops short of a subtree does not: the pass goes
+// down its own call stack for that subtree and answers exactly as before.
+//
+// So the walk and the pass are compared directly (stp/Util/DagWalk.h),
+// and this is the test of the comparison rather than of any pass: a walk and
+// a pass are played against each other by hand, agreeing and then failing to,
+// so that the check is known to report what it exists to report. A check
+// nobody has seen fail is a check nobody has.
+//
+// The audit is debug-only, so all of this compiles away under NDEBUG.
+
+#include "stp/NodeFactory/SimplifyingNodeFactory.h"
+#include "stp/STPManager/STPManager.h"
+#include "stp/Util/DagWalk.h"
+#include <gtest/gtest.h>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+
+using namespace stp;
+
+namespace
+{
+
+using WalkOperandResult = decltype(std::declval<const WalkOperands&>().at(
+    std::declval<const ASTNode&>(), size_t{0}));
+static_assert(std::is_same<WalkOperandResult, const ASTNode&>::value,
+              "operand views must not increment AST reference counts");
+
+struct Context
+{
+  STPMgr mgr;
+  SimplifyingNodeFactory snf;
+  NodeFactory* hf; // hashing factory: builds the input without folding it.
+
+  Context() : snf(*(mgr.hashingNodeFactory), mgr)
+  {
+    static const bool booted = []() {
+      CONSTANTBV::BitVector_Boot();
+      return true;
+    }();
+    (void)booted;
+
+    mgr.defaultNodeFactory = &snf;
+    hf = mgr.hashingNodeFactory;
+  }
+
+  // BVXOR(BVXOR(x0, x1), x2): two interior nodes, three leaves, and no rule
+  // in any factory that rewrites it.
+  ASTNode chain() { return chain(3); }
+
+  // The same nested `levels` deep.
+  ASTNode chain(unsigned levels)
+  {
+    ASTNode n = mgr.CreateSymbol(("x" + std::to_string(counter++)).c_str(), 0, 8);
+    for (unsigned i = 1; i < levels; i++)
+      n = hf->CreateTerm(
+          BVXOR, 8, n,
+          mgr.CreateSymbol(("x" + std::to_string(counter++)).c_str(), 0, 8));
+    return n;
+  }
+
+  unsigned counter = 0;
+
+  // The factory orders a commutative node's children, so which index holds
+  // the nested one is not fixed.
+  static ASTNode interiorChild(const ASTNode& n)
+  {
+    for (const ASTNode& c : n.GetChildren())
+      if (c.Degree() > 0)
+        return c;
+    return n;
+  }
+
+  static ASTNode leafChild(const ASTNode& n)
+  {
+    for (const ASTNode& c : n.GetChildren())
+      if (c.Degree() == 0)
+        return c;
+    return n;
+  }
+};
+
+// The manager is deliberately not destroyed, as in DeepDag_Test.cpp: what
+// tearing one down does while its nodes are still held is not what these
+// cases are about, and the process is about to exit anyway.
+Context& fresh()
+{
+  return *(new Context());
+}
+
+TEST(DagWalk, preorder_is_left_to_right_and_honours_pruning)
+{
+  Context& c = fresh();
+  const ASTNode a = c.mgr.CreateSymbol("preorder-a", 0, 4);
+  const ASTNode b = c.mgr.CreateSymbol("preorder-b", 0, 4);
+  const ASTNode d = c.mgr.CreateSymbol("preorder-d", 0, 4);
+  const ASTNode e = c.mgr.CreateSymbol("preorder-e", 0, 4);
+  const ASTNode left = c.hf->CreateTerm(BVCONCAT, 8, a, b);
+  const ASTNode pruned = c.hf->CreateTerm(BVCONCAT, 8, d, e);
+  const ASTNode top = c.hf->CreateTerm(BVCONCAT, 16, left, pruned);
+
+  ASTVec visited;
+  walkPreOrder(top, [&](const ASTNode& n) {
+    visited.push_back(n);
+    return n != pruned;
+  });
+
+  EXPECT_EQ((ASTVec{top, left, a, b, pruned}), visited);
+}
+
+TEST(DagWalk, postorder_rebuild_preserves_child_ranges_and_sharing)
+{
+  Context& c = fresh();
+  const ASTNode a = c.mgr.CreateSymbol("rebuild-a", 0, 4);
+  const ASTNode b = c.mgr.CreateSymbol("rebuild-b", 0, 4);
+  const ASTNode d = c.mgr.CreateSymbol("rebuild-d", 0, 4);
+  const ASTNode shared = c.hf->CreateTerm(BVXOR, 4, a, b);
+  const ASTNode left = c.hf->CreateTerm(BVPLUS, 4, shared, d);
+  const ASTNode top = c.hf->CreateTerm(BVAND, 4, left, shared);
+
+  ASTNodeMap cache;
+  std::vector<std::pair<ASTNode, ASTVec>> combined;
+  const ASTNode result = postOrderRebuild(
+      top, cache, [&](const ASTNode& n, const ASTVec& children) {
+        combined.push_back({n, children});
+        return n;
+      });
+
+  ASSERT_EQ(top, result);
+  ASSERT_EQ(3U, combined.size());
+  EXPECT_EQ(shared, combined[0].first);
+  EXPECT_EQ(toASTVec(shared.GetChildren()), combined[0].second);
+  EXPECT_EQ(left, combined[1].first);
+  EXPECT_EQ(toASTVec(left.GetChildren()), combined[1].second);
+  EXPECT_EQ(top, combined[2].first);
+  EXPECT_EQ(toASTVec(top.GetChildren()), combined[2].second);
+  EXPECT_EQ(3U, cache.size());
+}
+
+TEST(PrimeMemo, non_owning_operand_views_preserve_postorder)
+{
+  Context& c = fresh();
+  const ASTNode a = c.mgr.CreateSymbol("view-a", 0, 0);
+  const ASTNode b = c.mgr.CreateSymbol("view-b", 0, 0);
+  const ASTNode d = c.mgr.CreateSymbol("view-d", 0, 0);
+  const ASTNode e = c.mgr.CreateSymbol("view-e", 0, 0);
+  const ASTNode inner = c.hf->CreateNode(OR, ASTVec{a, b, d});
+  const ASTNode top = c.hf->CreateNode(AND, ASTVec{inner, e});
+
+  ASTVec visited;
+  primeMemo(
+      top, [](const ASTNode& n)
+      { return n.Degree() == 0 ? Walk::Visit : Walk::Descend; },
+      [&](const ASTNode& n)
+      {
+        if (n == top)
+          return WalkOperands::reversed(n);
+        if (n == inner)
+          return WalkOperands::range(1, n.Degree());
+        return WalkOperands::all(n);
+      },
+      [&](const ASTNode& n, PrimeMemoReady) { visited.push_back(n); });
+
+  ASTVec expected;
+  for (size_t i = top.Degree(); i != 0; --i)
+  {
+    const ASTNode child = top[i - 1];
+    if (child == inner)
+    {
+      for (size_t j = 1; j < inner.Degree(); ++j)
+        expected.push_back(inner[j]);
+      expected.push_back(inner);
+    }
+    else
+      expected.push_back(child);
+  }
+  expected.push_back(top);
+
+  EXPECT_EQ(expected, visited);
+}
+
+#ifndef NDEBUG
+
+// A pass, played by hand: it runs a node, asks for the nodes the test says it
+// asks for, and reports both to the audit exactly as a real pass does.
+void run(PrimeAudit& audit, const ASTNode& n, const ASTVec& asks)
+{
+  PrimeAudit::Running running(audit, n);
+  for (const ASTNode& child : asks)
+  {
+    PrimeAudit::Running below(audit, child);
+  }
+}
+
+// A pass that was not primed: it runs a node and, from inside it, the node
+// below -- one level of its own call stack per level of the input, which is
+// what priming exists to stop and what the depth claim is about.
+void runUnprimed(PrimeAudit& audit, const ASTNode& n)
+{
+  PrimeAudit::Running running(audit, n);
+
+  const ASTNode below = Context::interiorChild(n);
+  if (below != n) // the bottom of the chain answers with itself.
+    runUnprimed(audit, below);
+}
+
+// Holds the audit open while a case reads its verdict. The check runs when
+// the pass's outermost call returns, and where the pass is past its claim it
+// stops the process -- which is what it is for, and is checked below by a case
+// that lets it happen, but is not a thing to read a string out of.
+struct Held
+{
+  PrimeAudit& audit;
+  PrimeAudit::Running running;
+
+  Held(PrimeAudit& audit_, const ASTNode& sentinel)
+      : audit(audit_), running(audit_, sentinel)
+  {
+  }
+
+  // Cleared before the sentinel is dropped, so the comparison it triggers
+  // has nothing left to disagree about.
+  ~Held() { audit.clear(); }
+};
+
+// A primed pass: it runs a node, its operands answer from the memo, and its
+// own calls go one level. Whatever the input nests to.
+TEST(PrimeAudit, a_pass_within_its_claim_is_silent)
+{
+  Context& c = fresh();
+  const ASTNode top = c.chain(12);
+  const ASTNode inner = Context::interiorChild(top);
+  const ASTNode leaf = Context::leafChild(top);
+
+  PrimeAudit audit("test", 8);
+
+  {
+    PrimeAudit::Running running(audit, top);
+    run(audit, inner, ASTVec{inner[0], inner[1]});
+    PrimeAudit::Running below(audit, leaf);
+  }
+
+  EXPECT_EQ(audit.disagreement(), "");
+}
+
+// What priming getting it wrong looks like from here: the walk misses a
+// subtree, the pass reaches it anyway -- down its own call stack, one frame
+// per level, which is the crash priming exists to prevent. Nothing in the
+// output moves, so the CNF comparison cannot see it; the depth can.
+TEST(PrimeAudit, a_pass_that_nests_past_its_claim_is_reported)
+{
+  Context& c = fresh();
+  const ASTNode top = c.chain(12);
+
+  PrimeAudit audit("test", 4);
+
+  std::string bad;
+  {
+    Held held(audit, c.mgr.CreateSymbol("sentinel", 0, 8));
+    runUnprimed(audit, top); // nothing was primed, so it goes all the way.
+    bad = audit.disagreement();
+  }
+
+  EXPECT_NE(bad.find("nested 12 deep"), std::string::npos)
+      << "audit said: " << bad;
+  EXPECT_NE(bad.find("over its claim of 4"), std::string::npos)
+      << "audit said: " << bad;
+}
+
+// ... and it stops the process rather than reporting quietly, which is the
+// only way an assertions build has of insisting.
+TEST(PrimeAuditDeath, nesting_past_the_claim_stops_the_process)
+{
+  EXPECT_DEATH(
+      {
+        Context& c = fresh();
+        PrimeAudit audit("test", 4);
+        runUnprimed(audit, c.chain(12));
+      },
+      "nested 11 deep");
+}
+
+
+// Re-entering on a node the pass has just built is allowed, and is why the
+// claim is a small number rather than one or two: the operands of such a node
+// are already primed, so the nesting is a property of the rewriting and not
+// of the input.
+TEST(PrimeAudit, re_entering_on_a_built_node_is_within_the_claim)
+{
+  Context& c = fresh();
+  const ASTNode top = c.chain();
+  const ASTNode inner = Context::interiorChild(top);
+  const ASTNode leaf = Context::leafChild(top);
+
+  PrimeAudit audit("test", 8);
+
+  const ASTNode built = c.hf->CreateTerm(BVNOT, 8, top);
+
+  {
+    PrimeAudit::Running running(audit, top);
+    run(audit, inner, ASTVec{inner[0], inner[1]});
+    PrimeAudit::Running below(audit, leaf);
+    PrimeAudit::Running newer(audit, built); // asked for, never primed.
+  }
+
+  EXPECT_EQ(audit.disagreement(), "");
+}
+
+
+#endif // NDEBUG
+
+} // namespace

--- a/tests/unit-tests/SimplifyFormula_Test.cpp
+++ b/tests/unit-tests/SimplifyFormula_Test.cpp
@@ -93,6 +93,30 @@ struct Context
   {
     return hf->CreateNode(OR, a, b);
   }
+  ASTNode Xor(const ASTNode& a, const ASTNode& b)
+  {
+    return hf->CreateNode(XOR, a, b);
+  }
+  ASTNode Nand(const ASTNode& a, const ASTNode& b)
+  {
+    return hf->CreateNode(NAND, a, b);
+  }
+  ASTNode Nor(const ASTNode& a, const ASTNode& b)
+  {
+    return hf->CreateNode(NOR, a, b);
+  }
+  ASTNode Iff(const ASTNode& a, const ASTNode& b)
+  {
+    return hf->CreateNode(IFF, a, b);
+  }
+  ASTNode Implies(const ASTNode& a, const ASTNode& b)
+  {
+    return hf->CreateNode(IMPLIES, a, b);
+  }
+  ASTNode Ite(const ASTNode& a, const ASTNode& b, const ASTNode& d)
+  {
+    return hf->CreateNode(ITE, a, b, d);
+  }
 
   // Run the real top-level formula simplifier.
   ASTNode run(const ASTNode& f)
@@ -100,6 +124,16 @@ struct Context
     SubstitutionMap sm(&mgr);
     Simplifier simp(&mgr, &sm);
     return simp.SimplifyFormula_TopLevel(f, false);
+  }
+
+  // ... and with the negation the caller wants pushed inwards. Half of the
+  // pass's memo key, and the half every arm chooses per operand: this is the
+  // entry the arms below are exercised through in both polarities.
+  ASTNode runNeg(const ASTNode& f)
+  {
+    SubstitutionMap sm(&mgr);
+    Simplifier simp(&mgr, &sm);
+    return simp.SimplifyFormula_TopLevel(f, true);
   }
 
   // A firing check: the pass must both produce `expected` AND change the
@@ -150,6 +184,30 @@ struct Context
           if (evalBool(ch, asgn))
             return true;
         return false;
+      case NAND:
+        for (const auto& ch : n)
+          if (!evalBool(ch, asgn))
+            return true;
+        return false;
+      case NOR:
+        for (const auto& ch : n)
+          if (evalBool(ch, asgn))
+            return false;
+        return true;
+      case XOR:
+      {
+        bool odd = false;
+        for (const auto& ch : n)
+          odd ^= evalBool(ch, asgn);
+        return odd;
+      }
+      case IFF:
+        return evalBool(n[0], asgn) == evalBool(n[1], asgn);
+      case IMPLIES:
+        return !evalBool(n[0], asgn) || evalBool(n[1], asgn);
+      case ITE:
+        return evalBool(n[0], asgn) ? evalBool(n[1], asgn)
+                                    : evalBool(n[2], asgn);
       default:
         ADD_FAILURE() << "evalBool: unexpected kind in boolean formula: " << n;
         return false;
@@ -177,6 +235,30 @@ struct Context
   }
 
   void checkSound(const ASTNode& f) { checkEquivalent(f, run(f)); }
+
+  // Under pushNeg the pass is simplifying NOT(f), so the answer must mean the
+  // opposite of the input at every assignment.
+  void checkSoundNegated(const ASTNode& f)
+  {
+    const ASTNode out = runNeg(f);
+
+    ASTNodeSet symSet;
+    collectSymbols(f, symSet);
+    collectSymbols(out, symSet);
+    std::vector<ASTNode> syms(symSet.begin(), symSet.end());
+    ASSERT_LE(syms.size(), 16u) << "too many variables to enumerate";
+
+    const uint64_t combos = UINT64_C(1) << syms.size();
+    for (uint64_t c = 0; c < combos; c++)
+    {
+      std::map<ASTNode, bool> asgn;
+      for (size_t i = 0; i < syms.size(); i++)
+        asgn[syms[i]] = ((c >> i) & 1) != 0;
+      ASSERT_EQ(!evalBool(f, asgn), evalBool(out, asgn))
+          << "pushNeg answer is not the negation, at assignment " << c
+          << "\nbefore: " << f << "\nafter:  " << out;
+    }
+  }
 
   void checkIdempotent(const ASTNode& f)
   {
@@ -555,6 +637,323 @@ TEST(SimplifyAndOr, deep_omit_one_demorgan)
   ASTNode out = c.run(top);
   ASSERT_EQ(out.GetKind(), AND);
   EXPECT_EQ(out.Degree(), static_cast<size_t>(numVars));
+}
+
+/*===========================================================================
+ * ARM TESTS
+ *
+ * SimplifyFormula used to dispatch to eight functions; each is now an arm of
+ * one state machine, and the points where an arm used to call SimplifyFormula
+ * are phases it has to resume at. The tests above reach two of those arms
+ * (AND/OR and NOT); a fold that lost its resumption point in any of the other
+ * six -- IFF's re-simplification of the side a constant left, ITE's of the
+ * condition under (ite c false true) -- is invisible from here.
+ *
+ * So one test per arm, and each arm under both polarities, since pushNeg is
+ * half the memo key and each arm chooses what to hand its operands.
+ *=========================================================================*/
+
+// IMPLIES, both polarities: SimplifyImpliesFormula.
+TEST(SimplifyArms, implies_false_antecedent_is_true)
+{
+  Context c;
+  ASTNode x = c.boolean();
+  c.checkFires(c.Implies(c.mgr.ASTFalse, x), c.mgr.ASTTrue);
+}
+
+TEST(SimplifyArms, implies_true_antecedent_is_consequent)
+{
+  Context c;
+  ASTNode x = c.boolean();
+  c.checkFires(c.Implies(c.mgr.ASTTrue, x), x);
+}
+
+TEST(SimplifyArms, implies_same_is_true)
+{
+  Context c;
+  ASTNode x = c.boolean();
+  c.checkFires(c.Implies(x, x), c.mgr.ASTTrue);
+}
+
+TEST(SimplifyArms, implies_negated_antecedent_becomes_or)
+{
+  Context c;
+  ASTNode a = c.boolean(), b = c.boolean();
+  ASTNode input = c.Implies(c.Not(a), b);
+  ASTNode out = c.run(input);
+  EXPECT_EQ(out.GetKind(), OR) << "the NOT was not absorbed: " << out;
+  EXPECT_NE(out, input);
+  c.checkEquivalent(input, out);
+}
+
+TEST(SimplifyArms, implies_pushneg_is_a_conjunction)
+{
+  Context c;
+  ASTNode a = c.boolean(), b = c.boolean();
+  ASTNode input = c.Implies(a, b);
+  ASTNode out = c.runNeg(input);
+  EXPECT_EQ(out.GetKind(), AND) << "NOT(a=>b) should be a conjunction: " << out;
+  c.checkSoundNegated(input);
+}
+
+// IFF, including the fold that re-simplifies the surviving side negated.
+TEST(SimplifyArms, iff_true_left_is_right)
+{
+  Context c;
+  ASTNode x = c.boolean();
+  c.checkFires(c.Iff(c.mgr.ASTTrue, x), x);
+}
+
+TEST(SimplifyArms, iff_true_right_is_left)
+{
+  Context c;
+  ASTNode x = c.boolean();
+  c.checkFires(c.Iff(x, c.mgr.ASTTrue), x);
+}
+
+TEST(SimplifyArms, iff_false_left_negates_right)
+{
+  Context c;
+  ASTNode x = c.boolean();
+  c.checkFires(c.Iff(c.mgr.ASTFalse, x), c.Not(x));
+}
+
+TEST(SimplifyArms, iff_false_right_negates_left)
+{
+  Context c;
+  ASTNode x = c.boolean();
+  c.checkFires(c.Iff(x, c.mgr.ASTFalse), c.Not(x));
+}
+
+// The fold is a second walk over the side that survived. Where that side is a
+// compound the arm has already simplified at the opposite polarity, the walk
+// answers from CheckSimplifyMap's second lookup -- the one that negates a
+// pushNeg=false answer -- so what comes back is the negation wrapped around
+// it rather than the De Morgan'd form. Recorded rather than asserted as
+// desirable: the memo and that lookup are older than this state machine, and
+// the arm behaved this way when it was SimplifyIffFormula.
+TEST(SimplifyArms, iff_false_side_negates_the_survivor)
+{
+  Context c;
+  ASTNode a = c.boolean(), b = c.boolean();
+  ASTNode input = c.Iff(c.mgr.ASTFalse, c.And(a, b));
+  ASTNode out = c.run(input);
+  EXPECT_EQ(out.GetKind(), NOT) << "the survivor was not negated: " << out;
+  c.checkEquivalent(input, out);
+}
+
+TEST(SimplifyArms, iff_same_is_true)
+{
+  Context c;
+  ASTNode x = c.boolean();
+  c.checkFires(c.Iff(x, x), c.mgr.ASTTrue);
+}
+
+TEST(SimplifyArms, iff_complement_is_false)
+{
+  Context c;
+  ASTNode x = c.boolean();
+  c.checkFires(c.Iff(c.Not(x), x), c.mgr.ASTFalse);
+}
+
+TEST(SimplifyArms, iff_pushneg_sound)
+{
+  Context c;
+  ASTNode a = c.boolean(), b = c.boolean();
+  c.checkSoundNegated(c.Iff(a, b));
+}
+
+// The formula if-then-else, including its own fold.
+TEST(SimplifyArms, ite_true_condition_is_then)
+{
+  Context c;
+  ASTNode a = c.boolean(), b = c.boolean();
+  c.checkFires(c.Ite(c.mgr.ASTTrue, a, b), a);
+}
+
+TEST(SimplifyArms, ite_false_condition_is_else)
+{
+  Context c;
+  ASTNode a = c.boolean(), b = c.boolean();
+  c.checkFires(c.Ite(c.mgr.ASTFalse, a, b), b);
+}
+
+TEST(SimplifyArms, ite_false_true_branches_negate_condition)
+{
+  Context c;
+  ASTNode x = c.boolean();
+  c.checkFires(c.Ite(x, c.mgr.ASTFalse, c.mgr.ASTTrue), c.Not(x));
+}
+
+// ... by walking the condition again under pushNeg, which is why the arm
+// folds rather than letting the factory build the NOT. A condition the arm
+// has already simplified at pushNeg=false comes back through the same
+// negating lookup as the IFF fold above, so the arm's comment about exposing
+// more simplifications holds for a condition it has not seen before and not
+// for one it has.
+TEST(SimplifyArms, ite_false_true_negates_the_condition)
+{
+  Context c;
+  ASTNode a = c.boolean(), b = c.boolean();
+  ASTNode input = c.Ite(c.And(a, b), c.mgr.ASTFalse, c.mgr.ASTTrue);
+  ASTNode out = c.run(input);
+  EXPECT_EQ(out.GetKind(), NOT) << "the condition was not negated: " << out;
+  c.checkEquivalent(input, out);
+}
+
+TEST(SimplifyArms, ite_pushneg_sound)
+{
+  Context c;
+  ASTNode a = c.boolean(), b = c.boolean(), d = c.boolean();
+  c.checkSoundNegated(c.Ite(a, b, d));
+}
+
+// XOR: SimplifyXorFormula, which under pushNeg negates its first operand.
+TEST(SimplifyArms, xor_same_is_false)
+{
+  Context c;
+  ASTNode x = c.boolean();
+  c.checkFires(c.Xor(x, x), c.mgr.ASTFalse);
+}
+
+TEST(SimplifyArms, xor_true_false_is_true)
+{
+  Context c;
+  c.checkFires(c.Xor(c.mgr.ASTTrue, c.mgr.ASTFalse), c.mgr.ASTTrue);
+}
+
+TEST(SimplifyArms, xor_pushneg_sound)
+{
+  Context c;
+  ASTNode a = c.boolean(), b = c.boolean();
+  c.checkSoundNegated(c.Xor(a, b));
+}
+
+TEST(SimplifyArms, xor_nary_preserves_all_operands)
+{
+  Context c;
+  ASTNode a = c.boolean(), b = c.boolean(), d = c.boolean();
+  ASTNode input = c.hf->CreateNode(XOR, ASTVec{a, b, d});
+  ASTNode out = c.run(input);
+
+  EXPECT_EQ(XOR, out.GetKind());
+  EXPECT_EQ(3U, out.Degree());
+  c.checkEquivalent(input, out);
+  c.checkSoundNegated(input);
+}
+
+// NAND and NOR, whose implicit negation cancels with the caller's.
+TEST(SimplifyArms, nand_of_true_is_the_negated_other)
+{
+  Context c;
+  ASTNode x = c.boolean();
+  c.checkFires(c.Nand(c.mgr.ASTTrue, x), c.Not(x));
+}
+
+TEST(SimplifyArms, nor_of_false_is_the_negated_other)
+{
+  Context c;
+  ASTNode x = c.boolean();
+  c.checkFires(c.Nor(c.mgr.ASTFalse, x), c.Not(x));
+}
+
+TEST(SimplifyArms, nand_pushneg_is_the_conjunction)
+{
+  Context c;
+  ASTNode a = c.boolean(), b = c.boolean();
+  ASTNode out = c.runNeg(c.Nand(a, b));
+  EXPECT_EQ(out.GetKind(), AND) << "NOT(nand) should be the AND: " << out;
+  c.checkSoundNegated(c.Nand(a, b));
+}
+
+TEST(SimplifyArms, nor_pushneg_is_the_disjunction)
+{
+  Context c;
+  ASTNode a = c.boolean(), b = c.boolean();
+  ASTNode out = c.runNeg(c.Nor(a, b));
+  EXPECT_EQ(out.GetKind(), OR) << "NOT(nor) should be the OR: " << out;
+  c.checkSoundNegated(c.Nor(a, b));
+}
+
+// NOT: the arm counts the run above it and starts again from the parity.
+TEST(SimplifyArms, not_run_of_three_is_one)
+{
+  Context c;
+  ASTNode a = c.boolean(), b = c.boolean();
+  ASTNode input = c.Not(c.Not(c.Not(c.And(a, b))));
+  ASTNode out = c.run(input);
+  EXPECT_EQ(out.GetKind(), OR) << "odd parity should De Morgan: " << out;
+  c.checkEquivalent(input, out);
+}
+
+TEST(SimplifyArms, not_run_of_four_is_none)
+{
+  Context c;
+  ASTNode a = c.boolean(), b = c.boolean();
+  ASTNode input = c.Not(c.Not(c.Not(c.Not(c.And(a, b)))));
+  ASTNode out = c.run(input);
+  EXPECT_EQ(out.GetKind(), AND) << "even parity should not De Morgan: " << out;
+  c.checkEquivalent(input, out);
+}
+
+// Every arm, both polarities, on formulas that mix them.
+struct AllKindsFuzzer
+{
+  Context& c;
+  std::mt19937 rng;
+  std::vector<ASTNode> vars;
+
+  AllKindsFuzzer(Context& ctx, unsigned seed, unsigned numVars)
+      : c(ctx), rng(seed)
+  {
+    for (unsigned i = 0; i < numVars; i++)
+      vars.push_back(c.boolean());
+  }
+
+  ASTNode gen(unsigned depth)
+  {
+    std::uniform_int_distribution<int> pick(0, depth == 0 ? 2 : 11);
+    switch (pick(rng))
+    {
+      case 0:
+        return vars[std::uniform_int_distribution<size_t>(0, vars.size() - 1)(
+            rng)];
+      case 1:
+        return c.mgr.ASTTrue;
+      case 2:
+        return c.mgr.ASTFalse;
+      case 3:
+        return c.Not(gen(depth - 1));
+      case 4:
+        return c.And(gen(depth - 1), gen(depth - 1));
+      case 5:
+        return c.Or(gen(depth - 1), gen(depth - 1));
+      case 6:
+        return c.Xor(gen(depth - 1), gen(depth - 1));
+      case 7:
+        return c.Nand(gen(depth - 1), gen(depth - 1));
+      case 8:
+        return c.Nor(gen(depth - 1), gen(depth - 1));
+      case 9:
+        return c.Iff(gen(depth - 1), gen(depth - 1));
+      case 10:
+        return c.Implies(gen(depth - 1), gen(depth - 1));
+      default:
+        return c.Ite(gen(depth - 1), gen(depth - 1), gen(depth - 1));
+    }
+  }
+};
+
+TEST(SimplifyArms, fuzz_every_connective_sound_in_both_polarities)
+{
+  Context c;
+  AllKindsFuzzer f(c, /*seed=*/0x5EED, /*numVars=*/4);
+  for (int i = 0; i < 400; i++)
+  {
+    ASTNode formula = f.gen(/*depth=*/3);
+    c.checkSound(formula);
+    c.checkSoundNegated(formula);
+  }
 }
 
 } // namespace

--- a/tests/unit-tests/SimplifyingNodeFactory_Exhaustive_Test.cpp
+++ b/tests/unit-tests/SimplifyingNodeFactory_Exhaustive_Test.cpp
@@ -459,6 +459,35 @@ TEST(SimplifyingNodeFactory_Exhaustive, eq_concat_shared_half)
             c.nf->CreateNode(EQ, x, y));
 }
 
+/* constant = high ++ low --> high = constant[high] && low = constant[low].
+   This is the common one-level case, which does not need the nested-concat
+   continuation stack. */
+TEST(SimplifyingNodeFactory_Exhaustive, eq_constant_shallow_concat)
+{
+  Context c;
+  const ASTNode high = c.bv(2);
+  const ASTNode low = c.bv(3);
+  const ASTNode concat = c.hf->CreateTerm(BVCONCAT, 5, high, low);
+  const ASTNode constant = c.konst(0b10110, 5);
+  const ASTNode plain = c.hf->CreateNode(EQ, constant, concat);
+  const ASTNode simplified = c.nf->CreateNode(EQ, constant, concat);
+  const ASTNode reversePlain = c.hf->CreateNode(EQ, concat, constant);
+  const ASTNode reverseSimplified = c.nf->CreateNode(EQ, concat, constant);
+
+  const ASTNode lowEquality =
+      c.nf->CreateNode(EQ, low, c.konst(0b110, 3));
+  const ASTNode highEquality =
+      c.nf->CreateNode(EQ, high, c.konst(0b10, 2));
+  const ASTNode expected = c.nf->CreateNode(AND, lowEquality, highEquality);
+
+  EXPECT_NE(plain, simplified);
+  EXPECT_EQ(expected, simplified);
+  EXPECT_NE(reversePlain, reverseSimplified);
+  EXPECT_EQ(expected, reverseSimplified);
+  c.checkEquivalent(plain, simplified);
+  c.checkEquivalent(reversePlain, reverseSimplified);
+}
+
 /* equality and signed comparison of two sign extensions from the same
    width reduce to the originals */
 TEST(SimplifyingNodeFactory_Exhaustive, sx_pairs)

--- a/tests/unit-tests/SimplifyingNodeFactory_Test.cpp
+++ b/tests/unit-tests/SimplifyingNodeFactory_Test.cpp
@@ -917,6 +917,30 @@ TEST(SimplifyingNodeFactory_Test, bvand_complement_nested_deeply)
   ASSERT_EQ(n, c.mgr.ASTTrue);
 }
 
+TEST(SimplifyingNodeFactory_Test, bvand_complement_at_conjunct_limit)
+{
+  Context c;
+  const unsigned width = 20;
+  const ASTNode x = c.mgr.CreateSymbol("limit-x", 0, width);
+  const ASTNode notX =
+      c.mgr.hashingNodeFactory->CreateTerm(stp::BVNOT, width, ASTVec{x});
+
+  ASTVec children;
+  for (unsigned i = 0; i < 70; ++i)
+  {
+    const std::string name = "limit-y" + std::to_string(i);
+    children.push_back(i == 61 ? x
+                               : c.mgr.CreateSymbol(name.c_str(), 0, width));
+  }
+  const ASTNode nested =
+      c.mgr.hashingNodeFactory->CreateTerm(stp::BVAND, width, children);
+
+  // ~x is conjunct 1, the nested BVAND is conjunct 2, and its child 61 is
+  // conjunct 64. The bounded walk must still include that last slot.
+  EXPECT_EQ(c.mgr.CreateZeroConst(width),
+            c.snf.CreateTerm(stp::BVAND, width, ASTVec{notX, nested}));
+}
+
 TEST(SimplifyingNodeFactory_Test, bvand_no_complement_is_left_alone)
 {
   // The guard on the rule: no complementary pair here, so nothing may be

--- a/tests/unit-tests/SimplifyingNodeFactory_Test.cpp
+++ b/tests/unit-tests/SimplifyingNodeFactory_Test.cpp
@@ -73,6 +73,40 @@ struct Context
     }
 };
 
+TEST(SimplifyingNodeFactory_Test, child_view_uses_exact_subrange)
+{
+  Context c;
+  NodeFactory& factory = c.snf;
+
+  const ASTNode p = c.mgr.CreateSymbol("view-p", 0, 0);
+  const ASTNode q = c.mgr.CreateSymbol("view-q", 0, 0);
+  // Deliberately reversed: sorting may allocate, so the factory must create
+  // its view only after the owned sort buffer has reached its final storage.
+  ASTVec formulaArena{c.mgr.ASTFalse, q, p, c.mgr.ASTTrue};
+  const stp::ASTChildren formulaChildren(formulaArena.data() + 1, 2);
+  const ASTNode formula = factory.CreateNode(stp::AND, formulaChildren);
+
+  EXPECT_EQ(stp::AND, formula.GetKind());
+  ASSERT_EQ(2U, formula.Degree());
+  EXPECT_TRUE((formula[0] == p && formula[1] == q) ||
+              (formula[0] == q && formula[1] == p));
+
+  const ASTNode x = c.mgr.CreateSymbol("view-x", 0, 8);
+  const ASTNode y = c.mgr.CreateSymbol("view-y", 0, 8);
+  ASTVec termArena{c.mgr.CreateZeroConst(8), x, y,
+                   c.mgr.CreateOneConst(8)};
+  const stp::ASTChildren termChildren(termArena.data() + 1, 2);
+  const ASTNode term = factory.CreateArrayTerm(stp::BVXOR, 0, 8,
+                                                termChildren);
+
+  EXPECT_EQ(stp::BVXOR, term.GetKind());
+  EXPECT_EQ(0U, term.GetIndexWidth());
+  EXPECT_EQ(8U, term.GetValueWidth());
+  ASSERT_EQ(2U, term.Degree());
+  EXPECT_TRUE((term[0] == x && term[1] == y) ||
+              (term[0] == y && term[1] == x));
+}
+
 
 TEST(SimplifyingNodeFactory_Test, a)
 {


### PR DESCRIPTION
# Stack safety 14/14 — Make the continuation drivers explicit

**This PR builds on top of #818** (stack safety 13/14). Please review and merge that one first; this branch contains its commits.

The conversions in 11/14 through 13/14 trade recursive calls for heap-resident continuation frames. That mechanism stays: this follow-up makes the three state machines say more directly when a parent suspends, which child operation it requests, and where it resumes.

## The problem

The generated control flow was mechanically close to the recursive code, but not especially legible. Helpers named `want` combined the child job, child arguments and parent phase; broad phase enums allowed a formula job to be paired with a term phase; and the drivers lived as large functions with step lambdas closing over ambient state.

A reviewer therefore had to infer the central invariant: a child request suspends the current frame, pushes or shortcuts exactly one typed child operation, then resumes the parent immediately after that old recursive call.

## What changes

- `Simplifier`, `ArrayTransformer` and `AbsRefine_CounterExample` each get a small private driver class that owns the frame stack, result slot and step methods. The public entry points and the heap-frame mechanism are unchanged.
- `want` becomes typed operations such as `requestFormula`, `requestTerm`, `requestArray`, `requestRead` and `requestExpansion`. The child job is selected by the method instead of passed as a runtime argument.
- Resume phases are named for the return edge — `AfterIteCondition`, `AfterLeftOperand`, and so on — rather than merely naming the child. Formula, term, array/read and expansion jobs have separate phase enums, and `resumeAt` asserts that a phase belongs to its parent job.
- The frame budgets are explicit. The existing Simplifier and ArrayTransformer caps remain 88 and 56 bytes; CounterExample now has the missing 88-byte compile-time guard.

No traversal or rewrite is deliberately changed. In particular, this keeps the Simplifier's per-frame polarity and memo placement, ArrayTransformer's extensionality notification order and out-of-frame read state, and CounterExample's inline floating-point scope guard and pop-time model carrier.

## What to check during review

The useful comparison is each `request*` call against the recursive call it replaced in 11/14 through 13/14. Every request should name the child operation in its method and the exact return edge in its `After...` phase. The job-specific enums make cross-job phase mistakes visible at the call site instead of silently representable in one generic enum.

The driver classes are intentionally private implementation details. They are organization around the same continuation stacks, not a new evaluator abstraction or another traversal framework.

## Coverage added

`DeepDag_Test` grows from 99 to 101 cases. The CounterExample case exercises formula, term, ITE, boolean-extract, operand, definition and read-expansion resumptions, including the previously uncovered `CreateMaxConst` completion for an unconstrained read. The ArrayTransformer case covers selected ITE branches plus write hit, write miss and pushed-read resumptions.

## Testing

Local assertion-enabled validation for this follow-up:

- `DeepDag_TestTests`: 101/101
- `FpModelEquality_TestTests`: 4/4
- `Extensionality_TestTests`: 77/77
- `SimplifyFormula_TestTests`: 52/52
- `SimplifyingNodeFactory_TestTests`: 76/76
- Relevant array/floating-point API suites: 68/68
- Release `stp` target builds; `git diff --check` is clean

The full lit-backed `query-files` run reported by 13/14 was not repeated locally for this follow-up because lit is unavailable in this environment.