### PR TITLE
Enable CaDiCaL's bounded variable addition by default

### DIFF
--- a/docs/incremental-solving.rst
+++ b/docs/incremental-solving.rst
@@ -517,17 +517,22 @@ between solves safe. When CaDiCaL is compiled in it is the default
 backend.
 
 CaDiCaL's bounded variable addition (``--cadical-factor``) follows the
-batch pipeline's policy on the persistent solver too: an explicit ON
-always asks, AUTO asks for array sessions, and the decision has to land
-in the backend's configuration window, which closes at its first clause
--- the start of the first engaged check-sat, and again right after a
-relief-valve rebuild, whose fresh solver reopens the window. With factor
-on, clause literals, *assumption literals* and model lookups all travel
-through the wrapper's declared-variable translation table; assumptions
-are how every retractable formula is asserted here, so a literal that
-skipped the translation would silently constrain nothing. The
-``query-files-cadical-factor`` suite sweep re-runs every behavioural
-test, the incremental ones included, with factor forced on.
+batch pipeline's policy on the persistent solver too: ON -- the default
+since it was measured on bitvector-only problems -- always asks, AUTO
+asks for array sessions, and the decision has to land in the backend's
+configuration window, which closes at its first clause -- the start of
+the first engaged check-sat, and again right after a relief-valve
+rebuild, whose fresh solver reopens the window. Because ON is now the
+default, an engaged session asks for the factor whatever it contains,
+where before an array-free one did not; ``--cadical-factor=auto``
+restores the previous policy exactly. With factor on, clause literals,
+*assumption literals* and model lookups all travel through the wrapper's
+declared-variable translation table; assumptions are how every
+retractable formula is asserted here, so a literal that skipped the
+translation would silently constrain nothing. The
+``query-files-cadical-factor-off`` suite sweep re-runs every behavioural
+test, the incremental ones included, with the factor forced off, the
+side the default no longer covers.
 
 CaDiCaL's probe-based inprocessing re-runs over the whole persistent
 encoding at every solve, so on many-solve sessions its recurring cost

--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -320,18 +320,31 @@ public:
   SearchBias search_bias = SearchBias::NONE;
 
   // Whether CaDiCaL may use bounded variable addition (its "factor"
-  // technique). Measured on QF_ABV it is a large win on some
-  // array-refinement families (wchains: up to 5x) and a modest loss on
-  // others (countbitstable: ~30%), so AUTO -- the default -- enables it
-  // only for problems that still contain array operations after
-  // simplification, and an explicit ON/OFF from the user always wins.
+  // technique). ON is the default: measured on QF_BV, where the AUTO
+  // heuristic below never fires, it is worth a 0.76-0.80 geometric mean of
+  // wall clock on hard instances (>10 s, 259 files, three rounds) and -12.5%
+  // total wall over 42k easy ones, with no answer disagreements.
+  //
+  // AUTO enables it only for problems that still contain array operations
+  // after simplification. That was the default when the flag landed, fitted
+  // on QF_ABV alone: BVA is a large win on some array-refinement families
+  // (wchains: up to 5x) and a loss on countbitstable, whose arrays are
+  // Ackermannised away, so testing for surviving arrays separated the two.
+  // It is kept as an explicit choice because it is the only way back to that
+  // behaviour; on QF_BV it is equivalent to OFF.
   enum class BVAMode
   {
     AUTO = 0,
     ON,
     OFF
   };
-  BVAMode cadical_factor = BVAMode::AUTO;
+  BVAMode cadical_factor = BVAMode::ON;
+
+  // Whether ON above came from the command line rather than from the default.
+  // A backend with no BVA declines the request, and that is worth a warning
+  // only when a user actually asked for it -- otherwise every solve on a
+  // pre-3.0 CaDiCaL build would carry one.
+  bool cadical_factor_explicit = false;
 
   // Whether the incremental driver may retire CaDiCaL's probe-based
   // inprocessing mid-session. Inprobing re-runs over the whole

--- a/lib/STPManager/STP.cpp
+++ b/lib/STPManager/STP.cpp
@@ -398,10 +398,10 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
   // construction because AUTO wants the post-simplification answer: the
   // Ackermannisation above can remove every array operation, and arrayops
   // is only final from this point on. The solver has not yet been handed a
