### PR TITLE
Fix three pieces of undefined behaviour in ABC's CNF generation, and add a UBSan CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,6 +330,180 @@ jobs:
 
         echo "All builds agree on the CNF for every input compared."
 
+  # Undefined behaviour is invisible to every other job here. A build that
+  # executes it answers exactly like a build that does not, right up until an
+  # optimiser or a target decides otherwise, so it has to be looked for
+  # deliberately -- and nothing was looking. CMakeLists.txt has carried a
+  # SANITIZE option for years, but it only ever adds CXX flags, and ABC --
+  # the vendored library that turns every query's AIG into CNF -- is C, so
+  # the code most in need of the check was the code that option cannot reach.
+  #
+  # What was sitting there: a signed left shift that overflows for any cut
+  # whose truth table has bit 15 set, cuts handed out at addresses their own
+  # pointer members are not aligned for, and a hash mix that overflows a
+  # signed int once the AIG passes ~270,600 nodes. The first two are issue
+  # #881; the third turned up on fp-tests/rem-exponent-width-boundary.smt2
+  # when the whole suite was swept rather than that one regression. All three
+  # are fixed in patches/abc/, and this job is what keeps them fixed.
+  #
+  # -fno-sanitize-recover=all rather than UBSAN_OPTIONS=halt_on_error=1,
+  # because it makes aborting a property of the binary rather than of whoever
+  # runs it. Nothing has to remember to export anything -- not this workflow,
+  # not a developer reproducing a failure by hand -- and it does not rest on
+  # lit forwarding UBSAN_OPTIONS to the query file tests, which lit does do
+  # today but from a pass-through list that is lit's to change, not STP's.
+  build-ubsan:
+    name: clang (ubsan)
+    runs-on: ubuntu-latest
+
+    # 400M rather than 800M; see the note on the gcc/clang job above.
+    env:
+      CCACHE_MAXSIZE: 400M
+      # The file, line and check that failed are printed without this; it adds
+      # the stack that got there. lit forwards UBSAN_OPTIONS, so the query
+      # file tests get it too.
+      UBSAN_OPTIONS: print_stacktrace=1
+
+    steps:
+
+    - uses: actions/checkout@v7
+      with:
+          submodules: 'true'
+
+    # llvm for llvm-symbolizer, which is what turns the frames of a stack
+    # trace into names and line numbers.
+    - name: Packages
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          bison \
+          build-essential \
+          ccache \
+          clang \
+          cmake \
+          flex \
+          git \
+          llvm \
+          ninja-build \
+          python3 \
+          python3-pip \
+          python3-setuptools \
+          zlib1g-dev
+        sudo pip3 install -U lit
+
+    - name: Resolve dependency revisions
+      id: deps-key
+      run: ./scripts/deps/cache-key.sh >> "$GITHUB_OUTPUT"
+
+    - name: Restore dependencies
+      id: deps-cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          deps/cadical
+          deps/gtest
+          deps/OutputCheck
+        key: deps-x86_64-ubsan-${{ steps.deps-key.outputs.key }}
+
+    # CaDiCaL, and only CaDiCaL. The backend is built by its own script,
+    # uninstrumented, so whichever one is linked is not what is under test
+    # here; this is the one that is a static archive and builds in seconds.
+    - name: Dependencies
+      if: steps.deps-cache.outputs.cache-hit != 'true'
+      run: |
+        ./scripts/deps/setup-cadical.sh
+        ./scripts/deps/setup-gtest.sh
+        ./scripts/deps/setup-outputcheck.sh
+
+    - name: LibBF (real-literal folding)
+      run: ./scripts/deps/setup-libbf.sh
+
+    - name: Compiler cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ccache
+        key: ccache-ubsan-${{ github.run_id }}
+        restore-keys: ccache-ubsan-
+
+    # CMAKE_C_FLAGS is the half that matters most: ABC is C, and it is where
+    # the CNF that every query is decided from is built.
+    #
+    # -shared-libsan puts the sanitizer runtime in a shared object that
+    # libstp.so then records as a dependency, which is what lets the Python
+    # bindings dlopen it. With clang's default static runtime that dlopen
+    # fails outright -- "undefined symbol: __ubsan_handle_type_mismatch_v1" --
+    # and python-interface-tests is lost. Nothing then puts that shared object
+    # on the loader's path, hence the -rpath: clang adds none of its own, so
+    # without it every binary this job builds fails to start. The directory
+    # comes from -print-file-name rather than -print-runtime-dir because the
+    # two disagree on some distributions, and it is the one that answers where
+    # the file actually is.
+    #
+    # STP_ALLOCATOR=system leaves the vendored mimalloc out of the build. It
+    # is a third-party allocator that replaces malloc wholesale; instrumenting
+    # it would make this job partly about mimalloc rather than about STP and
+    # ABC.
+    #
+    # WERROR is left off deliberately. The clang job above already compiles
+    # this tree with -Werror, and gating a run-time check on whether an
+    # instrumented build warns differently would only add a way for this job
+    # to fail for a reason it is not looking for.
+    - name: Configure
+      run: |
+        set -u
+        soname=libclang_rt.ubsan_standalone-x86_64.so
+        rtdir=$(dirname "$(clang -print-file-name=$soname)")
+        echo "sanitizer runtime: $rtdir"
+        if [ ! -e "$rtdir/$soname" ]; then
+          echo "::error::clang cannot find $soname; -shared-libsan has nothing to link"
+          exit 1
+        fi
+
+        mkdir build
+        cd build
+        CC=clang CXX=clang++ cmake \
+          -DNOCRYPTOMINISAT:BOOL=ON \
+          -DUSE_CADICAL:BOOL=ON \
+          -DCADICAL_DIR:PATH="$GITHUB_WORKSPACE/deps/cadical" \
+          -DSTP_ALLOCATOR=system \
+          -DENABLE_TESTING:BOOL=ON \
+          -DPYTHON_EXECUTABLE:PATH="$(which python3)" \
+          -DCMAKE_C_FLAGS="-fsanitize=undefined -fno-sanitize-recover=all -fno-omit-frame-pointer" \
+          -DCMAKE_CXX_FLAGS="-fsanitize=undefined -fno-sanitize-recover=all -fno-omit-frame-pointer" \
+          -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=undefined -shared-libsan -Wl,-rpath,$rtdir" \
+          -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=undefined -shared-libsan -Wl,-rpath,$rtdir" \
+          -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+          -G Ninja ..
+
+    - name: Build
+      run: |
+        ccache --zero-stats
+        cmake --build . --parallel "$(nproc)"
+        ccache --show-stats
+      working-directory: build
+
+    # A job that quietly built without the sanitizer would pass everything
+    # below while checking nothing, so confirm the flags reached both
+    # artifacts before trusting the tests. The _abort suffix is the half that
+    # is easy to lose: those entry points are what -fno-sanitize-recover=all
+    # emits, and without it undefined behaviour only prints a line and
+    # carries on.
+    - name: The build really is instrumented
+      run: |
+        set -u
+        for f in build/stp build/lib/libstp.so; do
+          n=$(nm -D "$f" | grep -c '__ubsan_handle_.*_abort' || true)
+          echo "$f: $n aborting UBSan entry points"
+          if [ "$n" -eq 0 ]; then
+            echo "::error::$f was not built with -fsanitize=undefined -fno-sanitize-recover=all"
+            exit 1
+          fi
+        done
+
+    - name: Test
+      run: ctest --parallel "$(nproc)" -VV --output-on-failure
+      working-directory: build
+
   build-cadical:
     name: gcc (cadical ${{ matrix.cadical_tag }})
     runs-on: ubuntu-latest

