### PR TITLE
Stop two adder-sharing opportunities being thrown away before CommonSubSum sees them

### DIFF
--- a/include/stp/Simplifier/CommonSubSum.h
+++ b/include/stp/Simplifier/CommonSubSum.h
@@ -124,8 +124,15 @@ class CommonSubSum
   // additions share nothing is all of them.
   ankerl::unordered_dense::set<uint64_t> shareable;
 
+  // Pairs an addition of exactly two operands already builds. Extracting
+  // such a pair out of a wider addition costs nothing -- the node it makes
+  // hash-conses to the two-operand addition, whose adder is being built
+  // anyway -- so one wider addition holding it is enough to be worth doing.
+  ankerl::unordered_dense::map<NodePair, uint32_t, PairHash> realized;
+
   void collect(const ASTNode& n, ASTNodeSet& seen, ASTVec& plusNodes);
   void markShareable();
+  void markRealized(const ASTVec& v);
   void eligibleOf(const ASTVec& v, std::vector<uint64_t>& out) const;
   bool bump(uint64_t a, uint64_t b);
   void drop(uint64_t a, uint64_t b);

--- a/lib/Simplifier/CommonSubSum.cpp
+++ b/lib/Simplifier/CommonSubSum.cpp
@@ -78,6 +78,13 @@ void CommonSubSum::markShareable()
     // A two-operand addition already *is* its own pair; extracting from it
     // would leave a one-child BVPLUS that rebuilds to itself. It is not a
     // holder, because pairs are never enumerated over it.
+    //
+    // Counting it as one would widen this set to operands that can only ever
+    // pair *within* a single wide addition, and a pair internal to one
+    // addition is never shared. The wide addition would then pay a C(k,2)
+    // enumeration for nothing: on one addition over 1500 variables alongside
+    // two-operand additions of the same variables, that is 5.5s in a pass
+    // that otherwise does no work at all.
     if (v.size() < 3)
       continue;
 
@@ -117,6 +124,30 @@ void CommonSubSum::eligibleOf(const ASTVec& v, std::vector<uint64_t>& out) const
     if (shareable.count(num) != 0)
       out.push_back(num);
   }
+}
+
+// An addition of exactly two distinct operands is an adder the query is
+// already paying for. Recording its pair lets a single wider addition
+// holding both operands be rewritten to use it: the node the rewrite builds
+// hash-conses to this addition, so the extraction is free rather than
+// costing an adder to set up.
+//
+// This is what an addition whose operands are a sub-multiset of another's
+// needs. The greedy loop walks such a pair down to two operands and then
+// stops, because from there the smaller addition votes for nothing -- which
+// leaves the last adder, the one the two additions have in common, built
+// twice.
+void CommonSubSum::markRealized(const ASTVec& v)
+{
+  if (v.size() != 2 || v[0] == v[1])
+    return;
+
+  const uint64_t a = v[0].GetNodeNum();
+  const uint64_t b = v[1].GetNodeNum();
+  const NodePair key = (a < b) ? NodePair(a, b) : NodePair(b, a);
+
+  if (realized[key]++ == 0)
+    bump(a, b);
 }
 
 bool CommonSubSum::bump(uint64_t a, uint64_t b)
@@ -197,6 +228,10 @@ bool CommonSubSum::repair(const ASTVec& before, const ASTVec& after)
         return false;
   }
 
+  // An addition the extraction has just narrowed to two operands is from
+  // here on an adder others can reuse, exactly as one written that way.
+  markRealized(after);
+
   return true;
 }
 
@@ -230,8 +265,11 @@ bool CommonSubSum::promote(const ASTNode& n)
 bool CommonSubSum::buildOccurrences()
 {
   for (const auto& sum : operands)
+  {
+    markRealized(sum.second);
     if (!addPairs(sum.second))
       return false;
+  }
 
   return true;
 }
