### PR TITLE
Report the linked SAT solver versions in --version

### DIFF
--- a/include/stp/Sat/SATSolverFactory.h
+++ b/include/stp/Sat/SATSolverFactory.h
@@ -25,10 +25,24 @@ THE SOFTWARE.
 #ifndef SATSOLVERFACTORY_H_
 #define SATSOLVERFACTORY_H_
 
+#include <string>
+#include <vector>
+
 namespace stp
 {
 class SATSolver;
 struct UserDefinedFlags;
+
+// Every SAT backend compiled into this binary, as "name version".
+//
+// The version is what the linked library reports at run time, not what its
+// headers say. Those two can disagree -- a build picking up one checkout's
+// headers and another's library is a real and quiet failure mode -- and it
+// is the library that decides how the solver behaves, so that is the number
+// worth printing. Where the headers also carry a version and it differs,
+// the entry says so rather than choosing a side. Backends that expose no
+// version at all report their name alone.
+std::vector<std::string> compiledSolverVersions();
 
 // Construct the SAT backend that flags.solver_to_use selects, or exit with
 // a diagnostic if that backend was not compiled in. The caller owns the

--- a/lib/Sat/SATSolverFactory.cpp
+++ b/lib/Sat/SATSolverFactory.cpp
@@ -30,6 +30,7 @@ THE SOFTWARE.
 
 #ifdef USE_CRYPTOMINISAT
 #include "stp/Sat/CryptoMinisat5.h"
+#include "cryptominisat5/cryptominisat.h"
 #endif
 
 #ifdef USE_RISS
@@ -50,6 +51,56 @@ THE SOFTWARE.
 
 namespace stp
 {
+
+std::vector<std::string> compiledSolverVersions()
+{
+  std::vector<std::string> solvers;
+
+#ifdef USE_CADICAL
+  {
+    // Present in every CaDiCaL STP builds against, 1.8.0 included, and it
+    // returns the string compiled into the library rather than a macro the
+    // includer expanded.
+    const std::string linked = CaDiCaL::Solver::version();
+    std::string entry = "cadical " + linked;
+
+    // The semantic-version macros only arrived in the 3.x headers, so their
+    // absence is not a mismatch -- it just means there is nothing to check
+    // the library against.
+    //
+    // Major.minor only: CADICAL_PATCH is not maintained upstream (3.0.1
+    // ships a header saying 0), so comparing it flags every correct build
+    // and the note stops being worth reading. The mismatch actually worth
+    // catching is a whole different checkout -- headers from one, library
+    // from another -- which moves the major or the minor.
+#ifdef CADICAL_MAJOR
+    const std::string headers =
+        std::to_string(CADICAL_MAJOR) + "." + std::to_string(CADICAL_MINOR);
+    if (linked.compare(0, headers.size(), headers) != 0 ||
+        (linked.size() > headers.size() && linked[headers.size()] != '.'))
+      entry += " (built against headers " + headers + ".x)";
+#endif
+    solvers.push_back(entry);
+  }
+#endif
+
+#ifdef USE_CRYPTOMINISAT
+  solvers.push_back(std::string("cryptominisat ") +
+                    CMSat::SATSolver::get_version());
+#endif
+
+#ifdef USE_MINISAT
+  // MiniSat has no version API, and STP links a checkout that carries no
+  // version of its own either.
+  solvers.push_back("minisat (no version reported)");
+#endif
+
+#ifdef USE_RISS
+  solvers.push_back("riss (no version reported)");
+#endif
+
+  return solvers;
+}
 
 SATSolver* createSATSolver(const UserDefinedFlags& flags)
 {

--- a/tests/query-files/misc-tests/version-reports-sat-solvers.smt2
+++ b/tests/query-files/misc-tests/version-reports-sat-solvers.smt2
@@ -1,0 +1,17 @@
+; RUN: %solver --version %s | %OutputCheck %s
+;
+; --version names the SAT backends compiled into the binary and the version
+; each linked library reports at run time. Which SAT library is behind a
+; build is not otherwise visible from outside it, yet it decides both the
+; answers and the timings, so a build linking a different solver than
+; intended is a silent and expensive mistake to make.
+;
+; Only the label is checked: the list itself depends on the configure-time
+; options, and a build with a single backend is as valid as one with four.
+;
+; CHECK: ^STP SAT solvers
+(set-logic QF_BV)
+(declare-fun x () (_ BitVec 4))
+(assert (= x (_ bv1 4)))
+(check-sat)
+(exit)

--- a/tools/stp/main_common.cpp
+++ b/tools/stp/main_common.cpp
@@ -28,6 +28,7 @@ THE SOFTWARE.
 #include "sat/cnf/cnf.h"
 
 #include "stp/Parser/parser.h"
+#include "stp/Sat/SATSolverFactory.h"
 #include "stp/ToSat/ToSATAIG.h"
 #include "stp/cpp_interface.h"
 #include <memory>
@@ -71,6 +72,18 @@ void Main::printVersionInfo()
   cout << "STP version " << stp::get_git_version_tag() << std::endl;
   cout << "STP version SHA string " << stp::get_git_version_sha() << std::endl;
   cout << "STP compilation options " << stp::get_compilation_env() << std::endl;
+
+  // Which SAT library is behind the build is not otherwise visible from
+  // outside it, and it changes the answers -- so it belongs next to the STP
+  // version rather than buried in a --verbose solve.
+  const std::vector<std::string> solvers = stp::compiledSolverVersions();
+  cout << "STP SAT solvers";
+  for (size_t i = 0; i < solvers.size(); i++)
+    cout << (i == 0 ? " " : ", ") << solvers[i];
+  if (solvers.empty())
+    cout << " none";
+  cout << std::endl;
+
 #ifdef __GNUC__
   cout << "c compiled with gcc version " << __VERSION__ << endl;
 #else


### PR DESCRIPTION
Which SAT library is behind a build is not visible from outside it, yet it decides both the answers and the timings. A build linking a different solver than intended is easy to make and expensive to discover — `--help` lists every option the parser accepts whatever backend is actually present, so the flags give nothing away either.

`--version` now names each compiled-in backend and the version it reports:

```
STP version 2.4.1
STP version SHA string ...
STP compilation options ...
STP SAT solvers cadical 3.0.1, minisat (no version reported)
c compiled with gcc version 12.3.0
```

### Runtime, not headers

The version comes from the linked library at run time (`CaDiCaL::Solver::version()`, `CMSat::SATSolver::get_version()`), not from header macros.

Those two can disagree. Picking up one checkout's headers and another's library is a real failure mode, and it is quiet: where the build happens not to call an API the older library lacks, it links and runs fine — just with a different solver than intended. It is the library that decides behaviour, so that is the number worth printing. Where the headers also carry a version and it differs, the entry says so rather than choosing a side:

```
STP SAT solvers cadical 3.0.1 (built against headers 2.2.x), minisat (no version reported)
```

Only major.minor is compared. `CADICAL_PATCH` is not maintained upstream — 3.0.1 ships a header saying `0` — so comparing it flags every correct build, and a note that fires on correct builds stops being read. A genuine mispairing moves the major or the minor.

### Compatibility

`Solver::version()` is present in every CaDiCaL this builds against, 1.8.0 included, so the call needs no guard. The `CADICAL_MAJOR`/`MINOR` macros arrived in the 3.x headers and are `#ifdef`-guarded, so an older checkout simply gets no consistency check rather than a spurious note.

MiniSat and Riss expose no version API. They report their name alone rather than a fabricated number.

### Implementation

`compiledSolverVersions()` lives in `lib/Sat/SATSolverFactory.cpp`, which is already the one place enumerating every compiled-in backend, so no new `#ifdef` ladder is introduced and nothing is added to the `SATSolver` interface (no instance is needed to answer the question).

### Testing

New `tests/query-files/misc-tests/version-reports-sat-solvers.smt2` checks only the label, since which backends are listed depends on the configure-time options. Full `query-files` suite passes (572 passed, 20 unsupported, 0 failed); verified against both a CaDiCaL-only and a CaDiCaL+MiniSat build. The mismatch note was confirmed to fire by building 2.2.1 headers against the 3.0.1 library.