### PR TITLE
UF support (2/8): lower durable applications at the completed root

### DIFF
--- a/include/stp/AST/ASTNode.h
+++ b/include/stp/AST/ASTNode.h
@@ -35,6 +35,7 @@ namespace stp
 {
 using std::ostream;
 class ASTInternal;
+class UFContext;
 
 /******************************************************************
  *  A Kind of Smart pointer to actual ASTInternal datastructure.  *
@@ -45,6 +46,7 @@ class ASTNode
 {
   friend class STPMgr;
   friend class ASTInterior;
+  friend class UFContext;
   friend class vector<ASTNode>;
   friend ASTNode HashingNodeFactory::CreateNode(
       stp::Kind kind, stp::ASTChildren back_children);
@@ -119,6 +121,21 @@ public:
 
   // Check if it points to a null node
   inline bool IsNull() const { return _int_node_ptr == NULL; }
+
+  // Public construction APIs use this to reject cross-context operands before
+  // asking a node factory to build anything. Node ownership is immutable.
+  bool IsOwnedBy(const STPMgr* manager) const
+  {
+    return !IsNull() && GetSTPMgr() == manager;
+  }
+
+  // The owning manager is immutable. Public printers for context-owned
+  // durable nodes need to recover their declaration registry without relying
+  // on a process-global parser manager.
+  STPMgr* GetNodeManager() const
+  {
+    return IsNull() ? NULL : GetSTPMgr();
+  }
 
   bool isSimplfied() const;
   void hasBeenSimplfied() const;

--- a/include/stp/AST/SourceSort.h
+++ b/include/stp/AST/SourceSort.h
@@ -13,6 +13,7 @@
 #include <cassert>
 #include <cstddef>
 #include <memory>
+#include <string>
 #include <unordered_set>
 
 namespace stp
@@ -193,6 +194,11 @@ public:
     size_t operator()(const SourceSort& sort) const { return sort.hash(); }
   };
 };
+
+// Return the canonical SMT-LIB2 spelling used in diagnostics and model text.
+// Unknown is rendered explicitly rather than making diagnostic construction
+// itself partial.
+std::string sourceSortToSMTLib(const SourceSort& sort);
 
 } // namespace stp
 

--- a/include/stp/AbsRefineCounterExample/AbsRefine_CounterExample.h
+++ b/include/stp/AbsRefineCounterExample/AbsRefine_CounterExample.h
@@ -182,8 +182,10 @@ public:
 
   // Converts MINISAT counterexample into an AST memotable (i.e. the
   // function populates the datastructure CounterExampleMap)
-  void ConstructCounterExample(SATSolver& newS,
-                               const ToSATBase::ASTNodeToSATVar& satVarToSymbol);
+  void ConstructCounterExample(
+      SATSolver& newS,
+      const ToSATBase::ASTNodeToSATVar& satVarToSymbol,
+      bool internalCandidateRequired = false);
 
   // Prints MINISAT assigment one bit at a time, for debugging.
   void PrintSATModel(SATSolver& S, ToSATBase::ASTNodeToSATVar& satVarToSymbol);

--- a/include/stp/STPManager/STPManager.h
+++ b/include/stp/STPManager/STPManager.h
@@ -693,6 +693,14 @@ public:
     return current;
   }
 
+  // SourceSort-preserving deterministic scalar allocation. UF lowering runs
+  // before FP/array carrier erasure and must retain Bool versus nonzero BV as
+  // immutable symbol identity, including for a Boolean whose carrier width is
+  // historically zero.
+  ASTNode CreateDeterministicSourceVariable(const SourceSort& sourceSort,
+                                            const std::string& prefix,
+                                            const ASTNode& key);
+
   bool FoundIntroducedSymbolSet(const ASTNode& in)
   {
     if (Introduced_SymbolsSet.find(in) != Introduced_SymbolsSet.end())

--- a/include/stp/STPManager/STPManager.h
+++ b/include/stp/STPManager/STPManager.h
@@ -43,6 +43,7 @@ THE SOFTWARE.
 namespace stp
 {
 class ExtensionalityContext;
+class UFContext;
 
 // The five SMT-LIB floating-point special values. Their nodes are ordinary
 // packed interned constants (see STPMgr::CreateFPSpecialConst); a childless
@@ -112,6 +113,7 @@ private:
   ASTSymbolSet _symbol_unique_table;
 
   ExtensionalityContext* extensionality = nullptr;
+  UFContext* uninterpretedFunctions = nullptr;
 
   // Table to uniquefy bvconst
   ASTBVConstSet _bvconst_unique_table;
@@ -137,6 +139,12 @@ public:
   {
     return extensionality;
   }
+
+  // Manager-lifetime UF declarations and durable applications. Solve-local
+  // lowering/checker/model state is owned below this context and reset at the
+  // completed-root boundary.
+  DLL_PUBLIC UFContext* getUFContext();
+  UFContext* getUFContextIfAny() const { return uninterpretedFunctions; }
 
   // frequently used nodes
   ASTNode ASTFalse, ASTTrue, ASTUndefined;

--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -181,6 +181,11 @@ public:
   // ARRAY_EQ, which is lowered only after the complete query is assembled.
   bool enable_array_equality = false;
 
+  // Decide nonzero-arity uninterpreted functions over Bool, BitVec,
+  // RoundingMode and FloatingPoint
+  // using the UFSTP v2 dynamic-Ackermann reference profile.
+  bool enable_uninterpreted_functions = false;
+
   // Replace a (distinct x1 ... xn) whose operands are variables occurring
   // nowhere else with the strict chain x1 < x2 < ... < xn. Every permutation
   // of such operands maps the formula to itself, so fixing one of the n!

--- a/include/stp/Simplifier/SubstitutionMap.h
+++ b/include/stp/Simplifier/SubstitutionMap.h
@@ -61,13 +61,11 @@ class DLL_PUBLIC SubstitutionMap
                     std::set<ASTNode>& visited);
   bool loops(const ASTNode& n0, const ASTNode& n1);
 
-  // Array equality: while the complete-graph checker is active, refuse
-  // either orientation if it would delete a protected scalar definition or
-  // any READ-headed equation. Every read is checker-owned, independently of
-  // its other operand's shape or its connectivity to an equality operand.
-  // Oriented: "key" is the side that gets replaced. See the definition.
-  bool extensionalityProtected(const ASTNode& key,
-                               const ASTNode& value) const;
+  // Theory-generated scalars whose defining equations must survive ordinary
+  // preprocessing. Array equality additionally owns READ-headed keys while
+  // its complete-graph checker is active. Oriented: "key" is the side that
+  // gets replaced. See the definition.
+  bool theoryProtected(const ASTNode& key, const ASTNode& value) const;
 
   size_t substitutionsLastApplied;
   VariablesInExpression vars;
@@ -133,7 +131,7 @@ public:
   {
     ASTNode var = (BVEXTRACT == key.GetKind()) ? key[0] : key;
 
-    if (extensionalityProtected(var, value))
+    if (theoryProtected(var, value))
       return false;
 
     if (var.GetKind() == SYMBOL && loops(var, value))
@@ -165,7 +163,7 @@ public:
   {
     assert(e0.GetKind() == SYMBOL);
     assert(!InsideSubstitutionMap(e0) && "e0 MUST NOT be in the SolverMap");
-    if (extensionalityProtected(e0, e1))
+    if (theoryProtected(e0, e1))
       return false;
     (*SolverMap)[e0] = e1;
     return true;

--- a/include/stp/UninterpretedFunctions/UFContext.h
+++ b/include/stp/UninterpretedFunctions/UFContext.h
@@ -1,0 +1,152 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+/********************************************************************
+ * Manager-owned declaration and durable-application registry.
+ ********************************************************************/
+#ifndef STP_UFCONTEXT_H
+#define STP_UFCONTEXT_H
+
+#include "stp/AST/AST.h"
+#include "stp/UninterpretedFunctions/UFDecl.h"
+#include <map>
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace stp
+{
+
+class STPMgr;
+
+class DLL_PUBLIC UFContext final
+{
+public:
+  explicit UFContext(STPMgr* manager);
+  ~UFContext();
+
+  UFContext(const UFContext&) = delete;
+  UFContext& operator=(const UFContext&) = delete;
+
+  // Nonfatal public funnel. A failure returns NULL/ASTUndefined, writes a
+  // stable diagnostic, and changes no declaration/application registry.
+  const UFDecl* declareFunction(const std::string& name,
+                                const std::vector<SourceSort>& domain,
+                                const SourceSort& codomain,
+                                std::string* error = NULL);
+  bool deactivate(const UFDecl* decl, std::string* error = NULL);
+  void deactivateAll();
+
+  const UFDecl* lookup(const std::string& name) const;
+  const UFDecl* lookupIdentity(const ASTNode& identity) const;
+
+  // Every declaration's identity symbol. Such a symbol carries its
+  // declaration's codomain sort so that an application can derive its own, but
+  // it denotes the function rather than an element of that sort -- so anything
+  // counting terms of a sort has to leave these out.
+  void collectIdentitySymbols(ASTNodeSet& out) const;
+  bool isActive(const UFDecl* decl) const;
+  bool owns(const UFDecl* decl) const;
+  std::vector<const UFDecl*> activeDeclarations() const;
+
+  ASTNode apply(const UFDecl* decl, const ASTVec& actuals,
+                std::string* error = NULL);
+
+  // SMT-LIB commands are transactions. Applications built while reducing a
+  // command become durable only if the outer command is accepted; a later
+  // malformed subexpression rolls back every application first introduced
+  // by that command.
+  void beginParserCommand();
+  void finishParserCommand(bool accepted);
+
+  // HashingNodeFactory's backstop for rebuilds (define-fun, let and generic
+  // substitutions). It validates the immutable signature/context but does not
+  // require declaration liveness: a pre-existing durable node may outlive its
+  // parser scope and must remain structurally readable as a stale handle.
+  bool validateApplicationChildren(ASTChildren children,
+                                   std::string* error = NULL) const;
+  void noteApplication(const ASTNode& application);
+  bool isRegisteredApplication(const ASTNode& application) const;
+  bool isActiveApplication(const ASTNode& application) const;
+
+  // Generated lowering scalars are solve-local protected objects. The
+  // lowering view itself is adapter-owned; the context retains membership
+  // indexes for preprocessing protection and explicit SAT registration.
+  void beginSolveProtection();
+  void installSolveProtection(const ASTNodeSet& protectedSymbols,
+                              const ASTNodeSet& solveScalars);
+  void releaseSolveProtection();
+  bool activeInSolve() const
+  {
+    return solveProtectionActive_ && !solveScalars_.empty();
+  }
+  bool isProtected(const ASTNode& symbol) const;
+  bool isSolveScalar(const ASTNode& symbol) const;
+  const ASTNodeSet& getProtectedSymbols() const { return protectedSymbols_; }
+  const ASTNodeSet& getSolveScalars() const { return solveScalars_; }
+
+  // Only this lexical window lets preprocessing, candidate construction and
+  // SAT registration consume the just-installed solve-local indexes.  The
+  // lowered view/certified model may outlive it for get-value, without making
+  // a later frontend command look like part of the preceding solve.
+  class DLL_PUBLIC SolveScope final
+  {
+  public:
+    explicit SolveScope(UFContext* context);
+    ~SolveScope();
+
+    SolveScope(const SolveScope&) = delete;
+    SolveScope& operator=(const SolveScope&) = delete;
+
+  private:
+    UFContext* const context_;
+  };
+
+  size_t declarationCount() const { return declarations_.size(); }
+  size_t activeDeclarationCount() const { return activeByName_.size(); }
+  size_t registeredApplicationCount() const { return applications_.size(); }
+  STPMgr* manager() const { return manager_; }
+
+private:
+  void setError(std::string* error, const std::string& message) const;
+
+  STPMgr* const manager_;
+  uint64_t nextDeclarationId_ = 0;
+  std::vector<std::unique_ptr<UFDecl>> declarations_;
+  std::map<std::string, const UFDecl*> activeByName_;
+  std::map<uint64_t, const UFDecl*> allById_;
+  std::map<ASTNode, const UFDecl*> byIdentity_;
+  std::set<const UFDecl*> owned_;
+  ASTNodeSet applications_;
+  std::vector<ASTNode> parserCommandApplications_;
+  ASTNodeSet protectedSymbols_;
+  ASTNodeSet solveScalars_;
+  bool parserCommandActive_ = false;
+  bool solveProtectionActive_ = false;
+};
+
+} // namespace stp
+
+#endif

--- a/include/stp/UninterpretedFunctions/UFDecl.h
+++ b/include/stp/UninterpretedFunctions/UFDecl.h
@@ -1,0 +1,133 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+/********************************************************************
+ * Typed declaration identities for UFSTP v2.
+ ********************************************************************/
+#ifndef STP_UFDECL_H
+#define STP_UFDECL_H
+
+#include "stp/AST/ASTNode.h"
+#include "stp/AST/SourceSort.h"
+#include "stp/Util/Attributes.h"
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace stp
+{
+
+class UFContext;
+class STPMgr;
+
+// An immutable, ordered source-language signature. Carrier widths are not a
+// substitute for the sorts themselves: Bool has carrier width zero, and
+// RoundingMode's 5-bit carrier has thirty-two patterns where the sort has
+// five values.
+class DLL_PUBLIC UFSignature final
+{
+public:
+  UFSignature(std::vector<SourceSort> domain, SourceSort codomain);
+
+  const std::vector<SourceSort>& domain() const { return domain_; }
+  const SourceSort& codomain() const { return codomain_; }
+  size_t arity() const { return domain_.size(); }
+
+  // The single admission gate for a signature position. Everything in the UF
+  // core -- the checker, the lemma oracle, the CNF encoder, the model printer
+  // and BVTypeCheck's UF_APPLY rule -- asks this rather than repeating the
+  // sort list, so admitting a sort is one edit rather than six.
+  static bool isSupportedSort(const SourceSort& sort);
+  // The parenthetical the diagnostics share; kept beside the gate so the two
+  // cannot drift.
+  static const char* supportedSortsPhrase();
+
+  // The sort a signature position is *solved* at, as against the sort it is
+  // declared at. The two differ only for FloatingPoint.
+  //
+  // The UF core's currency is a concrete scalar compared by its bytes, and
+  // that is the sort's own equality for Bool, BitVec and RoundingMode. It is
+  // not for floats: SMT-LIB's = on floats is identity of values, and the NaN
+  // value has many representations, so bit-level bucketing would certify a
+  // model in which f(NaN) and f(NaN) differ. A float therefore enters and
+  // leaves the core through FP_TO_IEEE_BV -- pack o unpack, which collapses
+  // NaN payloads while keeping the two zeros apart -- and everything inside
+  // sees only Bool, BitVec and RoundingMode. This is the one function that
+  // says so.
+  static SourceSort loweringSort(const SourceSort& sort);
+  static bool validate(const std::vector<SourceSort>& domain,
+                       const SourceSort& codomain, std::string* error = NULL);
+
+  friend bool operator==(const UFSignature& left, const UFSignature& right)
+  {
+    return left.domain_ == right.domain_ && left.codomain_ == right.codomain_;
+  }
+  friend bool operator!=(const UFSignature& left, const UFSignature& right)
+  {
+    return !(left == right);
+  }
+
+private:
+  const std::vector<SourceSort> domain_;
+  const SourceSort codomain_;
+};
+
+// Context-owned immutable declaration identity. Liveness is intentionally
+// not stored here: a declaration object remains address-stable until its
+// STPMgr dies, while UFContext separately activates/deactivates it as parser
+// scopes come and go. That makes stale handles rejectable without dangling.
+class DLL_PUBLIC UFDecl final
+{
+public:
+  uint64_t id() const { return id_; }
+  const std::string& name() const { return name_; }
+  const UFSignature& signature() const { return signature_; }
+  const ASTNode& identityNode() const { return identity_; }
+  const STPMgr* owner() const { return owner_; }
+
+  UFDecl(const UFDecl&) = delete;
+  UFDecl& operator=(const UFDecl&) = delete;
+
+private:
+  friend class UFContext;
+
+  UFDecl(STPMgr* owner, uint64_t id, std::string name,
+         UFSignature signature, ASTNode identity)
+      : owner_(owner), id_(id), name_(std::move(name)),
+        signature_(std::move(signature)), identity_(std::move(identity))
+  {
+  }
+
+  STPMgr* const owner_;
+  const uint64_t id_;
+  const std::string name_;
+  const UFSignature signature_;
+  const ASTNode identity_;
+};
+
+} // namespace stp
+
+#endif

--- a/include/stp/UninterpretedFunctions/UFLowering.h
+++ b/include/stp/UninterpretedFunctions/UFLowering.h
@@ -1,0 +1,150 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+/********************************************************************
+ * Completed-root lowering for durable uninterpreted-function nodes.
+ ********************************************************************/
+#ifndef STP_UFLOWERING_H
+#define STP_UFLOWERING_H
+
+#include "stp/AST/AST.h"
+#include "stp/UninterpretedFunctions/UFDecl.h"
+#include <cstdint>
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace stp
+{
+
+class STPMgr;
+class UFContext;
+
+// The semantic owner of one lowering. Batch scopes live for one fresh SAT
+// query. Persistent scopes identify one exact-stack block in one encoding
+// epoch; the block guard is filled by the persistent adapter once encoded.
+struct DLL_PUBLIC UFSolveScope
+{
+  enum class Mode
+  {
+    Batch,
+    Persistent
+  };
+
+  Mode mode = Mode::Batch;
+  uint64_t id = 0;
+  uint64_t epoch = 0;
+  ASTNode blockGuard;
+
+  static UFSolveScope batch(uint64_t id_)
+  {
+    UFSolveScope scope;
+    scope.mode = Mode::Batch;
+    scope.id = id_;
+    return scope;
+  }
+
+  static UFSolveScope persistent(uint64_t id_, uint64_t epoch_)
+  {
+    UFSolveScope scope;
+    scope.mode = Mode::Persistent;
+    scope.id = id_;
+    scope.epoch = epoch_;
+    return scope;
+  }
+};
+
+// One application as seen after all frontend substitution and after nested
+// UF applications in its actuals have themselves been lowered.
+struct DLL_PUBLIC LoweredApplicationRecord
+{
+  ASTNode durableHandle;
+  const UFDecl* declaration = NULL;
+  ASTVec loweredActuals;
+  ASTVec namedActuals;
+  ASTNode resultSymbol;
+  UFSolveScope scope;
+  size_t stableOrder = 0;
+  // Whether the checker can read this application's argument tuple, i.e.
+  // whether every actual is a constant or a registered solve scalar. False
+  // when lowering declined to name a compound actual because the declaration
+  // has too few applications for any congruence lemma to mention it; such a
+  // record carries no namedActuals and is interpreted by a constant.
+  bool observableArguments = true;
+};
+
+// Value object owned by a solve-mode adapter. It deliberately contains no SAT
+// state: M3's checker consumes it as immutable semantic input, while the batch
+// and persistent adapters own their distinct clause/cache lifetimes.
+class DLL_PUBLIC LoweredApplicationView final
+{
+public:
+  UFSolveScope scope;
+  ASTNode publicRoot;
+  ASTNode semanticRoot;
+  std::vector<LoweredApplicationRecord> applications;
+  ASTNodeMap handleToResult;
+  ASTNodeMap nameToTerm;
+  ASTVec namingDefinitions;
+  // Side conditions without which a solve scalar would denote nothing. Only
+  // RoundingMode needs one today: its 5-bit carrier has thirty-two patterns
+  // and the sort has five values, so every RoundingMode scalar this lowering
+  // registers is pinned one-hot here. FpTotalise pins the same symbols when
+  // it runs, and the constraint is idempotent, but relying on that would make
+  // a model's legality depend on a pass ordering rather than on lowering.
+  ASTVec sortConstraints;
+  ASTNodeSet protectedSymbols;
+  // Every symbolic checker leaf has exactly one concrete candidate
+  // authority: its complete Bool/BV mapping in the live SAT backend.  This
+  // is deliberately explicit rather than inferred from formula reachability;
+  // preprocessing may leave a result or name only in future UF lemmas.
+  ASTNodeSet solveScalars;
+
+  bool active() const { return !applications.empty(); }
+  size_t size() const { return applications.size(); }
+
+  // Attach the query/block-local name definitions to the lowered semantic
+  // formula. Result symbols intentionally have no eager UF definition.
+  ASTNode semanticRootWithDefinitions(STPMgr* manager) const;
+};
+
+class DLL_PUBLIC UFLowering final
+{
+public:
+  explicit UFLowering(STPMgr* manager);
+
+  UFLowering(const UFLowering&) = delete;
+  UFLowering& operator=(const UFLowering&) = delete;
+
+  LoweredApplicationView lowerCompletedRoot(const ASTNode& publicRoot,
+                                            const UFSolveScope& scope) const;
+
+private:
+  STPMgr* const manager_;
+};
+
+} // namespace stp
+
+#endif

--- a/include/stp/cpp_interface.h
+++ b/include/stp/cpp_interface.h
@@ -115,7 +115,11 @@ struct TransparentStringHash
 class Cpp_interface
 {
   STPMgr& bm;
-  std::map<std::string, std::pair<unsigned, unsigned>> sort_aliases;
+  // Sort names the script introduced: define-sort's nullary floating-point
+  // aliases, and declare-sort's uninterpreted sorts. Both resolve to a
+  // SourceSort, so a name in sort position needs one lookup whichever
+  // command introduced it.
+  std::map<std::string, SourceSort> sort_aliases;
   bool print_success;
   bool ignoreCheckSatRequest;
 
@@ -163,7 +167,7 @@ private:
     // the global functions to be able to remove functions when we pop
     SolverFrame(ankerl::unordered_dense::map<std::string, Function>*
                     global_function_context,
-                std::map<std::string, std::pair<unsigned, unsigned>>*
+                std::map<std::string, SourceSort>*
                     global_sort_alias_context);
     virtual ~SolverFrame();
 
@@ -197,7 +201,7 @@ private:
         _symbol_bindings;
     ankerl::unordered_dense::map<std::string, Function>*
         _global_function_context;
-    std::map<std::string, std::pair<unsigned, unsigned>>*
+    std::map<std::string, SourceSort>*
         _global_sort_alias_context;
   };
 
@@ -344,10 +348,16 @@ public:
                                           unsigned exp_width,
                                           unsigned sig_width);
 
