### PR TITLE
Simplifier (prereq for UF support): rename extensionalityProtected to theoryProtected

### DIFF
--- a/include/stp/AbsRefineCounterExample/AbsRefine_CounterExample.h
+++ b/include/stp/AbsRefineCounterExample/AbsRefine_CounterExample.h
@@ -182,8 +182,10 @@ public:
 
   // Converts MINISAT counterexample into an AST memotable (i.e. the
   // function populates the datastructure CounterExampleMap)
-  void ConstructCounterExample(SATSolver& newS,
-                               const ToSATBase::ASTNodeToSATVar& satVarToSymbol);
+  void ConstructCounterExample(
+      SATSolver& newS,
+      const ToSATBase::ASTNodeToSATVar& satVarToSymbol,
+      bool internalCandidateRequired = false);
 
   // Prints MINISAT assigment one bit at a time, for debugging.
   void PrintSATModel(SATSolver& S, ToSATBase::ASTNodeToSATVar& satVarToSymbol);

--- a/include/stp/Simplifier/SubstitutionMap.h
+++ b/include/stp/Simplifier/SubstitutionMap.h
@@ -61,13 +61,11 @@ class DLL_PUBLIC SubstitutionMap
                     std::set<ASTNode>& visited);
   bool loops(const ASTNode& n0, const ASTNode& n1);
 
-  // Array equality: while the complete-graph checker is active, refuse
-  // either orientation if it would delete a protected scalar definition or
-  // any READ-headed equation. Every read is checker-owned, independently of
-  // its other operand's shape or its connectivity to an equality operand.
-  // Oriented: "key" is the side that gets replaced. See the definition.
-  bool extensionalityProtected(const ASTNode& key,
-                               const ASTNode& value) const;
+  // Theory-generated scalars whose defining equations must survive ordinary
+  // preprocessing. Array equality additionally owns READ-headed keys while
+  // its complete-graph checker is active. Oriented: "key" is the side that
+  // gets replaced. See the definition.
+  bool theoryProtected(const ASTNode& key, const ASTNode& value) const;
 
   size_t substitutionsLastApplied;
   VariablesInExpression vars;
