### PR TITLE
Point at the missing set-logic when a floating-point name fails to parse

### DIFF
--- a/include/stp/Parser/parser.h
+++ b/include/stp/Parser/parser.h
@@ -63,6 +63,12 @@ void SMT2SetFloatTokens(bool enable);
 // the grammar, so it has to consult the gate itself.
 bool SMT2FloatTokensActive();
 
+// Whether `text` is a floating-point name that the gate above handed to the
+// grammar as an ordinary undeclared identifier. The grammar cannot tell that
+// apart from a genuine typo, so its diagnostics ask this and append a hint
+// naming the set-logic that would have made the name a keyword.
+bool SMT2FpKeywordNeedsLogic(const char* text);
+
 DLL_PUBLIC int SMTParse(void* AssertsQuery);
 DLL_PUBLIC int SMT2Parse();
 DLL_PUBLIC int CVCParse(void* AssertsQuery);

--- a/lib/Parser/smt2.lex
+++ b/lib/Parser/smt2.lex
@@ -68,6 +68,15 @@
   // parsing). See fpKeyword() below and stp::SMT2SetFloatTokens.
   static thread_local bool floatTokensActive = false;
 
+  // The most recent floating-point name that the gate above handed back as an
+  // ordinary identifier without finding a declaration for it. A missing
+  // set-logic surfaces far from its cause -- the grammar just trips over an
+  // undeclared symbol, and says so in those terms -- so the diagnostic asks
+  // for this to name the token and what would have made it a keyword. Only
+  // *unresolved* names are recorded: a QF_BV file that really did declare
+  // "fp" is using its own symbol and must not be told about FP logics.
+  static thread_local std::string unresolvedFpKeyword;
+
 #ifdef _MSC_VER
   #include <io.h>
   // defining isatty to avoid dll symbol export inconsistencies
@@ -97,12 +106,30 @@ namespace stp
 {
   const std::string& smt2_skipped_text() { return skippedText; }
 
-  void SMT2SetFloatTokens(bool enable) { floatTokensActive = enable; }
+  void SMT2SetFloatTokens(bool enable)
+  {
+    floatTokensActive = enable;
+    // Either direction starts a fresh script's worth of history -- set-logic
+    // opens one, reset closes one -- and these are thread-locals that outlive
+    // a single parse. A name left behind by an earlier script must not attach
+    // its hint to this one's first error.
+    unresolvedFpKeyword.clear();
+  }
 
   // define-sort's body never reaches the rules below -- SKIP_SEXPR swallows
   // it and the grammar re-tokenises the text by hand -- so it has to ask the
   // gate itself rather than being answered by it. See tryRegisterFpSortAlias.
   bool SMT2FloatTokensActive() { return floatTokensActive; }
+
+  // Whether the token a diagnostic is about is a floating-point name that the
+  // gate demoted for want of an FP set-logic. Matched against the offending
+  // text rather than answered from the flag alone, so that an unrelated error
+  // later in the file cannot inherit an earlier name's hint.
+  bool SMT2FpKeywordNeedsLogic(const char* text)
+  {
+    return !floatTokensActive && text != NULL && !unresolvedFpKeyword.empty() &&
+           unresolvedFpKeyword == text;
+  }
 }
 
   static int lookup(char* s)
@@ -206,7 +233,17 @@ namespace stp
   {
     if (floatTokensActive)
       return token;
-    return lookup(smt2text);
+    const int fallback = lookup(smt2text);
+    if (fallback == STRING_TOK)
+      unresolvedFpKeyword = smt2text;
+    else if (unresolvedFpKeyword == smt2text)
+    {
+      // The name resolved this time, so the earlier record of it is stale:
+      // declaring "NaN" is exactly how a QF_BV file makes it its own, and a
+      // later error mentioning it deserves no floating-point hint.
+      unresolvedFpKeyword.clear();
+    }
+    return fallback;
   }
 %}
 

--- a/lib/Parser/smt2.y
+++ b/lib/Parser/smt2.y
@@ -267,6 +267,15 @@ namespace stp
     std::ostringstream o;
     o << "syntax error: line " << smt2lineno << " " << s
       << "  token: " << smt2text;
+    // Outside an FP logic a floating-point name is not an unknown name, it is
+    // a disabled keyword -- and every message that can land here says the
+    // opposite, from bison's "unexpected STRING_TOK" to the sort rules'
+    // "unknown sort (not built in...)". Nothing else in the output points at
+    // the missing set-logic, so this does.
+    if (stp::SMT2FpKeywordNeedsLogic(smt2text))
+      o << "  hint: " << smt2text << " is a floating-point name; those are "
+           "recognised only after (set-logic QF_FP), (set-logic QF_BVFP) or "
+           "(set-logic QF_ABVFP)";
     return o.str();
   }
 