@@ -323,10 +361,16 @@ bool CommonSubSum::extractOnePair()
     }
   }
 
-  if (applied < 2)
+  // An addition that already is this pair counts towards the two holders
+  // that make the extraction worth doing, and means no adder is spent
+  // building the shared node.
+  const auto existing = realized.find(bestPair);
+  const bool free = (existing != realized.end() && existing->second > 0);
+
+  if (applied + (free ? 1 : 0) < 2)
     return false;
 
-  saved += applied - 1;
+  saved += free ? applied : applied - 1;
   return !truncated;
 }
 
@@ -393,6 +437,7 @@ ASTNode CommonSubSum::topLevel(const ASTNode& n)
   byNum.clear();
   occurrences.clear();
   shareable.clear();
+  realized.clear();
 
   ASTNodeSet seen;
   ASTVec plusNodes;
@@ -455,6 +500,7 @@ ASTNode CommonSubSum::topLevel(const ASTNode& n)
   byNum.clear();
   occurrences.clear();
   shareable.clear();
+  realized.clear();
 
   stpMgr->GetRunTimes()->stop(RunTimes::CommonSubSum);
   return result;

--- a/lib/Simplifier/StrengthReduction.cpp
+++ b/lib/Simplifier/StrengthReduction.cpp
@@ -671,24 +671,66 @@ namespace stp
           // addition narrows to the width that can carry.
           const unsigned width = n.GetValueWidth();
 
+          // An operand with e possibly-one bits is at most 2^e - 1, so the
+          // sum is at most the sum of those, and the width that can carry
+          // it is that bound's bit length.
+          //
+          // Summing the bounds rather than taking the widest and allowing
+          // ceil(log2(m)) bits of carry is both tighter and, more usefully,
+          // stable: the loose form reads the operand *count*, so two
+          // additions over almost the same operands land on different
+          // widths whenever their counts straddle a power of two. Their
+          // operands are then extracted to different widths, share no node,
+          // and every later chance to build one adder instead of two --
+          // CommonSubSum's, and the bit-blaster's own structural sharing --
+          // is gone. See stp#444.
+          const unsigned limbs = width / 64 + 2;
+          std::vector<uint64_t> bound(limbs, 0);
           unsigned maxEffective = 0;
+
           for (unsigned i = 0; i < children.size(); i++)
           {
             unsigned nlz = 0;
             while (nlz < width && children[i]->isFixed(width - 1 - nlz) &&
                    !children[i]->getValue(width - 1 - nlz))
               nlz++;
-            if (width - nlz > maxEffective)
-              maxEffective = width - nlz;
+            const unsigned effective = width - nlz;
+            if (effective > maxEffective)
+              maxEffective = effective;
+
+            // 2^effective, taken back down to sum(2^e - 1) below. Adding
+            // the power is one bit and a carry walk; adding the mask is
+            // the same answer the long way round.
+            unsigned limb = effective / 64;
+            uint64_t addend = UINT64_C(1) << (effective % 64);
+            while (addend != 0 && limb < limbs)
+            {
+              bound[limb] += addend;
+              addend = (bound[limb] < addend) ? 1 : 0;
+              limb++;
+            }
           }
 
-          // Adding m terms can carry ceil(log2(m)) bits upwards.
-          unsigned carry = 0;
-          while ((1u << carry) < children.size())
-            carry++;
+          uint64_t borrow = children.size();
+          for (unsigned limb = 0; borrow != 0 && limb < limbs; limb++)
+          {
+            const uint64_t before = bound[limb];
+            bound[limb] -= borrow;
+            borrow = (bound[limb] > before) ? 1 : 0;
+          }
 
