### PR TITLE
Stack safety: find every extract without the call stack

### DIFF
--- a/lib/Simplifier/SplitExtracts.cpp
+++ b/lib/Simplifier/SplitExtracts.cpp
@@ -27,6 +27,12 @@ THE SOFTWARE.
 
 namespace stp
 {
+  // The walk is over the whole input, so its depth is the input's depth and
+  // it cannot be left on the call stack: the depth is chosen by whoever wrote
+  // the query. Frames carry the position within the parent's children, so
+  // the order entries are appended in is exactly what the recursion produced
+  // -- ranges for one symbol are sorted afterwards by an unstable sort, and
+  // equal keys would otherwise be free to reorder.
   void SplitExtracts::buildMap(const ASTNode & n, std::unordered_set<uint64_t> &visited, NodeToExtractsMap& nodeToExtracts)
   {
     if (n.Degree() == 0)
@@ -35,19 +41,45 @@ namespace stp
     if (!visited.insert(n.GetNodeNum()).second)
       return;
 
-    for (const auto & c :n)
+    struct Frame
     {
-      if (c.GetKind() == stp::SYMBOL && n.GetKind() == stp::BVEXTRACT)
+      ASTNode n;
+      size_t i = 0; // the operand being worked on
+    };
+
+    std::vector<Frame> stack;
+    stack.push_back(Frame{n});
+
+    while (!stack.empty())
+    {
+      if (stack.back().i == stack.back().n.Degree())
       {
-        nodeToExtracts[c].push_back(std::make_tuple(n, n[1].GetUnsignedConst(), n[2].GetUnsignedConst()));
+        stack.pop_back();
+        continue;
+      }
+
+      // Both are read before anything can push and invalidate the frame.
+      const ASTNode parent = stack.back().n;
+      const ASTNode c = parent[stack.back().i];
+      stack.back().i++;
+
+      if (c.GetKind() == stp::SYMBOL && parent.GetKind() == stp::BVEXTRACT)
+      {
+        nodeToExtracts[c].push_back(std::make_tuple(parent, parent[1].GetUnsignedConst(), parent[2].GetUnsignedConst()));
         extractsFound++;
       }
       else if (c.GetKind() == stp::SYMBOL)
       {
-      nodeToExtracts[c].push_back(std::make_tuple(ASTUndefined, UINT64_MAX,0));
+        nodeToExtracts[c].push_back(std::make_tuple(ASTUndefined, UINT64_MAX,0));
       }
 
-      buildMap(c,visited,nodeToExtracts);
+      // The two early returns of the recursive form, in the same order.
+      if (c.Degree() == 0)
+        continue;
+      if (!visited.insert(c.GetNodeNum()).second)
+        continue;
+
+      stack.push_back(Frame{c});
     }
   }
 

--- a/tests/unit-tests/DeepDag_Test.cpp
+++ b/tests/unit-tests/DeepDag_Test.cpp
@@ -63,6 +63,7 @@ THE SOFTWARE.
 #include "stp/Simplifier/PropagateEqualities.h"
 #include "stp/Simplifier/RemoveUnconstrained.h"
 #include "stp/Simplifier/Simplifier.h"
+#include "stp/Simplifier/SplitExtracts.h"
 #include "stp/Simplifier/UseITEContext.h"
 #include "stp/Simplifier/VariablesInExpression.h"
 #include "stp/ToSat/BBNodeManagerAIG.h"
@@ -408,6 +409,30 @@ bool substitutionOk(Context& c, unsigned depth)
       SubstitutionMap::replace(top, fromTo, cache, c.nf);
   c.roots.push_back(result);
   return result != top;
+}
+
+// SplitExtracts::buildMap, which records every extract-of-a-symbol in the
+// input so that overlapping uses of one symbol can be split into pieces.
+// On the default path -- enable_split_extracts is on, and TopLevelSTPAux
+// runs the pass on every query -- and the walk is over the whole input.
+//
+// No extract matches a chain of BVXORs over symbols, so what the pass does
+// here is exactly the traversal, and finding nothing to split means the
+// formula comes back unchanged.
+bool splitExtractsOk(Context& c, unsigned depth)
+{
+  const ASTNode top = c.formula(c.chain(BVXOR, depth));
+  c.roots.push_back(top);
+
+  c.mgr.UserFlags.enable_split_extracts = true;
+
+  SubstitutionMap sm(&c.mgr);
+  Simplifier simp(&c.mgr, &sm);
+  SplitExtracts split(c.mgr);
+
+  const ASTNode result = split.topLevel(top, &simp);
+  c.roots.push_back(result);
+  return result == top && split.getIntroduced() == 0;
 }
 
 // Releasing a DAG. A node that loses its last reference releases its
