### PR TITLE
Record the licensing position: CONTRIBUTING.md, LICENSE and LICENSE_COMPONENTS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing to STP
+
+Thanks for your interest in improving STP.
+
+## Licence
+
+STP is distributed under the MIT Licence (see [LICENSE](LICENSE)).
+
+By opening a pull request, you confirm that you wrote the contribution or
+otherwise have the right to submit it under the MIT Licence, and that you
+licence it on those terms. You keep the copyright in your work.
+
+If your contribution includes code written by someone else, please say so in
+the pull request and give its licence, which must be compatible with the MIT
+Licence.

--- a/LICENSE
+++ b/LICENSE
@@ -15,20 +15,6 @@ Copyright (c)
     2018 - 2019       Norbert Manthey
     2008 - 2010       Stephen McCamant
     2013 - 2014       Florian Merz
-    2008              Philippe Suter
-    2013              Matt Arsenault
-    2013 - 2014       Edward J. Schwartz
-    2015 - 2023       Jiri Slaby
-    2016 - 2025       Martin Nowack
-    2020              Brian Foley
-    2017              Robbepop
-    2014              Stephan Falke
-    2021 - 2022       Hennadii Chernyshchyk
-    2013              Alexander Jesner
-    2014 - 2022       Jerry James
-    2009 - 2010       Xi Wang
-    2009 - 2012       Peter Collingbourne
-    2009              Philip Guo
     2007              Tim King
     and the other contributors recorded in the revision history of this
     project

--- a/LICENSE
+++ b/LICENSE
@@ -15,6 +15,11 @@ Copyright (c)
     2008 - 2010 Stephen McCamant
     2013 - 2014 Florian Merz
     2008 - 2010 Michael Katelman
+    2008 - 2008 Philippe Suter
+    2009 - 2009 Philip Guo
+    2009 - 2010 Xi Wang
+    2010 - 2012 Peter Collingbourne
+    2011 - 2011 Raphael Michel
     and the other contributors recorded in the AUTHORS file and in the
     revision history of this project
 

--- a/LICENSE
+++ b/LICENSE
@@ -4,7 +4,7 @@ Copyright (c)
     2005 - 2010, 2015 Vijay Ganesh
     2009 - 2024, 2026 Trevor Hansen
     2009 - 2022       Mate Soos
-    2018 - 2026       Andrew V. Teylu
+    2018 - 2026       Andrew Teylu
     2013 - 2017       Dan Liew
     2013 - 2025       Ryan Govostes
     2005 - 2008       David L. Dill

--- a/LICENSE
+++ b/LICENSE
@@ -1,35 +1,35 @@
 The MIT License
 
 Copyright (c)
-    2005 - 2015       Vijay Ganesh
+    2005 - 2010, 2015 Vijay Ganesh
     2009 - 2024, 2026 Trevor Hansen
-    2013 - 2025       Ryan Govostes
-    2013 - 2017       Dan Liew
-    2011 - 2013       Khoo Yit Phang
-    2005 - 2015       David L. Dill
     2009 - 2022       Mate Soos
-    2007              Tim King
     2018 - 2026       Andrew V. Teylu
+    2013 - 2017       Dan Liew
+    2013 - 2025       Ryan Govostes
+    2005 - 2008       David L. Dill
     2017              Felix Kutzner
+    2011 - 2013       Khoo Yit Phang
     2014              Jurriaan Bremer
+    2008 - 2010       Michael Katelman
     2018 - 2019       Norbert Manthey
     2008 - 2010       Stephen McCamant
     2013 - 2014       Florian Merz
-    2008 - 2010       Michael Katelman
     2008              Philippe Suter
-    2009              Philip Guo
-    2009 - 2010       Xi Wang
-    2010 - 2012       Peter Collingbourne
-    2013              Alexander Jesner
     2013              Matt Arsenault
     2013 - 2014       Edward J. Schwartz
-    2014              Stephan Falke
-    2014 - 2022       Jerry James
     2015 - 2023       Jiri Slaby
     2016 - 2025       Martin Nowack
-    2017              Robbepop
     2020              Brian Foley
