### PR TITLE
Support :global-declarations, and close out the rest of #365

### DIFF
--- a/include/stp/Util/RunTimes.h
+++ b/include/stp/Util/RunTimes.h
@@ -40,6 +40,12 @@ namespace stp
 // Milliseconds since the epoch. Fixed width, because a millisecond count
 // does not fit the 32-bit "long" of an ILP32 or LLP64 target.
 DLL_PUBLIC int64_t getCurrentTime();
+
+// Process-wide, not per-solve: the CPU seconds spent in user mode so far,
+// and the peak resident set size in megabytes. Printed by --print-quickstat
+// and reported by (get-info :all-statistics).
+DLL_PUBLIC double processCpuTime();
+DLL_PUBLIC double peakMemoryMB();
 }
 
 class RunTimes // not copyable
@@ -106,6 +112,15 @@ public:
 
   typedef std::pair<Category, int64_t> Element;
 
+  // What one category has been charged with so far. Categories that have
+  // been charged nothing are left out.
+  struct CategoryTotal
+  {
+    Category category;
+    int count;
+    int64_t time_ms;
+  };
+
 private:
   RunTimes& operator=(const RunTimes&);
   RunTimes(const RunTimes& other);
@@ -123,6 +138,11 @@ public:
   DLL_PUBLIC void start(Category c);
   DLL_PUBLIC void stop(Category c);
   DLL_PUBLIC void print();
+
+  // Read what has been charged so far without disturbing it. print() ends by
+  // clearing, which a reader that only reports -- (get-info :all-statistics)
+  // -- must not do to a session that goes on solving.
+  DLL_PUBLIC std::vector<CategoryTotal> totals() const;
 
   std::string getDifference();
 

--- a/include/stp/cpp_interface.h
+++ b/include/stp/cpp_interface.h
@@ -178,6 +178,13 @@ private:
     bool removeSymbol(const ASTNode& symbol);
     bool lookupSymbol(std::string_view name, ASTNode& output) const;
 
+    // Take over every declaration made in `donor`, leaving it empty. Used
+    // for :global-declarations true, where a pop removes the assertion
+    // level but must not end the lifetime of the names declared in it: the
+    // frame being destroyed hands them to the base frame first, so its
+    // destructor has nothing left to erase from the global contexts.
+    void adoptDeclarations(SolverFrame& donor);
+
   private:
     vector<std::string> _scoped_functions;
     vector<std::string> _scoped_sort_aliases;
@@ -209,6 +216,16 @@ private:
   void resetIncrementalSolver();
 
   bool produce_models;
+
+  // :global-declarations. False (the required default) scopes declarations
+  // and definitions to the assertion level that made them; true makes them
+  // permanent, so pop and reset-assertions keep them and reset -- which
+  // discards every declaration -- is the only thing that takes them away.
+  //
+  // Initialised here rather than in init(), which reset() re-runs: reset
+  // empties the assertion stack and with it the declarations, but the option
+  // saying how later declarations are scoped outlives it.
+  bool global_declarations = false;
 
   // Whether the model held by the counterexample tables answers for the
   // current assertion stack. Set by checkSat from the solve's outcome;
@@ -294,8 +311,8 @@ public:
 
   // define-sort aliases for floating-point sorts. A real table: the alias
   // name is NOT interned as a symbol (the old scheme made the sort name
