### PR TITLE
Cut a third off the floating-point tests' cost, unchanged coverage

### DIFF
--- a/cmake/modules/AddSTPGTest.cmake
+++ b/cmake/modules/AddSTPGTest.cmake
@@ -45,8 +45,22 @@ function(AddSTPGTest sourcefile)
         #message(STATUS "Added flags to test ${testname} ${ARGN}")
     endif()
 
+    # The same allocator the stp binary links, for the same reason: the unit
+    # tests are as allocation-heavy as a solve -- the exhaustive ones build and
+    # tear down millions of interned nodes -- and on those the C library
+    # allocator is a fifth of the run. Listing it first keeps its definitions
+    # ahead of libc. Not under valgrind: memcheck replaces malloc by preloading
+    # into the process, and an allocator linked into the executable takes those
+    # calls before the preload sees them, so the run would report nothing.
+    # (-DSTP_ALLOCATOR=system opts out, which is what a sanitizer build already
+    # does.)
+    set(test_allocator "")
+    if(NOT USE_VALGRIND)
+        set(test_allocator ${STP_ALLOCATOR_LIBRARY})
+    endif()
+
     target_link_libraries(${testname}
-        stp ${GTEST_BOTH_LIBRARIES}
+        ${test_allocator} stp ${GTEST_BOTH_LIBRARIES}
     )
 
     # Add dependency so that building the testsuite

--- a/include/stp/Util/DagWalk.h
+++ b/include/stp/Util/DagWalk.h
@@ -182,13 +182,18 @@ public:
   void clear() { deepest = 0; }
 
 private:
+  // Runs at the end of every top-level call of an audited pass, and
+  // cacheFPFormat is one -- so on a floating-point input this is one of the
+  // hottest paths an assertions build has. Test the claim directly rather than
+  // asking disagreement() for a string to look at: building its ostringstream
+  // costs a locale and several allocations every time, to produce the empty
+  // string that says nothing happened.
   void finished()
   {
-    const std::string bad = disagreement();
-    if (!bad.empty())
+    if (deepest > limit)
     {
       std::cerr << "primeMemo preconditions violated (stp/Util/DagWalk.h):\n"
-                << bad;
+                << disagreement();
       assert(false && "a primed pass nests with its input after all");
     }
     clear();

--- a/tools/test_fpbackend/CMakeLists.txt
+++ b/tools/test_fpbackend/CMakeLists.txt
@@ -19,6 +19,9 @@
 # SOFTWARE.
 
 add_executable(test_fpbackend test_fpbackend.cpp)
-target_link_libraries(test_fpbackend stp)
+# The allocator goes first, as it does on the stp binary: this is an
+# exhaustive test that builds and tears down millions of interned nodes,
+# and the C library allocator is a fifth of the run.
+target_link_libraries(test_fpbackend ${STP_ALLOCATOR_LIBRARY} stp)
 
 # EOF

--- a/tools/test_fprewrites/CMakeLists.txt
+++ b/tools/test_fprewrites/CMakeLists.txt
@@ -19,6 +19,9 @@
 # SOFTWARE.
 
 add_executable(test_fprewrites test_fprewrites.cpp)
-target_link_libraries(test_fprewrites stp)
+# The allocator goes first, as it does on the stp binary: this is an
+# exhaustive test that builds and tears down millions of interned nodes,
+# and the C library allocator is a fifth of the run.
+target_link_libraries(test_fprewrites ${STP_ALLOCATOR_LIBRARY} stp)
 
 # EOF


### PR DESCRIPTION
`FpConstantFold_Test` is the longest test in the suite and sets its wall clock on its own. Two things it was paying for turn out not to be needed. Neither changes what any test asserts, and no test loses a single case.

## The audit's empty string

`PrimeAudit::finished` runs at the end of every top-level call of an audited pass, and `ASTNode::cacheFPFormat` is one of those passes — so on floating-point work it is one of the hottest paths an assertions build has. That includes the CI legs, which leave `CMAKE_BUILD_TYPE` unset and so keep assertions live.

It asked `disagreement()` for a string and checked whether it was empty. Building that string constructs an `ostringstream`, so every call paid for a locale and several allocations in order to produce the empty string that means nothing happened. It now tests the claim directly and formats only when there is something to report. `disagreement()` itself is unchanged — it stays public and a test still drives it directly.

## The allocator

STP links the vendored mimalloc into the `stp` binary because it is allocation-bound at every stage. The test executables were left on the C library allocator, even though the exhaustive tests build and tear down millions of interned nodes and are every bit as allocation-bound as a solve — a fifth of the run in a profile.

They now link the same allocator, first in the link, exactly as `stp` does. Two exclusions:

- **Not under valgrind.** Memcheck replaces `malloc` by preloading into the process; an allocator linked into the executable takes those calls before the preload sees them, so the run would quietly report nothing.
- `-DSTP_ALLOCATOR=system` opts out, which is what a sanitizer build already does for the same reason.

## Measurements

Instructions retired, RelWithDebInfo — the configuration CI builds. Instruction counts rather than wall clock because they are reproducible to a few parts in a million, and each row was measured interleaved with the others.

**`FpConstantFold`, the exhaustive differential**

| | instructions | vs baseline |
| --- | --- | --- |
| baseline | 257.9 G | |
| audit fix | 218.0 G | −15.5% |
| audit fix + allocator | 177.4 G | **−31.2%** |

**`test_fprewrites`**

| | instructions | vs baseline |
| --- | --- | --- |
| baseline | 351.5 G | |
| audit fix | 351.3 G | −0.1% |
| audit fix + allocator | 222.2 G | **−36.8%** |

The audit fix does nothing for `test_fprewrites` and a good deal for `FpConstantFold` because only the latter builds floating-point nodes in its inner loop; `test_fprewrites` folds an already-blasted bit-vector circuit and so reaches `cacheFPFormat` rarely. Both are equally allocation-bound.

The allocator change reaches every unit test, not just these two — these are simply the two where there was most to gain.

126 of 126 tests pass.