### PR TITLE
Pin the rounding-mode cells the array transform mints

### DIFF
--- a/include/stp/AbsRefineCounterExample/ArrayTransformer.h
+++ b/include/stp/AbsRefineCounterExample/ArrayTransformer.h
@@ -114,6 +114,14 @@ private:
   bool recordTouchedReads = false;
   ReadKeys touchedReads;
 
+  // The sort constraints owed by the read abstractions this run minted, to
+  // be conjoined onto the formula that minted them. Emptied at the start of
+  // every top-level transform: a row the registry already held was pinned
+  // onto the formula it was created for, exactly as its index anchor was,
+  // and re-emitting it here would attach the whole table's pins to every
+  // formula transformed afterwards. See TransformFormula_TopLevel.
+  ASTVec cellSortConstraints;
+
   // Under eager Ackermannisation: each array's reads in the order they
   // were seen, from which a new read's nested if-then-else over the
   // existing reads is built. Persistent callers carry this inside Registry

--- a/lib/AbsRefineCounterExample/ArrayTransformer.cpp
+++ b/lib/AbsRefineCounterExample/ArrayTransformer.cpp
@@ -84,6 +84,7 @@ ASTNode ArrayTransformer::TransformFormula_TopLevel(const ASTNode& form)
 
   assert(TransformMap == NULL);
   TransformMap = new ASTNodeMap(100);
+  cellSortConstraints.clear();
 
   ExtensionalityContext* ext = bm->getExtensionalityIfAny();
   // Constant-bit propagation also creates local ArrayTransformers for
@@ -111,6 +112,8 @@ ASTNode ArrayTransformer::TransformFormula_TopLevel(const ASTNode& form)
 
   if (bm->UserFlags.stats_flag)
     printArrayStats();
+
+  ASTVec sideConstraints;
 
   // This establishes equalities between every indexes, and a fresh variable.
   if (!bm->UserFlags.ackermannisation)
@@ -177,18 +180,24 @@ ASTNode ArrayTransformer::TransformFormula_TopLevel(const ASTNode& form)
       }
     }
 
-    runTimes->stop(RunTimes::Transforming);
+    sideConstraints.insert(sideConstraints.end(), equalsNodes.begin(),
+                           equalsNodes.end());
+  }
 
-    if (equalsNodes.size() > 0)
-      return nf->CreateNode(AND, result, equalsNodes);
-    else
-      return result;
-  }
-  else
-  {
-    runTimes->stop(RunTimes::Transforming);
-    return result;
-  }
+  // The sort constraints the fresh read abstractions owe. Not inside the
+  // branch above: eager Ackermannisation abstracts each read to one of
+  // these variables too -- it builds the if-then-else over them instead of
+  // leaving the refinement loop to relate them -- so the cells are exactly
+  // as much in need of pinning either way.
+  sideConstraints.insert(sideConstraints.end(), cellSortConstraints.begin(),
+                         cellSortConstraints.end());
+  cellSortConstraints.clear();
+
+  runTimes->stop(RunTimes::Transforming);
+
+  if (sideConstraints.size() > 0)
+    return nf->CreateNode(AND, result, sideConstraints);
+  return result;
 }
 
 ArrayTransformer::TransformResult
@@ -357,10 +366,31 @@ class ArrayTransformer::TransformDriver
   std::map<ASTNode, vector<std::pair<ASTNode, ASTNode>>>& ack_pair;
   const bool& recordTouchedReads;
   std::vector<std::pair<ASTNode, ASTNode>>& touchedReads;
