### PR TITLE
Make common sub-sum extraction linear in what actually changes

### DIFF
--- a/include/stp/Simplifier/CommonSubSum.h
+++ b/include/stp/Simplifier/CommonSubSum.h
@@ -46,6 +46,7 @@ THE SOFTWARE.
 #ifndef COMMONSUBSUM_H_
 #define COMMONSUBSUM_H_
 
+#include "extlib-unordered-dense/ankerl/unordered_dense.h"
 #include "stp/AST/AST.h"
 #include "stp/STPManager/STPManager.h"
 #include <map>
@@ -70,7 +71,42 @@ class CommonSubSum
   std::map<uint64_t, ASTVec> operands;
   std::map<uint64_t, ASTNode> byNum;
 
+  typedef std::pair<uint64_t, uint64_t> NodePair;
+
+  // Node numbers are allocated densely from zero, so the raw pair has almost
+  // no entropy in its high bits. One multiply-xor spreads it over the whole
+  // word, which is what 'is_avalanching' promises the table.
+  struct PairHash
+  {
+    using is_avalanching = void;
+    uint64_t operator()(const NodePair& p) const noexcept
+    {
+      return ankerl::unordered_dense::detail::wyhash::mix(
+          p.first + UINT64_C(0x9E3779B97F4A7C15), p.second);
+    }
+  };
+
+  // How many of the additions hold each pair of operands. Only the tally is
+  // kept: the additions holding the winning pair are recovered by a scan,
+  // which is far cheaper than a list of them hanging off every pair. The
+  // table is patched as additions change rather than rebuilt each round.
+  ankerl::unordered_dense::map<NodePair, uint32_t, PairHash> occurrences;
+
+  // Operands worth pairing. A pair can only be shared by two additions if
+  // each of its operands is, so an operand that starts out in one addition
+  // can be left out of the enumeration entirely -- which on a query whose
+  // additions share nothing is all of them.
+  ankerl::unordered_dense::set<uint64_t> shareable;
+
   void collect(const ASTNode& n, ASTNodeSet& seen, ASTVec& plusNodes);
+  void markShareable();
+  void eligibleOf(const ASTVec& v, std::vector<uint64_t>& out) const;
+  bool bump(uint64_t a, uint64_t b);
+  void drop(uint64_t a, uint64_t b);
+  bool addPairs(const ASTVec& v);
+  bool repair(const ASTVec& before, const ASTVec& after);
+  bool promote(const ASTNode& n);
+  bool buildOccurrences();
   bool extractOnePair();
   ASTNode rebuild(const ASTNode& n, const std::map<uint64_t, ASTVec>& changed,
                   ASTNodeMap& cache);

--- a/lib/Simplifier/CommonSubSum.cpp
+++ b/lib/Simplifier/CommonSubSum.cpp
@@ -23,15 +23,17 @@ THE SOFTWARE.
 
 #include "stp/Simplifier/CommonSubSum.h"
 #include <algorithm>
