### PR TITLE
Counterexamples (prereq for incremental solving 1/5): stop copying the symbol-to-SAT-variable map on every refinement round

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -180,7 +180,9 @@ Float128's would be ~33000 steps deep). Configuring with
 floating-point input with a clear "built without floating-point support"
 error; the library ABI is the same either way.
 
-STP uses minisat as its SAT solver when nothing else is available, but it also supports other SAT solvers including CryptoMiniSat as an optional extra. If installed, it will be detected during the cmake and becomes the default solver, with `--minisat` selecting minisat at runtime:
+STP supports CryptoMiniSat as an optional backend. If installed, it is
+detected by CMake and becomes the default unless CaDiCaL is enabled;
+`--minisat` is available only in a build configured with `-DUSE_MINISAT=ON`:
 
 ```
 $ git clone https://github.com/msoos/cryptominisat

--- a/include/stp/AbsRefineCounterExample/AbsRefine_CounterExample.h
+++ b/include/stp/AbsRefineCounterExample/AbsRefine_CounterExample.h
@@ -182,7 +182,7 @@ public:
   // Converts MINISAT counterexample into an AST memotable (i.e. the
   // function populates the datastructure CounterExampleMap)
   void ConstructCounterExample(SATSolver& newS,
-                               ToSATBase::ASTNodeToSATVar& satVarToSymbol);
+                               const ToSATBase::ASTNodeToSATVar& satVarToSymbol);
 
   // Prints MINISAT assigment one bit at a time, for debugging.
   void PrintSATModel(SATSolver& S, ToSATBase::ASTNodeToSATVar& satVarToSymbol);

--- a/lib/AbsRefineCounterExample/CounterExample.cpp
+++ b/lib/AbsRefineCounterExample/CounterExample.cpp
@@ -147,7 +147,7 @@ AbsRefine_CounterExample::requireFpEncodingContext() const
  * populate the CounterExampleMap data structure (ASTNode -> BVConst)
  */
 void AbsRefine_CounterExample::ConstructCounterExample(
-    SATSolver& newS, ToSATBase::ASTNodeToSATVar& satVarToSymbol)
+    SATSolver& newS, const ToSATBase::ASTNodeToSATVar& satVarToSymbol)
 {
   if (!newS.okay())
     return;
@@ -2741,7 +2741,11 @@ AbsRefine_CounterExample::CallSAT_ResultCheck(SATSolver& SatSolver,
     CounterExampleMap.clear();
     ComputeFormulaMap.clear();
 
-    ToSATBase::ASTNodeToSATVar satVarToSymbol = tosat->SATVar_to_SymbolIndexMap();
+    // By reference: the map holds an entry for every symbol ever bit-blasted,
+    // and copying it here cost that much again on every refinement round.
+    // ConstructCounterExample only ever iterates it.
+    const ToSATBase::ASTNodeToSATVar& satVarToSymbol =
+        tosat->SATVar_to_SymbolIndexMap();
     ConstructCounterExample(SatSolver, satVarToSymbol);
     if (bm->UserFlags.stats_flag && bm->UserFlags.print_nodes_flag)
     {

--- a/lib/Sat/Cadical.cpp
+++ b/lib/Sat/Cadical.cpp
@@ -103,7 +103,10 @@ Cadical::~Cadical()
 
 void Cadical::printStats() const
 {
-    std::cerr << "print stats not yet implemented.";
+    // The newline matters: without it this stderr fragment glues onto the
+    // next stdout line (the check-sat verdict) in a combined stream, which
+    // is exactly what line-anchored test checks read.
+    std::cerr << "print stats not yet implemented." << std::endl;
 }
 
 uint32_t Cadical::newVar()


### PR DESCRIPTION
# Counterexamples (prereq for incremental solving 1/5) — stop copying the symbol-to-SAT-variable map on every refinement round

**This PR builds on top of #829** (the Cadical stats prerequisite). This branch contains its commits. The four prerequisites touch disjoint files and do not depend on one another; they are chained only so the series has a single base, so if you would rather take them in another order they will merge in any.

## What's in it

`AbsRefine_CounterExample::CallSAT_ResultCheck` builds the counterexample like this:

```c++
ToSATBase::ASTNodeToSATVar satVarToSymbol = tosat->SATVar_to_SymbolIndexMap();
ConstructCounterExample(SatSolver, satVarToSymbol);
```

The first line is a copy. `ASTNodeToSATVar` maps every symbol that has ever been bit-blasted to its vector of SAT variable numbers, so the copy is proportional to the whole blasted symbol table — and `CallSAT_ResultCheck` is called once per round of array-read refinement, not once per query. `ConstructCounterExample` only ever iterates the map.

Taking it by `const` reference, and saying so in the signature so it cannot drift back.

## What to check during review

This is a pure performance change on a path that runs on every satisfiable query with arrays in it, so the thing worth confirming is that the callee really is read-only. It is: `ConstructCounterExample` iterates the map and looks entries up, and the `const` qualifier now makes that a compile-time fact rather than a claim. The only other caller of the map, `PrintSATModel`, is untouched and still takes its own copy — it runs only under `--stats --print-nodes`.

## Why it is in this series at all

It showed up while profiling refinement rounds on the incremental driver, where the same query can run many more rounds than the batch pipeline does. The cost was always there; incremental solving only made it easier to see.

## Verification

Every axis with `-DWERROR:BOOL=ON`:

| axis | result |
| --- | --- |
| FP + assertions + tests | **109/109 ctest**, 462 lit (444 passed, 18 unsupported, 0 failures), 103 deep-DAG cases |
| no-fp + tests | **80/80 ctest**, 90 deep-DAG cases |
| g++-13 Release | clean |
| clang-21 Release (`--target stp`) | clean, zero warnings from STP's own sources |

The 18 unsupported lit tests are the `REQUIRES: libbf` ones, which this configuration does not enable.
