### PR TITLE
Fold a distinct wider than its sort to false

### DIFF
--- a/lib/Parser/smt2.y
+++ b/lib/Parser/smt2.y
@@ -63,6 +63,7 @@
 
 #include <cctype>
 #include <cerrno>
+#include <cstdint>
 #include <cstdlib>
 #include <limits>
 #include <string>
@@ -342,6 +343,42 @@ namespace stp
       if (terms[i].GetSourceSort() != expected)
         fatal_yyerror(message);
     }
+  }
+
+  // (distinct t1 ... tn) is unsatisfiable as soon as n exceeds the number of
+  // values its operands' sort has: n terms cannot take n different values out
+  // of fewer than n. That is pigeonhole, and this parser expands distinct into
+  // C(n, 2) disequalities, so what would otherwise reach the solver is the
+  // binary-encoded form of it -- a shape whose cost to a CDCL search is out of
+  // all proportion to how it reads. Measured on this tree: sixteen operands
+  // over (_ BitVec 4) answer in 0.02s, seventeen take over seven minutes. The
+  // cliff is one operand wide, and n is already known here.
+  //
+  // Only a sort whose value count is exact is guarded, which here means Bool
+  // and the bit-vectors.
+  //
+  // FloatingPoint is deliberately left out. Its equality in these rules is
+  // FP_SMT_EQ, which identifies patterns the packed representation keeps apart
+  // (every NaN is one value), so the number of distinguishable values is below
+  // 2^width rather than equal to it; folding at n > 2^width would still be
+  // sound, merely weaker than it looks. RoundingMode is left out too, although
+  // its five values are exact: folding it would retire what
+  // fp-tests/array-rm-element-only-five-modes.smt2 exists to check, namely
+  // that a six-operand RoundingMode distinct comes out unsat through the
+  // solver. Arrays have no finite count worth computing.
+  bool distinctExceedsCardinality(const stp::SourceSort& sort, size_t operands)
+  {
+    typedef stp::SourceSort::Kind SortKind;
+    if (sort.kind() == SortKind::Bool)
+      return operands > 2;
+    if (sort.kind() != SortKind::BitVector)
+      return false;
+    const unsigned width = sort.bitVectorWidth();
+    // 2^64 operands cannot be written down, so a wide sort is never exceeded
+    // and the shift that would overflow is never taken.
+    if (width >= 64)
+      return false;
+    return static_cast<uint64_t>(operands) > (static_cast<uint64_t>(1) << width);
   }
 
   ASTNode* createNode(Kind k, ASTVec * c)
@@ -2386,29 +2423,40 @@ FORMID_TOK
 
   checkSameSourceSort(terms, "distinct requires operands of the same sort");
 
-  for(ASTVec::const_iterator it=terms.begin(),itend=terms.end();
-      it!=itend; it++)
+  // More operands than the sort has values: refuse the group here rather than
+  // hand the solver the C(n, 2) encoding of a pigeonhole it cannot search.
+  if (!terms.empty() &&
+      distinctExceedsCardinality(terms[0].GetSourceSort(), terms.size()))
   {
-    for(ASTVec::const_iterator it2=it+1; it2!=itend; it2++) {
-      // Equality of floats is FP_SMT_EQ, not the generic EQ -- the same
-      // distinction the (= ...) rule makes. Building plain EQ over float
-      // operands produces a node the later passes reject as a non-formula.
-      const Kind eqk =
-        ((*it).GetSourceSort().kind() ==
-         stp::SourceSort::Kind::FloatingPoint) ? FP_SMT_EQ : EQ;
-      ASTNode n =
-        stp::GlobalParserInterface->nf->CreateNode(NOT, stp::GlobalParserInterface->CreateNode(eqk, *it, *it2));
-
-      forms.push_back(n);
-    }
+    $$ = stp::GlobalParserInterface->newNode(
+        stp::GlobalParserInterface->CreateNode(FALSE));
   }
+  else
+  {
+    for(ASTVec::const_iterator it=terms.begin(),itend=terms.end();
+        it!=itend; it++)
+    {
+      for(ASTVec::const_iterator it2=it+1; it2!=itend; it2++) {
+        // Equality of floats is FP_SMT_EQ, not the generic EQ -- the same
+        // distinction the (= ...) rule makes. Building plain EQ over float
+        // operands produces a node the later passes reject as a non-formula.
+        const Kind eqk =
+          ((*it).GetSourceSort().kind() ==
+           stp::SourceSort::Kind::FloatingPoint) ? FP_SMT_EQ : EQ;
+        ASTNode n =
+          stp::GlobalParserInterface->nf->CreateNode(NOT, stp::GlobalParserInterface->CreateNode(eqk, *it, *it2));
 
-  if(forms.size() == 0)
-    fatal_yyerror("empty distinct");
+        forms.push_back(n);
+      }
+    }
 
-  $$ = (forms.size() == 1) ?
-    stp::GlobalParserInterface->newNode(forms[0]) :
-    stp::GlobalParserInterface->newNode(stp::GlobalParserInterface->CreateNode(AND, forms));
+    if(forms.size() == 0)
+      fatal_yyerror("empty distinct");
+
+    $$ = (forms.size() == 1) ?
+      stp::GlobalParserInterface->newNode(forms[0]) :
+      stp::GlobalParserInterface->newNode(stp::GlobalParserInterface->CreateNode(AND, forms));
+  }
 
   delete $3;
 }
