### PR TITLE
Docs (prereq for incremental solving 1/5): the README still calls MiniSat the fallback default

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -180,7 +180,9 @@ Float128's would be ~33000 steps deep). Configuring with
 floating-point input with a clear "built without floating-point support"
 error; the library ABI is the same either way.
 
-STP uses minisat as its SAT solver when nothing else is available, but it also supports other SAT solvers including CryptoMiniSat as an optional extra. If installed, it will be detected during the cmake and becomes the default solver, with `--minisat` selecting minisat at runtime:
+STP supports CryptoMiniSat as an optional backend. If installed, it is
+detected by CMake and becomes the default unless CaDiCaL is enabled;
+`--minisat` is available only in a build configured with `-DUSE_MINISAT=ON`:
 
 ```
 $ git clone https://github.com/msoos/cryptominisat


### PR DESCRIPTION
# Docs (prereq for incremental solving 1/5) — the README still calls MiniSat the fallback default

This is one of four prerequisites for the five-part incremental-solving series that follows, and it is the one with no code in it at all. The four touch disjoint files and do not depend on one another; they are chained only so the series has a single base, and they will merge in any order you prefer.

## What's in it

The SAT-backend paragraph still says STP "uses minisat as its SAT solver when nothing else is available, but it also supports other SAT solvers including CryptoMiniSat as an optional extra". That stopped being true when MiniSat became opt-in: `USE_MINISAT` defaults to OFF, so a default build contains no MiniSat and has no `--minisat` flag. A reader following the README today is told to expect a flag their build does not have.

Replaced with what the build actually does: CryptoMiniSat is an optional backend, detected by CMake and preferred unless CaDiCaL is enabled, and `--minisat` exists only in a build configured with `-DUSE_MINISAT=ON`.

## Why it is in this series at all

It was noticed while working out which backends the incremental driver can use, since that depends on which ones a default build actually contains. Nothing about it needs incremental solving to be worth fixing.

## Verification

Every axis with `-DWERROR:BOOL=ON`:

| axis | result |
| --- | --- |
| FP + assertions + tests | **109/109 ctest**, 462 lit (444 passed, 18 unsupported, 0 failures), 103 deep-DAG cases |
| no-fp + tests | **80/80 ctest**, 90 deep-DAG cases |
| g++-13 Release | clean |
| clang-21 Release (`--target stp`) | clean, zero warnings from STP's own sources |

The 18 unsupported lit tests are the `REQUIRES: libbf` ones, which this configuration does not enable.
