### PR TITLE
Restore BV abstraction C API controls and regressions

### DIFF
--- a/include/stp/c_interface.h
+++ b/include/stp/c_interface.h
@@ -364,7 +364,67 @@ enum ifaceflag_t
   //! count it stopped at -- the same sentence SMT-LIB2 reads through
   //! (get-info :reason-unknown).
   //!
-  AIG_NODE_BUDGET
+  AIG_NODE_BUDGET,
+
+  //! Replace a wide bit-vector equality with a fresh Boolean during
+  //! bit-blasting, refining it lazily via CEGAR.
+  //!
+  //! `param_value` nonzero enables, zero disables (the default). This is the
+  //! C API's way to reach --bv-eq-abstraction. Only equalities at least
+  //! BV_ABSTRACTION_WIDTH bits wide are abstracted.
+  //!
+  BV_EQ_ABSTRACTION,
+
+  //! The narrowest bit-vector operand width at which BV_EQ_ABSTRACTION and
+  //! BV_TERM_ABSTRACTION engage (default 64).
+  //!
+  //! `param_value` is that width. One abstracts every candidate; a width
+  //! wider than any term in the query leaves the query unabstracted. A
+  //! negative value is refused with a nonfatal diagnostic and leaves the
+  //! width unchanged, because the flag it sets is unsigned and would
+  //! otherwise wrap to a width nothing can reach. This is the C API's way to
+  //! reach --bv-abstraction-width.
+  //!
+  BV_ABSTRACTION_WIDTH,
+
+  //! The initial prefix width refined when an abstracted equality is found
+  //! inconsistent with the candidate model (default 0: refine the whole
+  //! width at once).
+  //!
+  //! `param_value` is that width; each further refinement of the same
+  //! equality doubles it, up to the equality's width. A negative value is
+  //! refused with a nonfatal diagnostic, as for BV_ABSTRACTION_WIDTH. This
+  //! is the C API's way to reach --bv-eq-refine-width.
+  //!
+  BV_EQ_REFINE_WIDTH,
+
+  //! Abstract wide bit-vector arithmetic, comparisons and ITE during
+  //! bit-blasting, refining them lazily via CEGAR.
+  //!
+  //! `param_value` nonzero enables, zero disables (the default). This is the
+  //! C API's way to reach --bv-term-abstraction. It shares the width floor
+  //! set by BV_ABSTRACTION_WIDTH.
+  //!
+  BV_TERM_ABSTRACTION,
+
+  //! Whether BV_TERM_ABSTRACTION covers BVMULT, BVDIV and BVMOD as well.
+  //!
+  //! `param_value` nonzero includes them (the default), zero leaves them
+  //! encoded exactly from the start. This is the C API's way to reach
+  //! --bv-term-abstraction-mult.
+  //!
+  BV_TERM_ABSTRACTION_MULT,
+
+  //! How many blocking lemmas one abstracted BVMULT, BVDIV or BVMOD may take
+  //! before its refinement encodes the operation exactly instead of ruling
+  //! out further operand pairs (default 32).
+  //!
+  //! `param_value` is that count; zero never escalates and enumerates without
+  //! limit. A negative value is refused with a nonfatal diagnostic and leaves
+  //! the count unchanged. This is the C API's way to reach
+  //! --bv-term-abstraction-rounds.
+  //!
+  BV_TERM_ABSTRACTION_ROUNDS
 
 };
 

--- a/lib/Interface/c_interface.cpp
+++ b/lib/Interface/c_interface.cpp
@@ -515,11 +515,9 @@ void vc_setInterfaceFlags(VC vc, enum ifaceflag_t f, int param_value)
     case CADICAL:
       b->UserFlags.solver_to_use = stp::UserDefinedFlags::CADICAL_SOLVER;
       break;
