### PR TITLE
Stop the CI caches from crowding each other out of the quota

### DIFF
--- a/.github/actions/build-static-linux/action.yml
+++ b/.github/actions/build-static-linux/action.yml
@@ -147,8 +147,9 @@ runs:
     id: build
     shell: bash
     working-directory: build
+    # 400M rather than 800M; see the note in ci.yml's gcc/clang job.
     env:
-      CCACHE_MAXSIZE: 800M
+      CCACHE_MAXSIZE: 400M
     run: |
       ccache --zero-stats
       cmake --build . --parallel "$(nproc)"

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -1,0 +1,70 @@
+# The repository gets one 10GB Actions cache allowance, shared by every key
+# every workflow writes, and ci.yml writes keys that can only accumulate: the
+# compiler caches end in github.run_id, so each run leaves its predecessor
+# behind, and a pull request's caches outlive the pull request. Nothing removed
+# either, so the allowance filled and GitHub started evicting by least-recent
+# use -- which falls on whatever is written in small pieces, the sccache objects
+# the Windows legs write above all, rather than on the multi-hundred-megabyte
+# tarballs that caused the pressure.
+#
+# scripts/prune-ci-caches.sh explains which entries are safe to delete and why.
+name: Cache cleanup
+
+on:
+  # After a CI run rather than inside one. The entries worth deleting are the
+  # ones that run has just superseded, and once it has finished nothing is
+  # going to ask for them. NB workflow_run only fires for the copy of this file
+  # on the default branch, so a pull request cannot exercise this path.
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+
+  # The backstop for entries no later run supersedes: a pull request merged and
+  # never built again, a branch deleted, a job renamed out of existence.
+  schedule:
+    - cron: '17 4 * * *'
+
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: Report what would be deleted, delete nothing
+        type: boolean
+        default: false
+
+permissions:
+  actions: write       # delete cache entries
+  contents: read       # check the script out
+  pull-requests: read  # tell an open pull request from a closed one
+
+# Prunes are interchangeable. One already running leaves this one nothing to
+# do, and cancelling one loses no work that the next will not redo.
+concurrency:
+  group: cache-cleanup
+  cancel-in-progress: true
+
+jobs:
+  prune:
+    name: Prune superseded caches
+    runs-on: ubuntu-latest
+
+    steps:
+
+    # No submodules: this job runs one script against the GitHub API and
+    # compiles nothing.
+    #
+    # The ref is pinned rather than left to default. A workflow_run job holds
+    # actions: write and is triggered by CI runs that include pull requests from
+    # forks, so what it executes must come from the branch this repository
+    # controls and never from the tree that triggered it. Pinning also costs
+    # nothing to work around: the script takes --dry-run and runs anywhere gh is
+    # authenticated, which is how a change to it should be tried out.
+    - uses: actions/checkout@v7
+      with:
+        ref: ${{ github.event.repository.default_branch }}
+
+    - name: Prune
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: ./scripts/prune-ci-caches.sh ${{ inputs.dry-run && '--dry-run' || '' }}
+
+# EOF

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,17 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ubuntu-latest
 
+    # 400M rather than the 800M this used to be. Every ccache leg compiles about
+    # 1280 files at a 99.6% hit rate, but what that costs in cache varies by
+    # 2.6x: 243MB on this leg, 645MB on cadical rel-2.1.3, for the same tree and
+    # the same hit rate. One build's working set is around 250MB; the rest is
+    # objects from source versions that will never be compiled again, which
+    # ccache had no reason to evict while the ceiling was 800M. That slack is not
+    # free -- the Actions cache is one 10GB allowance shared by every key in the
+    # repository -- and it buys nothing, since the leg holding a third as much
+    # hits just as often. See cache-cleanup.yml for the other half of this.
     env:
-      CCACHE_MAXSIZE: 800M
+      CCACHE_MAXSIZE: 400M
 
     steps:
 
@@ -334,8 +343,9 @@ jobs:
       matrix:
         cadical_tag: [rel-3.0.1, rel-2.1.3]
 
+    # 400M rather than 800M; see the note on the gcc/clang job above.
     env:
-      CCACHE_MAXSIZE: 800M
+      CCACHE_MAXSIZE: 400M
 
     steps:
 
@@ -505,8 +515,9 @@ jobs:
     name: cms + cadical
     runs-on: ubuntu-latest
 
+    # 400M rather than 800M; see the note on the gcc/clang job above.
     env:
