### PR TITLE
Run only the array rules in the pre-lowering unconstrained pass

### DIFF
--- a/include/stp/Simplifier/RemoveUnconstrained.h
+++ b/include/stp/Simplifier/RemoveUnconstrained.h
@@ -77,6 +77,15 @@ class RemoveUnconstrained
   // something to do; see TopLevelSTPAux.
   bool arrayRules;
 
+  // Whether the ordinary (bit-vector) rules may fire in this pass.
+  // The pre-lowering call leaves them off: they run later in
+  // sizeReducing anyway, and eliminating scalars that early costs the
+  // dwp_formulas flanagansaxe pair ~15x -- the abstraction refinement
+  // loop then needs 22 rounds where it had needed 2. Only the array
+  // rules have to run before the array-equality lowering, so only they
+  // do.
+  bool scalarRules;
+
 public:
   RemoveUnconstrained(STPMgr& bm);
 	
@@ -88,8 +97,11 @@ public:
   // level, an already-encoded conjunct) even though this formula alone
   // mentions them once. Merged with the extensionality frozen set when
   // both apply.
+  // `arrayRulesOnly` restricts the pass to the array rules; see
+  // scalarRules.
   ASTNode topLevel(const ASTNode& n, Simplifier* s,
-                   const std::set<ASTNode>* alsoUntouchable = NULL);
+                   const std::set<ASTNode>* alsoUntouchable = NULL,
+                   bool arrayRulesOnly = false);
 };
 }
 

--- a/lib/STPManager/STP.cpp
+++ b/lib/STPManager/STP.cpp
@@ -326,7 +326,8 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
         bm->UserFlags.enable_unconstrained)
     {
       RemoveUnconstrained r(*bm);
-      semantic_input = r.topLevel(semantic_input, simp);
+      semantic_input =
+          r.topLevel(semantic_input, simp, NULL, /*arrayRulesOnly=*/true);
       bm->ASTNodeStats(uc_message.c_str(), semantic_input);
     }
 