-    // The refinement knobs the CLI exposes as --uf-narrow-results,
-    // --uf-inject-args, --bv-eq-abstraction, --bv-eq-abstraction-width,
-    // --bv-eq-refine-width and --bv-term-abstraction. Each sets the same
-    // UserFlags field the CLI parser writes, so a C API client reaches the
-    // encodings that until now only a query read from a file could.
+    // The refinement knobs the CLI exposes. Each sets the same UserFlags
+    // field the CLI parser writes, so a C API client reaches the encodings
+    // that until now only a query read from a file could.
     case UF_NARROW_RESULTS:
       b->UserFlags.uf_narrow_results = param_value != 0;
       break;
@@ -532,9 +530,32 @@ void vc_setInterfaceFlags(VC vc, enum ifaceflag_t f, int param_value)
     case DISTINCT_ORDERING:
       b->UserFlags.distinct_ordering = param_value != 0;
       break;
-    // The two fields below are unsigned in UserFlags, so a negative value
-    // would wrap to something enormous: a budget so large it is no budget at
-    // all. Refuse it and leave the field as it was.
+    case BV_EQ_ABSTRACTION:
+      b->UserFlags.bv_eq_abstraction = param_value != 0;
+      break;
+    case BV_TERM_ABSTRACTION:
+      b->UserFlags.bv_term_abstraction = param_value != 0;
+      break;
+    case BV_TERM_ABSTRACTION_MULT:
+      b->UserFlags.bv_term_abstraction_mult = param_value != 0;
+      break;
+    // Every field below is unsigned in UserFlags, so a negative value would
+    // wrap to something enormous: for a width, a threshold no term can reach;
+    // for a budget, no limit at all. Refuse it and leave the field as it was.
+    case BV_ABSTRACTION_WIDTH:
+      if (nonNegativeFlag(param_value, "BV_ABSTRACTION_WIDTH"))
+        b->UserFlags.bv_abstraction_width =
+            static_cast<unsigned>(param_value);
+      break;
+    case BV_EQ_REFINE_WIDTH:
+      if (nonNegativeFlag(param_value, "BV_EQ_REFINE_WIDTH"))
+        b->UserFlags.bv_eq_refine_width = static_cast<unsigned>(param_value);
+      break;
+    case BV_TERM_ABSTRACTION_ROUNDS:
+      if (nonNegativeFlag(param_value, "BV_TERM_ABSTRACTION_ROUNDS"))
+        b->UserFlags.bv_term_abstraction_rounds =
+            static_cast<unsigned>(param_value);
+      break;
     case UF_LEMMAS_PER_ROUND:
       if (nonNegativeFlag(param_value, "UF_LEMMAS_PER_ROUND"))
         b->UserFlags.uf_lemmas_per_round = static_cast<unsigned>(param_value);

--- a/tests/api/C/CMakeLists.txt
+++ b/tests/api/C/CMakeLists.txt
@@ -24,6 +24,7 @@
 # -----------------------------------------------------------------------------
 AddSTPGTest(array-cvcl-02.cpp)
 AddSTPGTest(array-equality-retired-after-pop.cpp)
+AddSTPGTest(bv-abstraction-array-candidate-is-bound.cpp)
 AddSTPGTest(array-extensionality.cpp)
 AddSTPGTest(array-ite.cpp)
 AddSTPGTest(b4-c2.cpp)

