### PR TITLE
Release what a model read allocates, and keep Booleans Boolean

### DIFF
--- a/bindings/python/stp/stp.py.in
+++ b/bindings/python/stp/stp.py.in
@@ -540,18 +540,36 @@ class Solver(object):
     def _counterexample_int(self, expr, width):
         """The unsigned value of an (unboxed) expression in the current
         model, at any width. getBVUnsignedLongLong saturates at 64 bits,
-        so wider values are assembled from 64-bit extracts."""
+        so wider values are assembled from 64-bit extracts.
+
+        vc_getCounterExample and vc_bvExtract each hand back a handle this
+        binding owns and has to release; the carrier is the one handle here
+        that it does not (see _bit_carrier). Releasing them matters because
+        reading a model is something callers do in a loop.
+        """
         if width <= 64:
             value = _lib.vc_getCounterExample(self.vc, expr)
-            return _lib.getBVUnsignedLongLong(value)
-        carrier = self._bit_carrier(expr)
-        extract = 0
+            try:
+                return _lib.getBVUnsignedLongLong(value)
+            finally:
+                _lib.vc_DeleteExpr(value)
+
+        carrier = self._bit_carrier(expr)  # borrowed, not owned
+        result = 0
         for i in range((width - 1) // 64 + 1):
-            extractExpr = _lib.vc_bvExtract(self.vc, carrier,
-                                            min((i+1)*64, width)-1, i*64)
-            bvExpr = _lib.vc_getCounterExample(self.vc, extractExpr)
-            extract += (_lib.getBVUnsignedLongLong(bvExpr) << (64 * i))
-        return extract
+            slice_expr = _lib.vc_bvExtract(self.vc, carrier,
+                                           min((i + 1) * 64, width) - 1,
+                                           i * 64)
+            try:
+                slice_value = _lib.vc_getCounterExample(self.vc, slice_expr)
+                try:
+                    result += (_lib.getBVUnsignedLongLong(slice_value)
+                               << (64 * i))
+                finally:
+                    _lib.vc_DeleteExpr(slice_value)
+            finally:
+                _lib.vc_DeleteExpr(slice_expr)
+        return result
 
     def model(self, key=None, expr=None):
         """
@@ -609,6 +627,11 @@ class Solver(object):
         be sliced through its IEEE bits, which vc_fpToIEEEBV supplies and
         which are exactly the packed bits the slicing wants. A bit-vector is
         already its own carrier.
+
+        The result is borrowed, not owned. For a bit-vector it is the
+        caller's own argument, and for a float it is a handle vc_fpToIEEEBV
+        has already registered with the manager, which deletes it again at
+        vc_Destroy; passing either to vc_DeleteExpr is a double free.
         """
         if _lib.vc_getExpWidth(expr):
             return _lib.vc_fpToIEEEBV(self.vc, expr)
@@ -736,11 +759,18 @@ class Expr(AnyExpr):
         return Expr(self.s, self.width, expr)
 
     def _toexpr(self, other):
-        if isinstance(other, int):
-            return self.s.bitvecval(self.width, other)
-
         if isinstance(other, bool):
-            return self.s.true() if other else self.s.false()
+            # Python bool is an int subclass.  Preserve the historical
+            # bit-vector shorthand (True == 1, False == 0), while a Bool
+            # expression such as a UF predicate must stay in Bool sort.
+            if self.width is None:
+                return self.s.true() if other else self.s.false()
+            return self.s.bitvecval(self.width, int(other))
+
+        if isinstance(other, int):
+            if self.width is None:
+                raise TypeError('an integer is not a Boolean expression')
+            return self.s.bitvecval(self.width, other)
 
         return other
 
@@ -841,7 +871,22 @@ class Expr(AnyExpr):
         return self._2w(_lib.vc_sbvRemExpr, other, self)
 
     def eq(self, other):
-        return self._2(_lib.vc_eqExpr, other)
+        """Equality, in whichever sort the operands are.
+
+        A Boolean carries no bits, so two Booleans are compared with IFF;
+        vc_eqExpr would build a bit-vector equality over them and libstp
+        would then ask a Boolean for a value it has not got.
+        """
+        other = self._toexpr(other)
+        assert isinstance(other, Expr), 'Other object must be an Expr instance'
+        if (self.width is None) != (other.width is None):
+            raise TypeError('a Boolean expression compares only against '
+                            'another Boolean expression')
+        if self.width is None:
+            return Expr(self.s, None,
+                        _lib.vc_iffExpr(self.s.vc, self.expr, other.expr))
+        return Expr(self.s, self.width,
+                    _lib.vc_eqExpr(self.s.vc, self.expr, other.expr))
 
     __eq__ = eq
 

--- a/tests/api/python/tests.py.in
+++ b/tests/api/python/tests.py.in
@@ -34,6 +34,7 @@ sys.path.insert(0, "@PYTHON_INTERFACE_DIR@")
 import stp
 import unittest
 import ctypes
+import gc
 import importlib
 
 
@@ -46,6 +47,37 @@ def test0_foo(a, b):
 @stp.stp
 def test0_bar(a, b):
     return a * b == 12345
+
+
+class _MallInfo2(ctypes.Structure):
+    """glibc's struct mallinfo2, as of glibc 2.33."""
+    _fields_ = [(field, ctypes.c_size_t) for field in (
+        'arena', 'ordblks', 'smblks', 'hblks', 'hblkhd', 'usmblks',
+        'fsmblks', 'uordblks', 'fordblks', 'keepcost')]
+
+
+try:
+    _mallinfo2 = ctypes.CDLL('libc.so.6').mallinfo2
+    _mallinfo2.restype = _MallInfo2
+    _mallinfo2.argtypes = []
+except (OSError, AttributeError):  # not glibc, or older than 2.33
+    _mallinfo2 = None
+
+
+def _allocated_bytes():
+    """How many bytes the process allocator currently has handed out, or
+    None where it cannot be asked.
+
+    A leak inside libstp is invisible to the interpreter -- no Python object
+    holds the memory -- and invisible to the resident set as well, because a
+    heap that has been running for a while holds enough free space to absorb
+    megabytes of small allocations without faulting a single new page. The
+    allocator itself is the only witness.
+    """
+    if _mallinfo2 is None:
+        return None
+    gc.collect()
+    return _mallinfo2().uordblks
 
 
 class TestSTP(unittest.TestCase):
