### PR TITLE
Restrict CBP adoption to entries its pinning facts cover

### DIFF
--- a/lib/Incremental/IncrementalDriverCbp.cpp
+++ b/lib/Incremental/IncrementalDriverCbp.cpp
@@ -394,6 +394,19 @@ void IncrementalSolver::Impl::cbpFinishLevel()
 // refinement loop validates stay models of the raw stack. Fed
 // conjuncts are exempt: their own levels assert them for at least
 // as long as any adopter lives.
+//
+// The substitution handed to replace() is RESTRICTED to entries
+// whose keys occur in this conjunct's own DAG. replace() also maps
+// nodes it REBUILDS on the way up -- hash-consing folded children
+// can reproduce a fixed node the original conjunct never contained
+// (a ctx-substituted form collapsing back onto the raw interior AND
+// its level was fed as) -- and the fact walk, which can only see
+// the original DAG, would assert no pinning fact for it: the
+// fixing's whole constraint silently leaves the encoding, and the
+// model (or the verdict) is no longer the raw stack's. Restricting
+// the map makes "may fire" and "fact asserted" the same set again:
+// a rebuilt node can still hit an entry, but only one whose key
+// occurs -- and is therefore pinned -- somewhere in this conjunct.
 ASTNode IncrementalSolver::Impl::cbpAdopt(const ASTNode& conjunct,
                  std::vector<ScopedFact>& factsOut)
 {
@@ -404,21 +417,38 @@ ASTNode IncrementalSolver::Impl::cbpAdopt(const ASTNode& conjunct,
   if (profile.enabled)
     profile.cbpAdoptAttempts++;
 
-  // The conjunct's own entry (a ctx-substituted form can be fixed
-  // as an interior node without being a fed conjunct) never rewrites
-  // its own slot.
-  ASTNodeMap::iterator selfEntry = callCbpSubst.find(conjunct);
-  ASTNode selfConstant;
-  if (selfEntry != callCbpSubst.end())
+  // One walk collects the entries occurring in the conjunct, in a
+  // deterministic order the fact emission below reuses. The
+  // conjunct's own entry (a ctx-substituted form can be fixed as an
+  // interior node without being a fed conjunct) never rewrites its
+  // own slot, so the root is skipped as a domain.
+  ASTNodeMap occurring;
+  std::vector<std::pair<ASTNode, ASTNode>> occurringOrdered;
   {
-    selfConstant = selfEntry->second;
-    cbpEraseSubstitution(conjunct);
+    ASTNodeSet visited;
+    std::vector<ASTNode> pending(1, conjunct);
+    while (!pending.empty())
+    {
+      const ASTNode cur = pending.back();
+      pending.pop_back();
+      if (!visited.insert(cur).second)
+        continue;
+      ASTNodeMap::const_iterator sit = callCbpSubst.find(cur);
+      if (sit != callCbpSubst.end() && !(cur == conjunct))
+      {
+        occurring.insert(*sit);
+        occurringOrdered.push_back(*sit);
+      }
+      for (unsigned j = 0; j < cur.Degree(); j++)
+        pending.push_back(cur[j]);
+    }
   }
+  if (occurring.empty())
+    return conjunct;
+
   ASTNodeMap cache;
   const ASTNode adopted = SubstitutionMap::replace(
-      conjunct, callCbpSubst, cache, bm->defaultNodeFactory);
-  if (!selfConstant.IsNull())
-    cbpAssignSubstitution(conjunct, selfConstant);
+      conjunct, occurring, cache, bm->defaultNodeFactory);
   if (adopted == conjunct)
     return conjunct;
 
@@ -426,30 +456,20 @@ ASTNode IncrementalSolver::Impl::cbpAdopt(const ASTNode& conjunct,
   if (dagSizeUpTo(adopted, before) >= before)
     return conjunct;
 
-  ASTNodeSet visited;
-  std::vector<ASTNode> pending(1, conjunct);
-  while (!pending.empty())
+  for (const std::pair<ASTNode, ASTNode>& oe : occurringOrdered)
   {
-    const ASTNode cur = pending.back();
-    pending.pop_back();
-    if (!visited.insert(cur).second)
+    const ASTNode& cur = oe.first;
+    if (callCbpFedConjuncts.find(cur) != callCbpFedConjuncts.end() ||
+        !cbpInsertFactDomain(cur))
       continue;
-    ASTNodeMap::const_iterator sit = callCbpSubst.find(cur);
-    if (sit != callCbpSubst.end() &&
-        callCbpFedConjuncts.find(cur) == callCbpFedConjuncts.end() &&
-        cbpInsertFactDomain(cur))
-    {
-      ASTNode fact;
-      if (cur.GetType() == BOOLEAN_TYPE)
-        fact = sit->second == bm->ASTTrue
-                   ? cur
-                   : bm->defaultNodeFactory->CreateNode(NOT, cur);
-      else
-        fact = bm->defaultNodeFactory->CreateNode(EQ, cur, sit->second);
-      factsOut.push_back(ScopedFact(cur, fact));
-    }
-    for (unsigned j = 0; j < cur.Degree(); j++)
-      pending.push_back(cur[j]);
+    ASTNode fact;
+    if (cur.GetType() == BOOLEAN_TYPE)
+      fact = oe.second == bm->ASTTrue
+                 ? cur
+                 : bm->defaultNodeFactory->CreateNode(NOT, cur);
+    else
+      fact = bm->defaultNodeFactory->CreateNode(EQ, cur, oe.second);
+    factsOut.push_back(ScopedFact(cur, fact));
   }
 
   callCbpAdopted++;

--- a/tests/api/C/incremental-query.cpp
+++ b/tests/api/C/incremental-query.cpp
@@ -167,6 +167,69 @@ TEST(incremental_query, deep_alternating_chain)
   vc_Destroy(vc);
 }
 
+// CBP adoption rewrites a ctx-substituted conjunct under the engine's
+// fixings, and hash-consing can REBUILD the raw inner AND the feed fixed
+// TRUE -- a node the original conjunct no longer contained, so the
+// pinning-fact walk asserted nothing for it and the inner conjuncts
+// (here the definer and the sdiv comparison) silently left the encoding.
+// This is murxla's shape: flag 'i', no push, everything riding the C
+// API's retractable levels. The model must satisfy every raw conjunct
+// -- pre-fix it returned x4=0, falsifying (bvsgt (bvsdiv x4 x4) x4),
+// whose only witnesses are 0b10 and 0b11 -- and disequalities excluding
+// those witnesses (invisible to the bit-level engine) must flip the
+// verdict rather than stay sat against the dropped conjunct.
+TEST(incremental_query, cbp_adoption_keeps_rebuilt_fixed_node_constraint)
+{
+  VC vc = vc_createValidityChecker();
+  vc_setFlags(vc, 'i');
+  vc_setFlags(vc, 'c');
+
+  Type bv1 = vc_bvType(vc, 1);
+  Type bv2 = vc_bvType(vc, 2);
+  Expr x0 = vc_varExpr(vc, "x0", bv2);
+  Expr x2 = vc_varExpr(vc, "x2", bv1);
+  Expr x3 = vc_varExpr(vc, "x3", bv1);
+  Expr x4 = vc_varExpr(vc, "x4", bv2);
+
+  // (and (and (= x2 x3) (bvsgt (bvsdiv x4 x4) x4))
+  //      (bvsle (bvlshr x0 x0) x0))
+  Expr inner =
+      vc_andExpr(vc, vc_eqExpr(vc, x2, x3),
+                 vc_sbvGtExpr(vc, vc_sbvDivExpr(vc, 2, x4, x4), x4));
+  Expr outer = vc_andExpr(
+      vc, inner,
+      vc_sbvLeExpr(vc, vc_bvRightShiftExprExpr(vc, 2, x0, x0), x0));
+  vc_assertFormula(vc, outer);
+
+  EXPECT_EQ(0, vc_query(vc, vc_falseExpr(vc)));
+
+  // The model, checked against the raw conjuncts. Two-bit signed
+  // domain: 0b10 = -2, 0b11 = -1.
+  const uint64_t vx0 = getBVUnsignedLongLong(vc_getCounterExample(vc, x0));
+  const uint64_t vx2 = getBVUnsignedLongLong(vc_getCounterExample(vc, x2));
+  const uint64_t vx3 = getBVUnsignedLongLong(vc_getCounterExample(vc, x3));
+  const uint64_t vx4 = getBVUnsignedLongLong(vc_getCounterExample(vc, x4));
+  const auto asSigned = [](uint64_t b) {
+    return b >= 2 ? static_cast<int>(b) - 4 : static_cast<int>(b);
+  };
+  EXPECT_EQ(vx2, vx3);
+  // SMT-LIB bvsdiv: x/x is 1 except 0/0, which is -1.
+  const int sdiv = vx4 == 0 ? -1 : 1;
+  EXPECT_GT(sdiv, asSigned(vx4));
+  const uint64_t lshr = vx0 >= 2 ? 0 : (vx0 >> vx0) & 3;
+  EXPECT_LE(asSigned(lshr), asSigned(vx0));
+
+  // Only the sdiv conjunct refutes these; the bit-level engine learns
+  // nothing from a disequality, so a dropped conjunct answers sat.
+  Expr two = vc_bvConstExprFromInt(vc, 2, 2);
+  Expr three = vc_bvConstExprFromInt(vc, 2, 3);
+  vc_assertFormula(vc, vc_notExpr(vc, vc_eqExpr(vc, x4, two)));
+  vc_assertFormula(vc, vc_notExpr(vc, vc_eqExpr(vc, x4, three)));
+  EXPECT_EQ(1, vc_query(vc, vc_falseExpr(vc)));
+
+  vc_Destroy(vc);
+}
+
 // The 'c' flag alone -- construct counterexamples, no self-check -- must
 // keep its counterexamples through the driver. construct_counterexample
 // is a direct input here with no other trace of the request, and both the

--- a/tests/query-files/incremental-tests/cbp-adopt-rebuilt-fixed-node-rm.smt2
+++ b/tests/query-files/incremental-tests/cbp-adopt-rebuilt-fixed-node-rm.smt2
@@ -1,0 +1,26 @@
+; The RoundingMode face of cbp-adopt-rebuilt-fixed-node.smt2, kept as
+; murxla minimised it (including the duplicated assertion): the chained
+; equality's definer folds out under the pushed-definition context, the
+; adoption's substitution rebuilds the CBP-fixed inner AND, and the
+; whole (= (ite ...) _x12 _x8) constraint used to leave the encoding
+; with no pinning fact -- the returned model said _x0 = _x2 yet gave
+; _x12 and _x8 a value other than the ite's RNE.  --check-sanity
+; validates the model against the raw stack.
+; REQUIRES: floating-point
+; RUN: %solver --incremental --check-sanity %s | %OutputCheck %s
+; RUN: %solver --incremental --incremental-cbp-reset --check-sanity %s | %OutputCheck %s
+; RUN: %solver --incremental-auto-engage-at 1 --check-sanity %s | %OutputCheck %s
+(set-logic QF_FP)
+(declare-const _x0 RoundingMode)
+(declare-const _x2 RoundingMode)
+(declare-const _x7 RoundingMode)
+(declare-const _x8 RoundingMode)
+(declare-const _x12 RoundingMode)
+(push 1)
+(assert (= (ite (distinct _x0 _x2) RNA roundNearestTiesToEven) _x12 _x8))
+(assert (= (ite (distinct _x0 _x2) RNA roundNearestTiesToEven) _x12 _x8))
+(assert (distinct _x0 _x7))
+; CHECK: ^sat
+(check-sat)
+(pop 1)
+(exit)

--- a/tests/query-files/incremental-tests/cbp-adopt-rebuilt-fixed-node.smt2
+++ b/tests/query-files/incremental-tests/cbp-adopt-rebuilt-fixed-node.smt2
@@ -1,0 +1,48 @@
+; A conjunct arriving at CBP adoption is a ctx-substituted form: the
+; definer (= _x2 _x3) was folded out of the inner AND and re-joined on
+; top, so the node no longer contains the raw inner AND the feed fixed
+; TRUE.  Substituting the third conjunct's fixing (its bvsgt shell to
+; FALSE) then REBUILDS exactly that inner AND -- hash-consing hands the
+; substitution a node the walked DAG never contained, replace() maps
+; the rebuilt node too, and the pinning-fact walk asserted nothing for
+; it: the definer and the sdiv conjunct silently left the encoding.
+; The model falsified the raw stack (_x4=0b00 falsifies the sdiv
+; conjunct, which only 0b10/0b11 satisfy), and a second level
+; contradicting the dropped conjunct turned the verdict itself wrong:
+; sat on an unsat stack.  Found by murxla.  The adoption substitution
+; is now restricted to entries occurring in the conjunct's own DAG --
+; exactly the set the fact walk pins.
+; RUN: %solver --incremental --check-sanity -s %s 2>&1 | %OutputCheck %s
+; RUN: %solver --incremental --check-sanity %s | %OutputCheck --check-prefix=VERDICT %s
+; RUN: %solver --incremental --incremental-cbp-reset --check-sanity %s | %OutputCheck --check-prefix=VERDICT %s
+; RUN: %solver --incremental-auto-engage-at 1 --check-sanity %s | %OutputCheck --check-prefix=VERDICT %s
+(push 1)
+(declare-const _x0 (_ BitVec 2))
+(declare-const _x2 (_ BitVec 1))
+(declare-const _x3 (_ BitVec 1))
+(declare-const _x4 (_ BitVec 2))
+(assert (and (and (= _x2 _x3) (bvsgt (bvsdiv _x4 _x4) _x4)) (bvsle (bvlshr _x0 _x0) _x0)))
+; The adoption must still fire -- the fix restricts what it may
+; substitute, it does not retire the pass -- and --check-sanity
+; validates the model against the raw stack.
+; CHECK: cbp adopted
+; CHECK: ^sat
+; VERDICT: ^sat
+(check-sat)
+(push 1)
+; Bit-level transfer functions learn nothing from a disequality, so no
+; engine conflict masks the loss: only the encoded sdiv conjunct
+; (forcing _x4 to 0b10 or 0b11) can refute these.  With it dropped,
+; this answered sat.
+(assert (and (distinct _x4 #b10) (distinct _x4 #b11)))
+; CHECK: ^unsat
+; VERDICT: ^unsat
+(check-sat)
+(pop 1)
+; The disequalities retract; the replayed adoption must still carry
+; the sdiv conjunct's strength, with a model that satisfies it.
+; CHECK: ^sat
+; VERDICT: ^sat
+(check-sat)
+(pop 1)
+(exit)


### PR DESCRIPTION
Under `--incremental=on`, a check-sat whose assertions live on a retractable level could hand back a model that falsifies an asserted formula — and, with content contradicting the lost conjunct, answer `sat` on an unsat stack. Both reproducers came out of a murxla campaign as `--check-sanity` aborts (`IncrementalSolver: the model does not satisfy an asserted formula`); without the flag the answer is a quiet `sat` with a wrong model.

The smaller one, hand-minimised to two bits:

```smt2
(push 1)
(declare-const _x0 (_ BitVec 2))
(declare-const _x2 (_ BitVec 1))
(declare-const _x3 (_ BitVec 1))
(declare-const _x4 (_ BitVec 2))
(assert (and (and (= _x2 _x3) (bvsgt (bvsdiv _x4 _x4) _x4)) (bvsle (bvlshr _x0 _x0) _x0)))
(check-sat)
```

STP said `sat` with `_x4 = #b00` — but `(bvsdiv #b00 #b00)` is `#b11`, so `(bvsgt #b11 #b00)` is false under the model's own values. Only `#b10` and `#b11` satisfy that conjunct.

## The mechanism

CBP adoption rewrites a level's conjunct under the engine's fixed nodes, and it is sound because every replaced node's pinning fact (node = constant) is asserted alongside: the rewritten conjunct plus the facts is equivalent to the original. The facts are found by walking the conjunct's DAG and emitting one for every node with a substitution entry.

That walk sees every node the substitution can fire on — except the ones `SubstitutionMap::replace` invents. `replace()` re-checks the map against every node it *rebuilds* on the way up (the remap that keeps `READ(A, x)` under `{x → 0, READ(A,0) → 1}` idempotent), and here that behaviour meets hash-consing:

- the feed fixes the raw interior AND — `(and (= _x2 _x3) (bvsgt ...))` — to TRUE. It is an interior node, not a fed conjunct, so its entry goes straight into the substitution;
- the conjunct arriving at adoption is a *different* node: the definer `(= _x2 _x3)` was folded out by the pushed-definition context and re-joined on top, giving `(and (= _x2 _x3) (and (bvsgt ...) (bvsle ...)))`;
- the third conjunct's shell is fixed too — the factory already folded `(bvlshr _x0 _x0)` to `#b00` at parse, and the feed fixed the remaining `(bvsgt #b00 _x0)` to FALSE. Substituting that turns the inner `(and (bvsgt ...) TRUE)` into the bvsgt alone, and the outer rebuild hash-conses to *exactly* the fixed interior AND;
- `replace()` maps the rebuilt node to TRUE. The fact walk, which can only see the original DAG, asserted nothing for it — so the adopted conjunct is TRUE plus one fact about `_x0`, and the definer and the sdiv conjunct are simply gone from the encoding.

The verdict side follows: nothing is left in the solver to contradict. Push a level the bit-level transfer functions are blind to — disequalities fix no bits — excluding exactly the dropped conjunct's witnesses, and the pre-fix driver answers `sat` on an unsat stack:

```smt2
(push 1)
(assert (and (distinct _x4 #b10) (distinct _x4 #b11)))
(check-sat)
```

(An interval-visible contradiction like `(bvule _x4 #b01)` hides the bug instead: the feed sees it and refutes the level by itself, which is why the campaign only surfaced bad models.)

## The fix

The substitution handed to `replace()` is restricted to entries whose keys occur in the conjunct's own DAG — collected by the same walk that emits the facts, so "may fire" and "fact asserted" are the same set by construction. A rebuilt node can still hit an entry, but only one whose key occurs, and is therefore pinned, somewhere in the conjunct — or one keyed by a fed conjunct, which another live level asserts and which needs no fact.

Only CBP's map is exposed to the remap: every other substitution map in the driver (`sigma0`, the pushed-definition context) is symbol-keyed, and a rebuilt node is never a symbol. The old erase/restore dance around the conjunct's own entry is subsumed by skipping the root during collection, which also stops `replace()` canonicalising entries of `callCbpSubst` behind the undo trail's back (unreachable today, the values being constants, but no longer possible at all).

## Checking it

- **129/129 ctest.** Three regression tests, each verified failing before the fix: the BV shape through the SMT-LIB frontend (sanity-checked models, the disequality round flipping to `unsat`, and a retraction round exercising memo replay, across four flag variants), the RoundingMode reproducer as murxla minimised it, and the C API's no-push session that found it first, with the model values checked against SMT-LIB `bvsdiv` semantics directly in the test.
- All four murxla traces from the campaign replay clean against the fixed library.
- The adoption still fires on every reproducer — the fix restricts what it may substitute, it does not retire the pass — and the lit test pins `cbp adopted` in the stats so the path stays exercised rather than silently skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