-          const unsigned rest = maxEffective + carry;
-          if (maxEffective > 0 && rest < width)
+          unsigned rest = 0;
+          for (unsigned limb = limbs; limb-- > 0;)
+            if (bound[limb] != 0)
+            {
+              unsigned bit = 63;
+              while ((bound[limb] & (UINT64_C(1) << bit)) == 0)
+                bit--;
+              rest = limb * 64 + bit + 1;
+              break;
+            }
+
+          if (maxEffective > 0 && rest > 0 && rest < width)
           {
             ASTVec narrowed;
             narrowed.reserve(n.Degree());

--- a/tests/query-files/simplification-tests/adder-sharing-sub-multiset.smt2
+++ b/tests/query-files/simplification-tests/adder-sharing-sub-multiset.smt2
@@ -1,0 +1,52 @@
+; RUN: %solver %s | %OutputCheck %s
+; CHECK: ^unsat
+; The instance from stp#444, reduced with ddSMT from Sage2/bench_15307.smt2.
+; The second sum is the first plus two copies of a one-bit addend, written
+; with different nesting, so the query is unsat only because addition is
+; associative and commutative. STP timed out on it until flattening became a
+; default; this pins that, and the adder sharing that follows from it.
+(set-logic QF_BV)
+(declare-const __T1 (_ BitVec 5))
+(declare-const __ (_ BitVec 6))
+(declare-const _T1 (_ BitVec 3))
+(declare-const __T (_ BitVec 6))
+(declare-const T1 (_ BitVec 3))
+(declare-const T (_ BitVec 7))
+(declare-const _T (_ BitVec 1))
+(assert
+  (let
+    ((?x25 ((_ zero_extend 24) ((_ zero_extend 1) ((_ zero_extend 1) __T)))))
+    (bvslt
+      (_ bv111 32)
+      (bvadd
+        ((_ zero_extend 24) ((_ zero_extend 4) ((_ zero_extend 1) T1)))
+        (bvadd
+          ((_ zero_extend 24) ((_ zero_extend 1) T))
+          ?x25
+          (
+            (_ zero_extend 24)
+            ((_ zero_extend 1) ((_ zero_extend 1) ((_ zero_extend 1) __T1))))
+          ((_ zero_extend 24) ((_ zero_extend 4) ((_ zero_extend 1) _T1)))
+          ((_ zero_extend 24) ((_ zero_extend 1) ((_ zero_extend 1) __))))))))
+(assert
+  (let
+    (
+      (?x1088
+        (bvadd
+          ((_ zero_extend 24) ((_ zero_extend 7) _T))
+          ((_ zero_extend 24) ((_ zero_extend 1) ((_ zero_extend 1) __))))))
+    (bvsge
+      (_ bv111 32)
+      (bvadd
+        (bvadd
+          ((_ zero_extend 24) ((_ zero_extend 4) ((_ zero_extend 1) T1)))
+          (
+            (_ zero_extend 24)
+            ((_ zero_extend 1) ((_ zero_extend 1) ((_ zero_extend 1) __T1)))))
+        ?x1088
+        ((_ zero_extend 24) ((_ zero_extend 4) ((_ zero_extend 1) _T1)))
+        ((_ zero_extend 24) ((_ zero_extend 1) ((_ zero_extend 1) __T)))
+        (bvadd
+          ((_ zero_extend 24) ((_ zero_extend 7) _T))
+          ((_ zero_extend 24) ((_ zero_extend 1) T)))))))
+(check-sat)

--- a/tests/unit-tests/CommonSubSum_Test.cpp
+++ b/tests/unit-tests/CommonSubSum_Test.cpp
@@ -23,6 +23,7 @@ THE SOFTWARE.
 #include "stp/Simplifier/CommonSubSum.h"
 #include "stp/Simplifier/Flatten.h"
 #include <gtest/gtest.h>
+#include <algorithm>
 #include <set>
 
   const std::string start_input = R"(
@@ -165,6 +166,50 @@ TEST(CommonSubSum_Test, shared_pair_factored_into_one_node)
     if (parents == 2)
       shared++;
   }