-#include <set>
+#include <cassert>
 
 namespace stp
 {
 namespace
 {
-// Stop enumerating pairs once a round would visit this many, so a query with
-// very wide additions can't make the search quadratically expensive.
-const long PAIR_VISIT_LIMIT = 40000000;
+// Give up once the tally holds this many pairs, so a query with very wide
+// additions can't make the search quadratically expensive. An entry costs
+// about thirty bytes, so this is a cap of roughly a hundred megabytes -- the
+// bound is written in the units that actually run out.
+const size_t PAIR_ENTRY_LIMIT = 4000000;
 
 // Each round removes at least one adder, so this only bounds pathological
 // inputs, not ordinary ones.
@@ -60,52 +62,195 @@ void CommonSubSum::collect(const ASTNode& n, ASTNodeSet& seen,
   }
 }
 
-// Finds the operand pair shared by the most additions and pulls it out into
-// its own node. Returns false once no pair is shared, or a guard fires.
-bool CommonSubSum::extractOnePair()
+// Which operands are worth enumerating pairs of. An addition never gains an
+// operand it didn't start with -- a substitution only removes two and adds
+// the node built from them -- so an operand in one addition now is in one
+// addition for the rest of the pass, and no pair it belongs to can ever be
+// shared. Deciding this once is exact and costs a single walk.
+void CommonSubSum::markShareable()
 {
-  std::map<std::pair<uint64_t, uint64_t>, std::vector<uint64_t>> occurrences;
+  ankerl::unordered_dense::map<uint64_t, uint32_t> holders;
 
-  long visited = 0;
   for (const auto& sum : operands)
   {
     const ASTVec& v = sum.second;
 
     // A two-operand addition already *is* its own pair; extracting from it
-    // would leave a one-child BVPLUS that rebuilds to itself.
+    // would leave a one-child BVPLUS that rebuilds to itself. It is not a
+    // holder, because pairs are never enumerated over it.
     if (v.size() < 3)
       continue;
 
-    visited += (long)v.size() * (long)v.size();
-    if (visited > PAIR_VISIT_LIMIT)
-    {
-      truncated = true;
-      return false;
-    }
-
-    // Record each distinct pair once per addition. An operand repeated k
-    // times yields the same pair C(k,2) times, and counting those
-    // separately would both overstate the sharing and, worse, make the
-    // substitution below run repeatedly on one addition -- after the first
-    // pass its operands are gone, so the later passes would add the shared
-    // node without removing anything and change the addition's value.
-    std::set<std::pair<uint64_t, uint64_t>> pairsHere;
     for (size_t i = 0; i < v.size(); i++)
-      for (size_t j = i + 1; j < v.size(); j++)
-      {
-        const std::pair<uint64_t, uint64_t> key(v[i].GetNodeNum(),
-                                                v[j].GetNodeNum());
-        if (pairsHere.insert(key).second)
-          occurrences[key].push_back(sum.first);
-      }
+      if (i == 0 || v[i] != v[i - 1])
+        holders[v[i].GetNodeNum()]++;
   }
 
-  size_t best = 0;
-  std::pair<uint64_t, uint64_t> bestPair;
+  for (const auto& h : holders)
+    if (h.second >= 2)
+      shareable.insert(h.first);
+}
+
+// The operands of one addition that pairs are enumerated over: sorted, with
+// each repeat and each operand not worth pairing dropped.
+//
+// The list is already sorted by node number, so an operand repeated k times
+// sits in one run and taking each run once records every distinct pair once.
+// Counting the C(k,2) copies separately would both overstate the sharing
+// and, worse, make the substitution run repeatedly on one addition -- after
+// the first pass its operands are gone, so the later passes would add the
+// shared node without removing anything and change the addition's value.
+void CommonSubSum::eligibleOf(const ASTVec& v, std::vector<uint64_t>& out) const
+{
+  out.clear();
+
+  // A two-operand addition already *is* its own pair; extracting from it
+  // would leave a one-child BVPLUS that rebuilds to itself.
+  if (v.size() < 3)
+    return;
+
+  for (size_t i = 0; i < v.size(); i++)
+  {
+    if (i > 0 && v[i] == v[i - 1])
+      continue;
+    const uint64_t num = v[i].GetNodeNum();
+    if (shareable.count(num) != 0)
+      out.push_back(num);
+  }
+}
+
+bool CommonSubSum::bump(uint64_t a, uint64_t b)
+{
+  const NodePair key = (a < b) ? NodePair(a, b) : NodePair(b, a);
+
+  // Checked only at the cap, so the ordinary path pays one lookup, not two.
+  if (occurrences.size() >= PAIR_ENTRY_LIMIT &&
+      occurrences.find(key) == occurrences.end())
+    return false;
+
+  occurrences[key]++;
+  return true;
+}
+
+void CommonSubSum::drop(uint64_t a, uint64_t b)
+{
+  const NodePair key = (a < b) ? NodePair(a, b) : NodePair(b, a);
+  const auto it = occurrences.find(key);
+
+  assert(it != occurrences.end() && it->second > 0);
+  if (it != occurrences.end() && --it->second == 0)
+    occurrences.erase(it);
+}
+
+// One addition's whole contribution to the tally.
+bool CommonSubSum::addPairs(const ASTVec& v)
+{
+  std::vector<uint64_t> eligible;
+  eligibleOf(v, eligible);
+
+  for (size_t i = 0; i < eligible.size(); i++)
+    for (size_t j = i + 1; j < eligible.size(); j++)
+      if (!bump(eligible[i], eligible[j]))
+        return false;
+
+  return true;
+}
+
+// Moves the tally from one addition's operand list to its replacement.
+//
+// A substitution takes two operands out and puts one in, so all but a
+// handful of the addition's pairs are the same on both sides and only the
+// ones touching a departing or arriving operand need touching. Removing the
+// old list's pairs and adding the new list's would be quadratic in the
+// addition's width for a change that is linear in it -- which is what made a
+// query of overlapping sums quadratic in the number of rounds.
+bool CommonSubSum::repair(const ASTVec& before, const ASTVec& after)
+{
+  std::vector<uint64_t> was, now, gone, arrived, kept;
+  eligibleOf(before, was);
+  eligibleOf(after, now);
+
+  std::set_difference(was.begin(), was.end(), now.begin(), now.end(),
+                      std::back_inserter(gone));
+  std::set_difference(now.begin(), now.end(), was.begin(), was.end(),
+                      std::back_inserter(arrived));
+  std::set_intersection(was.begin(), was.end(), now.begin(), now.end(),
+                        std::back_inserter(kept));
+
+  // A pair of one departing and one arriving operand is in neither list's
+  // pair set, so it needs nothing.
+  for (size_t i = 0; i < gone.size(); i++)
+  {
+    for (size_t j = i + 1; j < gone.size(); j++)
+      drop(gone[i], gone[j]);
+    for (const uint64_t k : kept)
+      drop(gone[i], k);
+  }
+
+  for (size_t i = 0; i < arrived.size(); i++)
+  {
+    for (size_t j = i + 1; j < arrived.size(); j++)
+      if (!bump(arrived[i], arrived[j]))
+        return false;
+    for (const uint64_t k : kept)
+      if (!bump(arrived[i], k))
+        return false;
+  }
+
+  return true;
+}
+
+// A node this pass builds can turn out, through hash-consing, to be an
+// operand the query already had and that wasn't worth pairing. Making it
+// eligible now leaves every addition already holding it short of the pairs
+// it forms there, so those are added before anything reads the tally again.
+bool CommonSubSum::promote(const ASTNode& n)
+{
+  const uint64_t num = n.GetNodeNum();
+  if (!shareable.insert(num).second)
+    return true;
+
+  std::vector<uint64_t> eligible;
+  for (const auto& sum : operands)
+  {
+    const ASTVec& v = sum.second;
+    if (!std::binary_search(v.begin(), v.end(), n, byNodeNum))
+      continue;
+
+    eligibleOf(v, eligible);
+    for (const uint64_t other : eligible)
+      if (other != num && !bump(num, other))
+        return false;
+  }
+
+  return true;
+}
+
+// The tally over every addition, built once. Later rounds patch it.
+bool CommonSubSum::buildOccurrences()
+{
+  for (const auto& sum : operands)
+    if (!addPairs(sum.second))
+      return false;
+
+  return true;
+}
+
+// Finds the operand pair shared by the most additions and pulls it out into
+// its own node. Returns false once no pair is shared, or a guard fires.
+bool CommonSubSum::extractOnePair()
+{
+  // Ties go to the lowest-numbered pair. The tally is a hash table, so
+  // without that the choice -- and with it the formula handed to the
+  // bit-blaster -- would depend on the table's layout.
+  uint32_t best = 0;
+  NodePair bestPair(0, 0);
   for (const auto& entry : occurrences)
-    if (entry.second.size() > best)
+    if (entry.second >= 2 &&
+        (entry.second > best ||
+         (entry.second == best && entry.first < bestPair)))
     {
-      best = entry.second.size();
+      best = entry.second;
       bestPair = entry.first;
     }
 
@@ -119,7 +264,23 @@ bool CommonSubSum::extractOnePair()
       nf->CreateTerm(BVPLUS, first.GetValueWidth(), first, second);
   byNum[shared.GetNodeNum()] = shared;
 
-  const std::vector<uint64_t> hits = occurrences[bestPair];
+  // Before any operand list moves, so that the two stay in step.
+  if (!promote(shared))
+  {
+    truncated = true;
+    return false;
+  }
+
+  std::vector<uint64_t> hits;
+  for (const auto& sum : operands)
+  {
+    const ASTVec& v = sum.second;
+    if (v.size() >= 3 &&
+        std::binary_search(v.begin(), v.end(), first, byNodeNum) &&
+        std::binary_search(v.begin(), v.end(), second, byNodeNum))
+      hits.push_back(sum.first);
+  }
+
   long applied = 0;
   for (uint64_t sum : hits)
   {
@@ -147,15 +308,24 @@ bool CommonSubSum::extractOnePair()
 
     scratch.push_back(shared);
     std::sort(scratch.begin(), scratch.end(), byNodeNum);
+
+    // Only this addition's pairs moved, so only this addition's contribution
+    // is patched; every other pair's tally is still right.
+    const bool room = repair(v, scratch);
     v.swap(scratch);
     applied++;
+    if (!room)
+    {
+      truncated = true;
+      break;
+    }
   }
 
   if (applied < 2)
     return false;
 
   saved += applied - 1;
-  return true;
+  return !truncated;
 }
 
 // Rebuilds the DAG with the new operand lists. A replacement's children are
@@ -216,6 +386,8 @@ ASTNode CommonSubSum::topLevel(const ASTNode& n)
   truncated = false;
   operands.clear();
   byNum.clear();
+  occurrences.clear();
+  shareable.clear();
 
   ASTNodeSet seen;
   ASTVec plusNodes;
@@ -234,8 +406,22 @@ ASTNode CommonSubSum::topLevel(const ASTNode& n)
         byNum[k.GetNodeNum()] = k;
     }
 