-      CCACHE_MAXSIZE: 800M
+      CCACHE_MAXSIZE: 400M
 
     steps:
 
@@ -827,7 +838,7 @@ jobs:
       run: |
         mkdir -p .ccache
         docker run --rm -v "$GITHUB_WORKSPACE":/stp -w /stp \
-          -e CCACHE_DIR=/stp/.ccache -e CCACHE_MAXSIZE=800M -e CCACHE_UMASK=022 \
+          -e CCACHE_DIR=/stp/.ccache -e CCACHE_MAXSIZE=400M -e CCACHE_UMASK=022 \
           i386/debian:bookworm linux32 ./scripts/ci-32bit.sh
 
     # The container writes as root; hand the cached trees back to the runner

--- a/scripts/prune-ci-caches.sh
+++ b/scripts/prune-ci-caches.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+#
+# Delete the GitHub Actions cache entries that nothing will ever read again.
+#
+# A repository gets one 10GB Actions cache allowance, shared by every key any
+# workflow writes. Two habits of ci.yml consume it without bound:
+#
+#   - The ccache keys end in ${{ github.run_id }}. They have to: a cache key
+#     cannot be updated in place, so writing a fresh one per run and letting
+#     restore-keys pick the newest is the only way to carry a compiler cache
+#     forward. But every run leaves its predecessor behind, and only the newest
+#     is ever restored.
+#
+#   - A pull request writes its caches under refs/pull/<n>/merge. Merging or
+#     closing it does not remove them, and no later run can read them: cache
+#     reads see the current ref and the default branch, never another branch.
+#
+# Left alone the allowance fills, GitHub evicts whatever is least recently
+# used, and unrelated keys -- the sccache objects the Windows legs write, the
+# dependency trees -- are what get thrown out.
+#
+# So: keep the newest ccache entry per (ref, key prefix), drop the rest, and
+# drop everything belonging to a pull request that is no longer open. Content
+# keyed entries are left alone entirely, because a hit on one still means it is
+# valid: deps-*, codeql-*, msys2-*, and the individual sccache objects, whose
+# keys are hashes of what they hold rather than of when they were written.
+#
+# Deleting an entry that is not the newest cannot make a concurrent run miss:
+# restore-keys resolves to the newest match, which is the one kept.
+#
+#     scripts/prune-ci-caches.sh --dry-run    # report, delete nothing
+#     scripts/prune-ci-caches.sh
+#
+# Needs gh authenticated with actions:write to delete, and pull-requests:read
+# to tell an open pull request from a closed one.
+
+set -u -o pipefail
+
+dry_run=0
+case "${1-}" in
+    --dry-run) dry_run=1 ;;
+    "") ;;
+    *) echo "usage: $0 [--dry-run]" >&2; exit 2 ;;
+esac
+
+repo=${GITHUB_REPOSITORY:-$(gh repo view --json nameWithOwner --jq .nameWithOwner)}
+if [ -z "$repo" ]; then
+    echo "error: no repository; set GITHUB_REPOSITORY or run inside a checkout" >&2
+    exit 1
+fi
+echo "repository: $repo"
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+# id, ref, key, created_at, size. Sizes are what GitHub bills against the
+# allowance, so they are what the report below adds up.
+if ! gh api --paginate "repos/$repo/actions/caches?per_page=100" \
+        --jq '.actions_caches[] | [.id, .ref, .key, .created_at, .size_in_bytes] | @tsv' \
+        > "$work/raw.tsv"; then
+    echo "error: could not list caches" >&2
+    exit 1
+fi
+
+# The listing is paginated over a set that a running workflow is still adding
+# to, so an entry can shift across a page boundary and be returned twice --
+# 1751 rows for 1740 caches, when this was written. Deleting a duplicate is
+# harmless, but counting one is not, so the id decides and the report is honest.
+sort -u -t"$(printf '\t')" -k1,1 "$work/raw.tsv" > "$work/all.tsv"
+
+# The full listing carries size in column 5; the shortlists below are pairs of
+# id and size, so the column is named rather than assumed.
+report() {
+    awk -F'\t' -v label="$1" -v column="$3" '
+        { bytes += $column; n++ }
+        END { printf "%s: %d entries, %.2f GB\n", label, n, bytes / 1073741824 }
+    ' "$2"
+}
+report "in the cache" "$work/all.tsv" 5
+
+# Superseded compiler caches. The key is <prefix>-<run id>; strip the run id to
+# get the group, sort each group newest first, and mark everything after the
+# first. Restricted to ccache-* because that is the family whose key encodes
+# when it was written rather than what it contains -- applying this to a
+# content-keyed family would delete live entries.
+awk -F'\t' '$3 ~ /^ccache-.+-[0-9]+$/ {
+    prefix = $3
+    sub(/-[0-9]+$/, "", prefix)
+    print $2 "\t" prefix "\t" $4 "\t" $1 "\t" $5
+}' "$work/all.tsv" |
+    sort -t"$(printf '\t')" -k1,1 -k2,2 -k3,3r |
+    awk -F'\t' '
+        { group = $1 "\t" $2; if (group == previous) print $4 "\t" $5; previous = group }
+    ' > "$work/superseded.tsv"
+report "superseded compiler caches" "$work/superseded.tsv" 2
+
+# Caches belonging to pull requests that are no longer open. Each number is
+# asked about once; a request that 404s (deleted fork, say) is treated as
+# closed, since nothing can read its caches either way.
+: > "$work/abandoned.tsv"
+awk -F'\t' '$2 ~ /^refs\/pull\/[0-9]+\//' "$work/all.tsv" > "$work/pull.tsv"
+sed 's#^[^\t]*\trefs/pull/\([0-9]*\)/.*#\1#' "$work/pull.tsv" | sort -un > "$work/numbers.txt"
+while read -r number; do
+    [ -n "$number" ] || continue
+    state=$(gh api "repos/$repo/pulls/$number" --jq .state 2>/dev/null || echo closed)
+    [ "$state" = open ] && continue
+    awk -F'\t' -v n="$number" '$2 == "refs/pull/" n "/merge" || $2 == "refs/pull/" n "/head" {
+        print $1 "\t" $5
+    }' "$work/pull.tsv" >> "$work/abandoned.tsv"
+done < "$work/numbers.txt"
+report "caches of closed pull requests" "$work/abandoned.tsv" 2
+
+# A closed pull request's newest entry is in both lists.
+sort -u "$work/superseded.tsv" "$work/abandoned.tsv" > "$work/doomed.tsv"
+report "to delete" "$work/doomed.tsv" 2
+
+if [ "$dry_run" -eq 1 ]; then
+    echo "--dry-run: nothing deleted"
+    exit 0
+fi
+
+failed=0
+deleted=0
+while IFS=$'\t' read -r id _size; do
+    [ -n "$id" ] || continue
+    if gh api --method DELETE "repos/$repo/actions/caches/$id" --silent 2>/dev/null; then
+        deleted=$((deleted + 1))
+    else
+        # Another prune, or GitHub's own eviction, may have taken it first.
+        # That is the outcome this wanted, so it is not a failure.
+        failed=$((failed + 1))
+    fi
+done < "$work/doomed.tsv"
+
+echo "deleted $deleted, already gone $failed"
+
+# What the allowance looks like afterwards, from GitHub rather than from
+# subtraction, so the number reflects deletions this run did not make.
+gh api "repos/$repo/actions/cache/usage" \
+    --jq '"remaining: \(.active_caches_count) entries, \(.active_caches_size_in_bytes / 1073741824 * 100 | round / 100) GB"'