+  ASSERT_EQ(shared, 1);
+}
+
+// An addition whose operands are a sub-multiset of another's ends up being
+// the adder they have in common, rather than having it built twice:
+//   (v0 + v1 + v2), (v0 + v1 + v2 + v3)
+//     -->  s = (v0 + v1);  t = (s + v2);  t, (t + v3)
+// The greedy walks the smaller addition down to two operands and, at that
+// point, it *is* the pair the wider one still holds. Without counting a
+// two-operand addition as an adder others can reuse it votes for nothing
+// from there and stops one step short, leaving `t` built twice. This is the
+// shape stp#444 reduces to.
+TEST(CommonSubSum_Test, sub_multiset_sum_becomes_the_shared_node)
+{
+  const std::string input = R"(
+    (assert (= (bvmul v3 (bvadd v0 v1 v2)) (_ bv0 20)))
+    (assert (= (bvmul v0 (bvadd v0 v1 v2 v3)) (_ bv33 20)))
+    )";
+
+  Context c;
+  ASTNode n = c.process(input);
+
+  std::set<ASTNode> plusNodes, visited;
+  collectPlusNodes(n, plusNodes, visited);
+
+  // s, t, and the wider addition rewritten around t: three binary adders
+  // for what arrived as a three-operand and a four-operand addition.
+  ASSERT_EQ(plusNodes.size(), 3u);
+  for (const ASTNode& p : plusNodes)
+    ASSERT_EQ(p.Degree(), 2u);
+
+  // The smaller addition is now a child of the wider one. That is the last
+  // extraction, and it is the one that does not happen without the change.
+  const ASTNode& widest = *std::max_element(
+      plusNodes.begin(), plusNodes.end(),
+      [](const ASTNode& a, const ASTNode& b) {
+        return a.GetNodeNum() < b.GetNodeNum();
+      });
+
+  int shared = 0;
+  for (const ASTNode& s : plusNodes)
+    for (const ASTNode& child : widest.GetChildren())
+      if (child == s)
+        shared++;
   ASSERT_EQ(shared, 1);
 }
 

--- a/tests/unit-tests/CommonSubSum_Test.cpp
+++ b/tests/unit-tests/CommonSubSum_Test.cpp
@@ -270,10 +270,11 @@ TEST(CommonSubSum_Test, shared_pair_factored_into_one_product_node)
 
 // A larger shared operand subset falls out of repeated pair extraction.
 // {v0,v1,v4,v6} is common to both sums, so two rounds pull out two shared
-// pairs; the smaller sum ends as exactly the sum of those pairs and the
-// larger one keeps them as operands:
+// pairs, and once the smaller sum has narrowed to exactly those pairs it
+// counts as an adder the wider one can reuse, so a third round finishes
+// the job:
 //   (v0+v1+v4+v6), (v0+v1+v2+v3+v4+v5+v6)
-//     -->  s1+s2, (s1+s2+v2+v3+v5)   with s1, s2 shared.
+//     -->  t = s1+s2;  t, (t+v2+v3+v5)   with s1, s2 under t alone.
 TEST(CommonSubSum_Test, overlapping_operand_subset_cascades)
 {
   const std::string input = R"(
@@ -290,12 +291,12 @@ TEST(CommonSubSum_Test, overlapping_operand_subset_cascades)
   std::set<ASTNode> plusNodes, visited;
   collectPlusNodes(n, plusNodes, visited);
 
-  // The two shared pairs, the two-operand rewrite of the small sum, and the
-  // five-operand rewrite of the wide one.
+  // The two pairs, the narrowed small sum over them, and the wide sum
+  // rewritten around the small one.
   ASSERT_EQ(plusNodes.size(), 4u);
 
   std::multiset<unsigned> degrees;
-  int sharedTwice = 0;
+  int sharedOnce = 0;
   for (const ASTNode& s : plusNodes)
   {
     degrees.insert(s.Degree());
@@ -304,11 +305,13 @@ TEST(CommonSubSum_Test, overlapping_operand_subset_cascades)
       for (const ASTNode& child : p.GetChildren())
         if (child == s)
           parents++;
-    if (parents == 2)
-      sharedTwice++;
+    if (parents == 1)
+      sharedOnce++;
   }
-  EXPECT_EQ(degrees, (std::multiset<unsigned>{2, 2, 2, 5}));
-  EXPECT_EQ(sharedTwice, 2);
+  EXPECT_EQ(degrees, (std::multiset<unsigned>{2, 2, 2, 4}));
+  // s1 and s2 sit under the small sum, and the small sum under the wide
+  // one: a chain, not two duplicated adders.
+  EXPECT_EQ(sharedOnce, 3);
 }
 
 // A pair held by three sums is built once and referenced from all three.