-  // define-sort aliases for floating-point sorts. A real table: the alias
-  // name is NOT interned as a symbol (the old scheme made the sort name
-  // resolvable as a term variable). Aliases follow assertion-frame scope,
-  // and :global-declarations along with the other declarations.
+  // Sort names the script introduced. A real table: the alias name is NOT
+  // interned as a symbol (the old scheme made the sort name resolvable as a
+  // term variable). Aliases follow assertion-frame scope, and
+  // :global-declarations along with the other declarations.
+  DLL_PUBLIC void addSortAlias(const std::string& name, const SourceSort& sort);
+  DLL_PUBLIC bool lookupSortAlias(const std::string& name,
+                                  SourceSort& sort) const;
+
+  // The floating-point spelling of the same pair, kept because define-sort's
+  // callers speak in exponent/significand widths.
   DLL_PUBLIC void addSortAlias(const std::string& name, unsigned exp_width,
                                unsigned sig_width);
   DLL_PUBLIC bool lookupSortAlias(const std::string& name,

--- a/lib/AST/ASTKind.kinds
+++ b/lib/AST/ASTKind.kinds
@@ -213,3 +213,9 @@ FP_SMT_EQ           2    2    Form    FP
 # c_interface.h remain stable. The extensionality prepass lowers this before
 # ordinary solving.
 ARRAY_EQ        2       2       Form
+
+# Durable, typed application of an uninterpreted function. Child 0 is the
+# manager-owned declaration identity; the remaining children are the ordered
+# source-language actuals. This stays opaque until solve-boundary UF lowering.
+# Keep this last: existing public kind values are ABI-visible.
+UF_APPLY        2       -       Term    Form

--- a/lib/AST/ASTNode.cpp
+++ b/lib/AST/ASTNode.cpp
@@ -94,6 +94,28 @@ static bool deriveFPFormat(const ASTNode& n, unsigned int& e, unsigned int& s)
       return e != 0 && s != 0;
     }
 
+    // An application of an uninterpreted function whose codomain is a float
+    // yields a float in the codomain's format. That format is not carried by
+    // any operand -- the declaration identity in child 0 names it, in the
+    // same immutable source sort deriveSourceSort reads for the node's sort.
+    // Without this the application would be an FP-sorted node of no format,
+    // which types as a plain bit-vector: fp.add would refuse it as having a
+    // different format from its other operand, and fp.abs would build a
+    // (0, 0)-format result that blasts to the wrong bits.
+    case UF_APPLY:
+    {
+      if (n.Degree() < 1)
+        return false;
+
+      const SourceSort codomain = n[0].GetSourceSort();
+      if (codomain.kind() != SourceSort::Kind::FloatingPoint)
+        return false;
+
+      e = codomain.exponentWidth();
+      s = codomain.significandWidth();
+      return e != 0 && s != 0;
+    }
+
     // A read from an array of floats yields a float in the element's format,
     // which the array node carries.
     case READ:
