### PR TITLE
CryptoMiniSat (prereq for incremental solving 1/5): conflict budgets are per arming, not per solver lifetime

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -180,7 +180,9 @@ Float128's would be ~33000 steps deep). Configuring with
 floating-point input with a clear "built without floating-point support"
 error; the library ABI is the same either way.
 
-STP uses minisat as its SAT solver when nothing else is available, but it also supports other SAT solvers including CryptoMiniSat as an optional extra. If installed, it will be detected during the cmake and becomes the default solver, with `--minisat` selecting minisat at runtime:
+STP supports CryptoMiniSat as an optional backend. If installed, it is
+detected by CMake and becomes the default unless CaDiCaL is enabled;
+`--minisat` is available only in a build configured with `-DUSE_MINISAT=ON`:
 
 ```
 $ git clone https://github.com/msoos/cryptominisat

--- a/include/stp/AbsRefineCounterExample/AbsRefine_CounterExample.h
+++ b/include/stp/AbsRefineCounterExample/AbsRefine_CounterExample.h
@@ -182,7 +182,7 @@ public:
   // Converts MINISAT counterexample into an AST memotable (i.e. the
   // function populates the datastructure CounterExampleMap)
   void ConstructCounterExample(SATSolver& newS,
-                               ToSATBase::ASTNodeToSATVar& satVarToSymbol);
+                               const ToSATBase::ASTNodeToSATVar& satVarToSymbol);
 
   // Prints MINISAT assigment one bit at a time, for debugging.
   void PrintSATModel(SATSolver& S, ToSATBase::ASTNodeToSATVar& satVarToSymbol);

--- a/include/stp/Sat/CryptoMinisat5.h
+++ b/include/stp/Sat/CryptoMinisat5.h
@@ -94,6 +94,9 @@ private:
   // Negative means no budget was configured. This cannot default to 0,
   // which is now a budget of zero rather than the absence of one.
   int64_t max_confl = -1;
+  // The solver's lifetime conflict count when the budget was last armed;
+  // what the budget's query has spent is measured from here.
+  uint64_t confl_base = 0;
 };
 }
 

--- a/lib/AbsRefineCounterExample/CounterExample.cpp
+++ b/lib/AbsRefineCounterExample/CounterExample.cpp
@@ -147,7 +147,7 @@ AbsRefine_CounterExample::requireFpEncodingContext() const
  * populate the CounterExampleMap data structure (ASTNode -> BVConst)
  */
 void AbsRefine_CounterExample::ConstructCounterExample(
-    SATSolver& newS, ToSATBase::ASTNodeToSATVar& satVarToSymbol)
+    SATSolver& newS, const ToSATBase::ASTNodeToSATVar& satVarToSymbol)
 {
   if (!newS.okay())
     return;
@@ -2741,7 +2741,11 @@ AbsRefine_CounterExample::CallSAT_ResultCheck(SATSolver& SatSolver,
     CounterExampleMap.clear();
     ComputeFormulaMap.clear();
 
-    ToSATBase::ASTNodeToSATVar satVarToSymbol = tosat->SATVar_to_SymbolIndexMap();
+    // By reference: the map holds an entry for every symbol ever bit-blasted,
+    // and copying it here cost that much again on every refinement round.
+    // ConstructCounterExample only ever iterates it.
+    const ToSATBase::ASTNodeToSATVar& satVarToSymbol =
+        tosat->SATVar_to_SymbolIndexMap();
     ConstructCounterExample(SatSolver, satVarToSymbol);
     if (bm->UserFlags.stats_flag && bm->UserFlags.print_nodes_flag)
     {

--- a/lib/Sat/Cadical.cpp
+++ b/lib/Sat/Cadical.cpp
@@ -103,7 +103,10 @@ Cadical::~Cadical()
 
 void Cadical::printStats() const
 {
-    std::cerr << "print stats not yet implemented.";
+    // The newline matters: without it this stderr fragment glues onto the
+    // next stdout line (the check-sat verdict) in a combined stream, which
+    // is exactly what line-anchored test checks read.
+    std::cerr << "print stats not yet implemented." << std::endl;
 }
 
 uint32_t Cadical::newVar()

--- a/lib/Sat/CryptoMinisat5.cpp
+++ b/lib/Sat/CryptoMinisat5.cpp
@@ -61,6 +61,14 @@ void CryptoMiniSat5::setMaxConflicts(int64_t _max_confl)
 {
   assert(_max_confl >= 0);
   max_confl = _max_confl;
+
+  // The budget belongs to the query being armed for, so measure it from
+  // this point rather than from the solver's birth -- Minisat's
+  // setConfBudget does exactly this (conflicts + x). It made no difference
+  // while every query got a fresh solver; the incremental driver re-arms
+  // per check-sat on one long-lived solver, where counting from birth made
+  // each successive budget smaller until every solve gave up on arrival.
+  confl_base = s->get_sum_conflicts();
 }
 
 bool CryptoMiniSat5::addClause(
@@ -93,8 +101,9 @@ bool CryptoMiniSat5::solveInternal(bool& timeout_expired)
    * of zero down and relying on how CryptoMiniSat reads it.
    */
   if (max_confl >= 0) {
-     const int64_t remaining =
-         max_confl - static_cast<int64_t>(s->get_sum_conflicts());
+     const int64_t spent =
+         static_cast<int64_t>(s->get_sum_conflicts() - confl_base);
+     const int64_t remaining = max_confl - spent;
 
      if (remaining <= 0) {
         timeout_expired = true;


### PR DESCRIPTION
# CryptoMiniSat (prereq for incremental solving 1/5) — conflict budgets are per arming, not per solver lifetime

**This PR builds on top of #830** (the counterexample-map prerequisite). This branch contains its commits, and it is the last of the four prerequisites. They touch disjoint files and do not depend on one another; they are chained only so the series has a single base, so if you would rather take them in another order they will merge in any.

## The bug

`CryptoMiniSat5::setMaxConflicts` records a budget for the query that is about to run. `solveInternal` then works out what is left of it:

```c++
const int64_t remaining = max_confl - static_cast<int64_t>(s->get_sum_conflicts());
```

`get_sum_conflicts()` is the solver's count since it was constructed, not since the budget was armed. So the second `setMaxConflicts` on the same solver silently gets less than it asked for, by however many conflicts the first query spent; and once the lifetime count passes the budget, `remaining <= 0` on arrival and the solve reports itself exhausted without searching at all.

Recording the lifetime count at arming time and measuring from there is what MiniSat's `setConfBudget` already does — `conflicts + x` — so this makes the two backends agree.

## Why nothing has noticed

Every query gets a fresh solver today, so the lifetime count is always zero when the budget is armed and the subtraction is correct by accident. The bug needs a solver that outlives a query, which is exactly what the series that follows introduces.

## Why the regression test is not in this PR

Making the failure deterministic needs a formula that can be retracted between the two armings — assume a selector, burn the budget on a pigeonhole under it, then re-arm and solve with the selector negated, where propagation alone must answer `sat` within any budget. That needs `solveWithAssumptions`, which arrives in 1/5. The test lives there, in `SatSolverBudget_Test`, and covers MiniSat as well as CryptoMiniSat.

## Verification

Every axis with `-DWERROR:BOOL=ON`:

| axis | result |
| --- | --- |
| FP + assertions + tests | **109/109 ctest**, 462 lit (444 passed, 18 unsupported, 0 failures), 103 deep-DAG cases |
| no-fp + tests | **80/80 ctest**, 90 deep-DAG cases |
| g++-13 Release | clean |
| clang-21 Release (`--target stp`) | clean, zero warnings from STP's own sources |

The 18 unsupported lit tests are the `REQUIRES: libbf` ones, which this configuration does not enable.
