### PR TITLE
The incremental driver no longer needs a stack of its own

### DIFF
--- a/docs/incremental-solving.rst
+++ b/docs/incremental-solving.rst
@@ -123,15 +123,14 @@ repairs or resets on divergence. The conjunction can also change when an
 assertion is appended at the current depth, so depth alone is never a stable
 identity.
 
-Each check-sat runs on a worker thread with a large explicit stack.
-Several passes walk formulas by recursion -- the per-conjunct
-simplifier, substitution replace, the bit-blaster -- and parse-time
-inlining of chained ``define-fun``\ s builds nodes tens of thousands of
-levels deep out of flat input, deeper than a default-sized stack can
-walk. The worker inherits the process's thread-local solver state
-explicitly: it boots CONSTANTBV for itself and continues (then hands
-back) the node uid counter, which caches keyed on node numbers rely
-on.
+Each check-sat runs on the caller's stack. It did not always: the passes
+a check-sat drives -- the per-conjunct simplifier, substitution replace,
+the bit-blaster -- walked formulas by recursion, and parse-time inlining
+of chained ``define-fun``\ s builds nodes tens of thousands of levels deep
+out of flat input, deeper than a default-sized stack can walk, so the
+driver ran each check-sat on a worker thread with a 256 MiB stack. Those
+passes keep their working state on the heap now, and ``DeepDag_Test``
+drives a 20,000-deep check-sat under a 1 MiB stack bound to say so.
 
 Word-level rewriting is kept sound under retraction by construction
 rather than by backtracking:
@@ -629,8 +628,8 @@ whole-array-equality route is
 instead enclosed by ``extensionality-us``. ``refinement-us`` includes its SAT
 re-solves. ``rebuild-reset-us`` measures backend replacement and base
 re-simplification; the subsequent live-stack re-encoding is reported under
-``encode-us``. ``total-us`` begins immediately before the driver's large-stack
-worker is launched, but does not include frontend assertion snapshot
+``encode-us``. ``total-us`` begins immediately before the driver's
+check-sat body, but does not include frontend assertion snapshot
 construction, checks answered from the frontend cache or batch path, or a
 model materialized lazily after the solve.
 

--- a/include/stp/AST/ASTInternal.h
+++ b/include/stp/AST/ASTInternal.h
@@ -80,18 +80,6 @@ protected:
   uint64_t node_uid;
   static THREAD_LOCAL_IE uint64_t node_uid_cntr;
 
-public:
-  // The counter is thread-local. A worker thread that creates nodes must
-  // continue the spawning thread's numbering and hand the advanced value
-  // back when it finishes (the incremental driver's large-stack solve
-  // worker does exactly this); a worker that starts from its own zero
-  // gives fresh nodes uids that collide with live main-thread nodes, and
-  // every cache keyed on node numbers -- the deterministic
-  // extensionality names above all -- can cross-bind.
-  static uint64_t getUidCounter() { return node_uid_cntr; }
-  static void adoptUidCounter(uint64_t v) { node_uid_cntr = v; }
-
-protected:
   // reference counting for garbage collection
   uint32_t _ref_count;
 

--- a/include/stp/Incremental/IncrementalSolver.h
+++ b/include/stp/Incremental/IncrementalSolver.h
@@ -28,7 +28,6 @@ THE SOFTWARE.
 #include "stp/AST/AST.h"
 #include "stp/Globals/Globals.h"
 #include <cstdint>
-#include <functional>
 #include <memory>
 
 // The incremental solving driver; docs/incremental-solving.rst tells the
@@ -208,21 +207,14 @@ public:
   struct Impl;
 
 private:
-  // The body of checkSat. The public method runs it on a worker thread
-  // with a large explicit stack: several passes walk formulas by
-  // recursion, and parse-time inlining of chained define-funs builds
-  // nodes deep enough (tens of thousands of levels from flat input) to
-  // exhaust a default-sized stack.
-  SOLVER_RETURN_TYPE checkSatOnCurrentStack(const ASTVec& assertionsSMT2,
+  // The bodies of the two public entry points above, split out so that the
+  // profile bracket and the pending-model latch enclose every path through
+  // them -- both bodies return from many places.
+  SOLVER_RETURN_TYPE checkSatBody(const ASTVec& assertionsSMT2,
                                             bool assumeLastLevelPerConjunct,
                                             bool firstForcedIncrementalSolve);
 
-  // Run `body` on the large-stack worker with the thread-local solver
-  // state carried across (CONSTANTBV boot, the node uid counter);
-  // checkSat and deferred model construction both go through this.
-  void runOnDriverStack(const std::function<void()>& body);
-
-  void materializeOnCurrentStack();
+  void buildPendingModel();
 
   std::unique_ptr<Impl> impl;
 };