--- a/tests/unit-tests/StrengthReduction_Test.cpp
+++ b/tests/unit-tests/StrengthReduction_Test.cpp
@@ -496,6 +496,38 @@ TEST(StrengthReduction_Test , __LINE__)
   ASSERT_TRUE(presentWithWidth(stp::BVPLUS, n, 5));
 }
 
+// Two additions over the same masked operands, one of them carrying an extra
+// one-bit addend, narrow to the *same* width. Bounding the sum by the sum of
+// the operands' bounds is what makes that true: allowing the widest operand
+// ceil(log2(degree)) bits of carry instead would read the operand count, put
+// the four-operand sum in 6 bits and the five-operand one in 7, and leave the
+// two sharing no operand node at all. Issue #444.
+TEST(StrengthReduction_Test , __LINE__)
+{
+  const std::string input = R"(
+    (
+      assert
+            (and
+              ( = v4
+                (bvadd (bvand v0 (_ bv15 20)) (bvand v1 (_ bv15 20))
+                       (bvand v2 (_ bv15 20)) (bvand v3 (_ bv15 20)))
+              )
+              ( = v4
+                (bvadd (bvand v0 (_ bv15 20)) (bvand v1 (_ bv15 20))
+                       (bvand v2 (_ bv15 20)) (bvand v3 (_ bv15 20))
+                       ((_ zero_extend 19) x0))
+              )
+            )
+    )
+    )";
+
+  Context c;
+  ASTNode n = c.process(input);
+  ASSERT_FALSE(presentWithWidth(stp::BVPLUS, n, 20));
+  ASSERT_FALSE(presentWithWidth(stp::BVPLUS, n, 7));
+  ASSERT_TRUE(presentWithWidth(stp::BVPLUS, n, 6));
+}
+
 // An addition whose operands split at a bit boundary becomes a concat:
 // no adder, no bitwise operation at all.
 TEST(StrengthReduction_Test , __LINE__)


### PR DESCRIPTION
Two additions that share operands should build one adder between them. #777 added `CommonSubSum` to arrange exactly that, and it works — but two rules sitting on either side of it hand it inputs it cannot use, and both failures are silent: the pass reports `Adders saved:0` and nothing indicates anything was missed.

Found while checking whether #444 is still open. It isn't — the instance in it answers `unsat` in 0.02s on master, because #777 also turned `--flattening` on by default, which is what @TrevorHansen said would fix it when it was filed. These are the two things that turned up on the way to establishing that.

## The width-narrowing rule reads the operand count

`StrengthReduction` narrows an addition whose operands all have leading zeros: if the sum cannot reach the node's width, rebuild it at a width that can carry it, extracting each operand down. The width it picked was the widest operand plus `ceil(log2(degree))` bits of carry.

Sound, but it reads the operand *count*. Two additions over almost the same operands land on different widths as soon as their counts straddle a power of two — and then their operands are extracts of different widths, so they are different nodes, and the two additions share nothing at all. Not for `CommonSubSum`, which is hunting for precisely that sharing, and not for the bit-blaster's own structural hashing either.