--- a/tests/api/C/bv-abstraction-array-candidate-is-bound.cpp
+++ b/tests/api/C/bv-abstraction-array-candidate-is-bound.cpp
@@ -1,0 +1,155 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: August 2026
+ *
+ * LICENSE: Please view LICENSE file in the home dir of this Program
+ ********************************************************************/
+
+#include <gtest/gtest.h>
+#include <stp/c_interface.h>
+
+#include <string>
+
+// The array-equality consistency checker owns the complete array graph for a
+// solve, and ConstructCounterExample refuses to materialize a candidate before
+// that graph has been bound -- a model assembled ahead of the checker would be
+// read back as if the checker had certified it.
+//
+// A BV abstraction can reach that point first. It replaces an operation with
+// free Booleans and is refined from candidate models, so the driver has to pin
+// it before anything else reads the candidate; where it did not, a solve whose
+// array equality was still pending had a candidate built underneath it:
+//
+//   Fatal Error: array-equality: a SAT candidate was materialized before the
+//   complete array graph was bound
+//
+// The shape is a reduced fuzzer trace and every part of it is load-bearing.
+// The array disequality is not asserted until after the first solve has fixed
+// the abstraction records, and it arrives inside an assumption scope, so the
+// graph for it is bound on a later round than the one the abstraction was
+// installed on. A hand-written sequence does not get there: with the fix
+// reverted, half a dozen other guards on this route fire first, and only this
+// ordering reaches the one under test.
+//
+// Both queries answer for the caller's assertions, so the test pins the
+// verdicts as well as the absence of the abort: the first is unsatisfiable
+// under its assumptions and the second, with those assumptions retracted, is
+// satisfiable.
+
+namespace
+{
+
+// vc_query: 1 = VALID (the assertions are unsatisfiable), 0 = INVALID (they
+// are satisfiable, and a model is available).
+const int SAT = 0;
+const int UNSAT = 1;
+
+const int WIDE = 88;  // the width the abstraction engages on here
+const int INDEX = 32;
+
+} // namespace
+
+TEST(bv_abstraction_array_candidate_is_bound,
+     array_disequality_inside_an_assumption_scope)
+{
+  VC vc = vc_createValidityChecker();
+
+  vc_setFlag(vc, 'x'); // decide whole-array equality (extensional arrays)
+  vc_setFlag(vc, 'u'); // uninterpreted functions
+  vc_setInterfaceFlags(vc, BV_EQ_ABSTRACTION, 1);
+  vc_setInterfaceFlags(vc, BV_TERM_ABSTRACTION, 1);
+  vc_setInterfaceFlags(vc, BV_ABSTRACTION_WIDTH, 1);
+  vc_setInterfaceFlags(vc, BV_EQ_REFINE_WIDTH, 1);
+  vc_setFlag(vc, 'i'); // incremental driver from the first query
+
+  Type wide = vc_bvType(vc, WIDE);
+  Expr x = vc_varExpr(vc, "x", wide);
+  Expr y = vc_varExpr(vc, "y", wide);
+  Expr z = vc_varExpr(vc, "z", wide);
+  Expr w = vc_varExpr(vc, "w", wide);
+  Expr v = vc_varExpr(vc, "v", wide);
+
+  Expr maxSigned = vc_bvConstExprFromStr(
+      vc, std::string("0" + std::string(WIDE - 1, '1')).c_str());
+  Expr minSigned = vc_bvConstExprFromStr(
+      vc, std::string("1" + std::string(WIDE - 1, '0')).c_str());
+  Expr zero =
+      vc_bvConstExprFromStr(vc, std::string(WIDE, '0').c_str());
+
+  // A comparison over abstracted arithmetic: the term abstraction stands in
+  // for the remainder, and the comparison is what the refinement pins.
+  Expr rem = vc_sbvRemExpr(vc, WIDE, vc_bvUMinusExpr(vc, maxSigned),
+                           vc_bvUMinusExpr(vc, minSigned));
+  Expr remGtX = vc_bvGtExpr(vc, rem, x);
+  Expr quotient = vc_bvDivExpr(vc, WIDE, minSigned, minSigned);
+
+  Type unaryDomain[1] = {wide};
+  UFDeclHandle f =
+      vc_declareUninterpretedFunction(vc, "f", unaryDomain, 1, wide);
+  ASSERT_NE(0u, f);
+
+  Type predicateDomain[4] = {wide, vc_boolType(vc), wide, vc_boolType(vc)};
+  UFDeclHandle p = vc_declareUninterpretedFunction(
+      vc, "p", predicateDomain, 4, vc_boolType(vc));
+  ASSERT_NE(0u, p);
+
+  Expr rm = vc_fpRoundingModeVar(vc, "rm");
+  Expr converted = vc_fpToFPFromUnsignedBV(vc, 8, 24, rm, y);
+  Expr isNaN = vc_fpIsNaNExpr(vc, converted);
+
+  Expr pArgs0[4] = {v, remGtX, y, remGtX};
+  Expr p0 = vc_applyUninterpretedFunction(vc, p, pArgs0, 4);
+  ASSERT_NE(nullptr, p0);
+
+  Expr pArgs1[4] = {minSigned, vc_iffExpr(vc, remGtX, p0), y,
+                    vc_sbvGeExpr(vc, z, w)};
+  Expr p1 = vc_applyUninterpretedFunction(vc, p, pArgs1, 4);
+  ASSERT_NE(nullptr, p1);
+
+  Expr fArgs[1] = {y};
+  Expr fy = vc_applyUninterpretedFunction(vc, f, fArgs, 1);
+  ASSERT_NE(nullptr, fy);
+
+  Expr pArgs2[4] = {fy, isNaN, rem, p0};
+  Expr p2 = vc_applyUninterpretedFunction(vc, p, pArgs2, 4);
+  ASSERT_NE(nullptr, p2);
+
+  Expr pArgs3[4] = {y, remGtX, vc_varExpr(vc, "u", wide), remGtX};
+  Expr p3 = vc_applyUninterpretedFunction(vc, p, pArgs3, 4);
+  ASSERT_NE(nullptr, p3);
+
+  Expr pArgs4[4] = {zero, p3, y, p1};
+  Expr p4 = vc_applyUninterpretedFunction(vc, p, pArgs4, 4);
+  ASSERT_NE(nullptr, p4);
+
+  Expr root[2] = {p4, p2};
+  vc_assertFormula(vc, vc_andExprN(vc, root, 2));
+
+  // The array only enters after the abstraction records exist.
+  Expr array =
+      vc_varExpr(vc, "a", vc_arrayType(vc, vc_bvType(vc, INDEX), wide));
+  Expr index = vc_varExpr(vc, "i", vc_bvType(vc, INDEX));
+  Expr storeAtIndex = vc_writeExpr(vc, array, index, y);
+  Expr storeAtConst = vc_writeExpr(
+      vc, array,
+      vc_bvConstExprFromStr(vc, "01111011000001100101000100110101"),
+      quotient);
+  Expr storesDiffer =
+      vc_notExpr(vc, vc_eqExpr(vc, storeAtConst, storeAtIndex));
+
+  Expr pArgs5[4] = {x, p0, x, storesDiffer};
+  Expr p5 = vc_applyUninterpretedFunction(vc, p, pArgs5, 4);
+  ASSERT_NE(nullptr, p5);
+
+  vc_push(vc);
+  vc_assertFormula(vc, vc_iffExpr(vc, isNaN, p0));
+  vc_assertFormula(vc, p0);
+  vc_assertFormula(vc, vc_iffExpr(vc, p5, p0));
+  EXPECT_EQ(UNSAT, vc_query(vc, vc_falseExpr(vc)));
+
+  vc_pop(vc);
+  EXPECT_EQ(SAT, vc_query(vc, vc_falseExpr(vc)));
+
+  vc_Destroy(vc);
+}