@@ -198,6 +220,11 @@ static void fpFormatOperands(const ASTNode& n, size_t& from, size_t& to)
   {
     case READ:
     case WRITE:
+      to = (n.Degree() >= 1) ? 1 : 0;
+      break;
+
+    case UF_APPLY:
+      // The declaration identity's immutable source sort is the codomain.
       to = (n.Degree() >= 1) ? 1 : 0;
       break;
 
@@ -533,6 +560,9 @@ SourceSort ASTNode::deriveSourceSort() const
 {
   if (GetKind() == UNDEFINED)
     return SourceSort::unknown();
+
+  if (GetKind() == UF_APPLY && Degree() >= 1)
+    return (*this)[0].GetSourceSort();
 
   // API type nodes denote the corresponding source sort even though they
   // are not themselves value-bearing terms.

--- a/lib/AST/ASTmisc.cpp
+++ b/lib/AST/ASTmisc.cpp
@@ -23,6 +23,7 @@ THE SOFTWARE.
 ********************************************************************/
 
 #include "stp/AST/AST.h"
+#include "stp/UninterpretedFunctions/UFDecl.h"
 #include "stp/STPManager/STPManager.h"
 #include "stp/Util/NodeIterator.h"
 
@@ -633,6 +634,35 @@ bool BVTypeCheck_term_kind(const ASTNode& n, const Kind& k)
 
   switch (k)
   {
+    case UF_APPLY:
+    {
+      if (n.Degree() < 2 || n[0].GetKind() != SYMBOL)
+        FatalError("BVTypeCheck: malformed UF_APPLY declaration/arity", n);
+      const SourceSort sort = n.GetSourceSort();
+      if (!UFSignature::isSupportedSort(sort))
+        FatalError("BVTypeCheck: unsupported UF_APPLY result sort", n);
+      if (sort.kind() == SourceSort::Kind::Bool)
+      {
+        if (n.GetType() != BOOLEAN_TYPE)
+          FatalError("BVTypeCheck: Bool UF_APPLY has a non-Bool carrier", n);
+      }
+      // A float-codomain application derives its format from the same
+      // declaration identity its sort comes from, so it types as a float
+      // rather than as its packed carrier. Every other admitted sort has a
+      // bit-vector carrier of the packed width.
+      else if (sort.kind() == SourceSort::Kind::FloatingPoint)
+      {
+        if (n.GetType() != FLOATINGPOINT_TYPE ||
+            n.GetExpWidth() != sort.exponentWidth() ||
+            n.GetSigWidth() != sort.significandWidth())
+          FatalError("BVTypeCheck: float UF_APPLY has the wrong format", n);
+      }
+      else if (n.GetType() != BITVECTOR_TYPE ||
+               n.GetValueWidth() != sort.packedWidth())
+        FatalError("BVTypeCheck: UF_APPLY has the wrong carrier width", n);
+      break;
+    }
+
     case BVCONST:
       if (BITVECTOR_TYPE != n.GetType() && FLOATINGPOINT_TYPE != n.GetType())
         FatalError("BVTypeCheck: The term t does not typecheck, where t = \n",

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -39,6 +39,7 @@ add_library(AST OBJECT
     ${CMAKE_CURRENT_BINARY_DIR}/ASTKind.cpp
     ASTInterior.cpp
     ASTNode.cpp
+    SourceSort.cpp
     ASTUtil.cpp
     ASTBVConst.cpp
     ASTFPConst.cpp

--- a/lib/AST/SourceSort.cpp
+++ b/lib/AST/SourceSort.cpp
@@ -1,0 +1,52 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#include "stp/AST/SourceSort.h"
+
+namespace stp
+{
+
+std::string sourceSortToSMTLib(const SourceSort& sort)
+{
+  switch (sort.kind())
+  {
+    case SourceSort::Kind::Bool:
+      return "Bool";
+    case SourceSort::Kind::BitVector:
+      return "(_ BitVec " + std::to_string(sort.bitVectorWidth()) + ")";
+    case SourceSort::Kind::FloatingPoint:
+      return "(_ FloatingPoint " + std::to_string(sort.exponentWidth()) +
+             " " + std::to_string(sort.significandWidth()) + ")";
+    case SourceSort::Kind::RoundingMode:
+      return "RoundingMode";
+    case SourceSort::Kind::Array:
+      return "(Array " + sourceSortToSMTLib(sort.index()) + " " +
+             sourceSortToSMTLib(sort.element()) + ")";
+    case SourceSort::Kind::Unknown:
+      return "Unknown";
+  }
+  return "Unknown";
+}
+
+} // namespace stp

--- a/lib/AbsRefineCounterExample/CounterExample.cpp
+++ b/lib/AbsRefineCounterExample/CounterExample.cpp
@@ -147,11 +147,13 @@ AbsRefine_CounterExample::requireFpEncodingContext() const
  * populate the CounterExampleMap data structure (ASTNode -> BVConst)
  */
 void AbsRefine_CounterExample::ConstructCounterExample(
-    SATSolver& newS, const ToSATBase::ASTNodeToSATVar& satVarToSymbol)
+    SATSolver& newS, const ToSATBase::ASTNodeToSATVar& satVarToSymbol,
+    bool internalCandidateRequired)
 {
   if (!newS.okay())
     return;
-  if (!bm->UserFlags.construct_counterexample_flag)
+  if (!bm->UserFlags.construct_counterexample_flag &&
+      !internalCandidateRequired)
     return;
 
   assert(CounterExampleMap.size() == 0);

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -54,6 +54,7 @@ add_subdirectory(Globals)
 add_subdirectory(AST)
 add_subdirectory(AbsRefineCounterExample)
 add_subdirectory(Extensionality)
+add_subdirectory(UninterpretedFunctions)
 add_subdirectory(FloatBlaster)
 add_subdirectory(Simplifier)
 add_subdirectory(Printer)
@@ -80,6 +81,7 @@ set(stp_lib_targets
     stpmgr
     abstractionrefinement
     extensionality
+    uninterpretedfunctions
     tosat
     sat
     incremental

--- a/lib/FloatBlaster/FloatBlast.cpp
+++ b/lib/FloatBlaster/FloatBlast.cpp
@@ -347,6 +347,12 @@ private:
 
   ASTNode rebuild(const ASTNode& n, const ASTVec& children)
   {
+    // Nothing rebuilds a UF application: every path that could reach one
+    // returns it untouched (see lower). Substituting here would hand the
+    // node factory an application whose actual sorts no longer match its
+    // declaration, and the factory's job is to refuse that.
+    assert(n.GetKind() != UF_APPLY);
+
     if (n.GetType() == BOOLEAN_TYPE)
       return node_factory->CreateNode(n.GetKind(), children);
 
@@ -362,6 +368,21 @@ private:
   // this function and consume the unpacked view directly.
   ASTNode lower(const ASTNode& n)
   {
+    // A UF application is opaque to this pass, whatever its codomain. Its
+    // actuals are stated in source sorts and the UF layer both validates and
+    // compares them there, so lowering one underneath the application
+    // changes what the application denotes -- when it is admitted at all;
+    // an application of f to a float that arrives as the bits the float
+    // lowered to is exactly what the declaration check refuses.
+    //
+    // There is nothing to lower in return for that. The application already
+    // is the bits of its result: UFContext::apply builds it at the
+    // codomain's packed width, and its actuals are resolved at their source
+    // sorts by whoever consumes the application -- the UF lowering pass
+    // before a solve, the model evaluator's UF_APPLY arm after one.
+    if (n.GetKind() == UF_APPLY)
+      return n;
+
     if (n.GetSourceSort().kind() == SourceSort::Kind::FloatingPoint)
       return asPacked(n);
 
@@ -427,6 +448,16 @@ private:
     ASTNode out;
     if (n.Degree() == 0)
     {
+      out = n;
+    }
+    else if (n.GetKind() == UF_APPLY)
+    {
+      // Opaque carrier, like a leaf: the application's own bits are the
+      // packed value of its result, and nothing under it is lowered
+      // (lower). Deliberately not canonicalised -- the payload of a NaN the
+      // solve chose for an application is its payload, exactly as for a
+      // float symbol; canonicalPacked is where a caller that needs the
+      // quotient asks for it.
       out = n;
     }
     else if (n.GetKind() == READ)
@@ -550,6 +581,16 @@ private:
 
     if (n.Degree() == 0)
       return decodeCarrier(n, n);
+
+    if (kind == UF_APPLY)
+    {
+      // An opaque packed cell whose subterms stay as they are: unlike a
+      // READ, an application's children are its declaration identity and
+      // its actuals, and neither may be rewritten into the target language
+      // (lower).
+      packed_cache[n] = n;
+      return decodeCarrier(n, n);
+    }
 
     if (kind == READ)
     {

--- a/lib/Incremental/IncrementalSolverImpl.h
+++ b/lib/Incremental/IncrementalSolverImpl.h
@@ -2143,30 +2143,35 @@ struct IncrementalSolver::Impl
   // rootLit's encode runs this same guard, and each step removes its
   // variable from the dropped set before encoding, so the chain
   // terminates and a definition never restores itself twice.
+  // Restore one dropped base definition before any route mints the source
+  // symbol's raw bits.
+  void restoreDroppedSigma0Symbol(const ASTNode& s)
+  {
+    if (sigma0Dropped.erase(s) == 0)
+      return;
+    const ASTNode conj = sigma0DefiningConjunctOf.at(s);
+    mustKeepRaw.insert(conj);
+    // The conjunct's cached encoding is the eliminated TRUE form; evict it so
+    // the re-encode below produces the raw equation.
+    rootLitOf.erase(conj);
+    const int lit = rootLit(conj);
+    SATSolver::vec_literals unit;
+    unit.push(SATSolver::mkLit(lit >> 1, lit & 1));
+    addClause(unit);
+    baseLiveMass = addMass(baseLiveMass, addMass(clauseMassOf[conj], 1));
+    recordPermanentRoot(conj);
+    if (bm->UserFlags.stats_flag)
+      std::cerr << "Incremental: restored an eliminated base definition "
+                   "before its variable was encoded raw"
+                << std::endl;
+  }
+
   void restoreDroppedSigma0(const ASTNode& toEncode)
   {
     if (sigma0Dropped.empty())
       return;
     for (const ASTNode& s : symbolsOf(toEncode))
-    {
-      if (sigma0Dropped.erase(s) == 0)
-        continue;
-      const ASTNode conj = sigma0DefiningConjunctOf.at(s);
-      mustKeepRaw.insert(conj);
-      // The conjunct's cached encoding is the eliminated TRUE form; evict
-      // it so the re-encode below produces the raw equation.
-      rootLitOf.erase(conj);
-      const int lit = rootLit(conj);
-      SATSolver::vec_literals unit;
-      unit.push(SATSolver::mkLit(lit >> 1, lit & 1));
-      addClause(unit);
-      baseLiveMass = addMass(baseLiveMass, addMass(clauseMassOf[conj], 1));
-      recordPermanentRoot(conj);
-      if (bm->UserFlags.stats_flag)
-        std::cerr << "Incremental: restored an eliminated base definition "
-                     "before its variable was encoded raw"
-                  << std::endl;
-    }
+      restoreDroppedSigma0Symbol(s);
   }
 
   // Lower, transform and bit-blast a fully rewritten word-level formula

--- a/lib/Interface/cpp_interface.cpp
+++ b/lib/Interface/cpp_interface.cpp
@@ -207,26 +207,43 @@ ASTNode Cpp_interface::CreateFPSpecialConst(stp::FPSpecial which,
   return bm.CreateFPSpecialConst(which, exp_width, sig_width);
 }
 
-void Cpp_interface::addSortAlias(const std::string& name, unsigned exp_width,
-                                 unsigned sig_width)
+void Cpp_interface::addSortAlias(const std::string& name,
+                                 const SourceSort& sort)
 {
   // SMT-LIB does not allow redefining a sort name.
   if (sort_aliases.find(name) != sort_aliases.end())
-    FatalError("define-sort: the sort name is already defined");
-  sort_aliases[name] = std::make_pair(exp_width, sig_width);
+    FatalError("the sort name is already defined");
+  sort_aliases[name] = sort;
   frames.back()->addSortAlias(name);
   session_touched = true;
+}
+
+bool Cpp_interface::lookupSortAlias(const std::string& name,
+                                    SourceSort& sort) const
+{
+  const auto found = sort_aliases.find(name);
+  if (found == sort_aliases.end())
+    return false;
+  sort = found->second;
+  return true;
+}
+
+void Cpp_interface::addSortAlias(const std::string& name, unsigned exp_width,
+                                 unsigned sig_width)
+{
+  addSortAlias(name, SourceSort::floatingPoint(exp_width, sig_width));
 }
 
 bool Cpp_interface::lookupSortAlias(const std::string& name,
                                     unsigned& exp_width,
                                     unsigned& sig_width) const
 {
-  const auto found = sort_aliases.find(name);
-  if (found == sort_aliases.end())
+  SourceSort sort;
+  if (!lookupSortAlias(name, sort) ||
+      sort.kind() != SourceSort::Kind::FloatingPoint)
     return false;
-  exp_width = found->second.first;
-  sig_width = found->second.second;
+  exp_width = sort.exponentWidth();
+  sig_width = sort.significandWidth();
   return true;
 }
 
@@ -1421,7 +1438,7 @@ void CNFClearMemory()
 Cpp_interface::SolverFrame::SolverFrame(
     ankerl::unordered_dense::map<std::string, Function>*
         global_function_context,
-    std::map<std::string, std::pair<unsigned, unsigned>>*
+    std::map<std::string, SourceSort>*
         global_sort_alias_context)
     : _global_function_context(global_function_context),
       _global_sort_alias_context(global_sort_alias_context)

--- a/lib/NodeFactory/HashingNodeFactory.cpp
+++ b/lib/NodeFactory/HashingNodeFactory.cpp
@@ -25,6 +25,7 @@ THE SOFTWARE.
 #include "stp/NodeFactory/HashingNodeFactory.h"
 #include "stp/AST/AST.h"
 #include "stp/Extensionality/ExtensionalityContext.h"
+#include "stp/UninterpretedFunctions/UFContext.h"
 #include "stp/STPManager/STP.h"
 
 using namespace stp;
@@ -37,6 +38,15 @@ HashingNodeFactory::~HashingNodeFactory()
 ASTNode HashingNodeFactory::CreateNode(const Kind kind,
                                        const ASTChildren back_children)
 {
+  if (kind == UF_APPLY)
+  {
+    std::string error;
+    UFContext* context = bm.getUFContextIfAny();
+    if (context == NULL ||
+        !context->validateApplicationChildren(back_children, &error))
+      FatalError(("UF_APPLY: " + error).c_str());
+  }
+
   // We can't create NOT(NOT (..)) nodes because of how the numbering scheme we
   // use works. So you can't trust the hashing node factory even to return
   // nodes of the same kind that you ask for.
@@ -85,19 +95,28 @@ ASTNode HashingNodeFactory::CreateNode(const Kind kind,
   if (back_children.size()  <= 1 || !isCommutative(kind))
   {
     // Don't create a new vector if it won't be sorted.
-    return ASTNode(bm.LookupOrCreateInterior(kind, back_children));
+    ASTNode result(bm.LookupOrCreateInterior(kind, back_children));
+    if (kind == UF_APPLY)
+      bm.getUFContext()->noteApplication(result);
+    return result;
   }
   else if (is_Form_kind(kind)) // formula and commutative.
   {
     const bool isSorted =  std::is_sorted(back_children.begin(),back_children.end(),stp::ExprLess{});
     if (isSorted)
     {
-      return ASTNode(bm.LookupOrCreateInterior(kind, back_children));
+      ASTNode result(bm.LookupOrCreateInterior(kind, back_children));
+      if (kind == UF_APPLY)
+        bm.getUFContext()->noteApplication(result);
+      return result;
     }
 
     ASTVec sorted_children(back_children.begin(), back_children.end());
     SortByExprNum(sorted_children);
-    return ASTNode(bm.LookupOrCreateInterior(kind, sorted_children));
+    ASTNode result(bm.LookupOrCreateInterior(kind, sorted_children));
+    if (kind == UF_APPLY)
+      bm.getUFContext()->noteApplication(result);
+    return result;
   }
   else
   {
@@ -105,7 +124,10 @@ ASTNode HashingNodeFactory::CreateNode(const Kind kind,
                        stp::ArithLess{}))
     {
       // Don't create a new vector if it's already sorted.
-      return ASTNode(bm.LookupOrCreateInterior(kind, back_children));
+      ASTNode result(bm.LookupOrCreateInterior(kind, back_children));
+      if (kind == UF_APPLY)
+        bm.getUFContext()->noteApplication(result);
+      return result;
     }
 
     ASTVec children(back_children.begin(), back_children.end());
@@ -113,7 +135,10 @@ ASTNode HashingNodeFactory::CreateNode(const Kind kind,
     // LHS.
     SortByArith(children);
 
-    return ASTNode(bm.LookupOrCreateInterior(kind, children));
+    ASTNode result(bm.LookupOrCreateInterior(kind, children));
+    if (kind == UF_APPLY)
+      bm.getUFContext()->noteApplication(result);
+    return result;
   }
 }
 

--- a/lib/NodeFactory/SimplifyingNodeFactory.cpp
+++ b/lib/NodeFactory/SimplifyingNodeFactory.cpp
@@ -42,6 +42,7 @@ using stp::BVMULT;
 using stp::ITE;
 using stp::EQ;
 using stp::ARRAY_EQ;
+using stp::UF_APPLY;
 using stp::BVSRSHIFT;
 using stp::SBVREM;
 using stp::SBVMOD;
@@ -1039,6 +1040,10 @@ ASTNode SimplifyingNodeFactory::CreateNode(Kind kind,
         result = simplifyArrayEquality(children[0], children[1]);
       if (result.IsNull())
         result = hashing.CreateNode(ARRAY_EQ, children);
+      break;
+    case UF_APPLY:
+      // Durable applications are opaque until completed-root lowering.
+      result = hashing.CreateNode(UF_APPLY, children);
       break;
     case stp::IFF:
     {
@@ -3391,6 +3396,9 @@ ASTNode SimplifyingNodeFactory::CreateTerm(Kind kind, unsigned int width,
   const bool is_partial_fp_operation =
       kind == stp::FP_MIN || kind == stp::FP_MAX || kind == stp::FP_TO_UBV ||
       kind == stp::FP_TO_SBV;
+
+  if (kind == stp::UF_APPLY)
+    return hashing.CreateTerm(kind, width, children);
 
   // If all the parameters are constant, return the constant value.
   if (children_all_constants(children) && !is_partial_fp_operation)

--- a/lib/Printer/SMTLIBPrinter.cpp
+++ b/lib/Printer/SMTLIBPrinter.cpp
@@ -24,6 +24,8 @@ THE SOFTWARE.
 
 #include "stp/Printer/SMTLIBPrinter.h"
 #include "stp/Printer/printers.h"
+#include "stp/STPManager/STPManager.h"
+#include "stp/UninterpretedFunctions/UFContext.h"
 #include <cassert>
 
 // Functions shared between the printers: the letize pass used by all of
@@ -126,6 +128,24 @@ void SMTLIB_Print1(ostream& os, const ASTNode n, int indentation, bool letize)
       n.nodeprint(os);
       os << "|";
       break;
+    case UF_APPLY:
+    {
+      STPMgr* manager = n.GetNodeManager();
+      UFContext* context =
+          manager == NULL ? NULL : manager->getUFContextIfAny();
+      const UFDecl* declaration =
+          context == NULL || c.empty() ? NULL : context->lookupIdentity(c[0]);
+      if (declaration == NULL)
+        FatalError("cannot print an unregistered UF_APPLY", n);
+      os << "(|" << declaration->name() << '|';
+      for (size_t i = 1; i < c.size(); ++i)
+      {
+        os << ' ';
+        SMTLIB_Print1(os, c[i], 0, letize);
+      }
+      os << ')';
+      break;
+    }
     case FALSE:
       os << "false";
       break;

--- a/lib/STPManager/STP.cpp
+++ b/lib/STPManager/STP.cpp
@@ -980,9 +980,6 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
       return res;
     }
 
-    // Refinement reached no decision but the soft timeout has expired:
-    // report the timeout instead of iterating further (or falling into
-    // the fatal error below when nothing more is pending).
     if (bm->soft_timeout_expired)
     {
       if (toSATAIG.cbIsDestructed())

--- a/lib/STPManager/STPManager.cpp
+++ b/lib/STPManager/STPManager.cpp
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // to get the PRIu64 macro from inttypes, this needs to be defined.
 #include "stp/STPManager/STPManager.h"
 #include "stp/Extensionality/ExtensionalityContext.h"
+#include "stp/UninterpretedFunctions/UFContext.h"
 #include "stp/FloatBlaster/rounding_modes.h"
 #include "stp/Printer/SMTLIBPrinter.h"
 #include "stp/Util/CBVOps.h"
@@ -892,12 +893,22 @@ ExtensionalityContext* STPMgr::getExtensionality()
   return extensionality;
 }
 
+UFContext* STPMgr::getUFContext()
+{
+  if (uninterpretedFunctions == NULL)
+    uninterpretedFunctions = new UFContext(this);
+  return uninterpretedFunctions;
+}
+
 STPMgr::~STPMgr()
 {
   ClearAllTables();
 
   delete extensionality;
   extensionality = NULL;
+
+  delete uninterpretedFunctions;
+  uninterpretedFunctions = NULL;
 
   printer::NodeLetVarMap.clear();
   printer::NodeLetVarVec.clear();

--- a/lib/STPManager/STPManager.cpp
+++ b/lib/STPManager/STPManager.cpp
@@ -168,6 +168,44 @@ ASTNode STPMgr::introducedSymbol(const std::string& name,
   return symbol;
 }
 
+ASTNode STPMgr::CreateDeterministicSourceVariable(
+    const SourceSort& sourceSort, const std::string& prefix,
+    const ASTNode& key)
+{
+  // Bool, or any scalar sort with a carrier to blast: BitVec, RoundingMode
+  // and FloatingPoint all answer packedWidth(). A symbol whose sort needs a
+  // side condition to denote (RoundingMode is one-hot in five of thirty-two
+  // patterns) is still created here; asserting that condition belongs to
+  // whoever introduces the symbol, not to the factory.
+  if (!(sourceSort.kind() == SourceSort::Kind::Bool ||
+        (sourceSort.isScalar() && sourceSort.packedWidth() > 0)))
+    FatalError("CreateDeterministicSourceVariable requires Bool or a "
+               "nonzero-width scalar source sort");
+  if (key.IsNull() || !key.IsOwnedBy(this))
+    FatalError("CreateDeterministicSourceVariable requires a live local key");
+
+  std::ostringstream name;
+  name << '@' << prefix << "_k" << key.GetNodeNum();
+  const std::map<std::string, ASTNode>::const_iterator found =
+      _introduced_by_name.find(name.str());
+  if (found != _introduced_by_name.end())
+  {
+    if (found->second.GetSourceSort() != sourceSort)
+      FatalError("a deterministic introduced symbol was requested at two "
+                 "different source sorts",
+                 found->second);
+    return found->second;
+  }
+
+  if (LookupSymbol(name.str().c_str()))
+    FatalError("a symbol in STP's reserved deterministic namespace already "
+               "exists");
+  const ASTNode symbol = CreateSourceSymbol(name.str().c_str(), sourceSort);
+  noteIntroducedSymbol(symbol);
+  _introduced_by_name[name.str()] = symbol;
+  return symbol;
+}
+
 void STPMgr::indexSymbolName(ASTSymbol* symbol)
 {
   _symbol_name_index[symbol->GetName()].push_back(symbol);

--- a/lib/Simplifier/RemoveUnconstrained.cpp
+++ b/lib/Simplifier/RemoveUnconstrained.cpp
@@ -58,6 +58,7 @@ THE SOFTWARE.
 #include "stp/Simplifier/RemoveUnconstrained.h"
 #include "stp/AST/MutableASTNode.h"
 #include "stp/Extensionality/ExtensionalityContext.h"
+#include "stp/UninterpretedFunctions/UFContext.h"
 #include "stp/FloatBlaster/FloatBlaster.h"
 #include "stp/FloatBlaster/rounding_modes.h"
 #include "stp/Simplifier/AchievableImage.h"
@@ -93,12 +94,17 @@ ASTNode RemoveUnconstrained::topLevel(const ASTNode& n, Simplifier* simplifier,
   arrayRules = (ext == NULL || !ext->activeInSolve());
   const std::set<ASTNode>* extSet =
       (ext != NULL && ext->activeInSolve()) ? &ext->getFrozenSymbols() : NULL;
+  UFContext* uf = bm.getUFContextIfAny();
+  const ASTNodeSet* ufSet =
+      (uf != NULL && uf->activeInSolve()) ? &uf->getProtectedSymbols() : NULL;
   std::set<ASTNode> mergedUntouchable;
   const std::set<ASTNode>* effective = NULL;
-  if (extSet != NULL || alsoUntouchable != NULL)
+  if (extSet != NULL || ufSet != NULL || alsoUntouchable != NULL)
   {
     if (extSet != NULL)
       mergedUntouchable.insert(extSet->begin(), extSet->end());
+    if (ufSet != NULL)
+      mergedUntouchable.insert(ufSet->begin(), ufSet->end());
     if (alsoUntouchable != NULL)
       mergedUntouchable.insert(alsoUntouchable->begin(),
                                alsoUntouchable->end());

--- a/lib/Simplifier/RemoveUnconstrained.cpp
+++ b/lib/Simplifier/RemoveUnconstrained.cpp
@@ -95,15 +95,15 @@ ASTNode RemoveUnconstrained::topLevel(const ASTNode& n, Simplifier* simplifier,
       (ext != NULL && ext->activeInSolve()) ? &ext->getFrozenSymbols() : NULL;
   std::set<ASTNode> mergedUntouchable;
   const std::set<ASTNode>* effective = NULL;
-  if (extSet != NULL && alsoUntouchable != NULL)
+  if (extSet != NULL || alsoUntouchable != NULL)
   {
-    mergedUntouchable = *extSet;
-    mergedUntouchable.insert(alsoUntouchable->begin(),
-                             alsoUntouchable->end());
+    if (extSet != NULL)
+      mergedUntouchable.insert(extSet->begin(), extSet->end());
+    if (alsoUntouchable != NULL)
+      mergedUntouchable.insert(alsoUntouchable->begin(),
+                               alsoUntouchable->end());
     effective = &mergedUntouchable;
   }
-  else
-    effective = (extSet != NULL) ? extSet : alsoUntouchable;
   MutableASTNode::UntouchableScope protect(effective);
 
   bm.GetRunTimes()->start(RunTimes::RemoveUnconstrained);
@@ -217,7 +217,7 @@ void RemoveUnconstrained::replace(const ASTNode& from, const ASTNode to)
   if (simplifier->UpdateSubstitutionMapFewChecks(from, to))
     return;
 
-  // Refused (only SubstitutionMap::extensionalityProtected refuses).
+  // Refused (only SubstitutionMap::theoryProtected refuses).
   // The caller has already rewritten the graph to remove whatever
   // constrained "from", so dropping the definition here would leave it
   // free. Keep it as an ordinary conjunct instead; topLevel() attaches

--- a/lib/Simplifier/SubstitutionMap.cpp
+++ b/lib/Simplifier/SubstitutionMap.cpp
@@ -597,19 +597,20 @@ bool SubstitutionMap::loops(const ASTNode& n0, const ASTNode& n1)
 // "either side is a READ" test does -- suppressed BVSolver over every
 // read in the query, connected to an equality or not, and cost more
 // than the whole decision procedure on array-heavy input.
-bool SubstitutionMap::extensionalityProtected(const ASTNode& key,
-                                              const ASTNode& value) const
+bool SubstitutionMap::theoryProtected(const ASTNode& key,
+                                      const ASTNode& value) const
 {
   ExtensionalityContext* ext = bm->getExtensionalityIfAny();
-  if (ext == NULL || !ext->activeInSolve())
-    return false;
-  if (key.GetKind() == SYMBOL && ext->isProtected(key))
-    return true;
-  if (value.GetKind() == SYMBOL && ext->isProtected(value))
-    return true;
-  // The equation-deleting orientation: the read itself is the key.
-  if (key.GetKind() == READ)
-    return true;
+  if (ext != NULL && ext->activeInSolve())
+  {
+    if (key.GetKind() == SYMBOL && ext->isProtected(key))
+      return true;
+    if (value.GetKind() == SYMBOL && ext->isProtected(value))
+      return true;
+    // The equation-deleting orientation: the read itself is the key.
+    if (key.GetKind() == READ)
+      return true;
+  }
   return false;
 }
 
@@ -621,11 +622,11 @@ bool SubstitutionMap::UpdateSubstitutionMap(const ASTNode& e0,
     return false;
 
   // TermOrder has already chosen which side is the key: e0 when it
-  // returned 1, e1 when it returned -1. extensionalityProtected needs
+  // returned 1, e1 when it returned -1. theoryProtected needs
   // that orientation, because only a read in key position deletes an
   // access. The later "i = -1" flip below cannot change the answer:
   // it applies only when both sides are symbols.
-  if (extensionalityProtected(1 == i ? e0 : e1, 1 == i ? e1 : e0))
+  if (theoryProtected(1 == i ? e0 : e1, 1 == i ? e1 : e0))
     return false;
 
   assert(e0 != e1);

--- a/lib/Simplifier/SubstitutionMap.cpp
+++ b/lib/Simplifier/SubstitutionMap.cpp
@@ -25,6 +25,7 @@ THE SOFTWARE.
 #include "stp/Simplifier/SubstitutionMap.h"
 #include "stp/AbsRefineCounterExample/ArrayTransformer.h"
 #include "stp/Extensionality/ExtensionalityContext.h"
+#include "stp/UninterpretedFunctions/UFContext.h"
 #include "stp/Simplifier/Simplifier.h"
 #include <vector>
 
@@ -609,6 +610,15 @@ bool SubstitutionMap::theoryProtected(const ASTNode& key,
       return true;
     // The equation-deleting orientation: the read itself is the key.
     if (key.GetKind() == READ)
+      return true;
+  }
+
+  UFContext* uf = bm->getUFContextIfAny();
+  if (uf != NULL && uf->activeInSolve())
+  {
+    if (key.GetKind() == SYMBOL && uf->isProtected(key))
+      return true;
+    if (value.GetKind() == SYMBOL && uf->isProtected(value))
       return true;
   }
   return false;

--- a/lib/UninterpretedFunctions/CMakeLists.txt
+++ b/lib/UninterpretedFunctions/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(uninterpretedfunctions OBJECT
     UFDecl.cpp
     UFContext.cpp
+    UFLowering.cpp
 )
 
 add_dependencies(uninterpretedfunctions ASTKind_header)

--- a/lib/UninterpretedFunctions/CMakeLists.txt
+++ b/lib/UninterpretedFunctions/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_library(uninterpretedfunctions OBJECT
+    UFDecl.cpp
+    UFContext.cpp
+)
+
+add_dependencies(uninterpretedfunctions ASTKind_header)

--- a/lib/UninterpretedFunctions/UFContext.cpp
+++ b/lib/UninterpretedFunctions/UFContext.cpp
@@ -1,0 +1,399 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#include "stp/UninterpretedFunctions/UFContext.h"
+#include "stp/Globals/Globals.h"
+#include "stp/STPManager/STPManager.h"
+#include <algorithm>
+#include <cctype>
+#include <sstream>
+
+namespace stp
+{
+
+namespace
+{
+bool isRenderableExternalName(const std::string& name)
+{
+  // UF models quote every external declaration name. SMT-LIB quoted symbols
+  // have no escape for either delimiter character and admit only printable
+  // characters. Rejecting at declaration keeps every later model operation
+  // total and nonfatal.
+  for (const unsigned char c : name)
+    if (c == '|' || c == '\\' || !std::isprint(c))
+      return false;
+  return true;
+}
+} // namespace
+
+UFContext::UFContext(STPMgr* manager) : manager_(manager)
+{
+  assert(manager_ != NULL);
+}
+
+UFContext::~UFContext()
+{
+  releaseSolveProtection();
+  parserCommandApplications_.clear();
+  applications_.clear();
+  byIdentity_.clear();
+  activeByName_.clear();
+  owned_.clear();
+  allById_.clear();
+  declarations_.clear();
+}
+
+void UFContext::setError(std::string* error, const std::string& message) const
+{
+  if (error != NULL)
+    *error = message;
+}
+
+const UFDecl*
+UFContext::declareFunction(const std::string& name,
+                           const std::vector<SourceSort>& domain,
+                           const SourceSort& codomain, std::string* error)
+{
+  if (!manager_->UserFlags.enable_uninterpreted_functions)
+  {
+    setError(error, "uninterpreted functions are disabled");
+    return NULL;
+  }
+  if (name.empty())
+  {
+    setError(error, "uninterpreted-function name must not be empty");
+    return NULL;
+  }
+  if (!isRenderableExternalName(name))
+  {
+    setError(error, "uninterpreted-function name is not representable as an "
+                    "SMT-LIB2 quoted symbol");
+    return NULL;
+  }
+  if (STPMgr::isReservedSymbolName(name.c_str()))
+  {
+    setError(error, "an uninterpreted-function name beginning with '@' or "
+                    "'.' is reserved for solver use");
+    return NULL;
+  }
+  std::string signatureError;
+  if (!UFSignature::validate(domain, codomain, &signatureError))
+  {
+    setError(error, "uninterpreted functions: declaration of " + name +
+                        ": " + signatureError);
+    return NULL;
+  }
+  if (activeByName_.find(name) != activeByName_.end())
+  {
+    setError(error, "uninterpreted function '" + name +
+                    "' is already declared in the active namespace");
+    return NULL;
+  }
+
+  const uint64_t id = nextDeclarationId_++;
+  std::ostringstream identityName;
+  identityName << "@uf_decl_" << id;
+  const ASTNode identity =
+      manager_->CreateSourceSymbol(identityName.str().c_str(), codomain);
+  manager_->noteIntroducedSymbol(identity);
+
+  std::unique_ptr<UFDecl> record(new UFDecl(
+      manager_, id, name, UFSignature(domain, codomain), identity));
+  const UFDecl* result = record.get();
+  declarations_.push_back(std::move(record));
+  activeByName_.insert(std::make_pair(name, result));
+  allById_.insert(std::make_pair(id, result));
+  byIdentity_.insert(std::make_pair(identity, result));
+  owned_.insert(result);
+  return result;
+}
+
+bool UFContext::deactivate(const UFDecl* decl, std::string* error)
+{
+  if (!owns(decl))
+  {
+    setError(error, "uninterpreted-function declaration belongs to another "
+                    "context or is invalid");
+    return false;
+  }
+  const std::map<std::string, const UFDecl*>::iterator found =
+      activeByName_.find(decl->name());
+  if (found == activeByName_.end() || found->second != decl)
+  {
+    setError(error, "uninterpreted-function declaration is no longer active");
+    return false;
+  }
+  activeByName_.erase(found);
+  return true;
+}
+
+void UFContext::deactivateAll()
+{
+  activeByName_.clear();
+}
+
+const UFDecl* UFContext::lookup(const std::string& name) const
+{
+  const std::map<std::string, const UFDecl*>::const_iterator found =
+      activeByName_.find(name);
+  return found == activeByName_.end() ? NULL : found->second;
+}
+
+void UFContext::collectIdentitySymbols(ASTNodeSet& out) const
+{
+  for (const std::pair<const ASTNode, const UFDecl*>& entry : byIdentity_)
+    out.insert(entry.first);
+}
+
+const UFDecl* UFContext::lookupIdentity(const ASTNode& identity) const
+{
+  if (identity.IsNull() || !identity.IsOwnedBy(manager_))
+    return NULL;
+  const std::map<ASTNode, const UFDecl*>::const_iterator found =
+      byIdentity_.find(identity);
+  return found == byIdentity_.end() ? NULL : found->second;
+}
+
+bool UFContext::owns(const UFDecl* decl) const
+{
+  return decl != NULL && owned_.find(decl) != owned_.end();
+}
+
+bool UFContext::isActive(const UFDecl* decl) const
+{
+  if (!owns(decl))
+    return false;
+  const std::map<std::string, const UFDecl*>::const_iterator found =
+      activeByName_.find(decl->name());
+  return found != activeByName_.end() && found->second == decl;
+}
+
+std::vector<const UFDecl*> UFContext::activeDeclarations() const
+{
+  std::vector<const UFDecl*> result;
+  result.reserve(activeByName_.size());
+  for (const std::pair<const std::string, const UFDecl*>& entry :
+       activeByName_)
+    result.push_back(entry.second);
+  std::sort(result.begin(), result.end(),
+            [](const UFDecl* left, const UFDecl* right)
+            { return left->id() < right->id(); });
+  return result;
+}
+
+bool UFContext::validateApplicationChildren(ASTChildren children,
+                                            std::string* error) const
+{
+  if (children.empty())
+  {
+    setError(error, "UF_APPLY requires a declaration identity");
+    return false;
+  }
+  if (!children[0].IsOwnedBy(manager_))
+  {
+    setError(error, "UF_APPLY declaration identity belongs to another context");
+    return false;
+  }
+  const UFDecl* decl = lookupIdentity(children[0]);
+  if (decl == NULL)
+  {
+    setError(error, "UF_APPLY child 0 is not a registered declaration identity");
+    return false;
+  }
+  if (children.size() - 1 != decl->signature().arity())
+  {
+    const size_t expected = decl->signature().arity();
+    const size_t actual = children.size() - 1;
+    setError(error, "uninterpreted functions: " + decl->name() + " expects " +
+                        std::to_string(expected) +
+                        (expected == 1 ? " argument" : " arguments") +
+                        " but was applied to " + std::to_string(actual));
+    return false;
+  }
+  for (size_t i = 1; i < children.size(); ++i)
+  {
+    if (!children[i].IsOwnedBy(manager_))
+    {
+      setError(error, "uninterpreted functions: argument " +
+                          std::to_string(i - 1) + " of " + decl->name() +
+                          " belongs to another context");
+      return false;
+    }
+    const SourceSort& expected = decl->signature().domain()[i - 1];
+    const SourceSort actual = children[i].GetSourceSort();
+    if (actual != expected)
+    {
+      setError(error, "uninterpreted functions: argument " +
+                          std::to_string(i - 1) + " of " + decl->name() +
+                          " has sort " + sourceSortToSMTLib(actual) +
+                          " but the declaration requires " +
+                          sourceSortToSMTLib(expected));
+      return false;
+    }
+  }
+  return true;
+}
+
+ASTNode UFContext::apply(const UFDecl* decl, const ASTVec& actuals,
+                         std::string* error)
+{
+  if (!manager_->UserFlags.enable_uninterpreted_functions)
+  {
+    setError(error, "uninterpreted functions are disabled");
+    return manager_->ASTUndefined;
+  }
+  if (!owns(decl))
+  {
+    setError(error, "uninterpreted-function declaration belongs to another "
+                    "context or is invalid");
+    return manager_->ASTUndefined;
+  }
+  if (!isActive(decl))
+  {
+    setError(error, "uninterpreted-function declaration is no longer active");
+    return manager_->ASTUndefined;
+  }
+
+  ASTVec children;
+  children.reserve(actuals.size() + 1);
+  children.push_back(decl->identityNode());
+  children.insert(children.end(), actuals.begin(), actuals.end());
+  if (!validateApplicationChildren(children, error))
+    return manager_->ASTUndefined;
+
+  const SourceSort& resultSort = decl->signature().codomain();
+  ASTNode result;
+  if (resultSort.kind() == SourceSort::Kind::Bool)
+    result = manager_->defaultNodeFactory->CreateNode(UF_APPLY, children);
+  else
+    result = manager_->defaultNodeFactory->CreateTerm(
+        UF_APPLY, resultSort.packedWidth(), children);
+  noteApplication(result);
+  return result;
+}
+
+void UFContext::beginParserCommand()
+{
+  // A parser cannot start the next top-level command until the preceding
+  // command's closing parenthesis has committed or rolled it back.
+  assert(!parserCommandActive_);
+  parserCommandApplications_.clear();
+  parserCommandActive_ = true;
+}
+
+void UFContext::finishParserCommand(const bool accepted)
+{
+  // The UF context may have been created during a command (most commonly by
+  // its first declaration), after Cpp_interface had a context to begin. Such
+  // a command has no application prefix to transact.
+  if (!parserCommandActive_)
+    return;
+  if (!accepted)
+    for (const ASTNode& application : parserCommandApplications_)
+      applications_.erase(application);
+  parserCommandApplications_.clear();
+  parserCommandActive_ = false;
+}
+
+void UFContext::noteApplication(const ASTNode& application)
+{
+  assert(application.GetKind() == UF_APPLY);
+  const bool inserted = applications_.insert(application).second;
+  if (inserted && parserCommandActive_)
+    parserCommandApplications_.push_back(application);
+}
+
+bool UFContext::isRegisteredApplication(const ASTNode& application) const
+{
+  return !application.IsNull() && application.IsOwnedBy(manager_) &&
+         application.GetKind() == UF_APPLY &&
+         applications_.find(application) != applications_.end();
+}
+
+bool UFContext::isActiveApplication(const ASTNode& application) const
+{
+  return isRegisteredApplication(application) && application.Degree() >= 1 &&
+         isActive(lookupIdentity(application[0]));
+}
+
+void UFContext::beginSolveProtection()
+{
+  assert(!solveProtectionActive_);
+  protectedSymbols_.clear();
+  solveScalars_.clear();
+}
+
+void UFContext::installSolveProtection(
+    const ASTNodeSet& protectedSymbols, const ASTNodeSet& solveScalars)
+{
+  assert(!solveProtectionActive_);
+  for (const ASTNode& scalar : solveScalars)
+  {
+    if (scalar.IsNull() || !scalar.IsOwnedBy(manager_) ||
+        scalar.GetKind() != SYMBOL ||
+        protectedSymbols.find(scalar) == protectedSymbols.end())
+      FatalError("UF solve scalar is malformed or is not preprocessing "
+                 "protected",
+                 scalar);
+  }
+  protectedSymbols_ = protectedSymbols;
+  solveScalars_ = solveScalars;
+}
+
+void UFContext::releaseSolveProtection()
+{
+  protectedSymbols_.clear();
+  solveScalars_.clear();
+  solveProtectionActive_ = false;
+}
+
+bool UFContext::isProtected(const ASTNode& symbol) const
+{
+  return !symbol.IsNull() && symbol.IsOwnedBy(manager_) &&
+         symbol.GetKind() == SYMBOL &&
+         protectedSymbols_.find(symbol) != protectedSymbols_.end();
+}
+
+bool UFContext::isSolveScalar(const ASTNode& symbol) const
+{
+  return !symbol.IsNull() && symbol.IsOwnedBy(manager_) &&
+         symbol.GetKind() == SYMBOL &&
+         solveScalars_.find(symbol) != solveScalars_.end();
+}
+
+UFContext::SolveScope::SolveScope(UFContext* context) : context_(context)
+{
+  if (context_ == NULL)
+    return;
+  assert(!context_->solveProtectionActive_);
+  context_->solveProtectionActive_ = true;
+}
+
+UFContext::SolveScope::~SolveScope()
+{
+  if (context_ != NULL)
+    context_->solveProtectionActive_ = false;
+}
+
+} // namespace stp

--- a/lib/UninterpretedFunctions/UFDecl.cpp
+++ b/lib/UninterpretedFunctions/UFDecl.cpp
@@ -1,0 +1,108 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#include "stp/UninterpretedFunctions/UFDecl.h"
+
+namespace stp
+{
+
+const char* UFSignature::supportedSortsPhrase()
+{
+  return "only Bool, RoundingMode, FloatingPoint and nonzero-width "
+         "bit-vector sorts are supported";
+}
+
+bool UFSignature::isSupportedSort(const SourceSort& sort)
+{
+  // RoundingMode joins Bool and BitVec because its carrier's bit-equality is
+  // its own equality: each of the five modes is exactly one 5-bit one-hot
+  // pattern, so nothing in the checker or the lemma encoder has to learn a
+  // second notion of "equal". What it does need is the pin -- see
+  // UFLowering::lowerCompletedRoot -- because the carrier has thirty-two
+  // patterns and the sort has five.
+  //
+  // FloatingPoint is admitted on the opposite basis: its carrier's
+  // bit-equality is *not* its equality, so it is never solved at its own
+  // sort. See loweringSort.
+  if (sort.kind() == SourceSort::Kind::Bool ||
+      sort.kind() == SourceSort::Kind::RoundingMode ||
+      sort.kind() == SourceSort::Kind::FloatingPoint)
+    return true;
+  return sort.kind() == SourceSort::Kind::BitVector &&
+         sort.bitVectorWidth() > 0;
+}
+
+SourceSort UFSignature::loweringSort(const SourceSort& sort)
+{
+  // Only FloatingPoint is quotiented onto its carrier, and only because its
+  // carrier's bit-equality is not its equality. Everything else is solved at
+  // its own sort.
+  if (sort.kind() == SourceSort::Kind::FloatingPoint)
+    return SourceSort::bitVector(sort.packedWidth());
+  return sort;
+}
+
+bool UFSignature::validate(const std::vector<SourceSort>& domain,
+                           const SourceSort& codomain, std::string* error)
+{
+  if (domain.empty())
+  {
+    if (error != NULL)
+      *error = "a zero-arity declaration is an ordinary symbol, not an "
+               "uninterpreted function";
+    return false;
+  }
+
+  for (size_t i = 0; i < domain.size(); ++i)
+  {
+    if (!isSupportedSort(domain[i]))
+    {
+      if (error != NULL)
+        *error = "unsupported domain sort " +
+                 sourceSortToSMTLib(domain[i]) + " at argument " +
+                 std::to_string(i) + " (" + supportedSortsPhrase() + ")";
+      return false;
+    }
+  }
+
+  if (!isSupportedSort(codomain))
+  {
+    if (error != NULL)
+      *error = "unsupported result sort " + sourceSortToSMTLib(codomain) +
+               " (" + supportedSortsPhrase() + ")";
+    return false;
+  }
+  return true;
+}
+
+UFSignature::UFSignature(std::vector<SourceSort> domain,
+                         SourceSort codomain)
+    : domain_(std::move(domain)), codomain_(std::move(codomain))
+{
+  std::string error;
+  if (!validate(domain_, codomain_, &error))
+    throw std::invalid_argument(error);
+}
+
+} // namespace stp

--- a/lib/UninterpretedFunctions/UFLowering.cpp
+++ b/lib/UninterpretedFunctions/UFLowering.cpp
@@ -1,0 +1,393 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#include "stp/UninterpretedFunctions/UFLowering.h"
+#include "stp/Globals/Globals.h"
+#include "stp/STPManager/STPManager.h"
+#include "stp/UninterpretedFunctions/UFContext.h"
+#include "stp/Util/DagWalk.h"
+#include <string>
+
+namespace stp
+{
+
+namespace
+{
+
+bool isLeafActual(const ASTNode& actual)
+{
+  return actual.GetKind() == SYMBOL || actual.isConstant();
+}
+
+ASTNode rebuildWithChildren(const ASTNode& original,
+                            const ASTVec& loweredChildren, STPMgr* manager)
+{
+  assert(original.Degree() == loweredChildren.size());
+  bool changed = false;
+  for (size_t i = 0; i < loweredChildren.size(); ++i)
+    changed = changed || loweredChildren[i] != original[i];
+  if (!changed)
+    return original;
+
+  NodeFactory* const factory = manager->defaultNodeFactory;
+  ASTNode rebuilt;
+  if (original.GetValueWidth() == 0)
+    rebuilt = factory->CreateNode(original.GetKind(), loweredChildren);
+  else
+    // Mirror SubstitutionMap's rebuild funnel: CreateArrayTerm preserves both
+    // widths for arrays and is also the width-preserving CreateTerm path for
+    // non-Boolean bit-vector terms when the index width is zero.
+    rebuilt =
+        factory->CreateArrayTerm(original.GetKind(), original.GetIndexWidth(),
+                                 original.GetValueWidth(), loweredChildren);
+
+  if (rebuilt.GetSourceSort() != original.GetSourceSort())
+    FatalError("UF lowering rebuilt a node at the wrong SourceSort", rebuilt);
+  return rebuilt;
+}
+
+} // namespace
+
+ASTNode
+LoweredApplicationView::semanticRootWithDefinitions(STPMgr* manager) const
+{
+  assert(manager != NULL);
+  if (namingDefinitions.empty() && sortConstraints.empty())
+    return semanticRoot;
+  ASTVec conjuncts;
+  conjuncts.reserve(namingDefinitions.size() + sortConstraints.size() + 1);
+  conjuncts.push_back(semanticRoot);
+  conjuncts.insert(conjuncts.end(), namingDefinitions.begin(),
+                   namingDefinitions.end());
+  conjuncts.insert(conjuncts.end(), sortConstraints.begin(),
+                   sortConstraints.end());
+  return manager->defaultNodeFactory->CreateNode(AND, conjuncts);
+}
+
+UFLowering::UFLowering(STPMgr* manager) : manager_(manager)
+{
+  assert(manager_ != NULL);
+}
+
+LoweredApplicationView
+UFLowering::lowerCompletedRoot(const ASTNode& publicRoot,
+                               const UFSolveScope& scope) const
+{
+  if (publicRoot.IsNull() || !publicRoot.IsOwnedBy(manager_))
+    FatalError("UF lowering requires a completed root owned by its context");
+
+  LoweredApplicationView view;
+  view.scope = scope;
+  view.publicRoot = publicRoot;
+  view.semanticRoot = publicRoot;
+
+  UFContext* context = manager_->getUFContextIfAny();
+  if (!manager_->UserFlags.enable_uninterpreted_functions)
+  {
+    if (context != NULL)
+      context->releaseSolveProtection();
+    return view;
+  }
+
+  if (context == NULL)
+  {
+    if (containsKind(publicRoot, UF_APPLY))
+      FatalError("UF lowering found UF_APPLY without a manager context",
+                 publicRoot);
+    return view;
+  }
+  context->beginSolveProtection();
+
+  // A name is canonical per lowered expression, matching the reference
+  // oracle. This both avoids redundant definitions and makes an identical
+  // persistent block reconstruct the identical semantic root.
+  ASTNodeMap scalarNames;
+
+  // Pin every RoundingMode scalar this lowering makes the checker's authority
+  // for -- introduced results, introduced argument names, and the leaf
+  // symbols it registers as solve scalars in their own right. The sort has
+  // five values and its carrier thirty-two, so an unpinned one lets a model
+  // name no mode at all: the generated define-fun would print a term of no
+  // sort, and model evaluation could hand an illegal mode to an enclosing
+  // floating-point operation as a constant operand.
+  //
+  // FpTotalise pins the same symbols out of the semantic root when it runs,
+  // and an OR of five equalities is idempotent, so at worst this adds a
+  // duplicate conjunct. What it buys is that the pin arrives with the symbol
+  // instead of with a later pass: the persistent path decides whether to run
+  // that pass from the *raw* block, and reset-assertions can retract a
+  // declaration's own pin while keeping the declaration.
+  //
+  // Pins are appended in walk order rather than collected from
+  // view.solveScalars, so that an identical block rebuilds an identical
+  // conjunction without depending on a hash set's iteration order.
+  ASTNodeSet pinnedRoundingModes;
+  const auto pinIfRoundingMode = [&](const ASTNode& scalar) {
+    if (!manager_->isRoundingModeSymbol(scalar) ||
+        !pinnedRoundingModes.insert(scalar).second)
+      return;
+    view.sortConstraints.push_back(
+        manager_->roundingModeValidConstraint(scalar));
+  };
+
+  // An actual, as the checker will compare it. Only a float moves: it becomes
+  // its canonical packed bits, which is the sort's own equality rather than
+  // the carrier's, so two NaNs of different payloads compare equal and the
+  // two zeros stay apart. A constant takes the same boundary as everything
+  // else -- it needs no special case, because a float constant is already
+  // interned canonically (STPMgr::CreateFPConst quotients NaN) and the
+  // boundary folds over it rather than building a circuit.
+  const auto canonicalActual = [&](const ASTNode& lowered,
+                                   const SourceSort& declared) -> ASTNode {
+    if (declared.kind() != SourceSort::Kind::FloatingPoint)
+      return lowered;
+    return manager_->defaultNodeFactory->CreateTerm(
+        FP_TO_IEEE_BV, declared.packedWidth(), lowered);
+  };
+
+  // A result, as the formula that replaces the application will see it. The
+  // exact inverse of canonicalActual: the three-child to_fp reinterprets the
+  // solved bits at the declared format.
+  const auto theoryResult = [&](const ASTNode& result,
+                                const SourceSort& declared) -> ASTNode {
+    if (declared.kind() != SourceSort::Kind::FloatingPoint)
+      return result;
+    const ASTNode reinterpreted = manager_->defaultNodeFactory->CreateTerm(
+        FP_TOFP, declared.packedWidth(),
+        manager_->CreateBVConst(32, declared.exponentWidth()),
+        manager_->CreateBVConst(32, declared.significandWidth()), result);
+    if (reinterpreted.GetSourceSort() != declared)
+      FatalError("UF lowering rebuilt a float result at the wrong SourceSort",
+                 reinterpreted);
+    return reinterpreted;
+  };
+
+  // A compound actual cannot be named while the walk is running: whether the
+  // name is needed depends on how many applications its declaration turns out
+  // to have, and the last of them may not have been reached yet. Each one is
+  // parked here against the slot it will fill.
+  struct PendingName
+  {
+    size_t record;
+    size_t argument;
+    ASTNode lowered;
+    SourceSort sort;
+  };
+  std::vector<PendingName> pendingNames;
+
+  // Rewrite the completed root once, bottom-up. The explicit walk keeps its
+  // frames on the heap (input controls AST depth), visits each shared DAG node
+  // once, and guarantees that a nested UF application has become its scalar
+  // result before an enclosing application's actual is recorded.
+  DenseNodeMap rewritten;
+  view.semanticRoot = postOrderRebuild(
+      publicRoot, rewritten,
+      [&](const ASTNode& application, const ASTVec& loweredChildren) -> ASTNode
+      {
+        if (application.GetKind() != UF_APPLY)
+          return rebuildWithChildren(application, loweredChildren, manager_);
+
+        std::string diagnostic;
+        if (!context->isRegisteredApplication(application) ||
+            !context->validateApplicationChildren(application.GetChildren(),
+                                                  &diagnostic))
+          FatalError(("UF lowering rejected a malformed durable application: " +
+                      diagnostic)
+                         .c_str(),
+                     application);
+        if (!context->isActiveApplication(application))
+          FatalError("UF lowering rejected a stale or inactive durable "
+                     "application",
+                     application);
+
+        const UFDecl* declaration = context->lookupIdentity(application[0]);
+        if (declaration == NULL)
+          FatalError("UF lowering could not recover declaration identity",
+                     application);
+        if (loweredChildren.size() != application.Degree() ||
+            loweredChildren.empty() || loweredChildren[0] != application[0])
+          FatalError("UF lowering rewrote a declaration identity", application);
+
+        LoweredApplicationRecord record;
+        record.durableHandle = application;
+        record.declaration = declaration;
+        record.scope = scope;
+        record.stableOrder = view.applications.size();
+        record.loweredActuals.reserve(application.Degree() - 1);
+        record.namedActuals.reserve(application.Degree() - 1);
+
+        for (size_t i = 1; i < loweredChildren.size(); ++i)
+        {
+          const ASTNode& lowered = loweredChildren[i];
+          const SourceSort& expected = declaration->signature().domain()[i - 1];
+          if (application[i].GetSourceSort() != expected ||
+              lowered.GetSourceSort() != expected)
+            FatalError("UF lowering crossed a SourceSort boundary",
+                       application);
+
+          // From here down the record speaks the lowering sort. For every
+          // sort but FloatingPoint that is the declared sort unchanged; a
+          // float crosses into its canonical packed carrier here and does not
+          // cross back until the model boundary.
+          const SourceSort solved = UFSignature::loweringSort(expected);
+          const ASTNode scalar = canonicalActual(lowered, expected);
+          if (scalar.GetSourceSort() != solved)
+            FatalError("UF lowering produced an actual at the wrong lowering "
+                       "sort",
+                       scalar);
+          record.loweredActuals.push_back(scalar);
+
+          if (isLeafActual(scalar))
+          {
+            record.namedActuals.push_back(scalar);
+            // A source symbol is already its own canonical scalar name, but it
+            // still participates in future direct-CNF lemmas. Protect/register it
+            // exactly like an introduced name so ordinary preprocessing cannot
+            // substitute it away and leave the lemma talking about an unlinked
+            // fresh SAT value. Constants need no mapping or protection.
+            if (scalar.GetKind() == SYMBOL)
+            {
+              view.protectedSymbols.insert(scalar);
+              view.solveScalars.insert(scalar);
+              pinIfRoundingMode(scalar);
+            }
+            continue;
+          }
+
+          PendingName pending;
+          pending.record = record.stableOrder;
+          pending.argument = record.namedActuals.size();
+          pending.lowered = scalar;
+          pending.sort = solved;
+          pendingNames.push_back(pending);
+          record.namedActuals.push_back(ASTNode());
+        }
+
+        const SourceSort& codomain = declaration->signature().codomain();
+        if (application.GetSourceSort() != codomain)
+          FatalError("UF lowering found a durable result with the wrong "
+                     "SourceSort",
+                     application);
+        SourceSort solvedCodomain = UFSignature::loweringSort(codomain);
+        std::string resultPrefix = "uf_result";
+        record.resultSymbol = manager_->CreateDeterministicSourceVariable(
+            solvedCodomain, resultPrefix, application);
+        if (record.resultSymbol.GetSourceSort() != solvedCodomain)
+          FatalError("UF lowering allocated a result at the wrong SourceSort",
+                     record.resultSymbol);
+        view.protectedSymbols.insert(record.resultSymbol);
+        view.solveScalars.insert(record.resultSymbol);
+        pinIfRoundingMode(record.resultSymbol);
+        view.handleToResult.insert(
+            std::make_pair(application, record.resultSymbol));
+        view.applications.push_back(record);
+        // A float result is solved as a packed bit-vector but the formula it
+        // replaces expects a float, so it goes back in through the exact
+        // inverse of the boundary its arguments came through: the three-child
+        // "reinterpret these bits" to_fp. Every other sort is returned as
+        // itself.
+        return theoryResult(record.resultSymbol, codomain);
+      });
+
+  // Only a declaration with two or more lowered applications can ever produce
+  // a congruence lemma, and a name for a compound actual exists solely so that
+  // such a lemma has a scalar to equate. Naming one for a lone application
+  // costs a protected symbol and a defining equality that drag the whole
+  // argument expression into the bit-blast, where nothing can observe it.
+  //
+  // Two rounds, so that the decision does not depend on the order the walk
+  // reached things: every name a comparable record needs is created first, and
+  // a lone application sharing one of those terms then reuses it and stays
+  // readable for free. Only an actual left without a name after both rounds
+  // makes its record unobservable.
+  std::map<const UFDecl*, size_t> applicationsPerDeclaration;
+  for (const LoweredApplicationRecord& record : view.applications)
+    applicationsPerDeclaration[record.declaration]++;
+
+  const auto comparable = [&](const PendingName& pending) {
+    return applicationsPerDeclaration[view.applications[pending.record]
+                                          .declaration] > 1;
+  };
+
+  for (const PendingName& pending : pendingNames)
+  {
+    if (!comparable(pending))
+      continue;
+    ASTNode name;
+    const ASTNodeMap::const_iterator found = scalarNames.find(pending.lowered);
+    if (found != scalarNames.end())
+      name = found->second;
+    else
+    {
+      name = manager_->CreateDeterministicSourceVariable(pending.sort, "uf_arg",
+                                                         pending.lowered);
+      if (name.GetSourceSort() != pending.sort)
+        FatalError("UF lowering allocated an argument name at the wrong "
+                   "SourceSort",
+                   name);
+      scalarNames.insert(std::make_pair(pending.lowered, name));
+      view.nameToTerm.insert(std::make_pair(name, pending.lowered));
+      view.protectedSymbols.insert(name);
+      view.solveScalars.insert(name);
+      pinIfRoundingMode(name);
+      view.namingDefinitions.push_back(
+          manager_->defaultNodeFactory->CreateNode(
+              pending.sort.kind() == SourceSort::Kind::Bool ? IFF : EQ, name,
+              pending.lowered));
+    }
+    view.applications[pending.record].namedActuals[pending.argument] = name;
+  }
+
+  for (const PendingName& pending : pendingNames)
+  {
+    if (comparable(pending))
+      continue;
+    LoweredApplicationRecord& record = view.applications[pending.record];
+    const ASTNodeMap::const_iterator found = scalarNames.find(pending.lowered);
+    if (found != scalarNames.end())
+      record.namedActuals[pending.argument] = found->second;
+    else
+      record.observableArguments = false;
+  }
+
+  // An unobservable record keeps its durable handle, its result symbol and its
+  // lowered actuals; what it does not keep is a half-filled scalar tuple that
+  // no checker round may read.
+  for (LoweredApplicationRecord& record : view.applications)
+    if (!record.observableArguments)
+      record.namedActuals.clear();
+
+  // This checks the whole barrier once, including the naming definitions.
+  // Scanning every progressively larger actual separately would turn a
+  // linear post-order rewrite back into a quadratic algorithm on shared
+  // nested DAGs.
+  if (containsKind(view.semanticRootWithDefinitions(manager_), UF_APPLY))
+    FatalError("UF_APPLY crossed the completed-root lowering barrier",
+               view.semanticRoot);
+
+  context->installSolveProtection(view.protectedSymbols, view.solveScalars);
+  return view;
+}
+
+} // namespace stp

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -78,6 +78,7 @@ AddSTPGTest(FpTotalise_Test.cpp)
 AddSTPGTest(FpModelEquality_Test.cpp)
 AddSTPGTest(SourceSort_Test.cpp)
 AddSTPGTest(UninterpretedFunctionsFrontend_Test.cpp)
+AddSTPGTest(UFLowering_Test.cpp)
 # Builds float/rounding-mode constants, which is the whole point.
 AddSTPGTest(ConstantIdentity_Test.cpp)
 AddSTPGTest(FpConstantFold_Test.cpp)

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -77,6 +77,7 @@ AddSTPGTest(FpTotalise_Test.cpp)
 # equalities; the circuit's answers are covered elsewhere.
 AddSTPGTest(FpModelEquality_Test.cpp)
 AddSTPGTest(SourceSort_Test.cpp)
+AddSTPGTest(UninterpretedFunctionsFrontend_Test.cpp)
 # Builds float/rounding-mode constants, which is the whole point.
 AddSTPGTest(ConstantIdentity_Test.cpp)
 AddSTPGTest(FpConstantFold_Test.cpp)

--- a/tests/unit-tests/DeepDag_Test.cpp
+++ b/tests/unit-tests/DeepDag_Test.cpp
@@ -73,6 +73,8 @@ THE SOFTWARE.
 #include "stp/ToSat/BBNodeManagerAIG.h"
 #include "stp/ToSat/BitBlaster.h"
 #include "stp/ToSat/ToSATAIG.h"
+#include "stp/UninterpretedFunctions/UFContext.h"
+#include "stp/UninterpretedFunctions/UFLowering.h"
 #include "stp/Util/NodeIterator.h"
 #include "stp/Simplifier/StrengthReduction.h"
 #include "stp/Simplifier/SubstitutionMap.h"
@@ -282,6 +284,41 @@ ASTNode storeChain(Context& c, unsigned depth, const ASTNode& base,
 ASTNode storeChain(Context& c, unsigned depth)
 {
   return storeChain(c, depth, c.mgr.CreateSymbol("A", 8, 8));
+}
+
+// Completed-root UF lowering must keep the nesting chosen by the input off
+// the call stack. Each application is a child of the next one, so the
+// innermost result also has to be available before its parent is recorded.
+bool ufLoweringOk(Context& c, unsigned depth)
+{
+  c.mgr.UserFlags.enable_uninterpreted_functions = true;
+  UFContext* const context = c.mgr.getUFContext();
+  const SourceSort bv8 = SourceSort::bitVector(8);
+  std::string diagnostic;
+  const UFDecl* const f =
+      context->declareFunction("deep_uf", {bv8}, bv8, &diagnostic);
+  if (f == NULL)
+    return false;
+
+  const ASTNode x = c.mgr.CreateSourceSymbol("deep_uf_x", bv8);
+  ASTNode application = x;
+  for (unsigned i = 0; i < depth; ++i)
+  {
+    application = context->apply(f, {application}, &diagnostic);
+    if (application.IsNull())
+      return false;
+  }
+  const ASTNode root = c.hf->CreateNode(EQ, application, x);
+  c.roots.push_back(root);
+
+  UFLowering lowerer(&c.mgr);
+  const LoweredApplicationView view =
+      lowerer.lowerCompletedRoot(root, UFSolveScope::batch(1));
+  return view.size() == depth &&
+         view.applications.front().stableOrder == 0 &&
+         view.applications.back().stableOrder == depth - 1 &&
+         !containsKind(view.semanticRoot, UF_APPLY) &&
+         !containsKind(view.semanticRootWithDefinitions(&c.mgr), UF_APPLY);
 }
 
 // Dependencies::build, the parent map constant-bit propagation runs on.
@@ -2821,6 +2858,7 @@ TEST(DeepDag, deep_array_equality_lowering)
 }
 TEST(DeepDag, deep_transform_formula_spine) { EXPECT_STACK_SAFE(transformFormulaSpineOk, 20000); }
 TEST(DeepDag, deep_fp_totalise)        { EXPECT_STACK_SAFE(fpTotaliseChainOk, 20000); }
+TEST(DeepDag, deep_uf_lowering)        { EXPECT_STACK_SAFE(ufLoweringOk, 20000); }
 
 TEST(DeepDag, deep_printer_lisp)       { EXPECT_STACK_SAFE(printerLispOk, 20000); }
 TEST(DeepDag, deep_counterexample_eval) { EXPECT_STACK_SAFE(counterExampleEvalOk, 20000); }

--- a/tests/unit-tests/FloatBlast_Test.cpp
+++ b/tests/unit-tests/FloatBlast_Test.cpp
@@ -10,6 +10,7 @@
 #include "stp/Simplifier/Simplifier.h"
 #include "stp/ToSat/BBNodeManagerAIG.h"
 #include "stp/ToSat/BitBlaster.h"
+#include "stp/UninterpretedFunctions/UFContext.h"
 
 #include <gtest/gtest.h>
 #include <set>
@@ -62,6 +63,52 @@ ASTNode rne(STPMgr& mgr)
 {
   return mgr.CreateRMConst(
       symbolic_fp::ROUND_NEAREST_TIES_TO_EVEN);
+}
+
+bool contains(const ASTNode& haystack, const ASTNode& needle,
+              ASTNodeSet& visited)
+{
+  if (!visited.insert(haystack).second)
+    return false;
+  if (haystack == needle)
+    return true;
+  for (size_t i = 0; i < haystack.Degree(); ++i)
+    if (contains(haystack[i], needle, visited))
+      return true;
+  return false;
+}
+
+bool contains(const ASTNode& haystack, const ASTNode& needle)
+{
+  ASTNodeSet visited;
+  return contains(haystack, needle, visited);
+}
+
+// The one node of `kind` in `n`, or null if `n` holds none or several.
+ASTNode soleNodeOfKind(const ASTNode& n, Kind kind, ASTNodeSet& visited,
+                       ASTNode& found, bool& unique)
+{
+  if (!visited.insert(n).second)
+    return found;
+
+  if (n.GetKind() == kind)
+  {
+    if (!found.IsNull() && found != n)
+      unique = false;
+    found = n;
+  }
+  for (size_t i = 0; i < n.Degree(); ++i)
+    soleNodeOfKind(n[i], kind, visited, found, unique);
+  return found;
+}
+
+ASTNode soleNodeOfKind(const ASTNode& n, Kind kind)
+{
+  ASTNodeSet visited;
+  ASTNode found;
+  bool unique = true;
+  const ASTNode answer = soleNodeOfKind(n, kind, visited, found, unique);
+  return unique ? answer : ASTNode();
 }
 
 } // namespace
@@ -628,4 +675,127 @@ TEST(FloatBlast, native_comparison_agrees_with_symfpu_exhaustively)
     }
   }
   EXPECT_EQ(2 * values * values, muxed);
+}
+
+// A UF application is opaque to this pass.
+//
+// The generic rebuild substitutes lowered children into whatever node it is
+// rebuilding, and doing that under an application is wrong twice over: the
+// actuals are stated in source sorts and the UF layer both validates and
+// compares them there, so a float actual replaced by the bits it lowered to
+// no longer denotes the same argument -- and the node factory refuses to
+// build the application at all, which took the process down.
+//
+// It takes a *computed* actual to reach it. A symbol or a constant lowers to
+// itself, so the rebuild never fires; the second half of this test is that
+// case, which has to keep behaving the same way.
+TEST(FloatBlast, uf_application_is_an_opaque_carrier)
+{
+  STPMgr mgr;
+  mgr.UserFlags.enable_uninterpreted_functions = true;
+  UFContext* const context = mgr.getUFContext();
+  const SourceSort fp16 = SourceSort::floatingPoint(5, 11);
+  std::string diagnostic;
+  const UFDecl* const f =
+      context->declareFunction("f", {fp16}, fp16, &diagnostic);
+  ASSERT_NE(nullptr, f) << diagnostic;
+
+  const ASTNode x = mgr.CreateSourceSymbol("x", fp16);
+  const ASTNode magnitude = mgr.CreateTerm(FP_ABS, 16, x);
+  const ASTNode applied = context->apply(f, {magnitude}, &diagnostic);
+  ASSERT_FALSE(applied.IsNull()) << diagnostic;
+
+  // The actual is shared with the enclosing operation, which is what made
+  // the defect fire: fp.abs is lowered in its non-UF position first, and the
+  // cached lowering is what the rebuild then substituted under f.
+  const ASTNode sum = mgr.CreateTerm(
+      FP_ADD, 16, ASTVec{rne(mgr), magnitude, applied});
+
+  FloatBlast lower(&mgr);
+  const ASTNode lowered = lower.topLevel(sum);
+
+  // The application survives as itself -- same node, same actual, still at
+  // the declared float sort -- so the model evaluator can resolve it against
+  // the certified interpretation.
+  const ASTNode survivor = soleNodeOfKind(lowered, UF_APPLY);
+  ASSERT_FALSE(survivor.IsNull());
+  EXPECT_EQ(applied, survivor);
+  ASSERT_EQ(2u, survivor.Degree());
+  EXPECT_EQ(magnitude, survivor[1]);
+  EXPECT_EQ(fp16, survivor[1].GetSourceSort());
+
+  // Everything else is bits. The float operation under the application is
+  // deliberately among the exceptions: nothing below an application is
+  // lowered, so its fp.abs is still there, inside it and nowhere else.
+  EXPECT_EQ(1u, countKind(lowered, FP_ABS));
+  EXPECT_EQ(0u, countKind(lowered, FP_ADD));
+
+  // Two decodes: x, which the shared fp.abs consumes, and the application's
+  // own bits. An application is a carrier like any other leaf, not an
+  // operation to build a circuit for.
+  EXPECT_EQ(2u, lower.statistics().unpack_builds);
+  EXPECT_EQ(2u, lower.statistics().unpacked_operation_builds);
+
+  // A leaf actual takes the same route, and always did: the application is
+  // returned untouched because there was nothing to substitute.
+  const ASTNode leafApplied = context->apply(f, {x}, &diagnostic);
+  ASSERT_FALSE(leafApplied.IsNull()) << diagnostic;
+  const ASTNode leafSum = mgr.CreateTerm(
+      FP_ADD, 16, ASTVec{rne(mgr), x, leafApplied});
+
+  FloatBlast leafLower(&mgr);
+  const ASTNode leafLowered = leafLower.topLevel(leafSum);
+  const ASTNode leafSurvivor = soleNodeOfKind(leafLowered, UF_APPLY);
+  ASSERT_FALSE(leafSurvivor.IsNull());
+  EXPECT_EQ(leafApplied, leafSurvivor);
+}
+
+// The same rule, for the codomains that never reach the packed/unpacked
+// views at all. A Bool or bit-vector result puts the application on lower()'s
+// generic path, where the substitution was equally fatal -- the argument
+// sorts are what the factory checks, and they do not depend on the result.
+TEST(FloatBlast, uf_application_with_a_non_float_result_is_opaque_too)
+{
+  STPMgr mgr;
+  mgr.UserFlags.enable_uninterpreted_functions = true;
+  UFContext* const context = mgr.getUFContext();
+  const SourceSort fp16 = SourceSort::floatingPoint(5, 11);
+  std::string diagnostic;
+  const UFDecl* const p =
+      context->declareFunction("p", {fp16}, SourceSort::boolean(), &diagnostic);
+  const UFDecl* const w = context->declareFunction(
+      "w", {fp16}, SourceSort::bitVector(16), &diagnostic);
+  ASSERT_NE(nullptr, p) << diagnostic;
+  ASSERT_NE(nullptr, w) << diagnostic;
+
+  const ASTNode x = mgr.CreateSourceSymbol("x", fp16);
+  const ASTNode magnitude = mgr.CreateTerm(FP_ABS, 16, x);
+  const ASTNode predicate = context->apply(p, {magnitude}, &diagnostic);
+  const ASTNode bits = context->apply(w, {magnitude}, &diagnostic);
+  ASSERT_FALSE(predicate.IsNull()) << diagnostic;
+  ASSERT_FALSE(bits.IsNull()) << diagnostic;
+
+  // The bit-vector result is reinterpreted back into the float layer, so
+  // both applications sit under one float-valued term.
+  const ASTNode reinterpreted = mgr.CreateTerm(
+      FP_TOFP, 16,
+      ASTVec{mgr.CreateBVConst(32, 5), mgr.CreateBVConst(32, 11), bits});
+  const ASTNode mux = mgr.CreateTerm(
+      ITE, 16, ASTVec{predicate, magnitude, reinterpreted});
+  const ASTNode sum =
+      mgr.CreateTerm(FP_ADD, 16, ASTVec{rne(mgr), magnitude, mux});
+
+  FloatBlast lower(&mgr);
+  const ASTNode lowered = lower.topLevel(sum);
+
+  // Both applications survive as the nodes that were built, actuals and all.
+  EXPECT_EQ(2u, countKind(lowered, UF_APPLY));
+  EXPECT_TRUE(contains(lowered, predicate));
+  EXPECT_TRUE(contains(lowered, bits));
+
+  // Their shared fp.abs is the only float operation left, and it is left
+  // only because it is under them.
+  EXPECT_EQ(1u, countKind(lowered, FP_ABS));
+  EXPECT_EQ(0u, countKind(lowered, FP_ADD));
+  EXPECT_EQ(0u, countKind(lowered, FP_TOFP));
 }

--- a/tests/unit-tests/UFLowering_Test.cpp
+++ b/tests/unit-tests/UFLowering_Test.cpp
@@ -1,0 +1,181 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+/***********
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+**********************/
+
+#include "stp/STPManager/STPManager.h"
+#include "stp/UninterpretedFunctions/UFContext.h"
+#include "stp/UninterpretedFunctions/UFLowering.h"
+
+#include <gtest/gtest.h>
+
+using namespace stp;
+
+namespace
+{
+
+const LoweredApplicationRecord* findRecord(const LoweredApplicationView& view,
+                                           const ASTNode& durable)
+{
+  for (const LoweredApplicationRecord& record : view.applications)
+    if (record.durableHandle == durable)
+      return &record;
+  return NULL;
+}
+
+} // namespace
+
+TEST(UFLowering, SharedNestedCompoundActualGetsOneCanonicalName)
+{
+  STPMgr manager;
+  manager.UserFlags.enable_uninterpreted_functions = true;
+  UFContext* const context = manager.getUFContext();
+  const SourceSort bv8 = SourceSort::bitVector(8);
+  std::string diagnostic;
+  const UFDecl* const f =
+      context->declareFunction("f", {bv8}, bv8, &diagnostic);
+  const UFDecl* const g =
+      context->declareFunction("g", {bv8}, bv8, &diagnostic);
+  ASSERT_NE(nullptr, f) << diagnostic;
+  ASSERT_NE(nullptr, g) << diagnostic;
+
+  NodeFactory* const factory = manager.defaultNodeFactory;
+  const ASTNode x = manager.CreateSourceSymbol("x", bv8);
+  const ASTNode one = manager.CreateBVConst(8, 1);
+  const ASTNode inner = context->apply(f, {x}, &diagnostic);
+  const ASTNode compound = factory->CreateTerm(BVPLUS, 8, inner, one);
+  const ASTNode left = context->apply(f, {compound}, &diagnostic);
+  const ASTNode right = context->apply(g, {compound}, &diagnostic);
+  ASSERT_FALSE(inner.IsNull()) << diagnostic;
+  ASSERT_FALSE(left.IsNull()) << diagnostic;
+  ASSERT_FALSE(right.IsNull()) << diagnostic;
+
+  const ASTNode root = factory->CreateNode(
+      AND, factory->CreateNode(EQ, left, manager.CreateBVConst(8, 2)),
+      factory->CreateNode(EQ, right, manager.CreateBVConst(8, 3)));
+  UFLowering lowerer(&manager);
+  const LoweredApplicationView view =
+      lowerer.lowerCompletedRoot(root, UFSolveScope::batch(41));
+
+  ASSERT_EQ(3u, view.size());
+  const LoweredApplicationRecord* const innerRecord = findRecord(view, inner);
+  const LoweredApplicationRecord* const leftRecord = findRecord(view, left);
+  const LoweredApplicationRecord* const rightRecord = findRecord(view, right);
+  ASSERT_NE(nullptr, innerRecord);
+  ASSERT_NE(nullptr, leftRecord);
+  ASSERT_NE(nullptr, rightRecord);
+  EXPECT_LT(innerRecord->stableOrder, leftRecord->stableOrder);
+  EXPECT_LT(innerRecord->stableOrder, rightRecord->stableOrder);
+
+  const ASTNode expectedLowered =
+      factory->CreateTerm(BVPLUS, 8, innerRecord->resultSymbol, one);
+  ASSERT_EQ(1u, leftRecord->loweredActuals.size());
+  ASSERT_EQ(1u, rightRecord->loweredActuals.size());
+  EXPECT_EQ(expectedLowered, leftRecord->loweredActuals[0]);
+  EXPECT_EQ(expectedLowered, rightRecord->loweredActuals[0]);
+  EXPECT_EQ(leftRecord->namedActuals[0], rightRecord->namedActuals[0]);
+  EXPECT_EQ(1u, view.nameToTerm.size());
+  EXPECT_EQ(1u, view.namingDefinitions.size());
+
+  // The durable public tree is untouched, while both semantic forms enforce
+  // the completed-root barrier through a shared, nested application DAG.
+  EXPECT_TRUE(containsKind(view.publicRoot, UF_APPLY));
+  EXPECT_FALSE(containsKind(expectedLowered, UF_APPLY));
+  EXPECT_FALSE(containsKind(view.semanticRoot, UF_APPLY));
+  EXPECT_FALSE(
+      containsKind(view.semanticRootWithDefinitions(&manager), UF_APPLY));
+}
+
+TEST(UFLowering, ExplicitPostOrderHandlesDeepAdversarialSharedDag)
+{
+  STPMgr manager;
+  manager.UserFlags.enable_uninterpreted_functions = true;
+  UFContext* const context = manager.getUFContext();
+  const SourceSort bv8 = SourceSort::bitVector(8);
+  std::string diagnostic;
+  const UFDecl* const f =
+      context->declareFunction("deep_f", {bv8}, bv8, &diagnostic);
+  ASSERT_NE(nullptr, f) << diagnostic;
+
+  // Every application below consumes the entire growing prefix, and that
+  // prefix also contains the preceding application as a shared child. A
+  // separate substitution walk per application is quadratic in this shape;
+  // a single memoised post-order walk visits its O(depth) unique nodes once.
+  const size_t depth = 4096;
+  NodeFactory* const factory = manager.defaultNodeFactory;
+  const ASTNode x = manager.CreateSourceSymbol("deep_x", bv8);
+  ASTNode growing = x;
+  ASTVec durable;
+  durable.reserve(depth);
+  for (size_t i = 0; i < depth; ++i)
+  {
+    const ASTNode application = context->apply(f, {growing}, &diagnostic);
+    ASSERT_FALSE(application.IsNull()) << diagnostic;
+    durable.push_back(application);
+    if (i + 1 < depth)
+      growing = factory->CreateTerm(BVPLUS, 8, growing, application);
+  }
+
+  const ASTNode root = factory->CreateNode(EQ, durable.back(), x);
+  UFLowering lowerer(&manager);
+  const LoweredApplicationView view =
+      lowerer.lowerCompletedRoot(root, UFSolveScope::batch(42));
+
+  ASSERT_EQ(depth, view.size());
+  ASSERT_EQ(depth, view.handleToResult.size());
+  ASSERT_EQ(depth - 1, view.namingDefinitions.size());
+  ASSERT_EQ(depth - 1, view.nameToTerm.size());
+  for (size_t i = 0; i < depth; ++i)
+  {
+    EXPECT_EQ(i, view.applications[i].stableOrder);
+    EXPECT_EQ(durable[i], view.applications[i].durableHandle);
+    EXPECT_TRUE(context->isSolveScalar(view.applications[i].resultSymbol));
+  }
+
+  // Checking the deepest reconstructed actual exercises the whole rewritten
+  // prefix. Neither it nor either semantic root may retain a durable apply.
+  EXPECT_FALSE(
+      containsKind(view.applications.back().loweredActuals[0], UF_APPLY));
+  EXPECT_FALSE(containsKind(view.semanticRoot, UF_APPLY));
+  EXPECT_FALSE(
+      containsKind(view.semanticRootWithDefinitions(&manager), UF_APPLY));
+}

--- a/tests/unit-tests/UninterpretedFunctionsFrontend_Test.cpp
+++ b/tests/unit-tests/UninterpretedFunctionsFrontend_Test.cpp
@@ -26,10 +26,28 @@ THE SOFTWARE.
 #include "stp/Globals/Globals.h"
 #include "stp/STPManager/STPManager.h"
 #include "stp/UninterpretedFunctions/UFContext.h"
+#include "stp/UninterpretedFunctions/UFLowering.h"
 
 #include <gtest/gtest.h>
 
 using namespace stp;
+
+namespace
+{
+
+// Lowering order follows the post-order walk, so a test that adds
+// applications to reach a comparable declaration should not also have to
+// predict where each one lands.
+const LoweredApplicationRecord* recordFor(const LoweredApplicationView& view,
+                                          const ASTNode& durableHandle)
+{
+  for (const LoweredApplicationRecord& record : view.applications)
+    if (record.durableHandle == durableHandle)
+      return &record;
+  return NULL;
+}
+
+} // namespace
 
 TEST(UninterpretedFunctionsFrontend, IsDisabledByDefault)
 {
@@ -273,4 +291,221 @@ TEST(UninterpretedFunctionsFrontend, SubstitutionRebuildsDurableApplication)
   EXPECT_EQ(declaration->identityNode(), specialized[0]);
   EXPECT_EQ(actual, specialized[1]);
   EXPECT_TRUE(context->isRegisteredApplication(specialized));
+}
+
+TEST(UninterpretedFunctionsFrontend,
+     CompletedRootLoweringBuildsOnlyReachableNestedClosure)
+{
+  STPMgr manager;
+  manager.UserFlags.enable_uninterpreted_functions = true;
+  UFContext* context = manager.getUFContext();
+  std::string diagnostic;
+  const UFDecl* declaration = context->declareFunction(
+      "f", {SourceSort::bitVector(8)}, SourceSort::bitVector(8),
+      &diagnostic);
+  ASSERT_NE(nullptr, declaration) << diagnostic;
+
+  const ASTNode x =
+      manager.CreateSourceSymbol("x", SourceSort::bitVector(8));
+  const ASTNode inner = context->apply(declaration, {x}, &diagnostic);
+  const ASTNode outer = context->apply(declaration, {inner}, &diagnostic);
+  const ASTNode unreachable = context->apply(
+      declaration, {manager.CreateBVConst(8, 9)}, &diagnostic);
+  ASSERT_FALSE(unreachable.IsNull());
+  const ASTNode root =
+      manager.defaultNodeFactory->CreateNode(EQ, outer, x);
+
+  UFLowering lowerer(&manager);
+  const LoweredApplicationView view =
+      lowerer.lowerCompletedRoot(root, UFSolveScope::batch(17));
+
+  ASSERT_EQ(2u, view.size());
+  EXPECT_EQ(root, view.publicRoot);
+  EXPECT_FALSE(containsKind(view.semanticRoot, UF_APPLY));
+  EXPECT_TRUE(view.handleToResult.find(inner) != view.handleToResult.end());
+  EXPECT_TRUE(view.handleToResult.find(outer) != view.handleToResult.end());
+  EXPECT_TRUE(view.handleToResult.find(unreachable) ==
+              view.handleToResult.end());
+  EXPECT_EQ(inner, view.applications[0].durableHandle);
+  EXPECT_EQ(outer, view.applications[1].durableHandle);
+  ASSERT_EQ(1u, view.applications[1].namedActuals.size());
+  EXPECT_EQ(view.applications[0].resultSymbol,
+            view.applications[1].namedActuals[0]);
+  EXPECT_TRUE(context->isProtected(view.applications[0].resultSymbol));
+  EXPECT_TRUE(context->isProtected(view.applications[1].resultSymbol));
+  EXPECT_TRUE(context->isSolveScalar(view.applications[0].resultSymbol));
+  EXPECT_TRUE(context->isSolveScalar(view.applications[1].resultSymbol));
+}
+
+TEST(UninterpretedFunctionsFrontend,
+     CompletedRootLoweringNamesEachComplexActualOnce)
+{
+  STPMgr manager;
+  manager.UserFlags.enable_uninterpreted_functions = true;
+  UFContext* context = manager.getUFContext();
+  std::string diagnostic;
+  const UFDecl* f = context->declareFunction(
+      "f", {SourceSort::bitVector(8)}, SourceSort::bitVector(8),
+      &diagnostic);
+  const UFDecl* g = context->declareFunction(
+      "g", {SourceSort::bitVector(8)}, SourceSort::bitVector(8),
+      &diagnostic);
+  ASSERT_NE(nullptr, f);
+  ASSERT_NE(nullptr, g);
+  const ASTNode x =
+      manager.CreateSourceSymbol("x", SourceSort::bitVector(8));
+  const ASTNode one = manager.CreateBVConst(8, 1);
+  const ASTNode complex = manager.defaultNodeFactory->CreateTerm(
+      BVPLUS, 8, x, one);
+  const ASTNode fx = context->apply(f, {complex}, &diagnostic);
+  const ASTNode gx = context->apply(g, {complex}, &diagnostic);
+  // A compound actual is named only where a congruence lemma could mention
+  // it, so each declaration needs a second application; both are given a leaf
+  // actual, which introduces no further name.
+  const ASTNode fLeaf = context->apply(f, {x}, &diagnostic);
+  const ASTNode gLeaf = context->apply(g, {one}, &diagnostic);
+  const ASTNode root = manager.defaultNodeFactory->CreateNode(
+      AND, manager.defaultNodeFactory->CreateNode(EQ, fx, gx),
+      manager.defaultNodeFactory->CreateNode(EQ, fLeaf, gLeaf));
+
+  UFLowering lowerer(&manager);
+  const LoweredApplicationView view =
+      lowerer.lowerCompletedRoot(root, UFSolveScope::batch(18));
+  ASSERT_EQ(4u, view.size());
+  ASSERT_EQ(1u, view.namingDefinitions.size());
+  ASSERT_EQ(1u, view.nameToTerm.size());
+  const LoweredApplicationRecord* const fRecord = recordFor(view, fx);
+  const LoweredApplicationRecord* const gRecord = recordFor(view, gx);
+  ASSERT_NE(nullptr, fRecord);
+  ASSERT_NE(nullptr, gRecord);
+  EXPECT_TRUE(fRecord->observableArguments);
+  EXPECT_TRUE(gRecord->observableArguments);
+  EXPECT_EQ(fRecord->namedActuals[0], gRecord->namedActuals[0]);
+  EXPECT_TRUE(context->isProtected(fRecord->namedActuals[0]));
+  EXPECT_TRUE(context->isSolveScalar(fRecord->namedActuals[0]));
+  EXPECT_FALSE(containsKind(view.semanticRootWithDefinitions(&manager),
+                            UF_APPLY));
+
+  // The ordinary substitution funnel must not delete either a UF result or
+  // its argument-name definition after the lowering barrier.
+  SubstitutionMap substitutions(&manager);
+  EXPECT_FALSE(context->activeInSolve());
+  {
+    UFContext::SolveScope scope(context);
+    EXPECT_TRUE(context->activeInSolve());
+    EXPECT_FALSE(substitutions.UpdateSolverMap(fRecord->resultSymbol,
+                                               manager.CreateBVConst(8, 3)));
+    EXPECT_FALSE(
+        substitutions.UpdateSolverMap(fRecord->namedActuals[0], complex));
+  }
+  EXPECT_FALSE(context->activeInSolve());
+}
+
+TEST(UninterpretedFunctionsFrontend, LoneApplicationLeavesCompoundActualUnnamed)
+{
+  STPMgr manager;
+  manager.UserFlags.enable_uninterpreted_functions = true;
+  UFContext* context = manager.getUFContext();
+  std::string diagnostic;
+  const UFDecl* f = context->declareFunction(
+      "f", {SourceSort::bitVector(8)}, SourceSort::bitVector(8), &diagnostic);
+  ASSERT_NE(nullptr, f);
+  const ASTNode x = manager.CreateSourceSymbol("x", SourceSort::bitVector(8));
+  const ASTNode y = manager.CreateSourceSymbol("y", SourceSort::bitVector(8));
+  const ASTNode complex =
+      manager.defaultNodeFactory->CreateTerm(BVPLUS, 8, x, y);
+  const ASTNode fx = context->apply(f, {complex}, &diagnostic);
+  const ASTNode root = manager.defaultNodeFactory->CreateNode(
+      EQ, fx, manager.CreateBVConst(8, 3));
+
+  UFLowering lowerer(&manager);
+  const LoweredApplicationView view =
+      lowerer.lowerCompletedRoot(root, UFSolveScope::batch(30));
+  ASSERT_EQ(1u, view.size());
+  // No second application of f exists, so no congruence lemma can ever equate
+  // this actual with anything: naming it would only drag BVPLUS into the
+  // bit-blast where nothing can observe it.
+  EXPECT_FALSE(view.applications[0].observableArguments);
+  EXPECT_TRUE(view.applications[0].namedActuals.empty());
+  EXPECT_TRUE(view.namingDefinitions.empty());
+  EXPECT_TRUE(view.nameToTerm.empty());
+  EXPECT_FALSE(containsKind(view.semanticRootWithDefinitions(&manager),
+                            BVPLUS));
+
+  // The result symbol is still a protected solve scalar: it stands in for the
+  // application in the formula and carries the certified value.
+  EXPECT_TRUE(context->isProtected(view.applications[0].resultSymbol));
+  EXPECT_TRUE(context->isSolveScalar(view.applications[0].resultSymbol));
+}
+TEST(UninterpretedFunctionsFrontend, LoneApplicationReusesAnExistingName)
+{
+  STPMgr manager;
+  manager.UserFlags.enable_uninterpreted_functions = true;
+  UFContext* context = manager.getUFContext();
+  std::string diagnostic;
+  const UFDecl* f = context->declareFunction(
+      "f", {SourceSort::bitVector(8)}, SourceSort::bitVector(8), &diagnostic);
+  const UFDecl* g = context->declareFunction(
+      "g", {SourceSort::bitVector(8)}, SourceSort::bitVector(8), &diagnostic);
+  ASSERT_NE(nullptr, f);
+  ASSERT_NE(nullptr, g);
+  const ASTNode x = manager.CreateSourceSymbol("x", SourceSort::bitVector(8));
+  const ASTNode y = manager.CreateSourceSymbol("y", SourceSort::bitVector(8));
+  const ASTNode complex =
+      manager.defaultNodeFactory->CreateTerm(BVPLUS, 8, x, y);
+  // f is comparable and names `complex`; g's single application shares that
+  // term, so it costs nothing to keep g readable too.
+  const ASTNode fComplex = context->apply(f, {complex}, &diagnostic);
+  const ASTNode fLeaf = context->apply(f, {x}, &diagnostic);
+  const ASTNode gComplex = context->apply(g, {complex}, &diagnostic);
+  const ASTNode root = manager.defaultNodeFactory->CreateNode(
+      AND, manager.defaultNodeFactory->CreateNode(EQ, fComplex, fLeaf),
+      manager.defaultNodeFactory->CreateNode(EQ, gComplex,
+                                             manager.CreateBVConst(8, 3)));
+
+  UFLowering lowerer(&manager);
+  const LoweredApplicationView view =
+      lowerer.lowerCompletedRoot(root, UFSolveScope::batch(31));
+  ASSERT_EQ(3u, view.size());
+  ASSERT_EQ(1u, view.namingDefinitions.size());
+  const LoweredApplicationRecord* const fRecord = recordFor(view, fComplex);
+  const LoweredApplicationRecord* const gRecord = recordFor(view, gComplex);
+  ASSERT_NE(nullptr, fRecord);
+  ASSERT_NE(nullptr, gRecord);
+  EXPECT_TRUE(gRecord->observableArguments);
+  ASSERT_EQ(1u, gRecord->namedActuals.size());
+  EXPECT_EQ(fRecord->namedActuals[0], gRecord->namedActuals[0]);
+}
+
+TEST(UninterpretedFunctionsFrontend, BooleanLoweringRetainsBoolSourceSort)
+{
+  STPMgr manager;
+  manager.UserFlags.enable_uninterpreted_functions = true;
+  UFContext* context = manager.getUFContext();
+  std::string diagnostic;
+  const UFDecl* pred = context->declareFunction(
+      "p", {SourceSort::boolean()}, SourceSort::boolean(), &diagnostic);
+  ASSERT_NE(nullptr, pred);
+  const ASTNode a =
+      manager.CreateSourceSymbol("a", SourceSort::boolean());
+  const ASTNode b =
+      manager.CreateSourceSymbol("b", SourceSort::boolean());
+  const ASTNode complex =
+      manager.defaultNodeFactory->CreateNode(XOR, a, b);
+  const ASTNode app = context->apply(pred, {complex}, &diagnostic);
+  // Two applications, so the compound actual earns a name to be equated in.
+  const ASTNode leafApp = context->apply(pred, {a}, &diagnostic);
+  const ASTNode root =
+      manager.defaultNodeFactory->CreateNode(AND, app, leafApp);
+
+  UFLowering lowerer(&manager);
+  const LoweredApplicationView view =
+      lowerer.lowerCompletedRoot(root, UFSolveScope::batch(19));
+  ASSERT_EQ(2u, view.size());
+  ASSERT_EQ(1u, view.namingDefinitions.size());
+  const LoweredApplicationRecord* const record = recordFor(view, app);
+  ASSERT_NE(nullptr, record);
+  EXPECT_EQ(SourceSort::boolean(), record->resultSymbol.GetSourceSort());
+  EXPECT_EQ(SourceSort::boolean(), record->namedActuals[0].GetSourceSort());
+  EXPECT_EQ(IFF, view.namingDefinitions[0].GetKind());
 }

--- a/tests/unit-tests/UninterpretedFunctionsFrontend_Test.cpp
+++ b/tests/unit-tests/UninterpretedFunctionsFrontend_Test.cpp
@@ -1,0 +1,276 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#include "stp/Simplifier/SubstitutionMap.h"
+#include "stp/Globals/Globals.h"
+#include "stp/STPManager/STPManager.h"
+#include "stp/UninterpretedFunctions/UFContext.h"
+
+#include <gtest/gtest.h>
+
+using namespace stp;
+
+TEST(UninterpretedFunctionsFrontend, IsDisabledByDefault)
+{
+  STPMgr manager;
+  EXPECT_FALSE(manager.UserFlags.enable_uninterpreted_functions);
+
+  std::string diagnostic;
+  EXPECT_EQ(nullptr, manager.getUFContext()->declareFunction(
+                      "f", {SourceSort::bitVector(8)},
+                      SourceSort::bitVector(8), &diagnostic));
+  EXPECT_EQ(0u, manager.getUFContext()->declarationCount());
+  EXPECT_NE(std::string::npos, diagnostic.find("disabled"));
+}
+
+TEST(UninterpretedFunctionsFrontend, SignatureUsesRestrictedSourceSorts)
+{
+  EXPECT_THROW(UFSignature({}, SourceSort::boolean()), std::invalid_argument);
+  EXPECT_THROW(UFSignature({SourceSort::bitVector(8)},
+                           SourceSort::array(SourceSort::bitVector(8),
+                                             SourceSort::bitVector(8))),
+               std::invalid_argument);
+
+  const UFSignature signature(
+      {SourceSort::boolean(), SourceSort::bitVector(17)},
+      SourceSort::bitVector(3));
+  ASSERT_EQ(2u, signature.arity());
+  EXPECT_EQ(SourceSort::Kind::Bool, signature.domain()[0].kind());
+  EXPECT_EQ(17u, signature.domain()[1].bitVectorWidth());
+  EXPECT_EQ(3u, signature.codomain().bitVectorWidth());
+
+  // RoundingMode and FloatingPoint used to sit alongside the throwing rows
+  // above. Both are now admitted in either position; the rows are kept,
+  // inverted, so that a regression which re-rejected a sort fails here.
+  const UFSignature mode({SourceSort::roundingMode()},
+                         SourceSort::roundingMode());
+  ASSERT_EQ(1u, mode.arity());
+  EXPECT_EQ(SourceSort::Kind::RoundingMode, mode.domain()[0].kind());
+  EXPECT_EQ(SourceSort::Kind::RoundingMode, mode.codomain().kind());
+  EXPECT_EQ(5u, mode.codomain().packedWidth());
+
+  const UFSignature floats({SourceSort::floatingPoint(8, 24)},
+                           SourceSort::floatingPoint(11, 53));
+  ASSERT_EQ(1u, floats.arity());
+  EXPECT_EQ(SourceSort::Kind::FloatingPoint, floats.domain()[0].kind());
+  EXPECT_EQ(SourceSort::Kind::FloatingPoint, floats.codomain().kind());
+
+  // Admitted at its own sort, but never *solved* at it: a float is compared
+  // as its canonical packed carrier, because SMT-LIB's = on floats identifies
+  // every NaN and byte equality does not.
+  EXPECT_EQ(SourceSort::bitVector(32),
+            UFSignature::loweringSort(floats.domain()[0]));
+  EXPECT_EQ(SourceSort::bitVector(64),
+            UFSignature::loweringSort(floats.codomain()));
+  // Every other admitted sort is solved exactly as declared.
+  EXPECT_EQ(SourceSort::boolean(),
+            UFSignature::loweringSort(SourceSort::boolean()));
+  EXPECT_EQ(SourceSort::roundingMode(),
+            UFSignature::loweringSort(SourceSort::roundingMode()));
+  EXPECT_EQ(SourceSort::bitVector(17),
+            UFSignature::loweringSort(SourceSort::bitVector(17)));
+}
+
+TEST(UninterpretedFunctionsFrontend,
+     UnsupportedDirectSignaturesMutateNoRegistry)
+{
+  STPMgr manager;
+  manager.UserFlags.enable_uninterpreted_functions = true;
+  UFContext* context = manager.getUFContext();
+  const SourceSort bv8 = SourceSort::bitVector(8);
+  const SourceSort array = SourceSort::array(bv8, bv8);
+  std::string diagnostic;
+
+  EXPECT_EQ(nullptr,
+            context->declareFunction("empty", {}, bv8, &diagnostic));
+  EXPECT_EQ("uninterpreted functions: declaration of empty: a zero-arity "
+            "declaration is an ordinary symbol, not an uninterpreted function",
+            diagnostic);
+  // The RoundingMode and FloatingPoint rows that used to sit here are now
+  // admitted; they moved to the positive tests below, where the registry is
+  // expected to change rather than stay empty.
+  EXPECT_EQ(nullptr,
+            context->declareFunction("array", {array}, bv8, &diagnostic));
+  EXPECT_EQ("uninterpreted functions: declaration of array: unsupported "
+            "domain sort (Array (_ BitVec 8) (_ BitVec 8)) at argument 0 "
+            "(only Bool, RoundingMode, FloatingPoint and nonzero-width "
+            "bit-vector sorts are supported)",
+            diagnostic);
+  EXPECT_EQ(nullptr, context->declareFunction(
+                         "unknown", {SourceSort::unknown()}, bv8,
+                         &diagnostic));
+  EXPECT_EQ(nullptr,
+            context->declareFunction("result", {bv8}, array, &diagnostic));
+  EXPECT_EQ("uninterpreted functions: declaration of result: unsupported "
+            "result sort (Array (_ BitVec 8) (_ BitVec 8)) (only Bool, "
+            "RoundingMode, FloatingPoint and nonzero-width bit-vector "
+            "sorts are supported)",
+            diagnostic);
+  EXPECT_EQ(0u, context->declarationCount());
+  EXPECT_EQ(0u, context->registeredApplicationCount());
+}
+
+TEST(UninterpretedFunctionsFrontend, RoundingModeSignaturesAreAdmitted)
+{
+  STPMgr manager;
+  manager.UserFlags.enable_uninterpreted_functions = true;
+  UFContext* context = manager.getUFContext();
+  const SourceSort rm = SourceSort::roundingMode();
+  const SourceSort bv8 = SourceSort::bitVector(8);
+  std::string diagnostic;
+
+  const UFDecl* toMode =
+      context->declareFunction("toMode", {bv8}, rm, &diagnostic);
+  ASSERT_NE(nullptr, toMode) << diagnostic;
+  const UFDecl* fromMode =
+      context->declareFunction("fromMode", {rm}, bv8, &diagnostic);
+  ASSERT_NE(nullptr, fromMode) << diagnostic;
+  EXPECT_EQ(2u, context->declarationCount());
+
+  // Declaring a RoundingMode-sorted identity is enough to make the manager
+  // report the floating-point theory, which is what routes the query to
+  // FpTotalise and to the mode-aware model printers.
+  EXPECT_TRUE(manager.has_floating_point_theory);
+
+  const ASTNode x = manager.CreateSourceSymbol("x", bv8);
+  const ASTNode application = context->apply(toMode, {x}, &diagnostic);
+  ASSERT_FALSE(application.IsNull()) << diagnostic;
+  EXPECT_EQ(UF_APPLY, application.GetKind());
+  // The carrier is the packed one -- five bits -- while the source sort stays
+  // RoundingMode. BVTypeCheck's UF_APPLY rule enforces exactly this pairing.
+  EXPECT_EQ(SourceSort::Kind::RoundingMode,
+            application.GetSourceSort().kind());
+  EXPECT_EQ(BITVECTOR_TYPE, application.GetType());
+  EXPECT_EQ(5u, application.GetValueWidth());
+  EXPECT_TRUE(BVTypeCheck(application));
+}
+
+TEST(UninterpretedFunctionsFrontend, DurableApplicationsAreTypedAndHashConsed)
+{
+  STPMgr manager;
+  manager.UserFlags.enable_uninterpreted_functions = true;
+  UFContext* context = manager.getUFContext();
+
+  std::string diagnostic;
+  const UFDecl* bv = context->declareFunction(
+      "f", {SourceSort::bitVector(8), SourceSort::boolean()},
+      SourceSort::bitVector(16), &diagnostic);
+  const UFDecl* pred = context->declareFunction(
+      "p", {SourceSort::bitVector(8)}, SourceSort::boolean(), &diagnostic);
+  ASSERT_NE(nullptr, bv) << diagnostic;
+  ASSERT_NE(nullptr, pred) << diagnostic;
+
+  const ASTNode x =
+      manager.CreateSourceSymbol("x", SourceSort::bitVector(8));
+  const ASTNode b =
+      manager.CreateSourceSymbol("b", SourceSort::boolean());
+  const ASTNode app = context->apply(bv, {x, b}, &diagnostic);
+  const ASTNode again = context->apply(bv, {x, b}, &diagnostic);
+  const ASTNode boolApp = context->apply(pred, {x}, &diagnostic);
+
+  EXPECT_EQ(UF_APPLY, app.GetKind());
+  EXPECT_EQ(app, again);
+  EXPECT_EQ(bv->identityNode(), app[0]);
+  EXPECT_EQ(x, app[1]);
+  EXPECT_EQ(b, app[2]);
+  EXPECT_EQ(SourceSort::bitVector(16), app.GetSourceSort());
+  EXPECT_EQ(BITVECTOR_TYPE, app.GetType());
+  EXPECT_EQ(16u, app.GetValueWidth());
+  EXPECT_EQ(SourceSort::boolean(), boolApp.GetSourceSort());
+  EXPECT_EQ(BOOLEAN_TYPE, boolApp.GetType());
+  EXPECT_TRUE(context->isRegisteredApplication(app));
+  EXPECT_EQ(2u, context->registeredApplicationCount());
+  EXPECT_TRUE(BVTypeCheck(app));
+  EXPECT_TRUE(BVTypeCheck(boolApp));
+}
+
+TEST(UninterpretedFunctionsFrontend, FailedApplicationsRegisterNothing)
+{
+  STPMgr first;
+  STPMgr second;
+  first.UserFlags.enable_uninterpreted_functions = true;
+  second.UserFlags.enable_uninterpreted_functions = true;
+  UFContext* context = first.getUFContext();
+  std::string diagnostic;
+  const UFDecl* declaration = context->declareFunction(
+      "f", {SourceSort::bitVector(8)}, SourceSort::bitVector(8),
+      &diagnostic);
+  ASSERT_NE(nullptr, declaration);
+
+  const ASTNode wrong =
+      first.CreateSourceSymbol("wrong", SourceSort::boolean());
+  const ASTNode foreign =
+      second.CreateSourceSymbol("foreign", SourceSort::bitVector(8));
+  EXPECT_EQ(UNDEFINED,
+            context->apply(declaration, ASTVec(), &diagnostic).GetKind());
+  EXPECT_EQ("uninterpreted functions: f expects 1 argument but was applied "
+            "to 0",
+            diagnostic);
+  EXPECT_EQ(UNDEFINED,
+            context->apply(declaration, {wrong}, &diagnostic).GetKind());
+  EXPECT_EQ("uninterpreted functions: argument 0 of f has sort Bool but the "
+            "declaration requires (_ BitVec 8)",
+            diagnostic);
+  EXPECT_EQ(UNDEFINED,
+            context->apply(declaration, {foreign}, &diagnostic).GetKind());
+  EXPECT_EQ("uninterpreted functions: argument 0 of f belongs to another "
+            "context",
+            diagnostic);
+  EXPECT_EQ(0u, context->registeredApplicationCount());
+
+  ASSERT_TRUE(context->deactivate(declaration, &diagnostic));
+  const ASTNode x =
+      first.CreateSourceSymbol("x", SourceSort::bitVector(8));
+  EXPECT_EQ(UNDEFINED,
+            context->apply(declaration, {x}, &diagnostic).GetKind());
+  EXPECT_EQ(0u, context->registeredApplicationCount());
+}
+
+TEST(UninterpretedFunctionsFrontend, SubstitutionRebuildsDurableApplication)
+{
+  STPMgr manager;
+  manager.UserFlags.enable_uninterpreted_functions = true;
+  UFContext* context = manager.getUFContext();
+  std::string diagnostic;
+  const UFDecl* declaration = context->declareFunction(
+      "f", {SourceSort::bitVector(8)}, SourceSort::bitVector(8),
+      &diagnostic);
+  ASSERT_NE(nullptr, declaration);
+  const ASTNode formal =
+      manager.CreateSourceSymbol("formal", SourceSort::bitVector(8));
+  const ASTNode actual = manager.CreateBVConst(8, 42);
+  const ASTNode generic = context->apply(declaration, {formal}, &diagnostic);
+
+  ASTNodeMap substitutions;
+  substitutions.insert(std::make_pair(formal, actual));
+  ASTNodeMap cache;
+  const ASTNode specialized = SubstitutionMap::replace(
+      generic, substitutions, cache, manager.defaultNodeFactory);
+
+  ASSERT_EQ(UF_APPLY, specialized.GetKind());
+  EXPECT_NE(generic, specialized);
+  EXPECT_EQ(declaration->identityNode(), specialized[0]);
+  EXPECT_EQ(actual, specialized[1]);
+  EXPECT_TRUE(context->isRegisteredApplication(specialized));
+}


### PR DESCRIPTION
# UF support (2/8): lower durable applications at the completed root

**This PR builds on top of #933** (UF support (1/8): AST: the durable application node and its registry). Please review and merge it first; this branch contains its commits.

Add the one lowering boundary between durable UF_APPLY nodes and the bit-vector pipeline. A completed root is rewritten once, bottom-up: every application becomes a fresh deterministic result symbol of its codomain's lowering sort, nested applications resolve before the actuals that carry them are recorded, and each compound actual of a comparable declaration is named by a fresh scalar whose defining equality travels with the formula. Floats cross into the core through FP_TO_IEEE_BV -- pack of unpack, which collapses NaN payloads while keeping the two zeros apart -- and cross back through the three-child to_fp; every RoundingMode scalar the lowering registers is pinned one-hot at the source. Introduced scalars are recorded as protected and as solve scalars: the substitution funnel and RemoveUnconstrained now refuse to eliminate them, which is what keeps the future checker's one candidate authority -- the SAT assignment -- attached to what the formula actually says.

No solve path calls the lowering yet; it arrives with the decision procedure. This commit is the reference profile only: every congruence clause will be earned by a refuted candidate, and nothing is installed up front.
