### PR TITLE
Ask for GMP and zlib only when the backend that needs them is built

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -783,26 +783,37 @@ option(NOCRYPTOMINISAT "Don't try to use cryptominisat" OFF)
 
 if (NOT NOCRYPTOMINISAT)
   set(cryptominisat5_DIR "" CACHE PATH "Path to directory containing cryptominisat5Config.cmake")
-  find_package(GMP REQUIRED)
-  message(STATUS "GMP includes: ${GMP_INCLUDE_DIRS}")
-  message(STATUS "GMP libraries: ${GMP_LIBRARIES}")
-  include_directories(SYSTEM ${GMP_INCLUDE_DIRS})
-  set(LIBS ${LIBS} ${GMP_LIBRARIES})
-  # A static CryptoMiniSat references cadical/cadiback imported targets but its
-  # config file does not find them itself; a shared CryptoMiniSat has no such
-  # packages, hence QUIET. cadical's export in turn references Threads::Threads.
-  find_package(Threads QUIET)
-  find_package(cadical CONFIG QUIET)
-  find_package(cadiback CONFIG QUIET)
-  find_package(cryptominisat5 CONFIG)
-  if (cryptominisat5_FOUND AND HAVE_FLAG_STD_CPP11 AND (NOT NOCRYPTOMINISAT))
-    message(STATUS "CryptoMiniSat5 dynamic lib: ${CRYPTOMINISAT5_LIBRARIES}")
-    message(STATUS "CryptoMiniSat5 static lib:  ${CRYPTOMINISAT5_STATIC_LIBRARIES}")
-    message(STATUS "CryptoMiniSat5 static lib deps: ${CRYPTOMINISAT5_STATIC_LIBRARIES_DEPS}")
-    message(STATUS "CryptoMiniSat5 include dirs: ${CRYPTOMINISAT5_INCLUDE_DIRS}")
-    add_definitions(-DUSE_CRYPTOMINISAT)
-    set(USE_CRYPTOMINISAT ON)
+  # GMP is CryptoMiniSat's dependency, not STP's -- no STP source includes it.
+  # Look for it before CryptoMiniSat and treat it as part of finding that
+  # package: cryptominisat5Config.cmake asks pkg-config for gmp with REQUIRED,
+  # which aborts the whole configure when it is missing, so a box with neither
+  # installed would fail here rather than quietly building without CMS.
+  # scripts/deps/setup-cms.sh names libgmp-dev among the packages it needs.
+  find_package(GMP)
+  if (NOT GMP_FOUND)
+    message(STATUS "GMP not found, skipping CryptoMiniSat "
+                   "(install libgmp-dev to enable it)")
   else()
+    message(STATUS "GMP includes: ${GMP_INCLUDE_DIRS}")
+    message(STATUS "GMP libraries: ${GMP_LIBRARIES}")
+    # A static CryptoMiniSat references cadical/cadiback imported targets but its
+    # config file does not find them itself; a shared CryptoMiniSat has no such
+    # packages, hence QUIET. cadical's export in turn references Threads::Threads.
+    find_package(Threads QUIET)
+    find_package(cadical CONFIG QUIET)
+    find_package(cadiback CONFIG QUIET)
+    find_package(cryptominisat5 CONFIG)
+    if (cryptominisat5_FOUND AND HAVE_FLAG_STD_CPP11 AND (NOT NOCRYPTOMINISAT))
+      message(STATUS "CryptoMiniSat5 dynamic lib: ${CRYPTOMINISAT5_LIBRARIES}")
+      message(STATUS "CryptoMiniSat5 static lib:  ${CRYPTOMINISAT5_STATIC_LIBRARIES}")
+      message(STATUS "CryptoMiniSat5 static lib deps: ${CRYPTOMINISAT5_STATIC_LIBRARIES_DEPS}")
+      message(STATUS "CryptoMiniSat5 include dirs: ${CRYPTOMINISAT5_INCLUDE_DIRS}")
+      add_definitions(-DUSE_CRYPTOMINISAT)
+      set(USE_CRYPTOMINISAT ON)
+      # Only a build that actually links CryptoMiniSat needs GMP on its line.
+      include_directories(SYSTEM ${GMP_INCLUDE_DIRS})
+      set(LIBS ${LIBS} ${GMP_LIBRARIES})
+    endif()
   endif()
 endif()
 add_feature_info(CryptoMiniSat USE_CRYPTOMINISAT "Enables CryptoMiniSat solver, allows --cryptominisat5 option")

--- a/docs/building.rst
+++ b/docs/building.rst
@@ -22,14 +22,19 @@ On a Debian-like platform most of it comes from the package manager:
 
 .. code-block:: bash
 
-    sudo apt-get install build-essential cmake bison flex libgmp-dev \
-        zlib1g-dev python3
+    sudo apt-get install git build-essential cmake bison flex patch python3
 
 A python3 interpreter is needed at build time -- it generates the AST kind
-tables -- and also for the Python interface and the test suite. GMP is
-needed when building with CryptoMiniSat.
+tables -- and also for the Python interface and the test suite. git is needed
+for the submodules and for the vendored-patch step that runs at configure
+time; ``patch`` is used when building LibBF.
 