@@ -133,7 +131,7 @@ public:
   {
     ASTNode var = (BVEXTRACT == key.GetKind()) ? key[0] : key;
 
-    if (extensionalityProtected(var, value))
+    if (theoryProtected(var, value))
       return false;
 
     if (var.GetKind() == SYMBOL && loops(var, value))
@@ -165,7 +163,7 @@ public:
   {
     assert(e0.GetKind() == SYMBOL);
     assert(!InsideSubstitutionMap(e0) && "e0 MUST NOT be in the SolverMap");
-    if (extensionalityProtected(e0, e1))
+    if (theoryProtected(e0, e1))
       return false;
     (*SolverMap)[e0] = e1;
     return true;

--- a/lib/AbsRefineCounterExample/CounterExample.cpp
+++ b/lib/AbsRefineCounterExample/CounterExample.cpp
@@ -147,11 +147,13 @@ AbsRefine_CounterExample::requireFpEncodingContext() const
  * populate the CounterExampleMap data structure (ASTNode -> BVConst)
  */
 void AbsRefine_CounterExample::ConstructCounterExample(
-    SATSolver& newS, const ToSATBase::ASTNodeToSATVar& satVarToSymbol)
+    SATSolver& newS, const ToSATBase::ASTNodeToSATVar& satVarToSymbol,
+    bool internalCandidateRequired)
 {
   if (!newS.okay())
     return;
-  if (!bm->UserFlags.construct_counterexample_flag)
+  if (!bm->UserFlags.construct_counterexample_flag &&
+      !internalCandidateRequired)
     return;
 
   assert(CounterExampleMap.size() == 0);

--- a/lib/STPManager/STP.cpp
+++ b/lib/STPManager/STP.cpp
@@ -980,9 +980,6 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
       return res;
     }
 
-    // Refinement reached no decision but the soft timeout has expired:
-    // report the timeout instead of iterating further (or falling into
-    // the fatal error below when nothing more is pending).
     if (bm->soft_timeout_expired)
     {
       if (toSATAIG.cbIsDestructed())

--- a/lib/Simplifier/RemoveUnconstrained.cpp
+++ b/lib/Simplifier/RemoveUnconstrained.cpp
@@ -95,15 +95,15 @@ ASTNode RemoveUnconstrained::topLevel(const ASTNode& n, Simplifier* simplifier,
       (ext != NULL && ext->activeInSolve()) ? &ext->getFrozenSymbols() : NULL;
   std::set<ASTNode> mergedUntouchable;
   const std::set<ASTNode>* effective = NULL;
-  if (extSet != NULL && alsoUntouchable != NULL)
+  if (extSet != NULL || alsoUntouchable != NULL)
   {
-    mergedUntouchable = *extSet;
-    mergedUntouchable.insert(alsoUntouchable->begin(),
-                             alsoUntouchable->end());
+    if (extSet != NULL)
+      mergedUntouchable.insert(extSet->begin(), extSet->end());
+    if (alsoUntouchable != NULL)
+      mergedUntouchable.insert(alsoUntouchable->begin(),
+                               alsoUntouchable->end());
     effective = &mergedUntouchable;
   }
-  else
-    effective = (extSet != NULL) ? extSet : alsoUntouchable;
   MutableASTNode::UntouchableScope protect(effective);
 
   bm.GetRunTimes()->start(RunTimes::RemoveUnconstrained);
@@ -217,7 +217,7 @@ void RemoveUnconstrained::replace(const ASTNode& from, const ASTNode to)
   if (simplifier->UpdateSubstitutionMapFewChecks(from, to))
     return;
 
-  // Refused (only SubstitutionMap::extensionalityProtected refuses).
+  // Refused (only SubstitutionMap::theoryProtected refuses).
   // The caller has already rewritten the graph to remove whatever
   // constrained "from", so dropping the definition here would leave it
   // free. Keep it as an ordinary conjunct instead; topLevel() attaches

--- a/lib/Simplifier/SubstitutionMap.cpp
+++ b/lib/Simplifier/SubstitutionMap.cpp
@@ -597,19 +597,20 @@ bool SubstitutionMap::loops(const ASTNode& n0, const ASTNode& n1)
 // "either side is a READ" test does -- suppressed BVSolver over every
 // read in the query, connected to an equality or not, and cost more
 // than the whole decision procedure on array-heavy input.
-bool SubstitutionMap::extensionalityProtected(const ASTNode& key,
-                                              const ASTNode& value) const
+bool SubstitutionMap::theoryProtected(const ASTNode& key,
+                                      const ASTNode& value) const
 {
   ExtensionalityContext* ext = bm->getExtensionalityIfAny();
-  if (ext == NULL || !ext->activeInSolve())
-    return false;
-  if (key.GetKind() == SYMBOL && ext->isProtected(key))
-    return true;
-  if (value.GetKind() == SYMBOL && ext->isProtected(value))
-    return true;
-  // The equation-deleting orientation: the read itself is the key.
-  if (key.GetKind() == READ)
-    return true;
+  if (ext != NULL && ext->activeInSolve())
+  {
+    if (key.GetKind() == SYMBOL && ext->isProtected(key))
+      return true;
+    if (value.GetKind() == SYMBOL && ext->isProtected(value))
+      return true;
+    // The equation-deleting orientation: the read itself is the key.
+    if (key.GetKind() == READ)
+      return true;
+  }
   return false;
 }
 
@@ -621,11 +622,11 @@ bool SubstitutionMap::UpdateSubstitutionMap(const ASTNode& e0,
     return false;
 
   // TermOrder has already chosen which side is the key: e0 when it
-  // returned 1, e1 when it returned -1. extensionalityProtected needs
+  // returned 1, e1 when it returned -1. theoryProtected needs
   // that orientation, because only a read in key position deletes an
   // access. The later "i = -1" flip below cannot change the answer:
   // it applies only when both sides are symbols.
-  if (extensionalityProtected(1 == i ? e0 : e1, 1 == i ? e1 : e0))
+  if (theoryProtected(1 == i ? e0 : e1, 1 == i ? e1 : e0))
     return false;
 
   assert(e0 != e1);


### PR DESCRIPTION
# Simplifier (prereq for UF support): rename extensionalityProtected to theoryProtected

**This PR builds on top of #929** (Counterexamples (prereq for UF support): drain every refinement owner before the next solve). Please review and merge it first; this branch contains its commits.

The substitution funnel's protection question is not specific to array equality: any theory that generates scalars whose defining equations must survive ordinary preprocessing needs the same refusal. Rename the predicate and restructure it (and RemoveUnconstrained's untouchable merge) so a second theory's protected set can join without another special case. Extensionality is still the only contributor, so no behaviour changes.
