### PR TITLE
Fix the two FP-over-array-read crashes (#824, #825)

### DIFF
--- a/lib/AST/ASTNode.cpp
+++ b/lib/AST/ASTNode.cpp
@@ -587,7 +587,31 @@ SourceSort ASTNode::deriveSourceSort() const
   {
     const SourceSort then_sort = (*this)[1].GetSourceSort();
     const SourceSort else_sort = (*this)[2].GetSourceSort();
-    return then_sort == else_sort ? then_sort : SourceSort::unknown();
+    if (then_sort == else_sort)
+      return then_sort;
+    // After lowering, a float-valued mux may hold one branch as its packed
+    // circuit -- a plain bitvector of the float's packed width -- while the
+    // other branch still names the float sort. BVTypeCheck's ITE rule
+    // admits exactly this mix (it arises only when lowering replaces a
+    // branch with its circuit; public construction requires the branches to
+    // share a sort), and deriveFPFormat already reads the format from
+    // whichever branch kept it. The array transform builds such muxes when
+    // it expands a read over a write of a float array: the stored value is
+    // already a circuit, the fresh read variable is float-stamped. The
+    // float branch names the sort for both.
+    const bool then_is_float =
+        then_sort.kind() == SourceSort::Kind::FloatingPoint;
+    const bool else_is_float =
+        else_sort.kind() == SourceSort::Kind::FloatingPoint;
+    if (then_is_float != else_is_float)
+    {
+      const SourceSort& float_sort = then_is_float ? then_sort : else_sort;
+      const SourceSort& other_sort = then_is_float ? else_sort : then_sort;
+      if (other_sort.kind() == SourceSort::Kind::BitVector &&
+          other_sort.bitVectorWidth() == float_sort.packedWidth())
+        return float_sort;
+    }
+    return SourceSort::unknown();
   }
 
   // Compatibility for internal and legacy leaves that predate typed source

--- a/lib/FloatBlaster/FloatBlast.cpp
+++ b/lib/FloatBlaster/FloatBlast.cpp
@@ -216,9 +216,17 @@ private:
     // which is what the bit-blaster reads back here.
     if (n.GetKind() == READ)
     {
+      // asPacked rebuilds the read through the simplifying factory, whose
+      // read-over-write chase can fold the read away once lowering rewrites
+      // an index (a same-format to_fp on a store index collapses to the
+      // read index, for instance). The fold's result is whatever was
+      // stored, already lowered -- possibly an encode() circuit. Only a
+      // result that still carries the float sort is a packed view the
+      // predicate may consume; anything else sends the predicate to SymFPU,
+      // which decodes the same folded carrier.
       const ASTNode packed = asPacked(n);
-      assert(packed.GetKind() == READ);
-      assert(packed.GetSourceSort().kind() == SourceSort::Kind::FloatingPoint);
+      if (packed.GetSourceSort().kind() != SourceSort::Kind::FloatingPoint)
+        return ASTNode();
       return packed;
     }
     // A float-sorted ITE is a mux over packed bits once its branches are

--- a/tests/query-files/fp-tests/native-read-store-folds.smt2
+++ b/tests/query-files/fp-tests/native-read-store-folds.smt2
@@ -1,0 +1,24 @@
+; RUN: %solver --array-equality %s | %OutputCheck %s
+; RUN: %solver --array-equality --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver --array-equality --bb.fp-native-cmp=false %s | %OutputCheck %s
+;
+; Regression test for https://github.com/stp/stp/issues/824.
+;
+; The store index is a same-format to_fp of the read index, so lowering
+; collapses the two and the simplifying factory folds the read-over-store
+; to the stored value -- an encode() circuit for the fp.roundToIntegral,
+; not a read. The native comparison gate must notice the fold and send the
+; predicate to SymFPU rather than consume the circuit as if it carried a
+; float sort (it used to abort with std::length_error in BBfpIsNaN).
+;
+; CHECK: ^sat
+(set-logic QF_ABVFP)
+(declare-const _x0 (_ FloatingPoint 11 53))
+(declare-const _x2 (Array (_ FloatingPoint 11 53) (_ FloatingPoint 15 113)))
+(assert (let ((_let0 (select _x2 _x0)))
+  (let ((_let1 (fp.roundToIntegral RNA _let0)))
+  (let ((_let2 ((_ to_fp 11 53) RNA _x0)))
+    (=> (fp.gt (select (store _x2 _let2 _let1) _x0) _let0)
+        (distinct (store _x2 _let2 _let0) (store _x2 _x0 _let1)))))))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/native-read-store-mux.smt2
+++ b/tests/query-files/fp-tests/native-read-store-mux.smt2
@@ -1,0 +1,24 @@
+; RUN: %solver --array-equality %s | %OutputCheck %s
+; RUN: %solver %s | %OutputCheck %s
+; RUN: %solver --disable-simplifications %s | %OutputCheck %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck %s
+; RUN: %solver -r %s | %OutputCheck %s
+;
+; Regression test for https://github.com/stp/stp/issues/825.
+;
+; The classification's operand is a read over stores whose indexes stay
+; symbolic, so the array transform expands it into a mux mixing a lowered
+; packed circuit (the stored to_fp) with a float-stamped read variable. The
+; mux must still derive the float sort from the branch that kept it -- it
+; used to derive unknown and segfault in BBclassifyFP (makeTower over an
+; empty operand vector).
+;
+; CHECK: ^sat
+(set-logic QF_ABVFP)
+(declare-const __ (_ BitVec 1))
+(declare-const x7 (Array (_ BitVec 32) Float32))
+(declare-const x  (Array (_ BitVec 32) Float32))
+(assert (and (fp.lt (select x7 (_ bv2 32)) (ite (fp.lt (select x (_ bv0 32)) (select x ((_ zero_extend 31) __))) (_ +zero 8 24) (select x7 (_ bv3 32)))) (fp.leq (select x7 (_ bv0 32)) (select (store (store (store (store x7 (_ bv0 32) (select x7 (_ bv1 32))) (_ bv1 32) (select x7 (_ bv0 32))) (_ bv0 32) (select x (_ bv1 32))) ((_ zero_extend 31) __) (_ +zero 8 24)) (_ bv0 32)))))
+(assert (fp.isNormal (select (store (store x7 (_ bv0 32) ((_ to_fp 8 24) ((_ zero_extend 31) __))) (_ bv1 32) (select x7 ((_ zero_extend 31) __))) ((_ zero_extend 31) __))))
+(check-sat)
+(exit)


### PR DESCRIPTION
Fixes #824. Fixes #825.

Both crashes are murxla finds in the native-FP-over-array-read path that #762 widened, and each has its own root cause.

**#824 (`std::length_error` in `BBfpIsNaN`).** `comparisonLeaf`'s READ arm asserted that `asPacked` leaves a read a read. But `asPacked` rebuilds the read through the simplifying factory, whose read-over-write chase folds the read to the stored value once lowering makes a store index equal to the read index — in the reproducer, a same-format `to_fp` on the store index collapses to the read index itself. The stored value is already lowered, so the "read" comes back as an encode() circuit with no floating-point source sort, and `BBcompareFP` read garbage widths off it. The arm now keeps the result only while it still carries the float sort; anything else returns null and the predicate takes the SymFPU path, which decodes the same folded carrier — sound either way.

**#825 (segfault in `BBclassifyFP`).** The array transform expands a read over a write of a float array into `ITE(i=j, storedValue, freshReadVariable)`. Post-lowering the stored value is a packed circuit (a plain bitvector) while the fresh read variable is float-stamped, and the circuit branch can never carry the format itself — `SetExpWidth` refuses bitvector-kind interior nodes by design. `deriveSourceSort`'s ITE arm required the branches to agree, answered Unknown, and `BBclassifyFP` built its tower over an empty operand vector. `BVTypeCheck`'s ITE rule already documents this mixed mux as legal after lowering, and `deriveFPFormat` already reads the format from whichever branch kept it; the source-sort derivation now does the same, taking the float sort when exactly one branch is float-sorted and the other is a plain bitvector of the float's packed width. Contrary to the report, `--array-equality` is not needed for this one: the debug build trips the same assertion on the reproducer without the flag.

**Why #762's read-over-store test missed it:** `native-read-store.smt2` reads the cell it just stored, so the index equality folds and the mux-building path never ran. The new tests keep the store/read indexes symbolically distinct (#825's), and use the index-collapsing `to_fp` shape (#824's).

**Validation:** both reproducers answer `sat` and pass `-d` (construct counterexample and check it); the full test suite passes (108/108, including the exhaustive FP differential suites); an answer-comparison sweep of both binaries over every fp-tests and array-extensionality-tests query file shows no answer changes — only the two new tests differ, where the old binary crashes.