-    for (long round = 0; round < ROUND_LIMIT && extractOnePair(); round++)
-      ;
+    markShareable();
+
+    if (!buildOccurrences())
+      truncated = true;
+    else
+    {
+      long round = 0;
+      for (; round < ROUND_LIMIT && extractOnePair(); round++)
+        ;
+
+      // Rounds are what bounds the greedy loop, not what it converges on:
+      // exhausting them leaves shared pairs behind just as the size guard
+      // does, so say so rather than report a fixed point.
+      if (round == ROUND_LIMIT)
+        truncated = true;
+    }
 
     if (saved > 0)
     {
@@ -261,6 +447,8 @@ ASTNode CommonSubSum::topLevel(const ASTNode& n)
 
   operands.clear();
   byNum.clear();
+  occurrences.clear();
+  shareable.clear();
 
   stpMgr->GetRunTimes()->stop(RunTimes::CommonSubSum);
   return result;


### PR DESCRIPTION
`CommonSubSum` materialised **every unordered pair of operands of every n-ary `BVPLUS`** into a `std::map<pair<uint64,uint64>, vector<uint64>>`, and rebuilt that map from scratch on **every round** of the greedy loop. Peak memory and running time were both quadratic in the arity of the widest addition, bounded only by a guard counting "visits" — which permits about twenty million map entries, measured at roughly a hundred bytes each.

Two symptoms, from the same design:

- Two 4-bit additions of 6000 operands each, sharing nothing, cost **2.2 GB and 10 s** to establish there was nothing to extract (`Adders saved:0`).
- 298 prefix sums over 300 variables spent **96.9 s** in the pass, against 0.46 s for the whole query with it switched off.

Neither shows up on the QF_BV sets we usually run — the worst stage memory growth over a 259-file set of queries taking more than ten seconds was 16 MB — so this is a tail problem rather than a regression. Flattening is what manufactures the wide flat additions that trigger it.

## The tally

- **Operands are prefiltered by how many additions hold them.** A pair can only be shared by two additions if each of its operands is, and an addition only ever *loses* operands — a substitution removes two and adds the node built from them — so an operand in one addition now is in one addition for the rest of the pass. Deciding this once is exact, and stable, which is what lets a pair set be removed later using the same predicate it was added with. On a query whose additions share nothing it excludes every operand and the enumeration disappears.
- **Only the count is stored.** The additions holding the winning pair are recovered by one scan, which costs far less than a list of them hanging off every pair.
- **Repeated operands are skipped by their adjacency** in the already-sorted operand list, rather than by a per-addition `std::set` of every pair seen so far.
- **The table is `ankerl::unordered_dense`** rather than `std::map`, with an explicit lowest-pair tie-break so the chosen pair — and with it the formula handed to the bit-blaster — doesn't depend on the table's layout.

## How it is maintained

A substitution takes two operands out of an addition and puts one in, so all but a handful of that addition's pairs are the same on both sides. With `R` the eligible operands that left, `A` those that arrived and `C` those that stayed, the patch removes the pairs within `R` and `R×C` and adds those within `A` and `A×C`; pairs spanning `R` and `A` are in neither side's set and need nothing. `|R| ≤ 2` and `|A| ≤ 1`, so a round is linear in the addition's width where rebuilding was quadratic. Working from set differences rather than from the two named operands is also what keeps it right when an operand is repeated in the addition.

Rebuilding only the *changed* additions, rather than all of them, is not enough on its own: that intermediate form still recounts `O(k²)` pairs for an `O(k)` change, and got the prefix-sum query from 96.9 s only to 62.4 s, with `perf` putting 98.9% of the run in that recount.

One node can become newly eligible mid-run: the one the pass builds, which hash-consing can make a node the query already had and that wasn't worth pairing. Every addition already holding it is then short of the pairs it forms there, so `promote()` adds those before anything reads the tallies again.

## Guards

The size guard now counts entries rather than visits — the unit that actually runs out — and is checked *before* an addition is enumerated rather than after charging for it, so a single wide addition can no longer pass the check and then allocate its entire pair set in one go. Exhausting the round limit is reported as truncation too; it leaves shared pairs behind just as the size guard does, and the two were indistinguishable in the statistics.

## Measurements

The extraction itself is unchanged — the prefix-sum query reports the same `Adders saved:43956` before and after, so the difference is all bookkeeping.

| | before | after |
|---|---:|---:|
| 6000-ary addition, peak RSS | 2358 MB | 178 MB (= pass disabled) |
| 4000-ary addition, peak RSS | 1728 MB | 119 MB (= pass disabled) |
| 2000-ary addition, stage | 2131 ms / +380 MB | 2 ms / +0 MB |
| 298 prefix sums, stage | 96873 ms | 2489 ms |
| 259 QF_BV queries over 10 s, worst stage memory growth | 16 MB | 7 MB |
| 259 QF_BV queries over 10 s, total stage time | 19.7 s | 18.4 s |

## Testing

- CNF **byte-identical** over 1559 QF_BV queries (`--output-CNF --exit-after-CNF`, sha256 per file).
- `ctest` with `-DENABLE_ASSERTIONS=ON`: 128/128 pass.
- 600 generated queries with duplicated addends and nested `bvadd`s, answers compared with the pass on and off under an assertions build: no mismatch, no assertion failure. The pass fires on 256 of the 600.
- The tally-consistency assertion — a pair being removed must be present with a positive count — also ran over all 1559 corpus queries without firing.