### PR TITLE
Gate eager array expansion on its estimated cost

### DIFF
--- a/include/stp/AST/AST.h
+++ b/include/stp/AST/AST.h
@@ -74,6 +74,11 @@ bool containsArrayOps(const ASTNode& n, STPMgr* stp);
 bool containsFloatingPoint(const ASTNode& n, STPMgr* stp);
 bool containsFloatingPointTheory(const ASTNode& n, STPMgr* stp);
 bool numberOfReadsLessThan(const ASTNode& n, int v);
+// Whether the estimated structural cost of eagerly expanding every array read
+// is less than `limit`. See the definition: the read count alone does not
+// distinguish a cheap expansion from one that is dozens of times slower than
+// refinement.
+bool arrayEagerCostLessThan(const ASTNode& n, uint64_t limit);
 
 // Whether two constants spell the same bits. Node identity understates
 // this: a floating-point constant interns apart from the plain bitvector

--- a/lib/AST/ASTmisc.cpp
+++ b/lib/AST/ASTmisc.cpp
@@ -154,6 +154,87 @@ bool numberOfReadsLessThan(const ASTNode& n, int limit)
   }
 }
 
+// A bounded estimate of eager array Ackermannisation's structural cost.
+//
+// The read count the policy gates on is a proxy for how much the transform
+// builds, and it is a bad one: a read whose array operand is a chain of
+// WRITEs becomes one if-then-else per link in that chain, so nine reads over a
+// four-thousand-deep store chain add thirty-six thousand nodes beyond the
+// flat-array baseline. Measured, that is the difference between 0.12s and 5.8s
+// on the same query -- the eager path is 48x SLOWER there than leaving it to
+// read refinement.
+//
+// So this charges each distinct read for the WRITE and array-valued ITE nodes
+// reachable beneath its array operand, and stops as soon as the bound is
+// reached. It says nothing about the index-equality axioms the transform also
+// builds; it is the structural term that makes the difference between a cheap
+// eager expansion and a catastrophic one.
+bool arrayEagerCostLessThan(const ASTNode& n, uint64_t limit)
+{
+  if (limit == 0)
+    return false;
+
+  uint64_t cost = 0;
+  const auto charge = [&]() {
+    // The predicate is strict. Checking before incrementing also avoids
+    // wrapping when a caller supplies the largest possible bound.
+    if (cost >= limit - 1)
+      return false;
+    ++cost;
+    return true;
+  };
+
+  // Charge the structural expansion under one read. The transform pushes a
+  // read through both branches of an array-valued ITE, so both branches must
+  // be visited: following only one makes the policy depend on branch order.
+  // Shared array nodes are charged once per read, matching the transform map's
+  // sharing, while a shared spine reached by different reads is charged once
+  // for each read because each index produces its own expansion.
+  const auto chargeExpansion = [&](const ASTNode& start) {
+    std::unordered_set<uint64_t> expanded;
+    std::vector<ASTNode> pending(1, start);
+    while (!pending.empty())
+    {
+      const ASTNode current = pending.back();
+      pending.pop_back();
+      const auto kind = current.GetKind();
+      const bool arrayIte = kind == ITE && current.GetIndexWidth() > 0;
+      if ((kind != WRITE && !arrayIte) ||
+          !expanded.insert(current.GetNodeNum()).second)
+        continue;
+
+      if (!charge())
+        return false;
+      if (kind == WRITE)
+        pending.push_back(current[0]);
+      else
+      {
+        pending.push_back(current[1]);
+        pending.push_back(current[2]);
+      }
+    }
+    return true;
+  };
+
+  std::unordered_set<uint64_t> visited;
+  std::vector<ASTNode> pending(1, n);
+  while (!pending.empty())
+  {
+    const ASTNode current = pending.back();
+    pending.pop_back();
+    if (current.isAtom() || !visited.insert(current.GetNodeNum()).second)
+      continue;
+    if (current.GetKind() == READ)
+    {
+      if (!charge() || !chargeExpansion(current[0]))
+        return false;
+    }
+    for (size_t i = 0; i < current.Degree(); ++i)
+      pending.push_back(current[i]);
+  }
+  return true;
+}
+
 // See the declaration for why this exists: constants of one value need
 // not be one node, because a floating-point constant interns apart from
 // the plain constant with its bits.

--- a/lib/STPManager/STP.cpp
+++ b/lib/STPManager/STP.cpp
@@ -567,9 +567,22 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
   // TODO: I chose the number of reads we perform this operation at randomly.
   bool removed = false;
   const int arrayReadLimit = bm->UserFlags.ackermannisation ? 50 : 10;