@@ -2421,26 +2469,37 @@ FORMID_TOK
 
   checkSameSourceSort(terms, "distinct requires operands of the same sort");
 
-  for(ASTVec::const_iterator it=terms.begin(),itend=terms.end();
-      it!=itend; it++) {
-    for(ASTVec::const_iterator it2=it+1; it2!=itend; it2++) {
-      // Floats reach this (an_formulas) distinct rule too, since a
-      // floating-point function-id reduces as a formula. Their equality is
-      // FP_SMT_EQ, not IFF, which only holds between Booleans.
-      const Kind eqk =
-        ((*it).GetSourceSort().kind() ==
-         stp::SourceSort::Kind::FloatingPoint) ? FP_SMT_EQ : IFF;
-      ASTNode n = (stp::GlobalParserInterface->nf->CreateNode(NOT, stp::GlobalParserInterface->CreateNode(eqk, *it, *it2)));
-      forms.push_back(n);
-    }
+  // More operands than the sort has values: refuse the group here rather than
+  // hand the solver the C(n, 2) encoding of a pigeonhole it cannot search.
+  if (!terms.empty() &&
+      distinctExceedsCardinality(terms[0].GetSourceSort(), terms.size()))
+  {
+    $$ = stp::GlobalParserInterface->newNode(
+        stp::GlobalParserInterface->CreateNode(FALSE));
   }
+  else
+  {
+    for(ASTVec::const_iterator it=terms.begin(),itend=terms.end();
+        it!=itend; it++) {
+      for(ASTVec::const_iterator it2=it+1; it2!=itend; it2++) {
+        // Floats reach this (an_formulas) distinct rule too, since a
+        // floating-point function-id reduces as a formula. Their equality is
+        // FP_SMT_EQ, not IFF, which only holds between Booleans.
+        const Kind eqk =
+          ((*it).GetSourceSort().kind() ==
+           stp::SourceSort::Kind::FloatingPoint) ? FP_SMT_EQ : IFF;
+        ASTNode n = (stp::GlobalParserInterface->nf->CreateNode(NOT, stp::GlobalParserInterface->CreateNode(eqk, *it, *it2)));
+        forms.push_back(n);
+      }
+    }
 
-  if(forms.size() == 0)
-    fatal_yyerror("empty distinct");
+    if(forms.size() == 0)
+      fatal_yyerror("empty distinct");
 
-  $$ = (forms.size() == 1) ?
-    stp::GlobalParserInterface->newNode(forms[0]) :
-    stp::GlobalParserInterface->newNode(stp::GlobalParserInterface->CreateNode(AND, forms));
+    $$ = (forms.size() == 1) ?
+      stp::GlobalParserInterface->newNode(forms[0]) :
+      stp::GlobalParserInterface->newNode(stp::GlobalParserInterface->CreateNode(AND, forms));
+  }
 
   delete $3;
 }

--- a/tests/query-files/sample-smt-tests/arity1.smt2
+++ b/tests/query-files/sample-smt-tests/arity1.smt2
@@ -1,4 +1,15 @@
 ; RUN: %solver %s | %OutputCheck %s
+;
+; And the same query under --max-num-confl 0, a conflict budget no search can
+; spend. Expanded into its ten disequalities this group is binary-encoded
+; pigeonhole, which needs conflicts to refute, so a build that expands it
+; reports its timeout verdict instead of an answer. Refused where the operand
+; count is known, in the parser, it is the constant false and needs no search
+; at all -- which is what makes this a deterministic check rather than a timed
+; one, and why the directive below is the answer itself rather than the
+; absence of that verdict.
+;
+; RUN: %solver --max-num-confl 0 %s | %OutputCheck %s
 (set-info :smt-lib-version 2.6)
 (set-logic QF_BV)
 ; CHECK-NEXT: ^unsat

