### PR TITLE
Read the SMT-LIB floating-point LRA benchmarks

### DIFF
--- a/lib/Parser/smt2.lex
+++ b/lib/Parser/smt2.lex
@@ -40,6 +40,10 @@
 #include "stp/cpp_interface.h"
 #include "parsesmt2.tab.h"
 
+#include <cerrno>
+#include <cstdlib>
+#include <limits>
+
   extern char *smt2text;
   extern int smt2leng;
   extern int smt2error (const char *msg);
@@ -261,8 +265,24 @@ ANYTHING  ({LETTER}|{DIGIT}|{OPCHAR})
 %%
 [ \n\t\r\f] { if (*smt2text == '\n') smt2lineno++; /* skip whitespace */ }
 
- /* We limit numerals to maxint, in the specification they are arbitary precision.*/
-{DIGIT}+               { smt2lval.uintval = strtoul(smt2text, NULL, 10); return NUMERAL_TOK; }
+ /* Numerals are arbitrary precision in the specification, but every numeral
+    STP reads as a number is an index, a width or a count, all of which fit an
+    unsigned. One that does not is kept as its digits and returned as a
+    different token: a real literal converts from the digits and so stays
+    exact, while every other use of a numeral is a syntax error rather than
+    the silently wrapped value strtoul would hand back. */
+{DIGIT}+               {
+                         errno = 0;
+                         const unsigned long value = strtoul(smt2text, NULL, 10);
+                         if (errno == ERANGE ||
+                             value > std::numeric_limits<unsigned>::max())
+                         {
+                           smt2lval.str = new std::string(smt2text);
+                           return BIG_NUMERAL_TOK;
+                         }
+                         smt2lval.uintval = static_cast<unsigned>(value);
+                         return NUMERAL_TOK;
+                       }
 bv{DIGIT}+             { smt2lval.str = new std::string(smt2text+2); return BVCONST_DECIMAL_TOK; }
 #b{DIGIT}+             { smt2lval.str = new std::string(smt2text+2); return BVCONST_BINARY_TOK; }
 #x({DIGIT}|[a-fA-F])+  { smt2lval.str = new std::string(smt2text+2); return BVCONST_HEXIDECIMAL_TOK; }

--- a/lib/Parser/smt2.y
+++ b/lib/Parser/smt2.y
@@ -63,7 +63,9 @@
 #include <string>
 
 #include <cctype>
+#include <cerrno>
 #include <cstdlib>
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -256,6 +258,23 @@ namespace stp
   extern int smt2lineno;
   extern bool stringOnly;
 
+  // Whether a token is all digits and out of range for the unsigned that
+  // every numeric position in this grammar but a real magnitude wants. The
+  // lexer made the same call to choose the token; recomputing it keeps the
+  // diagnostic a function of the text it is reporting.
+  static bool numeralTooLargeForIndex(const char* text)
+  {
+    if (text == nullptr || *text == '\0')
+      return false;
+    for (const char* p = text; *p != '\0'; p++)
+      if (*p < '0' || *p > '9')
+        return false;
+    errno = 0;
+    const unsigned long value = strtoul(text, nullptr, 10);
+    return errno == ERANGE ||
+           value > std::numeric_limits<unsigned>::max();
+  }
+
   // The diagnostic, built once. It is the body of the SMT-LIB (error ...)
   // response on stdout and also what the fatal path hands to the error
   // handler -- which used to receive the empty string, so a caller that
@@ -276,6 +295,13 @@ namespace stp
       o << "  hint: " << smt2text << " is a floating-point name; those are "
            "recognised only after (set-logic QF_FP), (set-logic QF_BVFP) or "
            "(set-logic QF_ABVFP)";
+    // Likewise, a numeral the parser would not take is not a malformed
+    // numeral: it is one too large to be the index, width or count that the
+    // position calls for. Without this the report is bison's token name.
+    if (numeralTooLargeForIndex(smt2text))
+      o << "  hint: " << smt2text << " does not fit an unsigned, so it cannot "
+           "be an index, a width or a count; only a real literal may be this "
+           "large";
     return o.str();
   }
 
@@ -1283,6 +1309,12 @@ namespace stp
 %type <arr_sort> an_array_sort
 
 %token <uintval> NUMERAL_TOK
+
+ /* A numeral too large for an unsigned, carrying its digits. It is a real
+    magnitude and nothing else: as an index, a width or a count it is out of
+    range, and the grammar rejecting it there is the diagnosis. */
+%token <str> BIG_NUMERAL_TOK
+
 %token <str> BVCONST_DECIMAL_TOK
 %token <str> BVCONST_BINARY_TOK
 %token <str> BVCONST_HEXIDECIMAL_TOK
