### PR TITLE
Merge an if-then-else with a repeated branch one level down

### DIFF
--- a/lib/Simplifier/Rewriting.cpp
+++ b/lib/Simplifier/Rewriting.cpp
@@ -692,6 +692,75 @@ namespace stp
           c = nf->CreateNode(EQ, left,right);
         }
 
+/*
+  An if-then-else with an if-then-else one level down that chooses the same
+  value: the two multiplexers become one, selected by a connective. With the
+  inner one on the else side,
+
+    ITE(c, t, ITE(d, t, b))  -->  ITE(c OR d,     t, b)
+    ITE(c, t, ITE(d, a, t))  -->  ITE(c OR NOT d, t, a)
+
+  and on the then side, where the outer's else branch is what repeats,
+
+    ITE(c, ITE(d, a, e), e)  -->  ITE(c AND d,     a, e)
+    ITE(c, ITE(d, e, b), e)  -->  ITE(c AND NOT d, b, e)
+
+  Bit-blasting a w-bit multiplexer costs 3w AND gates and the connective costs
+  one, so this trades the whole width for a single gate. The two negated forms
+  additionally build a NOT, which is a complemented edge in the AIG and so
+  costs nothing there -- the pass's only rules that add an AST node without
+  adding bit-blasted difficulty.
+
+  All four need the inner multiplexer to die with the rewrite. Where it is
+  shared it stays, the merged node is built beside it, and the rewrite is a
+  straight loss -- hence the share count. Symbolic execution emits these:
+  a branch that leaves part of the state alone reaches the same value under
+  several guards.
+*/
+      if (
+        c.GetKind() == ITE
+        && c[2].GetKind() == ITE
+        && (c[2][1] == c[1] || c[2][2] == c[1])
+        && shareCount[c[2].GetNodeNum()] <= 1
+       )
+       {
+          // Which branch of the inner if-then-else repeats the outer's then.
+          const bool repeatedOnThen = (c[2][1] == c[1]);
+
+          const auto inner =
+              repeatedOnThen ? c[2][0] : nf->CreateNode(NOT, c[2][0]);
+          const auto cond = nf->CreateNode(OR, c[0], inner);
+          const auto other = repeatedOnThen ? c[2][2] : c[2][1];
+
+          if (c.GetType() == BOOLEAN_TYPE)
+            c = nf->CreateNode(ITE, cond, c[1], other);
+          else
+            c = nf->CreateArrayTerm(ITE, c.GetIndexWidth(), c.GetValueWidth(),
+                                    cond, c[1], other);
+       }
+
+      if (
+        c.GetKind() == ITE
+        && c[1].GetKind() == ITE
+        && (c[1][1] == c[2] || c[1][2] == c[2])
+        && shareCount[c[1].GetNodeNum()] <= 1
+       )
+       {
+          // Which branch of the inner if-then-else repeats the outer's else.
+          const bool repeatedOnThen = (c[1][1] == c[2]);
+
+          const auto inner =
+              repeatedOnThen ? nf->CreateNode(NOT, c[1][0]) : c[1][0];
+          const auto cond = nf->CreateNode(AND, c[0], inner);
+          const auto other = repeatedOnThen ? c[1][2] : c[1][1];
+
+          if (c.GetType() == BOOLEAN_TYPE)
+            c = nf->CreateNode(ITE, cond, other, c[2]);
+          else
+            c = nf->CreateArrayTerm(ITE, c.GetIndexWidth(), c.GetValueWidth(),
+                                    cond, other, c[2]);
+       }
+
     return c;
   }
 

--- a/tests/unit-tests/Rewriting_Exhaustive_Test.cpp
+++ b/tests/unit-tests/Rewriting_Exhaustive_Test.cpp
@@ -441,4 +441,167 @@ TEST(Rewriting_Exhaustive, plus_of_shared_factor_mults)
   c.checkEquivalent(top2, c.run(top2));
 }
 
