### PR TITLE
Order a distinct whose operands occur nowhere else

### DIFF
--- a/include/stp/STPManager/STPManager.h
+++ b/include/stp/STPManager/STPManager.h
@@ -56,6 +56,16 @@ enum class FPSpecial
   MinusZero,
 };
 
+// One (distinct t1 ... tn) as the parser saw it, before it was dissolved into
+// pairwise disequalities: the operands in source order, and the node the
+// dissolution produced. Declared here rather than beside the pass that reads
+// it, so that a core header does not have to include a Simplifier one.
+struct DLL_PUBLIC DistinctGroup
+{
+  ASTVec operands;
+  ASTNode emitted;
+};
+
 /*
  * STP Node Manager. Tools for managing AST nodes.
  */
@@ -111,6 +121,12 @@ private:
 public:
   HashingNodeFactory* hashingNodeFactory;
   NodeFactory* defaultNodeFactory;
+
+  // (distinct ...) groups as the parser saw them, before it dissolved each
+  // into pairwise disequalities. Kept so a later pass can ask whether the
+  // operands are symmetric and, if they are, state an order instead. Cleared
+  // whenever the assertion stack is.
+  std::vector<DistinctGroup> distinctGroups;
 
   // State of the array-equality (extensional arrays) decision procedure:
   // solve-local equality records, the complete per-solve array graph, and

--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -181,6 +181,16 @@ public:
   // ARRAY_EQ, which is lowered only after the complete query is assembled.
   bool enable_array_equality = false;
 
+  // Replace a (distinct x1 ... xn) whose operands are variables occurring
+  // nowhere else with the strict chain x1 < x2 < ... < xn. Every permutation
+  // of such operands maps the formula to itself, so fixing one of the n!
+  // orderings loses no answer, and n-1 comparisons replace n(n-1)/2
+  // disequalities that a bit-blaster would otherwise have to order for
+  // itself. Batch pipeline only: the guard is re-checked against each
+  // solve's own formula, so a later assert that mentions an operand simply
+  // stops the rewrite from applying on the next solve.
+  bool distinct_ordering = true;
+
   // construct the counterexample in terms of original variable based
   // on the counterexample returned by SAT solver
   bool print_counterexample_flag = false;
@@ -391,6 +401,7 @@ public:
     enable_pair_extract = false;
     enable_common_subsum = false;
     enable_ite_context = false;
+    distinct_ordering = false;
 
     simple_cnf=true;
   }

--- a/include/stp/Simplifier/DistinctOrdering.h
+++ b/include/stp/Simplifier/DistinctOrdering.h
@@ -1,0 +1,64 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+// Replace a fully symmetric distinct with a strict chain.
+
+#ifndef STP_DISTINCTORDERING_H
+#define STP_DISTINCTORDERING_H
+
+#include "stp/AST/AST.h"
+#include <vector>
+
+namespace stp
+{
+
+class STPMgr;
+struct DistinctGroup;
+
+// If the operands of a recorded distinct (see STPMgr::distinctGroups) are
+// variables that occur nowhere else, every permutation of them maps the
+// formula to itself, so requiring them to be strictly increasing loses no
+// models up to that symmetry -- and n-1 comparisons replace n(n-1)/2
+// disequalities.
+//
+// The gain is not marginal. Three hundred unconstrained 32-bit variables
+// under one distinct take 172s pairwise and 0.2s chained (RelWithDebInfo,
+// CaDiCaL), because the pairwise form asks a bit-blaster to discover an
+// ordering that the chain simply states.
+//
+// Returns `root` unchanged unless it rewrote something, and reports through
+// `ordered` how many groups it took. Sound in the direction that matters
+// unconditionally: the chain implies the distinct, so every model of the
+// result is a model of `root` and published models never need qualifying --
+// which is also why only positive occurrences are taken. The converse -- that
+// rewriting cannot turn satisfiable into unsatisfiable -- is what the
+// occurrence guard buys, and it is checked against `root` itself rather than
+// assumed from the parse.
+ASTNode applyDistinctOrdering(STPMgr* manager, const ASTNode& root,
+                              const std::vector<DistinctGroup>& groups,
+                              size_t* ordered = NULL);
+
+} // namespace stp
+
+#endif

