### PR TITLE
Report the SAT solver versions in (get-info :version)

### DIFF
--- a/lib/Interface/cpp_interface.cpp
+++ b/lib/Interface/cpp_interface.cpp
@@ -26,6 +26,7 @@ THE SOFTWARE.
 #include "stp/Extensionality/ExtensionalityContext.h"
 #include "stp/Parser/LetMgr.h"
 #include "stp/Printer/printers.h"
+#include "stp/Sat/SATSolverFactory.h"
 #include "stp/Util/GitSHA1.h"
 #include "stp/Incremental/IncrementalSolver.h"
 #include "stp/STPManager/STP.h"
@@ -1112,7 +1113,20 @@ void Cpp_interface::getInfo(std::string flag)
   if (flag == "name")
     cout << "(:name \"STP\")" << endl;
   else if (flag == "version")
-    cout << "(:version \"" << get_git_version_tag() << "\")" << endl;
+  {
+    // The SAT backend behind the build decides both the answers and the
+    // timings, and a session driving STP through SMT-LIB has no --version to
+    // ask; so the version string carries the same backend list --version
+    // prints. The standard's response here is a single string, which is why
+    // the list rides inside it rather than as info values of its own.
+    cout << "(:version \"" << get_git_version_tag() << " (SAT solvers";
+    const std::vector<std::string> solvers = compiledSolverVersions();
+    for (size_t i = 0; i < solvers.size(); i++)
+      cout << (i == 0 ? " " : ", ") << solvers[i];
+    if (solvers.empty())
+      cout << " none";
+    cout << ")\")" << endl;
+  }
   else if (flag == "authors")
   {
     // Required, like :name and :version (SMT-LIB 2.6, 4.1.8), and answered

--- a/tests/query-files/smt2-command-tests/get-info.smt2
+++ b/tests/query-files/smt2-command-tests/get-info.smt2
@@ -1,12 +1,18 @@
 ; The flags STP can answer are reported in the standard's response format; the
 ; rest must answer "unsupported" rather than an error. The four the standard
-; marks "support: required" (SMT-LIB 2.6, 4.1.8) are all among the former --
-; :version is not pinned here because its value is the build's version stamp.
+; marks "support: required" (SMT-LIB 2.6, 4.1.8) are all among the former.
 ; RUN: %solver %s | %OutputCheck %s
 (set-logic QF_BV)
 (declare-fun x () (_ BitVec 4))
 ; CHECK-NEXT: ^\(:name "STP"\)
 (get-info :name)
+; The stamp is the build's and the backend list depends on the configure-time
+; options, so only the shape is pinned: the version string ends with the SAT
+; backends compiled into the binary, the same list --version prints. Which
+; backend is behind a build changes the answers, and a session driving STP
+; through SMT-LIB has no --version to ask.
+; CHECK-NEXT: ^\(:version ".+ \(SAT solvers .+\)"\)$
+(get-info :version)
 ; CHECK-NEXT: ^\(:authors "the STP team"\)
 (get-info :authors)
 ; CHECK-NEXT: ^\(:error-behavior immediate-exit\)


### PR DESCRIPTION
#863 made `--version` name each compiled-in SAT backend and the version its linked library reports, on the grounds that which library is behind a build is not visible from outside it yet decides both the answers and the timings. A session driving STP through SMT-LIB has no `--version` to ask, and the backend is as much part of the version there as anywhere — so `(get-info :version)` now carries the same list, from the same `compiledSolverVersions()` (#866):

```
(:version "2.4.1 (SAT solvers cadical 3.0.1)")
```

The standard's response to `:version` is a single string (SMT-LIB 2.6, 4.1.8), which is why the list rides inside the string rather than as info values of its own. Multiple backends read exactly as `--version` prints them, header-mismatch notes included; a build with no backend at all — which configure refuses anyway — would say `(SAT solvers none)`, mirroring `--version`.

## Verification

`smt2-command-tests/get-info.smt2` previously left `:version` out, with a header note excusing it because the value is the build's version stamp. The suffix gives it a shape worth pinning, so the test now checks `^\(:version ".+ \(SAT solvers .+\)"\)$` while leaving the stamp and the backend list free to vary with the configure-time options — the same reasoning as #863's own test. I fed the old bare-stamp output through OutputCheck by hand to confirm the new directive rejects it rather than passing vacuously.

`ctest` is **129/129**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
