### PR TITLE
Give each unsat fact in these tests its own (check-sat)

### DIFF
--- a/tests/query-files/fp-tests/comparison-mirror.smt2
+++ b/tests/query-files/fp-tests/comparison-mirror.smt2
@@ -5,8 +5,8 @@
 ; the way BVLT mirrors onto BVGT: fp.lt(a, b) = fp.gt(b, a) and
 ; fp.leq(a, b) = fp.geq(b, a), exactly, NaN included.
 ;
-; Each xor pairs a comparison with its mirror, so the formula is
-; unsatisfiable -- and the two RUN lines check that for different reasons.
+; Each xor pairs a comparison with its mirror, so each is unsatisfiable on
+; its own -- and the two RUN lines check that for different reasons.
 ; With simplification, both xor operands intern as the SAME node and the
 ; factory collapses xor(n, n) to false before any circuit exists, so
 ; --exit-after-CNF still prints its verdict: that run passes only while the
@@ -14,11 +14,23 @@
 ; keeps all four comparison kinds, both circuits are built, and the SAT
 ; solver proves the semantic identity the rule relies on.
 ;
-; CHECK: ^unsat
+; One (check-sat) per mirror, so a rule that stops firing for just one of
+; the two pairs turns that query sat instead of hiding behind the other.
 (set-logic QF_FP)
 (declare-fun a () (_ FloatingPoint 3 5))
 (declare-fun b () (_ FloatingPoint 3 5))
+
+; fp.lt(a, b) = fp.gt(b, a)
+(push 1)
 (assert (xor (fp.lt a b) (fp.gt b a)))
-(assert (xor (fp.leq a b) (fp.geq b a)))
+; CHECK: ^unsat
 (check-sat)
+(pop 1)
+
+; fp.leq(a, b) = fp.geq(b, a)
+(push 1)
+(assert (xor (fp.leq a b) (fp.geq b a)))
+; CHECK-NEXT: ^unsat
+(check-sat)
+(pop 1)
 (exit)

--- a/tests/query-files/fp-tests/constant-index-collision.smt2
+++ b/tests/query-files/fp-tests/constant-index-collision.smt2
@@ -7,10 +7,8 @@
 ; transformer's index congruence, the refinement loop's index equalities --
 ; reads the wrong cell here.
 ;
-; The array is indexed by floats, so both writes address the same cell: 1.0
-; written first, then 2.0 over it. The read must see 2.0, and the assertion
-; that it is 1.0 must therefore be unsat. Skipping the second write on node
-; identity would answer sat.
+; The two directions get a (check-sat) each, so whichever one a broken rule
+; reverses shows up as a sat answer rather than being absorbed by the other.
 ;
 ; The bit-vector variable pins the same bit pattern into the problem as a
 ; plain constant as well, so both flavours are live in one manager.
