### PR TITLE
Narrow an extract without the call stack

### DIFF
--- a/include/stp/NodeFactory/SimplifyingNodeFactory.h
+++ b/include/stp/NodeFactory/SimplifyingNodeFactory.h
@@ -100,6 +100,10 @@ private:
 
   ASTNode chaseRead(ASTChildren children, unsigned int width);
 
+  // Push an extract down through the operators it passes through, in a loop.
+  // Null if none of them applies.
+  ASTNode narrowExtract(unsigned width, ASTChildren children);
+
   ASTNode simplifyArrayEquality(const ASTNode& a, const ASTNode& b);
 
   ASTNode plusRules(const ASTNode& n0, const ASTNode& n1);

--- a/lib/NodeFactory/SimplifyingNodeFactory.cpp
+++ b/lib/NodeFactory/SimplifyingNodeFactory.cpp
@@ -2122,6 +2122,125 @@ bool SimplifyingNodeFactory::foldRemainders(ASTVec& children)
   return true;
 }
 
+// Push an extract down through the operators it can pass through, narrowing
+// the slice as it goes: an extract of a concat reaches only one half, one of
+// an extract composes into a single extract, one of a bvnot is the complement
+// of the extract underneath, and one of a sign extension either lands inside
+// the original term or is a run of copies of its sign bit.
+//
+// Each of those walks into a term that stays as deep as the input made it --
+// nothing collapses a concat chain, or a sign extension over one -- so the
+// walk is a loop here rather than a rebuild of the extract one level down
+// with the factory taking the next step. Re-entering would spend a stack
+// frame per level, and CreateTerm's frame is large enough that a few thousand
+// of them exhaust the stack.
+//
+// Returns null if the extract reaches none of these, so the caller can go on
+// to the rules that do not narrow it.
+ASTNode SimplifyingNodeFactory::narrowExtract(unsigned width,
+                                              ASTChildren children)
+{
+  ASTNode term = children[0];
+  unsigned high = children[1].GetUnsignedConst();
+  unsigned low = children[2].GetUnsignedConst();
+  // Complements cancel in pairs, so only their parity has to be carried.
+  bool complement = false;
+
+  // The sign-extension rebase below moves the slice without changing the
+  // term, so "did anything happen" has to watch the offsets too.
+  const unsigned firstHigh = high;
+  const unsigned firstLow = low;
+
+  for (bool stepped = true; stepped;)
+  {
+    stepped = true;
+
+    switch (term.GetKind())
+    {
+      case BVEXTRACT:
+      {
+        // Slicing a slice is one slice, taken from where the inner one began.
+        const unsigned innerLow = term[2].GetUnsignedConst();
+        high += innerLow;
+        low += innerLow;
+        term = term[0];
+        break;
+      }
+
+      case BVCONCAT:
+      {
+        // The lower value holds the bottom bits, so it is what the offsets
+        // are measured against. An extract that straddles the split needs
+        // both halves and stops the walk.
+        const unsigned lowerWidth = term[1].GetValueWidth();
+
+        if (high < lowerWidth)
+          term = term[1];
+        else if (low >= lowerWidth)
+        {
+          term = term[0];
+          high -= lowerWidth;
+          low -= lowerWidth;
+        }
+        else
+          stepped = false;
+        break;
+      }
+
+      case stp::BVNOT:
+        complement = !complement;
+        term = term[0];
+        break;
+
+      case BVUMINUS:
+        // Negating cannot change the bottom bit: it is the only one with no
+        // borrow below it.
+        if (high == 0 && low == 0)
+          term = term[0];
+        else
+          stepped = false;
+        break;
+
+      case stp::BVSX:
+      {
+        const unsigned innerWidth = term[0].GetValueWidth();
+
+        if (low >= innerWidth)
+        {
+          // Entirely within the extension: every extracted bit is a copy of
+          // the sign bit, so rebase the extract to end at the sign bit.
+          // Extracts of different slices of the extension then share a node.
+          // The rebase leaves `low` at the sign bit, so it does not repeat.
+          high = high - low + innerWidth - 1;
+          low = innerWidth - 1;
+        }
+        else if (high < innerWidth)
+          term = term[0]; // Entirely within the original term.
+        else
+          stepped = false;
+        break;
+      }
+
+      default:
+        stepped = false;
+        break;
+    }
+  }
+
+  if (term == children[0] && high == firstHigh && low == firstLow &&
+      !complement)
+    return ASTNode(); // Nothing here narrows it.
+
+  const ASTNode slice =
+      (low == 0 && width == term.GetValueWidth())
+          ? term
+          : NodeFactory::CreateTerm(BVEXTRACT, width, term,
+                                    bm.CreateBVConst(32, high),
+                                    bm.CreateBVConst(32, low));
+
+  return complement ? NodeFactory::CreateTerm(stp::BVNOT, width, slice) : slice;
+}
+
 // This gets called with the arguments swapped as well. So the rules don't need
 // to know about commutivity.
 ASTNode SimplifyingNodeFactory::plusRules(const ASTNode& n0, const ASTNode& n1)
