### PR TITLE
Incremental solving (1/5): SAT backends: assumptions, unsat cores, phase hints, and a checked configuration window

### DIFF
--- a/include/stp/Sat/Cadical.h
+++ b/include/stp/Sat/Cadical.h
@@ -70,14 +70,16 @@ namespace stp
   // untranslated fast path bit-for-bit identical to pre-factor builds.
   std::vector<int> ext_of_stp;
   bool factor_enabled = false;
+
+  // Probed once at construction (inside the configuration window):
+  // whether this CaDiCaL build knows the "inprobing" option at all.
+  bool inprobing_control = false;
   void declareNewVariables();
 
 public:
   Cadical();
 
   ~Cadical();
-
-  bool addClause(const vec_literals& ps) override; // Add a clause to the solver.
 
   bool okay() const override; // FALSE means solver is in a conflicting state
 
@@ -91,9 +93,21 @@ public:
 
   void setFrozen(uint32_t var) override;
 
-  bool setSearchBias(SearchBias bias) override;
+  bool setSearchBiasInternal(SearchBias bias) override;
 
-  bool enableBVA() override;
+  bool enableBVAInternal() override;
+
+  bool supportsInprobingControl() const override;
+  bool disableInprobingInternal() override;
+  bool disableEliminationAndShrinkingInternal() override;
+  bool disableLuckyPhasesInternal() override;
+
+  bool enableTrailReuseInternal() override;
+
+  void suggestPhase(uint32_t var, bool value) override;
+
+  void unsatAssumptions(const vec_literals& assumps,
+                        std::vector<int>& out) override;
 
   void setVerbosity(int v) override;
 
@@ -109,8 +123,14 @@ public:
   lbool false_literal() const override { return ((uint8_t)-1); }
   lbool undef_literal() const override { return ((uint8_t)2); }
 
+public:
+  bool supportsAssumptions() const override { return true; }
+
 protected:
+  bool addClauseInternal(const vec_literals& ps) override;
   bool solveInternal(bool& timeout_expired) override;
+  bool solveWithAssumptionsInternal(const vec_literals& assumps,
+                                    bool& timeout_expired) override;
 
   // Cadical polls the Terminator we connect during search.
   bool canInterruptSearch() const override { return true; }

--- a/include/stp/Sat/CryptoMinisat5.h
+++ b/include/stp/Sat/CryptoMinisat5.h
@@ -54,15 +54,16 @@ public:
 
   void setMaxConflicts(int64_t max_confl) override; // set max solver conflicts
 
-  bool addClause(const vec_literals& ps) override; // Add a clause to the solver.
-
   bool okay() const override; // FALSE means solver is in a conflicting state
+
+  void unsatAssumptions(const vec_literals& assumps,
+                        std::vector<int>& out) override;
 
   uint8_t modelValue(uint32_t x) const override;
 
   uint32_t newVar() override;
 
-  bool setSearchBias(SearchBias bias) override;
+  bool setSearchBiasInternal(SearchBias bias) override;
 
   void setVerbosity(int v) override;
 
@@ -82,14 +83,20 @@ public:
 
   void solveAndDump();
 
+  bool supportsAssumptions() const override { return true; }
 
 protected:
+  bool addClauseInternal(const vec_literals& ps) override;
   bool solveInternal(bool& timeout_expired) override;
+  bool solveWithAssumptionsInternal(const vec_literals& assumps,
+                                    bool& timeout_expired) override;
 
   // CryptoMiniSat polls its own wall-clock limit during search.
   bool canInterruptSearch() const override { return true; }
 
 private:
+  bool armBudgets(bool& timeout_expired);
+
   void* temp_cl;
   // Negative means no budget was configured. This cannot default to 0,
   // which is now a budget of zero rather than the absence of one.

--- a/include/stp/Sat/MinisatCore.h
+++ b/include/stp/Sat/MinisatCore.h
@@ -53,9 +53,10 @@ public:
 
   ~MinisatCore();
 
-  bool addClause(const vec_literals& ps) override; // Add a clause to the solver.
-
   bool okay() const override; // FALSE means solver is in a conflicting state
+
+  void unsatAssumptions(const vec_literals& assumps,
+                        std::vector<int>& out) override;
 
   bool propagateWithAssumptions(const stp::SATSolver::vec_literals& assumps);
 
@@ -85,8 +86,13 @@ public:
 
   //bool unitPropagate(const vec_literals& ps);
 
+  bool supportsAssumptions() const override { return true; }
+
 protected:
+  bool addClauseInternal(const vec_literals& ps) override;
   bool solveInternal(bool& timeout_expired) override;
+  bool solveWithAssumptionsInternal(const vec_literals& assumps,
+                                    bool& timeout_expired) override;
 };
 }
 

--- a/include/stp/Sat/Riss.h
+++ b/include/stp/Sat/Riss.h
@@ -54,8 +54,6 @@ public:
 
   ~RissCore();
 
-  bool addClause(const vec_literals& ps) override; // Add a clause to the solver.
-
   bool okay() const override; // FALSE means solver is in a conflicting state
 
   bool propagateWithAssumptions(const stp::SATSolver::vec_literals& assumps);
@@ -86,8 +84,14 @@ public:
 
   //bool unitPropagate(const vec_literals& ps);
 
+public:
+  bool supportsAssumptions() const override { return true; }
+
 protected:
+  bool addClauseInternal(const vec_literals& ps) override;
   bool solveInternal(bool& timeout_expired) override;
+  bool solveWithAssumptionsInternal(const vec_literals& assumps,
+                                    bool& timeout_expired) override;
 };
 }
 

--- a/include/stp/Sat/SATSolver.h
+++ b/include/stp/Sat/SATSolver.h
@@ -64,8 +64,25 @@ public:
     Lit operator[](int i) const { return lits[static_cast<size_t>(i)]; }
   };
 
-  virtual bool addClause(
-      const SATSolver::vec_literals& ps) = 0; // Add a clause to the solver.
+  // Add a clause to the solver and count the submission at the common API
+  // boundary. Backend-reported clause counts are not suitable for persistent
+  // accounting: preprocessing may remove input clauses, and some backends do
+  // not expose a count at all. This monotone counter instead records exactly
+  // what STP has handed to the current backend instance, including a clause
+  // whose submission discovers that the formula is already inconsistent.
+  bool addClause(const SATSolver::vec_literals& ps)
+  {
+    submitted_clauses++;
+    return addClauseInternal(ps);
+  }
+
+  uint64_t submittedClauses() const { return submitted_clauses; }
+
+  // Whether this backend will still accept configuration. The window closes
+  // at the first clause; a caller that must decide about a LIVE solver and
+  // apply the choice to the fresh one a rebuild constructs can ask instead
+  // of relying on knowing where it is in the sequence.
+  bool configurationOpen() const { return submitted_clauses == 0; }
 
   virtual bool okay() const = 0; // FALSE means solver is in a conflicting state
 
@@ -90,6 +107,26 @@ public:
     return solveInternal(timeout_expired);
   }
 
+  // Search under assumption literals: each is treated as a unit clause for
+  // this call only, and leaves no trace afterwards. This is what makes the
+  // solver reusable across (check-sat) calls -- retractable assertions are
+  // assumed rather than added. Budget enforcement as in solve().
+  //
+  // Only meaningful when supportsAssumptions(); the incremental driver
+  // selects a backend on that basis.
+  bool solveWithAssumptions(const vec_literals& assumps, bool& timeout_expired)
+  {
+    if (timeLimitExpired())
+    {
+      timeout_expired = true;
+      return false;
+    }
+
+    return solveWithAssumptionsInternal(assumps, timeout_expired);
+  }
+
+  virtual bool supportsAssumptions() const { return false; }
+
   typedef uint8_t lbool;
 
   static inline Lit mkLit(uint32_t var, bool sign)
