### PR TITLE
Let --incremental say which of the three modes it means

### DIFF
--- a/docs/incremental-solving.rst
+++ b/docs/incremental-solving.rst
@@ -17,11 +17,32 @@ backend epoch.
 Usage
 -----
 
-Nothing needs to be enabled. Unless explicitly forced with ``--incremental``, a
-session becomes incremental at its first explicit or internal assertion scope:
+Nothing needs to be enabled. In the default ``--incremental=auto``, a session
+becomes incremental at its first explicit or internal assertion scope:
 normally ``(push ...)``, while ``check-sat-assuming`` creates a temporary scope
 itself. Ordinary sessions that create neither are entirely untouched and take
-the classic single-shot pipeline. Two refinements to know about:
+the classic single-shot pipeline.
+
+``--incremental`` is a three-valued flag, and its value must be attached with
+``=`` (``stp --incremental off file.smt2`` would parse ``off`` as the input
+file name, which STP reports as such rather than acting on):
+
+``--incremental=on``
+  Engage the driver from the first solve, whether or not the input ever
+  pushes. A bare ``--incremental`` is a spelling of this, so every existing
+  command line keeps its meaning.
+
+``--incremental=auto``
+  The default described above.
+
+``--incremental=off``
+  Never engage the driver: every ``(check-sat)`` takes the classic
+  single-shot pipeline, an input full of ``push`` and ``pop`` included, and
+  whatever ``--incremental-auto-engage-at`` says. The frontend verdict cache
+  below is not the driver and keeps working; ``off`` changes which solver
+  answers a check, never the answer.
+
+Two refinements to know about:
 
 - Automatic engagement is theory-specific. Pure ``QF_BV`` and ``QF_ABV``
   sessions engage the incremental driver from their *32nd* real solve; a
@@ -29,12 +50,13 @@ the classic single-shot pipeline. Two refinements to know about:
   pipeline's whole-formula simplification. Floating-point and other or
   unknown logics retain engagement from the *third* real solve. ``check-sat``
   calls made before the first explicit/internal scope still count toward the
-  threshold. ``--incremental`` engages the driver from the first solve.
+  threshold.
   ``--incremental-auto-engage-at=N`` is a diagnostic override: ``-1`` selects
   the theory policy, ``1`` engages on the first real solve, positive values
   name the solve ordinal, and ``0`` prevents automatic driver engagement
-  while leaving the frontend verdict cache active. Explicit ``--incremental``
-  takes precedence.
+  while leaving the frontend verdict cache active. It is an ``auto`` policy
+  knob: ``--incremental=on`` engages from the first solve whatever it says,
+  and ``--incremental=off`` engages never.
 - Independent of the driver, the frontend keeps a per-level verdict
   cache with sound monotonicity shortcuts: pushing under a known-unsat
   level inherits unsat, a sat answer marks the levels beneath it sat, and
@@ -61,7 +83,12 @@ untouched: the counterexample belongs to the last ``vc_query`` and
 deliberately survives the idiomatic push/query/pop bracket (see the
 documentation at those declarations); the driver fills the same
 counterexample tables the batch path does. The Python bindings sit on the
-C API and inherit all of this.
+C API and inherit all of this. ``vc_setFlags(vc, 'i')`` is the C API's
+``--incremental=on``; its ``--incremental=off`` is
+``vc_setInterfaceFlags(vc, INCREMENTAL_AUTO_ENGAGE_AT, 0)`` without ``'i'``,
+since a native session has no other way to engage. A C++ embedder can also
+set ``UserFlags.incremental_mode`` directly, and ``IncrementalMode::OFF``
+there additionally stops ``vc_push`` from making the session incremental.
 
 The whole input language is covered. Plain bit-vector assertions take the
 lean path described below; arrays, ``--ackermanize``, floating point and
@@ -77,7 +104,7 @@ preprocessing transactions, first-solve exact-stack shortcuts, stable-level
 promotion, activation-literal aggregation, retraction phase hints, trail reuse
 and automatic backend reconfiguration. Explicit backend requests such as
 ``--cadical-factor=on`` remain explicit requests. The option does not itself
