### PR TITLE
Rebuild a remainder from the division it was expanded into

### DIFF
--- a/include/stp/NodeFactory/SimplifyingNodeFactory.h
+++ b/include/stp/NodeFactory/SimplifyingNodeFactory.h
@@ -104,6 +104,14 @@ private:
 
   ASTNode plusRules(const ASTNode& n0, const ASTNode& n1);
 
+  // Rebuild a remainder from the dividend and the "- b * (a / b)" product
+  // that a plus was given. Null if the two do not have that shape.
+  ASTNode remainderFromDivision(const ASTNode& a, const ASTNode& product);
+
+  // One pass of the above over a sum's operands, replacing every dividend
+  // and product pair it finds. True if it folded anything.
+  bool foldRemainders(ASTVec& children);
+
   //Helper functions
   bool children_all_constants(ASTChildren children) const;
   ASTNode get_smallest_number(const unsigned width);

--- a/lib/NodeFactory/SimplifyingNodeFactory.cpp
+++ b/lib/NodeFactory/SimplifyingNodeFactory.cpp
@@ -2007,6 +2007,121 @@ ASTNode SimplifyingNodeFactory::simplifyArrayEquality(const ASTNode& a,
   return ASTNode();
 }
 
+// A remainder is what a division leaves behind: a == (a / b) * b + (a rem b)
+// holds for every a and b, so a + (-b) * (a / b) *is* the remainder. It holds
+// for the signed and the unsigned pair alike, and at every operand pair --
+// including b = 0 and the most negative dividend -- because SMT-LIB's
+// division and remainder are total and satisfy that identity everywhere.
+//
+// Producers that expand a remainder into a - (a / b) * b, as translation
+// validation tools routinely do, otherwise hand the bit-blaster a division
+// that nothing recognises as the remainder it is really computing, and it
+// gets blasted as a second, independent divider.
+//
+// Returns the remainder if `a` and `product` have that shape, else null.
+ASTNode SimplifyingNodeFactory::remainderFromDivision(const ASTNode& a,
+                                                     const ASTNode& product)
+{
+  // The subtracted form BVSUB(a, b * (a / b)) reaches here as a plus of the
+  // dividend and a negated product; otherwise the multiplier carries the
+  // negation itself.
+  const bool negated = (product.GetKind() == BVUMINUS);
+  const ASTNode& mult = negated ? product[0] : product;
+
+  if (mult.GetKind() != stp::BVMULT || mult.Degree() != 2)
+    return ASTNode();
+
+  const unsigned width = a.GetValueWidth();
+
+  for (unsigned i = 0; i < 2; i++)
+  {
+    const ASTNode& quotient = mult[i];
+    const ASTNode& multiplier = mult[1 - i];
+
+    const Kind k = quotient.GetKind();
+    if ((k != SBVDIV && k != stp::BVDIV) || quotient[0] != a)
+      continue;
+
+    const ASTNode& divisor = quotient[1];
+
+    // Only now is it worth building the negated divisor to compare against.
+    // Constants fold and a double negation cancels, so this single comparison
+    // covers a constant multiplier, a BVUMINUS one, and an already negated
+    // divisor alike.
+    if (negated ? (multiplier != divisor)
+                : (multiplier !=
+                   NodeFactory::CreateTerm(BVUMINUS, width, divisor)))
+      continue;
+
+    return NodeFactory::CreateTerm(k == SBVDIV ? SBVREM : BVMOD, width, a,
+                                   divisor);
+  }
+
+  return ASTNode();
+}
+
+// True if `n` could be the "- b * (a / b)" half of the pair above, using only
+// checks that cost nothing, so that the search over a wide plus gives up
+// immediately on almost every operand.
+static bool mightBeDivisionProduct(const ASTNode& n)
+{
+  const ASTNode& mult = (n.GetKind() == BVUMINUS) ? n[0] : n;
+
+  if (mult.GetKind() != stp::BVMULT || mult.Degree() != 2)
+    return false;
+
+  for (unsigned i = 0; i < 2; i++)
+    if (mult[i].GetKind() == SBVDIV || mult[i].GetKind() == stp::BVDIV)
+      return true;
+
+  return false;
+}
+
+// One pass of the pairing over a sum's operands: every dividend and its
+// product collapse to the remainder they compute, wherever the two sit.
+// Returns true if anything folded, so the caller can run it again -- a fold
+// can expose another, when the remainder it builds is itself the dividend of
+// a product the sum already held.
+bool SimplifyingNodeFactory::foldRemainders(ASTVec& children)
+{
+  std::vector<bool> paired(children.size(), false);
+  ASTVec folded;
+
+  for (size_t i = 0; i < children.size(); i++)
+  {
+    if (paired[i] || !mightBeDivisionProduct(children[i]))
+      continue;
+
+    for (size_t j = 0; j < children.size(); j++)
+    {
+      if (i == j || paired[j])
+        continue;
+
+      const ASTNode remainder = remainderFromDivision(children[j], children[i]);
+      if (remainder.IsNull())
+        continue;
+
+      folded.push_back(remainder);
+      paired[i] = true;
+      paired[j] = true;
+      break;
+    }
+  }
+
+  if (folded.empty())
+    return false;
+
+  for (size_t i = 0; i < children.size(); i++)
+    if (!paired[i])
+      folded.push_back(children[i]);
+
+  // Each fold takes two operands and gives back one, so a sum of more than
+  // two operands keeps at least two.
+  assert(folded.size() >= 2);
+  children.swap(folded);
+  return true;
+}
+
 // This gets called with the arguments swapped as well. So the rules don't need
 // to know about commutivity.
 ASTNode SimplifyingNodeFactory::plusRules(const ASTNode& n0, const ASTNode& n1)