--- a/tests/api/C/refinement-flags.cpp
+++ b/tests/api/C/refinement-flags.cpp
@@ -30,7 +30,10 @@ THE SOFTWARE.
 // UserFlags field the CLI parser writes -- the two refinement profiles
 // (--uf-narrow-results, --uf-inject-args), the eager congruence encoding
 // (--uf-ackermann, --uf-ackermann-budget, --uf-lemmas-per-round,
-// --uf-phase-hints), the declared-sort carrier (--uf-sort-width), the distinct
+// --uf-phase-hints), the declared-sort carrier (--uf-sort-width), the BV
+// abstractions and what bounds them (--bv-eq-abstraction,
+// --bv-abstraction-width, --bv-eq-refine-width, --bv-term-abstraction,
+// --bv-term-abstraction-mult, --bv-term-abstraction-rounds), the distinct
 // rewrite (--distinct-ordering) and the bit-blasting limit
 // (--aig-node-budget). --uninterpreted-functions itself already had a route,
 // through vc_setFlag(vc, 'u').
@@ -71,6 +74,12 @@ TEST(refinement_flags, DefaultsAreTheOnesTheCommandLineDocuments)
   EXPECT_EQ(16u, flags(vc).uf_sort_width);
   EXPECT_TRUE(flags(vc).distinct_ordering);
   EXPECT_EQ(-1, flags(vc).aig_node_budget);