-force driver engagement; combine it with ``--incremental`` or the automatic
+force driver engagement; combine it with ``--incremental=on`` or the automatic
 engagement controls. This profile is both a diagnostic baseline and an
 executable architectural boundary: optional performance machinery can be
 evaluated without being confused with the incremental algorithm itself.
@@ -308,7 +335,7 @@ once and then works shallow is not retired for good.
 behavior as a diagnostic oracle. It is intended for differential validation,
 not normal solving.
 
-When ``--incremental`` explicitly engages the driver on the first real solve,
+When ``--incremental=on`` explicitly engages the driver on the first real solve,
 there is not yet a CBP prefix to reuse. If the sum of the assertion-level DAGs
 exceeds ``--incremental-cbp-bootstrap-limit`` (100,000 nodes by default), that
 first solve skips only this cross-level prepass. A later real solve builds CBP
@@ -650,7 +677,7 @@ progress; the one-run reconciliation is correctness evidence and should not
 be used for quantitative timing conclusions.
 
 ``--incremental-profile`` enables a lower-noise profile for each invocation of
-the incremental driver. Pair it with ``--incremental`` to route the first
+the incremental driver. Pair it with ``--incremental=on`` to route the first
 check through that driver; the profile flag observes incremental work but does
 not itself change solver engagement. This is currently a command-line
 diagnostic rather than a C API option. Each invocation writes four keyed
@@ -797,7 +824,7 @@ Limitations
 - Extensionality rounds rebuild the procedure's solve-local records each
   check-sat; reuse for them is at the encoding level (cached blocks and
   shared subcircuits), not at the record level.
-- Forcing the driver from the first solve (``--incremental``) on a large
+- Forcing the driver from the first solve (``--incremental=on``) on a large
   all-new formula deliberately trades the batch pipeline's global
   simplification for encoding reuse that cannot pay off yet. The large-CBP
   bootstrap deferral removes one measured prepass cost, and the base-only

--- a/include/stp/STPManager/STP.h
+++ b/include/stp/STPManager/STP.h
@@ -99,8 +99,9 @@ public:
   // simplification), unless vc_setFlags 'i' asked for it from the start.
   // The SMT-LIB2 frontend keeps its own copies in Cpp_interface.
   bool incrementalFromStart = false;
-  // Session state, turned on by the first vc_push. Separate from
-  // UserFlags.incremental_solving, which stays the caller's request.
+  // Session state, turned on by the first vc_push unless the caller asked for
+  // IncrementalMode::OFF. Separate from UserFlags.incremental_mode, which
+  // stays the caller's request.
   bool sessionIncremental = false;
   size_t incrementalSolvesRun = 0;
 

--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -87,16 +87,29 @@ public:
   // Incremental solving (docs/incremental-solving.rst): keep one SAT solver
   // and one bit-blast/CNF encoding alive across (check-sat) calls, asserting
   // retractable formulas as SAT assumptions instead of re-solving from
-  // scratch. Switched on by the first (push) in an SMT-LIB session, or from
-  // the start with --incremental; sessions that never push are untouched.
-  bool incremental_solving = false;
+  // scratch.
+  //
+  // AUTO -- the default -- lets the session switch itself on at its first
+  // (push), subject to the engagement threshold below; sessions that never
+  // push are untouched. ON engages the driver from the first solve, whether
+  // or not the input ever pushes. OFF keeps every solve on the batch
+  // pipeline, a pushing input included; the frontend's per-level verdict
+  // cache, which is not the driver, keeps working either way.
+  enum class IncrementalMode
+  {
+    AUTO = 0,
+    ON,
+    OFF
+  };
+  IncrementalMode incremental_mode = IncrementalMode::AUTO;
 
   // The real-solve ordinal at which an automatically incremental SMT-LIB
   // session starts using the persistent driver. -1 selects the measured
   // per-logic policy (QF_BV/QF_ABV: 32; other/unknown logics: 3), 1 engages
   // on the first solve, and 0 disables automatic driver engagement without
-  // disabling the frontend's per-level verdict cache. Explicit --incremental
-  // always engages from the first solve and ignores this threshold.
+  // disabling the frontend's per-level verdict cache. --incremental=on always
+  // engages from the first solve and ignores this threshold, and
+  // --incremental=off never engages whatever it is set to.
   int64_t incremental_auto_engage_at = -1;
 
   // Emit fine-grained per-check and cumulative measurements for the