-  // clause, which is the only window in which it accepts the setting. A
-  // declined explicit ON is worth a warning (no CaDiCaL 3.x behind the
-  // build, or a different backend); a declined AUTO is just the default
-  // heuristic not applying.
+  // clause, which is the only window in which it accepts the setting. ON is
+  // the default, so a decline (no CaDiCaL 3.x behind the build, or a
+  // different backend) is only worth a warning when ON was asked for by
+  // name; a declined AUTO is just the heuristic not applying.
   enableBVAIfWanted(
       NewSolver, bm->UserFlags,
       bm->UserFlags.cadical_factor == UserDefinedFlags::BVAMode::ON ||

--- a/lib/Sat/SATSolverFactory.cpp
+++ b/lib/Sat/SATSolverFactory.cpp
@@ -129,7 +129,10 @@ void applySearchBias(SATSolver& s, const UserDefinedFlags& flags, bool warn)
 bool enableBVAIfWanted(SATSolver& s, const UserDefinedFlags& flags,
                        bool wants, bool warn)
 {
-  if (!wants || s.enableBVA() ||
+  // A declined request is only worth reporting when the user asked for it by
+  // name: ON is the default, so warning on the mode alone would put a warning
+  // on every solve of a build whose CaDiCaL has no factor.
+  if (!wants || s.enableBVA() || !flags.cadical_factor_explicit ||
       flags.cadical_factor != UserDefinedFlags::BVAMode::ON || !warn)
     return false;
   std::cerr << "Warning: --cadical-factor was requested but the SAT "

--- a/tests/query-files/CMakeLists.txt
+++ b/tests/query-files/CMakeLists.txt
@@ -57,22 +57,24 @@ add_test(NAME query-files
     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
 )
 
-# The run above only exercises CaDiCaL's bounded variable addition where the
-# AUTO default turns it on (array problems). Forcing it on for the whole
-# corpus also covers the declare/translate machinery on problems the
-# heuristic would leave alone, so a numbering mistake cannot hide behind the
-# heuristic. Only registered when the flag can actually engage; on pre-3.0
-# CaDiCaL builds the sweep would just repeat the run above behind warnings.
+# CaDiCaL's bounded variable addition is on by default, so the run above
+# already covers the declare/translate machinery across the whole corpus --
+# every STP variable travels through the translation table there. What it no
+# longer covers is the other side of the switch, so the sweep forces the
+# factor off instead: the untranslated path has to keep answering identically.
+# Only registered when the flag can engage at all; on pre-3.0 CaDiCaL builds
+# the factor is never on in the first place and the sweep would just repeat
+# the run above.
 if (USE_CADICAL AND CADICAL_HAS_FACTOR)
-    add_test(NAME query-files-cadical-factor
+    add_test(NAME query-files-cadical-factor-off
         COMMAND ${LIT_TOOL} ${LIT_ARGS} --config-prefix=$<CONFIG>
-                --param solver_params=--cadical-factor=on .
+                --param solver_params=--cadical-factor=off .
         WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
     )
     # Both lit invocations write per-test Output/ files into this same
     # directory, so running them concurrently under ctest -j corrupts each
     # other's results. Serialise them against each other (only).
-    set_tests_properties(query-files query-files-cadical-factor
+    set_tests_properties(query-files query-files-cadical-factor-off
         PROPERTIES RESOURCE_LOCK query-files-exec-root
     )
 endif()

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -235,10 +235,12 @@ void ExtraMain::create_options()
       ->group(solver_group);
   cadical_factor_option =
       app.add_option("--cadical-factor", cadical_factor,
-                     "let cadical use bounded variable addition: 'on', 'off', "
-                     "or 'auto' (the default, on only for problems with array "
-                     "operations). Needs a CaDiCaL 3.x build; otherwise the "
-                     "request is declined with a warning")
+                     "let cadical use bounded variable addition: 'on' (the "
+                     "default), 'off', or 'auto' (on only for problems with "
+                     "array operations, which was the default until it was "
+                     "measured on bitvector-only problems). Needs a CaDiCaL "
+                     "3.x build; otherwise an explicit request is declined "
+                     "with a warning")
           ->group(solver_group);
   incremental_inprobing_option =
       app.add_option(
@@ -783,6 +785,7 @@ int ExtraMain::parse_options(int argc, char** argv)
 #ifdef USE_CADICAL
   if (cadical_factor_option->count())
   {
+    bm->UserFlags.cadical_factor_explicit = true;
     if (cadical_factor == "on")
       bm->UserFlags.cadical_factor = UserDefinedFlags::BVAMode::ON;
     else if (cadical_factor == "off")


### PR DESCRIPTION
`--cadical-factor` defaulted to `auto`, which asks CaDiCaL for the factor only on problems that still contain array operations after simplification. That heuristic was fitted on array benchmarks alone — the technique is a large win on some refinement families and a loss on `countbitstable`, whose arrays are Ackermannised away, so testing for surviving arrays separates the two. Bitvector-only problems were never measured, and on them `auto` is equivalent to `off`. This makes `on` the default.

## Measurements

CaDiCaL 3.0.1, non-incremental bitvector benchmarks, static binary. Every arm's (arm × file) jobs go through one shuffled scheduler, so machine load is equal across arms by construction; solved counts are only compared within a round.

**259 instances taking over 10 s, 200 s wall budget, three independent rounds:**

| round | geomean wall vs default (co-solved) | PAR-2 |
|---|---|---|
| 1 | 0.757 | −11% |
| 2 | 0.795 | −6% |
| 3 | 0.796 | −5% |

The gains concentrate on repetitive encodings — five instances of one family go from 200 s timeouts to between 0.74 s and 25 s, and two of another from timeouts to 16–165 s, in every round. `mcm` and `fft` each lose a file, also in every round; Booth recoding does not recover them, so the regression belongs to the technique rather than to an interaction.

**42,264 easy instances, 60 s budget:** total wall clock 15,892 s → 13,911 s (**−12.5%**), PAR-2 −13%, two more solved, geomean 0.851 over the 16,828 files taking more than 0.05 s. Of the 15,452 files above 0.2 s, 68% get more than 10% faster and 22% more than 10% slower. **No answer disagreements on any of the 42,258 files both configurations decide** — the largest differential this flag has been through.

**`countbitstable`**, the family the array test exists to protect, costs less than its reputation. All 22 files, measured directly:

| file | default | factor on | ratio |
|---|---|---|---|
| countbitstable032 | 2.37 s | 4.00 s | 1.69 |
| countbitstable016 | 0.41 s | 0.54 s | 1.32 |
| countbitstable064 | 21.08 s | 27.55 s | 1.31 |
| countbitstable128 | 513.5 s | 515.4 s | **1.004** |
| the other 18 (`uninit`, `offbyone`) | | | 0.67 – 1.00 |

Only the small unsat instances regress; the sat variants are unaffected or slightly faster; and the ratio does not scale with width — at 128, where the family costs real time, it is gone. Worst absolute case in the family is 6.5 s.

## What else changes

- **`auto` stays selectable** and is the only way back to the previous behaviour.
- **The incremental driver keeps its own copy of the decision**, which `auto` still governs. Because `on` is now the default, an engaged session asks for the factor whatever it contains, where an array-free one previously did not. That path is not covered by the measurements above; `--cadical-factor=auto` restores the old policy there too.
- **A declined request is now reported only when the flag was given by name.** `on` being the default means warning on the mode alone would print a warning on every solve of a build whose CaDiCaL predates 3.0 and has no factor to enable.
- **The query-file corpus sweep now forces the factor off** rather than on. The default already exercises the declare-and-translate machinery on every test; the untranslated path is the side that lost its coverage.

## Testing

`ctest` on two builds, one with CaDiCaL 3.0.1 (factor available) and one with 1.8.0 (not):

- 3.0.1: 546 tests pass, including the whole query-file corpus under the new default and again under the new `query-files-cadical-factor-off` sweep, plus the BVA, SAT-configuration-window and incremental unit tests.
- 1.8.0: 128 tests pass; verified by hand that the default is silent, an explicit `--cadical-factor on` warns, and `auto`/`off` are silent.

Three `array-extensionality-tests/8*-ackermanize-*` failures appear in both builds and on both sides of the switch; they are untracked work-in-progress files in the tree the branch was cut from, not part of this change, and the suites are green once they are set aside.