@@ -2014,7 +2129,14 @@ ASTNode SimplifyingNodeFactory::plusRules(const ASTNode& n0, const ASTNode& n1)
   ASTNode result;
   const int width = n0.GetValueWidth();
 
-  if (n0.isConstant() && CONSTANTBV::BitVector_is_empty(n0.GetBVConst()))
+  // a + (-b) * (a / b) is the remainder a rem b. Tried ahead of the chain
+  // below so that the negation-pulling rules at its end cannot claim the
+  // pair first, and skipped again the moment the shape does not fit.
+  if (mightBeDivisionProduct(n1))
+    result = remainderFromDivision(n0, n1);
+
+  if (result.IsNull() && n0.isConstant() &&
+      CONSTANTBV::BitVector_is_empty(n0.GetBVConst()))
     result = n1;
   else if (width == 1 && n0 == n1)
     result = bm.CreateZeroConst(1);
@@ -2505,6 +2627,32 @@ ASTNode SimplifyingNodeFactory::plusRules(const ASTChildren oldChildren)
 {
   assert(oldChildren.size() > 2);
   const unsigned width = oldChildren[0].GetValueWidth();
+
+  // A dividend and its "- b * (a / b)" partner fold back into the remainder
+  // they compute, wherever in the sum the two happen to sit.
+  //
+  // Every pair is taken here, by looping the pass, rather than by rebuilding
+  // the sum around one fold and re-entering the factory to find the next:
+  // that costs a stack frame per pair, and a sum wide enough -- which is what
+  // flattening a long chain of these produces -- overflows the stack. The
+  // scan is skipped altogether unless some operand is a product of a
+  // division, which almost no sum has.
+  bool anyProduct = false;
+  for (size_t i = 0; i < oldChildren.size() && !anyProduct; i++)
+    anyProduct = mightBeDivisionProduct(oldChildren[i]);
+
+  if (anyProduct)
+  {
+    ASTVec remaining(oldChildren.begin(), oldChildren.end());
+
+    if (foldRemainders(remaining))
+    {
+      while (foldRemainders(remaining))
+        ;
+
+      return CreateTerm(BVPLUS, width, remaining);
+    }
+  }
 
   ASTNode accumulate= bm.CreateZeroConst(width);
 
@@ -3456,7 +3604,26 @@ ASTNode SimplifyingNodeFactory::CreateTerm(Kind kind, unsigned int width,
     break;
 
     case stp::BVDIV:
-      if (children[1].isConstant() && children[1] == bm.CreateOneConst(width))
+      if (children[0].GetKind() == BVMOD && children[0][1] == children[1])
+      {
+        // (x umod y) / y is zero: a remainder is smaller than the divisor it
+        // was taken against, so it cannot contain it once. Only y = 0 escapes,
+        // where the remainder is x and the total quotient is all ones.
+        // Checked before the rules below because the power-of-two divisor is
+        // rewritten to an extract, after which nothing sees the remainder.
+        if (children[1].isConstant())
+          result = CONSTANTBV::BitVector_is_empty(children[1].GetBVConst())
+                       ? bm.CreateMaxConst(width)
+                       : bm.CreateZeroConst(width);
+        else
+          result = NodeFactory::CreateTerm(
+              ITE, width,
+              NodeFactory::CreateNode(EQ, children[1],
+                                      bm.CreateZeroConst(width)),
+              bm.CreateMaxConst(width), bm.CreateZeroConst(width));
+      }
+      else if (children[1].isConstant() &&
+               children[1] == bm.CreateOneConst(width))
         result = children[0];
       else if (children[1].isConstant() && hasSingleOneBit(children[1]) &&
                lowestOneBit(children[1]) > 0)
@@ -3551,7 +3718,35 @@ ASTNode SimplifyingNodeFactory::CreateTerm(Kind kind, unsigned int width,
       // so (bvsdiv x 2^n) is NOT a plain arithmetic shift right (that would
       // round toward -inf for negative x); it needs a sign correction. Left for
       // the bit-blaster.
-      if (children[1].isConstant() && children[1] == bm.CreateOneConst(width))
+      if ((children[0].GetKind() == SBVREM || children[0].GetKind() == SBVMOD) &&
+          children[0][1] == children[1])
+      {
+        // (x srem y) / y and (x smod y) / y are both zero: either remainder is
+        // smaller in magnitude than the divisor it was taken against. Only
+        // y = 0 escapes, where both remainders are x and the total quotient is
+        // one for a negative x and all ones otherwise.
+        if (children[1].isConstant() &&
+            !CONSTANTBV::BitVector_is_empty(children[1].GetBVConst()))
+          result = bm.CreateZeroConst(width);
+        else
+        {
+          const ASTNode byZero = NodeFactory::CreateTerm(
+              ITE, width,
+              NodeFactory::CreateNode(stp::BVSLT, children[0][0],
+                                      bm.CreateZeroConst(width)),
+              bm.CreateOneConst(width), bm.CreateMaxConst(width));
+
+          result = children[1].isConstant()
+                       ? byZero
+                       : NodeFactory::CreateTerm(
+                             ITE, width,
+                             NodeFactory::CreateNode(
+                                 EQ, children[1], bm.CreateZeroConst(width)),
+                             byZero, bm.CreateZeroConst(width));
+        }
+      }
+      else if (children[1].isConstant() &&
+               children[1] == bm.CreateOneConst(width))
         result = children[0];
       else if (children[1].isConstant() &&
                CONSTANTBV::BitVector_is_full(children[1].GetBVConst()))

--- a/tests/query-files/misc-tests/srem-from-sdiv-product.smt2
+++ b/tests/query-files/misc-tests/srem-from-sdiv-product.smt2
@@ -1,0 +1,27 @@
+; RUN: %solver --SMTLIB2 %s | %OutputCheck %s
+; CHECK-NEXT: ^unsat
+;
+; A signed remainder written out as a - (a sdiv b) * b must be folded back
+; into a srem b, and a remainder divided by its own divisor must fold to zero.
+;
+; This is the shape a translation-validation tool emits for the LLVM identity
+; (x - (x sdiv 101) * 101) sdiv 101 == 0: the front end has no bvsrem in it,
+; so without the two rewrites the query holds three independent signed
+; divisions, each of which is bit-blasted into its own divider. Narrowed from
+; 64 bits, where the un-rewritten form runs for minutes, to 24 bits, where it
+; takes seconds -- enough to be conspicuous if either rewrite stops firing,
+; but bounded if it does.
+(set-logic QF_BV)
+(declare-fun %p0 () (_ BitVec 24))
+(declare-fun np_%p0 () Bool)
+(declare-fun isundef_%p0 () (_ BitVec 1))
+(assert
+ (let ((?x26 (bvadd (bvmul (_ bv33554431 25) ((_ sign_extend 1) (bvmul (_ bv101 24) (bvsdiv %p0 (_ bv101 24))))) ((_ sign_extend 1) %p0))))
+(let (($x20 (= (bvmul (_ bv101 48) ((_ sign_extend 24) (bvsdiv %p0 (_ bv101 24)))) ((_ sign_extend 24) (bvmul (_ bv101 24) (bvsdiv %p0 (_ bv101 24)))))))
+(let (($x22 (and np_%p0 $x20)))
+(let (($x33 (and (and np_%p0 $x22) (= ?x26 ((_ sign_extend 1) (bvadd %p0 (bvmul (_ bv16777115 24) (bvsdiv %p0 (_ bv101 24)))))))))
+(let (($x39 (or (not $x33) (= (_ bv0 24) (bvsdiv (bvadd %p0 (bvmul (_ bv16777115 24) (bvsdiv %p0 (_ bv101 24)))) (_ bv101 24))))))
+(let (($x41 (not $x39)))
+(let (($x12 (= (_ bv0 1) isundef_%p0)))
+(and $x12 $x41)))))))))
+(check-sat)

--- a/tests/unit-tests/DeepDag_Test.cpp
+++ b/tests/unit-tests/DeepDag_Test.cpp
@@ -385,6 +385,41 @@ bool flattenShareCountOk(Context& c, unsigned depth)
 // observed crash path -- but --flatten puts it back. BVMULT is not a
 // flattenable kind, which keeps this a test of the traversal rather than
 // of flattening.
+// The remainder reconstruction in the simplifying factory, which pairs a
+// dividend with the "- b * (a / b)" product beside it in a sum. The pairs are
+// independent of each other, so the number of them is chosen by the input,
+// not by its depth: folding one and re-entering the factory to find the next
+// would spend a frame per pair. Flattening a chain of these additions is what
+// hands the factory one sum this wide.
+bool remainderFoldingOk(Context& c, unsigned pairs)
+{
+  const unsigned width = 32;
+  const ASTNode divisor = c.mgr.CreateBVConst(width, 101);
+  // The negated divisor as the constant it reaches the factory as: every
+  // node in a real query has been through the simplifying factory, which
+  // folds a negated constant on creation.
+  const ASTNode negDivisor = c.mgr.CreateBVConst(width, (1ULL << width) - 101);
+
+  ASTVec children;
+  children.reserve(2 * pairs);
+  for (unsigned i = 0; i < pairs; i++)
+  {
+    const std::string name = "rem-fold-a" + std::to_string(i);
+    const ASTNode a = c.mgr.CreateSymbol(name.c_str(), 0, width);
+    children.push_back(a);
+    children.push_back(c.hf->CreateTerm(
+        BVMULT, width, negDivisor,
+        c.hf->CreateTerm(SBVDIV, width, a, divisor)));
+  }
+
+  const ASTNode sum = c.nf->CreateTerm(BVPLUS, width, children);
+  c.roots.push_back(sum);
+
+  // Every pair became a remainder, so the sum has one operand per pair.
+  return sum.GetKind() == BVPLUS && sum.Degree() == pairs &&
+         sum[0].GetKind() == SBVREM;
+}
+
 bool flattenIdentityOk(Context& c, unsigned depth)
 {
   const ASTNode top = c.formula(c.chain(BVMULT, depth));
@@ -1763,6 +1798,12 @@ TEST(DeepDag, shallow_rewriting_rule_fires)
   EXPECT_TRUE(rewritingRuleFiresOk(c, SHALLOW));
 }
 
+TEST(DeepDag, shallow_remainder_folding)
+{
+  Context c;
+  EXPECT_TRUE(remainderFoldingOk(c, SHALLOW));
+}
+
 TEST(DeepDag, shallow_flatten)
 {
   Context c;
@@ -2597,6 +2638,11 @@ TEST(DeepDag, deep_flatten_kind_depth)
 TEST(DeepDag, deep_strength_reduction)
 {
   EXPECT_STACK_SAFE(strengthReductionOk, 20000);
+}
+
+TEST(DeepDag, deep_remainder_folding)
+{
+  EXPECT_STACK_SAFE(remainderFoldingOk, 20000);
 }
 
 TEST(DeepDag, deep_simplify)

--- a/tests/unit-tests/SimplifyingNodeFactory_Exhaustive_Test.cpp
+++ b/tests/unit-tests/SimplifyingNodeFactory_Exhaustive_Test.cpp
@@ -964,4 +964,171 @@ TEST(SimplifyingNodeFactory_Exhaustive, plus_cancels_negated_sum)
   }
 }
 
+/* a + (-b) * (a sdiv b) --> a srem b, and the unsigned pair, for a symbolic
+   divisor and for every constant one. */
+TEST(SimplifyingNodeFactory_Exhaustive, plus_of_division_product)
+{
+  const unsigned w = 4;
+  const struct
+  {
+    Kind div;
+    Kind rem;
+  } pairs[] = {{SBVDIV, SBVREM}, {BVDIV, BVMOD}};
+
+  for (const auto& p : pairs)
+  {
+    {
+      Context c;
+      ASTNode a = c.bv(w);
+      ASTNode b = c.bv(w);
+      ASTNode quot = c.hf->CreateTerm(p.div, w, a, b);
+      ASTNode negB = c.hf->CreateTerm(BVUMINUS, w, b);
+      // The multiplier's operands, and the sum's, in both orders.
+      for (const ASTVec& mulArgs :
+           {ASTVec{negB, quot}, ASTVec{quot, negB}})
+      {
+        ASTNode mult = c.hf->CreateTerm(BVMULT, w, mulArgs);
+        EXPECT_EQ(c.nf->CreateTerm(BVPLUS, w, a, mult),
+                  c.nf->CreateTerm(p.rem, w, a, b));
+        c.checkTerm(BVPLUS, w, {a, mult});
+        c.checkTerm(BVPLUS, w, {mult, a});
+      }
+    }
+
+    for (unsigned bv = 0; bv < (1u << w); bv++)
+    {
+      Context c;
+      ASTNode a = c.bv(w);
+      ASTNode b = c.konst(bv, w);
+      ASTNode negB = c.konst(((1u << w) - bv) & ((1u << w) - 1), w);
+      ASTNode quot = c.hf->CreateTerm(p.div, w, a, b);
+      ASTNode mult = c.hf->CreateTerm(BVMULT, w, negB, quot);
+      EXPECT_EQ(c.nf->CreateTerm(BVPLUS, w, a, mult),
+                c.nf->CreateTerm(p.rem, w, a, b));
+      c.checkTerm(BVPLUS, w, {a, mult});
+    }
+  }
+}
+
+/* The same sum written as a subtraction: a - b * (a sdiv b), which reaches
+   the rule as a plus of a negated product. */
+TEST(SimplifyingNodeFactory_Exhaustive, subtract_division_product)
+{
+  const unsigned w = 4;
+  Context c;
+  ASTNode a = c.bv(w);
+  ASTNode b = c.bv(w);
+
+  for (const auto& p : {std::make_pair(SBVDIV, SBVREM),
+                        std::make_pair(BVDIV, BVMOD)})
+  {
+    ASTNode quot = c.hf->CreateTerm(p.first, w, a, b);
+    for (const ASTVec& mulArgs : {ASTVec{b, quot}, ASTVec{quot, b}})
+    {
+      ASTNode mult = c.hf->CreateTerm(BVMULT, w, mulArgs);
+      EXPECT_EQ(c.nf->CreateTerm(BVSUB, w, a, mult),
+                c.nf->CreateTerm(p.second, w, a, b));
+      c.checkTerm(BVSUB, w, {a, mult});
+      c.checkTerm(BVPLUS, w, {a, c.hf->CreateTerm(BVUMINUS, w, mult)});
+    }
+  }
+}
+
+/* The pair is found wherever it sits in a wider sum. */
+TEST(SimplifyingNodeFactory_Exhaustive, plus_of_division_product_nary)
+{
+  const unsigned w = 4;
+  Context c;
+  ASTNode a = c.bv(w);
+  ASTNode b = c.bv(w);
+  ASTNode other = c.bv(w);
+  ASTNode quot = c.hf->CreateTerm(SBVDIV, w, a, b);
+  ASTNode mult =
+      c.hf->CreateTerm(BVMULT, w, c.hf->CreateTerm(BVUMINUS, w, b), quot);
+
+  ASTNode expected =
+      c.nf->CreateTerm(BVPLUS, w, c.nf->CreateTerm(SBVREM, w, a, b), other);
+  EXPECT_EQ(c.nf->CreateTerm(BVPLUS, w, {a, mult, other}), expected);
+  EXPECT_EQ(c.nf->CreateTerm(BVPLUS, w, {other, mult, a}), expected);
+  c.checkTerm(BVPLUS, w, {a, mult, other});
+  c.checkTerm(BVPLUS, w, {mult, other, a});
+}
+
+/* Near misses: the multiplier is not the negated divisor, the dividend is not
+   the other operand, or the quotient is signed where the sum is not. */
+TEST(SimplifyingNodeFactory_Exhaustive, plus_of_division_product_near_misses)
+{
+  const unsigned w = 4;
+  Context c;
+  ASTNode a = c.bv(w);
+  ASTNode b = c.bv(w);
+  ASTNode d = c.bv(w);
+  ASTNode quot = c.hf->CreateTerm(SBVDIV, w, a, b);
+  ASTNode negB = c.hf->CreateTerm(BVUMINUS, w, b);
+  ASTNode negD = c.hf->CreateTerm(BVUMINUS, w, d);
+
+  // Multiplied by the divisor rather than its negation.
+  c.checkTerm(BVPLUS, w, {a, c.hf->CreateTerm(BVMULT, w, b, quot)}, false);
+  // Multiplied by an unrelated negated term.
+  c.checkTerm(BVPLUS, w, {a, c.hf->CreateTerm(BVMULT, w, negD, quot)}, false);
+  // Added to something that is not the dividend.
+  c.checkTerm(BVPLUS, w, {d, c.hf->CreateTerm(BVMULT, w, negB, quot)}, false);
+  // Subtracted product, but of the negated divisor.
+  c.checkTerm(BVSUB, w, {a, c.hf->CreateTerm(BVMULT, w, negB, quot)}, false);
+}
+
+/* (x srem y) / y, (x smod y) / y and (x umod y) / y are zero away from a zero
+   divisor, where they take the total quotient of the dividend. */
+TEST(SimplifyingNodeFactory_Exhaustive, division_of_remainder)
+{
+  const unsigned w = 4;
+  const struct
+  {
+    Kind rem;
+    Kind div;
+  } pairs[] = {{SBVREM, SBVDIV}, {SBVMOD, SBVDIV}, {BVMOD, BVDIV}};
+
+  for (const auto& p : pairs)
+  {
+    {
+      Context c;
+      ASTNode a = c.bv(w);
+      ASTNode b = c.bv(w);
+      ASTNode rem = c.hf->CreateTerm(p.rem, w, a, b);
+      c.checkTerm(p.div, w, {rem, b});
+    }
+
+    for (unsigned bv = 0; bv < (1u << w); bv++)
+    {
+      Context c;
+      ASTNode a = c.bv(w);
+      ASTNode b = c.konst(bv, w);
+      ASTNode rem = c.hf->CreateTerm(p.rem, w, a, b);
+      c.checkTerm(p.div, w, {rem, b});
+      if (bv != 0)
+      {
+        EXPECT_EQ(c.nf->CreateTerm(p.div, w, rem, b), c.konst(0, w));
+      }
+    }
+  }
+}
+
+/* Near misses for the same: a remainder taken against a different divisor,
+   and a remainder of the wrong signedness for the division. */
+TEST(SimplifyingNodeFactory_Exhaustive, division_of_remainder_near_misses)
+{
+  const unsigned w = 4;
+  Context c;
+  ASTNode a = c.bv(w);
+  ASTNode b = c.bv(w);
+  ASTNode d = c.bv(w);
+
+  c.checkTerm(SBVDIV, w, {c.hf->CreateTerm(SBVREM, w, a, d), b}, false);
+  c.checkTerm(BVDIV, w, {c.hf->CreateTerm(BVMOD, w, a, d), b}, false);
+  // An unsigned remainder can exceed a signed divisor's magnitude, and a
+  // signed one can exceed an unsigned divisor's, so neither cross pair folds.
+  c.checkTerm(SBVDIV, w, {c.hf->CreateTerm(BVMOD, w, a, b), b}, false);
+  c.checkTerm(BVDIV, w, {c.hf->CreateTerm(SBVREM, w, a, b), b}, false);
+}
+
 } // namespace


### PR DESCRIPTION
A signed remainder frequently reaches STP written out as `a - (a sdiv b) * b` rather than as a `bvsrem`. Translation-validation front ends emit the three-instruction sequence because that is what the IR they are checking contains, and nothing in STP recognised the sum for what it was, so the bit-blaster built a divider for it and then another for the division sitting above it. On the LLVM identity `(x - (x sdiv 101) * 101) sdiv 101 == 0` at 64 bits that is the difference between **4m26s and 0.01s**.

Two rewrites, both in the simplifying node factory.

## Reconstructing the remainder

`a == (a / b) * b + (a rem b)` holds for **every** `a` and `b`, so `a + (-b) * (a / b)` *is* the remainder:

```
a + (-b) * (a sdiv b)  ->  a srem b
a + (-b) * (a udiv b)  ->  a urem b
```

The identity needs no side conditions, because SMT-LIB's division and remainder are total and agree on it everywhere — including `b = 0`, where `a sdiv 0` is `-1`/`1` and `a srem 0` is `a`, and including the most negative dividend with `b = -1`, where the quotient wraps to itself and the remainder is `0`. Both edge cases fall out of modular arithmetic rather than needing to be excluded, and both are covered by the exhaustive tests below. In particular **the divisor does not have to be a constant**, and the rule is not restricted by the sign of either operand.

`remainderFromDivision` (`lib/NodeFactory/SimplifyingNodeFactory.cpp:2022`) also takes the forms this arrives in:

- either operand order in the sum and in the multiplication — the binary `plusRules` is already called both ways round, so it only has to consider one;
- the subtracted spelling `a - b * (a sdiv b)`, which reaches the factory as a plus of a negated product, since `BVSUB` is rewritten to `BVPLUS`/`BVUMINUS` at creation;
- a matching pair sitting anywhere in a wider n-ary `BVPLUS` (`:2640`).

**The n-ary case folds every pair in one loop rather than rebuilding the sum around a single fold and re-entering the factory to find the next.** How many pairs a sum holds is chosen by whoever wrote the input and is independent of its *depth*, so re-entering would spend a stack frame each; flattening a long enough chain of these additions produces one sum wide enough to overflow. `deep_remainder_folding` in `DeepDag_Test.cpp` covers it on the bounded stack those tests run under, and fails if the fold is made to take one pair per call again. The loop terminates because each pass drops at least one operand, and it is a loop rather than a single pass because a fold can expose another — the remainder it builds can itself be the dividend of a product the sum already held.

The negated-divisor test is one comparison against `CreateTerm(BVUMINUS, width, divisor)` rather than three special cases: constants fold, and a double negation cancels, so a constant multiplier, a `BVUMINUS` one, and an already-negated divisor all reduce to the same check. It is guarded by `mightBeDivisionProduct` (`:2066`), two kind comparisons, so a plus that is not of this shape — which is essentially all of them — pays nothing and no throwaway node is interned.

**This rule is placed ahead of the existing chain in `plusRules` rather than appended to it.** The chain ends with rules that pull negations out of a sum, and one of them will otherwise claim the pair first.

## Folding the division above it

A remainder is smaller in magnitude than the divisor it was taken against, so it cannot contain it even once:

```
(x srem y) sdiv y  ->  0
(x smod y) sdiv y  ->  0
(x umod y) udiv y  ->  0
```

away from `y = 0`, where the remainder is `x` and the result is the total-division value of `x sdiv 0` / `x udiv 0`. For a symbolic divisor the rule emits that guard as an `ITE`; for a constant one it collapses to `0` or to the by-zero value directly. `bvsmod` joins `bvsrem` here because its magnitude is bounded the same way, even though it is *not* the remainder the first rule reconstructs (see below).

**These are checked before the rest of their chains, and that placement is load-bearing.** The power-of-two divisor rule immediately below rewrites the division to an extract, and once that has happened nothing downstream can see that its operand was a remainder — so appending the rule instead of prepending it would silently do nothing for exactly the constant divisors that matter most.

## Why this is a small rule in STP specifically

`SBVDIV`/`SBVREM` are first-class kinds all the way to bit-blasting — the signed-to-unsigned translation happens in `TranslateSignedDivModRem` (`lib/ToSat/BitBlaster.cpp:102`), called from `BBTerm` at `:1098`, and `Simplifier.cpp` passes the signed kinds through untouched. So the sum is still in its natural form when the node factory sees it, and the rule can match the pre-elimination shape directly. A solver that eliminated signed division during rewriting would have to match the post-elimination `ite`/`bvudiv` pattern instead, and could then only do it for a value divisor.

## Verification

Every figure below is measured against this branch's merge-base, `df58fb28`, built in **its own build tree** — the two builds must not share one, because `build/stp` is a thin driver whose `RUNPATH` points at `build/lib`, so a copied binary silently tracks whatever library is rebuilt later.

| query | `df58fb28` | this branch |
| --- | --- | --- |
| the Alive2 query below, 64-bit | **4m26.1s** | 0.01s |
| the same, narrowed to 24-bit | 12.5s | 0.01s |
| `(bvsdiv (bvadd x (bvmul -101 (bvsdiv x 101))) 101) != 0`, 64-bit | timeout (>2m) | 0.01s |
| `(bvsrem x y) != (bvadd x (bvmul (bvneg y) (bvsdiv x y)))`, 32-bit, symbolic divisor | timeout (>2m) | 0.01s |
| `(bvsgt (bvadd x (bvmul -101 (bvsdiv x 101))) 100)`, 32-bit | timeout (>2m) | 0.01s |
| `(bvsdiv (bvadd x (bvmul (bvneg y) (bvsdiv x y))) y) = 7`, 24-bit, symbolic divisor | timeout (>2m) | 0.01s |

The last three matter more than the headline: they are not the motivating benchmark, they include symbolic divisors and a use of the remainder that is a comparison rather than a division, and each is a timeout today.

`ctest` is **129/129**, including the two new deep-DAG cases. Six new tests in `SimplifyingNodeFactory_Exhaustive_Test.cpp` (`:969` onwards) check both rules and their near misses at width 4 over **every assignment of the free variables**, against the same node built through the hashing factory — for symbolic divisors and for all 16 constant ones, in every operand order, and in the subtracted and n-ary spellings. The near-miss tests pin the cases that must *not* fold: a multiplier that is the divisor rather than its negation, a dividend that is not the other addend, a remainder taken against a different divisor, and the signed/unsigned cross pairs, where an unsigned remainder can exceed a signed divisor's magnitude and vice versa.

Differential over `tests/query-files` between the two builds: **200 files answered, 0 verdict disagreements**.

`misc-tests/srem-from-sdiv-product.smt2` is the regression test. It is **deliberately narrowed to 24 bits**, where the un-rewritten form takes 12.5s rather than four and a half minutes: the lit configuration sets no per-test timeout, so a 64-bit version would hang CI rather than fail it if either rewrite stopped firing.

The motivating query, from LLVM translation validation with [Alive2](https://github.com/AliveToolkit/alive2) — the optimiser folds `(x - (x sdiv 101) * 101) sdiv 101` to `0`:

```smt2
(set-info :status unknown)
(declare-fun %p0 () (_ BitVec 64))
(declare-fun np_%p0 () Bool)
(declare-fun isundef_%p0 () (_ BitVec 1))
(assert
 (let ((?x26 (bvadd (bvmul (_ bv36893488147419103231 65) ((_ sign_extend 1) (bvmul (_ bv101 64) (bvsdiv %p0 (_ bv101 64))))) ((_ sign_extend 1) %p0))))
(let (($x20 (= (bvmul (_ bv101 128) ((_ sign_extend 64) (bvsdiv %p0 (_ bv101 64)))) ((_ sign_extend 64) (bvmul (_ bv101 64) (bvsdiv %p0 (_ bv101 64)))))))
(let (($x22 (and np_%p0 $x20)))
(let (($x33 (and (and np_%p0 $x22) (= ?x26 ((_ sign_extend 1) (bvadd %p0 (bvmul (_ bv18446744073709551515 64) (bvsdiv %p0 (_ bv101 64)))))))))
(let (($x39 (or (not $x33) (= (_ bv0 64) (bvsdiv (bvadd %p0 (bvmul (_ bv18446744073709551515 64) (bvsdiv %p0 (_ bv101 64)))) (_ bv101 64))))))
(let (($x41 (not $x39)))
(let (($x12 (= (_ bv0 1) isundef_%p0)))
(and $x12 $x41)))))))))
(check-sat)
```

## Deliberately not done

- **No `bvsmod` reconstruction rule.** `a - (a sdiv b) * b` is `bvsrem`, not `bvsmod`, and STP itself says so: asserting the two equal at 8 bits is `sat`. `bvsmod` rounds toward negative infinity, so it pairs with a division STP does not have a kind for. It appears in the *second* rule only, where all that is needed is the magnitude bound.
- **Sharing the divider between `BVDIV(x,y)` and `BVMOD(x,y)`.** `BBDivMod` computes quotient and remainder together and the caller throws one away, but `BBTermMemo` is keyed on the node and the two kinds are different nodes, so a query holding both blasts two full dividers. That would help this shape too — the reconstructed `bvsrem` and the surviving `bvsdiv` are exactly such a pair — but it is a bit-blaster change rather than a rewrite one and belongs in its own PR.
- **A `Rewriting.cpp` home for these.** Both rules are size-reducing and sharing-independent, which is the stated criterion for living in the node factory instead.
