### PR TITLE
Report extensionality lemma rounds, and re-establish core granularity

### DIFF
--- a/include/stp/Extensionality/ExtensionalityContext.h
+++ b/include/stp/Extensionality/ExtensionalityContext.h
@@ -508,6 +508,24 @@ public:
   // entered the clause). Cumulative over the context lifetime.
   int lemmaAtomsFolded;
 
+  // Encoding rounds, and the largest single round. The checker
+  // deliberately collects every independent conflict a fixed point finds
+  // rather than stopping at the first, so a round has no upper bound, and
+  // neither the total nor the mean says whether that mattered: seventeen
+  // arrays asserted pairwise distinct take 54 rounds for 1477 lemmas, an
+  // average of 27, and the largest single round of that run is 120. These
+  // are what a decision about capping a round would have to be made on.
+  int lemmaRounds;
+  int lemmasInLargestRound;
+
+  // Print the four counters above under -s / --print-functionstat. Both
+  // the batch pipeline and the incremental driver call this where they
+  // print the rest of their per-solve statistics; the driver has its own
+  // encoding path and never enters the batch refinement loop, and it is
+  // the mode that accumulates the most rounds. Silent when the checker
+  // has encoded no round.
+  void reportLemmaStats() const;
+
 private:
   STPMgr* bm;
 

--- a/lib/Extensionality/ExtensionalityContext.cpp
+++ b/lib/Extensionality/ExtensionalityContext.cpp
@@ -181,7 +181,8 @@ ASTNode recoverAnchoredOperand(const ASTNode& rhs, const ASTNode& lambda,
 } // namespace
 
 ExtensionalityContext::ExtensionalityContext(STPMgr* bm_)
-    : lemmasEmitted(0), lemmaAtomsFolded(0), bm(bm_), solveInProgress(false),
+    : lemmasEmitted(0), lemmaAtomsFolded(0), lemmaRounds(0),
+      lemmasInLargestRound(0), bm(bm_), solveInProgress(false),
       registrySealed(false),
       arrayGraphIsFrozen(false), graphBound(false),
       readTransformInProgress(false), readTransformComplete(false),
@@ -1871,10 +1872,27 @@ void ExtensionalityContext::encodePendingLemmas(SATSolver& solver,
   if (!pendingLemmaValid || pendingLemmas.empty())
     FatalError("array-equality: lemma encoding began without a pending "
                "certificate");
+  lemmaRounds++;
+  if ((int)pendingLemmas.size() > lemmasInLargestRound)
+    lemmasInLargestRound = (int)pendingLemmas.size();
   for (size_t i = 0; i < pendingLemmas.size(); i++)
     encodeOneLemma(pendingLemmas[i], solver, tosat, guardLit);
   pendingLemmas.clear();
   pendingLemmaValid = false;
+}
+
+// See the header. Every figure is cumulative over the context lifetime -- a
+// running total and a lifetime maximum -- and only the printing is per
+// solve, so that a multi-query file shows how the accounting grew rather
+// than only where it ended up.
+void ExtensionalityContext::reportLemmaStats() const
+{
+  if (!bm->UserFlags.stats_flag || lemmaRounds == 0)
+    return;
+  std::cerr << "Array equality: " << lemmasEmitted << " lemmas, "
+            << lemmaRounds << " rounds, largest " << lemmasInLargestRound
+            << ", " << lemmaAtomsFolded << " atoms folded (cumulative)."
+            << std::endl;
 }
 
 // See the header. A premise is dropped when it is valid, the

--- a/lib/Incremental/IncrementalSolver.cpp
+++ b/lib/Incremental/IncrementalSolver.cpp
@@ -208,6 +208,12 @@ SOLVER_RETURN_TYPE IncrementalSolver::checkSat(const ASTVec& assertionsSMT2,
   const SOLVER_RETURN_TYPE result = checkSatBody(
       assertionsSMT2, assumeLastLevelPerConjunct, firstForcedIncrementalSolve);
   impl->finishProfile();
+  // The driver has its own encoding path and never enters the batch
+  // refinement loop, so the batch pipeline's report never runs here;
+  // without this the checker's rounds are invisible in exactly the mode
+  // that accumulates the most of them.
+  if (ExtensionalityContext* ext = impl->bm->getExtensionalityIfAny())
+    ext->reportLemmaStats();
   return result;
 }
 

