### PR TITLE
Fix use-after-free in RemoveUnconstrained's BVDIV ground-path collapse

### DIFF
--- a/lib/Simplifier/RemoveUnconstrained.cpp
+++ b/lib/Simplifier/RemoveUnconstrained.cpp
@@ -370,8 +370,11 @@ static bool invertStepSymbolic(NodeFactory* nf, STPMgr& bm, Simplifier* simp,
       if (!isBottom || s.pathIndex != 0 ||
           CONSTANTBV::BitVector_is_empty(c.GetBVConst()))
         return false;
-      std::vector<CBV> a = {bm.CreateMaxConst(w).GetBVConst(),
-                            c.GetBVConst()};
+      // Bind the CreateMaxConst node: it is a temporary, and GetBVConst()
+      // returns a pointer into it, so it must outlive the evaluator call
+      // below -- otherwise a[0] dangles (a use-after-free).
+      const ASTNode maxC = bm.CreateMaxConst(w);
+      std::vector<CBV> a = {maxC.GetBVConst(), c.GetBVConst()};
       CBV maxQ = NonMemberBVConstEvaluator(BVDIV, a, w);
       const ASTNode maxQn = bm.CreateBVConst(maxQ, w);
       if (maxQn == bm.CreateZeroConst(w))

--- a/tests/query-files/simplification-tests/removeunconstrained-bvdiv-createmaxconst-uaf.smt2
+++ b/tests/query-files/simplification-tests/removeunconstrained-bvdiv-createmaxconst-uaf.smt2
@@ -1,0 +1,15 @@
+; RUN: %solver %s | %OutputCheck %s
+; CHECK: ^sat
+; Regression for a heap-use-after-free in RemoveUnconstrained's ground-path
+; collapse: invertStepSymbolic's BVDIV case took a CBV from a CreateMaxConst
+; temporary and read it in NonMemberBVConstEvaluator after the temporary was
+; destroyed (RemoveUnconstrained.cpp, BVDIV case).
+;
+; NOTE: a plain build answers 'sat' whether or not the bug is present (the read
+; hits freed-but-unclobbered memory); build with -fsanitize=address to observe
+; the fault deterministically. Found by fuzzing STP with murxla.
+(set-logic QF_BV)
+(declare-const x3 (_ BitVec 104))
+(declare-const x4 (_ BitVec 104))
+(assert (distinct x3 (bvsrem #b00001001010001011001000101010000011100010001011000011011111110001101010110001100110111010011001010011100 ((_ rotate_left 21) #b01100011000111010101011011000101110101010101000000101000000101101100110001011000100000001001011010100001)) ((_ rotate_right 76) #b01111101111110000111111001101101100010010010011001001000010011001101001000111111100100110110111101010100) (bvudiv x4 #b01100110111101100111001101101011001101000010110011100101011111100111010101011010101110100111100111100011)))
+(check-sat)


### PR DESCRIPTION
Fixes #840.

`invertStepSymbolic`'s `BVDIV` case in `RemoveUnconstrained` built its evaluator arguments as `std::vector<CBV> a = {bm.CreateMaxConst(w).GetBVConst(), c.GetBVConst()};`. `CreateMaxConst(w)` returns a temporary `ASTNode`, and `GetBVConst()` takes the raw `CBV` pointer into it; the temporary is destroyed at the end of the initialiser, so `a[0]` dangles by the time `NonMemberBVConstEvaluator` clones it on the very next line — a heap-use-after-free.

AddressSanitizer pins it exactly (freed and allocated both at the `CreateMaxConst` statement, read one line later):

```
heap-use-after-free, READ of size 4
  #0 BitVector_Clone            constantbv.cpp:507
  #1 NonMemberBVConstEvaluator  consteval.cpp:376
  #2 invertStepSymbolic         RemoveUnconstrained.cpp (BVDIV case)
  #3 tryGroundPathCollapse
  ... Cpp_interface::checkSat ← smt2parse
```

The fix binds the max constant to a named `ASTNode` so its `CBV` outlives the evaluator call; `a[1]` was always fine because it comes from `s.constants[0]`, a persistent node.

Verified before/after under `-fsanitize=address`: on current master the reproducer reports the use-after-free; with this change it answers `sat` cleanly with no ASan error, matching bitwuzla.

One caveat on the regression test: a plain (non-sanitized) build answers `sat` whether or not the bug is present, because the freed 28-byte block is read before it gets reused — so `simplification-tests/removeunconstrained-bvdiv-createmaxconst-uaf.smt2` only *fails* under ASan, which the test comment states. CI currently has no sanitizer job, so this test cannot fail CI as-is; adding an ASan build to `ci.yml` would let it (and this whole class of lifetime bug) be caught — happy to do that separately if useful.

Found by fuzzing STP with [murxla](https://github.com/murxla/murxla); the affected code was introduced by #696 (no criticism intended — just noting the origin).
