### PR TITLE
Compress the unconstrained-divisor comments

### DIFF
--- a/lib/Simplifier/RemoveUnconstrained.cpp
+++ b/lib/Simplifier/RemoveUnconstrained.cpp
@@ -169,15 +169,11 @@ static bool isRNEConstant(const ASTNode& n)
 }
 
 // Whether narrowing a source-format quotient into the target format absorbs
-// the error of steering that quotient with a source-format divisor. Two
-// requirements, from the witness construction in the FP_DIV rule below: the
-// witness divisor and the division it feeds each contribute one part in
-// 2^(ss-1) of relative error, while the target's round-to-nearest interval
-// around any representable value is at least 2^-(ts+2) wide relative (the
-// tight case sits just above a power of two), so five extra significand
-// bits cover it with margin; and the witness quotient x/t -- |x| at most
-// the target's largest finite, |t| at least its smallest subnormal -- must
-// stay inside the source format's normal range, which spans 2^±emax_s.
+// the error of steering that quotient with a source-format divisor: five
+// extra significand bits cover the two rounding errors of the witness
+// against the target's tightest rounding interval, and the source exponent
+// range must hold the witness quotient x/t (largest target finite over
+// smallest target subnormal).
 static bool narrowingAbsorbsDivisorGrid(unsigned se, unsigned ss,
                                         unsigned te, unsigned ts)
 {
@@ -1333,35 +1329,17 @@ ASTNode RemoveUnconstrained::topLevel_other(const ASTNode& n,
 
       case FP_DIV:
       {
-        // A division whose divisor is unconstrained, rounded down into a
-        // narrower format:
-        //
-        //   to_fp[te,ts](RNE, fp.div(RNE, to_fp[se,ss](rm, x), u))
-        //
-        // takes every value of the narrow format as u ranges, provided the
-        // source format out-resolves the target one
-        // (narrowingAbsorbsDivisorGrid). For finite non-zero x the witness
-        // u0 = fl_src(x/t) reaches any finite target t: u0 is off from x/t
-        // by one part in 2^(ss-1), dividing by it costs one more, and the
-        // narrowing rounds an error that small back onto t. IEEE's special
-        // quotients (x/±0, x/±oo, x/NaN) supply the extremes. When x itself
-        // is NaN, zero or infinite the quotient is pinned to NaN, {±0, NaN}
-        // or {±oo, NaN} -- the free divisor sign still picks the sign, but
-        // the magnitude cannot leave the class -- so the stand-in is a
-        // fresh variable filtered through x's classification.
-        //
-        // The narrowing is essential, not decoration: at the division's own
-        // format the reachable quotient grid has holes no divisor fills, so
-        // this arm keys on the divisor and then insists on the conversion
-        // above it. Like FP_GT this must run while the division is one
-        // source node and the divisor one use -- after lowering the divisor
-        // feeds its unpack circuit many times over and stops looking
-        // unconstrained.
-        //
-        // Only round-to-nearest-even instances have been verified
-        // (exhaustively at small formats, and by re-evaluating witnesses at
-        // binary32/binary64), so both rounding modes must be that constant;
-        // directed modes would need their own verification first.
+        // to_fp[te,ts](RNE, fp.div(RNE, to_fp[se,ss](rm, x), u)) with u
+        // unconstrained takes every narrow value once the source format
+        // out-resolves the target (narrowingAbsorbsDivisorGrid): the
+        // witness fl_src(x/t) survives the double rounding, and the
+        // special quotients supply the extremes. A NaN, zero or infinite
+        // x pins the quotient's class (only its sign stays free), so the
+        // stand-in is a fresh variable filtered through x's
+        // classification. Without the narrowing the quotient grid has
+        // holes, so the arm insists on the conversion above the division.
+        // RNE-only: the verified envelope. As with FP_GT, this must run
+        // while the divisor is still one use.
 
         if (numberOfChildren != 3 || children[2] != var)
           break;
@@ -1431,12 +1409,9 @@ ASTNode RemoveUnconstrained::topLevel_other(const ASTNode& n,
                            nf->CreateTerm(ITE, tw, isInfX, vIfInf, v)));
 
         // The divisor that makes the original quotient come out at v,
-        // recorded for model construction. sign(quotient) = sign(x) XOR
-        // sign(u), so a zero or infinite quotient's sign picks the sign of
-        // the infinite (resp. zero) divisor, and NaN needs 0/0 (resp.
-        // oo/oo). Everywhere else fl_src(x/v) is the proof's witness, and
-        // IEEE's special quotients make the same expression cover v being
-        // NaN, a zero or an infinity.
+        // recorded for model construction: fl_src(x/v) in general, with
+        // sign-matched infinities/zeros (quotient sign = sign(x) XOR
+        // sign(u)) and 0/0 resp. oo/oo for a NaN quotient.
         const ASTNode isNegX = nf->CreateNode(FP_ISNEGATIVE, x);
         const ASTNode isNegV = nf->CreateNode(FP_ISNEGATIVE, v);
         const ASTNode signsDiffer = nf->CreateNode(XOR, isNegX, isNegV);
@@ -1462,11 +1437,10 @@ ASTNode RemoveUnconstrained::topLevel_other(const ASTNode& n,
             ITE, sw, isZeroX, uWhenZero,
             nf->CreateTerm(ITE, sw, isInfX, uWhenInf, uOtherwise));
 
-        // Splice the stand-in over the narrowing node. x appears verbatim
-        // under the classifications, so seed the builder's memo with its
-        // existing mutable node: rebuilding that subtree instead would give
-        // every symbol below x a duplicate parent, and the next divisor in
-        // a chain of these would stop looking unconstrained.
+        // Splice over the narrowing node, seeding the builder's memo with
+        // x's existing mutable node: a rebuilt copy of that subtree would
+        // give every symbol below x a duplicate parent, and the next
+        // divisor in a chain of these would stop looking unconstrained.
         std::unordered_map<uint64_t, MutableASTNode*> create;
         create.insert(std::make_pair(x.GetNodeNum(),
                                      mutable_children[1]->children[3]));

--- a/tests/query-files/fp-tests/unconstrained-fp-div-narrowed-inf.smt2
+++ b/tests/query-files/fp-tests/unconstrained-fp-div-narrowed-inf.smt2
@@ -1,8 +1,7 @@
 ; RUN: %solver -d %s | %OutputCheck %s
 ;
-; An infinite numerator confines the narrowed quotient to {+oo, -oo, NaN}:
-; reaching +oo from -oo takes a negative (finite or zero) divisor, which the
-; recorded witness supplies for the model check.
+; An infinite numerator confines the quotient to {+oo, -oo, NaN}; +oo from
+; -oo takes a negative divisor, which the witness supplies for -d.
 ;
 ; CHECK: ^sat
 (set-logic QF_FP)

--- a/tests/query-files/fp-tests/unconstrained-fp-div-narrowed-nan.smt2
+++ b/tests/query-files/fp-tests/unconstrained-fp-div-narrowed-nan.smt2
@@ -1,8 +1,7 @@
 ; RUN: %solver %s | %OutputCheck %s
 ;
-; A NaN numerator pins the narrowed quotient to NaN whatever the
-; unconstrained divisor is: the elimination's stand-in keeps the
-; classification, so asking for a non-NaN quotient stays unsatisfiable.
+; A NaN numerator pins the narrowed quotient to NaN whatever the divisor
+; is, so a non-NaN quotient stays unsatisfiable after the elimination.
 ;
 ; CHECK: ^unsat
 (set-logic QF_FP)

--- a/tests/query-files/fp-tests/unconstrained-fp-div-narrowed-rtz.smt2
+++ b/tests/query-files/fp-tests/unconstrained-fp-div-narrowed-rtz.smt2
@@ -1,7 +1,7 @@
 ; RUN: %solver %s | %OutputCheck %s
 ;
-; Directed rounding is outside the verified envelope, so the elimination
-; must NOT fire; the query still solves through the ordinary circuit.
+; Directed rounding is outside the verified envelope: no elimination, the
+; query solves through the ordinary circuit.
 ;
 ; CHECK: ^sat
 (set-logic QF_FP)

--- a/tests/query-files/fp-tests/unconstrained-fp-div-narrowed-zero-normal.smt2
+++ b/tests/query-files/fp-tests/unconstrained-fp-div-narrowed-zero-normal.smt2
@@ -1,7 +1,6 @@
 ; RUN: %solver %s | %OutputCheck %s
 ;
-; The other side of the zero-numerator class: no divisor makes 0/u a normal
-; number, and the elimination's classification filter preserves that.
+; No divisor makes 0/u a normal number; the classification filter keeps it.
 ;
 ; CHECK: ^unsat
 (set-logic QF_FP)

--- a/tests/query-files/fp-tests/unconstrained-fp-div-narrowed-zero.smt2
+++ b/tests/query-files/fp-tests/unconstrained-fp-div-narrowed-zero.smt2
@@ -1,10 +1,9 @@
 ; RUN: %solver -d %s | %OutputCheck %s
 ;
-; A zero numerator confines the narrowed quotient to {+0, -0, NaN}, with the
-; sign following the divisor's free sign: forcing the quotient to +0 from a
-; NEGATIVE zero numerator is satisfiable (divisor of matching sign), and the
-; model check reconstructs that divisor. The (= q +zero) spelling
-; distinguishes the zero signs, unlike fp.eq.
+; A zero numerator confines the narrowed quotient to {+0, -0, NaN}, sign
+; following the divisor's: +0 from a NEGATIVE zero numerator is satisfiable,
+; and -d reconstructs the sign-matched divisor. (= q +zero) distinguishes
+; the zero signs, unlike fp.eq.
 ;
 ; CHECK: ^sat
 (set-logic QF_FP)

--- a/tests/query-files/fp-tests/unconstrained-fp-div-narrowed.smt2
+++ b/tests/query-files/fp-tests/unconstrained-fp-div-narrowed.smt2
@@ -1,14 +1,9 @@
 ; RUN: %solver -d %s | %OutputCheck %s
 ;
 ; A division by an unconstrained float64 divisor, narrowed back to float32,
-; reaches every float32 value, so RemoveUnconstrained replaces the whole
-; quotient with a fresh variable (filtered through the numerator's
-; classification) and never builds the divider circuit. The pinned numerator
-; and pinned quotient collapse the rest at the word level.
-;
-; -d additionally constructs the model and checks it against this input,
-; which exercises the witness divisor recorded for the eliminated u: the
-; check evaluates the original division at u's reconstructed value.
+; reaches every float32 value: the whole quotient becomes a fresh variable
+; and the divider circuit is never built. -d checks the constructed model
+; against this input, evaluating the division at u's reconstructed value.
 ;
 ; CHECK: ^sat
 (set-logic QF_FP)

--- a/tests/unit-tests/RemoveUnconstrainedFpDiv_Test.cpp
+++ b/tests/unit-tests/RemoveUnconstrainedFpDiv_Test.cpp
@@ -19,29 +19,13 @@ THE SOFTWARE.
 **********************/
 
 /*
- * The FP_DIV arm of RemoveUnconstrained: a division by an unconstrained
- * divisor, rounded down into a narrower format,
- *
- *   to_fp[te,ts](RNE, fp.div(RNE, to_fp[se,ss](RNE, x), u))
- *
- * is replaced by a fresh variable of the narrow format, filtered through x's
- * classification, and u gets a witness definition in the substitution map.
- *
- * The pass re-parameterises rather than rewrites, so soundness is checked
- * from both directions, exhaustively at small formats (target (3, 4) inside
- * source (5, 9) -- the smallest pair the rule's format-gap test admits that
- * stays clear of the known symfpu small-significand trouble spots):
- *
- *  - Witness direction: substituting u's recorded definition back into the
- *    original quotient must reproduce the replacement, as a function of x
- *    and the fresh variable. Every rewritten model then lifts to a model of
- *    the original formula. Checked on all 2^7 x 2^7 assignments.
- *
- *  - Reachability direction: every value the original quotient attains must
- *    pass the replacement's classification filter (with the fresh variable
- *    set to that value), or a satisfiable input could turn unsatisfiable.
- *    Checked on all 2^7 numerators against every special divisor, every
- *    divisor exponent boundary, and a deterministic random sample.
+ * The FP_DIV arm of RemoveUnconstrained, checked from both directions at
+ * (3, 4) inside (5, 9): substituting u's recorded witness back into the
+ * original quotient must reproduce the replacement on all 2^7 x 2^7
+ * (x, fresh) assignments, and every value the original quotient attains
+ * must pass the replacement's classification filter (all numerators
+ * against every divisor exponent boundary, every special, and a random
+ * sample). Plus firing and no-fire gate checks.
  */
 
 #include "stp/AST/MutableASTNode.h"
@@ -60,12 +44,8 @@ using namespace stp;
 namespace
 {
 
-// Target and source formats. The gap tests in the rule require
-// ss >= ts + 5 and emax_s >= 2*emax_t + ts + 1: (3, 4) in (5, 9) is minimal
-// with te >= 3 (symfpu's float-to-float conversions into two-bit exponents
-// and its tiny-significand unpacking are known trouble spots upstream;
-// staying at (3, 4) matches the formats the constant folder is exhaustively
-// tested at).
+// (3, 4) in (5, 9): the smallest pair the rule's format-gap test admits
+// that stays clear of symfpu's small-format trouble spots.
 const unsigned TE = 3, TS = 4, SE = 5, SS = 9;
 const unsigned TW = TE + TS, SW = SE + SS;
 
@@ -177,9 +157,8 @@ struct Context
     return NonMemberBVConstEvaluator(&mgr, s);
   }
 
-  // A format-carrying float constant from packed bits. Interning
-  // canonicalises every NaN payload to one node, which is also STP's
-  // semantics for them, so enumerating packed encodings enumerates values.
+  // Interning canonicalises NaN payloads, which is also STP's semantics
+  // for them, so enumerating packed encodings enumerates values.
   ASTNode packed(unsigned bits, unsigned eb, unsigned sb)
   {
     return mgr.CreateFPConst(mgr.CreateBVConst(eb + sb, bits), eb, sb);
@@ -265,9 +244,8 @@ TEST(RemoveUnconstrainedFpDiv, every_original_quotient_is_reachable)
   find(replacement);
   ASSERT_FALSE(fresh.IsNull());
 
-  // Divisors: every value whose significand field is zero or all-ones at
-  // every exponent (all specials and every boundary the rounding can pivot
-  // on), plus a deterministic sample of the rest.
+  // All specials and significand-field boundaries, plus a deterministic
+  // sample of the rest.
   std::vector<unsigned> divisors;
   for (unsigned sign = 0; sign < 2; sign++)
     for (unsigned exp = 0; exp < (1u << SE); exp++)


### PR DESCRIPTION
Comment-only follow-up to #905: the derivations behind the FP_DIV arm are compressed to the constraints they establish (the full arguments live in #905's description and the exhaustive tests). No code changes — the diff has no non-comment lines.