--- a/lib/Incremental/IncrementalSolver.cpp
+++ b/lib/Incremental/IncrementalSolver.cpp
@@ -54,7 +54,6 @@ THE SOFTWARE.
 #include <cstdint>
 #include <cstdlib>
 #include <exception>
-#include <functional>
 #include <limits>
 #include <map>
 #include <memory>
@@ -62,18 +61,6 @@ THE SOFTWARE.
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
-
-#if defined(_WIN32)
-// windows.h defines min and max as macros, which swallow the parentheses of
-// every std::numeric_limits<T>::max() and std::min<T>() below. NOMINMAX is
-// the documented way to ask it not to.
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
-#include <windows.h>
-#else
-#include <pthread.h>
-#endif
 
 namespace stp
 {
@@ -947,7 +934,7 @@ struct IncrementalSolver::Impl
   uint64_t lastRetainedSemanticNodes = 0;
 
   // Probe-based inprocessing retirement (see the trigger in
-  // checkSatOnCurrentStack): how many solves this driver has run, and
+  // checkSatBody): how many solves this driver has run, and
   // whether the persistent solver now runs with inprobing off.
   size_t engagedSolves = 0;
   bool inprobingRetired = false;
@@ -5435,111 +5422,13 @@ bool IncrementalSolver::canHandle(const ASTVec& assertionsSMT2)
   return true;
 }
 
-namespace
-{
-
-// Several passes a check-sat runs -- the per-conjunct Simplifier,
-// substitution replace(), the bit-blaster -- walk formulas by recursion,
-// so their depth tolerance is the stack size. Parse-time inlining of
-// chained define-funs builds nodes tens of thousands deep from flat
-// input (27k chained defines reach depth ~25k, needing ~8.3MB right
-// where the common default stack ends), so the driver runs each
-// check-sat on a worker thread with an explicitly large stack instead
-// of inheriting whatever the process got. 256MB is reservation, not
-// commitment: pages are only touched as the recursion actually deepens.
-// The batch pipeline's smaller frames clear the same benchmarks within
-// a default stack, which is why this lives here and not process-wide.
-void* bigStackTrampoline(void* p)
-{
-  // CONSTANTBV keeps its working state -- word-size masks, the constants
-  // bits_() decodes every vector's header through -- in thread-local
-  // storage, initialised by BitVector_Boot. The frontend booted the main
-  // thread at startup; a worker that skips this reads every bit-vector
-  // constant through zeroed masks, which shows up as out-of-bounds reads
-  // and impossible widths far downstream.
-  CONSTANTBV::ErrCode c = CONSTANTBV::BitVector_Boot();
-  if (0 != c)
-    FatalError("IncrementalSolver: CONSTANTBV failed to boot on the "
-               "solve thread");
-  (*static_cast<std::function<void()>*>(p))();
-  return NULL;
-}
-
-void runOnBigStack(std::function<void()> fn)
-{
-  static const size_t stackBytes = 256 * 1024 * 1024;
-#if defined(_WIN32)
-  HANDLE t = CreateThread(NULL, stackBytes,
-                          (LPTHREAD_START_ROUTINE)bigStackTrampoline, &fn,
-                          STACK_SIZE_PARAM_IS_A_RESERVATION, NULL);
-  if (t != NULL)
-  {
-    WaitForSingleObject(t, INFINITE);
-    CloseHandle(t);
-    return;
-  }
-#else
-  pthread_attr_t attr;
-  if (pthread_attr_init(&attr) == 0)
-  {
-    pthread_t t;
-    const bool created = pthread_attr_setstacksize(&attr, stackBytes) == 0 &&
-                         pthread_create(&t, &attr, bigStackTrampoline, &fn) == 0;
-    pthread_attr_destroy(&attr);
-    if (created)
-    {
-      pthread_join(t, NULL);
-      return;
-    }
-  }
-#endif
-  // No thread to be had; the caller's stack is still a correct place to
-  // run, just without the extra headroom.
-  fn();
-}
-
-} // namespace
-
-void IncrementalSolver::runOnDriverStack(const std::function<void()>& body)
-{
-  std::exception_ptr thrown;
-
-  // The node uid counter is thread-local: the worker continues this
-  // thread's numbering and this thread adopts the advanced value back,
-  // so a uid names one node across both threads and the caches keyed on
-  // node numbers stay sound.
-  const uint64_t uidBefore = ASTInternal::getUidCounter();
-  uint64_t uidAfter = uidBefore;
-
-  runOnBigStack([&]() {
-    ASTInternal::adoptUidCounter(uidBefore);
-    try
-    {
-      body();
-    }
-    catch (...)
-    {
-      thrown = std::current_exception();
-    }
-    uidAfter = ASTInternal::getUidCounter();
-  });
-
-  ASTInternal::adoptUidCounter(uidAfter);
-  if (thrown)
-    std::rethrow_exception(thrown);
-}
-
 SOLVER_RETURN_TYPE IncrementalSolver::checkSat(const ASTVec& assertionsSMT2,
                                                bool assumeLastLevelPerConjunct,
                                                bool firstForcedIncrementalSolve)
 {
   impl->beginProfile(assertionsSMT2.size());
-  SOLVER_RETURN_TYPE result = SOLVER_ERROR;
-  runOnDriverStack([&]() {
-    result = checkSatOnCurrentStack(assertionsSMT2,
-                                    assumeLastLevelPerConjunct,
-                                    firstForcedIncrementalSolve);
-  });
+  const SOLVER_RETURN_TYPE result = checkSatBody(
+      assertionsSMT2, assumeLastLevelPerConjunct, firstForcedIncrementalSolve);
   impl->finishProfile();
   return result;
 }
