### PR TITLE
Re-export from the stp package everything stp/stp.py declares public

### DIFF
--- a/bindings/python/stp/__init__.py.in
+++ b/bindings/python/stp/__init__.py.in
@@ -25,17 +25,30 @@
 
 from .stp import (
     AnyExpr,
+    ArrayExpr,
     Expr,
     FloatExpr,
     Solver,
     stp,
     add,
+    array,
     bitvec,
     bitvecs,
     check,
     model,
+    RNE,
+    RTP,
+    RTN,
+    RTZ,
+    RNA,
     get_git_version_sha,
     get_git_version_tag,
     get_compilation_env,
     get_lib,
 )
+
+# This list is what `from stp import *` gives, and it must stay equal to
+# stp.stp.__all__ -- the names the module declares public are exactly the ones
+# the package should re-export. test_package_reexports_everything_public keeps
+# the two from drifting apart again.
+from .stp import __all__ as __all__

--- a/tests/api/python/tests.py.in
+++ b/tests/api/python/tests.py.in
@@ -34,6 +34,7 @@ sys.path.insert(0, "@PYTHON_INTERFACE_DIR@")
 import stp
 import unittest
 import ctypes
+import importlib
 
 
 @stp.stp
@@ -53,6 +54,40 @@ class TestSTP(unittest.TestCase):
         self.stp_solvers = set(
             ["Minisat", "SimplifyingMinisat", "Cryptominisat", "Riss", "Cadical"]
         )
+
+    def test_package_reexports_everything_public(self):
+        # stp/stp.py declares what is public; stp/__init__.py is what users
+        # actually import from. The two drifted once -- array, ArrayExpr and
+        # the rounding modes were declared but never re-exported, so
+        # `from stp import array` raised ImportError -- so check every name.
+        #
+        # Reached through importlib because the package re-exports a function
+        # called `stp`, which shadows the submodule of the same name.
+        module = importlib.import_module("stp.stp")
+        for name in module.__all__:
+            with self.subTest(name=name):
+                self.assertTrue(
+                    hasattr(stp, name),
+                    "%s is in stp/stp.py's __all__ but stp/__init__.py does "
+                    "not re-export it" % name,
+                )
+        self.assertEqual(list(stp.__all__), list(module.__all__))
+
+    def test_rounding_modes_are_distinct_and_one_hot(self):
+        # These mirror enum VCRoundingMode in c_interface.h, which is one-hot
+        # because it mirrors STP's internal encoding. They are five distinct
+        # modes rather than flags, so no two may share a value.
+        modes = {
+            "RNE": stp.RNE,
+            "RTP": stp.RTP,
+            "RTN": stp.RTN,
+            "RTZ": stp.RTZ,
+            "RNA": stp.RNA,
+        }
+        self.assertEqual(len(set(modes.values())), len(modes))
+        for name, value in modes.items():
+            with self.subTest(name=name):
+                self.assertEqual(value & (value - 1), 0)
 
     def test_long(self):
         s = self.s


### PR DESCRIPTION
`stp/stp.py` lists `ArrayExpr`, `array` and the five rounding-mode constants `RNE`, `RTP`, `RTN`, `RTZ` and `RNA` in its `__all__`, but `stp/__init__.py` — which is what `import stp` actually runs — never imported them. All seven were therefore unreachable:

```pycon
>>> from stp import array
ImportError: cannot import name 'array' from 'stp'
```

The names themselves were fine; only the re-export list had fallen behind, so this is a one-line-per-name fix. `__init__.py` now also adopts `stp/stp.py`'s `__all__` rather than leaving the package without one, so `from stp import *` delivers the documented set instead of whatever the explicit import list happened to bring in.

### Keeping it fixed

Two tests, in the existing Python API suite:

- `test_package_reexports_everything_public` walks `stp/stp.py`'s `__all__` and asserts the package re-exports each name, and that the two lists are equal. It reaches the submodule through `importlib` because the package re-exports a function called `stp`, which shadows the submodule of the same name — the first draft of this test tripped over exactly that.
- `test_rounding_modes_are_distinct_and_one_hot` asserts the five modes are distinct one-hot values, which is what `enum VCRoundingMode` in `c_interface.h` requires, since they mirror STP's internal encoding and are modes rather than flags.

### Checked

`ctest -R python` passes (both `python-interface-tests` and `python-allocator-tests`). Reverting just the `__init__.py` change and rebuilding fails the new test with one subtest per missing name — `ArrayExpr`, `array`, `RNE`, `RTP`, `RTN`, `RTZ`, `RNA` — so the guard does catch the regression it is there for. Also smoke-tested as a user would: `from stp import array` followed by building an array on a real solver returns an `ArrayExpr`.

Independent of #886 and #887 — this touches only `bindings/python` and `tests/api/python`, and is based on master.