--- a/lib/Interface/cpp_interface.cpp
+++ b/lib/Interface/cpp_interface.cpp
@@ -545,6 +545,13 @@ void Cpp_interface::reset()
   discardExtensionalitySolveState();
   resetIncrementalSolver();
 
+  // Recorded distinct groups name nodes from assertions that no longer
+  // exist. The ordering pass ignores a group its walk cannot reach, so
+  // keeping them would be harmless; dropping them keeps a long session's
+  // registry proportional to what is asserted rather than to what has ever
+  // been asserted.
+  bm.distinctGroups.clear();
+
   cleanUp();
 
   checkInvariant();
@@ -589,6 +596,7 @@ void Cpp_interface::resetAssertions()
   if (!global_declarations)
     removeFrame();
   cache.clear();
+  bm.distinctGroups.clear();
 
   // These tables may retain the discarded assertions or declarations.
   resetSolver();

--- a/lib/Parser/smt2.y
+++ b/lib/Parser/smt2.y
@@ -2472,6 +2472,18 @@ FORMID_TOK
     $$ = (forms.size() == 1) ?
       stp::GlobalParserInterface->newNode(forms[0]) :
       stp::GlobalParserInterface->newNode(stp::GlobalParserInterface->CreateNode(AND, forms));
+    // Remember the group. Dissolving distinct here loses the fact that its
+    // operands are interchangeable, and a later pass cannot recover it from a
+    // clique of disequalities; recording it costs a vector and commits to
+    // nothing, since that pass re-checks the symmetry against the real formula.
+    // A distinct the cardinality guard refused never reaches here: it has no
+    // operands left to order.
+    {
+      stp::DistinctGroup group;
+      group.operands = terms;
+      group.emitted = *$$;
+      stp::GlobalParserBM->distinctGroups.push_back(group);
+    }
   }
 
   delete $3;

--- a/lib/STPManager/STP.cpp
+++ b/lib/STPManager/STP.cpp
@@ -35,6 +35,7 @@ THE SOFTWARE.
 
 #include "stp/Simplifier/AIGSimplifyPropositionalCore.h"
 #include "stp/Simplifier/DifficultyScore.h"
+#include "stp/Simplifier/DistinctOrdering.h"
 #include "stp/Simplifier/FindPureLiterals.h"
 #include "stp/Simplifier/RemoveUnconstrained.h"
 #include "stp/Simplifier/UnsignedIntervalAnalysis.h"