--- a/tests/query-files/fp-tests/fp-declared-name-in-unrelated-error.smt2
+++ b/tests/query-files/fp-tests/fp-declared-name-in-unrelated-error.smt2
@@ -1,0 +1,15 @@
+; RUN: %solver %s 2>&1 | %OutputCheck %s
+; RUN: %solver %s 2>&1 | %OutputCheck --check-prefix=NOHINT %s
+;
+; The hint keys off the offending token, so a file that declares a
+; floating-point name and then makes an unrelated mistake *at* that name is
+; the case where it can misfire: bvult's arity error below reports "NaN" as
+; its token, and NaN was recorded as an unresolved floating-point name by the
+; very scan that preceded its declare-fun. Resolving the name has to retire
+; that record, or this file gets told to set an FP logic it does not want.
+; CHECK-L: unexpected TERMID_TOK, expecting RPAREN_TOK
+; NOHINT-NOT-L: is a floating-point name
+(set-logic QF_BV)
+(declare-fun NaN () (_ BitVec 8))
+(assert (bvult NaN NaN NaN))
+(check-sat)

--- a/tests/query-files/fp-tests/fp-named-sort-without-set-logic.smt2
+++ b/tests/query-files/fp-tests/fp-named-sort-without-set-logic.smt2
@@ -1,0 +1,12 @@
+; RUN: not %solver %s 2>&1 | %OutputCheck %s
+;
+; The named formats reach the sort rules as bare identifiers when no FP
+; set-logic is in force, and the diagnostic waiting for them there is not
+; merely unhelpful but wrong: "unknown sort (not built in, and not a
+; define-sort alias)" describes a typo, whereas Float64 is built in and only
+; disabled. The base message is left alone -- it is right for every other
+; name that lands on that rule -- and the hint corrects it for this one.
+; RoundingMode takes the same path.
+; CHECK-L: hint: Float64 is a floating-point name; those are recognised only after (set-logic QF_FP), (set-logic QF_BVFP) or (set-logic QF_ABVFP)
+(declare-const x Float64)
+(check-sat)

--- a/tests/query-files/fp-tests/fp-names-declared-outside-fp-logic.smt2
+++ b/tests/query-files/fp-tests/fp-names-declared-outside-fp-logic.smt2
@@ -1,0 +1,22 @@
+; RUN: %solver %s 2>&1 | %OutputCheck %s
+; RUN: %solver %s 2>&1 | %OutputCheck --check-prefix=NOHINT %s
+;
+; The gate exists so that a non-FP benchmark can own these names, and files
+; that do have parsed since before STP had floating-point support at all. The
+; hint must not cost them that: every name below resolves to the bitvector
+; this file declared, so the file still solves and says nothing about floats.
+;
+; The second pass is what makes the negative check mean anything. A CHECK-NOT
+; searches the region *between* its neighbouring matches, so pairing it with
+; the CHECK-L below would leave it an empty region to search; alone under its
+; own prefix it sees the whole output.
+; CHECK-L: sat
+; NOHINT-NOT-L: is a floating-point name
+(set-logic QF_BV)
+(declare-fun fp () (_ BitVec 8))
+(declare-fun NaN () (_ BitVec 8))
+(declare-fun RNE () (_ BitVec 8))
+(declare-fun Float64 () (_ BitVec 8))
+(assert (= fp NaN))
+(assert (= RNE Float64))
+(check-sat)

--- a/tests/query-files/fp-tests/fp-operator-without-set-logic.smt2
+++ b/tests/query-files/fp-tests/fp-operator-without-set-logic.smt2
@@ -1,0 +1,9 @@
+; RUN: %solver %s 2>&1 | %OutputCheck %s
+;
+; The third shape the gate's failures take: an operator rather than a sort.
+; Here bison has no expected-token list to offer at all, so without the hint
+; the entire diagnosis is "unexpected STRING_TOK  token: fp.isNaN".
+; CHECK-L: hint: fp.isNaN is a floating-point name; those are recognised only after (set-logic QF_FP), (set-logic QF_BVFP) or (set-logic QF_ABVFP)
+(declare-const x (_ BitVec 8))
+(assert (fp.isNaN x))
+(check-sat)