--- a/lib/Simplifier/RemoveUnconstrained.cpp
+++ b/lib/Simplifier/RemoveUnconstrained.cpp
@@ -74,8 +74,10 @@ RemoveUnconstrained::RemoveUnconstrained(STPMgr& _bm) : bm(_bm)
 }
 
 ASTNode RemoveUnconstrained::topLevel(const ASTNode& n, Simplifier* simplifier,
-                                      const std::set<ASTNode>* alsoUntouchable)
+                                      const std::set<ASTNode>* alsoUntouchable,
+                                      bool arrayRulesOnly)
 {
+  scalarRules = !arrayRulesOnly;
   ASTNode result(n);
 
   // Symbols the array-equality procedure depends on must not be
@@ -989,6 +991,11 @@ ASTNode RemoveUnconstrained::topLevel_other(const ASTNode& n,
     unsigned width = muteNode.getParent().n.GetValueWidth();
     unsigned indexWidth = muteNode.getParent().n.GetIndexWidth();
 
+    // Array rules only: everything else is left for the later passes.
+    if (!scalarRules && !(kind == READ || kind == WRITE ||
+                          (kind == ITE && indexWidth > 0)))
+      continue;
+
     ASTNode other;
     MutableASTNode* muteOther = NULL;
 
@@ -1641,8 +1648,9 @@ ASTNode RemoveUnconstrained::topLevel_other(const ASTNode& n,
     }
 
     // None of the per-kind rules fired (each detaches `var` from its
-    // parent when it does). Try the generalised ground-path collapse.
-    if (muteNode.isUnconstrained())
+    // parent when it does). Try the generalised ground-path collapse --
+    // a scalar rule, so not in an array-rules-only pass.
+    if (scalarRules && muteNode.isUnconstrained())
       tryGroundPathCollapse(muteNode, variable_array);
   }
 

--- a/tests/query-files/array-extensionality-tests/43-model-agrees-with-solved-out-read.smt2
+++ b/tests/query-files/array-extensionality-tests/43-model-agrees-with-solved-out-read.smt2
@@ -1,7 +1,9 @@
 ; RUN: %solver --array-equality %s | %OutputCheck %s
 ; CHECK: ^sat
-; CHECK-L: (define-fun |i| () (_ BitVec 8) #x01)
-; CHECK-L: (define-fun |b| () (Array (_ BitVec 4) (_ BitVec 8)) (store ((as const (Array (_ BitVec 4) (_ BitVec 8))) #x00) #x0 #x00))
+; The directives match in the order the model prints, which is j, i, b.
+; CHECK-L: (define-fun |j| () (_ BitVec 4) #x0)
+; CHECK-L: (define-fun |i| () (_ BitVec 8) #x00)
+; CHECK-L: (define-fun |b| () (Array (_ BitVec 4) (_ BitVec 8)) (store ((as const (Array (_ BitVec 4) (_ BitVec 8))) #x00) #x0 #x01))
 ; Unconstrained-variable elimination reaches this disequality from
 ; either side: i occurs once, and so does the array b beneath the read.
 ; The read rule is the one that fires -- select(b,j) with b free is
@@ -11,9 +13,16 @@
 ; that was eliminated, defined from select(b,j), and b printed with no
 ; cells at all.)
 ;
-; Either way the model has to be self-consistent, which is what this
-; pins: b[0] is the value the evaluation used, and i is one more than
-; it. With array equality enabled the model printer emits a *total*
+; What has to hold, however the elimination goes, is that the model is
+; self-consistent: the printed b[j] is the value the evaluation of i
+; actually used, so the two disagree exactly as the assertion demands.
+; The three values above are pinned together for that reason and only
+; that reason -- j selects cell 0, b's cell 0 is #x01, and i is #x00, so
+; i /= select(b,j) reading only what was printed. Which particular pair
+; of values it is depends on the rewrite order and has changed before;
+; if it changes again, check that they still disagree before repinning.
+;
+; With array equality enabled the model printer emits a *total*
 ; interpretation for every array, filling in zero wherever it finds no
 ; concrete-index entry, so a b whose printed cells disagreed with the
 ; value i was computed from would contradict the assertion the model was


### PR DESCRIPTION
Follow-up to #867, which flagged this regression as known and unexplained: `dwp_formulas/try5_small_noof_functions_flanagansaxe_{shuf,shred}` about 15x slower (0.15 s → 2.85 s), and the `try3` dwp pair about 3x.

**It is nothing to do with arrays.** The pass added before `lowerArrayEqualities` runs all of `RemoveUnconstrained`, not just the array rules that needed to be there — and the ordinary bit-vector rules had never run at that point before. Disabling each array rule in turn does not fix it; disabling *all* of them does not fix it; removing the call site does:

| file | master | as merged | array rules off, window on | array rules on, window off |
|:---|---:|---:|---:|---:|
| flanagansaxe_shuf | 0.15 | 2.83 | 2.80 | 0.15 |
| flanagansaxe_shred | 0.15 | 2.81 | 2.98 | 0.15 |
| unconstrained10 | 21.78 | 0.04 | 21.88 | 22.07 |
| unconstrained07 | 7.04 | 0.05 | 6.97 | 7.01 |

The cost follows the call site, not the rules — and the window is still needed, since without it neither `unconstrained` file is fixed.

**Nor is it the encoding.** Under `--print-functionstat` every arm hands the bit-blaster the same node count (2969) and the identical difficulty score (69750 / 182566). Only the pre-lowering pass's own output differs (5238 nodes with the scalar rules, 5778 without), and that difference is gone by the end. What changes is which fresh variables stand in for what, so a different counterexample comes back, and the read-axiom refinement loop then needs 22 rounds where it had needed 2:

| arm | SAT solving calls | counterexample generations |
|:---|---:|---:|
| master | 2 | 2 |
| as merged | 22 | 22 |
| this change | 2 | 2 |

A model-guidance effect rather than a structural one, which fits its hitting ~17 of 15148 files rather than a whole class.

### The change

Only the array rules have a reason to run before the lowering, so the pre-lowering pass runs only those. The scalar rules and the ground-path collapse stay in `sizeReducing`, where they always ran.

| file | master | as merged | this change |
|:---|---:|---:|---:|
| flanagansaxe_shuf | 0.15 | 2.84 | **0.15** |
| flanagansaxe_shred | 0.15 | 2.93 | **0.15** |
| try3_true_functions_dwp_shuf | 1.87 | 5.84 | **1.85** |
| try3_true_functions_dwp_shred | 1.92 | 6.02 | **1.85** |
| unconstrained10 | 21.46 | 0.02 | **0.05** |
| unconstrained07 | 7.03 | 0.04 | **0.05** |
| sharing-is-caring/bench_30_96 | 3.06 | 0.01 | **0.03** |

Every regression gone, every win kept.

### Testing

The full 15148-benchmark QF_ABV sweep again, with `--check-sanity` on the candidate arm so every sat answer's model is constructed and checked: **no answer changed** (10193 sat, 4533 unsat) and **no counterexample was rejected**. The files whose outcome moved were re-measured with both arms plain at 60 s:

| | count |
|:---|---:|
| faster by >25% | 22 |
| **slower by >25%** | **0** |
| newly unsolvable | 0 |

Before this change that middle row was 18.

`ctest` is 129/129. One array-equality test's model moves again, because the rewrite order does; it stays self-consistent, which is what the test is for, so the pinned values are updated and the comment now names the property being pinned rather than an arithmetic coincidence between the values.
