### PR TITLE
Add a --hard preset of option values for hard problems

### DIFF
--- a/tests/query-files/misc-tests/hard-preset-unsat.smt2
+++ b/tests/query-files/misc-tests/hard-preset-unsat.smt2
@@ -1,0 +1,12 @@
+; The --hard preset on an unsatisfiable problem.
+
+; RUN: %solver --hard %s | %OutputCheck %s
+; RUN: %solver --hard --flattening 0 %s | %OutputCheck %s
+; CHECK: ^unsat$
+
+(set-logic QF_BV)
+(declare-fun x () (_ BitVec 8))
+(assert (bvult x (_ bv4 8)))
+(assert (bvugt x (_ bv4 8)))
+(check-sat)
+(exit)

--- a/tests/query-files/misc-tests/hard-preset.smt2
+++ b/tests/query-files/misc-tests/hard-preset.smt2
@@ -1,0 +1,27 @@
+; --hard is a preset of option values, not a mode of its own: it must solve
+; the same problems, and every option it presets must still be settable on
+; the command line next to it.
+
+; RUN: %solver --help 2>&1 | %OutputCheck %s --check-prefix=HELP
+; HELP: --hard
+
+; RUN: %solver --hard %s | %OutputCheck %s --check-prefix=SOLVE
+
+; An option the preset covers, given explicitly: the command line wins, and
+; the run is otherwise unaffected.
+; RUN: %solver --hard --flattening 0 %s | %OutputCheck %s --check-prefix=SOLVE
+; RUN: %solver --hard --common-subsum 0 %s | %OutputCheck %s --check-prefix=SOLVE
+; RUN: %solver --hard --pair-extract 0 %s | %OutputCheck %s --check-prefix=SOLVE
+; RUN: %solver --hard --search-bias=sat %s | %OutputCheck %s --check-prefix=SOLVE
+
+; The preset is applied before the bulk setters, so these keep the last word.
+; RUN: %solver --hard --disable-simplifications %s | %OutputCheck %s --check-prefix=SOLVE
+; RUN: %solver --hard --size-reducing-only %s | %OutputCheck %s --check-prefix=SOLVE
+
+; SOLVE: ^sat$
+
+(set-logic QF_BV)
+(declare-fun x () (_ BitVec 8))
+(assert (= (bvadd x (_ bv1 8)) (_ bv43 8)))
+(check-sat)
+(exit)

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -26,6 +26,7 @@ THE SOFTWARE.
 
 #include <CLI/CLI.hpp>
 
+#include <algorithm>
 #include <initializer_list>
 #include <iterator>
 #include <string>
@@ -58,6 +59,7 @@ public:
 
   // Pure flags, true when given on the command line.
   bool version = false;
+  bool hard = false;
   bool disable_simplifications = false;
   bool switch_word = false;
   bool disable_opt_inc = false;
@@ -99,6 +101,11 @@ public:
   // option was given, so the value needs its own presence check.
   bool interactive = false;
   CLI::Option* interactive_option = nullptr;
+
+  // The names of the solver-selecting flags that were compiled in, filled
+  // in by create_options(). Kept so that parse_options() can ask whether a
+  // solver was chosen without repeating the list.
+  std::vector<std::string> solver_flags;
 };
 
 int ExtraMain::create_and_parse_options(int argc, char** argv)
@@ -125,6 +132,12 @@ void ExtraMain::create_options()
   const char* const general_group = "Most important options";
   app.set_help_flag("--help,-h", "print this help")->group(general_group);
   app.add_flag("--version", version, "print version number")
+      ->group(general_group);
+  app.add_flag("--hard", hard,
+               "preset of option values that pay off on hard problems "
+               "(enables sharing-aware flattening with common sub-sum "
+               "factoring and pair extraction, and prefers CaDiCaL). "
+               "Individual options given explicitly override the preset")
       ->group(general_group);
 
   const char* const simp_group = "Simplifications";
@@ -476,7 +489,6 @@ void ExtraMain::create_options()
   // consults them in a fixed sequence, so 'stp --cadical --minisat' quietly
   // ran CaDiCaL. Only one of them can be meant. Which ones exist depends on
   // what was compiled in.
-  std::vector<std::string> solver_flags;
 #ifdef USE_CADICAL
   solver_flags.emplace_back("--cadical");
 #endif
