### PR TITLE
Guard array-equality refinement lemmas with their block literal

### DIFF
--- a/include/stp/Extensionality/ExtensionalityContext.h
+++ b/include/stp/Extensionality/ExtensionalityContext.h
@@ -384,7 +384,21 @@ public:
   // candidate that produced it, so the batch rules out that candidate
   // by many more facts than one clause could, and the reified equality
   // literals the lemmas share are built once.
-  void encodePendingLemmas(SATSolver& solver, ToSATBase* tosat);
+  //
+  // `guardLit`: a literal (2*var+sign) added to every lemma clause, or
+  // -1 for none. A lemma is a theory fact about the terms this solve's
+  // naming and anchor equations bind the lemma's symbols to -- and
+  // those equations are conjuncts of the formula being solved, which
+  // preprocessing may have rewritten under content that is retractable
+  // (an assumption level substituted into the anchors). In a solver
+  // that outlives the solve, the lemma is therefore only valid where
+  // that formula holds: a caller keeping the solver must pass the
+  // negation of the literal under which the formula was assumed, so
+  // each clause is inert once the block is retracted and reactivates
+  // whenever the identical block is assumed again. A per-query solver
+  // (the batch pipeline) passes no guard.
+  void encodePendingLemmas(SATSolver& solver, ToSATBase* tosat,
+                           int guardLit = -1);
 
   // A lemma atom the simplifier can decide from its defining terms
   // needs no equality circuit, and its literal is dropped from the
@@ -577,11 +591,12 @@ private:
   bool pendingLemmaValid;
   std::vector<ExtConflict> pendingLemmas;
 
-  // Encode one lemma as the clause NOT p1 OR ... OR NOT pk OR
-  // conclusion; the shared reified-literal cache means later lemmas in
-  // a batch reuse the equality variables the earlier ones built.
+  // Encode one lemma as the clause guard OR NOT p1 OR ... OR NOT pk OR
+  // conclusion (guard per encodePendingLemmas, absent when -1); the
+  // shared reified-literal cache means later lemmas in a batch reuse
+  // the equality variables the earlier ones built.
   void encodeOneLemma(const ExtConflict& lemma, SATSolver& solver,
-                      ToSATBase* tosat);
+                      ToSATBase* tosat, int guardLit);
 
   // reified equality cache, scoped to the current SAT instance
   std::map<std::pair<uint64_t, uint64_t>, int> eqLitCache;

--- a/lib/Extensionality/ExtensionalityContext.cpp
+++ b/lib/Extensionality/ExtensionalityContext.cpp
@@ -1865,13 +1865,14 @@ ExtensionalityContext::checkPreencodedBV(const ASTNode& n,
 }
 
 void ExtensionalityContext::encodePendingLemmas(SATSolver& solver,
-                                                ToSATBase* tosat)
+                                                ToSATBase* tosat,
+                                                int guardLit)
 {
   if (!pendingLemmaValid || pendingLemmas.empty())
     FatalError("array-equality: lemma encoding began without a pending "
                "certificate");
   for (size_t i = 0; i < pendingLemmas.size(); i++)
-    encodeOneLemma(pendingLemmas[i], solver, tosat);
+    encodeOneLemma(pendingLemmas[i], solver, tosat, guardLit);
   pendingLemmas.clear();
   pendingLemmaValid = false;
 }
