### PR TITLE
Export compiledSolverVersions, and build the default configuration in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -664,6 +664,71 @@ jobs:
         build-type: ${{ matrix.build-type }}
         werror: ${{ matrix.werror }}
 
+  # -fvisibility=hidden is applied only when ENABLE_TESTING and
+  # BUILD_EXTRA_TOOLS are both off, because the tests and the extra tools
+  # call into entry points that are not part of the public API. Every other
+  # Linux job here turns at least one of them on, and the two that do not
+  # are STATICCOMPILE builds, where visibility does not affect linking at
+  # all. So the shared library CI built was never the one users get: the
+  # combination that hides symbols had no coverage.
+  #
+  # What that missed is a link failure, not a subtle one. Anything the stp
+  # binary calls in libstp has to be annotated DLL_PUBLIC, and a new call to
+  # an unannotated function -- get_git_version_tag's neighbour in
+  # printVersionInfo was exactly this -- fails to link in the default build
+  # while all of CI stays green.
+  #
+  # So: the documented build, no testing, no extra tools, shared library.
+  # The three settings are passed explicitly rather than left to their
+  # defaults, so that flipping a default cannot quietly stop covering the
+  # hidden-visibility case. MiniSat is the cheapest backend to install, and
+  # which one is linked does not matter here -- the point is the link.
+  build-default-shared:
+    name: gcc (default shared, hidden visibility)
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - uses: actions/checkout@v7
+      with:
+          submodules: 'true'
+
+    - name: Packages
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          bison \
+          build-essential \
+          cmake \
+          flex \
+          git \
+          ninja-build \
+          zlib1g-dev
+
+    - name: Dependencies
+      run: ./scripts/deps/setup-minisat.sh
+
+    - name: Configure
+      run: |
+        mkdir build
+        cd build
+        cmake -DUSE_MINISAT:BOOL=ON -DNOCRYPTOMINISAT:BOOL=ON -DWERROR:BOOL=ON -DBUILD_SHARED_LIBS:BOOL=ON -DENABLE_TESTING:BOOL=OFF -DBUILD_EXTRA_TOOLS:BOOL=OFF -G Ninja ..
+
+    - name: Build
+      run: cmake --build build --parallel "$(nproc)"
+
+    # Confirm the hidden library really is loadable and complete enough to
+    # solve, not merely linkable. --version is here because it is what broke:
+    # it reaches four separate accessors in libstp and prints them.
+    - name: Smoke test
+      run: |
+        ldd build/stp | grep libstp
+        build/stp --version
+        echo '(set-logic QF_BV)(declare-fun a () (_ BitVec 8))(declare-fun b () (_ BitVec 8))(assert (= (bvmul a b) #x21))(assert (bvult a b))(check-sat)' > test.smt2
+        out=$(build/stp test.smt2)
+        echo "output: '$out'"
+        [ "$out" = "sat" ]
+
   # The MiniSat backend is opt-in (-DUSE_MINISAT) and no other Linux job
   # enables it, so this is the configuration that keeps it honest: MiniSat
   # as the only backend, which also makes it the default solver the whole

--- a/include/stp/Sat/SATSolverFactory.h
+++ b/include/stp/Sat/SATSolverFactory.h
@@ -25,6 +25,7 @@ THE SOFTWARE.
 #ifndef SATSOLVERFACTORY_H_
 #define SATSOLVERFACTORY_H_
 
+#include "stp/Util/Attributes.h"
 #include <string>
 #include <vector>
 
@@ -42,7 +43,11 @@ struct UserDefinedFlags;
 // worth printing. Where the headers also carry a version and it differs,
 // the entry says so rather than choosing a side. Backends that expose no
 // version at all report their name alone.
-std::vector<std::string> compiledSolverVersions();
+//
+// DLL_PUBLIC because the stp binary prints this from --version, alongside
+// the equally-annotated accessors in GitSHA1.h, and the default build hides
+// everything else in the shared library.
+DLL_PUBLIC std::vector<std::string> compiledSolverVersions();
 
 // Construct the SAT backend that flags.solver_to_use selects, or exit with
 // a diagnostic if that backend was not compiled in. The caller owns the


### PR DESCRIPTION
The build documented in the README — `mkdir build && cd build && cmake .. && cmake --build .` — has not linked since #863:

```
main_common.cpp:79: undefined reference to `stp::compiledSolverVersions[abi:cxx11]()'
```

`printVersionInfo` calls four accessors in libstp. Three of them — `get_git_version_sha`, `get_git_version_tag`, `get_compilation_env` — are `DLL_PUBLIC`. `compiledSolverVersions`, added alongside them, is not, so `-fvisibility=hidden` keeps it out of the shared library's dynamic symbol table and the binary cannot resolve it. This annotates it like its neighbours.

### Why CI did not catch it

No job compiles with hidden visibility. The flag is applied only when `ENABLE_TESTING` and `BUILD_EXTRA_TOOLS` are both off, because the tests and the extra tools call into entry points that are not part of the public API — and every Linux job that builds a shared libstp turns at least one of them on:

| job | ENABLE_TESTING | BUILD_EXTRA_TOOLS | libstp | hidden visibility |
|:---|:---|:---|:---|:---|
| gcc / clang / gcc-release | ON | ON | shared | no |
| gcc (cadical *tag*) | ON | — | shared | no |
| gcc (cms + cadical) | ON | — | shared | no |
| gcc (minisat only) | ON | — | shared | no |
| gcc (riss only) | ON | — | shared | no |
| gcc (32-bit) | ON | — | shared | no |
| gcc (static), gcc (static, release) | — | — | **static** | not applicable |
| Windows | — | — | **static** | not applicable |

The two jobs that leave `ENABLE_TESTING` off are `STATICCOMPILE` builds, where visibility does not affect linking at all — the symbol stays in the archive either way. So the shared library CI built was never the one users get, and the untested cell is exactly the default configuration.

### The new job

`build-default-shared` covers that cell: shared library, no testing, no extra tools, MiniSat as the cheapest backend to install. Which backend is linked does not matter here; the point is the link.

The three settings are passed explicitly rather than left to their defaults, so that flipping a default cannot quietly stop covering the hidden-visibility case.

It builds and then smoke-tests `--version` — the call that broke, and the one that reaches four separate accessors — followed by a solve, so the library has to be loadable and complete rather than merely linkable.

### Verification

Confirmed in both directions with the job's own cmake line: with the annotation reverted it reproduces the undefined reference, and with it the binary links, reports its backend and answers a query. Checked that the configuration really does enable the flag, so the job is testing what it claims to.