--- a/docs/building.rst
+++ b/docs/building.rst
@@ -160,7 +160,10 @@ These apply to all generators:
    only)
 -  ``PYTHON_EXECUTABLE`` -- which Python 3 to use, when more than one is
    installed
--  ``SANITIZE`` -- use Clang's sanitization checks
+-  ``SANITIZE`` -- use Clang's sanitization checks. It sets C++ flags only,
+   and turns on the address and integer sanitizers alongside the undefined
+   one; for the undefined-behaviour build CI runs, which also covers the
+   vendored C, see :ref:`ubsan`
 -  ``STATICCOMPILE`` -- build static libraries and binaries instead of
    dynamic
 -  ``BUILD_SHARED_LIBS`` -- build ``libstp`` as a shared library

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -196,6 +196,57 @@ individual allocations. Configure with ``-DSTP_ALLOCATOR=system`` if you
 want to run the binary itself under valgrind, and use lit's own ``--vg``
 flag for that.
 
+.. _ubsan:
+
+Running the tests under UndefinedBehaviorSanitizer
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Undefined behaviour does not announce itself. A build that executes it
+answers exactly like a build that does not, right up until an optimiser or a
+target decides otherwise, so it has to be looked for on purpose. Clang's
+UndefinedBehaviorSanitizer compiles in the checks the language leaves to the
+implementation -- signed overflow, out-of-range shifts, misaligned accesses --
+and reports them as they happen.
+
+::
+
+    $ rtdir=$(dirname "$(clang -print-file-name=libclang_rt.ubsan_standalone-x86_64.so)")
+    $ cmake -S . -B build-ubsan -G Ninja \
+        -DENABLE_TESTING=ON -DPYTHON_EXECUTABLE="$(which python3)" \
+        -DSTP_ALLOCATOR=system \
+        -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
+        -DCMAKE_C_FLAGS="-fsanitize=undefined -fno-sanitize-recover=all -fno-omit-frame-pointer" \
+        -DCMAKE_CXX_FLAGS="-fsanitize=undefined -fno-sanitize-recover=all -fno-omit-frame-pointer" \
+        -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=undefined -shared-libsan -Wl,-rpath,$rtdir" \
+        -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=undefined -shared-libsan -Wl,-rpath,$rtdir"
+    $ cmake --build build-ubsan
+    $ ctest --test-dir build-ubsan -j8
+
+``CMAKE_C_FLAGS`` matters as much as the C++ one: ABC, the vendored library
+that turns each query's AIG into CNF, is C, and is where the undefined
+behaviour found so far has been. This is not what the ``SANITIZE``
+configuration variable does -- that one sets C++ flags only, and turns on the
+address and integer sanitizers as well.
+
+``-fno-sanitize-recover=all`` makes a failing check abort rather than print
+and carry on, which is what turns undefined behaviour into a failing test.
+``UBSAN_OPTIONS=halt_on_error=1`` would do the same thing for a run that
+remembers to set it -- lit does forward that variable to the query file tests
+-- but compiling it in makes it a property of the binary, so it holds however
+the binary is reached, including through the Python bindings. Leave the flag
+off when you would rather collect every report from a run than stop at the
+first, and set ``UBSAN_OPTIONS=print_stacktrace=1`` for a stack trace with
+each one.
+
+The rest is plumbing. ``-shared-libsan`` and the matching ``-rpath`` are what
+let ``python-interface-tests`` work: the bindings dlopen ``libstp.so``, which
+fails against clang's default static runtime with "undefined symbol:
+``__ubsan_handle_type_mismatch_v1``". ``STP_ALLOCATOR=system`` keeps the
+vendored mimalloc, which replaces ``malloc`` wholesale, out of the picture.
+
+CI runs this configuration on every pull request, as the ``clang (ubsan)``
+job in ``.github/workflows/ci.yml``.
+
 Notes for Query file tests
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/patches/abc/0002-aigmem-align-flex-entries.patch
+++ b/patches/abc/0002-aigmem-align-flex-entries.patch
@@ -1,0 +1,59 @@
+diff --git a/src/aig/aig/aigMem.c b/src/aig/aig/aigMem.c
+index 7626b5fb8..d46c1a4e5 100644
+--- a/src/aig/aig/aigMem.c
++++ b/src/aig/aig/aigMem.c
+@@ -65,6 +65,40 @@ struct Aig_MmFlex_t_
+     int           nMemoryAlloc;  // memory allocated
+ };
+ 
++// The alignment Aig_MmFlexEntryFetch() rounds every entry size up to.
++//
++// It hands out entries one after another from a chunk that ABC_ALLOC()
++// returns, and malloc() aligns that chunk for any type; so it is the entry
++// sizes, and only those, that decide whether the entries after the first one
++// are aligned too.
++//
++// Eight rather than four, because a caller casts what it gets back to a
++// struct with pointer members. Cnf_CutAlloc()'s request is sizeof(Cnf_Cut_t)
++// -- 24 -- plus four bytes per leaf plus the cut's truth table, so it is 4
++// modulo 8 for half the cut sizes ABC asks for, and it then writes
++// Cnf_Cut_t's two Vec_Int_t * fields through the result. One such cut left
++// the next one 4 bytes past an aligned address, and every access through
++// that one -- the stores in Cnf_CutAlloc(), the reads through Cnf_CutTruth()
++// and in cnfUtil.c and cnfWrite.c later on -- was undefined. It happened to
++// produce the right answers on x86-64, where an unaligned load is merely
++// slower, but nothing guarantees that on another target or under another
++// optimiser.
++//
++// ABC's own Makefile passes -DABC_MEMALIGN=4, which rounds but not far enough
++// (those sizes are already multiples of 4), and a build that defines it
++// nowhere -- STP's CMake build among them -- did not round at all. Hence a
++// floor rather than a plain default: a larger externally requested alignment
++// is still honoured.
++//
++// Aig_MmStepEntryFetch() needs nothing of the sort. Its buckets are 8 << i
++// bytes and Aig_MmFixedEntryFetch() spaces entries by the bucket size, so
++// they are 8-byte aligned already.
++#if defined(ABC_MEMALIGN) && ABC_MEMALIGN > 8
++#define AIG_MM_ALIGN  ABC_MEMALIGN
++#else
++#define AIG_MM_ALIGN  8
++#endif
++
+ struct Aig_MmStep_t_
+ {
+     int               nMems;    // the number of fixed memory managers employed
+@@ -366,10 +400,9 @@ void Aig_MmFlexStop( Aig_MmFlex_t * p, int fVerbose )
+ char * Aig_MmFlexEntryFetch( Aig_MmFlex_t * p, int nBytes )
+ {
+     char * pTemp;
+-#ifdef ABC_MEMALIGN
+-    // extend size to max alignment
+-    nBytes += (ABC_MEMALIGN - nBytes % ABC_MEMALIGN) % ABC_MEMALIGN;
+-#endif
++    // extend size to max alignment (see AIG_MM_ALIGN; unconditional, because
++    // an unrounded entry misaligns every entry that follows it)
++    nBytes += (AIG_MM_ALIGN - nBytes % AIG_MM_ALIGN) % AIG_MM_ALIGN;
+     // check if there are still free entries
+     if ( p->pCurrent == NULL || p->pCurrent + nBytes > p->pEnd )
+     { // need to allocate more entries

--- a/patches/abc/0003-cnfcut-unsigned-truth-shift.patch
+++ b/patches/abc/0003-cnfcut-unsigned-truth-shift.patch
@@ -1,0 +1,21 @@
+diff --git a/src/sat/cnf/cnfCut.c b/src/sat/cnf/cnfCut.c
+index ee9dcfa7e..1cfd3c54c 100644
+--- a/src/sat/cnf/cnfCut.c
++++ b/src/sat/cnf/cnfCut.c
+@@ -96,7 +96,15 @@ Cnf_Cut_t * Cnf_CutCreate( Cnf_Man_t * p, Aig_Obj_t * pObj )
+     pCut = Cnf_CutAlloc( p, pCutBest->nLeaves );
+     memcpy( pCut->pFanins, pCutBest->pLeaves, sizeof(int) * pCutBest->nLeaves );
+     pTruth = Cnf_CutTruth(pCut);
+-    *pTruth = (pCutBest->uTruth << 16) | pCutBest->uTruth;
++    // uTruth is a 16-bit unsigned bit-field, so the integer promotions make
++    // it a plain int before the shift, and any truth table with bit 15 set
++    // then shifts into that int's sign bit -- undefined, rather than the
++    // 4-variable table duplicated into both halves of a word that this is
++    // after. Widening to unsigned first is defined for every value of the
++    // field and produces exactly that duplication. A UBSan build reports the
++    // original as "left shift of 34952 by 16 places cannot be represented in
++    // type 'int'".
++    *pTruth = ((unsigned)pCutBest->uTruth << 16) | pCutBest->uTruth;
+     pCut->Cost = Cnf_CutSopCost( p, pCutBest );
+     return pCut;
+ }

--- a/patches/abc/0004-aightable-unsigned-hash-mix.patch
+++ b/patches/abc/0004-aightable-unsigned-hash-mix.patch
@@ -1,0 +1,26 @@
+diff --git a/src/aig/aig/aigTable.c b/src/aig/aig/aigTable.c
+index 2c7adee71..6c2463b4d 100644
+--- a/src/aig/aig/aigTable.c
++++ b/src/aig/aig/aigTable.c
+@@ -28,11 +28,19 @@ ABC_NAMESPACE_IMPL_START
+ ////////////////////////////////////////////////////////////////////////
+ 
+ // hashing the node
++//
++// Id is an int, so multiplying it by 7937 in int arithmetic overflows once the
++// manager holds about 270,600 objects -- a size an ordinary bit-blasted query
++// reaches -- and signed overflow is undefined rather than the wrap the mixing
++// step wants. Only the two Id products can get that large; the other three
++// terms multiply a 0/1 flag by a small constant. Doing those two in unsigned
++// arithmetic is defined for every Id and keeps the result a function of the
++// operands alone.
+ static unsigned long Aig_Hash( Aig_Obj_t * pObj, int TableSize ) 
+ {
+     unsigned long Key = Aig_ObjIsExor(pObj) * 1699;
+-    Key ^= Aig_ObjFanin0(pObj)->Id * 7937;
+-    Key ^= Aig_ObjFanin1(pObj)->Id * 2971;
++    Key ^= (unsigned)Aig_ObjFanin0(pObj)->Id * 7937u;
++    Key ^= (unsigned)Aig_ObjFanin1(pObj)->Id * 2971u;
+     Key ^= Aig_ObjFaninC0(pObj) * 911;
+     Key ^= Aig_ObjFaninC1(pObj) * 353;
+     return Key % TableSize;


### PR DESCRIPTION
A UBSan build of `master` executes undefined behaviour while solving an ordinary `QF_BV` regression, as #881 reports. The answers come out right on x86-64, where a misaligned load is merely slower and a signed overflow wraps — which is exactly what makes it worth fixing now rather than after an optimiser or another target decides otherwise. Three separate things, all in the vendored ABC, all carried as patches under `patches/abc/`.

```text
lib/extlib-abc/src/sat/cnf/cnfCut.c:99:33: runtime error: left shift of 34952 by 16 places cannot be represented in type 'int'
lib/extlib-abc/src/sat/cnf/cnfCut.c:51:11: runtime error: member access within misaligned address 0x… for type 'Cnf_Cut_t', which requires 8 byte alignment
lib/extlib-abc/src/aig/aig/aigTable.c:34:36: runtime error: signed integer overflow: 270568 * 7937 cannot be represented in type 'int'
```

## What was undefined

**Cuts are handed out at addresses they cannot be used at.** `Cnf_CutAlloc()` asks `Aig_MmFlexEntryFetch()` for `sizeof(Cnf_Cut_t)` — 24 — plus four bytes per leaf plus the cut's truth table, so half the cut sizes it uses come to 4 modulo 8, and it then writes `Cnf_Cut_t`'s two `Vec_Int_t *` members through the result. The flexible memory manager hands entries out one after another from a `malloc`ed chunk and rounded their sizes only under `#ifdef ABC_MEMALIGN`, which STP's build never defines, so one such cut left the next one four bytes past an aligned address and every access through that one — the stores in `Cnf_CutAlloc()`, the reads through `Cnf_CutTruth()`, and everything `cnfUtil.c` and `cnfWrite.c` do with it later — was undefined. It now rounds to 8 unconditionally, as a floor rather than a default, so a larger externally requested alignment is still honoured. ABC's own Makefile asks for `-DABC_MEMALIGN=4`, which was never enough for a struct with pointers in it either: those sizes are already multiples of 4.

**A truth table is shifted into the sign bit.** `Cnf_CutCreate()` computes `(pCutBest->uTruth << 16) | pCutBest->uTruth`. `uTruth` is a 16-bit unsigned bit-field, so the integer promotions make it a plain `int` before the shift, and any truth table with bit 15 set then shifts into that `int`'s sign bit. Widening to `unsigned` first is defined for every value the field can hold and produces exactly the duplication into both halves of a word that the expression is after.

**The structural hash overflows on large AIGs.** `Aig_Hash()` multiplies an object's `Id`, an `int`, by 7937, which overflows once the manager holds about 270,600 objects — a size an ordinary bit-blasted query reaches, and `tests/query-files/fp-tests/rem-exponent-width-boundary.smt2` does. The two `Id` products are now done in unsigned arithmetic. Nothing else changes: the hash only decides which bucket a node lands in, `Aig_TableLookup()` compares children and type exactly, and nothing iterates `pTable` in bucket order. That is checked rather than argued — `scripts/cnf-manifest.sh` over `tests/query-files` is byte-identical between a patched and an unpatched build.

The first two are #881. The third came out of sweeping the whole suite rather than the one regression that issue names, and is the one with teeth in practice: 270,600 AIG nodes is not a large query.

## Why nothing had caught it

`CMakeLists.txt` has carried a `SANITIZE` option for years, but it only ever adds C++ flags — and ABC is C. The code most in need of the check was the code that option cannot reach, which is why three pieces of undefined behaviour sat in the path every single query takes. The new `clang (ubsan)` job therefore passes `-fsanitize=undefined` on `CMAKE_C_FLAGS` as well as `CMAKE_CXX_FLAGS`; that is the whole reason it finds anything.

Two more details decide whether the job works at all. The abort is compiled in with `-fno-sanitize-recover=all` rather than asked for through `UBSAN_OPTIONS`, which makes it a property of the binary, so it holds however the binary is reached and nothing has to remember to export anything — lit does forward `UBSAN_OPTIONS` today, but from a pass-through list that is lit's to change, not STP's. And `python-interface-tests` needs `-shared-libsan`, since ctypes dlopening an instrumented `libstp.so` against clang's default *static* runtime fails outright with `undefined symbol: __ubsan_handle_type_mismatch_v1`; clang then adds no rpath of its own for that shared runtime, so without `-Wl,-rpath` every binary the job builds fails to start. The directory comes from `clang -print-file-name` rather than `-print-runtime-dir`, because the two disagree on some distributions and only the former answers where the file actually is.

`STP_ALLOCATOR=system` keeps the vendored mimalloc out, so the job is about STP and ABC rather than about a third-party allocator that replaces `malloc` wholesale. `WERROR` is deliberately off: the `clang` job already compiles this tree with `-Werror`, and gating a run-time check on whether an instrumented build warns differently would only add a way for this job to fail for a reason it is not looking for. A step greps `__ubsan_handle_*_abort` out of both `stp` and `libstp.so` before the tests run, because a job that quietly built without the sanitizer would pass everything and check nothing.

`docs/testing.rst` gains the same recipe for running it by hand, next to the valgrind one, and the `SANITIZE` entry in `docs/building.rst` now says what it actually covers.

## Checking it

- With the patches reverted, that job's configuration fails **27 of 129** ctest tests; with them, **129/129** pass, `python-interface-tests` included. Both directions were built and run, so the job is known to go red on the bug rather than merely green without it.
- Replaying all **827** `RUN` lines in `tests/query-files` against a *recovering* UBSan build — which reports every site instead of stopping at the first — produces no diagnostics. Before the patches the same sweep reports the `cnfCut.c` shift, and it is how the `aigTable.c` overflow was found in the first place.
- A sweep of **1174** files sampled from a benchmark corpus, including inputs orders of magnitude larger than anything in the test suite, is likewise clean.
- The four patches apply to a pristine ABC checkout in order and re-configure idempotently, and `sphinx -W` still builds the manual.

All three are candidates for upstreaming to berkeley-abc; none of them is STP-specific.

Closes #881.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
