### PR TITLE
BV abstraction (1/5): a congruence closure that explains its conflicts

### DIFF
--- a/include/stp/ToSat/BVEQCongruenceClosure.h
+++ b/include/stp/ToSat/BVEQCongruenceClosure.h
@@ -1,0 +1,93 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: Aug, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#ifndef BVEQ_CONGRUENCE_CLOSURE_H
+#define BVEQ_CONGRUENCE_CLOSURE_H
+
+#include "stp/Sat/SATSolver.h"
+#include <vector>
+
+namespace stp
+{
+
+// Word-level transitivity over the equality abstractions in one candidate
+// model: the equalities the model asserts are merged, and any disequality it
+// asserts between two terms that merging has brought together is a conflict.
+// Each conflict is handed back to the solver as the clause
+// (~e1 | ... | ~ek | d) -- the chain of asserted equalities that connects the
+// disequality's two sides, which is what makes the clause a theorem of
+// equality rather than a guess.
+//
+// Two structures, because they answer different questions. `parent_`/`rank_`
+// is the union-find that decides membership, and it links whole classes by
+// rank, so its edges say nothing about which equality justified a merge.
+// `proofParent_`/`proofEdge_` is a separate proof forest whose edges each
+// carry the one equality asserted between exactly those two endpoints; the
+// chain between any two terms is then the path between them in that forest.
+// Reading the explanation off the union-find instead drops the edges below
+// the link -- for a=b then b=c, the merge of c into a's class is recorded as
+// c's own link and the edge a=b is never on the path -- which yields a
+// clause the theory does not entail, and refutes satisfiable queries.
+class BVEQCongruenceClosure
+{
+public:
+  struct EqInfo
+  {
+    unsigned left;
+    unsigned right;
+    unsigned satVar;
+    bool modelTrue;
+  };
+
+  unsigned check(const std::vector<EqInfo>& equalities, SATSolver& solver);
+
+private:
+  // Membership only.
+  std::vector<unsigned> parent_;
+  std::vector<unsigned> rank_;
+
+  // The proof forest. Every merge adds one edge, so its components are the
+  // union-find's classes, and `proofEdge_[x]` indexes the equality asserted
+  // between `x` and `proofParent_[x]` themselves.
+  std::vector<unsigned> proofParent_;
+  std::vector<int> proofEdge_;
+
+  void init(unsigned n);
+  unsigned find(unsigned x);
+  void unite(unsigned x, unsigned y, unsigned eqIdx);
+
+  // Turn `x` into the root of its proof tree by reversing the links along
+  // the path it currently takes to the root. Each link keeps the equality it
+  // carried, since that equality is between the link's two endpoints and so
+  // justifies it in either direction.
+  void reroot(unsigned x);
+
+  // The equalities on the proof path from `x` to `y`, which must be in the
+  // same class. Appended to `edges`.
+  void explain(unsigned x, unsigned y, std::vector<unsigned>& edges);
+};
+
+} // namespace stp
+
+#endif