--- a/lib/Incremental/IncrementalSolverImpl.h
+++ b/lib/Incremental/IncrementalSolverImpl.h
@@ -1470,9 +1470,30 @@ struct IncrementalSolver::Impl
   std::vector<int> lastFailedLits;
   size_t lastLevelCount;
 
+  // A granular core is trustworthy only if every literal that could fail is
+  // one this call can attribute. The accessors go the other way -- they keep
+  // the failed literals they can find in assumedLitLevels and
+  // lastLevelLitConjuncts, and silently drop the rest -- so an assumed
+  // literal missing from those tables does not widen the reported core, it
+  // narrows it. The extensionality block literal is exactly such a literal
+  // (assumed, deliberately unrecorded), and a round that assumed one would
+  // report a core too shallow, letting the frontend cache unsat at a level
+  // that is satisfiable. Those rounds are routed to coarse today; this is
+  // the statement of why that routing is load-bearing, and it re-establishes
+  // the conclusion rather than trusting the routing, because coarse is
+  // always a correct answer and a wrong unsat is not.
   void recordUnsat(const SATSolver::vec_literals& assumptions,
                    size_t levelCount, bool coarse)
   {
+    if (!coarse)
+    {
+      std::unordered_set<int> attributable;
+      for (const std::pair<int, size_t>& ll : assumedLitLevels)
+        attributable.insert(ll.first);
+      for (int i = 0; i < assumptions.size() && !coarse; i++)
+        coarse = attributable.count(assumptions[i].x) == 0;
+      assert(!coarse && "granular unsat with an unattributable assumption");
+    }
     lastUnsat = true;
     lastUnsatCoarse = coarse;
     lastLevelCount = levelCount;

--- a/lib/STPManager/STP.cpp
+++ b/lib/STPManager/STP.cpp
@@ -872,6 +872,12 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
     if (toSATAIG.cbIsDestructed())
       cleaner.release();
 
+    // The counters are cumulative over the checker's lifetime, so a batch
+    // query decided before the refinement loop still has rounds to report
+    // -- earlier queries' rounds. Both decision exits report, or a later
+    // query would silently drop the line the driver prints for it.
+    if (ext != NULL)
+      ext->reportLemmaStats();
     CountersAndStats("print_func_stats", bm);
     return res;
   }
@@ -908,6 +914,8 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
       if (toSATAIG.cbIsDestructed())
         cleaner.release();
 
+      if (ext != NULL)
+        ext->reportLemmaStats();
       CountersAndStats("print_func_stats", bm);
       return res;
     }

--- a/tests/query-files/array-extensionality-tests/80-lemma-round-stats.smt2
+++ b/tests/query-files/array-extensionality-tests/80-lemma-round-stats.smt2
@@ -1,0 +1,47 @@
+; The extensionality checker reports what its rounds looked like, not just
+; how many lemmas it emitted.
+;
+; The checker deliberately keeps collecting after the first conflict a fixed
+; point finds, so a round has no upper bound. That is a good trade when the
+; large rounds come first and knock out whole classes of collision at once,
+; and a bad one when every round is large -- and a total, or a mean, cannot
+; tell those two apart. Until this line existed neither number was printed
+; anywhere, so whether to cap a round was not a question anyone could answer
+; from evidence.
+;
+; Five arrays over (Array (_ BitVec 2) (_ BitVec 2)) asserted pairwise
+; distinct. The array sort has 256 inhabitants, so this is satisfiable with
+; room to spare, but the first candidate model collapses arrays together and
+; several rounds of lemmas are needed to separate them: the first query
+; measures 3 rounds / 10 lemmas in batch and 5 / 17 in the driver, largest
+; round 6 on both. Those figures are search-dependent -- a MiniSat build
+; picks different candidates and reports 5 / 11 for the driver -- so what the
+; CHECKs pin is the line and its four fields, not the values.
+;
+; The second query is the reason the report sits at both of TopLevelSTPAux's
+; decision exits rather than only at the refinement loop's. It is a
+; propositional contradiction, so it is decided before the loop is ever
+; entered -- but the counters are cumulative over the checker's lifetime, so
+; the first query's rounds are still there to report. Reporting only at the
+; loop's exit dropped the line for exactly this query in batch, while the
+; driver printed it.
+;
+; RUN: %solver -s --array-equality --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver -s --array-equality --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: Array equality: [0-9]+ lemmas, [0-9]+ rounds, largest [0-9]+, [0-9]+ atoms folded
+; CHECK: ^sat
+; CHECK: Array equality: [0-9]+ lemmas, [0-9]+ rounds, largest [0-9]+, [0-9]+ atoms folded
+; CHECK: ^unsat
+;
+(set-logic QF_ABV)
+(declare-fun a () (Array (_ BitVec 2) (_ BitVec 2)))
+(declare-fun b () (Array (_ BitVec 2) (_ BitVec 2)))
+(declare-fun c () (Array (_ BitVec 2) (_ BitVec 2)))
+(declare-fun d () (Array (_ BitVec 2) (_ BitVec 2)))
+(declare-fun e () (Array (_ BitVec 2) (_ BitVec 2)))
+(declare-fun p () Bool)
+(assert (distinct a b c d e))
+(check-sat)
+(push 1)
+(assert (and p (not p)))
+(check-sat)


