### PR TITLE
Keep STP's CaDiCaL and CryptoMiniSat's bundled one apart

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,52 @@ jobs:
         ./tools/rewrite_rule_gen/rewrite_rule_gen generate 5 3
       working-directory: build
 
+    # CryptoMiniSat >= 5.14 builds its own CaDiCaL (the meelgroup fork, 2.1.3
+    # as of 5.14.7) and installs it into the same prefix as itself, so
+    # deps/install holds a second CaDiCaL that has nothing to do with the one
+    # setup-cadical.sh builds. This is the leg that can check they stay apart:
+    # it is the only one with a static CryptoMiniSat in deps/install, which is
+    # exactly the prefix the bundled copy lands in. Both properties below are
+    # settled during configure, so neither costs a build.
+    #
+    # Left unchecked, the two failure modes are a silent wrong answer and a
+    # misattributed one: the first linked CryptoMiniSat's 2.1.3 library into a
+    # libstp compiled against 3.x headers, and the second produced a wall of
+    # duplicate-symbol errors that never mentions CryptoMiniSat at all.
+    - name: CaDiCaL alongside CryptoMiniSat
+      if: matrix.name == 'gcc'
+      run: |
+        ./scripts/deps/setup-cadical.sh
+
+        # CADICAL_DIR has to outrank the CaDiCaL in deps/install. find_library
+        # reaches CMAKE_PREFIX_PATH before HINTS, and CMakeLists puts
+        # deps/install on that path, so a HINTS lookup resolved to the wrong one.
+        cmake -S . -B build-cadical-pick -G Ninja \
+          -DUSE_CADICAL:BOOL=ON \
+          -DCADICAL_DIR:PATH="$GITHUB_WORKSPACE/deps/cadical" \
+          -DNOCRYPTOMINISAT:BOOL=ON
+        picked=$(sed -n 's/^CADICAL_LIBRARY:FILEPATH=//p' build-cadical-pick/CMakeCache.txt)
+        echo "CADICAL_LIBRARY=$picked"
+        if [ "$picked" != "$GITHUB_WORKSPACE/deps/cadical/build/libcadical.a" ]; then
+          echo "::error::CADICAL_LIBRARY resolved to '$picked', not the CADICAL_DIR copy"
+          exit 1
+        fi
+
+        # A static CryptoMiniSat alongside USE_CADICAL has to be refused, and
+        # has to say why. Without the guard this reaches the linker instead.
+        if cmake -S . -B build-cadical-clash -G Ninja \
+             -DUSE_CADICAL:BOOL=ON \
+             -DCADICAL_DIR:PATH="$GITHUB_WORKSPACE/deps/cadical" \
+             -DNOCRYPTOMINISAT:BOOL=OFF > clash.log 2>&1; then
+          echo "::error::a static CryptoMiniSat with USE_CADICAL configured successfully; it should have been refused"
+          exit 1
+        fi
+        if ! grep -q "static CryptoMiniSat cannot be combined with USE_CADICAL" clash.log; then
+          echo "::error::configure failed, but not on the CryptoMiniSat/CaDiCaL guard"
+          cat clash.log
+          exit 1
+        fi
+
     # The bindings walk the CPython AST, whose node types drift between
     # releases: 3.14 removed NodeVisitor's visit_Num fallback, so every
     # numeric literal in an @stp-decorated function began reaching
@@ -336,9 +382,11 @@ jobs:
         key: deps-x86_64-cadical-${{ matrix.cadical_tag }}-${{ steps.deps-key.outputs.key }}
 
     # CryptoMiniSat is left out: USE_CADICAL makes CaDiCaL the default
-    # solver, so building CMS as well would only add build time. MiniSat is
-    # left out too, deliberately: this job is the one that proves STP
-    # configures, builds and passes its tests with no MiniSat anywhere.
+    # solver, so building CMS as well would only add build time. The
+    # combination itself is covered by the cms-cadical job below, which is
+    # where it has to be a shared CryptoMiniSat -- see the comment there.
+    # MiniSat is left out too, deliberately: this job is the one that proves
+    # STP configures, builds and passes its tests with no MiniSat anywhere.
     - name: Dependencies
       if: steps.deps-cache.outputs.cache-hit != 'true'
       run: |