-  // resolvable as a term variable). Aliases follow assertion-frame scope;
-  // STP does not support global declarations.
+  // resolvable as a term variable). Aliases follow assertion-frame scope,
+  // and :global-declarations along with the other declarations.
   DLL_PUBLIC void addSortAlias(const std::string& name, unsigned exp_width,
                                unsigned sig_width);
   DLL_PUBLIC bool lookupSortAlias(const std::string& name,
@@ -410,9 +427,9 @@ public:
   // Reset STP back to "just started up" state.
   DLL_PUBLIC void reset();
 
-  // Empty the assertion stack and discard its declarations/definitions,
-  // while retaining solver options and the selected logic. STP does not
-  // support :global-declarations, so its required default is false.
+  // Empty the assertion stack while retaining solver options and the
+  // selected logic. Under the default :global-declarations false this
+  // discards the declarations and definitions too; under true they stay.
   DLL_PUBLIC void resetAssertions();
   DLL_PUBLIC void pop();
   DLL_PUBLIC void push();

--- a/include/stp/cpp_interface.h
+++ b/include/stp/cpp_interface.h
@@ -234,6 +234,12 @@ private:
   // saying how later declarations are scoped outlives it.
   bool global_declarations = false;
 
+  // Whether anything has been declared, defined, asserted, pushed or solved
+  // since start-up or the last reset. :global-declarations may only be set
+  // while this is false -- see setOption. init() clears it, so reset makes
+  // the option settable again; reset-assertions deliberately does not.
+  bool session_touched;
+
   // Whether the model held by the counterexample tables answers for the
   // current assertion stack. Set by checkSat from the solve's outcome;
   // cleared by anything SMT-LIB says invalidates a model (assert, push,

--- a/include/stp/cpp_interface.h
+++ b/include/stp/cpp_interface.h
@@ -210,6 +210,13 @@ private:
 
   void checkInvariant();
   void init();
+
+  // Report (set-option :<option> <value>) where the option's argument is a
+  // <b_value> and the value is neither true nor false. Malformed rather than
+  // unsupported, so it is an error response and not "unsupported"; STP's
+  // :error-behavior is immediate-exit, so it does not return.
+  ATTR_NORETURN void badBooleanOptionValue(const std::string& option,
+                                           const std::string& value);
   void addFrame();
   void removeFrame();
   void assertRoundingModeValid(const ASTNode& s);

--- a/include/stp/cpp_interface.h
+++ b/include/stp/cpp_interface.h
@@ -208,8 +208,30 @@ private:
   ASTVec& getCurrentSymbols();
   vector<std::string>& getCurrentFunctions();
 
+  // What the most recent check-sat charged to each pipeline stage: the
+  // difference between two readings of the manager's run times taken around
+  // the solve, which is the granularity (get-info :all-statistics) reports on.
+  // Taking a difference rather than reading the totals is what keeps the
+  // answer to "the most recent check" from growing into a session total, and
+  // keeps it independent of --print-quickstat, which clears as it prints.
+  // Categories are held by index so this header need not know the enum.
+  struct CategoryWork
+  {
+    int category;
+    int count;
+    int64_t time_ms;
+  };
+  std::vector<CategoryWork> last_check_work;
+
   void checkInvariant();
   void init();
+
+  // The manager's run times as they stand, and -- given a reading taken in
+  // front of a solve -- what that solve added, which is what
+  // last_check_work holds. Declared over CategoryWork rather than over the
+  // run-time class's own type so this header does not have to know it.
+  std::vector<CategoryWork> currentWork() const;
+  void recordCheckWork(const std::vector<CategoryWork>& before);
 
   // Report (set-option :<option> <value>) where the option's argument is a
   // <b_value> and the value is neither true nor false. Malformed rather than

--- a/lib/Interface/cpp_interface.cpp
+++ b/lib/Interface/cpp_interface.cpp
@@ -64,6 +64,7 @@ void Cpp_interface::init()
   print_success = false;
   ignoreCheckSatRequest = false;
   produce_models = false;
+  session_touched = false;
   model_valid = false;
   incremental_from_start =
       bm.UserFlags.incremental_mode == UserDefinedFlags::IncrementalMode::ON;
@@ -164,6 +165,7 @@ void Cpp_interface::setLogic(const std::string& logic)
 void Cpp_interface::AddAssert(const ASTNode& assert)
 {
   bm.AddAssert(assert);
+  session_touched = true;
 
   // SMT-LIB: an assertion invalidates the most recent model, and the last
   // check-sat-assuming round with it.
@@ -212,6 +214,7 @@ void Cpp_interface::addSortAlias(const std::string& name, unsigned exp_width,
     FatalError("define-sort: the sort name is already defined");
   sort_aliases[name] = std::make_pair(exp_width, sig_width);
   frames.back()->addSortAlias(name);
+  session_touched = true;
 }
 
 bool Cpp_interface::lookupSortAlias(const std::string& name,
@@ -308,6 +311,7 @@ void Cpp_interface::storeFunction(const string& name, const ASTVec& params,
 
   // store the function in the global function store
   functions.insert(std::make_pair(f.name, f));
+  session_touched = true;
 
   // record which frame this function was created in, such that it can be
   // removed later (e.g., via pop)
@@ -437,6 +441,7 @@ void Cpp_interface::deleteNode(ASTNode* n)
 void Cpp_interface::addSymbol(ASTNode& s)
 {
   frames.back()->addSymbol(s);
+  session_touched = true;
 }
 
 void Cpp_interface::addRoundingModeSymbol(ASTNode& s)
@@ -655,6 +660,7 @@ void Cpp_interface::push()
 
   model_valid = false;
   lastCheckWasAssuming = false;
+  session_touched = true;
 
   bm.Push();
 
@@ -717,6 +723,7 @@ void Cpp_interface::checkSat(const ASTVec& assertionsSMT2,
   // Any ordinary check supersedes the last check-sat-assuming round;
   // checkSatAssuming re-records after this returns.
   lastCheckWasAssuming = false;
+  session_touched = true;
 
   bm.GetRunTimes()->stop(RunTimes::Parsing);
 
@@ -943,11 +950,22 @@ void Cpp_interface::setOption(std::string option, std::string value)
   }
   else if (option == "global-declarations")
   {
-    // SMT-LIB gives this option mode "start", so a conforming script sets it
-    // before set-logic. STP enforces no mode on any option and does not start
-    // here: the flag is read when a level is popped or the assertions are
-    // reset, so a script that sets it later is answered rather than refused,
-    // and gets the behaviour it asked for from that point on.
+    // SMT-LIB gives this option mode "start" (2.6, 4.1.7), and this is the
+    // one option where a late change is not merely untidy: pop reads the flag
+    // as it stands then, not the value that was in force when the declaration
+    // was made, so setting it with declarations already in hand would decide
+    // their scope after the fact. Refuse instead of answering that
+    // retroactively. Nothing is at stake before the first declaration or
+    // assertion, so set-logic, set-info and the other options may all precede
+    // it, and reset makes it settable again.
+    if (session_touched)
+    {
+      const std::string msg = "set-option :global-declarations must come "
+                              "before anything is declared or asserted";
+      error(msg);
+      FatalError(msg.c_str());
+    }
+
     if (value == "true")
     {
       global_declarations = true;

--- a/lib/Interface/cpp_interface.cpp
+++ b/lib/Interface/cpp_interface.cpp
@@ -557,8 +557,10 @@ void Cpp_interface::popToFirstLevel()
 }
 
 // Weaker than reset(): retain options and the selected logic, but empty the
-// assertion stack. With the supported/default :global-declarations=false,
-// SMT-LIB requires this to discard declarations and definitions too.
+// assertion stack. With :global-declarations false SMT-LIB requires this to
+// discard declarations and definitions too; with it true they are kept, which
+// is the point of the option for a driver that streams large terms once and
+// re-queries them.
 void Cpp_interface::resetAssertions()
 {
   // Pop the ordinary levels through the ordinary path so the assertion stack,
@@ -572,10 +574,14 @@ void Cpp_interface::resetAssertions()
 
   // The base is an assertion level too for declaration lifetime. Rebuild it
   // rather than merely replacing its assertions: destroying the frame drops
-  // its symbols, functions, and sort aliases together.
+  // its symbols, functions, and sort aliases together. Global declarations
+  // are exactly the case where that must not happen -- the pops above have
+  // already moved every level's declarations into this frame -- so there the
+  // frame stays and only its assertions go.
   model_valid = false;
   bm.Pop();
-  removeFrame();
+  if (!global_declarations)
+    removeFrame();
   cache.clear();
 
   // These tables may retain the discarded assertions or declarations.
@@ -584,7 +590,8 @@ void Cpp_interface::resetAssertions()
   resetIncrementalSolver();
 
   cache.push_back(Entry(SOLVER_UNDECIDED));
-  addFrame();
+  if (!global_declarations)
+    addFrame();
   bm.Push();
 
   checkInvariant();
@@ -610,6 +617,14 @@ void Cpp_interface::pop()
   cache.erase(cache.end() - 1);
 
   assert(letMgr->_parser_symbol_table.size() == 0);
+
+  // Popping a level undoes the assertions made in it either way; what it does
+  // to the declarations made in it is what :global-declarations selects
+  // (SMT-LIB 2.6, 4.1.5). When they are global, the level's declarations move
+  // down to the base frame -- which only reset destroys -- instead of dying
+  // with the frame.
+  if (global_declarations)
+    frames.front()->adoptDeclarations(*frames.back());
 
   removeFrame();
   checkInvariant();
@@ -911,6 +926,26 @@ void Cpp_interface::setOption(std::string option, std::string value)
     else
       unsupported();
   }
+  else if (option == "global-declarations")
+  {
+    // SMT-LIB gives this option mode "start", so a conforming script sets it
+    // before set-logic. STP enforces no mode on any option and does not start
+    // here: the flag is read when a level is popped or the assertions are
+    // reset, so a script that sets it later is answered rather than refused,
+    // and gets the behaviour it asked for from that point on.
+    if (value == "true")
+    {
+      global_declarations = true;
+      success();
+    }
+    else if (value == "false")
+    {
+      global_declarations = false;
+      success();
+    }
+    else
+      unsupported();
+  }
   else if (option == "produce-unsat-assumptions")
   {
     // get-unsat-assumptions is always answered; the option is accepted so
@@ -940,6 +975,8 @@ void Cpp_interface::getOption(std::string option)
     cout << (print_success ? "true" : "false") << endl;
   else if (option == "produce-models")
     cout << (produce_models ? "true" : "false") << endl;
+  else if (option == "global-declarations")
+    cout << (global_declarations ? "true" : "false") << endl;
   else if (option == "diagnostic-output-channel")
     cout << "\"stdout\"" << endl;
   else
@@ -1229,6 +1266,30 @@ bool Cpp_interface::SolverFrame::removeSymbol(const ASTNode& symbol)
     }
   }
   return false;
+}
+
+void Cpp_interface::SolverFrame::adoptDeclarations(SolverFrame& donor)
+{
+  // Re-add rather than splice: this frame's own bindings index has to end up
+  // knowing about the adopted symbols, and adding them in declaration order
+  // keeps the most recent declaration of a name the one lookupSymbol finds.
+  for (const ASTNode& symbol : donor._scoped_symbols)
+    addSymbol(symbol);
+  donor._scoped_symbols.clear();
+  donor._symbol_bindings.clear();
+
+  // Functions and sort aliases live in contexts shared by every frame; a
+  // frame only records the names it is responsible for erasing, so moving
+  // the names is what moves the responsibility.
+  _scoped_functions.insert(_scoped_functions.end(),
+                           donor._scoped_functions.begin(),
+                           donor._scoped_functions.end());
+  donor._scoped_functions.clear();
+
+  _scoped_sort_aliases.insert(_scoped_sort_aliases.end(),
+                              donor._scoped_sort_aliases.begin(),
+                              donor._scoped_sort_aliases.end());
+  donor._scoped_sort_aliases.clear();
 }
 
 bool Cpp_interface::SolverFrame::lookupSymbol(std::string_view name,

--- a/lib/Interface/cpp_interface.cpp
+++ b/lib/Interface/cpp_interface.cpp
@@ -727,6 +727,11 @@ void Cpp_interface::checkSat(const ASTVec& assertionsSMT2,
 
   bm.GetRunTimes()->stop(RunTimes::Parsing);
 
+  // Bracket the solve so (get-info :all-statistics) can report on this check
+  // alone. Taken here rather than at entry so the parse that preceded the
+  // check is not charged to it.
+  const std::vector<CategoryWork> work_before = currentWork();
+
   checkInvariant();
   assert(assertionsSMT2.size() == cache.size());
 
@@ -833,6 +838,8 @@ void Cpp_interface::checkSat(const ASTVec& assertionsSMT2,
   // no model wanted) nothing was constructed, so nothing may be read.
   model_valid = (last_run.result == SOLVER_SATISFIABLE) &&
                 bm.UserFlags.construct_counterexample_flag;
+
+  recordCheckWork(work_before);
 
   if (bm.UserFlags.quick_statistics_flag)
   {
@@ -1021,6 +1028,85 @@ void Cpp_interface::getOption(std::string option)
   flush(cout);
 }
 
+std::vector<Cpp_interface::CategoryWork> Cpp_interface::currentWork() const
+{
+  std::vector<CategoryWork> result;
+  for (const RunTimes::CategoryTotal& total : bm.GetRunTimes()->totals())
+  {
+    CategoryWork work;
+    work.category = static_cast<int>(total.category);
+    work.count = total.count;
+    work.time_ms = total.time_ms;
+    result.push_back(work);
+  }
+  return result;
+}
+
+void Cpp_interface::recordCheckWork(const std::vector<CategoryWork>& before)
+{
+  last_check_work.clear();
+  for (const CategoryWork& now : currentWork())
+  {
+    CategoryWork charged = now;
+    for (const CategoryWork& then : before)
+    {
+      if (then.category == now.category)
+      {
+        charged.count -= then.count;
+        charged.time_ms -= then.time_ms;
+        break;
+      }
+    }
+
+    // --print-quickstat clears the run times as it prints, so a later
+    // reading can be smaller than the one taken before the solve. Report
+    // nothing rather than a negative count when that happens.
+    if (charged.count > 0 && charged.time_ms >= 0)
+      last_check_work.push_back(charged);
+  }
+}
+
+// The keywords (get-info :all-statistics) answers with, one per run-time
+// category. Deliberately a table of its own rather than RunTimes' display
+// names: those are prose, they are what --print-quickstat prints, and one of
+// them is misspelled -- reusing them would make an output contract out of
+// text that exists to be read, where tidying a name later would break
+// whoever parses it.
+static const char* categoryKeyword(RunTimes::Category c)
+{
+  switch (c)
+  {
+    case RunTimes::Transforming: return "transforming";
+    case RunTimes::SimplifyTopLevel: return "simplifying";
+    case RunTimes::Parsing: return "parsing";
+    case RunTimes::CNFConversion: return "cnf-conversion";
+    case RunTimes::BitBlasting: return "bit-blasting";
+    case RunTimes::Solving: return "sat-solving";
+    case RunTimes::BVSolver: return "bitvector-solving";
+    case RunTimes::PropagateEqualities: return "variable-elimination";
+    case RunTimes::SendingToSAT: return "sending-to-sat-solver";
+    case RunTimes::CounterExampleGeneration:
+      return "counter-example-generation";
+    case RunTimes::SATSimplifying: return "sat-simplification";
+    case RunTimes::ConstantBitPropagation: return "constant-bit-propagation";
+    case RunTimes::ArrayReadRefinement: return "array-read-refinement";
+    case RunTimes::ApplyingSubstitutions: return "applying-substitutions";
+    case RunTimes::RemoveUnconstrained: return "removing-unconstrained";
+    case RunTimes::PureLiterals: return "pure-literals";
+    case RunTimes::UseITEContext: return "ite-contexts";
+    case RunTimes::AIGSimplifyCore: return "aig-core-simplification";
+    case RunTimes::IntervalPropagation: return "interval-propagation";
+    case RunTimes::Flatten: return "sharing-aware-flattening";
+    case RunTimes::NodeDomainAnalysis: return "node-domain-analysis";
+    case RunTimes::StrengthReduction: return "strength-reduction";
+    case RunTimes::SplitExtracts: return "split-extracts";
+    case RunTimes::Rewriting: return "sharing-aware-rewriting";
+    case RunTimes::MergeSame: return "merge-same";
+    case RunTimes::CommonSubSum: return "common-sub-sum-extraction";
+  }
+  return "unknown";
+}
+
 void Cpp_interface::getInfo(std::string flag)
 {
   if (flag == "name")
@@ -1040,6 +1126,39 @@ void Cpp_interface::getInfo(std::string flag)
     // FatalError() exits rather than unwinding to the next command.
     cout << "(:error-behavior immediate-exit)" << endl;
   }
+  else if (flag == "all-statistics")
+  {
+    // No standard statistics are defined (SMT-LIB 2.6, 4.1.8), so what is in
+    // here is STP's own; the response shape is the standard's, a sequence of
+    // info_response values. The per-stage numbers are the most recent check's,
+    // as the standard asks; the process ones are what they say, process-wide,
+    // and :check-sat-calls counts the session. Stages the check did no work in
+    // are left out, so a small query does not answer with a screen of zeroes.
+    //
+    // The standard permits this only in sat or unsat mode. STP answers it
+    // whenever it is asked, since the alternative under an immediate-exit
+    // error behaviour is killing a session over a diagnostic query.
+    std::ios_base::fmtflags saved(cout.flags());
+    const std::streamsize saved_precision = cout.precision();
+    cout << std::fixed;
+    cout.precision(2);
+
+    cout << "(:check-sat-calls " << solves_run << endl;
+    cout << " :cpu-time " << processCpuTime() << endl;
+    cout << " :peak-memory-mb " << peakMemoryMB();
+
+    cout.flags(saved);
+    cout.precision(saved_precision);
+
+    for (const CategoryWork& work : last_check_work)
+    {
+      const char* keyword =
+          categoryKeyword(static_cast<RunTimes::Category>(work.category));
+      cout << endl << " :" << keyword << " " << work.count;
+      cout << endl << " :" << keyword << "-time-ms " << work.time_ms;
+    }
+    cout << ")" << endl;
+  }
   else if (flag == "assertion-stack-levels")
   {
     // The base level is not an assertion level.
@@ -1048,8 +1167,9 @@ void Cpp_interface::getInfo(std::string flag)
   }
   else
   {
-    // The remaining standard flags, :all-statistics and :reason-unknown, are
-    // both optional and not reported.
+    // :reason-unknown, the one standard flag left, is optional and not
+    // reported: STP does not answer unknown, so there is never a reason to
+    // give for one.
     unsupported();
     return;
   }

--- a/lib/Interface/cpp_interface.cpp
+++ b/lib/Interface/cpp_interface.cpp
@@ -1027,6 +1027,14 @@ void Cpp_interface::getInfo(std::string flag)
     cout << "(:name \"STP\")" << endl;
   else if (flag == "version")
     cout << "(:version \"" << get_git_version_tag() << "\")" << endl;
+  else if (flag == "authors")
+  {
+    // Required, like :name and :version (SMT-LIB 2.6, 4.1.8), and answered
+    // collectively: the response is a fixed string, while the people it
+    // stands for are in AUTHORS, where they can be credited properly and
+    // kept current without touching the solver's output.
+    cout << "(:authors \"the STP team\")" << endl;
+  }
   else if (flag == "error-behavior")
   {
     // FatalError() exits rather than unwinding to the next command.
@@ -1040,7 +1048,8 @@ void Cpp_interface::getInfo(std::string flag)
   }
   else
   {
-    // :all-statistics, :authors and :reason-unknown are not reported.
+    // The remaining standard flags, :all-statistics and :reason-unknown, are
+    // both optional and not reported.
     unsupported();
     return;
   }

--- a/lib/Interface/cpp_interface.cpp
+++ b/lib/Interface/cpp_interface.cpp
@@ -879,6 +879,21 @@ void Cpp_interface::cleanUp()
   }
 }
 
+// SMT-LIB gives these options a <b_value> argument (2.6, figure 3.9), so a
+// value that is not true or false does not describe a command the solver
+// could have carried out: it is malformed input, and "unsupported" -- the
+// answer for what the solver cannot do (3.9.1) -- would misreport it as a
+// capability it lacks. Report it the way the parser reports its own
+// malformed input, with an error response and then a stop.
+void Cpp_interface::badBooleanOptionValue(const std::string& option,
+                                          const std::string& value)
+{
+  const std::string msg = "set-option :" + option +
+                          " takes true or false, but was given: " + value;
+  error(msg);
+  FatalError(msg.c_str());
+}
+
 void Cpp_interface::setOption(std::string option, std::string value)
 {
   /*
@@ -903,7 +918,7 @@ void Cpp_interface::setOption(std::string option, std::string value)
     else if (value == "false")
       setPrintSuccess(false);
     else
-      unsupported();
+      badBooleanOptionValue(option, value);
   }
   else if (option == "produce-models")
   {
@@ -924,7 +939,7 @@ void Cpp_interface::setOption(std::string option, std::string value)
       success();
     }
     else
-      unsupported();
+      badBooleanOptionValue(option, value);
   }
   else if (option == "global-declarations")
   {
@@ -944,7 +959,7 @@ void Cpp_interface::setOption(std::string option, std::string value)
       success();
     }
     else
-      unsupported();
+      badBooleanOptionValue(option, value);
   }
   else if (option == "produce-unsat-assumptions")
   {
@@ -953,7 +968,7 @@ void Cpp_interface::setOption(std::string option, std::string value)
     if (value == "true" || value == "false")
       success();
     else
-      unsupported();
+      badBooleanOptionValue(option, value);
   }
   else if (option == "diagnostic-output-channel")
   {

--- a/lib/Util/RunTimes.cpp
+++ b/lib/Util/RunTimes.cpp
@@ -70,7 +70,7 @@ int64_t getCurrentTime()
 }
 
 // CPU time this process has spent in user mode, in seconds.
-static double processCpuTime()
+double stp::processCpuTime()
 {
 #if defined(_WIN32)
   FILETIME creation, exited, kernel, user;
@@ -90,7 +90,7 @@ static double processCpuTime()
 }
 
 // Peak resident set size of this process, in megabytes.
-static double peakMemoryMB()
+double stp::peakMemoryMB()
 {
 #if defined(_WIN32)
   PROCESS_MEMORY_COUNTERS pmc;
@@ -148,11 +148,28 @@ void RunTimes::print()
   std::cerr.precision(2);
   std::cerr << "Statistics Total: " << ((double)cummulative_ms) / 1000 << "s"
             << std::endl;
-  std::cerr << "CPU Time Used   : " << processCpuTime() << "s" << std::endl;
-  std::cerr << "Peak Memory Used: " << peakMemoryMB() << "MB" << std::endl;
+  std::cerr << "CPU Time Used   : " << stp::processCpuTime() << "s" << std::endl;
+  std::cerr << "Peak Memory Used: " << stp::peakMemoryMB() << "MB" << std::endl;
 
   std::cerr.flags(f);
   clear();
+}
+
+std::vector<RunTimes::CategoryTotal> RunTimes::totals() const
+{
+  std::vector<CategoryTotal> result;
+  for (std::map<Category, int>::const_iterator it = counts.begin();
+       it != counts.end(); it++)
+  {
+    const std::map<Category, int64_t>::const_iterator time =
+        times.find(it->first);
+    CategoryTotal total;
+    total.category = it->first;
+    total.count = it->second;
+    total.time_ms = time == times.end() ? 0 : time->second;
+    result.push_back(total);
+  }
+  return result;
 }
 
 std::string RunTimes::getDifference()
@@ -161,7 +178,7 @@ std::string RunTimes::getDifference()
   int64_t val = stp::getCurrentTime();
   s << (val - lastTime) << "ms";
   lastTime = val;
-  s << ":" << std::fixed << std::setprecision(0) << peakMemoryMB() << "MB";
+  s << ":" << std::fixed << std::setprecision(0) << stp::peakMemoryMB() << "MB";
   return s.str();
 }
 

--- a/tests/query-files/smt2-command-tests/get-info-all-statistics.smt2
+++ b/tests/query-files/smt2-command-tests/get-info-all-statistics.smt2
@@ -1,0 +1,33 @@
+; No standard statistics are defined (SMT-LIB 2.6, 4.1.8), so what can be
+; pinned is the response shape and the two things in it that do not vary from
+; run to run: the session's check-sat count, and that every stage reports a
+; count and a time. Times and memory are measurements, and are matched as
+; numbers rather than values.
+;
+; The second RUN is the same file under --print-quickstat, which prints the
+; run times and clears them as it goes: what get-info reports is taken across
+; the solve itself, so the two must not interfere.
+; RUN: %solver %s | %OutputCheck %s
+; RUN: %solver -t %s | %OutputCheck %s
+(set-logic QF_BV)
+(declare-fun a () (_ BitVec 8))
+(declare-fun b () (_ BitVec 8))
+; Answered before any check rather than refused for being outside sat or
+; unsat mode. No stage has done work yet, so the process figures close it.
+; CHECK: ^\(:check-sat-calls 0$
+; CHECK-NEXT: ^ :cpu-time [0-9]+\.[0-9]+$
+; CHECK-NEXT: ^ :peak-memory-mb [0-9]+\.[0-9]+\)$
+(get-info :all-statistics)
+(assert (= (bvmul a b) #x0f))
+(assert (bvugt a #x01))
+; CHECK-NEXT: ^sat$
+(check-sat)
+; CHECK-NEXT: ^\(:check-sat-calls 1$
+; CHECK-NEXT: ^ :cpu-time [0-9]+\.[0-9]+$
+; CHECK-NEXT: ^ :peak-memory-mb [0-9]+\.[0-9]+$
+; The stages the check did work in follow, each as a count and a time, and
+; the last of them closes the response.
+; CHECK-NEXT: ^ :[a-z-]+ [0-9]+$
+; CHECK-NEXT: ^ :[a-z-]+-time-ms [0-9]+$
+; CHECK: ^ :[a-z-]+-time-ms [0-9]+\)$
+(get-info :all-statistics)

--- a/tests/query-files/smt2-command-tests/get-info.smt2
+++ b/tests/query-files/smt2-command-tests/get-info.smt2
@@ -17,7 +17,11 @@
 ; CHECK-NEXT: ^\(:assertion-stack-levels 1\)
 (get-info :assertion-stack-levels)
 (pop 1)
-; CHECK-NEXT: ^unsupported
+; Answered; its contents are get-info-all-statistics's business, so all that
+; is wanted here is that the flag is one of the answered ones.
+; CHECK-NEXT: ^\(:check-sat-calls 0$
+; CHECK-NEXT: ^ :cpu-time
+; CHECK-NEXT: ^ :peak-memory-mb
 (get-info :all-statistics)
 ; CHECK-NEXT: ^unsupported
 (get-info :reason-unknown)

--- a/tests/query-files/smt2-command-tests/get-info.smt2
+++ b/tests/query-files/smt2-command-tests/get-info.smt2
@@ -1,10 +1,14 @@
 ; The flags STP can answer are reported in the standard's response format; the
-; rest must answer "unsupported" rather than an error.
+; rest must answer "unsupported" rather than an error. The four the standard
+; marks "support: required" (SMT-LIB 2.6, 4.1.8) are all among the former --
+; :version is not pinned here because its value is the build's version stamp.
 ; RUN: %solver %s | %OutputCheck %s
 (set-logic QF_BV)
 (declare-fun x () (_ BitVec 4))
 ; CHECK-NEXT: ^\(:name "STP"\)
 (get-info :name)
+; CHECK-NEXT: ^\(:authors "the STP team"\)
+(get-info :authors)
 ; CHECK-NEXT: ^\(:error-behavior immediate-exit\)
 (get-info :error-behavior)
 ; CHECK-NEXT: ^\(:assertion-stack-levels 0\)
@@ -17,8 +21,6 @@
 (get-info :all-statistics)
 ; CHECK-NEXT: ^unsupported
 (get-info :reason-unknown)
-; CHECK-NEXT: ^unsupported
-(get-info :authors)
 ; CHECK-NEXT: ^unsupported
 (get-info :some-unknown-flag)
 (assert (= x #x1))

--- a/tests/query-files/smt2-command-tests/global-declarations-bad-value.smt2
+++ b/tests/query-files/smt2-command-tests/global-declarations-bad-value.smt2
@@ -1,0 +1,13 @@
+; The option takes a <b_value>, so a value that is neither true nor false is
+; a malformed command rather than an unsupported one: it gets an error
+; response, not "unsupported", and STP's :error-behavior is immediate-exit so
+; nothing after it runs. The same holds for every option whose argument is a
+; <b_value>; set-option-bad-boolean-value covers another of them.
+; RUN: not %solver %s 2>&1 | %OutputCheck %s
+; CHECK: ^\(error ".*:global-declarations takes true or false.*maybe"\)$
+(set-option :global-declarations maybe)
+(set-logic QF_BV)
+(declare-fun x () (_ BitVec 4))
+(assert (= x #x1))
+; CHECK-NOT: ^sat$
+(check-sat)

--- a/tests/query-files/smt2-command-tests/global-declarations-false-pop-definition.smt2
+++ b/tests/query-files/smt2-command-tests/global-declarations-false-pop-definition.smt2
@@ -1,0 +1,14 @@
+; The same rule covers definitions, not just declarations: with
+; :global-declarations false a define-fun made inside an assertion level goes
+; away with it. A definition whose body mentions a symbol from the same level
+; must not keep that symbol -- or itself -- alive past the pop.
+; RUN: %solver %s | %OutputCheck %s
+(set-option :global-declarations false)
+(set-logic QF_BV)
+(push 1)
+(declare-fun x!1 () Bool)
+(define-fun x!2 () Bool (not x!1))
+(pop 1)
+; CHECK: .*error.*token: x!2.*
+(assert (not x!2))
+(check-sat)

--- a/tests/query-files/smt2-command-tests/global-declarations-false-pop.smt2
+++ b/tests/query-files/smt2-command-tests/global-declarations-false-pop.smt2
@@ -1,0 +1,14 @@
+; :global-declarations false is the option's required default (SMT-LIB 2.6,
+; section 4.1.7): declarations belong to the assertion level that made them, so
+; popping that level takes the name out of scope again.
+; RUN: %solver %s | %OutputCheck %s
+(set-option :global-declarations false)
+(set-logic QF_BV)
+(push 1)
+(declare-fun x!1 () Bool)
+(define-fun x!2 () Bool (not x!1))
+(pop 1)
+; STP's :error-behavior is immediate-exit, so this is the last line that runs.
+; CHECK: .*error.*token: x!1.*
+(assert (not x!1))
+(check-sat)

--- a/tests/query-files/smt2-command-tests/global-declarations-false-redeclare-after-pop.smt2
+++ b/tests/query-files/smt2-command-tests/global-declarations-false-redeclare-after-pop.smt2
@@ -1,0 +1,30 @@
+; Because a popped declaration is gone, its name is free again -- and may come
+; back at a different sort. This is the observable difference between the two
+; settings of the option: the identical script must be rejected when
+; :global-declarations is true (see global-declarations-true-redeclare-is-error).
+; RUN: %solver %s | %OutputCheck %s
+(set-option :global-declarations false)
+; get-model is only answered when a model was asked for; an assertions
+; build constructs one either way, so without this the test passes there and
+; fails in a release build.
+(set-option :produce-models true)
+(set-logic QF_BV)
+(push 1)
+(declare-fun x!0 () Bool)
+(assert (not x!0))
+; CHECK: ^sat$
+(check-sat)
+; CHECK-NEXT: ^\($
+; CHECK-NEXT: ^\(define-fun \|x!0\| \(\) Bool false\)$
+; CHECK-NEXT: ^\)$
+(get-model)
+(pop 1)
+(push 1)
+(declare-fun x!0 () (_ BitVec 32))
+(assert (= x!0 (_ bv0 32)))
+; CHECK-NEXT: ^sat$
+(check-sat)
+; CHECK-NEXT: ^\($
+; CHECK-NEXT: ^\(define-fun \|x!0\| \(\) \(_ BitVec 32\) #x00000000\)$
+; CHECK-NEXT: ^\)$
+(get-model)

--- a/tests/query-files/smt2-command-tests/global-declarations-false-reset-assertions.smt2
+++ b/tests/query-files/smt2-command-tests/global-declarations-false-reset-assertions.smt2
@@ -1,0 +1,17 @@
+; reset-assertions is defined in terms of the same option (SMT-LIB 2.6, section
+; 4.2.4): with :global-declarations false it removes the base-level declarations
+; and definitions along with the assertions, so afterwards the name is unknown.
+; reset-assertions-drops-declarations covers the redeclaration side of this;
+; here the popped name is used rather than redeclared.
+; RUN: %solver %s | %OutputCheck %s
+(set-option :global-declarations false)
+(set-logic QF_BV)
+(declare-fun x () (_ BitVec 4))
+(define-fun y () (_ BitVec 4) (bvnot x))
+(assert (= x #x1))
+; CHECK: ^sat$
+(check-sat)
+(reset-assertions)
+; CHECK: .*error.*token: y.*
+(assert (= y #xE))
+(check-sat)

--- a/tests/query-files/smt2-command-tests/global-declarations-set-before-declarations.smt2
+++ b/tests/query-files/smt2-command-tests/global-declarations-set-before-declarations.smt2
@@ -1,0 +1,24 @@
+; The other side of global-declarations-set-late-is-refused: what makes the
+; option too late to set is a declaration or an assertion, not merely a
+; command. set-logic, set-info and other options do not close the window, and
+; reset re-opens it -- there are no declarations left to be ambiguous about.
+; RUN: %solver %s | %OutputCheck %s
+(set-logic QF_BV)
+(set-info :source "STP option-ordering test")
+(set-option :produce-models true)
+(set-option :global-declarations true)
+(push 1)
+(declare-fun x () (_ BitVec 4))
+(pop 1)
+(assert (= x #x1))
+; CHECK: ^sat$
+(check-sat)
+(reset)
+(set-logic QF_BV)
+(set-option :global-declarations true)
+(push 1)
+(declare-fun y () (_ BitVec 4))
+(pop 1)
+(assert (= y #x2))
+; CHECK-NEXT: ^sat$
+(check-sat)

--- a/tests/query-files/smt2-command-tests/global-declarations-set-late-is-refused.smt2
+++ b/tests/query-files/smt2-command-tests/global-declarations-set-late-is-refused.smt2
@@ -1,0 +1,12 @@
+; Once a declaration exists, the option can no longer be set: pop reads the
+; flag as it stands at the pop, so a late change would decide the scope of
+; declarations already made. Refused rather than answered retroactively, and
+; STP's :error-behavior is immediate-exit, so the query below never runs.
+; RUN: not %solver %s 2>&1 | %OutputCheck %s
+(set-logic QF_BV)
+(declare-fun x () (_ BitVec 4))
+; CHECK: ^\(error ".*:global-declarations must come before anything is declared or asserted"\)$
+(set-option :global-declarations true)
+(assert (= x #x1))
+; CHECK-NOT: ^sat$
+(check-sat)

--- a/tests/query-files/smt2-command-tests/global-declarations-true-assertions-not-global.smt2
+++ b/tests/query-files/smt2-command-tests/global-declarations-true-assertions-not-global.smt2
@@ -1,0 +1,17 @@
+; The option makes declarations global, not assertions: pop still undoes every
+; assertion made in the level it removes (SMT-LIB 2.6, section 4.1.4). The two
+; conflicting assertions below go away with the pop, while x stays declared, so
+; the second query is satisfiable.
+; RUN: %solver %s | %OutputCheck %s
+(set-option :global-declarations true)
+(set-logic QF_BV)
+(push 1)
+(declare-fun x () (_ BitVec 4))
+(assert (= x #x1))
+(assert (= x #x2))
+; CHECK: ^unsat$
+(check-sat)
+(pop 1)
+(assert (= x #x1))
+; CHECK-NEXT: ^sat$
+(check-sat)

--- a/tests/query-files/smt2-command-tests/global-declarations-true-nested-levels.smt2
+++ b/tests/query-files/smt2-command-tests/global-declarations-true-nested-levels.smt2
@@ -1,0 +1,18 @@
+; Levels declared at different depths, and a multi-level pop, must all leave the
+; declarations behind. A pop of several levels at once is the case where a
+; per-level symbol list is easiest to unwind too far.
+; RUN: %solver %s | %OutputCheck %s
+(set-option :global-declarations true)
+(set-logic QF_BV)
+(declare-fun base () (_ BitVec 4))
+(push 2)
+(declare-fun outer () (_ BitVec 4))
+(push 1)
+(declare-fun inner () (_ BitVec 4))
+(assert (= inner #x3))
+; CHECK: ^sat$
+(check-sat)
+(pop 3)
+(assert (and (= base #x1) (= outer #x2) (= inner #x3)))
+; CHECK-NEXT: ^sat$
+(check-sat)

--- a/tests/query-files/smt2-command-tests/global-declarations-true-option.smt2
+++ b/tests/query-files/smt2-command-tests/global-declarations-true-option.smt2
@@ -1,0 +1,14 @@
+; The option itself: it is a boolean whose required default is false (SMT-LIB
+; 2.6, section 4.1.7), it can be set in start mode, and get-option must report
+; back what was set instead of answering "unsupported".
+; RUN: %solver %s | %OutputCheck %s
+; CHECK: ^false$
+(get-option :global-declarations)
+(set-option :global-declarations true)
+; CHECK-NEXT: ^true$
+(get-option :global-declarations)
+(set-logic QF_BV)
+(declare-fun x () (_ BitVec 4))
+(assert (= x #x1))
+; CHECK-NEXT: ^sat$
+(check-sat)

--- a/tests/query-files/smt2-command-tests/global-declarations-true-pop-definition.smt2
+++ b/tests/query-files/smt2-command-tests/global-declarations-true-pop-definition.smt2
@@ -1,0 +1,14 @@
+; Definitions are global under the option just as declarations are, and a
+; definition made global keeps meaning what it meant: x!2 is still (not x!1)
+; after the pop, so asserting both is unsatisfiable rather than satisfiable.
+; RUN: %solver %s | %OutputCheck %s
+(set-option :global-declarations true)
+(set-logic QF_BV)
+(push 1)
+(declare-fun x!1 () Bool)
+(define-fun x!2 () Bool (not x!1))
+(pop 1)
+(assert (not x!1))
+(assert (not x!2))
+; CHECK: ^unsat$
+(check-sat)

--- a/tests/query-files/smt2-command-tests/global-declarations-true-pop.smt2
+++ b/tests/query-files/smt2-command-tests/global-declarations-true-pop.smt2
@@ -1,0 +1,12 @@
+; With :global-declarations true, declarations and definitions are permanent
+; rather than being added to the assertion stack (SMT-LIB 2.6, section 4.1.5), so
+; a name declared inside an assertion level is still in scope after the pop.
+; RUN: %solver %s | %OutputCheck %s
+(set-option :global-declarations true)
+(set-logic QF_BV)
+(push 1)
+(declare-fun x () (_ BitVec 4))
+(pop 1)
+(assert (= x #x1))
+; CHECK: ^sat$
+(check-sat)

--- a/tests/query-files/smt2-command-tests/global-declarations-true-redeclare-is-error.smt2
+++ b/tests/query-files/smt2-command-tests/global-declarations-true-redeclare-is-error.smt2
@@ -1,0 +1,19 @@
+; The mirror image of global-declarations-false-redeclare-after-pop: when the
+; declaration survives the pop, reusing the name is a redeclaration, and
+; SMT-LIB 2.6 section 4.2.1 forbids declaring a symbol that is already in scope.
+; Accepting this script under both settings of the option is the bug that makes
+; the two settings indistinguishable.
+; RUN: %solver %s | %OutputCheck %s
+(set-option :global-declarations true)
+(set-logic QF_BV)
+(push 1)
+(declare-fun x!0 () Bool)
+(assert (not x!0))
+; CHECK: ^sat$
+(check-sat)
+(pop 1)
+(push 1)
+; CHECK: .*error.*token: x!0.*
+(declare-fun x!0 () (_ BitVec 32))
+(assert (= x!0 (_ bv0 32)))
+(check-sat)

--- a/tests/query-files/smt2-command-tests/global-declarations-true-reset-assertions.smt2
+++ b/tests/query-files/smt2-command-tests/global-declarations-true-reset-assertions.smt2
@@ -1,0 +1,25 @@
+; reset-assertions keeps the declarations when :global-declarations is true and
+; only empties the assertion stack (SMT-LIB 2.6, section 4.2.4). This is the
+; shape an interactive driver wants: stream a large term once, then re-query it
+; against different assertions without redeclaring anything.
+; RUN: %solver %s | %OutputCheck %s
+(set-option :global-declarations true)
+; get-value below needs a model to have been asked for; see
+; global-declarations-false-redeclare-after-pop.
+(set-option :produce-models true)
+(set-logic QF_BV)
+(declare-fun x () (_ BitVec 3))
+(assert (= x #b010))
+; CHECK: ^sat$
+(check-sat)
+(assert (= x #b001))
+; CHECK-NEXT: ^unsat$
+(check-sat)
+(reset-assertions)
+(assert (= x #b011))
+; CHECK-NEXT: ^sat$
+(check-sat)
+; CHECK-NEXT: ^\($
+; CHECK-NEXT: .*\|x\|.*#b011.*
+; CHECK-NEXT: ^\)$
+(get-value (x))

--- a/tests/query-files/smt2-command-tests/global-declarations-true-sort-alias.smt2
+++ b/tests/query-files/smt2-command-tests/global-declarations-true-sort-alias.smt2
@@ -1,0 +1,14 @@
+; Sort aliases are definitions too, so define-sort obeys the option alongside
+; declare-fun and define-fun: the alias made inside the pushed level is still a
+; usable sort after the pop. define-sort-alias-scope covers the false side.
+; REQUIRES: floating-point
+; RUN: %solver %s | %OutputCheck %s
+(set-option :global-declarations true)
+(set-logic QF_FP)
+(push 1)
+(define-sort F32 () (_ FloatingPoint 8 24))
+(pop 1)
+(declare-const f F32)
+(assert (fp.isNormal f))
+; CHECK: ^sat$
+(check-sat)

--- a/tests/query-files/smt2-command-tests/global-declarations-true-survives-reset.smt2
+++ b/tests/query-files/smt2-command-tests/global-declarations-true-survives-reset.smt2
@@ -1,0 +1,28 @@
+; reset empties the assertion stack and takes every declaration with it,
+; global ones included -- but not the option itself, which says how the
+; declarations made after it are to be scoped. A driver that resets between
+; problems therefore does not have to set :global-declarations again.
+; RUN: %solver %s | %OutputCheck %s
+(set-option :global-declarations true)
+(set-logic QF_BV)
+(push 1)
+(declare-fun kept () (_ BitVec 4))
+(pop 1)
+(assert (= kept #x1))
+; CHECK: ^sat$
+(check-sat)
+(reset)
+; CHECK-NEXT: ^true$
+(get-option :global-declarations)
+(set-logic QF_BV)
+(push 1)
+(declare-fun after_reset () (_ BitVec 4))
+(pop 1)
+(assert (= after_reset #x2))
+; CHECK-NEXT: ^sat$
+(check-sat)
+; The declarations made before the reset did not survive it, so this name is
+; unknown again.
+; CHECK-NEXT: .*error.*token: kept.*
+(assert (= kept #x1))
+(check-sat)

--- a/tests/query-files/smt2-command-tests/set-option-bad-boolean-value.smt2
+++ b/tests/query-files/smt2-command-tests/set-option-bad-boolean-value.smt2
@@ -1,0 +1,13 @@
+; Not specific to one option: every option whose argument is a <b_value>
+; (SMT-LIB 2.6, figure 3.9) answers a malformed value the same way, with an
+; error response rather than "unsupported" -- which is reserved for what the
+; solver cannot do (3.9.1). One option per file, because the error stops the
+; run; global-declarations-bad-value covers :global-declarations.
+; RUN: not %solver %s 2>&1 | %OutputCheck %s
+; CHECK: ^\(error ".*:produce-models takes true or false.*yes"\)$
+(set-option :produce-models yes)
+(set-logic QF_BV)
+(declare-fun x () (_ BitVec 4))
+(assert (= x #x1))
+; CHECK-NOT: ^sat$
+(check-sat)


### PR DESCRIPTION
`(set-option :global-declarations true)` was answered `unsupported`, and the two settings of the option were indistinguishable: the same script that must be an error under one and satisfiable under the other was accepted both ways. #365 asked for this in 2020, for a symbolic-execution driver that streams very large terms on demand and does not want to stream them again every time a `pop` forgets the names they were bound to.

| | `false`, the default | `true` |
| --- | --- | --- |
| `pop` | drops the level's declarations, definitions and sort aliases | keeps them |
| `reset-assertions` | drops the base level's too | keeps them, drops only the assertions |
| `reset` | drops everything | drops the declarations, keeps the option |
| a name reused after its level is popped | a fresh declaration, at any sort | a redeclaration, and an error |

## Two places read the flag

Declarations already live in a per-level frame that erases them when it dies, so being global is not a second lifetime regime — it is the frame handing its contents to the base frame, the one only `reset` destroys, instead of erasing them:

```cpp
if (global_declarations)
  frames.front()->adoptDeclarations(*frames.back());

removeFrame();
```

and `reset-assertions` keeping that base frame rather than rebuilding it. Symbols are re-added rather than spliced, so the receiving frame's bindings index learns about them and the most recent declaration of a name stays the one `lookupSymbol` finds. Functions and sort aliases live in contexts shared by every frame and a frame records only the names it is responsible for erasing, so moving the names is what moves the responsibility.

Rejecting the redeclaration needed no code at all. The lexer resolves an in-scope name to `TERMID_TOK`/`FORMID_TOK` and `declare-fun`'s rule wants `STRING_TOK`, so a name that outlives its pop is refused on the way back in by the same mechanism that already refuses one declared twice at a level.

## Where z3, cvc5 and bitwuzla disagree with each other

Three questions the standard does not settle, or settles in a way nobody follows. I measured all three against `z3` at 5.0.0, `cvc5 -i` at 1.3.5-dev and `bitwuzla` at 0.9.1-dev rather than reading their sources for it.

**What `reset` does to the option.** All three drop the declarations and keep the option, so a driver resetting between problems does not set it again; STP now does the same, which is why the flag is initialised where it is declared rather than in `init()`, which `reset` re-runs. z3 also reports `true` from `get-option` afterwards and STP matches that. cvc5 reports `false` while still behaving as global, and that half I did not copy.

**Setting it late.** z3 and cvc5 refuse once the session has started; bitwuzla accepts it whenever. STP follows z3, case for case:

| the option is set after… | STP | z3 | cvc5 |
| --- | --- | --- | --- |
| `set-logic` alone | accepted | accepted | accepted |
| `set-info`, another `set-option` | accepted | accepted | accepted |
| `push` | **refused** | refused | refused |
| a declaration | **refused** | refused | *accepted* |
| an assertion | **refused** | refused | refused |
| `check-sat` | **refused** | refused | refused |
| `reset-assertions` | **refused** | refused | *accepted* |
| `reset` | accepted | accepted | accepted |

This is the one option worth gating, and the reason is not tidiness: `pop` reads the flag as it stands at the pop, not the value that was in force when the declaration was made, so setting it with declarations already in hand decides their scope after the fact. `:produce-models` set late changes what happens next and nothing that already happened. SMT-LIB gives nine options mode `start`, which would mean refusing all of them after `set-logic` — 19 tests in this tree set one there, as do benchmarks in the wild, and all three solvers accept those, so the gate is deliberately confined to this option.

**A malformed value.** `(set-option :produce-models yes)` was answered `unsupported`, which reports it as a capability STP lacks rather than as the malformed command it is — a driver reading that would conclude STP has no model production and fall back, when all that happened is that it wrote the value wrongly. These options take a `<b_value>` in the grammar, so `yes` describes nothing the solver could have carried out, and 3.9.1 reserves `unsupported` for what the solver cannot do. All three answer an error here; STP now does too, for every `<b_value>` option rather than just the one that prompted it. `:diagnostic-output-channel` takes a `<string>`, where a channel STP cannot write to really is unsupported, and an unrecognised option stays `unsupported` as well.

## The get-info flags the issue also asked for

`:name`, `:version` and `:error-behavior` have been answered since #641. `:authors` was not, and it is one of the four the standard marks `support: required` — so a driver checking the required set found a hole where a solver is not allowed to have one. It answers `"the STP team"`: a response naming individuals is a second list to keep current, and it would go stale in a released binary rather than in a file anyone can send a patch against.

`:all-statistics` is optional, and there was nothing to gain by declining it. The numbers existed and were unreachable from a script — `RunTimes` is collected unconditionally, but the only way to see it was `--print-quickstat`, which writes to stderr outside the response protocol and is a command-line decision rather than something a driver can ask for mid-session:

```
sat
(:check-sat-calls 1
 :cpu-time 0.03
 :peak-memory-mb 18.62
 :cnf-conversion 1
 :cnf-conversion-time-ms 18
 :bit-blasting 1
 :bit-blasting-time-ms 2
 …)
```

Three things about that are decisions rather than defaults. The per-stage figures are a **difference** between two readings taken around the solve, because 4.1.8 asks about the most recent check: running totals would answer a session figure to a question about one check, and would be at the mercy of `--print-quickstat`, which clears as it prints. The keywords are a table of their own rather than `RunTimes::CategoryNames`, which is prose meant to be read in `--print-quickstat` output — it has spaces, and one entry is misspelled — and reusing it would make an output contract out of text that exists to be readable, where fixing the spelling later would break whoever parses it. And the standard allows the flag only in sat or unsat mode, which this does not enforce, because under an immediate-exit error behaviour that means killing a session over a diagnostic query; z3 and cvc5 both answer it early too.

The incremental profile is deliberately not in there. Its own header says the counters travel with the timers so an ordinary solve does not touch them, so they are absent unless `--incremental-profile` is passed, and its fields are `cbpRollbackMultiplications`-grade internals that have no business in an output contract.

## Verification

`ctest` is **129/129** and `query-files` is **566 passed, 22 unsupported, 0 failed**, with 18 new test files.

The semantics were checked against all three solvers rather than against my reading of the standard. 200 generated `push`/`pop`/`declare`/`reset-assertions` scripts, 134 of them with the option on, agree verdict-for-verdict across STP, z3, cvc5 and bitwuzla — and across `--incremental=on`, `--incremental=off` and the default, and under `-d`, which found no bad counterexample. A dozen hand-written edge scripts (arrays, `check-sat-assuming` across a pop, partial and multi-level pops, toggling the option mid-run, redefinition) agree too.

Two claims in the issue thread I measured rather than inferred:

- **Popped symbols really are released.** 100 push/pop cycles declaring 2,000 symbols each — 200,000 declarations churned — peaks at **13.6 MB** under the default and **75.0 MB** with the option on, where they are retained on purpose. That is @TrevorHansen's reference-count invariant from #365 holding, and the option's retention visible at scale.
- **`RoundingMode` pins survive the option.** A mode symbol declared inside a level keeps its one-hot constraint after the pop *and* after `reset-assertions`, so `(distinct rm RNE RNA RTP RTN RTZ)` is `unsat` as it is in all three solvers. The pin is an assertion and the symbol now outlives its level, so this was the soundness question worth asking.

The tests cover both settings, which is the only way to show the option has an effect: the same script that answers `sat` under one has to be an error under the other. Both examples from the issue thread are in there — the redeclaration at a different sort, which must work under `false` and be rejected under `true`, and @TrevorHansen's cut-back `define-fun` example, whose two halves both error under `false` and answer `unsat` under `true`.

The error-path tests use the `not %solver` RUN idiom the other 45 error tests use; without it lit fails them on the exit status alone, whatever the output says. The statistics test pins the shape and the two things that do not vary run to run, and runs the file a second time under `--print-quickstat`, since that flag clearing the run times as it prints is exactly the interference the bracketing is there to survive. Both were checked against mutants — an expectation changed, a count bumped — so none of them is passing vacuously.

2,000 `check-sat`s run in 0.02s either side of the incremental switch, so the two readings per check do not show up.

Closes #365.