### PR DESCRIPTION
A repository gets one 10GB Actions cache allowance, shared by every key every workflow writes. `stp/stp` has been over it — 12.64GB when I first measured, 9.77GB an hour later, the difference being GitHub evicting. Eviction is least-recently-used, so what it takes is whatever is written in small pieces: the sccache objects the Windows legs write are ~90KB each, against ccache tarballs of 600MB. That is how #851 ended up with `Cache write errors 573` on its first run and, on the MinGW leg, *every* write failing.

Measured against the live repository:

```
in the cache:                     3151 entries, 9.77 GB
superseded compiler caches:          9 entries, 2.84 GB
caches of closed pull requests:   1740 entries, 3.66 GB
to delete:                        1747 entries, 5.83 GB
```

**Sixty percent of the allowance is entries that nothing can ever read again.**

## Two families that only accumulate

**The compiler caches end in `github.run_id`.** They have to: a cache key cannot be updated in place, so writing a fresh entry per run and letting `restore-keys` find the newest is the only way to carry ccache forward at all. The comment in `ci.yml` says as much. What it did not say is that the entry each run supersedes stays behind for good, and only the newest is ever restored.

**A pull request's caches outlive the pull request.** They live under `refs/pull/<n>/merge`; merging or closing does not remove them, and no later run can read them, because a cache lookup sees the current ref and the default branch and nothing else. #851's own caches are 1740 of the 1747 entries above.