@@ -1747,6 +1779,14 @@ cmdi:
 |
      NOTES_TOK attribute NUMERAL_TOK
     {
+      stp::GlobalParserInterface->success();
+    }
+|
+     /* set-info values are not interpreted, so an oversized one is no more
+        of a problem here than an ordinary numeral is. */
+     NOTES_TOK attribute BIG_NUMERAL_TOK
+    {
+      delete $3;
       stp::GlobalParserInterface->success();
     }
 |
@@ -2704,9 +2744,10 @@ BVCONST_HEXIDECIMAL_TOK
   $$ = createFPFromParts($2, $3, $4);
 };
 
- /* The magnitude of a real constant: a decimal, or a numeral (which the
-    lexer delivers as its value -- numerals are capped at machine range
-    here, as everywhere else in this parser). */
+ /* The magnitude of a real constant: a decimal, or a numeral. Conversion is
+    from the digits, so a magnitude is exact however many of them there are --
+    the numerals that fit an unsigned arrive as their value and are printed
+    back, the rest arrive as their text already. */
 an_real_magnitude:
   DECIMAL_TOK
 {
@@ -2717,6 +2758,10 @@ an_real_magnitude:
   std::ostringstream os;
   os << $1;
   $$ = new std::string(os.str());
+}
+| BIG_NUMERAL_TOK
+{
+  $$ = $1;
 }
 ;
 

--- a/lib/Parser/smt2.y
+++ b/lib/Parser/smt2.y
@@ -293,8 +293,8 @@ namespace stp
     // the missing set-logic, so this does.
     if (stp::SMT2FpKeywordNeedsLogic(smt2text))
       o << "  hint: " << smt2text << " is a floating-point name; those are "
-           "recognised only after (set-logic QF_FP), (set-logic QF_BVFP) or "
-           "(set-logic QF_ABVFP)";
+           "recognised only after a floating-point (set-logic): QF_FP, "
+           "QF_BVFP, QF_ABVFP or one of their LRA variants";
     // Likewise, a numeral the parser would not take is not a malformed
     // numeral: it is one too large to be the index, width or count that the
     // position calls for. Without this the report is bison's token name.