### PR DESCRIPTION
Two things, both about being able to see, or being able to trust, something that until now was only true by construction.

The extensionality checker keeps collecting conflicts after the first one a fixed point finds, so a round has no upper bound. Whether that is a good trade depends entirely on the shape, and neither a total nor a mean can show it: seventeen arrays over `(Array (_ BitVec 2) (_ BitVec 2))` asserted pairwise distinct take 54 rounds for 1477 lemmas — an average of 27 — while the largest single round of that run is 120. A run whose large rounds come first is being served well by the collecting and a run of uniformly large rounds is not, and those two runs can have the same total. The two counters that existed were read by nothing but a unit test and printed nowhere; they now have a round count and a largest-round figure beside them, and one line under `-s` / `--print-functionstat`.

The checker prints that line itself, at both of the batch pipeline's decision exits and once per `check-sat` in the driver. Both batch exits matter because the counters are cumulative over the checker's lifetime: a query decided before the refinement loop is ever entered still has earlier queries' rounds to report, so reporting only at the loop's exit dropped the line for exactly those queries while the driver printed it.

That is the evidence a decision about capping a round would need, and the reason this installs no cap: in STP a round is a full SAT solve, so a per-round quota trades an unbounded clause count for an unbounded solve count, which is the more expensive resource.

The second is a soundness invariant that nothing stated. A granular unsat core is assembled by keeping the failed literals that can be attributed to a level or a conjunct and dropping the rest, so an assumed literal missing from those tables narrows the reported core rather than widening it. The extensionality block literal is exactly such a literal: assumed, deliberately unrecorded. A core that is too small is not a smaller answer but a wrong one, because the frontend caches "unsat at the deepest level in the core".

Rounds that could assume one are routed to a coarse core today — a whole-array equality claims the exact stack, which records coarsely — so the situation does not arise. `recordUnsat` now says so: a granular record whose assumptions are not all attributable degrades to coarse rather than publishing a core it cannot stand behind, and asserts that the degradation never fires. Coarse is always a correct answer and a wrong `unsat` is not, so the check re-establishes the conclusion rather than trusting the routing to keep holding.

Release compiles that assertion away but not the scan it guards, so the degradation itself survives into release builds: an assertion build aborts where a release build silently reports a coarse core, which is still a correct answer. The scan is also stricter than the invariant needs — it walks every assumption rather than only the failed ones — which costs an `unordered_set<int>` build per granular unsat, negligible beside the SAT solve it follows.

## Verification

`tests/query-files/array-extensionality-tests/80-lemma-round-stats.smt2` **fails on master**, which answers both of its queries correctly but prints no `Array equality:` line at all. It runs a satisfiable pairwise-distinct over five arrays and then a propositional contradiction, which is decided before the refinement loop is entered, so it pins the both-exits placement as well as the line itself.

Its figures are search-dependent rather than semantic — under CaDiCaL the first query measures 3 rounds / 10 lemmas in batch and 5 / 17 in the driver, largest round 6 on both, while a `-DUSE_MINISAT=ON` build reports 5 / 11 for the driver — so the `CHECK`s pin the line and its four fields, not the values. I ran it on that MiniSat build too, under the default backend and under `--simplifying-minisat`, since CI has a leg that runs the suite there; Riss I did not test.

**135/135** `ctest`, in RelWithDebInfo with assertions on and in Release with `-Werror`, the CI leg.

The attributability check has no fixture that discriminates against master, and cannot have one: by construction it never changes an answer on any reachable input, so any query written for it produces byte-identical output before and after. What it does have is live-fire coverage — every granular unsat already in `tests/query-files/incremental-tests/` runs the new scan — so an assertion build aborts if the routing above it ever stops holding.