`scripts/prune-ci-caches.sh` deletes exactly those two sets, and `cache-cleanup.yml` runs it after each CI run, daily, and on demand.

Content-keyed families are left alone entirely — `deps-*`, `codeql-*`, `msys2-*`, and the individual sccache objects — because a hit on one of those still means it is valid; their keys hash what they hold rather than when they were written. The `ccache-*` restriction in the script is what enforces that, and it is deliberate rather than incidental: the same "strip the trailing number, keep the newest" rule applied to a content-keyed family would delete live entries.

Deleting an entry that is not the newest cannot make a concurrent run miss. `restore-keys` resolves to the newest match, which is the one kept — so the safety of this does not depend on when it runs relative to CI.

## The ceiling was also too high, and the legs disagree about it

`CCACHE_MAXSIZE` drops from 800M to 400M, on measurement rather than taste:

| leg | cache used | of 800M | hit rate |
| --- | --- | --- | --- |
| `gcc (cadical rel-2.1.3)` | 645 MB | 85.29% | 99.61% |
| `gcc (static)` | 616 MB | 81.62% | 99.57% |
| `gcc (cadical rel-3.0.1)` | 452 MB | 59.86% | — |
| `gcc (i386)` | 436 MB | 57.90% | — |
| `clang` | 274 MB | 36.92% | — |
| `gcc` | **243 MB** | 33.40% | **99.61%** |
| `cms + cadical` | 182 MB | 22.69% | — |
| `gcc-release` | 67 MB | 9.96% | — |
| `gcc (static, release)` | 48 MB | 7.59% | — |

The `gcc` and `cadical rel-2.1.3` legs compile the same tree — 1289 and 1280 cacheable calls — and reach **the same 99.61% hit rate**, one holding 243MB and the other 645MB. A build's working set is therefore around 250MB, and everything above that is objects from source versions that will never be compiled again, which ccache had no reason to evict while the ceiling was 800M. 400M leaves every leg about 60% of headroom over its working set.

This is the smaller half of the fix and is stated as such: on its own it would take the live set from ~2.9GB to ~2.4GB, which does not solve anything, because the waste is in how many copies are retained rather than in how big each one is. It is here because the slack is measurably not earning its space, not because trimming it fixes the quota.

## Two things that are easy to get wrong

**The `workflow_run` job holds `actions: write`, and CI runs include pull requests from forks.** Its checkout is therefore pinned to the default branch rather than left to default, so what executes always comes from the branch this repository controls and never from the tree that triggered it. Pinning costs nothing to work around, because the script takes `--dry-run` and runs anywhere `gh` is authenticated — which is how a change to it should be tried out, and how the numbers above were produced.

**The paginated cache listing returns some entries twice.** It pages over a set that a running workflow is still adding to, so an entry can shift across a page boundary: 1751 rows for 1740 caches while I was testing. Deleting a duplicate is harmless — the second attempt 404s and is counted as already gone — but *counting* one is not, and it silently inflated my first report by 11 entries. The script now deduplicates on the cache id before anything else, so the figures it prints are the figures GitHub bills.

## Deliberately not done

- **Saving the ccache only on master, and never on pull requests.** It would remove the PR churn at the source and is a smaller diff conceptually, but it costs every pull request the cache its own earlier runs built, and it leaves master's own accumulation untouched. Pruning covers both, and covers branches and triggers that do not exist yet.
- **Pruning the sccache objects.** They are content-keyed, so a hit means valid, and at ~90KB each they are not what fills the allowance — 1740 of them come to 3.66GB only because they belong to a closed pull request, and that is the rule that removes them. GitHub's own 7-day unused eviction handles the rest.
- **Touching what any job builds or tests.** No build flag, no test, no dependency changes here.

## Verification

`scripts/prune-ci-caches.sh --dry-run` was run against `stp/stp` repeatedly during development; the block at the top of this description is its real output, and every figure quoted here comes from it or from the `ccache --show-stats` output of run [31695396863](https://github.com/stp/stp/actions/runs/31695396863). The script is shellcheck-clean and all three modified or added YAML files parse.

What has **not** been executed is the deletion path — the dry run stops before it — and the `workflow_run` trigger, which by design only fires for the copy of the file on the default branch and so cannot be exercised from a pull request. After merging, the safe first step is `workflow_dispatch` with `dry-run: true`, which prints the same report without deleting; the unguarded run is one dispatch later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