@@ -438,6 +486,126 @@ jobs:
         cmake --build build-example --parallel "$(nproc)"
         LD_LIBRARY_PATH="$GITHUB_WORKSPACE/install/lib:$GITHUB_WORKSPACE/deps/install/lib" \
           ./build-example/stp-example
+
+  # CryptoMiniSat and CaDiCaL in one binary. Every other Linux job enables
+  # exactly one of them, so until this job existed nothing established that
+  # the combination works -- the exclusions elsewhere were about build time,
+  # not about it being known-good, and a user who wanted both had only a link
+  # error to go on.
+  #
+  # CryptoMiniSat has to be built shared here, and that is the whole subtlety.
+  # Since 5.14 it builds its own CaDiCaL and exports it as an imported target
+  # named plainly `cadical`; a static libcryptominisat5 carries that target in
+  # its link interface, so both CaDiCaLs reach libstp's link line and collide.
+  # CMakeLists refuses that combination outright, and the gcc leg checks that
+  # it does. A shared libcryptominisat5 resolves the dependency inside the .so
+  # and exports no CaDiCaL symbols, so only the CaDiCaL from setup-cadical.sh
+  # is ever linked or called -- which is what this job builds and tests.
+  cms-cadical:
+    name: cms + cadical
+    runs-on: ubuntu-latest
+
+    env:
+      CCACHE_MAXSIZE: 800M
+
+    steps:
+
+    - uses: actions/checkout@v7
+      with:
+          submodules: 'true'
+
+    - name: Packages
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          bison \
+          build-essential \
+          ccache \
+          cmake \
+          flex \
+          gcc \
+          git \
+          ninja-build \
+          python3 \
+          python3-pip \
+          python3-setuptools \
+          zlib1g-dev
+        sudo pip3 install -U lit
+
+    - name: Resolve dependency revisions
+      id: deps-key
+      run: ./scripts/deps/cache-key.sh >> "$GITHUB_OUTPUT"
+
+    # Its own key prefix, and not just because the dependency set differs: this
+    # is the only job whose deps/install holds a *shared* CryptoMiniSat.
+    # Restoring the static one another job cached would land precisely the
+    # configuration this job exists to keep out.
+    - name: Restore dependencies
+      id: deps-cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          deps/install
+          deps/cadical
+          deps/gtest
+          deps/OutputCheck
+        key: deps-x86_64-cms-shared-cadical-${{ steps.deps-key.outputs.key }}
+
+    - name: Dependencies
+      if: steps.deps-cache.outputs.cache-hit != 'true'
+      run: |
+        ./scripts/deps/setup-cms.sh -DBUILD_SHARED_LIBS=ON
+        ./scripts/deps/setup-cadical.sh
+        ./scripts/deps/setup-gtest.sh
+        ./scripts/deps/setup-outputcheck.sh
+
+    - name: Compiler cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ccache
+        key: ccache-cms-cadical-${{ github.run_id }}
+        restore-keys: ccache-cms-cadical-
+
+    - name: Configure
+      run: |
+        mkdir build
+        cd build
+        cmake -DUSE_CADICAL:BOOL=ON -DCADICAL_DIR:PATH="$GITHUB_WORKSPACE/deps/cadical" -DNOCRYPTOMINISAT:BOOL=OFF -DENABLE_TESTING:BOOL=ON -DWERROR:BOOL=ON -DPYTHON_EXECUTABLE:PATH="$(which python3)" -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -G Ninja ..
+
+    - name: Build
+      run: |
+        ccache --zero-stats
+        cmake --build . --parallel "$(nproc)"
+        ccache --show-stats
+      working-directory: build
+
+    # libcryptominisat5.so is in the dependency prefix, which is not on the
+    # loader's default path.
+    - name: Test
+      run: |
+        LD_LIBRARY_PATH="$GITHUB_WORKSPACE/deps/install/lib:$GITHUB_WORKSPACE/deps/install/lib64" \
+          ctest --parallel "$(nproc)" -VV --output-on-failure
+      working-directory: build
+
+    # ctest only ever reaches the default backend, which USE_CADICAL makes
+    # CaDiCaL. Linking is not the property under test here -- having two
+    # CaDiCaLs in one process is -- so solve through each backend by name and
+    # check the answers. A binary that links but whose CryptoMiniSat calls are
+    # bound to the wrong CaDiCaL would pass everything above and fail here.
+    - name: Both backends solve
+      run: |
+        export LD_LIBRARY_PATH="$GITHUB_WORKSPACE/deps/install/lib:$GITHUB_WORKSPACE/deps/install/lib64"
+        stp=build/stp
+        echo '(set-logic QF_BV)(declare-fun a () (_ BitVec 8))(declare-fun b () (_ BitVec 8))(assert (= (bvmul a b) #x21))(assert (bvult a b))(check-sat)' > sat.smt2
+        echo '(set-logic QF_BV)(declare-fun a () (_ BitVec 8))(assert (and (= a #x01) (= a #x02)))(check-sat)' > unsat.smt2
+        for backend in --cadical --cryptominisat; do
+          out=$("$stp" $backend sat.smt2)
+          echo "$backend sat.smt2 -> '$out'"
+          [ "$out" = "sat" ] || { echo "::error::$backend answered '$out', expected sat"; exit 1; }
+          out=$("$stp" $backend unsat.smt2)
+          echo "$backend unsat.smt2 -> '$out'"
+          [ "$out" = "unsat" ] || { echo "::error::$backend answered '$out', expected unsat"; exit 1; }
+        done
 
   # Until this job existed, the only static build in CI was the Windows one,
   # so a break that only shows up when everything is linked into one

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -53,11 +53,15 @@ jobs:
     # the same way (tests/CMakeLists.txt compiles it as part of the STP
     # build); it is cloned here and filtered out of the results below.
     #