+  // The read count is a proxy for what the transform builds, and on its own a
+  // poor one: a read over a chain of WRITEs becomes one ITE per link, so nine
+  // reads over a deep store chain expand into tens of thousands of nodes and
+  // take 48x longer than leaving them to read refinement. Ask what the
+  // expansion would actually cost as well, so the flat-array queries this
+  // threshold was tuned for still take it and the deep-chain ones do not.
+  // Give each read admitted by the count policy twenty structural expansion
+  // units before preferring refinement. This is a safety threshold, not a
+  // prediction of total solver work.
+  constexpr uint64_t arrayEagerCostPerRead = 20;
+  const uint64_t arrayEagerCostLimit =
+      static_cast<uint64_t>(arrayReadLimit) * arrayEagerCostPerRead;
   if (arrayops &&
       !extActive && // array equality needs the refinement loop
-      numberOfReadsLessThan(inputToSat, arrayReadLimit))
+      numberOfReadsLessThan(inputToSat, arrayReadLimit) &&
+      arrayEagerCostLessThan(inputToSat, arrayEagerCostLimit))
   {
     // If the number of axioms that would be added it small. Remove them.
     bm->UserFlags.ackermannisation = true;

--- a/tests/query-files/smt2-command-tests/array-eager-cost-gate.smt2
+++ b/tests/query-files/smt2-command-tests/array-eager-cost-gate.smt2
@@ -1,0 +1,51 @@
+; Eager array Ackermannisation is gated on what the expansion would build,
+; not only on how many reads there are.
+;
+; A read whose array operand is a chain of stores becomes one if-then-else per
+; link in that chain, so the read count alone cannot tell a cheap expansion from
+; a ruinous one: nine reads over a deep chain expand into tens of thousands of
+; nodes and took 48x longer than leaving them to read refinement, on a query
+; differing from a fast one by a single read.
+;
+; All three legs here have nine reads, which is under the count threshold. The
+; first two read through an array-valued ITE with the same 25-deep store chain
+; on opposite branches; neither may take the eager path, because the transform
+; expands both branches. The third reads the bare array and must take the eager
+; path, proving the gate still admits the flat queries the threshold was tuned
+; for.
+;
+; RUN: %solver -s --incremental=off %s 2>&1 | %OutputCheck %s
+; CHECK-NOT: Have removed array operations
+; CHECK: ^sat
+; CHECK: SHALLOW-THEN-DONE
+; CHECK-NOT: Have removed array operations
+; CHECK: ^sat
+; CHECK: DEEP-THEN-DONE
+; CHECK: Have removed array operations
+; CHECK: ^sat
+;
+(set-logic QF_ABV)
+(declare-const A (Array (_ BitVec 16) (_ BitVec 16)))
+(declare-const c Bool)
+(declare-const r0 (_ BitVec 16))
+(declare-const r1 (_ BitVec 16))
+(declare-const r2 (_ BitVec 16))
+(declare-const r3 (_ BitVec 16))
+(declare-const r4 (_ BitVec 16))
+(declare-const r5 (_ BitVec 16))
+(declare-const r6 (_ BitVec 16))
+(declare-const r7 (_ BitVec 16))
+(declare-const r8 (_ BitVec 16))
+(define-fun deep () (Array (_ BitVec 16) (_ BitVec 16)) (store (store (store (store (store (store (store (store (store (store (store (store (store (store (store (store (store (store (store (store (store (store (store (store (store A (_ bv0 16) (_ bv1 16)) (_ bv1 16) (_ bv4 16)) (_ bv2 16) (_ bv7 16)) (_ bv3 16) (_ bv10 16)) (_ bv4 16) (_ bv13 16)) (_ bv5 16) (_ bv16 16)) (_ bv6 16) (_ bv19 16)) (_ bv7 16) (_ bv22 16)) (_ bv8 16) (_ bv25 16)) (_ bv9 16) (_ bv28 16)) (_ bv10 16) (_ bv31 16)) (_ bv11 16) (_ bv34 16)) (_ bv12 16) (_ bv37 16)) (_ bv13 16) (_ bv40 16)) (_ bv14 16) (_ bv43 16)) (_ bv15 16) (_ bv46 16)) (_ bv16 16) (_ bv49 16)) (_ bv17 16) (_ bv52 16)) (_ bv18 16) (_ bv55 16)) (_ bv19 16) (_ bv58 16)) (_ bv20 16) (_ bv61 16)) (_ bv21 16) (_ bv64 16)) (_ bv22 16) (_ bv67 16)) (_ bv23 16) (_ bv70 16)) (_ bv24 16) (_ bv73 16)))
+(push 1)
+(assert (distinct (select (ite c A deep) r0) (select (ite c A deep) r1) (select (ite c A deep) r2) (select (ite c A deep) r3) (select (ite c A deep) r4) (select (ite c A deep) r5) (select (ite c A deep) r6) (select (ite c A deep) r7) (select (ite c A deep) r8)))
+(check-sat)
+(echo "SHALLOW-THEN-DONE")
+(pop 1)
+(push 1)
+(assert (distinct (select (ite c deep A) r0) (select (ite c deep A) r1) (select (ite c deep A) r2) (select (ite c deep A) r3) (select (ite c deep A) r4) (select (ite c deep A) r5) (select (ite c deep A) r6) (select (ite c deep A) r7) (select (ite c deep A) r8)))
+(check-sat)
+(echo "DEEP-THEN-DONE")
+(pop 1)
+(assert (distinct (select A r0) (select A r1) (select A r2) (select A r3) (select A r4) (select A r5) (select A r6) (select A r7) (select A r8)))
+(check-sat)


### PR DESCRIPTION
## Summary

- add a bounded per-read DAG walk that estimates eager array expansion cost
- traverse both arms of array-valued ITEs and count shared structural nodes once per read, so the decision is independent of branch order
- gate eager Ackermannisation on that estimate while retaining the existing read-count threshold
- keep flat arrays eligible and decline expensive deep WRITE chains
- add a three-leg SMT-LIB regression covering both ITE branch orders and the flat positive case

## Testing

- GCC 11.5 with `WERROR=ON`: build at `--parallel 24`; 151/151 tests passed
- Clang 21.1.6 with `WERROR=ON`: build at `--parallel 24`; 151/151 tests passed
- all 760 query-file tests passed, including the new branch-order regression
- all four CI `rewrite_rule_gen` smoke checks passed under both compilers