### PR TITLE
Update the Pages actions off Node 20

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -38,7 +38,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: actions/jekyll-build-pages@v1
         with:
@@ -49,7 +49,7 @@ jobs:
       # back root-owned and later steps (running as `runner`) cannot write to it.
       - run: sudo chown -R "$(id -u):$(id -g)" _site
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.12'
 
@@ -59,7 +59,7 @@ jobs:
       # than quietly publishing a broken manual.
       - run: sphinx-build -W -b html docs _site/docs
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: _site
 
@@ -72,4 +72,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Every run of `Publish site` logs:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/checkout@v4`, `actions/setup-python@v5`, `actions/upload-artifact@v4`.

The pins were several majors behind:

| action | was | now |
| --- | --- | --- |
| `actions/checkout` | v4 | v7 |
| `actions/setup-python` | v5 | v7 |
| `actions/upload-pages-artifact` | v3 | v5 |
| `actions/deploy-pages` | v4 | v5 |

`actions/jekyll-build-pages@v1` is unchanged — it is a container action, so the Node runtime does not apply, and v1.0.13 is current.

Nothing is broken today; the runner transparently forces Node 24. But the shim is temporary, and the failure mode when it goes away is the site silently stopping publishing.

This was written as part of #873 but missed the squash merge, so it is going in on its own. The PR build exercises the new versions before anything deploys.