@@ -110,13 +147,105 @@ public:
   // FALSE means this backend has nothing corresponding to the requested bias.
   // That isn't an error: the bias is a hint about the workload, and a backend
   // that ignores it is slower rather than wrong.
-  virtual bool setSearchBias(SearchBias /*bias*/) { return false; }
+  bool setSearchBias(SearchBias bias)
+  {
+    assertConfigurable("setSearchBias");
+    return setSearchBiasInternal(bias);
+  }
 
   // Ask the backend to turn on bounded variable addition (BVA, CaDiCaL's
   // "factor"). Like setSearchBias this is only ever called before the first
   // clause is added, and FALSE means the backend has no such technique to
   // enable -- a performance hint declined, not an error.
-  virtual bool enableBVA() { return false; }
+  bool enableBVA()
+  {
+    assertConfigurable("enableBVA");
+    return enableBVAInternal();
+  }
+
+  // Ask the backend to reuse the solver trail across incremental solve
+  // calls when consecutive assumption sequences share a prefix, instead of
+  // re-deciding and re-propagating from the root every call (CaDiCaL's
+  // incremental lazy backtracking). Only correct to rely on when the
+  // caller keeps its assumption order prefix-stable across calls, which
+  // the incremental driver does: assumptions are emitted in assertion
+  // stack order and push/pop only ever change the suffix. FALSE means the
+  // backend has no such mechanism -- a performance hint declined, not an
+  // error.
+  bool enableTrailReuse()
+  {
+    assertConfigurable("enableTrailReuse");
+    return enableTrailReuseInternal();
+  }
+
+  // Whether this backend can turn probe-based inprocessing off, and the
+  // switch itself. disableInprobing() is only ever called before the
+  // first clause is added (backends may only accept configuration while
+  // empty); the capability query is free of that restriction, so a
+  // caller can decide about a LIVE solver and apply the choice to the
+  // fresh one a rebuild constructs. FALSE from the query means the
+  // backend has no such technique to control -- a performance hint
+  // declined, not an error.
+  virtual bool supportsInprobingControl() const { return false; }
+  bool disableInprobing()
+  {
+    assertConfigurable("disableInprobing");
+    return disableInprobingInternal();
+  }
+
+  // The rest of the recurring-inprocessing retirement, applied alongside
+  // disableInprobing under the same configuration-window rule: bounded
+  // variable elimination re-eliminates restored variables every solve on
+  // a persistent solver whose content churns (retractable encodings
+  // mention eliminated variables and CaDiCaL restores them on contact),
+  // and learned-clause shrinking taxes every conflict of a many-solve
+  // session. Both measured as steady per-solve losses on the sessions
+  // that retire inprobing, and their removal composes with it.
+  bool disableEliminationAndShrinking()
+  {
+    assertConfigurable("disableEliminationAndShrinking");
+    return disableEliminationAndShrinkingInternal();
+  }
+
+  // Turn off the backend's lucky-phase probing, which re-tries trivial
+  // whole-assignment patterns over the entire clause database at every
+  // solve call. Worth its price once per formula; on a persistent
+  // many-solve solver it is a recurring tax. Configuration-window-only,
+  // like the rest; FALSE means nothing to turn off.
+  bool disableLuckyPhases()
+  {
+    assertConfigurable("disableLuckyPhases");
+    return disableLuckyPhasesInternal();
+  }
+
+  // After solveWithAssumptions returned false: the subset of the assumed
+  // literals that the refutation actually used, in the same 2*var+sign
+  // encoding they were passed in. Any superset of a genuine core is a
+  // correct answer -- the full assumption set always is one, and that is
+  // the default for backends without the query. Only meaningful
+  // immediately after an unsatisfiable assumption solve, before anything
+  // else touches the solver.
+  virtual void unsatAssumptions(const vec_literals& assumps,
+                                std::vector<int>& out)
+  {
+    out.clear();
+    for (int i = 0; i < assumps.size(); i++)
+      out.push_back(assumps[i].x);
+  }
+
+  // Suggest the value the decision heuristic should try first for a
+  // variable. Pure search advice: it cannot change any verdict, only
+  // which model is found first. The incremental driver uses it to steer
+  // the search away from retracted content -- a popped level's
+  // activation variable is unconstrained, and a backend whose default
+  // phase is positive would otherwise keep dragging the dead level's
+  // cone into the search. Backends without a cheap phase interface
+  // ignore it.
+  virtual void suggestPhase(uint32_t var, bool value)
+  {
+    (void)var;
+    (void)value;
+  }
 
   // ---------------------------------------------------------------------
   // Resource budgets.
@@ -221,9 +350,51 @@ public:
   }
 
 protected:
+  // Backends may only accept configuration while they are still empty --
+  // CaDiCaL closes its option window at the first clause and answers a late
+  // setter by aborting the process. This header stated that rule in prose
+  // beside five separate methods and checked it nowhere; a rebuild that
+  // configured in the wrong order would have died inside a third-party
+  // library with no STP frame to name the caller. submitted_clauses is
+  // already exactly the latch -- it counts what STP handed THIS backend
+  // instance, and a rebuild constructs a fresh one -- so the window needs no
+  // state of its own, only asking.
+  void assertConfigurable(const char* what) const
+  {
+    (void)what;
+    assert(submitted_clauses == 0 &&
+           "backend configured after its first clause: the configuration "
+           "window closes there");
+  }
+
+  // Backend-specific configuration. Callers use the non-virtual facades
+  // above, which check the window first. FALSE means the backend has no such
+  // technique -- a performance hint declined, not an error.
+  virtual bool setSearchBiasInternal(SearchBias /*bias*/) { return false; }
+  virtual bool enableBVAInternal() { return false; }
+  virtual bool enableTrailReuseInternal() { return false; }
+  virtual bool disableInprobingInternal() { return false; }
+  virtual bool disableEliminationAndShrinkingInternal() { return false; }
+  virtual bool disableLuckyPhasesInternal() { return false; }
+
+  // Backend-specific clause translation. Callers use addClause(), whose
+  // non-virtual facade keeps submission accounting complete for every path,
+  // including theory refinement code that only sees SATSolver&.
+  virtual bool addClauseInternal(const vec_literals& ps) = 0;
+
   // Search without assumptions, having already been given a non-empty share
   // of whatever budget was configured. Implemented by each backend.
   virtual bool solveInternal(bool& timeout_expired) = 0;
+
+  // Search under assumptions. Backends that return true from
+  // supportsAssumptions() override this; the default must be unreachable.
+  virtual bool solveWithAssumptionsInternal(const vec_literals& /*assumps*/,
+                                            bool& /*timeout_expired*/)
+  {
+    std::cerr << "ERROR: this SAT backend does not support assumptions"
+              << std::endl;
+    exit(-1);
+  }
 
   // TRUE if the backend can abandon a search that is already running, either
   // through a callback or through a limit of its own. Backends that cannot
@@ -231,6 +402,7 @@ protected:
   virtual bool canInterruptSearch() const { return false; }
 
 private:
+  uint64_t submitted_clauses = 0;
   std::chrono::steady_clock::time_point deadline;
   bool deadline_set = false;
 };

--- a/include/stp/Sat/SimplifyingMinisat.h
+++ b/include/stp/Sat/SimplifyingMinisat.h
@@ -42,8 +42,6 @@ public:
   SimplifyingMinisat();
   ~SimplifyingMinisat();
 
-  bool addClause(const vec_literals& ps) override; // Add a clause to the solver.
-
   bool okay() const override; // FALSE means solver is in a conflicting state
 
   bool simplify() override; // Removes already satisfied clauses.
@@ -67,6 +65,7 @@ public:
   void setFrozen(uint32_t x) override;
 
 protected:
+  bool addClauseInternal(const vec_literals& ps) override;
   bool solveInternal(bool& timeout_expired) override;
 };
 }