@@ -1896,7 +1897,7 @@ ExtensionalityContext::requiredFoldVerdict(ExtLemmaAtom::Op op,
 
 void ExtensionalityContext::encodeOneLemma(const ExtConflict& pendingLemma,
                                            SATSolver& solver,
-                                           ToSATBase* tosat)
+                                           ToSATBase* tosat, int guardLit)
 {
   ToSATBase::ASTNodeToSATVar& satVar = tosat->SATVar_to_SymbolIndexMap();
 
@@ -2085,6 +2086,14 @@ void ExtensionalityContext::encodeOneLemma(const ExtConflict& pendingLemma,
   if (clause.size() == 0)
     FatalError("array-equality: refinement produced an empty clause "
                "(the candidate should have been unsatisfiable already)");
+
+  // Scope the clause to the formula whose equations give its symbols
+  // their meaning (see the header). Added after the emptiness check:
+  // a lemma that is empty before its guard still means the candidate
+  // should never have existed, and must keep failing loudly rather
+  // than quietly asserting the block's negation.
+  if (guardLit >= 0)
+    clause.push(SATSolver::mkLit(guardLit >> 1, (guardLit & 1) != 0));
 
   solver.addClause(clause);
   lemmasEmitted++;

--- a/lib/Incremental/IncrementalExactStack.cpp
+++ b/lib/Incremental/IncrementalExactStack.cpp
@@ -546,7 +546,19 @@ IncrementalSolver::Impl::exactStackCheckSat(
       if (!ext->hasPendingLemma())
         FatalError("IncrementalSolver: an active array-equality refinement "
                    "round has neither a decision nor a pending lemma");
-      ext->encodePendingLemmas(*solver, tosat);
+      // The lemmas persist in this session's solver, but their symbols
+      // mean what THIS block's anchor and naming equations say they
+      // mean -- and the whole-block preprocessing above may have
+      // rewritten those equations under a retractable conjunct (a
+      // check-sat-assuming level substituted into the anchors, say).
+      // Each lemma clause therefore carries the negated block literal:
+      // inert once this block is retracted, active again whenever the
+      // identical stack re-assumes it. Without the guard, a lemma whose
+      // atoms folded under such a substitution survives as an
+      // unconditional fact -- concretely, a refuted index-equality
+      // assumption left a permanent NOT-proxy unit behind, turning the
+      // next assumption-free solve of the satisfiable base stack unsat.
+      ext->encodePendingLemmas(*solver, tosat, blockLit ^ 1);
       res = ce->CallSAT_ResultCheck(*solver, bm->ASTTrue, semantic, prepared,
                                     tosat, true);
     }

--- a/tests/query-files/incremental-tests/ext-lemma-retracted-assumption-bv.smt2
+++ b/tests/query-files/incremental-tests/ext-lemma-retracted-assumption-bv.smt2
@@ -3,15 +3,20 @@
 ; sort, which reached it in the wild only because floating point engages
 ; the incremental driver from the third check while pure QF_ABV waits
 ; until the thirty-second. Engaged from the first check, the same
-; refuted (= j i) assumption fed the same anchor substitution, and the
-; final base-only check -- here a straight reuse of the second check's
-; block -- answered unsat from the leaked unit before lemmas were
-; guarded by their block literal.
+; refuted (= j i) assumption fed the same anchor substitution and left
+; the same permanent unit behind before lemmas were guarded by their
+; block literal.
+;
+; As in the twin, the plain check after the unsat round can be answered
+; from the frontend's propagated-sat verdict cache on a Release build,
+; so the q probe forces a genuinely new stack through a driver
+; array-equality round, where the leaked unit turned the answer unsat.
 ; RUN: %solver --incremental-auto-engage-at 1 --array-equality -s %s 2>&1 | %OutputCheck %s
 ; RUN: %solver --incremental --array-equality -s %s 2>&1 | %OutputCheck %s
 (set-logic QF_ABV)
 (declare-const i (_ BitVec 3))
 (declare-const j (_ BitVec 3))
+(declare-const q Bool)
 (declare-const a (Array (_ BitVec 3) (_ BitVec 2)))
 (assert (= (store a i #b01) (store a j #b00)))
 ; CHECK: ^sat
@@ -23,6 +28,9 @@
 ; CHECK: array-equality round
 ; CHECK: ^unsat
 (check-sat-assuming ((= j i)))
+; CHECK: ^sat
+(check-sat)
+(assert q)
 ; CHECK: array-equality round, block of 1 levels
 ; CHECK: ^sat
 (check-sat)

--- a/tests/query-files/incremental-tests/ext-lemma-retracted-assumption-bv.smt2
+++ b/tests/query-files/incremental-tests/ext-lemma-retracted-assumption-bv.smt2
@@ -1,0 +1,29 @@
+; The bit-vector-indexed twin of ext-lemma-retracted-assumption.smt2:
+; the lemma-guard channel has nothing to do with the rounding-mode index
+; sort, which reached it in the wild only because floating point engages
+; the incremental driver from the third check while pure QF_ABV waits
+; until the thirty-second. Engaged from the first check, the same
+; refuted (= j i) assumption fed the same anchor substitution, and the
+; final base-only check -- here a straight reuse of the second check's
+; block -- answered unsat from the leaked unit before lemmas were
+; guarded by their block literal.
+; RUN: %solver --incremental-auto-engage-at 1 --array-equality -s %s 2>&1 | %OutputCheck %s
+; RUN: %solver --incremental --array-equality -s %s 2>&1 | %OutputCheck %s
+(set-logic QF_ABV)
+(declare-const i (_ BitVec 3))
+(declare-const j (_ BitVec 3))
+(declare-const a (Array (_ BitVec 3) (_ BitVec 2)))
+(assert (= (store a i #b01) (store a j #b00)))
+; CHECK: ^sat
+(check-sat-assuming ((= (store a i #b01) (store a j #b00))))
+; CHECK: ^sat
+(check-sat)
+; CHECK: ^sat
+(check-sat-assuming ((= (store a i #b01) (store a j #b00))))
+; CHECK: array-equality round
+; CHECK: ^unsat
+(check-sat-assuming ((= j i)))
+; CHECK: array-equality round, block of 1 levels
+; CHECK: ^sat
+(check-sat)
+(exit)

--- a/tests/query-files/incremental-tests/ext-lemma-retracted-assumption.smt2
+++ b/tests/query-files/incremental-tests/ext-lemma-retracted-assumption.smt2
@@ -1,0 +1,36 @@
+; A refuted check-sat-assuming must not poison the next assumption-free
+; solve of an active array equality. The assumption level is part of the
+; round's exact-stack block, so its (= j i) substitutes into the record's
+; anchor equations during whole-block preprocessing; the refinement lemma
+; derived under those bindings collapses to NOT-proxy (the conclusion
+; folds unsatisfiable and drops). Encoded unguarded, that unit survived
+; the retraction as a permanent fact, and the final check answered unsat
+; on the satisfiable base stack -- two identical plain check-sats around
+; it disagreed. Every lemma now carries the negated block literal, so it
+; retracts with the block; the final check below must still run a driver
+; array-equality round over the base-only stack and answer sat.
+;
+; The base assertion forces i != j (equal indices would need the cell to
+; be 01 and 00 at once), so the (= j i) assumption is genuinely unsat and
+; the base alone is genuinely sat.
+; RUN: %solver --array-equality -s %s 2>&1 | %OutputCheck %s
+; RUN: %solver --incremental --array-equality -s %s 2>&1 | %OutputCheck %s
+(set-logic QF_ABVFP)
+(declare-const i RoundingMode)
+(declare-const j RoundingMode)
+(declare-const a (Array RoundingMode (_ BitVec 2)))
+(assert (= (store a i #b01) (store a j #b00)))
+; CHECK: ^sat
+(check-sat-assuming ((= (store a i #b01) (store a j #b00))))
+; CHECK: ^sat
+(check-sat)
+; CHECK: ^sat
+(check-sat-assuming ((= (store a i #b01) (store a j #b00))))
+; CHECK: array-equality round
+; CHECK: ^unsat
+(check-sat-assuming ((= j i)))
+; the poisoned answer was unsat, from the leaked NOT-proxy unit
+; CHECK: array-equality round, block of 1 levels
+; CHECK: ^sat
+(check-sat)
+(exit)

--- a/tests/query-files/incremental-tests/ext-lemma-retracted-assumption.smt2
+++ b/tests/query-files/incremental-tests/ext-lemma-retracted-assumption.smt2
@@ -1,23 +1,30 @@
-; A refuted check-sat-assuming must not poison the next assumption-free
-; solve of an active array equality. The assumption level is part of the
-; round's exact-stack block, so its (= j i) substitutes into the record's
-; anchor equations during whole-block preprocessing; the refinement lemma
-; derived under those bindings collapses to NOT-proxy (the conclusion
-; folds unsatisfiable and drops). Encoded unguarded, that unit survived
-; the retraction as a permanent fact, and the final check answered unsat
-; on the satisfiable base stack -- two identical plain check-sats around
-; it disagreed. Every lemma now carries the negated block literal, so it
-; retracts with the block; the final check below must still run a driver
-; array-equality round over the base-only stack and answer sat.
+; A refuted check-sat-assuming must not poison later solves of an active
+; array equality. The assumption level is part of the round's exact-stack
+; block, so its (= j i) substitutes into the record's anchor equations
+; during whole-block preprocessing; the refinement lemma derived under
+; those bindings collapses to NOT-proxy (the conclusion folds
+; unsatisfiable and drops). Encoded unguarded, that unit survived the
+; retraction as a permanent fact over the pair-deterministic proxy
+; variable, and later solves asserting the same equality answered unsat
+; on satisfiable stacks. Every lemma now carries the negated block
+; literal, so it retracts with the block.
 ;
 ; The base assertion forces i != j (equal indices would need the cell to
 ; be 01 and 00 at once), so the (= j i) assumption is genuinely unsat and
 ; the base alone is genuinely sat.
+;
+; The identical plain check after the unsat round reproduces the found
+; bug on an assertions build, but a Release build answers it from the
+; frontend's propagated-sat verdict cache without consulting the solver.
+; The q probe makes the stack new, which no cache may answer: that final
+; check must run a driver array-equality round over the grown base --
+; the stats line pins that it did -- and still say sat.
 ; RUN: %solver --array-equality -s %s 2>&1 | %OutputCheck %s
 ; RUN: %solver --incremental --array-equality -s %s 2>&1 | %OutputCheck %s
 (set-logic QF_ABVFP)
 (declare-const i RoundingMode)
 (declare-const j RoundingMode)
+(declare-const q Bool)
 (declare-const a (Array RoundingMode (_ BitVec 2)))
 (assert (= (store a i #b01) (store a j #b00)))
 ; CHECK: ^sat
@@ -30,6 +37,9 @@
 ; CHECK: ^unsat
 (check-sat-assuming ((= j i)))
 ; the poisoned answer was unsat, from the leaked NOT-proxy unit
+; CHECK: ^sat
+(check-sat)
+(assert q)
 ; CHECK: array-equality round, block of 1 levels
 ; CHECK: ^sat
 (check-sat)


### PR DESCRIPTION
Under the incremental driver, a refuted `check-sat-assuming` whose assumption constrains the index variables of an active array equality poisoned every later solve: two *identical* plain `(check-sat)` commands, with the same single assertion on the stack and nothing between them but the refuted assumption round, answered `sat` and then `unsat`. That is the dangerous direction — a wrong `unsat` claims no model exists. Found by a murxla campaign as a cross-check disagreement against bitwuzla (one hit in 13.4M runs), but STP contradicts itself standalone:

```smt2
(set-logic QF_ABVFP)
(declare-const i RoundingMode)
(declare-const j RoundingMode)
(declare-const a (Array RoundingMode (_ BitVec 2)))
(assert (= (store a i #b01) (store a j #b00)))
(check-sat-assuming ((= (store a i #b01) (store a j #b00))))
(check-sat)
(check-sat-assuming ((= (store a i #b01) (store a j #b00))))
(check-sat-assuming ((= j i)))
(check-sat)
```

`stp --array-equality` answered `sat sat sat unsat unsat`. The base assertion forces `i != j` (equal indices would need the cell to hold `#b01` and `#b00` at once), so the assumption round is rightly `unsat` and the final answer must return to `sat` — which is what `--incremental=off` and bitwuzla both say. No `push`/`pop` and no `--incremental` is involved: an ordinary multi-check session auto-engages the driver.

## The mechanism

The exact-stack route encodes the whole active stack — assumption level included — as one block under a retractable assumption literal, but the refinement lemmas derived while solving it entered the persistent SAT solver as unconditional clauses. A lemma is a theory fact about the terms the solve's anchor and naming equations bind its symbols to, and those equations are conjuncts of the block, which the whole-block preprocessing may have rewritten under a retractable conjunct.

That is exactly what the reproducer does. The `(= j i)` level is preprocessed into the block, folding the two index variables together, so the record's canonical operands become two stores at one shared index with different constants. The checker's certificate then collapses to a single premise: the conclusion (`#b01 = #b00`) folds structurally unsatisfiable and its literal is dropped, leaving the permanent unit `NOT proxy`. The proxy variable is deterministic in the raw operand pair — the same determinism that lets a repeated stack reuse its encoding — so the final check's block asserts exactly that variable, and the solve is unsat before refinement ever runs. Traced live, the poison is literally a one-literal clause landing in the solver during the assumption round.

The reproducer's RoundingMode index sort is incidental. It needed a non-bit-vector index only because floating point engages the driver from the third check while pure QF_ABV waits for the thirty-second, so the five-check bit-vector control never left the batch pipeline. Engaged from the first check, the same file with a `(_ BitVec 3)` index fails identically.

## The fix

Every lemma clause now carries the negated block literal — the same assumption that already scopes the block's own CNF. In the deriving round the guard is falsified by the assumed literal, so the round's refutation power is unchanged; once the block is retracted the clause is inert; and when the identical stack is re-assumed, its lemmas come back with it, which is the lifetime the deterministic-name reuse depends on. The linked SAT backends offer permanent clauses plus per-call assumptions and nothing else — there is no clause-removal primitive — so the activation-literal idiom *is* the solver-level mechanism for a retractable clause. The batch pipeline passes no guard: its solver dies with the query.

## Checking it

- **129/129 ctest** on both an assertions build and a Release build, both cadical-factor legs. Two regression tests, each verified failing before the fix and passing after on *both* build types: the RoundingMode reproducer under both automatic engagement and forced `--incremental`, and its bit-vector-indexed twin under forced first-check engagement. Both pin the driver's `array-equality round, block of 1 levels` stats line for the final solve, so an engagement-policy change cannot leave them passing while checking nothing.
- The verbatim five-check sequence only shows the bug where the final check actually solves. An assertions build re-solves it (`modelConstructionRequired()` forces construction), but a Release build answers it from the sat verdict the third check propagated into the frontend cache — no solve, so the poisoned solver state goes unconsulted and the first CI round's gcc-release leg failed on the missing stats line. The tests therefore keep the verbatim sequence and then grow the base with a fresh Boolean, a stack no cache may answer: against the pre-fix code that probe answers `unsat` on Release too, so the leaked unit is caught in both build flavours.
- The campaign's original 391-line trace, murxla's dd-minimised form, and the hand-reduced reproducers all now match `--incremental=off` — under `auto`, forced `on`, and `--check-sanity`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