--- a/lib/ToSat/BVEQCongruenceClosure.cpp
+++ b/lib/ToSat/BVEQCongruenceClosure.cpp
@@ -1,0 +1,182 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: Aug, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#include "stp/ToSat/BVEQCongruenceClosure.h"
+
+namespace stp
+{
+
+void BVEQCongruenceClosure::init(unsigned n)
+{
+  parent_.assign(n, 0);
+  rank_.assign(n, 0);
+  proofParent_.assign(n, 0);
+  proofEdge_.assign(n, -1);
+  for (unsigned i = 0; i < n; ++i)
+  {
+    parent_[i] = i;
+    proofParent_[i] = i;
+  }
+}
+
+unsigned BVEQCongruenceClosure::find(unsigned x)
+{
+  while (parent_[x] != x)
+    x = parent_[x];
+  return x;
+}
+
+void BVEQCongruenceClosure::reroot(unsigned x)
+{
+  // Walk to the root first, then relink on the way back: rewriting the links
+  // in place while following them would lose the rest of the path.
+  std::vector<unsigned> nodes;
+  std::vector<int> edges;
+  unsigned cur = x;
+  while (proofParent_[cur] != cur)
+  {
+    nodes.push_back(cur);
+    edges.push_back(proofEdge_[cur]);
+    cur = proofParent_[cur];
+  }
+  nodes.push_back(cur);
+
+  for (size_t i = nodes.size(); i-- > 1;)
+  {
+    proofParent_[nodes[i]] = nodes[i - 1];
+    proofEdge_[nodes[i]] = edges[i - 1];
+  }
+  proofParent_[x] = x;
+  proofEdge_[x] = -1;
+}
+
+void BVEQCongruenceClosure::unite(unsigned x, unsigned y, unsigned eqIdx)
+{
+  unsigned rx = find(x);
+  unsigned ry = find(y);
+  if (rx == ry)
+    return;
+
+  // The proof edge goes between the equality's own two sides, not between
+  // the class representatives -- that is the whole point of keeping it apart
+  // from the union-find below.
+  reroot(x);
+  proofParent_[x] = y;
+  proofEdge_[x] = static_cast<int>(eqIdx);
+
+  if (rank_[rx] < rank_[ry])
+  {
+    parent_[rx] = ry;
+  }
+  else if (rank_[rx] > rank_[ry])
+  {
+    parent_[ry] = rx;
+  }
+  else
+  {
+    parent_[ry] = rx;
+    rank_[rx]++;
+  }
+}
+
+void BVEQCongruenceClosure::explain(unsigned x, unsigned y,
+                                    std::vector<unsigned>& edges)
+{
+  std::vector<unsigned> px, py;
+  for (unsigned cur = x;; cur = proofParent_[cur])
+  {
+    px.push_back(cur);
+    if (proofParent_[cur] == cur)
+      break;
+  }
+  for (unsigned cur = y;; cur = proofParent_[cur])
+  {
+    py.push_back(cur);
+    if (proofParent_[cur] == cur)
+      break;
+  }
+
+  // Both paths end at the root of the shared proof tree. Dropping the common
+  // suffix leaves the two halves that meet at the deepest shared ancestor,
+  // which together are the path from x to y.
+  size_t i = px.size();
+  size_t j = py.size();
+  while (i > 0 && j > 0 && px[i - 1] == py[j - 1])
+  {
+    --i;
+    --j;
+  }
+
+  for (size_t k = 0; k < i; ++k)
+    edges.push_back(static_cast<unsigned>(proofEdge_[px[k]]));
+  for (size_t k = 0; k < j; ++k)
+    edges.push_back(static_cast<unsigned>(proofEdge_[py[k]]));
+}
+
+unsigned BVEQCongruenceClosure::check(
+    const std::vector<EqInfo>& equalities, SATSolver& solver)
+{
+  if (equalities.empty())
+    return 0;
+
+  unsigned maxNode = 0;
+  for (const auto& eq : equalities)
+  {
+    if (eq.left > maxNode) maxNode = eq.left;
+    if (eq.right > maxNode) maxNode = eq.right;
+  }
+  init(maxNode + 1);
+
+  for (unsigned i = 0; i < equalities.size(); ++i)
+  {
+    if (equalities[i].modelTrue)
+      unite(equalities[i].left, equalities[i].right, i);
+  }
+
+  unsigned conflicts = 0;
+  for (unsigned i = 0; i < equalities.size(); ++i)
+  {
+    if (equalities[i].modelTrue)
+      continue;
+
+    unsigned rl = find(equalities[i].left);
+    unsigned rr = find(equalities[i].right);
+    if (rl != rr)
+      continue;
+
+    std::vector<unsigned> path;
+    explain(equalities[i].left, equalities[i].right, path);
+
+    SATSolver::vec_literals cl;
+    for (unsigned idx : path)
+      cl.push(SATSolver::mkLit(equalities[idx].satVar, true));
+    cl.push(SATSolver::mkLit(equalities[i].satVar, false));
+    solver.addClause(cl);
+
+    conflicts++;
+  }
+  return conflicts;
+}
+
+} // namespace stp