+    2017              Robbepop
+    2014              Stephan Falke
     2021 - 2022       Hennadii Chernyshchyk
+    2013              Alexander Jesner
+    2014 - 2022       Jerry James
+    2009 - 2010       Xi Wang
+    2010 - 2012       Peter Collingbourne
+    2009              Philip Guo
+    2007              Tim King
     and the other contributors recorded in the AUTHORS file and in the
     revision history of this project
 

--- a/LICENSE
+++ b/LICENSE
@@ -2,12 +2,21 @@ The MIT License
 
 Copyright (c)
     2005 - 2015 Vijay Ganesh. Main codebase, project lead
-    2010 - 2014 Trevor Hansen
-    2013 - 2015 Ryan Govostes
-    2013 - 2015 Dan Liew
+    2009 - 2026 Trevor Hansen
+    2013 - 2025 Ryan Govostes
+    2013 - 2017 Dan Liew
     2011 - 2013 Khoo Yit Phang
     2005 - 2015 David L. Dill
-    2009 - 2015 Mate Soos
+    2009 - 2022 Mate Soos
+    2018 - 2026 Andrew V. Teylu
+    2017 - 2017 Felix Kutzner
+    2014 - 2014 Jurriaan Bremer
+    2018 - 2019 Norbert Manthey
+    2008 - 2010 Stephen McCamant
+    2013 - 2014 Florian Merz
+    2008 - 2010 Michael Katelman
+    and the other contributors recorded in the AUTHORS file and in the
+    revision history of this project
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
@@ -30,12 +39,14 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---
 
-Also includes copyrighted software from:
-    * Bit::Vector -- Copyright (c) 1995 - 2004 by Steffen Beyer
-    * CVC's SMT-LIB Parser -- Copyright (C) 2004 by the Board of Trustees
-        of Leland Stanford Junior University and by New York University.
-    * ABC -- Copyright (c) The Regents of the University of California.
-    * mimalloc -- Copyright (c) 2018-2025 Microsoft Corporation, Daan Leijen
-    * ankerl::unordered_dense -- Copyright (c) 2022-2024 Martin Leitner-Ankerl
+The authors assert their moral rights, and in particular the right to be
+identified as the authors of this work. Moral rights are personal to each
+author and are not transferred by the licence above.
 
-For licenses of these SW packages, please see LICENSE_COMPONENTS
+---
+
+STP incorporates code from other projects, and is distributed with further
+third-party code that it does not compile in. That code is not covered by
+the licence above: each component is licensed by its own authors, on its own
+terms. The components, and the terms they are licensed under, are listed in
+LICENSE_COMPONENTS.

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 The MIT License
 
 Copyright (c)
-    2005 - 2015       Vijay Ganesh. Main codebase, project lead
+    2005 - 2015       Vijay Ganesh
     2009 - 2024, 2026 Trevor Hansen
     2013 - 2025       Ryan Govostes
     2013 - 2017       Dan Liew

--- a/LICENSE
+++ b/LICENSE
@@ -1,34 +1,35 @@
 The MIT License
 
 Copyright (c)