--- a/tests/query-files/fp-tests/fp-sort-without-set-logic.smt2
+++ b/tests/query-files/fp-tests/fp-sort-without-set-logic.smt2
@@ -1,0 +1,14 @@
+; RUN: %solver %s 2>&1 | %OutputCheck %s
+;
+; The floating-point keywords are live only under an FP set-logic (the
+; fpKeyword gate in smt2.lex), so a benchmark that omits set-logic entirely --
+; as fuzzer-generated ones do -- has "FloatingPoint" handed to the grammar as
+; an ordinary undeclared symbol. All bison can say is that it did not expect a
+; STRING_TOK there, which points nowhere near the cause. The hint names the
+; token and the logics that would have made it a keyword.
+;
+; Recovery is non-fatal here, so the process still exits zero: the check is
+; the error response, not the exit code.
+; CHECK-L: hint: FloatingPoint is a floating-point name; those are recognised only after (set-logic QF_FP), (set-logic QF_BVFP) or (set-logic QF_ABVFP)
+(declare-const x (_ FloatingPoint 11 53))
+(check-sat)


### PR DESCRIPTION
# Point at the missing set-logic when a floating-point name fails to parse

The floating-point keywords are live only under an FP set-logic — SMT-LIB reserves theory names per-logic, and QF_BV inputs legitimately declare symbols called `fp`, `NaN` or `RNE`. `fpKeyword()` in `smt2.lex` implements that: outside an FP logic it hands the name to the ordinary identifier path instead of returning its token. Nothing downstream knows that happened, so the diagnostic depends entirely on where the grammar happens to trip over the resulting undeclared symbol, and none of the three possibilities mentions `set-logic`:

| input, no `set-logic` | message |
| --- | --- |
| `(_ FloatingPoint 11 53)` | `unexpected STRING_TOK, expecting BITVEC_TOK or FLOATINGPOINT_TOK  token: FloatingPoint` |
| `Float64`, `RoundingMode` | `unknown sort (not built in, and not a define-sort alias)` |
| `fp.isNaN`, `fp.add`, … | `unexpected STRING_TOK  token: fp.isNaN` |

The middle one is not merely unhelpful but wrong: `Float64` *is* built in, it is only disabled. And stating `(set-logic QF_BV)` explicitly changes nothing — the message is identical, with no hint that some other logic is the one that would work.

This matters most for benchmarks that omit `set-logic` altogether, which fuzzer-generated files routinely do. Such a file fails on its first declaration, several lines before anything floating-point-specific happens, with no indication of the cause.

Two well-worded gates already exist next door — `--array-equality` names the flag, the C API call and the Python keyword; `checkFpSupported()` says "reconfigure with `-DENABLE_FLOATING_POINT=ON`" — but the latter is only reachable *after* an FP `set-logic` has been accepted, so it structurally cannot cover this case.

## The change

`fpKeyword()` records each floating-point name the gate demotes *and* for which `lookup()` found no declaration. `smt2_diagnostic()` in `smt2.y` — the one formatter every parse diagnostic passes through, both bison's `yyerror` and `fatal_yyerror`'s fatal path — appends a hint when the offending token is that name:

```
(error "syntax error: line 2 syntax error, unexpected STRING_TOK, expecting BITVEC_TOK or FLOATINGPOINT_TOK  token: FloatingPoint  hint: FloatingPoint is a floating-point name; those are recognised only after (set-logic QF_FP), (set-logic QF_BVFP) or (set-logic QF_ABVFP)")
```

One hook therefore covers all three shapes, and the successful-parse path is untouched: the base messages are left exactly as they were, since they are right for every other name that reaches those rules.

The hint is matched against the offending token rather than answered from the gate flag alone, so an unrelated error later in the file cannot inherit an earlier name's hint. The record is also retired when the name later resolves — declaring `NaN` is exactly how a QF_BV file makes that name its own, and without that step an unrelated arity error reported at `NaN` would tell such a file to set a floating-point logic it does not want.

## Verification

The motivating input, a QF_ABVFP benchmark with no `set-logic` line, previously failed on line 2 with `unexpected STRING_TOK` and now names the cause. Adding `(set-logic QF_ABVFP)` makes it parse and solve.

Five lit tests in `tests/query-files/fp-tests/`: one per failure shape (`fp-sort-`, `fp-named-sort-`, `fp-operator-without-set-logic.smt2`), one for a QF_BV file that declares and uses `fp`, `NaN`, `RNE` and `Float64` and must stay silent about floats, and one for an unrelated error raised at a declared name.

The negative tests were checked for vacuity rather than assumed: stashing the fix fails the three hint tests and passes both negatives, and deleting only the record-retiring branch fails `fp-declared-name-in-unrelated-error.smt2` alone. Note that a `CHECK-NOT` searches only the region between its neighbouring matches, so pairing one with a `CHECK-L` that matches the sole output line leaves it an empty region and it passes regardless; both negative tests give it its own pass via a second `RUN:` line with `--check-prefix=`, where it is the only directive and sees the whole output.

Local run: 127/127 ctest green.
