### PR TITLE
Raise FlattenKind's output budget above what real formulas reach

### DIFF
--- a/lib/AST/ASTmisc.cpp
+++ b/lib/AST/ASTmisc.cpp
@@ -512,7 +512,17 @@ void FlattenKindNoDuplicates(const Kind k, const ASTChildren& children,
 //
 // Returns false if the budget was passed, in which case flat_children holds a
 // prefix of the operands and must be discarded: a truncated sum is not the sum.
-const size_t FLATTEN_OUTPUT_BUDGET = 1000;
+//
+// The budget only has to stop the explosion, so it is set far above what a
+// formula plausibly needs rather than close to it. Declining to flatten is not
+// a small loss: generated-tests/form_32.var_64.bits_32.cvc wants 1054 operands
+// at its widest, and capping it below that leaves BVPLUS nested, which turns a
+// two-second solve into one that has not finished after five minutes. A cap
+// tight enough to be reached by an ordinary formula is worse than no pass at
+// all. Against that, raising it costs the pathological file almost nothing:
+// on QF_BV/Sage2/bench_16265.smt2 the walk that used to reach 30GB is abandoned
+// at 0.68s and 53MB here, against 0.53s and 53MB at a thousand.
+const size_t FLATTEN_OUTPUT_BUDGET = 100000;
 
 bool FlattenKind(const Kind k, const ASTChildren& children, ASTVec& flat_children, int depth)
 {

--- a/tests/unit-tests/FlattenKindSharing_Test.cpp
+++ b/tests/unit-tests/FlattenKindSharing_Test.cpp
@@ -77,7 +77,7 @@ const int SOLVER_MAX_DEPTH = 50;
 // Matches FLATTEN_OUTPUT_BUDGET in ASTmisc.cpp. Kept as its own constant so a
 // change there shows up here as a failure rather than as a silent shift in
 // what these tests mean.
-const size_t OUTPUT_BUDGET = 1000;
+const size_t OUTPUT_BUDGET = 100000;
 
 // Deep enough that path-enumeration would be unmistakable: 2^22 operands from
 // 23 nodes, which is ~32MB of ASTVec if nothing stops it.


### PR DESCRIPTION
CI has not completed on any branch since #891 landed. Every job that runs the test suite, master's own push runs included, sits until the six-hour ceiling and is cancelled. The build is fine; the hang is in `query-files`, on one file.

### What happens

The output budget added in #891 fires on `tests/query-files/generated-tests/form_32.var_64.bits_32.cvc`. Its widest flatten is **1054 operands**, against a cap of 1000.

Over budget the pass hands the operands back exactly as they arrived, so the `BVPLUS` never widens and the CNF that comes out is one the SAT solver does not finish:

| budget | result |
|---|---|
| 1000 | no answer after 5 minutes |
| 5000 | `Invalid.` in 9.4s |
| 20000 | `Invalid.` in 2.0s |
| 100000 | `Invalid.` in 1.8s |

A 5% shortfall in the cap is the difference between a two-second solve and one that does not return. The 600 QF_BV benchmarks the number was sampled against did not include the repository's own test files, which is how a cap that an in-tree test reaches looked like a cap nothing reaches.

### The value

A budget an ordinary formula can reach is worse than not having the pass at all, so it belongs far above what a formula plausibly needs rather than just above it. Stopping the explosion is all it has to do, and raising it costs the file it was added for almost nothing — on `QF_BV/Sage2/bench_16265.smt2`, the walk that grew past 30GB unbounded:

| budget | time | peak RSS |
|---|---|---|
| 1000 | 0.53s | 53MB |
| 100000 | 0.68s | 53MB |
| 1000000 | 14.2s | 178MB |

100000 is a hundred times the widest flatten seen in the suite and about 800KB of `ASTVec`, and the pathological file does not notice it. A million does, so the margin stops there.

### Verification

The `.cvc` file is already in the suite, so it is the regression test: at 1000 the run does not terminate.

- `query-files`: was hanging → **591 passed, 2 unsupported, 0 failed**, 9.8s
- full `ctest`: **130/130 passed**, 45s

### Not fixed here

The cliff is still a cliff. When the budget does fire, the result is not "flattened a bit less" but "not flattened at all", and this file shows that can be catastrophic rather than the under-2% the original measurement suggested. Bounding the walk without the discontinuity — expanding each distinct same-kind child once instead of once per path, which is linear in the DAG and needs no budget — looks like the better shape, but it is a redesign of the traversal and wants its own change and its own review. This one only moves the number so CI can run.