-    2005 - 2015 Vijay Ganesh. Main codebase, project lead
-    2009 - 2026 Trevor Hansen
-    2013 - 2025 Ryan Govostes
-    2013 - 2017 Dan Liew
-    2011 - 2013 Khoo Yit Phang
-    2005 - 2015 David L. Dill
-    2009 - 2022 Mate Soos
-    2018 - 2026 Andrew V. Teylu
-    2017 - 2017 Felix Kutzner
-    2014 - 2014 Jurriaan Bremer
-    2018 - 2019 Norbert Manthey
-    2008 - 2010 Stephen McCamant
-    2013 - 2014 Florian Merz
-    2008 - 2010 Michael Katelman
-    2008 - 2008 Philippe Suter
-    2009 - 2009 Philip Guo
-    2009 - 2010 Xi Wang
-    2010 - 2012 Peter Collingbourne
-    2013 - 2013 Alexander Jesner
-    2013 - 2013 Matt Arsenault
-    2013 - 2014 Edward J. Schwartz
-    2014 - 2014 Stephan Falke
-    2014 - 2022 Jerry James
-    2015 - 2023 Jiri Slaby
-    2016 - 2025 Martin Nowack
-    2017 - 2017 Robbepop
-    2020 - 2020 Brian Foley
-    2021 - 2022 Hennadii Chernyshchyk
+    2005 - 2015       Vijay Ganesh. Main codebase, project lead
+    2009 - 2024, 2026 Trevor Hansen
+    2013 - 2025       Ryan Govostes
+    2013 - 2017       Dan Liew
+    2011 - 2013       Khoo Yit Phang
+    2005 - 2015       David L. Dill
+    2009 - 2022       Mate Soos
+    2007              Tim King
+    2018 - 2026       Andrew V. Teylu
+    2017              Felix Kutzner
+    2014              Jurriaan Bremer
+    2018 - 2019       Norbert Manthey
+    2008 - 2010       Stephen McCamant
+    2013 - 2014       Florian Merz
+    2008 - 2010       Michael Katelman
+    2008              Philippe Suter
+    2009              Philip Guo
+    2009 - 2010       Xi Wang
+    2010 - 2012       Peter Collingbourne
+    2013              Alexander Jesner
+    2013              Matt Arsenault
+    2013 - 2014       Edward J. Schwartz
+    2014              Stephan Falke
+    2014 - 2022       Jerry James
+    2015 - 2023       Jiri Slaby
+    2016 - 2025       Martin Nowack
+    2017              Robbepop
+    2020              Brian Foley
+    2021 - 2022       Hennadii Chernyshchyk
     and the other contributors recorded in the AUTHORS file and in the
     revision history of this project
 

--- a/LICENSE
+++ b/LICENSE
@@ -30,8 +30,8 @@ Copyright (c)
     2010 - 2012       Peter Collingbourne
     2009              Philip Guo
     2007              Tim King
-    and the other contributors recorded in the AUTHORS file and in the
-    revision history of this project
+    and the other contributors recorded in the revision history of this
+    project
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/LICENSE
+++ b/LICENSE
@@ -19,7 +19,16 @@ Copyright (c)
     2009 - 2009 Philip Guo
     2009 - 2010 Xi Wang
     2010 - 2012 Peter Collingbourne
-    2011 - 2011 Raphael Michel
+    2013 - 2013 Alexander Jesner
+    2013 - 2013 Matt Arsenault
+    2013 - 2014 Edward J. Schwartz
+    2014 - 2014 Stephan Falke
+    2014 - 2022 Jerry James
+    2015 - 2023 Jiri Slaby
+    2016 - 2025 Martin Nowack
+    2017 - 2017 Robbepop
+    2020 - 2020 Brian Foley
+    2021 - 2022 Hennadii Chernyshchyk
     and the other contributors recorded in the AUTHORS file and in the
     revision history of this project
 

--- a/LICENSE
+++ b/LICENSE
@@ -27,7 +27,7 @@ Copyright (c)
     2013              Alexander Jesner
     2014 - 2022       Jerry James
     2009 - 2010       Xi Wang
-    2010 - 2012       Peter Collingbourne
+    2009 - 2012       Peter Collingbourne
     2009              Philip Guo
     2007              Tim King
     and the other contributors recorded in the revision history of this

--- a/LICENSE_COMPONENTS
+++ b/LICENSE_COMPONENTS
@@ -385,46 +385,36 @@ GetGitRevisionDescription.cmake (cmake/modules)
 	DEALINGS IN THE SOFTWARE.
 
 LLVM integration tester (llvm-lit)
-	University of Illinois/NCSA
-	Open Source License
+	The LLVM Project, of which lit is part, is under the Apache License v2.0
+	with LLVM Exceptions. The Apache License v2.0 runs to some two hundred
+	lines and is not reproduced here; it is at
+	http://www.apache.org/licenses/LICENSE-2.0 and in the LICENSE.TXT that
+	ships inside a lit installation. The exceptions LLVM adds to it are:
 