--- a/tests/query-files/smt2-command-tests/distinct-cardinality.smt2
+++ b/tests/query-files/smt2-command-tests/distinct-cardinality.smt2
@@ -1,0 +1,137 @@
+; (distinct t1 ... tn) over a sort with fewer than n values is unsatisfiable by
+; pigeonhole. The parser expands distinct into C(n, 2) disequalities, so what
+; would otherwise reach the solver is the binary-encoded form of it -- a shape
+; whose cost to a CDCL search is out of all proportion to how it reads:
+; sixteen operands over (_ BitVec 4) answer in 0.02s, seventeen take over seven
+; minutes. The count is checked where the sort is known instead, in the parser.
+;
+; Pinned here, at each sort the guard knows: exactly saturating stays
+; satisfiable and must not be folded, one more is refused, and a sort no
+; writable operand count can exceed is left alone. The saturating groups also
+; keep the pairwise reading of distinct honest, which is what arity1.smt2 was
+; written for -- four operands over (_ BitVec 2) plus (= c0 c2) is unsat only
+; if the expansion includes the non-adjacent pair.
+;
+; The refused side stops at the saturating count on purpose. A case that fails
+; only by taking seven minutes would turn a regression of the fold into a hung
+; CI job rather than a red one; sample-smt-tests/arity1.smt2 pins the refused
+; side deterministically instead, under --max-num-confl 0.
+;
+; RUN: %solver --SMTLIB2 --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --SMTLIB2 --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: ^sat
+; CHECK-NEXT: ^sat
+; CHECK-NEXT: ^unsat
+; CHECK-NEXT: ^unsat
+; CHECK-NEXT: ^sat
+; CHECK-NEXT: ^unsat
+; CHECK-NEXT: ^sat
+; CHECK-NEXT: ^unsat
+; CHECK-NEXT: ^unsat
+; CHECK-NEXT: ^sat
+; CHECK-NEXT: ^sat
+; CHECK: REACHED-END
+;
+(set-logic QF_BV)
+
+; sixteen values, sixteen operands: satisfiable, and it must not be folded.
+(push 1)
+(declare-const a0 (_ BitVec 4))
+(declare-const a1 (_ BitVec 4))
+(declare-const a2 (_ BitVec 4))
+(declare-const a3 (_ BitVec 4))
+(declare-const a4 (_ BitVec 4))
+(declare-const a5 (_ BitVec 4))
+(declare-const a6 (_ BitVec 4))
+(declare-const a7 (_ BitVec 4))
+(declare-const a8 (_ BitVec 4))
+(declare-const a9 (_ BitVec 4))
+(declare-const a10 (_ BitVec 4))
+(declare-const a11 (_ BitVec 4))
+(declare-const a12 (_ BitVec 4))
+(declare-const a13 (_ BitVec 4))
+(declare-const a14 (_ BitVec 4))
+(declare-const a15 (_ BitVec 4))
+(assert (distinct a0 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 a13 a14 a15))
+(check-sat)
+(pop 1)
+
+; four values, four operands: satisfiable, and still expanded pairwise -- the
+; equality below is between operands that are not adjacent in the group.
+(push 1)
+(declare-const c0 (_ BitVec 2))
+(declare-const c1 (_ BitVec 2))
+(declare-const c2 (_ BitVec 2))
+(declare-const c3 (_ BitVec 2))
+(assert (distinct c0 c1 c2 c3))
+(check-sat)
+(assert (= c0 c2))
+(check-sat)
+(pop 1)
+
+; one more than the sort holds: refused.
+(push 1)
+(declare-const d0 (_ BitVec 2))
+(declare-const d1 (_ BitVec 2))
+(declare-const d2 (_ BitVec 2))
+(declare-const d3 (_ BitVec 2))
+(declare-const d4 (_ BitVec 2))
+(assert (distinct d0 d1 d2 d3 d4))
+(check-sat)
+(pop 1)
+
+; two values, one bit down: two operands saturate it, three do not fit.
+(push 1)
+(declare-const b0 (_ BitVec 1))
+(declare-const b1 (_ BitVec 1))
+(assert (distinct b0 b1))
+(check-sat)
+(pop 1)
+(push 1)
+(declare-const b0 (_ BitVec 1))
+(declare-const b1 (_ BitVec 1))
+(declare-const b2 (_ BitVec 1))
+(assert (distinct b0 b1 b2))
+(check-sat)
+(pop 1)
+
+; Bool has two values, and reaches the other distinct rule.
+(push 1)
+(declare-const s Bool)
+(declare-const t Bool)
+(assert (distinct s t))
+(check-sat)
+(pop 1)
+(push 1)
+(declare-const p Bool)
+(declare-const q Bool)
+(declare-const r Bool)
+(assert (distinct p q r))
+(check-sat)
+(pop 1)
+
+; A width no writable operand count can exceed is left alone: this is
+; unsatisfiable for an ordinary reason, not by cardinality.
+(push 1)
+(declare-const w0 (_ BitVec 32))
+(declare-const w1 (_ BitVec 32))
+(assert (distinct w0 w1))
+(assert (= w0 w1))
+(check-sat)
+(pop 1)
+
+; At 64 bits and above the guard returns early rather than compute 1 << width,
+; which would be undefined. Both of these stay satisfiable.
+(push 1)
+(declare-const x0 (_ BitVec 64))
+(declare-const x1 (_ BitVec 64))
+(assert (distinct x0 x1))
+(check-sat)
+(pop 1)
+(push 1)
+(declare-const y0 (_ BitVec 128))
+(declare-const y1 (_ BitVec 128))
+(assert (distinct y0 y1))
+(check-sat)
+(pop 1)
+(echo "REACHED-END")