--- a/lib/ToSat/CMakeLists.txt
+++ b/lib/ToSat/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(tosat OBJECT
     BBNodeManagerAIG.cpp
     ToCNFAIG.cpp
     ToSATAIG.cpp
+    BVEQCongruenceClosure.cpp
 )
 
 add_dependencies(tosat ASTKind_header)

--- a/tests/unit-tests/BVEQCongruenceClosure_Test.cpp
+++ b/tests/unit-tests/BVEQCongruenceClosure_Test.cpp
@@ -1,0 +1,257 @@
+/***********
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+**********************/
+
+#include "stp/ToSat/BVEQCongruenceClosure.h"
+
+#include <gtest/gtest.h>
+
+#include <set>
+#include <utility>
+#include <vector>
+
+using namespace stp;
+
+namespace
+{
+
+// ---------------------------------------------------------------------------
+// The explanation a conflict is reported with, read directly off the class.
+//
+// Detecting the conflict is the easy half. The clause the closure hands the
+// solver is the other half, and it is only sound if the equalities it names
+// really do chain the disequality's two sides: the solver takes
+// (~e1 | ... | ~ek | d) as a theorem, so an explanation that omits a link
+// asserts an implication equality does not license and refutes satisfiable
+// queries. These drive check() straight, because that is the only way to see
+// the clause rather than the verdict it eventually produces.
+
+// Records what was added instead of solving. Variable numbering matches what
+// the tests hand in as satVar.
+class RecordingSolver : public stp::SATSolver
+{
+public:
+  std::vector<std::vector<stp::SATSolver::Lit>> clauses;
+
+  bool okay() const override { return true; }
+  uint8_t modelValue(uint32_t) const override { return undef_literal(); }
+  uint32_t newVar() override { return vars++; }
+  uint32_t nVars() const override { return vars; }
+  void printStats() const override {}
+  void setVerbosity(int) override {}
+  lbool true_literal() const override { return 0; }
+  lbool false_literal() const override { return 1; }
+  lbool undef_literal() const override { return 2; }
+
+protected:
+  bool addClauseInternal(const vec_literals& ps) override
+  {
+    std::vector<stp::SATSolver::Lit> c;
+    for (int i = 0; i < ps.size(); ++i)
+      c.push_back(ps[i]);
+    clauses.push_back(c);
+    return true;
+  }
+
+  bool solveInternal(bool&) override { return false; }
+
+private:
+  uint32_t vars = 0;
+};
+
+// The clause as (satVar, negated) pairs, order-insensitive.
+std::set<std::pair<unsigned, bool>> asLiteralSet(
+    const std::vector<stp::SATSolver::Lit>& clause)
+{
+  std::set<std::pair<unsigned, bool>> out;
+  for (stp::SATSolver::Lit l : clause)
+    out.insert({stp::SATSolver::var(l), stp::SATSolver::sign(l)});
+  return out;
+}
+
+// Whether the equalities named negatively in `clause` connect the two sides
+// of the equality named positively -- that is, whether the clause is a
+// theorem of equality. This is the property the closure owes the solver, and
+// checking it rather than a literal-for-literal expectation is what makes
+// these tests indifferent to which spanning tree the union-find happens to
+// build.
+bool clauseIsEntailed(const std::vector<stp::SATSolver::Lit>& clause,
+                      const std::vector<stp::BVEQCongruenceClosure::EqInfo>& eqs)
+{
+  const stp::BVEQCongruenceClosure::EqInfo* conclusion = nullptr;
+  std::vector<const stp::BVEQCongruenceClosure::EqInfo*> antecedents;
+
+  for (stp::SATSolver::Lit l : clause)
+  {
+    const stp::BVEQCongruenceClosure::EqInfo* named = nullptr;
+    for (const auto& eq : eqs)
+      if (eq.satVar == stp::SATSolver::var(l))
+        named = &eq;
+    if (named == nullptr)
+      return false; // names a variable that is no equality of ours
+    if (stp::SATSolver::sign(l))
+      antecedents.push_back(named);
+    else if (conclusion == nullptr)
+      conclusion = named;
+    else
+      return false; // two positive literals is not the shape we emit
+  }
+
+  if (conclusion == nullptr)
+    return false;
+
+  // Close the antecedents and see whether they reach the conclusion's sides.
+  std::set<unsigned> reached{conclusion->left};
+  bool grew = true;
+  while (grew)
+  {
+    grew = false;
+    for (const auto* a : antecedents)
+    {
+      if (reached.count(a->left) && !reached.count(a->right))
+      {
+        reached.insert(a->right);
+        grew = true;
+      }
+      else if (reached.count(a->right) && !reached.count(a->left))
+      {
+        reached.insert(a->left);
+        grew = true;
+      }
+    }
+  }
+  return reached.count(conclusion->right) > 0;
+}
+
+TEST(BVEQCCExplanation, ChainThroughAnEarlierMergeIsNamedInFull)
+{
+  // a=b then b=c, so c joins a class that already holds two terms. The merge
+  // that brings c in is justified by b=c *and* by a=b, which is what puts b
+  // and a together in the first place; naming only b=c would assert
+  // (b=c) -> (a=c).
+  stp::BVEQCongruenceClosure cc;
+  RecordingSolver solver;
+
+  const std::vector<stp::BVEQCongruenceClosure::EqInfo> eqs = {
+      {0, 1, 10, true},   // a = b
+      {1, 2, 11, true},   // b = c
+      {0, 2, 12, false},  // a != c  <- the conflict
+  };
+
+  EXPECT_EQ(1u, cc.check(eqs, solver));
+  ASSERT_EQ(1u, solver.clauses.size());
+
+  const std::set<std::pair<unsigned, bool>> expected = {
+      {10, true}, {11, true}, {12, false}};
+  EXPECT_EQ(expected, asLiteralSet(solver.clauses[0]));
+  EXPECT_TRUE(clauseIsEntailed(solver.clauses[0], eqs));
+}
+
+TEST(BVEQCCExplanation, MergeOrderDoesNotDropLinks)
+{
+  // The same three terms, with the two equalities the other way round, so
+  // that the second merge attaches to a class built by the first from the
+  // other end.
+  stp::BVEQCongruenceClosure cc;
+  RecordingSolver solver;
+
+  const std::vector<stp::BVEQCongruenceClosure::EqInfo> eqs = {
+      {1, 2, 20, true},   // b = c
+      {0, 1, 21, true},   // a = b
+      {0, 2, 22, false},  // a != c
+  };
+
+  EXPECT_EQ(1u, cc.check(eqs, solver));
+  ASSERT_EQ(1u, solver.clauses.size());
+
+  const std::set<std::pair<unsigned, bool>> expected = {
+      {20, true}, {21, true}, {22, false}};
+  EXPECT_EQ(expected, asLiteralSet(solver.clauses[0]));
+}
+
+TEST(BVEQCCExplanation, OnlyTheConnectingChainIsNamed)
+{
+  // An equality the model asserts but which lies off the path must not be
+  // dragged in: a weaker clause is sound but blocks less of the search than
+  // the conflict entitles it to.
+  stp::BVEQCongruenceClosure cc;
+  RecordingSolver solver;
+
+  const std::vector<stp::BVEQCongruenceClosure::EqInfo> eqs = {
+      {0, 1, 30, true},   // a = b
+      {1, 2, 31, true},   // b = c
+      {2, 3, 32, true},   // c = d, past the conflict's endpoints
+      {0, 2, 33, false},  // a != c
+  };
+
+  EXPECT_EQ(1u, cc.check(eqs, solver));
+  ASSERT_EQ(1u, solver.clauses.size());
+
+  const std::set<std::pair<unsigned, bool>> expected = {
+      {30, true}, {31, true}, {33, false}};
+  EXPECT_EQ(expected, asLiteralSet(solver.clauses[0]));
+}
+
+TEST(BVEQCCExplanation, EveryClauseOverAStarIsEntailed)
+{
+  // A hub term equal to five others -- the shape a RoundingMode validity
+  // constraint takes, where one symbol is asserted equal to several mode
+  // constants at once -- with a disequality between two of the spokes. Every
+  // spoke pair is checked, so this covers explanations that must turn a
+  // corner at the hub rather than run straight up one branch.
+  for (unsigned i = 0; i < 5; ++i)
+    for (unsigned j = i + 1; j < 5; ++j)
+    {
+      stp::BVEQCongruenceClosure cc;
+      RecordingSolver solver;
+
+      std::vector<stp::BVEQCongruenceClosure::EqInfo> eqs;
+      for (unsigned k = 0; k < 5; ++k)
+        eqs.push_back({0, k + 1, 40 + k, true}); // hub = spoke_k
+      eqs.push_back({i + 1, j + 1, 50, false});  // spoke_i != spoke_j
+
+      EXPECT_EQ(1u, cc.check(eqs, solver));
+      ASSERT_EQ(1u, solver.clauses.size());
+      EXPECT_TRUE(clauseIsEntailed(solver.clauses[0], eqs))
+          << "spokes " << i << " and " << j;
+
+      // The path runs spoke_i - hub - spoke_j and no further.
+      const std::set<std::pair<unsigned, bool>> expected = {
+          {40 + i, true}, {40 + j, true}, {50, false}};
+      EXPECT_EQ(expected, asLiteralSet(solver.clauses[0]))
+          << "spokes " << i << " and " << j;
+    }
+}
+
+TEST(BVEQCCExplanation, DisequalityAcrossClassesIsNotAConflict)
+{
+  stp::BVEQCongruenceClosure cc;
+  RecordingSolver solver;
+
+  const std::vector<stp::BVEQCongruenceClosure::EqInfo> eqs = {
+      {0, 1, 60, true},   // a = b
+      {2, 3, 61, true},   // c = d
+      {0, 2, 62, false},  // a != c, and nothing joins the two classes
+  };
+
+  EXPECT_EQ(0u, cc.check(eqs, solver));
+  EXPECT_TRUE(solver.clauses.empty());
+}
+
+} // namespace

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -58,6 +58,7 @@ add_dependencies(BBNodeManagerAIG_TestTests libabc-pic)
 AddSTPGTest(AIGBudget_Test.cpp)
 target_link_libraries(AIGBudget_TestTests $<TARGET_FILE:libabc-pic>)
 add_dependencies(AIGBudget_TestTests libabc-pic)