+  EXPECT_FALSE(flags(vc).bv_eq_abstraction);
+  EXPECT_EQ(64u, flags(vc).bv_abstraction_width);
+  EXPECT_EQ(0u, flags(vc).bv_eq_refine_width);
+  EXPECT_FALSE(flags(vc).bv_term_abstraction);
+  EXPECT_TRUE(flags(vc).bv_term_abstraction_mult);
+  EXPECT_EQ(32u, flags(vc).bv_term_abstraction_rounds);
   vc_Destroy(vc);
 }
 
@@ -106,6 +115,38 @@ TEST(refinement_flags, EachFlagReachesTheFieldTheCLIWrites)
   vc_setInterfaceFlags(vc, DISTINCT_ORDERING, 1);
   EXPECT_TRUE(flags(vc).distinct_ordering);
 
+  vc_setInterfaceFlags(vc, BV_EQ_ABSTRACTION, 1);
+  EXPECT_TRUE(flags(vc).bv_eq_abstraction);
+  vc_setInterfaceFlags(vc, BV_EQ_ABSTRACTION, 0);
+  EXPECT_FALSE(flags(vc).bv_eq_abstraction);
+
+  vc_setInterfaceFlags(vc, BV_TERM_ABSTRACTION, 1);
+  EXPECT_TRUE(flags(vc).bv_term_abstraction);
+  vc_setInterfaceFlags(vc, BV_TERM_ABSTRACTION, 0);
+  EXPECT_FALSE(flags(vc).bv_term_abstraction);
+
+  vc_setInterfaceFlags(vc, BV_TERM_ABSTRACTION_MULT, 0);
+  EXPECT_FALSE(flags(vc).bv_term_abstraction_mult);
+  vc_setInterfaceFlags(vc, BV_TERM_ABSTRACTION_MULT, 1);
+  EXPECT_TRUE(flags(vc).bv_term_abstraction_mult);
+
+  // Any nonzero enables, as everywhere else in this call.
+  vc_setInterfaceFlags(vc, BV_EQ_ABSTRACTION, 2);
+  EXPECT_TRUE(flags(vc).bv_eq_abstraction);
+
+  vc_setInterfaceFlags(vc, BV_ABSTRACTION_WIDTH, 1);
+  EXPECT_EQ(1u, flags(vc).bv_abstraction_width);
+  vc_setInterfaceFlags(vc, BV_ABSTRACTION_WIDTH, 0);
+  EXPECT_EQ(0u, flags(vc).bv_abstraction_width);
+
+  vc_setInterfaceFlags(vc, BV_EQ_REFINE_WIDTH, 8);
+  EXPECT_EQ(8u, flags(vc).bv_eq_refine_width);
+
+  vc_setInterfaceFlags(vc, BV_TERM_ABSTRACTION_ROUNDS, 0);
+  EXPECT_EQ(0u, flags(vc).bv_term_abstraction_rounds);
+  vc_setInterfaceFlags(vc, BV_TERM_ABSTRACTION_ROUNDS, 4);
+  EXPECT_EQ(4u, flags(vc).bv_term_abstraction_rounds);
+
   // Zero is a meaning of its own for both of these, not an absence: install
   // every conflict the candidate exposes, and a budget of no gates at all.
   vc_setInterfaceFlags(vc, UF_LEMMAS_PER_ROUND, 0);