+  ASTVec& cellSortConstraints;
 
   ASTNode finishTransformTerm(const ASTNode& term, const ASTNode& result)
   {
     return owner.finishTransformTerm(term, result);
+  }
+
+  // A cell of an array of modes holds a mode, and five bits carry one only
+  // through five of their thirty-two patterns. FpTotalise pins the reads the
+  // formula names, and it has run by now; a read minted here is either newer
+  // than that pass -- the ones read-over-write and read-over-if-then-else
+  // expansion introduce over a base array, and the ones a solved write chain
+  // or a refinement lemma introduces -- or is one the pass did cover, in
+  // which case this is the same constraint again and the conjunction absorbs
+  // it. Left free, such a cell is not merely an unanswered don't-care: the
+  // solve is entitled to witness a disequality of two arrays of modes with
+  // carriers that name no mode at all, and every reader downstream -- the
+  // congruence axioms, which compare the carriers, and the model, which must
+  // publish a mode -- is then reading a different cell than the other. Pin it
+  // where the array-equality checker pins its own virtual reads, so that
+  // there is one answer.
+  void pinRoundingModeCell(const ASTNode& arrName, const ASTNode& cell)
+  {
+    if (bm->arrayHasRmElement(arrName))
+      cellSortConstraints.push_back(bm->roundingModeValidConstraint(cell));
   }
 
   struct Frame
@@ -889,6 +919,13 @@ class ArrayTransformer::TransformDriver
           CurrentSymbol.SetExpWidth(term.GetExpWidth());
           CurrentSymbol.SetSigWidth(term.GetSigWidth());
 
+          // See pinRoundingModeCell. A write chain equated with its own base
+          // is rewritten rather than abstracted, so the cells it names are
+          // reads of the base minted right here, after totalisation -- and
+          // the equality it replaced leaves no record for the checker to pin
+          // them through either.
+          pinRoundingModeCell(arrName, CurrentSymbol);
+
           result = CurrentSymbol;
           arrayToIndexToRead[arrName].insert(
               make_pair(readIndex, ArrayRead(result, CurrentSymbol)));
@@ -941,6 +978,9 @@ class ArrayTransformer::TransformDriver
           // a formatless bitvector.
           CurrentSymbol.SetExpWidth(term.GetExpWidth());
           CurrentSymbol.SetSigWidth(term.GetSigWidth());
+
+          // See pinRoundingModeCell.
+          pinRoundingModeCell(arrName, CurrentSymbol);
 
           ASTNode symbolResult = CurrentSymbol;
 
@@ -1143,7 +1183,8 @@ public:
         ASTFalse(owner.ASTFalse), ASTUndefined(owner.ASTUndefined),
         arrayToIndexToRead(owner.arrayToIndexToRead), ack_pair(owner.ack_pair),
         recordTouchedReads(owner.recordTouchedReads),
-        touchedReads(owner.touchedReads)
+        touchedReads(owner.touchedReads),
+        cellSortConstraints(owner.cellSortConstraints)
   {
   }
 

