### PR TITLE
UF support (4/8): decide it, behind --uninterpreted-functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,20 @@ jobs:
       run: ctest --parallel "$(nproc)" -VV --output-on-failure
       working-directory: build
 
+    # Independently lower generated UF problems to eager Ackermann constraints
+    # and decide those through the classic feature-off path.  Compare that
+    # oracle with both lazy UF adapters, including push/pop verdict sequences.
+    # Run once per matrix rather than once per compiler: this checks semantics,
+    # while the full suite above supplies compiler/build-mode coverage.
+    - name: UF differential oracle and trend corpus
+      if: matrix.name == 'gcc'
+      run: |
+        python3 scripts/fuzz/uf-differential-fuzz.py \
+          --stp build/stp --seed 42 --rounds 150
+        python3 tests/ufstp/performance.py \
+          --stp build/stp --scales 16 --repeats 1 \
+          --evidence-out build/uf-performance-evidence.json
+
     # BUILD_EXTRA_TOOLS is off by default and nothing else compiles these five
     # tools, so all of them had quietly stopped building: headers that were
     # never self-contained, and calls into APIs that had changed shape. Getting

--- a/include/stp/AST/ASTNode.h
+++ b/include/stp/AST/ASTNode.h
@@ -35,6 +35,7 @@ namespace stp
 {
 using std::ostream;
 class ASTInternal;
+class UFContext;
 
 /******************************************************************
  *  A Kind of Smart pointer to actual ASTInternal datastructure.  *
@@ -45,6 +46,7 @@ class ASTNode
 {
   friend class STPMgr;
   friend class ASTInterior;
+  friend class UFContext;
   friend class vector<ASTNode>;
   friend ASTNode HashingNodeFactory::CreateNode(
       stp::Kind kind, stp::ASTChildren back_children);
@@ -119,6 +121,21 @@ public:
 
   // Check if it points to a null node
   inline bool IsNull() const { return _int_node_ptr == NULL; }
+
+  // Public construction APIs use this to reject cross-context operands before
+  // asking a node factory to build anything. Node ownership is immutable.
+  bool IsOwnedBy(const STPMgr* manager) const
+  {
+    return !IsNull() && GetSTPMgr() == manager;
+  }
+
+  // The owning manager is immutable. Public printers for context-owned
+  // durable nodes need to recover their declaration registry without relying
+  // on a process-global parser manager.
+  STPMgr* GetNodeManager() const
+  {
+    return IsNull() ? NULL : GetSTPMgr();
+  }
 
   bool isSimplfied() const;
   void hasBeenSimplfied() const;

--- a/include/stp/AST/SourceSort.h
+++ b/include/stp/AST/SourceSort.h
@@ -13,6 +13,7 @@
 #include <cassert>
 #include <cstddef>
 #include <memory>
+#include <string>
 #include <unordered_set>
 
 namespace stp
@@ -193,6 +194,11 @@ public:
     size_t operator()(const SourceSort& sort) const { return sort.hash(); }
   };
 };
+
+// Return the canonical SMT-LIB2 spelling used in diagnostics and model text.
+// Unknown is rendered explicitly rather than making diagnostic construction
+// itself partial.
+std::string sourceSortToSMTLib(const SourceSort& sort);
 
 } // namespace stp
 

--- a/include/stp/AbsRefineCounterExample/AbsRefine_CounterExample.h
+++ b/include/stp/AbsRefineCounterExample/AbsRefine_CounterExample.h
@@ -182,8 +182,10 @@ public:
 
   // Converts MINISAT counterexample into an AST memotable (i.e. the
   // function populates the datastructure CounterExampleMap)
-  void ConstructCounterExample(SATSolver& newS,
-                               const ToSATBase::ASTNodeToSATVar& satVarToSymbol);
+  void ConstructCounterExample(
+      SATSolver& newS,
+      const ToSATBase::ASTNodeToSATVar& satVarToSymbol,
+      bool internalCandidateRequired = false);
 
   // Prints MINISAT assigment one bit at a time, for debugging.
   void PrintSATModel(SATSolver& S, ToSATBase::ASTNodeToSATVar& satVarToSymbol);

--- a/include/stp/AbsRefineCounterExample/AbsRefine_CounterExample.h
+++ b/include/stp/AbsRefineCounterExample/AbsRefine_CounterExample.h
@@ -57,6 +57,7 @@ uint32_t getEquals(SATSolver& SatSolver, const ASTNode& a, const ASTNode& b,
 
 class FpEncodingContext;
 class ArrayReadRefinementProgress;
+class UFTheoryAdapter;
 
 class AbsRefine_CounterExample // not copyable
 {
@@ -87,6 +88,10 @@ private:
   // Its descendants retain source-sort metadata, but must not be lowered a
   // second time merely because of that metadata.
   unsigned int fpEncodedEvaluationDepth;
+
+  // Non-owning current solve-mode coordinator. STP owns the fresh-query
+  // adapter; IncrementalSolver owns the exact-stack adapter.
+  UFTheoryAdapter* ufTheoryAdapter;
 
   FpEncodingContext& requireFpEncodingContext() const;
 
@@ -193,7 +198,7 @@ public:
 public:
   AbsRefine_CounterExample(STPMgr* b, Simplifier* s, ArrayTransformer* at)
       : bm(b), simp(s), ArrayTransform(at), fpEncodingContext(NULL),
-        fpEncodedEvaluationDepth(0)
+        fpEncodedEvaluationDepth(0), ufTheoryAdapter(NULL)
   {
     ASTTrue = bm->CreateNode(TRUE);
     ASTFalse = bm->CreateNode(FALSE);
@@ -204,6 +209,12 @@ public:
   {
     fpEncodingContext = context;
   }
+
+  void setUFTheoryAdapter(UFTheoryAdapter* adapter)
+  {
+    ufTheoryAdapter = adapter;
+  }
+  UFTheoryAdapter* getUFTheoryAdapter() const { return ufTheoryAdapter; }
 
   // Prints the counterexample to stdout
   void PrintCounterExample(bool t, std::ostream& os = std::cout);
@@ -346,12 +357,12 @@ public:
   //
   // Twenty-seven of the carrier's thirty-two patterns denote no mode, and
   // every mode the current formula names is pinned to the five -- by the
-  // declaration, by FpTotalise, by the array transform where it mints a
-  // cell. So a carrier that denotes nothing did not escape a pin: it is
-  // bits no constraint of this solve reached, a don't-care exactly like
-  // the cell no observation covers, and owed the same completion.
-  // Anything that does denote a mode is the solve's answer and is
-  // returned untouched.
+  // declaration, by UF lowering, by FpTotalise, by the array transform
+  // where it mints a cell. So a carrier that denotes nothing did not
+  // escape a pin: it is bits no constraint of this solve reached, a
+  // don't-care exactly like the cell no observation covers, and owed the
+  // same completion. Anything that does denote a mode is the solve's
+  // answer and is returned untouched.
   ASTNode completeRoundingMode(const ASTNode& carrier) const;
 
   // ComputeFormulaUsingModel for a caller asking a question about the

--- a/include/stp/FloatBlaster/rounding_modes.h
+++ b/include/stp/FloatBlaster/rounding_modes.h
@@ -47,6 +47,19 @@ enum rounding_modes
   ROUND_NEAREST_TIES_TO_AWAY = ROUND_TOWARD_ZERO << 1,
 };
 
+// Whether a 5-bit carrier value denotes a rounding mode at all. Twenty-seven
+// of the thirty-two patterns denote nothing, so anything that reads a mode
+// back out of a carrier -- a model value, a checker candidate -- has to ask
+// rather than assume.
+inline bool isRoundingModeEncoding(unsigned encoding)
+{
+  return encoding == ROUND_NEAREST_TIES_TO_EVEN ||
+         encoding == ROUND_TOWARD_POSITIVE ||
+         encoding == ROUND_TOWARD_NEGATIVE ||
+         encoding == ROUND_TOWARD_ZERO ||
+         encoding == ROUND_NEAREST_TIES_TO_AWAY;
+}
+
 } // namespace symbolic_fp
 } // namespace stp
 

--- a/include/stp/Parser/parser.h
+++ b/include/stp/Parser/parser.h
@@ -30,6 +30,7 @@ THE SOFTWARE.
 #include "stp/STPManager/STPManager.h"
 #include "stp/Util/Attributes.h"
 #include <cstdio>
+#include <string>
 
 namespace stp
 {
@@ -62,6 +63,48 @@ void SMT2SetFloatTokens(bool enable);
 // rules: define-sort's body is swallowed whole and re-tokenised by hand in
 // the grammar, so it has to consult the gate itself.
 bool SMT2FloatTokensActive();
+
+// The next ordinary identifier is the declaration site of a define-fun
+// formal.  The lexer must return its spelling rather than resolving it in a
+// top-level namespace; once installed, that temporary binding takes
+// precedence while the function body is parsed.
+void SMT2ExpectFunctionParameterName();
+
+// Clear command-local lexer expectations after parser recovery/abort and
+// before the next top-level command. This includes declaration-name and
+// define-fun-formal latches and the declassified-name record below, none of
+// which may leak across commands.
+void SMT2ResetCommandLexerState();
+
+// The declassified declare-fun name. With uninterpreted functions enabled,
+// a name in exactly the declare-fun name position that the lexer WOULD
+// classify into a typed token (TERMID_TOK, a *_FUNCTIONID_TOK, a
+// UF_*_FUNCTIONID_TOK -- none of which any var_decl alternative accepts) is
+// handed back as a plain STRING_TOK instead, and the classification it would
+// have received is recorded here: token kind, line, and the token text
+// exactly as yyerror would have printed it. That lets the grammar see the
+// declaration's SHAPE: only a nonzero-arity declaration continues into the
+// nonfatal UF declaration funnel (which consumes the record); every zero-arity
+// shape replicates the pinned classified-token syntax error byte-for-byte
+// from the record and abandons the parse, exactly as the legacy grammar did
+// at the name. Unknown names, and every other position, are untouched.
+bool SMT2DeclassifiedNamePending();
+int SMT2DeclassifiedNameToken();
+int SMT2DeclassifiedNameLine();
+const std::string& SMT2DeclassifiedNameText();
+void SMT2ConsumeDeclassifiedName();
+
+// Thrown when the parse fails downstream of a declassified declare-fun name
+// somewhere bison cannot unwind by itself -- a fatal sort rule, an illegal
+// character in the lexer. The pinned response is the name-position error
+// ALONE, so the failure in progress must not add its own message or its own
+// exit path. Caught in SMT2Parse(), which answers 1 exactly as an ordinary
+// abandoned parse does. (A bison syntax error downstream of the name needs
+// no throw: yyerror prints the name-position error and returns, and bison's
+// own abort reclaims its stack.)
+struct DeclassifiedNameAbandon
+{
+};
 
 // Whether `text` is a floating-point name that the gate above handed to the
 // grammar as an ordinary undeclared identifier. The grammar cannot tell that

--- a/include/stp/STPManager/STP.h
+++ b/include/stp/STPManager/STP.h
@@ -37,12 +37,13 @@ THE SOFTWARE.
 #include "stp/Util/Attributes.h"
 #include "stp/ToSat/ToSATAIG.h"
 #include "stp/Simplifier/NodeDomainAnalysis.h"
-
 #include <memory>
 
 namespace stp
 {
 class IncrementalSolver;
+class LoweredApplicationView;
+class UFBatchAdapter;
 
 // FIXME: This needs a better name
 class STP
@@ -79,6 +80,13 @@ class STP
   // The source-to-carrier mapping for the most recent solve. It remains
   // alive after TopLevelSTP returns so model queries use that exact encoding.
   std::unique_ptr<FpEncodingContext> fpEncodingContext;
+
+  // Public and semantic UF roots for the most recent fresh-query solve. The
+  // value remains alive with the model, while all SAT/checker mutation belongs
+  // to the batch adapter added at M4.
+  std::unique_ptr<LoweredApplicationView> batchUFView;
+  std::unique_ptr<UFBatchAdapter> batchUFAdapter;
+  uint64_t batchUFScopeGeneration = 0;
 
 public:
   STPMgr* bm;
@@ -124,26 +132,16 @@ public:
   DLL_PUBLIC IncrementalSolver* getIncrementalSolver();
   DLL_PUBLIC void resetIncrementalSolver();
   bool hasIncrementalSolver() const { return incrementalSolver != nullptr; }
+  const LoweredApplicationView& lastBatchUFView() const;
 
 public:
-  STP(STPMgr* b)
-  {
-    bm = b;
-    substitutionMap = new stp::SubstitutionMap(bm);
-    simp = new Simplifier(bm,substitutionMap);
-    arrayTransformer = new ArrayTransformer(bm, simp);
-    Ctr_Example = new AbsRefine_CounterExample(bm, simp, arrayTransformer);
-    tosat = new ToSATAIG(bm, arrayTransformer);
-  }
+  // Out of line so the UF implementation types above remain incomplete here.
+  DLL_PUBLIC STP(STPMgr* b);
 
-  STP( const STP& ) = delete; 
-  STP& operator=( const STP& ) = delete; 
+  STP(const STP&) = delete;
+  STP& operator=(const STP&) = delete;
 
-  ~STP() 
-  { 
-    ClearAllTables(); 
-    deleteObjects();
-  }
+  DLL_PUBLIC ~STP();
 
   // NB doesn't delete the STPMgr.
   void deleteObjects()
@@ -151,7 +149,10 @@ public:
     resetIncrementalSolver();
 
     if (Ctr_Example != NULL)
+    {
       Ctr_Example->setFpEncodingContext(NULL);
+      Ctr_Example->setUFTheoryAdapter(NULL);
+    }
     fpEncodingContext.reset();
 
     delete Ctr_Example;
@@ -179,26 +180,7 @@ public:
   ASTNode callSizeReducing(ASTNode simplified_solved_InputToSAT,
                            BVSolver* bvSolver, PropagateEqualities* pe, NodeDomainAnalysis* domain);
 
-  void ClearAllTables(void)
-  {
-    // The counterexample goes with them, so there is no longer a model to
-    // read. Whoever decides the next query says so again.
-    queryAnswered = false;
-
-    if (simp != NULL)
-      simp->ClearAllTables();
-    if (arrayTransformer != NULL)
-      arrayTransformer->ClearAllTables();
-    if (tosat != NULL)
-      tosat->ClearAllTables();
-    if (Ctr_Example != NULL)
-    {
-      Ctr_Example->ClearAllTables();
-      Ctr_Example->setFpEncodingContext(NULL);
-    }
-    fpEncodingContext.reset();
-    // bm->ClearAllTables();
-  }
+  DLL_PUBLIC void ClearAllTables(void);
 };
 } // end of namespace
 #endif

--- a/include/stp/STPManager/STPManager.h
+++ b/include/stp/STPManager/STPManager.h
@@ -693,6 +693,14 @@ public:
     return current;
   }
 
+  // SourceSort-preserving deterministic scalar allocation. UF lowering runs
+  // before FP/array carrier erasure and must retain Bool versus nonzero BV as
+  // immutable symbol identity, including for a Boolean whose carrier width is
+  // historically zero.
+  ASTNode CreateDeterministicSourceVariable(const SourceSort& sourceSort,
+                                            const std::string& prefix,
+                                            const ASTNode& key);
+
   bool FoundIntroducedSymbolSet(const ASTNode& in)
   {
     if (Introduced_SymbolsSet.find(in) != Introduced_SymbolsSet.end())

--- a/include/stp/STPManager/STPManager.h
+++ b/include/stp/STPManager/STPManager.h
@@ -43,6 +43,7 @@ THE SOFTWARE.
 namespace stp
 {
 class ExtensionalityContext;
+class UFContext;
 
 // The five SMT-LIB floating-point special values. Their nodes are ordinary
 // packed interned constants (see STPMgr::CreateFPSpecialConst); a childless
@@ -112,6 +113,7 @@ private:
   ASTSymbolSet _symbol_unique_table;
 
   ExtensionalityContext* extensionality = nullptr;
+  UFContext* uninterpretedFunctions = nullptr;
 
   // Table to uniquefy bvconst
   ASTBVConstSet _bvconst_unique_table;
@@ -137,6 +139,12 @@ public:
   {
     return extensionality;
   }
+
+  // Manager-lifetime UF declarations and durable applications. Solve-local
+  // lowering/checker/model state is owned below this context and reset at the
+  // completed-root boundary.
+  DLL_PUBLIC UFContext* getUFContext();
+  UFContext* getUFContextIfAny() const { return uninterpretedFunctions; }
 
   // frequently used nodes
   ASTNode ASTFalse, ASTTrue, ASTUndefined;

--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -181,6 +181,11 @@ public:
   // ARRAY_EQ, which is lowered only after the complete query is assembled.
   bool enable_array_equality = false;
 
+  // Decide nonzero-arity uninterpreted functions over Bool, BitVec,
+  // RoundingMode and FloatingPoint
+  // using the UFSTP v2 dynamic-Ackermann reference profile.
+  bool enable_uninterpreted_functions = false;
+
   // Replace a (distinct x1 ... xn) whose operands are variables occurring
   // nowhere else with the strict chain x1 < x2 < ... < xn. Every permutation
   // of such operands maps the formula to itself, so fixing one of the n!

--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -183,8 +183,23 @@ public:
 
   // Decide nonzero-arity uninterpreted functions over Bool, BitVec,
   // RoundingMode and FloatingPoint
-  // using the UFSTP v2 dynamic-Ackermann reference profile.
+  // using the UFSTP v2 dynamic-Ackermann reference profile. Logic names never
+  // toggle this runtime semantic option -- though the UF+FP logic names are
+  // only accepted while it is set, since they exist to let one query name
+  // both fragments.
   bool enable_uninterpreted_functions = false;
+
+  // How many congruence lemmas one refuted candidate may install before the
+  // solver is asked again; 0 is unlimited. Every conflict a candidate exposes
+  // is refuted by that same assignment, so installing several together trades
+  // clauses for whole SAT calls. The trade is not monotone: a small batch is
+  // worth several rounds, while draining every conflict installs most of the
+  // quadratic congruence encoding a round at a time and is slower than
+  // emitting one. Measured over collision and pigeonhole families at 30..100
+  // applications, 8 was the best of 1/2/4/8/16/32/unlimited everywhere and
+  // 2.3x-4x faster than 1; unlimited was the worst setting tried. 1 restores
+  // the one-lemma-per-round reference profile.
+  unsigned uf_lemmas_per_round = 8;
 
   // Replace a (distinct x1 ... xn) whose operands are variables occurring
   // nowhere else with the strict chain x1 < x2 < ... < xn. Every permutation

--- a/include/stp/Simplifier/SubstitutionMap.h
+++ b/include/stp/Simplifier/SubstitutionMap.h
@@ -61,13 +61,11 @@ class DLL_PUBLIC SubstitutionMap
                     std::set<ASTNode>& visited);
   bool loops(const ASTNode& n0, const ASTNode& n1);
 
-  // Array equality: while the complete-graph checker is active, refuse
-  // either orientation if it would delete a protected scalar definition or
-  // any READ-headed equation. Every read is checker-owned, independently of
-  // its other operand's shape or its connectivity to an equality operand.
-  // Oriented: "key" is the side that gets replaced. See the definition.
-  bool extensionalityProtected(const ASTNode& key,
-                               const ASTNode& value) const;
+  // Theory-generated scalars whose defining equations must survive ordinary
+  // preprocessing. Array equality additionally owns READ-headed keys while
+  // its complete-graph checker is active. Oriented: "key" is the side that
+  // gets replaced. See the definition.
+  bool theoryProtected(const ASTNode& key, const ASTNode& value) const;
 
   size_t substitutionsLastApplied;
   VariablesInExpression vars;
@@ -133,7 +131,7 @@ public:
   {
     ASTNode var = (BVEXTRACT == key.GetKind()) ? key[0] : key;
 
-    if (extensionalityProtected(var, value))
+    if (theoryProtected(var, value))
       return false;
 
     if (var.GetKind() == SYMBOL && loops(var, value))
@@ -165,7 +163,7 @@ public:
   {
     assert(e0.GetKind() == SYMBOL);
     assert(!InsideSubstitutionMap(e0) && "e0 MUST NOT be in the SolverMap");
-    if (extensionalityProtected(e0, e1))
+    if (theoryProtected(e0, e1))
       return false;
     (*SolverMap)[e0] = e1;
     return true;

--- a/include/stp/UninterpretedFunctions/UFChecker.h
+++ b/include/stp/UninterpretedFunctions/UFChecker.h
@@ -1,0 +1,221 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+/********************************************************************
+ * Pure dynamic-Ackermann consistency checker.
+ ********************************************************************/
+#ifndef STP_UFCHECKER_H
+#define STP_UFCHECKER_H
+
+#include "stp/UninterpretedFunctions/UFLowering.h"
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace stp
+{
+
+// Normalized, width-aware scalar value. The byte vector is little-endian;
+// unused high bits are always zero. It owns no AST or SAT object.
+class DLL_PUBLIC UFConcreteValue final
+{
+public:
+  UFConcreteValue() = default;
+
+  static UFConcreteValue boolean(bool value);
+  // Any non-Bool admitted sort, stored as its packed carrier: a bit-vector's
+  // own bits, a rounding mode's one-hot five, a float's IEEE interchange
+  // encoding. The sort travels with the bytes, so two values of different
+  // sorts never compare equal however their carriers line up.
+  static UFConcreteValue scalar(const SourceSort& sort,
+                                const std::vector<uint8_t>& bytes);
+  static UFConcreteValue bitVector(unsigned width,
+                                   const std::vector<uint8_t>& bytes);
+  static UFConcreteValue fromUInt(unsigned width, uint64_t value);
+  // One of the five one-hot RoundingMode encodings, as a value of that sort.
+  static UFConcreteValue fromMode(unsigned encoding);
+  // The interpretation to give a case nothing observed: all-zeros, except for
+  // RoundingMode, whose all-zero carrier denotes no mode at all and which
+  // therefore defaults to RNE.
+  static UFConcreteValue zero(const SourceSort& sort);
+  static bool fromConstant(const ASTNode& constant, const SourceSort& sort,
+                           UFConcreteValue& value, std::string& diagnostic);
+
+  const SourceSort& sort() const { return sort_; }
+  const std::vector<uint8_t>& bytes() const { return bytes_; }
+  bool booleanValue() const;
+
+  friend bool operator==(const UFConcreteValue& left,
+                         const UFConcreteValue& right);
+  friend bool operator!=(const UFConcreteValue& left,
+                         const UFConcreteValue& right)
+  {
+    return !(left == right);
+  }
+  friend bool operator<(const UFConcreteValue& left,
+                        const UFConcreteValue& right);
+
+private:
+  SourceSort sort_;
+  std::vector<uint8_t> bytes_;
+};
+
+typedef std::vector<UFConcreteValue> UFConcreteTuple;
+
+// Read-only host bridge. Implementations may read a batch model map or a
+// persistent totalized assignment, but the checker neither knows nor mutates
+// either representation.
+class DLL_PUBLIC UFScalarCandidate
+{
+public:
+  virtual ~UFScalarCandidate() = default;
+  virtual uint64_t version() const = 0;
+  virtual bool read(const ASTNode& scalar, const SourceSort& expected,
+                    UFConcreteValue& value,
+                    std::string& diagnostic) const = 0;
+};
+
+struct DLL_PUBLIC UFCongruenceArgument
+{
+  size_t position = 0;
+  SourceSort sort;
+  ASTNode leftTheory;
+  ASTNode rightTheory;
+  ASTNode leftScalar;
+  ASTNode rightScalar;
+  UFConcreteValue concreteValue;
+};
+
+struct DLL_PUBLIC UFCongruenceConflict
+{
+  const UFDecl* declaration = NULL;
+  ASTNode representativeHandle;
+  ASTNode conflictingHandle;
+  size_t representativeOrder = 0;
+  size_t conflictingOrder = 0;
+  std::vector<UFCongruenceArgument> arguments;
+  ASTNode leftResult;
+  ASTNode rightResult;
+  UFConcreteValue leftResultValue;
+  UFConcreteValue rightResultValue;
+  uint64_t candidateVersion = 0;
+  size_t stableConflictOrder = 0;
+};
+
+struct DLL_PUBLIC UFModelCase
+{
+  UFConcreteTuple arguments;
+  UFConcreteValue result;
+  ASTNode representativeHandle;
+};
+
+struct DLL_PUBLIC UFFunctionModelSeed
+{
+  const UFDecl* declaration = NULL;
+  std::vector<UFModelCase> cases;
+  UFConcreteValue defaultValue;
+};
+
+struct DLL_PUBLIC UFFunctionModelSeedSet
+{
+  uint64_t candidateVersion = 0;
+  std::vector<UFFunctionModelSeed> functions;
+};
+
+struct DLL_PUBLIC UFCheckStats
+{
+  size_t functions = 0;
+  size_t activeApplications = 0;
+  size_t insertions = 0;
+  size_t comparisons = 0;
+};
+
+class DLL_PUBLIC UFCheckResult final
+{
+public:
+  enum class Status
+  {
+    Consistent,
+    Conflict,
+    InternalError
+  };
+
+  Status status = Status::InternalError;
+  // Every conflict the candidate exposes, in the deterministic order the scan
+  // met them. A conflicting candidate has no model seed.
+  std::vector<UFCongruenceConflict> conflicts;
+  UFFunctionModelSeedSet modelSeed;
+  UFCheckStats stats;
+  std::string diagnostic;
+
+  bool consistent() const { return status == Status::Consistent; }
+  bool hasConflict() const { return status == Status::Conflict; }
+};
+
+// Immutable, validated indexing of one lowered view. Adapters construct this
+// once at beginQuery/beginBlock; candidate rounds therefore never repeat
+// declaration sorting, ownership/type validation, or record grouping.
+class DLL_PUBLIC UFCheckPlan final
+{
+public:
+  bool valid() const { return valid_; }
+  const std::string& diagnostic() const { return diagnostic_; }
+
+private:
+  friend class UFChecker;
+  bool valid_ = false;
+  const LoweredApplicationView* view_ = NULL;
+  std::vector<const UFDecl*> declarations_;
+  std::vector<std::vector<const LoweredApplicationRecord*>> recordsByDecl_;
+  std::string diagnostic_;
+};
+
+// Stateless logical core. Every model-dependent tuple table is local to
+// check(), making reset across refinement rounds a structural property rather
+// than a caller obligation. The immutable structural work lives in a plan.
+class DLL_PUBLIC UFChecker final
+{
+public:
+  static UFCheckPlan
+  validate(const std::vector<const UFDecl*>& activeDeclarations,
+           const LoweredApplicationView& view);
+
+  // maxConflicts caps how many conflicts one candidate may yield; 0 is
+  // unlimited. Stopping early costs nothing but extra refinement rounds, so
+  // the cap exists to bound clause growth, not to keep the scan cheap.
+  static UFCheckResult check(const UFCheckPlan& plan,
+                             const UFScalarCandidate& candidate,
+                             size_t maxConflicts = 0);
+
+  // Convenience for isolated callers and unit tests. Solve-mode adapters use
+  // validate() once and the prepared overload above for every candidate.
+  static UFCheckResult
+  check(const std::vector<const UFDecl*>& activeDeclarations,
+        const LoweredApplicationView& view,
+        const UFScalarCandidate& candidate, size_t maxConflicts = 0);
+};
+
+} // namespace stp
+
+#endif

--- a/include/stp/UninterpretedFunctions/UFContext.h
+++ b/include/stp/UninterpretedFunctions/UFContext.h
@@ -1,0 +1,152 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+/********************************************************************
+ * Manager-owned declaration and durable-application registry.
+ ********************************************************************/
+#ifndef STP_UFCONTEXT_H
+#define STP_UFCONTEXT_H
+
+#include "stp/AST/AST.h"
+#include "stp/UninterpretedFunctions/UFDecl.h"
+#include <map>
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace stp
+{
+
+class STPMgr;
+
+class DLL_PUBLIC UFContext final
+{
+public:
+  explicit UFContext(STPMgr* manager);
+  ~UFContext();
+
+  UFContext(const UFContext&) = delete;
+  UFContext& operator=(const UFContext&) = delete;
+
+  // Nonfatal public funnel. A failure returns NULL/ASTUndefined, writes a
+  // stable diagnostic, and changes no declaration/application registry.
+  const UFDecl* declareFunction(const std::string& name,
+                                const std::vector<SourceSort>& domain,
+                                const SourceSort& codomain,
+                                std::string* error = NULL);
+  bool deactivate(const UFDecl* decl, std::string* error = NULL);
+  void deactivateAll();
+
+  const UFDecl* lookup(const std::string& name) const;
+  const UFDecl* lookupIdentity(const ASTNode& identity) const;
+
+  // Every declaration's identity symbol. Such a symbol carries its
+  // declaration's codomain sort so that an application can derive its own, but
+  // it denotes the function rather than an element of that sort -- so anything
+  // counting terms of a sort has to leave these out.
+  void collectIdentitySymbols(ASTNodeSet& out) const;
+  bool isActive(const UFDecl* decl) const;
+  bool owns(const UFDecl* decl) const;
+  std::vector<const UFDecl*> activeDeclarations() const;
+
+  ASTNode apply(const UFDecl* decl, const ASTVec& actuals,
+                std::string* error = NULL);
+
+  // SMT-LIB commands are transactions. Applications built while reducing a
+  // command become durable only if the outer command is accepted; a later
+  // malformed subexpression rolls back every application first introduced
+  // by that command.
+  void beginParserCommand();
+  void finishParserCommand(bool accepted);
+
+  // HashingNodeFactory's backstop for rebuilds (define-fun, let and generic
+  // substitutions). It validates the immutable signature/context but does not
+  // require declaration liveness: a pre-existing durable node may outlive its
+  // parser scope and must remain structurally readable as a stale handle.
+  bool validateApplicationChildren(ASTChildren children,
+                                   std::string* error = NULL) const;
+  void noteApplication(const ASTNode& application);
+  bool isRegisteredApplication(const ASTNode& application) const;
+  bool isActiveApplication(const ASTNode& application) const;
+
+  // Generated lowering scalars are solve-local protected objects. The
+  // lowering view itself is adapter-owned; the context retains membership
+  // indexes for preprocessing protection and explicit SAT registration.
+  void beginSolveProtection();
+  void installSolveProtection(const ASTNodeSet& protectedSymbols,
+                              const ASTNodeSet& solveScalars);
+  void releaseSolveProtection();
+  bool activeInSolve() const
+  {
+    return solveProtectionActive_ && !solveScalars_.empty();
+  }
+  bool isProtected(const ASTNode& symbol) const;
+  bool isSolveScalar(const ASTNode& symbol) const;
+  const ASTNodeSet& getProtectedSymbols() const { return protectedSymbols_; }
+  const ASTNodeSet& getSolveScalars() const { return solveScalars_; }
+
+  // Only this lexical window lets preprocessing, candidate construction and
+  // SAT registration consume the just-installed solve-local indexes.  The
+  // lowered view/certified model may outlive it for get-value, without making
+  // a later frontend command look like part of the preceding solve.
+  class DLL_PUBLIC SolveScope final
+  {
+  public:
+    explicit SolveScope(UFContext* context);
+    ~SolveScope();
+
+    SolveScope(const SolveScope&) = delete;
+    SolveScope& operator=(const SolveScope&) = delete;
+
+  private:
+    UFContext* const context_;
+  };
+
+  size_t declarationCount() const { return declarations_.size(); }
+  size_t activeDeclarationCount() const { return activeByName_.size(); }
+  size_t registeredApplicationCount() const { return applications_.size(); }
+  STPMgr* manager() const { return manager_; }
+
+private:
+  void setError(std::string* error, const std::string& message) const;
+
+  STPMgr* const manager_;
+  uint64_t nextDeclarationId_ = 0;
+  std::vector<std::unique_ptr<UFDecl>> declarations_;
+  std::map<std::string, const UFDecl*> activeByName_;
+  std::map<uint64_t, const UFDecl*> allById_;
+  std::map<ASTNode, const UFDecl*> byIdentity_;
+  std::set<const UFDecl*> owned_;
+  ASTNodeSet applications_;
+  std::vector<ASTNode> parserCommandApplications_;
+  ASTNodeSet protectedSymbols_;
+  ASTNodeSet solveScalars_;
+  bool parserCommandActive_ = false;
+  bool solveProtectionActive_ = false;
+};
+
+} // namespace stp
+
+#endif

--- a/include/stp/UninterpretedFunctions/UFDecl.h
+++ b/include/stp/UninterpretedFunctions/UFDecl.h
@@ -1,0 +1,133 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+/********************************************************************
+ * Typed declaration identities for UFSTP v2.
+ ********************************************************************/
+#ifndef STP_UFDECL_H
+#define STP_UFDECL_H
+
+#include "stp/AST/ASTNode.h"
+#include "stp/AST/SourceSort.h"
+#include "stp/Util/Attributes.h"
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace stp
+{
+
+class UFContext;
+class STPMgr;
+
+// An immutable, ordered source-language signature. Carrier widths are not a
+// substitute for the sorts themselves: Bool has carrier width zero, and
+// RoundingMode's 5-bit carrier has thirty-two patterns where the sort has
+// five values.
+class DLL_PUBLIC UFSignature final
+{
+public:
+  UFSignature(std::vector<SourceSort> domain, SourceSort codomain);
+
+  const std::vector<SourceSort>& domain() const { return domain_; }
+  const SourceSort& codomain() const { return codomain_; }
+  size_t arity() const { return domain_.size(); }
+
+  // The single admission gate for a signature position. Everything in the UF
+  // core -- the checker, the lemma oracle, the CNF encoder, the model printer
+  // and BVTypeCheck's UF_APPLY rule -- asks this rather than repeating the
+  // sort list, so admitting a sort is one edit rather than six.
+  static bool isSupportedSort(const SourceSort& sort);
+  // The parenthetical the diagnostics share; kept beside the gate so the two
+  // cannot drift.
+  static const char* supportedSortsPhrase();
+
+  // The sort a signature position is *solved* at, as against the sort it is
+  // declared at. The two differ only for FloatingPoint.
+  //
+  // The UF core's currency is a concrete scalar compared by its bytes, and
+  // that is the sort's own equality for Bool, BitVec and RoundingMode. It is
+  // not for floats: SMT-LIB's = on floats is identity of values, and the NaN
+  // value has many representations, so bit-level bucketing would certify a
+  // model in which f(NaN) and f(NaN) differ. A float therefore enters and
+  // leaves the core through FP_TO_IEEE_BV -- pack o unpack, which collapses
+  // NaN payloads while keeping the two zeros apart -- and everything inside
+  // sees only Bool, BitVec and RoundingMode. This is the one function that
+  // says so.
+  static SourceSort loweringSort(const SourceSort& sort);
+  static bool validate(const std::vector<SourceSort>& domain,
+                       const SourceSort& codomain, std::string* error = NULL);
+
+  friend bool operator==(const UFSignature& left, const UFSignature& right)
+  {
+    return left.domain_ == right.domain_ && left.codomain_ == right.codomain_;
+  }
+  friend bool operator!=(const UFSignature& left, const UFSignature& right)
+  {
+    return !(left == right);
+  }
+
+private:
+  const std::vector<SourceSort> domain_;
+  const SourceSort codomain_;
+};
+
+// Context-owned immutable declaration identity. Liveness is intentionally
+// not stored here: a declaration object remains address-stable until its
+// STPMgr dies, while UFContext separately activates/deactivates it as parser
+// scopes come and go. That makes stale handles rejectable without dangling.
+class DLL_PUBLIC UFDecl final
+{
+public:
+  uint64_t id() const { return id_; }
+  const std::string& name() const { return name_; }
+  const UFSignature& signature() const { return signature_; }
+  const ASTNode& identityNode() const { return identity_; }
+  const STPMgr* owner() const { return owner_; }
+
+  UFDecl(const UFDecl&) = delete;
+  UFDecl& operator=(const UFDecl&) = delete;
+
+private:
+  friend class UFContext;
+
+  UFDecl(STPMgr* owner, uint64_t id, std::string name,
+         UFSignature signature, ASTNode identity)
+      : owner_(owner), id_(id), name_(std::move(name)),
+        signature_(std::move(signature)), identity_(std::move(identity))
+  {
+  }
+
+  STPMgr* const owner_;
+  const uint64_t id_;
+  const std::string name_;
+  const UFSignature signature_;
+  const ASTNode identity_;
+};
+
+} // namespace stp
+
+#endif

--- a/include/stp/UninterpretedFunctions/UFLemma.h
+++ b/include/stp/UninterpretedFunctions/UFLemma.h
@@ -1,0 +1,70 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+/********************************************************************
+ * Side-effect-free congruence lemma canonicalization/validation.
+ ********************************************************************/
+#ifndef STP_UFLEMMA_H
+#define STP_UFLEMMA_H
+
+#include "stp/UninterpretedFunctions/UFChecker.h"
+
+namespace stp
+{
+
+struct DLL_PUBLIC UFEqualityAtom
+{
+  ASTNode left;
+  ASTNode right;
+  SourceSort sort;
+  size_t originalPosition = 0;
+};
+
+struct DLL_PUBLIC UFAbstractLemma
+{
+  std::vector<UFEqualityAtom> premise;
+  UFEqualityAtom conclusion;
+  uint64_t candidateVersion = 0;
+
+  // The final implication clause has one negated literal per premise and one
+  // positive conclusion literal. This evaluates it from already observed
+  // equality truth values without constructing an AST or touching SAT.
+  bool evaluate(bool conclusionEquality,
+                const std::vector<bool>& premiseEqualities) const;
+};
+
+class DLL_PUBLIC UFLemmaOracle final
+{
+public:
+  // Produces the canonical abstract layer and proves it rejects the
+  // certificate's unchanged candidate before either host adapter may mutate
+  // SAT. A false return is an internal error and carries a diagnostic.
+  static bool buildAndValidate(const UFCongruenceConflict& conflict,
+                               UFAbstractLemma& lemma,
+                               std::string& diagnostic);
+};
+
+} // namespace stp
+
+#endif

--- a/include/stp/UninterpretedFunctions/UFLowering.h
+++ b/include/stp/UninterpretedFunctions/UFLowering.h
@@ -1,0 +1,150 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+/********************************************************************
+ * Completed-root lowering for durable uninterpreted-function nodes.
+ ********************************************************************/
+#ifndef STP_UFLOWERING_H
+#define STP_UFLOWERING_H
+
+#include "stp/AST/AST.h"
+#include "stp/UninterpretedFunctions/UFDecl.h"
+#include <cstdint>
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace stp
+{
+
+class STPMgr;
+class UFContext;
+
+// The semantic owner of one lowering. Batch scopes live for one fresh SAT
+// query. Persistent scopes identify one exact-stack block in one encoding
+// epoch; the block guard is filled by the persistent adapter once encoded.
+struct DLL_PUBLIC UFSolveScope
+{
+  enum class Mode
+  {
+    Batch,
+    Persistent
+  };
+
+  Mode mode = Mode::Batch;
+  uint64_t id = 0;
+  uint64_t epoch = 0;
+  ASTNode blockGuard;
+
+  static UFSolveScope batch(uint64_t id_)
+  {
+    UFSolveScope scope;
+    scope.mode = Mode::Batch;
+    scope.id = id_;
+    return scope;
+  }
+
+  static UFSolveScope persistent(uint64_t id_, uint64_t epoch_)
+  {
+    UFSolveScope scope;
+    scope.mode = Mode::Persistent;
+    scope.id = id_;
+    scope.epoch = epoch_;
+    return scope;
+  }
+};
+
+// One application as seen after all frontend substitution and after nested
+// UF applications in its actuals have themselves been lowered.
+struct DLL_PUBLIC LoweredApplicationRecord
+{
+  ASTNode durableHandle;
+  const UFDecl* declaration = NULL;
+  ASTVec loweredActuals;
+  ASTVec namedActuals;
+  ASTNode resultSymbol;
+  UFSolveScope scope;
+  size_t stableOrder = 0;
+  // Whether the checker can read this application's argument tuple, i.e.
+  // whether every actual is a constant or a registered solve scalar. False
+  // when lowering declined to name a compound actual because the declaration
+  // has too few applications for any congruence lemma to mention it; such a
+  // record carries no namedActuals and is interpreted by a constant.
+  bool observableArguments = true;
+};
+
+// Value object owned by a solve-mode adapter. It deliberately contains no SAT
+// state: M3's checker consumes it as immutable semantic input, while the batch
+// and persistent adapters own their distinct clause/cache lifetimes.
+class DLL_PUBLIC LoweredApplicationView final
+{
+public:
+  UFSolveScope scope;
+  ASTNode publicRoot;
+  ASTNode semanticRoot;
+  std::vector<LoweredApplicationRecord> applications;
+  ASTNodeMap handleToResult;
+  ASTNodeMap nameToTerm;
+  ASTVec namingDefinitions;
+  // Side conditions without which a solve scalar would denote nothing. Only
+  // RoundingMode needs one today: its 5-bit carrier has thirty-two patterns
+  // and the sort has five values, so every RoundingMode scalar this lowering
+  // registers is pinned one-hot here. FpTotalise pins the same symbols when
+  // it runs, and the constraint is idempotent, but relying on that would make
+  // a model's legality depend on a pass ordering rather than on lowering.
+  ASTVec sortConstraints;
+  ASTNodeSet protectedSymbols;
+  // Every symbolic checker leaf has exactly one concrete candidate
+  // authority: its complete Bool/BV mapping in the live SAT backend.  This
+  // is deliberately explicit rather than inferred from formula reachability;
+  // preprocessing may leave a result or name only in future UF lemmas.
+  ASTNodeSet solveScalars;
+
+  bool active() const { return !applications.empty(); }
+  size_t size() const { return applications.size(); }
+
+  // Attach the query/block-local name definitions to the lowered semantic
+  // formula. Result symbols intentionally have no eager UF definition.
+  ASTNode semanticRootWithDefinitions(STPMgr* manager) const;
+};
+
+class DLL_PUBLIC UFLowering final
+{
+public:
+  explicit UFLowering(STPMgr* manager);
+
+  UFLowering(const UFLowering&) = delete;
+  UFLowering& operator=(const UFLowering&) = delete;
+
+  LoweredApplicationView lowerCompletedRoot(const ASTNode& publicRoot,
+                                            const UFSolveScope& scope) const;
+
+private:
+  STPMgr* const manager_;
+};
+
+} // namespace stp
+
+#endif

--- a/include/stp/UninterpretedFunctions/UFModel.h
+++ b/include/stp/UninterpretedFunctions/UFModel.h
@@ -1,0 +1,71 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+/********************************************************************
+ * Certified public models for durable uninterpreted applications.
+ ********************************************************************/
+#ifndef STP_UFMODEL_H
+#define STP_UFMODEL_H
+
+#include "stp/UninterpretedFunctions/UFChecker.h"
+#include <iosfwd>
+#include <string>
+
+namespace stp
+{
+
+class STPMgr;
+
+// The only boundary from UFCHK's representation-independent values to host
+// ASTs and public output. Lowered result/name symbols never cross it.
+class DLL_PUBLIC UFModel final
+{
+public:
+  // Build a constant of the value's own source sort in manager: a Boolean, a
+  // bit-vector literal, or a rounding-mode constant. A carrier that denotes
+  // no value of the sort is refused rather than published.
+  static ASTNode concreteValue(STPMgr* manager,
+                               const UFConcreteValue& value);
+
+  // As above, for a value stored at a signature position's *lowering* sort
+  // and published at its declared one. The two differ only for
+  // FloatingPoint, which is solved as its canonical packed carrier and
+  // becomes a float again here.
+  static ASTNode concreteValue(STPMgr* manager, const UFConcreteValue& value,
+                               const SourceSort& declared);
+
+  // Vacuous certified interpretation for active declarations when the
+  // completed root contains no UF application at all.
+  static UFFunctionModelSeedSet
+  defaultSeed(const std::vector<const UFDecl*>& declarations);
+
+  // Emit one valid deterministic SMT-LIB2 define-fun per active declaration,
+  // including declarations with no active observations.
+  static void printSMTLIB2(std::ostream& os,
+                           const UFFunctionModelSeedSet& seed);
+};
+
+} // namespace stp
+
+#endif

--- a/include/stp/UninterpretedFunctions/UFModel.h
+++ b/include/stp/UninterpretedFunctions/UFModel.h
@@ -35,7 +35,9 @@ THE SOFTWARE.
 namespace stp
 {
 
+class AbsRefine_CounterExample;
 class STPMgr;
+class UFTheoryAdapter;
 
 // The only boundary from UFCHK's representation-independent values to host
 // ASTs and public output. Lowered result/name symbols never cross it.
@@ -54,6 +56,47 @@ public:
   // becomes a float again here.
   static ASTNode concreteValue(STPMgr* manager, const UFConcreteValue& value,
                                const SourceSort& declared);
+
+  // Evaluate one context-owned, active, registered durable application from
+  // the most recently certified solve map. Failures are nonfatal and leave
+  // value undefined.
+  static bool evaluateApplication(STPMgr* manager,
+                                  const UFTheoryAdapter* adapter,
+                                  const ASTNode& durableHandle,
+                                  ASTNode& value,
+                                  std::string& diagnostic);
+
+  // Evaluate a durable application when it appears *inside* a larger term
+  // being read against the model, where refusing is not an option: the
+  // enclosing operator needs a constant operand.
+  //
+  // An application the certified solve reached resolves exactly as
+  // evaluateApplication does. One it did not reach is completed through the
+  // certified function-model seed, keyed on `actualValues` -- the actuals
+  // already evaluated to Bool/BV constants, in declaration order. That is the
+  // same total interpretation printSMTLIB2 emits, so model output and model
+  // evaluation cannot disagree, and equal argument tuples always give equal
+  // results (completing with an arbitrary constant instead would break
+  // congruence). A declaration with no certified observations at all is
+  // completed with its codomain's zero.
+  //
+  // Failures are nonfatal and leave value undefined.
+  static bool evaluateApplicationInTerm(
+      STPMgr* manager, const UFTheoryAdapter* adapter,
+      const ASTNode& durableHandle, const std::vector<ASTNode>& actualValues,
+      ASTNode& value, std::string& diagnostic);
+
+  // Complete every durable application in the preserved public root with its
+  // certified value. This is used for the final pointwise model replay; the
+  // returned root contains no UF_APPLY and no solve-local symbol.
+  static bool completePublicRoot(STPMgr* manager,
+                                 const UFTheoryAdapter& adapter,
+                                 ASTNode& completed,
+                                 std::string& diagnostic);
+
+  static bool replayPublicRoot(AbsRefine_CounterExample& counterexample,
+                               const UFTheoryAdapter& adapter,
+                               std::string& diagnostic);
 
   // Vacuous certified interpretation for active declarations when the
   // completed root contains no UF application at all.

--- a/include/stp/UninterpretedFunctions/UFRefinement.h
+++ b/include/stp/UninterpretedFunctions/UFRefinement.h
@@ -1,0 +1,116 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+/********************************************************************
+ * Mode-specific UF refinement adapters and shared CNF semantics.
+ ********************************************************************/
+#ifndef STP_UFREFINEMENT_H
+#define STP_UFREFINEMENT_H
+
+#include "stp/UninterpretedFunctions/UFLemma.h"
+#include <cstdint>
+#include <memory>
+#include <string>
+
+namespace stp
+{
+
+class AbsRefine_CounterExample;
+class SATSolver;
+class STPMgr;
+class ToSATBase;
+
+enum class UFCandidateOutcome
+{
+  Skipped,
+  Consistent,
+  Conflict,
+  InternalError
+};
+
+// Candidate-coordinator seam used by CallSAT_ResultCheck. Logical checking is
+// shared in UFChecker; implementations below deliberately keep all mutable
+// cache, clause-lifetime and publication state mode-local.
+class DLL_PUBLIC UFTheoryAdapter
+{
+public:
+  virtual ~UFTheoryAdapter() = default;
+
+  virtual bool active() const = 0;
+  virtual UFCandidateOutcome
+  checkCandidate(AbsRefine_CounterExample& counterexample) = 0;
+  virtual bool hasPendingLemma() const = 0;
+  // Installs every lemma the last refuted candidate produced. All of them are
+  // validated before any of them mutates SAT, so the batch is as atomic as a
+  // single clause was.
+  virtual void encodePendingLemmas(SATSolver& solver, ToSATBase* tosat) = 0;
+
+  virtual bool hasCertifiedModel() const = 0;
+  virtual void invalidateCertifiedModel() = 0;
+  virtual const UFFunctionModelSeedSet* certifiedModelSeed() const = 0;
+  virtual bool lookupCertifiedApplication(const ASTNode& durableHandle,
+                                          UFConcreteValue& value) const = 0;
+  virtual const LoweredApplicationView* applicationView() const = 0;
+  virtual const std::string& diagnostic() const = 0;
+  virtual uint64_t candidateChecks() const = 0;
+  virtual uint64_t lemmasEmitted() const = 0;
+};
+
+// One fresh-query owner. Clauses and equality literals are intentionally
+// unguarded because the SAT instance dies with the query.
+class DLL_PUBLIC UFBatchAdapter final : public UFTheoryAdapter
+{
+public:
+  explicit UFBatchAdapter(STPMgr* manager);
+  ~UFBatchAdapter() override;
+
+  UFBatchAdapter(const UFBatchAdapter&) = delete;
+  UFBatchAdapter& operator=(const UFBatchAdapter&) = delete;
+
+  void beginQuery(const LoweredApplicationView* view);
+  void clear();
+
+  bool active() const override;
+  UFCandidateOutcome
+  checkCandidate(AbsRefine_CounterExample& counterexample) override;
+  bool hasPendingLemma() const override;
+  void encodePendingLemmas(SATSolver& solver, ToSATBase* tosat) override;
+  bool hasCertifiedModel() const override;
+  void invalidateCertifiedModel() override;
+  const UFFunctionModelSeedSet* certifiedModelSeed() const override;
+  bool lookupCertifiedApplication(const ASTNode& durableHandle,
+                                  UFConcreteValue& value) const override;
+  const LoweredApplicationView* applicationView() const override;
+  const std::string& diagnostic() const override;
+  uint64_t candidateChecks() const override;
+  uint64_t lemmasEmitted() const override;
+
+private:
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+} // namespace stp
+
+#endif

--- a/include/stp/cpp_interface.h
+++ b/include/stp/cpp_interface.h
@@ -26,6 +26,7 @@ THE SOFTWARE.
 #define CPP_INTERFACE_H_
 
 #include "stp/AST/AST.h"
+#include "stp/UninterpretedFunctions/UFDecl.h"
 #include "stp/NodeFactory/NodeFactory.h"
 #include "stp/Util/Attributes.h"
 #include "extlib-unordered-dense/ankerl/unordered_dense.h"
@@ -34,6 +35,7 @@ THE SOFTWARE.
 #include <memory>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 namespace stp
@@ -97,6 +99,25 @@ struct array_sort
   {
     return SourceSort::array(index.sourceSort(), elem.sourceSort());
   }
+};
+
+// Command-local semantic carrier for one sort in a nonzero-arity
+// declare-fun. Keeping unsupported sorts as data lets the enclosing
+// declaration report its name and argument position without parser-global
+// latches, while still postponing every mutation until the signature is valid.
+struct parsed_uf_sort
+{
+  parsed_uf_sort(SourceSort sourceSort, std::string display,
+                 bool isSupported, bool isKnown = true)
+      : sort(std::move(sourceSort)), spelling(std::move(display)),
+        supported(isSupported), known(isKnown)
+  {
+  }
+
+  SourceSort sort;
+  std::string spelling;
+  bool supported;
+  bool known;
 };
 
 // Heterogeneous string hash: lets a string-keyed table be probed with a
@@ -168,7 +189,8 @@ private:
     SolverFrame(ankerl::unordered_dense::map<std::string, Function>*
                     global_function_context,
                 std::map<std::string, SourceSort>*
-                    global_sort_alias_context);
+                    global_sort_alias_context,
+                STPMgr* manager);
     virtual ~SolverFrame();
 
     // Obtain the functions for the current frame
@@ -179,8 +201,12 @@ private:
 
     void addSortAlias(const std::string& name);
     void addSymbol(const ASTNode& symbol);
+    void addTemporarySymbol(const ASTNode& symbol);
+    void clearTemporarySymbols();
+    void addUFDeclaration(const UFDecl* declaration);
     bool removeSymbol(const ASTNode& symbol);
     bool lookupSymbol(std::string_view name, ASTNode& output) const;
+    bool lookupTemporarySymbol(std::string_view name, ASTNode& output) const;
 
     // Take over every declaration made in `donor`, leaving it empty. Used
     // for :global-declarations true, where a pop removes the assertion
@@ -192,6 +218,7 @@ private:
   private:
     vector<std::string> _scoped_functions;
     vector<std::string> _scoped_sort_aliases;
+    vector<const UFDecl*> _scoped_uf_declarations;
     ASTVec _scoped_symbols;
     // Hash map, not std::map: files declare tens of thousands of symbols
     // with long common prefixes, and a tree walk memcmps the prefix at
@@ -199,10 +226,14 @@ private:
     ankerl::unordered_dense::map<std::string, std::vector<ASTNode>,
                                  TransparentStringHash, std::equal_to<>>
         _symbol_bindings;
+    ankerl::unordered_dense::map<std::string, std::vector<ASTNode>,
+                                 TransparentStringHash, std::equal_to<>>
+        _temporary_symbol_bindings;
     ankerl::unordered_dense::map<std::string, Function>*
         _global_function_context;
     std::map<std::string, SourceSort>*
         _global_sort_alias_context;
+    STPMgr* _manager;
   };
 
   // The vector of all frames that have been created by calling push
@@ -272,6 +303,15 @@ private:
   // pop, reset, reset-assertions). get-value/get-model refuse when false
   // rather than print a model of an assertion set that no longer exists.
   bool model_valid;
+
+  // A malformed UF expression is diagnosed without aborting the SMT-LIB
+  // script.  The parser still has to reduce the enclosing typed production,
+  // so it carries a canonical value of the declared result sort to the end
+  // of the command.  This latch prevents that parser-only carrier (or any
+  // other side effect in the rejected command) from entering solver state.
+  // It is cleared exactly at the outer command boundary.
+  bool current_command_rejected;
+  bool current_command_active;
 
   // Unless --incremental=on or an explicit threshold overrides it, pure
   // QF_BV/QF_ABV sessions delay the persistent driver until solve 32; other
@@ -411,8 +451,30 @@ public:
   DLL_PUBLIC SourceSort functionReturnSourceSort(const std::string& name);
   bool hasFunctions() const { return !functions.empty(); }
 
+  // Context-owned uninterpreted declarations are distinct from stored
+  // define-fun macros. The general forms are the direct C++ API (context
+  // lifetime); the scoped declaration form is the SMT-LIB frame funnel.
+  DLL_PUBLIC const UFDecl* declareUninterpretedFunction(
+      const std::string& name, const std::vector<SourceSort>& domain,
+      const SourceSort& codomain, std::string* diagnostic = NULL);
+  DLL_PUBLIC const UFDecl* declareScopedUninterpretedFunction(
+      const std::string& name, const std::vector<SourceSort>& domain,
+      const SourceSort& codomain, std::string* diagnostic = NULL);
+  DLL_PUBLIC const UFDecl* lookupUninterpretedFunction(
+      const std::string& name) const;
+  DLL_PUBLIC ASTNode applyUninterpretedFunction(
+      const UFDecl* declaration, const ASTVec& actuals,
+      std::string* diagnostic = NULL);
+  // Evaluate an active durable UF_APPLY in the most recently certified
+  // model. The returned node is a public Bool/BV constant, never a lowered
+  // result symbol. Failure is nonfatal and returns ASTUndefined.
+  DLL_PUBLIC ASTNode getUninterpretedApplicationValue(
+      const ASTNode& application, std::string* diagnostic = NULL);
+  bool hasUninterpretedFunctions() const;
+
   DLL_PUBLIC ASTNode LookupOrCreateSymbol(std::string name);
   DLL_PUBLIC bool LookupSymbol(const char* const name, ASTNode& output);
+  DLL_PUBLIC bool LookupTemporarySymbol(const char* name, ASTNode& output);
   DLL_PUBLIC bool isSymbolAlreadyDeclared(char* name);
   DLL_PUBLIC void setPrintSuccess(bool ps);
   DLL_PUBLIC bool isSymbolAlreadyDeclared(std::string name);
@@ -438,6 +500,20 @@ public:
 
   DLL_PUBLIC void deleteNode(ASTNode* n);
   DLL_PUBLIC void addSymbol(ASTNode& s);
+  // Function formal parameters are parser-local bindings. They may shadow a
+  // top-level declaration and must still be installed temporarily while a
+  // containing define-fun command is being rejected and reduced.
+  DLL_PUBLIC void addTemporarySymbol(ASTNode& s);
+
+  // Check the shared top-level name space before the parser mutates a frame.
+  // With UF enabled, a NONZERO-ARITY declare-fun name is deliberately lexed
+  // unclassified so that a collision reaches this semantic check and is
+  // reported nonfatally. Every UF-free shape (zero-arity declare-fun,
+  // declare-const, define-fun) keeps the legacy classified-token syntax error
+  // at the name instead; for those this check is a backstop the lexer
+  // normally pre-empts.
+  DLL_PUBLIC bool validateTopLevelDeclarationName(
+      const std::string& name, std::string* diagnostic = NULL);
 
   // Declare a symbol of SMT-LIB's RoundingMode sort: registers it like
   // addSymbol, marks it for the model printers, and asserts that it takes
@@ -464,6 +540,14 @@ public:
   DLL_PUBLIC void success();
   DLL_PUBLIC void error(std::string msg);
   DLL_PUBLIC void unsupported();
+
+  // Nonfatal SMT-LIB command rejection used by the typed UF funnel.  No
+  // malformed UF_APPLY or fresh placeholder is constructed or registered.
+  DLL_PUBLIC void beginCurrentCommand();
+  DLL_PUBLIC void abortCurrentCommand();
+  DLL_PUBLIC void rejectCurrentCommand(const std::string& diagnostic);
+  DLL_PUBLIC void finishCurrentCommand();
+  bool currentCommandRejected() const { return current_command_rejected; }
 
   // Resets the tables used by STP, but keeps all the nodes that have been
   // created.
@@ -503,6 +587,7 @@ public:
   DLL_PUBLIC void setOption(std::string, std::string);
   DLL_PUBLIC void getOption(std::string);
   DLL_PUBLIC void getInfo(std::string);
+
   DLL_PUBLIC void getAssertions();
 
   DLL_PUBLIC void getModel();

--- a/include/stp/cpp_interface.h
+++ b/include/stp/cpp_interface.h
@@ -115,7 +115,11 @@ struct TransparentStringHash
 class Cpp_interface
 {
   STPMgr& bm;
-  std::map<std::string, std::pair<unsigned, unsigned>> sort_aliases;
+  // Sort names the script introduced: define-sort's nullary floating-point
+  // aliases, and declare-sort's uninterpreted sorts. Both resolve to a
+  // SourceSort, so a name in sort position needs one lookup whichever
+  // command introduced it.
+  std::map<std::string, SourceSort> sort_aliases;
   bool print_success;
   bool ignoreCheckSatRequest;
 
@@ -163,7 +167,7 @@ private:
     // the global functions to be able to remove functions when we pop
     SolverFrame(ankerl::unordered_dense::map<std::string, Function>*
                     global_function_context,
-                std::map<std::string, std::pair<unsigned, unsigned>>*
+                std::map<std::string, SourceSort>*
                     global_sort_alias_context);
     virtual ~SolverFrame();
 
@@ -197,7 +201,7 @@ private:
         _symbol_bindings;
     ankerl::unordered_dense::map<std::string, Function>*
         _global_function_context;
-    std::map<std::string, std::pair<unsigned, unsigned>>*
+    std::map<std::string, SourceSort>*
         _global_sort_alias_context;
   };
 
@@ -344,10 +348,16 @@ public:
                                           unsigned exp_width,
                                           unsigned sig_width);
 
-  // define-sort aliases for floating-point sorts. A real table: the alias
-  // name is NOT interned as a symbol (the old scheme made the sort name
-  // resolvable as a term variable). Aliases follow assertion-frame scope,
-  // and :global-declarations along with the other declarations.
+  // Sort names the script introduced. A real table: the alias name is NOT
+  // interned as a symbol (the old scheme made the sort name resolvable as a
+  // term variable). Aliases follow assertion-frame scope, and
+  // :global-declarations along with the other declarations.
+  DLL_PUBLIC void addSortAlias(const std::string& name, const SourceSort& sort);
+  DLL_PUBLIC bool lookupSortAlias(const std::string& name,
+                                  SourceSort& sort) const;
+
+  // The floating-point spelling of the same pair, kept because define-sort's
+  // callers speak in exponent/significand widths.
   DLL_PUBLIC void addSortAlias(const std::string& name, unsigned exp_width,
                                unsigned sig_width);
   DLL_PUBLIC bool lookupSortAlias(const std::string& name,

--- a/lib/AST/ASTKind.kinds
+++ b/lib/AST/ASTKind.kinds
@@ -213,3 +213,9 @@ FP_SMT_EQ           2    2    Form    FP
 # c_interface.h remain stable. The extensionality prepass lowers this before
 # ordinary solving.
 ARRAY_EQ        2       2       Form
+
+# Durable, typed application of an uninterpreted function. Child 0 is the
+# manager-owned declaration identity; the remaining children are the ordered
+# source-language actuals. This stays opaque until solve-boundary UF lowering.
+# Keep this last: existing public kind values are ABI-visible.
+UF_APPLY        2       -       Term    Form

--- a/lib/AST/ASTNode.cpp
+++ b/lib/AST/ASTNode.cpp
@@ -94,6 +94,28 @@ static bool deriveFPFormat(const ASTNode& n, unsigned int& e, unsigned int& s)
       return e != 0 && s != 0;
     }
 
+    // An application of an uninterpreted function whose codomain is a float
+    // yields a float in the codomain's format. That format is not carried by
+    // any operand -- the declaration identity in child 0 names it, in the
+    // same immutable source sort deriveSourceSort reads for the node's sort.
+    // Without this the application would be an FP-sorted node of no format,
+    // which types as a plain bit-vector: fp.add would refuse it as having a
+    // different format from its other operand, and fp.abs would build a
+    // (0, 0)-format result that blasts to the wrong bits.
+    case UF_APPLY:
+    {
+      if (n.Degree() < 1)
+        return false;
+
+      const SourceSort codomain = n[0].GetSourceSort();
+      if (codomain.kind() != SourceSort::Kind::FloatingPoint)
+        return false;
+
+      e = codomain.exponentWidth();
+      s = codomain.significandWidth();
+      return e != 0 && s != 0;
+    }
+
     // A read from an array of floats yields a float in the element's format,
     // which the array node carries.
     case READ:
@@ -198,6 +220,11 @@ static void fpFormatOperands(const ASTNode& n, size_t& from, size_t& to)
   {
     case READ:
     case WRITE:
+      to = (n.Degree() >= 1) ? 1 : 0;
+      break;
+
+    case UF_APPLY:
+      // The declaration identity's immutable source sort is the codomain.
       to = (n.Degree() >= 1) ? 1 : 0;
       break;
 
@@ -533,6 +560,9 @@ SourceSort ASTNode::deriveSourceSort() const
 {
   if (GetKind() == UNDEFINED)
     return SourceSort::unknown();
+
+  if (GetKind() == UF_APPLY && Degree() >= 1)
+    return (*this)[0].GetSourceSort();
 
   // API type nodes denote the corresponding source sort even though they
   // are not themselves value-bearing terms.

--- a/lib/AST/ASTmisc.cpp
+++ b/lib/AST/ASTmisc.cpp
@@ -23,6 +23,7 @@ THE SOFTWARE.
 ********************************************************************/
 
 #include "stp/AST/AST.h"
+#include "stp/UninterpretedFunctions/UFDecl.h"
 #include "stp/STPManager/STPManager.h"
 #include "stp/Util/NodeIterator.h"
 
@@ -633,6 +634,35 @@ bool BVTypeCheck_term_kind(const ASTNode& n, const Kind& k)
 
   switch (k)
   {
+    case UF_APPLY:
+    {
+      if (n.Degree() < 2 || n[0].GetKind() != SYMBOL)
+        FatalError("BVTypeCheck: malformed UF_APPLY declaration/arity", n);
+      const SourceSort sort = n.GetSourceSort();
+      if (!UFSignature::isSupportedSort(sort))
+        FatalError("BVTypeCheck: unsupported UF_APPLY result sort", n);
+      if (sort.kind() == SourceSort::Kind::Bool)
+      {
+        if (n.GetType() != BOOLEAN_TYPE)
+          FatalError("BVTypeCheck: Bool UF_APPLY has a non-Bool carrier", n);
+      }
+      // A float-codomain application derives its format from the same
+      // declaration identity its sort comes from, so it types as a float
+      // rather than as its packed carrier. Every other admitted sort has a
+      // bit-vector carrier of the packed width.
+      else if (sort.kind() == SourceSort::Kind::FloatingPoint)
+      {
+        if (n.GetType() != FLOATINGPOINT_TYPE ||
+            n.GetExpWidth() != sort.exponentWidth() ||
+            n.GetSigWidth() != sort.significandWidth())
+          FatalError("BVTypeCheck: float UF_APPLY has the wrong format", n);
+      }
+      else if (n.GetType() != BITVECTOR_TYPE ||
+               n.GetValueWidth() != sort.packedWidth())
+        FatalError("BVTypeCheck: UF_APPLY has the wrong carrier width", n);
+      break;
+    }
+
     case BVCONST:
       if (BITVECTOR_TYPE != n.GetType() && FLOATINGPOINT_TYPE != n.GetType())
         FatalError("BVTypeCheck: The term t does not typecheck, where t = \n",

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -39,6 +39,7 @@ add_library(AST OBJECT
     ${CMAKE_CURRENT_BINARY_DIR}/ASTKind.cpp
     ASTInterior.cpp
     ASTNode.cpp
+    SourceSort.cpp
     ASTUtil.cpp
     ASTBVConst.cpp
     ASTFPConst.cpp

--- a/lib/AST/SourceSort.cpp
+++ b/lib/AST/SourceSort.cpp
@@ -1,0 +1,52 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#include "stp/AST/SourceSort.h"
+
+namespace stp
+{
+
+std::string sourceSortToSMTLib(const SourceSort& sort)
+{
+  switch (sort.kind())
+  {
+    case SourceSort::Kind::Bool:
+      return "Bool";
+    case SourceSort::Kind::BitVector:
+      return "(_ BitVec " + std::to_string(sort.bitVectorWidth()) + ")";
+    case SourceSort::Kind::FloatingPoint:
+      return "(_ FloatingPoint " + std::to_string(sort.exponentWidth()) +
+             " " + std::to_string(sort.significandWidth()) + ")";
+    case SourceSort::Kind::RoundingMode:
+      return "RoundingMode";
+    case SourceSort::Kind::Array:
+      return "(Array " + sourceSortToSMTLib(sort.index()) + " " +
+             sourceSortToSMTLib(sort.element()) + ")";
+    case SourceSort::Kind::Unknown:
+      return "Unknown";
+  }
+  return "Unknown";
+}
+
+} // namespace stp

--- a/lib/AbsRefineCounterExample/CounterExample.cpp
+++ b/lib/AbsRefineCounterExample/CounterExample.cpp
@@ -147,11 +147,13 @@ AbsRefine_CounterExample::requireFpEncodingContext() const
  * populate the CounterExampleMap data structure (ASTNode -> BVConst)
  */
 void AbsRefine_CounterExample::ConstructCounterExample(
-    SATSolver& newS, const ToSATBase::ASTNodeToSATVar& satVarToSymbol)
+    SATSolver& newS, const ToSATBase::ASTNodeToSATVar& satVarToSymbol,
+    bool internalCandidateRequired)
 {
   if (!newS.okay())
     return;
-  if (!bm->UserFlags.construct_counterexample_flag)
+  if (!bm->UserFlags.construct_counterexample_flag &&
+      !internalCandidateRequired)
     return;
 
   assert(CounterExampleMap.size() == 0);

--- a/lib/AbsRefineCounterExample/CounterExample.cpp
+++ b/lib/AbsRefineCounterExample/CounterExample.cpp
@@ -29,6 +29,9 @@ THE SOFTWARE.
 #include "stp/FloatBlaster/FpEncodingContext.h"
 #include "stp/Printer/printers.h"
 #include "stp/ToSat/ToSATAIG.h"
+#include "stp/UninterpretedFunctions/UFContext.h"
+#include "stp/UninterpretedFunctions/UFModel.h"
+#include "stp/UninterpretedFunctions/UFRefinement.h"
 #include <vector>
 
 const bool debug_counterexample = false;
@@ -235,6 +238,27 @@ void AbsRefine_CounterExample::ConstructCounterExample(
       CounterExampleMap[symbol] = bm->isRoundingModeSortedTerm(symbol)
                                       ? completeRoundingMode(assigned)
                                       : assigned;
+    }
+  }
+
+  // UFCHK consumes an internal scalar candidate independently of public
+  // model settings. Backends may leave an unconstrained Boolean don't-care
+  // undefined; complete every registered UF Boolean deterministically to false,
+  // just as the BV path above completes undefined bits to zero.
+  UFContext* ufContext = bm->getUFContextIfAny();
+  if (ufContext != NULL && ufContext->activeInSolve())
+  {
+    for (const ASTNode& symbol : ufContext->getSolveScalars())
+    {
+      if (symbol.GetSourceSort().kind() != SourceSort::Kind::Bool)
+        continue;
+      ASTNodeMap::iterator assigned = CounterExampleMap.find(symbol);
+      if (assigned == CounterExampleMap.end())
+        CounterExampleMap[symbol] = ASTFalse;
+      else if (assigned->second.GetKind() != TRUE &&
+               assigned->second.GetKind() != FALSE)
+        FatalError("UF solve scalar has a non-Boolean candidate value",
+                   symbol);
     }
   }
 
@@ -667,6 +691,24 @@ class AbsRefine_CounterExample::EvaluationDriver
     return StepResult::Pushed;
   }
 
+  /* One actual of an uninterpreted-function application. Each is needed as a
+   * constant to key the certified function seed, so anything but a Bool is
+   * requested strictly (ArrayReadFlag false) rather than being allowed back
+   * as a symbolic read. Bool is the only admitted domain sort that is not a
+   * bit-vector carrier: RoundingMode is BITVECTOR_TYPE (five bits) and a
+   * float is FLOATINGPOINT_TYPE, and both belong on the term walk, so the
+   * split is on the carrier's type rather than on the source sort.
+   * Both walks reach this, so the resume phase is the caller's own.
+   */
+  template <typename ResumePhase>
+  StepResult requestUFActual(Frame& f, const ResumePhase resume,
+                             const ASTNode& actual)
+  {
+    if (actual.GetType() == BOOLEAN_TYPE)
+      return requestFormula(f, resume, actual);
+    return requestTerm(f, resume, actual, false);
+  }
+
   /* One step of ComputeFormulaUsingModel, which accepts a non-constant
    * formula and checks if the formula is ASTTrue or ASTFalse w.r.t to a
    * model.
@@ -910,6 +952,36 @@ class AbsRefine_CounterExample::EvaluationDriver
         assert(blasted != form);
 
         return requestFormula(f, Frame::FormulaPhase::AfterFpBlast, blasted);
+      }
+      case UF_APPLY:
+      {
+        // A Bool-codomain application reaches the formula walk rather than the
+        // term walk; the resolution is otherwise identical to the UF_APPLY arm
+        // of stepTerm, which documents it.
+        if (f.formulaPhase == Frame::FormulaPhase::AfterOperand)
+        {
+          f.parts.push_back(result);
+          f.i++;
+        }
+        else
+        {
+          f.parts.reserve(form.Degree() - 1);
+          f.i = 1;
+        }
+
+        if (f.i < form.Degree())
+          return requestUFActual(f, Frame::FormulaPhase::AfterOperand,
+                                 form[f.i]);
+
+        ASTNode value;
+        std::string diagnostic;
+        if (!UFModel::evaluateApplicationInTerm(bm, owner.getUFTheoryAdapter(),
+                                                form, f.parts, value,
+                                                diagnostic))
+          FatalError(
+              (" ComputeFormulaUsingModel: " + diagnostic + ": ").c_str(),
+              form);
+        return finish(value);
       }
       default:
         cerr << _kind_names[k];
@@ -1321,6 +1393,40 @@ class AbsRefine_CounterExample::EvaluationDriver
         }
 
         return finish(result);
+      }
+      case UF_APPLY:
+      {
+        // Child 0 is the declaration identity, which is not a value; children
+        // 1.. are the actuals. Evaluate each actual to a constant -- a Bool
+        // one through the formula walk, as everywhere else -- then resolve the
+        // application against the certified model. Reaching here at all means
+        // the application sits inside a larger term, so refusing is not an
+        // option: the enclosing operator needs a constant operand. UFModel
+        // completes an application the solve never reached through the
+        // certified function seed rather than failing.
+        if (f.termPhase == Frame::TermPhase::AfterOperand)
+        {
+          f.parts.push_back(result);
+          f.i++;
+        }
+        else
+        {
+          f.parts.reserve(term.Degree() - 1);
+          f.i = 1;
+        }
+
+        if (f.i < term.Degree())
+          return requestUFActual(f, Frame::TermPhase::AfterOperand,
+                                 term[f.i]);
+
+        ASTNode value;
+        std::string diagnostic;
+        if (!UFModel::evaluateApplicationInTerm(bm, owner.getUFTheoryAdapter(),
+                                                term, f.parts, value,
+                                                diagnostic))
+          FatalError(("TermToConstTermUsingModel: " + diagnostic + ": ").c_str(),
+                     term);
+        return finish(value);
       }
       default:
       {
@@ -2404,6 +2510,19 @@ void AbsRefine_CounterExample::PrintFullCounterExampleSMTLIB2(std::ostream& os)
     {
       outputLine(os, e.first, e.second);
     }
+    if (ufTheoryAdapter != NULL && ufTheoryAdapter->hasCertifiedModel())
+    {
+      const UFFunctionModelSeedSet* seed =
+          ufTheoryAdapter->certifiedModelSeed();
+      if (seed == NULL)
+        FatalError("certified UF adapter has no model seed");
+      UFModel::printSMTLIB2(os, *seed);
+    }
+    else if (bm->UserFlags.enable_uninterpreted_functions &&
+             bm->getUFContextIfAny() != NULL)
+      UFModel::printSMTLIB2(
+          os, UFModel::defaultSeed(
+                  bm->getUFContextIfAny()->activeDeclarations()));
     os.flush();
     return;
   }
@@ -2530,6 +2649,20 @@ void AbsRefine_CounterExample::PrintFullCounterExampleSMTLIB2(std::ostream& os)
     os << ")" << std::endl;
   }
 
+  if (ufTheoryAdapter != NULL && ufTheoryAdapter->hasCertifiedModel())
+  {
+    const UFFunctionModelSeedSet* seed =
+        ufTheoryAdapter->certifiedModelSeed();
+    if (seed == NULL)
+      FatalError("certified UF adapter has no model seed");
+    UFModel::printSMTLIB2(os, *seed);
+  }
+  else if (bm->UserFlags.enable_uninterpreted_functions &&
+           bm->getUFContextIfAny() != NULL)
+    UFModel::printSMTLIB2(
+        os, UFModel::defaultSeed(
+                bm->getUFContextIfAny()->activeDeclarations()));
+
   os.flush();
 }
 
@@ -2549,6 +2682,19 @@ void AbsRefine_CounterExample::PrintCounterExampleSMTLIB2(std::ostream& os)
     outputLine(os, f,se);
 
   }
+  if (ufTheoryAdapter != NULL && ufTheoryAdapter->hasCertifiedModel())
+  {
+    const UFFunctionModelSeedSet* seed =
+        ufTheoryAdapter->certifiedModelSeed();
+    if (seed == NULL)
+      FatalError("certified UF adapter has no model seed");
+    UFModel::printSMTLIB2(os, *seed);
+  }
+  else if (bm->UserFlags.enable_uninterpreted_functions &&
+           bm->getUFContextIfAny() != NULL)
+    UFModel::printSMTLIB2(
+        os, UFModel::defaultSeed(
+                bm->getUFContextIfAny()->activeDeclarations()));
   os.flush();
 }
 
@@ -2791,12 +2937,16 @@ AbsRefine_CounterExample::CallSAT_ResultCheck(SATSolver& SatSolver,
                                               ToSATBase* tosat, bool refinement)
 {
   bool sat = tosat->CallSAT(SatSolver, modified_input, refinement);
+  const bool ufActive =
+      ufTheoryAdapter != NULL && ufTheoryAdapter->active();
 
   if (bm->soft_timeout_expired)
     return SOLVER_TIMEOUT;
 
   if (!sat)
   {
+    if (ufActive)
+      ufTheoryAdapter->invalidateCertifiedModel();
     return SOLVER_VALID;
   }
   else if (SatSolver.okay())
@@ -2819,7 +2969,7 @@ AbsRefine_CounterExample::CallSAT_ResultCheck(SATSolver& SatSolver,
     if (tosat->refineAbstractions(SatSolver) > 0)
       return SOLVER_UNDECIDED;
 
-    if (!bm->UserFlags.construct_counterexample_flag)
+    if (!bm->UserFlags.construct_counterexample_flag && !ufActive)
       return SOLVER_INVALID;
 
     bm->GetRunTimes()->start(RunTimes::CounterExampleGeneration);
@@ -2831,7 +2981,7 @@ AbsRefine_CounterExample::CallSAT_ResultCheck(SATSolver& SatSolver,
     // ConstructCounterExample only ever iterates it.
     const ToSATBase::ASTNodeToSATVar& satVarToSymbol =
         tosat->SATVar_to_SymbolIndexMap();
-    ConstructCounterExample(SatSolver, satVarToSymbol);
+    ConstructCounterExample(SatSolver, satVarToSymbol, ufActive);
     if (bm->UserFlags.stats_flag && bm->UserFlags.print_nodes_flag)
     {
       ToSATBase::ASTNodeToSATVar m = tosat->SATVar_to_SymbolIndexMap();
@@ -2875,6 +3025,10 @@ AbsRefine_CounterExample::CallSAT_ResultCheck(SATSolver& SatSolver,
     {
       if (!ext->hasPendingLemma())
         FatalError("array-equality: a checker conflict has no pending lemma");
+      if (bm->UserFlags.stats_flag)
+        std::cerr << "Theory coordination: EXTCHK conflict; UFCHK and "
+                     "ordinary replay skipped"
+                  << std::endl;
       bm->GetRunTimes()->stop(RunTimes::CounterExampleGeneration);
       return SOLVER_UNDECIDED;
     }
@@ -2882,12 +3036,58 @@ AbsRefine_CounterExample::CallSAT_ResultCheck(SATSolver& SatSolver,
       FatalError("array-equality: the checker could neither certify nor "
                  "refute a materialized candidate");
 
+    // Theory ownership remains disjoint. The coordinator invokes UFCHK only
+    // after EXTCHK accepted this exact candidate, and a UF conflict ends the
+    // round before any ordinary model replay.
+    UFCandidateOutcome ufOutcome = UFCandidateOutcome::Skipped;
+    if (ufActive)
+      ufOutcome = ufTheoryAdapter->checkCandidate(*this);
+    if (ufOutcome == UFCandidateOutcome::Conflict)
+    {
+      if (!ufTheoryAdapter->hasPendingLemma())
+        FatalError("UFCHK reported a conflict without a pending lemma");
+      if (bm->UserFlags.stats_flag)
+        std::cerr << "Theory coordination: EXTCHK "
+                  << (extActive ? "accepted" : "skipped")
+                  << "; UFCHK conflict; ordinary replay skipped"
+                  << std::endl;
+      bm->GetRunTimes()->stop(RunTimes::CounterExampleGeneration);
+      return SOLVER_UNDECIDED;
+    }
+    if (ufOutcome == UFCandidateOutcome::InternalError)
+      FatalError(("UFCHK internal error: " + ufTheoryAdapter->diagnostic())
+                     .c_str());
+    if (ufActive && ufOutcome != UFCandidateOutcome::Consistent)
+      FatalError("UFCHK could neither certify nor refute an active candidate");
+
     // check if the counterexample is good or not
     ASTNode orig_result = ComputeFormulaUsingModel(original_input);
     if (!(ASTTrue == orig_result || ASTFalse == orig_result))
       FatalError("TopLevelSat: Original input must compute to "
                  "true or false against model");
     bm->GetRunTimes()->stop(RunTimes::CounterExampleGeneration);
+
+    // A consistency seed is certified only if the ordinary lowered-root
+    // replay accepts the same candidate. Legacy array-read refinement can
+    // still reject after both independent theory checkers accepted.
+    if (ufActive && orig_result != ASTTrue)
+      ufTheoryAdapter->invalidateCertifiedModel();
+
+    // The scalar replay above deliberately sees the semantic root. Once it
+    // accepts, complete the independently retained public root pointwise from
+    // the certified durable-handle map and replay that too. This is both the
+    // model sanity check and the proof that no public reader needs a lowered
+    // @uf_result symbol. Publication in checkCandidate precedes both replays;
+    // a failure withdraws it before reporting the integration error.
+    if (ufActive && orig_result == ASTTrue)
+    {
+      std::string diagnostic;
+      if (!UFModel::replayPublicRoot(*this, *ufTheoryAdapter, diagnostic))
+      {
+        ufTheoryAdapter->invalidateCertifiedModel();
+        FatalError(("UF public-model replay failed: " + diagnostic).c_str());
+      }
+    }
 
     switch (ExtensionalityContext::decideCertification(
         ASTTrue == orig_result, extActive, extOutcome))

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -54,6 +54,7 @@ add_subdirectory(Globals)
 add_subdirectory(AST)
 add_subdirectory(AbsRefineCounterExample)
 add_subdirectory(Extensionality)
+add_subdirectory(UninterpretedFunctions)
 add_subdirectory(FloatBlaster)
 add_subdirectory(Simplifier)
 add_subdirectory(Printer)
@@ -80,6 +81,7 @@ set(stp_lib_targets
     stpmgr
     abstractionrefinement
     extensionality
+    uninterpretedfunctions
     tosat
     sat
     incremental

--- a/lib/FloatBlaster/FloatBlast.cpp
+++ b/lib/FloatBlaster/FloatBlast.cpp
@@ -347,6 +347,12 @@ private:
 
   ASTNode rebuild(const ASTNode& n, const ASTVec& children)
   {
+    // Nothing rebuilds a UF application: every path that could reach one
+    // returns it untouched (see lower). Substituting here would hand the
+    // node factory an application whose actual sorts no longer match its
+    // declaration, and the factory's job is to refuse that.
+    assert(n.GetKind() != UF_APPLY);
+
     if (n.GetType() == BOOLEAN_TYPE)
       return node_factory->CreateNode(n.GetKind(), children);
 
@@ -362,6 +368,21 @@ private:
   // this function and consume the unpacked view directly.
   ASTNode lower(const ASTNode& n)
   {
+    // A UF application is opaque to this pass, whatever its codomain. Its
+    // actuals are stated in source sorts and the UF layer both validates and
+    // compares them there, so lowering one underneath the application
+    // changes what the application denotes -- when it is admitted at all;
+    // an application of f to a float that arrives as the bits the float
+    // lowered to is exactly what the declaration check refuses.
+    //
+    // There is nothing to lower in return for that. The application already
+    // is the bits of its result: UFContext::apply builds it at the
+    // codomain's packed width, and its actuals are resolved at their source
+    // sorts by whoever consumes the application -- the UF lowering pass
+    // before a solve, the model evaluator's UF_APPLY arm after one.
+    if (n.GetKind() == UF_APPLY)
+      return n;
+
     if (n.GetSourceSort().kind() == SourceSort::Kind::FloatingPoint)
       return asPacked(n);
 
@@ -427,6 +448,16 @@ private:
     ASTNode out;
     if (n.Degree() == 0)
     {
+      out = n;
+    }
+    else if (n.GetKind() == UF_APPLY)
+    {
+      // Opaque carrier, like a leaf: the application's own bits are the
+      // packed value of its result, and nothing under it is lowered
+      // (lower). Deliberately not canonicalised -- the payload of a NaN the
+      // solve chose for an application is its payload, exactly as for a
+      // float symbol; canonicalPacked is where a caller that needs the
+      // quotient asks for it.
       out = n;
     }
     else if (n.GetKind() == READ)
@@ -550,6 +581,16 @@ private:
 
     if (n.Degree() == 0)
       return decodeCarrier(n, n);
+
+    if (kind == UF_APPLY)
+    {
+      // An opaque packed cell whose subterms stay as they are: unlike a
+      // READ, an application's children are its declaration identity and
+      // its actuals, and neither may be rewritten into the target language
+      // (lower).
+      packed_cache[n] = n;
+      return decodeCarrier(n, n);
+    }
 
     if (kind == READ)
     {

--- a/lib/Incremental/IncrementalSolver.cpp
+++ b/lib/Incremental/IncrementalSolver.cpp
@@ -196,6 +196,15 @@ bool IncrementalSolver::canHandle(const ASTVec& assertionsSMT2)
   // bit-vectors, arrays (lazy or --ackermanize), floating point, and
   // whole-array equality. The method remains the seam for any future
   // exclusion.
+  //
+  // TEMPORARY: a stack that applies an uninterpreted function is refused,
+  // which routes every one of its checks through the batch pipeline. The
+  // persistent driver has no exact-stack lowering for durable applications
+  // yet; the change that adds one deletes this refusal.
+  if (impl->bm->UserFlags.enable_uninterpreted_functions)
+    for (const ASTNode& levelConjunction : assertionsSMT2)
+      if (containsKind(levelConjunction, UF_APPLY))
+        return false;
   (void)assertionsSMT2;
   return true;
 }

--- a/lib/Incremental/IncrementalSolverImpl.h
+++ b/lib/Incremental/IncrementalSolverImpl.h
@@ -2143,30 +2143,35 @@ struct IncrementalSolver::Impl
   // rootLit's encode runs this same guard, and each step removes its
   // variable from the dropped set before encoding, so the chain
   // terminates and a definition never restores itself twice.
+  // Restore one dropped base definition before any route mints the source
+  // symbol's raw bits.
+  void restoreDroppedSigma0Symbol(const ASTNode& s)
+  {
+    if (sigma0Dropped.erase(s) == 0)
+      return;
+    const ASTNode conj = sigma0DefiningConjunctOf.at(s);
+    mustKeepRaw.insert(conj);
+    // The conjunct's cached encoding is the eliminated TRUE form; evict it so
+    // the re-encode below produces the raw equation.
+    rootLitOf.erase(conj);
+    const int lit = rootLit(conj);
+    SATSolver::vec_literals unit;
+    unit.push(SATSolver::mkLit(lit >> 1, lit & 1));
+    addClause(unit);
+    baseLiveMass = addMass(baseLiveMass, addMass(clauseMassOf[conj], 1));
+    recordPermanentRoot(conj);
+    if (bm->UserFlags.stats_flag)
+      std::cerr << "Incremental: restored an eliminated base definition "
+                   "before its variable was encoded raw"
+                << std::endl;
+  }
+
   void restoreDroppedSigma0(const ASTNode& toEncode)
   {
     if (sigma0Dropped.empty())
       return;
     for (const ASTNode& s : symbolsOf(toEncode))
-    {
-      if (sigma0Dropped.erase(s) == 0)
-        continue;
-      const ASTNode conj = sigma0DefiningConjunctOf.at(s);
-      mustKeepRaw.insert(conj);
-      // The conjunct's cached encoding is the eliminated TRUE form; evict
-      // it so the re-encode below produces the raw equation.
-      rootLitOf.erase(conj);
-      const int lit = rootLit(conj);
-      SATSolver::vec_literals unit;
-      unit.push(SATSolver::mkLit(lit >> 1, lit & 1));
-      addClause(unit);
-      baseLiveMass = addMass(baseLiveMass, addMass(clauseMassOf[conj], 1));
-      recordPermanentRoot(conj);
-      if (bm->UserFlags.stats_flag)
-        std::cerr << "Incremental: restored an eliminated base definition "
-                     "before its variable was encoded raw"
-                  << std::endl;
-    }
+      restoreDroppedSigma0Symbol(s);
   }
 
   // Lower, transform and bit-blast a fully rewritten word-level formula

--- a/lib/Interface/cpp_interface.cpp
+++ b/lib/Interface/cpp_interface.cpp
@@ -207,26 +207,43 @@ ASTNode Cpp_interface::CreateFPSpecialConst(stp::FPSpecial which,
   return bm.CreateFPSpecialConst(which, exp_width, sig_width);
 }
 
-void Cpp_interface::addSortAlias(const std::string& name, unsigned exp_width,
-                                 unsigned sig_width)
+void Cpp_interface::addSortAlias(const std::string& name,
+                                 const SourceSort& sort)
 {
   // SMT-LIB does not allow redefining a sort name.
   if (sort_aliases.find(name) != sort_aliases.end())
-    FatalError("define-sort: the sort name is already defined");
-  sort_aliases[name] = std::make_pair(exp_width, sig_width);
+    FatalError("the sort name is already defined");
+  sort_aliases[name] = sort;
   frames.back()->addSortAlias(name);
   session_touched = true;
+}
+
+bool Cpp_interface::lookupSortAlias(const std::string& name,
+                                    SourceSort& sort) const
+{
+  const auto found = sort_aliases.find(name);
+  if (found == sort_aliases.end())
+    return false;
+  sort = found->second;
+  return true;
+}
+
+void Cpp_interface::addSortAlias(const std::string& name, unsigned exp_width,
+                                 unsigned sig_width)
+{
+  addSortAlias(name, SourceSort::floatingPoint(exp_width, sig_width));
 }
 
 bool Cpp_interface::lookupSortAlias(const std::string& name,
                                     unsigned& exp_width,
                                     unsigned& sig_width) const
 {
-  const auto found = sort_aliases.find(name);
-  if (found == sort_aliases.end())
+  SourceSort sort;
+  if (!lookupSortAlias(name, sort) ||
+      sort.kind() != SourceSort::Kind::FloatingPoint)
     return false;
-  exp_width = found->second.first;
-  sig_width = found->second.second;
+  exp_width = sort.exponentWidth();
+  sig_width = sort.significandWidth();
   return true;
 }
 
@@ -1421,7 +1438,7 @@ void CNFClearMemory()
 Cpp_interface::SolverFrame::SolverFrame(
     ankerl::unordered_dense::map<std::string, Function>*
         global_function_context,
-    std::map<std::string, std::pair<unsigned, unsigned>>*
+    std::map<std::string, SourceSort>*
         global_sort_alias_context)
     : _global_function_context(global_function_context),
       _global_sort_alias_context(global_sort_alias_context)

--- a/lib/Interface/cpp_interface.cpp
+++ b/lib/Interface/cpp_interface.cpp
@@ -25,6 +25,7 @@ THE SOFTWARE.
 #include "stp/cpp_interface.h"
 #include "stp/Extensionality/ExtensionalityContext.h"
 #include "stp/Parser/LetMgr.h"
+#include "stp/Parser/parser.h"
 #include "stp/Printer/printers.h"
 #include "stp/Sat/SATSolverFactory.h"
 #include "stp/Util/GitSHA1.h"
@@ -32,6 +33,9 @@ THE SOFTWARE.
 #include "stp/STPManager/STP.h"
 #include "stp/STPManager/STPManager.h"
 #include "stp/ToSat/ToSATAIG.h"
+#include "stp/UninterpretedFunctions/UFContext.h"
+#include "stp/UninterpretedFunctions/UFModel.h"
+#include "stp/UninterpretedFunctions/UFRefinement.h"
 #include <cassert>
 
 using std::cerr;
@@ -67,6 +71,8 @@ void Cpp_interface::init()
   produce_models = false;
   session_touched = false;
   model_valid = false;
+  current_command_rejected = false;
+  current_command_active = false;
   incremental_from_start =
       bm.UserFlags.incremental_mode == UserDefinedFlags::IncrementalMode::ON;
   session_incremental = incremental_from_start;
@@ -77,7 +83,7 @@ void Cpp_interface::init()
 void Cpp_interface::addFrame()
 {
   // create a new frame
-  SolverFrame* new_frame = new SolverFrame(&functions, &sort_aliases);
+  SolverFrame* new_frame = new SolverFrame(&functions, &sort_aliases, &bm);
 
   // store the new frame
   frames.push_back(new_frame);
@@ -165,6 +171,8 @@ void Cpp_interface::setLogic(const std::string& logic)
 
 void Cpp_interface::AddAssert(const ASTNode& assert)
 {
+  if (current_command_rejected)
+    return;
   bm.AddAssert(assert);
   session_touched = true;
 
@@ -312,6 +320,8 @@ void Cpp_interface::removeSymbol(ASTNode to_remove)
 void Cpp_interface::storeFunction(const string& name, const ASTVec& params,
                                   const ASTNode& function)
 {
+  if (current_command_rejected)
+    return;
   Function f;
   f.name = name;
 
@@ -393,6 +403,100 @@ SourceSort Cpp_interface::functionReturnSourceSort(const string& name)
                                   : found->second.function.GetSourceSort();
 }
 
+const UFDecl* Cpp_interface::declareUninterpretedFunction(
+    const std::string& name, const std::vector<SourceSort>& domain,
+    const SourceSort& codomain, std::string* diagnostic)
+{
+  if (lookupFunction(name) != NULL)
+  {
+    if (diagnostic != NULL)
+      *diagnostic = "name '" + name + "' already denotes a define-fun";
+    return NULL;
+  }
+  ASTNode symbol;
+  if (LookupSymbol(name.c_str(), symbol))
+  {
+    if (diagnostic != NULL)
+      *diagnostic = "name '" + name + "' already denotes an ordinary symbol";
+    return NULL;
+  }
+  const UFDecl* result =
+      bm.getUFContext()->declareFunction(name, domain, codomain, diagnostic);
+  if (result != NULL)
+  {
+    session_touched = true;
+    model_valid = false;
+    if (GlobalSTP != NULL &&
+        GlobalSTP->Ctr_Example->getUFTheoryAdapter() != NULL)
+      GlobalSTP->Ctr_Example->getUFTheoryAdapter()
+          ->invalidateCertifiedModel();
+  }
+  return result;
+}
+
+const UFDecl* Cpp_interface::declareScopedUninterpretedFunction(
+    const std::string& name, const std::vector<SourceSort>& domain,
+    const SourceSort& codomain, std::string* diagnostic)
+{
+  const UFDecl* result =
+      declareUninterpretedFunction(name, domain, codomain, diagnostic);
+  if (result != NULL)
+    frames.back()->addUFDeclaration(result);
+  return result;
+}
+
+const UFDecl*
+Cpp_interface::lookupUninterpretedFunction(const std::string& name) const
+{
+  const UFContext* context = bm.getUFContextIfAny();
+  return context == NULL ? NULL : context->lookup(name);
+}
+
+ASTNode Cpp_interface::applyUninterpretedFunction(
+    const UFDecl* declaration, const ASTVec& actuals,
+    std::string* diagnostic)
+{
+  UFContext* context = bm.getUFContextIfAny();
+  if (context == NULL)
+  {
+    if (diagnostic != NULL)
+      *diagnostic = "uninterpreted-function declaration is not owned by this "
+                    "context";
+    return bm.ASTUndefined;
+  }
+  return context->apply(declaration, actuals, diagnostic);
+}
+
+ASTNode Cpp_interface::getUninterpretedApplicationValue(
+    const ASTNode& application, std::string* diagnostic)
+{
+  if (!model_valid || GlobalSTP == NULL)
+  {
+    if (diagnostic != NULL)
+      *diagnostic = "no current certified model is available";
+    return bm.ASTUndefined;
+  }
+  if (GlobalSTP->hasIncrementalSolver())
+    GlobalSTP->getIncrementalSolver()->materializePendingModel();
+  ASTNode value;
+  std::string localDiagnostic;
+  if (!UFModel::evaluateApplication(
+          &bm, GlobalSTP->Ctr_Example->getUFTheoryAdapter(), application,
+          value, localDiagnostic))
+  {
+    if (diagnostic != NULL)
+      *diagnostic = localDiagnostic;
+    return bm.ASTUndefined;
+  }
+  return value;
+}
+
+bool Cpp_interface::hasUninterpretedFunctions() const
+{
+  const UFContext* context = bm.getUFContextIfAny();
+  return context != NULL && context->activeDeclarationCount() != 0;
+}
+
 ASTNode Cpp_interface::LookupOrCreateSymbol(string name)
 {
   return LookupOrCreateSymbol(name.c_str());
@@ -405,6 +509,18 @@ bool Cpp_interface::LookupSymbol(const char* const name, ASTNode& output)
   for (auto it = frames.rbegin(); it != frames.rend(); ++it)
   {
     if ((*it)->lookupSymbol(sv, output))
+      return true;
+  }
+  return false;
+}
+
+bool Cpp_interface::LookupTemporarySymbol(const char* const name,
+                                          ASTNode& output)
+{
+  const std::string_view sv(name);
+  for (auto it = frames.rbegin(); it != frames.rend(); ++it)
+  {
+    if ((*it)->lookupTemporarySymbol(sv, output))
       return true;
   }
   return false;
@@ -458,8 +574,40 @@ void Cpp_interface::deleteNode(ASTNode* n)
 
 void Cpp_interface::addSymbol(ASTNode& s)
 {
+  if (current_command_rejected)
+    return;
   frames.back()->addSymbol(s);
   session_touched = true;
+}
+
+void Cpp_interface::addTemporarySymbol(ASTNode& s)
+{
+  // A formal is parser-local scratch, not a declaration. The successful
+  // storeFunction call is what makes the command observable and marks the
+  // session touched; a rejected define-fun leaves neither behind.
+  frames.back()->addTemporarySymbol(s);
+}
+
+bool Cpp_interface::validateTopLevelDeclarationName(
+    const std::string& name, std::string* diagnostic)
+{
+  std::string message;
+  if (lookupFunction(name) != NULL)
+    message = "name '" + name + "' already denotes a define-fun";
+  else if (lookupUninterpretedFunction(name) != NULL)
+    message = "name '" + name +
+              "' already denotes an uninterpreted function";
+  else
+  {
+    ASTNode symbol;
+    if (LookupSymbol(name.c_str(), symbol))
+      message = "name '" + name + "' already denotes an ordinary symbol";
+  }
+  if (message.empty())
+    return true;
+  if (diagnostic != NULL)
+    *diagnostic = message;
+  return false;
 }
 
 void Cpp_interface::addRoundingModeSymbol(ASTNode& s)
@@ -494,6 +642,8 @@ bool Cpp_interface::arraySortsAgree(const ASTNode& arr, const array_sort& sort)
 
 void Cpp_interface::success()
 {
+  if (current_command_rejected)
+    return;
   if (print_success)
   {
     cout << "success" << endl;
@@ -512,6 +662,57 @@ void Cpp_interface::unsupported()
 {
   cout << "unsupported" << endl;
   flush(cout);
+}
+
+void Cpp_interface::beginCurrentCommand()
+{
+  // A prior parse may have aborted while reducing a formal declaration. Its
+  // command and lexer state are not part of this new top-level command.
+  if (current_command_active)
+    abortCurrentCommand();
+  SMT2ResetCommandLexerState();
+  current_command_active = true;
+  current_command_rejected = false;
+  if (UFContext* context = bm.getUFContextIfAny())
+    context->beginParserCommand();
+}
+
+void Cpp_interface::abortCurrentCommand()
+{
+  if (current_command_active)
+  {
+    if (UFContext* context = bm.getUFContextIfAny())
+      context->finishParserCommand(false);
+    frames.back()->clearTemporarySymbols();
+  }
+  current_command_rejected = false;
+  current_command_active = false;
+  SMT2ResetCommandLexerState();
+}
+
+void Cpp_interface::rejectCurrentCommand(const std::string& diagnostic)
+{
+  // One command has one rejection response. Continue reducing with typed
+  // carriers, but do not emit a diagnostic for every malformed descendant.
+  if (current_command_rejected)
+    return;
+  current_command_rejected = true;
+  error(diagnostic);
+}
+
+void Cpp_interface::finishCurrentCommand()
+{
+  if (current_command_active)
+  {
+    if (UFContext* context = bm.getUFContextIfAny())
+      context->finishParserCommand(!current_command_rejected);
+    // Function formals are command-local even if error recovery skipped a
+    // define-fun production's ordinary removal loop.
+    frames.back()->clearTemporarySymbols();
+  }
+  current_command_rejected = false;
+  current_command_active = false;
+  SMT2ResetCommandLexerState();
 }
 
 void Cpp_interface::resetSolver()
@@ -544,6 +745,12 @@ void Cpp_interface::discardExtensionalitySolveState()
 // Can clear away the base frame..
 void Cpp_interface::reset()
 {
+  // reset destroys the current frame and UF context itself, so close its
+  // accepted command transaction while both are still alive. The grammar's
+  // outer finish becomes a harmless no-op after init().
+  if (current_command_active)
+    finishCurrentCommand();
+
   popToFirstLevel();
 
   if (frames.size() > 0)
@@ -713,6 +920,12 @@ void Cpp_interface::popAssumptionFrame()
 
 void Cpp_interface::checkSatAssuming(const ASTVec& assumptions)
 {
+  // The parser reduces a malformed UF subexpression to a typed carrier so it
+  // can reach this outer boundary. Rejection is transactional: in particular
+  // do not push, invalidate a model, solve the base stack, or print a verdict.
+  if (current_command_rejected)
+    return;
+
   // An internal assertion level holding exactly the assumptions. push()
   // inherits a known-UNSAT verdict from the level below, and a SAT answer
   // propagates to the levels beneath, so the verdict cache keeps working
@@ -909,6 +1122,11 @@ Cpp_interface::Cpp_interface(STPMgr& bm_)
 
 void Cpp_interface::cleanUp()
 {
+  // exit and reset perform cleanup from inside their command action and do
+  // not return through the ordinary closing-parenthesis reduction.
+  if (current_command_active)
+    finishCurrentCommand();
+
   letMgr->cleanupParserSymbolTable();
   cache.clear();
 
@@ -1288,6 +1506,8 @@ void Cpp_interface::getAssertions()
 
 void Cpp_interface::getValue(const ASTVec& v)
 {
+  if (current_command_rejected)
+    return;
   if (!bm.UserFlags.construct_counterexample_flag || !model_valid)
   {
     unsupported();
@@ -1307,10 +1527,54 @@ void Cpp_interface::getValue(const ASTVec& v)
 
   for (ASTNode n : v)
   {
+    if (n.GetKind() == UF_APPLY)
+    {
+      std::string diagnostic;
+      const ASTNode value =
+          getUninterpretedApplicationValue(n, &diagnostic);
+      if (value.GetKind() == UNDEFINED)
+      {
+        // The solve never reached this application, so there is no certified
+        // value to hand back -- but there is still an answer, and the same
+        // command list was already giving it: an application nested inside a
+        // term goes through the model evaluator, which completes it against
+        // the published interpretation, so (bvadd (f #x07) #x01) answered
+        // while the bare (f #x07) was refused. The printed model is total and
+        // says what (f #x07) is; refusing to repeat it here was the one place
+        // the two disagreed.
+        //
+        // Fall through to the ordinary term path, which is that evaluator.
+        // Anything genuinely unanswerable -- no model at all, an application
+        // from another context, one whose model has been invalidated -- fails
+        // there too, and the diagnostic computed above is what it reports.
+        if (!model_valid || GlobalSTP == NULL)
+        {
+          if (diagnostic.empty())
+            diagnostic = "uninterpreted-function application has no certified "
+                         "value";
+          rejectCurrentCommand(diagnostic);
+          return;
+        }
+        GlobalSTP->Ctr_Example->PrintSMTLIB2(os, n);
+        os << std::endl;
+        continue;
+      }
+      os << "( ";
+      // Through the letizing entry point, for the reason the note above
+      // AbsRefine_CounterExample::PrintSMTLIB2 gives: an application's
+      // arguments may be a shared DAG a caller built out of very little
+      // input text.
+      printer::SMTLIB2_PrintTerm(os, &bm, n);
+      os << " ";
+      printer::SMTLIB2_Print1(os, value, 0, false);
+      os << " )" << std::endl;
+      continue;
+    }
     // (get-value ...) asks for the value of arbitrary well-sorted terms and
     // not just of variables, and the model evaluator already decides all of
-    // them. The one shape with no value to print is an array: (get-model)
-    // prints the completed array interpretations instead. That refusal is
+    // them -- including terms built over uninterpreted applications. The one
+    // shape with no value to print is an array: (get-model) prints the
+    // completed array interpretations instead. That refusal is
     // unconditional, because reaching the printer with an array aborted the
     // process rather than answering when array equality was disabled -- and
     // disabled is the default.
@@ -1439,9 +1703,10 @@ Cpp_interface::SolverFrame::SolverFrame(
     ankerl::unordered_dense::map<std::string, Function>*
         global_function_context,
     std::map<std::string, SourceSort>*
-        global_sort_alias_context)
+        global_sort_alias_context,
+    STPMgr* manager)
     : _global_function_context(global_function_context),
-      _global_sort_alias_context(global_sort_alias_context)
+      _global_sort_alias_context(global_sort_alias_context), _manager(manager)
 {
 }
 
@@ -1452,6 +1717,18 @@ Cpp_interface::SolverFrame::SolverFrame(
 // function declarations are correctly decremented.
 Cpp_interface::SolverFrame::~SolverFrame()
 {
+  UFContext* uf = _manager->getUFContextIfAny();
+  if (uf != NULL)
+  {
+    for (const UFDecl* declaration : _scoped_uf_declarations)
+    {
+      std::string ignored;
+      const bool removed = uf->deactivate(declaration, &ignored);
+      assert(removed);
+      (void)removed;
+    }
+  }
+
   // Iterate on the function names in our current scope
   for (const auto& scoped_function_name : getFunctions())
   {
@@ -1497,14 +1774,47 @@ void Cpp_interface::SolverFrame::addSortAlias(const std::string& name)
   _scoped_sort_aliases.push_back(name);
 }
 
+void Cpp_interface::SolverFrame::addUFDeclaration(const UFDecl* declaration)
+{
+  assert(declaration != NULL);
+  _scoped_uf_declarations.push_back(declaration);
+}
+
 void Cpp_interface::SolverFrame::addSymbol(const ASTNode& symbol)
 {
   _scoped_symbols.push_back(symbol);
   _symbol_bindings[std::string(symbol.GetName())].push_back(symbol);
 }
 
+void Cpp_interface::SolverFrame::addTemporarySymbol(const ASTNode& symbol)
+{
+  addSymbol(symbol);
+  _temporary_symbol_bindings[std::string(symbol.GetName())].push_back(symbol);
+}
+
+void Cpp_interface::SolverFrame::clearTemporarySymbols()
+{
+  while (!_temporary_symbol_bindings.empty())
+  {
+    const ASTNode symbol = _temporary_symbol_bindings.begin()->second.back();
+    const bool removed = removeSymbol(symbol);
+    assert(removed);
+    (void)removed;
+  }
+}
+
 bool Cpp_interface::SolverFrame::removeSymbol(const ASTNode& symbol)
 {
+  const auto temporary =
+      _temporary_symbol_bindings.find(std::string_view(symbol.GetName()));
+  if (temporary != _temporary_symbol_bindings.end() &&
+      !temporary->second.empty() && temporary->second.back() == symbol)
+  {
+    temporary->second.pop_back();
+    if (temporary->second.empty())
+      _temporary_symbol_bindings.erase(temporary);
+  }
+
   const auto binding = _symbol_bindings.find(std::string_view(symbol.GetName()));
   if (binding == _symbol_bindings.end() || binding->second.empty() ||
       binding->second.back() != symbol)
@@ -1547,6 +1857,11 @@ void Cpp_interface::SolverFrame::adoptDeclarations(SolverFrame& donor)
                               donor._scoped_sort_aliases.begin(),
                               donor._scoped_sort_aliases.end());
   donor._scoped_sort_aliases.clear();
+
+  _scoped_uf_declarations.insert(_scoped_uf_declarations.end(),
+                                 donor._scoped_uf_declarations.begin(),
+                                 donor._scoped_uf_declarations.end());
+  donor._scoped_uf_declarations.clear();
 }
 
 bool Cpp_interface::SolverFrame::lookupSymbol(std::string_view name,
@@ -1554,6 +1869,16 @@ bool Cpp_interface::SolverFrame::lookupSymbol(std::string_view name,
 {
   const auto found = _symbol_bindings.find(name);
   if (found == _symbol_bindings.end() || found->second.empty())
+    return false;
+  output = found->second.back();
+  return true;
+}
+
+bool Cpp_interface::SolverFrame::lookupTemporarySymbol(
+    const std::string_view name, ASTNode& output) const
+{
+  const auto found = _temporary_symbol_bindings.find(name);
+  if (found == _temporary_symbol_bindings.end() || found->second.empty())
     return false;
   output = found->second.back();
   return true;

--- a/lib/NodeFactory/HashingNodeFactory.cpp
+++ b/lib/NodeFactory/HashingNodeFactory.cpp
@@ -25,6 +25,7 @@ THE SOFTWARE.
 #include "stp/NodeFactory/HashingNodeFactory.h"
 #include "stp/AST/AST.h"
 #include "stp/Extensionality/ExtensionalityContext.h"
+#include "stp/UninterpretedFunctions/UFContext.h"
 #include "stp/STPManager/STP.h"
 
 using namespace stp;
@@ -37,6 +38,15 @@ HashingNodeFactory::~HashingNodeFactory()
 ASTNode HashingNodeFactory::CreateNode(const Kind kind,
                                        const ASTChildren back_children)
 {
+  if (kind == UF_APPLY)
+  {
+    std::string error;
+    UFContext* context = bm.getUFContextIfAny();
+    if (context == NULL ||
+        !context->validateApplicationChildren(back_children, &error))
+      FatalError(("UF_APPLY: " + error).c_str());
+  }
+
   // We can't create NOT(NOT (..)) nodes because of how the numbering scheme we
   // use works. So you can't trust the hashing node factory even to return
   // nodes of the same kind that you ask for.
@@ -85,19 +95,28 @@ ASTNode HashingNodeFactory::CreateNode(const Kind kind,
   if (back_children.size()  <= 1 || !isCommutative(kind))
   {
     // Don't create a new vector if it won't be sorted.
-    return ASTNode(bm.LookupOrCreateInterior(kind, back_children));
+    ASTNode result(bm.LookupOrCreateInterior(kind, back_children));
+    if (kind == UF_APPLY)
+      bm.getUFContext()->noteApplication(result);
+    return result;
   }
   else if (is_Form_kind(kind)) // formula and commutative.
   {
     const bool isSorted =  std::is_sorted(back_children.begin(),back_children.end(),stp::ExprLess{});
     if (isSorted)
     {
-      return ASTNode(bm.LookupOrCreateInterior(kind, back_children));
+      ASTNode result(bm.LookupOrCreateInterior(kind, back_children));
+      if (kind == UF_APPLY)
+        bm.getUFContext()->noteApplication(result);
+      return result;
     }
 
     ASTVec sorted_children(back_children.begin(), back_children.end());
     SortByExprNum(sorted_children);
-    return ASTNode(bm.LookupOrCreateInterior(kind, sorted_children));
+    ASTNode result(bm.LookupOrCreateInterior(kind, sorted_children));
+    if (kind == UF_APPLY)
+      bm.getUFContext()->noteApplication(result);
+    return result;
   }
   else
   {
@@ -105,7 +124,10 @@ ASTNode HashingNodeFactory::CreateNode(const Kind kind,
                        stp::ArithLess{}))
     {
       // Don't create a new vector if it's already sorted.
-      return ASTNode(bm.LookupOrCreateInterior(kind, back_children));
+      ASTNode result(bm.LookupOrCreateInterior(kind, back_children));
+      if (kind == UF_APPLY)
+        bm.getUFContext()->noteApplication(result);
+      return result;
     }
 
     ASTVec children(back_children.begin(), back_children.end());
@@ -113,7 +135,10 @@ ASTNode HashingNodeFactory::CreateNode(const Kind kind,
     // LHS.
     SortByArith(children);
 
-    return ASTNode(bm.LookupOrCreateInterior(kind, children));
+    ASTNode result(bm.LookupOrCreateInterior(kind, children));
+    if (kind == UF_APPLY)
+      bm.getUFContext()->noteApplication(result);
+    return result;
   }
 }
 

--- a/lib/NodeFactory/SimplifyingNodeFactory.cpp
+++ b/lib/NodeFactory/SimplifyingNodeFactory.cpp
@@ -42,6 +42,7 @@ using stp::BVMULT;
 using stp::ITE;
 using stp::EQ;
 using stp::ARRAY_EQ;
+using stp::UF_APPLY;
 using stp::BVSRSHIFT;
 using stp::SBVREM;
 using stp::SBVMOD;
@@ -1039,6 +1040,10 @@ ASTNode SimplifyingNodeFactory::CreateNode(Kind kind,
         result = simplifyArrayEquality(children[0], children[1]);
       if (result.IsNull())
         result = hashing.CreateNode(ARRAY_EQ, children);
+      break;
+    case UF_APPLY:
+      // Durable applications are opaque until completed-root lowering.
+      result = hashing.CreateNode(UF_APPLY, children);
       break;
     case stp::IFF:
     {
@@ -3391,6 +3396,9 @@ ASTNode SimplifyingNodeFactory::CreateTerm(Kind kind, unsigned int width,
   const bool is_partial_fp_operation =
       kind == stp::FP_MIN || kind == stp::FP_MAX || kind == stp::FP_TO_UBV ||
       kind == stp::FP_TO_SBV;
+
+  if (kind == stp::UF_APPLY)
+    return hashing.CreateTerm(kind, width, children);
 
   // If all the parameters are constant, return the constant value.
   if (children_all_constants(children) && !is_partial_fp_operation)

--- a/lib/Parser/smt2.lex
+++ b/lib/Parser/smt2.lex
@@ -81,6 +81,34 @@
   // "fp" is using its own symbol and must not be told about FP logics.
   static thread_local std::string unresolvedFpKeyword;
 
+  // With the UF feature enabled, the next identifier sits in declare-fun's
+  // name position. A name that is already classified in some namespace is
+  // handed back UNclassified there -- as a plain STRING_TOK -- so that the
+  // grammar can see the declaration's shape and route a NONZERO-ARITY
+  // collision into the nonfatal UF declaration funnel. Every other shape
+  // owes the pinned legacy response, so what the classification would have
+  // been is recorded (below) for the grammar to replicate it from. Only the
+  // declare-fun name is treated this way: declare-const and define-fun are
+  // UF-free shapes and keep the legacy classified-token syntax error at
+  // the name, feature on or off. Feature-off lexing remains byte-for-byte
+  // on the legacy path.
+  static thread_local bool ufDeclarationNamePending = false;
+
+  // The declassification record (see SMT2DeclassifiedNamePending in
+  // parser.h): the token kind the name would have carried, where, and the
+  // token text exactly as yyerror would have printed it. For |quoted| names
+  // lookup() chops the closing bar in place, so smt2text is "|name" --
+  // that is what the legacy error printed, and what is recorded.
+  static thread_local bool declassifiedNamePending = false;
+  static thread_local int declassifiedNameToken = 0;
+  static thread_local int declassifiedNameLine = 0;
+  static thread_local std::string declassifiedNameText;
+
+  // Set by the grammar immediately after the '(' that opens one define-fun
+  // formal. The following identifier is a declaration site, not a reference
+  // to a top-level function, UF, or symbol.
+  static thread_local bool functionParameterNamePending = false;
+
 #ifdef _MSC_VER
   #include <io.h>
   // defining isatty to avoid dll symbol export inconsistencies
@@ -125,6 +153,28 @@ namespace stp
   // gate itself rather than being answered by it. See tryRegisterFpSortAlias.
   bool SMT2FloatTokensActive() { return floatTokensActive; }
 
+  void SMT2ExpectFunctionParameterName()
+  {
+    assert(!functionParameterNamePending);
+    functionParameterNamePending = true;
+  }
+
+  void SMT2ResetCommandLexerState()
+  {
+    ufDeclarationNamePending = false;
+    functionParameterNamePending = false;
+    declassifiedNamePending = false;
+  }
+
+  bool SMT2DeclassifiedNamePending() { return declassifiedNamePending; }
+  int SMT2DeclassifiedNameToken() { return declassifiedNameToken; }
+  int SMT2DeclassifiedNameLine() { return declassifiedNameLine; }
+  const std::string& SMT2DeclassifiedNameText()
+  {
+    return declassifiedNameText;
+  }
+  void SMT2ConsumeDeclassifiedName() { declassifiedNamePending = false; }
+
   // Whether the token a diagnostic is about is a floating-point name that the
   // gate demoted for want of an FP set-logic. Matched against the offending
   // text rather than answered from the flag alone, so that an unrelated error
@@ -135,6 +185,8 @@ namespace stp
            unresolvedFpKeyword == text;
   }
 }
+
+  static int classify(char* s);
 
   static int lookup(char* s)
   {
@@ -159,56 +211,116 @@ namespace stp
       return STRING_TOK;
     }
 
+    if (ufDeclarationNamePending)
+    {
+      // Declare-fun's name position, feature on. Classify exactly as the
+      // legacy lexer would, then hand a classified name back unclassified
+      // and record what it would have been (see the statics above).
+      ufDeclarationNamePending = false;
+      const int token = classify(s);
+      if (token == STRING_TOK)
+        return token;
+      if (token == FORMID_TOK || token == TERMID_TOK)
+      {
+        // classify() handed the grammar a fresh node it will never see.
+        stp::GlobalParserInterface->deleteNode(smt2lval.node);
+        smt2lval.node = NULL;
+      }
+      declassifiedNamePending = true;
+      declassifiedNameToken = token;
+      declassifiedNameLine = smt2lineno;
+      declassifiedNameText = smt2text;
+      smt2lval.str = new std::string(s);
+      return STRING_TOK;
+    }
+
+    return classify(s);
+  }
+
+  // The legacy classification of an identifier: a let binder, a define-fun
+  // formal, a define-fun, an uninterpreted function, a declared symbol, or
+  // -- unseen before -- a plain string carrying its spelling.
+  static int classify(char* s)
+  {
     stp::ASTNode nptr;
     bool found = false;
 
-    if (const stp::ASTNode* let = stp::GlobalParserInterface->letMgr->lookupLet(s)) // Lets shadow everything else.
+    if (functionParameterNamePending)
     {
-      nptr = *let;
+      functionParameterNamePending = false;
+      // Preserve the existing rejection of duplicate formals: an earlier
+      // formal with this spelling is already a binder, not a global name to
+      // be shadowed. Every other spelling is returned unresolved here.
+      if (!stp::GlobalParserInterface->LookupTemporarySymbol(s, nptr))
+      {
+        smt2lval.str = new std::string(s);
+        return STRING_TOK;
+      }
       found = true;
     }
-    // Checking the functions before the symbols saves a symbol-table
-    // probe in files built almost entirely from define-funs. A name can't
-    // legally be both, so the order isn't observable on valid input. One
-    // map probe resolves the name; the token carries the resolved function
-    // so the grammar never probes again, and the sort of the stored body
-    // (memoised on the node) classifies the token.
-    else if (stp::GlobalParserInterface->hasFunctions())
+
+    if (!found)
     {
-      const stp::Cpp_interface::Function* fn =
-          stp::GlobalParserInterface->lookupFunction(s);
-      if (fn != NULL)
+      if (const stp::ASTNode* let =
+              stp::GlobalParserInterface->letMgr->lookupLet(s))
       {
-        smt2lval.fn = fn;
-        switch (fn->function.GetSourceSort().kind())
-        {
-          case stp::SourceSort::Kind::RoundingMode:
-            return ROUNDINGMODE_FUNCTIONID_TOK;
-          case stp::SourceSort::Kind::BitVector:
-            return BITVECTOR_FUNCTIONID_TOK;
-          case stp::SourceSort::Kind::Bool:
-            return BOOLEAN_FUNCTIONID_TOK;
-          case stp::SourceSort::Kind::FloatingPoint:
-            return FLOATINGPOINT_FUNCTIONID_TOK;
-          // A nullary define-fun whose body has array type is a pure name
-          // for that body, so it is accepted whether or not --array-equality
-          // is on (QF_ABVFP benchmarks use them with no whole-array
-          // equalities in sight). Uses of the name expand to the body in
-          // the grammar.
-          case stp::SourceSort::Kind::Array:
-            return ARRAY_FUNCTIONID_TOK;
-          case stp::SourceSort::Kind::Unknown:
-            smt2error("Function with underivable return sort.");
-        }
-      }
-      else if (stp::GlobalParserInterface->LookupSymbol(s,nptr)) // it's a symbol.
-      {
+        nptr = *let;
         found = true;
       }
+      // Function formals are lexical binders and therefore resolve before
+      // all top-level namespaces. Lets remain first because a nested let may
+      // shadow a formal in the define-fun body.
+      else if (stp::GlobalParserInterface->LookupTemporarySymbol(s, nptr))
+        found = true;
     }
-    else if (stp::GlobalParserInterface->LookupSymbol(s,nptr)) // it's a symbol.
+    if (!found)
     {
-      found = true;
+      // Checking functions before ordinary top-level symbols saves a symbol
+      // table probe in files built almost entirely from define-funs. Legal
+      // top-level input cannot occupy both namespaces.
+      if (stp::GlobalParserInterface->hasFunctions())
+      {
+        const stp::Cpp_interface::Function* fn =
+            stp::GlobalParserInterface->lookupFunction(s);
+        if (fn != NULL)
+        {
+          smt2lval.fn = fn;
+          switch (fn->function.GetSourceSort().kind())
+          {
+            case stp::SourceSort::Kind::RoundingMode:
+              return ROUNDINGMODE_FUNCTIONID_TOK;
+            case stp::SourceSort::Kind::BitVector:
+              return BITVECTOR_FUNCTIONID_TOK;
+            case stp::SourceSort::Kind::Bool:
+              return BOOLEAN_FUNCTIONID_TOK;
+            case stp::SourceSort::Kind::FloatingPoint:
+              return FLOATINGPOINT_FUNCTIONID_TOK;
+            case stp::SourceSort::Kind::Array:
+              return ARRAY_FUNCTIONID_TOK;
+            case stp::SourceSort::Kind::Unknown:
+              smt2error("Function with underivable return sort.");
+          }
+        }
+      }
+
+      if (stp::GlobalParserInterface->getUserFlags()
+              .enable_uninterpreted_functions &&
+          stp::GlobalParserInterface->hasUninterpretedFunctions())
+      {
+        const stp::UFDecl* declaration =
+            stp::GlobalParserInterface->lookupUninterpretedFunction(s);
+        if (declaration != NULL)
+        {
+          smt2lval.ufdecl = declaration;
+          return declaration->signature().codomain().kind() ==
+                         stp::SourceSort::Kind::Bool
+                     ? UF_BOOL_FUNCTIONID_TOK
+                     : UF_BV_FUNCTIONID_TOK;
+        }
+      }
+
+      if (stp::GlobalParserInterface->LookupSymbol(s,nptr))
+        found = true;
     }
 
     if (found)
@@ -329,8 +441,13 @@ bv{DIGIT}+             { smt2lval.str = new std::string(smt2text+2); return BVCO
 "assert"                  { return ASSERT_TOK; }
 "check-sat"               { return CHECK_SAT_TOK; }
 "check-sat-assuming"      { return CHECK_SAT_ASSUMING_TOK;}
-"declare-const"           { return DECLARE_CONST_TOK;}
-"declare-fun"             { return DECLARE_FUNCTION_TOK; }
+"declare-const"           { return DECLARE_CONST_TOK; }
+"declare-fun"             {
+                              ufDeclarationNamePending =
+                                  stp::GlobalParserInterface->getUserFlags()
+                                      .enable_uninterpreted_functions;
+                              return DECLARE_FUNCTION_TOK;
+                            }
 "declare-sort"            { return DECLARE_SORT_TOK;}
 "define-fun"              { return DEFINE_FUNCTION_TOK; }
 "echo"                    { return ECHO_TOK;}
@@ -543,7 +660,16 @@ bv{DIGIT}+             { smt2lval.str = new std::string(smt2text+2); return BVCO
 ({LETTER}|{OPCHAR})({ANYTHING})*  {return lookup(smt2text);}
 \|([^\|]|[\x80-\xff]|\n)*\| { countNewlines(smt2text, smt2leng); return lookup(smt2text); }
 
-. { smt2error("Illegal input character."); }
+. {
+    // Downstream of a declassified declare-fun name the pinned response is
+    // the name-position error alone (smt2error prints it in place of this
+    // message), and the parse abandons there: the legacy grammar never
+    // reached this character. Otherwise report and keep scanning, as ever.
+    const bool abandon = stp::SMT2DeclassifiedNamePending();
+    smt2error("Illegal input character.");
+    if (abandon)
+      throw stp::DeclassifiedNameAbandon();
+  }
 %%
 
 namespace stp {

--- a/lib/Parser/smt2.y
+++ b/lib/Parser/smt2.y
@@ -304,13 +304,39 @@ namespace stp
     return o.str();
   }
 
+  void reportRedeclaredName();
+
   int yyerror(const char *s) {
-    cout << "(error \"" << smt2_diagnostic(s) << "\")" << endl;
+    if (stp::SMT2DeclassifiedNamePending())
+    {
+      // Bison ran past a declassified declare-fun name and hit a syntax
+      // error before any var_decl action consumed the record: a malformed
+      // zero-arity declaration shape. The legacy grammar died AT the name,
+      // so the name-position error is the whole pinned response, whatever
+      // `s` says. Return rather than throw: the grammar has no error
+      // productions, so bison now abandons the parse itself and reclaims
+      // its stack through the %destructor rules. (Nothing but bison calls
+      // yyerror while a record is pending: only sort rules sit between the
+      // name and the action, and those fail through fatal_yyerror below;
+      // the lexer's illegal-character rule handles its own case.)
+      reportRedeclaredName();
+      return 1;
+    }
+    stp::GlobalParserInterface->rejectCurrentCommand(smt2_diagnostic(s));
     return 1;
   }
 
   int fatal_yyerror(const char *s) 
   {
+    if (stp::SMT2DeclassifiedNamePending())
+    {
+      // A sort rule inside a zero-arity declaration over a known name is
+      // rejecting a width or format. The legacy grammar never reached it:
+      // it died at the name. Print that error alone and unwind to
+      // SMT2Parse() -- neither the sort's own message nor FatalError's exit.
+      reportRedeclaredName();
+      throw stp::DeclassifiedNameAbandon();
+    }
     yyerror(s);
     stp::FatalError(smt2_diagnostic(s).c_str());
   }
@@ -392,6 +418,117 @@ namespace stp
    delete c;
    return n;
    }
+
+  static std::string unsupportedUFDomainSort(
+      const std::string& name, const stp::parsed_uf_sort& sort,
+      const size_t argument)
+  {
+    std::string diagnostic =
+        "uninterpreted functions: unsupported domain sort " + sort.spelling +
+        " at argument " + std::to_string(argument) + " of " + name;
+    diagnostic += sort.known
+                      ? " (" + std::string(
+                            stp::UFSignature::supportedSortsPhrase()) + ")"
+                      : " (unknown; " + std::string(
+                            stp::UFSignature::supportedSortsPhrase()) + ")";
+    return diagnostic;
+  }
+
+  static std::string unsupportedUFResultSort(
+      const std::string& name, const stp::parsed_uf_sort& sort)
+  {
+    std::string diagnostic =
+        "uninterpreted functions: unsupported result sort " + sort.spelling +
+        " of " + name;
+    diagnostic += sort.known
+                      ? " (" + std::string(
+                            stp::UFSignature::supportedSortsPhrase()) + ")"
+                      : " (unknown; " + std::string(
+                            stp::UFSignature::supportedSortsPhrase()) + ")";
+    return diagnostic;
+  }
+
+  static ASTNode* applyParsedUF(const stp::UFDecl* declaration,
+                                ASTVec* actuals)
+  {
+    std::string diagnostic;
+    ASTNode application =
+        stp::GlobalParserInterface->applyUninterpretedFunction(
+            declaration, *actuals, &diagnostic);
+    delete actuals;
+    if (application.GetKind() == UNDEFINED)
+    {
+      stp::GlobalParserInterface->rejectCurrentCommand(diagnostic);
+
+      // Bison still needs a value of the production's statically selected
+      // result sort in order to reduce the rest of this command.  Reuse a
+      // canonical constant and discard the command at its outer boundary;
+      // unlike the v1 sketch this creates neither a fresh malformed
+      // placeholder nor a UF application/registration.
+      //
+      // The enclosing production reduces before the command is discarded and
+      // sort-checks its operands, so the placeholder has to be a term of the
+      // declared sort and not merely of that sort's carrier width -- a bare
+      // five-bit zero where a RoundingMode is expected turns this nonfatal
+      // rejection into a fatal "operands of the same sort" error.
+      const stp::SourceSort resultSort =
+          declaration == NULL ? stp::SourceSort::boolean()
+                              : declaration->signature().codomain();
+      switch (resultSort.kind())
+      {
+        case stp::SourceSort::Kind::Bool:
+          application = stp::GlobalParserInterface->CreateNode(FALSE);
+          break;
+        case stp::SourceSort::Kind::RoundingMode:
+          application = stp::GlobalParserInterface->CreateRMConst(
+              stp::symbolic_fp::ROUND_NEAREST_TIES_TO_EVEN);
+          break;
+        case stp::SourceSort::Kind::FloatingPoint:
+          application = stp::GlobalParserInterface->CreateFPSpecialConst(
+              stp::FPSpecial::PlusZero, resultSort.exponentWidth(),
+              resultSort.significandWidth());
+          break;
+        default:
+          application = stp::GlobalParserInterface->CreateZeroConst(
+              resultSort.packedWidth());
+          break;
+      }
+    }
+    return stp::GlobalParserInterface->newNode(application);
+  }
+
+  // The zero-arity var_decl actions: a declassified declare-fun name means
+  // the legacy grammar rejected this declaration AT the name, so replicate
+  // that error and abandon. YYABORT does not reclaim the aborting rule's own
+  // right-hand side, so the action releases what it owns first (see
+  // "Cleanup: popping" in the generated parser).
+#define ABANDON_IF_REDECLARED_ZERO_ARITY(release)                            \
+  do                                                                        \
+  {                                                                         \
+    if (stp::SMT2DeclassifiedNamePending())                                 \
+    {                                                                       \
+      reportRedeclaredName();                                               \
+      release;                                                              \
+      YYABORT;                                                              \
+    }                                                                       \
+  } while (0)
+
+  static bool acceptTopLevelDeclarationName(const std::string& name)
+  {
+    // Preserve the pinned frontend byte-for-byte when UFSTP is disabled.
+    // The additional shared-namespace check exists only because an enabled
+    // UFDecl registry is otherwise invisible to the legacy symbol/function
+    // tables.
+    if (!stp::GlobalParserInterface->getUserFlags()
+             .enable_uninterpreted_functions)
+      return true;
+    std::string diagnostic;
+    if (stp::GlobalParserInterface->validateTopLevelDeclarationName(
+            name, &diagnostic))
+      return true;
+    stp::GlobalParserInterface->rejectCurrentCommand(diagnostic);
+    return false;
+  }
 
   ASTNode* createNode(Kind k, ASTNode* c0, ASTNode *c1)
   {
@@ -1275,15 +1412,37 @@ namespace stp
   // of the declare-fun and declare-const productions. Frees both arguments.
   void declareArraySymbol(std::string* name, stp::array_sort* sort)
   {
-    ASTNode s = stp::GlobalParserInterface->CreateSourceSymbol(
-        name->c_str(), sort->sourceSort());
-    stp::GlobalParserInterface->addArraySymbol(s, *sort);
+    if (acceptTopLevelDeclarationName(*name))
+    {
+      ASTNode s = stp::GlobalParserInterface->CreateSourceSymbol(
+          name->c_str(), sort->sourceSort());
+      stp::GlobalParserInterface->addArraySymbol(s, *sort);
 
-    if (s.GetType() != ARRAY_TYPE)
-      fatal_yyerror("failed to declare an array.");
+      if (s.GetType() != ARRAY_TYPE)
+        fatal_yyerror("failed to declare an array.");
+    }
 
     delete name;
     delete sort;
+  }
+
+  // Shared scalar declaration action. A rejected cross-namespace name is
+  // diagnosed before interning/registration and the rest of the command is
+  // reduced only for recovery.
+  void declareScalarSymbol(std::string* name,
+                           const stp::SourceSort& sourceSort,
+                           bool roundingMode = false)
+  {
+    if (acceptTopLevelDeclarationName(*name))
+    {
+      ASTNode s = stp::GlobalParserInterface->CreateSourceSymbol(
+          name->c_str(), sourceSort);
+      if (roundingMode)
+        stp::GlobalParserInterface->addRoundingModeSymbol(s);
+      else
+        stp::GlobalParserInterface->addSymbol(s);
+    }
+    delete name;
   }
 
 #define YYLTYPE_IS_TRIVIAL 1
@@ -1319,7 +1478,17 @@ namespace stp
      only mutates between commands, never inside a term, so the pointer
      outlives the token that carries it. */
   const stp::Cpp_interface::Function *fn;
+  const stp::UFDecl *ufdecl;
+  stp::parsed_uf_sort *ufsort;
+  std::vector<stp::parsed_uf_sort> *ufsortvec;
 };
+
+/* Successful reductions transfer/delete strings in their grammar actions.
+   Values discarded by Bison during recovery or parse abort remain Bison's
+   responsibility; release them here so malformed commands do not leak their
+   identifier/string lookahead. */
+%destructor { delete $$; } <str>
+%destructor { delete $$; } <ufsort> <ufsortvec>
 
 %start cmd
 
@@ -1329,6 +1498,9 @@ namespace stp
 %type <node> an_term  an_formula function_param an_const an_fp_term an_fp_predicate an_rounding_mode
 %type <uintval> an_fp_const
 %type <str> info_flag
+%type <str> uf_decl_name function_def_name
+%type <ufsortvec> uf_domain_sorts
+%type <ufsort> uf_sort uf_codomain_sort
 
 %type <fp_size> an_fp_sort
 %type <arr_component> an_array_sort_component
@@ -1354,6 +1526,7 @@ namespace stp
 %token <node> FORMID_TOK TERMID_TOK
 %token <str> STRING_TOK
 %token <fn> BITVECTOR_FUNCTIONID_TOK BOOLEAN_FUNCTIONID_TOK FLOATINGPOINT_FUNCTIONID_TOK ARRAY_FUNCTIONID_TOK
+%token <ufdecl> UF_BV_FUNCTIONID_TOK UF_BOOL_FUNCTIONID_TOK
 
  /* set-info tokens */
 %token SOURCE_TOK
@@ -1547,9 +1720,21 @@ cmd: commands END
 }
 ;
 
-commands: commands LPAREN_TOK cmdi RPAREN_TOK
-| LPAREN_TOK cmdi RPAREN_TOK
-{}
+command_open:
+LPAREN_TOK
+{
+  stp::GlobalParserInterface->beginCurrentCommand();
+}
+;
+
+commands: commands command_open cmdi RPAREN_TOK
+{
+  stp::GlobalParserInterface->finishCurrentCommand();
+}
+| command_open cmdi RPAREN_TOK
+{
+  stp::GlobalParserInterface->finishCurrentCommand();
+}
 ;
 
 cmdi:
@@ -1764,17 +1949,39 @@ cmdi:
       // Anything more (a Real declaration, arithmetic over reals) has no
       // production and is a syntax error, so accepting the name here cannot
       // answer a query STP could not decide.
+      // The UF+FP names are gated on the feature exactly as QF_UFBV is, and
+      // are floating-point logics in their own right: without them no query
+      // can name a fragment admitting both uninterpreted functions and the
+      // floating-point keywords, and outside an FP logic "RoundingMode" is
+      // not even a token (see SMT2SetFloatTokens below).
+      //
+      // SMT-LIB orders the theory letters A, UF, BV, FP, so the name a
+      // benchmark carries for arrays with uninterpreted functions and floats
+      // is QF_AUFBVFP -- the same order this file already uses for QF_AUFBV.
+      // QF_UFABVFP is accepted as an alias for it: it is the spelling this
+      // branch shipped first and several fixtures name it.
+      const bool uf_fp_logic =
+            (0 == strcmp($2->c_str(),"QF_UFFP") ||
+             0 == strcmp($2->c_str(),"QF_UFBVFP") ||
+             0 == strcmp($2->c_str(),"QF_AUFBVFP") ||
+             0 == strcmp($2->c_str(),"QF_UFABVFP")) &&
+            stp::GlobalParserInterface->getUserFlags()
+                .enable_uninterpreted_functions;
       const bool fp_logic =
             0 == strcmp($2->c_str(),"QF_FP") ||
             0 == strcmp($2->c_str(),"QF_BVFP") ||
             0 == strcmp($2->c_str(),"QF_ABVFP") ||
             0 == strcmp($2->c_str(),"QF_FPLRA") ||
             0 == strcmp($2->c_str(),"QF_BVFPLRA") ||
-            0 == strcmp($2->c_str(),"QF_ABVFPLRA");
+            0 == strcmp($2->c_str(),"QF_ABVFPLRA") ||
+            uf_fp_logic;
       if (!(
             0 == strcmp($2->c_str(),"QF_BV") ||
             0 == strcmp($2->c_str(),"QF_ABV") ||
             0 == strcmp($2->c_str(),"QF_AUFBV") ||
+            (0 == strcmp($2->c_str(),"QF_UFBV") &&
+             stp::GlobalParserInterface->getUserFlags()
+                 .enable_uninterpreted_functions) ||
             fp_logic
             )) {
         yyerror("Wrong input logic");
@@ -1823,33 +2030,65 @@ cmdi:
 
 ;
 
+function_param_open:
+LPAREN_TOK
+{
+  stp::SMT2ExpectFunctionParameterName();
+}
+;
+
 function_param:
-LPAREN_TOK STRING_TOK LPAREN_TOK UNDERSCORE_TOK BITVEC_TOK NUMERAL_TOK RPAREN_TOK RPAREN_TOK
+function_param_open STRING_TOK LPAREN_TOK UNDERSCORE_TOK BITVEC_TOK NUMERAL_TOK RPAREN_TOK RPAREN_TOK
 {
   checkBitVectorWidth($6);
   $$ = new ASTNode(stp::GlobalParserInterface->CreateSourceSymbol(
       $2->c_str(), stp::SourceSort::bitVector($6)));
-  stp::GlobalParserInterface->addSymbol(*$$);
+  stp::GlobalParserInterface->addTemporarySymbol(*$$);
   delete $2;
 }
 |
-LPAREN_TOK STRING_TOK an_fp_sort RPAREN_TOK
+function_param_open STRING_TOK BOOL_TOK RPAREN_TOK
+{
+  $$ = new ASTNode(stp::GlobalParserInterface->CreateSourceSymbol(
+      $2->c_str(), stp::SourceSort::boolean()));
+  stp::GlobalParserInterface->addTemporarySymbol(*$$);
+  delete $2;
+}
+|
+function_param_open STRING_TOK an_fp_sort RPAREN_TOK
 {
   $$ = new ASTNode(stp::GlobalParserInterface->CreateSourceSymbol(
       $2->c_str(),
       stp::SourceSort::floatingPoint($3->exp_bits, $3->sig_bits)));
-  stp::GlobalParserInterface->addSymbol(*$$);
+  stp::GlobalParserInterface->addTemporarySymbol(*$$);
   delete $2;
   delete $3;
 }
 |
-LPAREN_TOK STRING_TOK ROUNDINGMODE_TOK RPAREN_TOK
+function_param_open STRING_TOK ROUNDINGMODE_TOK RPAREN_TOK
 {
   $$ = new ASTNode(stp::GlobalParserInterface->CreateSourceSymbol(
       $2->c_str(), stp::SourceSort::roundingMode()));
-  stp::GlobalParserInterface->addSymbol(*$$);
+  stp::GlobalParserInterface->addTemporarySymbol(*$$);
   delete $2;
-};
+}
+|
+function_param_open STRING_TOK STRING_TOK RPAREN_TOK
+{
+  // A formal whose sort is a name the script introduced. This is how the
+  // uninterpreted-sort benchmarks bind their state parameter:
+  //   (define-fun p ((state S)) Bool ...)
+  stp::SourceSort resolved;
+  if (!stp::GlobalParserInterface->lookupSortAlias(*$3, resolved))
+  {
+    fatal_yyerror("unknown sort (not built in, and not a declared sort)");
+  }
+  $$ = new ASTNode(
+      stp::GlobalParserInterface->CreateSourceSymbol($2->c_str(), resolved));
+  stp::GlobalParserInterface->addTemporarySymbol(*$$);
+  delete $2;
+  delete $3;
+}
 ;
 
 /* Returns a vector of parameters.*/
@@ -1867,8 +2106,16 @@ function_param
   stp::GlobalParserInterface->deleteNode($2);
 };
 
+function_def_name:
+STRING_TOK
+{
+  (void)acceptTopLevelDeclarationName(*$1);
+  $$ = $1;
+}
+;
+
 function_def:
-STRING_TOK LPAREN_TOK function_params RPAREN_TOK LPAREN_TOK UNDERSCORE_TOK BITVEC_TOK NUMERAL_TOK RPAREN_TOK  an_term
+function_def_name LPAREN_TOK function_params RPAREN_TOK LPAREN_TOK UNDERSCORE_TOK BITVEC_TOK NUMERAL_TOK RPAREN_TOK  an_term
 {
   checkBitVectorWidth($8);
   checkBitVectorTerm(*$10);
@@ -1890,7 +2137,58 @@ STRING_TOK LPAREN_TOK function_params RPAREN_TOK LPAREN_TOK UNDERSCORE_TOK BITVE
   stp::GlobalParserInterface->deleteNode($10);
 }
 |
-STRING_TOK LPAREN_TOK function_params RPAREN_TOK BOOL_TOK an_formula
+function_def_name LPAREN_TOK function_params RPAREN_TOK STRING_TOK an_term
+{
+  // A result sort written as a name the script introduced. The body has to
+  // carry that sort already -- nothing is coerced here, exactly as the
+  // floating-point arm below refuses a mismatched format.
+  stp::SourceSort resolved;
+  if (!stp::GlobalParserInterface->lookupSortAlias(*$5, resolved))
+  {
+    fatal_yyerror("unknown sort (not built in, and not a declared sort)");
+  }
+  if ($6->GetSourceSort() != resolved)
+  {
+    fatal_yyerror("define-fun: the body's sort does not match the declared "
+                  "result sort");
+  }
+
+  stp::GlobalParserInterface->storeFunction(*$1, *$3, *$6);
+
+  for (size_t i = 0; i < $3->size(); i++)
+    stp::GlobalParserInterface->removeSymbol((*$3)[i]);
+
+  delete $1;
+  delete $3;
+  delete $5;
+  stp::GlobalParserInterface->deleteNode($6);
+}
+|
+function_def_name LPAREN_TOK RPAREN_TOK STRING_TOK an_term
+{
+  // The zero-arity form of the arm above. It was missing, which is what stopped
+  // a printed model from being read back: the model of a symbol of a declared
+  // sort is exactly a nullary define-fun at that sort.
+  stp::SourceSort resolved;
+  if (!stp::GlobalParserInterface->lookupSortAlias(*$4, resolved))
+  {
+    fatal_yyerror("unknown sort (not built in, and not a declared sort)");
+  }
+  if ($5->GetSourceSort() != resolved)
+  {
+    fatal_yyerror("define-fun: the body's sort does not match the declared "
+                  "result sort");
+  }
+
+  ASTVec empty;
+  stp::GlobalParserInterface->storeFunction(*$1, empty, *$5);
+
+  delete $1;
+  delete $4;
+  stp::GlobalParserInterface->deleteNode($5);
+}
+|
+function_def_name LPAREN_TOK function_params RPAREN_TOK BOOL_TOK an_formula
 {
   stp::GlobalParserInterface->storeFunction(*$1, *$3, *$6);
 
@@ -1903,7 +2201,7 @@ STRING_TOK LPAREN_TOK function_params RPAREN_TOK BOOL_TOK an_formula
   stp::GlobalParserInterface->deleteNode($6);
 }
 |
-STRING_TOK LPAREN_TOK RPAREN_TOK BOOL_TOK an_formula
+function_def_name LPAREN_TOK RPAREN_TOK BOOL_TOK an_formula
 {
   ASTVec empty;
   stp::GlobalParserInterface->storeFunction(*$1, empty, *$5);
@@ -1912,7 +2210,7 @@ STRING_TOK LPAREN_TOK RPAREN_TOK BOOL_TOK an_formula
   stp::GlobalParserInterface->deleteNode($5);
 }
 |
-STRING_TOK LPAREN_TOK RPAREN_TOK ROUNDINGMODE_TOK an_term
+function_def_name LPAREN_TOK RPAREN_TOK ROUNDINGMODE_TOK an_term
 {
   if ($5->GetSourceSort().kind() != stp::SourceSort::Kind::RoundingMode)
   {
@@ -1926,7 +2224,7 @@ STRING_TOK LPAREN_TOK RPAREN_TOK ROUNDINGMODE_TOK an_term
   stp::GlobalParserInterface->deleteNode($5);
 }
 |
-STRING_TOK LPAREN_TOK function_params RPAREN_TOK ROUNDINGMODE_TOK an_term
+function_def_name LPAREN_TOK function_params RPAREN_TOK ROUNDINGMODE_TOK an_term
 {
   if ($6->GetSourceSort().kind() != stp::SourceSort::Kind::RoundingMode)
     fatal_yyerror("define-fun: the body is not a rounding mode");
@@ -1940,7 +2238,7 @@ STRING_TOK LPAREN_TOK function_params RPAREN_TOK ROUNDINGMODE_TOK an_term
   stp::GlobalParserInterface->deleteNode($6);
 }
 |
-STRING_TOK LPAREN_TOK RPAREN_TOK an_fp_sort an_term
+function_def_name LPAREN_TOK RPAREN_TOK an_fp_sort an_term
 {
   if ($5->GetSourceSort() != stp::SourceSort::floatingPoint(
                                   $4->exp_bits, $4->sig_bits))
@@ -1957,7 +2255,7 @@ STRING_TOK LPAREN_TOK RPAREN_TOK an_fp_sort an_term
   stp::GlobalParserInterface->deleteNode($5);
 }
 |
-STRING_TOK LPAREN_TOK function_params RPAREN_TOK an_fp_sort an_term
+function_def_name LPAREN_TOK function_params RPAREN_TOK an_fp_sort an_term
 {
   // This action was empty: the function was silently dropped, and -- worse --
   // its parameter symbols stayed interned, resolvable as free variables that
@@ -1981,7 +2279,7 @@ STRING_TOK LPAREN_TOK function_params RPAREN_TOK an_fp_sort an_term
   stp::GlobalParserInterface->deleteNode($6);
 }
 |
-STRING_TOK LPAREN_TOK RPAREN_TOK LPAREN_TOK UNDERSCORE_TOK BITVEC_TOK NUMERAL_TOK RPAREN_TOK an_term
+function_def_name LPAREN_TOK RPAREN_TOK LPAREN_TOK UNDERSCORE_TOK BITVEC_TOK NUMERAL_TOK RPAREN_TOK an_term
 {
   checkBitVectorWidth($7);
   checkBitVectorTerm(*$9);
@@ -1999,7 +2297,7 @@ STRING_TOK LPAREN_TOK RPAREN_TOK LPAREN_TOK UNDERSCORE_TOK BITVEC_TOK NUMERAL_TO
   stp::GlobalParserInterface->deleteNode($9);
 }
 |
-STRING_TOK LPAREN_TOK function_params RPAREN_TOK an_array_sort an_term
+function_def_name LPAREN_TOK function_params RPAREN_TOK an_array_sort an_term
 {
   stp::GlobalParserInterface->unsupported();
 
@@ -2015,7 +2313,7 @@ STRING_TOK LPAREN_TOK function_params RPAREN_TOK an_array_sort an_term
   stp::GlobalParserInterface->deleteNode($6);
 }
 |
-STRING_TOK LPAREN_TOK RPAREN_TOK an_array_sort an_term
+function_def_name LPAREN_TOK RPAREN_TOK an_array_sort an_term
 {
   // A nullary define-fun whose result is an array. This is just a name for
   // its body, stored like any other nullary function -- accepted with or
@@ -2189,37 +2487,32 @@ LPAREN_TOK ARRAY_TOK an_array_sort_component an_array_sort_component RPAREN_TOK
 var_decl:
 STRING_TOK LPAREN_TOK RPAREN_TOK LPAREN_TOK UNDERSCORE_TOK BITVEC_TOK NUMERAL_TOK RPAREN_TOK
 {
+  ABANDON_IF_REDECLARED_ZERO_ARITY(delete $1);
   checkBitVectorWidth($7);
-  ASTNode s = stp::GlobalParserInterface->CreateSourceSymbol(
-      $1->c_str(), stp::SourceSort::bitVector($7));
-  stp::GlobalParserInterface->addSymbol(s);
-  delete $1;
+  declareScalarSymbol($1, stp::SourceSort::bitVector($7));
 }
 | STRING_TOK LPAREN_TOK RPAREN_TOK STRING_TOK
 {
-  // The sort position holds a bare name: a define-sort alias. (This used to
-  // match any TERM symbol, so `(declare-fun y () x)` with x a variable
-  // "worked" as an alias use.)
-  unsigned eb, sb;
-  if (!stp::GlobalParserInterface->lookupSortAlias(*$4, eb, sb))
+  ABANDON_IF_REDECLARED_ZERO_ARITY((delete $1, delete $4));
+  // The sort position holds a bare name: a sort the script introduced, by
+  // define-sort or declare-sort. (This used to match any TERM symbol, so
+  // `(declare-fun y () x)` with x a variable "worked" as an alias use.)
+  stp::SourceSort resolved;
+  if (!stp::GlobalParserInterface->lookupSortAlias(*$4, resolved))
   {
-    fatal_yyerror("unknown sort (not built in, and not a define-sort alias)");
+    fatal_yyerror("unknown sort (not built in, and not a declared sort)");
   }
-  ASTNode s = stp::GlobalParserInterface->CreateSourceSymbol(
-      $1->c_str(), stp::SourceSort::floatingPoint(eb, sb));
-  stp::GlobalParserInterface->addSymbol(s);
-  delete $1;
+  declareScalarSymbol($1, resolved);
   delete $4;
 }
 | STRING_TOK LPAREN_TOK RPAREN_TOK BOOL_TOK
 {
-  ASTNode s = stp::GlobalParserInterface->CreateSourceSymbol(
-      $1->c_str(), stp::SourceSort::boolean());
-  stp::GlobalParserInterface->addSymbol(s);
-  delete $1;
+  ABANDON_IF_REDECLARED_ZERO_ARITY(delete $1);
+  declareScalarSymbol($1, stp::SourceSort::boolean());
 }
 | STRING_TOK LPAREN_TOK RPAREN_TOK an_array_sort
 {
+  ABANDON_IF_REDECLARED_ZERO_ARITY((delete $1, delete $4));
   // An array over any pairing of bitvector, floating-point and RoundingMode
   // index/element sorts. A float element's format lives on the array node
   // -- a read off it inherits the format (see deriveFPFormat) -- while a
@@ -2230,24 +2523,205 @@ STRING_TOK LPAREN_TOK RPAREN_TOK LPAREN_TOK UNDERSCORE_TOK BITVEC_TOK NUMERAL_TO
 }
 | STRING_TOK LPAREN_TOK RPAREN_TOK an_fp_sort
 {
-  ASTNode s = stp::GlobalParserInterface->CreateSourceSymbol(
-      $1->c_str(), stp::SourceSort::floatingPoint($4->exp_bits,
-                                                   $4->sig_bits));
-  stp::GlobalParserInterface->addSymbol(s);
-  delete $1;
+  ABANDON_IF_REDECLARED_ZERO_ARITY((delete $1, delete $4));
+  declareScalarSymbol(
+      $1, stp::SourceSort::floatingPoint($4->exp_bits, $4->sig_bits));
   delete $4;
 }
 | STRING_TOK LPAREN_TOK RPAREN_TOK ROUNDINGMODE_TOK
 {
+  ABANDON_IF_REDECLARED_ZERO_ARITY(delete $1);
   // A rounding mode is carried as a 5-bit one-hot bitvector, so a variable of
   // that sort is a 5-bit symbol. Declaring it as anything else -- or, as
   // before, not declaring it at all -- leaves every use of the name
   // unresolved, and the lexer hands it back as a bare string.
   // addRoundingModeSymbol also pins the symbol to the five legal encodings,
   // without which the sort would have 32 values instead of 5.
-  ASTNode s = stp::GlobalParserInterface->CreateSourceSymbol(
-      $1->c_str(), stp::SourceSort::roundingMode());
-  stp::GlobalParserInterface->addRoundingModeSymbol(s);
+  declareScalarSymbol($1, stp::SourceSort::roundingMode(), true);
+}
+| uf_decl_name uf_domain_sorts RPAREN_TOK uf_codomain_sort
+{
+  bool valid = true;
+  std::vector<stp::SourceSort> domain;
+  domain.reserve($2->size());
+  for (size_t i = 0; i < $2->size(); ++i)
+  {
+    const stp::parsed_uf_sort& parsed = (*$2)[i];
+    if (!parsed.supported)
+    {
+      if (valid)
+        stp::GlobalParserInterface->rejectCurrentCommand(
+            unsupportedUFDomainSort(*$1, parsed, i));
+      valid = false;
+      continue;
+    }
+    domain.push_back(parsed.sort);
+  }
+  if (!$4->supported)
+  {
+    if (valid)
+      stp::GlobalParserInterface->rejectCurrentCommand(
+          unsupportedUFResultSort(*$1, *$4));
+    valid = false;
+  }
+  if (valid)
+  {
+    std::string diagnostic;
+    const stp::UFDecl* declaration =
+        stp::GlobalParserInterface->declareScopedUninterpretedFunction(
+            *$1, domain, $4->sort, &diagnostic);
+    if (declaration == NULL)
+      stp::GlobalParserInterface->rejectCurrentCommand(diagnostic);
+  }
+  delete $1;
+  delete $2;
+  delete $4;
+}
+;
+
+// A nonempty domain distinguishes a UF declaration from the existing
+// zero-arity symbol productions. The action runs only after the next token
+// has selected this branch, so feature-off reports the pinned legacy error at
+// the first domain sort and abandons the remainder of the script.
+uf_decl_name:
+STRING_TOK LPAREN_TOK
+{
+  if (!stp::GlobalParserInterface->getUserFlags()
+           .enable_uninterpreted_functions)
+  {
+    // The first domain token selected this branch, and the legacy grammar
+    // rejected the declaration at that token. Use Bison's generated symbol
+    // table so the diagnostic retains the exact token name. yytname and
+    // YYTRANSLATE are available throughout STP's supported Bison range;
+    // yysymbol_name and the prefixed empty-token enum are newer additions.
+    std::string message = "syntax error, unexpected ";
+    message += yychar < 0 ? "end of file" : yytname[YYTRANSLATE(yychar)];
+    message += ", expecting RPAREN_TOK";
+    yyerror(message.c_str());
+    delete $1;
+    YYABORT;
+  }
+  // The first domain token proves this declaration is nonzero-arity: the
+  // only shape that continues into the nonfatal UF declaration funnel over
+  // a known name. Retire the lexer's record of the classification the name
+  // would have carried; the funnel reports collisions itself.
+  stp::SMT2ConsumeDeclassifiedName();
+  $$ = $1;
+}
+;
+
+uf_domain_sorts:
+uf_sort
+{
+  $$ = new std::vector<stp::parsed_uf_sort>();
+  $$->push_back(std::move(*$1));
+  delete $1;
+}
+| uf_domain_sorts uf_sort
+{
+  $1->push_back(std::move(*$2));
+  delete $2;
+  $$ = $1;
+}
+;
+
+uf_sort:
+LPAREN_TOK UNDERSCORE_TOK BITVEC_TOK NUMERAL_TOK RPAREN_TOK
+{
+  if ($4 == 0)
+    $$ = new stp::parsed_uf_sort(stp::SourceSort::unknown(),
+                                 "(_ BitVec 0)", false);
+  else
+  {
+    const stp::SourceSort sort = stp::SourceSort::bitVector($4);
+    $$ = new stp::parsed_uf_sort(
+        sort, stp::sourceSortToSMTLib(sort), true);
+  }
+}
+| BOOL_TOK
+{
+  $$ = new stp::parsed_uf_sort(stp::SourceSort::boolean(), "Bool", true);
+}
+| an_array_sort
+{
+  const stp::SourceSort sort = $1->sourceSort();
+  $$ = new stp::parsed_uf_sort(
+      sort, stp::sourceSortToSMTLib(sort), false);
+  delete $1;
+}
+| an_fp_sort
+{
+  const stp::SourceSort sort =
+      stp::SourceSort::floatingPoint($1->exp_bits, $1->sig_bits);
+  $$ = new stp::parsed_uf_sort(
+      sort, stp::sourceSortToSMTLib(sort), true);
+  delete $1;
+}
+| ROUNDINGMODE_TOK
+{
+  $$ = new stp::parsed_uf_sort(
+      stp::SourceSort::roundingMode(), "RoundingMode", true);
+}
+| STRING_TOK
+{
+  // A bare name in a signature: a sort the script introduced, by declare-sort
+  // or by define-sort. Anything else is genuinely unknown and is reported
+  // with its spelling by the caller.
+  stp::SourceSort resolved;
+  if (stp::GlobalParserInterface->lookupSortAlias(*$1, resolved))
+    $$ = new stp::parsed_uf_sort(resolved, *$1, true);
+  else
+    $$ = new stp::parsed_uf_sort(
+        stp::SourceSort::unknown(), *$1, false, false);
+  delete $1;
+}
+;
+
+uf_codomain_sort:
+LPAREN_TOK UNDERSCORE_TOK BITVEC_TOK NUMERAL_TOK RPAREN_TOK
+{
+  if ($4 == 0)
+    $$ = new stp::parsed_uf_sort(stp::SourceSort::unknown(),
+                                 "(_ BitVec 0)", false);
+  else
+  {
+    const stp::SourceSort sort = stp::SourceSort::bitVector($4);
+    $$ = new stp::parsed_uf_sort(
+        sort, stp::sourceSortToSMTLib(sort), true);
+  }
+}
+| BOOL_TOK
+{
+  $$ = new stp::parsed_uf_sort(stp::SourceSort::boolean(), "Bool", true);
+}
+| an_array_sort
+{
+  const stp::SourceSort sort = $1->sourceSort();
+  $$ = new stp::parsed_uf_sort(
+      sort, stp::sourceSortToSMTLib(sort), false);
+  delete $1;
+}
+| an_fp_sort
+{
+  const stp::SourceSort sort =
+      stp::SourceSort::floatingPoint($1->exp_bits, $1->sig_bits);
+  $$ = new stp::parsed_uf_sort(
+      sort, stp::sourceSortToSMTLib(sort), true);
+  delete $1;
+}
+| ROUNDINGMODE_TOK
+{
+  $$ = new stp::parsed_uf_sort(
+      stp::SourceSort::roundingMode(), "RoundingMode", true);
+}
+| STRING_TOK
+{
+  stp::SourceSort resolved;
+  if (stp::GlobalParserInterface->lookupSortAlias(*$1, resolved))
+    $$ = new stp::parsed_uf_sort(resolved, *$1, true);
+  else
+    $$ = new stp::parsed_uf_sort(
+        stp::SourceSort::unknown(), *$1, false, false);
   delete $1;
 }
 ;
@@ -2256,17 +2730,11 @@ const_decl:
 STRING_TOK  LPAREN_TOK UNDERSCORE_TOK BITVEC_TOK NUMERAL_TOK RPAREN_TOK
 {
   checkBitVectorWidth($5);
-  ASTNode s = stp::GlobalParserInterface->CreateSourceSymbol(
-      $1->c_str(), stp::SourceSort::bitVector($5));
-  stp::GlobalParserInterface->addSymbol(s);
-  delete $1;
+  declareScalarSymbol($1, stp::SourceSort::bitVector($5));
 }
 | STRING_TOK BOOL_TOK
 {
-  ASTNode s = stp::GlobalParserInterface->CreateSourceSymbol(
-      $1->c_str(), stp::SourceSort::boolean());
-  stp::GlobalParserInterface->addSymbol(s);
-  delete $1;
+  declareScalarSymbol($1, stp::SourceSort::boolean());
 }
 | STRING_TOK an_array_sort
 {
@@ -2280,35 +2748,26 @@ STRING_TOK  LPAREN_TOK UNDERSCORE_TOK BITVEC_TOK NUMERAL_TOK RPAREN_TOK
   // The format must land on the symbol, or it types as a Boolean and every
   // use of the name is a syntax error (this branch used to forget it while
   // declare-fun's twin set it).
-  ASTNode s = stp::GlobalParserInterface->CreateSourceSymbol(
-      $1->c_str(), stp::SourceSort::floatingPoint($2->exp_bits,
-                                                   $2->sig_bits));
-  stp::GlobalParserInterface->addSymbol(s);
-  delete $1;
+  declareScalarSymbol(
+      $1, stp::SourceSort::floatingPoint($2->exp_bits, $2->sig_bits));
   delete $2;
 }
 | STRING_TOK STRING_TOK
 {
-  // declare-const with a define-sort alias in sort position.
-  unsigned eb, sb;
-  if (!stp::GlobalParserInterface->lookupSortAlias(*$2, eb, sb))
+  // declare-const with a script-introduced sort name in sort position.
+  stp::SourceSort resolved;
+  if (!stp::GlobalParserInterface->lookupSortAlias(*$2, resolved))
   {
-    fatal_yyerror("unknown sort (not built in, and not a define-sort alias)");
+    fatal_yyerror("unknown sort (not built in, and not a declared sort)");
   }
-  ASTNode s = stp::GlobalParserInterface->CreateSourceSymbol(
-      $1->c_str(), stp::SourceSort::floatingPoint(eb, sb));
-  stp::GlobalParserInterface->addSymbol(s);
-  delete $1;
+  declareScalarSymbol($1, resolved);
   delete $2;
 }
 | STRING_TOK ROUNDINGMODE_TOK
 {
   // As above: 5 bits, not 0 (a zero-width symbol would be a Boolean), and
   // pinned to the five legal encodings.
-  ASTNode s = stp::GlobalParserInterface->CreateSourceSymbol(
-      $1->c_str(), stp::SourceSort::roundingMode());
-  stp::GlobalParserInterface->addRoundingModeSymbol(s);
-  delete $1;
+  declareScalarSymbol($1, stp::SourceSort::roundingMode(), true);
 }
 ;
 
@@ -2695,6 +3154,14 @@ FORMID_TOK
 {
   $$ = stp::GlobalParserInterface->newNode(stp::GlobalParserInterface->applyFunction(*$2,*$3));
   delete $3;
+}
+| LPAREN_TOK UF_BOOL_FUNCTIONID_TOK an_mixed RPAREN_TOK
+{
+  $$ = applyParsedUF($2, $3);
+}
+| LPAREN_TOK UF_BOOL_FUNCTIONID_TOK RPAREN_TOK
+{
+  $$ = applyParsedUF($2, new ASTVec());
 }
 | BOOLEAN_FUNCTIONID_TOK
 {
@@ -3372,6 +3839,14 @@ TERMID_TOK
 
   delete $3;
 }
+| LPAREN_TOK UF_BV_FUNCTIONID_TOK an_mixed RPAREN_TOK
+{
+  $$ = applyParsedUF($2, $3);
+}
+| LPAREN_TOK UF_BV_FUNCTIONID_TOK RPAREN_TOK
+{
+  $$ = applyParsedUF($2, new ASTVec());
+}
 | LPAREN_TOK FLOATINGPOINT_FUNCTIONID_TOK an_mixed RPAREN_TOK
 {
   $$ = stp::GlobalParserInterface->newNode(stp::GlobalParserInterface->applyFunction(*$2,*$3));
@@ -3442,12 +3917,45 @@ TERMID_TOK
 
 %%
 
+// The pinned response to `(declare-fun name ...)` over an already-known
+// name in every shape but the nonzero-arity one: exactly the syntax error
+// bison raised when the lexer classified the name into a typed token that
+// no var_decl alternative accepts -- same message, same token-kind name
+// (from the parser's own symbol table, so it tracks the grammar), same
+// token text as recorded by the lexer at the name -- through the same
+// rejection path an ordinary syntax error takes. The caller abandons the
+// parse. Defined after the grammar because yytname and YYTRANSLATE live in
+// the generated parser body.
+void reportRedeclaredName()
+{
+  std::ostringstream o;
+  o << "syntax error: line " << stp::SMT2DeclassifiedNameLine()
+    << " syntax error, unexpected "
+    << yytname[YYTRANSLATE(stp::SMT2DeclassifiedNameToken())]
+    << ", expecting STRING_TOK  token: " << stp::SMT2DeclassifiedNameText();
+  stp::SMT2ConsumeDeclassifiedName();
+  stp::GlobalParserInterface->rejectCurrentCommand(o.str());
+}
+
 namespace stp {
   int SMT2Parse() {
     GlobalParserInterface->letMgr->frameMode = true;
     // Each SMT2Parse is one script: the floating-point keywords start
     // disabled and turn on at an FP set-logic.
     SMT2SetFloatTokens(false);
-    return smt2parse();
+    SMT2ResetCommandLexerState();
+    int result;
+    try
+    {
+      result = smt2parse();
+    }
+    catch (const stp::DeclassifiedNameAbandon&)
+    {
+      result = 1;
+    }
+    if (result != 0)
+      GlobalParserInterface->abortCurrentCommand();
+    SMT2ResetCommandLexerState();
+    return result;
   }
 }

--- a/lib/Printer/SMTLIBPrinter.cpp
+++ b/lib/Printer/SMTLIBPrinter.cpp
@@ -24,6 +24,8 @@ THE SOFTWARE.
 
 #include "stp/Printer/SMTLIBPrinter.h"
 #include "stp/Printer/printers.h"
+#include "stp/STPManager/STPManager.h"
+#include "stp/UninterpretedFunctions/UFContext.h"
 #include <cassert>
 
 // Functions shared between the printers: the letize pass used by all of
@@ -126,6 +128,24 @@ void SMTLIB_Print1(ostream& os, const ASTNode n, int indentation, bool letize)
       n.nodeprint(os);
       os << "|";
       break;
+    case UF_APPLY:
+    {
+      STPMgr* manager = n.GetNodeManager();
+      UFContext* context =
+          manager == NULL ? NULL : manager->getUFContextIfAny();
+      const UFDecl* declaration =
+          context == NULL || c.empty() ? NULL : context->lookupIdentity(c[0]);
+      if (declaration == NULL)
+        FatalError("cannot print an unregistered UF_APPLY", n);
+      os << "(|" << declaration->name() << '|';
+      for (size_t i = 1; i < c.size(); ++i)
+      {
+        os << ' ';
+        SMTLIB_Print1(os, c[i], 0, letize);
+      }
+      os << ')';
+      break;
+    }
     case FALSE:
       os << "false";
       break;

--- a/lib/STPManager/STP.cpp
+++ b/lib/STPManager/STP.cpp
@@ -980,9 +980,6 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
       return res;
     }
 
-    // Refinement reached no decision but the soft timeout has expired:
-    // report the timeout instead of iterating further (or falling into
-    // the fatal error below when nothing more is pending).
     if (bm->soft_timeout_expired)
     {
       if (toSATAIG.cbIsDestructed())

--- a/lib/STPManager/STP.cpp
+++ b/lib/STPManager/STP.cpp
@@ -24,6 +24,9 @@ THE SOFTWARE.
 
 #include "stp/STPManager/STP.h"
 #include "stp/Extensionality/ExtensionalityContext.h"
+#include "stp/UninterpretedFunctions/UFContext.h"
+#include "stp/UninterpretedFunctions/UFLowering.h"
+#include "stp/UninterpretedFunctions/UFRefinement.h"
 #include "stp/Incremental/IncrementalSolver.h"
 #include "stp/Simplifier/constantBitP/ConstantBitPropagation.h"
 #include "stp/Simplifier/constantBitP/NodeToFixedBitsMap.h"
@@ -61,6 +64,57 @@ const static string size_inc_message = "After Speculative Simplifications. ";
 const static string pe_message = "After Propagating Equalities. ";
 const static string domain_message = "After Domain Analysis. ";
 const static string se_message = "After Split Extracts. ";
+
+STP::STP(STPMgr* b)
+{
+  bm = b;
+  substitutionMap = new stp::SubstitutionMap(bm);
+  simp = new Simplifier(bm, substitutionMap);
+  arrayTransformer = new ArrayTransformer(bm, simp);
+  Ctr_Example = new AbsRefine_CounterExample(bm, simp, arrayTransformer);
+  batchUFView.reset(new LoweredApplicationView());
+  batchUFAdapter.reset(new UFBatchAdapter(bm));
+  tosat = new ToSATAIG(bm, arrayTransformer);
+}
+
+STP::~STP()
+{
+  ClearAllTables();
+  deleteObjects();
+}
+
+const LoweredApplicationView& STP::lastBatchUFView() const
+{
+  return *batchUFView;
+}
+
+void STP::ClearAllTables(void)
+{
+  // The counterexample goes with them, so there is no longer a model to read.
+  // Whoever decides the next query says so again.
+  queryAnswered = false;
+
+  if (simp != NULL)
+    simp->ClearAllTables();
+  if (arrayTransformer != NULL)
+    arrayTransformer->ClearAllTables();
+  if (tosat != NULL)
+    tosat->ClearAllTables();
+  if (Ctr_Example != NULL)
+  {
+    Ctr_Example->ClearAllTables();
+    Ctr_Example->setFpEncodingContext(NULL);
+  }
+  fpEncodingContext.reset();
+  *batchUFView = LoweredApplicationView();
+  if (batchUFAdapter)
+    batchUFAdapter->clear();
+  if (Ctr_Example != NULL)
+    Ctr_Example->setUFTheoryAdapter(NULL);
+  if (bm != NULL && bm->getUFContextIfAny() != NULL)
+    bm->getUFContextIfAny()->releaseSolveProtection();
+  // bm->ClearAllTables();
+}
 
 SOLVER_RETURN_TYPE STP::solve_by_sat_solver(SATSolver* newS,
                                             ASTNode original_input,
@@ -107,6 +161,11 @@ SATSolver* STP::get_new_sat_solver()
 SOLVER_RETURN_TYPE STP::TopLevelSTP(const ASTNode& inputasserts,
                                     const ASTNode& query)
 {
+  // Candidate construction is an implementation requirement; publication is
+  // a caller permission. TopLevelSTPAux may force construction for array/UF
+  // refinement, but nothing after this solve may interpret that as an SMT-LIB
+  // get-model/get-value request.
+  const bool constructForCaller = bm->UserFlags.callerRequestedModel();
 
   // One encoding context per actual solve. Keep it after this function
   // returns so counterexample/get-value requests reuse the exact mappings
@@ -146,6 +205,30 @@ SOLVER_RETURN_TYPE STP::TopLevelSTP(const ASTNode& inputasserts,
                 << std::endl;
   }
 
+  // Durable UF nodes stay visible through frontend substitution and query
+  // assembly. This is their one batch lowering boundary: before FP
+  // totalisation, opaque array equality, or any ordinary preprocessor. Keep
+  // the submitted root in batchUFView and pass only its semantic replacement
+  // plus query-local naming definitions onward.
+  *batchUFView = LoweredApplicationView();
+  if (bm->UserFlags.enable_uninterpreted_functions)
+  {
+    UFLowering lowerer(bm);
+    *batchUFView = lowerer.lowerCompletedRoot(
+        original_input, UFSolveScope::batch(++batchUFScopeGeneration));
+    original_input = batchUFView->semanticRootWithDefinitions(bm);
+    if (containsKind(original_input, UF_APPLY))
+      FatalError("UF_APPLY crossed the batch completed-root lowering barrier",
+                 original_input);
+  }
+  else if (bm->getUFContextIfAny() != NULL)
+    bm->getUFContextIfAny()->releaseSolveProtection();
+
+  batchUFAdapter->beginQuery(batchUFView.get());
+  Ctr_Example->setUFTheoryAdapter(batchUFView->active()
+                                      ? batchUFAdapter.get()
+                                      : NULL);
+
   // The latch is the same kind of cheap fast-negative the lowering test below
   // uses, widened to cover RoundingMode -- which carries no format, so it
   // never reaches noteFloatingPoint, and which is exactly why this test could
@@ -174,6 +257,7 @@ SOLVER_RETURN_TYPE STP::TopLevelSTP(const ASTNode& inputasserts,
       solve_by_sat_solver(newS, original_input, arrayEqualityRewrites);
   delete newS;
 
+  bm->UserFlags.construct_counterexample_flag = constructForCaller;
   bm->UserFlags.ackermannisation = saved_ack;
   return result;
 }
@@ -280,6 +364,18 @@ SOLVER_RETURN_TYPE
 STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
                     const ASTNodeMap& arrayEqualityRewrites)
 {
+  if (bm->UserFlags.enable_uninterpreted_functions &&
+      containsKind(original_input, UF_APPLY))
+    FatalError("UF_APPLY reached ordinary batch preprocessing",
+               original_input);
+
+  // Lowering has installed the current view's protected/registered scalars.
+  // Activate them for exactly the preprocessing, SAT and refinement window;
+  // retained batch model data remains readable after this scope closes.
+  UFContext* ufSolveContext =
+      batchUFView->active() ? bm->getUFContextIfAny() : NULL;
+  UFContext::SolveScope ufSolveScope(ufSolveContext);
+
   // ARRAY_EQ remains a normal, traversable AST node through query assembly
   // and macro/function substitution. Lower it only now, at the complete-query
   // boundary and before any ordinary simplifier or array transform runs.
@@ -451,7 +547,8 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
   // candidate model cannot leave construction switched on for the rest of
   // the session.
   bm->UserFlags.construct_counterexample_flag =
-      bm->UserFlags.modelConstructionRequired(arrayops && !removed);
+      bm->UserFlags.modelConstructionRequired(
+          (arrayops && !removed) || batchUFView->active());
 
   if (bm->UserFlags.enable_flatten)
   {
@@ -588,12 +685,16 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
           // These replacements are not recorded in the solver map, so
           // a symbol the array-equality procedure depends on must not
           // be replaced away.
-          if (extActive)
+          UFContext* ufContext = bm->getUFContextIfAny();
+          if (extActive ||
+              (ufContext != NULL && ufContext->activeInSolve()))
             for (ASTNodeMap::iterator cit = constants.begin();
                  cit != constants.end();)
             {
               if (cit->first.GetKind() == SYMBOL &&
-                  ext->isProtected(cit->first))
+                  ((extActive && ext->isProtected(cit->first)) ||
+                   (ufContext != NULL &&
+                    ufContext->isProtected(cit->first))))
                 cit = constants.erase(cit);
               else
                 ++cit;
@@ -836,7 +937,8 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
   // array operation in it.
   const bool maybeRefinement = (arrayops && !bm->UserFlags.ackermannisation) ||
                                bm->UserFlags.bv_eq_abstraction ||
-                               bm->UserFlags.bv_term_abstraction;
+                               bm->UserFlags.bv_term_abstraction ||
+                               batchUFView->active();
 
   simplifier::constantBitP::ConstantBitPropagation* cb = NULL;
   std::unique_ptr<simplifier::constantBitP::ConstantBitPropagation> cleaner;
@@ -909,13 +1011,14 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
     return res;
   }
 
-  // An undecided result belongs to an active array or bit-vector
-  // abstraction refinement owner.
+  // An undecided result belongs to an active array, bit-vector abstraction
+  // or UF refinement owner.
   assert(arrayops || toSATAIG.hasBVEQAbstractions() ||
-         toSATAIG.hasBVTermAbstractions());
-  // Refinement must be enabled too.
+         toSATAIG.hasBVTermAbstractions() || batchUFView->active());
+  // Refinement must be enabled too, unless an abstraction or UF owns the
+  // round.
   assert(toSATAIG.hasBVEQAbstractions() || toSATAIG.hasBVTermAbstractions() ||
-         !bm->UserFlags.ackermannisation);
+         batchUFView->active() || !bm->UserFlags.ackermannisation);
 
   // Refinement driver. Every owner that retained a candidate-blocking
   // lemma is drained before the next solve, rather than the first one
@@ -943,8 +1046,9 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
     if (extActive)
     {
       // An undecided candidate the abstraction did not account for is
-      // still the checker's, and it still owes a lemma for it.
-      if (!progress && !ext->hasPendingLemma())
+      // still a checker's, and one of them still owes a lemma for it.
+      if (!progress && !ext->hasPendingLemma() &&
+          !(batchUFView->active() && batchUFAdapter->hasPendingLemma()))
         FatalError("array-equality: an active refinement round has neither "
                    "a decision nor a pending theory lemma");
       if (ext->hasPendingLemma())
@@ -952,6 +1056,11 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
         ext->encodePendingLemmas(NewSolver, satBase);
         progress = true;
       }
+    }
+    if (batchUFView->active() && batchUFAdapter->hasPendingLemma())
+    {
+      batchUFAdapter->encodePendingLemmas(NewSolver, satBase);
+      progress = true;
     }
 
     if (progress)
@@ -988,7 +1097,7 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
     }
 
     if (!toSATAIG.hasBVEQAbstractions() && !toSATAIG.hasBVTermAbstractions() &&
-        !extActive)
+        !extActive && !batchUFView->active())
       break;
   }
 

--- a/lib/STPManager/STPManager.cpp
+++ b/lib/STPManager/STPManager.cpp
@@ -25,6 +25,7 @@ THE SOFTWARE.
 // to get the PRIu64 macro from inttypes, this needs to be defined.
 #include "stp/STPManager/STPManager.h"
 #include "stp/Extensionality/ExtensionalityContext.h"
+#include "stp/UninterpretedFunctions/UFContext.h"
 #include "stp/FloatBlaster/rounding_modes.h"
 #include "stp/Printer/SMTLIBPrinter.h"
 #include "stp/Util/CBVOps.h"
@@ -892,12 +893,22 @@ ExtensionalityContext* STPMgr::getExtensionality()
   return extensionality;
 }
 
+UFContext* STPMgr::getUFContext()
+{
+  if (uninterpretedFunctions == NULL)
+    uninterpretedFunctions = new UFContext(this);
+  return uninterpretedFunctions;
+}
+
 STPMgr::~STPMgr()
 {
   ClearAllTables();
 
   delete extensionality;
   extensionality = NULL;
+
+  delete uninterpretedFunctions;
+  uninterpretedFunctions = NULL;
 
   printer::NodeLetVarMap.clear();
   printer::NodeLetVarVec.clear();

--- a/lib/STPManager/STPManager.cpp
+++ b/lib/STPManager/STPManager.cpp
@@ -168,6 +168,44 @@ ASTNode STPMgr::introducedSymbol(const std::string& name,
   return symbol;
 }
 
+ASTNode STPMgr::CreateDeterministicSourceVariable(
+    const SourceSort& sourceSort, const std::string& prefix,
+    const ASTNode& key)
+{
+  // Bool, or any scalar sort with a carrier to blast: BitVec, RoundingMode
+  // and FloatingPoint all answer packedWidth(). A symbol whose sort needs a
+  // side condition to denote (RoundingMode is one-hot in five of thirty-two
+  // patterns) is still created here; asserting that condition belongs to
+  // whoever introduces the symbol, not to the factory.
+  if (!(sourceSort.kind() == SourceSort::Kind::Bool ||
+        (sourceSort.isScalar() && sourceSort.packedWidth() > 0)))
+    FatalError("CreateDeterministicSourceVariable requires Bool or a "
+               "nonzero-width scalar source sort");
+  if (key.IsNull() || !key.IsOwnedBy(this))
+    FatalError("CreateDeterministicSourceVariable requires a live local key");
+
+  std::ostringstream name;
+  name << '@' << prefix << "_k" << key.GetNodeNum();
+  const std::map<std::string, ASTNode>::const_iterator found =
+      _introduced_by_name.find(name.str());
+  if (found != _introduced_by_name.end())
+  {
+    if (found->second.GetSourceSort() != sourceSort)
+      FatalError("a deterministic introduced symbol was requested at two "
+                 "different source sorts",
+                 found->second);
+    return found->second;
+  }
+
+  if (LookupSymbol(name.str().c_str()))
+    FatalError("a symbol in STP's reserved deterministic namespace already "
+               "exists");
+  const ASTNode symbol = CreateSourceSymbol(name.str().c_str(), sourceSort);
+  noteIntroducedSymbol(symbol);
+  _introduced_by_name[name.str()] = symbol;
+  return symbol;
+}
+
 void STPMgr::indexSymbolName(ASTSymbol* symbol)
 {
   _symbol_name_index[symbol->GetName()].push_back(symbol);

--- a/lib/Simplifier/RemoveUnconstrained.cpp
+++ b/lib/Simplifier/RemoveUnconstrained.cpp
@@ -58,6 +58,7 @@ THE SOFTWARE.
 #include "stp/Simplifier/RemoveUnconstrained.h"
 #include "stp/AST/MutableASTNode.h"
 #include "stp/Extensionality/ExtensionalityContext.h"
+#include "stp/UninterpretedFunctions/UFContext.h"
 #include "stp/FloatBlaster/FloatBlaster.h"
 #include "stp/FloatBlaster/rounding_modes.h"
 #include "stp/Simplifier/AchievableImage.h"
@@ -93,12 +94,17 @@ ASTNode RemoveUnconstrained::topLevel(const ASTNode& n, Simplifier* simplifier,
   arrayRules = (ext == NULL || !ext->activeInSolve());
   const std::set<ASTNode>* extSet =
       (ext != NULL && ext->activeInSolve()) ? &ext->getFrozenSymbols() : NULL;
+  UFContext* uf = bm.getUFContextIfAny();
+  const ASTNodeSet* ufSet =
+      (uf != NULL && uf->activeInSolve()) ? &uf->getProtectedSymbols() : NULL;
   std::set<ASTNode> mergedUntouchable;
   const std::set<ASTNode>* effective = NULL;
-  if (extSet != NULL || alsoUntouchable != NULL)
+  if (extSet != NULL || ufSet != NULL || alsoUntouchable != NULL)
   {
     if (extSet != NULL)
       mergedUntouchable.insert(extSet->begin(), extSet->end());
+    if (ufSet != NULL)
+      mergedUntouchable.insert(ufSet->begin(), ufSet->end());
     if (alsoUntouchable != NULL)
       mergedUntouchable.insert(alsoUntouchable->begin(),
                                alsoUntouchable->end());

--- a/lib/Simplifier/RemoveUnconstrained.cpp
+++ b/lib/Simplifier/RemoveUnconstrained.cpp
@@ -95,15 +95,15 @@ ASTNode RemoveUnconstrained::topLevel(const ASTNode& n, Simplifier* simplifier,
       (ext != NULL && ext->activeInSolve()) ? &ext->getFrozenSymbols() : NULL;
   std::set<ASTNode> mergedUntouchable;
   const std::set<ASTNode>* effective = NULL;
-  if (extSet != NULL && alsoUntouchable != NULL)
+  if (extSet != NULL || alsoUntouchable != NULL)
   {
-    mergedUntouchable = *extSet;
-    mergedUntouchable.insert(alsoUntouchable->begin(),
-                             alsoUntouchable->end());
+    if (extSet != NULL)
+      mergedUntouchable.insert(extSet->begin(), extSet->end());
+    if (alsoUntouchable != NULL)
+      mergedUntouchable.insert(alsoUntouchable->begin(),
+                               alsoUntouchable->end());
     effective = &mergedUntouchable;
   }
-  else
-    effective = (extSet != NULL) ? extSet : alsoUntouchable;
   MutableASTNode::UntouchableScope protect(effective);
 
   bm.GetRunTimes()->start(RunTimes::RemoveUnconstrained);
@@ -217,7 +217,7 @@ void RemoveUnconstrained::replace(const ASTNode& from, const ASTNode to)
   if (simplifier->UpdateSubstitutionMapFewChecks(from, to))
     return;
 
-  // Refused (only SubstitutionMap::extensionalityProtected refuses).
+  // Refused (only SubstitutionMap::theoryProtected refuses).
   // The caller has already rewritten the graph to remove whatever
   // constrained "from", so dropping the definition here would leave it
   // free. Keep it as an ordinary conjunct instead; topLevel() attaches

--- a/lib/Simplifier/SubstitutionMap.cpp
+++ b/lib/Simplifier/SubstitutionMap.cpp
@@ -597,19 +597,20 @@ bool SubstitutionMap::loops(const ASTNode& n0, const ASTNode& n1)
 // "either side is a READ" test does -- suppressed BVSolver over every
 // read in the query, connected to an equality or not, and cost more
 // than the whole decision procedure on array-heavy input.
-bool SubstitutionMap::extensionalityProtected(const ASTNode& key,
-                                              const ASTNode& value) const
+bool SubstitutionMap::theoryProtected(const ASTNode& key,
+                                      const ASTNode& value) const
 {
   ExtensionalityContext* ext = bm->getExtensionalityIfAny();
-  if (ext == NULL || !ext->activeInSolve())
-    return false;
-  if (key.GetKind() == SYMBOL && ext->isProtected(key))
-    return true;
-  if (value.GetKind() == SYMBOL && ext->isProtected(value))
-    return true;
-  // The equation-deleting orientation: the read itself is the key.
-  if (key.GetKind() == READ)
-    return true;
+  if (ext != NULL && ext->activeInSolve())
+  {
+    if (key.GetKind() == SYMBOL && ext->isProtected(key))
+      return true;
+    if (value.GetKind() == SYMBOL && ext->isProtected(value))
+      return true;
+    // The equation-deleting orientation: the read itself is the key.
+    if (key.GetKind() == READ)
+      return true;
+  }
   return false;
 }
 
@@ -621,11 +622,11 @@ bool SubstitutionMap::UpdateSubstitutionMap(const ASTNode& e0,
     return false;
 
   // TermOrder has already chosen which side is the key: e0 when it
-  // returned 1, e1 when it returned -1. extensionalityProtected needs
+  // returned 1, e1 when it returned -1. theoryProtected needs
   // that orientation, because only a read in key position deletes an
   // access. The later "i = -1" flip below cannot change the answer:
   // it applies only when both sides are symbols.
-  if (extensionalityProtected(1 == i ? e0 : e1, 1 == i ? e1 : e0))
+  if (theoryProtected(1 == i ? e0 : e1, 1 == i ? e1 : e0))
     return false;
 
   assert(e0 != e1);

--- a/lib/Simplifier/SubstitutionMap.cpp
+++ b/lib/Simplifier/SubstitutionMap.cpp
@@ -25,6 +25,7 @@ THE SOFTWARE.
 #include "stp/Simplifier/SubstitutionMap.h"
 #include "stp/AbsRefineCounterExample/ArrayTransformer.h"
 #include "stp/Extensionality/ExtensionalityContext.h"
+#include "stp/UninterpretedFunctions/UFContext.h"
 #include "stp/Simplifier/Simplifier.h"
 #include <vector>
 
@@ -609,6 +610,15 @@ bool SubstitutionMap::theoryProtected(const ASTNode& key,
       return true;
     // The equation-deleting orientation: the read itself is the key.
     if (key.GetKind() == READ)
+      return true;
+  }
+
+  UFContext* uf = bm->getUFContextIfAny();
+  if (uf != NULL && uf->activeInSolve())
+  {
+    if (key.GetKind() == SYMBOL && uf->isProtected(key))
+      return true;
+    if (value.GetKind() == SYMBOL && uf->isProtected(value))
       return true;
   }
   return false;

--- a/lib/ToSat/ToSATAIG.cpp
+++ b/lib/ToSat/ToSATAIG.cpp
@@ -24,6 +24,7 @@ THE SOFTWARE.
 
 #include "stp/ToSat/ToSATAIG.h"
 #include "stp/Extensionality/ExtensionalityContext.h"
+#include "stp/UninterpretedFunctions/UFContext.h"
 #include "stp/Simplifier/Simplifier.h"
 #include "stp/Simplifier/constantBitP/ConstantBitPropagation.h"
 #include <sstream>
@@ -52,7 +53,24 @@ bool ToSATAIG::CallSAT(SATSolver& satSolver, const ASTNode& input,
     return false;
 
   if (input == ASTTrue)
-    return true;
+  {
+    // A formula which preprocessing proved true can still own active UF
+    // results and argument names.  They are the sole candidate authority for
+    // the checker and future congruence lemmas, so the ordinary constant-root
+    // shortcut is legal only when there are no such scalars.  Register and
+    // solve the disconnected variables here instead of letting the model
+    // evaluator invent values for symbols which never reached SAT.
+    UFContext* uf = bm->getUFContextIfAny();
+    if (uf == NULL || !uf->activeInSolve() || uf->getSolveScalars().empty())
+      return true;
+
+    first = false;
+    delete cb;
+    cb = NULL;
+    assert(satSolver.nVars() == 0);
+    mark_variables_as_frozen(satSolver);
+    return runSolver(satSolver);
+  }
 
   first = false;
   Cnf_Dat_t* cnfData = bitblast(input, needAbsRef);
@@ -373,6 +391,39 @@ void ToSATAIG::mark_variables_as_frozen(SATSolver& satSolver)
   // restores an eliminated variable on contact or never eliminates one --
   // makeBackend refuses the simplifying MiniSat outright.
   abstraction_.freezeVariables(satSolver, nodeToSATVar);
+
+  // Give every checker-visible scalar one complete mapping in this backend.
+  // Connected bits retain their CNF variables; missing/disconnected bits get
+  // fresh unconstrained variables, which is exactly their formula semantics.
+  // Registration happens after CNF conversion so no second AIG-side meaning
+  // can compete with the mapping the checker and lemma encoder both consume.
+  UFContext* ufContext = bm->getUFContextIfAny();
+  if (ufContext != NULL && ufContext->activeInSolve())
+  {
+    for (const ASTNode& symbol : ufContext->getSolveScalars())
+    {
+      if (symbol.GetKind() != SYMBOL)
+        FatalError("UF solve-scalar registrar received a non-symbol", symbol);
+      const unsigned width = std::max((unsigned)1, symbol.GetValueWidth());
+      ASTNodeToSATVar::iterator found = nodeToSATVar.find(symbol);
+      if (found == nodeToSATVar.end())
+        found = nodeToSATVar
+                    .insert(std::make_pair(
+                        symbol, vector<unsigned>(width, ~((unsigned)0))))
+                    .first;
+      if (found->second.size() > width)
+        FatalError("UF batch liveness mapping has the wrong width", symbol);
+      if (found->second.size() < width)
+        found->second.resize(width, ~((unsigned)0));
+      for (unsigned bit = 0; bit < width; ++bit)
+      {
+        if (found->second[bit] == ~((unsigned)0))
+          found->second[bit] = satSolver.newVar();
+        satSolver.setFrozen(found->second[bit]);
+      }
+    }
+  }
+
 }
 
 bool ToSATAIG::runSolver(SATSolver& satSolver)

--- a/lib/UninterpretedFunctions/CMakeLists.txt
+++ b/lib/UninterpretedFunctions/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(uninterpretedfunctions OBJECT
     UFDecl.cpp
     UFContext.cpp
+    UFLowering.cpp
 )
 
 add_dependencies(uninterpretedfunctions ASTKind_header)

--- a/lib/UninterpretedFunctions/CMakeLists.txt
+++ b/lib/UninterpretedFunctions/CMakeLists.txt
@@ -2,6 +2,9 @@ add_library(uninterpretedfunctions OBJECT
     UFDecl.cpp
     UFContext.cpp
     UFLowering.cpp
+    UFChecker.cpp
+    UFLemma.cpp
+    UFModel.cpp
 )
 
 add_dependencies(uninterpretedfunctions ASTKind_header)

--- a/lib/UninterpretedFunctions/CMakeLists.txt
+++ b/lib/UninterpretedFunctions/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(uninterpretedfunctions OBJECT
     UFLowering.cpp
     UFChecker.cpp
     UFLemma.cpp
+    UFRefinement.cpp
     UFModel.cpp
 )
 

--- a/lib/UninterpretedFunctions/CMakeLists.txt
+++ b/lib/UninterpretedFunctions/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_library(uninterpretedfunctions OBJECT
+    UFDecl.cpp
+    UFContext.cpp
+)
+
+add_dependencies(uninterpretedfunctions ASTKind_header)

--- a/lib/UninterpretedFunctions/UFChecker.cpp
+++ b/lib/UninterpretedFunctions/UFChecker.cpp
@@ -1,0 +1,691 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#include "stp/UninterpretedFunctions/UFChecker.h"
+#include "stp/FloatBlaster/rounding_modes.h"
+#include "extlib-constbv/constantbv.h"
+#include "extlib-unordered-dense/ankerl/unordered_dense.h"
+#include <algorithm>
+
+namespace stp
+{
+
+namespace
+{
+
+bool supportedSort(const SourceSort& sort)
+{
+  return UFSignature::isSupportedSort(sort);
+}
+
+// Bool occupies one byte; every other admitted sort is stored as its packed
+// carrier, so RoundingMode is five bits in one byte and a float is its IEEE
+// interchange width.
+size_t byteWidth(const SourceSort& sort)
+{
+  return sort.kind() == SourceSort::Kind::Bool
+             ? 1
+             : (sort.packedWidth() + 7) / 8;
+}
+
+int compareSort(const SourceSort& left, const SourceSort& right)
+{
+  const int lk = left.kind() == SourceSort::Kind::Bool ? 0 : 1;
+  const int rk = right.kind() == SourceSort::Kind::Bool ? 0 : 1;
+  if (lk != rk)
+    return lk < rk ? -1 : 1;
+  if (lk == 0)
+    return 0;
+  // Two values of the same packed width but different sorts never meet in
+  // one comparison: a tuple position has one signature sort, and the model
+  // order this feeds only ever sorts tuples of the same signature.
+  if (left.packedWidth() == right.packedWidth())
+    return 0;
+  return left.packedWidth() < right.packedWidth() ? -1 : 1;
+}
+
+bool readScalar(const ASTNode& scalar, const SourceSort& expected,
+                const UFScalarCandidate& candidate, UFConcreteValue& value,
+                std::string& diagnostic)
+{
+  if (scalar.IsNull() ||
+      (scalar.GetKind() != SYMBOL && !scalar.isConstant()) ||
+      scalar.GetSourceSort() != expected)
+  {
+    diagnostic = "UFCHK scalar is not a canonical leaf of the expected "
+                 "SourceSort";
+    return false;
+  }
+  if (scalar.isConstant())
+    return UFConcreteValue::fromConstant(scalar, expected, value, diagnostic);
+  if (!candidate.read(scalar, expected, value, diagnostic))
+    return false;
+  if (value.sort() != expected)
+  {
+    diagnostic = "UFCHK candidate returned a value at the wrong SourceSort";
+    return false;
+  }
+  return true;
+}
+
+struct Observation
+{
+  const LoweredApplicationRecord* record = NULL;
+  UFConcreteValue result;
+};
+
+// Position-sensitive value hashing. Equality remains full typed tuple
+// equality, so even adversarial collisions are semantically harmless. The
+// hash owns no AST identity and does not assume constant interning.
+struct ConcreteTupleHasher
+{
+  size_t operator()(const UFConcreteTuple& tuple) const
+  {
+    size_t hash = static_cast<size_t>(0x9e3779b97f4a7c15ULL);
+    for (size_t i = 0; i < tuple.size(); ++i)
+    {
+      const UFConcreteValue& value = tuple[i];
+      size_t component = value.sort().hash();
+      for (const uint8_t byte : value.bytes())
+        component = component * 1315423911u + byte;
+      hash = (hash * 1315423911u) ^ ((i + 1) * 2654435761u) ^
+             component;
+      hash = hash * 1315423911u + i;
+    }
+    return hash;
+  }
+};
+
+typedef ankerl::unordered_dense::map<UFConcreteTuple, Observation,
+                                     ConcreteTupleHasher>
+    ObservationTable;
+
+} // namespace
+
+UFConcreteValue UFConcreteValue::boolean(bool value)
+{
+  UFConcreteValue out;
+  out.sort_ = SourceSort::boolean();
+  out.bytes_.push_back(value ? 1 : 0);
+  return out;
+}
+
+UFConcreteValue UFConcreteValue::scalar(const SourceSort& sort,
+                                        const std::vector<uint8_t>& bytes)
+{
+  assert(sort.isScalar() && sort.packedWidth() > 0);
+  const unsigned width = sort.packedWidth();
+  UFConcreteValue out;
+  out.sort_ = sort;
+  out.bytes_ = bytes;
+  out.bytes_.resize((width + 7) / 8, 0);
+  const unsigned used = width % 8;
+  if (used != 0)
+    out.bytes_.back() &= static_cast<uint8_t>((1u << used) - 1u);
+  return out;
+}
+
+UFConcreteValue UFConcreteValue::bitVector(
+    unsigned width, const std::vector<uint8_t>& bytes)
+{
+  assert(width > 0);
+  return scalar(SourceSort::bitVector(width), bytes);
+}
+
+UFConcreteValue UFConcreteValue::fromUInt(unsigned width, uint64_t value)
+{
+  std::vector<uint8_t> bytes((width + 7) / 8, 0);
+  for (size_t i = 0; i < bytes.size() && i < sizeof(value); ++i)
+    bytes[i] = static_cast<uint8_t>((value >> (8 * i)) & 0xffu);
+  return bitVector(width, bytes);
+}
+
+UFConcreteValue UFConcreteValue::zero(const SourceSort& sort)
+{
+  if (sort.kind() == SourceSort::Kind::Bool)
+    return boolean(false);
+  assert(supportedSort(sort));
+  // All-zeros is a value of every admitted sort but one. A rounding mode is
+  // one-hot, so the all-zero carrier denotes no mode: it would print as the
+  // else branch of a generated define-fun that is then not a legal term, and
+  // it would be handed to an enclosing operator as a constant operand when a
+  // nested application falls through to the default. RNE is the arbitrary
+  // choice SMT-LIB itself makes wherever a mode is implied.
+  if (sort.kind() == SourceSort::Kind::RoundingMode)
+    return fromMode(symbolic_fp::ROUND_NEAREST_TIES_TO_EVEN);
+  return scalar(sort, std::vector<uint8_t>(byteWidth(sort), 0));
+}
+
+UFConcreteValue UFConcreteValue::fromMode(unsigned encoding)
+{
+  assert(symbolic_fp::isRoundingModeEncoding(encoding));
+  std::vector<uint8_t> bytes(1, static_cast<uint8_t>(encoding));
+  return scalar(SourceSort::roundingMode(), bytes);
+}
+
+bool UFConcreteValue::fromConstant(const ASTNode& constant,
+                                   const SourceSort& sort,
+                                   UFConcreteValue& value,
+                                   std::string& diagnostic)
+{
+  if (!supportedSort(sort))
+  {
+    diagnostic = "UFCHK constant was requested at an unsupported SourceSort";
+    return false;
+  }
+  // A model answers with the *carrier* of a source-sorted leaf -- a plain
+  // BVCONST -- because that is what the SAT assignment materialises, while a
+  // constant written in the query still carries its own sort. Both spell the
+  // same value, so accept either: the leaf node's sort has already been
+  // checked by whoever asked, and what is converted here is that leaf's
+  // value. Widths must still agree exactly.
+  const SourceSort constantSort = constant.GetSourceSort();
+  const bool isCarrier = sort.kind() != SourceSort::Kind::Bool &&
+                         constantSort.kind() == SourceSort::Kind::BitVector &&
+                         constantSort.bitVectorWidth() == sort.packedWidth();
+  if (constantSort != sort && !isCarrier)
+  {
+    diagnostic = "UFCHK constant does not match its expected SourceSort";
+    return false;
+  }
+  if (sort.kind() == SourceSort::Kind::Bool)
+  {
+    if (constant.GetKind() != TRUE && constant.GetKind() != FALSE)
+    {
+      diagnostic = "UFCHK expected a concrete Boolean value";
+      return false;
+    }
+    value = boolean(constant.GetKind() == TRUE);
+    return true;
+  }
+  const unsigned width = sort.packedWidth();
+  if (constant.GetKind() != BVCONST || constant.GetValueWidth() != width)
+  {
+    diagnostic = "UFCHK expected a concrete scalar value";
+    return false;
+  }
+  // Bucketing by raw bytes is only the sort's own equality where every
+  // representable carrier denotes a value. RoundingMode is the one admitted
+  // sort where it is not: twenty-seven of its thirty-two patterns denote no
+  // mode. Every RoundingMode scalar the checker can reach is pinned one-hot
+  // -- by its declaration, by UF lowering, and again by FpTotalise -- so a
+  // value that is not is a broken invariant, not an input the checker should
+  // quietly bucket.
+  if (sort.kind() == SourceSort::Kind::RoundingMode &&
+      !symbolic_fp::isRoundingModeEncoding(constant.GetUnsignedConst()))
+  {
+    diagnostic = "UFCHK read a RoundingMode carrier that denotes no mode";
+    return false;
+  }
+  std::vector<uint8_t> bytes(byteWidth(sort), 0);
+  const CBV bits = constant.GetBVConst();
+  for (unsigned i = 0; i < width; ++i)
+    if (CONSTANTBV::BitVector_bit_test(bits, i))
+      bytes[i / 8] |= static_cast<uint8_t>(1u << (i % 8));
+  value = scalar(sort, bytes);
+  return true;
+}
+
+bool UFConcreteValue::booleanValue() const
+{
+  assert(sort_.kind() == SourceSort::Kind::Bool && bytes_.size() == 1);
+  return bytes_[0] != 0;
+}
+
+bool operator==(const UFConcreteValue& left, const UFConcreteValue& right)
+{
+  return left.sort_ == right.sort_ && left.bytes_ == right.bytes_;
+}
+
+bool operator<(const UFConcreteValue& left, const UFConcreteValue& right)
+{
+  const int sortOrder = compareSort(left.sort_, right.sort_);
+  if (sortOrder != 0)
+    return sortOrder < 0;
+  // Numeric order: compare the most significant byte first.
+  return std::lexicographical_compare(left.bytes_.rbegin(), left.bytes_.rend(),
+                                      right.bytes_.rbegin(),
+                                      right.bytes_.rend());
+}
+
+UFCheckPlan UFChecker::validate(
+    const std::vector<const UFDecl*>& activeDeclarations,
+    const LoweredApplicationView& view)
+{
+  UFCheckPlan plan;
+  plan.view_ = &view;
+  plan.declarations_ = activeDeclarations;
+  std::sort(plan.declarations_.begin(), plan.declarations_.end(),
+            [](const UFDecl* left, const UFDecl* right)
+            {
+              if (left == NULL || right == NULL)
+                return left < right;
+              return left->id() < right->id();
+            });
+  if (std::find(plan.declarations_.begin(), plan.declarations_.end(),
+                nullptr) != plan.declarations_.end())
+  {
+    plan.diagnostic_ = "UFCHK received a null active declaration";
+    return plan;
+  }
+  if (std::adjacent_find(plan.declarations_.begin(),
+                         plan.declarations_.end()) !=
+      plan.declarations_.end())
+  {
+    plan.diagnostic_ = "UFCHK received a duplicate active declaration";
+    return plan;
+  }
+  const STPMgr* declarationOwner = NULL;
+  for (size_t i = 0; i < plan.declarations_.size(); ++i)
+  {
+    const UFDecl* declaration = plan.declarations_[i];
+    if (declaration->owner() == NULL)
+    {
+      plan.diagnostic_ = "UFCHK received an ownerless active declaration";
+      return plan;
+    }
+    if (i != 0 && plan.declarations_[i - 1]->id() == declaration->id())
+    {
+      plan.diagnostic_ = "UFCHK received duplicate declaration identities";
+      return plan;
+    }
+    if (declarationOwner == NULL)
+      declarationOwner = declaration->owner();
+    else if (declarationOwner != declaration->owner())
+    {
+      plan.diagnostic_ =
+          "UFCHK active declarations cross manager ownership";
+      return plan;
+    }
+    if (!supportedSort(declaration->signature().codomain()))
+    {
+      plan.diagnostic_ =
+          "UFCHK active declaration has an unsupported codomain";
+      return plan;
+    }
+    for (const SourceSort& sort : declaration->signature().domain())
+      if (!supportedSort(sort))
+      {
+        plan.diagnostic_ =
+            "UFCHK active declaration has an unsupported domain";
+        return plan;
+      }
+  }
+
+  plan.recordsByDecl_.resize(plan.declarations_.size());
+  ankerl::unordered_dense::map<const UFDecl*, size_t> declarationIndex;
+  declarationIndex.reserve(plan.declarations_.size());
+  for (size_t i = 0; i < plan.declarations_.size(); ++i)
+    declarationIndex.emplace(plan.declarations_[i], i);
+
+  ankerl::unordered_dense::set<ASTNode, ASTNode::ASTNodeHasher,
+                               ASTNode::ASTNodeEqual>
+      handles;
+  handles.reserve(view.applications.size());
+  if (view.handleToResult.size() != view.applications.size())
+  {
+    plan.diagnostic_ =
+        "UFCHK durable-handle result mapping has the wrong size";
+    return plan;
+  }
+  size_t previousOrder = 0;
+  bool firstRecord = true;
+  for (const LoweredApplicationRecord& record : view.applications)
+  {
+    if (record.declaration == NULL || record.durableHandle.IsNull() ||
+        record.resultSymbol.IsNull() ||
+        record.durableHandle.GetKind() != UF_APPLY ||
+        record.resultSymbol.GetKind() != SYMBOL ||
+        !record.durableHandle.IsOwnedBy(record.declaration->owner()) ||
+        !record.resultSymbol.IsOwnedBy(record.declaration->owner()) ||
+        record.loweredActuals.size() != record.declaration->signature().arity() ||
+        record.namedActuals.size() !=
+            (record.observableArguments ? record.declaration->signature().arity()
+                                        : 0))
+    {
+      plan.diagnostic_ =
+          "UFCHK received a malformed lowered application view";
+      return plan;
+    }
+    if (!firstRecord && record.stableOrder <= previousOrder)
+    {
+      plan.diagnostic_ = "UFCHK application order is not strictly stable";
+      return plan;
+    }
+    firstRecord = false;
+    previousOrder = record.stableOrder;
+    if (!handles.insert(record.durableHandle).second)
+    {
+      plan.diagnostic_ = "UFCHK received a duplicate durable application";
+      return plan;
+    }
+    const auto declarationIt = declarationIndex.find(record.declaration);
+    if (declarationIt == declarationIndex.end())
+    {
+      plan.diagnostic_ = "UFCHK view references an inactive declaration";
+      return plan;
+    }
+    const UFSignature& signature = record.declaration->signature();
+    // Every scalar in a record is at the *lowering* sort. It coincides with
+    // the declared sort everywhere but FloatingPoint, which the core never
+    // sees: it is solved as its canonical packed carrier and only becomes a
+    // float again at the model boundary.
+    {
+      const SourceSort expected =
+          UFSignature::loweringSort(signature.codomain());
+      if (record.resultSymbol.GetSourceSort() != expected)
+      {
+        plan.diagnostic_ = "UFCHK result symbol has the wrong SourceSort";
+        return plan;
+      }
+    }
+    for (size_t i = 0; i < signature.arity(); ++i)
+    {
+      const SourceSort solved =
+          UFSignature::loweringSort(signature.domain()[i]);
+      if (record.loweredActuals[i].IsNull() ||
+          !record.loweredActuals[i].IsOwnedBy(record.declaration->owner()) ||
+          record.loweredActuals[i].GetSourceSort() != solved)
+      {
+        plan.diagnostic_ = "UFCHK argument record is not a typed canonical "
+                           "scalar pair";
+        return plan;
+      }
+      // An unobservable record has no scalar tuple at all; the canonical-leaf
+      // obligation applies to the records a candidate round actually reads.
+      if (!record.observableArguments)
+        continue;
+      if (record.namedActuals[i].IsNull() ||
+          !record.namedActuals[i].IsOwnedBy(record.declaration->owner()) ||
+          record.namedActuals[i].GetSourceSort() != solved ||
+          (record.namedActuals[i].GetKind() != SYMBOL &&
+           !record.namedActuals[i].isConstant()))
+      {
+        plan.diagnostic_ = "UFCHK argument record is not a typed canonical "
+                           "scalar pair";
+        return plan;
+      }
+    }
+    const ASTNodeMap::const_iterator resultIt =
+        view.handleToResult.find(record.durableHandle);
+    if (resultIt == view.handleToResult.end() ||
+        resultIt->second != record.resultSymbol)
+    {
+      plan.diagnostic_ =
+          "UFCHK durable-handle result mapping is inconsistent";
+      return plan;
+    }
+    plan.recordsByDecl_[declarationIt->second].push_back(&record);
+  }
+
+  // Lowering withholds a scalar tuple only where no congruence lemma can ever
+  // mention it. Once a declaration reaches two applications every one of them
+  // must be readable, or a real conflict would go unnoticed and an unsound
+  // model would be certified.
+  for (const std::vector<const LoweredApplicationRecord*>& records :
+       plan.recordsByDecl_)
+  {
+    if (records.size() < 2)
+      continue;
+    for (const LoweredApplicationRecord* record : records)
+      if (!record->observableArguments)
+      {
+        plan.diagnostic_ = "UFCHK found a comparable declaration with an "
+                           "unreadable application";
+        return plan;
+      }
+  }
+
+  plan.valid_ = true;
+  return plan;
+}
+
+UFCheckResult UFChecker::check(const UFCheckPlan& plan,
+                               const UFScalarCandidate& candidate,
+                               const size_t maxConflicts)
+{
+  UFCheckResult out;
+  const uint64_t candidateVersion = candidate.version();
+  out.modelSeed.candidateVersion = candidateVersion;
+  if (!plan.valid_ || plan.view_ == NULL)
+  {
+    out.diagnostic = plan.diagnostic_.empty()
+                         ? "UFCHK received an unvalidated check plan"
+                         : plan.diagnostic_;
+    return out;
+  }
+  out.stats.activeApplications = plan.view_->applications.size();
+  out.stats.functions = plan.declarations_.size();
+
+  size_t conflictOrder = 0;
+  for (size_t declarationIndex = 0;
+       declarationIndex < plan.declarations_.size(); ++declarationIndex)
+  {
+    const UFDecl* declaration = plan.declarations_[declarationIndex];
+    const std::vector<const LoweredApplicationRecord*>& records =
+        plan.recordsByDecl_[declarationIndex];
+    ObservationTable table;
+    table.reserve(records.size());
+    // A declaration whose single application has no readable argument tuple is
+    // interpreted by the constant its result took: total, and by construction
+    // in agreement with that one application, which is all any interpretation
+    // of it has to satisfy.
+    bool constantInterpretation = false;
+    UFConcreteValue constantValue;
+    const SourceSort resultSort = records.empty()
+        ? UFSignature::loweringSort(declaration->signature().codomain())
+        : records[0]->resultSymbol.GetSourceSort();
+    for (const LoweredApplicationRecord* record : records)
+    {
+      if (!record->observableArguments)
+      {
+        if (!readScalar(record->resultSymbol, resultSort,
+                        candidate, constantValue, out.diagnostic))
+          return out;
+        constantInterpretation = true;
+        continue;
+      }
+
+      UFConcreteTuple tuple;
+      tuple.reserve(record->namedActuals.size());
+      for (size_t i = 0; i < record->namedActuals.size(); ++i)
+      {
+        UFConcreteValue value;
+        if (!readScalar(record->namedActuals[i],
+                        UFSignature::loweringSort(
+                            declaration->signature().domain()[i]),
+                        candidate, value, out.diagnostic))
+          return out;
+        tuple.push_back(value);
+      }
+      UFConcreteValue result;
+      if (!readScalar(record->resultSymbol, resultSort,
+                      candidate, result, out.diagnostic))
+        return out;
+
+      const ObservationTable::iterator found = table.find(tuple);
+      if (found == table.end())
+      {
+        Observation observation;
+        observation.record = record;
+        observation.result = result;
+        table.insert(std::make_pair(tuple, observation));
+        out.stats.insertions++;
+        continue;
+      }
+
+      out.stats.comparisons++;
+      conflictOrder++;
+      // Each record is compared against the one before it in the bucket, not
+      // against the bucket's first record. Both relate every member of a
+      // bucket after n-1 lemmas, but they differ in which pair a round that
+      // hits the lemma cap actually emits. Against the first record, a
+      // decisive pair of two adjacent late members is never stated directly:
+      // if each of them happens to agree with the first record it yields no
+      // conflict at all, and the pair only surfaces once every other member
+      // has been forced out of the bucket. Chaining states it in the round it
+      // appears.
+      //
+      // The property the encoder relies on is unchanged: a record is still
+      // the right-hand side of at most one conflict, so two conflicts from one
+      // candidate still cannot canonicalise to the same lemma and no duplicate
+      // filter is needed. The bucket entry is updated whether or not the two
+      // agreed, so the comparison is always against the immediate predecessor.
+      const LoweredApplicationRecord& representative = *found->second.record;
+      const UFConcreteValue previousResult = found->second.result;
+      found->second.record = record;
+      found->second.result = result;
+      if (previousResult == result)
+        continue;
+      out.status = UFCheckResult::Status::Conflict;
+      UFCongruenceConflict conflict;
+      conflict.declaration = declaration;
+      conflict.representativeHandle = representative.durableHandle;
+      conflict.conflictingHandle = record->durableHandle;
+      conflict.representativeOrder = representative.stableOrder;
+      conflict.conflictingOrder = record->stableOrder;
+      conflict.leftResult = representative.resultSymbol;
+      conflict.rightResult = record->resultSymbol;
+      conflict.leftResultValue = previousResult;
+      conflict.rightResultValue = result;
+      conflict.candidateVersion = candidateVersion;
+      conflict.stableConflictOrder = conflictOrder;
+      for (size_t i = 0; i < tuple.size(); ++i)
+      {
+        UFCongruenceArgument argument;
+        argument.position = i;
+        argument.sort =
+            UFSignature::loweringSort(declaration->signature().domain()[i]);
+        argument.leftTheory = representative.loweredActuals[i];
+        argument.rightTheory = record->loweredActuals[i];
+        argument.leftScalar = representative.namedActuals[i];
+        argument.rightScalar = record->namedActuals[i];
+        argument.concreteValue = tuple[i];
+        conflict.arguments.push_back(argument);
+      }
+      out.conflicts.push_back(conflict);
+      if (maxConflicts != 0 && out.conflicts.size() >= maxConflicts)
+        break;
+    }
+
+    if (maxConflicts != 0 && out.conflicts.size() >= maxConflicts)
+      break;
+
+    // A conflicting candidate publishes no model, so stop paying for one --
+    // including the case sort -- from the first conflict onwards.
+    if (!out.conflicts.empty())
+      continue;
+
+    UFFunctionModelSeed function;
+    function.declaration = declaration;
+    function.defaultValue =
+        constantInterpretation
+            ? constantValue
+            : UFConcreteValue::zero(resultSort);
+    function.cases.reserve(table.size());
+    for (const auto& entry : table)
+    {
+      UFModelCase modelCase;
+      modelCase.arguments = entry.first;
+      modelCase.result = entry.second.result;
+      modelCase.representativeHandle =
+          entry.second.record->durableHandle;
+      function.cases.push_back(modelCase);
+    }
+    // Dense-table iteration is an implementation detail. Preserve the old
+    // typed lexicographic model order explicitly, and pay this O(n log n)
+    // cost only for the final consistent candidate rather than every round.
+    std::sort(function.cases.begin(), function.cases.end(),
+              [](const UFModelCase& left, const UFModelCase& right)
+              { return left.arguments < right.arguments; });
+    // Publish the commonest observed value as the else branch and drop every
+    // case that agrees with it. The published interpretation is unchanged --
+    // a dropped case falls through to exactly the value it named -- but a
+    // function that took one value at all but a few of its observed points
+    // now prints those few rather than one ite per point.
+    //
+    // A declaration interpreted by a constant keeps that constant: the record
+    // that produced it has no readable tuple, so it has no case of its own and
+    // only the else branch can satisfy it. Ties go to the smaller value, so
+    // the choice stays a function of the candidate alone.
+    if (!constantInterpretation && !function.cases.empty())
+    {
+      std::map<UFConcreteValue, size_t> byResult;
+      for (const UFModelCase& modelCase : function.cases)
+        byResult[modelCase.result]++;
+      // std::map orders by UFConcreteValue, so scanning it forwards and
+      // keeping a strict improvement makes ties go to the smaller value.
+      size_t bestCount = 0;
+      UFConcreteValue chosen;
+      for (const std::pair<const UFConcreteValue, size_t>& entry : byResult)
+        if (entry.second > bestCount)
+        {
+          bestCount = entry.second;
+          chosen = entry.first;
+        }
+      if (bestCount > 1)
+      {
+        function.defaultValue = chosen;
+        std::vector<UFModelCase> kept;
+        kept.reserve(function.cases.size() - bestCount);
+        for (const UFModelCase& modelCase : function.cases)
+          if (modelCase.result != chosen)
+            kept.push_back(modelCase);
+        function.cases.swap(kept);
+      }
+    }
+    out.modelSeed.functions.push_back(function);
+  }
+
+  // One version test covers the whole scan, conflicting or not: a candidate
+  // that moved under it invalidates every conflict collected as well as any
+  // seed, because the lemmas are only false against the assignment they were
+  // read from.
+  if (candidate.version() != candidateVersion)
+  {
+    out.status = UFCheckResult::Status::InternalError;
+    out.diagnostic = "UFCHK candidate changed during one logical check";
+    out.conflicts.clear();
+    out.modelSeed = UFFunctionModelSeedSet();
+    return out;
+  }
+  if (!out.conflicts.empty())
+  {
+    out.modelSeed = UFFunctionModelSeedSet();
+    out.modelSeed.candidateVersion = candidateVersion;
+    return out; // status is already Conflict
+  }
+  out.status = UFCheckResult::Status::Consistent;
+  return out;
+}
+
+UFCheckResult UFChecker::check(
+    const std::vector<const UFDecl*>& activeDeclarations,
+    const LoweredApplicationView& view, const UFScalarCandidate& candidate,
+    const size_t maxConflicts)
+{
+  return check(validate(activeDeclarations, view), candidate, maxConflicts);
+}
+
+} // namespace stp

--- a/lib/UninterpretedFunctions/UFContext.cpp
+++ b/lib/UninterpretedFunctions/UFContext.cpp
@@ -1,0 +1,399 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#include "stp/UninterpretedFunctions/UFContext.h"
+#include "stp/Globals/Globals.h"
+#include "stp/STPManager/STPManager.h"
+#include <algorithm>
+#include <cctype>
+#include <sstream>
+
+namespace stp
+{
+
+namespace
+{
+bool isRenderableExternalName(const std::string& name)
+{
+  // UF models quote every external declaration name. SMT-LIB quoted symbols
+  // have no escape for either delimiter character and admit only printable
+  // characters. Rejecting at declaration keeps every later model operation
+  // total and nonfatal.
+  for (const unsigned char c : name)
+    if (c == '|' || c == '\\' || !std::isprint(c))
+      return false;
+  return true;
+}
+} // namespace
+
+UFContext::UFContext(STPMgr* manager) : manager_(manager)
+{
+  assert(manager_ != NULL);
+}
+
+UFContext::~UFContext()
+{
+  releaseSolveProtection();
+  parserCommandApplications_.clear();
+  applications_.clear();
+  byIdentity_.clear();
+  activeByName_.clear();
+  owned_.clear();
+  allById_.clear();
+  declarations_.clear();
+}
+
+void UFContext::setError(std::string* error, const std::string& message) const
+{
+  if (error != NULL)
+    *error = message;
+}
+
+const UFDecl*
+UFContext::declareFunction(const std::string& name,
+                           const std::vector<SourceSort>& domain,
+                           const SourceSort& codomain, std::string* error)
+{
+  if (!manager_->UserFlags.enable_uninterpreted_functions)
+  {
+    setError(error, "uninterpreted functions are disabled");
+    return NULL;
+  }
+  if (name.empty())
+  {
+    setError(error, "uninterpreted-function name must not be empty");
+    return NULL;
+  }
+  if (!isRenderableExternalName(name))
+  {
+    setError(error, "uninterpreted-function name is not representable as an "
+                    "SMT-LIB2 quoted symbol");
+    return NULL;
+  }
+  if (STPMgr::isReservedSymbolName(name.c_str()))
+  {
+    setError(error, "an uninterpreted-function name beginning with '@' or "
+                    "'.' is reserved for solver use");
+    return NULL;
+  }
+  std::string signatureError;
+  if (!UFSignature::validate(domain, codomain, &signatureError))
+  {
+    setError(error, "uninterpreted functions: declaration of " + name +
+                        ": " + signatureError);
+    return NULL;
+  }
+  if (activeByName_.find(name) != activeByName_.end())
+  {
+    setError(error, "uninterpreted function '" + name +
+                    "' is already declared in the active namespace");
+    return NULL;
+  }
+
+  const uint64_t id = nextDeclarationId_++;
+  std::ostringstream identityName;
+  identityName << "@uf_decl_" << id;
+  const ASTNode identity =
+      manager_->CreateSourceSymbol(identityName.str().c_str(), codomain);
+  manager_->noteIntroducedSymbol(identity);
+
+  std::unique_ptr<UFDecl> record(new UFDecl(
+      manager_, id, name, UFSignature(domain, codomain), identity));
+  const UFDecl* result = record.get();
+  declarations_.push_back(std::move(record));
+  activeByName_.insert(std::make_pair(name, result));
+  allById_.insert(std::make_pair(id, result));
+  byIdentity_.insert(std::make_pair(identity, result));
+  owned_.insert(result);
+  return result;
+}
+
+bool UFContext::deactivate(const UFDecl* decl, std::string* error)
+{
+  if (!owns(decl))
+  {
+    setError(error, "uninterpreted-function declaration belongs to another "
+                    "context or is invalid");
+    return false;
+  }
+  const std::map<std::string, const UFDecl*>::iterator found =
+      activeByName_.find(decl->name());
+  if (found == activeByName_.end() || found->second != decl)
+  {
+    setError(error, "uninterpreted-function declaration is no longer active");
+    return false;
+  }
+  activeByName_.erase(found);
+  return true;
+}
+
+void UFContext::deactivateAll()
+{
+  activeByName_.clear();
+}
+
+const UFDecl* UFContext::lookup(const std::string& name) const
+{
+  const std::map<std::string, const UFDecl*>::const_iterator found =
+      activeByName_.find(name);
+  return found == activeByName_.end() ? NULL : found->second;
+}
+
+void UFContext::collectIdentitySymbols(ASTNodeSet& out) const
+{
+  for (const std::pair<const ASTNode, const UFDecl*>& entry : byIdentity_)
+    out.insert(entry.first);
+}
+
+const UFDecl* UFContext::lookupIdentity(const ASTNode& identity) const
+{
+  if (identity.IsNull() || !identity.IsOwnedBy(manager_))
+    return NULL;
+  const std::map<ASTNode, const UFDecl*>::const_iterator found =
+      byIdentity_.find(identity);
+  return found == byIdentity_.end() ? NULL : found->second;
+}
+
+bool UFContext::owns(const UFDecl* decl) const
+{
+  return decl != NULL && owned_.find(decl) != owned_.end();
+}
+
+bool UFContext::isActive(const UFDecl* decl) const
+{
+  if (!owns(decl))
+    return false;
+  const std::map<std::string, const UFDecl*>::const_iterator found =
+      activeByName_.find(decl->name());
+  return found != activeByName_.end() && found->second == decl;
+}
+
+std::vector<const UFDecl*> UFContext::activeDeclarations() const
+{
+  std::vector<const UFDecl*> result;
+  result.reserve(activeByName_.size());
+  for (const std::pair<const std::string, const UFDecl*>& entry :
+       activeByName_)
+    result.push_back(entry.second);
+  std::sort(result.begin(), result.end(),
+            [](const UFDecl* left, const UFDecl* right)
+            { return left->id() < right->id(); });
+  return result;
+}
+
+bool UFContext::validateApplicationChildren(ASTChildren children,
+                                            std::string* error) const
+{
+  if (children.empty())
+  {
+    setError(error, "UF_APPLY requires a declaration identity");
+    return false;
+  }
+  if (!children[0].IsOwnedBy(manager_))
+  {
+    setError(error, "UF_APPLY declaration identity belongs to another context");
+    return false;
+  }
+  const UFDecl* decl = lookupIdentity(children[0]);
+  if (decl == NULL)
+  {
+    setError(error, "UF_APPLY child 0 is not a registered declaration identity");
+    return false;
+  }
+  if (children.size() - 1 != decl->signature().arity())
+  {
+    const size_t expected = decl->signature().arity();
+    const size_t actual = children.size() - 1;
+    setError(error, "uninterpreted functions: " + decl->name() + " expects " +
+                        std::to_string(expected) +
+                        (expected == 1 ? " argument" : " arguments") +
+                        " but was applied to " + std::to_string(actual));
+    return false;
+  }
+  for (size_t i = 1; i < children.size(); ++i)
+  {
+    if (!children[i].IsOwnedBy(manager_))
+    {
+      setError(error, "uninterpreted functions: argument " +
+                          std::to_string(i - 1) + " of " + decl->name() +
+                          " belongs to another context");
+      return false;
+    }
+    const SourceSort& expected = decl->signature().domain()[i - 1];
+    const SourceSort actual = children[i].GetSourceSort();
+    if (actual != expected)
+    {
+      setError(error, "uninterpreted functions: argument " +
+                          std::to_string(i - 1) + " of " + decl->name() +
+                          " has sort " + sourceSortToSMTLib(actual) +
+                          " but the declaration requires " +
+                          sourceSortToSMTLib(expected));
+      return false;
+    }
+  }
+  return true;
+}
+
+ASTNode UFContext::apply(const UFDecl* decl, const ASTVec& actuals,
+                         std::string* error)
+{
+  if (!manager_->UserFlags.enable_uninterpreted_functions)
+  {
+    setError(error, "uninterpreted functions are disabled");
+    return manager_->ASTUndefined;
+  }
+  if (!owns(decl))
+  {
+    setError(error, "uninterpreted-function declaration belongs to another "
+                    "context or is invalid");
+    return manager_->ASTUndefined;
+  }
+  if (!isActive(decl))
+  {
+    setError(error, "uninterpreted-function declaration is no longer active");
+    return manager_->ASTUndefined;
+  }
+
+  ASTVec children;
+  children.reserve(actuals.size() + 1);
+  children.push_back(decl->identityNode());
+  children.insert(children.end(), actuals.begin(), actuals.end());
+  if (!validateApplicationChildren(children, error))
+    return manager_->ASTUndefined;
+
+  const SourceSort& resultSort = decl->signature().codomain();
+  ASTNode result;
+  if (resultSort.kind() == SourceSort::Kind::Bool)
+    result = manager_->defaultNodeFactory->CreateNode(UF_APPLY, children);
+  else
+    result = manager_->defaultNodeFactory->CreateTerm(
+        UF_APPLY, resultSort.packedWidth(), children);
+  noteApplication(result);
+  return result;
+}
+
+void UFContext::beginParserCommand()
+{
+  // A parser cannot start the next top-level command until the preceding
+  // command's closing parenthesis has committed or rolled it back.
+  assert(!parserCommandActive_);
+  parserCommandApplications_.clear();
+  parserCommandActive_ = true;
+}
+
+void UFContext::finishParserCommand(const bool accepted)
+{
+  // The UF context may have been created during a command (most commonly by
+  // its first declaration), after Cpp_interface had a context to begin. Such
+  // a command has no application prefix to transact.
+  if (!parserCommandActive_)
+    return;
+  if (!accepted)
+    for (const ASTNode& application : parserCommandApplications_)
+      applications_.erase(application);
+  parserCommandApplications_.clear();
+  parserCommandActive_ = false;
+}
+
+void UFContext::noteApplication(const ASTNode& application)
+{
+  assert(application.GetKind() == UF_APPLY);
+  const bool inserted = applications_.insert(application).second;
+  if (inserted && parserCommandActive_)
+    parserCommandApplications_.push_back(application);
+}
+
+bool UFContext::isRegisteredApplication(const ASTNode& application) const
+{
+  return !application.IsNull() && application.IsOwnedBy(manager_) &&
+         application.GetKind() == UF_APPLY &&
+         applications_.find(application) != applications_.end();
+}
+
+bool UFContext::isActiveApplication(const ASTNode& application) const
+{
+  return isRegisteredApplication(application) && application.Degree() >= 1 &&
+         isActive(lookupIdentity(application[0]));
+}
+
+void UFContext::beginSolveProtection()
+{
+  assert(!solveProtectionActive_);
+  protectedSymbols_.clear();
+  solveScalars_.clear();
+}
+
+void UFContext::installSolveProtection(
+    const ASTNodeSet& protectedSymbols, const ASTNodeSet& solveScalars)
+{
+  assert(!solveProtectionActive_);
+  for (const ASTNode& scalar : solveScalars)
+  {
+    if (scalar.IsNull() || !scalar.IsOwnedBy(manager_) ||
+        scalar.GetKind() != SYMBOL ||
+        protectedSymbols.find(scalar) == protectedSymbols.end())
+      FatalError("UF solve scalar is malformed or is not preprocessing "
+                 "protected",
+                 scalar);
+  }
+  protectedSymbols_ = protectedSymbols;
+  solveScalars_ = solveScalars;
+}
+
+void UFContext::releaseSolveProtection()
+{
+  protectedSymbols_.clear();
+  solveScalars_.clear();
+  solveProtectionActive_ = false;
+}
+
+bool UFContext::isProtected(const ASTNode& symbol) const
+{
+  return !symbol.IsNull() && symbol.IsOwnedBy(manager_) &&
+         symbol.GetKind() == SYMBOL &&
+         protectedSymbols_.find(symbol) != protectedSymbols_.end();
+}
+
+bool UFContext::isSolveScalar(const ASTNode& symbol) const
+{
+  return !symbol.IsNull() && symbol.IsOwnedBy(manager_) &&
+         symbol.GetKind() == SYMBOL &&
+         solveScalars_.find(symbol) != solveScalars_.end();
+}
+
+UFContext::SolveScope::SolveScope(UFContext* context) : context_(context)
+{
+  if (context_ == NULL)
+    return;
+  assert(!context_->solveProtectionActive_);
+  context_->solveProtectionActive_ = true;
+}
+
+UFContext::SolveScope::~SolveScope()
+{
+  if (context_ != NULL)
+    context_->solveProtectionActive_ = false;
+}
+
+} // namespace stp

--- a/lib/UninterpretedFunctions/UFDecl.cpp
+++ b/lib/UninterpretedFunctions/UFDecl.cpp
@@ -1,0 +1,108 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#include "stp/UninterpretedFunctions/UFDecl.h"
+
+namespace stp
+{
+
+const char* UFSignature::supportedSortsPhrase()
+{
+  return "only Bool, RoundingMode, FloatingPoint and nonzero-width "
+         "bit-vector sorts are supported";
+}
+
+bool UFSignature::isSupportedSort(const SourceSort& sort)
+{
+  // RoundingMode joins Bool and BitVec because its carrier's bit-equality is
+  // its own equality: each of the five modes is exactly one 5-bit one-hot
+  // pattern, so nothing in the checker or the lemma encoder has to learn a
+  // second notion of "equal". What it does need is the pin -- see
+  // UFLowering::lowerCompletedRoot -- because the carrier has thirty-two
+  // patterns and the sort has five.
+  //
+  // FloatingPoint is admitted on the opposite basis: its carrier's
+  // bit-equality is *not* its equality, so it is never solved at its own
+  // sort. See loweringSort.
+  if (sort.kind() == SourceSort::Kind::Bool ||
+      sort.kind() == SourceSort::Kind::RoundingMode ||
+      sort.kind() == SourceSort::Kind::FloatingPoint)
+    return true;
+  return sort.kind() == SourceSort::Kind::BitVector &&
+         sort.bitVectorWidth() > 0;
+}
+
+SourceSort UFSignature::loweringSort(const SourceSort& sort)
+{
+  // Only FloatingPoint is quotiented onto its carrier, and only because its
+  // carrier's bit-equality is not its equality. Everything else is solved at
+  // its own sort.
+  if (sort.kind() == SourceSort::Kind::FloatingPoint)
+    return SourceSort::bitVector(sort.packedWidth());
+  return sort;
+}
+
+bool UFSignature::validate(const std::vector<SourceSort>& domain,
+                           const SourceSort& codomain, std::string* error)
+{
+  if (domain.empty())
+  {
+    if (error != NULL)
+      *error = "a zero-arity declaration is an ordinary symbol, not an "
+               "uninterpreted function";
+    return false;
+  }
+
+  for (size_t i = 0; i < domain.size(); ++i)
+  {
+    if (!isSupportedSort(domain[i]))
+    {
+      if (error != NULL)
+        *error = "unsupported domain sort " +
+                 sourceSortToSMTLib(domain[i]) + " at argument " +
+                 std::to_string(i) + " (" + supportedSortsPhrase() + ")";
+      return false;
+    }
+  }
+
+  if (!isSupportedSort(codomain))
+  {
+    if (error != NULL)
+      *error = "unsupported result sort " + sourceSortToSMTLib(codomain) +
+               " (" + supportedSortsPhrase() + ")";
+    return false;
+  }
+  return true;
+}
+
+UFSignature::UFSignature(std::vector<SourceSort> domain,
+                         SourceSort codomain)
+    : domain_(std::move(domain)), codomain_(std::move(codomain))
+{
+  std::string error;
+  if (!validate(domain_, codomain_, &error))
+    throw std::invalid_argument(error);
+}
+
+} // namespace stp

--- a/lib/UninterpretedFunctions/UFLemma.cpp
+++ b/lib/UninterpretedFunctions/UFLemma.cpp
@@ -1,0 +1,213 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#include "stp/UninterpretedFunctions/UFLemma.h"
+#include <set>
+
+namespace stp
+{
+
+namespace
+{
+
+struct EqualityKey
+{
+  ASTNode left;
+  ASTNode right;
+  SourceSort sort;
+
+  bool operator<(const EqualityKey& other) const
+  {
+    if (sort.kind() != other.sort.kind())
+      return static_cast<int>(sort.kind()) <
+             static_cast<int>(other.sort.kind());
+    // Bool is the one admitted sort with no carrier width to compare;
+    // everything else is separated by its packed width within a kind.
+    if (sort.kind() != SourceSort::Kind::Bool &&
+        sort.packedWidth() != other.sort.packedWidth())
+      return sort.packedWidth() < other.sort.packedWidth();
+    if (left != other.left)
+      return left < other.left;
+    return right < other.right;
+  }
+};
+
+EqualityKey keyFor(ASTNode left, ASTNode right, const SourceSort& sort)
+{
+  if (right < left)
+    std::swap(left, right);
+  EqualityKey key;
+  key.left = left;
+  key.right = right;
+  key.sort = sort;
+  return key;
+}
+
+// What a lemma atom may be stated over. This is the *lowering* sort list, not
+// the signature one: FloatingPoint is an admitted signature sort but is never
+// a lemma sort, because a float is quotiented to its packed carrier before it
+// reaches the checker at all.
+bool supported(const SourceSort& sort)
+{
+  return UFSignature::isSupportedSort(sort) &&
+         sort.kind() != SourceSort::Kind::FloatingPoint;
+}
+
+} // namespace
+
+bool UFAbstractLemma::evaluate(
+    bool conclusionEquality,
+    const std::vector<bool>& premiseEqualities) const
+{
+  if (premiseEqualities.size() != premise.size())
+    return false;
+  bool premiseValue = true;
+  for (const bool value : premiseEqualities)
+    premiseValue = premiseValue && value;
+  return !premiseValue || conclusionEquality;
+}
+
+bool UFLemmaOracle::buildAndValidate(const UFCongruenceConflict& conflict,
+                                     UFAbstractLemma& lemma,
+                                     std::string& diagnostic)
+{
+  lemma = UFAbstractLemma();
+  diagnostic.clear();
+  if (conflict.declaration == NULL || conflict.leftResult.IsNull() ||
+      conflict.rightResult.IsNull() ||
+      conflict.leftResultValue == conflict.rightResultValue)
+  {
+    diagnostic = "UF lemma certificate has no result conflict";
+    return false;
+  }
+  // Certificates are stated at the lowering sort, which is what the CNF
+  // encoder can build equalities over. It differs from the declared sort only
+  // for FloatingPoint, whose bit-equality is not its equality -- so a float
+  // reaches this oracle already quotiented to its canonical packed bits, and
+  // never as a float.
+  const SourceSort resultSort = UFSignature::loweringSort(
+      conflict.declaration->signature().codomain());
+  if (!supported(resultSort) ||
+      conflict.leftResult.GetSourceSort() != resultSort ||
+      conflict.rightResult.GetSourceSort() != resultSort ||
+      conflict.leftResultValue.sort() != resultSort ||
+      conflict.rightResultValue.sort() != resultSort)
+  {
+    diagnostic = "UF lemma certificate has an invalid result sort";
+    return false;
+  }
+
+  std::set<EqualityKey> seen;
+  size_t expectedPosition = 0;
+  for (const UFCongruenceArgument& argument : conflict.arguments)
+  {
+    if (argument.position != expectedPosition++ ||
+        argument.position >= conflict.declaration->signature().arity() ||
+        argument.sort != UFSignature::loweringSort(
+                             conflict.declaration->signature()
+                                 .domain()[argument.position]) ||
+        argument.concreteValue.sort() != argument.sort ||
+        argument.leftTheory.IsNull() || argument.rightTheory.IsNull() ||
+        argument.leftTheory.GetSourceSort() != argument.sort ||
+        argument.rightTheory.GetSourceSort() != argument.sort ||
+        argument.leftScalar.IsNull() || argument.rightScalar.IsNull() ||
+        argument.leftScalar.GetSourceSort() != argument.sort ||
+        argument.rightScalar.GetSourceSort() != argument.sort ||
+        (argument.leftScalar.GetKind() != SYMBOL &&
+         !argument.leftScalar.isConstant()) ||
+        (argument.rightScalar.GetKind() != SYMBOL &&
+         !argument.rightScalar.isConstant()))
+    {
+      diagnostic = "UF lemma certificate has an invalid argument pair";
+      return false;
+    }
+
+    // Exact identity makes this premise a reflexive true atom. Concrete
+    // equality alone is deliberately insufficient to omit it.
+    if (argument.leftScalar == argument.rightScalar)
+      continue;
+
+    // A constant/constant atom is decided without a SAT circuit. The
+    // collided tuple says every premise is true, so unequal constants expose
+    // a corrupt certificate; equal constants are canonical `true` and drop.
+    if (argument.leftScalar.isConstant() &&
+        argument.rightScalar.isConstant())
+    {
+      UFConcreteValue left;
+      UFConcreteValue right;
+      if (!UFConcreteValue::fromConstant(argument.leftScalar, argument.sort,
+                                         left, diagnostic) ||
+          !UFConcreteValue::fromConstant(argument.rightScalar, argument.sort,
+                                         right, diagnostic))
+        return false;
+      if (left != right)
+      {
+        diagnostic = "UF lemma contains a structurally false constant "
+                     "premise";
+        return false;
+      }
+      continue;
+    }
+
+    const EqualityKey key = keyFor(argument.leftScalar, argument.rightScalar,
+                                   argument.sort);
+    if (!seen.insert(key).second)
+      continue;
+
+    UFEqualityAtom atom;
+    atom.left = key.left;
+    atom.right = key.right;
+    atom.sort = argument.sort;
+    atom.originalPosition = argument.position;
+    lemma.premise.push_back(atom);
+  }
+
+  const EqualityKey conclusion =
+      keyFor(conflict.leftResult, conflict.rightResult, resultSort);
+  if (conclusion.left == conclusion.right)
+  {
+    diagnostic = "UF lemma conflict has a reflexive result equality";
+    return false;
+  }
+  lemma.conclusion.left = conclusion.left;
+  lemma.conclusion.right = conclusion.right;
+  lemma.conclusion.sort = resultSort;
+  lemma.conclusion.originalPosition = conflict.arguments.size();
+  lemma.candidateVersion = conflict.candidateVersion;
+
+  // The tuple collision proves every retained premise true; the distinct
+  // result values prove the conclusion false. Evaluate the abstract clause
+  // explicitly so validate-before-mutate is exercised in every build mode,
+  // with assertions providing an additional debug audit rather than the only
+  // enforcement.
+  const std::vector<bool> premiseValues(lemma.premise.size(), true);
+  if (lemma.evaluate(false, premiseValues))
+  {
+    diagnostic = "UF lemma does not reject its triggering candidate";
+    return false;
+  }
+  return true;
+}
+
+} // namespace stp

--- a/lib/UninterpretedFunctions/UFLowering.cpp
+++ b/lib/UninterpretedFunctions/UFLowering.cpp
@@ -1,0 +1,393 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#include "stp/UninterpretedFunctions/UFLowering.h"
+#include "stp/Globals/Globals.h"
+#include "stp/STPManager/STPManager.h"
+#include "stp/UninterpretedFunctions/UFContext.h"
+#include "stp/Util/DagWalk.h"
+#include <string>
+
+namespace stp
+{
+
+namespace
+{
+
+bool isLeafActual(const ASTNode& actual)
+{
+  return actual.GetKind() == SYMBOL || actual.isConstant();
+}
+
+ASTNode rebuildWithChildren(const ASTNode& original,
+                            const ASTVec& loweredChildren, STPMgr* manager)
+{
+  assert(original.Degree() == loweredChildren.size());
+  bool changed = false;
+  for (size_t i = 0; i < loweredChildren.size(); ++i)
+    changed = changed || loweredChildren[i] != original[i];
+  if (!changed)
+    return original;
+
+  NodeFactory* const factory = manager->defaultNodeFactory;
+  ASTNode rebuilt;
+  if (original.GetValueWidth() == 0)
+    rebuilt = factory->CreateNode(original.GetKind(), loweredChildren);
+  else
+    // Mirror SubstitutionMap's rebuild funnel: CreateArrayTerm preserves both
+    // widths for arrays and is also the width-preserving CreateTerm path for
+    // non-Boolean bit-vector terms when the index width is zero.
+    rebuilt =
+        factory->CreateArrayTerm(original.GetKind(), original.GetIndexWidth(),
+                                 original.GetValueWidth(), loweredChildren);
+
+  if (rebuilt.GetSourceSort() != original.GetSourceSort())
+    FatalError("UF lowering rebuilt a node at the wrong SourceSort", rebuilt);
+  return rebuilt;
+}
+
+} // namespace
+
+ASTNode
+LoweredApplicationView::semanticRootWithDefinitions(STPMgr* manager) const
+{
+  assert(manager != NULL);
+  if (namingDefinitions.empty() && sortConstraints.empty())
+    return semanticRoot;
+  ASTVec conjuncts;
+  conjuncts.reserve(namingDefinitions.size() + sortConstraints.size() + 1);
+  conjuncts.push_back(semanticRoot);
+  conjuncts.insert(conjuncts.end(), namingDefinitions.begin(),
+                   namingDefinitions.end());
+  conjuncts.insert(conjuncts.end(), sortConstraints.begin(),
+                   sortConstraints.end());
+  return manager->defaultNodeFactory->CreateNode(AND, conjuncts);
+}
+
+UFLowering::UFLowering(STPMgr* manager) : manager_(manager)
+{
+  assert(manager_ != NULL);
+}
+
+LoweredApplicationView
+UFLowering::lowerCompletedRoot(const ASTNode& publicRoot,
+                               const UFSolveScope& scope) const
+{
+  if (publicRoot.IsNull() || !publicRoot.IsOwnedBy(manager_))
+    FatalError("UF lowering requires a completed root owned by its context");
+
+  LoweredApplicationView view;
+  view.scope = scope;
+  view.publicRoot = publicRoot;
+  view.semanticRoot = publicRoot;
+
+  UFContext* context = manager_->getUFContextIfAny();
+  if (!manager_->UserFlags.enable_uninterpreted_functions)
+  {
+    if (context != NULL)
+      context->releaseSolveProtection();
+    return view;
+  }
+
+  if (context == NULL)
+  {
+    if (containsKind(publicRoot, UF_APPLY))
+      FatalError("UF lowering found UF_APPLY without a manager context",
+                 publicRoot);
+    return view;
+  }
+  context->beginSolveProtection();
+
+  // A name is canonical per lowered expression, matching the reference
+  // oracle. This both avoids redundant definitions and makes an identical
+  // persistent block reconstruct the identical semantic root.
+  ASTNodeMap scalarNames;
+
+  // Pin every RoundingMode scalar this lowering makes the checker's authority
+  // for -- introduced results, introduced argument names, and the leaf
+  // symbols it registers as solve scalars in their own right. The sort has
+  // five values and its carrier thirty-two, so an unpinned one lets a model
+  // name no mode at all: the generated define-fun would print a term of no
+  // sort, and model evaluation could hand an illegal mode to an enclosing
+  // floating-point operation as a constant operand.
+  //
+  // FpTotalise pins the same symbols out of the semantic root when it runs,
+  // and an OR of five equalities is idempotent, so at worst this adds a
+  // duplicate conjunct. What it buys is that the pin arrives with the symbol
+  // instead of with a later pass: the persistent path decides whether to run
+  // that pass from the *raw* block, and reset-assertions can retract a
+  // declaration's own pin while keeping the declaration.
+  //
+  // Pins are appended in walk order rather than collected from
+  // view.solveScalars, so that an identical block rebuilds an identical
+  // conjunction without depending on a hash set's iteration order.
+  ASTNodeSet pinnedRoundingModes;
+  const auto pinIfRoundingMode = [&](const ASTNode& scalar) {
+    if (!manager_->isRoundingModeSymbol(scalar) ||
+        !pinnedRoundingModes.insert(scalar).second)
+      return;
+    view.sortConstraints.push_back(
+        manager_->roundingModeValidConstraint(scalar));
+  };
+
+  // An actual, as the checker will compare it. Only a float moves: it becomes
+  // its canonical packed bits, which is the sort's own equality rather than
+  // the carrier's, so two NaNs of different payloads compare equal and the
+  // two zeros stay apart. A constant takes the same boundary as everything
+  // else -- it needs no special case, because a float constant is already
+  // interned canonically (STPMgr::CreateFPConst quotients NaN) and the
+  // boundary folds over it rather than building a circuit.
+  const auto canonicalActual = [&](const ASTNode& lowered,
+                                   const SourceSort& declared) -> ASTNode {
+    if (declared.kind() != SourceSort::Kind::FloatingPoint)
+      return lowered;
+    return manager_->defaultNodeFactory->CreateTerm(
+        FP_TO_IEEE_BV, declared.packedWidth(), lowered);
+  };
+
+  // A result, as the formula that replaces the application will see it. The
+  // exact inverse of canonicalActual: the three-child to_fp reinterprets the
+  // solved bits at the declared format.
+  const auto theoryResult = [&](const ASTNode& result,
+                                const SourceSort& declared) -> ASTNode {
+    if (declared.kind() != SourceSort::Kind::FloatingPoint)
+      return result;
+    const ASTNode reinterpreted = manager_->defaultNodeFactory->CreateTerm(
+        FP_TOFP, declared.packedWidth(),
+        manager_->CreateBVConst(32, declared.exponentWidth()),
+        manager_->CreateBVConst(32, declared.significandWidth()), result);
+    if (reinterpreted.GetSourceSort() != declared)
+      FatalError("UF lowering rebuilt a float result at the wrong SourceSort",
+                 reinterpreted);
+    return reinterpreted;
+  };
+
+  // A compound actual cannot be named while the walk is running: whether the
+  // name is needed depends on how many applications its declaration turns out
+  // to have, and the last of them may not have been reached yet. Each one is
+  // parked here against the slot it will fill.
+  struct PendingName
+  {
+    size_t record;
+    size_t argument;
+    ASTNode lowered;
+    SourceSort sort;
+  };
+  std::vector<PendingName> pendingNames;
+
+  // Rewrite the completed root once, bottom-up. The explicit walk keeps its
+  // frames on the heap (input controls AST depth), visits each shared DAG node
+  // once, and guarantees that a nested UF application has become its scalar
+  // result before an enclosing application's actual is recorded.
+  DenseNodeMap rewritten;
+  view.semanticRoot = postOrderRebuild(
+      publicRoot, rewritten,
+      [&](const ASTNode& application, const ASTVec& loweredChildren) -> ASTNode
+      {
+        if (application.GetKind() != UF_APPLY)
+          return rebuildWithChildren(application, loweredChildren, manager_);
+
+        std::string diagnostic;
+        if (!context->isRegisteredApplication(application) ||
+            !context->validateApplicationChildren(application.GetChildren(),
+                                                  &diagnostic))
+          FatalError(("UF lowering rejected a malformed durable application: " +
+                      diagnostic)
+                         .c_str(),
+                     application);
+        if (!context->isActiveApplication(application))
+          FatalError("UF lowering rejected a stale or inactive durable "
+                     "application",
+                     application);
+
+        const UFDecl* declaration = context->lookupIdentity(application[0]);
+        if (declaration == NULL)
+          FatalError("UF lowering could not recover declaration identity",
+                     application);
+        if (loweredChildren.size() != application.Degree() ||
+            loweredChildren.empty() || loweredChildren[0] != application[0])
+          FatalError("UF lowering rewrote a declaration identity", application);
+
+        LoweredApplicationRecord record;
+        record.durableHandle = application;
+        record.declaration = declaration;
+        record.scope = scope;
+        record.stableOrder = view.applications.size();
+        record.loweredActuals.reserve(application.Degree() - 1);
+        record.namedActuals.reserve(application.Degree() - 1);
+
+        for (size_t i = 1; i < loweredChildren.size(); ++i)
+        {
+          const ASTNode& lowered = loweredChildren[i];
+          const SourceSort& expected = declaration->signature().domain()[i - 1];
+          if (application[i].GetSourceSort() != expected ||
+              lowered.GetSourceSort() != expected)
+            FatalError("UF lowering crossed a SourceSort boundary",
+                       application);
+
+          // From here down the record speaks the lowering sort. For every
+          // sort but FloatingPoint that is the declared sort unchanged; a
+          // float crosses into its canonical packed carrier here and does not
+          // cross back until the model boundary.
+          const SourceSort solved = UFSignature::loweringSort(expected);
+          const ASTNode scalar = canonicalActual(lowered, expected);
+          if (scalar.GetSourceSort() != solved)
+            FatalError("UF lowering produced an actual at the wrong lowering "
+                       "sort",
+                       scalar);
+          record.loweredActuals.push_back(scalar);
+
+          if (isLeafActual(scalar))
+          {
+            record.namedActuals.push_back(scalar);
+            // A source symbol is already its own canonical scalar name, but it
+            // still participates in future direct-CNF lemmas. Protect/register it
+            // exactly like an introduced name so ordinary preprocessing cannot
+            // substitute it away and leave the lemma talking about an unlinked
+            // fresh SAT value. Constants need no mapping or protection.
+            if (scalar.GetKind() == SYMBOL)
+            {
+              view.protectedSymbols.insert(scalar);
+              view.solveScalars.insert(scalar);
+              pinIfRoundingMode(scalar);
+            }
+            continue;
+          }
+
+          PendingName pending;
+          pending.record = record.stableOrder;
+          pending.argument = record.namedActuals.size();
+          pending.lowered = scalar;
+          pending.sort = solved;
+          pendingNames.push_back(pending);
+          record.namedActuals.push_back(ASTNode());
+        }
+
+        const SourceSort& codomain = declaration->signature().codomain();
+        if (application.GetSourceSort() != codomain)
+          FatalError("UF lowering found a durable result with the wrong "
+                     "SourceSort",
+                     application);
+        SourceSort solvedCodomain = UFSignature::loweringSort(codomain);
+        std::string resultPrefix = "uf_result";
+        record.resultSymbol = manager_->CreateDeterministicSourceVariable(
+            solvedCodomain, resultPrefix, application);
+        if (record.resultSymbol.GetSourceSort() != solvedCodomain)
+          FatalError("UF lowering allocated a result at the wrong SourceSort",
+                     record.resultSymbol);
+        view.protectedSymbols.insert(record.resultSymbol);
+        view.solveScalars.insert(record.resultSymbol);
+        pinIfRoundingMode(record.resultSymbol);
+        view.handleToResult.insert(
+            std::make_pair(application, record.resultSymbol));
+        view.applications.push_back(record);
+        // A float result is solved as a packed bit-vector but the formula it
+        // replaces expects a float, so it goes back in through the exact
+        // inverse of the boundary its arguments came through: the three-child
+        // "reinterpret these bits" to_fp. Every other sort is returned as
+        // itself.
+        return theoryResult(record.resultSymbol, codomain);
+      });
+
+  // Only a declaration with two or more lowered applications can ever produce
+  // a congruence lemma, and a name for a compound actual exists solely so that
+  // such a lemma has a scalar to equate. Naming one for a lone application
+  // costs a protected symbol and a defining equality that drag the whole
+  // argument expression into the bit-blast, where nothing can observe it.
+  //
+  // Two rounds, so that the decision does not depend on the order the walk
+  // reached things: every name a comparable record needs is created first, and
+  // a lone application sharing one of those terms then reuses it and stays
+  // readable for free. Only an actual left without a name after both rounds
+  // makes its record unobservable.
+  std::map<const UFDecl*, size_t> applicationsPerDeclaration;
+  for (const LoweredApplicationRecord& record : view.applications)
+    applicationsPerDeclaration[record.declaration]++;
+
+  const auto comparable = [&](const PendingName& pending) {
+    return applicationsPerDeclaration[view.applications[pending.record]
+                                          .declaration] > 1;
+  };
+
+  for (const PendingName& pending : pendingNames)
+  {
+    if (!comparable(pending))
+      continue;
+    ASTNode name;
+    const ASTNodeMap::const_iterator found = scalarNames.find(pending.lowered);
+    if (found != scalarNames.end())
+      name = found->second;
+    else
+    {
+      name = manager_->CreateDeterministicSourceVariable(pending.sort, "uf_arg",
+                                                         pending.lowered);
+      if (name.GetSourceSort() != pending.sort)
+        FatalError("UF lowering allocated an argument name at the wrong "
+                   "SourceSort",
+                   name);
+      scalarNames.insert(std::make_pair(pending.lowered, name));
+      view.nameToTerm.insert(std::make_pair(name, pending.lowered));
+      view.protectedSymbols.insert(name);
+      view.solveScalars.insert(name);
+      pinIfRoundingMode(name);
+      view.namingDefinitions.push_back(
+          manager_->defaultNodeFactory->CreateNode(
+              pending.sort.kind() == SourceSort::Kind::Bool ? IFF : EQ, name,
+              pending.lowered));
+    }
+    view.applications[pending.record].namedActuals[pending.argument] = name;
+  }
+
+  for (const PendingName& pending : pendingNames)
+  {
+    if (comparable(pending))
+      continue;
+    LoweredApplicationRecord& record = view.applications[pending.record];
+    const ASTNodeMap::const_iterator found = scalarNames.find(pending.lowered);
+    if (found != scalarNames.end())
+      record.namedActuals[pending.argument] = found->second;
+    else
+      record.observableArguments = false;
+  }
+
+  // An unobservable record keeps its durable handle, its result symbol and its
+  // lowered actuals; what it does not keep is a half-filled scalar tuple that
+  // no checker round may read.
+  for (LoweredApplicationRecord& record : view.applications)
+    if (!record.observableArguments)
+      record.namedActuals.clear();
+
+  // This checks the whole barrier once, including the naming definitions.
+  // Scanning every progressively larger actual separately would turn a
+  // linear post-order rewrite back into a quadratic algorithm on shared
+  // nested DAGs.
+  if (containsKind(view.semanticRootWithDefinitions(manager_), UF_APPLY))
+    FatalError("UF_APPLY crossed the completed-root lowering barrier",
+               view.semanticRoot);
+
+  context->installSolveProtection(view.protectedSymbols, view.solveScalars);
+  return view;
+}
+
+} // namespace stp

--- a/lib/UninterpretedFunctions/UFModel.cpp
+++ b/lib/UninterpretedFunctions/UFModel.cpp
@@ -1,0 +1,263 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#include "stp/UninterpretedFunctions/UFModel.h"
+#include "stp/Printer/printers.h"
+#include "stp/STPManager/STPManager.h"
+#include "extlib-constbv/constantbv.h"
+#include <algorithm>
+#include <cctype>
+#include <sstream>
+
+namespace stp
+{
+
+namespace
+{
+
+bool validQuotedSymbol(const std::string& name)
+{
+  // SMT-LIB quoted symbols have no escape for either delimiter character.
+  // Parser declarations have already stripped their surrounding bars.
+  for (const unsigned char c : name)
+    if (c == '|' || c == '\\' || !std::isprint(c))
+      return false;
+  return true;
+}
+
+void printQuotedSymbol(std::ostream& os, const std::string& name)
+{
+  if (!validQuotedSymbol(name))
+    FatalError("UF model contains an external name that cannot be rendered "
+               "as an SMT-LIB2 quoted symbol");
+  os << '|' << name << '|';
+}
+
+void printSort(std::ostream& os, STPMgr* manager, const SourceSort& sort)
+{
+  (void)manager;
+  if (!UFSignature::isSupportedSort(sort))
+    FatalError("UF model tried to print an unsupported SourceSort");
+  os << sourceSortToSMTLib(sort);
+}
+
+// Seed values are stored at the lowering sort; `declared` is the signature
+// sort they will be published at. The two differ only for FloatingPoint.
+void requireValueSort(const UFConcreteValue& value,
+                      const SourceSort& declared)
+{
+  const SourceSort expected = UFSignature::loweringSort(declared);
+  if (value.sort() == expected)
+    return;
+  FatalError("UF model seed contains a value at the wrong SourceSort");
+}
+
+void printValue(std::ostream& os, STPMgr* manager,
+                const UFConcreteValue& value, const SourceSort& declared)
+{
+  const ASTNode constant = UFModel::concreteValue(manager, value, declared);
+  if (declared.kind() == SourceSort::Kind::Bool)
+  {
+    os << (constant.GetKind() == TRUE ? "true" : "false");
+    return;
+  }
+  // A rounding mode denotes one of five modes, not a 5-bit number, so the
+  // define-fun this text goes into has to name the mode; a bit-vector
+  // literal there is not a term of the sort. concreteValue has already
+  // refused any carrier that names none.
+  if (declared.kind() == SourceSort::Kind::RoundingMode)
+  {
+    const char* name = printer::roundingModeName(constant.GetUnsignedConst());
+    if (name == NULL)
+      FatalError("UF model holds a RoundingMode value that denotes no mode");
+    os << name;
+    return;
+  }
+  // Likewise a float: (fp #bS #bE #bM) at the declared format, not the packed
+  // carrier the checker solved it as.
+  if (declared.kind() == SourceSort::Kind::FloatingPoint)
+  {
+    printer::outputFloatingPointSMTLIB2(constant, os, constant);
+    return;
+  }
+  printer::outputBitVecSMTLIB2(constant, os);
+}
+
+void printCondition(std::ostream& os, STPMgr* manager,
+                    const UFSignature& signature,
+                    const UFConcreteTuple& arguments)
+{
+  if (arguments.size() != signature.arity())
+    FatalError("UF model case has the wrong arity");
+  if (arguments.size() > 1)
+    os << "(and ";
+  for (size_t i = 0; i < arguments.size(); ++i)
+  {
+    if (i != 0)
+      os << ' ';
+    requireValueSort(arguments[i], signature.domain()[i]);
+    os << "(= x" << i << ' ';
+    printValue(os, manager, arguments[i], signature.domain()[i]);
+    os << ')';
+  }
+  if (arguments.size() > 1)
+    os << ')';
+}
+
+bool seedFunctionBefore(const UFFunctionModelSeed* left,
+                        const UFFunctionModelSeed* right)
+{
+  if (left == NULL || right == NULL || left->declaration == NULL ||
+      right->declaration == NULL)
+    return left < right;
+  if (left->declaration->name() != right->declaration->name())
+    return left->declaration->name() < right->declaration->name();
+  return left->declaration->id() < right->declaration->id();
+}
+
+} // namespace
+
+ASTNode UFModel::concreteValue(STPMgr* manager,
+                               const UFConcreteValue& value)
+{
+  if (manager == NULL)
+    FatalError("UF concrete-value conversion has no manager");
+  const SourceSort& sort = value.sort();
+  if (sort.kind() == SourceSort::Kind::Bool)
+    return value.booleanValue() ? manager->ASTTrue : manager->ASTFalse;
+  if (!UFSignature::isSupportedSort(sort))
+    FatalError("UF concrete-value conversion received an unsupported sort");
+
+  const unsigned width = sort.packedWidth();
+  const std::vector<uint8_t>& bytes = value.bytes();
+  if (bytes.size() != (width + 7) / 8)
+    FatalError("UF concrete-value conversion received malformed bytes");
+  CBV bits = CONSTANTBV::BitVector_Create(width, true);
+  CONSTANTBV::BitVector_Empty(bits);
+  for (unsigned i = 0; i < width; ++i)
+    if ((bytes[i / 8] & static_cast<uint8_t>(1u << (i % 8))) != 0)
+      CONSTANTBV::BitVector_Bit_On(bits, i);
+  const ASTNode carrier = manager->CreateBVConst(bits, width); // consumes bits
+  // The checker's currency is the packed carrier; a model has to hand back a
+  // term of the declared sort. LiftSourceValue is the funnel that already
+  // does this for every other model boundary, and it refuses a carrier that
+  // denotes nothing -- an all-zero "rounding mode", say -- rather than
+  // publishing it.
+  return manager->LiftSourceValue(carrier, sort);
+}
+
+ASTNode UFModel::concreteValue(STPMgr* manager, const UFConcreteValue& value,
+                               const SourceSort& declared)
+{
+  const SourceSort expected = UFSignature::loweringSort(declared);
+  if (value.sort() != expected)
+    FatalError("UF concrete-value conversion received a value at the wrong "
+               "lowering sort");
+  const ASTNode solved = concreteValue(manager, value);
+  if (declared.kind() != SourceSort::Kind::FloatingPoint)
+    return solved;
+  return manager->LiftSourceValue(solved, declared);
+}
+
+UFFunctionModelSeedSet
+UFModel::defaultSeed(const std::vector<const UFDecl*>& declarations)
+{
+  UFFunctionModelSeedSet seed;
+  std::vector<const UFDecl*> ordered = declarations;
+  std::sort(ordered.begin(), ordered.end(),
+            [](const UFDecl* left, const UFDecl* right) {
+              if (left == NULL || right == NULL)
+                return left < right;
+              return left->id() < right->id();
+            });
+  for (const UFDecl* declaration : ordered)
+  {
+    if (declaration == NULL)
+      FatalError("UF default model received a null declaration");
+    UFFunctionModelSeed function;
+    function.declaration = declaration;
+    function.defaultValue = UFConcreteValue::zero(
+        UFSignature::loweringSort(declaration->signature().codomain()));
+    seed.functions.push_back(function);
+  }
+  return seed;
+}
+
+void UFModel::printSMTLIB2(std::ostream& os,
+                           const UFFunctionModelSeedSet& seed)
+{
+  std::vector<const UFFunctionModelSeed*> functions;
+  functions.reserve(seed.functions.size());
+  for (const UFFunctionModelSeed& function : seed.functions)
+    functions.push_back(&function);
+  std::sort(functions.begin(), functions.end(), seedFunctionBefore);
+
+  for (const UFFunctionModelSeed* function : functions)
+  {
+    if (function == NULL || function->declaration == NULL ||
+        function->declaration->owner() == NULL)
+      FatalError("UF model seed contains an invalid declaration");
+    const UFDecl& declaration = *function->declaration;
+    const UFSignature& signature = declaration.signature();
+    STPMgr* manager = const_cast<STPMgr*>(declaration.owner());
+    requireValueSort(function->defaultValue, signature.codomain());
+
+    os << "(define-fun ";
+    printQuotedSymbol(os, declaration.name());
+    os << " (";
+    for (size_t i = 0; i < signature.arity(); ++i)
+    {
+      if (i != 0)
+        os << ' ';
+      os << "(x" << i << ' ';
+      printSort(os, manager, signature.domain()[i]);
+      os << ')';
+    }
+    os << ") ";
+    printSort(os, manager, signature.codomain());
+    os << '\n' << "  ";
+
+    // The checker already stores cases in typed tuple order. Emitting them in
+    // that order while nesting leaves the lexicographically first case
+    // outermost, matching the reference renderer and making text independent
+    // of insertion order.
+    for (const UFModelCase& modelCase : function->cases)
+    {
+      if (modelCase.arguments.size() != signature.arity())
+        FatalError("UF model seed contains a wrong-arity case");
+      requireValueSort(modelCase.result, signature.codomain());
+      os << "(ite ";
+      printCondition(os, manager, signature, modelCase.arguments);
+      os << ' ';
+      printValue(os, manager, modelCase.result, signature.codomain());
+      os << ' ';
+    }
+    printValue(os, manager, function->defaultValue, signature.codomain());
+    for (size_t i = 0; i < function->cases.size(); ++i)
+      os << ')';
+    os << ")\n";
+  }
+}
+
+} // namespace stp

--- a/lib/UninterpretedFunctions/UFModel.cpp
+++ b/lib/UninterpretedFunctions/UFModel.cpp
@@ -23,8 +23,12 @@ THE SOFTWARE.
 ********************************************************************/
 
 #include "stp/UninterpretedFunctions/UFModel.h"
+#include "stp/AbsRefineCounterExample/AbsRefine_CounterExample.h"
 #include "stp/Printer/printers.h"
 #include "stp/STPManager/STPManager.h"
+#include "stp/Simplifier/SubstitutionMap.h"
+#include "stp/UninterpretedFunctions/UFContext.h"
+#include "stp/UninterpretedFunctions/UFRefinement.h"
 #include "extlib-constbv/constantbv.h"
 #include <algorithm>
 #include <cctype>
@@ -56,9 +60,9 @@ void printQuotedSymbol(std::ostream& os, const std::string& name)
 
 void printSort(std::ostream& os, STPMgr* manager, const SourceSort& sort)
 {
-  (void)manager;
   if (!UFSignature::isSupportedSort(sort))
     FatalError("UF model tried to print an unsupported SourceSort");
+  (void)manager;
   os << sourceSortToSMTLib(sort);
 }
 
@@ -125,6 +129,28 @@ void printCondition(std::ostream& os, STPMgr* manager,
     os << ')';
 }
 
+// A floating-point actual as the checker would have bucketed it: its
+// canonical packed bits.
+//
+// The value arrives either as a float constant or as the bare carrier the SAT
+// assignment materialised, so it is lifted to the declared sort first --
+// which is where NaN gets quotiented, since STPMgr::CreateFPConst interns
+// every NaN pattern as the one canonical quiet NaN -- and then taken back
+// through the same FP_TO_IEEE_BV boundary UF lowering puts on the argument
+// side. Over a constant that folds rather than building a circuit; a null
+// return means it did not, which the caller reports rather than guessing.
+ASTNode canonicalConstant(STPMgr* manager, const ASTNode& constant,
+                          const SourceSort& declared)
+{
+  if (constant.GetKind() != BVCONST ||
+      constant.GetValueWidth() != declared.packedWidth())
+    return ASTNode();
+  const ASTNode packed = manager->defaultNodeFactory->CreateTerm(
+      FP_TO_IEEE_BV, declared.packedWidth(),
+      manager->LiftSourceValue(constant, declared));
+  return packed.GetKind() == BVCONST ? packed : ASTNode();
+}
+
 bool seedFunctionBefore(const UFFunctionModelSeed* left,
                         const UFFunctionModelSeed* right)
 {
@@ -178,6 +204,235 @@ ASTNode UFModel::concreteValue(STPMgr* manager, const UFConcreteValue& value,
   if (declared.kind() != SourceSort::Kind::FloatingPoint)
     return solved;
   return manager->LiftSourceValue(solved, declared);
+}
+
+bool UFModel::evaluateApplication(STPMgr* manager,
+                                  const UFTheoryAdapter* adapter,
+                                  const ASTNode& durableHandle,
+                                  ASTNode& value,
+                                  std::string& diagnostic)
+{
+  value = ASTNode();
+  if (manager == NULL || durableHandle.IsNull() ||
+      !durableHandle.IsOwnedBy(manager))
+  {
+    diagnostic = "uninterpreted-function application belongs to another "
+                 "context or is invalid";
+    return false;
+  }
+  UFContext* context = manager->getUFContextIfAny();
+  if (context == NULL ||
+      !context->isRegisteredApplication(durableHandle))
+  {
+    diagnostic = "expression is not a registered durable "
+                 "uninterpreted-function application";
+    return false;
+  }
+  if (!context->isActiveApplication(durableHandle))
+  {
+    diagnostic = "uninterpreted-function application is stale or inactive";
+    return false;
+  }
+  if (adapter == NULL || !adapter->hasCertifiedModel())
+  {
+    diagnostic = "no certified uninterpreted-function model is available";
+    return false;
+  }
+  UFConcreteValue concrete;
+  if (!adapter->lookupCertifiedApplication(durableHandle, concrete))
+  {
+    diagnostic = "uninterpreted-function application was not active in the "
+                 "certified solve";
+    return false;
+  }
+  const SourceSort declared = durableHandle.GetSourceSort();
+  const SourceSort expected = UFSignature::loweringSort(declared);
+  if (concrete.sort() != expected)
+  {
+    diagnostic = "certified uninterpreted-function value has the wrong "
+                 "SourceSort";
+    return false;
+  }
+  value = concreteValue(manager, concrete, declared);
+  return true;
+}
+
+bool UFModel::evaluateApplicationInTerm(
+    STPMgr* manager, const UFTheoryAdapter* adapter,
+    const ASTNode& durableHandle, const std::vector<ASTNode>& actualValues,
+    ASTNode& value, std::string& diagnostic)
+{
+  // An application the solve reached has a certified value; prefer it.
+  if (evaluateApplication(manager, adapter, durableHandle, value, diagnostic))
+    return true;
+
+  value = ASTNode();
+  if (manager == NULL || durableHandle.IsNull() ||
+      !durableHandle.IsOwnedBy(manager) ||
+      durableHandle.GetKind() != UF_APPLY || durableHandle.Degree() == 0)
+  {
+    diagnostic = "uninterpreted-function application belongs to another "
+                 "context or is invalid";
+    return false;
+  }
+  UFContext* context = manager->getUFContextIfAny();
+  const UFDecl* declaration =
+      context == NULL ? NULL : context->lookupIdentity(durableHandle[0]);
+  if (declaration == NULL)
+  {
+    diagnostic = "expression is not a registered durable "
+                 "uninterpreted-function application";
+    return false;
+  }
+  const UFSignature& signature = declaration->signature();
+  if (actualValues.size() != signature.arity())
+  {
+    diagnostic = "uninterpreted-function application was given the wrong "
+                 "number of evaluated actuals";
+    return false;
+  }
+
+  // The actuals, as the seed keys them -- which is at the lowering sort, and
+  // canonicalised.
+  //
+  // This is the quiet half of the boundary. The checker observed the
+  // canonically-packed actual, so a query that supplies a differently
+  // payloaded NaN for the same argument is asking about the same value and
+  // must reach the same case. Keying the seed with the raw constant instead
+  // would fall through to the default, and model evaluation would disagree
+  // with the interpretation the define-fun printed -- silently, because both
+  // answers are well-sorted.
+  UFConcreteTuple arguments;
+  arguments.reserve(actualValues.size());
+  for (size_t i = 0; i < actualValues.size(); ++i)
+  {
+    const SourceSort& declared = signature.domain()[i];
+    ASTNode actual = actualValues[i];
+    if (declared.kind() == SourceSort::Kind::FloatingPoint)
+    {
+      actual = canonicalConstant(manager, actual, declared);
+      if (actual.IsNull())
+      {
+        diagnostic = "uninterpreted-function application was given a "
+                     "floating-point actual that does not fold to a "
+                     "canonical value";
+        return false;
+      }
+    }
+    UFConcreteValue argument;
+    if (!UFConcreteValue::fromConstant(
+            actual, UFSignature::loweringSort(declared), argument, diagnostic))
+      return false;
+    arguments.push_back(argument);
+  }
+
+  // The certified seed is a total function: a case per observed tuple, then a
+  // default. Nothing certified for this declaration means no application of
+  // it was observed, so any constant interpretation is consistent.
+  const UFFunctionModelSeedSet* seed =
+      (adapter != NULL && adapter->hasCertifiedModel())
+          ? adapter->certifiedModelSeed()
+          : NULL;
+  const UFFunctionModelSeed* function = NULL;
+  if (seed != NULL)
+  {
+    for (const UFFunctionModelSeed& candidate : seed->functions)
+      if (candidate.declaration == declaration)
+      {
+        function = &candidate;
+        break;
+      }
+  }
+  if (function == NULL)
+  {
+    value = concreteValue(
+        manager,
+        UFConcreteValue::zero(
+            UFSignature::loweringSort(signature.codomain())),
+        signature.codomain());
+    return true;
+  }
+
+  for (const UFModelCase& entry : function->cases)
+    if (entry.arguments == arguments)
+    {
+      requireValueSort(entry.result, signature.codomain());
+      value = concreteValue(manager, entry.result, signature.codomain());
+      return true;
+    }
+
+  requireValueSort(function->defaultValue, signature.codomain());
+  value = concreteValue(manager, function->defaultValue, signature.codomain());
+  return true;
+}
+
+bool UFModel::completePublicRoot(STPMgr* manager,
+                                 const UFTheoryAdapter& adapter,
+                                 ASTNode& completed,
+                                 std::string& diagnostic)
+{
+  completed = ASTNode();
+  const LoweredApplicationView* view = adapter.applicationView();
+  if (manager == NULL || view == NULL || !view->active() ||
+      view->publicRoot.IsNull() || !view->publicRoot.IsOwnedBy(manager))
+  {
+    diagnostic = "certified UF adapter has no owned active public root";
+    return false;
+  }
+  if (!adapter.hasCertifiedModel())
+  {
+    diagnostic = "UF public-root completion began before certification";
+    return false;
+  }
+
+  ASTNodeMap replacements;
+  for (const LoweredApplicationRecord& record : view->applications)
+  {
+    ASTNode constant;
+    if (!evaluateApplication(manager, &adapter, record.durableHandle,
+                             constant, diagnostic))
+      return false;
+    if (!replacements.insert(
+             std::make_pair(record.durableHandle, constant)).second)
+    {
+      diagnostic = "UF public-root completion saw a duplicate handle";
+      return false;
+    }
+  }
+  ASTNodeMap cache;
+  completed = SubstitutionMap::replace(view->publicRoot, replacements, cache,
+                                       manager->defaultNodeFactory);
+  if (containsKind(completed, UF_APPLY))
+  {
+    diagnostic = "UF public-root completion left an application behind";
+    completed = ASTNode();
+    return false;
+  }
+  return true;
+}
+
+bool UFModel::replayPublicRoot(
+    AbsRefine_CounterExample& counterexample,
+    const UFTheoryAdapter& adapter, std::string& diagnostic)
+{
+  const LoweredApplicationView* view = adapter.applicationView();
+  STPMgr* manager = view == NULL || view->publicRoot.IsNull()
+                        ? NULL
+                        : view->publicRoot.GetNodeManager();
+  ASTNode completed;
+  if (!completePublicRoot(manager, adapter, completed, diagnostic))
+    return false;
+  const ASTNode result = counterexample.QueryFormulaAgainstModel(completed);
+  if (result != manager->ASTTrue)
+  {
+    diagnostic = result == manager->ASTFalse
+                     ? "certified UF interpretation does not satisfy the "
+                       "preserved public root"
+                     : "preserved UF public root did not replay to a Boolean "
+                       "constant";
+    return false;
+  }
+  return true;
 }
 
 UFFunctionModelSeedSet

--- a/lib/UninterpretedFunctions/UFRefinement.cpp
+++ b/lib/UninterpretedFunctions/UFRefinement.cpp
@@ -1,0 +1,818 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#include "stp/UninterpretedFunctions/UFRefinement.h"
+#include "stp/AbsRefineCounterExample/AbsRefine_CounterExample.h"
+#include "stp/STPManager/STPManager.h"
+#include "stp/Sat/SATSolver.h"
+#include "stp/ToSat/ToSATBase.h"
+#include "stp/UninterpretedFunctions/UFContext.h"
+#include "extlib-constbv/constantbv.h"
+#include <algorithm>
+#include <iostream>
+#include <map>
+#include <set>
+#include <sstream>
+
+namespace stp
+{
+
+namespace
+{
+
+struct EqualityKey
+{
+  ASTNode left;
+  ASTNode right;
+  SourceSort sort;
+
+  bool operator<(const EqualityKey& other) const
+  {
+    if (sort.kind() != other.sort.kind())
+      return static_cast<int>(sort.kind()) <
+             static_cast<int>(other.sort.kind());
+    // Bool is the one admitted sort with no carrier width to compare;
+    // everything else is separated by its packed width within a kind.
+    if (sort.kind() != SourceSort::Kind::Bool &&
+        sort.packedWidth() != other.sort.packedWidth())
+      return sort.packedWidth() < other.sort.packedWidth();
+    if (left != other.left)
+      return left < other.left;
+    return right < other.right;
+  }
+};
+
+EqualityKey equalityKey(ASTNode left, ASTNode right, const SourceSort& sort)
+{
+  if (right < left)
+    std::swap(left, right);
+  EqualityKey key;
+  key.left = left;
+  key.right = right;
+  key.sort = sort;
+  return key;
+}
+
+class CounterExampleCandidate final : public UFScalarCandidate
+{
+public:
+  CounterExampleCandidate(AbsRefine_CounterExample& ce,
+                          const UFContext& context, uint64_t version)
+      : ce_(ce), context_(context), version_(version)
+  {
+  }
+
+  uint64_t version() const override { return version_; }
+
+  bool read(const ASTNode& scalar, const SourceSort& expected,
+            UFConcreteValue& value,
+            std::string& diagnostic) const override
+  {
+    if (scalar.IsNull() || scalar.GetKind() != SYMBOL ||
+        scalar.GetSourceSort() != expected)
+    {
+      diagnostic = "UF adapter was asked to read a non-symbol or wrong-sort "
+                   "candidate scalar";
+      return false;
+    }
+    if (!context_.isSolveScalar(scalar))
+    {
+      diagnostic = "UF checker scalar was not registered as a SAT candidate "
+                   "authority";
+      return false;
+    }
+    ASTNode assigned = ce_.LookupAssignedValue(scalar);
+    if (assigned.IsNull() || !assigned.isConstant())
+    {
+      // Every symbolic argument leaf, introduced actual name and result has
+      // one authority: the complete mapping registered in the current SAT
+      // backend.  Never fall back through SolverMap/model evaluation here;
+      // doing so would let a lemma encode one value while the checker read
+      // another.
+      diagnostic = "UF solve scalar has no direct up-front SAT assignment";
+      return false;
+    }
+    return UFConcreteValue::fromConstant(assigned, expected, value,
+                                         diagnostic);
+  }
+
+private:
+  AbsRefine_CounterExample& ce_;
+  const UFContext& context_;
+  const uint64_t version_;
+};
+
+// One validated congruence clause waiting to be installed, with the
+// declaration whose candidate it refutes: that name is what the `-s` trace
+// prints when the clause goes in.
+struct PendingLemma
+{
+  UFAbstractLemma lemma;
+  const UFDecl* declaration = NULL;
+};
+
+struct MutableAdapterState
+{
+  explicit MutableAdapterState(STPMgr* manager_) : manager(manager_) {}
+
+  STPMgr* manager;
+  const LoweredApplicationView* view = NULL;
+  UFCheckPlan checkPlan;
+  std::string checkPlanDiagnostic;
+  // Every lemma the last refuted candidate produced, in the checker's
+  // deterministic conflict order. Empty exactly when no candidate is pending.
+  std::vector<PendingLemma> pending;
+  bool certified = false;
+  UFFunctionModelSeedSet seed;
+  std::map<ASTNode, UFConcreteValue> handleValues;
+  std::string diagnostic;
+  uint64_t nextCandidateVersion = 0;
+  uint64_t candidateCheckCount = 0;
+  uint64_t emittedLemmaCount = 0;
+
+  void clearRound()
+  {
+    pending.clear();
+    certified = false;
+    seed = UFFunctionModelSeedSet();
+    handleValues.clear();
+    diagnostic.clear();
+  }
+
+  void clearActive()
+  {
+    clearRound();
+    view = NULL;
+    checkPlan = UFCheckPlan();
+    checkPlanDiagnostic.clear();
+  }
+
+  void beginView(const LoweredApplicationView* nextView)
+  {
+    clearRound();
+    view = nextView;
+    checkPlan = UFCheckPlan();
+    checkPlanDiagnostic.clear();
+    if (view == NULL || !view->active())
+      return;
+    UFContext* context = manager->getUFContextIfAny();
+    if (context == NULL)
+    {
+      checkPlanDiagnostic =
+          "UF adapter has an active view but no UF context";
+      return;
+    }
+    checkPlan = UFChecker::validate(context->activeDeclarations(), *view);
+    if (!checkPlan.valid())
+      checkPlanDiagnostic = checkPlan.diagnostic();
+  }
+};
+
+UFCandidateOutcome checkOneCandidate(
+    MutableAdapterState& state,
+    AbsRefine_CounterExample& counterexample)
+{
+  state.clearRound();
+  if (state.view == NULL || !state.view->active())
+    return UFCandidateOutcome::Skipped;
+  if (!state.checkPlan.valid())
+  {
+    state.diagnostic = state.checkPlanDiagnostic.empty()
+                           ? "UF adapter has no validated checker plan"
+                           : state.checkPlanDiagnostic;
+    return UFCandidateOutcome::InternalError;
+  }
+  UFContext* context = state.manager->getUFContextIfAny();
+  if (context == NULL)
+  {
+    state.diagnostic = "UF adapter has an active view but no UF context";
+    return UFCandidateOutcome::InternalError;
+  }
+
+  const uint64_t version = ++state.nextCandidateVersion;
+  state.candidateCheckCount++;
+  CounterExampleCandidate candidate(counterexample, *context, version);
+  UFCheckResult result = UFChecker::check(
+      state.checkPlan, candidate,
+      state.manager->UserFlags.uf_lemmas_per_round);
+  if (result.status == UFCheckResult::Status::InternalError)
+  {
+    state.diagnostic = result.diagnostic;
+    return UFCandidateOutcome::InternalError;
+  }
+  if (result.hasConflict())
+  {
+    if (result.conflicts.empty())
+    {
+      state.diagnostic = "UFCHK reported a conflict with no certificate";
+      return UFCandidateOutcome::InternalError;
+    }
+    // Each conflict is refuted by the same unchanged candidate, so all of
+    // them are built and validated here, before the encoder is allowed to
+    // touch SAT at all. A single failure abandons the whole batch.
+    state.pending.reserve(result.conflicts.size());
+    for (const UFCongruenceConflict& conflict : result.conflicts)
+    {
+      PendingLemma entry;
+      if (!UFLemmaOracle::buildAndValidate(conflict, entry.lemma,
+                                           state.diagnostic))
+      {
+        state.pending.clear();
+        return UFCandidateOutcome::InternalError;
+      }
+      if (entry.lemma.candidateVersion != version)
+      {
+        state.pending.clear();
+        state.diagnostic = "UF lemma retained the wrong candidate version";
+        return UFCandidateOutcome::InternalError;
+      }
+      entry.declaration = conflict.declaration;
+      state.pending.push_back(entry);
+    }
+    return UFCandidateOutcome::Conflict;
+  }
+
+  if (!result.consistent() || result.modelSeed.candidateVersion != version)
+  {
+    state.diagnostic = "UF checker returned a malformed consistency seed";
+    return UFCandidateOutcome::InternalError;
+  }
+
+  // Preserve every active durable handle, including duplicate applications
+  // omitted from the finite table's one representative per concrete tuple.
+  for (const LoweredApplicationRecord& record : state.view->applications)
+  {
+    UFConcreteValue value;
+    if (!candidate.read(record.resultSymbol,
+                        record.resultSymbol.GetSourceSort(),
+                        value, state.diagnostic))
+      return UFCandidateOutcome::InternalError;
+    state.handleValues.insert(std::make_pair(record.durableHandle, value));
+  }
+  if (candidate.version() != version)
+  {
+    state.diagnostic = "UF candidate changed while retaining certified "
+                       "handle values";
+    return UFCandidateOutcome::InternalError;
+  }
+  state.seed = result.modelSeed;
+  state.certified = true;
+  return UFCandidateOutcome::Consistent;
+}
+
+// As in UFLemma: CNF leaves live at the lowering sort, where FloatingPoint
+// never appears.
+bool supportedSort(const SourceSort& sort)
+{
+  return UFSignature::isSupportedSort(sort) &&
+         sort.kind() != SourceSort::Kind::FloatingPoint;
+}
+
+// How many SAT bits one scalar of this sort occupies. Bool is a single
+// literal; everything else is its packed carrier, which is exactly what the
+// solve-scalar registrar in ToSATAIG allocates from GetValueWidth().
+unsigned scalarWidth(const SourceSort& sort)
+{
+  return sort.kind() == SourceSort::Kind::Bool ? 1 : sort.packedWidth();
+}
+
+const char* validateLeaf(
+    const ASTNode& leaf, const SourceSort& sort,
+    const ToSATBase::ASTNodeToSATVar& bindings)
+{
+  if (!supportedSort(sort) || leaf.IsNull() || leaf.GetSourceSort() != sort)
+    return "UF CNF leaf has the wrong SourceSort";
+  if (leaf.isConstant())
+  {
+    if (sort.kind() == SourceSort::Kind::Bool)
+      return leaf.GetKind() == TRUE || leaf.GetKind() == FALSE
+                 ? NULL
+                 : "UF CNF Boolean constant is malformed";
+    return leaf.GetKind() == BVCONST &&
+                   leaf.GetValueWidth() == sort.packedWidth()
+               ? NULL
+               : "UF CNF scalar constant is malformed";
+  }
+  if (leaf.GetKind() != SYMBOL)
+    return "UF CNF leaf is neither a constant nor a symbol";
+  const ToSATBase::ASTNodeToSATVar::const_iterator found = bindings.find(leaf);
+  if (found == bindings.end())
+    return "UF CNF leaf was not registered before the first candidate";
+  if (found->second.size() != scalarWidth(sort))
+    return "UF CNF leaf has a wrong-width SAT mapping";
+  for (const unsigned variable : found->second)
+    if (variable == ~((unsigned)0))
+      return "UF CNF leaf has an unencoded SAT bit";
+  return NULL;
+}
+
+void validateLemmaBeforeMutation(
+    const UFAbstractLemma& lemma,
+    const ToSATBase::ASTNodeToSATVar& bindings, SATSolver& solver,
+    int guardLiteral)
+{
+  std::vector<const UFEqualityAtom*> atoms;
+  atoms.reserve(lemma.premise.size() + 1);
+  for (const UFEqualityAtom& atom : lemma.premise)
+    atoms.push_back(&atom);
+  atoms.push_back(&lemma.conclusion);
+  for (const UFEqualityAtom* atom : atoms)
+  {
+    const char* reason = validateLeaf(atom->left, atom->sort, bindings);
+    if (reason != NULL)
+      FatalError(reason, atom->left);
+    reason = validateLeaf(atom->right, atom->sort, bindings);
+    if (reason != NULL)
+      FatalError(reason, atom->right);
+  }
+  // Backends expose different variable bases through this historical API
+  // (CaDiCaL is one-based, MiniSat-family wrappers are zero-based), so nVars
+  // cannot portably validate the upper bound. The exact-stack encoder handed
+  // us a nonnegative literal obtained from its own live AIG binding; retain
+  // that provenance check without inventing a backend-specific comparison.
+  (void)solver;
+  if (guardLiteral < -1)
+    FatalError("UF persistent block guard is malformed");
+  const std::vector<bool> premises(lemma.premise.size(), true);
+  if (lemma.evaluate(false, premises))
+    FatalError("UF abstract lemma does not reject its triggering candidate");
+}
+
+struct BitOperand
+{
+  bool constant = false;
+  bool value = false;
+  unsigned variable = 0;
+};
+
+BitOperand bitOperand(const ASTNode& leaf, const SourceSort& sort,
+                      unsigned bit,
+                      const ToSATBase::ASTNodeToSATVar& bindings)
+{
+  BitOperand result;
+  if (!leaf.isConstant())
+  {
+    result.variable = bindings.find(leaf)->second[bit];
+    return result;
+  }
+  result.constant = true;
+  if (sort.kind() == SourceSort::Kind::Bool)
+    result.value = leaf.GetKind() == TRUE;
+  else
+    result.value =
+        CONSTANTBV::BitVector_bit_test(leaf.GetBVConst(), bit) != 0;
+  return result;
+}
+
+struct ClauseTerm
+{
+  bool constant = false;
+  bool value = false;
+  int literal = -1;
+
+  static ClauseTerm constantValue(bool value_)
+  {
+    ClauseTerm term;
+    term.constant = true;
+    term.value = value_;
+    return term;
+  }
+  static ClauseTerm satLiteral(int literal_)
+  {
+    ClauseTerm term;
+    term.literal = literal_;
+    return term;
+  }
+};
+
+ClauseTerm negate(ClauseTerm term)
+{
+  if (term.constant)
+    term.value = !term.value;
+  else
+    term.literal ^= 1;
+  return term;
+}
+
+ClauseTerm exclusionLiteral(const BitOperand& operand, bool assignment)
+{
+  if (operand.constant)
+    return ClauseTerm::constantValue(operand.value != assignment);
+  return ClauseTerm::satLiteral(
+      static_cast<int>(2 * operand.variable + (assignment ? 1 : 0)));
+}
+
+void addGuardedClause(SATSolver& solver,
+                      const std::vector<ClauseTerm>& terms,
+                      int guardLiteral)
+{
+  SATSolver::vec_literals clause;
+  for (const ClauseTerm& term : terms)
+  {
+    if (term.constant)
+    {
+      if (term.value)
+        return; // tautology
+      continue;
+    }
+    clause.push(SATSolver::mkLit(term.literal >> 1,
+                                 (term.literal & 1) != 0));
+  }
+  if (guardLiteral >= 0)
+    clause.push(SATSolver::mkLit(guardLiteral >> 1,
+                                 (guardLiteral & 1) != 0));
+  solver.addClause(clause);
+}
+
+// How the equality literal is about to be used in the lemma clause. A premise
+// appears negated and a conclusion positive, and each direction of the
+// definition is needed by exactly one of them:
+//
+//   conclusion   ... v q      needs  q -> equality
+//   premise      ... v ~q     needs  equality -> q
+//
+// Emitting only the needed half is sound because the other direction only
+// ever constrains the helper in a polarity no clause mentions: the solver may
+// set the helper freely there, and every clause that names it stays
+// satisfied for the same reason it was before. The halves are tracked per
+// cached atom, so an atom later used in the opposite polarity is completed
+// then rather than being defined twice.
+enum class Polarity
+{
+  Positive, // the literal appears positively: define q -> equality
+  Negative  // the literal appears negated: define equality -> q
+};
+
+// One bit of an equality, as it was encoded. `allocated` distinguishes a
+// fresh XNOR helper, which has to be defined, from a literal that already is
+// the bit equality (a constant operand collapses to the other operand's
+// literal) and needs no clauses at all.
+struct BitHelper
+{
+  int literal = -1;
+  bool allocated = false;
+  BitOperand left;
+  BitOperand right;
+};
+
+// One cached equality atom: its literal, the per-bit helpers behind it, and
+// which halves of the definition have been emitted so far.
+struct CachedEquality
+{
+  int literal = -1;
+  std::vector<BitHelper> bits;
+  bool aggregateAllocated = false;
+  bool positiveDefined = false;
+  bool negativeDefined = false;
+};
+
+void defineBitHelper(SATSolver& solver, const BitHelper& helper,
+                     Polarity polarity, int guardLiteral)
+{
+  if (!helper.allocated)
+    return;
+  const unsigned q = static_cast<unsigned>(helper.literal >> 1);
+  // The clause set below blocks each assignment that would falsify the
+  // definition. Those with q true are exactly q -> (l = r); those with q
+  // false are exactly (l = r) -> q.
+  const bool wantQTrue = polarity == Polarity::Positive;
+  for (unsigned lv = 0; lv < 2; ++lv)
+    for (unsigned rv = 0; rv < 2; ++rv)
+    {
+      const unsigned qv = (lv == rv) ? 0u : 1u;
+      if ((qv != 0) != wantQTrue)
+        continue;
+      std::vector<ClauseTerm> clause;
+      clause.push_back(exclusionLiteral(helper.left, lv != 0));
+      clause.push_back(exclusionLiteral(helper.right, rv != 0));
+      clause.push_back(ClauseTerm::satLiteral(
+          static_cast<int>(2 * q + (qv != 0 ? 1 : 0))));
+      addGuardedClause(solver, clause, guardLiteral);
+    }
+}
+
+void defineEquality(SATSolver& solver, CachedEquality& cached,
+                    Polarity polarity, int guardLiteral)
+{
+  bool& done = polarity == Polarity::Positive ? cached.positiveDefined
+                                              : cached.negativeDefined;
+  if (done)
+    return;
+  done = true;
+  for (const BitHelper& helper : cached.bits)
+    defineBitHelper(solver, helper, polarity, guardLiteral);
+  if (!cached.aggregateAllocated)
+    return;
+  if (polarity == Polarity::Positive)
+  {
+    // q -> every bit equality
+    for (const BitHelper& helper : cached.bits)
+    {
+      std::vector<ClauseTerm> clause;
+      clause.push_back(ClauseTerm::satLiteral(cached.literal ^ 1));
+      clause.push_back(ClauseTerm::satLiteral(helper.literal));
+      addGuardedClause(solver, clause, guardLiteral);
+    }
+    return;
+  }
+  // every bit equality -> q
+  std::vector<ClauseTerm> reverse;
+  reverse.push_back(ClauseTerm::satLiteral(cached.literal));
+  for (const BitHelper& helper : cached.bits)
+    reverse.push_back(ClauseTerm::satLiteral(helper.literal ^ 1));
+  addGuardedClause(solver, reverse, guardLiteral);
+}
+
+// Fold constants and SAT aliases before allocating an XNOR helper; the helper
+// itself is left undefined here and is given whichever half the use needs.
+BitHelper bitEquality(SATSolver& solver, const BitOperand& left,
+                      const BitOperand& right, bool& constantResult,
+                      bool& constantValue)
+{
+  BitHelper helper;
+  helper.left = left;
+  helper.right = right;
+  constantResult = false;
+  if (left.constant && right.constant)
+  {
+    constantResult = true;
+    constantValue = left.value == right.value;
+    return helper;
+  }
+  if (!left.constant && !right.constant && left.variable == right.variable)
+  {
+    constantResult = true;
+    constantValue = true;
+    return helper;
+  }
+  if (left.constant || right.constant)
+  {
+    const BitOperand& constant = left.constant ? left : right;
+    const BitOperand& symbol = left.constant ? right : left;
+    helper.literal =
+        static_cast<int>(2 * symbol.variable + (constant.value ? 0 : 1));
+    return helper;
+  }
+
+  const unsigned q = solver.newVar();
+  solver.setFrozen(q);
+  helper.literal = static_cast<int>(2 * q);
+  helper.allocated = true;
+  return helper;
+}
+
+ClauseTerm equalityTerm(SATSolver& solver,
+                        const ToSATBase::ASTNodeToSATVar& bindings,
+                        const UFEqualityAtom& atom, Polarity polarity,
+                        int guardLiteral,
+                        std::map<EqualityKey, CachedEquality>& cache)
+{
+  const EqualityKey key = equalityKey(atom.left, atom.right, atom.sort);
+  if (key.left == key.right)
+    return ClauseTerm::constantValue(true);
+  if (key.left.isConstant() && key.right.isConstant())
+  {
+    const bool equal = atom.sort.kind() == SourceSort::Kind::Bool
+                           ? key.left.GetKind() == key.right.GetKind()
+                           : constantsSameBits(key.left, key.right);
+    return ClauseTerm::constantValue(equal);
+  }
+  const std::map<EqualityKey, CachedEquality>::iterator hit = cache.find(key);
+  if (hit != cache.end())
+  {
+    defineEquality(solver, hit->second, polarity, guardLiteral);
+    return ClauseTerm::satLiteral(hit->second.literal);
+  }
+
+  const unsigned width = scalarWidth(atom.sort);
+  CachedEquality cached;
+  cached.bits.reserve(width);
+  for (unsigned bit = 0; bit < width; ++bit)
+  {
+    const BitOperand left = bitOperand(key.left, atom.sort, bit, bindings);
+    const BitOperand right = bitOperand(key.right, atom.sort, bit, bindings);
+    bool constantResult = false;
+    bool constantValue = false;
+    const BitHelper helper =
+        bitEquality(solver, left, right, constantResult, constantValue);
+    if (constantResult)
+    {
+      // A bit that can never agree makes the whole equality false; one that
+      // always agrees contributes nothing. Neither needs a helper, and a
+      // false one abandons the atom before anything is cached -- any helper
+      // already allocated for an earlier bit simply stays undefined and
+      // unused.
+      if (!constantValue)
+        return ClauseTerm::constantValue(false);
+      continue;
+    }
+    cached.bits.push_back(helper);
+  }
+
+  if (cached.bits.empty())
+    return ClauseTerm::constantValue(true);
+
+  cached.literal = cached.bits[0].literal;
+  if (cached.bits.size() > 1)
+  {
+    const unsigned q = solver.newVar();
+    solver.setFrozen(q);
+    cached.literal = static_cast<int>(2 * q);
+    cached.aggregateAllocated = true;
+  }
+  const std::map<EqualityKey, CachedEquality>::iterator inserted =
+      cache.insert(std::make_pair(key, cached)).first;
+  defineEquality(solver, inserted->second, polarity, guardLiteral);
+  return ClauseTerm::satLiteral(inserted->second.literal);
+}
+
+void encodeOneLemma(MutableAdapterState& state, const PendingLemma& entry,
+                    SATSolver& solver,
+                    ToSATBase::ASTNodeToSATVar& bindings, int guardLiteral,
+                    std::map<EqualityKey, CachedEquality>& cache)
+{
+  std::vector<ClauseTerm> body;
+  body.reserve(entry.lemma.premise.size() + 1);
+  for (const UFEqualityAtom& premise : entry.lemma.premise)
+  {
+    const ClauseTerm equality =
+        equalityTerm(solver, bindings, premise, Polarity::Negative,
+                     guardLiteral, cache);
+    if (equality.constant)
+    {
+      if (!equality.value)
+        FatalError("UF lemma premise is structurally false", premise.left);
+      continue;
+    }
+    body.push_back(negate(equality));
+  }
+  const ClauseTerm conclusion =
+      equalityTerm(solver, bindings, entry.lemma.conclusion,
+                   Polarity::Positive, guardLiteral, cache);
+  if (conclusion.constant)
+  {
+    if (conclusion.value)
+      FatalError("UF conflicting conclusion is structurally true",
+                 entry.lemma.conclusion.left);
+  }
+  else
+    body.push_back(conclusion);
+  addGuardedClause(solver, body, guardLiteral);
+  state.emittedLemmaCount++;
+  // Observability under -s: the reference profile installs no congruence
+  // clause up front, so every lemma here was earned by a refuted candidate.
+  // One line per installation names the declaration and the host: a batch
+  // lemma is query-local, a persistent one carries the exact-stack block
+  // guard.
+  if (state.manager->UserFlags.stats_flag)
+    std::cerr << "UF: installed congruence lemma " << state.emittedLemmaCount
+              << " for "
+              << (entry.declaration != NULL ? entry.declaration->name()
+                                            : std::string("<unknown>"))
+              << (guardLiteral >= 0 ? " (block guarded)" : " (query local)")
+              << std::endl;
+}
+
+void encodeLemmas(MutableAdapterState& state, SATSolver& solver,
+                  ToSATBase* tosat, int guardLiteral,
+                  std::map<EqualityKey, CachedEquality>& cache)
+{
+  if (state.pending.empty() || tosat == NULL)
+    FatalError("UF lemma encoding began without a pending certificate");
+  ToSATBase::ASTNodeToSATVar& bindings = tosat->SATVar_to_SymbolIndexMap();
+
+  // Validate the whole batch before any of it mutates SAT. Splitting the two
+  // loops is what keeps the batch as atomic as a single clause was: a lemma
+  // the encoder would reject cannot leave earlier clauses of the same
+  // candidate behind.
+  for (const PendingLemma& entry : state.pending)
+    validateLemmaBeforeMutation(entry.lemma, bindings, solver, guardLiteral);
+
+  for (const PendingLemma& entry : state.pending)
+    encodeOneLemma(state, entry, solver, bindings, guardLiteral, cache);
+
+  // Some backends detect at insertion time that a validated blocking clause
+  // closes the entire instance. That is a normal refinement outcome: leave the
+  // solver in its UNSAT state so the coordinator's next solve can certify it,
+  // rather than misclassifying progress as an internal error. The rest of the
+  // batch is still installed -- every clause is a theory consequence, so
+  // adding one to an already-closed instance changes nothing.
+  if (state.manager->UserFlags.stats_flag && state.pending.size() > 1)
+    std::cerr << "UF: candidate refuted by " << state.pending.size()
+              << " congruence lemmas" << std::endl;
+  state.pending.clear();
+}
+
+bool lookupCertified(const MutableAdapterState& state,
+                     const ASTNode& durableHandle, UFConcreteValue& value)
+{
+  if (!state.certified)
+    return false;
+  const std::map<ASTNode, UFConcreteValue>::const_iterator found =
+      state.handleValues.find(durableHandle);
+  if (found == state.handleValues.end())
+    return false;
+  value = found->second;
+  return true;
+}
+
+} // namespace
+
+class UFBatchAdapter::Impl
+{
+public:
+  explicit Impl(STPMgr* manager) : state(manager) {}
+  MutableAdapterState state;
+  std::map<EqualityKey, CachedEquality> equalityCache;
+};
+
+UFBatchAdapter::UFBatchAdapter(STPMgr* manager) : impl_(new Impl(manager))
+{
+  assert(manager != NULL);
+}
+UFBatchAdapter::~UFBatchAdapter() = default;
+void UFBatchAdapter::beginQuery(const LoweredApplicationView* view)
+{
+  clear();
+  impl_->state.beginView(view);
+}
+void UFBatchAdapter::clear()
+{
+  impl_->state.clearActive();
+  impl_->equalityCache.clear();
+}
+bool UFBatchAdapter::active() const
+{
+  return impl_->state.view != NULL && impl_->state.view->active();
+}
+UFCandidateOutcome UFBatchAdapter::checkCandidate(
+    AbsRefine_CounterExample& counterexample)
+{
+  return checkOneCandidate(impl_->state, counterexample);
+}
+bool UFBatchAdapter::hasPendingLemma() const
+{
+  return !impl_->state.pending.empty();
+}
+void UFBatchAdapter::encodePendingLemmas(SATSolver& solver, ToSATBase* tosat)
+{
+  encodeLemmas(impl_->state, solver, tosat, -1, impl_->equalityCache);
+}
+bool UFBatchAdapter::hasCertifiedModel() const
+{
+  return impl_->state.certified;
+}
+void UFBatchAdapter::invalidateCertifiedModel()
+{
+  impl_->state.certified = false;
+  impl_->state.seed = UFFunctionModelSeedSet();
+  impl_->state.handleValues.clear();
+}
+const UFFunctionModelSeedSet* UFBatchAdapter::certifiedModelSeed() const
+{
+  return impl_->state.certified ? &impl_->state.seed : NULL;
+}
+bool UFBatchAdapter::lookupCertifiedApplication(
+    const ASTNode& durableHandle, UFConcreteValue& value) const
+{
+  return lookupCertified(impl_->state, durableHandle, value);
+}
+const LoweredApplicationView* UFBatchAdapter::applicationView() const
+{
+  return impl_->state.view;
+}
+const std::string& UFBatchAdapter::diagnostic() const
+{
+  return impl_->state.diagnostic;
+}
+uint64_t UFBatchAdapter::candidateChecks() const
+{
+  return impl_->state.candidateCheckCount;
+}
+uint64_t UFBatchAdapter::lemmasEmitted() const
+{
+  return impl_->state.emittedLemmaCount;
+}
+
+} // namespace stp

--- a/scripts/build-sanitized.sh
+++ b/scripts/build-sanitized.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Build STP with Clang ASan+UBSan and run the UF lifecycle surface.  This
+# deliberately supplies C and C++ flags: ABC is C, while -DSANITIZE=ON only
+# instruments C++ at this baseline.  The system allocator keeps mimalloc from
+# replacing malloc underneath ASan.
+#
+# Usage:
+#   scripts/build-sanitized.sh [build-dir] [lit-tool] [extra cmake args...]
+#
+# A SAT backend still has to be supplied when it is not discoverable in the
+# usual deps directory, for example:
+#   scripts/build-sanitized.sh build-sanitize "$(command -v lit)" \
+#     -DUSE_CADICAL=ON -DCADICAL_DIR="$PWD/deps/cadical"
+set -eu
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+sanitized_build="${1:-$repo_root/build-sanitize}"
+lit_tool="${2:-$(command -v lit || true)}"
+shift "$(( $# > 2 ? 2 : $# ))"
+
+lit_cmake_arg=()
+if [ -n "$lit_tool" ]; then
+  lit_cmake_arg+=("-DLIT_TOOL=$lit_tool")
+fi
+
+cmake -S "$repo_root" -B "$sanitized_build" \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+  -DCMAKE_C_COMPILER=clang \
+  -DCMAKE_CXX_COMPILER=clang++ \
+  -DCMAKE_C_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer" \
+  -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer" \
+  -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined" \
+  -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=address,undefined" \
+  -DENABLE_ASSERTIONS=ON \
+  -DENABLE_TESTING=ON \
+  -DSTP_ALLOCATOR=system \
+  "${lit_cmake_arg[@]}" \
+  "$@"
+
+cmake --build "$sanitized_build" --parallel "$(nproc)"
+
+ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 \
+UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
+ctest --test-dir "$sanitized_build" \
+  -R '(uninterpreted-functions|UninterpretedFunctions|UFChecker|UFRefinement|UFLowering)' \
+  --output-on-failure
+
+if [ -n "$lit_tool" ]; then
+  (
+    cd "$sanitized_build/tests/query-files"
+    ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 \
+    UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
+      "$lit_tool" -s --config-prefix=RelWithDebInfo --filter='uf/' .
+  )
+fi
+
+echo "Sanitized UF build and tests passed: $sanitized_build"

--- a/scripts/fuzz/uf-differential-fuzz.py
+++ b/scripts/fuzz/uf-differential-fuzz.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+"""Differential fuzzing for UFSTP.
+
+Each round generates one random quantifier-free Bool/BV UF instance and
+decides it several independent ways:
+
+  1. UFSTP (the implementation under test), forced batch and forced
+     persistent, on every requested backend;
+  2. a generator-side EAGER Ackermannization of the same instance --
+     fresh result variables plus all-pairs congruence implications --
+     handed to classic STP with the UF feature OFF (a pre-existing,
+     independently trusted decision path);
+  3. optionally a brute-force enumeration over tiny domains.
+
+Any disagreement is a soundness bug and is dumped for replay. Push/pop
+script rounds additionally compare per-level verdict sequences between
+batch and persistent routing.
+"""
+import argparse
+import itertools
+import os
+import random
+import shlex
+import subprocess
+import sys
+
+STP = None
+CMS = None
+ROUNDS = 0
+OUTDIR = None
+TIMEOUT = 60.0
+EXTERNALS = []
+rng = random.Random()
+
+class Gen:
+    def __init__(self):
+        self.widths = rng.choice([[2], [2, 3], [3, 4], [2, 8]])
+        self.nvars = rng.randint(2, 4)
+        self.vars = []   # (name, sort) sort: int width or 'bool'
+        for i in range(self.nvars):
+            sort = rng.choice(self.widths + ['bool'])
+            self.vars.append(("v%d" % i, sort))
+        self.funcs = []  # (name, [domain sorts], codomain)
+        for i in range(rng.randint(1, 2)):
+            arity = rng.randint(1, 2)
+            dom = [rng.choice(self.widths + ['bool']) for _ in range(arity)]
+            cod = rng.choice(self.widths + ['bool'])
+            self.funcs.append(("f%d" % i, dom, cod))
+        self.apps = []   # (func index, [arg terms]) -> recorded at build
+        self.use_define = rng.random() < 0.3
+        self.use_let = rng.random() < 0.3
+
+    def sort_str(self, s):
+        return "Bool" if s == 'bool' else "(_ BitVec %d)" % s
+
+    def leaf(self, sort, depth):
+        choices = [v for v, s in self.vars if s == sort]
+        if choices and rng.random() < 0.7:
+            return rng.choice(choices)
+        if sort == 'bool':
+            return rng.choice(["true", "false"])
+        return "#b" + "".join(rng.choice("01") for _ in range(sort))
+
+    def term(self, sort, depth):
+        if depth <= 0 or rng.random() < 0.3:
+            return self.leaf(sort, depth)
+        fits = [(i, f) for i, f in enumerate(self.funcs) if f[2] == sort]
+        if fits and rng.random() < 0.55:
+            i, (name, dom, cod) = rng.choice(fits)
+            args = [self.term(d, depth - 1) for d in dom]
+            app = "(%s %s)" % (name, " ".join(args))
+            self.apps.append((i, args))
+            return app
+        if sort == 'bool':
+            op = rng.choice(['and', 'or', 'xor', 'not', '=', 'bvult'])
+            if op == 'not':
+                return "(not %s)" % self.term('bool', depth - 1)
+            if op in ('=', 'bvult'):
+                w = rng.choice(self.widths)
+                return "(%s %s %s)" % (op, self.term(w, depth - 1),
+                                       self.term(w, depth - 1))
+            return "(%s %s %s)" % (op, self.term('bool', depth - 1),
+                                   self.term('bool', depth - 1))
+        op = rng.choice(['bvadd', 'bvand', 'bvxor', 'bvnot', 'ite'])
+        if op == 'bvnot':
+            return "(bvnot %s)" % self.term(sort, depth - 1)
+        if op == 'ite':
+            return "(ite %s %s %s)" % (self.term('bool', depth - 1),
+                                       self.term(sort, depth - 1),
+                                       self.term(sort, depth - 1))
+        return "(%s %s %s)" % (op, self.term(sort, depth - 1),
+                               self.term(sort, depth - 1))
+
+    def build(self):
+        decls = []
+        for v, s in self.vars:
+            decls.append("(declare-fun %s () %s)" % (v, self.sort_str(s)))
+        for name, dom, cod in self.funcs:
+            decls.append("(declare-fun %s (%s) %s)" %
+                         (name, " ".join(self.sort_str(d) for d in dom),
+                          self.sort_str(cod)))
+        asserts = []
+        for _ in range(rng.randint(2, 5)):
+            asserts.append("(assert %s)" % self.term('bool', rng.randint(1, 3)))
+        # Optional define-fun reuse of an application body.
+        extra_defs = []
+        if self.use_define and self.funcs:
+            name, dom, cod = self.funcs[0]
+            if len(dom) == 1 and dom[0] != 'bool':
+                extra_defs.append(
+                    "(define-fun hh ((z (_ BitVec %d))) %s (%s z))" %
+                    (dom[0], self.sort_str(cod), name))
+                w = dom[0]
+                a = "(hh %s)" % self.leaf(w, 0)
+                b = "(hh %s)" % self.leaf(w, 0)
+                # Record indirectly: parse-side substitution creates the
+                # applications; the eager reducer re-derives them from the
+                # expanded text below, so nothing to track here.
+                if cod == 'bool':
+                    asserts.append("(assert (= %s %s))" % (a, b))
+                else:
+                    asserts.append("(assert (= %s %s))" % (a, b))
+        if self.use_let:
+            w = rng.choice(self.widths)
+            body = self.term('bool', 2)
+            asserts.append("(assert (let ((tmp %s)) (or %s (= tmp tmp))))"
+                           % (self.leaf(w, 0), body))
+        return decls, extra_defs, asserts
+
+
+def expand_defines(defs, text):
+    # Only the one 'hh' shape above: (hh X) -> (f0 X).
+    if not defs:
+        return text
+    out = text
+    while "(hh " in out:
+        i = out.index("(hh ")
+        depth = 0
+        j = i
+        while True:
+            if out[j] == '(':
+                depth += 1
+            elif out[j] == ')':
+                depth -= 1
+                if depth == 0:
+                    break
+            j += 1
+        arg = out[i + 4:j].strip()
+        out = out[:i] + "(f0 %s)" % arg + out[j + 1:]
+    return out
+
+
+def collect_apps(text, funcs):
+    """All (fN args...) occurrences in the fully define-expanded text."""
+    apps = {}
+    for idx, (name, dom, cod) in enumerate(funcs):
+        needle = "(%s " % name
+        start = 0
+        while True:
+            i = text.find(needle, start)
+            if i < 0:
+                break
+            depth = 0
+            j = i
+            while True:
+                if text[j] == '(':
+                    depth += 1
+                elif text[j] == ')':
+                    depth -= 1
+                    if depth == 0:
+                        break
+                j += 1
+            whole = text[i:j + 1]
+            inner = text[i + len(needle):j]
+            # split args at top level
+            args, cur, d = [], [], 0
+            for ch in inner:
+                if ch == '(':
+                    d += 1
+                elif ch == ')':
+                    d -= 1
+                if ch == ' ' and d == 0:
+                    if cur:
+                        args.append("".join(cur))
+                        cur = []
+                else:
+                    cur.append(ch)
+            if cur:
+                args.append("".join(cur))
+            apps.setdefault(idx, {})[whole] = args
+            start = i + 1
+    return apps
+
+
+def eager_script(decls, defs, asserts, funcs):
+    """The same instance with every application replaced by a fresh result
+    variable and all-pairs congruence implications added: pure QF_BV,
+    decidable by classic STP with the UF feature off."""
+    text = "\n".join(asserts)
+    text = expand_defines(defs, text)
+    # innermost-first replacement: iterate until no application remains.
+    # Only VARIABLE declarations survive; the function declarations are
+    # compiled away (classic STP rejects nonzero-arity declare-fun).
+    fnames = set(f[0] for f in funcs)
+    lines = [d for d in decls
+             if not any(d.startswith("(declare-fun %s (" % n) and
+                        not d.startswith("(declare-fun %s ()" % n)
+                        for n in fnames)]
+    congruence = []
+    counter = [0]
+    mapping = {}
+
+    def sort_str(s):
+        return "Bool" if s == 'bool' else "(_ BitVec %d)" % s
+
+    changed = True
+    while changed:
+        apps = collect_apps(text, funcs)
+        # pick innermost applications: ones whose args contain no app
+        flat = []
+        for idx, entries in apps.items():
+            for whole, args in entries.items():
+                if not any(("(f%d " % k) in a for k in range(len(funcs))
+                           for a in args):
+                    flat.append((idx, whole, args))
+        changed = bool(flat)
+        for idx, whole, args in flat:
+            if whole not in mapping:
+                name, dom, cod = funcs[idx]
+                r = "r%d" % counter[0]
+                counter[0] += 1
+                lines.append("(declare-fun %s () %s)" % (r, sort_str(cod)))
+                mapping[whole] = (idx, args, r)
+            r = mapping[whole][2]
+            text = text.replace(whole, r)
+
+    # all-pairs congruence per function
+    per_func = {}
+    for whole, (idx, args, r) in mapping.items():
+        per_func.setdefault(idx, []).append((args, r))
+    for idx, entries in per_func.items():
+        name, dom, cod = funcs[idx]
+        for (a1, r1), (a2, r2) in itertools.combinations(entries, 2):
+            prem = " ".join("(= %s %s)" % (expand_defines(defs, x),
+                                           expand_defines(defs, y))
+                            for x, y in zip(a1, a2))
+            congruence.append(
+                "(assert (=> (and %s true) (= %s %s)))" % (prem, r1, r2))
+    return "\n".join(["(set-logic QF_BV)"] + lines + [text] + congruence +
+                     ["(check-sat)"])
+
+
+def run(script, args):
+    # Modern STP builds can contain every SAT backend, so --cryptominisat is
+    # normally just another selector on STP.  Keep the alternate executable
+    # hook for comparing an older/dedicated CryptoMiniSat build.
+    executable = CMS if '--cryptominisat' in args and CMS else STP
+    p = subprocess.run([executable, '--SMTLIB2'] + args,
+                       input=script.encode(), capture_output=True,
+                       timeout=TIMEOUT)
+    out = p.stdout.decode()
+    for line in out.splitlines():
+        if line.strip() in ('sat', 'unsat'):
+            return line.strip()
+    return 'ERROR:' + out[:200] + p.stderr.decode()[:200]
+
+
+def run_external(cmd, script):
+    p = subprocess.run(cmd, input=script.encode(), capture_output=True,
+                       timeout=TIMEOUT)
+    out = p.stdout.decode()
+    for line in out.splitlines():
+        if line.strip() in ('sat', 'unsat'):
+            return line.strip()
+    return 'ERROR:' + out[:200] + p.stderr.decode()[:200]
+
+
+def one_round(rnum, backends):
+    g = Gen()
+    decls, defs, asserts = g.build()
+    uf_script = "\n".join(["(set-logic QF_UFBV)"] + decls + defs + asserts +
+                          ["(check-sat)"])
+    eager = eager_script(decls, defs, asserts, g.funcs)
+
+    reference = run(eager, ['--incremental=off'])
+    verdicts = {'eager-classic': reference}
+    for i, cmd in enumerate(EXTERNALS):
+        verdicts['external-%d-%s' % (i, os.path.basename(cmd[0]))] = \
+            run_external(cmd, uf_script)
+    for be in backends:
+        for mode in ['--incremental=off', '--incremental=on']:
+            key = "%s %s" % (be if be else 'default', mode)
+            flags = ([be] if be else []) + [mode, '--uninterpreted-functions']
+            verdicts[key] = run(uf_script, flags)
+
+    answers = set(verdicts.values())
+    if len(answers) != 1 or not answers <= {'sat', 'unsat'}:
+        os.makedirs(OUTDIR, exist_ok=True)
+        with open(os.path.join(OUTDIR, 'round%d.smt2' % rnum), 'w') as f:
+            f.write(uf_script)
+        with open(os.path.join(OUTDIR, 'round%d-eager.smt2' % rnum), 'w') as f:
+            f.write(eager)
+        print("DISAGREE round", rnum, verdicts)
+        return False
+    return True
+
+
+def pushpop_round(rnum):
+    """Per-level verdict agreement between forced batch and persistent."""
+    g = Gen()
+    decls, defs, asserts = g.build()
+    script = ["(set-logic QF_UFBV)"] + decls + defs
+    script.append("(assert %s)" % g.term('bool', 2))
+    script.append("(check-sat)")
+    for a in asserts[:3]:
+        script.append("(push 1)")
+        script.append(a)
+        script.append("(check-sat)")
+    for _ in range(min(3, len(asserts[:3]))):
+        script.append("(pop 1)")
+        script.append("(check-sat)")
+    text = "\n".join(script)
+
+    def seq(mode):
+        p = subprocess.run([STP, '--SMTLIB2', '--uninterpreted-functions',
+                            mode], input=text.encode(), capture_output=True,
+                           timeout=TIMEOUT)
+        return [l for l in p.stdout.decode().splitlines()
+                if l.strip() in ('sat', 'unsat')]
+
+    a = seq('--incremental=off')
+    b = seq('--incremental=on')
+    ok = a == b and len(a) > 0
+    # SMT-LIB monotonicity sanity: pops can only relax.
+    if not ok:
+        os.makedirs(OUTDIR, exist_ok=True)
+        with open(os.path.join(OUTDIR, 'pushpop%d.smt2' % rnum), 'w') as f:
+            f.write(text)
+        print("PUSHPOP DISAGREE round", rnum, a, b)
+    return ok
+
+
+def main():
+    global STP, CMS, ROUNDS, OUTDIR, TIMEOUT, EXTERNALS, rng
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--stp', default=os.environ.get('STP_BIN'))
+    parser.add_argument('--cryptominisat-stp',
+                        default=os.environ.get('STP_CMS_BIN'),
+                        help=('optional alternate STP executable for the '
+                              '--cryptominisat backend'))
+    parser.add_argument('--seed', type=int,
+                        default=int(os.environ.get('SEED', '1')))
+    parser.add_argument('--rounds', type=int,
+                        default=int(os.environ.get('ROUNDS', '200')))
+    parser.add_argument('--outdir',
+                        default=os.environ.get(
+                            'OUTDIR', '/tmp/uf-fuzz-failures'))
+    parser.add_argument('--timeout', type=float, default=60.0)
+    parser.add_argument(
+        '--backend', action='append', default=[],
+        help='one STP SAT-backend flag (repeatable; default backend included)')
+    parser.add_argument(
+        '--external', action='append', default=[],
+        help='stdin reference-solver command (repeatable)')
+    args = parser.parse_args()
+    if not args.stp:
+        parser.error('--stp (or STP_BIN) is required')
+    if args.rounds <= 0 or args.timeout <= 0:
+        parser.error('--rounds and --timeout must be positive')
+    STP = args.stp
+    CMS = args.cryptominisat_stp
+    ROUNDS = args.rounds
+    OUTDIR = args.outdir
+    TIMEOUT = args.timeout
+    rng = random.Random(args.seed)
+
+    external_specs = list(args.external)
+    if not external_specs:
+        external_specs = [item.strip() for item in
+                          os.environ.get('EXTERNAL_SOLVERS', '').split(';')
+                          if item.strip()]
+    EXTERNALS = [shlex.split(item) for item in external_specs]
+
+    backends = [''] + args.backend
+    if not args.backend:
+        backends += os.environ.get('BACKENDS', '').split()
+    bad = 0
+    for r in range(ROUNDS):
+        if not one_round(r, backends):
+            bad += 1
+    pp_bad = 0
+    for r in range(ROUNDS // 4):
+        if not pushpop_round(r):
+            pp_bad += 1
+    print("fuzz done: %d rounds, %d disagreements; %d push/pop rounds, %d "
+          "disagreements" % (ROUNDS, bad, ROUNDS // 4, pp_bad))
+    return 1 if (bad or pp_bad) else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/fuzz/uf-model-cross-validate.py
+++ b/scripts/fuzz/uf-model-cross-validate.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""Cross-validate finite UF models without baking in local solver paths.
+
+STP batch and persistent are always producers; STP batch is always a
+validator.  Additional stdin-oriented producers and validators are supplied
+as NAME=COMMAND arguments (for example z3, Bitwuzla, and cvc5).  Each SAT
+model replaces the corresponding declarations in a replay of the assertion
+stack active at that check, and every validator must answer SAT.
+
+Cases are explicit inputs.  The harness rejects reset-driven scripts because
+their declaration policy belongs to UFSTP v2's native lifecycle suite rather
+than to this branch-neutral model relay.
+"""
+
+import argparse
+import json
+from pathlib import Path
+import re
+import shlex
+import subprocess
+
+
+VERDICT = re.compile(r"^(sat|unsat|unknown)$", re.MULTILINE)
+
+
+def strip_comments(text):
+    output = []
+    index = 0
+    quoted = None
+    while index < len(text):
+        character = text[index]
+        if quoted is None:
+            if character == ";":
+                while index < len(text) and text[index] != "\n":
+                    index += 1
+                continue
+            if character in ("|", '"'):
+                quoted = character
+            output.append(character)
+        else:
+            output.append(character)
+            if character == quoted:
+                quoted = None
+        index += 1
+    return "".join(output)
+
+
+def commands(text):
+    cleaned = strip_comments(text)
+    result = []
+    depth = 0
+    start = None
+    quoted = None
+    escaped = False
+    for index, character in enumerate(cleaned):
+        if quoted == '"':
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == '"':
+                quoted = None
+            continue
+        if quoted == "|":
+            if character == "|":
+                quoted = None
+            continue
+        if character in ('"', "|"):
+            quoted = character
+            continue
+        if character == "(":
+            if depth == 0:
+                start = index
+            depth += 1
+        elif character == ")":
+            depth -= 1
+            if depth < 0:
+                raise ValueError("unbalanced closing parenthesis")
+            if depth == 0 and start is not None:
+                result.append(cleaned[start:index + 1])
+                start = None
+    if depth != 0 or quoted is not None:
+        raise ValueError("unterminated SMT-LIB command")
+    return result
+
+
+def head(command_text):
+    body = command_text[1:].lstrip()
+    return body.split(None, 1)[0].rstrip(")") if body else ""
+
+
+def declared_name(command_text):
+    pieces = command_text.split(None, 2)
+    if len(pieces) < 2:
+        raise ValueError("declaration has no name: %s" % command_text)
+    return pieces[1].strip("|")
+
+
+def subexpressions(block):
+    stripped = block.strip()
+    if not (stripped.startswith("(") and stripped.endswith(")")):
+        return []
+    return commands(stripped[1:-1])
+
+
+def parse_count(command_text):
+    match = re.match(r"\([^\s()]+\s+(\d+)\s*\)$", command_text.strip())
+    return int(match.group(1)) if match else 1
+
+
+def parse_case(source):
+    if re.search(r"\(reset(?:-assertions)?\b", source):
+        raise ValueError("reset/reset-assertions cases are v2-policy-owned")
+    levels = [[]]
+    checks = []
+    producer = ["(set-option :produce-models true)"]
+    logic = None
+    declarations = []
+    macros = []
+    for item in commands(source):
+        item_head = head(item)
+        if item_head == "set-option":
+            continue
+        if item_head == "set-logic":
+            logic = item
+        if item_head in ("declare-fun", "declare-const"):
+            declarations.append((declared_name(item), item))
+        if item_head in ("define-fun", "define-const"):
+            macros.append((declared_name(item), item))
+        if item_head == "assert":
+            levels[-1].append(item)
+        elif item_head == "push":
+            for _ in range(parse_count(item)):
+                levels.append([])
+        elif item_head == "pop":
+            count = parse_count(item)
+            if count >= len(levels):
+                raise ValueError("pop exceeds active assertion levels")
+            for _ in range(count):
+                levels.pop()
+        elif item_head in ("check-sat", "check-sat-assuming"):
+            assumptions = []
+            if item_head == "check-sat-assuming":
+                inner = item[item.find("(", 1):item.rfind(")")].strip()
+                assumptions = subexpressions(inner)
+                if not assumptions and inner:
+                    assumptions = [inner]
+            checks.append((
+                [assertion for level in levels for assertion in level],
+                assumptions))
+            producer.extend((item, "(get-model)"))
+            continue
+        elif item_head in ("get-model", "get-value", "exit"):
+            continue
+        producer.append(item)
+    if logic is None or not checks:
+        raise ValueError("case needs set-logic and at least one check-sat")
+    return {
+        "checks": checks,
+        "producer": "\n".join(producer) + "\n",
+        "logic": logic,
+        "declarations": declarations,
+        "macros": macros,
+    }
+
+
+def solver_spec(specification):
+    if "=" not in specification:
+        raise ValueError("solver specification must be NAME=COMMAND")
+    name, command_text = specification.split("=", 1)
+    argv = shlex.split(command_text)
+    if not name or not argv:
+        raise ValueError("solver specification must be NAME=COMMAND")
+    return name, argv
+
+
+def invoke(argv, source, timeout):
+    process = subprocess.run(
+        argv, input=source, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        text=True, timeout=timeout, check=False)
+    return process.returncode, process.stdout
+
+
+def balanced_block(lines, start):
+    depth = 0
+    block = []
+    for index in range(start, len(lines)):
+        line = lines[index]
+        block.append(line)
+        depth += line.count("(") - line.count(")")
+        if depth == 0:
+            return "\n".join(block), index + 1
+    return None, start
+
+
+def verdicts_and_models(output):
+    lines = output.splitlines()
+    result = []
+    index = 0
+    while index < len(lines):
+        verdict = lines[index].strip()
+        if verdict not in ("sat", "unsat", "unknown"):
+            index += 1
+            continue
+        model = None
+        next_index = index + 1
+        while next_index < len(lines) and not lines[next_index].strip():
+            next_index += 1
+        if verdict == "sat" and next_index < len(lines) and \
+                lines[next_index].lstrip().startswith("("):
+            model, next_index = balanced_block(lines, next_index)
+        result.append((verdict, model))
+        index = max(index + 1, next_index)
+    return result
+
+
+def model_definitions(model):
+    if not model:
+        return []
+    top = subexpressions(model)
+    if len(top) == 1 and head(top[0]) == "model":
+        top = subexpressions(top[0][top[0].find("model") + 5:].strip())
+    return [item for item in top if head(item) == "define-fun"]
+
+
+def relay_safe(text):
+    # Alpha-rename common solver-reserved binder spellings.  These are local
+    # names, so the rewrite changes no function interpretation.
+    return text.replace("@bzla.", "bzla_").replace("@", "at_")
+
+
+def replay(case, check_index, definitions):
+    defined = {declared_name(item) for item in definitions}
+    lines = [case["logic"]]
+    lines.extend(relay_safe(item) for item in definitions)
+    for name, macro in case["macros"]:
+        if name not in defined:
+            lines.append(macro)
+    for name, declaration in case["declarations"]:
+        if name not in defined:
+            lines.append(declaration)
+    assertions, assumptions = case["checks"][check_index]
+    lines.extend(assertions)
+    lines.extend("(assert %s)" % assumption for assumption in assumptions)
+    lines.append("(check-sat)")
+    return "\n".join(lines) + "\n"
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--stp", required=True)
+    parser.add_argument("--case", action="append", required=True)
+    parser.add_argument(
+        "--producer", action="append", default=[],
+        help="additional NAME=COMMAND stdin model producer")
+    parser.add_argument(
+        "--validator", action="append", default=[],
+        help="additional NAME=COMMAND stdin validator")
+    parser.add_argument("--timeout", type=float, default=120.0)
+    parser.add_argument("--evidence-out")
+    args = parser.parse_args()
+    if args.timeout <= 0:
+        parser.error("--timeout must be positive")
+
+    stp = shlex.split(args.stp)
+    if not stp:
+        parser.error("--stp must not be empty")
+    try:
+        extra_producers = [solver_spec(item) for item in args.producer]
+        extra_validators = [solver_spec(item) for item in args.validator]
+    except ValueError as error:
+        parser.error(str(error))
+    producers = [
+        ("stp-batch", stp + ["--SMTLIB2", "--uninterpreted-functions",
+                             "--incremental=off"]),
+        ("stp-persistent",
+         stp + ["--SMTLIB2", "--uninterpreted-functions",
+                "--incremental=on"]),
+    ] + extra_producers
+    validators = [
+        ("stp-batch", stp + ["--SMTLIB2", "--uninterpreted-functions",
+                             "--incremental=off"]),
+    ] + extra_validators
+
+    failures = []
+    checked = 0
+    produced = 0
+    for case_path_text in args.case:
+        case_path = Path(case_path_text)
+        try:
+            case = parse_case(case_path.read_text())
+        except (OSError, ValueError) as error:
+            parser.error("%s: %s" % (case_path, error))
+        for producer_name, producer_argv in producers:
+            returncode, output = invoke(
+                producer_argv, case["producer"], args.timeout)
+            observations = verdicts_and_models(output)
+            if returncode != 0 or len(observations) != len(case["checks"]):
+                failures.append({
+                    "case": str(case_path), "producer": producer_name,
+                    "reason": "producer-command",
+                    "returncode": returncode, "output": output[:1000],
+                })
+                continue
+            for check_index, (verdict, model) in enumerate(observations):
+                if verdict != "sat":
+                    continue
+                produced += 1
+                definitions = model_definitions(model)
+                if not definitions:
+                    failures.append({
+                        "case": str(case_path), "producer": producer_name,
+                        "check": check_index, "reason": "missing-model",
+                        "output": output[:1000],
+                    })
+                    continue
+                source = replay(case, check_index, definitions)
+                for validator_name, validator_argv in validators:
+                    returncode, validation_output = invoke(
+                        validator_argv, source, args.timeout)
+                    observed = VERDICT.findall(validation_output)
+                    checked += 1
+                    if returncode == 0 and observed == ["sat"]:
+                        continue
+                    failures.append({
+                        "case": str(case_path), "producer": producer_name,
+                        "validator": validator_name, "check": check_index,
+                        "reason": "model-rejected", "observed": observed,
+                        "returncode": returncode,
+                        "output": validation_output[:1000],
+                    })
+
+    evidence = {
+        "schema": 1,
+        "cases": len(args.case),
+        "producers": [name for name, _ in producers],
+        "validators": [name for name, _ in validators],
+        "sat_models_produced": produced,
+        "model_validator_pairs": checked,
+        "failures": failures,
+        "result": "pass" if not failures else "fail",
+    }
+    encoded = json.dumps(evidence, indent=2, sort_keys=True) + "\n"
+    if args.evidence_out:
+        Path(args.evidence_out).write_text(encoded)
+    print(encoded, end="")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/fuzz/uf-peer-regressions.py
+++ b/scripts/fuzz/uf-peer-regressions.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Run the branch-neutral QF_UFBV slice of peer regression suites.
+
+The peer trees remain external inputs: this script deliberately selects only
+ordinary sat/unsat queries whose semantics agree with UFSTP v2.  Parser-error,
+lifecycle-policy, higher-order, unsupported-sort, and public-model tests are
+left to the native v2 suite instead of importing a peer project's contract by
+accident.
+"""
+
+import argparse
+import json
+import os
+from pathlib import Path
+import re
+import shlex
+import subprocess
+
+
+VERDICT = re.compile(r"^(sat|unsat|unknown)$", re.MULTILINE)
+NONZERO_DECL = re.compile(r"\(declare-fun\s+[^\s()]+\s*\(\s*[^)\s]")
+UF_ARRAY_SIGNATURE = re.compile(
+    r"\(declare-fun\s+[^\s()]+\s*\((?![\s)]*\)).*Array")
+BOOL_ARRAY = re.compile(r"\(Array\s+Bool")
+OUT_OF_FRAGMENT = re.compile(
+    r"\b(forall|exists|declare-sort|define-sort|declare-datatype|"
+    r"Int\b|Real\b|String\b|FloatingPoint|Float\d+|RoundingMode|"
+    r"to_fp|bv2nat|nat2bv|int2bv|bv2int|ubv_to_int|sbv_to_int|"
+    r"get-interpolant|par\s*\()")
+LIFECYCLE_OR_MODEL = re.compile(
+    r"\((?:reset(?:-assertions)?|get-model|get-value)\b|"
+    r"\(set-option\s+:global-declarations\b")
+
+
+def command(specification):
+    argv = shlex.split(specification)
+    if not argv:
+        raise ValueError("empty solver command")
+    return argv
+
+
+def expected_verdicts(text):
+    expected = re.findall(r";\s*EXPECT:\s*(sat|unsat)\b", text)
+    if not expected:
+        expected = re.findall(r":status\s+(sat|unsat)\b", text)
+    return expected
+
+
+def has_higher_order_use(text):
+    function_names = re.findall(
+        r"\(declare-fun\s+([^\s()]+)\s*\(\s*[^)\s]", text)
+    for name in function_names:
+        quoted = re.escape(name)
+        if re.search(r"\(\s*=\s+" + quoted + r"[\s)]", text):
+            return True
+        if re.search(r"\(get-value\s*\(\s*" + quoted + r"[\s)]", text):
+            return True
+    return False
+
+
+def classify(path, max_bytes):
+    if path.stat().st_size > max_bytes:
+        return None, "too-large"
+    text = path.read_text(errors="replace")
+    if not NONZERO_DECL.search(text):
+        return None, "no-uf"
+    logics = re.findall(r"\(set-logic\s+([A-Z_]+)\)", text)
+    if logics and any(logic not in ("QF_UFBV", "QF_AUFBV")
+                      for logic in logics):
+        return None, "logic"
+    if OUT_OF_FRAGMENT.search(text) or BOOL_ARRAY.search(text):
+        return None, "unsupported-feature"
+    if any(UF_ARRAY_SIGNATURE.search(line) for line in text.splitlines()):
+        return None, "array-in-uf-signature"
+    if LIFECYCLE_OR_MODEL.search(text):
+        return None, "v2-policy-owned"
+    if has_higher_order_use(text):
+        return None, "higher-order"
+    expected = expected_verdicts(text)
+    if not expected or text.count("(check-sat") != len(expected):
+        return None, "expectations"
+    return (text, expected), None
+
+
+def run(argv, text, timeout):
+    process = subprocess.run(
+        argv, input=text, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        text=True, timeout=timeout, check=False)
+    return process.returncode, VERDICT.findall(process.stdout), process.stdout
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--stp", required=True)
+    parser.add_argument(
+        "--root", action="append", required=True,
+        help="peer regression root (repeatable)")
+    parser.add_argument(
+        "--mode", action="append", choices=("batch", "persistent"),
+        help="STP solve mode (repeatable; default: both)")
+    parser.add_argument(
+        "--arbiter",
+        help="optional stdin solver command used to arbitrate mismatches")
+    parser.add_argument("--max-bytes", type=int, default=100000)
+    parser.add_argument("--timeout", type=float, default=120.0)
+    parser.add_argument("--evidence-out")
+    args = parser.parse_args()
+    if args.max_bytes <= 0 or args.timeout <= 0:
+        parser.error("--max-bytes and --timeout must be positive")
+
+    modes = args.mode or ["batch", "persistent"]
+    stp = command(args.stp)
+    arbiter = command(args.arbiter) if args.arbiter else None
+    selected = []
+    skipped = {}
+    for root_text in args.root:
+        root = Path(os.path.expanduser(root_text))
+        if not root.is_dir():
+            parser.error("peer root is not a directory: %s" % root)
+        for path in root.rglob("*.smt2"):
+            item, reason = classify(path, args.max_bytes)
+            if item is None:
+                skipped[reason] = skipped.get(reason, 0) + 1
+            else:
+                selected.append((path, item[0], item[1]))
+
+    failures = []
+    runs = 0
+    for path, source, expected in sorted(selected):
+        for mode in modes:
+            argv = stp + ["--SMTLIB2", "--uninterpreted-functions",
+                          "--incremental=" + ("off" if mode == "batch"
+                                               else "on")]
+            returncode, observed, output = run(argv, source, args.timeout)
+            runs += 1
+            if returncode == 0 and observed == expected:
+                continue
+            arbitration = None
+            if arbiter is not None:
+                arbiter_rc, arbitration, arbiter_output = run(
+                    arbiter, source, args.timeout)
+                if arbiter_rc != 0:
+                    arbitration = ["command-failed", arbiter_output[:400]]
+            failures.append({
+                "file": str(path),
+                "mode": mode,
+                "expected": expected,
+                "observed": observed,
+                "returncode": returncode,
+                "arbiter": arbitration,
+                "output": output[:1000],
+            })
+
+    evidence = {
+        "schema": 1,
+        "selected_files": len(selected),
+        "solver_runs": runs,
+        "modes": modes,
+        "skipped_by_reason": dict(sorted(skipped.items())),
+        "failures": failures,
+        "result": "pass" if not failures else "fail",
+    }
+    encoded = json.dumps(evidence, indent=2, sort_keys=True) + "\n"
+    if args.evidence_out:
+        Path(args.evidence_out).write_text(encoded)
+    print(encoded, end="")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/query-files/array-extensionality-tests/11-get-model-replayable.smt2
+++ b/tests/query-files/array-extensionality-tests/11-get-model-replayable.smt2
@@ -6,6 +6,7 @@
 ; keyword) of valid nullary define-funs whose bodies are constant arrays
 ; under stores, replayable in a conforming SMT-LIB2 solver.
 (set-logic QF_ABV)
+(set-option :produce-models true)
 (declare-fun a () (Array (_ BitVec 2) (_ BitVec 2)))
 (declare-fun b () (Array (_ BitVec 2) (_ BitVec 2)))
 (assert (distinct a b))

--- a/tests/query-files/array-extensionality-tests/43-model-agrees-with-solved-out-read.smt2
+++ b/tests/query-files/array-extensionality-tests/43-model-agrees-with-solved-out-read.smt2
@@ -22,6 +22,7 @@
 ; here, ReadUsingModel, and the contents comparison the post-solve audit
 ; makes -- without anything having to be recorded to keep them in step.
 (set-logic QF_ABV)
+(set-option :produce-models true)
 (declare-fun a () (Array (_ BitVec 4) (_ BitVec 8)))
 (declare-fun c () (Array (_ BitVec 4) (_ BitVec 8)))
 (declare-fun b () (Array (_ BitVec 4) (_ BitVec 8)))

--- a/tests/query-files/fp-tests/fp-named-sort-without-set-logic.smt2
+++ b/tests/query-files/fp-tests/fp-named-sort-without-set-logic.smt2
@@ -3,7 +3,7 @@
 ; The named formats reach the sort rules as bare identifiers when no FP
 ; set-logic is in force, and the diagnostic waiting for them there is not
 ; merely unhelpful but wrong: "unknown sort (not built in, and not a
-; define-sort alias)" describes a typo, whereas Float64 is built in and only
+; declared sort)" describes a typo, whereas Float64 is built in and only
 ; disabled. The base message is left alone -- it is right for every other
 ; name that lands on that rule -- and the hint corrects it for this one.
 ; RoundingMode takes the same path.

--- a/tests/query-files/fp-tests/logic-lra-real-is-still-refused.smt2
+++ b/tests/query-files/fp-tests/logic-lra-real-is-still-refused.smt2
@@ -8,7 +8,7 @@
 ;
 ; Resolving a sort is fatal where recovering from a bison error is not, so
 ; this one does exit non-zero.
-; CHECK-L: unknown sort (not built in, and not a define-sort alias)  token: Real
+; CHECK-L: unknown sort (not built in, and not a declared sort)  token: Real
 ; NOANSWER-NOT: ^sat$
 ; NOANSWER-NOT: ^unsat$
 (set-logic QF_BVFPLRA)

--- a/tests/query-files/uf/01-unary-congruence-unsat.smt2
+++ b/tests/query-files/uf/01-unary-congruence-unsat.smt2
@@ -1,0 +1,12 @@
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: ^unsat
+;
+; EXPECT: unsat
+(set-logic QF_UFBV)
+(declare-fun x () (_ BitVec 4))
+(declare-fun y () (_ BitVec 4))
+(declare-fun f ((_ BitVec 4)) (_ BitVec 8))
+(assert (= x y))
+(assert (distinct (f x) (f y)))
+(check-sat)

--- a/tests/query-files/uf/02-noninjective-sat.smt2
+++ b/tests/query-files/uf/02-noninjective-sat.smt2
@@ -1,0 +1,15 @@
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: ^sat
+; CHECK: define-fun \|f\|
+;
+; EXPECT: sat
+(set-logic QF_UFBV)
+(set-option :produce-models true)
+(declare-fun x () (_ BitVec 4))
+(declare-fun y () (_ BitVec 4))
+(declare-fun f ((_ BitVec 4)) (_ BitVec 8))
+(assert (distinct x y))
+(assert (= (f x) (f y)))
+(check-sat)
+(get-model)

--- a/tests/query-files/uf/03-binary-congruence-unsat.smt2
+++ b/tests/query-files/uf/03-binary-congruence-unsat.smt2
@@ -1,0 +1,15 @@
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: ^unsat
+;
+; EXPECT: unsat
+(set-logic QF_UFBV)
+(declare-fun x1 () (_ BitVec 4))
+(declare-fun x2 () Bool)
+(declare-fun y1 () (_ BitVec 4))
+(declare-fun y2 () Bool)
+(declare-fun f ((_ BitVec 4) Bool) (_ BitVec 3))
+(assert (= x1 y1))
+(assert (= x2 y2))
+(assert (distinct (f x1 x2) (f y1 y2)))
+(check-sat)

--- a/tests/query-files/uf/04-nested-congruence-unsat.smt2
+++ b/tests/query-files/uf/04-nested-congruence-unsat.smt2
@@ -1,0 +1,13 @@
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: ^unsat
+;
+; EXPECT: unsat
+(set-logic QF_UFBV)
+(declare-fun x () (_ BitVec 4))
+(declare-fun y () (_ BitVec 4))
+(declare-fun g ((_ BitVec 4)) (_ BitVec 4))
+(declare-fun f ((_ BitVec 4)) (_ BitVec 4))
+(assert (= x y))
+(assert (distinct (f (g x)) (f (g y))))
+(check-sat)

--- a/tests/query-files/uf/05-boolean-predicate-unsat.smt2
+++ b/tests/query-files/uf/05-boolean-predicate-unsat.smt2
@@ -1,0 +1,16 @@
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: ^unsat
+;
+; EXPECT: unsat
+(set-logic QF_UFBV)
+(declare-fun b1 () Bool)
+(declare-fun b2 () Bool)
+(declare-fun x () (_ BitVec 2))
+(declare-fun y () (_ BitVec 2))
+(declare-fun p (Bool (_ BitVec 2)) Bool)
+(assert (= b1 b2))
+(assert (= x y))
+(assert (p b1 x))
+(assert (not (p b2 y)))
+(check-sat)

--- a/tests/query-files/uf/06-array-read-as-uf-argument-unsat.smt2
+++ b/tests/query-files/uf/06-array-read-as-uf-argument-unsat.smt2
@@ -1,0 +1,13 @@
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: ^unsat
+;
+; EXPECT: unsat
+(set-logic QF_AUFBV)
+(declare-fun a () (Array (_ BitVec 4) (_ BitVec 8)))
+(declare-fun i () (_ BitVec 4))
+(declare-fun j () (_ BitVec 4))
+(declare-fun f ((_ BitVec 8)) (_ BitVec 8))
+(assert (= i j))
+(assert (distinct (f (select a i)) (f (select a j))))
+(check-sat)

--- a/tests/query-files/uf/07-uf-result-as-array-index-unsat.smt2
+++ b/tests/query-files/uf/07-uf-result-as-array-index-unsat.smt2
@@ -1,0 +1,13 @@
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: ^unsat
+;
+; EXPECT: unsat
+(set-logic QF_AUFBV)
+(declare-fun a () (Array (_ BitVec 4) (_ BitVec 8)))
+(declare-fun x () (_ BitVec 4))
+(declare-fun y () (_ BitVec 4))
+(declare-fun f ((_ BitVec 4)) (_ BitVec 4))
+(assert (= x y))
+(assert (distinct (select a (f x)) (select a (f y))))
+(check-sat)

--- a/tests/query-files/uf/08-mixed-signature-roundtrip.smt2
+++ b/tests/query-files/uf/08-mixed-signature-roundtrip.smt2
@@ -1,0 +1,16 @@
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: ^sat
+; CHECK: REACHED-END
+;
+; RUN WITH: --uninterpreted-functions
+; EXPECT: sat, then REACHED-END
+(set-logic QF_UFBV)
+(declare-fun b () Bool)
+(declare-fun x () (_ BitVec 8))
+(declare-fun p (Bool (_ BitVec 8)) Bool)
+(declare-fun f (Bool (_ BitVec 8)) (_ BitVec 3))
+(assert (= (p b x) (p b x)))
+(assert (= (f b x) (f b x)))
+(check-sat)
+(echo "REACHED-END")

--- a/tests/query-files/uf/09-malformed-arity-continues.smt2
+++ b/tests/query-files/uf/09-malformed-arity-continues.smt2
@@ -1,0 +1,14 @@
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: f expects 1 argument but was applied to 2
+; CHECK: ^sat
+; CHECK: REACHED-END
+;
+; RUN WITH: --uninterpreted-functions
+; EXPECT: one nonfatal arity error, then sat, then REACHED-END
+(set-logic QF_UFBV)
+(declare-fun x () (_ BitVec 8))
+(declare-fun f ((_ BitVec 8)) (_ BitVec 4))
+(assert (= (f x x) #b0000))
+(check-sat)
+(echo "REACHED-END")

--- a/tests/query-files/uf/10-malformed-sort-continues.smt2
+++ b/tests/query-files/uf/10-malformed-sort-continues.smt2
@@ -1,0 +1,14 @@
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: argument 0 of f has sort Bool but the declaration requires \(_ BitVec 8\)
+; CHECK: ^sat
+; CHECK: REACHED-END
+;
+; RUN WITH: --uninterpreted-functions
+; EXPECT: one nonfatal sort error, then sat, then REACHED-END
+(set-logic QF_UFBV)
+(declare-fun b () Bool)
+(declare-fun f ((_ BitVec 8)) Bool)
+(assert (f b))
+(check-sat)
+(echo "REACHED-END")

--- a/tests/query-files/uf/11-declaration-push-pop.smt2
+++ b/tests/query-files/uf/11-declaration-push-pop.smt2
@@ -1,0 +1,18 @@
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: ^sat
+; CHECK: ^sat
+;
+; RUN WITH: --uninterpreted-functions
+; EXPECT: sat, sat; the popped declaration is removed and may be redeclared
+(set-logic QF_UFBV)
+(push 1)
+(declare-fun f ((_ BitVec 4)) (_ BitVec 4))
+(declare-fun x () (_ BitVec 4))
+(assert (= (f x) (f x)))
+(check-sat)
+(pop 1)
+(declare-fun f ((_ BitVec 8)) (_ BitVec 8))
+(declare-fun y () (_ BitVec 8))
+(assert (= (f y) (f y)))
+(check-sat)

--- a/tests/query-files/uf/12-reset-assertions-keeps-declaration.smt2
+++ b/tests/query-files/uf/12-reset-assertions-keeps-declaration.smt2
@@ -1,0 +1,16 @@
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: ^unsat
+; CHECK: ^sat
+;
+; RUN WITH: --uninterpreted-functions
+; EXPECT: unsat, then sat; base declaration survives reset-assertions
+(set-logic QF_UFBV)
+(set-option :global-declarations true)
+(declare-fun f ((_ BitVec 4)) (_ BitVec 4))
+(declare-fun x () (_ BitVec 4))
+(assert (distinct (f x) (f x)))
+(check-sat)
+(reset-assertions)
+(assert (= (f x) (f x)))
+(check-sat)

--- a/tests/query-files/uf/13-reset-drops-declaration.smt2
+++ b/tests/query-files/uf/13-reset-drops-declaration.smt2
@@ -1,0 +1,18 @@
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: ^sat
+; CHECK: ^sat
+;
+; RUN WITH: --uninterpreted-functions
+; EXPECT: sat, sat; reset destroys declarations and permits a changed signature
+(set-logic QF_UFBV)
+(declare-fun f ((_ BitVec 4)) (_ BitVec 4))
+(declare-fun x () (_ BitVec 4))
+(assert (= (f x) (f x)))
+(check-sat)
+(reset)
+(set-logic QF_UFBV)
+(declare-fun f ((_ BitVec 8)) Bool)
+(declare-fun y () (_ BitVec 8))
+(assert (= (f y) (f y)))
+(check-sat)

--- a/tests/query-files/uf/14-hidden-boolean-result-unsat.smt2
+++ b/tests/query-files/uf/14-hidden-boolean-result-unsat.smt2
@@ -1,0 +1,14 @@
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: ^unsat
+;
+; RUN WITH: --uninterpreted-functions (release build)
+; EXPECT: unsat; hidden Boolean inner results must each have one SAT variable
+(set-logic QF_UFBV)
+(declare-fun x () (_ BitVec 4))
+(declare-fun y () (_ BitVec 4))
+(declare-fun p ((_ BitVec 4)) Bool)
+(declare-fun f (Bool) (_ BitVec 3))
+(assert (= x y))
+(assert (distinct (f (p x)) (f (p y))))
+(check-sat)

--- a/tests/query-files/uf/15-function-model-active-only.smt2
+++ b/tests/query-files/uf/15-function-model-active-only.smt2
@@ -1,0 +1,19 @@
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: ^sat
+; CHECK: define-fun \|f\|
+; CHECK: \(ite \(= x0  #x1\)  #x2A \(ite \(= x0  #x2\)  #x7F  #x00\)\)
+;
+; RUN WITH: --uninterpreted-functions
+; EXPECT: sat and replayable deterministic nested-ite model for f
+(set-logic QF_UFBV)
+(set-option :produce-models true)
+(declare-fun x () (_ BitVec 4))
+(declare-fun y () (_ BitVec 4))
+(declare-fun f ((_ BitVec 4)) (_ BitVec 8))
+(assert (= x #x1))
+(assert (= y #x2))
+(assert (= (f x) #x2a))
+(assert (= (f y) #x7f))
+(check-sat)
+(get-model)

--- a/tests/query-files/uf/16-distinct-functions-sat.smt2
+++ b/tests/query-files/uf/16-distinct-functions-sat.smt2
@@ -1,0 +1,12 @@
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: ^sat
+;
+; RUN WITH: --uninterpreted-functions
+; EXPECT: sat; f and g have independent congruence tables
+(set-logic QF_UFBV)
+(declare-fun x () (_ BitVec 4))
+(declare-fun f ((_ BitVec 4)) (_ BitVec 8))
+(declare-fun g ((_ BitVec 4)) (_ BitVec 8))
+(assert (distinct (f x) (g x)))
+(check-sat)

--- a/tests/query-files/uf/17-interpreted-equal-arguments-unsat.smt2
+++ b/tests/query-files/uf/17-interpreted-equal-arguments-unsat.smt2
@@ -1,0 +1,11 @@
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: ^unsat
+;
+; RUN WITH: --uninterpreted-functions
+; EXPECT: unsat; tuple equality is by model value, not syntax
+(set-logic QF_UFBV)
+(declare-fun x () (_ BitVec 4))
+(declare-fun f ((_ BitVec 4)) (_ BitVec 8))
+(assert (distinct (f x) (f (bvadd x #x0))))
+(check-sat)

--- a/tests/query-files/uf/18-default-off-nonnullary-declare-fun.smt2
+++ b/tests/query-files/uf/18-default-off-nonnullary-declare-fun.smt2
@@ -1,0 +1,10 @@
+; RUN: %solver --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: Wrong input logic
+; CHECK-NOT: REACHED-END
+;
+; RUN WITHOUT: --uninterpreted-functions
+; EXPECT: exact baseline syntax-error output, parse abandonment, no REACHED-END
+(set-logic QF_UFBV)
+(declare-fun f ((_ BitVec 4)) (_ BitVec 4))
+(echo "REACHED-END")

--- a/tests/query-files/uf/ackermanize-arrays-with-uf.smt2
+++ b/tests/query-files/uf/ackermanize-arrays-with-uf.smt2
@@ -1,0 +1,13 @@
+; RUN: %solver --uninterpreted-functions --ackermanize --incremental=off %s | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --ackermanize --incremental=on %s | %OutputCheck %s
+; CHECK-NEXT: ^unsat
+; GATE-03 boundary: --ackermanize eagerly compiles ARRAYS only; UF
+; stays on the dynamic reference profile and still refines.
+(set-logic QF_AUFBV)
+(declare-fun a () (Array (_ BitVec 4) (_ BitVec 8)))
+(declare-fun i () (_ BitVec 4))
+(declare-fun j () (_ BitVec 4))
+(declare-fun f ((_ BitVec 8)) (_ BitVec 8))
+(assert (= i j))
+(assert (distinct (f (select a i)) (f (select a j))))
+(check-sat)

--- a/tests/query-files/uf/active-model-scope.smt2
+++ b/tests/query-files/uf/active-model-scope.smt2
@@ -1,0 +1,25 @@
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: ^sat
+; CHECK: ^sat
+; CHECK: define-fun \|f\|
+; CHECK: \(ite \(= x0  #x2\)  #x22  #x00\)
+; CHECK: define-fun \|unused\|
+; CHECK: false
+; CHECK-NOT: \(= x0  #x1\)
+;
+; The first solve certifies f(#x1) in a pushed block. Pop invalidates that
+; seed; the second published interpretation contains only its active #x2
+; observation. An active declaration with no observations is totalized by its
+; deterministic false default.
+(set-option :produce-models true)
+(set-logic QF_UFBV)
+(declare-fun f ((_ BitVec 4)) (_ BitVec 8))
+(declare-fun unused (Bool) Bool)
+(push 1)
+(assert (= (f #x1) #x11))
+(check-sat)
+(pop 1)
+(assert (= (f #x2) #x22))
+(check-sat)
+(get-model)

--- a/tests/query-files/uf/array-uf-solve-window-defeq.smt2
+++ b/tests/query-files/uf/array-uf-solve-window-defeq.smt2
@@ -1,0 +1,20 @@
+; A definitional whole-array equality must likewise leave the protected UF
+; leaves registered for direct-CNF refinement rather than substituting them
+; out before the solve window opens.
+;
+; RUN: %solver --uninterpreted-functions --array-equality --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --array-equality --incremental=on %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --array-equality %s 2>&1 | %OutputCheck %s
+; CHECK-NOT: Fatal Error
+; CHECK: ^unsat
+;
+(set-logic QF_AUFBV)
+(declare-const a (Array (_ BitVec 4) (_ BitVec 8)))
+(declare-const b (Array (_ BitVec 4) (_ BitVec 8)))
+(declare-const x (_ BitVec 4))
+(declare-const y (_ BitVec 4))
+(declare-fun f ((_ BitVec 4)) (_ BitVec 8))
+(assert (= a b))
+(assert (= x y))
+(assert (distinct (f x) (f y)))
+(check-sat)

--- a/tests/query-files/uf/array-uf-solve-window-store.smt2
+++ b/tests/query-files/uf/array-uf-solve-window-store.smt2
@@ -1,0 +1,23 @@
+; The batch solve window must protect UF result scalars while array equality
+; propagation and unconstrained elimination process an accepted store
+; equality.  Otherwise the congruence semantics can be substituted away.
+;
+; RUN: %solver --uninterpreted-functions --array-equality --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --array-equality --incremental=on %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --array-equality %s 2>&1 | %OutputCheck %s
+; CHECK-NEXT: ^unsat
+;
+(set-logic QF_AUFBV)
+(declare-const a (Array (_ BitVec 4) (_ BitVec 8)))
+(declare-const b (Array (_ BitVec 4) (_ BitVec 8)))
+(declare-const i (_ BitVec 4))
+(declare-const j (_ BitVec 4))
+(declare-const e1 (_ BitVec 8))
+(declare-const e2 (_ BitVec 8))
+(declare-const x (_ BitVec 4))
+(declare-const y (_ BitVec 4))
+(declare-fun f ((_ BitVec 4)) (_ BitVec 8))
+(assert (= (store a i e1) (store b j e2)))
+(assert (= x y))
+(assert (distinct (f x) (f y)))
+(check-sat)

--- a/tests/query-files/uf/aufbvfp-logic-name.smt2
+++ b/tests/query-files/uf/aufbvfp-logic-name.smt2
@@ -1,0 +1,12 @@
+; QF_AUFBVFP is gated on the feature exactly as its aliases and QF_UFBV are:
+; with --uninterpreted-functions absent it is not a logic STP admits, and the
+; report is the ordinary recoverable wrong-logic error rather than anything
+; UF-specific.
+;
+; RUN: %solver --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: Wrong input logic
+; CHECK-NEXT: ^sat
+;
+(set-logic QF_AUFBVFP)
+(check-sat)

--- a/tests/query-files/uf/batch-compound-result-liveness.smt2
+++ b/tests/query-files/uf/batch-compound-result-liveness.smt2
@@ -1,0 +1,15 @@
+; A UF result equated to a compound term must retain one concrete candidate
+; authority.  The batch liveness registrar must not turn the compound side's
+; model definition into a second, missing direct assignment for the generated
+; result scalar.
+;
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; CHECK: ^sat
+;
+(set-logic QF_UFBV)
+(declare-fun a () (_ BitVec 4))
+(declare-fun b () (_ BitVec 4))
+(declare-fun f ((_ BitVec 4)) (_ BitVec 4))
+(assert (= (bvadd a b) (f a)))
+(check-sat)
+(exit)

--- a/tests/query-files/uf/check-sat-assuming-lifecycle.smt2
+++ b/tests/query-files/uf/check-sat-assuming-lifecycle.smt2
@@ -1,0 +1,17 @@
+; A congruence conflict introduced only by assumptions retracts with those
+; assumptions.  This is the useful branch-neutral lifecycle case from the
+; peer UF suite; it makes no declaration-scope or error-recovery assumption.
+;
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: ^unsat
+; CHECK: ^sat
+;
+(set-logic QF_UFBV)
+(declare-fun f ((_ BitVec 8)) (_ BitVec 8))
+(declare-const x (_ BitVec 8))
+(declare-const y (_ BitVec 8))
+(assert (distinct (f x) (f y)))
+(check-sat-assuming ((= x y)))
+(check-sat)
+(exit)

--- a/tests/query-files/uf/combined-model.smt2
+++ b/tests/query-files/uf/combined-model.smt2
@@ -1,0 +1,22 @@
+; RUN: %solver --uninterpreted-functions --array-equality --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --array-equality --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: ^sat
+; CHECK: define-fun \|x\| .*#x01
+; CHECK: define-fun \|a\| .*#x2A
+; CHECK: define-fun \|f\|
+; CHECK: #x7F
+; CHECK: \( \(\|f\| \|x\|\)  #x7F \)
+;
+; Scalar, array, and UF authorities publish one certified model. The direct
+; value query goes through the durable application handle, not @uf_result.
+(set-option :produce-models true)
+(set-logic QF_AUFBV)
+(declare-const a (Array (_ BitVec 8) (_ BitVec 8)))
+(declare-const x (_ BitVec 8))
+(declare-fun f ((_ BitVec 8)) (_ BitVec 8))
+(assert (= x #x01))
+(assert (= (select a #x00) #x2a))
+(assert (= (f x) #x7f))
+(check-sat)
+(get-model)
+(get-value ((f x)))

--- a/tests/query-files/uf/declaration-push-pop-global.smt2
+++ b/tests/query-files/uf/declaration-push-pop-global.smt2
@@ -1,0 +1,17 @@
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: ^unsat
+; CHECK: ^sat
+;
+; With global declarations enabled, popping retracts only the assertion. The
+; declaration and its durable application remain usable in the outer frame.
+(set-option :global-declarations true)
+(set-logic QF_UFBV)
+(push 1)
+(declare-fun f ((_ BitVec 8)) (_ BitVec 8))
+(declare-const x (_ BitVec 8))
+(assert (distinct (f x) (f x)))
+(check-sat)
+(pop 1)
+(assert (= (f x) (f x)))
+(check-sat)

--- a/tests/query-files/uf/deep-chain.smt2
+++ b/tests/query-files/uf/deep-chain.smt2
@@ -1,0 +1,14 @@
+; RUN: %solver --uninterpreted-functions --incremental=off %s | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions %s | %OutputCheck %s
+; CHECK-NEXT: ^unsat
+; T-UF-09: a deeper hidden application chain through completed-root
+; traversal and up-front liveness.
+(set-logic QF_UFBV)
+(declare-fun g ((_ BitVec 4)) (_ BitVec 4))
+(declare-fun f ((_ BitVec 4)) (_ BitVec 4))
+(declare-fun x () (_ BitVec 4))
+(declare-fun y () (_ BitVec 4))
+(assert (= x y))
+(assert (distinct (f (g (f (g x)))) (f (g (f (g y))))))
+(check-sat)

--- a/tests/query-files/uf/default-off-first-domain-token-bool.smt2
+++ b/tests/query-files/uf/default-off-first-domain-token-bool.smt2
@@ -1,0 +1,12 @@
+; RUN: %solver --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK-NEXT: ^\(error "syntax error: line 10 syntax error, unexpected BOOL_TOK, expecting RPAREN_TOK  token: Bool"\)
+; CHECK-NOT: REACHED-END
+;
+; RUN WITHOUT: --uninterpreted-functions. The disabled-feature rejection of a
+; nonzero-arity declare-fun must stay byte-identical to the baseline grammar,
+; which errored at the first domain token and named its kind (not LPAREN's).
+(set-logic QF_BV)
+(declare-fun f (Bool) (_ BitVec 8))
+(check-sat)
+(echo "REACHED-END")

--- a/tests/query-files/uf/default-off-first-domain-token-numeral.smt2
+++ b/tests/query-files/uf/default-off-first-domain-token-numeral.smt2
@@ -1,0 +1,13 @@
+; RUN: %solver --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK-NEXT: ^\(error "syntax error: line 11 syntax error, unexpected NUMERAL_TOK, expecting RPAREN_TOK  token: 8"\)
+; CHECK-NOT: REACHED-END
+;
+; RUN WITHOUT: --uninterpreted-functions. A first domain token outside the
+; UF sort grammar's FIRST set reaches the declaration branch through Bison's
+; default reduction; the rejection must name that lookahead just as the
+; baseline grammar did.
+(set-logic QF_BV)
+(declare-fun f (8) (_ BitVec 8))
+(check-sat)
+(echo "REACHED-END")

--- a/tests/query-files/uf/deferred-model.smt2
+++ b/tests/query-files/uf/deferred-model.smt2
@@ -1,0 +1,19 @@
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: ^sat
+; CHECK: define-fun \|f\|
+; CHECK: \( \(\|f\| \|x\|\)  #x2A \)
+; CHECK: unsupported
+;
+(set-logic QF_UFBV)
+(set-option :produce-models true)
+(declare-fun f ((_ BitVec 8)) (_ BitVec 8))
+(declare-const x (_ BitVec 8))
+(assert (= (f x) #x2a))
+(check-sat)
+(get-model)
+(get-value ((f x)))
+(push 1)
+(assert (distinct x x))
+(get-value ((f x)))
+(pop 1)

--- a/tests/query-files/uf/define-fun-application-identity.smt2
+++ b/tests/query-files/uf/define-fun-application-identity.smt2
@@ -1,0 +1,14 @@
+; Instantiating a define-fun whose body is a UF application must recover the
+; same durable application identity as spelling that application directly.
+;
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions %s 2>&1 | %OutputCheck %s
+; CHECK-NEXT: ^unsat
+;
+(set-logic QF_UFBV)
+(declare-fun f ((_ BitVec 8)) (_ BitVec 8))
+(define-fun h ((x (_ BitVec 8))) (_ BitVec 8) (f x))
+(declare-const a (_ BitVec 8))
+(assert (distinct (h a) (f a)))
+(check-sat)

--- a/tests/query-files/uf/define-fun-specialization.smt2
+++ b/tests/query-files/uf/define-fun-specialization.smt2
@@ -1,0 +1,9 @@
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: ^sat
+;
+(set-logic QF_UFBV)
+(declare-fun f ((_ BitVec 8)) (_ BitVec 8))
+(define-fun h ((x (_ BitVec 8))) (_ BitVec 8) (f x))
+(assert (distinct (h #x00) (h #x01)))
+(check-sat) ; expected sat: distinct specializations must not alias

--- a/tests/query-files/uf/ext-shortcircuit-no-uf-lemma.smt2
+++ b/tests/query-files/uf/ext-shortcircuit-no-uf-lemma.smt2
@@ -1,0 +1,17 @@
+; An extensionality conflict ends the candidate round before the active but
+; consistent UF checker is allowed to install a refinement clause.
+;
+; RUN: %solver -s --uninterpreted-functions --array-equality --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver -s --uninterpreted-functions --array-equality --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK-NOT: UF: installed congruence lemma
+; CHECK: ^unsat
+;
+(set-logic QF_AUFBV)
+(declare-fun f ((_ BitVec 8)) (_ BitVec 8))
+(declare-const a (Array (_ BitVec 8) (_ BitVec 8)))
+(declare-const b (Array (_ BitVec 8) (_ BitVec 8)))
+(declare-const i (_ BitVec 8))
+(assert (= a b))
+(assert (distinct (select a i) (select b i)))
+(assert (= (f i) (f i)))
+(check-sat)

--- a/tests/query-files/uf/flag-on-empty-view.smt2
+++ b/tests/query-files/uf/flag-on-empty-view.smt2
@@ -1,0 +1,13 @@
+; RUN: %solver --uninterpreted-functions --incremental=off %s | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions %s | %OutputCheck %s
+; CHECK-NEXT: ^sat
+; CHECK-NEXT: ^"REACHED-END"
+; T-DNH-01 (flag-on arm): declarations with no reachable application
+; engage nothing -- no lowering work, no checker, ordinary answers.
+(set-logic QF_UFBV)
+(declare-fun f ((_ BitVec 8)) (_ BitVec 8))
+(declare-const x (_ BitVec 8))
+(assert (= x #x01))
+(check-sat)
+(echo "REACHED-END")

--- a/tests/query-files/uf/fp-application-actual-not-lowered.smt2
+++ b/tests/query-files/uf/fp-application-actual-not-lowered.smt2
@@ -1,0 +1,71 @@
+; Float blasting must not lower a UF application's actual.
+;
+; Reading a model value for a float-valued term runs the float blaster over
+; that term, and the blaster's generic rebuild substitutes each lowered child
+; into the node it is rebuilding. Under a UF application that is wrong twice
+; over: an application's actuals are stated in source sorts and the UF layer
+; both validates and compares them there, so replacing a float actual with the
+; bits it lowered to changes what the application denotes -- and the node
+; factory refuses to build it at all, which took the process down with
+;
+;   Fatal Error: UF_APPLY: uninterpreted functions: argument 0 of f has sort
+;                (_ BitVec 32) but the declaration requires (_ FloatingPoint 8 24)
+;
+; The application already *is* the bits of its result -- UFContext::apply
+; builds it at the codomain's packed width -- so there was nothing to gain by
+; descending into one either. The blaster now treats an application as an
+; opaque carrier, exactly as it treats a float symbol or an array read, and
+; leaves its actuals to whoever resolves the application: the UF lowering pass
+; before a solve, the counterexample walk's UF_APPLY arm after one.
+;
+; It takes a *computed* actual to reach this. A symbol or a constant lowers to
+; itself, so the rebuild never fired and the application came back untouched:
+; the first two rows are those cases, kept so a fix cannot quietly change
+; them. The rest are the defect, under each of the three codomain kinds a
+; declaration can have.
+;
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+;
+; The term half of each pair is printed through get-value's letizing entry
+; point, so the computed actual -- named once as the operand and again inside
+; the application -- comes back as a let binding rather than twice over.
+;
+; CHECK: ^sat
+; x is -3, so fp.abs x is 3, f(3) is 10, and f(-3) is 20.
+; CHECK-L: ( (fp.min |x| (|f| |x|)) (fp #b1 #b10000000 #b10000000000000000000000) )
+; CHECK-L: ( (|f| (fp.abs |x|)) (fp #b0 #b10000010 #b01000000000000000000000) )
+; min(3, 10) = 3, max(3, 10) = 10, 3 + 10 = 13.
+; CHECK-L: ( (let ((|?let_k_0| (fp.abs |x|))) (fp.min |?let_k_0| (|f| |?let_k_0|))) (fp #b0 #b10000000 #b10000000000000000000000) )
+; CHECK-L: ( (let ((|?let_k_0| (fp.abs |x|))) (fp.max |?let_k_0| (|f| |?let_k_0|))) (fp #b0 #b10000010 #b01000000000000000000000) )
+; CHECK-L: ( (let ((|?let_k_0| (fp.abs |x|))) (fp.add RTN |?let_k_0| (|f| |?let_k_0|))) (fp #b0 #b10000010 #b10100000000000000000000) )
+; A Bool-codomain application over the same computed actual, reached inside a
+; float-valued term through the mux it selects: p(3) holds, so min(3, x) = -3.
+; CHECK-L: ( (let ((|?let_k_0| (fp.abs |x|))) (fp.min |?let_k_0| (ite (|p| |?let_k_0|) |x| |y|))) (fp #b1 #b10000000 #b10000000000000000000000) )
+; A bit-vector-codomain application over it, read back into the float layer:
+; w(3) is 5, and min(3, 5) = 3.
+; CHECK-L: ( (let ((|?let_k_0| (fp.abs |x|))) (fp.min |?let_k_0| ((_ to_fp 8 24) RNE (|w| |?let_k_0|)))) (fp #b0 #b10000000 #b10000000000000000000000) )
+; CHECK: REACHED-END
+;
+(set-option :produce-models true)
+(set-logic QF_UFBVFP)
+(declare-fun f ((_ FloatingPoint 8 24)) (_ FloatingPoint 8 24))
+(declare-fun p ((_ FloatingPoint 8 24)) Bool)
+(declare-fun w ((_ FloatingPoint 8 24)) (_ BitVec 8))
+(declare-const x (_ FloatingPoint 8 24))
+(declare-const y (_ FloatingPoint 8 24))
+(assert (= x ((_ to_fp 8 24) RNE (- 3.0))))
+(assert (= y ((_ to_fp 8 24) RNE 1.0)))
+(assert (= (f x) ((_ to_fp 8 24) RNE 20.0)))
+(assert (= (f (fp.abs x)) ((_ to_fp 8 24) RNE 10.0)))
+(assert (p (fp.abs x)))
+(assert (= (w (fp.abs x)) #x05))
+(check-sat)
+(get-value ((fp.min x (f x))))
+(get-value ((f (fp.abs x))))
+(get-value ((fp.min (fp.abs x) (f (fp.abs x)))))
+(get-value ((fp.max (fp.abs x) (f (fp.abs x)))))
+(get-value ((fp.add RTN (fp.abs x) (f (fp.abs x)))))
+(get-value ((fp.min (fp.abs x) (ite (p (fp.abs x)) x y))))
+(get-value ((fp.min (fp.abs x) ((_ to_fp 8 24) RNE (w (fp.abs x))))))
+(echo "REACHED-END")

--- a/tests/query-files/uf/fp-array-boundary.smt2
+++ b/tests/query-files/uf/fp-array-boundary.smt2
@@ -1,0 +1,15 @@
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: ^unsat
+;
+(set-logic QF_ABVFP)
+(declare-fun f (Bool (_ BitVec 8) (_ BitVec 8)) (_ BitVec 4))
+(declare-const a (Array (_ BitVec 4) (_ BitVec 8)))
+(declare-const i (_ BitVec 4))
+(declare-const j (_ BitVec 4))
+(declare-const z (_ FloatingPoint 8 24))
+(assert (= i j))
+(assert (distinct
+  (f (fp.isNaN z) (select a i) ((_ fp.to_ubv 8) RNE z))
+  (f (fp.isNaN z) (select a j) ((_ fp.to_ubv 8) RNE z))))
+(check-sat)

--- a/tests/query-files/uf/fp-derived-actual.smt2
+++ b/tests/query-files/uf/fp-derived-actual.smt2
@@ -1,0 +1,12 @@
+; RUN: %solver --uninterpreted-functions --incremental=off %s | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s | %OutputCheck %s
+; CHECK-NEXT: ^unsat
+; DR-T-FP-BOUNDARY-01 / T-UF-07: a Bool actual containing an
+; FP-derived predicate is named at the UF boundary, then the naming
+; equation is lowered by the FP pipeline; congruence still binds.
+(set-logic QF_BVFP)
+(declare-fun u () (_ FloatingPoint 8 24))
+(declare-fun v () (_ FloatingPoint 8 24))
+(declare-fun f (Bool) (_ BitVec 4))
+(assert (distinct (f (fp.lt u v)) (f (fp.lt u v))))
+(check-sat)

--- a/tests/query-files/uf/fp-model-values.smt2
+++ b/tests/query-files/uf/fp-model-values.smt2
@@ -1,0 +1,32 @@
+; A floating-point UF result is published in floating-point syntax, at the
+; declared sort, not as the packed bit-vector the checker actually stores.
+; The generated define-fun has to be a legal SMT-LIB term: its signature
+; names (_ FloatingPoint 8 24) and every value in it is an (fp ...).
+;
+; --check-sanity replays the certified interpretation against the raw stack,
+; so the printed model and the model used to satisfy the assertions cannot
+; quietly differ.
+;
+; RUN: %solver --uninterpreted-functions --check-sanity --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --check-sanity --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: ^sat
+; CHECK-L: define-fun |q| ((x0 (_ BitVec 4))) (_ FloatingPoint 8 24)
+; CHECK-L: (fp #b0 #b10000000 #b10000000000000000000000)
+; CHECK-L: ( (|q| |i|) (fp #b0 #b10000000 #b10000000000000000000000) )
+; CHECK-L: ( (|w| |z|)  #x01 )
+; CHECK: REACHED-END
+;
+(set-option :produce-models true)
+(set-logic QF_UFBVFP)
+(declare-fun q ((_ BitVec 4)) (_ FloatingPoint 8 24))
+(declare-fun w ((_ FloatingPoint 8 24)) (_ BitVec 8))
+(declare-const i (_ BitVec 4))
+(declare-const z (_ FloatingPoint 8 24))
+(assert (= i #x1))
+(assert (= (q i) (fp #b0 #b10000000 #b10000000000000000000000)))
+(assert (= (w z) #x01))
+(check-sat)
+(get-model)
+(get-value ((q i)))
+(get-value ((w z)))
+(echo "REACHED-END")

--- a/tests/query-files/uf/fp-nan-model-query.smt2
+++ b/tests/query-files/uf/fp-nan-model-query.smt2
@@ -1,0 +1,48 @@
+; The seam option A creates, and the one place in the floating-point work
+; where getting it wrong is quiet rather than loud.
+;
+; The checker observed the canonically-packed actual, because the name it
+; read is defined as FP_TO_IEEE_BV of the argument. A model query about an
+; application the solve never reached is answered from that same certified
+; seed, keyed on actuals the counterexample walk evaluates -- and those come
+; back as raw carriers out of the SAT assignment, with whatever NaN payload
+; the solver happened to pick. Keying the seed with the raw carrier would
+; miss the case and fall through to the default, so model evaluation would
+; disagree with the interpretation the define-fun printed. Nothing aborts to
+; say so: both answers are well-sorted.
+;
+; f(fp.abs x) is the query that reaches it. x is NaN, so fp.abs x is the same
+; *value* and congruence requires the same result -- but it is a distinct
+; durable node the solve never reached, and its evaluated carrier need not be
+; the one the seed was keyed on.
+;
+; The literal rows below test something weaker but worth keeping: every NaN
+; pattern interns as the one canonical quiet NaN at construction
+; (STPMgr::CreateFPConst), so two spellings are one node before the UF
+; machinery ever sees them. Both echo back as that canonical literal.
+;
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: ^sat
+; CHECK-L: ( (|f| |x|)  #x3 )
+; CHECK-L: ( (=  #x3 (|f| (fp.abs |x|))) true )
+; CHECK-L: ( (=  #x3 (|f| (fp #b0 #b11111111 #b10000000000000000000000))) true )
+; CHECK-L: ( (=  #x3 (|f| (fp #b0 #b11111111 #b10000000000000000000000))) true )
+; A non-NaN actual is a different value and carries no such obligation, so it
+; resolves through the default instead. It must still be answerable.
+; CHECK-L: ( (bvadd  #x1 (|f| (fp #b0 #b10000000 #b00000000000000000000000)))
+; CHECK: REACHED-END
+;
+(set-option :produce-models true)
+(set-logic QF_UFBVFP)
+(declare-fun f ((_ FloatingPoint 8 24)) (_ BitVec 4))
+(declare-const x (_ FloatingPoint 8 24))
+(assert (fp.isNaN x))
+(assert (= (f x) #x3))
+(check-sat)
+(get-value ((f x)))
+(get-value ((= (f (fp.abs x)) #x3)))
+(get-value ((= (f (fp #b0 #b11111111 #b00000000000000000000001)) #x3)))
+(get-value ((= (f (fp #b1 #b11111111 #b11000000000000000000000)) #x3)))
+(get-value ((bvadd (f (fp #b0 #b10000000 #b00000000000000000000000)) #x1)))
+(echo "REACHED-END")

--- a/tests/query-files/uf/fp-result-identity.smt2
+++ b/tests/query-files/uf/fp-result-identity.smt2
@@ -1,0 +1,34 @@
+; = and fp.eq disagree on a floating-point UF result, and both answers have
+; to be right.
+;
+; = is identity of values and is reflexive, so a result cannot differ from
+; itself whatever it is -- including NaN. fp.eq is IEEE equality, which is
+; false at NaN, so a result is not obliged to be fp.eq to itself. A result
+; symbol encoded so that = and fp.eq coincided would get one of these wrong.
+;
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: ^unsat
+; CHECK: ^sat
+; CHECK: ^unsat
+; CHECK: REACHED-END
+;
+(set-logic QF_UFBVFP)
+(declare-fun q ((_ BitVec 4)) (_ FloatingPoint 8 24))
+(declare-fun p (Bool) Bool)
+(declare-const i (_ BitVec 4))
+(push 1)
+(assert (distinct (q i) (q i)))
+(check-sat)
+(pop 1)
+(push 1)
+(assert (not (fp.eq (q i) (q i))))
+(check-sat)
+(pop 1)
+(push 1)
+; The Bool-codomain companion, for the same reflexivity property on a sort
+; with no NaN in it.
+(assert (distinct (p true) (p true)))
+(check-sat)
+(pop 1)
+(echo "REACHED-END")

--- a/tests/query-files/uf/fp-rm-model-cases.smt2
+++ b/tests/query-files/uf/fp-rm-model-cases.smt2
@@ -1,0 +1,35 @@
+; A generated define-fun with floating-point and rounding-mode values in its
+; *conditions*, not just in its result.
+;
+; fp-model-values.smt2 pins a float codomain, where the values printed are
+; the ite branches. This pins the other half: the case conditions are
+; (= x0 <value>) over the declared domain sorts, so a float there has to
+; print in (fp ...) syntax and a rounding mode by name, or the define-fun is
+; not a legal SMT-LIB term however correct the interpretation behind it is.
+;
+; --check-sanity replays the certified interpretation against the raw stack,
+; so the text below and the model that satisfied the assertions cannot
+; quietly differ.
+;
+; RUN: %solver --uninterpreted-functions --check-sanity --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --check-sanity --incremental=on %s 2>&1 | %OutputCheck %s
+;
+; CHECK: ^sat
+; Both cases land on one line, so they are pinned as one literal -- which
+; also pins the nesting and the else branch.
+; CHECK-L: (define-fun |f| ((x0 (_ FloatingPoint 8 24)) (x1 RoundingMode)) (_ BitVec 4)
+; CHECK-L: (ite (and (= x0 (fp #b0 #b10000000 #b00000000000000000000000)) (= x1 RNE))  #x1 (ite (and (= x0 (fp #b1 #b10000001 #b01000000000000000000000)) (= x1 RTZ))  #x2  #x0)))
+; CHECK: REACHED-END
+;
+(set-logic QF_UFBVFP)
+(set-option :produce-models true)
+(declare-fun f ((_ FloatingPoint 8 24) RoundingMode) (_ BitVec 4))
+(declare-const u (_ FloatingPoint 8 24))
+(declare-const v (_ FloatingPoint 8 24))
+(assert (= u (fp #b0 #b10000000 #b00000000000000000000000)))
+(assert (= v (fp #b1 #b10000001 #b01000000000000000000000)))
+(assert (= (f u RNE) #x1))
+(assert (= (f v RTZ) #x2))
+(check-sat)
+(get-model)
+(echo "REACHED-END")

--- a/tests/query-files/uf/frontend-golden/README.md
+++ b/tests/query-files/uf/frontend-golden/README.md
@@ -1,0 +1,7 @@
+# UFSTP typed frontend golden tests
+
+These tests cover `DR-T-GRAMMAR-01`, `T-FE-04`, `T-FE-05`, `T-FE-07`, and
+`T-FE-08`: feature/logic independence, top-level namespace collisions,
+define-fun and let priority, atomic nonfatal rejection, and parser recovery.
+The production grammar is generated with `%expect 0`; any Bison conflict is a
+build failure.

--- a/tests/query-files/uf/frontend-golden/aufbv-does-not-enable.smt2
+++ b/tests/query-files/uf/frontend-golden/aufbv-does-not-enable.smt2
@@ -1,0 +1,10 @@
+; RUN: %solver --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: syntax error, unexpected LPAREN_TOK, expecting RPAREN_TOK
+; CHECK-NOT: REACHED-END
+;
+; QF_AUFBV is an accepted host logic even with UFSTP disabled. Its spelling
+; must not, however, enable non-nullary uninterpreted functions.
+(set-logic QF_AUFBV)
+(declare-fun f ((_ BitVec 8)) (_ BitVec 8))
+(echo "REACHED-END")

--- a/tests/query-files/uf/frontend-golden/bool-define-fun-roundtrip.smt2
+++ b/tests/query-files/uf/frontend-golden/bool-define-fun-roundtrip.smt2
@@ -1,0 +1,21 @@
+; Boolean parameters in define-fun are part of the ordinary SMT-LIB surface,
+; including with UF support disabled.  This is also the form emitted for a
+; Bool-domain function model, so the printer's output must reparse.
+;
+; RUN: %solver %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK-NEXT: ^sat
+; CHECK-NEXT: ^"REACHED-END"
+;
+(set-logic QF_BV)
+(define-fun mand ((a Bool) (b Bool)) Bool (and a b))
+(define-fun g ((x0 Bool) (x1 (_ BitVec 2))) Bool
+  (ite (and (= x0 true) (= x1 #b01)) true false))
+(declare-const p Bool)
+(declare-const w (_ BitVec 2))
+(assert (mand p true))
+(assert (g true #b01))
+(assert (not (g p w)))
+(check-sat)
+(echo "REACHED-END")

--- a/tests/query-files/uf/frontend-golden/declare-const-known-name-pinned.smt2
+++ b/tests/query-files/uf/frontend-golden/declare-const-known-name-pinned.smt2
@@ -1,0 +1,12 @@
+; RUN: %solver --uninterpreted-functions %s 2>&1 | %OutputCheck %s
+; CHECK-NEXT: ^\(error "syntax error: line 10 syntax error, unexpected UF_BV_FUNCTIONID_TOK, expecting STRING_TOK  token: f"\)$
+; CHECK-NOT: REACHED-END
+; declare-const is a UF-free shape: its name is never declassified, so a
+; known name -- here a declared uninterpreted function, the only new kind
+; of owner the feature introduces -- meets the legacy classified-token
+; syntax error at the name and the parse abandons, feature on or off.
+(set-logic QF_UFBV)
+(declare-fun f ((_ BitVec 8)) (_ BitVec 8))
+(declare-const f (_ BitVec 8))
+(check-sat)
+(echo "REACHED-END")

--- a/tests/query-files/uf/frontend-golden/define-fun-bool-formal-shadows-uf.smt2
+++ b/tests/query-files/uf/frontend-golden/define-fun-bool-formal-shadows-uf.smt2
@@ -1,0 +1,13 @@
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK-NEXT: ^unsat
+; CHECK-NEXT: ^"REACHED-END"
+;
+; Boolean formals obey the same binder-before-global-namespace rule as
+; bit-vector formals.
+(set-logic QF_UFBV)
+(declare-fun predicate (Bool) Bool)
+(define-fun identity ((predicate Bool)) Bool predicate)
+(assert (not (identity true)))
+(check-sat)
+(echo "REACHED-END")

--- a/tests/query-files/uf/frontend-golden/define-fun-bool-parameter.smt2
+++ b/tests/query-files/uf/frontend-golden/define-fun-bool-parameter.smt2
@@ -1,0 +1,17 @@
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: ^unsat
+;
+; Bool and BV define-fun formals both retain SourceSort through substitution
+; into a durable mixed-signature application.
+(set-logic QF_UFBV)
+(declare-fun f ((_ BitVec 8) Bool) (_ BitVec 8))
+(define-fun h ((x (_ BitVec 8)) (b Bool)) (_ BitVec 8) (f x b))
+(declare-const x (_ BitVec 8))
+(declare-const y (_ BitVec 8))
+(declare-const b Bool)
+(declare-const c Bool)
+(assert (= x y))
+(assert (= b c))
+(assert (distinct (h x b) (h y c)))
+(check-sat)

--- a/tests/query-files/uf/frontend-golden/define-fun-bv-formal-shadows-uf.smt2
+++ b/tests/query-files/uf/frontend-golden/define-fun-bv-formal-shadows-uf.smt2
@@ -1,0 +1,13 @@
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK-NEXT: ^unsat
+; CHECK-NEXT: ^"REACHED-END"
+;
+; A define-fun formal is a binder, so it takes precedence over a global UF
+; with the same spelling while both the formal list and body are parsed.
+(set-logic QF_UFBV)
+(declare-fun value ((_ BitVec 8)) (_ BitVec 8))
+(define-fun identity ((value (_ BitVec 8))) (_ BitVec 8) value)
+(assert (distinct (identity #x2a) #x2a))
+(check-sat)
+(echo "REACHED-END")

--- a/tests/query-files/uf/frontend-golden/define-fun-known-name-pinned.smt2
+++ b/tests/query-files/uf/frontend-golden/define-fun-known-name-pinned.smt2
@@ -1,0 +1,12 @@
+; RUN: %solver --uninterpreted-functions %s 2>&1 | %OutputCheck %s
+; CHECK-NEXT: ^\(error "syntax error: line 10 syntax error, unexpected UF_BV_FUNCTIONID_TOK, expecting STRING_TOK  token: f"\)$
+; CHECK-NOT: REACHED-END
+; define-fun is a UF-free shape: its name is never declassified, so a
+; known name -- here a declared uninterpreted function -- meets the legacy
+; classified-token syntax error at the name and the parse abandons,
+; feature on or off. Nothing is defined and nothing after it runs.
+(set-logic QF_UFBV)
+(declare-fun f ((_ BitVec 8)) (_ BitVec 8))
+(define-fun f ((q (_ BitVec 8))) (_ BitVec 8) q)
+(check-sat)
+(echo "REACHED-END")

--- a/tests/query-files/uf/frontend-golden/feature-off-known-name-redeclaration.smt2
+++ b/tests/query-files/uf/frontend-golden/feature-off-known-name-redeclaration.smt2
@@ -1,0 +1,12 @@
+; With UF support disabled, even a known name must not make a non-nullary
+; declaration reachable.  Preserve the baseline parse abandonment.
+;
+; RUN: %solver %s 2>&1 | %OutputCheck %s
+; CHECK-NEXT: ^\(error ".*syntax error.*x"\)
+; CHECK-NOT: REACHED-END
+;
+(set-logic QF_BV)
+(declare-const x (_ BitVec 8))
+(declare-fun x ((_ BitVec 8)) (_ BitVec 8))
+(check-sat)
+(echo "REACHED-END")

--- a/tests/query-files/uf/frontend-golden/feature-off-qf-ufbv-recovery.smt2
+++ b/tests/query-files/uf/frontend-golden/feature-off-qf-ufbv-recovery.smt2
@@ -1,0 +1,9 @@
+; A disabled UF feature does not recognize QF_UFBV, but the logic error is a
+; command-local error: the following UF-free check remains usable.
+;
+; RUN: %solver %s 2>&1 | %OutputCheck %s
+; CHECK-NEXT: ^\(error ".*Wrong input logic.*QF_UFBV"\)
+; CHECK-NEXT: ^sat
+;
+(set-logic QF_UFBV)
+(check-sat)

--- a/tests/query-files/uf/frontend-golden/let-shadows-uf-name.smt2
+++ b/tests/query-files/uf/frontend-golden/let-shadows-uf-name.smt2
@@ -1,0 +1,16 @@
+; A local binder is resolved before the global UF namespace.  The same name
+; remains an applicable function outside the let expression.
+;
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions %s 2>&1 | %OutputCheck %s
+; CHECK-NEXT: ^sat
+; CHECK-NEXT: ^"REACHED-END"
+;
+(set-logic QF_UFBV)
+(declare-fun f ((_ BitVec 8)) (_ BitVec 8))
+(declare-const x (_ BitVec 8))
+(assert (= (let ((f #x03)) (bvadd f #x01)) #x04))
+(assert (= (f x) (f x)))
+(check-sat)
+(echo "REACHED-END")

--- a/tests/query-files/uf/frontend-golden/logic-policy.smt2
+++ b/tests/query-files/uf/frontend-golden/logic-policy.smt2
@@ -1,0 +1,14 @@
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: ^sat
+; CHECK: ^sat
+;
+(set-logic QF_UFBV)
+(declare-fun f ((_ BitVec 8)) (_ BitVec 8))
+(check-sat)
+(reset)
+(set-logic QF_AUFBV)
+(declare-fun g ((_ BitVec 8)) (_ BitVec 8))
+(declare-const a (Array (_ BitVec 8) (_ BitVec 8)))
+(assert (= (g (select a #x00)) (g (select a #x00))))
+(check-sat)

--- a/tests/query-files/uf/frontend-golden/malformed-check-sat-assuming-no-leak.smt2
+++ b/tests/query-files/uf/frontend-golden/malformed-check-sat-assuming-no-leak.smt2
@@ -1,0 +1,19 @@
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK-NEXT: ^\(error ".*f expects 1 argument but was applied to 2"\)
+; CHECK-NEXT: ^unsat
+; CHECK-NEXT: ^"REACHED-END"
+;
+; malformed-command-atomicity pins that a rejected check-sat-assuming prints
+; no verdict. This pins the other half of the recovery: the rejection must not
+; leak into the following command. A malformed assumption used to be consumed
+; by the internal AddAssert, which dropped the poisoned assumption and left
+; the latch for the NEXT assertion to consume, so (assert false) vanished and
+; this file answered sat.
+(set-logic QF_UFBV)
+(declare-fun f ((_ BitVec 4)) (_ BitVec 4))
+(declare-const x (_ BitVec 4))
+(check-sat-assuming ((= (f x x) x)))
+(assert false)
+(check-sat)
+(echo "REACHED-END")

--- a/tests/query-files/uf/frontend-golden/malformed-command-atomicity.smt2
+++ b/tests/query-files/uf/frontend-golden/malformed-command-atomicity.smt2
@@ -1,0 +1,18 @@
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK-NEXT: ^\(error ".*f expects 1 argument but was applied to 2"\)
+; CHECK-NEXT: ^\(error ".*f expects 1 argument but was applied to 2"\)
+; CHECK-NEXT: ^sat
+; CHECK-NEXT: ^"REACHED-END"
+;
+; A malformed command is rejected as a unit.  The valid prefix of the first
+; command must not become an assertion, and the rejected check-sat-assuming
+; must neither solve its valid prefix nor print a verdict.
+(set-logic QF_UFBV)
+(declare-fun f ((_ BitVec 8)) (_ BitVec 8))
+(declare-const x (_ BitVec 8))
+(assert (= (f x) #x2a))
+(assert (and (= (f x) #x00) (= (f x x) #x00)))
+(check-sat-assuming ((= (f x) #x00) (= (f x x) #x00)))
+(check-sat)
+(echo "REACHED-END")

--- a/tests/query-files/uf/frontend-golden/malformed-define-fun-atomicity.smt2
+++ b/tests/query-files/uf/frontend-golden/malformed-define-fun-atomicity.smt2
@@ -1,0 +1,16 @@
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK-NEXT: ^\(error ".*f expects 1 argument but was applied to 2"\)
+; CHECK-NEXT: ^unsat
+; CHECK-NEXT: ^"REACHED-END"
+;
+; A rejected define-fun stores neither its typed recovery carrier nor its
+; temporary formal. Its command latch is consumed at the closing parenthesis,
+; so the independent assertion immediately following it must still take
+; effect.
+(set-logic QF_UFBV)
+(declare-fun f ((_ BitVec 8)) (_ BitVec 8))
+(define-fun malformed ((x (_ BitVec 8))) (_ BitVec 8) (f x x))
+(assert false)
+(check-sat)
+(echo "REACHED-END")

--- a/tests/query-files/uf/frontend-golden/malformed-nullary-define-fun-atomicity.smt2
+++ b/tests/query-files/uf/frontend-golden/malformed-nullary-define-fun-atomicity.smt2
@@ -1,0 +1,20 @@
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK-NEXT: ^\(error ".*f expects 1 argument but was applied to 2"\)
+; CHECK-NEXT: ^unsat
+; CHECK-NEXT: ^"REACHED-END"
+;
+; The parameterless bit-vector define-fun is its own grammar action, distinct
+; from the one with formals covered by malformed-define-fun-atomicity. A
+; malformed application in its body used to leave the command latch set:
+; define-fun printed success without consuming it, and the NEXT command's
+; assertion consumed the stale latch and was silently dropped, so this file
+; answered sat. The definition must register nothing, the diagnostic is
+; nonfatal, and (assert false) must keep its effect.
+(set-logic QF_UFBV)
+(declare-fun f ((_ BitVec 4)) (_ BitVec 4))
+(declare-const x (_ BitVec 4))
+(define-fun bad () (_ BitVec 4) (f x x))
+(assert false)
+(check-sat)
+(echo "REACHED-END")

--- a/tests/query-files/uf/frontend-golden/namespace-and-shadowing.smt2
+++ b/tests/query-files/uf/frontend-golden/namespace-and-shadowing.smt2
@@ -1,0 +1,27 @@
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: already denotes an ordinary symbol
+; CHECK: uninterpreted function .f. is already declared
+; CHECK: already denotes a define-fun
+; CHECK: ^sat
+; CHECK: REACHED-END
+; CHECK-NOT: syntax error
+;
+; UF declarations, scalar symbols, and define-fun macros share the SMT-LIB
+; top-level namespace. A nonzero-arity declaration over any of them is
+; rejected nonfatally and leaves the prior owner intact. (The reverse
+; direction -- a zero-arity declare-fun, declare-const or define-fun over a
+; UF name -- is a UF-free shape and keeps the legacy syntax error; see the
+; *-known-name-pinned and zero-arity-uf-name-pinned files.) Nested let
+; binders still shadow normally and resolve before UF application
+; hash-consing.
+(set-logic QF_UFBV)
+(declare-fun f ((_ BitVec 8)) (_ BitVec 8))
+(declare-const x (_ BitVec 8))
+(declare-fun x ((_ BitVec 8)) (_ BitVec 8))
+(declare-fun f ((_ BitVec 8)) Bool)
+(define-fun m ((q (_ BitVec 8))) (_ BitVec 8) q)
+(declare-fun m ((_ BitVec 8)) (_ BitVec 8))
+(assert (= (let ((x #x01)) (let ((x #x02)) (f x))) (f #x02)))
+(check-sat)
+(echo "REACHED-END")

--- a/tests/query-files/uf/frontend-golden/redeclaration-recovery.smt2
+++ b/tests/query-files/uf/frontend-golden/redeclaration-recovery.smt2
@@ -1,0 +1,29 @@
+; Every top-level declaration kind shares one namespace, and only the
+; NONZERO-ARITY declare-fun -- the one shape the legacy grammar could not
+; parse at all -- adopts report-and-continue over a known name: the
+; rejected declaration is command-local, registers nothing, and leaves the
+; original binding usable.  Zero-arity redeclarations are UF-free shapes and
+; keep the legacy classified-token syntax error and parse abandonment (see
+; zero-arity-redeclare-pinned, zero-arity-uf-name-pinned,
+; declare-const-known-name-pinned, define-fun-known-name-pinned).
+;
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions %s 2>&1 | %OutputCheck %s
+; CHECK-NEXT: ^\(error ".*g.*already.*"\)
+; CHECK-NEXT: ^\(error ".*d.*define-fun"\)
+; CHECK-NEXT: ^\(error ".*s.*ordinary symbol"\)
+; CHECK-NEXT: ^unsat
+; CHECK-NEXT: ^"REACHED-END"
+; CHECK-NOT: syntax error
+;
+(set-logic QF_UFBV)
+(declare-fun g ((_ BitVec 8)) (_ BitVec 8))
+(define-fun d ((x (_ BitVec 8))) (_ BitVec 8) (bvnot x))
+(declare-const s (_ BitVec 8))
+(declare-fun g ((_ BitVec 8)) (_ BitVec 4))
+(declare-fun d ((_ BitVec 8)) (_ BitVec 8))
+(declare-fun s ((_ BitVec 8)) (_ BitVec 8))
+(assert (distinct (g #x03) (g #x03)))
+(check-sat)
+(echo "REACHED-END")

--- a/tests/query-files/uf/frontend-golden/zero-arity-redeclare-fatal-sort-pinned.smt2
+++ b/tests/query-files/uf/frontend-golden/zero-arity-redeclare-fatal-sort-pinned.smt2
@@ -1,0 +1,14 @@
+; RUN: %solver --uninterpreted-functions %s 2>&1 | %OutputCheck %s
+; CHECK-NEXT: ^\(error "syntax error: line 12 syntax error, unexpected TERMID_TOK, expecting STRING_TOK  token: s"\)$
+; CHECK-NOT: REACHED-END
+; CHECK-NOT: Fatal
+; CHECK-NOT: FloatingPoint
+; The same pin when the sort rule would have been FATAL (a floating-point
+; format too small to exist): the legacy grammar died at the name before
+; the sort rule ran, so neither the sort's own message nor a fatal exit may
+; appear. The name-position error alone, and the parse abandons.
+(set-logic QF_UFBV)
+(declare-const s (_ BitVec 8))
+(declare-fun s () (_ FloatingPoint 1 1))
+(check-sat)
+(echo "REACHED-END")

--- a/tests/query-files/uf/frontend-golden/zero-arity-redeclare-malformed-sort-pinned.smt2
+++ b/tests/query-files/uf/frontend-golden/zero-arity-redeclare-malformed-sort-pinned.smt2
@@ -1,0 +1,13 @@
+; RUN: %solver --uninterpreted-functions %s 2>&1 | %OutputCheck %s
+; CHECK-NEXT: ^\(error "syntax error: line 11 syntax error, unexpected TERMID_TOK, expecting STRING_TOK  token: s"\)$
+; CHECK-NOT: REACHED-END
+; CHECK-NOT: BitVec
+; A zero-arity redeclaration whose sort is ALSO malformed: the legacy
+; grammar died at the name and never saw the sort, so the name-position
+; error is the whole response even though bison only fails later, at the
+; sort. The parse abandons; the malformed sort adds nothing.
+(set-logic QF_UFBV)
+(declare-const s (_ BitVec 8))
+(declare-fun s () (_ BitVec x))
+(check-sat)
+(echo "REACHED-END")

--- a/tests/query-files/uf/frontend-golden/zero-arity-redeclare-pinned.smt2
+++ b/tests/query-files/uf/frontend-golden/zero-arity-redeclare-pinned.smt2
@@ -1,0 +1,15 @@
+; RUN: %solver --uninterpreted-functions %s 2>&1 | %OutputCheck %s
+; CHECK-NEXT: ^\(error "syntax error: line 13 syntax error, unexpected TERMID_TOK, expecting STRING_TOK  token: s"\)$
+; CHECK-NOT: REACHED-END
+; FE-05 / FE-07 keep their scope: only the NONZERO-ARITY (UF) declaration
+; shape adopts report-and-continue. A ZERO-ARITY redeclaration -- the
+; UF-free shape -- keeps the pinned classified-token syntax error and
+; parse abandonment byte-for-byte even with the feature ON: the lexer
+; declassifies the known name so the grammar can see the shape, and the
+; zero-arity action replicates exactly the error the classification
+; would have raised at the name.
+(set-logic QF_UFBV)
+(declare-fun s () (_ BitVec 8))
+(declare-fun s () (_ BitVec 8))
+(check-sat)
+(echo "REACHED-END")

--- a/tests/query-files/uf/frontend-golden/zero-arity-uf-name-pinned.smt2
+++ b/tests/query-files/uf/frontend-golden/zero-arity-uf-name-pinned.smt2
@@ -1,0 +1,13 @@
+; RUN: %solver --uninterpreted-functions %s 2>&1 | %OutputCheck %s
+; CHECK-NEXT: ^\(error "syntax error: line 11 syntax error, unexpected UF_BV_FUNCTIONID_TOK, expecting STRING_TOK  token: g"\)$
+; CHECK-NOT: REACHED-END
+; The zero-arity pin holds for every classification a known name can
+; carry, including the UF-declaration tokens that only exist with the
+; feature on: zero-arity declare-fun over a declared uninterpreted
+; function replicates the error the classified name would have raised
+; before declassification existed, and abandons.
+(set-logic QF_UFBV)
+(declare-fun g ((_ BitVec 8)) (_ BitVec 8))
+(declare-fun g () (_ BitVec 8))
+(check-sat)
+(echo "REACHED-END")

--- a/tests/query-files/uf/get-value-terms-containing-applications.smt2
+++ b/tests/query-files/uf/get-value-terms-containing-applications.smt2
@@ -1,0 +1,52 @@
+; ede9d4bd taught both counterexample walks to evaluate a term that *contains*
+; an application. That reached the C API, which evaluates whatever term it is
+; handed, but not (get-value ...), whose own argument filter still demanded a
+; bare symbol or a bare application. The evaluator could answer these; the
+; command would not ask. Now it does.
+;
+; The last row is the one worth having: f(#x07) is a durable node the solve
+; never reached, so it has no certified value of its own and (get-value
+; ((f #x07))) is still refused at the root. Inside a term it must complete
+; through the certified seed and agree with f(x), because x is pinned to 7 and
+; equal argument tuples give equal results.
+;
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+;
+; Terms echo as STP's interned nodes, so commutative operands come back in
+; STP's canonical order rather than as written.
+;
+; CHECK: ^sat
+; CHECK-L: ( (|f| |x|)  #x03 )
+; CHECK-L: ( (bvadd  #x01 (|f| |x|))  #x04 )
+; CHECK-L: ( (= (|f| |x|)  #x03) true )
+; CHECK-L: ( (|g| |p|) true )
+; CHECK-L: ( (not (|g| |p|)) false )
+; CHECK-L: ( (and |q| (|g| |p|)) true )
+; CHECK-L: ( (= (|k| |x|) RTZ) true )
+; CHECK-L: ( (bvadd  #x01 (|f|  #x07))  #x04 )
+; CHECK: REACHED-END
+;
+(set-option :produce-models true)
+(set-logic QF_UFBVFP)
+(declare-fun f ((_ BitVec 8)) (_ BitVec 8))
+(declare-fun g (Bool) Bool)
+(declare-fun k ((_ BitVec 8)) RoundingMode)
+(declare-const x (_ BitVec 8))
+(declare-const p Bool)
+(declare-const q Bool)
+(assert (= x #x07))
+(assert (= (f x) #x03))
+(assert (= (k x) RTZ))
+(assert (g p))
+(assert q)
+(check-sat)
+(get-value ((f x)))
+(get-value ((bvadd (f x) #x01)))
+(get-value ((= (f x) #x03)))
+(get-value ((g p)))
+(get-value ((not (g p))))
+(get-value ((and (g p) q)))
+(get-value ((= (k x) RTZ)))
+(get-value ((bvadd (f #x07) #x01)))
+(echo "REACHED-END")

--- a/tests/query-files/uf/get-value-unobserved-application.smt2
+++ b/tests/query-files/uf/get-value-unobserved-application.smt2
@@ -1,0 +1,51 @@
+; get-value answers an application the solve never reached, with the value the
+; published interpretation gives it.
+;
+; The model a check-sat leaves behind is total: (get-model) prints a define-fun
+; with an else branch, and that branch is what f takes at every argument the
+; query did not mention. get-value used to refuse exactly those points while
+; the model printed them, and -- worse -- while the same command list answered
+; them whenever the application sat inside a larger term, because a nested
+; application goes through the model evaluator and is completed there. The two
+; halves of one command disagreed.
+;
+; An application the solve DID reach still answers with its certified value,
+; which is the exact one, not the completion.
+;
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK-NEXT: ^sat
+; CHECK-NEXT: ^\($
+; CHECK-NEXT: ^\( \(\|f\| \|x\|\)  #x03 \)$
+; CHECK-NEXT: ^\)$
+; CHECK-NEXT: ^\($
+; CHECK-NEXT: ^\( \(\|f\|  #xEE\)  #x00 \)$
+; CHECK-NEXT: ^\)$
+; A mixed list is one command and answers as one.
+; CHECK-NEXT: ^\($
+; CHECK-NEXT: ^\( \(\|f\| \|x\|\)  #x03 \)$
+; CHECK-NEXT: ^\( \(\|f\|  #xEE\)  #x00 \)$
+; CHECK-NEXT: ^\)$
+; The completion agrees with the term path, which is what used to differ.
+; CHECK-NEXT: ^\($
+; CHECK-NEXT: ^\( \(bvadd  #x01 \(\|f\|  #xEE\)\)  #x01 \)$
+; CHECK-NEXT: ^\)$
+; An assertion invalidates the model, and then there is genuinely nothing to
+; answer from -- the generic refusal, as before uninterpreted functions.
+; CHECK-NEXT: ^unsupported$
+; CHECK-NEXT: ^"REACHED-END"$
+;
+(set-option :produce-models true)
+(set-logic QF_UFBV)
+(declare-fun f ((_ BitVec 8)) (_ BitVec 8))
+(declare-const x (_ BitVec 8))
+(assert (= (f x) #x03))
+(check-sat)
+(get-value ((f x)))
+(get-value ((f #xee)))
+(get-value ((f x) (f #xee)))
+(get-value ((bvadd (f #xee) #x01)))
+(assert (= x #x01))
+(get-value ((f #xee)))
+(echo "REACHED-END")
+(exit)

--- a/tests/query-files/uf/let-specialization.smt2
+++ b/tests/query-files/uf/let-specialization.smt2
@@ -1,0 +1,9 @@
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: ^unsat
+;
+(set-logic QF_UFBV)
+(declare-fun f ((_ BitVec 8)) (_ BitVec 8))
+(assert (distinct (let ((x #x00)) (f x)) (f #x00)))
+(assert (= (let ((x #x01)) (let ((x #x00)) (f x))) (f #x00)))
+(check-sat) ; expected unsat

--- a/tests/query-files/uf/lone-application-unnamed-actual.smt2
+++ b/tests/query-files/uf/lone-application-unnamed-actual.smt2
@@ -1,0 +1,23 @@
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: ^sat
+; CHECK: define-fun \|f\| \(\(x0 \(_ BitVec 8\)\)\) \(_ BitVec 8\)
+; CHECK-NOT: ite
+; CHECK: #x2A
+; CHECK: \( \(\|f\| \(bvadd \|x\| \|y\|\)\)  #x2A \)
+;
+; f has one application, so no congruence lemma can ever equate its actual
+; with anything and the compound argument needs no name. Without a name the
+; addition leaves the formula entirely, and the certified interpretation is
+; the constant the result took -- total, and in agreement with the single
+; application, which is all any interpretation of f has to satisfy. The
+; durable handle still answers get-value from that same certified result.
+(set-logic QF_UFBV)
+(set-option :produce-models true)
+(declare-fun f ((_ BitVec 8)) (_ BitVec 8))
+(declare-const x (_ BitVec 8))
+(declare-const y (_ BitVec 8))
+(assert (= (f (bvadd x y)) #x2a))
+(check-sat)
+(get-model)
+(get-value ((f (bvadd x y))))

--- a/tests/query-files/uf/no-public-model-check.smt2
+++ b/tests/query-files/uf/no-public-model-check.smt2
@@ -1,0 +1,12 @@
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: ^unsat
+;
+(set-logic QF_UFBV)
+(set-option :produce-models false)
+(declare-fun f ((_ BitVec 8)) (_ BitVec 8))
+(declare-const x (_ BitVec 8))
+(declare-const y (_ BitVec 8))
+(assert (= x y))
+(assert (distinct (f x) (f y)))
+(check-sat) ; unsat

--- a/tests/query-files/uf/push-pop-scope.smt2
+++ b/tests/query-files/uf/push-pop-scope.smt2
@@ -1,0 +1,15 @@
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: ^unsat
+; CHECK: ^sat
+;
+(set-logic QF_UFBV)
+(declare-fun f ((_ BitVec 8)) (_ BitVec 8))
+(declare-const x (_ BitVec 8))
+(declare-const y (_ BitVec 8))
+(push 1)
+(assert (= x y))
+(assert (distinct (f x) (f y)))
+(check-sat) ; unsat
+(pop 1)
+(check-sat) ; sat

--- a/tests/query-files/uf/repeated-verdict-cache.smt2
+++ b/tests/query-files/uf/repeated-verdict-cache.smt2
@@ -1,0 +1,22 @@
+; A byte-identical repeated UF query is answered by the frontend verdict
+; cache.  :check-sat-calls counts real solves, so it must remain one after
+; both printed verdicts in every routing mode.
+;
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions %s 2>&1 | %OutputCheck %s
+; CHECK-NEXT: ^unsat
+; CHECK-NEXT: ^\(:check-sat-calls 1$
+; CHECK: ^unsat
+; CHECK-NEXT: ^\(:check-sat-calls 1$
+;
+(set-logic QF_UFBV)
+(declare-fun f ((_ BitVec 8)) (_ BitVec 8))
+(declare-const x (_ BitVec 8))
+(declare-const y (_ BitVec 8))
+(assert (= x y))
+(assert (distinct (f x) (f y)))
+(check-sat)
+(get-info :all-statistics)
+(check-sat)
+(get-info :all-statistics)

--- a/tests/query-files/uf/reset-assertions-local-drops-declarations.smt2
+++ b/tests/query-files/uf/reset-assertions-local-drops-declarations.smt2
@@ -1,0 +1,20 @@
+; With the default :global-declarations false, reset-assertions drops both
+; declarations.  Reusing the old application must fail before another
+; check-sat is issued.
+;
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions %s 2>&1 | %OutputCheck %s
+; CHECK-NEXT: ^unsat
+; CHECK-NEXT: ^\(error ".*f.*"\)
+; CHECK-NOT: REACHED-END
+;
+(set-logic QF_UFBV)
+(declare-fun f ((_ BitVec 4)) (_ BitVec 4))
+(declare-const x (_ BitVec 4))
+(assert (distinct (f x) (f x)))
+(check-sat)
+(reset-assertions)
+(assert (= (f x) (f x)))
+(check-sat)
+(echo "REACHED-END")

--- a/tests/query-files/uf/reset-lifecycle.smt2
+++ b/tests/query-files/uf/reset-lifecycle.smt2
@@ -1,0 +1,23 @@
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: ^unsat
+; CHECK: ^sat
+; CHECK: ^sat
+;
+(set-logic QF_UFBV)
+(declare-fun f ((_ BitVec 4)) (_ BitVec 4))
+(declare-const x (_ BitVec 4))
+(assert (distinct (f x) (f x)))
+(check-sat)
+(reset-assertions)
+; The default false global-declarations policy drops f and x, permitting a
+; changed signature in the same retained logic.
+(declare-fun f ((_ BitVec 8)) (_ BitVec 8))
+(declare-const y (_ BitVec 8))
+(assert (= (f y) (f y)))
+(check-sat)
+(reset)
+(set-logic QF_UFBV)
+(declare-fun f (Bool) Bool)
+(assert (= (f true) (f true)))
+(check-sat)

--- a/tests/query-files/uf/result-liveness.smt2
+++ b/tests/query-files/uf/result-liveness.smt2
@@ -1,0 +1,18 @@
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: ^unsat
+;
+(set-logic QF_UFBV)
+(declare-fun p ((_ BitVec 8)) Bool)
+(declare-fun f (Bool) (_ BitVec 8))
+(declare-fun g ((_ BitVec 8)) (_ BitVec 8))
+(declare-fun r ((_ BitVec 8)) Bool)
+(declare-const x (_ BitVec 8))
+(declare-const y (_ BitVec 8))
+(assert (= x y))
+; p's Boolean results and g's BV results occur only as nested UF actuals.
+; Both must be totalized before the first checker candidate.
+(assert (distinct (f (p x)) (f (p y))))
+(assert (r (g x)))
+(assert (not (r (g y))))
+(check-sat)

--- a/tests/query-files/uf/rm-malformed-application-continues.smt2
+++ b/tests/query-files/uf/rm-malformed-application-continues.smt2
@@ -1,0 +1,25 @@
+; A malformed application of a RoundingMode-returning function is rejected
+; nonfatally, exactly as 09-malformed-arity-continues.smt2 pins for a
+; bit-vector one, and the session carries on to answer the rest.
+;
+; The enclosing (= ...) reduces before the rejected command is discarded, and
+; it sort-checks its operands. So the placeholder the parser substitutes has
+; to be a term of the declared sort: a bare five-bit zero has the right
+; carrier width and the wrong sort, and turns this into a fatal syntax error.
+;
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: k expects 1 argument but was applied to 2
+; CHECK: argument 0 of f has sort \(_ BitVec 4\) but the declaration requires RoundingMode
+; CHECK-NOT: operands of the same sort
+; CHECK: ^sat
+; CHECK: REACHED-END
+;
+(set-logic QF_UFBVFP)
+(declare-fun k ((_ BitVec 4)) RoundingMode)
+(declare-fun f (RoundingMode) (_ BitVec 4))
+(assert (= (k #x0 #x1) RNE))
+(assert (= (f #x0) #x2))
+(assert (= (k #x0) RTZ))
+(check-sat)
+(echo "REACHED-END")

--- a/tests/query-files/uf/rm-mixed-signature.smt2
+++ b/tests/query-files/uf/rm-mixed-signature.smt2
@@ -1,0 +1,33 @@
+; A signature that mixes RoundingMode with the sorts UFSTP already admitted,
+; in both directions, in the shape of 08-mixed-signature-roundtrip.smt2. The
+; first pair of applications is forced congruent and the second is not, so a
+; lowering that dropped a RoundingMode position from the argument tuple would
+; show up as a wrong unsat here rather than as a missing lemma.
+;
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: ^unsat
+; CHECK: ^sat
+; CHECK: REACHED-END
+;
+(set-logic QF_UFBVFP)
+(declare-fun g (RoundingMode (_ BitVec 8) Bool) RoundingMode)
+(declare-const r RoundingMode)
+(declare-const s RoundingMode)
+(declare-const x (_ BitVec 8))
+(declare-const y (_ BitVec 8))
+(declare-const b Bool)
+(push 1)
+(assert (= r s))
+(assert (= x y))
+(assert (distinct (g r x b) (g s y b)))
+(check-sat)
+(pop 1)
+(push 1)
+; Only the bit-vector position agrees, so nothing forces the results equal.
+(assert (distinct r s))
+(assert (= x y))
+(assert (distinct (g r x b) (g s y b)))
+(check-sat)
+(pop 1)
+(echo "REACHED-END")

--- a/tests/query-files/uf/rm-model-values.smt2
+++ b/tests/query-files/uf/rm-model-values.smt2
@@ -1,0 +1,28 @@
+; A RoundingMode value is published as a mode name, never as its raw 5-bit
+; carrier: in the generated define-fun's signature, in its case values, in
+; its else branch, and in the answer get-value gives for the application.
+;
+; The else branch is UFConcreteValue::zero of the codomain. All-zeros is not
+; a one-hot mode and denotes nothing, so a defaulted RoundingMode case has to
+; name a legal mode -- RNE -- rather than print a carrier that is not a term
+; of the sort at all.
+;
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: ^sat
+; CHECK: define-fun \|k\| \(\(x0 \(_ BitVec 8\)\)\) RoundingMode
+; CHECK: \(ite \(= x0  #x01\) RTZ RNE\)
+; CHECK: \( \(\|k\| \|x\|\) RTZ \)
+; CHECK: REACHED-END
+; CHECK-NOT: #b00000
+;
+(set-option :produce-models true)
+(set-logic QF_UFBVFP)
+(declare-fun k ((_ BitVec 8)) RoundingMode)
+(declare-const x (_ BitVec 8))
+(assert (= x #x01))
+(assert (= (k x) RTZ))
+(check-sat)
+(get-model)
+(get-value ((k x)))
+(echo "REACHED-END")

--- a/tests/query-files/uf/rm-noninjective-sat.smt2
+++ b/tests/query-files/uf/rm-noninjective-sat.smt2
@@ -1,0 +1,16 @@
+; The other corner of rm-congruence-unsat: distinct rounding modes put no
+; obligation on f at all, so an interpretation that separates them exists.
+; A pin that over-constrained the domain, or a congruence conclusion emitted
+; where none was earned, would be caught here rather than by a wrong unsat.
+;
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: ^sat
+;
+(set-logic QF_UFBVFP)
+(declare-fun f (RoundingMode) (_ BitVec 4))
+(declare-const r RoundingMode)
+(declare-const s RoundingMode)
+(assert (distinct r s))
+(assert (distinct (f r) (f s)))
+(check-sat)

--- a/tests/query-files/uf/rm-reset-assertions-pin.smt2
+++ b/tests/query-files/uf/rm-reset-assertions-pin.smt2
@@ -1,0 +1,34 @@
+; reset-assertions keeps declarations and drops assertions -- including the
+; one-hot pin a RoundingMode declaration asserted for itself. The symbol is
+; still a legal leaf afterwards, and UF lowering registers it as a checker
+; authority the moment it appears as an actual, so lowering pins every
+; RoundingMode solve scalar it registers rather than assuming an earlier
+; assertion is still there.
+;
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: ^unsat
+; CHECK: ^unsat
+; CHECK: REACHED-END
+;
+(set-logic QF_UFBVFP)
+(set-option :global-declarations true)
+(declare-fun k (RoundingMode) RoundingMode)
+(declare-const r RoundingMode)
+; The introduced result symbol has to name a mode.
+(assert (distinct (k r) RNE))
+(assert (distinct (k r) RTZ))
+(assert (distinct (k r) RTP))
+(assert (distinct (k r) RTN))
+(assert (distinct (k r) RNA))
+(check-sat)
+(reset-assertions)
+; And so does the declared leaf actual, whose own pin has just been dropped.
+(assert (= (k r) (k r)))
+(assert (distinct r RNE))
+(assert (distinct r RTZ))
+(assert (distinct r RTP))
+(assert (distinct r RTN))
+(assert (distinct r RNA))
+(check-sat)
+(echo "REACHED-END")

--- a/tests/query-files/uf/rm-result-pinned-unsat.smt2
+++ b/tests/query-files/uf/rm-result-pinned-unsat.smt2
@@ -1,0 +1,18 @@
+; A RoundingMode result symbol must be pinned to the five legal one-hot
+; encodings. The sort has five values; its carrier has thirty-two. Without a
+; pin the checker is free to hand @uf_result_kN a sixth "mode" that differs
+; from all five, and the query answers sat -- a model naming no rounding mode
+; at all.
+;
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: ^unsat
+;
+(set-logic QF_UFBVFP)
+(declare-fun k ((_ BitVec 4)) RoundingMode)
+(assert (distinct (k #x0) RNE))
+(assert (distinct (k #x0) RTZ))
+(assert (distinct (k #x0) RTP))
+(assert (distinct (k #x0) RTN))
+(assert (distinct (k #x0) RNA))
+(check-sat)

--- a/tests/query-files/uf/rm-uf-logics.smt2
+++ b/tests/query-files/uf/rm-uf-logics.smt2
@@ -1,0 +1,45 @@
+; The UF+FP logic names. Without them no query can name a logic that admits
+; both uninterpreted functions and the floating-point keywords: outside an FP
+; logic "RoundingMode" is not a token at all, so a signature naming it is a
+; plain syntax error rather than a UF diagnostic (see smt2.lex's
+; SMT2SetFloatTokens gate).
+;
+; Each logic is accepted, turns the floating-point keywords on, and still
+; admits a UF declaration; and each of them is gated on the feature flag
+; exactly as QF_UFBV already is.
+;
+; QF_AUFBVFP is the SMT-LIB spelling -- the theory letters go A, UF, BV, FP,
+; which is the order QF_AUFBV already uses here. QF_UFABVFP is the spelling
+; this branch shipped first and stays accepted as an alias for it.
+;
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK-NOT: Wrong input logic
+; CHECK: ^unsat
+; CHECK: ^unsat
+; CHECK: ^unsat
+; CHECK: ^unsat
+; CHECK: REACHED-END
+;
+(set-logic QF_UFFP)
+(declare-fun kf (RoundingMode) RoundingMode)
+(assert (distinct (kf RNE) (kf RNE)))
+(check-sat)
+(reset)
+(set-logic QF_UFBVFP)
+(declare-fun kb ((_ BitVec 4)) RoundingMode)
+(assert (distinct (kb #x0) (kb #x0)))
+(check-sat)
+(reset)
+(set-logic QF_UFABVFP)
+(declare-fun ka ((_ BitVec 4)) RoundingMode)
+(declare-const a (Array (_ BitVec 4) (_ BitVec 4)))
+(assert (distinct (ka (select a #x0)) (ka (select a #x0))))
+(check-sat)
+(reset)
+(set-logic QF_AUFBVFP)
+(declare-fun kc ((_ BitVec 4)) RoundingMode)
+(declare-const c (Array (_ BitVec 4) (_ BitVec 4)))
+(assert (distinct (kc (select c #x0)) (kc (select c #x0))))
+(check-sat)
+(echo "REACHED-END")

--- a/tests/query-files/uf/sanity-checked.smt2
+++ b/tests/query-files/uf/sanity-checked.smt2
@@ -1,0 +1,22 @@
+; RUN: %solver --uninterpreted-functions --check-sanity --incremental=off %s | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --check-sanity --incremental=on %s | %OutputCheck %s
+; CHECK-NEXT: ^sat
+; CHECK-NEXT: ^unsat
+; CHECK-NEXT: ^sat
+; MDL-07 / OBL-04: --check-sanity replays every certified model
+; against the raw stack (durable applications resolved through the
+; certified handle map) across a mixed sat/unsat session.
+(set-logic QF_UFBV)
+(declare-fun f ((_ BitVec 8)) (_ BitVec 8))
+(declare-fun g ((_ BitVec 8)) Bool)
+(declare-const x (_ BitVec 8))
+(declare-const y (_ BitVec 8))
+(assert (= (f x) #x11))
+(assert (g (f x)))
+(check-sat)
+(push 1)
+(assert (= x y))
+(assert (distinct (f x) (f y)))
+(check-sat)
+(pop 1)
+(check-sat)

--- a/tests/query-files/uf/source-sort-boundary.smt2
+++ b/tests/query-files/uf/source-sort-boundary.smt2
@@ -1,0 +1,29 @@
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: unsupported domain sort \(Array \(_ BitVec 8\) \(_ BitVec 8\)\) at argument 0 of bad-array
+; CHECK: unsupported domain sort UnknownSort at argument 0 of bad-unknown \(unknown
+; CHECK: unsupported domain sort \(_ BitVec 0\) at argument 0 of bad-zero
+; CHECK: unsupported result sort \(Array \(_ BitVec 8\) \(_ BitVec 8\)\) of bad-result
+; CHECK-NOT: of ok-fp
+; CHECK-NOT: of ok-rm
+; CHECK: ^sat
+; CHECK: REACHED-END
+;
+; The RoundingMode and FloatingPoint rows are now on the admitted side of the
+; boundary: each is retained as a declaration that goes through and is
+; applied, so that the sorts' positions here are pinned rather than merely
+; unmentioned. Array and (_ BitVec 0) stay exactly where they were.
+(set-logic QF_UFABVFP)
+(declare-fun bad-array ((Array (_ BitVec 8) (_ BitVec 8))) Bool)
+(declare-fun bad-unknown (UnknownSort) Bool)
+(declare-fun bad-zero ((_ BitVec 0)) Bool)
+(declare-fun bad-result (Bool) (Array (_ BitVec 8) (_ BitVec 8)))
+(declare-fun ok-rm (RoundingMode) Bool)
+(declare-fun ok-fp ((_ FloatingPoint 8 24)) Bool)
+(declare-fun p (Bool (_ BitVec 8)) Bool)
+(assert (= (p true #x00) (p true #x00)))
+(assert (= (ok-rm RTZ) (ok-rm RTZ)))
+(assert (= (ok-fp (fp #b0 #b10000000 #b00000000000000000000000))
+           (ok-fp (fp #b0 #b10000000 #b00000000000000000000000))))
+(check-sat)
+(echo "REACHED-END")

--- a/tests/query-files/uf/source-sort-rejections.smt2
+++ b/tests/query-files/uf/source-sort-rejections.smt2
@@ -1,0 +1,28 @@
+; Unsupported UF signature sorts reject their declarations transactionally,
+; and the admitted ones go through in the same session so that the boundary
+; between the two is pinned from both sides.
+;
+; RoundingMode and FloatingPoint moved across that boundary and are now
+; admitted; the rows for them are retained as positive ones rather than
+; dropped, so a regression that re-rejected either sort would fail here as
+; loudly as one that admitted Array.
+;
+; RUN: %solver --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; RUN: %solver --uninterpreted-functions --incremental=on %s 2>&1 | %OutputCheck %s
+; CHECK: unsupported domain sort \(_ BitVec 0\) at argument 0 of bad-zero
+; CHECK: unsupported domain sort \(Array \(_ BitVec 4\) \(_ BitVec 4\)\) at argument 0 of bad-array
+; CHECK-NOT: of ok-fp
+; CHECK-NOT: of ok-rm
+; CHECK: ^unsat
+; CHECK: ^"REACHED-END"
+;
+(set-logic QF_UFABVFP)
+(declare-fun bad-zero ((_ BitVec 0)) Bool)
+(declare-fun bad-array ((Array (_ BitVec 4) (_ BitVec 4))) Bool)
+(declare-fun ok-fp ((_ BitVec 8)) (_ FloatingPoint 8 24))
+(declare-fun ok-rm (RoundingMode) RoundingMode)
+(assert (distinct (ok-rm RNE) (ok-rm RNE)))
+(assert (distinct (ok-fp #x00) (ok-fp #x00)))
+(check-sat)
+(echo "REACHED-END")
+(exit)

--- a/tests/ufstp/README.md
+++ b/tests/ufstp/README.md
@@ -1,0 +1,49 @@
+# UF acceptance harnesses
+
+These deterministic harnesses generate their SMT-LIB corpus on demand, check
+every verdict, and can write machine-readable evidence whose corpus digest
+pins the exact generated inputs.
+
+`performance.py` exercises durable lowering, `define-fun` reuse, nested
+`let`, identical-query reuse, pop scoping, and encoding-epoch rebuilds in
+both batch and persistent modes, plus one family each for floating-point
+congruence and rounding-mode exhaustion. Those two are separate rows because
+the sorts do not scale like the bit-vector ones: a float actual reaches the
+checker through a pack/unpack boundary, and the query's own `(= a b)` over
+floats is `FP_SMT_EQ`, which equality propagation cannot substitute through.
+It is an answer-checked trend benchmark, not a wall-clock threshold:
+
+```sh
+python3 tests/ufstp/performance.py \
+  --stp build/stp --scales 16,64 --repeats 2 \
+  --evidence-out /tmp/uf-performance.json
+```
+
+`differential_fuzz.py` covers nested congruence, non-injectivity, Boolean
+predicates, interpreted equality, arrays as actuals, declaration separation,
+compound-result liveness, and RoundingMode and FloatingPoint in both
+signature positions --
+including result tuples that exhaust all five rounding modes (which forces an
+introduced result symbol to be pinned rather than merely constrained) and
+NaN-against-the-zeros floating-point tuples (which tell a semantic quotient
+from a convenient normalisation). Every case runs in both STP modes and
+through each named reference solver:
+
+```sh
+python3 tests/ufstp/differential_fuzz.py \
+  --stp build/stp \
+  --reference z3=/usr/bin/z3 \
+  --reference cvc5=/usr/bin/cvc5 \
+  --seeds 240 --evidence-out /tmp/uf-differential.json
+```
+
+References are repeatable. Z3 and CVC5 command-line forms are recognized;
+other solvers are invoked as `COMMAND input.smt2`. A separately built peer
+STP can also be used as `--reference "peer=/path/to/stp
+--uninterpreted-functions"`.
+
+For CI without external solvers, `scripts/fuzz/uf-differential-fuzz.py`
+provides an independent local oracle: the generator eagerly Ackermannizes
+each UF instance and submits that UF-free formula to STP's classic solver,
+then compares it with both lazy UF adapters. It also compares complete
+push/pop verdict sequences.

--- a/tests/ufstp/differential_fuzz.py
+++ b/tests/ufstp/differential_fuzz.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""Deterministic UFSTP differential campaign.
+
+The generated corpus exercises nested applications, Bool/BV/RoundingMode
+signatures, define-fun specialization, let resolution, non-injectivity,
+interpreted equalities, arrays-as-actuals, and guarded push/pop checks.
+Every case is run through both STP solve adapters and one or more independent
+SMT solvers.  Any unknown/error, timeout, or verdict disagreement is a hard
+failure.
+
+The RoundingMode families are mode-biased rather than value-biased: the sort
+has five values and its carrier thirty-two, so what is worth generating is
+tuples that exhaust the modes, which is what forces a result symbol to be
+pinned rather than merely constrained.
+
+The FloatingPoint families are NaN-biased for the same reason. Bit patterns
+are not what distinguishes floating-point values: NaN has many encodings and
+is one value, while the two zeros share an fp.eq and are two. Generating
+those two cases against each other is what tells a semantic quotient from a
+convenient normalisation.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import shlex
+import subprocess
+import tempfile
+import time
+
+
+VERDICT = re.compile(r"^(sat|unsat|unknown)$", re.MULTILINE)
+
+
+def nested(term, depth):
+    for _ in range(depth):
+        term = "(g %s)" % term
+    return term
+
+
+FAMILIES = 11
+
+MODES = ("RNE", "RTZ", "RTP", "RTN", "RNA")
+
+
+def make_case(seed):
+    width = 2 + seed % 7
+    bv = "(_ BitVec %d)" % width
+    zero = "#b" + "0" * width
+    family = seed % FAMILIES
+    if family == 4:
+        logic = "QF_AUFBV"
+    elif family >= 7:
+        logic = "QF_UFBVFP"
+    else:
+        logic = "QF_UFBV"
+    depth = 1 + (seed // 6) % 5
+    gx = nested("x", depth)
+    gy = nested("y", depth)
+
+    lines = [
+        "(set-logic %s)" % logic,
+        "(declare-fun f (%s Bool) %s)" % (bv, bv),
+        "(declare-fun g (%s) %s)" % (bv, bv),
+        "(declare-fun p (%s Bool) Bool)" % bv,
+        "(declare-const x %s)" % bv,
+        "(declare-const y %s)" % bv,
+        "(declare-const u %s)" % bv,
+        "(declare-const v %s)" % bv,
+        "(declare-const b Bool)",
+        "(declare-const c Bool)",
+        "(declare-const d Bool)",
+        "(declare-const e Bool)",
+        "(define-fun h ((z %s) (q Bool)) %s (f %s q))"
+        % (bv, bv, nested("z", depth)),
+    ]
+
+    expected = "unsat"
+    if family == 0:
+        lines += [
+            "(assert (= x y))",
+            "(assert (= b c))",
+            "(assert (distinct (let ((z x)) (h z b)) (h y c)))",
+        ]
+    elif family == 1:
+        expected = "sat"
+        lines += [
+            "(assert (distinct x y))",
+            "(assert (= b c))",
+            "(assert (= (h x b) (h y c)))",
+        ]
+    elif family == 2:
+        lines += [
+            "(assert (= x y))",
+            "(assert (= b c))",
+            "(assert (p %s b))" % gx,
+            "(assert (not (p %s c)))" % gy,
+        ]
+    elif family == 3:
+        lines += [
+            "(assert (distinct (f (bvadd x %s) b) (f x b)))" % zero,
+        ]
+    elif family == 4:
+        lines += [
+            "(declare-const a (Array %s %s))" % (bv, bv),
+            "(declare-const i %s)" % bv,
+            "(declare-const j %s)" % bv,
+            "(assert (= i j))",
+            "(assert (distinct (f (select a i) b) (f (select a j) b)))",
+        ]
+    elif family == 5:
+        expected = "sat"
+        lines += [
+            "(declare-fun q (%s Bool) %s)" % (bv, bv),
+            "(assert (distinct (f x b) (q x b)))",
+        ]
+    elif family == 7:
+        # RoundingMode in a domain position. Its carrier's bit-equality is the
+        # sort's own equality, so congruence binds exactly when the two modes
+        # are forced equal and not when they are forced apart.
+        congruent = (seed // FAMILIES) % 2 == 0
+        expected = "unsat" if congruent else "sat"
+        lines += [
+            "(declare-fun km (RoundingMode Bool) %s)" % bv,
+            "(declare-const r RoundingMode)",
+            "(declare-const s RoundingMode)",
+            "(assert (%s r s))" % ("=" if congruent else "distinct"),
+            "(assert (= b c))",
+            "(assert (distinct (km r b) (km s c)))",
+        ]
+    elif family == 8:
+        # RoundingMode in a result position, exhausted. Ruling out all five
+        # modes is unsatisfiable only if the introduced result symbol is
+        # pinned to them; ruling out four leaves exactly one and must stay
+        # satisfiable, so an over-constrained pin fails here too.
+        exhaustive = (seed // FAMILIES) % 2 == 0
+        excluded = MODES if exhaustive else MODES[:4]
+        expected = "unsat" if exhaustive else "sat"
+        lines += ["(declare-fun kr (%s Bool) RoundingMode)" % bv]
+        lines += ["(assert (distinct (kr x b) %s))" % mode
+                  for mode in excluded]
+    elif family == 9:
+        # FloatingPoint in a domain position, NaN against the zeros. Two NaNs
+        # are one value however they are spelled, so congruence binds; -0 and
+        # +0 are two values that merely compare fp.eq, so it does not.
+        nan_biased = (seed // FAMILIES) % 2 == 0
+        expected = "unsat" if nan_biased else "sat"
+        lines += [
+            "(declare-fun kf ((_ FloatingPoint 8 24) Bool) %s)" % bv,
+            "(declare-const fu (_ FloatingPoint 8 24))",
+            "(declare-const fv (_ FloatingPoint 8 24))",
+        ]
+        if nan_biased:
+            lines += ["(assert (fp.isNaN fu))", "(assert (fp.isNaN fv))"]
+        else:
+            lines += ["(assert (fp.isZero fu))",
+                      "(assert (fp.isNegative fu))",
+                      "(assert (fp.isZero fv))",
+                      "(assert (fp.isPositive fv))"]
+        lines += ["(assert (= b c))",
+                  "(assert (distinct (kf fu b) (kf fv c)))"]
+    elif family == 10:
+        # FloatingPoint in a result position. = is identity and is reflexive
+        # whatever the result is; fp.eq is IEEE equality and is false at NaN,
+        # so a result need not be fp.eq to itself.
+        reflexive = (seed // FAMILIES) % 2 == 0
+        expected = "unsat" if reflexive else "sat"
+        lines += ["(declare-fun kg (%s Bool) (_ FloatingPoint 8 24))" % bv]
+        lines += ["(assert (distinct (kg x b) (kg x b)))"] if reflexive else [
+            "(assert (not (fp.eq (kg x b) (kg x b))))"]
+    else:
+        # A generated UF result connected to the formula only through a
+        # compound term must keep the SAT assignment for that connection.
+        # Vary both width and operator across seeds; every instance is SAT
+        # because f may choose exactly the compound value at (x,b).
+        expected = "sat"
+        operator = ("bvadd", "bvxor", "bvand", "bvor")[(seed // 7) % 4]
+        lines += [
+            "(assert (= (%s x u) (f x b)))" % operator,
+        ]
+
+    # The pushed block has a fresh congruence conflict in every family. It is
+    # then popped, so the third answer must recover the base verdict.
+    lines += [
+        "(check-sat)",
+        "(push 1)",
+        "(assert (= u v))",
+        "(assert (= d e))",
+        "(assert (distinct (f u d) (f v e)))",
+        "(check-sat)",
+        "(pop 1)",
+        "(check-sat)",
+        "(exit)",
+    ]
+    return "\n".join(lines) + "\n", [expected, "unsat", expected]
+
+
+def reference_command(spec, path):
+    name, command = spec.split("=", 1)
+    argv = shlex.split(command)
+    executable = os.path.basename(argv[0]).lower()
+    if "cvc5" in executable:
+        argv += ["--lang=smt2", "--incremental", str(path)]
+    elif executable == "z3" or executable.startswith("z3-"):
+        argv += ["-smt2", str(path)]
+    else:
+        argv.append(str(path))
+    return name, argv
+
+
+def stp_command(stp, specification, mode, path):
+    name, flags = specification.split("=", 1)
+    argv = [stp]
+    argv += shlex.split(flags)
+    argv += ["--uninterpreted-functions",
+             "--incremental=" + ("on" if mode == "persistent" else "off"),
+             str(path)]
+    return "stp-%s-%s" % (name, mode), argv
+
+
+def run(argv, timeout):
+    started = time.monotonic()
+    process = subprocess.run(argv, stdout=subprocess.PIPE,
+                             stderr=subprocess.STDOUT, text=True,
+                             timeout=timeout, check=False)
+    elapsed = time.monotonic() - started
+    verdicts = VERDICT.findall(process.stdout)
+    if process.returncode != 0:
+        raise RuntimeError("command failed (%d): %s\n%s" %
+                           (process.returncode, shlex.join(argv),
+                            process.stdout))
+    if "unknown" in verdicts:
+        raise RuntimeError("solver returned unknown: %s\n%s" %
+                           (shlex.join(argv), process.stdout))
+    return verdicts, elapsed
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--stp", required=True)
+    parser.add_argument(
+        "--backend", action="append",
+        help="NAME=STP_SOLVER_FLAG (repeatable; default is NAME=default)")
+    parser.add_argument("--reference", action="append", required=True,
+                        help="NAME=/path/to/solver (repeatable)")
+    parser.add_argument("--seeds", type=int, default=240)
+    parser.add_argument("--timeout", type=float, default=10.0)
+    parser.add_argument("--evidence-out")
+    parser.add_argument("--keep-corpus")
+    args = parser.parse_args()
+    if args.seeds <= 0:
+        parser.error("--seeds must be positive")
+    backends = args.backend or ["default="]
+    if any("=" not in specification for specification in backends):
+        parser.error("each --backend must be NAME=STP_SOLVER_FLAG")
+
+    temporary = None
+    if args.keep_corpus:
+        corpus = Path(args.keep_corpus)
+        corpus.mkdir(parents=True, exist_ok=True)
+    else:
+        temporary = tempfile.TemporaryDirectory(prefix="ufstp-fuzz-")
+        corpus = Path(temporary.name)
+
+    digest = hashlib.sha256()
+    cases = []
+    totals = {}
+    for specification in backends:
+        name = specification.split("=", 1)[0]
+        totals["stp-%s-batch" % name] = 0.0
+        totals["stp-%s-persistent" % name] = 0.0
+    for specification in args.reference:
+        totals[specification.split("=", 1)[0]] = 0.0
+
+    for seed in range(args.seeds):
+        text, expected = make_case(seed)
+        digest.update(("case-%06d\0" % seed).encode())
+        digest.update(text.encode())
+        path = corpus / ("case-%06d.smt2" % seed)
+        path.write_text(text)
+
+        commands = []
+        for specification in backends:
+            commands.append(stp_command(args.stp, specification,
+                                        "batch", path))
+            commands.append(stp_command(args.stp, specification,
+                                        "persistent", path))
+        commands += [reference_command(specification, path)
+                     for specification in args.reference]
+        observed = {}
+        for name, command in commands:
+            verdicts, elapsed = run(command, args.timeout)
+            totals[name] += elapsed
+            observed[name] = verdicts
+            if verdicts != expected:
+                # Which side diverged is the first question, so say it: the
+                # expected verdicts are derived by construction, STP is what
+                # is under test, and a reference disagreeing with a
+                # construction-derived expectation is a finding about that
+                # reference rather than about STP.
+                side = ("STP" if name.startswith("stp-")
+                        else "reference solver")
+                raise RuntimeError(
+                    "seed %d: %s %s disagreed: expected %r, got %r\n%s" %
+                    (seed, side, name, expected, verdicts, path.read_text()))
+        cases.append({"seed": seed, "expected": expected,
+                      "observed": observed})
+
+    evidence = {
+        "schema": 1,
+        "seed_count": args.seeds,
+        "checks_per_seed": 3,
+        "solver_runs": args.seeds * (2 * len(backends) +
+                                      len(args.reference)),
+        "stp_backends": [specification.split("=", 1)[0]
+                         for specification in backends],
+        "corpus_sha256": digest.hexdigest(),
+        "families": ["nested-congruence", "noninjectivity",
+                     "boolean-predicate", "interpreted-equality",
+                     "array-actual", "declaration-separation",
+                     "compound-result-liveness", "rounding-mode-actual",
+                     "rounding-mode-result-exhaustion",
+                     "floating-point-nan-actual",
+                     "floating-point-result-identity"],
+        "seconds_by_solver": {key: round(value, 6)
+                              for key, value in totals.items()},
+        "result": "pass",
+    }
+    encoded = json.dumps(evidence, sort_keys=True, indent=2) + "\n"
+    if args.evidence_out:
+        Path(args.evidence_out).write_text(encoded)
+    print(encoded, end="")
+    if temporary is not None:
+        temporary.cleanup()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/ufstp/performance.py
+++ b/tests/ufstp/performance.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""Deterministic UFSTP v2 benchmark-family runner.
+
+This is acceptance evidence, not a pass/fail micro-optimization target.  It
+checks every answer while timing the six M7 families named by T-PERF-01 in
+both fresh-query and persistent exact-stack modes, plus one family each for
+the floating-point and rounding-mode sorts, which do not scale like the
+bit-vector ones.  Two fixed scales make unexpected nonlinear regressions
+visible in the emitted JSON.
+"""
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import re
+import statistics
+import subprocess
+import tempfile
+import time
+
+
+VERDICT = re.compile(r"^(sat|unsat|unknown)$", re.MULTILINE)
+
+
+def header():
+    return [
+        "(set-logic QF_UFBV)",
+        "(declare-fun f ((_ BitVec 16)) (_ BitVec 16))",
+    ]
+
+
+def bv(value):
+    return "#x%04X" % (value & 0xFFFF)
+
+
+def durable_traversal(size):
+    lines = header()
+    for index in range(size):
+        lines.append("(assert (= (f %s) %s))" %
+                     (bv(index), bv(index * 17 + 3)))
+    lines += ["(check-sat)", "(exit)"]
+    return "\n".join(lines) + "\n", ["sat"]
+
+
+def define_fun_reuse(size):
+    lines = header()
+    lines.append(
+        "(define-fun h ((z (_ BitVec 16))) (_ BitVec 16) "
+        "(f (bvadd z #x0001)))")
+    for index in range(size):
+        # The second occurrence must reuse the specialized durable node.
+        lines.append("(assert (= (h %s) (h %s)))" %
+                     (bv(index), bv(index)))
+        lines.append("(assert (= (h %s) %s))" %
+                     (bv(index), bv(index * 13 + 5)))
+    lines += ["(check-sat)", "(exit)"]
+    return "\n".join(lines) + "\n", ["sat"]
+
+
+def nested_let(size):
+    lines = header()
+    for index in range(size):
+        value = bv(index)
+        lines.append(
+            "(assert (= (let ((a %s)) (let ((b a)) (let ((c b)) "
+            "(f c)))) %s))" % (value, bv(index * 11 + 7)))
+    lines += ["(check-sat)", "(exit)"]
+    return "\n".join(lines) + "\n", ["sat"]
+
+
+def identical_block_reuse(size):
+    lines = header() + [
+        "(declare-const x (_ BitVec 16))",
+        "(assert (= (f x) #x0033))",
+    ]
+    lines += ["(check-sat)"] * size
+    lines.append("(exit)")
+    return "\n".join(lines) + "\n", ["sat"] * size
+
+
+def pop_scope(size):
+    cycles = max(2, size // 4)
+    lines = header()
+    for index in range(cycles):
+        lines += [
+            "(declare-const x%d (_ BitVec 16))" % index,
+            "(declare-const y%d (_ BitVec 16))" % index,
+        ]
+    expected = []
+    for index in range(cycles):
+        lines += [
+            "(push 1)",
+            "(assert (= x%d y%d))" % (index, index),
+            "(assert (distinct (f x%d) (f y%d)))" % (index, index),
+            "(check-sat)",
+            "(pop 1)",
+            "(check-sat)",
+        ]
+        expected += ["unsat", "sat"]
+    lines.append("(exit)")
+    return "\n".join(lines) + "\n", expected
+
+
+def epoch_rebuild(size):
+    churn = max(4, size // 2)
+    lines = header() + [
+        "(declare-const base (_ BitVec 16))",
+        "(assert (= (f base) #x0000))",
+    ]
+    for index in range(churn):
+        lines.append("(declare-const e%d (_ BitVec 16))" % index)
+    expected = []
+    for index in range(churn):
+        threshold = "#x0003" if index % 2 == 0 else "#x0027"
+        lines += [
+            "(push 1)",
+            "(assert (bvugt (bvmul e%d e%d) %s))" %
+            (index, index, threshold),
+            "(check-sat)",
+            "(pop 1)",
+        ]
+        expected.append("sat")
+    lines += [
+        "(push 1)",
+        "(assert (= base e0))",
+        "(assert (distinct (f base) (f e0)))",
+        "(check-sat)",
+        "(pop 1)",
+        "(check-sat)",
+        "(exit)",
+    ]
+    expected += ["unsat", "sat"]
+    return "\n".join(lines) + "\n", expected
+
+
+def float_congruence(size):
+    """Congruence over a floating-point argument, at the sort's own equality.
+
+    The other families are bit-vector, and the two sorts do not scale alike:
+    a float actual reaches the checker through a pack/unpack boundary, and
+    the query's own (= a b) is FP_SMT_EQ, which equality propagation cannot
+    substitute through. Both cost more as the family grows, so the trend is
+    worth its own row rather than being assumed to follow the bit-vector one.
+    """
+    lines = [
+        "(set-logic QF_UFBVFP)",
+        "(declare-fun ff ((_ FloatingPoint 8 24)) (_ BitVec 16))",
+    ]
+    for index in range(size):
+        lines.append("(declare-const w%d (_ FloatingPoint 8 24))" % index)
+    for index in range(1, size):
+        lines.append("(assert (= w0 w%d))" % index)
+    lines.append("(assert (distinct %s))"
+                 % " ".join("(ff w%d)" % index for index in range(size)))
+    lines += ["(check-sat)", "(exit)"]
+    return "\n".join(lines) + "\n", ["unsat"]
+
+
+def rounding_mode_exhaustion(size):
+    """A rounding-mode result, ruled out mode by mode.
+
+    Each block excludes all five modes of one application, so it is
+    unsatisfiable only because the introduced result symbol is pinned to
+    them. This is the shape that grows the pin rather than the congruence
+    machinery.
+    """
+    modes = ("RNE", "RTP", "RTN", "RTZ", "RNA")
+    lines = [
+        "(set-logic QF_UFBVFP)",
+        "(declare-fun kk ((_ BitVec 16)) RoundingMode)",
+    ]
+    expected = []
+    for index in range(size):
+        lines.append("(push 1)")
+        for mode in modes:
+            lines.append("(assert (distinct (kk %s) %s))" % (bv(index), mode))
+        lines += ["(check-sat)", "(pop 1)"]
+        expected.append("unsat")
+    lines += ["(check-sat)", "(exit)"]
+    expected.append("sat")
+    return "\n".join(lines) + "\n", expected
+
+
+FAMILIES = {
+    "durable-traversal-lowering": durable_traversal,
+    "define-fun-reuse": define_fun_reuse,
+    "nested-let": nested_let,
+    "persistent-identical-block-reuse": identical_block_reuse,
+    "pop-scope": pop_scope,
+    "encoding-epoch-rebuild": epoch_rebuild,
+    "float-congruence": float_congruence,
+    "rounding-mode-exhaustion": rounding_mode_exhaustion,
+}
+
+
+def invoke(stp, mode, path, timeout, epoch):
+    command = [stp, "--uninterpreted-functions",
+               "--incremental=" + ("on" if mode == "persistent" else "off")]
+    if epoch and mode == "persistent":
+        command += ["--incremental-reencode-limit=1"]
+    command.append(str(path))
+    started = time.monotonic()
+    process = subprocess.run(command, stdout=subprocess.PIPE,
+                             stderr=subprocess.STDOUT, text=True,
+                             timeout=timeout, check=False)
+    elapsed = time.monotonic() - started
+    if process.returncode != 0:
+        raise RuntimeError("benchmark command failed: %r\n%s" %
+                           (command, process.stdout))
+    answers = VERDICT.findall(process.stdout)
+    if "unknown" in answers:
+        raise RuntimeError("benchmark returned unknown: %r\n%s" %
+                           (command, process.stdout))
+    return answers, elapsed
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--stp", required=True)
+    parser.add_argument("--scales", default="16,64")
+    parser.add_argument("--repeats", type=int, default=2)
+    parser.add_argument("--timeout", type=float, default=30.0)
+    parser.add_argument("--evidence-out")
+    args = parser.parse_args()
+    scales = [int(item) for item in args.scales.split(",")]
+    if not scales or any(item <= 0 for item in scales):
+        parser.error("--scales must contain positive integers")
+    if args.repeats <= 0:
+        parser.error("--repeats must be positive")
+
+    digest = hashlib.sha256()
+    rows = []
+    with tempfile.TemporaryDirectory(prefix="ufstp-perf-") as directory:
+        root = Path(directory)
+        for family, generator in FAMILIES.items():
+            for scale in scales:
+                source, expected = generator(scale)
+                digest.update((family + "\0" + str(scale) + "\0").encode())
+                digest.update(source.encode())
+                path = root / (family + "-" + str(scale) + ".smt2")
+                path.write_text(source)
+                for mode in ("batch", "persistent"):
+                    samples = []
+                    for _ in range(args.repeats):
+                        answers, elapsed = invoke(
+                            args.stp, mode, path, args.timeout,
+                            family == "encoding-epoch-rebuild")
+                        if answers != expected:
+                            raise RuntimeError(
+                                "%s/%d/%s: expected %r, got %r" %
+                                (family, scale, mode, expected, answers))
+                        samples.append(elapsed)
+                    rows.append({
+                        "family": family,
+                        "scale": scale,
+                        "mode": mode,
+                        "answer_count": len(expected),
+                        "median_seconds": round(statistics.median(samples), 6),
+                        "samples_seconds": [round(value, 6)
+                                            for value in samples],
+                    })
+
+    evidence = {
+        "schema": 1,
+        "result": "pass",
+        "families": list(FAMILIES),
+        "scales": scales,
+        "repeats": args.repeats,
+        "corpus_sha256": digest.hexdigest(),
+        "rows": rows,
+    }
+    encoded = json.dumps(evidence, indent=2, sort_keys=True) + "\n"
+    if args.evidence_out:
+        Path(args.evidence_out).write_text(encoded)
+    print(encoded, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -80,6 +80,7 @@ AddSTPGTest(SourceSort_Test.cpp)
 AddSTPGTest(UninterpretedFunctionsFrontend_Test.cpp)
 AddSTPGTest(UFLowering_Test.cpp)
 AddSTPGTest(UFChecker_Test.cpp)
+AddSTPGTest(UFRefinement_Test.cpp)
 # Builds float/rounding-mode constants, which is the whole point.
 AddSTPGTest(ConstantIdentity_Test.cpp)
 AddSTPGTest(FpConstantFold_Test.cpp)

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -78,6 +78,7 @@ AddSTPGTest(FpTotalise_Test.cpp)
 AddSTPGTest(FpModelEquality_Test.cpp)
 AddSTPGTest(SourceSort_Test.cpp)
 AddSTPGTest(UninterpretedFunctionsFrontend_Test.cpp)
+AddSTPGTest(UFLowering_Test.cpp)
 # Builds float/rounding-mode constants, which is the whole point.
 AddSTPGTest(ConstantIdentity_Test.cpp)
 AddSTPGTest(FpConstantFold_Test.cpp)

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -79,6 +79,7 @@ AddSTPGTest(FpModelEquality_Test.cpp)
 AddSTPGTest(SourceSort_Test.cpp)
 AddSTPGTest(UninterpretedFunctionsFrontend_Test.cpp)
 AddSTPGTest(UFLowering_Test.cpp)
+AddSTPGTest(UFChecker_Test.cpp)
 # Builds float/rounding-mode constants, which is the whole point.
 AddSTPGTest(ConstantIdentity_Test.cpp)
 AddSTPGTest(FpConstantFold_Test.cpp)

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -77,6 +77,7 @@ AddSTPGTest(FpTotalise_Test.cpp)
 # equalities; the circuit's answers are covered elsewhere.
 AddSTPGTest(FpModelEquality_Test.cpp)
 AddSTPGTest(SourceSort_Test.cpp)
+AddSTPGTest(UninterpretedFunctionsFrontend_Test.cpp)
 # Builds float/rounding-mode constants, which is the whole point.
 AddSTPGTest(ConstantIdentity_Test.cpp)
 AddSTPGTest(FpConstantFold_Test.cpp)

--- a/tests/unit-tests/DeepDag_Test.cpp
+++ b/tests/unit-tests/DeepDag_Test.cpp
@@ -73,6 +73,8 @@ THE SOFTWARE.
 #include "stp/ToSat/BBNodeManagerAIG.h"
 #include "stp/ToSat/BitBlaster.h"
 #include "stp/ToSat/ToSATAIG.h"
+#include "stp/UninterpretedFunctions/UFContext.h"
+#include "stp/UninterpretedFunctions/UFLowering.h"
 #include "stp/Util/NodeIterator.h"
 #include "stp/Simplifier/StrengthReduction.h"
 #include "stp/Simplifier/SubstitutionMap.h"
@@ -282,6 +284,41 @@ ASTNode storeChain(Context& c, unsigned depth, const ASTNode& base,
 ASTNode storeChain(Context& c, unsigned depth)
 {
   return storeChain(c, depth, c.mgr.CreateSymbol("A", 8, 8));
+}
+
+// Completed-root UF lowering must keep the nesting chosen by the input off
+// the call stack. Each application is a child of the next one, so the
+// innermost result also has to be available before its parent is recorded.
+bool ufLoweringOk(Context& c, unsigned depth)
+{
+  c.mgr.UserFlags.enable_uninterpreted_functions = true;
+  UFContext* const context = c.mgr.getUFContext();
+  const SourceSort bv8 = SourceSort::bitVector(8);
+  std::string diagnostic;
+  const UFDecl* const f =
+      context->declareFunction("deep_uf", {bv8}, bv8, &diagnostic);
+  if (f == NULL)
+    return false;
+
+  const ASTNode x = c.mgr.CreateSourceSymbol("deep_uf_x", bv8);
+  ASTNode application = x;
+  for (unsigned i = 0; i < depth; ++i)
+  {
+    application = context->apply(f, {application}, &diagnostic);
+    if (application.IsNull())
+      return false;
+  }
+  const ASTNode root = c.hf->CreateNode(EQ, application, x);
+  c.roots.push_back(root);
+
+  UFLowering lowerer(&c.mgr);
+  const LoweredApplicationView view =
+      lowerer.lowerCompletedRoot(root, UFSolveScope::batch(1));
+  return view.size() == depth &&
+         view.applications.front().stableOrder == 0 &&
+         view.applications.back().stableOrder == depth - 1 &&
+         !containsKind(view.semanticRoot, UF_APPLY) &&
+         !containsKind(view.semanticRootWithDefinitions(&c.mgr), UF_APPLY);
 }
 
 // Dependencies::build, the parent map constant-bit propagation runs on.
@@ -2821,6 +2858,7 @@ TEST(DeepDag, deep_array_equality_lowering)
 }
 TEST(DeepDag, deep_transform_formula_spine) { EXPECT_STACK_SAFE(transformFormulaSpineOk, 20000); }
 TEST(DeepDag, deep_fp_totalise)        { EXPECT_STACK_SAFE(fpTotaliseChainOk, 20000); }
+TEST(DeepDag, deep_uf_lowering)        { EXPECT_STACK_SAFE(ufLoweringOk, 20000); }
 
 TEST(DeepDag, deep_printer_lisp)       { EXPECT_STACK_SAFE(printerLispOk, 20000); }
 TEST(DeepDag, deep_counterexample_eval) { EXPECT_STACK_SAFE(counterExampleEvalOk, 20000); }

--- a/tests/unit-tests/FloatBlast_Test.cpp
+++ b/tests/unit-tests/FloatBlast_Test.cpp
@@ -10,6 +10,7 @@
 #include "stp/Simplifier/Simplifier.h"
 #include "stp/ToSat/BBNodeManagerAIG.h"
 #include "stp/ToSat/BitBlaster.h"
+#include "stp/UninterpretedFunctions/UFContext.h"
 
 #include <gtest/gtest.h>
 #include <set>
@@ -62,6 +63,52 @@ ASTNode rne(STPMgr& mgr)
 {
   return mgr.CreateRMConst(
       symbolic_fp::ROUND_NEAREST_TIES_TO_EVEN);
+}
+
+bool contains(const ASTNode& haystack, const ASTNode& needle,
+              ASTNodeSet& visited)
+{
+  if (!visited.insert(haystack).second)
+    return false;
+  if (haystack == needle)
+    return true;
+  for (size_t i = 0; i < haystack.Degree(); ++i)
+    if (contains(haystack[i], needle, visited))
+      return true;
+  return false;
+}
+
+bool contains(const ASTNode& haystack, const ASTNode& needle)
+{
+  ASTNodeSet visited;
+  return contains(haystack, needle, visited);
+}
+
+// The one node of `kind` in `n`, or null if `n` holds none or several.
+ASTNode soleNodeOfKind(const ASTNode& n, Kind kind, ASTNodeSet& visited,
+                       ASTNode& found, bool& unique)
+{
+  if (!visited.insert(n).second)
+    return found;
+
+  if (n.GetKind() == kind)
+  {
+    if (!found.IsNull() && found != n)
+      unique = false;
+    found = n;
+  }
+  for (size_t i = 0; i < n.Degree(); ++i)
+    soleNodeOfKind(n[i], kind, visited, found, unique);
+  return found;
+}
+
+ASTNode soleNodeOfKind(const ASTNode& n, Kind kind)
+{
+  ASTNodeSet visited;
+  ASTNode found;
+  bool unique = true;
+  const ASTNode answer = soleNodeOfKind(n, kind, visited, found, unique);
+  return unique ? answer : ASTNode();
 }
 
 } // namespace
@@ -628,4 +675,127 @@ TEST(FloatBlast, native_comparison_agrees_with_symfpu_exhaustively)
     }
   }
   EXPECT_EQ(2 * values * values, muxed);
+}
+
+// A UF application is opaque to this pass.
+//
+// The generic rebuild substitutes lowered children into whatever node it is
+// rebuilding, and doing that under an application is wrong twice over: the
+// actuals are stated in source sorts and the UF layer both validates and
+// compares them there, so a float actual replaced by the bits it lowered to
+// no longer denotes the same argument -- and the node factory refuses to
+// build the application at all, which took the process down.
+//
+// It takes a *computed* actual to reach it. A symbol or a constant lowers to
+// itself, so the rebuild never fires; the second half of this test is that
+// case, which has to keep behaving the same way.
+TEST(FloatBlast, uf_application_is_an_opaque_carrier)
+{
+  STPMgr mgr;
+  mgr.UserFlags.enable_uninterpreted_functions = true;
+  UFContext* const context = mgr.getUFContext();
+  const SourceSort fp16 = SourceSort::floatingPoint(5, 11);
+  std::string diagnostic;
+  const UFDecl* const f =
+      context->declareFunction("f", {fp16}, fp16, &diagnostic);
+  ASSERT_NE(nullptr, f) << diagnostic;
+
+  const ASTNode x = mgr.CreateSourceSymbol("x", fp16);
+  const ASTNode magnitude = mgr.CreateTerm(FP_ABS, 16, x);
+  const ASTNode applied = context->apply(f, {magnitude}, &diagnostic);
+  ASSERT_FALSE(applied.IsNull()) << diagnostic;
+
+  // The actual is shared with the enclosing operation, which is what made
+  // the defect fire: fp.abs is lowered in its non-UF position first, and the
+  // cached lowering is what the rebuild then substituted under f.
+  const ASTNode sum = mgr.CreateTerm(
+      FP_ADD, 16, ASTVec{rne(mgr), magnitude, applied});
+
+  FloatBlast lower(&mgr);
+  const ASTNode lowered = lower.topLevel(sum);
+
+  // The application survives as itself -- same node, same actual, still at
+  // the declared float sort -- so the model evaluator can resolve it against
+  // the certified interpretation.
+  const ASTNode survivor = soleNodeOfKind(lowered, UF_APPLY);
+  ASSERT_FALSE(survivor.IsNull());
+  EXPECT_EQ(applied, survivor);
+  ASSERT_EQ(2u, survivor.Degree());
+  EXPECT_EQ(magnitude, survivor[1]);
+  EXPECT_EQ(fp16, survivor[1].GetSourceSort());
+
+  // Everything else is bits. The float operation under the application is
+  // deliberately among the exceptions: nothing below an application is
+  // lowered, so its fp.abs is still there, inside it and nowhere else.
+  EXPECT_EQ(1u, countKind(lowered, FP_ABS));
+  EXPECT_EQ(0u, countKind(lowered, FP_ADD));
+
+  // Two decodes: x, which the shared fp.abs consumes, and the application's
+  // own bits. An application is a carrier like any other leaf, not an
+  // operation to build a circuit for.
+  EXPECT_EQ(2u, lower.statistics().unpack_builds);
+  EXPECT_EQ(2u, lower.statistics().unpacked_operation_builds);
+
+  // A leaf actual takes the same route, and always did: the application is
+  // returned untouched because there was nothing to substitute.
+  const ASTNode leafApplied = context->apply(f, {x}, &diagnostic);
+  ASSERT_FALSE(leafApplied.IsNull()) << diagnostic;
+  const ASTNode leafSum = mgr.CreateTerm(
+      FP_ADD, 16, ASTVec{rne(mgr), x, leafApplied});
+
+  FloatBlast leafLower(&mgr);
+  const ASTNode leafLowered = leafLower.topLevel(leafSum);
+  const ASTNode leafSurvivor = soleNodeOfKind(leafLowered, UF_APPLY);
+  ASSERT_FALSE(leafSurvivor.IsNull());
+  EXPECT_EQ(leafApplied, leafSurvivor);
+}
+
+// The same rule, for the codomains that never reach the packed/unpacked
+// views at all. A Bool or bit-vector result puts the application on lower()'s
+// generic path, where the substitution was equally fatal -- the argument
+// sorts are what the factory checks, and they do not depend on the result.
+TEST(FloatBlast, uf_application_with_a_non_float_result_is_opaque_too)
+{
+  STPMgr mgr;
+  mgr.UserFlags.enable_uninterpreted_functions = true;
+  UFContext* const context = mgr.getUFContext();
+  const SourceSort fp16 = SourceSort::floatingPoint(5, 11);
+  std::string diagnostic;
+  const UFDecl* const p =
+      context->declareFunction("p", {fp16}, SourceSort::boolean(), &diagnostic);
+  const UFDecl* const w = context->declareFunction(
+      "w", {fp16}, SourceSort::bitVector(16), &diagnostic);
+  ASSERT_NE(nullptr, p) << diagnostic;
+  ASSERT_NE(nullptr, w) << diagnostic;
+
+  const ASTNode x = mgr.CreateSourceSymbol("x", fp16);
+  const ASTNode magnitude = mgr.CreateTerm(FP_ABS, 16, x);
+  const ASTNode predicate = context->apply(p, {magnitude}, &diagnostic);
+  const ASTNode bits = context->apply(w, {magnitude}, &diagnostic);
+  ASSERT_FALSE(predicate.IsNull()) << diagnostic;
+  ASSERT_FALSE(bits.IsNull()) << diagnostic;
+
+  // The bit-vector result is reinterpreted back into the float layer, so
+  // both applications sit under one float-valued term.
+  const ASTNode reinterpreted = mgr.CreateTerm(
+      FP_TOFP, 16,
+      ASTVec{mgr.CreateBVConst(32, 5), mgr.CreateBVConst(32, 11), bits});
+  const ASTNode mux = mgr.CreateTerm(
+      ITE, 16, ASTVec{predicate, magnitude, reinterpreted});
+  const ASTNode sum =
+      mgr.CreateTerm(FP_ADD, 16, ASTVec{rne(mgr), magnitude, mux});
+
+  FloatBlast lower(&mgr);
+  const ASTNode lowered = lower.topLevel(sum);
+
+  // Both applications survive as the nodes that were built, actuals and all.
+  EXPECT_EQ(2u, countKind(lowered, UF_APPLY));
+  EXPECT_TRUE(contains(lowered, predicate));
+  EXPECT_TRUE(contains(lowered, bits));
+
+  // Their shared fp.abs is the only float operation left, and it is left
+  // only because it is under them.
+  EXPECT_EQ(1u, countKind(lowered, FP_ABS));
+  EXPECT_EQ(0u, countKind(lowered, FP_ADD));
+  EXPECT_EQ(0u, countKind(lowered, FP_TOFP));
 }

--- a/tests/unit-tests/UFChecker_Test.cpp
+++ b/tests/unit-tests/UFChecker_Test.cpp
@@ -1,0 +1,824 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#include "stp/FloatBlaster/rounding_modes.h"
+#include "stp/STPManager/STPManager.h"
+#include "stp/UninterpretedFunctions/UFChecker.h"
+#include "stp/UninterpretedFunctions/UFContext.h"
+#include "stp/UninterpretedFunctions/UFLemma.h"
+#include "stp/UninterpretedFunctions/UFModel.h"
+
+#include <gtest/gtest.h>
+#include <map>
+#include <sstream>
+
+using namespace stp;
+
+namespace
+{
+
+class Candidate final : public UFScalarCandidate
+{
+public:
+  explicit Candidate(uint64_t version = 1) : version_(version) {}
+
+  void set(const ASTNode& scalar, const UFConcreteValue& value)
+  {
+    values_[scalar] = value;
+  }
+
+  uint64_t version() const override { return version_; }
+
+  bool read(const ASTNode& scalar, const SourceSort& expected,
+            UFConcreteValue& value,
+            std::string& diagnostic) const override
+  {
+    const std::map<ASTNode, UFConcreteValue>::const_iterator found =
+        values_.find(scalar);
+    if (found == values_.end())
+    {
+      diagnostic = "test candidate is missing a scalar";
+      return false;
+    }
+    if (found->second.sort() != expected)
+    {
+      diagnostic = "test candidate scalar sort mismatch";
+      return false;
+    }
+    value = found->second;
+    return true;
+  }
+
+private:
+  uint64_t version_;
+  std::map<ASTNode, UFConcreteValue> values_;
+};
+
+struct UnaryFixture
+{
+  STPMgr manager;
+  UFContext* context;
+  const UFDecl* f;
+  ASTNode x;
+  ASTNode y;
+  ASTNode fx;
+  ASTNode fy;
+  LoweredApplicationView view;
+
+  UnaryFixture() : context(NULL), f(NULL)
+  {
+    manager.UserFlags.enable_uninterpreted_functions = true;
+    context = manager.getUFContext();
+    std::string diagnostic;
+    f = context->declareFunction(
+        "f", {SourceSort::bitVector(8)}, SourceSort::bitVector(8),
+        &diagnostic);
+    x = manager.CreateSourceSymbol("x", SourceSort::bitVector(8));
+    y = manager.CreateSourceSymbol("y", SourceSort::bitVector(8));
+    fx = context->apply(f, {x}, &diagnostic);
+    fy = context->apply(f, {y}, &diagnostic);
+    const ASTNode root = manager.defaultNodeFactory->CreateNode(EQ, fx, fy);
+    UFLowering lowerer(&manager);
+    view = lowerer.lowerCompletedRoot(root, UFSolveScope::batch(1));
+  }
+
+  Candidate candidate(uint64_t version, uint64_t xValue, uint64_t yValue,
+                      uint64_t fxValue, uint64_t fyValue) const
+  {
+    Candidate result(version);
+    for (const LoweredApplicationRecord& record : view.applications)
+    {
+      const bool isX = record.durableHandle == fx;
+      result.set(record.namedActuals[0],
+                 UFConcreteValue::fromUInt(8, isX ? xValue : yValue));
+      result.set(record.resultSymbol,
+                 UFConcreteValue::fromUInt(8, isX ? fxValue : fyValue));
+    }
+    return result;
+  }
+};
+
+} // namespace
+
+TEST(UFChecker, ReturnsStableUnaryConflictAndValidatedLemma)
+{
+  UnaryFixture fixture;
+  const Candidate candidate = fixture.candidate(42, 3, 3, 10, 11);
+  const UFCheckResult result = UFChecker::check(
+      fixture.context->activeDeclarations(), fixture.view, candidate);
+
+  ASSERT_TRUE(result.hasConflict()) << result.diagnostic;
+  EXPECT_EQ(42u, result.conflicts[0].candidateVersion);
+  EXPECT_EQ(fixture.f, result.conflicts[0].declaration);
+  EXPECT_EQ(fixture.fx, result.conflicts[0].representativeHandle);
+  EXPECT_EQ(fixture.fy, result.conflicts[0].conflictingHandle);
+  ASSERT_EQ(1u, result.conflicts[0].arguments.size());
+  EXPECT_EQ(UFConcreteValue::fromUInt(8, 3),
+            result.conflicts[0].arguments[0].concreteValue);
+  EXPECT_EQ(1u, result.stats.insertions);
+  EXPECT_EQ(1u, result.stats.comparisons);
+
+  UFAbstractLemma lemma;
+  std::string diagnostic;
+  ASSERT_TRUE(UFLemmaOracle::buildAndValidate(result.conflicts[0], lemma,
+                                              diagnostic))
+      << diagnostic;
+  ASSERT_EQ(1u, lemma.premise.size());
+  EXPECT_FALSE(lemma.evaluate(false, {true}));
+  EXPECT_TRUE(lemma.evaluate(true, {true}));
+  EXPECT_TRUE(lemma.evaluate(false, {false}));
+}
+
+namespace
+{
+
+// Four applications of one function, all reachable from a single root so the
+// lowering keeps them in one view. Handed a candidate that gives every actual
+// the same value and every result a different one, the bucket holds one
+// representative and three records that disagree with it.
+struct CollidingFixture
+{
+  STPMgr manager;
+  UFContext* context;
+  const UFDecl* f;
+  std::vector<ASTNode> arguments;
+  std::vector<ASTNode> applications;
+  LoweredApplicationView view;
+
+  CollidingFixture() : context(NULL), f(NULL)
+  {
+    manager.UserFlags.enable_uninterpreted_functions = true;
+    context = manager.getUFContext();
+    std::string diagnostic;
+    f = context->declareFunction("f", {SourceSort::bitVector(8)},
+                                 SourceSort::bitVector(8), &diagnostic);
+    ASTVec conjuncts;
+    for (size_t i = 0; i < 4; ++i)
+    {
+      const ASTNode argument = manager.CreateSourceSymbol(
+          ("a" + std::to_string(i)).c_str(), SourceSort::bitVector(8));
+      arguments.push_back(argument);
+      applications.push_back(context->apply(f, {argument}, &diagnostic));
+      conjuncts.push_back(manager.defaultNodeFactory->CreateNode(
+          EQ, applications.back(), manager.CreateBVConst(8, i)));
+    }
+    const ASTNode root =
+        manager.defaultNodeFactory->CreateNode(AND, conjuncts);
+    UFLowering lowerer(&manager);
+    view = lowerer.lowerCompletedRoot(root, UFSolveScope::batch(40));
+  }
+
+  // Every argument reads 7; result i reads i, so records 1..3 each disagree
+  // with record 0.
+  Candidate collidingCandidate(uint64_t version) const
+  {
+    return candidateWithResults(version, {0, 1, 2, 3});
+  }
+
+  // Every argument reads 7; result i reads the caller's value, so the caller
+  // chooses which records in the one bucket disagree and which agree.
+  Candidate candidateWithResults(uint64_t version,
+                                 const std::vector<uint64_t>& results) const
+  {
+    Candidate candidate(version);
+    for (const LoweredApplicationRecord& record : view.applications)
+    {
+      candidate.set(record.namedActuals[0], UFConcreteValue::fromUInt(8, 7));
+      for (size_t i = 0; i < applications.size(); ++i)
+        if (record.durableHandle == applications[i])
+          candidate.set(record.resultSymbol,
+                        UFConcreteValue::fromUInt(8, results[i]));
+    }
+    return candidate;
+  }
+
+  // The record whose durable handle is applications[index], as the view
+  // ordered it.
+  const LoweredApplicationRecord* recordFor(size_t index) const
+  {
+    for (const LoweredApplicationRecord& record : view.applications)
+      if (record.durableHandle == applications[index])
+        return &record;
+    return NULL;
+  }
+};
+
+} // namespace
+
+TEST(UFChecker, ConflictsAgainstThePredecessorNotTheFirstRecord)
+{
+  CollidingFixture fixture;
+  // Three records agree and the last one differs. Comparing against the
+  // bucket's first record would state the pair (first, last); comparing
+  // against the predecessor states (third, last), which is the pair whose
+  // disagreement the candidate actually exhibits.
+  const UFCheckResult result = UFChecker::check(
+      fixture.context->activeDeclarations(), fixture.view,
+      fixture.candidateWithResults(3, {5, 5, 5, 9}));
+
+  ASSERT_TRUE(result.hasConflict()) << result.diagnostic;
+  ASSERT_EQ(1u, result.conflicts.size());
+  EXPECT_EQ(fixture.recordFor(2)->durableHandle,
+            result.conflicts[0].representativeHandle);
+  EXPECT_EQ(fixture.recordFor(3)->durableHandle,
+            result.conflicts[0].conflictingHandle);
+  EXPECT_EQ(UFConcreteValue::fromUInt(8, 5),
+            result.conflicts[0].leftResultValue);
+  EXPECT_EQ(UFConcreteValue::fromUInt(8, 9),
+            result.conflicts[0].rightResultValue);
+
+  // The lemma is still one the candidate refutes.
+  UFAbstractLemma lemma;
+  std::string diagnostic;
+  ASSERT_TRUE(UFLemmaOracle::buildAndValidate(result.conflicts[0], lemma,
+                                              diagnostic))
+      << diagnostic;
+  EXPECT_FALSE(lemma.evaluate(false, std::vector<bool>(lemma.premise.size(),
+                                                       true)));
+}
+
+TEST(UFChecker, CollectsEveryConflictOneCandidateExposes)
+{
+  CollidingFixture fixture;
+  const UFCheckResult result =
+      UFChecker::check(fixture.context->activeDeclarations(), fixture.view,
+                       fixture.collidingCandidate(7));
+
+  ASSERT_TRUE(result.hasConflict()) << result.diagnostic;
+  // One bucket, four records, three consecutive pairs disagreeing.
+  ASSERT_EQ(3u, result.conflicts.size());
+  EXPECT_EQ(1u, result.stats.insertions);
+  EXPECT_EQ(3u, result.stats.comparisons);
+
+  // The bucket is chained, not starred: each conflict is against the record
+  // immediately before it, so conflict i's representative is conflict i-1's
+  // conflicting record. That is what lets a decisive pair of two adjacent
+  // records be stated in the round it appears.
+  for (size_t i = 1; i < result.conflicts.size(); ++i)
+    EXPECT_EQ(result.conflicts[i - 1].conflictingHandle,
+              result.conflicts[i].representativeHandle);
+
+  // Every conflict is stamped with the candidate it was read from and
+  // reports a strictly increasing order.
+  size_t previousOrder = 0;
+  for (const UFCongruenceConflict& conflict : result.conflicts)
+  {
+    EXPECT_EQ(fixture.f, conflict.declaration);
+    EXPECT_NE(conflict.representativeHandle, conflict.conflictingHandle);
+    EXPECT_EQ(7u, conflict.candidateVersion);
+    EXPECT_LT(previousOrder, conflict.stableConflictOrder);
+    previousOrder = conflict.stableConflictOrder;
+
+    UFAbstractLemma lemma;
+    std::string diagnostic;
+    ASSERT_TRUE(UFLemmaOracle::buildAndValidate(conflict, lemma, diagnostic))
+        << diagnostic;
+    // Each one independently rejects the candidate it came from.
+    EXPECT_FALSE(lemma.evaluate(false, std::vector<bool>(
+                                           lemma.premise.size(), true)));
+  }
+
+  // A conflicting candidate publishes no model.
+  EXPECT_TRUE(result.modelSeed.functions.empty());
+}
+
+TEST(UFChecker, ConflictCapStopsTheScanAndIsAPrefix)
+{
+  CollidingFixture fixture;
+  const std::vector<const UFDecl*> declarations =
+      fixture.context->activeDeclarations();
+  const UFCheckPlan plan = UFChecker::validate(declarations, fixture.view);
+  ASSERT_TRUE(plan.valid()) << plan.diagnostic();
+
+  const UFCheckResult unlimited =
+      UFChecker::check(plan, fixture.collidingCandidate(9), 0);
+  ASSERT_EQ(3u, unlimited.conflicts.size());
+
+  for (size_t cap = 1; cap <= 3; ++cap)
+  {
+    const UFCheckResult capped =
+        UFChecker::check(plan, fixture.collidingCandidate(9), cap);
+    ASSERT_TRUE(capped.hasConflict()) << capped.diagnostic;
+    ASSERT_EQ(cap, capped.conflicts.size());
+    // Capping only stops the scan early: what it does report is the same
+    // prefix, in the same order, as the uncapped run.
+    for (size_t i = 0; i < cap; ++i)
+    {
+      EXPECT_EQ(unlimited.conflicts[i].conflictingHandle,
+                capped.conflicts[i].conflictingHandle);
+      EXPECT_EQ(unlimited.conflicts[i].stableConflictOrder,
+                capped.conflicts[i].stableConflictOrder);
+    }
+  }
+}
+
+TEST(UFChecker, PreparedPlanIsReusableAndRejectsMalformedViews)
+{
+  UnaryFixture fixture;
+  const UFCheckPlan plan = UFChecker::validate(
+      fixture.context->activeDeclarations(), fixture.view);
+  ASSERT_TRUE(plan.valid()) << plan.diagnostic();
+
+  const UFCheckResult conflict =
+      UFChecker::check(plan, fixture.candidate(43, 3, 3, 10, 11));
+  ASSERT_TRUE(conflict.hasConflict()) << conflict.diagnostic;
+  const UFCheckResult consistent =
+      UFChecker::check(plan, fixture.candidate(44, 3, 4, 10, 11));
+  ASSERT_TRUE(consistent.consistent()) << consistent.diagnostic;
+
+  LoweredApplicationView malformed = fixture.view;
+  malformed.handleToResult.clear();
+  const UFCheckPlan rejected = UFChecker::validate(
+      fixture.context->activeDeclarations(), malformed);
+  EXPECT_FALSE(rejected.valid());
+  EXPECT_NE(std::string::npos, rejected.diagnostic().find("wrong size"));
+}
+
+TEST(UFChecker, PreservesNonInjectivity)
+{
+  UnaryFixture fixture;
+  const Candidate candidate = fixture.candidate(2, 1, 2, 7, 7);
+  const UFCheckResult result = UFChecker::check(
+      fixture.context->activeDeclarations(), fixture.view, candidate);
+  ASSERT_TRUE(result.consistent()) << result.diagnostic;
+  ASSERT_EQ(1u, result.modelSeed.functions.size());
+  // Two distinct arguments observed at the same result: the interpretation
+  // is the constant 7, which is exactly the non-injective function the
+  // candidate exhibits. Condensing against the commonest value leaves the
+  // else branch to answer both points instead of an ite per point.
+  EXPECT_EQ(UFConcreteValue::fromUInt(8, 7),
+            result.modelSeed.functions[0].defaultValue);
+  EXPECT_TRUE(result.modelSeed.functions[0].cases.empty());
+}
+
+TEST(UFChecker, CondensesTheSeedAgainstItsCommonestValue)
+{
+  CollidingFixture fixture;
+  // Four distinct arguments, three of them observed at 5 and one at 9. The
+  // else branch takes 5 and only the odd point is published as a case.
+  Candidate candidate(11);
+  const uint64_t results[4] = {5, 5, 5, 9};
+  for (const LoweredApplicationRecord& record : fixture.view.applications)
+    for (size_t i = 0; i < fixture.applications.size(); ++i)
+      if (record.durableHandle == fixture.applications[i])
+      {
+        candidate.set(record.namedActuals[0],
+                      UFConcreteValue::fromUInt(8, 20 + i));
+        candidate.set(record.resultSymbol,
+                      UFConcreteValue::fromUInt(8, results[i]));
+      }
+
+  const UFCheckResult result = UFChecker::check(
+      fixture.context->activeDeclarations(), fixture.view, candidate);
+  ASSERT_TRUE(result.consistent()) << result.diagnostic;
+  ASSERT_EQ(1u, result.modelSeed.functions.size());
+  const UFFunctionModelSeed& seed = result.modelSeed.functions[0];
+  EXPECT_EQ(UFConcreteValue::fromUInt(8, 5), seed.defaultValue);
+  ASSERT_EQ(1u, seed.cases.size());
+  EXPECT_EQ(UFConcreteValue::fromUInt(8, 9), seed.cases[0].result);
+  EXPECT_EQ(UFConcreteValue::fromUInt(8, 23), seed.cases[0].arguments[0]);
+}
+
+TEST(UFChecker, KeepsTuplePositionsAndDeclarationsIndependent)
+{
+  STPMgr manager;
+  manager.UserFlags.enable_uninterpreted_functions = true;
+  UFContext* context = manager.getUFContext();
+  std::string diagnostic;
+  const SourceSort bv = SourceSort::bitVector(4);
+  const UFDecl* f = context->declareFunction("f", {bv, bv}, bv, &diagnostic);
+  const UFDecl* g = context->declareFunction("g", {bv, bv}, bv, &diagnostic);
+  const ASTNode a = manager.CreateSourceSymbol("a", bv);
+  const ASTNode b = manager.CreateSourceSymbol("b", bv);
+  const ASTNode fab = context->apply(f, {a, b}, &diagnostic);
+  const ASTNode fba = context->apply(f, {b, a}, &diagnostic);
+  const ASTNode gab = context->apply(g, {a, b}, &diagnostic);
+  const ASTNode root = manager.defaultNodeFactory->CreateNode(
+      AND, manager.defaultNodeFactory->CreateNode(EQ, fab, fba),
+      manager.defaultNodeFactory->CreateNode(EQ, fba, gab));
+  UFLowering lowerer(&manager);
+  const LoweredApplicationView view =
+      lowerer.lowerCompletedRoot(root, UFSolveScope::batch(2));
+
+  Candidate candidate(3);
+  for (const LoweredApplicationRecord& record : view.applications)
+  {
+    candidate.set(record.namedActuals[0],
+                  UFConcreteValue::fromUInt(4,
+                      record.namedActuals[0] == a ? 1 : 2));
+    candidate.set(record.namedActuals[1],
+                  UFConcreteValue::fromUInt(4,
+                      record.namedActuals[1] == a ? 1 : 2));
+    candidate.set(record.resultSymbol,
+                  UFConcreteValue::fromUInt(4,
+                      record.durableHandle == fab ? 3 :
+                      record.durableHandle == fba ? 4 : 9));
+  }
+  const UFCheckResult result =
+      UFChecker::check(context->activeDeclarations(), view, candidate);
+  ASSERT_TRUE(result.consistent()) << result.diagnostic;
+  ASSERT_EQ(2u, result.modelSeed.functions.size());
+  EXPECT_EQ(f, result.modelSeed.functions[0].declaration);
+  EXPECT_EQ(2u, result.modelSeed.functions[0].cases.size());
+  EXPECT_EQ(g, result.modelSeed.functions[1].declaration);
+  EXPECT_EQ(1u, result.modelSeed.functions[1].cases.size());
+}
+
+TEST(UFChecker, SupportsMixedBooleanAndBitVectorTuples)
+{
+  STPMgr manager;
+  manager.UserFlags.enable_uninterpreted_functions = true;
+  UFContext* context = manager.getUFContext();
+  std::string diagnostic;
+  const UFDecl* p = context->declareFunction(
+      "p", {SourceSort::boolean(), SourceSort::bitVector(5)},
+      SourceSort::boolean(), &diagnostic);
+  const ASTNode a =
+      manager.CreateSourceSymbol("a", SourceSort::boolean());
+  const ASTNode b =
+      manager.CreateSourceSymbol("b", SourceSort::boolean());
+  const ASTNode x =
+      manager.CreateSourceSymbol("x", SourceSort::bitVector(5));
+  const ASTNode y =
+      manager.CreateSourceSymbol("y", SourceSort::bitVector(5));
+  const ASTNode left = context->apply(p, {a, x}, &diagnostic);
+  const ASTNode right = context->apply(p, {b, y}, &diagnostic);
+  UFLowering lowerer(&manager);
+  const LoweredApplicationView view = lowerer.lowerCompletedRoot(
+      manager.defaultNodeFactory->CreateNode(IFF, left, right),
+      UFSolveScope::batch(3));
+
+  Candidate candidate(4);
+  for (const LoweredApplicationRecord& record : view.applications)
+  {
+    candidate.set(record.namedActuals[0], UFConcreteValue::boolean(true));
+    candidate.set(record.namedActuals[1], UFConcreteValue::fromUInt(5, 17));
+    candidate.set(record.resultSymbol,
+                  UFConcreteValue::boolean(record.durableHandle == left));
+  }
+  const UFCheckResult result =
+      UFChecker::check(context->activeDeclarations(), view, candidate);
+  ASSERT_TRUE(result.hasConflict()) << result.diagnostic;
+  EXPECT_EQ(SourceSort::Kind::Bool,
+            result.conflicts[0].arguments[0].concreteValue.sort().kind());
+  EXPECT_EQ(5u,
+            result.conflicts[0].arguments[1].concreteValue.sort().bitVectorWidth());
+  EXPECT_EQ(SourceSort::Kind::Bool,
+            result.conflicts[0].leftResultValue.sort().kind());
+}
+
+TEST(UFChecker, PreservesValuesWiderThanMachineWords)
+{
+  STPMgr manager;
+  manager.UserFlags.enable_uninterpreted_functions = true;
+  UFContext* context = manager.getUFContext();
+  std::string diagnostic;
+  const SourceSort wide = SourceSort::bitVector(129);
+  const UFDecl* f =
+      context->declareFunction("wide", {wide}, wide, &diagnostic);
+  ASSERT_NE(nullptr, f) << diagnostic;
+  const ASTNode x = manager.CreateSourceSymbol("x129", wide);
+  const ASTNode y = manager.CreateSourceSymbol("y129", wide);
+  const ASTNode left = context->apply(f, {x}, &diagnostic);
+  const ASTNode right = context->apply(f, {y}, &diagnostic);
+  UFLowering lowerer(&manager);
+  const LoweredApplicationView view = lowerer.lowerCompletedRoot(
+      manager.defaultNodeFactory->CreateNode(EQ, left, right),
+      UFSolveScope::batch(31));
+
+  std::vector<uint8_t> tupleBytes(17, 0);
+  tupleBytes[0] = 0xA5;
+  tupleBytes[16] = 0xFF; // normalized to the one used bit at width 129
+  const UFConcreteValue tuple =
+      UFConcreteValue::bitVector(129, tupleBytes);
+  ASSERT_EQ(17u, tuple.bytes().size());
+  EXPECT_EQ(1u, tuple.bytes().back());
+
+  std::vector<uint8_t> leftBytes(17, 0);
+  std::vector<uint8_t> rightBytes(17, 0);
+  leftBytes[8] = 0x40;
+  rightBytes[12] = 0x20;
+  Candidate candidate(32);
+  for (const LoweredApplicationRecord& record : view.applications)
+  {
+    candidate.set(record.namedActuals[0], tuple);
+    candidate.set(record.resultSymbol, UFConcreteValue::bitVector(
+        129, record.durableHandle == left ? leftBytes : rightBytes));
+  }
+  const UFCheckResult result =
+      UFChecker::check(context->activeDeclarations(), view, candidate);
+  ASSERT_TRUE(result.hasConflict()) << result.diagnostic;
+  EXPECT_EQ(129u,
+            result.conflicts[0].arguments[0].concreteValue.sort().bitVectorWidth());
+  EXPECT_NE(result.conflicts[0].leftResultValue,
+            result.conflicts[0].rightResultValue);
+}
+
+TEST(UFChecker, OmitsOnlyIdenticalAndDuplicatePremises)
+{
+  STPMgr manager;
+  manager.UserFlags.enable_uninterpreted_functions = true;
+  UFContext* context = manager.getUFContext();
+  std::string diagnostic;
+  const SourceSort bv = SourceSort::bitVector(8);
+  const UFDecl* f = context->declareFunction("f", {bv, bv, bv}, bv,
+                                             &diagnostic);
+  const ASTNode x = manager.CreateSourceSymbol("x", bv);
+  const ASTNode y = manager.CreateSourceSymbol("y", bv);
+  const ASTNode z = manager.CreateSourceSymbol("z", bv);
+  const ASTNode left = context->apply(f, {x, x, z}, &diagnostic);
+  const ASTNode right = context->apply(f, {x, y, y}, &diagnostic);
+  UFLowering lowerer(&manager);
+  const LoweredApplicationView view = lowerer.lowerCompletedRoot(
+      manager.defaultNodeFactory->CreateNode(EQ, left, right),
+      UFSolveScope::batch(4));
+
+  Candidate candidate(5);
+  for (const LoweredApplicationRecord& record : view.applications)
+  {
+    for (const ASTNode& arg : record.namedActuals)
+      candidate.set(arg, UFConcreteValue::fromUInt(8, 6));
+    candidate.set(record.resultSymbol,
+                  UFConcreteValue::fromUInt(
+                      8, record.durableHandle == left ? 1 : 2));
+  }
+  const UFCheckResult result =
+      UFChecker::check(context->activeDeclarations(), view, candidate);
+  ASSERT_TRUE(result.hasConflict()) << result.diagnostic;
+  UFAbstractLemma lemma;
+  ASSERT_TRUE(UFLemmaOracle::buildAndValidate(result.conflicts[0], lemma,
+                                              diagnostic))
+      << diagnostic;
+  // Position 0 is reflexive. Positions 1 and 2 both normalize to x=y and
+  // z=y respectively in this shape, so neither is dropped merely because
+  // the candidate values agree.
+  ASSERT_EQ(2u, lemma.premise.size());
+  EXPECT_EQ(1u, lemma.premise[0].originalPosition);
+  EXPECT_EQ(2u, lemma.premise[1].originalPosition);
+}
+
+TEST(UFChecker, DeduplicatesExactlyRepeatedPremiseAtoms)
+{
+  STPMgr manager;
+  manager.UserFlags.enable_uninterpreted_functions = true;
+  UFContext* context = manager.getUFContext();
+  std::string diagnostic;
+  const SourceSort bv = SourceSort::bitVector(8);
+  const UFDecl* f = context->declareFunction("f", {bv, bv}, bv, &diagnostic);
+  const ASTNode x = manager.CreateSourceSymbol("x", bv);
+  const ASTNode y = manager.CreateSourceSymbol("y", bv);
+  const ASTNode left = context->apply(f, {x, x}, &diagnostic);
+  const ASTNode right = context->apply(f, {y, y}, &diagnostic);
+  UFLowering lowerer(&manager);
+  const LoweredApplicationView view = lowerer.lowerCompletedRoot(
+      manager.defaultNodeFactory->CreateNode(EQ, left, right),
+      UFSolveScope::batch(5));
+  Candidate candidate(6);
+  for (const LoweredApplicationRecord& record : view.applications)
+  {
+    for (const ASTNode& arg : record.namedActuals)
+      candidate.set(arg, UFConcreteValue::fromUInt(8, 0));
+    candidate.set(record.resultSymbol,
+                  UFConcreteValue::fromUInt(
+                      8, record.durableHandle == left ? 1 : 2));
+  }
+  const UFCheckResult result =
+      UFChecker::check(context->activeDeclarations(), view, candidate);
+  ASSERT_TRUE(result.hasConflict());
+  UFAbstractLemma lemma;
+  ASSERT_TRUE(UFLemmaOracle::buildAndValidate(result.conflicts[0], lemma,
+                                              diagnostic));
+  ASSERT_EQ(1u, lemma.premise.size());
+  EXPECT_EQ(0u, lemma.premise[0].originalPosition);
+}
+
+TEST(UFChecker, ReturnsInternalErrorForUnobservableScalar)
+{
+  UnaryFixture fixture;
+  Candidate incomplete(7);
+  const LoweredApplicationRecord& first = fixture.view.applications[0];
+  incomplete.set(first.namedActuals[0], UFConcreteValue::fromUInt(8, 1));
+  const UFCheckResult result = UFChecker::check(
+      fixture.context->activeDeclarations(), fixture.view, incomplete);
+  EXPECT_EQ(UFCheckResult::Status::InternalError, result.status);
+  EXPECT_NE(std::string::npos, result.diagnostic.find("missing"));
+}
+
+TEST(UFChecker, ProducesDefaultSeedForDeclarationWithoutObservation)
+{
+  UnaryFixture fixture;
+  std::string diagnostic;
+  const UFDecl* unused = fixture.context->declareFunction(
+      "unused", {SourceSort::bitVector(3)}, SourceSort::boolean(),
+      &diagnostic);
+  ASSERT_NE(nullptr, unused);
+  const Candidate candidate = fixture.candidate(8, 1, 2, 3, 4);
+  const UFCheckResult result = UFChecker::check(
+      fixture.context->activeDeclarations(), fixture.view, candidate);
+  ASSERT_TRUE(result.consistent()) << result.diagnostic;
+  ASSERT_EQ(2u, result.modelSeed.functions.size());
+  EXPECT_EQ(unused, result.modelSeed.functions[1].declaration);
+  EXPECT_TRUE(result.modelSeed.functions[1].cases.empty());
+  EXPECT_EQ(UFConcreteValue::boolean(false),
+            result.modelSeed.functions[1].defaultValue);
+}
+
+namespace
+{
+
+// Whether `needle` occurs anywhere in `haystack`. The DAGs here are tiny, so
+// a plain memoised walk is enough.
+bool reaches(const ASTNode& haystack, const ASTNode& needle,
+             ASTNodeSet* seen = NULL)
+{
+  ASTNodeSet local;
+  if (seen == NULL)
+    seen = &local;
+  if (haystack == needle)
+    return true;
+  if (!seen->insert(haystack).second)
+    return false;
+  for (const ASTNode& child : haystack.GetChildren())
+    if (reaches(child, needle, seen))
+      return true;
+  return false;
+}
+
+// A RoundingMode signature in both positions, with two applications so the
+// declaration is comparable and both actuals stay readable.
+struct RoundingModeFixture
+{
+  STPMgr manager;
+  UFContext* context;
+  const UFDecl* k;
+  ASTNode r;
+  ASTNode s;
+  ASTNode kr;
+  ASTNode ks;
+  LoweredApplicationView view;
+
+  RoundingModeFixture() : context(NULL), k(NULL)
+  {
+    manager.UserFlags.enable_uninterpreted_functions = true;
+    context = manager.getUFContext();
+    std::string diagnostic;
+    k = context->declareFunction("k", {SourceSort::roundingMode()},
+                                 SourceSort::roundingMode(), &diagnostic);
+    r = manager.CreateSourceSymbol("r", SourceSort::roundingMode());
+    s = manager.CreateSourceSymbol("s", SourceSort::roundingMode());
+    kr = context->apply(k, {r}, &diagnostic);
+    ks = context->apply(k, {s}, &diagnostic);
+    const ASTNode root = manager.defaultNodeFactory->CreateNode(EQ, kr, ks);
+    UFLowering lowerer(&manager);
+    view = lowerer.lowerCompletedRoot(root, UFSolveScope::batch(1));
+  }
+
+  // Both actuals read the same mode; the two results read the modes given.
+  Candidate candidate(uint64_t version, unsigned argument,
+                      unsigned leftResult, unsigned rightResult) const
+  {
+    Candidate result(version);
+    for (const LoweredApplicationRecord& record : view.applications)
+    {
+      const bool isLeft = record.durableHandle == kr;
+      result.set(record.namedActuals[0], UFConcreteValue::fromMode(argument));
+      result.set(record.resultSymbol,
+                 UFConcreteValue::fromMode(isLeft ? leftResult : rightResult));
+    }
+    return result;
+  }
+};
+
+} // namespace
+
+TEST(UFChecker, RoundingModeDefaultsToALegalMode)
+{
+  using namespace symbolic_fp;
+  const UFConcreteValue value =
+      UFConcreteValue::zero(SourceSort::roundingMode());
+  EXPECT_EQ(SourceSort::roundingMode(), value.sort());
+  EXPECT_EQ(UFConcreteValue::fromMode(ROUND_NEAREST_TIES_TO_EVEN), value);
+
+  // All-zeros is the natural default and is exactly what must not happen: it
+  // is not one of the five one-hot encodings, so it denotes no mode.
+  STPMgr manager;
+  const ASTNode constant = UFModel::concreteValue(&manager, value);
+  EXPECT_EQ(SourceSort::Kind::RoundingMode, constant.GetSourceSort().kind());
+  EXPECT_EQ(static_cast<unsigned>(ROUND_NEAREST_TIES_TO_EVEN),
+            constant.GetUnsignedConst());
+}
+
+TEST(UFChecker, RoundingModeValuesAcceptCarriersAndRejectNonModes)
+{
+  using namespace symbolic_fp;
+  STPMgr manager;
+  const SourceSort rm = SourceSort::roundingMode();
+  UFConcreteValue value;
+  std::string diagnostic;
+
+  // A constant written in the query keeps the sort ...
+  ASSERT_TRUE(UFConcreteValue::fromConstant(
+      manager.CreateRMConst(ROUND_TOWARD_ZERO), rm, value, diagnostic))
+      << diagnostic;
+  EXPECT_EQ(UFConcreteValue::fromMode(ROUND_TOWARD_ZERO), value);
+
+  // ... while a SAT assignment materialises the bare 5-bit carrier. Both name
+  // the same value and both have to key the same observation bucket.
+  ASSERT_TRUE(UFConcreteValue::fromConstant(
+      manager.CreateBVConst(5, ROUND_TOWARD_ZERO), rm, value, diagnostic))
+      << diagnostic;
+  EXPECT_EQ(UFConcreteValue::fromMode(ROUND_TOWARD_ZERO), value);
+
+  // A carrier that is not one-hot denotes nothing. Bucketing it by its bytes
+  // would make the checker certify an interpretation naming no mode, so it is
+  // refused instead.
+  EXPECT_FALSE(UFConcreteValue::fromConstant(manager.CreateBVConst(5, 0), rm,
+                                             value, diagnostic));
+  EXPECT_NE(std::string::npos, diagnostic.find("denotes no mode"));
+  EXPECT_FALSE(UFConcreteValue::fromConstant(manager.CreateBVConst(5, 3), rm,
+                                             value, diagnostic));
+  // The width still has to match exactly; a wider carrier is not a mode.
+  EXPECT_FALSE(UFConcreteValue::fromConstant(manager.CreateBVConst(8, 1), rm,
+                                             value, diagnostic));
+}
+
+TEST(UFChecker, RoundingModeLoweringPinsEverySolveScalar)
+{
+  RoundingModeFixture fixture;
+  // Two results and two leaf actuals, each pinned exactly once.
+  EXPECT_EQ(4u, fixture.view.solveScalars.size());
+  EXPECT_EQ(4u, fixture.view.sortConstraints.size());
+  for (const ASTNode& constraint : fixture.view.sortConstraints)
+  {
+    EXPECT_EQ(OR, constraint.GetKind());
+    EXPECT_EQ(5u, constraint.Degree()); // one equality per legal mode
+  }
+  // The pin reaches both solve modes through the one funnel that already
+  // carries naming definitions.
+  const ASTNode complete =
+      fixture.view.semanticRootWithDefinitions(&fixture.manager);
+  for (const ASTNode& constraint : fixture.view.sortConstraints)
+    EXPECT_TRUE(reaches(complete, constraint));
+}
+
+TEST(UFChecker, RoundingModeCongruenceAndSeed)
+{
+  using namespace symbolic_fp;
+  RoundingModeFixture fixture;
+
+  // Same argument mode, different result modes: a conflict, at RoundingMode.
+  const Candidate conflicting = fixture.candidate(
+      3, ROUND_TOWARD_ZERO, ROUND_TOWARD_POSITIVE, ROUND_TOWARD_NEGATIVE);
+  const UFCheckResult refuted = UFChecker::check(
+      fixture.context->activeDeclarations(), fixture.view, conflicting);
+  ASSERT_TRUE(refuted.hasConflict()) << refuted.diagnostic;
+  ASSERT_EQ(1u, refuted.conflicts[0].arguments.size());
+  EXPECT_EQ(SourceSort::roundingMode(),
+            refuted.conflicts[0].arguments[0].sort);
+  UFAbstractLemma lemma;
+  std::string diagnostic;
+  ASSERT_TRUE(UFLemmaOracle::buildAndValidate(refuted.conflicts[0], lemma,
+                                              diagnostic))
+      << diagnostic;
+  EXPECT_EQ(SourceSort::roundingMode(), lemma.conclusion.sort);
+
+  // Agreeing results: consistent, and the seed's uncovered cases default to a
+  // mode that exists.
+  const Candidate consistent = fixture.candidate(
+      4, ROUND_TOWARD_ZERO, ROUND_TOWARD_POSITIVE, ROUND_TOWARD_POSITIVE);
+  const UFCheckResult certified = UFChecker::check(
+      fixture.context->activeDeclarations(), fixture.view, consistent);
+  ASSERT_TRUE(certified.consistent()) << certified.diagnostic;
+  ASSERT_EQ(1u, certified.modelSeed.functions.size());
+  EXPECT_EQ(UFConcreteValue::fromMode(ROUND_NEAREST_TIES_TO_EVEN),
+            certified.modelSeed.functions[0].defaultValue);
+
+  // Every mode in the printed interpretation is named, not spelled as a
+  // five-bit literal, or the define-fun is not a legal SMT-LIB term.
+  std::ostringstream printed;
+  UFModel::printSMTLIB2(printed, certified.modelSeed);
+  EXPECT_EQ("(define-fun |k| ((x0 RoundingMode)) RoundingMode\n"
+            "  (ite (= x0 RTZ) RTP RNE))\n",
+            printed.str());
+}

--- a/tests/unit-tests/UFChecker_Test.cpp
+++ b/tests/unit-tests/UFChecker_Test.cpp
@@ -822,3 +822,33 @@ TEST(UFChecker, RoundingModeCongruenceAndSeed)
             "  (ite (= x0 RTZ) RTP RNE))\n",
             printed.str());
 }
+
+TEST(UFChecker, RoundingModeApplicationInTermCompletesToALegalMode)
+{
+  using namespace symbolic_fp;
+  RoundingModeFixture fixture;
+
+  // No adapter at all: nothing was certified for this declaration, so the
+  // application is completed with the codomain's default. It is handed to the
+  // enclosing operator as a constant operand, so an illegal mode here would
+  // not merely print badly -- it would be evaluated.
+  ASTNode value;
+  std::string diagnostic;
+  ASSERT_TRUE(UFModel::evaluateApplicationInTerm(
+      &fixture.manager, NULL, fixture.kr,
+      {fixture.manager.CreateRMConst(ROUND_TOWARD_ZERO)}, value, diagnostic))
+      << diagnostic;
+  EXPECT_EQ(SourceSort::Kind::RoundingMode, value.GetSourceSort().kind());
+  EXPECT_EQ(static_cast<unsigned>(ROUND_NEAREST_TIES_TO_EVEN),
+            value.GetUnsignedConst());
+
+  // The actual may equally arrive as its bare carrier, which is what the
+  // counterexample walk produces for a RoundingMode symbol.
+  ASSERT_TRUE(UFModel::evaluateApplicationInTerm(
+      &fixture.manager, NULL, fixture.kr,
+      {fixture.manager.CreateBVConst(5, ROUND_TOWARD_ZERO)}, value,
+      diagnostic))
+      << diagnostic;
+  EXPECT_EQ(static_cast<unsigned>(ROUND_NEAREST_TIES_TO_EVEN),
+            value.GetUnsignedConst());
+}

--- a/tests/unit-tests/UFLowering_Test.cpp
+++ b/tests/unit-tests/UFLowering_Test.cpp
@@ -1,0 +1,181 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+/***********
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+**********************/
+
+#include "stp/STPManager/STPManager.h"
+#include "stp/UninterpretedFunctions/UFContext.h"
+#include "stp/UninterpretedFunctions/UFLowering.h"
+
+#include <gtest/gtest.h>
+
+using namespace stp;
+
+namespace
+{
+
+const LoweredApplicationRecord* findRecord(const LoweredApplicationView& view,
+                                           const ASTNode& durable)
+{
+  for (const LoweredApplicationRecord& record : view.applications)
+    if (record.durableHandle == durable)
+      return &record;
+  return NULL;
+}
+
+} // namespace
+
+TEST(UFLowering, SharedNestedCompoundActualGetsOneCanonicalName)
+{
+  STPMgr manager;
+  manager.UserFlags.enable_uninterpreted_functions = true;
+  UFContext* const context = manager.getUFContext();
+  const SourceSort bv8 = SourceSort::bitVector(8);
+  std::string diagnostic;
+  const UFDecl* const f =
+      context->declareFunction("f", {bv8}, bv8, &diagnostic);
+  const UFDecl* const g =
+      context->declareFunction("g", {bv8}, bv8, &diagnostic);
+  ASSERT_NE(nullptr, f) << diagnostic;
+  ASSERT_NE(nullptr, g) << diagnostic;
+
+  NodeFactory* const factory = manager.defaultNodeFactory;
+  const ASTNode x = manager.CreateSourceSymbol("x", bv8);
+  const ASTNode one = manager.CreateBVConst(8, 1);
+  const ASTNode inner = context->apply(f, {x}, &diagnostic);
+  const ASTNode compound = factory->CreateTerm(BVPLUS, 8, inner, one);
+  const ASTNode left = context->apply(f, {compound}, &diagnostic);
+  const ASTNode right = context->apply(g, {compound}, &diagnostic);
+  ASSERT_FALSE(inner.IsNull()) << diagnostic;
+  ASSERT_FALSE(left.IsNull()) << diagnostic;
+  ASSERT_FALSE(right.IsNull()) << diagnostic;
+
+  const ASTNode root = factory->CreateNode(
+      AND, factory->CreateNode(EQ, left, manager.CreateBVConst(8, 2)),
+      factory->CreateNode(EQ, right, manager.CreateBVConst(8, 3)));
+  UFLowering lowerer(&manager);
+  const LoweredApplicationView view =
+      lowerer.lowerCompletedRoot(root, UFSolveScope::batch(41));
+
+  ASSERT_EQ(3u, view.size());
+  const LoweredApplicationRecord* const innerRecord = findRecord(view, inner);
+  const LoweredApplicationRecord* const leftRecord = findRecord(view, left);
+  const LoweredApplicationRecord* const rightRecord = findRecord(view, right);
+  ASSERT_NE(nullptr, innerRecord);
+  ASSERT_NE(nullptr, leftRecord);
+  ASSERT_NE(nullptr, rightRecord);
+  EXPECT_LT(innerRecord->stableOrder, leftRecord->stableOrder);
+  EXPECT_LT(innerRecord->stableOrder, rightRecord->stableOrder);
+
+  const ASTNode expectedLowered =
+      factory->CreateTerm(BVPLUS, 8, innerRecord->resultSymbol, one);
+  ASSERT_EQ(1u, leftRecord->loweredActuals.size());
+  ASSERT_EQ(1u, rightRecord->loweredActuals.size());
+  EXPECT_EQ(expectedLowered, leftRecord->loweredActuals[0]);
+  EXPECT_EQ(expectedLowered, rightRecord->loweredActuals[0]);
+  EXPECT_EQ(leftRecord->namedActuals[0], rightRecord->namedActuals[0]);
+  EXPECT_EQ(1u, view.nameToTerm.size());
+  EXPECT_EQ(1u, view.namingDefinitions.size());
+
+  // The durable public tree is untouched, while both semantic forms enforce
+  // the completed-root barrier through a shared, nested application DAG.
+  EXPECT_TRUE(containsKind(view.publicRoot, UF_APPLY));
+  EXPECT_FALSE(containsKind(expectedLowered, UF_APPLY));
+  EXPECT_FALSE(containsKind(view.semanticRoot, UF_APPLY));
+  EXPECT_FALSE(
+      containsKind(view.semanticRootWithDefinitions(&manager), UF_APPLY));
+}
+
+TEST(UFLowering, ExplicitPostOrderHandlesDeepAdversarialSharedDag)
+{
+  STPMgr manager;
+  manager.UserFlags.enable_uninterpreted_functions = true;
+  UFContext* const context = manager.getUFContext();
+  const SourceSort bv8 = SourceSort::bitVector(8);
+  std::string diagnostic;
+  const UFDecl* const f =
+      context->declareFunction("deep_f", {bv8}, bv8, &diagnostic);
+  ASSERT_NE(nullptr, f) << diagnostic;
+
+  // Every application below consumes the entire growing prefix, and that
+  // prefix also contains the preceding application as a shared child. A
+  // separate substitution walk per application is quadratic in this shape;
+  // a single memoised post-order walk visits its O(depth) unique nodes once.
+  const size_t depth = 4096;
+  NodeFactory* const factory = manager.defaultNodeFactory;
+  const ASTNode x = manager.CreateSourceSymbol("deep_x", bv8);
+  ASTNode growing = x;
+  ASTVec durable;
+  durable.reserve(depth);
+  for (size_t i = 0; i < depth; ++i)
+  {
+    const ASTNode application = context->apply(f, {growing}, &diagnostic);
+    ASSERT_FALSE(application.IsNull()) << diagnostic;
+    durable.push_back(application);
+    if (i + 1 < depth)
+      growing = factory->CreateTerm(BVPLUS, 8, growing, application);
+  }
+
+  const ASTNode root = factory->CreateNode(EQ, durable.back(), x);
+  UFLowering lowerer(&manager);
+  const LoweredApplicationView view =
+      lowerer.lowerCompletedRoot(root, UFSolveScope::batch(42));
+
+  ASSERT_EQ(depth, view.size());
+  ASSERT_EQ(depth, view.handleToResult.size());
+  ASSERT_EQ(depth - 1, view.namingDefinitions.size());
+  ASSERT_EQ(depth - 1, view.nameToTerm.size());
+  for (size_t i = 0; i < depth; ++i)
+  {
+    EXPECT_EQ(i, view.applications[i].stableOrder);
+    EXPECT_EQ(durable[i], view.applications[i].durableHandle);
+    EXPECT_TRUE(context->isSolveScalar(view.applications[i].resultSymbol));
+  }
+
+  // Checking the deepest reconstructed actual exercises the whole rewritten
+  // prefix. Neither it nor either semantic root may retain a durable apply.
+  EXPECT_FALSE(
+      containsKind(view.applications.back().loweredActuals[0], UF_APPLY));
+  EXPECT_FALSE(containsKind(view.semanticRoot, UF_APPLY));
+  EXPECT_FALSE(
+      containsKind(view.semanticRootWithDefinitions(&manager), UF_APPLY));
+}

--- a/tests/unit-tests/UFRefinement_Test.cpp
+++ b/tests/unit-tests/UFRefinement_Test.cpp
@@ -1,0 +1,561 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+// Native UF refinement clauses must be fully reified and, in the persistent
+// adapter, every helper and semantic clause must carry the exact-stack block
+// guard.  These tests drive the production checker and adapters with a
+// concrete candidate, then inspect a backend-neutral recording SAT solver.
+
+#include "stp/AbsRefineCounterExample/AbsRefine_CounterExample.h"
+#include "stp/AbsRefineCounterExample/ArrayTransformer.h"
+#include "stp/Sat/SATSolver.h"
+#include "stp/Simplifier/Simplifier.h"
+#include "stp/Simplifier/SubstitutionMap.h"
+#include "stp/ToSat/ToSATBase.h"
+#include "stp/UninterpretedFunctions/UFContext.h"
+#include "stp/UninterpretedFunctions/UFLowering.h"
+#include "stp/UninterpretedFunctions/UFRefinement.h"
+
+#include <gtest/gtest.h>
+#include <algorithm>
+#include <vector>
+
+using namespace stp;
+
+namespace
+{
+
+class RecordingSolver final : public SATSolver
+{
+public:
+  explicit RecordingSolver(unsigned firstFresh) : next_(firstFresh) {}
+
+  bool okay() const override { return true; }
+  uint8_t modelValue(uint32_t) const override { return undef_literal(); }
+  uint32_t newVar() override
+  {
+    if (rejectMutation_)
+      FatalError("test observed SAT mutation before UF leaf validation");
+    return next_++;
+  }
+  uint32_t nVars() const override { return next_; }
+  void printStats() const override {}
+  void setVerbosity(int) override {}
+  lbool true_literal() const override { return 0; }
+  lbool false_literal() const override { return 1; }
+  lbool undef_literal() const override { return 2; }
+
+  unsigned nextVariable() const { return next_; }
+  const std::vector<std::vector<int>>& clauses() const { return clauses_; }
+  void rejectMutation() { rejectMutation_ = true; }
+
+protected:
+  bool addClauseInternal(const vec_literals& clause) override
+  {
+    if (rejectMutation_)
+      FatalError("test observed SAT mutation before UF leaf validation");
+    std::vector<int> copy;
+    for (int i = 0; i < clause.size(); ++i)
+      copy.push_back(toInt(clause[i]));
+    clauses_.push_back(copy);
+    return true;
+  }
+  bool solveInternal(bool&) override { return false; }
+
+private:
+  unsigned next_;
+  bool rejectMutation_ = false;
+  std::vector<std::vector<int>> clauses_;
+};
+
+class RecordingToSAT final : public ToSATBase
+{
+public:
+  explicit RecordingToSAT(STPMgr* manager) : ToSATBase(manager) {}
+
+  bool CallSAT(SATSolver&, const ASTNode&, bool) override { return false; }
+  ASTNodeToSATVar& SATVar_to_SymbolIndexMap() override { return bindings_; }
+  void ClearAllTables() override { bindings_.clear(); }
+
+  void bind(const ASTNode& node, std::initializer_list<unsigned> variables)
+  {
+    bindings_[node] = std::vector<unsigned>(variables);
+  }
+
+  void unbind(const ASTNode& node) { bindings_.erase(node); }
+
+private:
+  ASTNodeToSATVar bindings_;
+};
+
+struct RefinementFixture
+{
+  STPMgr manager;
+  SubstitutionMap substitutions;
+  Simplifier simplifier;
+  ArrayTransformer transformer;
+  AbsRefine_CounterExample counterexample;
+  UFContext* context;
+  const UFDecl* function;
+  ASTNode a;
+  ASTNode b;
+  ASTNode left;
+  ASTNode right;
+  LoweredApplicationView batchView;
+  LoweredApplicationView persistentView;
+  RecordingToSAT tosat;
+
+  RefinementFixture()
+      : substitutions(&manager), simplifier(&manager, &substitutions),
+        transformer(&manager, &simplifier),
+        counterexample(&manager, &simplifier, &transformer), context(NULL),
+        function(NULL), tosat(&manager)
+  {
+    manager.UserFlags.enable_uninterpreted_functions = true;
+    context = manager.getUFContext();
+    std::string diagnostic;
+    function = context->declareFunction(
+        "f", {SourceSort::boolean()}, SourceSort::bitVector(2),
+        &diagnostic);
+    EXPECT_NE(nullptr, function) << diagnostic;
+    a = manager.CreateSourceSymbol("a", SourceSort::boolean());
+    b = manager.CreateSourceSymbol("b", SourceSort::boolean());
+    left = context->apply(function, {a}, &diagnostic);
+    right = context->apply(function, {b}, &diagnostic);
+    const ASTNode root = manager.defaultNodeFactory->CreateNode(
+        NOT, manager.defaultNodeFactory->CreateNode(EQ, left, right));
+    UFLowering lowerer(&manager);
+    batchView = lowerer.lowerCompletedRoot(root, UFSolveScope::batch(1));
+    persistentView = lowerer.lowerCompletedRoot(
+        root, UFSolveScope::persistent(9, 7));
+
+    populate(batchView);
+    populate(persistentView);
+  }
+
+  void populate(const LoweredApplicationView& view)
+  {
+    ASSERT_EQ(2u, view.applications.size());
+    for (const LoweredApplicationRecord& record : view.applications)
+    {
+      const bool isLeft = record.durableHandle == left;
+      counterexample.InsertIntoCounterExampleMap(
+          record.namedActuals[0], manager.CreateNode(TRUE));
+      counterexample.InsertIntoCounterExampleMap(
+          record.resultSymbol, manager.CreateBVConst(2, isLeft ? 1 : 2));
+      if (isLeft)
+      {
+        tosat.bind(record.namedActuals[0], {0});
+        tosat.bind(record.resultSymbol, {2, 3});
+      }
+      else
+      {
+        tosat.bind(record.namedActuals[0], {1});
+        tosat.bind(record.resultSymbol, {4, 5});
+      }
+    }
+  }
+};
+
+// The first two actuals are equal Bool/BV constants in both applications;
+// the latter two collide through a symbol/constant equality.  This reaches
+// constant handling through the checker and adapter instead of exposing the
+// encoder's private equality helper to the test.
+struct ConstantOperandFixture
+{
+  STPMgr manager;
+  SubstitutionMap substitutions;
+  Simplifier simplifier;
+  ArrayTransformer transformer;
+  AbsRefine_CounterExample counterexample;
+  UFContext* context;
+  const UFDecl* function;
+  ASTNode predicate;
+  ASTNode x;
+  ASTNode left;
+  ASTNode right;
+  LoweredApplicationView view;
+  LoweredApplicationView persistentView;
+  RecordingToSAT tosat;
+
+  ConstantOperandFixture()
+      : substitutions(&manager), simplifier(&manager, &substitutions),
+        transformer(&manager, &simplifier),
+        counterexample(&manager, &simplifier, &transformer), context(NULL),
+        function(NULL), tosat(&manager)
+  {
+    manager.UserFlags.enable_uninterpreted_functions = true;
+    context = manager.getUFContext();
+    std::string diagnostic;
+    const SourceSort boolean = SourceSort::boolean();
+    const SourceSort bv2 = SourceSort::bitVector(2);
+    function = context->declareFunction(
+        "constant_operand_f", {boolean, bv2, boolean, bv2}, bv2,
+        &diagnostic);
+    EXPECT_NE(nullptr, function) << diagnostic;
+
+    predicate = manager.CreateSourceSymbol("constant_operand_p", boolean);
+    x = manager.CreateSourceSymbol("constant_operand_x", bv2);
+    const ASTNode one = manager.CreateBVConst(2, 1);
+    left = context->apply(function, {manager.ASTTrue, one, predicate, x},
+                          &diagnostic);
+    right = context->apply(
+        function, {manager.ASTTrue, one, manager.ASTTrue, one}, &diagnostic);
+    const ASTNode root = manager.defaultNodeFactory->CreateNode(
+        NOT, manager.defaultNodeFactory->CreateNode(EQ, left, right));
+    UFLowering lowerer(&manager);
+    view = lowerer.lowerCompletedRoot(root, UFSolveScope::batch(11));
+    persistentView = lowerer.lowerCompletedRoot(
+        root, UFSolveScope::persistent(11, 7));
+
+    EXPECT_EQ(2u, view.applications.size());
+    EXPECT_EQ(2u, persistentView.applications.size());
+    counterexample.InsertIntoCounterExampleMap(predicate, manager.ASTTrue);
+    counterexample.InsertIntoCounterExampleMap(x, one);
+    tosat.bind(predicate, {0});
+    tosat.bind(x, {1, 2});
+    populate(view);
+    populate(persistentView);
+  }
+
+  void populate(const LoweredApplicationView& applicationView)
+  {
+    for (const LoweredApplicationRecord& record : applicationView.applications)
+    {
+      const bool isLeft = record.durableHandle == left;
+      counterexample.InsertIntoCounterExampleMap(
+          record.resultSymbol, manager.CreateBVConst(2, isLeft ? 0 : 2));
+      if (isLeft)
+        tosat.bind(record.resultSymbol, {3, 4});
+      else
+        tosat.bind(record.resultSymbol, {5, 6});
+    }
+  }
+};
+
+// One exact-identical BV premise and one genuine BV premise.  The former
+// must disappear before CNF construction, while the latter is reusable from
+// the adapter's query-local equality cache.
+struct IdenticalPremiseFixture
+{
+  STPMgr manager;
+  SubstitutionMap substitutions;
+  Simplifier simplifier;
+  ArrayTransformer transformer;
+  AbsRefine_CounterExample counterexample;
+  UFContext* context;
+  const UFDecl* function;
+  ASTNode shared;
+  ASTNode x;
+  ASTNode y;
+  ASTNode left;
+  ASTNode right;
+  LoweredApplicationView view;
+  RecordingToSAT tosat;
+
+  IdenticalPremiseFixture()
+      : substitutions(&manager), simplifier(&manager, &substitutions),
+        transformer(&manager, &simplifier),
+        counterexample(&manager, &simplifier, &transformer), context(NULL),
+        function(NULL), tosat(&manager)
+  {
+    manager.UserFlags.enable_uninterpreted_functions = true;
+    context = manager.getUFContext();
+    std::string diagnostic;
+    const SourceSort bv2 = SourceSort::bitVector(2);
+    function = context->declareFunction("identical_premise_f", {bv2, bv2},
+                                        bv2, &diagnostic);
+    EXPECT_NE(nullptr, function) << diagnostic;
+    shared = manager.CreateSourceSymbol("identical_premise_shared", bv2);
+    x = manager.CreateSourceSymbol("identical_premise_x", bv2);
+    y = manager.CreateSourceSymbol("identical_premise_y", bv2);
+    left = context->apply(function, {shared, x}, &diagnostic);
+    right = context->apply(function, {shared, y}, &diagnostic);
+    const ASTNode root = manager.defaultNodeFactory->CreateNode(
+        NOT, manager.defaultNodeFactory->CreateNode(EQ, left, right));
+    UFLowering lowerer(&manager);
+    view = lowerer.lowerCompletedRoot(root, UFSolveScope::batch(12));
+
+    EXPECT_EQ(2u, view.applications.size());
+    counterexample.InsertIntoCounterExampleMap(shared,
+                                               manager.CreateBVConst(2, 0));
+    counterexample.InsertIntoCounterExampleMap(x,
+                                               manager.CreateBVConst(2, 3));
+    counterexample.InsertIntoCounterExampleMap(y,
+                                               manager.CreateBVConst(2, 3));
+    tosat.bind(shared, {0, 1});
+    tosat.bind(x, {2, 3});
+    tosat.bind(y, {4, 5});
+    for (const LoweredApplicationRecord& record : view.applications)
+    {
+      const bool isLeft = record.durableHandle == left;
+      counterexample.InsertIntoCounterExampleMap(
+          record.resultSymbol, manager.CreateBVConst(2, isLeft ? 1 : 2));
+      if (isLeft)
+        tosat.bind(record.resultSymbol, {6, 7});
+      else
+        tosat.bind(record.resultSymbol, {8, 9});
+    }
+  }
+};
+
+bool satisfies(const std::vector<std::vector<int>>& clauses,
+               const std::vector<bool>& assignment)
+{
+  for (const std::vector<int>& clause : clauses)
+  {
+    bool clauseValue = false;
+    for (const int literal : clause)
+    {
+      const unsigned variable = static_cast<unsigned>(literal) >> 1;
+      const bool sign = (literal & 1) != 0;
+      clauseValue = clauseValue || (assignment[variable] != sign);
+    }
+    if (!clauseValue)
+      return false;
+  }
+  return true;
+}
+
+} // namespace
+
+TEST(UFRefinement, CompletesACachedHelperUsedInBothPolarities)
+{
+  // The same equality can be a premise in one lemma and a conclusion in
+  // another. Each use needs the opposite half of the helper definition, so
+  // the second one has to complete what the first left out rather than
+  // reuse the literal as it stands.
+  //
+  // Both applications of f take the same Bool argument here, so the argument
+  // equality is the one the checker states as a premise, while the result
+  // equality is the conclusion; the fixture's second, identical candidate
+  // then reuses both from the cache. Whatever the order, the projection onto
+  // the original variables must still be exactly the congruence implication,
+  // which is what the exhaustive check below asserts.
+  RefinementFixture fixture;
+  UFBatchAdapter adapter(&fixture.manager);
+  adapter.beginQuery(&fixture.batchView);
+  ASSERT_EQ(UFCandidateOutcome::Conflict,
+            adapter.checkCandidate(fixture.counterexample));
+
+  RecordingSolver solver(6);
+  adapter.encodePendingLemmas(solver, &fixture.tosat);
+  const std::size_t afterFirst = solver.clauses().size();
+
+  ASSERT_EQ(UFCandidateOutcome::Conflict,
+            adapter.checkCandidate(fixture.counterexample));
+  adapter.encodePendingLemmas(solver, &fixture.tosat);
+  // A repeat in the same polarity completes nothing: one new implication.
+  EXPECT_EQ(afterFirst + 1, solver.clauses().size());
+
+  const unsigned helperCount = solver.nextVariable() - 6;
+  for (unsigned original = 0; original < (1u << 6); ++original)
+  {
+    const bool argumentEqual =
+        ((original >> 0) & 1u) == ((original >> 1) & 1u);
+    const bool resultEqual =
+        ((original >> 2) & 1u) == ((original >> 4) & 1u) &&
+        ((original >> 3) & 1u) == ((original >> 5) & 1u);
+    const bool expected = !argumentEqual || resultEqual;
+    bool encoded = false;
+    for (unsigned helpers = 0; helpers < (1u << helperCount); ++helpers)
+    {
+      std::vector<bool> assignment(solver.nextVariable(), false);
+      for (unsigned bit = 0; bit < 6; ++bit)
+        assignment[bit] = ((original >> bit) & 1u) != 0;
+      for (unsigned bit = 0; bit < helperCount; ++bit)
+        assignment[6 + bit] = ((helpers >> bit) & 1u) != 0;
+      if (satisfies(solver.clauses(), assignment))
+      {
+        encoded = true;
+        break;
+      }
+    }
+    EXPECT_EQ(expected, encoded) << "original assignment " << original;
+  }
+}
+
+TEST(UFRefinement, BatchCNFExactlyImplementsCongruenceImplication)
+{
+  RefinementFixture fixture;
+  UFBatchAdapter adapter(&fixture.manager);
+  adapter.beginQuery(&fixture.batchView);
+  ASSERT_EQ(UFCandidateOutcome::Conflict,
+            adapter.checkCandidate(fixture.counterexample));
+  ASSERT_TRUE(adapter.hasPendingLemma());
+
+  RecordingSolver solver(6);
+  adapter.encodePendingLemmas(solver, &fixture.tosat);
+  EXPECT_FALSE(adapter.hasPendingLemma());
+  EXPECT_EQ(1u, adapter.lemmasEmitted());
+  // Each helper is defined in the one polarity its use needs, which is half
+  // of each definition. The premise appears negated, so its Bool XNOR gets
+  // the two clauses for (l = r) -> q: 2. The conclusion appears positive, so
+  // its two BV-bit XNORs get the two clauses each for q -> (l = r), and the
+  // conjunction gets one clause per bit for q -> every bit: 4 + 2. The
+  // semantic implication: 1.
+  ASSERT_EQ(9u, solver.clauses().size());
+
+  const unsigned helperCount = solver.nextVariable() - 6;
+  for (unsigned original = 0; original < (1u << 6); ++original)
+  {
+    const bool argumentEqual =
+        ((original >> 0) & 1u) == ((original >> 1) & 1u);
+    const bool resultEqual =
+        ((original >> 2) & 1u) == ((original >> 4) & 1u) &&
+        ((original >> 3) & 1u) == ((original >> 5) & 1u);
+    const bool expected = !argumentEqual || resultEqual;
+    bool encoded = false;
+    for (unsigned helpers = 0; helpers < (1u << helperCount); ++helpers)
+    {
+      std::vector<bool> assignment(solver.nextVariable(), false);
+      for (unsigned bit = 0; bit < 6; ++bit)
+        assignment[bit] = ((original >> bit) & 1u) != 0;
+      for (unsigned bit = 0; bit < helperCount; ++bit)
+        assignment[6 + bit] = ((helpers >> bit) & 1u) != 0;
+      if (satisfies(solver.clauses(), assignment))
+      {
+        encoded = true;
+        break;
+      }
+    }
+    EXPECT_EQ(expected, encoded) << "original assignment " << original;
+  }
+
+  // A repeated candidate in one fresh query reuses both equality literals
+  // and submits only the new candidate-blocking implication.
+  ASSERT_EQ(UFCandidateOutcome::Conflict,
+            adapter.checkCandidate(fixture.counterexample));
+  adapter.encodePendingLemmas(solver, &fixture.tosat);
+  EXPECT_EQ(10u, solver.clauses().size());
+  EXPECT_EQ(2u, adapter.lemmasEmitted());
+}
+
+TEST(UFRefinement, BatchCNFFoldsBoolAndBitVectorConstantOperands)
+{
+  ConstantOperandFixture fixture;
+  UFBatchAdapter adapter(&fixture.manager);
+  adapter.beginQuery(&fixture.view);
+  ASSERT_EQ(UFCandidateOutcome::Conflict,
+            adapter.checkCandidate(fixture.counterexample));
+
+  RecordingSolver solver(7);
+  adapter.encodePendingLemmas(solver, &fixture.tosat);
+
+  // The two exact constant/constant premises disappear. p=true aliases p's
+  // existing literal, while x=1 needs only the one clause that its negated
+  // use requires of the conjunction of its two constant-adjusted bit
+  // literals. The BV result equality, used positively, needs six. The
+  // semantic implication one. Constants acquire no SAT vars.
+  ASSERT_EQ(8u, solver.clauses().size());
+  ASSERT_EQ(11u, solver.nextVariable());
+
+  const unsigned helperCount = solver.nextVariable() - 7;
+  for (unsigned original = 0; original < (1u << 7); ++original)
+  {
+    const bool predicate = ((original >> 0) & 1u) != 0;
+    const unsigned x = ((original >> 1) & 1u) |
+                       (((original >> 2) & 1u) << 1);
+    const unsigned leftResult = ((original >> 3) & 1u) |
+                                (((original >> 4) & 1u) << 1);
+    const unsigned rightResult = ((original >> 5) & 1u) |
+                                 (((original >> 6) & 1u) << 1);
+    const bool expected = !predicate || x != 1 || leftResult == rightResult;
+    bool encoded = false;
+    for (unsigned helpers = 0; helpers < (1u << helperCount); ++helpers)
+    {
+      std::vector<bool> assignment(solver.nextVariable(), false);
+      for (unsigned bit = 0; bit < 7; ++bit)
+        assignment[bit] = ((original >> bit) & 1u) != 0;
+      for (unsigned bit = 0; bit < helperCount; ++bit)
+        assignment[7 + bit] = ((helpers >> bit) & 1u) != 0;
+      if (satisfies(solver.clauses(), assignment))
+      {
+        encoded = true;
+        break;
+      }
+    }
+    EXPECT_EQ(expected, encoded) << "original assignment " << original;
+  }
+}
+
+TEST(UFRefinement, RejectsMalformedPreencodedLeavesBeforeSATMutation)
+{
+  RefinementFixture fixture;
+  UFBatchAdapter adapter(&fixture.manager);
+  adapter.beginQuery(&fixture.batchView);
+  ASSERT_EQ(UFCandidateOutcome::Conflict,
+            adapter.checkCandidate(fixture.counterexample));
+  ASSERT_TRUE(adapter.hasPendingLemma());
+
+  // If validation regresses behind helper allocation or clause insertion,
+  // this solver dies with a different diagnostic and the death check fails.
+  RecordingSolver solver(6);
+  solver.rejectMutation();
+  // Corrupt a conclusion leaf, which is validated after every premise.  A
+  // validate-as-you-encode implementation would already have allocated the
+  // premise helper before it discovered any of these faults.
+  const ASTNode leaf = fixture.batchView.applications[0].resultSymbol;
+  ASSERT_EQ(SourceSort::bitVector(2), leaf.GetSourceSort());
+
+  fixture.tosat.unbind(leaf);
+  EXPECT_DEATH(adapter.encodePendingLemmas(solver, &fixture.tosat),
+               "not registered before the first candidate");
+
+  fixture.tosat.bind(leaf, {2});
+  EXPECT_DEATH(adapter.encodePendingLemmas(solver, &fixture.tosat),
+               "wrong-width SAT mapping");
+
+  fixture.tosat.bind(leaf, {2, ~0u});
+  EXPECT_DEATH(adapter.encodePendingLemmas(solver, &fixture.tosat),
+               "unencoded SAT bit");
+}
+
+TEST(UFRefinement, BatchCNFEliminatesIdenticalPremiseAndReusesCache)
+{
+  IdenticalPremiseFixture fixture;
+  UFBatchAdapter adapter(&fixture.manager);
+  adapter.beginQuery(&fixture.view);
+  ASSERT_EQ(UFCandidateOutcome::Conflict,
+            adapter.checkCandidate(fixture.counterexample));
+
+  RecordingSolver solver(10);
+  adapter.encodePendingLemmas(solver, &fixture.tosat);
+  // Only x=y and the result equality remain: two BV2 XNOR/conjunction
+  // bundles of three helpers each, defined in the one polarity each use
+  // needs -- five clauses for the negated premise, six for the positive
+  // conclusion -- plus the implication.
+  EXPECT_EQ(12u, solver.clauses().size());
+  EXPECT_EQ(16u, solver.nextVariable());
+
+  ASSERT_EQ(UFCandidateOutcome::Conflict,
+            adapter.checkCandidate(fixture.counterexample));
+  adapter.encodePendingLemmas(solver, &fixture.tosat);
+  // Both surviving equality literals are cache hits, and each is reused in
+  // the same polarity it was defined in.  The repeat contributes just another
+  // candidate-blocking implication and no new helper variable.
+  EXPECT_EQ(13u, solver.clauses().size());
+  EXPECT_EQ(16u, solver.nextVariable());
+}
+

--- a/tests/unit-tests/UninterpretedFunctionsFrontend_Test.cpp
+++ b/tests/unit-tests/UninterpretedFunctionsFrontend_Test.cpp
@@ -24,7 +24,10 @@ THE SOFTWARE.
 
 #include "stp/Simplifier/SubstitutionMap.h"
 #include "stp/Globals/Globals.h"
+#include "stp/Parser/parser.h"
+#include "stp/STPManager/STP.h"
 #include "stp/STPManager/STPManager.h"
+#include "stp/cpp_interface.h"
 #include "stp/UninterpretedFunctions/UFContext.h"
 #include "stp/UninterpretedFunctions/UFLowering.h"
 
@@ -263,6 +266,97 @@ TEST(UninterpretedFunctionsFrontend, FailedApplicationsRegisterNothing)
   EXPECT_EQ(UNDEFINED,
             context->apply(declaration, {x}, &diagnostic).GetKind());
   EXPECT_EQ(0u, context->registeredApplicationCount());
+}
+
+TEST(UninterpretedFunctionsFrontend,
+     MalformedParserApplicationRejectsWholeCommandAndContinues)
+{
+  STPMgr manager;
+  Cpp_interface interface(manager, manager.defaultNodeFactory);
+  STPMgr* const savedManager = GlobalParserBM;
+  Cpp_interface* const savedInterface = GlobalParserInterface;
+  GlobalParserBM = &manager;
+  GlobalParserInterface = &interface;
+  interface.startup();
+  manager.UserFlags.enable_uninterpreted_functions = true;
+
+  // The first assertion has a valid application followed by one with the
+  // wrong arity. Its valid prefix and parser-side carrier must both roll back:
+  // neither may become an assertion or a registered durable application.
+  // Parsing must nevertheless continue to the independent assertion.
+  const char* const input = R"(
+    (set-logic QF_UFBV)
+    (declare-fun f ((_ BitVec 8)) (_ BitVec 8))
+    (declare-const x (_ BitVec 8))
+    (assert (and (= (f x) x) (= (f x x) x)))
+    (assert (= x #x00))
+  )";
+  SMT2ScanString(input);
+  EXPECT_EQ(0, SMT2Parse());
+  smt2lex_destroy();
+
+  const std::size_t applicationCount =
+      manager.getUFContext()->registeredApplicationCount();
+  const std::size_t declarationCount =
+      manager.getUFContext()->declarationCount();
+  const bool xIsUF = manager.getUFContext()->lookup("x") != nullptr;
+  const ASTVec assertions = manager.GetAsserts();
+  const bool containsApplication =
+      !assertions.empty() && containsKind(assertions[0], UF_APPLY);
+  const bool rejected = interface.currentCommandRejected();
+
+  GlobalParserBM = savedManager;
+  GlobalParserInterface = savedInterface;
+
+  EXPECT_EQ(0u, applicationCount);
+  EXPECT_EQ(1u, declarationCount);
+  EXPECT_FALSE(xIsUF);
+  ASSERT_EQ(1u, assertions.size());
+  EXPECT_FALSE(containsApplication);
+  EXPECT_FALSE(rejected);
+}
+
+TEST(UninterpretedFunctionsFrontend,
+     MalformedFormalCannotLeakLexerOrTemporaryStateAcrossParses)
+{
+  STPMgr manager;
+  Cpp_interface interface(manager, manager.defaultNodeFactory);
+  STPMgr* const savedManager = GlobalParserBM;
+  Cpp_interface* const savedInterface = GlobalParserInterface;
+  GlobalParserBM = &manager;
+  GlobalParserInterface = &interface;
+  interface.startup();
+  manager.UserFlags.enable_uninterpreted_functions = true;
+
+  // The empty formal reaches function_param_open but supplies no identifier,
+  // leaving the lexer's next-name expectation armed unless parse-abort cleanup
+  // explicitly clears it.
+  SMT2ScanString(R"(
+    (set-logic QF_UFBV)
+    (define-fun broken (() Bool) Bool true)
+  )");
+  EXPECT_NE(0, SMT2Parse());
+  smt2lex_destroy();
+
+  // A second parse on the same interface must start a fresh command and may
+  // declare/use another formal normally.
+  SMT2ScanString(R"(
+    (define-fun good ((fresh Bool)) Bool fresh)
+    (declare-const witness Bool)
+    (assert (good witness))
+  )");
+  EXPECT_EQ(0, SMT2Parse());
+  smt2lex_destroy();
+
+  const ASTVec assertions = manager.GetAsserts();
+
+  GlobalParserBM = savedManager;
+  GlobalParserInterface = savedInterface;
+
+  ASSERT_EQ(1u, assertions.size());
+  EXPECT_EQ(SYMBOL, assertions[0].GetKind());
+  EXPECT_STREQ("witness", assertions[0].GetName());
+  EXPECT_EQ(SourceSort::boolean(), assertions[0].GetSourceSort());
 }
 
 TEST(UninterpretedFunctionsFrontend, SubstitutionRebuildsDurableApplication)

--- a/tests/unit-tests/UninterpretedFunctionsFrontend_Test.cpp
+++ b/tests/unit-tests/UninterpretedFunctionsFrontend_Test.cpp
@@ -26,10 +26,28 @@ THE SOFTWARE.
 #include "stp/Globals/Globals.h"
 #include "stp/STPManager/STPManager.h"
 #include "stp/UninterpretedFunctions/UFContext.h"
+#include "stp/UninterpretedFunctions/UFLowering.h"
 
 #include <gtest/gtest.h>
 
 using namespace stp;
+
+namespace
+{
+
+// Lowering order follows the post-order walk, so a test that adds
+// applications to reach a comparable declaration should not also have to
+// predict where each one lands.
+const LoweredApplicationRecord* recordFor(const LoweredApplicationView& view,
+                                          const ASTNode& durableHandle)
+{
+  for (const LoweredApplicationRecord& record : view.applications)
+    if (record.durableHandle == durableHandle)
+      return &record;
+  return NULL;
+}
+
+} // namespace
 
 TEST(UninterpretedFunctionsFrontend, IsDisabledByDefault)
 {
@@ -273,4 +291,221 @@ TEST(UninterpretedFunctionsFrontend, SubstitutionRebuildsDurableApplication)
   EXPECT_EQ(declaration->identityNode(), specialized[0]);
   EXPECT_EQ(actual, specialized[1]);
   EXPECT_TRUE(context->isRegisteredApplication(specialized));
+}
+
+TEST(UninterpretedFunctionsFrontend,
+     CompletedRootLoweringBuildsOnlyReachableNestedClosure)
+{
+  STPMgr manager;
+  manager.UserFlags.enable_uninterpreted_functions = true;
+  UFContext* context = manager.getUFContext();
+  std::string diagnostic;
+  const UFDecl* declaration = context->declareFunction(
+      "f", {SourceSort::bitVector(8)}, SourceSort::bitVector(8),
+      &diagnostic);
+  ASSERT_NE(nullptr, declaration) << diagnostic;
+
+  const ASTNode x =
+      manager.CreateSourceSymbol("x", SourceSort::bitVector(8));
+  const ASTNode inner = context->apply(declaration, {x}, &diagnostic);
+  const ASTNode outer = context->apply(declaration, {inner}, &diagnostic);
+  const ASTNode unreachable = context->apply(
+      declaration, {manager.CreateBVConst(8, 9)}, &diagnostic);
+  ASSERT_FALSE(unreachable.IsNull());
+  const ASTNode root =
+      manager.defaultNodeFactory->CreateNode(EQ, outer, x);
+
+  UFLowering lowerer(&manager);
+  const LoweredApplicationView view =
+      lowerer.lowerCompletedRoot(root, UFSolveScope::batch(17));
+
+  ASSERT_EQ(2u, view.size());
+  EXPECT_EQ(root, view.publicRoot);
+  EXPECT_FALSE(containsKind(view.semanticRoot, UF_APPLY));
+  EXPECT_TRUE(view.handleToResult.find(inner) != view.handleToResult.end());
+  EXPECT_TRUE(view.handleToResult.find(outer) != view.handleToResult.end());
+  EXPECT_TRUE(view.handleToResult.find(unreachable) ==
+              view.handleToResult.end());
+  EXPECT_EQ(inner, view.applications[0].durableHandle);
+  EXPECT_EQ(outer, view.applications[1].durableHandle);
+  ASSERT_EQ(1u, view.applications[1].namedActuals.size());
+  EXPECT_EQ(view.applications[0].resultSymbol,
+            view.applications[1].namedActuals[0]);
+  EXPECT_TRUE(context->isProtected(view.applications[0].resultSymbol));
+  EXPECT_TRUE(context->isProtected(view.applications[1].resultSymbol));
+  EXPECT_TRUE(context->isSolveScalar(view.applications[0].resultSymbol));
+  EXPECT_TRUE(context->isSolveScalar(view.applications[1].resultSymbol));
+}
+
+TEST(UninterpretedFunctionsFrontend,
+     CompletedRootLoweringNamesEachComplexActualOnce)
+{
+  STPMgr manager;
+  manager.UserFlags.enable_uninterpreted_functions = true;
+  UFContext* context = manager.getUFContext();
+  std::string diagnostic;
+  const UFDecl* f = context->declareFunction(
+      "f", {SourceSort::bitVector(8)}, SourceSort::bitVector(8),
+      &diagnostic);
+  const UFDecl* g = context->declareFunction(
+      "g", {SourceSort::bitVector(8)}, SourceSort::bitVector(8),
+      &diagnostic);
+  ASSERT_NE(nullptr, f);
+  ASSERT_NE(nullptr, g);
+  const ASTNode x =
+      manager.CreateSourceSymbol("x", SourceSort::bitVector(8));
+  const ASTNode one = manager.CreateBVConst(8, 1);
+  const ASTNode complex = manager.defaultNodeFactory->CreateTerm(
+      BVPLUS, 8, x, one);
+  const ASTNode fx = context->apply(f, {complex}, &diagnostic);
+  const ASTNode gx = context->apply(g, {complex}, &diagnostic);
+  // A compound actual is named only where a congruence lemma could mention
+  // it, so each declaration needs a second application; both are given a leaf
+  // actual, which introduces no further name.
+  const ASTNode fLeaf = context->apply(f, {x}, &diagnostic);
+  const ASTNode gLeaf = context->apply(g, {one}, &diagnostic);
+  const ASTNode root = manager.defaultNodeFactory->CreateNode(
+      AND, manager.defaultNodeFactory->CreateNode(EQ, fx, gx),
+      manager.defaultNodeFactory->CreateNode(EQ, fLeaf, gLeaf));
+
+  UFLowering lowerer(&manager);
+  const LoweredApplicationView view =
+      lowerer.lowerCompletedRoot(root, UFSolveScope::batch(18));
+  ASSERT_EQ(4u, view.size());
+  ASSERT_EQ(1u, view.namingDefinitions.size());
+  ASSERT_EQ(1u, view.nameToTerm.size());
+  const LoweredApplicationRecord* const fRecord = recordFor(view, fx);
+  const LoweredApplicationRecord* const gRecord = recordFor(view, gx);
+  ASSERT_NE(nullptr, fRecord);
+  ASSERT_NE(nullptr, gRecord);
+  EXPECT_TRUE(fRecord->observableArguments);
+  EXPECT_TRUE(gRecord->observableArguments);
+  EXPECT_EQ(fRecord->namedActuals[0], gRecord->namedActuals[0]);
+  EXPECT_TRUE(context->isProtected(fRecord->namedActuals[0]));
+  EXPECT_TRUE(context->isSolveScalar(fRecord->namedActuals[0]));
+  EXPECT_FALSE(containsKind(view.semanticRootWithDefinitions(&manager),
+                            UF_APPLY));
+
+  // The ordinary substitution funnel must not delete either a UF result or
+  // its argument-name definition after the lowering barrier.
+  SubstitutionMap substitutions(&manager);
+  EXPECT_FALSE(context->activeInSolve());
+  {
+    UFContext::SolveScope scope(context);
+    EXPECT_TRUE(context->activeInSolve());
+    EXPECT_FALSE(substitutions.UpdateSolverMap(fRecord->resultSymbol,
+                                               manager.CreateBVConst(8, 3)));
+    EXPECT_FALSE(
+        substitutions.UpdateSolverMap(fRecord->namedActuals[0], complex));
+  }
+  EXPECT_FALSE(context->activeInSolve());
+}
+
+TEST(UninterpretedFunctionsFrontend, LoneApplicationLeavesCompoundActualUnnamed)
+{
+  STPMgr manager;
+  manager.UserFlags.enable_uninterpreted_functions = true;
+  UFContext* context = manager.getUFContext();
+  std::string diagnostic;
+  const UFDecl* f = context->declareFunction(
+      "f", {SourceSort::bitVector(8)}, SourceSort::bitVector(8), &diagnostic);
+  ASSERT_NE(nullptr, f);
+  const ASTNode x = manager.CreateSourceSymbol("x", SourceSort::bitVector(8));
+  const ASTNode y = manager.CreateSourceSymbol("y", SourceSort::bitVector(8));
+  const ASTNode complex =
+      manager.defaultNodeFactory->CreateTerm(BVPLUS, 8, x, y);
+  const ASTNode fx = context->apply(f, {complex}, &diagnostic);
+  const ASTNode root = manager.defaultNodeFactory->CreateNode(
+      EQ, fx, manager.CreateBVConst(8, 3));
+
+  UFLowering lowerer(&manager);
+  const LoweredApplicationView view =
+      lowerer.lowerCompletedRoot(root, UFSolveScope::batch(30));
+  ASSERT_EQ(1u, view.size());
+  // No second application of f exists, so no congruence lemma can ever equate
+  // this actual with anything: naming it would only drag BVPLUS into the
+  // bit-blast where nothing can observe it.
+  EXPECT_FALSE(view.applications[0].observableArguments);
+  EXPECT_TRUE(view.applications[0].namedActuals.empty());
+  EXPECT_TRUE(view.namingDefinitions.empty());
+  EXPECT_TRUE(view.nameToTerm.empty());
+  EXPECT_FALSE(containsKind(view.semanticRootWithDefinitions(&manager),
+                            BVPLUS));
+
+  // The result symbol is still a protected solve scalar: it stands in for the
+  // application in the formula and carries the certified value.
+  EXPECT_TRUE(context->isProtected(view.applications[0].resultSymbol));
+  EXPECT_TRUE(context->isSolveScalar(view.applications[0].resultSymbol));
+}
+TEST(UninterpretedFunctionsFrontend, LoneApplicationReusesAnExistingName)
+{
+  STPMgr manager;
+  manager.UserFlags.enable_uninterpreted_functions = true;
+  UFContext* context = manager.getUFContext();
+  std::string diagnostic;
+  const UFDecl* f = context->declareFunction(
+      "f", {SourceSort::bitVector(8)}, SourceSort::bitVector(8), &diagnostic);
+  const UFDecl* g = context->declareFunction(
+      "g", {SourceSort::bitVector(8)}, SourceSort::bitVector(8), &diagnostic);
+  ASSERT_NE(nullptr, f);
+  ASSERT_NE(nullptr, g);
+  const ASTNode x = manager.CreateSourceSymbol("x", SourceSort::bitVector(8));
+  const ASTNode y = manager.CreateSourceSymbol("y", SourceSort::bitVector(8));
+  const ASTNode complex =
+      manager.defaultNodeFactory->CreateTerm(BVPLUS, 8, x, y);
+  // f is comparable and names `complex`; g's single application shares that
+  // term, so it costs nothing to keep g readable too.
+  const ASTNode fComplex = context->apply(f, {complex}, &diagnostic);
+  const ASTNode fLeaf = context->apply(f, {x}, &diagnostic);
+  const ASTNode gComplex = context->apply(g, {complex}, &diagnostic);
+  const ASTNode root = manager.defaultNodeFactory->CreateNode(
+      AND, manager.defaultNodeFactory->CreateNode(EQ, fComplex, fLeaf),
+      manager.defaultNodeFactory->CreateNode(EQ, gComplex,
+                                             manager.CreateBVConst(8, 3)));
+
+  UFLowering lowerer(&manager);
+  const LoweredApplicationView view =
+      lowerer.lowerCompletedRoot(root, UFSolveScope::batch(31));
+  ASSERT_EQ(3u, view.size());
+  ASSERT_EQ(1u, view.namingDefinitions.size());
+  const LoweredApplicationRecord* const fRecord = recordFor(view, fComplex);
+  const LoweredApplicationRecord* const gRecord = recordFor(view, gComplex);
+  ASSERT_NE(nullptr, fRecord);
+  ASSERT_NE(nullptr, gRecord);
+  EXPECT_TRUE(gRecord->observableArguments);
+  ASSERT_EQ(1u, gRecord->namedActuals.size());
+  EXPECT_EQ(fRecord->namedActuals[0], gRecord->namedActuals[0]);
+}
+
+TEST(UninterpretedFunctionsFrontend, BooleanLoweringRetainsBoolSourceSort)
+{
+  STPMgr manager;
+  manager.UserFlags.enable_uninterpreted_functions = true;
+  UFContext* context = manager.getUFContext();
+  std::string diagnostic;
+  const UFDecl* pred = context->declareFunction(
+      "p", {SourceSort::boolean()}, SourceSort::boolean(), &diagnostic);
+  ASSERT_NE(nullptr, pred);
+  const ASTNode a =
+      manager.CreateSourceSymbol("a", SourceSort::boolean());
+  const ASTNode b =
+      manager.CreateSourceSymbol("b", SourceSort::boolean());
+  const ASTNode complex =
+      manager.defaultNodeFactory->CreateNode(XOR, a, b);
+  const ASTNode app = context->apply(pred, {complex}, &diagnostic);
+  // Two applications, so the compound actual earns a name to be equated in.
+  const ASTNode leafApp = context->apply(pred, {a}, &diagnostic);
+  const ASTNode root =
+      manager.defaultNodeFactory->CreateNode(AND, app, leafApp);
+
+  UFLowering lowerer(&manager);
+  const LoweredApplicationView view =
+      lowerer.lowerCompletedRoot(root, UFSolveScope::batch(19));
+  ASSERT_EQ(2u, view.size());
+  ASSERT_EQ(1u, view.namingDefinitions.size());
+  const LoweredApplicationRecord* const record = recordFor(view, app);
+  ASSERT_NE(nullptr, record);
+  EXPECT_EQ(SourceSort::boolean(), record->resultSymbol.GetSourceSort());
+  EXPECT_EQ(SourceSort::boolean(), record->namedActuals[0].GetSourceSort());
+  EXPECT_EQ(IFF, view.namingDefinitions[0].GetKind());
 }

--- a/tests/unit-tests/UninterpretedFunctionsFrontend_Test.cpp
+++ b/tests/unit-tests/UninterpretedFunctionsFrontend_Test.cpp
@@ -1,0 +1,276 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#include "stp/Simplifier/SubstitutionMap.h"
+#include "stp/Globals/Globals.h"
+#include "stp/STPManager/STPManager.h"
+#include "stp/UninterpretedFunctions/UFContext.h"
+
+#include <gtest/gtest.h>
+
+using namespace stp;
+
+TEST(UninterpretedFunctionsFrontend, IsDisabledByDefault)
+{
+  STPMgr manager;
+  EXPECT_FALSE(manager.UserFlags.enable_uninterpreted_functions);
+
+  std::string diagnostic;
+  EXPECT_EQ(nullptr, manager.getUFContext()->declareFunction(
+                      "f", {SourceSort::bitVector(8)},
+                      SourceSort::bitVector(8), &diagnostic));
+  EXPECT_EQ(0u, manager.getUFContext()->declarationCount());
+  EXPECT_NE(std::string::npos, diagnostic.find("disabled"));
+}
+
+TEST(UninterpretedFunctionsFrontend, SignatureUsesRestrictedSourceSorts)
+{
+  EXPECT_THROW(UFSignature({}, SourceSort::boolean()), std::invalid_argument);
+  EXPECT_THROW(UFSignature({SourceSort::bitVector(8)},
+                           SourceSort::array(SourceSort::bitVector(8),
+                                             SourceSort::bitVector(8))),
+               std::invalid_argument);
+
+  const UFSignature signature(
+      {SourceSort::boolean(), SourceSort::bitVector(17)},
+      SourceSort::bitVector(3));
+  ASSERT_EQ(2u, signature.arity());
+  EXPECT_EQ(SourceSort::Kind::Bool, signature.domain()[0].kind());
+  EXPECT_EQ(17u, signature.domain()[1].bitVectorWidth());
+  EXPECT_EQ(3u, signature.codomain().bitVectorWidth());
+
+  // RoundingMode and FloatingPoint used to sit alongside the throwing rows
+  // above. Both are now admitted in either position; the rows are kept,
+  // inverted, so that a regression which re-rejected a sort fails here.
+  const UFSignature mode({SourceSort::roundingMode()},
+                         SourceSort::roundingMode());
+  ASSERT_EQ(1u, mode.arity());
+  EXPECT_EQ(SourceSort::Kind::RoundingMode, mode.domain()[0].kind());
+  EXPECT_EQ(SourceSort::Kind::RoundingMode, mode.codomain().kind());
+  EXPECT_EQ(5u, mode.codomain().packedWidth());
+
+  const UFSignature floats({SourceSort::floatingPoint(8, 24)},
+                           SourceSort::floatingPoint(11, 53));
+  ASSERT_EQ(1u, floats.arity());
+  EXPECT_EQ(SourceSort::Kind::FloatingPoint, floats.domain()[0].kind());
+  EXPECT_EQ(SourceSort::Kind::FloatingPoint, floats.codomain().kind());
+
+  // Admitted at its own sort, but never *solved* at it: a float is compared
+  // as its canonical packed carrier, because SMT-LIB's = on floats identifies
+  // every NaN and byte equality does not.
+  EXPECT_EQ(SourceSort::bitVector(32),
+            UFSignature::loweringSort(floats.domain()[0]));
+  EXPECT_EQ(SourceSort::bitVector(64),
+            UFSignature::loweringSort(floats.codomain()));
+  // Every other admitted sort is solved exactly as declared.
+  EXPECT_EQ(SourceSort::boolean(),
+            UFSignature::loweringSort(SourceSort::boolean()));
+  EXPECT_EQ(SourceSort::roundingMode(),
+            UFSignature::loweringSort(SourceSort::roundingMode()));
+  EXPECT_EQ(SourceSort::bitVector(17),
+            UFSignature::loweringSort(SourceSort::bitVector(17)));
+}
+
+TEST(UninterpretedFunctionsFrontend,
+     UnsupportedDirectSignaturesMutateNoRegistry)
+{
+  STPMgr manager;
+  manager.UserFlags.enable_uninterpreted_functions = true;
+  UFContext* context = manager.getUFContext();
+  const SourceSort bv8 = SourceSort::bitVector(8);
+  const SourceSort array = SourceSort::array(bv8, bv8);
+  std::string diagnostic;
+
+  EXPECT_EQ(nullptr,
+            context->declareFunction("empty", {}, bv8, &diagnostic));
+  EXPECT_EQ("uninterpreted functions: declaration of empty: a zero-arity "
+            "declaration is an ordinary symbol, not an uninterpreted function",
+            diagnostic);
+  // The RoundingMode and FloatingPoint rows that used to sit here are now
+  // admitted; they moved to the positive tests below, where the registry is
+  // expected to change rather than stay empty.
+  EXPECT_EQ(nullptr,
+            context->declareFunction("array", {array}, bv8, &diagnostic));
+  EXPECT_EQ("uninterpreted functions: declaration of array: unsupported "
+            "domain sort (Array (_ BitVec 8) (_ BitVec 8)) at argument 0 "
+            "(only Bool, RoundingMode, FloatingPoint and nonzero-width "
+            "bit-vector sorts are supported)",
+            diagnostic);
+  EXPECT_EQ(nullptr, context->declareFunction(
+                         "unknown", {SourceSort::unknown()}, bv8,
+                         &diagnostic));
+  EXPECT_EQ(nullptr,
+            context->declareFunction("result", {bv8}, array, &diagnostic));
+  EXPECT_EQ("uninterpreted functions: declaration of result: unsupported "
+            "result sort (Array (_ BitVec 8) (_ BitVec 8)) (only Bool, "
+            "RoundingMode, FloatingPoint and nonzero-width bit-vector "
+            "sorts are supported)",
+            diagnostic);
+  EXPECT_EQ(0u, context->declarationCount());
+  EXPECT_EQ(0u, context->registeredApplicationCount());
+}
+
+TEST(UninterpretedFunctionsFrontend, RoundingModeSignaturesAreAdmitted)
+{
+  STPMgr manager;
+  manager.UserFlags.enable_uninterpreted_functions = true;
+  UFContext* context = manager.getUFContext();
+  const SourceSort rm = SourceSort::roundingMode();
+  const SourceSort bv8 = SourceSort::bitVector(8);
+  std::string diagnostic;
+
+  const UFDecl* toMode =
+      context->declareFunction("toMode", {bv8}, rm, &diagnostic);
+  ASSERT_NE(nullptr, toMode) << diagnostic;
+  const UFDecl* fromMode =
+      context->declareFunction("fromMode", {rm}, bv8, &diagnostic);
+  ASSERT_NE(nullptr, fromMode) << diagnostic;
+  EXPECT_EQ(2u, context->declarationCount());
+
+  // Declaring a RoundingMode-sorted identity is enough to make the manager
+  // report the floating-point theory, which is what routes the query to
+  // FpTotalise and to the mode-aware model printers.
+  EXPECT_TRUE(manager.has_floating_point_theory);
+
+  const ASTNode x = manager.CreateSourceSymbol("x", bv8);
+  const ASTNode application = context->apply(toMode, {x}, &diagnostic);
+  ASSERT_FALSE(application.IsNull()) << diagnostic;
+  EXPECT_EQ(UF_APPLY, application.GetKind());
+  // The carrier is the packed one -- five bits -- while the source sort stays
+  // RoundingMode. BVTypeCheck's UF_APPLY rule enforces exactly this pairing.
+  EXPECT_EQ(SourceSort::Kind::RoundingMode,
+            application.GetSourceSort().kind());
+  EXPECT_EQ(BITVECTOR_TYPE, application.GetType());
+  EXPECT_EQ(5u, application.GetValueWidth());
+  EXPECT_TRUE(BVTypeCheck(application));
+}
+
+TEST(UninterpretedFunctionsFrontend, DurableApplicationsAreTypedAndHashConsed)
+{
+  STPMgr manager;
+  manager.UserFlags.enable_uninterpreted_functions = true;
+  UFContext* context = manager.getUFContext();
+
+  std::string diagnostic;
+  const UFDecl* bv = context->declareFunction(
+      "f", {SourceSort::bitVector(8), SourceSort::boolean()},
+      SourceSort::bitVector(16), &diagnostic);
+  const UFDecl* pred = context->declareFunction(
+      "p", {SourceSort::bitVector(8)}, SourceSort::boolean(), &diagnostic);
+  ASSERT_NE(nullptr, bv) << diagnostic;
+  ASSERT_NE(nullptr, pred) << diagnostic;
+
+  const ASTNode x =
+      manager.CreateSourceSymbol("x", SourceSort::bitVector(8));
+  const ASTNode b =
+      manager.CreateSourceSymbol("b", SourceSort::boolean());
+  const ASTNode app = context->apply(bv, {x, b}, &diagnostic);
+  const ASTNode again = context->apply(bv, {x, b}, &diagnostic);
+  const ASTNode boolApp = context->apply(pred, {x}, &diagnostic);
+
+  EXPECT_EQ(UF_APPLY, app.GetKind());
+  EXPECT_EQ(app, again);
+  EXPECT_EQ(bv->identityNode(), app[0]);
+  EXPECT_EQ(x, app[1]);
+  EXPECT_EQ(b, app[2]);
+  EXPECT_EQ(SourceSort::bitVector(16), app.GetSourceSort());
+  EXPECT_EQ(BITVECTOR_TYPE, app.GetType());
+  EXPECT_EQ(16u, app.GetValueWidth());
+  EXPECT_EQ(SourceSort::boolean(), boolApp.GetSourceSort());
+  EXPECT_EQ(BOOLEAN_TYPE, boolApp.GetType());
+  EXPECT_TRUE(context->isRegisteredApplication(app));
+  EXPECT_EQ(2u, context->registeredApplicationCount());
+  EXPECT_TRUE(BVTypeCheck(app));
+  EXPECT_TRUE(BVTypeCheck(boolApp));
+}
+
+TEST(UninterpretedFunctionsFrontend, FailedApplicationsRegisterNothing)
+{
+  STPMgr first;
+  STPMgr second;
+  first.UserFlags.enable_uninterpreted_functions = true;
+  second.UserFlags.enable_uninterpreted_functions = true;
+  UFContext* context = first.getUFContext();
+  std::string diagnostic;
+  const UFDecl* declaration = context->declareFunction(
+      "f", {SourceSort::bitVector(8)}, SourceSort::bitVector(8),
+      &diagnostic);
+  ASSERT_NE(nullptr, declaration);
+
+  const ASTNode wrong =
+      first.CreateSourceSymbol("wrong", SourceSort::boolean());
+  const ASTNode foreign =
+      second.CreateSourceSymbol("foreign", SourceSort::bitVector(8));
+  EXPECT_EQ(UNDEFINED,
+            context->apply(declaration, ASTVec(), &diagnostic).GetKind());
+  EXPECT_EQ("uninterpreted functions: f expects 1 argument but was applied "
+            "to 0",
+            diagnostic);
+  EXPECT_EQ(UNDEFINED,
+            context->apply(declaration, {wrong}, &diagnostic).GetKind());
+  EXPECT_EQ("uninterpreted functions: argument 0 of f has sort Bool but the "
+            "declaration requires (_ BitVec 8)",
+            diagnostic);
+  EXPECT_EQ(UNDEFINED,
+            context->apply(declaration, {foreign}, &diagnostic).GetKind());
+  EXPECT_EQ("uninterpreted functions: argument 0 of f belongs to another "
+            "context",
+            diagnostic);
+  EXPECT_EQ(0u, context->registeredApplicationCount());
+
+  ASSERT_TRUE(context->deactivate(declaration, &diagnostic));
+  const ASTNode x =
+      first.CreateSourceSymbol("x", SourceSort::bitVector(8));
+  EXPECT_EQ(UNDEFINED,
+            context->apply(declaration, {x}, &diagnostic).GetKind());
+  EXPECT_EQ(0u, context->registeredApplicationCount());
+}
+
+TEST(UninterpretedFunctionsFrontend, SubstitutionRebuildsDurableApplication)
+{
+  STPMgr manager;
+  manager.UserFlags.enable_uninterpreted_functions = true;
+  UFContext* context = manager.getUFContext();
+  std::string diagnostic;
+  const UFDecl* declaration = context->declareFunction(
+      "f", {SourceSort::bitVector(8)}, SourceSort::bitVector(8),
+      &diagnostic);
+  ASSERT_NE(nullptr, declaration);
+  const ASTNode formal =
+      manager.CreateSourceSymbol("formal", SourceSort::bitVector(8));
+  const ASTNode actual = manager.CreateBVConst(8, 42);
+  const ASTNode generic = context->apply(declaration, {formal}, &diagnostic);
+
+  ASTNodeMap substitutions;
+  substitutions.insert(std::make_pair(formal, actual));
+  ASTNodeMap cache;
+  const ASTNode specialized = SubstitutionMap::replace(
+      generic, substitutions, cache, manager.defaultNodeFactory);
+
+  ASSERT_EQ(UF_APPLY, specialized.GetKind());
+  EXPECT_NE(generic, specialized);
+  EXPECT_EQ(declaration->identityNode(), specialized[0]);
+  EXPECT_EQ(actual, specialized[1]);
+  EXPECT_TRUE(context->isRegisteredApplication(specialized));
+}

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -349,6 +349,19 @@ void ExtraMain::create_options()
       ->group(refinement_group)
       ->capture_default_str();
 
+  app.add_flag("--uninterpreted-functions",
+               bm->UserFlags.enable_uninterpreted_functions,
+               "decide uninterpreted functions over Bool, bit-vector, "
+               "RoundingMode and floating-point sorts by dynamic Ackermann "
+               "refinement")
+      ->group(refinement_group);
+  app.add_option("--uf-lemmas-per-round",
+                 bm->UserFlags.uf_lemmas_per_round,
+                 "how many congruence lemmas one refuted candidate may "
+                 "install (0: every conflict it exposes; 1: the "
+                 "one-lemma-per-round reference profile)")
+      ->group(refinement_group)
+      ->capture_default_str();
   const char* const bb_group = "Bit-blasting options";
   bool_arg("--bb.div-v1", bm->UserFlags.division_variant_1,
            "unsigned division encoding variant 1", bb_group);


### PR DESCRIPTION
# UF support (4/8): decide it, behind --uninterpreted-functions

**This PR builds on top of #935** (UF support (3/8): the consistency checker, its lemmas, and the certified value boundary). Please review and merge it first; this branch contains its commits.

Wire the theory end to end for fresh-query solves. The SMT-LIB2 frontend accepts nonzero-arity declare-fun behind the flag -- with it clear the parser refuses one exactly as it always did, byte for byte -- and every command that builds applications is a transaction: a malformed subexpression rolls back the applications the command introduced and the script continues. QF_UFBV and the UF+FP logic names are accepted while the flag is set.

The batch pipeline lowers the completed root at its one boundary, registers every checker scalar in the SAT backend with a complete frozen mapping, reads candidates back through the counterexample, and drains every refinement owner holding a candidate-blocking lemma before the next solve. A candidate is certified only after the extensionality checker (when active), the congruence checker, a replay of the pre-simplification semantic root, and a pointwise replay of the preserved public root all accept it; get-value answers for applications and for terms built over them, and get-model prints one replayable define-fun per declaration.

The incremental driver refuses a stack that applies an uninterpreted function, which routes each of its checks through this batch pipeline; the refusal is temporary and the persistent exact-stack integration that deletes it comes next. The differential oracle -- eager Ackermann constraints decided through the classic feature-off path, compared against the lazy adapter, including push/pop verdict sequences -- runs 150 rounds in CI.