--- a/lib/Sat/Cadical.cpp
+++ b/lib/Sat/Cadical.cpp
@@ -89,10 +89,46 @@ bool Cadical::solveInternal(bool& timeout_expired)
   return ret == 10;
 }
 
+bool Cadical::solveWithAssumptionsInternal(const vec_literals& assumps,
+                                           bool& timeout_expired)
+{
+  // Assumptions hold for the next solve() call only, which is exactly the
+  // semantics solveWithAssumptions promises. Literal conversion as in
+  // addClause -- including the factor translation: an assumption placed
+  // under a raw STP index would bind a different CaDiCaL variable than the
+  // clauses use, silently constraining nothing. Declaration must also
+  // happen before the assumption names the variable, not first inside
+  // solveInternal: an assumed variable no clause has mentioned yet would
+  // otherwise be imported undeclared, and the range declared for it
+  // afterwards would map it elsewhere for the rest of the session.
+  //
+  // Guarded exactly as the other two call sites are: declareNewVariables()
+  // asserts that factoring is on and that there is a gap to close, so an
+  // unguarded call aborts on the first assumption solve of a build without
+  // factoring -- which is every default build.
+  if (factor_enabled && ext_of_stp.size() <= next_variable)
+    declareNewVariables();
+  for (int i = 0; i < assumps.size(); i++)
+  {
+    uint32_t var = assumps[i].x >> 1;
+    uint32_t polarity = assumps[i].x & 1;
+    if (factor_enabled)
+      var = (uint32_t)ext_of_stp[var];
+    s->assume(polarity ? -(int)var : (int)var);
+  }
+
+  return solveInternal(timeout_expired);
+}
+
 Cadical::Cadical() : time_limit(*this)
 {
   s = new CaDiCaL::Solver ();
   s->set("quiet",1);
+  // Probe for the "inprobing" option (CaDiCaL 3.x) while the
+  // configuration window is certainly open: setting it to its current
+  // value changes nothing but reports whether the option exists, which
+  // lets a caller decide about a LIVE solver without touching it.
+  inprobing_control = s->set("inprobing", s->get("inprobing"));
 }
 
 Cadical::~Cadical()
@@ -131,7 +167,7 @@ void Cadical::setFrozen(uint32_t var)
   (void)var;
 }
 
-bool Cadical::setSearchBias(SearchBias bias)
+bool Cadical::setSearchBiasInternal(SearchBias bias)
 {
   // Cadical has named configurations of its own, so this is a straight
   // translation. "unsat" turns off stabilising search and the local-search
@@ -185,7 +221,7 @@ bool Cadical::okay()
 // factor's contract allows, and CaDiCaL places each declared range itself.
 // Only ever called while the solver is still empty (CONFIGURING), which is
 // the one state "factor" may be set in.
-bool Cadical::enableBVA()
+bool Cadical::enableBVAInternal()
 {
 #ifdef STP_CADICAL_HAS_FACTOR
   s->set("factor", 1);
@@ -196,6 +232,79 @@ bool Cadical::enableBVA()
   // impossible or untested; solving is unaffected.
   return false;
 #endif
+}
+
+// Incremental lazy backtracking: on a new solve whose assumptions extend a
+// prefix of the previous call's, CaDiCaL backtracks only to the first
+// difference and keeps the shared trail, instead of re-deciding and
+// re-propagating everything from the root. Mode 1 restricts the kept
+// trail to the assumption prefix; measured equal to mode 2 on the
+// many-small-queries workloads this targets.
+bool Cadical::enableTrailReuseInternal()
+{
+  // Like factor, "ilb" may only be set while the solver is still in its
+  // configuration window; the driver's size gate therefore works by
+  // rebuilding onto a fresh solver rather than by toggling.
+  return s->set("ilb", 1);
+}
+
+bool Cadical::supportsInprobingControl() const
+{
+  return inprobing_control;
+}
+
+bool Cadical::disableInprobingInternal()
+{
+  // Configuration-window-only, like factor and ilb: the incremental
+  // driver's retirement therefore rebuilds onto a fresh solver and
+  // applies this there.
+  return s->set("inprobing", 0);
+}
+
+bool Cadical::disableEliminationAndShrinkingInternal()
+{
+  const bool a = s->set("elim", 0);
+  const bool b = s->set("shrink", 0);
+  return a && b;
+}
+
+bool Cadical::disableLuckyPhasesInternal()
+{
+  return s->set("lucky", 0);
+}
+
+void Cadical::unsatAssumptions(const vec_literals& assumps,
+                               std::vector<int>& out)
+{
+  // failed() answers per assumed literal, in CaDiCaL's external numbering
+  // -- so the query literal travels through the factor translation exactly
+  // as the assumption itself did.
+  out.clear();
+  for (int i = 0; i < assumps.size(); i++)
+  {
+    uint32_t var = assumps[i].x >> 1;
+    uint32_t polarity = assumps[i].x & 1;
+    if (factor_enabled)
+      var = (uint32_t)ext_of_stp[var];
+    if (s->failed(polarity ? -(int)var : (int)var))
+      out.push_back(assumps[i].x);
+  }
+}
+
+void Cadical::suggestPhase(uint32_t var, bool value)
+{
+  // No declareNewVariables() here, deliberately. Declaring can reach
+  // CaDiCaL's declare_more_variables, which leaves the SATISFIED state and
+  // resets the extension -- too much for an advisory hint to do. Nothing is
+  // lost: every literal worth phasing has had a clause added and is
+  // therefore already declared, and one that has not is guarded below.
+  if (factor_enabled)
+  {
+    if (var >= ext_of_stp.size())
+      return; // never declared: nothing to phase.
+    var = (uint32_t)ext_of_stp[var];
+  }
+  s->phase(value ? (int)var : -(int)var);
 }
 
 // With factor enabled, external variables must be declared before use, and
@@ -223,7 +332,8 @@ void Cadical::declareNewVariables()
 #endif
 }
 
-bool Cadical::addClause(const vec_literals& ps) // Add a clause to the solver.
+bool Cadical::addClauseInternal(
+    const vec_literals& ps) // Add a clause to the solver.
 {
   if (factor_enabled && ext_of_stp.size() <= next_variable)
     declareNewVariables();

--- a/lib/Sat/CryptoMinisat5.cpp
+++ b/lib/Sat/CryptoMinisat5.cpp
@@ -71,7 +71,7 @@ void CryptoMiniSat5::setMaxConflicts(int64_t _max_confl)
   confl_base = s->get_sum_conflicts();
 }
 