@@ -455,6 +487,107 @@ class TestSTP(unittest.TestCase):
         expr_for_add = x.add(bitvecval.mul(2))
         value_from_model = solver.model(expr=expr_for_add)
         self.assertEqual(value_from_model, value_for_x + (value_for_bitvecval * 2))
+
+    def test_model_reads_release_the_expressions_they_are_handed(self):
+        # vc_getCounterExample hands back a freshly allocated expression that
+        # the caller owns, and so does every vc_bvExtract used to slice a
+        # value wider than 64 bits. _counterexample_int dropped all of them
+        # on the floor: 32 bytes for an 8-bit read, and 128 for a 128-bit one
+        # -- two slices, each costing an extract and a counterexample.
+        # Polling a model in a loop, which is what enumerating solutions
+        # looks like, therefore grew the process for as long as it ran.
+        #
+        # Only bit-vectors are measured. A float wider than binary64 is
+        # sliced through vc_fpToIEEEBV, whose result libstp registers for
+        # destruction with the manager, so that read still grows the persist
+        # list by one entry -- 44 bytes a read here against master's 172, but
+        # not nothing. Emptying it needs a C entry point that does not exist.
+        if _allocated_bytes() is None:
+            self.skipTest('the leak is in libstp\'s heap, and only the '
+                          'process allocator can see it; this one cannot '
+                          'be asked')
+
+        s = stp.Solver()
+        narrow = s.bitvec('narrow', 8)
+        wide = s.bitvec('wide', 128)
+        wide_value = (1 << 100) + 5
+        s.add(narrow == 3, wide == wide_value)
+        self.assertTrue(s.check())
+
+        # The leak costs 640 KiB over the first loop and 512 KiB over the
+        # second, so eight kibibytes is two orders of magnitude clear of it
+        # -- and clear the other way too, since a loop that releases what it
+        # takes drifts by nothing at all once its first few reads have
+        # populated the caches they touch.
+        budget = 8 << 10
+
+        for _ in range(2000):
+            narrow.value
+        before = _allocated_bytes()
+        for _ in range(20000):
+            narrow.value
+        self.assertEqual(narrow.value, 3)
+        self.assertLess(_allocated_bytes() - before, budget,
+                        'reading an 8-bit model value leaks')
+
+        for _ in range(1000):
+            wide.value
+        before = _allocated_bytes()
+        for _ in range(4000):
+            wide.value
+        self.assertEqual(wide.value, wide_value)
+        self.assertLess(_allocated_bytes() - before, budget,
+                        'reading a 128-bit model value leaks')
+
+    def test_a_boolean_literal_stays_in_boolean_sort(self):
+        # A Python bool is an int, so the literal coercion has to ask about
+        # bool before it asks about int, or True and False never reach their
+        # own arm: a Boolean expression compared against True asked for a
+        # bit-vector constant of width None and died three frames inside the
+        # binding. Comparing two Booleans then has to be IFF -- a Boolean has
+        # no bits for a bit-vector equality to compare, and libstp ends the
+        # process rather than answer for them.
+        s = self.s
+        a, b = s.bitvecs('a b', 8)
+        overflow = a.uaddo(b)
+        self.assertIsNone(overflow.width)
+
+        # An integer is not a Boolean, and now says so where a caller can
+        # hear it.
+        with self.assertRaises(TypeError):
+            overflow.eq(1)
+
+        # Neither do the two sorts mix, in either order.
+        with self.assertRaises(TypeError):
+            overflow.eq(a)
+        with self.assertRaises(TypeError):
+            a.eq(overflow)
+
+        # Every spelling of "this Boolean holds" builds a formula the solver
+        # accepts, and they all say the same thing.
+        for formula in (overflow == True, overflow.eq(True),
+                        overflow != False,
+                        s.and_(overflow, b.uaddo(a)) == True):
+            self.assertIsNone(formula.width)
+            s.add(formula)
+        self.assertTrue(s.check())
+        self.assertGreaterEqual(a.value + b.value, 1 << 8)
+
+        # ...and the same spellings can deny it, so this is not vacuous.
+        denied = stp.Solver()
+        x, y = denied.bitvecs('x y', 8)
+        denied.add(x.uaddo(y) == False, x == 200)
+        self.assertTrue(denied.check())
+        self.assertLess(x.value + y.value, 1 << 8)
+
+        # Against a bit-vector the historical shorthand is unchanged: True is
+        # one and False is zero.
+        shorthand = stp.Solver()
+        p, q = shorthand.bitvecs('p q', 8)
+        shorthand.add(p == True, q == False)
+        self.assertTrue(shorthand.check())
+        self.assertEqual(p.value, 1)
+        self.assertEqual(q.value, 0)
 
     def test_floating_point(self):
         #