@@ -1831,6 +1856,12 @@ TEST(DeepDag, wide_fp_rounding_mode_walk_adds_every_constraint)
 #endif // STP_ENABLE_FLOATING_POINT
 
 
+TEST(DeepDag, shallow_split_extracts)
+{
+  Context c;
+  EXPECT_TRUE(splitExtractsOk(c, SHALLOW));
+}
+
 TEST(DeepDag, shallow_substitution)
 {
   Context c;
@@ -2480,6 +2511,11 @@ TEST(DeepDag, deep_flatten_share_count)
 TEST(DeepDag, deep_flatten)
 {
   EXPECT_STACK_SAFE(flattenIdentityOk, 10000);
+}
+
+TEST(DeepDag, deep_split_extracts)
+{
+  EXPECT_STACK_SAFE(splitExtractsOk, 50000);
 }
 
 TEST(DeepDag, deep_substitution)


### PR DESCRIPTION
# Stack safety: find every extract without the call stack

A follow-up to the fourteen-part stack-safety series (#806–#818, #823), which closed with a list of what was still recursive. `SplitExtracts::buildMap` was the first name on it. This is that one.

## Why it matters

`buildMap` recurses once per level of the input DAG, so the depth it tolerates is the stack size — and the depth is chosen by whoever wrote the query, not by us. It is on the default path: `enable_split_extracts` defaults on and `TopLevelSTPAux` runs the pass on every query.

The audit measured it dying at around 60,000 on a default 8 MiB stack. Under the 1 MiB stack `DeepDag_Test` bounds itself to, a chain of 50,000 dies — which is why its deep case runs deeper than the 20,000 the rest of the suite uses: the frames here are small, and 20,000 of them survive.

**No input in the query corpus reaches this.** The deepest CPAchecker trace is about 9,300 levels. This is the difference between "no traversal is bounded by the stack" and "no traversal we have hit yet is", and only the first of those is a property you can rely on.

## The conversion

An explicit stack of frames. Each frame carries its position within the parent's children rather than pushing all of them at once, so entries are appended in exactly the order the recursion produced them. That ordering is load-bearing: the ranges recorded for one symbol are sorted afterwards by an unstable sort, so entries with equal keys would otherwise be free to reorder relative to each other, and the split that follows would pick a different representative.

The two early returns of the recursive form — a leaf, and a node already visited — are kept at the point the recursive call would have been made, in their original order, so a leaf is still never marked visited.

`Frame` follows the naming the drivers in #823 settled on: `n` for the node, `i` for the operand being worked on.

## Testing

**109/109 ctest** with floating point and assertions on, which includes the lit query corpus as `query-files`; **103 deep-DAG cases**, up from 101.

- `deep_split_extracts` is the case. It dies on the recursive form and passes on this one.
- `shallow_split_extracts` is the control: no extract matches a chain of BVXORs over symbols, so what the pass does there is exactly the traversal, and finding nothing to split leaves the formula unchanged.

Also built clean under `-DWERROR=ON` with g++-13 Release, clang Release, and a `-DENABLE_FLOATING_POINT=OFF` build (80/80 ctest, 90 deep cases).

```
cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_ASSERTIONS=ON \
  -DENABLE_TESTING=ON -DWERROR:BOOL=ON -DPYTHON_EXECUTABLE=/usr/bin/python3 \
  -DLIT_TOOL=$(command -v lit)
cmake --build build -j$(nproc) && (cd build && ctest -j12)
```

## What is still recursive after this

`UseITEContext::visit`, `CommonSubSum::rebuild` and the SMT-LIB2 printer. Two of those have disabled reproducers in `DeepDag_Test.cpp`. Every conversion in the series so far has revealed the next traversal behind it, so that list is a snapshot rather than a promise.