--- a/include/stp/cpp_interface.h
+++ b/include/stp/cpp_interface.h
@@ -217,17 +217,17 @@ private:
   // rather than print a model of an assertion set that no longer exists.
   bool model_valid;
 
-  // Unless --incremental or an explicit threshold overrides it, pure
+  // Unless --incremental=on or an explicit threshold overrides it, pure
   // QF_BV/QF_ABV sessions delay the persistent driver until solve 32; other
   // and unknown logics retain solve 3. The first solves carry the largest
   // all-new formulas, and the batch pipeline's whole-formula simplification
   // earns its keep there.
   // The user's REQUEST, read once from the flags, and the SESSION's state,
-  // which a push turns on. Keeping them apart matters because reset() starts
-  // a new session: folding the session bit back into the request made a
-  // session that pushed and then reset behave for the rest of its life as
-  // though --incremental had been passed, forced-first-solve policies and
-  // all.
+  // which a push turns on unless --incremental=off forbids it. Keeping them
+  // apart matters because reset() starts a new session: folding the session
+  // bit back into the request made a session that pushed and then reset
+  // behave for the rest of its life as though --incremental=on had been
+  // passed, forced-first-solve policies and all.
   bool incremental_from_start;
   bool session_incremental;
   bool delayed_bv_auto_engagement;

--- a/lib/Interface/c_interface.cpp
+++ b/lib/Interface/c_interface.cpp
@@ -902,8 +902,12 @@ void vc_push(VC vc)
   stp::STPMgr* b = stp_i->bm;
 
   // The session is incremental from the first push on, exactly as the
-  // SMT-LIB2 frontend behaves; sessions that never push are untouched.
-  stp_i->sessionIncremental = true;
+  // SMT-LIB2 frontend behaves; sessions that never push are untouched, and a
+  // caller that set IncrementalMode::OFF has asked that not even a pushing
+  // session become incremental.
+  if (b->UserFlags.incremental_mode !=
+      stp::UserDefinedFlags::IncrementalMode::OFF)
+    stp_i->sessionIncremental = true;
 
   stp_i->ClearAllTables();
   b->Push();
@@ -3264,7 +3268,8 @@ void process_argument(const char ch, VC vc)
       // encoding live across queries, with the negated query and the
       // pushed levels' assertions assumed rather than re-encoded. See
       // docs/incremental-solving.rst.
-      bm->UserFlags.incremental_solving = true;
+      bm->UserFlags.incremental_mode =
+          stp::UserDefinedFlags::IncrementalMode::ON;
       ((stp::STP*)vc)->incrementalFromStart = true;
       ((stp::STP*)vc)->sessionIncremental = true;
       break;

--- a/lib/Interface/cpp_interface.cpp
+++ b/lib/Interface/cpp_interface.cpp
@@ -65,7 +65,8 @@ void Cpp_interface::init()
   ignoreCheckSatRequest = false;
   produce_models = false;
   model_valid = false;
-  incremental_from_start = bm.UserFlags.incremental_solving;
+  incremental_from_start =
+      bm.UserFlags.incremental_mode == UserDefinedFlags::IncrementalMode::ON;
   session_incremental = incremental_from_start;
   delayed_bv_auto_engagement = false;
   solves_run = 0;
@@ -619,8 +620,11 @@ void Cpp_interface::push()
   // The session is incremental from the first push on (the same trigger z3
   // uses): later check-sats go through the incremental driver where they
   // can. Sessions that never push are untouched by this. This is session
-  // state, not the user's request, so it does not travel through UserFlags.
-  session_incremental = true;
+  // state, not the user's request, so it does not travel through UserFlags --
+  // but --incremental=off is a request that no session become incremental,
+  // pushing ones included, so it is the one thing that stops this.
+  if (bm.UserFlags.incremental_mode != UserDefinedFlags::IncrementalMode::OFF)
+    session_incremental = true;
 
   // If the prior one is unsatisiable then the new one will be too. The
   // core provenance rides along, so a shortcut taken above a core-recorded