@@ -721,6 +733,43 @@ int ExtraMain::parse_options(int argc, char** argv)
   {
     cerr << "ERROR: --max-time must be -1 (no limit) or greater" << endl;
     std::exit(-1);
+  }
+
+  // ---------------------------------------------------------------------
+  // The --hard preset
+  // ---------------------------------------------------------------------
+  // Values that pay off on hard problems, each applied only when the
+  // option that owns it was not given on the command line, so anything
+  // explicit beats the preset. count() is per option, so it covers every
+  // spelling of an option that has aliases.
+  //
+  // This runs before disableSimplifications() and
+  // disableSizeIncreasingSimplifications() below, so those keep the last
+  // word over the simplification fields and '--hard
+  // --disable-simplifications' behaves like '--disable-simplifications'.
+  if (hard)
+  {
+    const auto not_given = [this](const char* name) {
+      return app.get_option(name)->count() == 0;
+    };
+
+    // One line per preset value.
+    if (not_given("--flattening"))
+      bm->UserFlags.enable_flatten = true;
+    if (not_given("--common-subsum"))
+      bm->UserFlags.enable_common_subsum = true;
+    if (not_given("--pair-extract"))
+      bm->UserFlags.enable_pair_extract = true;
+
+#ifdef USE_CADICAL
+    const bool solver_given =
+        std::any_of(solver_flags.begin(), solver_flags.end(),
+                    [this](const std::string& flag) {
+                      return app.get_option(flag)->count() != 0;
+                    });
+    if (!solver_given)
+      bm->UserFlags.solver_to_use = UserDefinedFlags::CADICAL_SOLVER;
+#endif
   }
 
   if (disable_simplifications)


### PR DESCRIPTION
Adds `--hard`, a preset of existing option values tuned for hard problems. It enables sharing-aware flattening together with common sub-sum factoring and pair extraction, and prefers CaDiCaL when no solver was selected explicitly. Every individual option still wins over the preset when given on the command line, and the bulk setters (`--disable-simplifications`, `--size-reducing-only`) keep the last word over the simplification fields, so `--hard --disable-simplifications` behaves like `--disable-simplifications`.

### Why these values

Measured on 259 QF_BV non-incremental SMT-LIB instances that take more than 10 seconds at current master defaults (179 solving in 10–200 s plus 80 family-stratified 200 s timeouts, 40 benchmark families), with CaDiCaL, a 200 s wall budget per file, and all arms interleaved through one scheduler so machine load is identical across arms. Replicating identical configurations put the noise floor at ±1 solved.

| configuration | solved /259 | PAR-2 |
|---|---|---|
| defaults | 175, 176 (two replicates) | 42670, 42310 |
| `--flattening 1` | 176, 177 (two replicates) | 42454, 41946 |
| `--flattening 1 --common-subsum 1 --pair-extract 1` (= `--hard`) | **179** | **41171** |

The preset trio is also 8.5% faster (geometric mean) on the 173 files both it and the paired baseline solve, with no benchmark family losing more than one file. An end-to-end validation of this branch's binary, default vs `--hard` interleaved on the same corpus, reproduced the effect: 175 → 177 solved, PAR-2 −650, 8.1% geometric-mean faster on the 172 co-solved files. Answers were cross-checked against reference answers on every run; no mismatches.

Candidate levers that measured worse at a wall-clock budget and were left out:

- `--cnf-generation-effort high`/`very-high`/`low`: lose 19–24 solved. Where they help they search faster, but on deep carry/comparator chains the LUT-mapped encoding is far worse for the solver despite being smaller: on a 20,000-bit unsat comparator instance, solving the emitted CNFs directly takes 14 s with medium's encoding versus over 220 s with high's, which has 10% fewer clauses — the mapping fuses stages of the carry chain into wide clauses and breaks its unit-propagation ladder. All three Mf-path levels (`low`, `high`, `very-high`) also segfault at the default 8 MB stack on three 512-bit SMT-LIB instances (ABC's recursive CNF walk; they solve fine under `ulimit -s unlimited`) — worth fixing on its own, after which a structure-aware effort raise is worth remeasuring.
- `--search-bias unsat`: −27 solved; sat instances collapse and even the unsat count drops at this budget.
- `--difficulty-reversion 0`: −30 solved; the reversion default is doing real work on hard problems.

### Tests

Two lit tests: the preset solves sat and unsat problems, `--help` lists the flag, each preset option can be overridden next to `--hard`, and the bulk setters still apply. Preset equivalence was additionally verified by byte-comparing the emitted CNF of `--hard` against the explicit option trio, and explicit overrides against plain defaults.