+// Distinct nodes of a kind reachable from n, so a shared node counts once.
+static void countKind(const Kind k, const ASTNode& n, ASTNodeSet& seen,
+                      unsigned& found)
+{
+  if (!seen.insert(n).second)
+    return;
+  if (n.GetKind() == k)
+    found++;
+  for (const auto& c : n)
+    countKind(k, c, seen, found);
+}
+
+static unsigned countKind(const Kind k, const ASTNode& n)
+{
+  ASTNodeSet seen;
+  unsigned found = 0;
+  countKind(k, n, seen, found);
+  return found;
+}
+
+/* ITE(p, x, ITE(q, x, y)) --> ITE(p OR q, x, y): the inner multiplexer is
+   unshared, so it dies with the rewrite. */
+TEST(Rewriting_Exhaustive, ite_chain_repeated_then)
+{
+  Context c;
+  ASTNode p = c.boolean(), q = c.boolean();
+  ASTNode x = c.bv(3), y = c.bv(3);
+  ASTNode inner = c.hf->CreateTerm(ITE, 3, q, x, y);
+  ASTNode outer = c.hf->CreateTerm(ITE, 3, p, x, inner);
+  ASTNode top = c.hf->CreateNode(EQ, outer, c.bv(3));
+
+  ASTNode after = c.run(top);
+  ASSERT_EQ(2u, countKind(ITE, top));
+  ASSERT_EQ(1u, countKind(ITE, after));
+  c.checkEquivalent(top, after);
+}
+
+/* ITE(p, x, ITE(q, y, x)) --> ITE(p OR NOT q, x, y). */
+TEST(Rewriting_Exhaustive, ite_chain_repeated_else)
+{
+  Context c;
+  ASTNode p = c.boolean(), q = c.boolean();
+  ASTNode x = c.bv(3), y = c.bv(3);
+  ASTNode inner = c.hf->CreateTerm(ITE, 3, q, y, x);
+  ASTNode outer = c.hf->CreateTerm(ITE, 3, p, x, inner);
+  ASTNode top = c.hf->CreateNode(EQ, outer, c.bv(3));
+
+  ASTNode after = c.run(top);
+  ASSERT_EQ(2u, countKind(ITE, top));
+  ASSERT_EQ(1u, countKind(ITE, after));
+  c.checkEquivalent(top, after);
+}
+
+/* A chain of them collapses into one disjunction, one multiplexer at a time.
+   */
+TEST(Rewriting_Exhaustive, ite_chain_three_deep)
+{
+  Context c;
+  ASTNode p = c.boolean(), q = c.boolean(), r = c.boolean();
+  ASTNode x = c.bv(2), y = c.bv(2);
+  ASTNode i2 = c.hf->CreateTerm(ITE, 2, r, x, y);
+  ASTNode i1 = c.hf->CreateTerm(ITE, 2, q, x, i2);
+  ASTNode i0 = c.hf->CreateTerm(ITE, 2, p, x, i1);
+  ASTNode top = c.hf->CreateNode(EQ, i0, c.bv(2));
+
+  ASTNode after = c.run(top);
+  ASSERT_EQ(3u, countKind(ITE, top));
+  ASSERT_EQ(1u, countKind(ITE, after));
+  c.checkEquivalent(top, after);
+}
+
+/* With the inner multiplexer shared, merging would leave it in place and
+   build the merged node beside it, so the rule declines. */
+TEST(Rewriting_Exhaustive, ite_chain_inner_shared)
+{
+  Context c;
+  ASTNode p = c.boolean(), q = c.boolean();
+  ASTNode x = c.bv(3), y = c.bv(3);
+  ASTNode inner = c.hf->CreateTerm(ITE, 3, q, x, y);
+  ASTNode outer = c.hf->CreateTerm(ITE, 3, p, x, inner);
+  ASTNode top = c.hf->CreateNode(EQ, outer, inner);
+
+  ASTNode after = c.run(top);
+  ASSERT_EQ(2u, countKind(ITE, after));
+  c.checkEquivalent(top, after);
+}
+
+/* The same shape over formulas rather than terms. */
+TEST(Rewriting_Exhaustive, ite_chain_boolean)
+{
+  Context c;
+  ASTNode p = c.boolean(), q = c.boolean();
+  ASTNode x = c.boolean(), y = c.boolean();
+  ASTNode inner = c.hf->CreateNode(ITE, q, x, y);
+  ASTNode outer = c.hf->CreateNode(ITE, p, x, inner);
+  ASTNode top = c.hf->CreateNode(NOT, outer);
+
+  c.checkEquivalent(top, c.run(top));
+}
+
+/* ITE(p, ITE(q, x, y), y) --> ITE(p AND q, x, y): the inner multiplexer is
+   the then branch this time, and the outer's else is what repeats. */
+TEST(Rewriting_Exhaustive, ite_chain_then_side_repeated_else)
+{
+  Context c;
+  ASTNode p = c.boolean(), q = c.boolean();
+  ASTNode x = c.bv(3), y = c.bv(3);
+  ASTNode inner = c.hf->CreateTerm(ITE, 3, q, x, y);
+  ASTNode outer = c.hf->CreateTerm(ITE, 3, p, inner, y);
+  ASTNode top = c.hf->CreateNode(EQ, outer, c.bv(3));
+
+  ASTNode after = c.run(top);
+  ASSERT_EQ(2u, countKind(ITE, top));
+  ASSERT_EQ(1u, countKind(ITE, after));
+  c.checkEquivalent(top, after);
+}
+
+/* ITE(p, ITE(q, y, x), y) --> ITE(p AND NOT q, x, y). */
+TEST(Rewriting_Exhaustive, ite_chain_then_side_repeated_then)
+{
+  Context c;
+  ASTNode p = c.boolean(), q = c.boolean();
+  ASTNode x = c.bv(3), y = c.bv(3);
+  ASTNode inner = c.hf->CreateTerm(ITE, 3, q, y, x);
+  ASTNode outer = c.hf->CreateTerm(ITE, 3, p, inner, y);
+  ASTNode top = c.hf->CreateNode(EQ, outer, c.bv(3));
+
+  ASTNode after = c.run(top);
+  ASSERT_EQ(2u, countKind(ITE, top));
+  ASSERT_EQ(1u, countKind(ITE, after));
+  c.checkEquivalent(top, after);
+}
+
+/* The then-side rule respects sharing too. */
+TEST(Rewriting_Exhaustive, ite_chain_then_side_inner_shared)
+{
+  Context c;
+  ASTNode p = c.boolean(), q = c.boolean();
+  ASTNode x = c.bv(3), y = c.bv(3);
+  ASTNode inner = c.hf->CreateTerm(ITE, 3, q, x, y);
+  ASTNode outer = c.hf->CreateTerm(ITE, 3, p, inner, y);
+  ASTNode top = c.hf->CreateNode(EQ, outer, inner);
+
+  ASTNode after = c.run(top);
+  ASSERT_EQ(2u, countKind(ITE, after));
+  c.checkEquivalent(top, after);
+}
+
+/* Both sides at once: an inner multiplexer on each branch, each repeating the
+   value the other branch of the outer selects. */
+TEST(Rewriting_Exhaustive, ite_chain_both_sides)
+{
+  Context c;
+  ASTNode p = c.boolean(), q = c.boolean(), r = c.boolean();
+  ASTNode x = c.bv(2), y = c.bv(2), z = c.bv(2);
+  ASTNode thenSide = c.hf->CreateTerm(ITE, 2, q, x, y);
+  ASTNode elseSide = c.hf->CreateTerm(ITE, 2, r, thenSide, z);
+  ASTNode outer = c.hf->CreateTerm(ITE, 2, p, thenSide, elseSide);
+  ASTNode top = c.hf->CreateNode(EQ, outer, c.bv(2));
+
+  c.checkEquivalent(top, c.run(top));
+}
+
 } // namespace


