### PR TITLE
Skip constant-bit propagation of floating-point constants in simplify_during_bb

### DIFF
--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -713,7 +713,12 @@ BitBlaster::simplify_during_bb(ASTNode& term,
       else
         nBits = it->second;
 
-      if (n_term.isConstant())
+      // concreteToAbstract only models bit-vector and boolean constants;
+      // a floating-point constant reaches its unhandled default and aborts.
+      // Such a node keeps its default (all-unknown) FixedBits, which is sound.
+      if (n_term.isConstant() &&
+          (n_term.GetType() == BITVECTOR_TYPE ||
+           n_term.GetType() == BOOLEAN_TYPE))
       {
         // It's assumed elsewhere that constants map to themselves in the
         // fixed map.

--- a/tests/query-files/fp-tests/simplify-during-bb-fp-constant-float64.smt2
+++ b/tests/query-files/fp-tests/simplify-during-bb-fp-constant-float64.smt2
@@ -1,0 +1,11 @@
+; RUN: %solver --bb.simplify-during-bb=1 --array-equality %s 2>&1 | %OutputCheck %s
+; CHECK: ^sat
+; The same abort as simplify-during-bb-fp-constant.smt2, reached with a
+; 64-bit float: a Float64 +0.0 constant stored into the array is handed
+; to FixedBits::concreteToAbstract by simplify_during_bb, which only
+; models bit-vector and boolean constants.
+(set-logic QF_ABVFP)
+(declare-fun v () (_ BitVec 10))
+(declare-fun a () (Array (_ BitVec 5) Float64))
+(assert (= (fp (_ bv0 1) (_ bv0 11) (_ bv0 52)) (select (store a (_ bv0 5) (fp (_ bv0 1) (_ bv0 11) (_ bv0 52))) ((_ sign_extend 4) (ite (bvsgt ((_ sign_extend 4) v) (_ bv874 14)) (_ bv1 1) (_ bv0 1))))))
+(check-sat)

--- a/tests/query-files/fp-tests/simplify-during-bb-fp-constant.smt2
+++ b/tests/query-files/fp-tests/simplify-during-bb-fp-constant.smt2
@@ -1,0 +1,14 @@
+; RUN: %solver --bb.simplify-during-bb=1 --array-equality %s 2>&1 | %OutputCheck %s
+; CHECK: ^sat
+; A floating-point constant that reaches constant-bit propagation while
+; bit-blasting used to abort with Fatal Error: Unexpected:
+; BitBlaster::simplify_during_bb hands constant operands to
+; FixedBits::concreteToAbstract, which only models bit-vector and boolean
+; constants. --bb.simplify-during-bb=1 is what routes the +0.0 / -0.0
+; stored below through that path. The guard now skips the FP constant, so
+; solving proceeds and the array reads are satisfiable.
+(set-logic QF_ABVFP)
+(declare-fun v () (_ BitVec 1))
+(declare-fun a () (Array (_ BitVec 2) Float32))
+(assert (fp.geq (select a (_ bv1 2)) (select (store (store a (_ bv0 2) (fp (_ bv0 1) (_ bv0 8) (_ bv0 23))) ((_ sign_extend 1) (bvsdiv (_ bv1 1) v)) (fp (_ bv1 1) (_ bv0 8) (_ bv0 23))) (_ bv0 2))))
+(check-sat)


### PR DESCRIPTION
## Problem

With `--bb.simplify-during-bb=1`, STP aborts on QF_FP / QF_ABVFP problems that contain a floating-point constant:

```
Fatal Error: Unexpected

126:0xC1300000
```

`BitBlaster::simplify_during_bb` calls `FixedBits::concreteToAbstract` on constant operands while bit-blasting. That function only models bit-vector and boolean constants — a floating-point constant (type `FLOATINGPOINT`, kind `BVCONST`; here the float32 `-11.0` = `0xC1300000`) reaches the unhandled `else` and calls `FatalError("Unexpected", n)`, exiting 255. bitwuzla solves the same instances.

Only `--bb.simplify-during-bb=1` triggers it (off by default), so the default configuration is unaffected.

## Fix

Guard the `concreteToAbstract` call so only bit-vector and boolean constants are abstracted. A floating-point constant then keeps its default all-unknown `FixedBits`, which is a sound over-approximation, and solving proceeds normally.

## Testing

- Three fuzzer-found QF_ABVFP reproducers that previously aborted now return `sat`, matching bitwuzla.
- `--bb.simplify-during-bb=1` on QF_BV / QF_ABV instances still matches bitwuzla — the bit-vector path (the point of that flag) is unchanged.