@@ -138,27 +179,38 @@ TEST(refinement_flags, EachFlagReachesTheFieldTheCLIWrites)
   vc_Destroy(vc);
 }
 
-// A negative count would wrap to a budget nothing can exhaust, silently
-// removing the limit the caller was asking for. It is refused with a
-// diagnostic and the field it would have wrecked is left as it was.
-TEST(refinement_flags, ANegativeCountIsRefusedAndLeavesTheFieldAlone)
+// A negative value would wrap in every unsigned field below, silently
+// disabling an abstraction or removing the limit the caller asked for. It is
+// refused with a diagnostic and the field it would have wrecked is unchanged.
+TEST(refinement_flags, ANegativeUnsignedValueIsRefusedAndLeavesTheFieldAlone)
 {
   vc_registerErrorHandler(countError);
   errors = 0;
 
   VC vc = vc_createValidityChecker();
+  vc_setInterfaceFlags(vc, BV_ABSTRACTION_WIDTH, 32);
+  vc_setInterfaceFlags(vc, BV_EQ_REFINE_WIDTH, 4);
+  vc_setInterfaceFlags(vc, BV_TERM_ABSTRACTION_ROUNDS, 12);
+
+  vc_setInterfaceFlags(vc, BV_ABSTRACTION_WIDTH, -1);
+  EXPECT_EQ(32u, flags(vc).bv_abstraction_width);
+  vc_setInterfaceFlags(vc, BV_EQ_REFINE_WIDTH, -64);
+  EXPECT_EQ(4u, flags(vc).bv_eq_refine_width);
+  vc_setInterfaceFlags(vc, BV_TERM_ABSTRACTION_ROUNDS, -2);
+  EXPECT_EQ(12u, flags(vc).bv_term_abstraction_rounds);
+
   vc_setInterfaceFlags(vc, UF_LEMMAS_PER_ROUND, -1);
   EXPECT_EQ(8u, flags(vc).uf_lemmas_per_round);
   vc_setInterfaceFlags(vc, UF_ACKERMANN_BUDGET, -1);
   EXPECT_EQ(256u, flags(vc).uf_eager_budget);
-  EXPECT_EQ(2, errors);
+  EXPECT_EQ(5, errors);
 
   // The AIG budget is signed underneath and -1 is a value of its own there,
   // so only a value below it names nothing and only that is refused.
   vc_setInterfaceFlags(vc, AIG_NODE_BUDGET, 7);
   vc_setInterfaceFlags(vc, AIG_NODE_BUDGET, -2);
   EXPECT_EQ(7, flags(vc).aig_node_budget);
-  EXPECT_EQ(3, errors);
+  EXPECT_EQ(6, errors);
 
   vc_Destroy(vc);
   vc_registerErrorHandler(nullptr);

--- a/tests/query-files/incremental-tests/bv-abstraction-verdict-survives.smt2
+++ b/tests/query-files/incremental-tests/bv-abstraction-verdict-survives.smt2
@@ -1,0 +1,36 @@
+; An unrefined abstraction is an over-approximation, so it can answer sat to
+; a query that is not.
+;
+; The persistent driver bit-blasted through a blaster that was abstracting and
+; then never refined, which makes every abstracted equality a free Boolean for
+; the life of the solve. A relaxation has models the query does not, and this
+; query -- the smallest one found that reaches it -- is one where that showed:
+; unabstracted it is unsatisfiable, and the round that noticed the candidate
+; was not a model of it had no owner able to say why, so the driver stopped on
+; its own guard rather than on an answer:
+;
+;   Fatal Error: IncrementalSolver: UF refinement rejected a candidate without
+;   retaining a block-scoped lemma
+;
+; The guard was right that the loop could not progress. What was missing is
+; the party that should have progressed it: the equality inside the rounding
+; mode's carrier had been replaced by a Boolean nobody was pinning.
+;
+; The two legs must agree, and what they have to agree on is unsat -- a leg
+; that merely does not abort would pass on a lost refutation.
+;
+; RUN: %solver --incremental=on --uninterpreted-functions --bv-eq-abstraction=1 --bv-abstraction-width=1 %s 2>&1 | %OutputCheck --check-prefix=ABSTRACTED %s
+; RUN: %solver --incremental=on --uninterpreted-functions %s 2>&1 | %OutputCheck --check-prefix=PLAIN %s
+;
+; ABSTRACTED-NOT: Fatal Error
+; ABSTRACTED-NOT: Assertion
+; ABSTRACTED: ^unsat$
+;
+; PLAIN: ^unsat$
+;
+(set-logic QF_UFFP)
+(declare-fun x0 (Bool) Bool)
+(declare-const x2 RoundingMode)
+(assert (fp.isZero (ite (x0 (= RNE RNE)) (_ -oo 3 5) (fp.roundToIntegral x2 (fp #b1 #b101 #b0110)))))
+(check-sat)
+(exit)

--- a/tests/query-files/misc-tests/bv-abstraction-uf-carrier-is-a-real-mode.smt2
+++ b/tests/query-files/misc-tests/bv-abstraction-uf-carrier-is-a-real-mode.smt2
@@ -1,0 +1,36 @@
+; The UF checker is never handed a candidate an abstraction has not been
+; refined against.
+;
+; A RoundingMode is carried as a bit vector of which only five values name a
+; mode. The UF congruence checker reads the carrier of an application's
+; argument and result back out of the candidate model and asserts it is one of
+; those five, because every carrier it can legitimately be shown was written by
+; the lowering's own equations.
+;
+; --bv-eq-abstraction replaces those equations' equalities by free Booleans
+; until refinement pins them, so the solver was free to leave the carrier on
+; one of the bit patterns that denotes nothing, and the checker read it:
+;
+;   Fatal Error: UFCHK internal error: UFCHK read a RoundingMode carrier that
+;   denotes no mode
+;
+; The invariant is the checker's to keep and it is not wrong; what was wrong
+; is who it was asked about. The abstraction is now the first refinement owner
+; consulted on a candidate, before either theory checker and before model
+; evaluation, so a candidate that contradicts one never reaches them.
+;
+; One application of one RoundingMode function is enough to reach it.
+;
+; RUN: %solver --incremental=off -d --uninterpreted-functions --bv-eq-abstraction=1 --bv-abstraction-width=1 %s 2>&1 | %OutputCheck --check-prefix=ABSTRACTED %s
+; RUN: %solver --incremental=off -d --uninterpreted-functions %s 2>&1 | %OutputCheck --check-prefix=PLAIN %s
+;
+; ABSTRACTED-NOT: Fatal Error
+; ABSTRACTED-NOT: Assertion
+; ABSTRACTED: ^sat$
+;
+; PLAIN: ^sat$
+;
+(set-logic QF_UFFP)
+(declare-fun f (RoundingMode) RoundingMode)
+(assert (= (f RTN) RTN))
+(check-sat)


### PR DESCRIPTION
## Summary

- expose all six BV-abstraction settings through the C API, appending their enum values after `AIG_NODE_BUDGET`
- reject negative count and width values before converting them to unsigned fields
- restore the UF-carrier and incremental-verdict SMT-LIB regressions
- restore the original C API array-equality reproducer in C

## Testing

- GCC 11.5 with `WERROR=ON`: build at `--parallel 24`; 152/152 tests passed
- Clang 21.1.6 with `WERROR=ON`: build at `--parallel 24`; 152/152 tests passed
- all four CI `rewrite_rule_gen` smoke checks passed