--- a/tests/query-files/fp-tests/array-rm-abstracted-cell-is-a-mode.smt2
+++ b/tests/query-files/fp-tests/array-rm-abstracted-cell-is-a-mode.smt2
@@ -1,0 +1,37 @@
+; RUN: %solver --array-equality %s | %OutputCheck %s
+; RUN: %solver --array-equality -r %s | %OutputCheck %s
+; RUN: %solver --incremental=on --array-equality %s | %OutputCheck %s
+; RUN: %solver --incremental=on --array-equality -r %s | %OutputCheck %s
+;
+; The same cell, minted on the other route. Sibling of
+; array-rm-write-chain-cell-is-a-mode.smt2.
+;
+; The array transform has two places where it stands a fresh variable in for
+; a read of a symbol array: the read-refinement one, and the one taken when
+; the complete-array checker is live over the read's array. The first
+; disequality here is not a write chain, so it registers a record and the
+; checker is live; the five that follow are write chains, which are solved by
+; rewriting whatever else is in the query, so their cells are still reads
+; minted after FpTotalise ran -- but now they are minted on the checker's
+; route. A pin on the refinement route alone leaves them free, and one free
+; carrier again satisfies all five at once.
+;
+; The index is a bit-vector, not a mode. Nothing about the defect or the fix
+; depends on the index sort: a chain of one write differs from its base
+; exactly when the base's cell at that index differs from the value written,
+; whatever sort the index has, and it is the element sort that makes five
+; disequalities exhaustive.
+;
+; CHECK: ^unsat
+(set-logic QF_ABVFP)
+(declare-fun a () (Array (_ BitVec 3) RoundingMode))
+(declare-fun b () (Array (_ BitVec 3) RoundingMode))
+(declare-fun j () (_ BitVec 3))
+(assert (not (= a b)))
+(assert (not (= (store b j RNE) b)))
+(assert (not (= (store b j RNA) b)))
+(assert (not (= (store b j RTP) b)))
+(assert (not (= (store b j RTN) b)))
+(assert (not (= (store b j RTZ) b)))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/array-rm-write-chain-cell-is-a-mode.smt2
+++ b/tests/query-files/fp-tests/array-rm-write-chain-cell-is-a-mode.smt2
@@ -1,0 +1,39 @@
+; RUN: %solver --array-equality %s | %OutputCheck %s
+; RUN: %solver --array-equality -r %s | %OutputCheck %s
+; RUN: %solver --incremental=on --array-equality %s | %OutputCheck %s
+; RUN: %solver --incremental=on --array-equality -r %s | %OutputCheck %s
+;
+; A cell of an array of rounding modes holds one of the five modes -- the
+; cells an array equality introduces after the pinning pass has run included.
+;
+; RoundingMode is carried in five bits, one-hot, so twenty-seven of the
+; thirty-two carriers name no mode at all. Every mode a query names is pinned
+; to the five: by its declaration, and by FpTotalise at solve time, which
+; covers the reads the formula names as well as its symbols. An equality
+; between a chain of writes and its own base is not abstracted at all,
+; though -- it is rewritten, each write contributing "the base's cell at this
+; index is the value written, unless a later write shadowed it"
+; (ExtensionalityContext::solveWriteChain). The cells that rewrite reads are
+; new reads, minted after FpTotalise has run, and nothing pinned them.
+;
+; One free carrier could therefore witness all five of these disequalities at
+; once: a[i] naming no mode differs from every mode there is. There are only
+; five, and the five assertions exclude each of them, so this is
+; unsatisfiable. STP answered "sat" on all four routes below.
+;
+; The array transform now pins the cells it mints, as the array-equality
+; checker already pinned its own virtual reads. The sibling
+; array-rm-abstracted-cell-is-a-mode.smt2 covers the transform's other
+; minting site.
+;
+; CHECK: ^unsat
+(set-logic QF_ABVFP)
+(declare-fun a () (Array RoundingMode RoundingMode))
+(declare-fun i () RoundingMode)
+(assert (not (= (store a i RNE) a)))
+(assert (not (= (store a i RNA) a)))
+(assert (not (= (store a i RTP) a)))
+(assert (not (= (store a i RTN) a)))
+(assert (not (= (store a i RTZ) a)))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/array-rm-write-chain-cell-model.smt2
+++ b/tests/query-files/fp-tests/array-rm-write-chain-cell-model.smt2
@@ -1,0 +1,39 @@
+; RUN: %solver --array-equality %s | %OutputCheck %s
+; RUN: %solver --array-equality -r %s | %OutputCheck %s
+; RUN: %solver --incremental=on --array-equality %s | %OutputCheck %s
+; RUN: %solver --incremental=on --array-equality -r %s | %OutputCheck %s
+;
+; The model half of array-rm-write-chain-cell-is-a-mode.smt2, and the control
+; that pinning the cell is not the same as publishing a default for it.
+;
+; Four of the five modes are excluded from a[i] by four disequalities between
+; a chain of one write and its own base, which the array-equality context
+; rewrites into constraints on that cell rather than abstracting them. The
+; cell is a read minted after the pinning pass ran, so a free carrier could
+; satisfy all four at once by naming no mode -- and get-value then published
+; the carrier itself, a raw five-bit pattern where a mode name belongs:
+;
+;   ( (select |a| |i|)  #b11000 )
+;
+; a value of no RoundingMode, and a different one on each route (#b11000 on
+; the batch routes of one build, #b01001 on the incremental ones), because
+; nothing constrained it. The congruence axioms compare the carriers the
+; solve decided; model evaluation compares what those bits are taken to mean.
+;
+; RNA is the only mode the four leave, and it is the answer whether or not any
+; cell needed completing: a fix that pinned the cell but published a
+; completion for it instead of the value the solve decided would fail here.
+;
+; CHECK: ^sat
+; CHECK: ^\( \(select \|a\| \|i\|\) RNA \)$
+(set-logic QF_ABVFP)
+(set-option :produce-models true)
+(declare-fun a () (Array RoundingMode RoundingMode))
+(declare-fun i () RoundingMode)
+(assert (not (= (store a i RNE) a)))
+(assert (not (= (store a i RTP) a)))
+(assert (not (= (store a i RTN) a)))
+(assert (not (= (store a i RTZ) a)))
+(check-sat)
+(get-value ((select a i)))
+(exit)


### PR DESCRIPTION
This is unsatisfiable — there are five rounding modes and it excludes each of them — and STP answers `sat`, on every route:

```smt2
(declare-fun a () (Array RoundingMode RoundingMode))
(declare-fun i () RoundingMode)
(assert (not (= (store a i RNE) a)))
(assert (not (= (store a i RNA) a)))
(assert (not (= (store a i RTP) a)))
(assert (not (= (store a i RTN) a)))
(assert (not (= (store a i RTZ) a)))
(check-sat)
```

A mode is carried in five bits, one-hot, so twenty-seven of the thirty-two patterns name no mode at all. Every mode a query names is pinned to the five, by its declaration and again by `FpTotalise` at solve time, which covers the reads the formula names as well as its symbols. Reads minted after that pass has run are covered by neither.

An equality between a chain of writes and its own base is one of the ways such a read is minted. `solveWriteChain` does not abstract that shape, it rewrites it, so the cells it builds are new reads over the base array created well after totalisation — and the equality, solved by rewriting, leaves no record behind, so the complete-array checker has nothing to pin them through either. One free carrier can then witness all five disequalities at once.

`ArrayTransformer` now conjoins `roundingModeValidConstraint` onto every fresh read variable it mints over a RoundingMode-element array. It mints one at two sites and both need it: the read-refinement site, and the site taken instead as soon as the complete-array checker is live over the read's array, which is as soon as the query holds one array equality the write-chain rewrite does not solve. The constraint is emitted on the eager-Ackermannisation route as well as the refinement route. Both helpers already existed.

The wrong answer is one shape the free cell takes; the model is the other. Ask for the cell on a query that leaves one mode open, and `get-value` publishes `( (select |a| |i|)  #b11000 )` for a term of RoundingMode sort — a raw bit-vector pattern where a mode name belongs, and a different one on each route, because nothing constrained it.

## Verification

Three query files in `tests/query-files/fp-tests/`. Each **fails on `master` and passes here**, checked through `lit` against a binary built from the current `master` tip.

- `array-rm-write-chain-cell-is-a-mode.smt2` — the query above. `sat` on master, `unsat` here, on all four routes that reach the cell: batch and `--incremental`, with and without `--ackermanize`.
- `array-rm-write-chain-cell-model.smt2` — the model half, and its own control that pinning the cell is not the same as publishing a default for it: four modes are excluded, RNA is the only one left. Master publishes the unconstrained carrier (`#b11000` on the batch routes, `#b01001` on the incremental ones); here it publishes `RNA`.
- `array-rm-abstracted-cell-is-a-mode.smt2` — the checker's minting site, reached by putting one non-write-chain array equality in front of the same five disequalities. Its arrays are indexed by a bit-vector, because nothing about the defect or the fix turns on the index sort: a chain of one write differs from its base exactly when the base's cell at that index differs from the value written, whatever sort the index has, and it is the element sort that makes five disequalities exhaustive.

Beyond the fixtures, 400 generated queries in this family — write chains against their own base over RoundingMode-element arrays, with and without a further equality that makes the checker live, mode and bit-vector indexes — were differentially checked against Bitwuzla on all four routes. `master` disagrees on 34, every one of them `sat` on an unsatisfiable query; this branch disagrees on none.

**137/137** `ctest`, in RelWithDebInfo and in Release with `-DWERROR=ON`.