-bool CryptoMiniSat5::addClause(
+bool CryptoMiniSat5::addClauseInternal(
     const vec_literals& ps) // Add a clause to the solver.
 {
   // Cryptominisat uses a slightly different vec class.
@@ -87,13 +87,32 @@ bool CryptoMiniSat5::addClause(
   return s->add_clause(real_temp_cl);
 }
 
+void CryptoMiniSat5::unsatAssumptions(const vec_literals& assumps,
+                                      std::vector<int>& out)
+{
+  // As in MiniSat, get_conflict() is the final conflict clause expressed over
+  // the assumptions, so it holds the NEGATION of each one the refutation
+  // used. An assumption is in the core iff its negation appears there.
+  const std::vector<CMSat::Lit>& conflict = s->get_conflict();
+
+  out.clear();
+  for (int i = 0; i < assumps.size(); i++)
+  {
+    const CMSat::Lit assumed(var(assumps[i]), sign(assumps[i]));
+    if (std::find(conflict.begin(), conflict.end(), ~assumed) != conflict.end())
+      out.push_back(assumps[i].x);
+  }
+}
+
 bool CryptoMiniSat5::okay()
     const // FALSE means solver is in a conflicting state
 {
   return s->okay();
 }
 
-bool CryptoMiniSat5::solveInternal(bool& timeout_expired)
+// Arm what is left of the query's conflict/time budgets before a solve call;
+// FALSE means a budget is already spent and the caller should give up now.
+bool CryptoMiniSat5::armBudgets(bool& timeout_expired)
 {
   /*
    * The conflict budget is for the query, so what is handed over is what is
@@ -133,7 +152,35 @@ bool CryptoMiniSat5::solveInternal(bool& timeout_expired)
      s->set_max_time(remaining);
   }
 
+  return true;
+}
+
+bool CryptoMiniSat5::solveInternal(bool& timeout_expired)
+{
+  if (!armBudgets(timeout_expired))
+    return false;
+
   CMSat::lbool ret = s->solve();
+  if (ret == CMSat::l_Undef)
+  {
+    timeout_expired = true;
+  }
+  return ret == CMSat::l_True;
+}
+
+bool CryptoMiniSat5::solveWithAssumptionsInternal(
+    const stp::SATSolver::vec_literals& assumps, bool& timeout_expired)
+{
+  if (!armBudgets(timeout_expired))
+    return false;
+
+  // Cryptominisat uses its own vec and Lit classes, as in addClause.
+  std::vector<CMSat::Lit> real_assumps;
+  real_assumps.reserve(assumps.size());
+  for (int i = 0; i < assumps.size(); i++)
+    real_assumps.push_back(CMSat::Lit(var(assumps[i]), sign(assumps[i])));
+
+  CMSat::lbool ret = s->solve(&real_assumps);
   if (ret == CMSat::l_Undef)
   {
     timeout_expired = true;
@@ -152,7 +199,7 @@ uint32_t CryptoMiniSat5::newVar()
   return s->nVars() - 1;
 }
 
-bool CryptoMiniSat5::setSearchBias(SearchBias bias)
+bool CryptoMiniSat5::setSearchBiasInternal(SearchBias bias)
 {
   // CryptoMiniSat has no named configurations, so what it offers has to be
   // picked out by hand. Turning off SLS is the piece that carries over: it is

--- a/lib/Sat/MinisatCore.cpp
+++ b/lib/Sat/MinisatCore.cpp
@@ -66,12 +66,28 @@ void MinisatCore::setMaxConflicts(int64_t max_confl)
   s->setConfBudget(max_confl);
 }
 
-bool MinisatCore::addClause(
+bool MinisatCore::addClauseInternal(
     const SATSolver::vec_literals& ps) // Add a clause to the solver.
 {
   Minisat::vec<Minisat::Lit> clause;
   convert(ps, clause);
   return s->addClause_(clause);
+}
+
+void MinisatCore::unsatAssumptions(const vec_literals& assumps,
+                                   std::vector<int>& out)
+{
+  // After an unsat assumption solve, MiniSat's `conflict` holds the final
+  // conflict clause expressed in the assumptions: the negations of the
+  // failed ones. An assumption is in the core iff its negation appears.
+  out.clear();
+  for (int i = 0; i < assumps.size(); i++)
+  {
+    const Minisat::Lit assumed =
+        Minisat::toLit(SATSolver::toInt(assumps[i]));
+    if (s->conflict.has(~assumed))
+      out.push_back(assumps[i].x);
+  }
 }
 
 bool MinisatCore::okay() const // FALSE means solver is in a conflicting state
@@ -102,6 +118,25 @@ bool MinisatCore::solveInternal(bool& timeout_expired)
 
   Minisat::vec<Minisat::Lit> assumps;
   Minisat::lbool ret = s->solveLimited(assumps);
+  if (ret == (Minisat::lbool)Minisat::l_Undef)
+  {
+    timeout_expired = true;
+  }
+
+  return ret == (Minisat::lbool)Minisat::l_True;
+}
+
+bool MinisatCore::solveWithAssumptionsInternal(
+    const stp::SATSolver::vec_literals& assumps, bool& timeout_expired)
+{
+  // simplify() only removes clauses satisfied at level 0; the core solver
+  // never eliminates variables, so assumption literals are safe across it.
+  if (!s->simplify())
+    return false;
+
+  Minisat::vec<Minisat::Lit> ms_assumps;
+  convert(assumps, ms_assumps);
+  Minisat::lbool ret = s->solveLimited(ms_assumps);
   if (ret == (Minisat::lbool)Minisat::l_Undef)
   {
     timeout_expired = true;

--- a/lib/Sat/RissCore.cpp
+++ b/lib/Sat/RissCore.cpp
@@ -63,14 +63,15 @@ void RissCore::setMaxConflicts(int64_t max_confl)
   s->setConfBudget(max_confl);
 }
 
-bool RissCore::addClause(
+bool RissCore::addClauseInternal(
     const SATSolver::vec_literals& ps) // Add a clause to the solver.
 {
   // convert the vector
   Riss::vec<Lit> &v = *(Riss::vec<Riss::Lit> *)riss_clause;
   v.capacity(ps.size());
   v.clear();
-  for(int i = 0 ; i < ps.size(); ++ i) v.push_(Riss::toLit(toInt(ps[i])));
+  for(int i = 0 ; i < ps.size(); ++ i)
+    v.push_(Riss::toLit(SATSolver::toInt(ps[i])));
 
   return s->addClause(v);
 }
@@ -94,7 +95,8 @@ bool RissCore::propagateWithAssumptions(
   Riss::vec<Lit> &v = *(Riss::vec<Riss::Lit> *)riss_clause;
   v.capacity(assumps.size());
   v.clear();
-  for(int i = 0 ; i < assumps.size(); ++ i) v.push_(Riss::toLit(toInt(assumps[i])));
+  for(int i = 0 ; i < assumps.size(); ++ i)
+    v.push_(Riss::toLit(SATSolver::toInt(assumps[i])));
 
   Riss::lbool ret = s->solveLimited(v);
   assert(s->conflicts ==0);
@@ -108,6 +110,27 @@ bool RissCore::solveInternal(bool& timeout_expired)
 
   Riss::vec<Riss::Lit> assumps;
   Riss::lbool ret = s->solveLimited(assumps);
+  if (ret == (Riss::lbool)l_Undef)
+  {
+    timeout_expired = true;
+  }
+
+  return ret == (Riss::lbool)l_True;
+}
+
+bool RissCore::solveWithAssumptionsInternal(
+    const stp::SATSolver::vec_literals& assumps, bool& timeout_expired)
+{
+  if (!s->simplify())
+    return false;
+
+  // convert the vector, as in addClause
+  Riss::vec<Riss::Lit> riss_assumps;
+  riss_assumps.capacity(assumps.size());
+  for (int i = 0; i < assumps.size(); ++i)
+    riss_assumps.push_(Riss::toLit(SATSolver::toInt(assumps[i])));
+
+  Riss::lbool ret = s->solveLimited(riss_assumps);
   if (ret == (Riss::lbool)l_Undef)
   {
     timeout_expired = true;

--- a/lib/Sat/SimplifyingMinisat.cpp
+++ b/lib/Sat/SimplifyingMinisat.cpp
@@ -54,7 +54,7 @@ void SimplifyingMinisat::setMaxConflicts(int64_t max_confl)
   s->setConfBudget(max_confl);
 }
 
-bool SimplifyingMinisat::addClause(
+bool SimplifyingMinisat::addClauseInternal(
     const vec_literals& ps) // Add a clause to the solver.
 {
   // STP's literal encoding (variable*2 + sign) is MiniSat's own, so the

--- a/tests/unit-tests/Bva_Test.cpp
+++ b/tests/unit-tests/Bva_Test.cpp
@@ -64,6 +64,47 @@ TEST(Bva, CadicalReportsConfigureTimeSupport)
 #endif
 }
 
+// The incremental driver's pattern with BVA on: everything retractable is
+// solved under assumptions, and an assumption may name a variable created
+// after the last declared batch. Assumption literals must travel through
+// the same declare/translate machinery as clause literals -- an assumption
+// placed under a raw STP index binds a different CaDiCaL variable than the
+// clauses and the model lookups use, which first shows up as an assumption
+// that silently fails to constrain anything (sat where unsat, model values
+// contradicting the assumption). The final unsat/sat pair is the
+// deterministic version of that: a unit clause against an assumed negation
+// must conflict, and must stop conflicting when the assumption is dropped.
+TEST(Bva, CadicalAssumptionsShareTheTranslation)
+{
+  stp::Cadical s;
+  // On pre-3.0 CaDiCaL this declines and the same expectations pin the
+  // untranslated path instead.
+  s.enableBVA();
+
+  bool timed_out = false;
+  const uint32_t x = s.newVar();
+  const uint32_t y = s.newVar();
+  addBinary(s, x, false, y, false); // (x | y)
+
+  SATSolver::vec_literals notX;
+  notX.push(SATSolver::mkLit(x, true));
+  ASSERT_TRUE(s.solveWithAssumptions(notX, timed_out));
+  EXPECT_EQ(s.modelValue(y), s.true_literal());
+
+  // A variable no clause has mentioned yet: assuming it is what forces the
+  // declaration to happen at assume time, not first at the next addClause.
+  const uint32_t z = s.newVar();
+  SATSolver::vec_literals notZ;
+  notZ.push(SATSolver::mkLit(z, true));
+  ASSERT_TRUE(s.solveWithAssumptions(notZ, timed_out));
+  EXPECT_EQ(s.modelValue(z), s.false_literal());
+
+  addUnit(s, z, false); // (z)
+  EXPECT_FALSE(s.solveWithAssumptions(notZ, timed_out));
+  ASSERT_TRUE(s.solve(timed_out));
+  EXPECT_EQ(s.modelValue(z), s.true_literal());
+}
+
 // The refinement-loop pattern with BVA on: solve, read the model, add
 // clauses over fresh variables, solve again. Every variable here crosses
 // the declare/translate machinery, so a mapping mistake shows up as a

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -22,6 +22,11 @@
 # -----------------------------------------------------------------------------
 # C API tests (these should be .cpp or .cxx files because GTest needs C++)
 # -----------------------------------------------------------------------------
+AddSTPGTest(SATSolver_Test.cpp)
+AddSTPGTest(SatSolverBudget_Test.cpp)
+AddSTPGTest(TrailReuse_Test.cpp)
+AddSTPGTest(SuggestPhase_Test.cpp)
+AddSTPGTest(UnsatAssumptions_Test.cpp)
 AddSTPGTest(PropagateEqualities_Test.cpp)
 AddSTPGTest(SimplifyingNodeFactory_Test.cpp)
 AddSTPGTest(FindPureLiterals_Test.cpp)
@@ -118,6 +123,7 @@ AddSTPGTest(ValueSet_Test.cpp)
 AddSTPGTest(ValueSet_Exhaustive_Test.cpp)
 AddSTPGTest(SearchBias_Test.cpp)
 AddSTPGTest(Bva_Test.cpp)
+AddSTPGTest(SATSolverConfigWindow_Test.cpp)
 AddSTPGTest(FdOStream_Test.cpp)
 # Deeply nested input must not put the AST-depth-recursive traversals through
 # the call stack. Each case runs in a forked child on a 1 MiB stack.

--- a/tests/unit-tests/SATSolverConfigWindow_Test.cpp
+++ b/tests/unit-tests/SATSolverConfigWindow_Test.cpp
@@ -1,0 +1,85 @@
+// The backend configuration window.
+//
+// Backends may only accept configuration while they are still empty: CaDiCaL
+// closes its option window at the first clause and answers a late setter by
+// aborting the process. SATSolver.h stated that rule in prose beside five
+// separate methods and checked it nowhere, so the only thing standing between
+// a mis-ordered rebuild and an abort inside a third-party library was the
+// call order happening to be right. The setters are now non-virtual facades
+// that check the window before dispatching, and the window is the clause
+// counter STP already keeps -- no new state, and a rebuild's fresh backend
+// starts open again.
+#include "stp/Sat/SATSolver.h"
+#include <gtest/gtest.h>
+
+#ifdef USE_CADICAL
+#include "stp/Sat/Cadical.h"
+#endif
+#ifdef USE_MINISAT
+#include "stp/Sat/MinisatCore.h"
+#endif
+
+using stp::SATSolver;
+
+namespace
+{
+// Only the two backends below drive clauses into a solver here; a build with
+// neither compiles every use away, and an unguarded definition is then an
+// unused function.
+#if defined(USE_CADICAL) || defined(USE_MINISAT)
+void addUnit(SATSolver& s, uint32_t var)
+{
+  s.newVar();
+  SATSolver::vec_literals c;
+  c.push(SATSolver::mkLit(var, false));
+  s.addClause(c);
+}
+#endif
+} // namespace
+
+#ifdef USE_CADICAL
+// Open until the first clause, closed from it on.
+TEST(SATSolverConfigWindow, ClosesAtTheFirstClause)
+{
+  stp::Cadical s;
+  EXPECT_TRUE(s.configurationOpen());
+  // configuration inside the window is accepted (or honestly declined)
+  s.disableLuckyPhases();
+  EXPECT_TRUE(s.configurationOpen());
+  addUnit(s, 0);
+  EXPECT_FALSE(s.configurationOpen());
+}
+
+// Every setter that carries the window rule is reachable while open. This is
+// the ordering the driver relies on at every rebuild.
+TEST(SATSolverConfigWindow, AllConfigurationIsAcceptedWhileOpen)
+{
+  stp::Cadical s;
+  s.setSearchBias(stp::SearchBias::NONE);
+  s.enableBVA();
+  s.enableTrailReuse();
+  if (s.supportsInprobingControl())
+  {
+    s.disableInprobing();
+    s.disableEliminationAndShrinking();
+    s.disableLuckyPhases();
+  }
+  EXPECT_TRUE(s.configurationOpen());
+  addUnit(s, 0);
+  EXPECT_FALSE(s.configurationOpen());
+}
+#endif
+
+#ifdef USE_MINISAT
+// The window is a property of the facade, not of any one backend: a backend
+// that declines every hint still reports the window honestly.
+TEST(SATSolverConfigWindow, HoldsForABackendThatDeclinesEveryHint)
+{
+  stp::MinisatCore s;
+  EXPECT_TRUE(s.configurationOpen());
+  EXPECT_FALSE(s.enableBVA());
+  EXPECT_TRUE(s.configurationOpen());
+  addUnit(s, 0);
+  EXPECT_FALSE(s.configurationOpen());
+}
+#endif

--- a/tests/unit-tests/SATSolver_Test.cpp
+++ b/tests/unit-tests/SATSolver_Test.cpp
@@ -1,0 +1,51 @@
+// The submitted-clause count belongs to the backend-neutral facade: theory
+// refinement and other generic clients only hold SATSolver&, and every one of
+// their clauses must be visible to persistent-solver accounting regardless of
+// what a backend later simplifies away.
+#include "stp/Sat/SATSolver.h"
+#include <gtest/gtest.h>
+
+namespace
+{
+
+class StubSolver : public stp::SATSolver
+{
+  bool accept = true;
+
+public:
+  void setAccept(bool value) { accept = value; }
+
+  bool okay() const override { return true; }
+  uint8_t modelValue(uint32_t) const override { return undef_literal(); }
+  uint32_t newVar() override { return 0; }
+  uint32_t nVars() const override { return 0; }
+  void printStats() const override {}
+  void setVerbosity(int) override {}
+  lbool true_literal() const override { return 0; }
+  lbool false_literal() const override { return 1; }
+  lbool undef_literal() const override { return 2; }
+
+protected:
+  bool addClauseInternal(const vec_literals&) override { return accept; }
+  bool solveInternal(bool&) override { return false; }
+};
+
+TEST(SATSolver, CountsEverySubmittedClause)
+{
+  StubSolver solver;
+  stp::SATSolver& generic = solver;
+  stp::SATSolver::vec_literals clause;
+  clause.push(stp::SATSolver::mkLit(0, false));
+
+  EXPECT_EQ(0u, generic.submittedClauses());
+  EXPECT_TRUE(generic.addClause(clause));
+  EXPECT_EQ(1u, generic.submittedClauses());
+
+  // A rejected clause is still a submission and must remain in the retained
+  // input accounting; it commonly means this add discovered inconsistency.
+  solver.setAccept(false);
+  EXPECT_FALSE(generic.addClause(clause));
+  EXPECT_EQ(2u, generic.submittedClauses());
+}
+
+} // namespace

--- a/tests/unit-tests/SatSolverBudget_Test.cpp
+++ b/tests/unit-tests/SatSolverBudget_Test.cpp
@@ -1,0 +1,113 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: Aug, 2026
+ *
+ * LICENSE: Please view LICENSE file in the home dir of this Program
+ ********************************************************************/
+
+#include "stp/Sat/SATSolver.h"
+#ifdef USE_CRYPTOMINISAT
+#include "stp/Sat/CryptoMinisat5.h"
+#endif
+#ifdef USE_MINISAT
+#include "stp/Sat/MinisatCore.h"
+#endif
+#include <gtest/gtest.h>
+
+// A conflict budget belongs to the query it was armed for, measured from
+// the arming point -- NOT from the solver's birth. The distinction was
+// invisible while every query got a fresh solver; the incremental driver
+// re-arms per check-sat on one long-lived solver, where birth-relative
+// accounting shrank every successive budget until each solve gave up on
+// arrival.
+//
+// The recipe makes the bug deterministic: a pigeonhole formula, guarded by
+// a selector so it can be retracted by assumption, burns far more than the
+// budget under {s}; the re-armed solve under {~s} satisfies every guarded
+// clause by propagation alone and MUST come back sat, not exhausted.
+
+namespace
+{
+
+#if defined(USE_CRYPTOMINISAT) || defined(USE_MINISAT)
+
+// Pigeonhole 6 pigeons / 5 holes over fresh solver variables, every clause
+// guarded by ~sel so the whole formula is retractable.
+void addGuardedPigeonhole(stp::SATSolver& s, uint32_t sel)
+{
+  const int P = 6, H = 5;
+  uint32_t var[P][H];
+  for (int p = 0; p < P; p++)
+    for (int h = 0; h < H; h++)
+      var[p][h] = s.newVar();
+
+  // Each pigeon sits somewhere.
+  for (int p = 0; p < P; p++)
+  {
+    stp::SATSolver::vec_literals c;
+    c.push(stp::SATSolver::mkLit(sel, true));
+    for (int h = 0; h < H; h++)
+      c.push(stp::SATSolver::mkLit(var[p][h], false));
+    s.addClause(c);
+  }
+
+  // No two pigeons share a hole.
+  for (int h = 0; h < H; h++)
+    for (int p1 = 0; p1 < P; p1++)
+      for (int p2 = p1 + 1; p2 < P; p2++)
+      {
+        stp::SATSolver::vec_literals c;
+        c.push(stp::SATSolver::mkLit(sel, true));
+        c.push(stp::SATSolver::mkLit(var[p1][h], true));
+        c.push(stp::SATSolver::mkLit(var[p2][h], true));
+        s.addClause(c);
+      }
+}
+
+void budgetIsPerArming(stp::SATSolver& s)
+{
+  const uint32_t sel = s.newVar();
+  addGuardedPigeonhole(s, sel);
+
+  // Far too little budget for the pigeonhole: exhausted, and the budget's
+  // conflicts are spent.
+  s.setMaxConflicts(10);
+  bool timeout = false;
+  stp::SATSolver::vec_literals on;
+  on.push(stp::SATSolver::mkLit(sel, false));
+  bool sat = s.solveWithAssumptions(on, timeout);
+  EXPECT_FALSE(sat);
+  EXPECT_TRUE(timeout);
+
+  // Re-armed, the retracted formula is satisfied by propagating ~sel: this
+  // must answer sat within any budget. Birth-relative accounting answered
+  // "exhausted on arrival" here.
+  s.setMaxConflicts(10);
+  timeout = false;
+  stp::SATSolver::vec_literals off;
+  off.push(stp::SATSolver::mkLit(sel, true));
+  sat = s.solveWithAssumptions(off, timeout);
+  EXPECT_TRUE(sat);
+  EXPECT_FALSE(timeout);
+}
+
+#endif
+
+} // namespace
+
+#ifdef USE_CRYPTOMINISAT
+TEST(SatSolverBudget, cryptominisat_budget_is_per_arming)
+{
+  stp::CryptoMiniSat5 s(1);
+  budgetIsPerArming(s);
+}
+#endif
+
+#ifdef USE_MINISAT
+TEST(SatSolverBudget, minisat_budget_is_per_arming)
+{
+  stp::MinisatCore s;
+  budgetIsPerArming(s);
+}
+#endif

--- a/tests/unit-tests/SuggestPhase_Test.cpp
+++ b/tests/unit-tests/SuggestPhase_Test.cpp
@@ -1,0 +1,109 @@
+// Guards suggestPhase, the phase-hint the incremental driver uses to
+// steer the search away from retracted levels. The contract is
+// deliberately weak -- hints are search advice a backend may ignore and
+// can never change a verdict -- so that is what these tests pin, plus
+// the one sharp edge: with CaDiCaL's factor enabled, a hint must travel
+// through the same declared-variable translation as clause and
+// assumption literals. (Which model a hint produces is solver-internal:
+// CaDiCaL's lucky-phase probing can satisfy small instances before any
+// decision consults a phase, so asserting model shapes here would test
+// the solver's mood, not our contract.)
+#include "stp/Sat/SATSolver.h"
+#include <gtest/gtest.h>
+
+#ifdef USE_MINISAT
+#include "stp/Sat/MinisatCore.h"
+#endif
+#ifdef USE_CADICAL
+#include "stp/Sat/Cadical.h"
+#endif
+
+using stp::SATSolver;
+
+// The base-class default ignores hints; solving must be unaffected.
+#ifdef USE_MINISAT
+TEST(SuggestPhase, MinisatIgnoresHints)
+{
+  stp::MinisatCore s;
+  const uint32_t a = s.newVar();
+  SATSolver::vec_literals c;
+  c.push(SATSolver::mkLit(a, false));
+  s.addClause(c);
+  s.suggestPhase(a, false); // advice against the unit; must change nothing
+  bool timed_out = false;
+  ASSERT_TRUE(s.solve(timed_out));
+  EXPECT_EQ(s.modelValue(a), s.true_literal());
+}
+#endif
+
+#ifdef USE_CADICAL
+
+// Hints never move a verdict: a satisfiable clause stays satisfiable
+// under hostile hints (and the model still satisfies it), an unsat core
+// stays unsat under helpful ones.
+TEST(SuggestPhase, CadicalVerdictsUnmovedByHints)
+{
+  bool timed_out = false;
+  {
+    stp::Cadical s;
+    const uint32_t a = s.newVar();
+    const uint32_t b = s.newVar();
+    SATSolver::vec_literals c;
+    c.push(SATSolver::mkLit(a, false));
+    c.push(SATSolver::mkLit(b, false));
+    s.addClause(c);
+    s.suggestPhase(a, false);
+    s.suggestPhase(b, false);
+    ASSERT_TRUE(s.solve(timed_out));
+    EXPECT_TRUE(s.modelValue(a) == s.true_literal() ||
+                s.modelValue(b) == s.true_literal());
+  }
+  {
+    stp::Cadical s;
+    const uint32_t a = s.newVar();
+    SATSolver::vec_literals pos, neg;
+    pos.push(SATSolver::mkLit(a, false));
+    neg.push(SATSolver::mkLit(a, true));
+    s.addClause(pos);
+    s.addClause(neg);
+    s.suggestPhase(a, true);
+    EXPECT_FALSE(s.solve(timed_out));
+  }
+}
+
+// With factor enabled every literal travels through the declared-variable
+// translation table; a hint on a raw STP index would phase a different
+// CaDiCaL variable than the clauses use. This exercises hints before and
+// after the variable's declaring clause, plus one on a variable no clause
+// has mentioned (which must be safely ignorable, not a crash).
+TEST(SuggestPhase, CadicalHintsTranslateUnderFactor)
+{
+  stp::Cadical s;
+  s.enableBVA();
+
+  bool timed_out = false;
+  const uint32_t a = s.newVar();
+  const uint32_t b = s.newVar();
+  s.suggestPhase(a, false); // before any clause names a
+  SATSolver::vec_literals c;
+  c.push(SATSolver::mkLit(a, false));
+  c.push(SATSolver::mkLit(b, false));
+  s.addClause(c);
+  s.suggestPhase(b, true); // after declaration
+
+  const uint32_t never_claused = s.newVar();
+  s.suggestPhase(never_claused, true);
+
+  ASSERT_TRUE(s.solve(timed_out));
+  EXPECT_TRUE(s.modelValue(a) == s.true_literal() ||
+              s.modelValue(b) == s.true_literal());
+
+  SATSolver::vec_literals killA, killB;
+  killA.push(SATSolver::mkLit(a, true));
+  killB.push(SATSolver::mkLit(b, true));
+  s.addClause(killA);
+  s.addClause(killB);
+  EXPECT_FALSE(s.solve(timed_out));
+}
+
+#endif

--- a/tests/unit-tests/TrailReuse_Test.cpp
+++ b/tests/unit-tests/TrailReuse_Test.cpp
@@ -1,0 +1,93 @@
+// Guards enableTrailReuse (CaDiCaL's incremental lazy backtracking).
+// Correctness under trail reuse is the solver's own business; what these
+// tests pin is the wrapper contract the incremental driver relies on: a
+// backend without the mechanism says so, and with it enabled the driver's
+// exact usage pattern -- solves whose assumption sequences share prefixes,
+// clauses added between solves under unchanged assumptions -- keeps
+// producing the right verdicts and model values.
+#include "stp/Sat/SATSolver.h"
+#include <gtest/gtest.h>
+
+#ifdef USE_MINISAT
+#include "stp/Sat/MinisatCore.h"
+#endif
+#ifdef USE_CADICAL
+#include "stp/Sat/Cadical.h"
+#endif
+
+using stp::SATSolver;
+
+#ifdef USE_MINISAT
+TEST(TrailReuse, MinisatReportsNoSupport)
+{
+  stp::MinisatCore s;
+  EXPECT_FALSE(s.enableTrailReuse());
+}
+#endif
+
+#ifdef USE_CADICAL
+
+namespace
+{
+void addBinary(SATSolver& s, uint32_t a, bool a_neg, uint32_t b, bool b_neg)
+{
+  SATSolver::vec_literals c;
+  c.push(SATSolver::mkLit(a, a_neg));
+  c.push(SATSolver::mkLit(b, b_neg));
+  s.addClause(c);
+}
+} // namespace
+
+// The driver's shape: a stable assumption prefix, a varying suffix, and
+// definitional clauses arriving between solves. Every answer and model
+// read below crosses whatever trail the solver kept from the call before.
+TEST(TrailReuse, CadicalPrefixStableAssumptionRounds)
+{
+  stp::Cadical s;
+  // On a CaDiCaL without the option this declines, and the same
+  // expectations pin the ordinary re-descending path instead.
+  s.enableTrailReuse();
+
+  bool timed_out = false;
+  const uint32_t base = s.newVar();
+  const uint32_t x = s.newVar();
+  const uint32_t y = s.newVar();
+  addBinary(s, base, true, x, false); // base -> x
+
+  SATSolver::vec_literals a1;
+  a1.push(SATSolver::mkLit(base, false));
+  ASSERT_TRUE(s.solveWithAssumptions(a1, timed_out));
+  EXPECT_EQ(s.modelValue(x), s.true_literal());
+
+  // Extend the prefix: [base] -> [base, y].
+  addBinary(s, y, true, x, true); // y -> ~x, contradicting base -> x
+  SATSolver::vec_literals a2;
+  a2.push(SATSolver::mkLit(base, false));
+  a2.push(SATSolver::mkLit(y, false));
+  EXPECT_FALSE(s.solveWithAssumptions(a2, timed_out));
+
+  // Retreat to the shared prefix again: satisfiable as before.
+  ASSERT_TRUE(s.solveWithAssumptions(a1, timed_out));
+  EXPECT_EQ(s.modelValue(x), s.true_literal());
+
+  // Diverge the suffix: [base, z] with z forcing a fresh chain encoded
+  // only now -- clauses added after three solves already ran.
+  const uint32_t z = s.newVar();
+  const uint32_t w = s.newVar();
+  addBinary(s, z, true, w, false); // z -> w
+  SATSolver::vec_literals a3;
+  a3.push(SATSolver::mkLit(base, false));
+  a3.push(SATSolver::mkLit(z, false));
+  ASSERT_TRUE(s.solveWithAssumptions(a3, timed_out));
+  EXPECT_EQ(s.modelValue(x), s.true_literal());
+  EXPECT_EQ(s.modelValue(w), s.true_literal());
+
+  // And a permanent unit added between solves must invalidate what the
+  // kept trail believed: base becomes false, so assuming it is now unsat.
+  SATSolver::vec_literals unit;
+  unit.push(SATSolver::mkLit(base, true));
+  s.addClause(unit);
+  EXPECT_FALSE(s.solveWithAssumptions(a1, timed_out));
+}
+
+#endif

--- a/tests/unit-tests/UnsatAssumptions_Test.cpp
+++ b/tests/unit-tests/UnsatAssumptions_Test.cpp
@@ -1,0 +1,121 @@
+// Guards unsatAssumptions, the wrapper query behind get-unsat-assumptions
+// and the core-aware verdict cache. The contract: after an unsat
+// assumption solve it returns a subset of the assumed literals that is
+// itself unsatisfiable with the clauses -- any superset of a genuine core
+// qualifies, so the assertions accept supersets but insist the culprit is
+// present and that irrelevant assumptions are droppable: solving again
+// without the reported literals' complement must stay consistent.
+#include "stp/Sat/SATSolver.h"
+#include <algorithm>
+#include <gtest/gtest.h>
+#include <vector>
+
+#ifdef USE_MINISAT
+#include "stp/Sat/MinisatCore.h"
+#endif
+#ifdef USE_CADICAL
+#include "stp/Sat/Cadical.h"
+#endif
+#ifdef USE_CRYPTOMINISAT
+#include "stp/Sat/CryptoMinisat5.h"
+#endif
+
+using stp::SATSolver;
+
+namespace
+{
+
+// Three assumptions over a unit-contradicted variable: only the middle
+// one can ever be in a genuine core.
+void culpritIsReported(SATSolver& s)
+{
+  bool timed_out = false;
+  const uint32_t a = s.newVar();
+  const uint32_t b = s.newVar();
+  const uint32_t c = s.newVar();
+
+  SATSolver::vec_literals unit;
+  unit.push(SATSolver::mkLit(b, true)); // (~b)
+  s.addClause(unit);
+
+  SATSolver::vec_literals assumps;
+  assumps.push(SATSolver::mkLit(a, false));
+  assumps.push(SATSolver::mkLit(b, false)); // contradicts the unit
+  assumps.push(SATSolver::mkLit(c, false));
+  ASSERT_FALSE(s.solveWithAssumptions(assumps, timed_out));
+
+  std::vector<int> failed;
+  s.unsatAssumptions(assumps, failed);
+
+  // Reporting every assumption is a correct answer but not this one: a and c
+  // are unconstrained, so no genuine core mentions them. A backend that
+  // overrides unsatAssumptions has to narrow to b, which is what makes this
+  // test distinguish real granularity from the base class's superset.
+  const int culprit = SATSolver::mkLit(b, false).x;
+  EXPECT_TRUE(std::find(failed.begin(), failed.end(), culprit) !=
+              failed.end());
+  EXPECT_EQ(1u, failed.size());
+  // Every reported literal is one of the assumptions.
+  for (const int lit : failed)
+  {
+    bool known = false;
+    for (int i = 0; i < assumps.size(); i++)
+      known |= static_cast<int>(assumps[i].x) == lit;
+    EXPECT_TRUE(known);
+  }
+  // Dropping the culprit leaves a satisfiable assumption set.
+  SATSolver::vec_literals rest;
+  rest.push(SATSolver::mkLit(a, false));
+  rest.push(SATSolver::mkLit(c, false));
+  EXPECT_TRUE(s.solveWithAssumptions(rest, timed_out));
+}
+
+} // namespace
+
+#ifdef USE_MINISAT
+TEST(UnsatAssumptions, MinisatReportsCulprit)
+{
+  stp::MinisatCore s;
+  culpritIsReported(s);
+}
+#endif
+
+#ifdef USE_CADICAL
+TEST(UnsatAssumptions, CadicalReportsCulprit)
+{
+  stp::Cadical s;
+  culpritIsReported(s);
+}
+
+// With factor on, failed() must be queried through the same translation
+// the assumptions travelled through.
+TEST(UnsatAssumptions, CadicalReportsCulpritUnderFactor)
+{
+  stp::Cadical s;
+  s.enableBVA();
+  bool timed_out = false;
+  const uint32_t a = s.newVar();
+  const uint32_t b = s.newVar();
+  SATSolver::vec_literals unit;
+  unit.push(SATSolver::mkLit(b, true));
+  s.addClause(unit);
+
+  SATSolver::vec_literals assumps;
+  assumps.push(SATSolver::mkLit(a, false));
+  assumps.push(SATSolver::mkLit(b, false));
+  ASSERT_FALSE(s.solveWithAssumptions(assumps, timed_out));
+
+  std::vector<int> failed;
+  s.unsatAssumptions(assumps, failed);
+  EXPECT_TRUE(std::find(failed.begin(), failed.end(),
+                        SATSolver::mkLit(b, false).x) != failed.end());
+}
+#endif
+
+#ifdef USE_CRYPTOMINISAT
+TEST(UnsatAssumptions, CryptoMiniSatReportsCulprit)
+{
+  stp::CryptoMiniSat5 s(1);
+  culpritIsReported(s);
+}
+#endif


### PR DESCRIPTION
# Incremental solving 1/5 — SAT backends: assumptions, unsat cores, phase hints, and a checked configuration window

**This PR builds on top of #831** (the last of the four prerequisites). Please review and merge those first; this branch contains their commits.

The first part of the incremental-solving series, and the layer everything above it is written against. STP's `SATSolver` wrapper can currently only ask a backend to solve everything it has been given; this adds the rest of the interface a solver that is *kept alive across queries* needs, implemented for every backend that has it.

**Nothing here changes an answer STP gives, and nothing in the tree calls the new entry points yet.** That is deliberate — it makes this reviewable on its own terms: is this the right shape for a backend-neutral assumption interface? Every piece is unit-tested against real backends rather than left to be exercised later.

## Assumptions, and why retraction is not clause deletion

`solveWithAssumptions(assumps, timeout)` searches under literals that hold for that call only and leave no trace afterwards. This is the mechanism the whole series rests on: a formula is made retractable by assuming a literal that implies it, not by deleting its clauses, so learned clauses stay valid and nothing has to be undone.

`supportsAssumptions()` says whether a backend has it. MiniSat, CryptoMiniSat, CaDiCaL and Riss do. The simplifying MiniSat deliberately does not — its variable elimination cannot cope with later clauses over eliminated variables — so it answers false and a caller that needs assumptions selects a different backend rather than getting a wrong answer.

## Unsat cores

`unsatAssumptions(assumps, out)` reports which of the assumed literals the refutation actually used. **Any superset of a genuine core is a correct answer**, and the full assumption set always is one, so that is the base-class default and a backend without the query is not wrong, only imprecise. MiniSat overrides it by reading its final conflict clause — an assumption is in the core exactly when its negation appears there. CaDiCaL asks `failed()`, with the query literal travelling through the same factor translation the assumption itself took.

## Phase hints

`suggestPhase(var, value)` suggests which value the decision heuristic should try first. It is pure advice: it cannot change a verdict, only which model is found first. Backends without a cheap phase interface ignore it. CaDiCaL's implementation deliberately does *not* declare variables first — declaring can reach `declare_more_variables`, which leaves the `SATISFIED` state and resets the extension, which is far too much for an advisory hint to do.

## The configuration window becomes a checked invariant

This is the part most worth reading. Backends may only accept configuration while they are still empty — CaDiCaL answers a late option setter by **aborting the process**. That rule was stated in prose beside five separate methods and checked nowhere, so a caller that configured in the wrong order would have died inside a third-party library with no STP frame to name it.

`addClause` becomes a non-virtual facade over `addClauseInternal` that counts submissions, and `submitted_clauses` is already exactly the latch the window needs: it counts what STP handed *this* backend instance, and a rebuild constructs a fresh one. `assertConfigurable()` then turns the rule into an assertion, and `configurationOpen()` exposes it — answerable about a *live* solver, so a caller can decide about one and apply the choice to the fresh solver a rebuild constructs.

Four configuration hints join the two that already existed: `enableTrailReuse` (CaDiCaL's incremental lazy backtracking, correct to rely on only when assumption order is prefix-stable across calls), `disableInprobing`, `disableEliminationAndShrinking` and `disableLuckyPhases`. All four return false from a backend that has nothing to turn off — a performance hint declined, not an error. `supportsInprobingControl()` is a capability query deliberately free of the window restriction, so it can be asked of a live solver; CaDiCaL probes for the option once at construction by setting it to its current value.

## Clause accounting

Counting at the facade also fixes the accounting, which is why the counter is not merely private state. Backend-reported clause counts are not usable for this: preprocessing removes input clauses, and some backends expose no count at all. `submittedClauses()` instead records exactly what STP has handed the current backend instance, including the clause whose submission discovers the formula is already inconsistent — and it does so for every path, including theory-refinement code that only holds a `SATSolver&`.

## CryptoMiniSat's budget arming

`solveInternal`'s budget arithmetic moves into `armBudgets()` so the assumption path enforces the same conflict and time limits as the plain one, rather than quietly having none.

## One interaction with the stack-safety series

`declareNewVariables()` asserts that bounded variable addition is on, and its two existing call sites are guarded to match. `solveWithAssumptionsInternal` needs it too -- an assumed variable that no clause has mentioned yet would otherwise be imported undeclared, and the range declared for it afterwards would map it elsewhere for the rest of the session -- so it takes the same guard.

Worth naming explicitly because a textual merge does not produce it: the assert and the call arrived from different branches, and a build without factoring aborts on its first assumption solve without one.

## Verification

Every axis with `-DWERROR:BOOL=ON`:

| axis | result |
| --- | --- |
| FP + assertions + tests | **115/115 ctest**, 462 lit (444 passed, 18 unsupported, 0 failures), 103 deep-DAG cases |
| no-fp + tests | **86/86 ctest**, 90 deep-DAG cases |
| g++-13 Release | clean |
| clang-21 Release (`--target stp`) | clean, zero warnings from STP's own sources |

The 18 unsupported lit tests are the `REQUIRES: libbf` ones, which this configuration does not enable.