@@ -19,13 +17,27 @@
 (declare-fun b () (_ BitVec 32))
 
 (assert (= b #x3f800000))
+
+; Distinct float constants really are distinct cells: 1.0 holds #x01 and
+; 2.0 holds #x02, so the read at 1.0 must see #x01. Failing to skip the
+; 2.0 write would make this sat.
+(push 1)
 (assert (= (select (store (store a ((_ to_fp 8 24) #x3f800000) #x01)
                           ((_ to_fp 8 24) #x40000000) #x02)
                    ((_ to_fp 8 24) #x3f800000))
            #x02))
+; CHECK: ^unsat$
+(check-sat)
+(pop 1)
+
+; Equal float constants are the same cell: both writes address 1.0, #x01
+; first and #x02 over it, so the read must see #x02. Skipping the second
+; write on node identity would answer sat.
+(push 1)
 (assert (= (select (store (store a ((_ to_fp 8 24) #x3f800000) #x01)
                           ((_ to_fp 8 24) #x3f800000) #x02)
                    ((_ to_fp 8 24) #x3f800000))
            #x01))
-; CHECK: ^unsat$
+; CHECK-NEXT: ^unsat$
 (check-sat)
+(pop 1)

--- a/tests/query-files/overflow-tests/bvnego_equiv.smt2
+++ b/tests/query-files/overflow-tests/bvnego_equiv.smt2
@@ -1,9 +1,19 @@
 ; RUN: %solver %s | %OutputCheck %s
+; bvnego(x) iff x is the signed minimum (0x80), and independently iff
+; -x==x and x!=0. One (check-sat) per characterisation: bundling both
+; behind a single query would let one of them turn sat unnoticed.
 (set-logic QF_BV)
 (declare-fun x () (_ BitVec 8))
-; bvnego(x) iff x is the signed minimum (0x80), and independently iff -x==x and x!=0.
+
+(push 1)
 (assert (not (= (bvnego x) (= x #x80))))
+; CHECK: ^unsat
+(check-sat)
+(pop 1)
+
+(push 1)
 (assert (not (= (bvnego x) (and (= x (bvneg x)) (distinct x #x00)))))
 ; CHECK-NEXT: ^unsat
 (check-sat)
+(pop 1)
 (exit)

--- a/tests/query-files/overflow-tests/overflow_width1.smt2
+++ b/tests/query-files/overflow-tests/overflow_width1.smt2
@@ -1,17 +1,48 @@
 ; RUN: %solver %s | %OutputCheck %s
+; Each overflow predicate is checked against its own definition at width 1,
+; under its own (check-sat), so a predicate that stops agreeing turns its
+; query sat instead of hiding behind the other five.
 (set-logic QF_BV)
 (declare-fun a () (_ BitVec 1))
 (declare-fun b () (_ BitVec 1))
+
+(push 1)
 (assert (not (= (bvnego a) (= a #b1))))
+; CHECK: ^unsat
+(check-sat)
+(pop 1)
+
+(push 1)
 (assert (not (= (bvuaddo a b) (bvult (bvadd a b) a))))
+; CHECK-NEXT: ^unsat
+(check-sat)
+(pop 1)
+
+(push 1)
 (assert (not (= (bvsmulo a b)
   (let ((p (bvmul ((_ sign_extend 1) a) ((_ sign_extend 1) b))))
     (distinct p ((_ sign_extend 1) ((_ extract 0 0) p)))))))
+; CHECK-NEXT: ^unsat
+(check-sat)
+(pop 1)
+
+(push 1)
 (assert (not (= (bvusubo a b) (bvult a b))))
+; CHECK-NEXT: ^unsat
+(check-sat)
+(pop 1)
+
+(push 1)
 (assert (not (= (bvsdivo a b) (and (= a #b1) (= b #b1)))))
+; CHECK-NEXT: ^unsat
+(check-sat)
+(pop 1)
+
+(push 1)
 (assert (not (= (bvssubo a b)
   (let ((d (bvsub ((_ sign_extend 1) a) ((_ sign_extend 1) b))))
     (distinct ((_ extract 1 1) d) ((_ extract 0 0) d))))))
 ; CHECK-NEXT: ^unsat
 (check-sat)
+(pop 1)
 (exit)

--- a/tests/query-files/simplification-tests/unconstrained-ground-path3.smt2
+++ b/tests/query-files/simplification-tests/unconstrained-ground-path3.smt2
@@ -1,5 +1,4 @@
 ; RUN: %solver %s | %OutputCheck %s
-; CHECK: ^unsat
 (set-logic QF_BV)
 (set-info :smt-lib-version 2.0)
 (set-info :category "check")
@@ -16,14 +15,25 @@
 ; collapse, and a shift by a constant has no per-kind rule of its own.
 ; The width must be exactly 64 for the back-propagated value to be the
 ; UINT64_MAX that overflows.
+;
+; Each variant gets its own (check-sat): they crash through different
+; paths and are separately unsat, so bundling them would let one of them
+; start answering sat behind the other's verdict. Unsat either way: a
+; square is 0 or 1 mod 4, never 3.
 (declare-fun x () (_ BitVec 64))
+(declare-fun y () (_ BitVec 64))
+
+(push 1)
 (assert (= (bvmul (bvlshr x #x0000000000000001) (bvlshr x #x0000000000000001)) #xffffffffffffffff))
+; CHECK: ^unsat
+(check-sat)
+(pop 1)
 
 ; Same crash reached with the constant back-propagated rather than
 ; written out: bvnot maps 0 to all-ones on the way down the chain.
-(declare-fun y () (_ BitVec 64))
+(push 1)
 (assert (bvule (bvnot (bvmul (bvudiv y #x0000000000000003) (bvudiv y #x0000000000000003))) #x0000000000000000))
-
-; Unsat either way: a square is 0 or 1 mod 4, never 3.
+; CHECK-NEXT: ^unsat
 (check-sat)
+(pop 1)
 (exit)


### PR DESCRIPTION
Five query-file tests asserted several independently-unsatisfiable facts behind a single `(check-sat)`. A query like that cannot fail usefully: if one of the facts regresses and becomes satisfiable, the remaining ones are still contradictory, so the file still prints `unsat` and the regression goes unnoticed.

`overflow-tests/overflow_width1.smt2` was the clearest case — six overflow predicates (`bvnego`, `bvuaddo`, `bvsmulo`, `bvusubo`, `bvsdivo`, `bvssubo`) each checked against its definition at width 1, all behind one query. Five of the six could stop agreeing with their definition and the test would still pass.

| file | independently-unsat assertions behind one `(check-sat)` |
| --- | --- |
| `overflow-tests/overflow_width1.smt2` | 6 |
| `overflow-tests/bvnego_equiv.smt2` | 2 |
| `fp-tests/comparison-mirror.smt2` | 2 |
| `fp-tests/constant-index-collision.smt2` | 2 |
| `simplification-tests/unconstrained-ground-path3.smt2` | 2 |

Each file now runs one `push`/`assert`/`check-sat`/`pop` unit per fact, with its own `CHECK` line, so a fact that turns sat names itself. No assertion was changed, added or dropped — only the scoping around them.

`fp-tests/constant-index-collision.smt2` was also carrying an undocumented second scenario: two writes at *distinct* float constants read back at the first index, checking that read-over-write correctly skips the second store. That is the complement of the documented scenario (two writes at the *same* float constant), so both now have a comment saying which direction they pin.

### How these were found

For every `(check-sat)` in `tests/query-files` that answers `unsat`, the in-scope assertion set was minimised by deletion, and then the resulting minimal unsat core was tested for uniqueness: for each core member `c`, re-solve the full set without `c`. If every such solve is `sat` the core is unique and nothing can be masked; if any is still `unsat`, a second independent core exists. Run at two granularities — assertions as written, and again with `(assert (and a b))` mechanically split per conjunct.

Of 1182 `(check-sat)` commands, 357 answer `unsat`. 236 of those were already perfectly tight, and the five above were the only ones holding assertions that are unsatisfiable entirely on their own. The push/pop-per-row style already used across `fp-tests` is the right pattern and is applied consistently elsewhere.

A further nine unsat queries do have more than one minimal core, but they are one fact with two proofs rather than separate tests glued together — the redundancy comes from setup shared with a neighbouring `sat` query, and no assertion in them is unsat on its own. Those are left alone here.

### Testing

All 732 `; RUN:` lines in `tests/query-files` pass against a release build with floating-point support and CaDiCaL (23 files skipped for `REQUIRES: minisat|libbf|cryptominisat`). The five changed files pass under every one of their RUN lines, including the `--exit-after-CNF` / `--disable-simplifications` pair on `comparison-mirror.smt2`, and each of the resulting queries re-audits as having exactly one in-scope assertion which is its own minimal core.