One 1-bit addend is enough. Two additions of n 24-bit addends inside 64 bits, the second carrying one extra 1-bit addend:

| n | 15 | **16** | 17 | 31 | **32** | 33 | 63 | **64** | **65** |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| `Adders saved`, master | 14 | **0** | 16 | 30 | **0** | 32 | 62 | **0** | **0** |
| `Adders saved`, this PR | 14 | **15** | 16 | 30 | **31** | 32 | 62 | **63** | **63** |

n=64 goes 0.11s → 0.05s and n=65 0.22s → 0.05s. The cliff is invisible from the outside; the query just costs twice the adders it needs to.

Bounding the sum by the sum of the operands' bounds removes it. An operand with `e` possibly-one bits is at most `2^e - 1`, so the sum is at most `sum(2^e_i - 1)`, and the width that carries it is that bound's bit length. Two things follow:

- **It is never wider than the old choice.** `sum(2^e_i - 1) < 2^(maxEffective + ceil(log2(m)))` for every input, so this only ever narrows further — the existing narrowing tests are unchanged.
- **It is stable.** A bound dominated by the large operands does not move far enough for a couple of tiny addends to push it past the next power of two, which is the property #444's shape needs.

The bound is accumulated in limbs rather than a machine word, because the node's width is whatever the input asked for. The headroom is `width+65` bits against a bound below `2^(width+32)`.

## CommonSubSum stalls one step short of a sub-multiset

The greedy pulls out the operand pair held by the most additions. Additions of fewer than three operands were skipped entirely, on the grounds that such an addition already *is* its own pair and extracting from it would leave a one-child `BVPLUS`. True of rewriting it — but it also meant a two-operand addition never counted as holding its operands, so a pair it already builds was invisible to every wider addition holding the same two.

The case that costs is an addition whose operands are a sub-multiset of another's, which is what #444 reduces to: a sum compared against itself plus two more addends. The greedy walks the smaller addition down to two operands and stops, because from there it votes for nothing — leaving the last adder the two have in common built twice. On the instance from that issue the pass reports four adders saved where five are available.

So count a two-operand addition as holding its operands, and tally its pair as one already realized. Extracting such a pair is not merely worthwhile, it is **free**: the node the extraction builds hash-conses to the addition that was already there, so no adder is spent setting it up, and one wider addition holding the pair is enough to be worth rewriting rather than the two the general rule needs. An addition the greedy has just narrowed to two operands becomes realized the same way, which is what lets the walk take its last step instead of stalling.

## Checking it

- **129/129 ctest**, including two new unit tests. Both fail without their change: `CommonSubSum_Test.sub_multiset_sum_becomes_the_shared_node` gets a 3-operand sum back instead of the shared node, and the new `StrengthReduction_Test` case sees the two additions at widths 7 and 6 instead of both at 6.
- **1500-query differential fuzz** built around the narrowing rule — random sums of zero-extended narrow variables and constants against random bounds — against a binary built from this branch's parent: **0 disagreements**, 938 unsat / 562 sat.
- **300 real QF_BV files** ([Zenodo 15493096](https://zenodo.org/records/15493096)) against the same baseline: **0 answer mismatches**, 186.5s vs 187.6s total. Neutral, which is what I expect — SVCOMP-style queries have few wide n-ary sums, and neither change can fire without them. I have not run a large-corpus performance campaign; if that matters before merging, say so and I will.

The query file added under `simplification-tests` is the instance from #444 itself. It answers `unsat` either way today, so it pins the issue rather than this PR — the unit tests are what fail without these changes.

## What I looked at and left alone

`Flatten` is deliberately sharing-aware: it splices a child into its parent only when the child has one reference. That means two AC-equal additions whose intermediate sums are referenced elsewhere keep their own nesting and stay distinct nodes. It reads like a third gap, but I could not build an instance where it actually costs anything, so I am not claiming it as one.
