### PR TITLE
Keep the floating-point format on constants discovered while bit-blasting

### DIFF
--- a/include/stp/NodeFactory/NodeFactory.h
+++ b/include/stp/NodeFactory/NodeFactory.h
@@ -60,6 +60,8 @@ public:
   NodeFactory(STPMgr& bm_) : bm(bm_) {}
   virtual ~NodeFactory() {}
 
+  STPMgr& getStpMgr() const { return bm; }
+
   // A non-owning contiguous child range. ASTVec converts to this view, while
   // callers which already own another contiguous arena avoid materialising
   // a vector merely to cross the factory boundary.

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ********************************************************************/
 #include "stp/ToSat/BitBlaster.h"
+#include "stp/FloatBlaster/FloatBlaster.h"
 #include "stp/Simplifier/Simplifier.h"
 #include "stp/Simplifier/constantBitP/ConstantBitPropagation.h"
 #include "stp/Simplifier/constantBitP/FixedBits.h"
@@ -328,14 +329,9 @@ void BitBlaster::getConsts(const ASTNode& form,
     if (!constNode)
       continue;
 
-    CBV val = CONSTANTBV::BitVector_Create(n.GetValueWidth(), true);
-    for (int i = 0; i < (int)x.size(); i++)
-    {
-      if (x[i] == BBTrue)
-        CONSTANTBV::BitVector_Bit_On(val, i);
-    }
-
-    ASTNode r = ASTNF->CreateConstant(val, n.GetValueWidth());
+    // getConstant re-makes a float's packed bits as an ASTFPConst, keeping
+    // the substitution type-correct.
+    ASTNode r = getConstant(x, n);
     if (n.GetKind() == SYMBOL)
       simp->UpdateSubstitutionMap(n, r);
     else
@@ -617,7 +613,18 @@ ASTNode BitBlaster::getConstant(const BBNodeVec& v,
     if (v[i] == nf->getTrue())
       CONSTANTBV::BitVector_Bit_On(bv, i);
 
-  return ASTNF->CreateConstant(bv, v.size());
+  const ASTNode result = ASTNF->CreateConstant(bv, v.size());
+
+  // n may be a float carried as its packed bits (see isBitsValued). A plain
+  // BVCONST cannot hold the format, so the constant that stands in for n has
+  // to be re-made as an interned ASTFPConst -- otherwise the rebuilt parent
+  // carries a bitvector where an fp is required and fails BVTypeCheck.
+  const unsigned int exp_width = n.GetExpWidth();
+  if (exp_width != 0)
+    return FloatBlaster::withFormat(&ASTNF->getStpMgr(), result, exp_width,
+                                    n.GetSigWidth());
+
+  return result;
 }
 
 // This block checks if the bitblasting/fixed bits have discovered

--- a/tests/query-files/fp-tests/simplify-during-bb-fp-native-add-constant-child.smt2
+++ b/tests/query-files/fp-tests/simplify-during-bb-fp-native-add-constant-child.smt2
@@ -1,0 +1,16 @@
+; RUN: %solver --bb.simplify-during-bb=1 --bb.fp-native-arith=1 --array-equality %s 2>&1 | %OutputCheck %s
+; CHECK: ^sat
+; The select's index is constant only at the bit level (1 sdiv v is 1 for
+; both values of v), so the word-level simplifier leaves the select alone
+; and simplify_during_bb is what discovers, mid-blast, that the fp.add's
+; float operand is a constant. getConstant used to re-make that operand as
+; a plain BVCONST -- the FLOATINGPOINT format does not survive -- and the
+; rebuilt fp.add failed BVTypeCheck with "argument to <fp> is not an fp".
+; --bb.fp-native-arith=1 is what keeps the fp.add alive into the
+; bit-blaster; getConstant now re-makes the operand as an ASTFPConst.
+(set-logic QF_ABVFP)
+(declare-fun v () (_ BitVec 1))
+(declare-fun x () Float32)
+(declare-fun a () (Array (_ BitVec 2) Float32))
+(assert (fp.geq (fp.add roundNearestTiesToEven x (select (store a ((_ sign_extend 1) (bvsdiv (_ bv1 1) v)) (fp #b0 #b10000000 #b10000000000000000000000)) (_ bv3 2))) x))
+(check-sat)

--- a/tests/query-files/fp-tests/simplify-during-bb-fp-native-mul-constant-child.smt2
+++ b/tests/query-files/fp-tests/simplify-during-bb-fp-native-mul-constant-child.smt2
@@ -1,0 +1,13 @@
+; RUN: %solver --bb.simplify-during-bb=1 --bb.fp-native-arith=1 --array-equality %s 2>&1 | %OutputCheck %s
+; CHECK: ^sat
+; As simplify-during-bb-fp-native-add-constant-child.smt2, over fp.mul with
+; a -1.0 operand: the constant the blaster discovers also drives the
+; simplifying factory's fold of x * -1.0, which builds new floating-point
+; structure over the re-made constant. Before getConstant kept the format
+; this aborted with "argument to <fp> is not an fp".
+(set-logic QF_ABVFP)
+(declare-fun v () (_ BitVec 1))
+(declare-fun x () Float32)
+(declare-fun a () (Array (_ BitVec 2) Float32))
+(assert (fp.gt (fp.mul roundTowardZero x (select (store a ((_ sign_extend 1) (bvsdiv (_ bv1 1) v)) (fp #b1 #b01111111 #b00000000000000000000000)) (_ bv3 2))) x))
+(check-sat)

--- a/tests/query-files/fp-tests/simplify-during-bb-fp-native-to_fp-constant-child.smt2
+++ b/tests/query-files/fp-tests/simplify-during-bb-fp-native-to_fp-constant-child.smt2
@@ -1,0 +1,13 @@
+; RUN: %solver --bb.simplify-during-bb=1 --bb.fp-native-arith=1 --array-equality %s 2>&1 | %OutputCheck %s
+; CHECK: ^sat
+; As simplify-during-bb-fp-native-add-constant-child.smt2, but the operand
+; that simplify_during_bb discovers to be constant sits under a
+; float-to-float to_fp. With the format lost off the re-made constant the
+; conversion's lowering aborted with "FloatBlast expected a floating-point
+; source expression".
+(set-logic QF_ABVFP)
+(declare-fun v () (_ BitVec 1))
+(declare-fun y () Float64)
+(declare-fun a () (Array (_ BitVec 2) Float32))
+(assert (fp.geq (fp.add roundNearestTiesToEven y ((_ to_fp 11 53) roundNearestTiesToEven (select (store a ((_ sign_extend 1) (bvsdiv (_ bv1 1) v)) (fp #b0 #b10000000 #b10000000000000000000000)) (_ bv3 2)))) y))
+(check-sat)


### PR DESCRIPTION
## Problem

With `--bb.simplify-during-bb=1 --bb.fp-native-arith=1`, QF_ABVFP problems abort where they should solve. An overnight fuzz run saved 31 instances of this across four fatal-error signatures:

```
Fatal Error: argument to <fp> is not an fp

104784:(FP_MUL
  38:rm26323
  1538:0x47FE471C8E84D7DF9ECCF306C8BB351A
  104782:0x4033DF46DC0000000000000000000000)
```

plus "FloatBlast: unhandled target-valued floating-point kind" (on FP_NEG), "FloatBlast expected a floating-point source expression", and "to_fp's argument is not an fp" — different checkpoints, one cause.

`simplify_during_bb` replaces a child whose bits the blaster has fully fixed with a constant built by `getConstant`, which always made a plain BVCONST. A float travels through the blaster as its packed bits (see `isBitsValued`), so the replacement dropped the FLOATINGPOINT format and the rebuilt parent carried a bitvector where an fp is required — the FP_MUL above, whose float operands print as bare hex constants. 9b9e51ea (#903) guarded the `concreteToAbstract` call in the same function but not the replacement itself. bitwuzla solves every saved instance.

Both flags are off by default, so the default configuration is unaffected.

## Fix

Route `getConstant`'s result through `FloatBlaster::withFormat`, the documented funnel for putting the format back on a rebuilt node: the constant is re-made as an interned `ASTFPConst`, distinct from the plain constant with the same bits, so nothing retypes shared bitvector constants. `getConsts` had the same hole and now calls `getConstant`. `NodeFactory` gains a `getStpMgr()` accessor so the blaster can reach the manager `withFormat` needs.

## Testing

- Three new query files pin the mechanism with a select index that is constant only at the bit level — `(bvsdiv (_ bv1 1) v)` is 1 for both values of v — so the word-level simplifier leaves the select alone and the constant is discovered mid-blast, feeding an fp.add, an fp.mul, and a float-to-float to_fp that `--bb.fp-native-arith=1` keeps alive into the blaster. Each aborts on the parent commit (the first two with "argument to <fp> is not an fp", the third with "FloatBlast expected a floating-point source expression") and solves to `sat`, matching bitwuzla, on this branch.
- All 31 fuzzer-saved failures solve with their full original option strings and match bitwuzla; the fuzzer has found nothing new since running on the fixed build.
- Full query-files suite: 575 passed, 0 failed. DeepDag (111), FloatBlast (9), DifficultyScore (6) and IncrementalCBP (4) unit tests all pass.