-	Copyright (c) 2003-2014 University of Illinois at Urbana-Champaign.
-	All rights reserved.
+	---- LLVM Exceptions to the Apache 2.0 License ----
 
-	Developed by:
+	As an exception, if, as a result of your compiling your source code, portions
+	of this Software are embedded into an Object form of such source code, you
+	may redistribute such embedded portions in such Object form without complying
+	with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
 
-		LLVM Team
+	In addition, if you combine or link compiled forms of this Software with
+	software that is licensed under the GPLv2 ("Combined Software") and if a
+	court of competent jurisdiction determines that the patent provision (Section
+	3), the indemnity provision (Section 9) or other Section of the License
+	conflicts with the conditions of the GPLv2, you may retroactively and
+	prospectively choose to deem waived or otherwise exclude such Section(s) of
+	the License, but only in their entirety and only with respect to the Combined
+	Software.
 
-		University of Illinois at Urbana-Champaign
-
-		http://llvm.org
-
-	Permission is hereby granted, free of charge, to any person obtaining a copy of
-	this software and associated documentation files (the "Software"), to deal with
-	the Software without restriction, including without limitation the rights to
-	use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-	of the Software, and to permit persons to whom the Software is furnished to do
-	so, subject to the following conditions:
-
-		* Redistributions of source code must retain the above copyright notice,
-			this list of conditions and the following disclaimers.
-
-		* Redistributions in binary form must reproduce the above copyright notice,
-			this list of conditions and the following disclaimers in the
-			documentation and/or other materials provided with the distribution.
-
-		* Neither the names of the LLVM Team, University of Illinois at
-			Urbana-Champaign, nor the names of its contributors may be used to
-			endorse or promote products derived from this Software without specific
-			prior written permission.
-
-	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-	FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
-	CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
-	SOFTWARE.
+	[STP note: lit is installed separately, with e.g. `pip install lit`, and is
+	run to drive the test suites. No part of it is compiled into or distributed
+	with STP, so these terms are recorded for completeness rather than to meet
+	a redistribution condition. LLVM relicensed in 2019, from the University of
+	Illinois/NCSA Open Source License to the above; lit releases predating that
+	carry the NCSA terms, which LLVM still reproduces in its LICENSE.TXT under
+	the heading "Legacy LLVM License". This entry was checked against lit
+	16.0.6.]
 
 OutputCheck
 	Copyright (c) 2014, Daniel Liew All rights reserved.

--- a/LICENSE_COMPONENTS
+++ b/LICENSE_COMPONENTS
@@ -11,6 +11,25 @@ STP imports code from the following libraries:
 	* CLI11 Copyright (c) 2017-2026 University of Cincinnati (only compiled
 		into the stp command-line tool, not into the library).
 
+STP is built against a SAT solver, which it does not import but does link.
+Which solvers are present depends on the build configuration, and a static
+build puts their code inside the binary, so the released binaries carry them:
+	* CryptoMiniSat Copyright (C) 2009-2020 Authors of CryptoMiniSat. The
+		released binaries are built against it.
+	* CaDiCaL Copyright (c) 2016-2026 by the authors listed below, and
+		CadiBack Copyright (c) 2023 Armin Biere. CryptoMiniSat 5.14 builds
+		both and bundles them into its own library, so they are present
+		whenever CryptoMiniSat is, as well as when CaDiCaL is selected
+		directly with -DUSE_CADICAL=ON.
+	* MiniSat Copyright (c) 2003-2010 Niklas Een, Niklas Sorensson, when
+		selected with -DUSE_MINISAT=ON.
+
+	Riss can also be selected, with -DUSE_RISS=ON. STP neither downloads nor
+	distributes Riss -- the build requires a checkout that the person building
+	it supplies -- so no licence for it is reproduced here. It is not MIT
+	licensed like the solvers above, and anyone redistributing a binary built
+	with it should check what its terms require.
+
 Our build system includes third-party CMake modules (these are not compiled
 into STP, but they are distributed with it):
 	* GetGitRevisionDescription.cmake Copyright Iowa State University 2009-2010.