@@ -3377,80 +3496,8 @@ ASTNode SimplifyingNodeFactory::CreateTerm(Kind kind, unsigned int width,
     case BVEXTRACT:
       if (width == children[0].GetValueWidth())
         result = children[0];
-      else if (BVEXTRACT ==
-               children[0].GetKind()) // reduce an extract over an extract.
-      {
-        const unsigned outerLow = children[2].GetUnsignedConst();
-        const unsigned outerHigh = children[1].GetUnsignedConst();
-
-        const unsigned innerLow = children[0][2].GetUnsignedConst();
-        // const unsigned innerHigh = children[0][1].GetUnsignedConst();
-        result =
-            NodeFactory::CreateTerm(BVEXTRACT, width, children[0][0],
-                                    bm.CreateBVConst(32, outerHigh + innerLow),
-                                    bm.CreateBVConst(32, outerLow + innerLow));
-      }
-      else if (BVCONCAT == children[0].GetKind())
-      {
-        // If the extract doesn't cross the concat, then remove the concat.
-        const ASTNode& a = children[0][0];
-        const ASTNode& b = children[0][1];
-
-        const unsigned low = children[2].GetUnsignedConst();
-        const unsigned high = children[1].GetUnsignedConst();
-
-        if (high <
-            b.GetValueWidth()) // Extract entirely from the lower value (b).
-        {
-          result = NodeFactory::CreateTerm(BVEXTRACT, width, b, children[1],
-                                           children[2]);
-        }
-        if (low >=
-            b.GetValueWidth()) // Extract entirely from the upper value (a).
-        {
-          ASTNode i = bm.CreateBVConst(32, high - b.GetValueWidth());
-          ASTNode j = bm.CreateBVConst(32, low - b.GetValueWidth());
-          result = NodeFactory::CreateTerm(BVEXTRACT, width, a, i, j);
-        }
-      }
-      else if (BVUMINUS == children[0].GetKind() &&
-               children[1] == bm.CreateZeroConst(children[1].GetValueWidth()) &&
-               children[2] == bm.CreateZeroConst(children[2].GetValueWidth()))
-      {
-        result = NodeFactory::CreateTerm(BVEXTRACT, width, children[0][0],
-                                         children[1], children[2]);
-      }
-      else if (stp::BVNOT == children[0].GetKind())
-      {
-        // pull the bvnot above the extract.
-        result = NodeFactory::CreateTerm(
-            stp::BVNOT, width,
-            NodeFactory::CreateTerm(BVEXTRACT, width, children[0][0],
-                                    children[1], children[2]));
-      }
-      else if (stp::BVSX == children[0].GetKind())
-      {
-        const unsigned innerWidth = children[0][0].GetValueWidth();
-        const unsigned high = children[1].GetUnsignedConst();
-        const unsigned low = children[2].GetUnsignedConst();
-
-        if (low >= innerWidth)
-        {
-          // Entirely within the extension: every extracted bit is a copy of
-          // the sign bit, so rebase the extract to end at the sign bit.
-          // Extracts of different slices of the extension then share a node.
-          result = NodeFactory::CreateTerm(
-              BVEXTRACT, width, children[0],
-              bm.CreateBVConst(32, high - low + innerWidth - 1),
-              bm.CreateBVConst(32, innerWidth - 1));
-        }
-        else if (high < innerWidth)
-        {
-          // Entirely within the original term: the extension is irrelevant.
-          result = NodeFactory::CreateTerm(BVEXTRACT, width, children[0][0],
-                                           children[1], children[2]);
-        }
-      }
+      else if (ASTNode narrowed = narrowExtract(width, children); !narrowed.IsNull())
+        result = narrowed;
       else if (stp::BVMULT == children[0].GetKind() &&
                children[0].Degree() == 2 &&
                (children[0][0].GetKind() == stp::BVCONST ||

--- a/tests/unit-tests/DeepDag_Test.cpp
+++ b/tests/unit-tests/DeepDag_Test.cpp
@@ -385,6 +385,55 @@ bool flattenShareCountOk(Context& c, unsigned depth)
 // observed crash path -- but --flatten puts it back. BVMULT is not a
 // flattenable kind, which keeps this a test of the traversal rather than
 // of flattening.
+// The extract-over-concat rule in the simplifying factory, which drops the
+// halves of a concat the extract does not reach into. A concat chain is a
+// normal form, so it stays as deep as the input made it, and an extract of
+// the far end has to walk the whole thing.
+//
+// Built with the simplifying factory rather than the hashing one: the rule
+// under test is the factory's, and it fires as the extract is created. The
+// chain itself is hash-consed either way -- no rule rewrites a concat of
+// distinct symbols -- so `nf` still produces the deep chain this needs.
+bool extractOverConcatOk(Context& c, unsigned links)
+{
+  const unsigned piece = 8;
+
+  // Symbols rather than constants: a concat of constants is folded on
+  // creation, so a chain built from them would collapse as it was built and
+  // there would be no depth here to walk.
+  const ASTNode chainTail = c.mgr.CreateSymbol("extract-concat-tail", 0, piece);
+  ASTNode chain = chainTail;
+
+  // One symbol serves every link. What makes each concat a distinct node is
+  // its right operand, which is a longer chain at each turn, so the left
+  // operands do not have to differ -- unlike the xor and multiply chains
+  // above, where a repeated symbol would cancel the depth away.
+  const ASTNode link = c.mgr.CreateSymbol("extract-concat-link", 0, piece);
+
+  for (unsigned i = 0; i < links; i++)
+    chain = c.nf->CreateTerm(BVCONCAT, chain.GetValueWidth() + piece, link,
+                             chain);
+  c.roots.push_back(chain);
+
+  // Every link still contributes its bits, so the walk below really is over
+  // that many of them. Without this the test goes on passing if some later
+  // rule flattens the chain, while no longer testing anything.
+  if (chain.GetValueWidth() != piece * (links + 1))
+    return false;
+
+  // The bottom byte is the tail, at the far end of the chain, so the walk
+  // has to have descended through every link to reach it. The tail is a
+  // different symbol from the links precisely so that this can say which
+  // one the extract landed on rather than merely that it landed on some
+  // symbol.
+  const ASTNode extract =
+      c.nf->CreateTerm(BVEXTRACT, piece, chain, c.mgr.CreateBVConst(32, 7),
+                       c.mgr.CreateBVConst(32, 0));
+  c.roots.push_back(extract);
+
+  return extract == chainTail;
+}
+
 // The remainder reconstruction in the simplifying factory, which pairs a
 // dividend with the "- b * (a / b)" product beside it in a sum. The pairs are
 // independent of each other, so the number of them is chosen by the input,
@@ -1798,6 +1847,12 @@ TEST(DeepDag, shallow_rewriting_rule_fires)
   EXPECT_TRUE(rewritingRuleFiresOk(c, SHALLOW));
 }
 
+TEST(DeepDag, shallow_extract_over_concat)
+{
+  Context c;
+  EXPECT_TRUE(extractOverConcatOk(c, SHALLOW));
+}
+
 TEST(DeepDag, shallow_remainder_folding)
 {
   Context c;
@@ -2638,6 +2693,11 @@ TEST(DeepDag, deep_flatten_kind_depth)
 TEST(DeepDag, deep_strength_reduction)
 {
   EXPECT_STACK_SAFE(strengthReductionOk, 20000);
+}
+
+TEST(DeepDag, deep_extract_over_concat)
+{
+  EXPECT_STACK_SAFE(extractOverConcatOk, 20000);
 }
 
 TEST(DeepDag, deep_remainder_folding)

--- a/tests/unit-tests/SimplifyingNodeFactory_Exhaustive_Test.cpp
+++ b/tests/unit-tests/SimplifyingNodeFactory_Exhaustive_Test.cpp
@@ -1131,4 +1131,42 @@ TEST(SimplifyingNodeFactory_Exhaustive, division_of_remainder_near_misses)
   c.checkTerm(BVDIV, w, {c.hf->CreateTerm(SBVREM, w, a, b), b}, false);
 }
 
+/* An extract narrows through a whole stack of operators at once, not just the
+   one immediately beneath it: every slice of a term built from concats, sign
+   extensions, complements and nested extracts must mean what it meant before
+   the pushes, at every assignment and for every slice. */
+TEST(SimplifyingNodeFactory_Exhaustive, extract_narrows_through_a_stack)
+{
+  Context c;
+  ASTNode x = c.bv(2);
+  ASTNode y = c.bv(2);
+
+  // (~(sx(x, 4) ++ y))[hi:lo], and the same under an outer extract, so the
+  // walk crosses concat, bvnot, bvsx and extract in one go.
+  ASTNode sx = c.hf->CreateTerm(BVSX, 4, x, c.konst(4, 32));
+  ASTNode cat = c.hf->CreateTerm(BVCONCAT, 6, sx, y);
+  ASTNode nt = c.hf->CreateTerm(BVNOT, 6, cat);
+  ASTNode neg = c.hf->CreateTerm(BVUMINUS, 6, nt);
+
+  for (const ASTNode& base : {cat, nt, neg})
+  {
+    for (unsigned hi = 0; hi < 6; hi++)
+    {
+      for (unsigned lo = 0; lo <= hi; lo++)
+      {
+        // Every slice, whichever side of the concat it falls on and whether
+        // or not it straddles the split.
+        c.checkTerm(BVEXTRACT, hi - lo + 1,
+                    {base, c.konst(hi, 32), c.konst(lo, 32)}, false);
+
+        // The same slice reached through an outer extract of an inner one.
+        ASTNode inner = c.hf->CreateTerm(BVEXTRACT, hi + 1, base,
+                                         c.konst(hi, 32), c.konst(0, 32));
+        c.checkTerm(BVEXTRACT, hi - lo + 1,
+                    {inner, c.konst(hi - lo, 32), c.konst(0, 32)}, false);
+      }
+    }
+  }
+}
+
 } // namespace


### PR DESCRIPTION
An extract of the far end of a chain of 20,000 concats segfaults STP, on master today:

```smt2
(assert (= (_ bv0 8) ((_ extract 7 0) (concat x0 (concat x1 (... (concat x19999 y)))))))
```

This is the sibling of what #815 fixed. That one found `CreateSimpleEQ` recursing once per concat level and left a comment saying so — *"A concat can itself be one of those parts, so the old pair of `CreateNode(EQ, ...)` calls made this recurse once per concat level"*. The extract rules a few hundred lines further down walk the same chains the same way, through `CreateTerm(BVEXTRACT, ...)` rather than `CreateNode(EQ, ...)`, and were not looked at.

## What recurses

An extract pushes down through four operators, each rule rebuilding the extract one level lower and leaving the factory to take the next step:

| under the extract | what the rule does |
| --- | --- |
| `BVCONCAT` | the slice reaches only one half, so drop the other |
| `BVEXTRACT` | slicing a slice is one slice, taken from where the inner one began |
| `BVNOT` | the slice of a complement is the complement of the slice |
| `BVSX` | the slice is inside the original term, or is a run of copies of its sign bit |

None of the terms being walked collapses. A concat chain is a normal form, and so is a sign extension or a complement over one — nothing rewrites them away, so they stay exactly as deep as the input made them. That is what makes this a stack overflow rather than a slow path: **the depth belongs to whoever wrote the query**.

`narrowExtract` (`lib/NodeFactory/SimplifyingNodeFactory.cpp:2140`) walks the term in a loop instead, narrowing the slice as it goes. Complements are carried as a parity rather than applied per level, since they cancel in pairs.

## Fixing only the concat branch makes a different query worse

Worth spelling out, because it is the reason this touches all four rules rather than just the one with a reproducer.

`SimplifyingNodeFactory::CreateTerm` is one enormous switch, and its stack frame is over 300 bytes. **Every recursive path through the factory pays that frame**, including ones that have nothing to do with the rule being edited. Adding three locals to it moved a cliff elsewhere:

| | `CreateTerm` frame | concat chain | `bvnot`/`concat` alternation |
| --- | --- | --- | --- |
| master | `sub $0x148` = 328 B | **segfaults at 20,000** | survives 8,000, segfaults at 9,000 |
| concat branch only | `sub $0x158` = 344 B | fine at 100,000 | **segfaults at 8,000** |
| this PR | `sub $0x158` = 344 B | fine at 100,000 | fine at 100,000 |

So a fix that only handled the branch I had a reproducer for would have traded one overflow for a slightly worse one — `(bvnot (concat z0 (bvnot (concat z1 ...))))` alternates the two rules and recurses through both. The lesson generalises: *"the remaining recursive paths have enough headroom"* is a fact about today's frame layout, not a property of the code, so the fix is to remove the recursion rather than to measure the margin.

## The trap in the rewrite, since the next person will hit it

The sign-extension rebase — *"entirely within the extension: every extracted bit is a copy of the sign bit"* — moves the **slice** without changing the **term**. A loop that decides whether anything happened by comparing the term alone silently drops that rewrite and the rule stops firing. `extract_over_sx` catches it immediately, which is what that assertion is for; the check watches the offsets as well, and says why.

## Verification

Both reproducers run at **100,000 levels** where master segfaults:

| input | master | this PR |
| --- | --- | --- |
| extract of a 100,000-link concat chain | segfault | ok |
| extract of a 100,000-deep `bvnot`/`concat` alternation | segfault | ok |

`ctest` is **129/129**, including 111 deep-DAG cases and 54 exhaustive node-factory ones.

Two new tests, and I checked that the first of them actually catches this rather than assuming it — with the old rule restored, `deep_extract_over_concat` fails and its shallow control still passes:

- `deep_extract_over_concat` / `shallow_extract_over_concat` (`DeepDag_Test.cpp:397`) run the walk on the bounded stack that file's harness sets, so a pass means "does not use the stack for depth" rather than "this machine had room". It builds through the **simplifying** factory, since the rule under test is the factory's and fires as the extract is created — the same shape as `deep_concat_equality` from #815.
- `extract_narrows_through_a_stack` (`SimplifyingNodeFactory_Exhaustive_Test.cpp:1138`) takes a term built from all four operators at once and checks **every** slice of it, and each slice reached through an outer extract, over **every** assignment of the free variables, against the same slice taken before the pushes.

Two differentials against `c4b81ce8` built in its own tree — the two builds must not share one, since `build/stp` is a thin driver whose `RUNPATH` points at `build/lib`, so a copied binary tracks whatever library is rebuilt later:

- `tests/query-files`: **200 files answered, 0 verdict disagreements**;
- **400 randomly generated extract-heavy queries** (nested concat / extract / sign-extend / complement / multiply-by-a-power-of-two at widths 4-8, sliced at a random range): **0 disagreements**.

## Deliberately not done

- **`BVMULT` by a power of two stays outside the loop.** It is the one extract push that *builds* a term rather than just moving the slice — it rewrites the multiply as a concat with zeroes and extracts from that — so it stays a terminal step. It cannot chain, because constant multipliers fold together, but I have not stress-tested it and am not claiming it.
- **The passes have not been re-audited for this shape.** #806-#818 covered them for *traversal* recursion, which is a different question from a rewrite rule re-entering its own kind. The factory is where both known instances of this shape were, so that is what I enumerated: ~46 sites where a rule creates the kind it is handling, of which all but this family are bounded, because bottom-up construction means the operand is already in normal form.
