### PR TITLE
Cadical (prereq for incremental solving 1/5): terminate the stats placeholder with a newline

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -180,7 +180,9 @@ Float128's would be ~33000 steps deep). Configuring with
 floating-point input with a clear "built without floating-point support"
 error; the library ABI is the same either way.
 
-STP uses minisat as its SAT solver when nothing else is available, but it also supports other SAT solvers including CryptoMiniSat as an optional extra. If installed, it will be detected during the cmake and becomes the default solver, with `--minisat` selecting minisat at runtime:
+STP supports CryptoMiniSat as an optional backend. If installed, it is
+detected by CMake and becomes the default unless CaDiCaL is enabled;
+`--minisat` is available only in a build configured with `-DUSE_MINISAT=ON`:
 
 ```
 $ git clone https://github.com/msoos/cryptominisat

--- a/lib/Sat/Cadical.cpp
+++ b/lib/Sat/Cadical.cpp
@@ -103,7 +103,10 @@ Cadical::~Cadical()
 
 void Cadical::printStats() const
 {
-    std::cerr << "print stats not yet implemented.";
+    // The newline matters: without it this stderr fragment glues onto the
+    // next stdout line (the check-sat verdict) in a combined stream, which
+    // is exactly what line-anchored test checks read.
+    std::cerr << "print stats not yet implemented." << std::endl;
 }
 
 uint32_t Cadical::newVar()


### PR DESCRIPTION
# Cadical (prereq for incremental solving 1/5) — terminate the stats placeholder with a newline

**This PR builds on top of #828** (the README prerequisite). This branch contains its commit. The four prerequisites touch disjoint files and do not depend on one another; they are chained only so the series has a single base, so if you would rather take them in another order they will merge in any.

## What's in it

`Cadical::printStats` writes `"print stats not yet implemented."` to stderr without a trailing newline. Every other backend's `printStats` ends its output; this one leaves the line open, so in a combined stream the fragment glues onto whatever is printed next — which, under `-s`, is the `sat` or `unsat` verdict on stdout.

One `std::endl`.

## Why it is in this series at all

The incremental tests run under `-s` and check named lines of the diagnostic output, so they read a stream where this matters: a check anchored to the start of a line silently stops matching when a stderr fragment is prepended to it. The bug is not specific to those tests — any tooling that reads STP's combined output has the same problem — but that is where it surfaced.

## Verification

Every axis with `-DWERROR:BOOL=ON`:

| axis | result |
| --- | --- |
| FP + assertions + tests | **109/109 ctest**, 462 lit (444 passed, 18 unsupported, 0 failures), 103 deep-DAG cases |
| no-fp + tests | **80/80 ctest**, 90 deep-DAG cases |
| g++-13 Release | clean |
| clang-21 Release (`--target stp`) | clean, zero warnings from STP's own sources |

The 18 unsupported lit tests are the `REQUIRES: libbf` ones, which this configuration does not enable.