@@ -128,6 +129,21 @@ SOLVER_RETURN_TYPE STP::TopLevelSTP(const ASTNode& inputasserts,
   else
   {
     original_input = inputasserts;
+  }
+
+  // Order fully symmetric distincts before anything else looks at the
+  // formula. It runs here, on this solve's own assembled root, rather than
+  // in the parser: only the whole formula shows whether the operands really
+  // do occur nowhere else, and re-deciding it per solve is what keeps a
+  // later assert from inheriting an ordering it never earned.
+  if (bm->UserFlags.distinct_ordering && !bm->distinctGroups.empty())
+  {
+    size_t ordered = 0;
+    original_input = applyDistinctOrdering(bm, original_input,
+                                           bm->distinctGroups, &ordered);
+    if (ordered > 0 && bm->UserFlags.stats_flag)
+      std::cerr << "Ordered " << ordered << " symmetric distinct group(s)."
+                << std::endl;
   }
 
   // The latch is the same kind of cheap fast-negative the lowering test below

--- a/lib/STPManager/STPManager.cpp
+++ b/lib/STPManager/STPManager.cpp
@@ -919,6 +919,12 @@ STPMgr::~STPMgr()
   if (NULL != CreateBVConstVal)
     CONSTANTBV::BitVector_Destroy(CreateBVConstVal);
 
+  // Released here, in the body, for the same reason as every other member
+  // above: destroying a node reaches back into this manager (ASTSymbol::CleanUp
+  // unindexes its name, ASTInterior::CleanUp erases from the interior table),
+  // and the implicit member-destruction phase runs after those tables are gone.
+  distinctGroups.clear();
+
   Introduced_SymbolsSet.clear();
   _symbol_unique_table.clear();
   _symbol_name_index.clear();

--- a/lib/Simplifier/CMakeLists.txt
+++ b/lib/Simplifier/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(simplifier OBJECT
     BVSolver.cpp
     consteval.cpp
     PropagateEqualities.cpp
+    DistinctOrdering.cpp
     RemoveUnconstrained.cpp
     Simplifier.cpp
     SubstitutionMap.cpp

--- a/lib/Simplifier/DistinctOrdering.cpp
+++ b/lib/Simplifier/DistinctOrdering.cpp
@@ -1,0 +1,257 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#include "stp/Simplifier/DistinctOrdering.h"
+#include "stp/STPManager/STPManager.h"
+#include "stp/Util/DagWalk.h"
+#include <set>
+
+namespace stp
+{
+
+namespace
+{
+
+const unsigned POSITIVE = 1;
+const unsigned NEGATIVE = 2;
+
+unsigned flipped(const unsigned polarity)
+{
+  unsigned result = 0;
+  if ((polarity & POSITIVE) != 0)
+    result |= NEGATIVE;
+  if ((polarity & NEGATIVE) != 0)
+    result |= POSITIVE;
+  return result;
+}
+
+// A node under XOR, boolean EQ, or an ITE condition is used both ways at
+// once, and so is everything beneath it.
+//
+// IMPLIES is here for safety rather than because it is reached: the node
+// factory rewrites (=> x y) to (or (not x) y) before this pass sees the
+// formula, so a distinct in either position arrives with its polarity already
+// spelled out. The entry costs nothing and keeps the list honest about which
+// kinds mix polarity, so a factory that stopped rewriting implications would
+// not silently make this walk wrong.
+bool usedBothWays(const Kind kind)
+{
+  return kind == XOR || kind == IFF || kind == EQ || kind == ITE ||
+         kind == IMPLIES;
+}
+
+// One walk answering both questions the guard asks. It records the polarity
+// each candidate group's emitted node is reached at, and -- descending
+// through everything *except* those nodes -- the SYMBOLs that occur outside
+// them. A node reached at both polarities is expanded once per polarity,
+// which is what makes the record exact rather than merely conservative.
+void surveyOutside(const ASTNode& root, const ASTNodeSet& opaque,
+                   ASTNodeSet& symbols, ASTNodeCountMap& opaquePolarity)
+{
+  ASTNodeCountMap seen;
+  std::vector<std::pair<ASTNode, unsigned>> pending;
+  pending.push_back(std::make_pair(root, POSITIVE));
+  while (!pending.empty())
+  {
+    const ASTNode current = pending.back().first;
+    const unsigned polarity = pending.back().second;
+    pending.pop_back();
+
+    int32_t& already = seen[current];
+    if ((already & (int32_t)polarity) == (int32_t)polarity)
+      continue;
+    already |= (int32_t)polarity;
+
+    if (opaque.count(current) != 0)
+    {
+      opaquePolarity[current] |= (int32_t)polarity;
+      continue;
+    }
+    if (current.GetKind() == SYMBOL)
+    {
+      symbols.insert(current);
+      continue;
+    }
+
+    const Kind kind = current.GetKind();
+    const unsigned childPolarity =
+        usedBothWays(kind) ? (POSITIVE | NEGATIVE)
+                           : (kind == NOT ? flipped(polarity) : polarity);
+    for (size_t i = 0; i < current.Degree(); ++i)
+      pending.push_back(std::make_pair(current[i], childPolarity));
+  }
+}
+
+// Whether a group is even the shape this pass orders: at least three operands
+// (two are already one disequality, so there is nothing to gain and the guard
+// would only add risk), every operand a distinct bit-vector SYMBOL of the same
+// width.
+//
+// This runs before the occurrence walk, and decides what that walk treats as
+// opaque, which is why it has to be exactly this test. Descent stops at a
+// candidate's node, so the only symbols that node can conceal are its own
+// operands -- and those are compared name by name afterwards. A group with a
+// compound operand would conceal symbols that no later comparison names, so it
+// is not made opaque at all and the walk goes straight through it.
+bool candidate(const DistinctGroup& group)
+{
+  if (group.operands.size() < 3 || group.emitted.IsNull())
+    return false;
+  std::set<ASTNode> seen;
+  unsigned width = 0;
+  for (const ASTNode& operand : group.operands)
+  {
+    if (operand.GetKind() != SYMBOL || operand.GetType() != BITVECTOR_TYPE ||
+        operand.GetIndexWidth() != 0)
+      return false;
+    // A sort whose equality is not bit equality would make the order mean
+    // something else; only plain bit-vectors are ordered here.
+    if (operand.GetSourceSort().kind() != SourceSort::Kind::BitVector)
+      return false;
+    if (width == 0)
+      width = operand.GetValueWidth();
+    else if (operand.GetValueWidth() != width)
+      return false;
+    if (!seen.insert(operand).second)
+      return false; // a repeated operand makes the distinct false, not
+                    // symmetric; leave it to the ordinary path
+  }
+  return width != 0;
+}
+
+ASTNode chainFor(STPMgr* manager, const ASTVec& operands)
+{
+  ASTVec conjuncts;
+  conjuncts.reserve(operands.size() - 1);
+  for (size_t i = 0; i + 1 < operands.size(); ++i)
+    conjuncts.push_back(manager->defaultNodeFactory->CreateNode(
+        BVLT, operands[i], operands[i + 1]));
+  return conjuncts.size() == 1
+             ? conjuncts[0]
+             : manager->defaultNodeFactory->CreateNode(AND, conjuncts);
+}
+
+} // namespace
+
+ASTNode applyDistinctOrdering(STPMgr* manager, const ASTNode& root,
+                              const std::vector<DistinctGroup>& groups,
+                              size_t* ordered)
+{
+  if (groups.empty() || root.IsNull() || root.GetType() != BOOLEAN_TYPE)
+    return root;
+
+  // Each group is judged against the root with every candidate group held
+  // opaque, not just its own. Two groups sharing an operand would otherwise
+  // each conclude the operand is theirs alone, and ordering both would be
+  // two symmetry claims that are only valid one at a time.
+  std::vector<const DistinctGroup*> candidates;
+  ASTNodeSet opaque;
+  for (const DistinctGroup& group : groups)
+    if (candidate(group))
+    {
+      candidates.push_back(&group);
+      opaque.insert(group.emitted);
+    }
+  if (candidates.empty())
+    return root;
+
+  ASTNodeSet outside;
+  ASTNodeCountMap polarity;
+  surveyOutside(root, opaque, outside, polarity);
+
+  // The registry spans a whole session, so most of it is usually about some
+  // other query. A group whose node the walk never reached is not part of
+  // this formula and must not constrain what this formula may do -- in
+  // particular it must not be counted as an overlap. Duplicate registrations
+  // of one node -- the same distinct parsed twice -- are one group, or every
+  // operand would look shared with itself.
+  std::vector<const DistinctGroup*> reached;
+  ASTNodeCountMap owners;
+  ASTNodeSet counted;
+  for (const DistinctGroup* candidatePtr : candidates)
+  {
+    if (polarity.find(candidatePtr->emitted) == polarity.end())
+      continue;
+    if (!counted.insert(candidatePtr->emitted).second)
+      continue;
+    reached.push_back(candidatePtr);
+    for (const ASTNode& operand : candidatePtr->operands)
+      owners[operand] += 1;
+  }
+
+  ASTNodeMap replacements;
+  for (const DistinctGroup* groupPtr : reached)
+  {
+    const DistinctGroup& group = *groupPtr;
+    // Positive occurrences only. The chain is strictly stronger than the
+    // clique, so under a negation it would be strictly weaker, and while
+    // that stays equisatisfiable under this same occurrence guard it stops
+    // the reported model from being a model of the input -- which is a
+    // price this pass is not entitled to charge.
+    if (polarity.find(group.emitted)->second != (int32_t)POSITIVE)
+      continue;
+    // An operand this group's own node conceals must still be its own: if it
+    // occurs anywhere outside, the walk saw it; if it occurs inside another
+    // candidate's node, only this count can see it.
+    bool escapes = false;
+    for (const ASTNode& operand : group.operands)
+      escapes = escapes || outside.count(operand) != 0 || owners[operand] > 1;
+    if (escapes)
+      continue;
+    replacements.insert(
+        std::make_pair(group.emitted, chainFor(manager, group.operands)));
+  }
+  if (ordered != NULL)
+    *ordered = replacements.size();
+  if (replacements.empty())
+    return root;
+
+  DenseNodeMap rewritten;
+  return postOrderRebuild(
+      root, rewritten,
+      [&](const ASTNode& node, const ASTVec& children) -> ASTNode
+      {
+        const ASTNodeMap::const_iterator found = replacements.find(node);
+        if (found != replacements.end())
+          return found->second;
+        bool changed = false;
+        for (size_t i = 0; i < children.size() && !changed; ++i)
+          changed = children[i] != node[i];
+        if (!changed)
+          return node;
+        if (node.GetType() == BOOLEAN_TYPE)
+          return manager->defaultNodeFactory->CreateNode(node.GetKind(),
+                                                         children);
+        // A replacement is a formula, and the one place a formula sits under
+        // a term is an if-then-else condition -- which this pass reads as
+        // both polarities and therefore never rewrites. So no term should
+        // reach here; rebuilding it correctly costs a line and means the
+        // rebuild does not quietly depend on that argument staying true.
+        return manager->defaultNodeFactory->CreateArrayTerm(
+            node.GetKind(), node.GetIndexWidth(), node.GetValueWidth(),
+            children);
+      });
+}
+
+} // namespace stp

--- a/tests/query-files/incremental-tests/distinct-ordering-batch-only.smt2
+++ b/tests/query-files/incremental-tests/distinct-ordering-batch-only.smt2
@@ -1,0 +1,53 @@
+; The ordering rewrite does not reach the persistent driver, and must not.
+;
+; Batch rebuilds the formula from the stored assertions at every solve, so the
+; guard is re-decided each time and an assertion arriving after one check-sat
+; simply stops the rewrite applying at the next. The driver's clauses are
+; persistent: a chain encoded into a block would stay in force when a later
+; assertion destroyed the symmetry that justified it, and there is no round
+; at which that could be noticed. The containment is structural -- the driver
+; has its own path and never enters the batch pipeline -- and this pins it,
+; because it is the kind of separation a refactor removes by accident.
+;
+; The middle solve is where a leak would be a wrong answer rather than a
+; missing stats line: a is compared there, so an inherited a < b < c would
+; contradict a > b and report unsat, and the answer is sat. The last solve
+; pops that comparison away and asserts something unrelated instead, and the
+; group is orderable again -- the decision is per solve, in both directions.
+;
+; RUN: %solver -s --incremental=off %s 2>&1 | %OutputCheck --check-prefix=BATCH %s
+; RUN: %solver -s --incremental=on %s 2>&1 | %OutputCheck --check-prefix=DRIVER %s
+;
+; BATCH: Ordered 1 symmetric distinct group\(s\)
+; BATCH: ^sat
+; BATCH: SYMMETRIC-DONE
+; BATCH-NOT: Ordered
+; BATCH: ^sat
+; BATCH: COMPARED-DONE
+; BATCH: Ordered 1 symmetric distinct group\(s\)
+; BATCH: ^sat
+;
+; DRIVER-NOT: Ordered
+; DRIVER: ^sat
+; DRIVER: SYMMETRIC-DONE
+; DRIVER-NOT: Ordered
+; DRIVER: ^sat
+; DRIVER: COMPARED-DONE
+; DRIVER-NOT: Ordered
+; DRIVER: ^sat
+;
+(set-logic QF_BV)
+(declare-const a (_ BitVec 8))
+(declare-const b (_ BitVec 8))
+(declare-const c (_ BitVec 8))
+(declare-const keep (_ BitVec 8))
+(assert (distinct a b c))
+(check-sat)
+(echo "SYMMETRIC-DONE")
+(push 1)
+(assert (bvugt a b))
+(check-sat)
+(echo "COMPARED-DONE")
+(pop 1)
+(assert (bvult keep #x10))
+(check-sat)

--- a/tests/query-files/smt2-command-tests/distinct-ordering-boundaries.smt2
+++ b/tests/query-files/smt2-command-tests/distinct-ordering-boundaries.smt2
@@ -1,0 +1,75 @@
+; The cases at the edge of the ordering rewrite's guard.
+;
+; Two groups sharing an operand are each symmetric on their own and not
+; symmetric together: ordering both would fix a < b < c and c < b < d at once,
+; which no assignment satisfies, so a query that is plainly sat would come back
+; unsat. Neither is taken -- the operand belongs to neither group exclusively.
+;
+; A repeated operand makes the distinct false, not symmetric. That block is
+; pinned by the absence of the stats line rather than by its answer: unsat is
+; correct, and a < b < a would be unsat too, so only the CHECK-NOT says the
+; candidate test rejected it instead of ordering it by accident.
+;
+; Two independent groups over disjoint operands are both taken, which is what
+; says the overlap rule rejects sharing rather than plurality.
+;
+; The last block is the one the overlap rule cannot decide. p occurs nowhere
+; but inside two distincts, and the second has a compound operand, so p is not
+; among the names that rule compares -- it has to be found by descending into
+; that distinct instead. Only the group that really is isolated is ordered.
+;
+; RUN: %solver -s --incremental=off %s 2>&1 | %OutputCheck %s
+; CHECK-NOT: Ordered
+; CHECK: ^sat
+; CHECK: OVERLAP-DONE
+; CHECK-NOT: Ordered
+; CHECK: ^unsat
+; CHECK: REPEAT-DONE
+; CHECK: Ordered 2 symmetric distinct group\(s\)
+; CHECK: ^sat
+; CHECK: PLURAL-DONE
+; CHECK: Ordered 1 symmetric distinct group\(s\)
+; CHECK: ^sat
+;
+(set-logic QF_BV)
+(declare-const a (_ BitVec 8))
+(declare-const b (_ BitVec 8))
+(declare-const c (_ BitVec 8))
+(declare-const d (_ BitVec 8))
+(assert (distinct a b c))
+(assert (distinct c b d))
+(check-sat)
+(echo "OVERLAP-DONE")
+(reset)
+(set-logic QF_BV)
+(declare-const a (_ BitVec 8))
+(declare-const b (_ BitVec 8))
+(assert (distinct a b a))
+(check-sat)
+(echo "REPEAT-DONE")
+(reset)
+(set-logic QF_BV)
+(declare-const a (_ BitVec 8))
+(declare-const b (_ BitVec 8))
+(declare-const c (_ BitVec 8))
+(declare-const p (_ BitVec 8))
+(declare-const q (_ BitVec 8))
+(declare-const r (_ BitVec 8))
+(assert (distinct a b c))
+(assert (distinct p q r))
+(check-sat)
+(echo "PLURAL-DONE")
+(reset)
+(set-logic QF_BV)
+(declare-const p (_ BitVec 8))
+(declare-const q (_ BitVec 8))
+(declare-const r (_ BitVec 8))
+(declare-const x (_ BitVec 8))
+(declare-const y (_ BitVec 8))
+(declare-const u (_ BitVec 8))
+(declare-const v (_ BitVec 8))
+(declare-const w (_ BitVec 8))
+(assert (distinct p q r))
+(assert (distinct (bvadd p #x01) x y))
+(assert (distinct u v w))
+(check-sat)

--- a/tests/query-files/smt2-command-tests/distinct-ordering.smt2
+++ b/tests/query-files/smt2-command-tests/distinct-ordering.smt2
@@ -1,0 +1,78 @@
+; A distinct whose operands are variables occurring nowhere else is ordered.
+;
+; Every permutation of such operands maps the formula to itself, so requiring
+; them to increase discards n!-1 copies of each answer and keeps one. What is
+; left is n-1 comparisons in place of n(n-1)/2 disequalities, and, more to the
+; point, an ordering the bit-blaster is told rather than made to find: three
+; hundred unconstrained 32-bit variables under one distinct are decided in
+; 0.2 seconds rather than 172 (RelWithDebInfo, CaDiCaL).
+;
+; The four blocks are the guard's decision, not four shapes of the same case.
+; Only the first is symmetric. In the second, b is compared outside the
+; distinct, so the operands are no longer interchangeable and imposing
+; a < b < c would contradict b < a -- reporting unsat where the answer is sat.
+; In the third the distinct is negated, where the chain is the weaker claim,
+; so a model of the rewritten formula need not be a model of the input; the
+; rewrite declines rather than publish a model it cannot stand behind. That
+; block is pinned by the absence of the stats line alone: negated or not, the
+; answer is sat either way.
+;
+; The fourth block is the model. Four two-bit variables have exactly one
+; increasing assignment, so the chain names it outright, which is both what
+; makes the values worth checking -- they are a model of the unrewritten
+; distinct, all four differing -- and a reminder that the shape of a published
+; model is now canonical where it used to be any of the 24 permutations.
+;
+; RUN: %solver -s --incremental=off %s 2>&1 | %OutputCheck %s
+; CHECK: Ordered 1 symmetric distinct group\(s\)
+; CHECK: ^sat
+; CHECK: SYMMETRIC-DONE
+; CHECK-NOT: Ordered
+; CHECK: ^sat
+; CHECK: LEAKED-DONE
+; CHECK-NOT: Ordered
+; CHECK: ^sat
+; CHECK: NEGATED-DONE
+; CHECK: Ordered 1 symmetric distinct group\(s\)
+; CHECK: ^sat
+; CHECK: \|a\| +#b00
+; CHECK: \|b\| +#b01
+; CHECK: \|c\| +#b10
+; CHECK: \|d\| +#b11
+;
+(set-logic QF_BV)
+(declare-const a (_ BitVec 8))
+(declare-const b (_ BitVec 8))
+(declare-const c (_ BitVec 8))
+(declare-const keep (_ BitVec 8))
+(assert (distinct a b c))
+(assert (bvult keep #x10))
+(check-sat)
+(echo "SYMMETRIC-DONE")
+(reset)
+(set-logic QF_BV)
+(declare-const a (_ BitVec 8))
+(declare-const b (_ BitVec 8))
+(declare-const c (_ BitVec 8))
+(assert (distinct a b c))
+(assert (bvult b a))
+(check-sat)
+(echo "LEAKED-DONE")
+(reset)
+(set-logic QF_BV)
+(declare-const a (_ BitVec 8))
+(declare-const b (_ BitVec 8))
+(declare-const c (_ BitVec 8))
+(assert (not (distinct a b c)))
+(check-sat)
+(echo "NEGATED-DONE")
+(reset)
+(set-logic QF_BV)
+(set-option :produce-models true)
+(declare-const a (_ BitVec 2))
+(declare-const b (_ BitVec 2))
+(declare-const c (_ BitVec 2))
+(declare-const d (_ BitVec 2))
+(assert (distinct a b c d))
+(check-sat)
+(get-value (a b c d))

--- a/tests/unit-tests/UserDefinedFlags_Test.cpp
+++ b/tests/unit-tests/UserDefinedFlags_Test.cpp
@@ -32,6 +32,17 @@ TEST(UserDefinedFlags_Test, disable_simplifications_clears_flattening_stack)
   EXPECT_FALSE(uf.enable_pair_extract);
 }
 
+// A rewrite that defaults on has to be reachable by the same escape hatch as
+// the rest: --disable-simplifications is how a wrong answer gets bisected down
+// to a minimal pipeline, and a rewrite that survives it is never bisected out.
+TEST(UserDefinedFlags_Test, disable_simplifications_clears_distinct_ordering)
+{
+  stp::UserDefinedFlags uf;
+  EXPECT_TRUE(uf.distinct_ordering);
+  uf.disableSimplifications();
+  EXPECT_FALSE(uf.distinct_ordering);
+}
+
 TEST(UserDefinedFlags_Test, caller_model_request_is_derived_from_source_flags)
 {
   stp::UserDefinedFlags uf;

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -236,6 +236,13 @@ void ExtraMain::create_options()
            "problem simpler",
            simp_group);
 
+  bool_arg("--distinct-ordering", bm->UserFlags.distinct_ordering,
+           "replace a (distinct ...) over variables that occur nowhere else "
+           "with a strict chain, which fixes one of the n! equivalent "
+           "orderings the bit-blaster would otherwise search. Batch pipeline "
+           "only; --incremental=on never applies it",
+           simp_group);
+
   const char* const solver_group = "SAT Solver options";
 
 #ifdef USE_CADICAL
@@ -304,7 +311,6 @@ void ExtraMain::create_options()
                "decide whole-array equality/disequality (extensional arrays) "
                "by lemmas on demand")
       ->group(refinement_group);
-
   const char* const bb_group = "Bit-blasting options";
   bool_arg("--bb.div-v1", bm->UserFlags.division_variant_1,
            "unsigned division encoding variant 1", bb_group);
@@ -631,7 +637,7 @@ void ExtraMain::create_options()
                 "--flattening", "--rewriting", "--split-extracts",
                 "--ite-context-simplifications", "--use-intervals",
                 "--pure-literals", "--common-subsum", "--pair-extract",
-                "--merge-same"});
+                "--merge-same", "--distinct-ordering"});
 
   // Likewise for what disableSizeIncreasingSimplifications() forces.
   excludes_all("--size-reducing-only",


### PR DESCRIPTION
A `(distinct x1 ... xn)` over variables that appear in no other assertion is invariant under every permutation of those variables, so of the `n!` assignments that differ only by which variable got which value, `n!-1` are copies. The solver searches them all.

Requiring `x1 < x2 < ... < xn` keeps one copy of every answer and replaces `n(n-1)/2` disequalities with `n-1` comparisons — and, more to the point, states an ordering the bit-blaster would otherwise have to find. Three hundred unconstrained 32-bit variables under one distinct go from **172s to 0.2s** (RelWithDebInfo, CaDiCaL, this machine). That is the only measurement quoted anywhere in the branch: the header comment, the fixture comment and the commit message all give the same pair of numbers and the same build.

The parser records each group before it dissolves it, because a clique of disequalities does not say which variables were interchangeable and nothing downstream can recover it. The record is manager state, so the two-field `DistinctGroup` is declared next to the member that holds it rather than in the Simplifier header that reads it — a core header does not need to include a Simplifier one to name a struct. `~STPMgr` releases the vector in its body, alongside every other member that holds nodes and for the same reason: releasing a node calls back into the manager to unindex the symbol's name, and the implicit member-destruction phase runs after that index has already been destroyed.

Deciding is left to a pass over the assembled formula, since only the whole formula shows whether the operands really do occur nowhere else. That pass runs per solve in the batch pipeline, so an assertion added after one `check-sat` simply stops the rewrite applying at the next — an ordering is never inherited by a formula that did not earn it. It is batch-only, and deliberately so: the persistent driver's clauses survive the solve that produced them, so a chain encoded into a block would still be in force once a later assertion destroyed the symmetry behind it. Under `--incremental=on` nothing is ever ordered.

The guard has three cases to get right, and two of the three are wrong answers if it fails. An operand used outside the distinct is not interchangeable, and ordering it would report `unsat` where the answer is `sat`. Two groups sharing an operand are each symmetric alone and not symmetric together, and ordering both would again turn a satisfiable query unsatisfiable. The third is a negated distinct, where the chain becomes the weaker claim: still equisatisfiable, but the model would not be a model of the input, so the rewrite declines rather than publish one it cannot stand behind — and that block answers `sat` either way, so it is pinned by the absence of the stats line rather than by its verdict. The comments in the fixtures say which is which.

The models are checked, not just asserted. Four two-bit variables under one distinct have exactly one increasing assignment, so the last block of `distinct-ordering.smt2` reads the model back and pins all four values: they are a model of the unrewritten distinct, all four differing, and the chain leaves the solver no other choice, so the check is stable rather than a snapshot of what CaDiCaL happened to pick. It is also where the user-visible consequence is recorded: a published model is now canonical where it used to be any of the 24 permutations.

## Verification

`distinct-ordering.smt2`, `distinct-ordering-boundaries.smt2` and `incremental-tests/distinct-ordering-batch-only.smt2` all **fail on master**, and the model block alone fails on master independently of the stats line. The new `UserDefinedFlags_Test` case does not compile against master's headers at all.

**135/135** `ctest` in RelWithDebInfo and in Release with `-DWERROR=ON`; the latter with a `ccache`-disabled rebuild of all 135 translation units, which produced no warning from any STP source.

`valgrind` is clean over all three fixtures. The destructor ordering above does not show up there on its own, because the manager's other tables are emptied in the destructor body and that makes the late release benign in practice; removing one of those body clears in a probe build turns it into 49 error contexts, every one of them arriving through `~vector<DistinctGroup>` and none of them present when the query holds no `distinct`, and the same probe build with this commit's one-line release reports none.

3000 randomised differential cases, 680 of which exercised the rewrite, agree with `--distinct-ordering false`, and all 2096 reported models re-check as models of the unrewritten assertions.

## The default

The flag `--distinct-ordering` defaults to **on**, so this changes what every user of the batch pipeline gets, and it reroutes the existing `sample-smt-tests/arity1.smt2` — still `unsat`, now by a chain over five two-bit variables rather than by pigeonhole. **Worth a maintainer's opinion on the default.** If it stays on: it is registered under "Simplifications" rather than with the refinement loops, `--distinct-ordering false` switches it off, and `--disable-simplifications` clears it along with the rest of that stack (asking for both at once is refused, the same way the other fourteen are).
