### PR TITLE
Answer (get-value ...) for any well-sorted term

### DIFF
--- a/docs/array-extensionality.rst
+++ b/docs/array-extensionality.rst
@@ -51,7 +51,8 @@ With the option enabled:
 * ``vc_getCounterExampleArray`` returns one entry per concrete index in
   ascending index order;
 * array-valued ``(get-value ...)`` is rejected as unsupported (use
-  ``(get-model)``).
+  ``(get-model)``). This is not conditional on the option: an array has no
+  value spelling in a valuation pair either way.
 
 Nullary array-sorted ``define-fun`` is accepted by the SMT-LIB2 parser
 whether or not the option is on: such a definition is a pure name for its

--- a/include/stp/Printer/SMTLIBPrinter.h
+++ b/include/stp/Printer/SMTLIBPrinter.h
@@ -49,6 +49,9 @@ void SMTLIB_Print1(ostream& os, const stp::ASTNode n, int indentation,
 
 ostream& SMTLIB_Print(ostream& os, STPMgr*, const ASTNode n,
                       const int indentation);
+
+// Prints one term on one line, sharing repeated subterms through `let`.
+ostream& SMTLIB_PrintTerm(ostream& os, STPMgr*, const ASTNode n);
 }
 
 #endif

--- a/include/stp/Printer/printers.h
+++ b/include/stp/Printer/printers.h
@@ -77,6 +77,13 @@ DLL_PUBLIC void SMTLIB2_PrintBack(ostream& os, const ASTNode& n, STPMgr* stp,
 DLL_PUBLIC void SMTLIB2_Print1(ostream& os, const stp::ASTNode n,
                                int indentation, bool letize);
 
+// Prints one term on one line, without declarations and without a trailing
+// newline, sharing every repeated subterm through `let`. Used by get-value,
+// which echoes back a term the caller chose and so cannot assume it is small
+// or unshared -- printing a DAG as a tree is exponential in its sharing.
+DLL_PUBLIC void SMTLIB2_PrintTerm(ostream& os, STPMgr* stp,
+                                  const stp::ASTNode& n);
+
 // Emitters for a BVCONST (or a BITVECTOR wrapping one).
 void outputBitVecSMTLIB2(const ASTNode n, ostream& os);
 void outputFloatingPointSMTLIB2(const ASTNode n, ostream& os,

--- a/lib/AbsRefineCounterExample/CounterExample.cpp
+++ b/lib/AbsRefineCounterExample/CounterExample.cpp
@@ -2079,49 +2079,66 @@ AbsRefine_CounterExample::GetCounterExampleArray(bool t, const ASTNode& e)
   return entries;
 }
 
-// TODO printing of expressions.
 // TODO move to printer file.
+//
+// One (term value) pair of a get-value response. `n` is any non-array term
+// the caller asked about, printed back as SMT-LIB2 followed by the value the
+// model gives it. Arrays are the caller's to refuse: they have no value
+// spelling here, and (get-model) prints their completed interpretations.
+//
+// The term printed is STP's node for it, which is what a get-value response
+// can be built from: hash-consing and rewriting happen in the node factory
+// as the parser builds each term, so the text the caller wrote is gone by
+// the time anything can be asked about the term. The node is equivalent to
+// what was asked about but frequently not equal to it in spelling -- (bvule
+// x y) comes back as (not (bvugt |x| |y|)), and a term the factory folds
+// comes back as the constant it folded to. Pairs are therefore matched
+// positionally: response i answers term i, as SMT-LIB requires.
 void AbsRefine_CounterExample::PrintSMTLIB2(std::ostream& os, const ASTNode& n)
 {
-  if (n.GetKind() == SYMBOL)
+  if (n.GetType() == stp::ARRAY_TYPE)
+    FatalError("get-value: an array-valued term has no printable value", n);
+
+  os << "( ";
+  // The first component of the pair is a term, not just a name: a symbol
+  // prints as |x| exactly as it did when this only accepted symbols, and a
+  // compound term prints as itself. Not, however, as the caller spelled it --
+  // see the note above PrintSMTLIB2. Printed through the letizing entry
+  // point, because the node may be a shared DAG and a caller can build a
+  // large one out of very little input text.
+  printer::SMTLIB2_PrintTerm(os, bm, n);
+  os << " ";
+
+  if (bm->isRoundingModeSortedTerm(n))
   {
-    os << "( ";
-
-    os << "|";
-    n.nodeprint(os);
-    os << "| ";
-
-    if (bm->isRoundingModeSymbol(n))
-    {
-      // A RoundingMode value must print as a mode name -- a legal term of
-      // the sort -- not as its raw 5-bit carrier. The declaration pinned the
-      // symbol one-hot, so the model value always names a mode; anything
-      // else would be a bug, but print the bits rather than crash.
-      const ASTNode v = TermToConstTermUsingModel(n, false);
-      const char* name = printer::roundingModeName(v.GetUnsignedConst());
-      if (name != NULL)
-        os << name;
-      else
-        printer::outputBitVecSMTLIB2(v, os);
-    }
-    else if (n.GetType() == stp::FLOATINGPOINT_TYPE)
-      // A floating-point value must be printed in floating-point syntax
-      // (fp #bS #bE #bM), not as the raw packed bit-vector -- the get-model
-      // path (outputLine) does this; get-value must match, or it hands back a
-      // bit-vector literal where an operand of floating-point sort is expected.
-      printer::outputFloatingPointSMTLIB2(TermToConstTermUsingModel(n, false),
-                                          os, n);
-    else if (n.GetType() == stp::BITVECTOR_TYPE)
-      printer::outputBitVecSMTLIB2(TermToConstTermUsingModel(n, false), os);
+    // A RoundingMode value must print as a mode name -- a legal term of
+    // the sort -- not as its raw 5-bit carrier. Every rounding mode a query
+    // can name is pinned one-hot, so the model value always names a mode;
+    // anything else would be a bug, but print the bits rather than crash.
+    const ASTNode v = TermToConstTermUsingModel(n, false);
+    const char* name = printer::roundingModeName(v.GetUnsignedConst());
+    if (name != NULL)
+      os << name;
     else
-    {
-      if (ASTTrue == ComputeFormulaUsingModel(n))
-        os << "true";
-      else
-        os << "false";
-    }
-    os << " )";
+      printer::outputBitVecSMTLIB2(v, os);
   }
+  else if (n.GetType() == stp::FLOATINGPOINT_TYPE)
+    // A floating-point value must be printed in floating-point syntax
+    // (fp #bS #bE #bM), not as the raw packed bit-vector -- the get-model
+    // path (outputLine) does this; get-value must match, or it hands back a
+    // bit-vector literal where an operand of floating-point sort is expected.
+    printer::outputFloatingPointSMTLIB2(TermToConstTermUsingModel(n, false),
+                                        os, n);
+  else if (n.GetType() == stp::BITVECTOR_TYPE)
+    printer::outputBitVecSMTLIB2(TermToConstTermUsingModel(n, false), os);
+  else
+  {
+    if (ASTTrue == ComputeFormulaUsingModel(n))
+      os << "true";
+    else
+      os << "false";
+  }
+  os << " )";
 }
 
 //todo does it need to be member?

--- a/lib/Interface/cpp_interface.cpp
+++ b/lib/Interface/cpp_interface.cpp
@@ -1228,12 +1228,14 @@ void Cpp_interface::getValue(const ASTVec& v)
 
   for (ASTNode n : v)
   {
-    // Array-valued get-value is explicitly unsupported when array
-    // equality is enabled; use (get-model), which prints the completed
-    // array interpretations. With the feature disabled the
-    // pre-extension behavior is preserved unchanged.
-    if (n.GetKind() != SYMBOL ||
-        (n.GetType() == ARRAY_TYPE && bm.UserFlags.enable_array_equality))
+    // (get-value ...) asks for the value of arbitrary well-sorted terms and
+    // not just of variables, and the model evaluator already decides all of
+    // them. The one shape with no value to print is an array: (get-model)
+    // prints the completed array interpretations instead. That refusal is
+    // unconditional, because reaching the printer with an array aborted the
+    // process rather than answering when array equality was disabled -- and
+    // disabled is the default.
+    if (n.GetType() == ARRAY_TYPE)
     {
       unsupported();
       return;

--- a/lib/Printer/SMTLIB2Printer.cpp
+++ b/lib/Printer/SMTLIB2Printer.cpp
@@ -466,4 +466,11 @@ void SMTLIB2_Print1(ostream& os, const ASTNode n, int indentation, bool letize)
 {
   SMTLIB_Print1(os, n, indentation, letize);
 }
+
+// Thin wrapper over the letizing single-term print. Declared in printers.h
+// because get-value echoes the term it was asked about through it.
+void SMTLIB2_PrintTerm(ostream& os, STPMgr* stp, const ASTNode& n)
+{
+  SMTLIB_PrintTerm(os, stp, n);
+}
 }

--- a/lib/Printer/SMTLIBPrinter.cpp
+++ b/lib/Printer/SMTLIBPrinter.cpp
@@ -372,6 +372,61 @@ ostream& SMTLIB_Print(ostream& os, STPMgr* mgr, const ASTNode n,
   return os;
 }
 
+// One term, printed so that a repeated subterm is written once: the letize
+// pass names every non-atomic subterm that occurs more than once, and the
+// bindings are emitted as a chain of lets around the body.
+//
+// Without this a shared DAG is written out as a tree. get-value answers about
+// arbitrary terms now, and terms built by a chain of define-funs share
+// aggressively: twenty steps of t[i+1] = (bvxor (bvand t[i] y) (bvor t[i] x))
+// wrote 40MB for one (get-value (t20)), twenty-four steps wrote 638MB, and
+// twenty-six steps wrote 2.5GB while holding 4.9GB.
+//
+// Unlike SMTLIB_Print this writes no newline anywhere, because the caller is
+// composing one line of a response, and it leaves the letize maps empty on
+// exit rather than populated. That second part matters twice: nothing it did
+// is visible to a later SMTLIB_Print1, and the let variables -- which are
+// real, interned symbols -- lose their last reference with the maps, so they
+// leave the symbol table that (get-model) enumerates.
+ostream& SMTLIB_PrintTerm(ostream& os, STPMgr* mgr, const ASTNode n)
+{
+  NodeLetVarMap.clear();
+  NodeLetVarVec.clear();
+  NodeLetVarMap1.clear();
+
+  {
+    ASTNodeSet seen;
+    LetizeState st = {seen, NodeLetVarMap, NodeLetVarVec, "?let_k_"};
+    LetizeNode(n, st, mgr);
+  }
+
+  const bool letized = !NodeLetVarVec.empty();
+  string closing;
+  for (auto it = NodeLetVarVec.begin(), itend = NodeLetVarVec.end();
+       it != itend; it++)
+  {
+    os << "(let ((";
+    SMTLIB_Print1(os, it->first, 0, false);
+    os << " ";
+    // A binding's right-hand side sees the bindings already made and not the
+    // ones still to come, which is why NodeLetVarMap1 is filled in as we go.
+    // The letize pass finishes a subterm before it can name it, so a subterm
+    // repeated inside this right-hand side was named before it -- each
+    // binding therefore prints its own sub-DAG once.
+    SMTLIB_Print1(os, it->second, 0, false);
+    os << ")) ";
+    NodeLetVarMap1[it->second] = it->first;
+    closing += ")";
+  }
+  SMTLIB_Print1(os, n, 0, letized);
+  os << closing;
+
+  NodeLetVarMap.clear();
+  NodeLetVarVec.clear();
+  NodeLetVarMap1.clear();
+  return os;
+}
+
 void LetizeNode(const ASTNode& n, LetizeState& st, STPMgr* stp)
 {
   if (n.isAtom())

--- a/tests/query-files/smt2-command-tests/get-value-compound-terms.smt2
+++ b/tests/query-files/smt2-command-tests/get-value-compound-terms.smt2
@@ -1,0 +1,93 @@
+; (get-value (t1 ... tn)) answers ((t1 v1) ... (tn vn)) for any well-sorted
+; terms, not only for variables. STP used to accept a bare symbol and answer
+; "unsupported" for everything else, so no query could read the model value of
+; an expression it had actually written.
+;
+; The model evaluator already decides all of these -- get-value simply refused
+; to ask it. Each row below is a shape the evaluator handles: an arithmetic
+; term, a predicate, an array read, an if-then-else, a compound floating-point
+; term and a compound rounding-mode term. Values are pinned by construction so
+; the output is deterministic.
+;
+; RUN: %solver --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --incremental=on %s 2>&1 | %OutputCheck %s
+;
+; The first half of each pair is STP's node for the term, not the text that
+; was written: hash-consing and rewriting happen in the node factory as the
+; parser builds each term, so the input spelling is gone before anything can
+; be asked about it. Commutative operands come back in canonical order, a
+; rewritten term comes back rewritten, and a folded term comes back as the
+; constant it folded to -- see the (bvadd #x01 #x01) row below. Pairs are
+; therefore matched positionally, response i to term i, which is what SMT-LIB
+; asks of a caller; they cannot be matched by spelling.
+;
+; A term is echoed through the letizing printer, so a shared subterm is
+; printed once. The chain of define-funs at the end builds a node whose tree
+; expansion is exponential in the chain length; it must come back as a `let`.
+;
+; CHECK: ^sat
+; CHECK-L: ( |x|  #x2A )
+; CHECK-L: ( |p| true )
+; CHECK-L: ( (bvadd  #x01 |x|)  #x2B )
+; CHECK-L: ( (= |x|  #x2A) true )
+; CHECK-L: ( (= |x|  #x00) false )
+; CHECK-L: ( (select |a|  #x00)  #x07 )
+; CHECK-L: ( (ite |p| |x|  #x00)  #x2A )
+; A constant-folded query keeps its answer but loses its spelling.
+; CHECK-L: (  #x02  #x02 )
+; CHECK-L: ( |f| (fp #b0 #b10000000 #b10000000000000000000000) )
+; CHECK-L: ( (fp.add RNE |f| |f|) (fp #b0 #b10000001 #b10000000000000000000000) )
+; A floating-point predicate is a Boolean, and answers like one.
+; CHECK-L: ( (fp.isNaN |f|) false )
+; CHECK-L: ( |r| RTZ )
+; A rounding-mode-sorted expression prints a mode name, not its bit carrier.
+; CHECK-L: ( (ite |p| RTZ RNE) RTZ )
+; CHECK-L: ( (fp.mul |r| |f| |f|) (fp #b0 #b10000010 #b00100000000000000000000) )
+; A single command answers every term it was given, in the order asked.
+; CHECK-L: ( |x|  #x2A )
+; CHECK-L: ( (bvnot |x|)  #xD5 )
+; CHECK-L: ( |p| true )
+; A shared subterm is bound once rather than expanded at each use.
+; CHECK: \(let \(\(\|\?let_k_0\|.*  #x05 \)
+; An array has no SMT-LIB2 value spelling here; (get-model) prints the
+; completed interpretation instead. It is refused, not evaluated -- reaching
+; the Boolean branch of the printer with an array used to abort the process,
+; in the default configuration.
+; CHECK-L: unsupported
+; CHECK: REACHED-END
+;
+(set-logic QF_ABVFP)
+(set-option :produce-models true)
+(declare-const x (_ BitVec 8))
+(declare-const p Bool)
+(declare-const a (Array (_ BitVec 8) (_ BitVec 8)))
+(declare-const f (_ FloatingPoint 8 24))
+(declare-const r RoundingMode)
+(define-fun g0 () (_ BitVec 8) x)
+(define-fun g1 () (_ BitVec 8) (bvxor (bvand g0 x) (bvor g0 #x0f)))
+(define-fun g2 () (_ BitVec 8) (bvxor (bvand g1 x) (bvor g1 #x0f)))
+(define-fun g3 () (_ BitVec 8) (bvxor (bvand g2 x) (bvor g2 #x0f)))
+(assert (= x #x2a))
+(assert p)
+(assert (= (select a #x00) #x07))
+(assert (= f (fp #b0 #b10000000 #b10000000000000000000000)))
+(assert (= r RTZ))
+(check-sat)
+(get-value (x))
+(get-value (p))
+(get-value ((bvadd x #x01)))
+(get-value ((= x #x2a)))
+(get-value ((= x #x00)))
+(get-value ((select a #x00)))
+(get-value ((ite p x #x00)))
+(get-value ((bvadd #x01 #x01)))
+(get-value (f))
+(get-value ((fp.add RNE f f)))
+(get-value ((fp.isNaN f)))
+(get-value (r))
+(get-value ((ite p RTZ RNE)))
+(get-value ((fp.mul r f f)))
+(get-value (x (bvnot x) p))
+(get-value (g3))
+(get-value (a))
+(echo "REACHED-END")


### PR DESCRIPTION
SMT-LIB 2.6 defines `(get-value ...)` over arbitrary closed, well-sorted terms. `Cpp_interface::getValue` accepted a bare symbol and answered `unsupported` for everything else, so no query could read the model value of an expression it had written.

`PrintSMTLIB2` now takes any non-array term: the term is echoed back, and the value dispatch keys on the term's sort rather than on its being a symbol. A symbol still prints as `|x|`, exactly as the old hand-rolled spelling did, so existing output is unchanged byte for byte. RoundingMode uses `isRoundingModeSortedTerm`, so a mode-sorted *expression* prints a mode name and not its five-bit carrier, as a mode-sorted variable already did.

Arrays are refused, and now unconditionally. They have no value spelling here and `(get-model)` prints their completed interpretations instead. That also closes a second defect, and in the out-of-the-box configuration rather than a corner one: `enable_array_equality` defaults to **false** — `--array-equality` is what turns it on — and with it off an array symbol passed the old `SYMBOL` filter, reached `PrintSMTLIB2`, matched none of its arms and fell into the Boolean `else`, where `ComputeConstFormUsingModel` aborted the process on a legal command. On master, with no flags at all, `(get-value (a))` prints `Fatal Error: ComputeConstFormUsingModel: The input is a non-formula:` and exits 255.

## Printing the echoed term

The echo goes through a new letizing entry point, `SMTLIB2_PrintTerm`, and not through the un-letized `SMTLIB2_Print1`. A term the caller names can be a shared DAG, and printing a DAG as a tree is exponential in its sharing depth. Measured with an ordinary chain of define-funs, `t[i+1] = (bvxor (bvand t[i] y) (bvor t[i] x))`, and a single `(get-value (t[N]))` — about thirty lines of input in total:

| N | before | after |
|---|---|---|
| 20 | 0.6 s, 40 MB of output | 0.00 s, 1.8 KB |
| 22 | 2.4 s, 159 MB | 0.00 s, 2.0 KB |
| 24 | 9.4 s, 638 MB, 1.7 GB RSS | 0.00 s, 2.2 KB |
| 26 | 48.5 s, 2.5 GB, 4.9 GB RSS | 0.00 s, 2.4 KB |

`SMTLIB2_PrintTerm` also leaves the printer's letize maps empty on exit rather than populated. That matters twice: nothing it did is visible to a later `SMTLIB2_Print1` (the maps are thread-local globals that `SMTLIB_Print` leaves populated today), and the generated `let` variables — which are real, interned symbols — lose their last reference with the maps, so they leave the manager's symbol table again and do not turn up as cells in a subsequent `(get-model)`.

## Known limitation: the echoed term is STP's node, not your text

What comes back as the first half of each pair is STP's node for the term, not the text that was written. Hash-consing and rewriting happen in the node factory as the parser builds each term, and the SMT-LIB2 parser keeps no source spans, so the input spelling is already gone by the time anything can be asked about the term. Concretely, on this branch with `x = #x2a` and `y = #x11`: `(bvule x y)` answers `( (not (bvugt |x| |y|)) false )`, `((_ zero_extend 4) x)` answers `( (concat  #x0 |x|)  #x02A )`, `(bvxnor x y)` answers `( (bvnot (bvxor |x| |y|))  #xC4 )`, and a term the factory folds loses its spelling entirely — `(get-value ((bvadd #x01 #x01) (bvsub #x03 #x01)))` answers two pairs both spelled `(  #x02  #x02 )`.

Echoing the source text is not a small change: it needs the lexer and grammar to carry a source span for every `get-value` argument through to `Cpp_interface::getValue`, and the lexer reads from a `FILE*` that may be `stdin`. I have not attempted it here. The consequence for a caller is that **pairs must be matched positionally — response *i* answers term *i*, which is what SMT-LIB asks of a caller — and cannot be matched by spelling**. This is stated in the source, above `PrintSMTLIB2`, and in the fixture's header comment.

One further observable: evaluating an out-of-range array read installs a completion cell in the counterexample map, so `(get-value ((select a #x01)))` followed by `(get-model)` prints a cell for `#x01` that `(get-model)` alone would not. The added value is the one the model gives, so the model stays sound and self-consistent; it is a query command changing model output, which is worth knowing about.

## Verification

`tests/query-files/smt2-command-tests/get-value-compound-terms.smt2` covers an arithmetic term, a predicate, an array read, an if-then-else, a constant-folded term, a compound floating-point term (`(fp.add RNE f f)`), a floating-point predicate, a compound rounding-mode term (`(ite p RTZ RNE)`), a rounding-mode-sorted operand in a rounded operation (`(fp.mul r f f)`), a multi-term command, a shared DAG that must come back as a `let`, and the array refusal. Bare `f` and `r` rows are kept only as the byte-compatibility anchors for the old symbol path — master already answers those two identically; every other row is `unsupported` on master, and `(get-value (a))` kills master's process before the closing `(echo "REACHED-END")` can run. It **fails on master** and passes here, under both `--incremental=off` and `--incremental=on`, whose outputs are byte-identical to each other and deterministic across repeated runs.

`docs/array-extensionality.rst` recorded the array `(get-value ...)` refusal as a property of the `--array-equality` feature; it is now noted as unconditional.

**135/135** `ctest`, unchanged from master, in both RelWithDebInfo and Release with `-DWERROR=ON`. No new warnings from any STP source in either build.