@@ -723,7 +727,8 @@ void Cpp_interface::checkSat(const ASTVec& assertionsSMT2,
     resetSolver();
 
     // The policy itself lives on the driver, so this frontend and the C API
-    // cannot drift apart again; explicit --incremental overrides it.
+    // cannot drift apart again; --incremental=on overrides it, and
+    // --incremental=off has already kept session_incremental false.
     const bool autoEngaged = IncrementalSolver::automaticEngagementReady(
         bm.UserFlags.incremental_auto_engage_at, delayed_bv_auto_engagement,
         solves_run);

--- a/tests/query-files/incremental-tests/incremental-tristate.smt2
+++ b/tests/query-files/incremental-tests/incremental-tristate.smt2
@@ -1,0 +1,62 @@
+; --incremental selects between three modes, and only the mode decides which
+; solver answers a check -- never what the answer is.
+;
+; The observable is the driver's own -s line, which nothing but a driver solve
+; prints. The -NOT directives below are not vacuous: the identical stack under
+; ON prints it, so a change that stopped printing it altogether would fail
+; those RUN lines rather than quietly pass these.
+;
+; --incremental-auto-engage-at=1 is what makes 'auto' and 'off' tell
+; themselves apart on a file this short. Without it the measured pure-QF_BV
+; policy delays engagement to the 32nd solve, so an automatic session of three
+; checks stays on the batch pipeline and looks exactly like 'off'.
+
+; 'on': the driver from the first solve, and a bare --incremental means it.
+; RUN: %solver -s --incremental=on --check-sanity %s 2>&1 | %OutputCheck %s --check-prefix=ON
+; RUN: %solver -s --incremental --check-sanity %s 2>&1 | %OutputCheck %s --check-prefix=ON
+
+; 'auto' with the threshold reached: the push turns the session incremental.
+; RUN: %solver -s --incremental=auto --incremental-auto-engage-at=1 --check-sanity %s 2>&1 | %OutputCheck %s --check-prefix=ON
+
+; 'auto' is the default, so these two runs must agree with each other -- and
+; on the QF_BV policy, three solves is short of the 32 it waits for.
+; RUN: %solver -s --incremental=auto --check-sanity %s 2>&1 | %OutputCheck %s --check-prefix=BATCH
+; RUN: %solver -s --check-sanity %s 2>&1 | %OutputCheck %s --check-prefix=BATCH
+
+; 'off': never the driver, though the file pushes throughout and though the
+; threshold that engaged 'auto' above is asked for explicitly.
+; RUN: %solver -s --incremental=off --check-sanity %s 2>&1 | %OutputCheck %s --check-prefix=BATCH
+; RUN: %solver -s --incremental=off --incremental-auto-engage-at=1 --check-sanity %s 2>&1 | %OutputCheck %s --check-prefix=BATCH
+
+; ON: ^Incremental:
+; BATCH-NOT: ^Incremental:
+
+(set-logic QF_BV)
+(declare-fun x () (_ BitVec 8))
+(declare-fun y () (_ BitVec 8))
+
+(push 1)
+(assert (= x #x01))
+; ON: ^sat
+; BATCH: ^sat
+(check-sat)
+
+; Contradicts the level below, so this level alone is unsatisfiable.
+(push 1)
+(assert (bvult x #x01))
+; ON: ^unsat
+; BATCH: ^unsat
+(check-sat)
+
+; Popping that level must not leave the unsat behind: the replacement is
+; satisfiable, and its model is the same one either way.
+(pop 1)
+(push 1)
+(assert (= (bvadd x y) #x03))
+; ON: ^sat
+; BATCH: ^sat
+(check-sat)
+; ON: \|y\| +#x02
+; BATCH: \|y\| +#x02
+(get-value (y))
+(exit)

--- a/tests/query-files/misc-tests/bad-cli-options.smt2
+++ b/tests/query-files/misc-tests/bad-cli-options.smt2
@@ -43,6 +43,17 @@
 ; BADBIAS-NOT: terminate called
 ; BADBIAS: --search-bias must be one of
 
+; RUN: not %solver --incremental=bogus %s 2>&1 | %OutputCheck %s --check-prefix=BADINCREMENTAL
+; BADINCREMENTAL-NOT: terminate called
+; BADINCREMENTAL: --incremental must be one of
+
+; --incremental is a flag, so a value spelled as a separate argument is read
+; as the input file name instead. Diagnosed by name rather than left to fail
+; later as a file that cannot be opened.
+; RUN: not %solver --incremental off 2>&1 | %OutputCheck %s --check-prefix=SPLITINCREMENTAL
+; SPLITINCREMENTAL-NOT: terminate called
+; SPLITINCREMENTAL: --incremental takes its value attached
+
 ; RUN: not %solver --max-time=-5 %s 2>&1 | %OutputCheck %s --check-prefix=BADTIME
 ; BADTIME-NOT: terminate called
 ; BADTIME: --max-time must be -1

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -97,6 +97,13 @@ public:
   CLI::Option* incremental_inprobing_option = nullptr;
 #endif
 
+  // Likewise for UserFlags.incremental_mode. This one is a flag rather than
+  // an option so that a bare --incremental keeps meaning what it always has;
+  // a value has to be attached with '=', which is also what stops it from
+  // swallowing the input file.
+  std::string incremental;
+  CLI::Option* incremental_option = nullptr;
+
   // Likewise for UserFlags.cnf_effort; always mapped, so it carries the
   // default spelling.
   std::string cnf_effort = "medium";
@@ -439,27 +446,33 @@ void ExtraMain::create_options()
                      "stdin, off when reading from a file. SMT-LIB2 only.")
           ->group(misc_group);
 
-  app.add_flag("--incremental", bm->UserFlags.incremental_solving,
-               "solve incrementally from the start: keep the SAT solver and "
-               "the bit-blasted encoding across (check-sat) commands, "
-               "asserting retractable formulas as SAT assumptions. Switches "
-               "itself on at the first (push) even without this flag. "
-               "SMT-LIB2 only.")
-      ->group(misc_group);
+  incremental_option =
+      app.add_flag("--incremental{on}", incremental,
+                   "whether to solve incrementally -- keeping the SAT solver "
+                   "and the bit-blasted encoding across (check-sat) commands, "
+                   "asserting retractable formulas as SAT assumptions: 'on' "
+                   "(from the first solve, pushes or no pushes), 'off' (never, "
+                   "not even for an input that pushes), or 'auto' (the "
+                   "default: an input that pushes switches it on for itself). "
+                   "A bare --incremental means 'on'; a value must be attached "
+                   "with '=' rather than spelled as a separate argument. "
+                   "SMT-LIB2 only.")
+          ->group(misc_group);
 
   int64_arg("--incremental-auto-engage-at",
             bm->UserFlags.incremental_auto_engage_at,
             "real-solve ordinal at which an automatically incremental "
             "SMT-LIB session engages the persistent driver; -1 uses the "
             "theory default (QF_BV/QF_ABV: 32, others: 3), 1 engages on "
-            "the first solve, and 0 never engages automatically (explicit "
-            "--incremental still engages at 1)",
+            "the first solve, and 0 never engages automatically "
+            "(--incremental=on still engages at 1, and --incremental=off "
+            "engages never)",
             misc_group);
 
   app.add_flag("--incremental-profile", bm->UserFlags.incremental_profile,
                "print fine-grained per-check and cumulative timings and "
                "work counters for the incremental driver (use with "
-               "--incremental to profile from the first check)")
+               "--incremental=on to profile from the first check)")
       ->group(misc_group);
 
   app.add_flag("--incremental-core-only",
@@ -476,8 +489,8 @@ void ExtraMain::create_options()
 
   int64_arg("--incremental-cbp-bootstrap-limit",
             bm->UserFlags.incremental_cbp_bootstrap_limit,
-            "on an explicitly forced first incremental solve, defer the "
-            "cross-level CBP bootstrap when the assertion stack exceeds "
+            "on a first incremental solve forced by --incremental=on, defer "
+            "the cross-level CBP bootstrap when the assertion stack exceeds "
             "this many DAG nodes. 0 disables the deferral.",
             misc_group);
 
@@ -814,6 +827,39 @@ int ExtraMain::parse_options(int argc, char** argv)
     }
   }
 #endif
+
+  if (incremental_option->count())
+  {
+    if (incremental == "on")
+      bm->UserFlags.incremental_mode = UserDefinedFlags::IncrementalMode::ON;
+    else if (incremental == "off")
+      bm->UserFlags.incremental_mode = UserDefinedFlags::IncrementalMode::OFF;
+    else if (incremental == "auto")
+      bm->UserFlags.incremental_mode = UserDefinedFlags::IncrementalMode::AUTO;
+    else
+    {
+      cerr << "ERROR: --incremental must be one of 'on', 'off' or 'auto', "
+              "attached with '=' (a bare --incremental means 'on')"
+           << endl;
+      std::exit(-1);
+    }
+  }
+
+  // A flag's value has to be attached, so 'stp --incremental off' parses as
+  // --incremental (which means 'on') followed by an input file named 'off' --
+  // the opposite of what was asked for, reported as "Cannot open off", which
+  // names neither half of the mistake.
+  if (incremental_option->count() &&
+      (infile == "on" || infile == "off" || infile == "auto"))
+  {
+    cerr << "ERROR: --incremental takes its value attached with '=', as "
+            "--incremental="
+         << infile
+         << "; given as a separate argument it was read as the name of the "
+            "input file"
+         << endl;
+    std::exit(-1);
+  }
 
   /*
    * -1 is the only negative value with a meaning ("no limit"); anything more

--- a/tools/test_fprewrites/test_fprewrites.cpp
+++ b/tools/test_fprewrites/test_fprewrites.cpp
@@ -719,10 +719,10 @@ static void run(Ctx& c)
     ASTNode x = c.fp(EB, SB);
     report("x = x -> true",
            c.nf->CreateNode(FP_SMT_EQ, {x, x}) == c.mgr.ASTTrue);
-    c.mgr.UserFlags.incremental_solving = true;
+    c.mgr.UserFlags.incremental_mode = UserDefinedFlags::IncrementalMode::ON;
     report("x = x -> true, incremental mode included",
            c.nf->CreateNode(FP_SMT_EQ, {x, x}) == c.mgr.ASTTrue);
-    c.mgr.UserFlags.incremental_solving = false;
+    c.mgr.UserFlags.incremental_mode = UserDefinedFlags::IncrementalMode::AUTO;
     report("fp.eq(x, x) -> not isNaN(x)",
            c.nf->CreateNode(FP_EQ, {x, x}) ==
                c.hf->CreateNode(NOT, {c.hf->CreateNode(FP_ISNAN, {x})}));


### PR DESCRIPTION
`--incremental` was a boolean, and only one of its two ends was reachable. Passing it forced the persistent driver on from the first solve; leaving it off left each session to decide for itself at its first `push`. There was no way to say the third thing — that a file full of `push` and `pop` is to stay on the batch pipeline regardless.

| | engagement |
| --- | --- |
| `--incremental=on` | from the first solve, pushes or no pushes. A bare `--incremental` is a spelling of this |
| `--incremental=auto` | the default, unchanged: the first `push` turns the session incremental, subject to the measured per-logic threshold |
| `--incremental=off` | never, whatever the input pushes and whatever `--incremental-auto-engage-at` says |

`--incremental-auto-engage-at=0` comes close and is worth being straight about: its sentinel value does already keep the driver out of an *automatic* session, and I checked that rather than assuming it. It is not the same request. It is a number on a diagnostic policy knob rather than a mode; it says nothing about a session that asked for the driver explicitly, since `--incremental` still engages at 1 beside it; and it leaves the session itself marked incremental, which is the state `vc_push` sets on the native API too.

## Why a flag and not an option

CLI11 options are greedy over the argument that follows them, and STP's input file is positional. As an option, `stp --incremental file.smt2` would read **the file name as the mode** — which is the form roughly fifty existing lit tests use.

As a flag with a value (`--incremental{on}`), a bare `--incremental` keeps meaning `on` and the value has to be attached with `=`. The cost is that the separate-argument spelling silently means something else:

| command line | parsed as |
| --- | --- |
| `stp --incremental f.smt2` | mode `on`, file `f.smt2` |
| `stp --incremental=off f.smt2` | mode `off`, file `f.smt2` |
| `stp --incremental off f.smt2` | mode **`on`**, file `off`, and `f.smt2` unexpected |

The third row is the one that costs something — someone asking for `off` would get the driver forced **on** — so it is refused by name in `parse_options` rather than left to fail later as a file that cannot be opened.

## How `off` is made total

`push()` is the only thing that sets `session_incremental`, and `use_incremental` already required it, so `off` is one gate at the source rather than a condition every solve has to remember:

```cpp
if (bm.UserFlags.incremental_mode != UserDefinedFlags::IncrementalMode::OFF)
  session_incremental = true;
```

`check-sat-assuming` pushes through that same function, so it is covered by construction. The driver object is then never constructed at all, which the model and unsat-core readers already handle — they ask `hasIncrementalSolver()` and fall back, and `get-unsat-assumptions` returns the full assumption set, which is always a correct core.

`vc_push` gets the same gate, so the native API cannot drift from the SMT-LIB2 frontend. `UserFlags.incremental_solving` becomes `incremental_mode`, a bool no longer being able to carry it.

## What `off` restores, and what it does not

`off` restores the pre-incremental **solver**, not the pre-incremental **frontend**, and it seems worth documenting which is which rather than leaving it to be discovered.

The solve route is the pre-incremental one verbatim — conjoin the stack, call `GlobalSTP->TopLevelSTP(query, ASTFalse)`. No persistent SAT solver, no assumptions, no cross-level constant propagation, and no core-aware verdict caching, that last one living inside the `use_incremental` branch. The per-level verdict cache that remains is not incremental machinery: it predates the driver, which only added a `fromCore` field to it.

The tree is not rolled back, though. I built `d1c9293e` — the merge immediately before the incremental series #832–#836 — and ran it against this branch under `--incremental=off` over all 502 files in `tests/query-files`. Sixteen differ; ten are unrelated later work (FP parse hints, LRA, the UTF-8 lexer fix, the numeral fix, and two files where the old binary trips an assertion and dumps core). The remaining six are these two, and neither is undone by `off`:

| behaviour | pre-incremental | today, under `off` |
| --- | --- | --- |
| `check-sat-assuming` / `get-unsat-assumptions` | `unsupported` | answered, on the batch path |
| `get-value` after a `pop` with no intervening check-sat | prints the stale model | `unsupported`, per SMT-LIB |

A third is not covered by any test in the corpus, so I checked it by hand: `:produce-models` no longer implies counterexample **checking**. The old `checkSat` did `check_counterexample_flag = produce_models`, so `(set-option :produce-models false)` in a file silently cancelled a `--check-sanity` on the command line, and `:produce-models true` switched the self-check on by itself. Both directions confirmed against the baseline binary with `-s | grep "checking counterexample"`.

All three are SMT-LIB conformance fixes rather than incremental machinery, so I have deliberately left them on under `off`.

Rerunning the same 502-file differential with `-p` added finds three more, all alternative-but-valid models from unrelated rewrite work, and **no** name differences — so the deterministic minting of generated array and extensionality variables, which is also unconditional, never reaches printed output.

## Verification

`ctest` is **129/129**, and the 502-file differential above is green apart from the categories named.

Separately, `--incremental=on` against `--incremental=off` over all 92 incremental test files agree everywhere except two benign cases: one alternative satisfying model, which passes `--check-sanity` both ways, and one coarser unsat core from `get-unsat-assumptions`, which is the documented fallback for when the driver did not run.

`incremental-tests/incremental-tristate.smt2` drives all three modes over one `push`/`pop` file, checking both the answers and which solver produced them, the observable being the `-s` line only a driver solve prints.

Two things about that test are deliberate. It passes `--incremental-auto-engage-at=1` to the runs that have to tell `auto` from `off`, because the measured pure-QF_BV policy delays engagement to the 32nd solve — a three-check automatic session is on the batch pipeline anyway, so without the threshold the two modes are indistinguishable and the test would pass while checking nothing. And its `-NOT` directives are not vacuous: the same stack under `on` matches the marker they forbid, in the same file, so a change that stopped printing the marker altogether fails those runs rather than quietly passing these.

Error paths are in `misc-tests/bad-cli-options.smt2` alongside the existing ones: `--incremental=bogus`, and the separate-argument spelling from the table above.