-    # CryptoMiniSat is built shared, unlike everywhere else: this is the one
-    # build that links CMS and CaDiCaL at the same time, and a static CMS
-    # drags its own FetchContent-built libcadical.a onto libstp's link line,
-    # where it collides with the newer CaDiCaL from setup-cadical.sh. A
-    # shared libcryptominisat5 keeps its bundled cadical internal.
+    # CryptoMiniSat is built shared, unlike everywhere else: this job links CMS
+    # and CaDiCaL at the same time, and a static CMS drags its own
+    # FetchContent-built libcadical.a onto libstp's link line, where it
+    # collides with the CaDiCaL from setup-cadical.sh. A shared
+    # libcryptominisat5 resolves that dependency inside the .so and exports no
+    # CaDiCaL symbols, so only setup-cadical.sh's copy is linked. Dropping the
+    # flag no longer fails at link time -- CMakeLists rejects a static CMS
+    # alongside USE_CADICAL outright, and the cms-cadical job in ci.yml covers
+    # both halves of that.
     - name: Dependencies
       if: matrix.language == 'cpp'
       run: |
@@ -78,10 +82,6 @@ jobs:
     # the analysis job, and dropping the backend here would leave its
     # wrappers unanalysed anywhere.
     #
-    # CADICAL_LIBRARY is pinned by hand: CMS installs its own bundled cadical
-    # into deps/install, and find_library searches CMAKE_PREFIX_PATH (which
-    # CMakeLists points at deps/install) before the CADICAL_DIR hint, so
-    # without the pin libstp links the older library against the 3.x headers.
     - name: Build
       if: matrix.language == 'cpp'
       run: |
@@ -92,7 +92,6 @@ jobs:
           -DNOCRYPTOMINISAT:BOOL=OFF \
           -DUSE_CADICAL:BOOL=ON \
           -DCADICAL_DIR:PATH="$GITHUB_WORKSPACE/deps/cadical" \