### PR DESCRIPTION
Two independent defects in the Python bindings.

`Solver._counterexample_int` leaks. `vc_getCounterExample` returns a freshly `new`ed handle that the caller owns, and so does every `vc_bvExtract` used to slice a value wider than 64 bits, and none of them were released: 32 bytes per read at 64 bits or under, and 128 bytes per 128-bit read (two slices, each costing an extract and a counterexample). Polling a model in a loop -- which is what enumerating solutions looks like -- therefore grew the process for as long as it ran. Each of those handles is now released in a `finally`. The carrier is deliberately not: for a float `_bit_carrier` returns `vc_fpToIEEEBV`'s node, which `persistNode` has already put on the manager's own delete list, and passing it to `vc_DeleteExpr` would be a double free at `vc_Destroy`. `_bit_carrier`'s docstring now says so.

`Expr._toexpr` tests `isinstance(other, int)` before `isinstance(other, bool)`. In Python `bool` is a subclass of `int`, so a Boolean expression compared against `True` took the bit-vector arm and asked for a `bitvecval` of width `None`, which surfaced as a `ctypes.ArgumentError: argument 2: TypeError: 'NoneType' object cannot be interpreted as an integer` raised three frames inside the binding rather than as anything a caller could act on. The `bool` arm comes first now, and an ordinary integer against a Boolean raises `TypeError`.

Getting the literal into the right sort exposes the second half of the same problem: `Expr.eq` built the comparison with `vc_eqExpr`, whose generic `EQ` compares bit-vector carriers, and a Boolean has none -- `libstp` answers `Fatal Error: GetBVConst: non bitvector-constant` and ends the process. Two Booleans are compared with `vc_iffExpr` instead (already bound, and until now unused), and a Boolean against a bit-vector raises `TypeError` where it used to abort. So `p == True`, `p.eq(True)`, `p != False` and `s.and_(p, q) == True` all build a formula the solver accepts; against a bit-vector, `True` is still 1 and `False` still 0.

## Cost

Releasing a handle is a `vc_DeleteExpr` call across the FFI, one per handle taken, and that is not free: an 8-bit read goes from 2.8 us to 3.2 us and a 128-bit one from 9.2 us to 11.0 us, roughly a fifth slower either way (best of five timings of 20,000 and 5,000 reads, RelWithDebInfo, master against this branch). The number of calls into `libstp` per read is unchanged -- one `vc_getCounterExample` at 64 bits or under, two per 64-bit slice above that -- and nothing was added to the query path.

## What this does not fix

A float wider than binary64 has to be sliced through its IEEE bits, and `vc_fpToIEEEBV` registers its result with the manager. Reading such a value in a loop therefore still grows `STPMgr::persist` by one entry per read -- 44 bytes against master's 172, but not zero. There is no C entry point that un-registers a node, so closing that one needs a change on the C side; the test says as much where it measures only the bit-vector paths.

## Verification

`tests/api/python/tests.py.in` gains two tests, both of which fail against master in the full-file run that CI uses.

`test_model_reads_release_the_expressions_they_are_handed` measures `mallinfo2().uordblks`, the bytes glibc's allocator currently has handed out process-wide, rather than the resident set: a leak inside `libstp` is invisible to the interpreter, and invisible to RSS as well, because a heap that has been running for sixty tests holds enough free space to absorb megabytes of 32-byte leaks without faulting a single new page. Against master it reports **640,896 bytes** over 20,000 8-bit reads and **512,672** over 4,000 128-bit reads -- 32.04 and 128.17 a read -- against a budget of 8 KiB; here it reports **0** and **0**. Repeated runs reproduce master's figures to within a few hundred bytes and this branch's exactly. The test costs 0.2 s.

`test_a_boolean_literal_stays_in_boolean_sort` errors on master with the `ctypes.ArgumentError` above, and passes here.

**135/135** `ctest` in both RelWithDebInfo and Release+`-DWERROR=ON`, `python-interface-tests` included. No C++ is touched, so the WERROR leg compiles exactly what master does.