-Three dependencies are vendored as submodules and need nothing installed:
+The SAT backends bring their own dependencies, which are needed only if you
+build that backend, and which the ``scripts/deps`` script for each one names:
+CryptoMiniSat needs GMP (``libgmp-dev``), MiniSat needs zlib
+(``zlib1g-dev``). Neither is used by STP itself.
+
+Four dependencies are vendored as submodules and need nothing installed:
 ABC, mimalloc, the command-line parser
 `CLI11 <https://github.com/CLIUtils/CLI11>`__, and the header-only
 floating-point library `SymFPU <https://github.com/martin-cs/symfpu>`__.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,7 +27,7 @@ On a Debian-like platform, from a clean checkout:
 .. code-block:: bash
 
     sudo apt-get install git build-essential cmake bison flex curl patch \
-        libgmp-dev python3
+        python3 libgmp-dev
     git clone https://github.com/stp/stp
     cd stp
     git submodule init && git submodule update
@@ -42,7 +42,9 @@ Every step is needed. ABC and mimalloc are submodules and are built as
 part of STP; LibBF is required; and a build with no SAT backend enabled
 does not configure. The two ``setup`` scripts fetch and build LibBF and
 the SAT solver into ``deps/``, where the build finds them without being
-told where to look.
+told where to look. ``libgmp-dev`` is in the list for CryptoMiniSat's sake
+-- it is the only thing that needs it, and a build without CryptoMiniSat
+does not.
 
 That gives a solver backed by CryptoMiniSat, which is the default.
 CaDiCaL is also supported, and is chosen at configure time rather than at

--- a/scripts/deps/setup-cms.sh
+++ b/scripts/deps/setup-cms.sh
@@ -2,6 +2,11 @@
 
 set -e -u -o pipefail
 
+# CryptoMiniSat needs GMP, both to build and to be found afterwards: the
+# cryptominisat5Config.cmake it installs asks pkg-config for gmp. Nothing else
+# in STP uses GMP, so install it here rather than as a baseline dependency --
+# on Debian-likes that is `libgmp-dev`, on macOS `brew install gmp`.
+
 dep_dir="deps"
 install_dir=$(readlink -fm "${dep_dir}"/install)
 

--- a/scripts/deps/setup-minisat.sh
+++ b/scripts/deps/setup-minisat.sh
@@ -2,6 +2,12 @@
 
 set -e -u -o pipefail
 
+# MiniSat needs zlib -- it reads gzipped DIMACS, and its public headers include
+# zlib.h, so a build of STP with -DUSE_MINISAT=ON needs the headers too. No
+# other part of STP uses zlib, so install it here rather than as a baseline
+# dependency: on Debian-likes that is `zlib1g-dev`, on macOS zlib ships with
+# the SDK.
+
 dep_dir="deps"
 install_dir=$(readlink -fm "${dep_dir}"/install)
 


### PR DESCRIPTION
> Stacked on #885 — the base of this PR is `remove-perl-build-dependency`, not `master`. Please merge that one first; this diff is only the second commit.

Neither library is used by STP itself: no source under `lib/`, `tools/` or `include/` includes `gmp.h` or `zlib.h`. GMP is CryptoMiniSat's dependency and zlib is MiniSat's, but both were documented as baseline requirements.

GMP was more than documented. `find_package(GMP REQUIRED)` ran whenever `NOCRYPTOMINISAT` was off, which is the default, so configuring on a machine without `libgmp-dev` failed even when CryptoMiniSat was not installed and some other backend was going to be used.

Deleting the call outright would only move the failure. The `cryptominisat5Config.cmake` that CryptoMiniSat installs asks pkg-config for gmp with `REQUIRED`, which aborts the configure from inside the config file, with an error that does not obviously point at GMP. So the lookup stays, becomes optional, and gates the CryptoMiniSat search: without GMP the search is skipped with a message naming `libgmp-dev`, and the build carries on with whatever other backend is enabled. `FORCE_CMS` still fails, as it should. GMP joins the include path and the link line only once CryptoMiniSat has actually been found.

zlib needed no build change — `find_package(ZLIB)` has been inside `if (USE_MINISAT)` since that backend became opt-in, and `USE_MINISAT` defaults to `OFF`. Only the documentation was wrong to list `zlib1g-dev` as a baseline package.

Each `scripts/deps` setup script now names the package its backend needs, so the information sits beside the thing that requires it.

### Documentation

The apt line in the build page loses both packages and gains `git` and `patch`, which it was missing but which are genuinely needed: git for the submodules and for the vendored-patch step that runs at configure time, and `patch` when building LibBF. The install recipe in the manual keeps `libgmp-dev`, since that recipe does run the CryptoMiniSat setup script, but now says why it is there. While in that paragraph, the vendored submodules are four, not three.

### Checked

Configured three ways: with CryptoMiniSat available, which still finds it and links `stp`; with GMP unavailable, which now configures and builds against another backend instead of failing; and with `FORCE_CMS=ON` and no GMP, which still stops with an error.