-          -DCADICAL_LIBRARY:FILEPATH="$GITHUB_WORKSPACE/deps/cadical/build/libcadical.a" \
           -DENABLE_TESTING:BOOL=ON \
           -DBUILD_EXTRA_TOOLS:BOOL=ON \
           -DPYTHON_EXECUTABLE:PATH="$(which python3)" \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -610,8 +610,19 @@ add_feature_info(Cadical USE_CADICAL "Enables Cadical solver")
 
 if (USE_CADICAL)
     set(CADICAL_DIR "" CACHE PATH "Path to a CaDiCaL checkout (the directory containing src/cadical.hpp and build/libcadical.a)")
-    find_path(CADICAL_INCLUDE_DIR NAMES src/cadical.hpp HINTS ${CADICAL_DIR})
-    find_library(CADICAL_LIBRARY NAMES cadical HINTS ${CADICAL_DIR}/build)
+    # PATHS with NO_DEFAULT_PATH rather than HINTS, so that CADICAL_DIR decides
+    # and nothing else gets a say. find_library searches CMAKE_PREFIX_PATH
+    # before it reaches HINTS, and this file puts deps/install on that path, so
+    # any libcadical.a installed there outranked the checkout the caller named.
+    # CryptoMiniSat >= 5.14 installs exactly that: its own bundled CaDiCaL.
+    #
+    # The header lookup never went wrong in the same way -- src/cadical.hpp is
+    # a checkout-only path, absent from any install tree -- and that asymmetry
+    # was the whole problem. STP compiled against the headers CADICAL_DIR named
+    # and linked against a different CaDiCaL's library. Pinning both to
+    # CADICAL_DIR is what stops the two disagreeing.
+    find_path(CADICAL_INCLUDE_DIR NAMES src/cadical.hpp PATHS ${CADICAL_DIR} NO_DEFAULT_PATH)
+    find_library(CADICAL_LIBRARY NAMES cadical PATHS ${CADICAL_DIR}/build NO_DEFAULT_PATH)
     if (NOT CADICAL_INCLUDE_DIR OR NOT CADICAL_LIBRARY)
         message(FATAL_ERROR "USE_CADICAL is set but CaDiCaL was not found. "
                 "Set CADICAL_DIR to a CaDiCaL checkout containing src/cadical.hpp and build/libcadical.a")