@@ -5549,12 +5438,10 @@ void IncrementalSolver::materializePendingModel()
   if (!impl->modelPending)
     return;
   impl->modelPending = false;
-  // Construction evaluates terms over deep formulas by recursion, so it
-  // gets the same stack the solve itself had.
-  runOnDriverStack([&]() { materializeOnCurrentStack(); });
+  buildPendingModel();
 }
 
-void IncrementalSolver::materializeOnCurrentStack()
+void IncrementalSolver::buildPendingModel()
 {
   STPMgr* bm = impl->bm;
   bm->GetRunTimes()->start(RunTimes::CounterExampleGeneration);
@@ -5573,7 +5460,7 @@ void IncrementalSolver::materializeOnCurrentStack()
 }
 
 SOLVER_RETURN_TYPE
-IncrementalSolver::checkSatOnCurrentStack(const ASTVec& assertionsSMT2,
+IncrementalSolver::checkSatBody(const ASTVec& assertionsSMT2,
                                           bool assumeLastLevelPerConjunct,
                                           bool firstForcedIncrementalSolve)
 {

--- a/tests/unit-tests/DeepDag_Test.cpp
+++ b/tests/unit-tests/DeepDag_Test.cpp
@@ -64,6 +64,10 @@ THE SOFTWARE.
 #include "stp/Simplifier/RemoveUnconstrained.h"
 #include "stp/Simplifier/Simplifier.h"
 #include "stp/Simplifier/SplitExtracts.h"
+#include "stp/Incremental/IncrementalSolver.h"
+#include "stp/AbsRefineCounterExample/AbsRefine_CounterExample.h"
+#include "stp/AbsRefineCounterExample/ArrayTransformer.h"
+#include "stp/Simplifier/SubstitutionMap.h"
 #include "stp/Simplifier/UseITEContext.h"
 #include "stp/Simplifier/VariablesInExpression.h"
 #include "stp/ToSat/BBNodeManagerAIG.h"
@@ -419,6 +423,31 @@ bool substitutionOk(Context& c, unsigned depth)
 // No extract matches a chain of BVXORs over symbols, so what the pass does
 // here is exactly the traversal, and finding nothing to split means the
 // formula comes back unchanged.
+// The incremental driver's check-sat. It used to run its body on a worker
+// thread with a 256 MiB stack, because the passes it drives -- the
+// per-conjunct simplifier, substitution replace(), the bit-blaster -- were
+// depth-recursive. They are not any more, and this is what says so: the
+// driver now runs on whatever stack it is called on, so it has to clear the
+// same 1 MiB bound as every other pass here.
+bool incrementalDriverOk(Context& c, unsigned depth)
+{
+  const ASTNode top = c.formula(c.chain(BVXOR, depth));
+  c.roots.push_back(top);
+
+  // The minimal core: no fitted preparation, promotion or backend policy, so
+  // what this measures is the encode/solve path itself.
+  c.mgr.UserFlags.incremental_core_only = true;
+
+  SubstitutionMap sm(&c.mgr);
+  Simplifier simp(&c.mgr, &sm);
+  ArrayTransformer at(&c.mgr, &simp);
+  AbsRefine_CounterExample ce(&c.mgr, &simp, &at);
+  IncrementalSolver inc(&c.mgr, &ce, &simp, &at);
+
+  const ASTVec stack{top};
+  return inc.checkSat(stack) == SOLVER_SATISFIABLE;
+}
+
 bool splitExtractsOk(Context& c, unsigned depth)
 {
   const ASTNode top = c.formula(c.chain(BVXOR, depth));
@@ -1856,6 +1885,12 @@ TEST(DeepDag, wide_fp_rounding_mode_walk_adds_every_constraint)
 #endif // STP_ENABLE_FLOATING_POINT
 
 
+TEST(DeepDag, shallow_incremental_driver)
+{
+  Context c;
+  EXPECT_TRUE(incrementalDriverOk(c, SHALLOW));
+}
+
 TEST(DeepDag, shallow_split_extracts)
 {
   Context c;
@@ -2511,6 +2546,11 @@ TEST(DeepDag, deep_flatten_share_count)
 TEST(DeepDag, deep_flatten)
 {
   EXPECT_STACK_SAFE(flattenIdentityOk, 10000);
+}
+
+TEST(DeepDag, deep_incremental_driver)
+{
+  EXPECT_STACK_SAFE(incrementalDriverOk, 20000);
 }
 
 TEST(DeepDag, deep_split_extracts)


### PR DESCRIPTION
# The incremental driver no longer needs a stack of its own

Follow-up to the incremental-solving series (#832-#836), and a direct consequence of the stack-safety series (#806-#823) landing before it. Net **-150/+54**.

`IncrementalSolver::checkSat` ran its body on a worker thread with a 256 MiB stack. That was not a preference: the passes a check-sat drives -- the per-conjunct simplifier, `SubstitutionMap::replace`, the bit-blaster -- walked formulas by recursion, and parse-time inlining of chained `define-fun`s builds nodes tens of thousands of levels deep out of flat input. The depth is whoever wrote the query's choice, so no fixed stack is a fix.

Those passes keep their working state on the heap now. The driver's own last recursive walk, `splitConjuncts`, went iterative with the driver itself in #836. So the thread has nothing left to buy, and it goes.

## What goes with it

Everything that existed only to serve the worker:

- **The CONSTANTBV boot.** The worker had to call `BitVector_Boot()` for itself, because CONSTANTBV keeps its word-size masks in thread-local storage and a worker that skipped it read every bit-vector constant through zeroed masks. No thread, no second boot.
- **`ASTInternal::getUidCounter` / `adoptUidCounter`.** The node uid counter is thread-local, so the worker had to continue the spawning thread's numbering and hand the advanced value back -- otherwise fresh nodes got uids colliding with live main-thread nodes and every cache keyed on node numbers could cross-bind. Nothing else ever called these.
- **The `windows.h` and `pthread.h` includes** -- and with them `NOMINMAX`. That was only ever needed because `windows.h` defines `min` and `max` as macros, which swallowed the parentheses of every `std::numeric_limits<T>::max()` in the file. Removing the include removes the problem rather than working around it.

The two private helpers lose their names with it. `checkSatOnCurrentStack` and `materializeOnCurrentStack` were named for the distinction the worker created -- the body, on whatever stack you are already on, as against the public method that dispatched onto the big one. With no second stack that distinction does not exist, and "current stack" now reads as the *assertion* stack, which is what the public `checkSat` takes. They are `checkSatBody` and `buildPendingModel`; the split itself stays, because the profile bracket and the pending-model latch have to enclose bodies that return from many places.

## The measurement

The point of this PR is not the deletion, which is easy. It is being able to check the deletion rather than argue it.

`DeepDag_Test` gains `deep_incremental_driver`: a 20,000-deep `check-sat` run in a forked child under the harness's 1 MiB `RLIMIT_STACK`, alongside `shallow_incremental_driver` as the control.

**This case measures nothing while the worker exists** -- the body would run on the worker's 256 MiB stack, not the bounded one -- so it is only meaningful from this commit onward, where it guards the absence. Reviewers should read it as the guard it becomes, not as evidence gathered before the change.

Margin: 200,000 also passes, in about ten seconds. The suite ships 20,000, which runs in about one, matching what the other cases in that file cost.

## What this does not claim

The stack-safety audit still lists on-path traversals whose depth is unmeasured, and `DeepDag_Test` still carries two `DISABLED_` cases (`use_ite_context`, `printer_smtlib2`). This PR measures the driver's path, not all of them. What it establishes is that nothing the incremental driver reaches needs more than 1 MiB at a depth of 200,000 -- which is what the worker was there for.

## Verification

`-DWERROR:BOOL=ON`, CaDiCaL 3.0.1 + MiniSat, RelWithDebInfo with assertions:

**127/127 ctest, 553 lit (535 passed, 18 unsupported, 0 failures)** -- the 18 are the `REQUIRES: libbf` set.

The no-fp, g++-13 Release, clang-21 Release and CryptoMiniSat-only configurations are covered by CI.
