### PR TITLE
Eliminate unconstrained array terms

### DIFF
--- a/include/stp/Simplifier/RemoveUnconstrained.h
+++ b/include/stp/Simplifier/RemoveUnconstrained.h
@@ -67,6 +67,16 @@ class RemoveUnconstrained
   // primary mechanism.
   ASTVec refusedDefinitions;
 
+  // Whether the array rules may fire in this pass; set per topLevel()
+  // call. They are off once the array-equality procedure owns the
+  // formula, because by then every array term worth rewriting sits under
+  // a witness read whose shape ExtensionalityContext must be able to
+  // recover -- and the frozen-symbol set cannot express that, since it
+  // protects the anchors' own symbols rather than the arrays beneath
+  // them. Running before the lowering pass is what gives the rules
+  // something to do; see TopLevelSTPAux.
+  bool arrayRules;
+
 public:
   RemoveUnconstrained(STPMgr& bm);
 	

--- a/lib/STPManager/STP.cpp
+++ b/lib/STPManager/STP.cpp
@@ -309,6 +309,27 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
       bm->ASTNodeStats(pe_message.c_str(), semantic_input);
     }
 
+    // The same argument for unconstrained elimination, and it is the
+    // only window where its array rules can do anything: an equality
+    // with an unconstrained operand is a free Boolean, so it settles
+    // here rather than costing a record, a witness pair and a refinement
+    // loop. Afterwards the operands sit under witness reads whose shape
+    // ExtensionalityContext has to recognise, and the rules turn
+    // themselves off (RemoveUnconstrained::arrayRules).
+    //
+    // This is what the "unconstrained" benchmarks of Brummayer's
+    // dissertation ask for. Their arrays are each used once and the
+    // selector bits come from wide divisions that no model needs, so
+    // reaching abstraction at all means bit-blasting an unsatisfiable
+    // amount of dead arithmetic.
+    if (hasOpaqueEquality && bm->UserFlags.optimize_flag &&
+        bm->UserFlags.enable_unconstrained)
+    {
+      RemoveUnconstrained r(*bm);
+      semantic_input = r.topLevel(semantic_input, simp);
+      bm->ASTNodeStats(uc_message.c_str(), semantic_input);
+    }
+
     if (ext == NULL && hasOpaqueEquality)
     {
       ext = bm->getExtensionality();

--- a/lib/Simplifier/RemoveUnconstrained.cpp
+++ b/lib/Simplifier/RemoveUnconstrained.cpp
@@ -26,12 +26,33 @@ THE SOFTWARE.
  * Identifies unconstrained variables and remove them from the input.
  * Robert Bruttomesso's & Robert Brummayer's dissertations describe this.
  *
- * Nb. this isn't finished. It doesn't do reads / writes.
- *
  * Kinds without a per-kind rule (bvsx, bvzx, bvurem/bvudiv by a
  * constant, masks, ...) can still be eliminated when the variable's
  * whole use is a predicate over it and constants: see
  * tryGroundPathCollapse.
+ *
+ * The array rules (READ, WRITE and array-sorted ITE) are the ones
+ * Brummayer's dissertation states for the extensional theory of
+ * arrays. One condition is less obvious than it looks: a write is
+ * unconstrained only when its *value* is unconstrained as well as its
+ * base array. write(a, i, e) with a free but e fixed is pinned to e at
+ * i, so it does not range over every array, and treating it as free
+ * would decide equalities that are in fact unsatisfiable.
+ *
+ * The corresponding rule for array equality -- one unconstrained side
+ * is enough to make the equality a free boolean -- is deliberately
+ * absent. It was implemented and measured over QF_ABV: it won nothing
+ * that the other three do not already win, and it cost the
+ * brummayerbiere fifo family up to 4x, because replacing a settled
+ * equality with a free boolean leaves the abstraction refinement loop
+ * to rediscover it -- 22 rounds rather than 2.
+ * RemoveUnconstrained_Collapse.array_equality pins the absence.
+ *
+ * Float- and RoundingMode-sorted arrays are excluded throughout, for
+ * the reason PropagateEqualities excludes them from the equivalent
+ * substitution: the model machinery that reconstructs a substituted
+ * symbol's cells reads them as plain bits, which is wrong under NaN's
+ * many packings and float index canonicalisation.
  */
 
 #include "stp/Simplifier/RemoveUnconstrained.h"
@@ -68,6 +89,7 @@ ASTNode RemoveUnconstrained::topLevel(const ASTNode& n, Simplifier* simplifier,
   // untouchable set -- symbols constrained outside this formula -- is
   // honoured the same way, merged when both apply.
   ExtensionalityContext* ext = bm.getExtensionalityIfAny();
+  arrayRules = (ext == NULL || !ext->activeInSolve());
   const std::set<ASTNode>* extSet =
       (ext != NULL && ext->activeInSolve()) ? &ext->getFrozenSymbols() : NULL;
   std::set<ASTNode> mergedUntouchable;
@@ -120,6 +142,15 @@ ASTNode RemoveUnconstrained::topLevel(const ASTNode& n, Simplifier* simplifier,
   return result;
 }
 
+// Whether an array-sorted node may take part in the array rules. A
+// float- or RoundingMode-sorted array is left alone: see the header
+// comment.
+static bool eligibleArray(const ASTNode& n)
+{
+  return n.GetIndexWidth() > 0 && n.GetType() == ARRAY_TYPE &&
+         !n.GetSourceSort().usesFloatingPointTheory();
+}
+
 bool allChildrenAreUnconstrained(vector<MutableASTNode*> children)
 {
   for (size_t i = 0; i < children.size(); i++)
@@ -134,8 +165,11 @@ RemoveUnconstrained::replaceParentWithFresh(MutableASTNode& mute,
                                             vector<MutableASTNode*>& variables)
 {
   const ASTNode& parent = mute.n;
-  ASTNode v =
-      bm.CreateFreshVariable(0, parent.GetValueWidth(), "unconstrained");
+  // An array-sorted parent (a write, or an if-then-else over arrays)
+  // needs an array-sorted stand-in; the index width is zero for
+  // everything else, so this is the ordinary case too.
+  ASTNode v = bm.CreateFreshVariable(parent.GetIndexWidth(),
+                                     parent.GetValueWidth(), "unconstrained");
   // A float-valued parent's stand-in must carry the format too, or the
   // blaster later meets a formatless bitvector where a float belongs.
   v.SetExpWidth(parent.GetExpWidth());
@@ -1339,8 +1373,8 @@ ASTNode RemoveUnconstrained::topLevel_other(const ASTNode& n,
 
       case ITE:
       {
-        if (indexWidth > 0)
-          continue; // don't do arrays.
+        if (indexWidth > 0 && (!arrayRules || !eligibleArray(muteParent.n)))
+          continue;
 
         if (mutable_children[0]->isUnconstrained() &&
             mutable_children[1]->isUnconstrained() &&
@@ -1439,6 +1473,52 @@ ASTNode RemoveUnconstrained::topLevel_other(const ASTNode& n,
           ASTNode inverse = simplifier->MultiplicativeInverse(other);
           ASTNode rhs = nf->CreateTerm(BVMULT, width, inverse, v);
           replace(var, rhs);
+        }
+      }
+      break;
+
+      case READ:
+      {
+        assert(numberOfChildren == 2);
+        // Only the array side is interesting. An unconstrained *index*
+        // says nothing: the cell it selects is still whatever the array
+        // holds there.
+        if (!arrayRules || children[0] != var || !eligibleArray(var))
+          break;
+
+        // read(a, i) with a free ranges over every value, so the read
+        // becomes a fresh scalar. Recovering a from it needs an array
+        // agreeing with v at i and free elsewhere, which is exactly a
+        // write of v into a second fresh array.
+        ASTNode v = replaceParentWithFresh(muteParent, variable_array);
+        ASTNode rest = bm.CreateFreshVariable(
+            var.GetIndexWidth(), var.GetValueWidth(), "unconstrained_array");
+        replace(var, nf->CreateArrayTerm(WRITE, var.GetIndexWidth(),
+                                         var.GetValueWidth(), rest,
+                                         mutable_children[1]->toASTNode(&bm),
+                                         v));
+      }
+      break;
+
+      case WRITE:
+      {
+        assert(numberOfChildren == 3);
+        if (!arrayRules || !eligibleArray(muteParent.n))
+          break;
+
+        // Both the base array and the written value have to be free.
+        // With the value fixed the result is pinned at the write index
+        // and is not an arbitrary array; see the header comment.
+        if (mutable_children[0]->isUnconstrained() &&
+            mutable_children[2]->isUnconstrained())
+        {
+          ASTNode v = replaceParentWithFresh(muteParent, variable_array);
+          // write(a, i, e) == v is met by a := v and e := v[i], for any
+          // i: writing a cell's own value back changes nothing.
+          replace(children[0], v);
+          replace(children[2],
+                  nf->CreateTerm(READ, muteParent.n.GetValueWidth(), v,
+                                 mutable_children[1]->toASTNode(&bm)));
         }
       }
       break;

--- a/tests/api/C/array-extensionality.cpp
+++ b/tests/api/C/array-extensionality.cpp
@@ -867,6 +867,14 @@ TEST(array_extensionality, handle_for_a_discarded_equality_matches_the_model)
   vc_Destroy(vc);
 }
 
+// The same invariant as handle_for_a_discarded_equality_matches_the_model,
+// on the path that test now has to switch off: an equality with an
+// unconstrained operand is settled by unconstrained elimination, which
+// replaces it with a fresh boolean and defines the operand from it.
+// Whatever that boolean comes out as, the arrays the model publishes
+// have to say the same thing -- a reconstruction that forgot to make
+// them differ in the false case, or that made them differ in the true
+// case, would be reported here as a model contradicting itself.
 // The equality was never part of any query. There is no lowering for it
 // and never was, so this is the same path with no discarding involved:
 // the answer still comes from the model, and still agrees with what the
@@ -1447,6 +1455,10 @@ TEST(array_extensionality, ite_replacement_survives_a_rewritten_condition)
   // test pins the abstraction/checker path itself, so keep the
   // equality there.
   static_cast<stp::STP*>(vc)->bm->UserFlags.propagate_equalities = false;
+  // And for the same reason: all three arrays are used once, so
+  // unconstrained elimination would collapse the if-then-else and then
+  // the equality, minting no record for the checker to work on.
+  static_cast<stp::STP*>(vc)->bm->UserFlags.enable_unconstrained = false;
 
   Type bv8 = vc_bvType(vc, 8);
   Type bv4 = vc_bvType(vc, 4);

--- a/tests/query-files/array-extensionality-tests/43-model-agrees-with-solved-out-read.smt2
+++ b/tests/query-files/array-extensionality-tests/43-model-agrees-with-solved-out-read.smt2
@@ -1,23 +1,26 @@
 ; RUN: %solver --array-equality %s | %OutputCheck %s
 ; CHECK: ^sat
 ; CHECK-L: (define-fun |i| () (_ BitVec 8) #x01)
-; CHECK-L: (define-fun |b| () (Array (_ BitVec 4) (_ BitVec 8)) ((as const (Array (_ BitVec 4) (_ BitVec 8))) #x00))
-; i occurs once, so unconstrained-variable elimination replaces the
-; disequality by a fresh boolean and defines i from select(b,j); the
-; read then reaches the bit-blaster nowhere, and evaluating i against
-; the model invents a value for b[j] on the spot. With array equality
-; enabled the model printer emits a *total* interpretation for every
-; array, filling in zero wherever it finds no concrete-index entry --
-; so an invented value other than zero makes the printed b say
-; b[0] = #x00 while i was computed from something else, and the model
-; contradicts the assertion it was produced for.
+; CHECK-L: (define-fun |b| () (Array (_ BitVec 4) (_ BitVec 8)) (store ((as const (Array (_ BitVec 4) (_ BitVec 8))) #x00) #x0 #x00))
+; Unconstrained-variable elimination reaches this disequality from
+; either side: i occurs once, and so does the array b beneath the read.
+; The read rule is the one that fires -- select(b,j) with b free is
+; itself free -- so the read becomes a fresh value and b is defined as a
+; write of it, which is why b prints with an explicit cell rather than
+; as the bare constant array. (Before the array rules existed it was i
+; that was eliminated, defined from select(b,j), and b printed with no
+; cells at all.)
 ;
-; Pinned exactly because both halves must agree: b[0] is the value the
-; evaluation used, and i is one more than it. The don't-care is zero
-; precisely so that it agrees with the completion every other reader of
-; the model applies -- the printer here, ReadUsingModel, and the
-; contents comparison the post-solve audit makes -- without anything
-; having to be recorded to keep them in step.
+; Either way the model has to be self-consistent, which is what this
+; pins: b[0] is the value the evaluation used, and i is one more than
+; it. With array equality enabled the model printer emits a *total*
+; interpretation for every array, filling in zero wherever it finds no
+; concrete-index entry, so a b whose printed cells disagreed with the
+; value i was computed from would contradict the assertion the model was
+; produced for. The don't-care is zero precisely so that it agrees with
+; the completion every other reader of the model applies -- the printer
+; here, ReadUsingModel, and the contents comparison the post-solve audit
+; makes -- without anything having to be recorded to keep them in step.
 (set-logic QF_ABV)
 (declare-fun a () (Array (_ BitVec 4) (_ BitVec 8)))
 (declare-fun c () (Array (_ BitVec 4) (_ BitVec 8)))

--- a/tests/unit-tests/RemoveUnconstrained_Exhaustive_Test.cpp
+++ b/tests/unit-tests/RemoveUnconstrained_Exhaustive_Test.cpp
@@ -256,6 +256,163 @@ struct Context
     checkEquivalent(back, result);
   }
 
+  //-------------------------------------------------------------------
+  // Arrays.
+  //
+  // An array symbol has no scalar domain to enumerate, so the checks
+  // above cannot see one. At the widths used here it has a small
+  // explicit one: an index width of IW and an element width of VW makes
+  // (2^VW)^(2^IW) distinct arrays -- four for the 1x1 arrays below. So
+  // the same exhaustive identity is available, once array-sorted terms
+  // can be evaluated under an assignment of concrete arrays.
+  //
+  // ground() does that by folding every array-rooted subterm away: a
+  // read becomes the cell it selects and an array equality becomes a
+  // constant, after which the formula is array-free and the existing
+  // scalar evaluator finishes the job.
+  //-------------------------------------------------------------------
+
+  static constexpr unsigned IW = 1; // index width of the test arrays
+  static constexpr unsigned VW = 1; // element width
+
+  typedef std::vector<unsigned> Cells; // one entry per index, 2^IW of them
+  typedef std::map<ASTNode, Cells> ArrayAssignment;
+
+  ASTNode array(unsigned iw = IW, unsigned vw = VW)
+  {
+    return mgr.CreateSymbol(("a" + std::to_string(counter++)).c_str(), iw, vw);
+  }
+
+  unsigned evalConst(const ASTNode& groundScalar)
+  {
+    ASTNode c = groundScalar.isConstant()
+                    ? groundScalar
+                    : NonMemberBVConstEvaluator(&mgr, groundScalar);
+    if (c.GetType() == BOOLEAN_TYPE)
+      return c == mgr.ASTTrue ? 1 : 0;
+    return c.GetUnsignedConst();
+  }
+
+  Cells arrayValue(const ASTNode& n, const ArrayAssignment& av)
+  {
+    if (n.GetKind() == SYMBOL)
+    {
+      auto it = av.find(n);
+      EXPECT_NE(it, av.end()) << "no value for array symbol " << n;
+      return it == av.end() ? Cells(1u << IW, 0) : it->second;
+    }
+    if (n.GetKind() == WRITE)
+    {
+      Cells v = arrayValue(n[0], av);
+      v[evalConst(ground(n[1], av))] = evalConst(ground(n[2], av));
+      return v;
+    }
+    if (n.GetKind() == ITE)
+      return evalConst(ground(n[0], av)) ? arrayValue(n[1], av)
+                                         : arrayValue(n[2], av);
+    ADD_FAILURE() << "cannot evaluate array term of kind " << n.GetKind();
+    return Cells(1u << IW, 0);
+  }
+
+  // `n` with every array-rooted subterm folded to a constant.
+  ASTNode ground(const ASTNode& n, const ArrayAssignment& av)
+  {
+    if (n.GetKind() == READ)
+    {
+      const Cells cells = arrayValue(n[0], av);
+      return konst(cells[evalConst(ground(n[1], av))], n.GetValueWidth());
+    }
+    if (n.GetKind() == ARRAY_EQ)
+      return arrayValue(n[0], av) == arrayValue(n[1], av) ? mgr.ASTTrue
+                                                          : mgr.ASTFalse;
+    if (n.GetKind() == SYMBOL || n.isConstant() || n.Degree() == 0)
+      return n;
+
+    ASTVec children;
+    children.reserve(n.Degree());
+    for (const auto& c : n)
+      children.push_back(ground(c, av));
+
+    if (n.GetType() == BOOLEAN_TYPE)
+      return nf->CreateNode(n.GetKind(), children);
+    return nf->CreateTerm(n.GetKind(), n.GetValueWidth(), children);
+  }
+
+  // As checkEquivalent, but ranging over array symbols as well: every
+  // assignment of concrete arrays, times every scalar assignment.
+  //
+  // The scalars are substituted first. A write's index and value are
+  // ordinary scalar terms -- and the write rule exists precisely because
+  // the value can be an unconstrained symbol -- so grounding an array
+  // term needs them already settled.
+  void checkEquivalentWithArrays(const ASTNode& before, const ASTNode& after)
+  {
+    ASTNodeSet symSet;
+    collectSymbols(before, symSet);
+    collectSymbols(after, symSet);
+
+    std::vector<ASTNode> arrays, scalars;
+    for (const auto& s : symSet)
+      (s.GetIndexWidth() > 0 ? arrays : scalars).push_back(s);
+
+    const unsigned cellCount = 1u << IW;
+    const unsigned perArray = 1u << (cellCount * VW); // arrays of this sort
+    uint64_t arrayCombos = 1;
+    for (size_t i = 0; i < arrays.size(); i++)
+      arrayCombos *= perArray;
+    uint64_t scalarCombos = 1;
+    for (const auto& s : scalars)
+      scalarCombos *= domainSize(s);
+    ASSERT_LE(arrayCombos * scalarCombos, 1u << 16)
+        << "too many assignments -- lower the widths";
+
+    for (uint64_t ac = 0; ac < arrayCombos; ac++)
+    {
+      ArrayAssignment av;
+      uint64_t rest = ac;
+      for (size_t i = 0; i < arrays.size(); i++)
+      {
+        unsigned code = rest % perArray;
+        rest /= perArray;
+        Cells cells(cellCount);
+        for (unsigned j = 0; j < cellCount; j++)
+        {
+          cells[j] = code & ((1u << VW) - 1);
+          code >>= VW;
+        }
+        av.insert({arrays[i], cells});
+      }
+
+      for (uint64_t sc = 0; sc < scalarCombos; sc++)
+      {
+        ASTNodeMap assignment;
+        uint64_t srest = sc;
+        for (size_t i = 0; i < scalars.size(); i++)
+        {
+          const unsigned size = domainSize(scalars[i]);
+          assignment.insert({scalars[i], valueFor(scalars[i], srest % size)});
+          srest /= size;
+        }
+
+        ASTNodeMap m1 = assignment, m2 = assignment, ca1, ca2, e1, e2;
+        const ASTNode b =
+            ground(SubstitutionMap::replace(before, m1, ca1, &snf), av);
+        const ASTNode a =
+            ground(SubstitutionMap::replace(after, m2, ca2, &snf), av);
+        ASSERT_EQ(eval(b, e1), eval(a, e2))
+            << "unconstrained rewrite changed the meaning at array "
+            << "assignment " << ac << ", scalar assignment " << sc;
+      }
+    }
+  }
+
+  void checkSoundArrays(const ASTNode& top)
+  {
+    ASTNode result = run(top);
+    ASTNode back = backSubstitute(top);
+    checkEquivalentWithArrays(back, result);
+  }
+
   // As checkSound, but the operator takes the surviving `keep` as one operand
   // (used for the binary comparisons, which have a dedicated one-sided rule).
   void checkSoundWithKeep(Kind k, bool termLevel)
@@ -445,6 +602,119 @@ TEST(RemoveUnconstrained_Exhaustive, uge_one_sided)
 {
   Context c;
   c.checkSoundWithKeep(BVGE, /*termLevel=*/false);
+}
+
+// --- Array rules. Each enumerates every concrete array as well as every
+// scalar assignment; see checkEquivalentWithArrays. ---
+
+TEST(RemoveUnconstrained_Exhaustive, array_read)
+{
+  Context c;
+  // read(a, 0) with `a` used once. The read is free, so it stands in
+  // for `keep`, which survives via the anchor.
+  ASTNode a = c.array();
+  ASTNode keep = c.bv(Context::VW);
+  ASTNode read = c.hf->CreateTerm(READ, Context::VW, a, c.konst(0, Context::IW));
+  c.checkSoundArrays(c.hf->CreateNode(
+      AND, c.hf->CreateNode(EQ, read, keep), c.anchorFor(keep)));
+}
+
+TEST(RemoveUnconstrained_Exhaustive, array_read_constrained_array_untouched)
+{
+  Context c;
+  // Two reads of the same array: it is not unconstrained, and neither
+  // read may be replaced by a free value -- congruence has to hold.
+  ASTNode a = c.array();
+  ASTNode keep = c.bv(Context::VW);
+  ASTNode r0 = c.hf->CreateTerm(READ, Context::VW, a, c.konst(0, Context::IW));
+  ASTNode r1 = c.hf->CreateTerm(READ, Context::VW, a, c.konst(0, Context::IW));
+  c.checkSoundArrays(c.hf->CreateNode(
+      AND, c.hf->CreateNode(EQ, c.hf->CreateTerm(BVPLUS, Context::VW, r0, r1),
+                            keep),
+      c.anchorFor(keep)));
+}
+
+TEST(RemoveUnconstrained_Exhaustive, array_write)
+{
+  Context c;
+  // write(a, 0, e) with both the base array and the written value free.
+  ASTNode a = c.array();
+  ASTNode e = c.bv(Context::VW);
+  ASTNode keep = c.bv(Context::VW);
+  ASTNode w = c.hf->CreateArrayTerm(WRITE, Context::IW, Context::VW, a,
+                                    c.konst(0, Context::IW), e);
+  ASTNode read = c.hf->CreateTerm(READ, Context::VW, w,
+                                  c.konst(1 % (1u << Context::IW), Context::IW));
+  c.checkSoundArrays(c.hf->CreateNode(
+      AND, c.hf->CreateNode(EQ, read, keep), c.anchorFor(keep)));
+}
+
+TEST(RemoveUnconstrained_Exhaustive, array_write_constrained_value)
+{
+  Context c;
+  // The value is a constant, so the write is pinned at index 0 and is
+  // NOT a free array. This is the case the rule's value condition
+  // exists for: a rule keyed on the base array alone would be unsound
+  // here, and the enumeration would catch it.
+  ASTNode a = c.array();
+  ASTNode keep = c.bv(Context::VW);
+  ASTNode w = c.hf->CreateArrayTerm(WRITE, Context::IW, Context::VW, a,
+                                    c.konst(0, Context::IW),
+                                    c.konst(1, Context::VW));
+  ASTNode read =
+      c.hf->CreateTerm(READ, Context::VW, w, c.konst(0, Context::IW));
+  c.checkSoundArrays(c.hf->CreateNode(
+      AND, c.hf->CreateNode(EQ, read, keep), c.anchorFor(keep)));
+}
+
+TEST(RemoveUnconstrained_Exhaustive, array_write_shared_value)
+{
+  Context c;
+  // As above, but the written value is a symbol used a second time, so
+  // it is constrained rather than constant. Dropping the rule's value
+  // condition makes it fire here and answer wrongly -- the write
+  // is pinned to whatever `e` turns out to be -- which the enumeration
+  // below detects. (With a *constant* value the same mistake trips
+  // replace()'s SYMBOL precondition instead, so this is the case that
+  // keeps the guard honest.)
+  ASTNode a = c.array();
+  ASTNode e = c.bv(Context::VW);
+  ASTNode keep = c.bv(Context::VW);
+  ASTNode w = c.hf->CreateArrayTerm(WRITE, Context::IW, Context::VW, a,
+                                    c.konst(0, Context::IW), e);
+  ASTNode read =
+      c.hf->CreateTerm(READ, Context::VW, w, c.konst(0, Context::IW));
+  ASTVec conjuncts;
+  conjuncts.push_back(c.hf->CreateNode(EQ, read, keep));
+  conjuncts.push_back(c.hf->CreateNode(EQ, e, keep)); // second use of `e`
+  conjuncts.push_back(c.anchorFor(keep));
+  c.checkSoundArrays(c.hf->CreateNode(AND, conjuncts));
+}
+
+TEST(RemoveUnconstrained_Exhaustive, array_ite)
+{
+  Context c;
+  // An if-then-else over two free arrays is itself free.
+  ASTNode cond = c.boolean();
+  ASTNode keep = c.bv(Context::VW);
+  ASTNode ite = c.hf->CreateArrayTerm(ITE, Context::IW, Context::VW, cond,
+                                      c.array(), c.array());
+  ASTNode read =
+      c.hf->CreateTerm(READ, Context::VW, ite, c.konst(0, Context::IW));
+  c.checkSoundArrays(c.hf->CreateNode(
+      AND, c.hf->CreateNode(EQ, read, keep), c.anchorFor(keep)));
+}
+
+TEST(RemoveUnconstrained_Collapse, array_equality)
+{
+  // The literature's rule set also eliminates an array equality with
+  // one unconstrained side. STP deliberately does not -- see the header
+  // comment in RemoveUnconstrained.cpp -- so this must NOT collapse. If
+  // a rule is added back, this is the test that will say so.
+  expectNoCollapse([](Context& c) {
+    c.mgr.UserFlags.enable_array_equality = true;
+    return c.hf->CreateNode(ARRAY_EQ, c.array(), c.array());
+  });
 }
 
 /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
`RemoveUnconstrained` had no rules for arrays — *"Nb. this isn't finished. It doesn't do reads / writes"* — so an array used once was never eliminated, and neither was anything reachable only through it.

The brummayerbiere `unconstrained` benchmarks are built to punish exactly that. Their arrays are each used once, and the only other content is five 1024-bit divisions feeding the selector bits of two 513-deep array if-then-else trees. Nothing in a model depends on those divisions, but STP bit-blasts them: ~20M CNF variables, a projected 35–40 GB on `unconstrained10`. `unconstrained07` dies the same way at 7.5 GB. The file's own header says what it is for: *"This benchmark demonstrates the need for propagating unconstrained arrays and bit-vectors."*

### The rules

The ones Brummayer's dissertation states for the extensional theory of arrays — the same source already credited at the top of this pass for the bit-vector rules:

| rule | condition |
|:---|:---|
| `READ(a,i)` | array unconstrained; the index is irrelevant |
| `WRITE(a,i,v)` | base array **and value** unconstrained |
| array-sorted `ITE` | both branches, or condition plus one branch |

The write rule's condition is the subtle one: `write(a, i, e)` with `e` fixed is pinned to `e` at `i`, so it is not an arbitrary array, and a rule keyed on the base array alone would decide equalities that are actually unsatisfiable.

Float- and RoundingMode-sorted arrays are excluded throughout, for the reason `PropagateEqualities` already excludes them from the equivalent substitution.

### Where they run

In a query with an array equality, by the time the existing passes see the formula the operands sit under witness reads whose shape `recoverAnchoredOperand` has to recognise — so rewriting there either does nothing or breaks the procedure. This adds a pass before `lowerArrayEqualities`, the window `PropagateEqualities` already has and for the same reason, and turns the array rules off once the procedure owns the formula.

### The rule that is deliberately absent

The fourth rule — an array equality with one unconstrained side becomes a free boolean — is not here. It was implemented and measured, and it is pure cost on this corpus: it won nothing the other three do not already win (checked file by file: 0 of 30 wins lost without it), and it cost the `fifo` family up to 4x. The stage timings say why — not CNF (62 ms → 85 ms) but the refinement loop:

| | master | with the rule |
|:---|---:|---:|
| SAT solving calls | 2 | 22 |
| SAT solving time | 9 ms | 3593 ms |

Replacing a settled equality with a free boolean leaves abstraction refinement to rediscover it. `RemoveUnconstrained_Collapse.array_equality` pins the absence so it is not re-added silently.

### Testing

`RemoveUnconstrained_Exhaustive_Test.cpp` gains array support: at an index and element width of one there are four distinct arrays, so the same exhaustive back-substitution identity the scalar rules are checked against is available. Each new rule was then mutated to confirm the checks are not vacuous:

| mutation | caught by |
|:---|:---|
| read rule reconstructs without writing the fresh value back | the enumeration |
| write rule drops the value condition, constant value | `replace()`'s SYMBOL precondition |
| write rule drops the value condition, shared-symbol value | substitution-map precondition |
| array-equality reconstruction never differs | `--check-sanity`: "counterexample bogus" |

Over all 15148 QF_ABV benchmarks, master versus this branch, with the candidate arm running `--check-sanity` so every sat answer's model is constructed and checked: **no answer changed** (10206 sat, 4549 unsat) and **no counterexample was rejected**. The 72 files whose outcome differed at a 5 s limit were re-measured with both arms plain at 60 s — nothing master solves became unsolvable.

### Result

| | master | this branch |
|:---|---:|---:|
| unconstrained10 | ~35–40 GB projected, OOM | 0.04 s, 19 MB |
| unconstrained07 | SIGSEGV at 7.5 GB | 0.05 s, 21 MB |
| sharing-is-caring family | 3.6–22.3 s | 0.01–0.05 s (up to 456x) |

`sharing-is-caring` contains no array equality at all, so that speedup is the ordinary passes doing the work rather than the new window.

### Known regression

`dwp_formulas/try5_small_noof_functions_flanagansaxe_shuf` and `_shred` are about 15x slower (0.17–0.19 s → ~2.9 s). Both remain well under a second of absolute cost and no benchmark crossed 60 s, but the mechanism is not yet understood and I am looking into it — flagging it rather than leaving it to be found.