@@ -771,6 +782,42 @@ add_feature_info(CryptoMiniSat USE_CRYPTOMINISAT "Enables CryptoMiniSat solver, 
 option(FORCE_CMS "Must build with CryptoMiniSat" OFF)
 if (FORCE_CMS AND NOT USE_CRYPTOMINISAT)
     message(FATAL_ERROR "CryptoMiniSat 5.x was not found but it was requested. Exiting.")
+endif()
+
+# CryptoMiniSat >= 5.14 builds its own CaDiCaL -- the meelgroup fork, 2.1.3 as
+# of 5.14.7 -- and installs it beside itself, exported as an imported target
+# named plainly `cadical`. cryptominisat5Targets.cmake then requires a target
+# by that name to exist, which is why the block above has to find_package it.
+#
+# When libcryptominisat5 is static, that target is part of its link interface:
+# a consumer has to resolve a static library's private dependencies itself, so
+# both CaDiCaLs reach libstp's link line and their symbols collide. Neither
+# target can be renamed, so refuse the combination here. Left to the linker it
+# surfaces as pages of duplicate definitions that never mention CryptoMiniSat.
+#
+# A shared libcryptominisat5 is fine and is not rejected: CMake resolves its
+# private dependencies inside the .so, which exports no CaDiCaL symbols at all,
+# so only the CaDiCaL that CADICAL_DIR names is ever linked or called.
+if (USE_CADICAL AND USE_CRYPTOMINISAT AND TARGET cryptominisat5 AND TARGET cadical)
+    get_target_property(_cms_type cryptominisat5 TYPE)
+    if (_cms_type STREQUAL "STATIC_LIBRARY")
+        get_target_property(_cms_cadical cadical IMPORTED_LOCATION_RELEASE)
+        if (NOT _cms_cadical)
+            get_target_property(_cms_cadical cadical IMPORTED_LOCATION)
+        endif()
+        if (NOT _cms_cadical)
+            set(_cms_cadical "the copy in CryptoMiniSat's install prefix")
+        endif()
+        message(FATAL_ERROR
+            "A static CryptoMiniSat cannot be combined with USE_CADICAL. Both "
+            "put a CaDiCaL on libstp's link line and their symbols collide:\n"
+            "    CryptoMiniSat's bundled CaDiCaL: ${_cms_cadical}\n"
+            "    CADICAL_DIR's CaDiCaL:           ${CADICAL_LIBRARY}\n"
+            "Either build CryptoMiniSat as a shared library "
+            "(scripts/deps/setup-cms.sh -DBUILD_SHARED_LIBS=ON), which keeps "
+            "its bundled CaDiCaL to itself, or leave CryptoMiniSat out with "
+            "-DNOCRYPTOMINISAT=ON.")
+    endif()
 endif()
 
 # -----------------------------------------------------------------------------

--- a/scripts/deps/cache-key.sh
+++ b/scripts/deps/cache-key.sh
@@ -9,6 +9,16 @@
 # CaDiCaL, GTest and minisat are pinned to a tag or commit inside their
 # scripts, which the script hash already covers -- OutputCheck, a test-only
 # dependency that is never linked into anything, is the one that is not.
+#
+# One gap is known and deliberately left open. CryptoMiniSat's own tag is
+# pinned, but from 5.14 it fetches cadical and cadiback from meelgroup's
+# default branches, so what it bundles is pinned by nothing here and a cached
+# deps/install can hold an older bundle than a fresh build would produce.
+# Folding those two in would invalidate this key -- and so rebuild
+# CryptoMiniSat, the most expensive dependency in CI -- every time an
+# unrelated fork moves. The bundle stays inside CryptoMiniSat, and STP's own
+# CaDiCaL comes from CADICAL_DIR and nowhere else, so the drift is not worth
+# paying that for.
 
 set -e -u -o pipefail
 

--- a/scripts/deps/setup-cms.sh
+++ b/scripts/deps/setup-cms.sh
@@ -13,6 +13,24 @@ cd "${dep_dir}"
 
 # CMS >= 5.14 builds its cadical/cadiback dependencies itself (via CMake
 # FetchContent), so they no longer need to be built here.
+#
+# It also installs them, which matters to anything else using this prefix:
+# ${install_dir} ends up holding a libcadical.a, its headers and its CMake
+# package, none of which have anything to do with the CaDiCaL that
+# setup-cadical.sh builds. STP pins its own lookup to CADICAL_DIR so the two
+# cannot be confused, and refuses at configure time to link both at once --
+# see the USE_CADICAL block and the guard after the CryptoMiniSat block in
+# the top-level CMakeLists. Building CMS shared (-DBUILD_SHARED_LIBS=ON) is
+# what makes the combination work, because the bundled CaDiCaL then stays
+# inside libcryptominisat5.so; ci.yml's cms-cadical job does exactly that.
+#
+# Note also that the tag below does not pin the bundle: CMS fetches cadical
+# and cadiback from meelgroup's default branches, so which version arrives
+# depends on the day (5.14.7 brought CaDiCaL 2.1.3). cache-key.sh does not
+# track that -- it folds in a revision only for repositories its own scripts
+# clone unpinned -- so a cached deps/install can hold a bundle older than a
+# fresh build would produce. That drift stays inside CryptoMiniSat, which is
+# why it is tolerated rather than chased.
 
 git clone https://github.com/msoos/cryptominisat "${dep}"
 cd "${dep}"


### PR DESCRIPTION
STP builds fine with CryptoMiniSat alone and fine with CaDiCaL alone. It does not build with both, and the two ways it fails turn out to have unrelated causes — which is why "CryptoMiniSat and CaDiCaL collide" is the wrong summary, and why the obvious fix (give CryptoMiniSat its own install prefix) addresses neither of them properly.

The shared observation is that **CryptoMiniSat >= 5.14 builds and installs its own CaDiCaL.** `setup-cms.sh` already said half of it — "CMS >= 5.14 builds its cadical/cadiback dependencies itself (via CMake FetchContent), so they no longer need to be built here" — but not that `cmake --install` then drops that CaDiCaL into the prefix as `lib64/libcadical.a`, `include/cadical/cadical.hpp` and `lib64/cmake/cadical/cadicalConfig.cmake`. It is `meelgroup/cadical` 2.1.3, a fork, fetched at `GIT_TAG master`, and a different lineage from the `arminbiere/cadical` that `setup-cadical.sh` builds.

## The silent failure was ours

With `-DNOCRYPTOMINISAT:BOOL=ON` — the documented way to keep CryptoMiniSat out — the duplicate symbols go away but the stray CaDiCaL does not:

```
ld: lib/libstp.so.2.4: undefined reference to 'CaDiCaL::Solver::declare_more_variables(int)'
ld: lib/libstp.so.2.4: undefined reference to 'CaDiCaL::Solver::val(int, bool)'
```

That is not CryptoMiniSat's doing. STP looked its CaDiCaL up with `find_library(CADICAL_LIBRARY NAMES cadical HINTS ${CADICAL_DIR}/build)`, and `find_library` searches `CMAKE_PREFIX_PATH` *before* it reaches `HINTS`. Since `CMakeLists.txt:42` unconditionally appends `deps/install` to that path, `CADICAL_DIR` was only advisory: any `libcadical.a` in the prefix outranked the checkout the caller named, whatever put it there. I confirmed the ordering directly on both `lib/` and `lib64/` layouts.

The header lookup was immune, and that asymmetry is what made it dangerous — `src/cadical.hpp` is a checkout-only path that no install tree contains, so the headers still came from `CADICAL_DIR`. STP therefore compiled against 3.0.1 and linked 2.1.3. It failed at link time only because 3.0.1 *added* `declare_more_variables` and `val(int, bool)`; a skew in the other direction, or one that only changed behaviour, would have linked cleanly and misbehaved.

Both lookups now use `PATHS ... NO_DEFAULT_PATH`, so `CADICAL_DIR` decides and nothing else gets a say. This costs nothing: every `USE_CADICAL` site in `.github/` already passes it, and a system-installed CaDiCaL was never findable anyway, because the include lookup already required a checkout layout.

## The loud failure is structural

```
ld: deps/install/lib64/libcadical.a(elim.cpp.o): multiple definition of 'CaDiCaL::Internal::elim_resolvents_are_bounded(...)';
    cadical/build/libcadical.a(elim.o): first defined here
```

The cause is in CryptoMiniSat's exported package rather than in the prefix layout. `cryptominisat5Targets.cmake` carries `INTERFACE_LINK_LIBRARIES "$<LINK_ONLY:cadiback>;$<LINK_ONLY:cadical>;..."` plus a `foreach(_target "cadiback" "cadical")` block that makes `find_package(cryptominisat5)` fail outright unless targets by those names already exist — which is why STP's CMakeLists has to `find_package(cadical CONFIG QUIET)` before it. The imported target is named plainly `cadical`, unnamespaced. Because a consumer has to resolve a *static* library's private dependencies itself, a static `libcryptominisat5` puts its CaDiCaL on libstp's link line next to the one `CADICAL_DIR` names.

Neither target can be renamed, so **no prefix arrangement fixes this** — moving CryptoMiniSat to its own prefix only changes which file gets found, not whether two are linked. Configure now refuses the combination and names both libraries, instead of leaving it to a linker error that never mentions CryptoMiniSat at all.

The guard keys on the `cryptominisat5` target being `STATIC_LIBRARY`, which took some pinning down. The bundled CaDiCaL is *always* a static archive — meelgroup's CMakeLists says `add_library(cadical STATIC ...)` unconditionally, has no `BUILD_SHARED_LIBS` handling, and installs its package config either way — so keying on the cadical target instead would reject the shared build, which works. Confirmed by configuring against both kinds of install and reading the generated link line:

| CryptoMiniSat install | `cryptominisat5` target type | CaDiCaLs on libstp's link line |
| --- | --- | --- |
| static | `STATIC_LIBRARY` | **both** |
| shared | `SHARED_LIBRARY` | only `CADICAL_DIR`'s |

`libcryptominisat5.so` also exports 384 symbols of which **zero** are `CaDiCaL::`, so the bundle is genuinely internal and there is no interposition hazard at runtime either. Building CryptoMiniSat shared is therefore the supported way to have both.

## Nothing recorded whether the combination worked

Every `ci.yml` job enables exactly one backend, and the comment on the CaDiCaL job put that down to build time — which reads as "untried" rather than "known to need care". `codeql-analysis.yml` *did* build all three together and pass, but only by carrying a workaround for each: `-DBUILD_SHARED_LIBS=ON` on `setup-cms.sh` for the first failure, and a hand-pinned `-DCADICAL_LIBRARY:FILEPATH=` for the second, whose comment already diagnosed the `find_library` ordering. The knowledge existed; it was trapped in one job instead of fixed at the source. That job also runs `make` and no tests.

So a new `cms-cadical` job builds shared CryptoMiniSat with CaDiCaL, runs ctest, and then solves a sat and an unsat query through each backend by name — ctest alone only ever reaches the default backend, so it would not notice a binary whose CryptoMiniSat calls bound to the wrong CaDiCaL. The `gcc` leg, which already has a static CryptoMiniSat in `deps/install`, additionally checks both configure-time properties above for the price of a CaDiCaL clone; they are settled during configure, so neither needs a build. The CodeQL pin is gone, so that job now exercises the fix rather than working around it.

## Deliberately not done

- **Giving CryptoMiniSat its own install prefix.** It does not address the duplicate symbols at all, and the version skew is better fixed where the bug actually was.
- **Telling CryptoMiniSat to use STP's CaDiCaL.** The switch exists (`cadical_DIR`), but it does `find_package(cadical CONFIG REQUIRED)` and the bundle is meelgroup's fork. STP's CaDiCaL is arminbiere's, built with `./configure && make`, and ships no CMake package config at all, so `cadical_DIR` cannot point at it. Sharing one CaDiCaL would mean moving STP to a fork that is still on 2.1.3 while upstream is on 3.0.1 — and `--cadical-factor` is gated on CaDiCaL >= 3.0.0, so it would cost bounded variable addition outright.
- **Pinning CryptoMiniSat's bundled CaDiCaL in the CI cache key.** Real, but closing it would rebuild the most expensive dependency in CI whenever an unrelated fork moves, to chase drift that stays inside CryptoMiniSat. `cache-key.sh` records the gap instead — its comment previously claimed the script hash covered CryptoMiniSat, which is true of the tag but not of the `cadical`/`cadiback` it fetches from default branches.

## Verification

Configured real STP against both a static and a shared CryptoMiniSat install, with a CaDiCaL 3.0.1 checkout, and checked all three behaviours: with the poisoned prefix on `CMAKE_PREFIX_PATH` and `NOCRYPTOMINISAT=ON`, `CADICAL_LIBRARY` resolves to the `CADICAL_DIR` copy; with a static CryptoMiniSat the guard fires and names both libraries; with a shared one it stays silent and the correct library is selected. Both workflows parse, the modified shell scripts lint clean apart from a pre-existing SC2043, and every `USE_CADICAL` site in `.github/` passes `CADICAL_DIR` — including the Windows MinGW leg, which builds into `${CADICAL_DIR}/build` as expected, so `NO_DEFAULT_PATH` regresses nothing.

One gap worth stating plainly: the full shared-CryptoMiniSat build and its ctest run have **not** been executed locally — submodules will not clone in the worktree I was working in (`transport 'file' not allowed`), so the configure checks above complete past the guard but the build cannot. The new `cms-cadical` job is what proves that end, and this PR's own CI run is its first execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
