### PR TITLE
Count addition columns a word at a time

### DIFF
--- a/lib/Simplifier/constantBitP/ConstantBitP_Arithmetic.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_Arithmetic.cpp
@@ -225,17 +225,26 @@ void initialiseColumnCounts(int columnL[], int columnH[], const int bitWidth,
     columnH[i] = numberOfChildren;
   }
 
-  // Set the column totals.
-  for (int i = 0; i < bitWidth; i++)
+  // Set the column totals. Walk a child's fixed bits a word at a time,
+  // visiting only the bits that are actually fixed: on wide sums most
+  // addends are entirely unfixed, and those cost nothing here.
+  const unsigned words = ((unsigned)bitWidth + 63) / 64;
+  for (int j = 0; j < numberOfChildren; j++)
   {
-    for (int j = 0; j < numberOfChildren; j++)
+    const FixedBits& child = *children[j];
+    for (unsigned w = 0; w < words; w++)
     {
-      if (children[j]->isFixed(i))
+      uint64_t fixed, ones;
+      child.fillPackedWord(w, fixed, ones);
+      const unsigned base = w * 64;
+      while (fixed != 0)
       {
-        if (children[j]->getValue(i))
-          columnL[i]++;
+        const unsigned bit = ::stp::countTrailingZeroes64(fixed);
+        fixed &= fixed - 1;
+        if ((ones >> bit) & 1)
+          columnL[base + bit]++;
         else
-          columnH[i]--;
+          columnH[base + bit]--;
       }
     }
   }


### PR DESCRIPTION
The n-ary addition transfer function in constant-bit propagation begins every visit by rebuilding its column counts: for each of the `bitWidth` columns, how many addends are fixed to one and how many to zero. That was a `bitWidth x children` loop of `isFixed()` / `getValue()` calls, so a 32-bit sum of *n* addends spent 64*n* accessor calls before deriving anything, on every visit.

`FixedBits` has been word-packed for a while, so the same counts can be read a word at a time. For each addend the loop now pulls the packed fixedness and value words and walks only the bits that are actually fixed, using count-trailing-zeros. An addend with nothing fixed costs two loads instead of `2 x bitWidth` accessor calls; one with *k* fixed bits costs *k* iterations instead of the full width.

The counts are identical, so what propagation derives is unchanged. This is purely how they are computed.

### Measurements

Release build, one SAT backend, best of two runs per file, on fifteen QF_BV benchmarks previously identified as spending an unusually long time in constant-bit propagation:

| | total wall clock |
|---|---|
| master | 86.0 s |
| this change | 76.1 s (-11.5%) |

Twelve of the fifteen are faster; the largest single win is -48%, the largest regression +6%. Three files are slower by 6.2%, 3.2% and 0.4%, all within the run-to-run noise on this hardware.

Separately, on a mixed boolean-arithmetic benchmark from the QF_AUFBV set whose simplified form contains a single `BVPLUS` with 76,215 addends, this takes 343 s to 221 s. That file is still dominated by constant-bit propagation revisiting that one node, which needs a different fix; this change only makes each of those visits cheaper.

### Checking

- Full test suite passes (129/129).
- Answers unchanged across 400 files of a local fuzz corpus.