### PR DESCRIPTION
Symbolic execution emits multiplexer chains where a branch that leaves part of the state alone reaches the same value under several guards. Two adjacent multiplexers then select one value between them, and collapse into one:

```
ITE(c, t, ITE(d, t, b))  -->  ITE(c OR d,      t, b)
ITE(c, t, ITE(d, a, t))  -->  ITE(c OR NOT d,  t, a)
ITE(c, ITE(d, a, e), e)  -->  ITE(c AND d,     a, e)
ITE(c, ITE(d, e, b), e)  -->  ITE(c AND NOT d, b, e)
```

Bit-blasting a `w`-bit multiplexer costs `3w` AND gates and the connective costs one, so this trades the whole width for a single gate. The two negated forms also build a `NOT`, which is a complemented edge in the AIG and so free there: they are the only rules in this pass that add an AST node without adding bit-blasted difficulty.

### Why `Rewriting`

All four need the inner multiplexer to die with the rewrite. Where it is shared it stays, the merged node is built beside it, and the rewrite is a straight loss. That makes them sharing-dependent, which is exactly this pass's contract — it already keeps a per-node reference count, and its header says every rule here should leave the node count the same or smaller, using the share count to prove the nodes it replaces really die. A sharing-independent rule would belong in `SimplifyingNodeFactory` instead, and a domain-driven one in `StrengthReduction`; neither fits.

`Rewriting` re-applies its rules to what they produce, so a chain over one repeated value collapses one multiplexer at a time into a single disjunction, with no extra machinery.

### Measured

On a family of symbolic-execution benchmarks that are 85% 28-bit if-then-else (1.05M nodes, 139 free variables — a RISC-V verification set generated by Rosette):

| | matches | AIG AND gates removed |
| --- | ---: | ---: |
| 8-bit member | 716 | 15,661 of 7,297,075 (0.21%) |
| 28-bit member | 2,156 | 175,961 of 81,076,389 (0.22%) |

which is what the shape count predicts: 716 x 3 x 8 = 17,184 and 2,156 x 3 x 28 = 181,104. The agreement is the check that the rule fires everywhere it should rather than being turned away by the share-count guard.

The two then-side forms never fire on that family — the generator always descends the else side, so a repeated value can only land there — and fire on one file in a 2,501-file fuzz corpus. They are included because they are the same rule, and the asymmetry is a property of one generator rather than of the rewrite.

This is a small, general win rather than a fix for that family: those benchmarks are hard for reasons well upstream of 0.2% of the AIG.

### Testing

Nine exhaustive-equivalence tests in `Rewriting_Exhaustive_Test.cpp`, in the harness that file already had, each checking every assignment of the free variables:

- both else-side shapes and both then-side shapes,
- a three-deep chain collapsing to a single multiplexer,
- both shared-inner cases, asserting the rule declines and both multiplexers survive,
- the formula-typed shape,
- an inner multiplexer on each branch at once.

Answers over a 2,501-file fuzz corpus are unchanged against a prior binary.