### PR TITLE
Account for the duplicate filter in Flatten's rebuild check

### DIFF
--- a/lib/Simplifier/Flatten.cpp
+++ b/lib/Simplifier/Flatten.cpp
@@ -149,12 +149,16 @@ namespace stp
       ASTVec newChildren;
       ASTVec nextChildren;
       std::unordered_set<uint64_t> seen;
+      // Entries merged into this frame instead of kept as children; balances
+      // the rebuild bookkeeping check below.
+      size_t flattenedIn = 0;
 
       void clear()
       {
         newChildren.clear();
         nextChildren.clear();
         seen.clear();
+        flattenedIn = 0;
       }
     };
 
@@ -239,6 +243,7 @@ namespace stp
             top_removed++;
           else
             removed++;
+          scratch.flattenedIn++;
 
           for (const auto& e : c.GetChildren())
           {
@@ -283,7 +288,13 @@ namespace stp
       if (done.changed)
       {
         Scratch& scratch = scratches[done.scratch];
-        assert(done.n.Degree() <= scratch.newChildren.size());
+        // Every consumed entry either landed in newChildren or was flattened
+        // in, adding its children to nextChildren minus what the AND/OR
+        // duplicate filter dropped. The filter means newChildren can end up
+        // *smaller* than the original degree, so the check is this balance,
+        // not `Degree() <= newChildren.size()`.
+        assert(scratch.newChildren.size() + scratch.flattenedIn ==
+               done.n.Degree() + scratch.nextChildren.size());
 
         if (done.n.GetType() == BOOLEAN_TYPE)
           result = nf->CreateNode(done.k, scratch.newChildren);

--- a/tests/query-files/misc-tests/flatten-dedup-shrinks-conjunction.smt2
+++ b/tests/query-files/misc-tests/flatten-dedup-shrinks-conjunction.smt2
@@ -1,0 +1,17 @@
+; RUN: %solver --flattening=true -d %s | %OutputCheck %s
+; CHECK-NEXT: ^sat
+;
+; The three conjuncts contain one another once the chainable equalities are
+; expanded: each later assertion is an AND wrapping the previous one. When
+; Flatten merges them into the top-level conjunction, its AND/OR duplicate
+; filter drops every already-seen entry, so the rebuilt AND legitimately has
+; *fewer* children than the original. An over-strong
+; assert(Degree() <= newChildren.size()) aborted every assertions-enabled
+; build on this input; found by murxla. -d checks the model against the
+; original query, guarding against a conjunct genuinely going missing.
+(declare-const _x0 Bool)
+(declare-const _x3 Bool)
+(assert (= true _x0 (= _x3 _x0)))
+(assert (and (= true _x0 (= _x3 _x0)) _x0))
+(assert (= (and (= true _x0 (= _x3 _x0)) _x0) true _x0))
+(check-sat)

--- a/tests/unit-tests/Flatten_Test.cpp
+++ b/tests/unit-tests/Flatten_Test.cpp
@@ -127,6 +127,27 @@ TEST(Flatten_Test, DISABLED__LINE__)
 
 
 
+// The three conjuncts contain one another: expanding the chainable
+// equalities makes each later assertion an AND wrapping the previous one.
+// Merging them into the top-level conjunction sends only already-seen
+// entries through the AND/OR duplicate filter, so the rebuilt AND has
+// fewer children than the original's degree -- which is fine, and used to
+// trip an over-strong assert. Found by murxla.
+TEST(Flatten_Test, __LINE__)
+{
+  const std::string input = R"(
+    (assert (= true a (= b a)))
+    (assert (and (= true a (= b a)) a))
+    (assert (= (and (= true a (= b a)) a) true a))
+    )";
+
+  Context c;
+  ASTNode n = c.process(input);
+  ASTNode a = c.mgr.LookupOrCreateSymbol("a");
+  ASTNode b = c.mgr.LookupOrCreateSymbol("b");
+  ASSERT_EQ(n, c.mgr.CreateNode(stp::AND, a, b));
+}
+
 TEST(Flatten_Test, __LINE__)
 {
   const std::string input = R"(


### PR DESCRIPTION
An assertions-enabled build of STP aborts on this pure-Boolean input — a single `(check-sat)` on the ordinary batch path. A Release build answers `sat`, and `sat` is correct (Release compiles the assert out: `CMakeLists.txt` forces `ENABLE_ASSERTIONS=OFF` for Release regardless of what was passed on the command line). Found by an unrestricted murxla campaign, then hand-minimised:

```smt2
(declare-const _x0 Bool)
(declare-const _x3 Bool)
(assert (= true _x0 (= _x3 _x0)))
(assert (and (= true _x0 (= _x3 _x0)) _x0))
(assert (= (and (= true _x0 (= _x3 _x0)) _x0) true _x0))
(check-sat)
```

```
stp: lib/Simplifier/Flatten.cpp:286: stp::ASTNode stp::Flatten::flatten(const stp::ASTNode&, bool): Assertion `done.n.Degree() <= scratch.newChildren.size()' failed.
```

## The mechanism

`flatten()` asserts that a rebuilt node keeps at least as many children as it started with, on the theory that merging a same-kind child in always trades one entry for two or more. The AND/OR duplicate filter breaks that theory: entries already pushed are dropped, so a merged-in conjunct can contribute nothing at all.

On the reproducer, the three assertions parse into ANDs that contain one another — expanding the chainable equalities makes each later assertion an AND wrapping the previous one. Flattening the top-level conjunction then goes: the first conjunct contributes its two children, the second and third re-offer only entries the filter has already seen, and the `(= _x3 _x0)`-under-`(= true _x0 ...)` XOR chain collapses to `_x3` on the way through. A degree-3 AND rebuilds with 2 children — `(AND _x0 _x3)` — and that node is exact: every conjunct is still represented, directly or through its flattened form. Which is why Release was never wrong: the node it constructed behind the compiled-out assert was the right one.

The check and the filter have contradicted each other since the day both landed — 92a80672 added the assert, af48256d the filter, on 2022-05-16 — waiting for an input whose repeated conjuncts survive the node factory's own folding (plain `(and a b (and a b))` never reaches Flatten, which is why the collision took this long to surface). The explicit-stack rewrite (5a3c6cd3) carried the pair over faithfully.

## The fix

Replace the inequality with the balance that actually holds. Every consumed entry either lands in `newChildren` or is flattened in, contributing its post-filter children to `nextChildren`, so at rebuild time:

```
newChildren.size() + flattenedIn == Degree() + nextChildren.size()
```

This still catches genuinely lost or duplicated children — the failure the old check was reaching for — and tolerates the filter. Costs one counter per scratch slot.

## Checking it

- **129/129 ctest** on an assertions-enabled build; both the minimised and the campaign's unreduced reproducer now answer `sat` cleanly.
- The reproducer joins the tests twice, each verified aborting before the fix and green after: as a query file run with `-d`, so the recovered model is checked against the original query — guarding the conjunct-actually-dropped failure this bug was one arithmetic slip away from being — and as a `Flatten_Test` unit case pinning the rebuilt node to exactly `(AND a b)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