### PR DESCRIPTION
`(distinct t1 ... tn)` over a sort with fewer than `n` values is unsatisfiable by pigeonhole. The parser expands `distinct` into `C(n, 2)` disequalities, so what reached the solver was the binary-encoded form of that pigeonhole — a shape whose cost to a CDCL search is out of all proportion to how the query reads. Sixteen operands over `(_ BitVec 4)` answer in **0.02s** and seventeen take **over seven minutes**; the cliff is one operand wide.

The count is now checked where the sort is known, in the parser, and a group with more operands than its sort has values becomes `false` without ever being expanded. Both `distinct` rules are guarded, since `Bool` operands reach the `an_formulas` one; eight hundred `Bool` operands under one `distinct` go from **1.04s to under 0.01s**.

Three sorts are deliberately left unfolded. `FloatingPoint`, because its equality in these rules is `FP_SMT_EQ`, which identifies patterns the packed representation keeps apart — every NaN is one value — so `2^width` is an over-count rather than the count; folding there would still be sound, merely weaker than it looks. `RoundingMode`, whose five values *are* exact, because `fp-tests/array-rm-element-only-five-modes.smt2` exists to check that a six-mode `distinct` comes out `unsat` through the solver, and folding it in the parser would retire that test. And arrays, which have no finite count worth computing. A width of 64 or more returns early rather than compute `1 << width`, which would be undefined; that many operands cannot be written down, so nothing is given up.

`sample-smt-tests/arity1.smt2` is five operands over `(_ BitVec 2)` — the regression test for #330, and exactly the shape this folds. Left alone it would go on printing `unsat` while asserting nothing, so it gains a second RUN line under `--max-num-confl 0`, a conflict budget no search can spend: that run reports a timeout instead of an answer on master (`Timed Out.`, as STP spells it today) and answers `unsat` without searching here. The one line is both the deterministic check on the refusal and the file's replacement job.

`smt2-command-tests/distinct-cardinality.smt2` pins the boundary from the other side, at every sort the guard knows: exactly saturating stays satisfiable and must not be folded, one more is refused, `Bool` is refused at three, a width no writable operand count can exceed is left alone — that block is `unsat`, but for an ordinary reason, since it also asserts `(= w0 w1)` — and 64 and 128 bits take the early return. Four operands over `(_ BitVec 2)` plus an equality between two that are not adjacent in the group keeps the pairwise reading of `distinct` honest, which is what arity1 was written for.

## Verification

`sample-smt-tests/arity1.smt2` **fails on master**, in both build types and on both lit sweeps `ctest` registers (`query-files` and `query-files-cadical-factor-off`).

`distinct-cardinality.smt2` is a regression pin rather than a discriminator: master answers it identically, in 0.04s. What it catches is the guard going wrong — changing `>` to `>=` folds the saturating cases and it fails; deleting the `width >= 64` early return makes `1 << 64` fold two 64-bit operands and it fails. Both mutations were built and run. It stops at the saturating count on purpose: a case that failed only by taking seven minutes would turn a regression of the fold into a hung CI job rather than a red one, and the refused side is pinned deterministically by arity1 instead.

**135/135** `ctest`, in RelWithDebInfo and again in Release with `WERROR=ON`. The count is unchanged from master by design: both fixtures live inside the pre-existing `query-files` lit sweep rather than registering `ctest` entries of their own.

Two things worth a maintainer's opinion. The fold can only ever engage for `Bool` and for genuinely narrow sorts, because the operands have to be physically written in the file; it does nothing about the quadratic `C(n, 2)` blow-up for large-but-fitting groups, and no corpus evidence is offered that a real benchmark hits it. And the `Bool` arm is a speed-only change that no test can distinguish: master already refutes a `Bool` `distinct` quickly, so deleting that arm leaves the whole lit sweep green — its bound is pinned, since `(distinct s t)` must stay `sat`, but its presence is not.

Two smaller notes. The SMT-LIB1 parser (`lib/Parser/smt.y`) still expands `distinct` unguarded; it has no `SourceSort` to ask, so the guard has nothing to stand on there. And this touches the same lines of the `an_terms` rule as the distinct-ordering change, so whichever of the two lands second will conflict — the resolution is that the group recording belongs inside this guard's `else`, because a refused `distinct` has no group left to order.