+AddSTPGTest(BVEQCongruenceClosure_Test.cpp)
 AddSTPGTest(FPPrintBack_Test.cpp)
 AddSTPGTest(FloatBlast_Test.cpp)
 # The native-comparison differential instantiates BBNodeManagerAIG, whose


### PR DESCRIPTION
# BV abstraction (1/5): a congruence closure that explains its conflicts

The first piece of a lazy abstraction for wide bit-vector operations, split out of one development branch into five self-contained PRs; nothing in this PR is reachable from the command line yet.

`BVEQCongruenceClosure` is a word-level transitivity check over the equality literals of one candidate model: the equalities the model asserts are merged, and a disequality it also asserts between two terms that merging has brought together is a conflict, handed back as the clause `(~e1 | ... | ~ek | d)` — the chain of asserted equalities that connects the disequality's two sides.

The explanation matters as much as the refutation. The solver takes that clause as a theorem of equality, so it is one only if the named equalities really chain the two sides: an explanation that omits a link asserts an implication equality does not license, and refutes satisfiable queries. That is why membership and explanation are two structures — a rank-balanced union-find whose edges say nothing about which equality justified a merge, and a separate proof forest carrying one edge per merge between the equality's own two endpoints, rerooted before each link so the path between any two terms names exactly the asserted equalities that connect them.

## Tests

The unit tests drive `check()` directly, because the clause is the contract: the classic failure (explaining off the union-find links, which drops the edges below a rank-based merge) is pinned by name, and a property test over a five-spoke hub checks that every emitted clause is entailed by the equalities it names, whichever spanning tree the union-find happens to build.