@@ -221,6 +240,119 @@ CLI11
 	ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 	(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 	SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+CryptoMiniSat
+	Copyright (C) 2009-2020 Authors of CryptoMiniSat, see AUTHORS file
+	All rights reserved.
+
+	The general priciple of the licensing is as follows. Everything that's
+	needed to run/build/install/link the system is MIT licensed. This allows
+	easy distribution and running of the system everywhere. Files that
+	have no copyright header are also MIT licensed. Note that in case you
+	compile with Bliss, then Bliss's GPL license affects the final executable
+	and library.
+
+	Everything else that's not needed to run/build/install/link is usually GPLv2
+	licensed or compatible (see the copyright headers.)
+
+	[STP note: STP links the CryptoMiniSat library, which is the MIT licensed
+	part, and scripts/deps/setup-cms.sh does not build it with Bliss. The MIT
+	terms are reproduced here; for the GPLv2 text covering the parts STP does
+	not link, see the LICENSE.txt of a CryptoMiniSat checkout.]
+
+	Permission is hereby granted, free of charge, to any person obtaining a copy
+	of this software and associated documentation files (the "Software"), to deal
+	in the Software without restriction, including without limitation the rights
+	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+	copies of the Software, and to permit persons to whom the Software is
+	furnished to do so, subject to the following conditions:
+
+	The above copyright notice and this permission notice shall be included in
+	all copies or substantial portions of the Software.
+
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+	THE SOFTWARE.
+
+CaDiCaL
+	MIT License
+
+	Copyright (c) 2016-2021 Armin Biere, Johannes Kepler University Linz, Austria
+	Copyright (c) 2020-2021 Mathias Fleury, Johannes Kepler University Linz, Austria
+	Copyright (c) 2020-2021 Nils Froleyks, Johannes Kepler University Linz, Austria
+	Copyright (c) 2022-2026 Katalin Fazekas, Vienna University of Technology, Austria
+	Copyright (c) 2021-2026 Armin Biere, University of Freiburg, Germany
+	Copyright (c) 2021-2026 Mathias Fleury, University of Freiburg, Germany
+	Copyright (c) 2023-2026 Florian Pollitt, University of Freiburg, Germany
+	Copyright (c) 2024-2026 Tobias Faller, University of Freiburg, Germany
+
+	Permission is hereby granted, free of charge, to any person obtaining a copy
+	of this software and associated documentation files (the "Software"), to deal
+	in the Software without restriction, including without limitation the rights
+	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+	copies of the Software, and to permit persons to whom the Software is
+	furnished to do so, subject to the following conditions:
+
+	The above copyright notice and this permission notice shall be included in all
+	copies or substantial portions of the Software.
+
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+	SOFTWARE.
+
+CadiBack
+	MIT License
+
+	Copyright (c) 2023 Armin Biere
+
+	Permission is hereby granted, free of charge, to any person obtaining a copy
+	of this software and associated documentation files (the "Software"), to deal
+	in the Software without restriction, including without limitation the rights
+	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+	copies of the Software, and to permit persons to whom the Software is
+	furnished to do so, subject to the following conditions:
+
+	The above copyright notice and this permission notice shall be included in all
+	copies or substantial portions of the Software.
+
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+	SOFTWARE.
+
+MiniSat
+	MiniSat -- Copyright (c) 2003-2006, Niklas Een, Niklas Sorensson
+	           Copyright (c) 2007-2010  Niklas Sorensson
+
+	Permission is hereby granted, free of charge, to any person obtaining a
+	copy of this software and associated documentation files (the
+	"Software"), to deal in the Software without restriction, including
+	without limitation the rights to use, copy, modify, merge, publish,
+	distribute, sublicense, and/or sell copies of the Software, and to
+	permit persons to whom the Software is furnished to do so, subject to
+	the following conditions:
+
+	The above copyright notice and this permission notice shall be included
+	in all copies or substantial portions of the Software.
+
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+	OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+	MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+	NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+	LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+	OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+	WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 GetGitRevisionDescription.cmake (cmake/modules)
 	Original Author:

--- a/bindings/python/stp/__init__.py.in
+++ b/bindings/python/stp/__init__.py.in
@@ -1,7 +1,7 @@
 # author: Dan Liew
 # date: Sep, 2014
 #
-# author: Andrew V. Jones
+# author: Andrew Teylu
 # date: Apr, 2019
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/bindings/python/stp/library_path.py.in
+++ b/bindings/python/stp/library_path.py.in
@@ -1,4 +1,4 @@
-# AUTHORS: Dan Liew, Andrew V. Jones
+# AUTHORS: Dan Liew, Andrew Teylu
 #
 # BEGIN DATE: May, 2014
 #

--- a/include/stp/Sat/CryptoMinisat5.h
+++ b/include/stp/Sat/CryptoMinisat5.h
@@ -1,5 +1,5 @@
 /********************************************************************
- * AUTHORS: Mate Soos, Andrew V. Jones
+ * AUTHORS: Mate Soos, Andrew Teylu
  *
  * BEGIN DATE: November, 2013
  *

--- a/lib/Sat/CryptoMinisat5.cpp
+++ b/lib/Sat/CryptoMinisat5.cpp
@@ -1,5 +1,5 @@
 /********************************************************************
- * AUTHORS: Mate Soos, Andrew V. Jones
+ * AUTHORS: Mate Soos, Andrew Teylu
  *
  * BEGIN DATE: November, 2013
  *

--- a/tests/api/C/bit_string.cpp
+++ b/tests/api/C/bit_string.cpp
@@ -1,5 +1,5 @@
 /***********
-AUTHORS:   Andrew V. Jones
+AUTHORS:   Andrew Teylu
 
 BEGIN DATE: July, 2020
 

--- a/tests/api/C/check_sizes.cpp
+++ b/tests/api/C/check_sizes.cpp
@@ -1,5 +1,5 @@
 /***********
-AUTHORS: Andrew V. Jones
+AUTHORS: Andrew Teylu
 
 BEGIN DATE: January 2021
 


### PR DESCRIPTION
STP has never recorded the terms under which contributions are accepted, and the copyright notice in `LICENSE` has not kept up with who has written the code. #199 asked for the copyright position to be made explicit and was never resolved. This is an attempt at the uncontentious parts of that.

### CONTRIBUTING.md

A short new file saying that contributions are accepted under the MIT Licence, that contributors confirm they have the right to submit the code on those terms, and that they keep the copyright in their work. It documents existing practice rather than changing it — no copyright assignment and no contributor licence agreement are required. GitHub links this file from the new issue and new pull request forms, so contributors see the terms at the point of submitting.

### LICENSE

**Copyright holders.** The block named seven people and omitted several substantial contributors; Andrew V. Teylu alone has over three hundred commits. Everyone with a real body of work in the revision history is now listed, and the list ends with a catch-all — with no contributor licence agreement every contributor keeps copyright in their own work, so no enumeration can be complete and it should not imply otherwise. Names were taken from `git shortlog`, and nobody has been removed.

**Subversion-era contributors.** `git shortlog` cannot see work predating the migration to git. The Subversion repository is still live on SourceForge — 1673 revisions, February 2008 to February 2013 — and the git history starts part way through it, in October 2008, having dropped roughly a fifth of the revisions on the way. Philippe Suter is invisible to git entirely, since all eight of his revisions predate its first commit, and Raphael Michel's ten Subversion revisions arrive as one. Peter Collingbourne, Xi Wang and Philip Guo are thin or absent likewise. They are now listed, except Raphael Michel: his Subversion work was string and regular expression support on a branch that never reached trunk, and his single git commit adds his own name to AUTHORS and nothing else, so no code of his is in STP. Names come from the SourceForge profiles behind the committer handles; year ranges from the Subversion log, which agrees with git wherever both hold a revision. One committer, `ar2rd`, is left out — a single path fix in a test file, and the profile behind the handle is gone, so there is no name to record.

**Year ranges** now match each holder's first and last commits, and the block is ordered by contribution rather than by the sequence names happened to be added in.

Two ranges are narrowed rather than widened, both belonging to the founders. Each read 2005 - 2015, and neither end date meant what it looked like: the 2015 came from Vijay Ganesh's last commit, `f02f1216`, titled "added David Dill to COPYRIGHT", so it recorded the year the entry was written rather than a year either of them worked on STP. Vijay Ganesh becomes 2005 - 2010, 2015, his code commits having stopped on 2010-09-03 with only that copyright edit after. David L. Dill ends in 2008.

Neither Dill nor Tim King has a commit in either repository — their work predates the Subversion history, which begins in 2008, and the CVS history it was converted from did not survive. Dill's 2008 end date rests on the project's own knowledge rather than on anything recoverable from the repositories.

**Moral rights.** A short assertion. These are personal to each author and cannot be transferred by a licence; the MIT text does not address them.

**Third-party components.** The inline list is replaced by a pointer to `LICENSE_COMPONENTS`. It had drifted — five components listed against eleven in `LICENSE_COMPONENTS` — and keeping two copies invites that again. The new wording also states what the old list left to inference: that third-party code is not covered by the grant above.

### LICENSE_COMPONENTS

The file was organised around code STP imports into its own tree, so the solvers it links fell outside it and went unrecorded. That is the wrong boundary for a notice file: the released asset is one static binary, and `release.yml` ships `LICENSE` and `LICENSE_COMPONENTS` beside it precisely because the MIT and BSD notices have to accompany a binary distribution. CryptoMiniSat, and the CaDiCaL and CadiBack that CryptoMiniSat 5.14 bundles into its library, are inside every released binary and were named nowhere.

There is now a section for the linked solvers, noting that which are present depends on the build configuration, with the licences of CryptoMiniSat, CaDiCaL, CadiBack and MiniSat. The CaDiCaL, CadiBack and MiniSat texts are reproduced verbatim from the sources the build uses. For CryptoMiniSat only the MIT part is reproduced, which is the part STP links, with a note pointing at the GPLv2 remainder.

Riss gets a note rather than a licence, since STP neither downloads nor distributes it — `USE_RISS` needs a checkout supplied by whoever is building — but it is not MIT licensed like the others, so a binary built with it does not redistribute on the same terms.

I also checked the existing entries against the versions in the tree: mimalloc, CLI11, ankerl::unordered_dense and SymFPU all still match, so nothing has drifted.

The `llvm-lit` entry was stale and is corrected. It reproduced the University of Illinois/NCSA licence, which LLVM moved away from in 2019; lit is now under the Apache License v2.0 with LLVM Exceptions, confirmed against the `LICENSE.TXT` and package metadata of an installed lit 16.0.6. The exceptions are recorded verbatim, with a pointer to the Apache text rather than two hundred lines reproduced for a tool that is installed separately and never distributed with STP. The old text was not wrong so much as superseded — LLVM still carries it under the heading "Legacy LLVM License".

### Worth reviewing

- The two narrowed ranges are the sharpest edit here, and one of them is Vijay Ganesh's own. Nothing else in the block has been shortened.
- The **copyright holder list** is the part that needs other eyes. Being named is a claim about ownership, and it sits against the statement in #199 that only Vijay Ganesh is a copyright holder. If that is still the intended position then that commit is wrong and should be dropped.
- The threshold for inclusion is arbitrary — copyright subsists in short contributions too. That is why the catch-all matters more than the enumeration. The bar is now four commits or revisions, applied across both eras, which names 24 people. Below it the tail is another 37 contributors, covered by the catch-all clause. `Robbepop` is recorded as the handle the contributor used — guessing at the person behind it would be worse than recording what the revision history says.
- GitHub currently reports STP's licence as `NOASSERTION` / "Other" rather than MIT, because the detector matches `LICENSE` against the canonical text and the extra material defeats it. Removing the component list helps, but the moral rights paragraph may keep it failing. Detection is computed from the default branch, so this can only be checked after merge. If the MIT label matters more, both paragraphs could move to a `NOTICE` file.

### Not included

No `Signed-off-by` / DCO requirement. As written the confirmation in CONTRIBUTING.md is passive. A DCO would put the assertion in the commit trailer, which is better evidence, but it needs a CI check and blocks pull requests, so it should be agreed separately.