@@ -1736,10 +1736,19 @@ cmdi:
 |
      LOGIC_TOK STRING_TOK
     {
+      // The *LRA logics are the FP logics plus a theory of reals. STP has no
+      // such theory, and the grammar admits a real only as the literal
+      // argument of to_fp -- which is the only way these benchmarks use one.
+      // Anything more (a Real declaration, arithmetic over reals) has no
+      // production and is a syntax error, so accepting the name here cannot
+      // answer a query STP could not decide.
       const bool fp_logic =
             0 == strcmp($2->c_str(),"QF_FP") ||
             0 == strcmp($2->c_str(),"QF_BVFP") ||
-            0 == strcmp($2->c_str(),"QF_ABVFP");
+            0 == strcmp($2->c_str(),"QF_ABVFP") ||
+            0 == strcmp($2->c_str(),"QF_FPLRA") ||
+            0 == strcmp($2->c_str(),"QF_BVFPLRA") ||
+            0 == strcmp($2->c_str(),"QF_ABVFPLRA");
       if (!(
             0 == strcmp($2->c_str(),"QF_BV") ||
             0 == strcmp($2->c_str(),"QF_ABV") ||

--- a/tests/query-files/fp-tests/fp-named-sort-without-set-logic.smt2
+++ b/tests/query-files/fp-tests/fp-named-sort-without-set-logic.smt2
@@ -7,6 +7,6 @@
 ; disabled. The base message is left alone -- it is right for every other
 ; name that lands on that rule -- and the hint corrects it for this one.
 ; RoundingMode takes the same path.
-; CHECK-L: hint: Float64 is a floating-point name; those are recognised only after (set-logic QF_FP), (set-logic QF_BVFP) or (set-logic QF_ABVFP)
+; CHECK-L: hint: Float64 is a floating-point name; those are recognised only after a floating-point (set-logic): QF_FP, QF_BVFP, QF_ABVFP or one of their LRA variants
 (declare-const x Float64)
 (check-sat)

--- a/tests/query-files/fp-tests/fp-operator-without-set-logic.smt2
+++ b/tests/query-files/fp-tests/fp-operator-without-set-logic.smt2
@@ -3,7 +3,7 @@
 ; The third shape the gate's failures take: an operator rather than a sort.
 ; Here bison has no expected-token list to offer at all, so without the hint
 ; the entire diagnosis is "unexpected STRING_TOK  token: fp.isNaN".
-; CHECK-L: hint: fp.isNaN is a floating-point name; those are recognised only after (set-logic QF_FP), (set-logic QF_BVFP) or (set-logic QF_ABVFP)
+; CHECK-L: hint: fp.isNaN is a floating-point name; those are recognised only after a floating-point (set-logic): QF_FP, QF_BVFP, QF_ABVFP or one of their LRA variants
 (declare-const x (_ BitVec 8))
 (assert (fp.isNaN x))
 (check-sat)

--- a/tests/query-files/fp-tests/fp-sort-without-set-logic.smt2
+++ b/tests/query-files/fp-tests/fp-sort-without-set-logic.smt2
@@ -9,6 +9,6 @@
 ;
 ; Recovery is non-fatal here, so the process still exits zero: the check is
 ; the error response, not the exit code.
-; CHECK-L: hint: FloatingPoint is a floating-point name; those are recognised only after (set-logic QF_FP), (set-logic QF_BVFP) or (set-logic QF_ABVFP)
+; CHECK-L: hint: FloatingPoint is a floating-point name; those are recognised only after a floating-point (set-logic): QF_FP, QF_BVFP, QF_ABVFP or one of their LRA variants
 (declare-const x (_ FloatingPoint 11 53))
 (check-sat)

--- a/tests/query-files/fp-tests/logic-lra-real-is-still-refused.smt2
+++ b/tests/query-files/fp-tests/logic-lra-real-is-still-refused.smt2
@@ -1,0 +1,17 @@
+; RUN: not %solver %s 2>&1 | %OutputCheck %s
+; RUN: not %solver %s 2>&1 | %OutputCheck --check-prefix=NOANSWER %s
+;
+; Accepting the *LRA logic names does not give STP a theory of reals. A real
+; that is not the literal argument of to_fp has no production, so it is
+; refused rather than quietly dropped -- answering a query STP had not fully
+; read is the one outcome that would be worse than refusing it.
+;
+; Resolving a sort is fatal where recovering from a bison error is not, so
+; this one does exit non-zero.
+; CHECK-L: unknown sort (not built in, and not a define-sort alias)  token: Real
+; NOANSWER-NOT: ^sat$
+; NOANSWER-NOT: ^unsat$
+(set-logic QF_BVFPLRA)
+(declare-fun r () Real)
+(assert (> r 0.0))
+(check-sat)

--- a/tests/query-files/fp-tests/logic-lra-variants.smt2
+++ b/tests/query-files/fp-tests/logic-lra-variants.smt2
@@ -1,0 +1,14 @@
+; REQUIRES: libbf
+; RUN: %solver %s | %OutputCheck %s
+;
+; The *LRA logics are the FP logics plus a theory of reals. The benchmarks
+; in them use a real only as the literal argument of to_fp, which is the
+; one real term this grammar has, so the names are accepted and the
+; floating-point keywords they imply are enabled.
+(set-logic QF_BVFPLRA)
+(declare-fun x () (_ FloatingPoint 8 24))
+(declare-fun v () (_ BitVec 32))
+(assert (= x ((_ to_fp 8 24) RNE (/ 1 2))))
+(assert (= v ((_ fp.to_sbv 32) RTZ x)))
+; CHECK: ^sat
+(check-sat)

--- a/tests/query-files/fp-tests/real-literal-large-numerals.smt2
+++ b/tests/query-files/fp-tests/real-literal-large-numerals.smt2
@@ -1,0 +1,31 @@
+; REQUIRES: libbf
+; RUN: %solver %s | %OutputCheck %s
+;
+; Numerals in a real literal are converted from their digits, so they are
+; exact however large they are. Before, a numeral reached the fold as an
+; unsigned that strtoul had wrapped: 2^32 + 1 arrived as 1, the 2^59
+; denominator of a benchmark rational arrived as 0, and the fold either
+; folded the wrong constant or refused a well-formed one.
+;
+; 2^1074, the denominator that names the smallest subnormal double, is
+; past any fixed-width integer -- 324 digits -- and is the case that says
+; the conversion reads digits rather than a machine number.
+(set-logic QF_FP)
+(declare-fun a () (_ FloatingPoint 11 53))
+(declare-fun b () (_ FloatingPoint 11 53))
+(declare-fun c () (_ FloatingPoint 11 53))
+(declare-fun d () (_ FloatingPoint 11 53))
+(declare-fun e () (_ FloatingPoint 11 53))
+(assert (= a ((_ to_fp 11 53) RNE (/ 4294967297 1))))
+(assert (= b ((_ to_fp 11 53) RNE 4294967297)))
+(assert (= c ((_ to_fp 11 53) RNE (/ 45000000000000000 1))))
+(assert (= d ((_ to_fp 11 53) RNE (/ 5764607523034235 576460752303423488))))
+(assert (= e ((_ to_fp 11 53) RNE (/ 1 202402253307310618352495346718917307049556649764142118356901358027430339567995346891960383701437124495187077864316811911389808737385793476867013399940738509921517424276566361364466907742093216341239767678472745068562007483424692698618103355649159556340810056512358769552333414615230502532186327508646006263307707741093494784))))
+(assert (or
+  (distinct a ((_ to_fp 11 53) #x41f0000000100000))
+  (distinct a b)
+  (distinct c ((_ to_fp 11 53) #x4363fbe85edc9000))
+  (distinct d ((_ to_fp 11 53) #x3f847ae147ae147b))
+  (distinct e ((_ to_fp 11 53) #x0000000000000001))))
+; CHECK: ^unsat
+(check-sat)

--- a/tests/query-files/misc-tests/parser-numeral-too-large.smt2
+++ b/tests/query-files/misc-tests/parser-numeral-too-large.smt2
@@ -1,0 +1,18 @@
+; RUN: %solver %s 2>&1 | %OutputCheck %s
+; RUN: %solver %s 2>&1 | %OutputCheck --check-prefix=NOANSWER %s
+;
+; A numeral too large for an unsigned, in a position that wants a width.
+; The lexer assigned strtoul's result to an unsigned, so it wrapped: this
+; declared a one-bit vector -- 2^32 + 1 modulo 2^32 -- and answered a
+; question the file had not asked. Such a numeral is its own token now and
+; has no production here, so it is reported instead of rounded off.
+;
+; Recovery is non-fatal, so the process still exits zero: the checks are the
+; error response and the absence of an answer, not the exit code.
+; CHECK-L: token: 4294967297  hint: 4294967297 does not fit an unsigned
+; NOANSWER-NOT: ^sat$
+; NOANSWER-NOT: ^unsat$
+(set-logic QF_BV)
+(declare-fun x () (_ BitVec 4294967297))
+(assert (= x x))
+(check-sat)


### PR DESCRIPTION
# Read the SMT-LIB floating-point LRA benchmarks

The SMT-LIB benchmark set has three logics that are floating-point arithmetic plus a theory of reals: `QF_FPLRA`, `QF_BVFPLRA` and `QF_ABVFPLRA`, 381 files across the incremental and non-incremental divisions. They use the theory of reals for exactly one thing — the literal argument of `to_fp` — which is the only real term this grammar has ever had a production for. STP could not read a single one of them, and the two reasons turned out to be worth separating.

The second reason is a wrong answer, so this is not only a coverage change.

## `set-logic` rejected the names (cef649ba)

The accepted-logic list in `smt2.y` did not have the three `*LRA` names, so every file failed on line 2. Worse, the rejection is non-fatal and leaves the floating-point keywords disabled, so what a reader actually sees is a *second* error about something else entirely:

```
(error "syntax error: line 2 Wrong input logic  token: QF_FPLRA")
(error "syntax error: line 17 syntax error, unexpected STRING_TOK, expecting BITVEC_TOK or FLOATINGPOINT_TOK  token: FloatingPoint  hint: FloatingPoint is a floating-point name; those are recognised only after (set-logic QF_FP), (set-logic QF_BVFP) or (set-logic QF_ABVFP)")
```

Accepting a logic name is not a claim to decide the logic. A real anywhere other than the argument of `to_fp` — a `Real` declaration, arithmetic over reals — has no production and is refused, so a query STP cannot decide is still one it declines to answer rather than answers wrongly. `logic-lra-real-is-still-refused.smt2` pins that.

The hint added in #844 named its three logics literally, which this makes untrue; it now describes the family rather than listing six.

## Numerals wrapped at 32 bits (6661e229)

`smt2.lex` assigned `strtoul`'s result to the `%union`'s `unsigned`, so any numeral past 2^32 wrapped silently. Widths, indices and counts are small enough that this never showed. A real literal is not:

```smt2
; QF_FPLRA/2019-Gudemann/maxReward.smt2
((_ to_fp 11 53) roundNearestTiesToEven (/ 45000000000000000 1))
```

| | folded to |
| --- | --- |
| before | `4142170112.0` (45000000000000000 mod 2^32) |
| after | `4.5e16` |

Decimals were always right, because `DECIMAL_TOK` carries its lexeme text while `an_real_magnitude` stringified the already-wrapped `unsigned` — so `4294967297.0` and `(/ 4294967297 1)` disagreed on the same value.

Where the *denominator* was a multiple of 2^32 the wrap was at least loud: `(/ 5764607523034235 576460752303423488)` has 2^59 underneath, which wraps to 0, and the literal was refused as a division by zero that no input contains. 13 of the 381 files died that way.

**A numeral too large for an unsigned is now its own token, carrying its digits.** `an_real_magnitude` accepts it, so conversion reads digits and is exact at any size — including the 324-digit 2^1074 that names the smallest subnormal double, which is why this is a separate token rather than a wider integer type. No other numeral position has a production for it, so a width or index out of range is now reported instead of silently becoming whatever it is congruent to:

```
(error "syntax error: line 2 syntax error, unexpected BIG_NUMERAL_TOK, expecting NUMERAL_TOK  token: 4294967297  hint: 4294967297 does not fit an unsigned, so it cannot be an index, a width or a count; only a real literal may be this large")
```

`(_ BitVec 4294967297)` previously declared a one-bit vector and solved happily. `set-info` still accepts an oversized numeral, since it does not interpret the value.

## Worth review attention: this changed an answer

1240 of the 1584 rational literals in these benchmarks (78%) are past 2^32, across 47 files. That is a lot of wrong constants, and the natural question is whether any of them decided a query. One did:

```smt2
; QF_BVFPLRA/.../sine_4_true-unreach-call_true-termination.i_..._TraceCheck_0.smt2
(/ 157079632679 100000000000)   ; pi/2, 1.57079632679
```

wraps to `(/ 2460810023 1215752192)`, which is 2.0241…, and STP answered **sat** where it now answers **unsat**.

It is worth saying how nearly this was missed, because it bears on how much the numbers below are worth. The file's `set-info :status` is `unknown`, so no oracle covers it; and in the post-fix run it timed out at the 120s budget, which made a pre/post comparison look flip-free when it was not. It only surfaced on re-running the one file that had gone from an answer to no answer. Every other file that answered in both runs answered identically.

## Verification

**127/127 ctest green**, both commits, each built and tested on its own before committing so the pair bisects.

All 381 benchmarks, unmodified, `--array-equality`, 60s:

| | before | after |
| --- | --- | --- |
| solved | 0 | **329** |
| parse error | 381 | 41 |
| timeout | 0 | 11 |

The "before" column is 0 by `set-logic`; measured against a tree with only the logic names accepted it is 321 solved / 54 parse errors, and the 13-file difference is the zero-denominator refusals — 10 of which now solve and 3 of which are simply hard.

Against the declared `set-info :status` on the non-incremental files: **201 agree, 0 disagree**, 100 declared `unknown`.

The remaining 41 parse errors are not related to floating point, reals or these logics. They are one family (`20190429-UltimateAutomizerSvcomp2019`) declaring array sorts STP does not have — `(Array (_ BitVec 32) (Array (_ BitVec 32) (_ BitVec 32)))` and `(Array (_ BitVec 32) Bool)`. Both are refused identically under plain `QF_ABV`, so they are a pre-existing gap rather than anything this touches, and I have left them alone.

Four lit tests. `real-literal-large-numerals.smt2` covers 2^32+1 by both spellings, the two benchmark literals above and the 2^1074 subnormal; `parser-numeral-too-large.smt2` covers the oversized width; `logic-lra-variants.smt2` and `logic-lra-real-is-still-refused.smt2` cover the logic names and the limit of what accepting them means.

Both negative tests were checked for vacuity rather than assumed, by replaying pre-fix output through OutputCheck: a `CHECK-NOT` sees only the region between its neighbours, so pairing one with a `CHECK` that matches the sole output line leaves it an empty region and it passes regardless. Each gets its own `RUN:` line with `--check-prefix=` where it is the only directive.

Two notes on coverage. `real-literal-large-numerals.smt2` and `logic-lra-variants.smt2` are `REQUIRES: libbf` and so run only in libbf-enabled jobs; the other two run everywhere. And a non-fatal syntax error still exits zero, which is pre-existing and already documented in the suite's own test comments — the oversized-numeral test checks the error response and the absence of an answer rather than the exit code, as its neighbours do.

Found by checking a claim in the [Bitwuzla](https://bitwuzla.github.io/) tool paper — that the benchmarks in these logics only convert to floating point from real values, and need no LRA reasoning. That is accurate for all 381, and acting on it is what surfaced the truncation.
