### PR TITLE
Make unknown the sole no-answer verdict

### DIFF
--- a/docs/array-extensionality.rst
+++ b/docs/array-extensionality.rst
@@ -82,8 +82,8 @@ whole-array equality is refused with an error naming the option, where
 the baseline warned and continued (pinned by a lit test). One
 behavioral corner also deliberately differs: when the
 soft timeout expires while lazy refinement is still undecided, the
-solve now reports a timeout where it previously aborted with an
-internal error.
+solve now reports ``unknown`` with a timeout reason where it previously
+aborted with an internal error.
 
 Limitations: arrays of arrays are not supported (STP's sort system has
 no nested array sorts), and there is no constant-array

--- a/include/stp/Globals/Globals.h
+++ b/include/stp/Globals/Globals.h
@@ -83,7 +83,7 @@ enum SOLVER_RETURN_TYPE
   // caller that only wants to know whether there is an answer keeps the one
   // test it already had, and the budgets are told apart by
   // (get-info :reason-unknown) rather than by the verdict.
-  SOLVER_TIMEOUT = 3,
+  SOLVER_UNKNOWN = 3,
   SOLVER_ERROR = -100,
   SOLVER_UNSATISFIABLE = 1,
   SOLVER_SATISFIABLE = 0
@@ -104,14 +104,14 @@ enum class UnknownReason
   // deterministic and will not.
   ConflictBudget,
   // Something other than a budget on the search: the encoding itself was
-  // abandoned. Carries its own sentence in STPMgr::unknown_detail, because
+  // abandoned. Carries its own sentence in STPMgr's unknown detail, because
   // the name alone does not say what was abandoned or what to do about it.
-  // The two below are that same claim with a name of their own, appended
-  // rather than inserted so that nothing already reporting Incomplete moves.
-  // SMT-LIB2 spells all three the same, as (incomplete "..."), since the
-  // sentence already says which; they are separate values because a caller
-  // holding only the value -- vc_getReasonUnknown -- has nothing to read the
-  // sentence for, and the action differs: each names a different flag.
+  // The named causes below are that same claim with a name of their own,
+  // appended rather than inserted so that nothing already reporting
+  // Incomplete moves. SMT-LIB2 spells all of them the same, as (incomplete
+  // "..."), since the sentence already says which; they are separate values
+  // because a caller holding only the value -- vc_getReasonUnknown -- has
+  // nothing to read the sentence for, and the action differs.
   Incomplete,
   // A declared sort's carrier was too narrow for the query, so an unsat that
   // may be an artefact of the encoding was withheld. Raise --uf-sort-width.
@@ -121,7 +121,10 @@ enum class UnknownReason
   // may rest on it, so the unsat was withheld. Both shipped drivers do close
   // that question -- see STPMgr::solveRetractingInjectivity -- so this is the
   // floor a driver falls to rather than report an unsat nobody can attribute.
-  AssumedInjectivity
+  AssumedInjectivity,
+  // --aig-node-budget stopped bit-blasting before the AIG exhausted memory.
+  // Raise that budget; the accompanying sentence says what it stopped at.
+  AIGBudget
 };
 
 // Empty vector. Useful commonly used ASTNodes

--- a/include/stp/STPManager/STP.h
+++ b/include/stp/STPManager/STP.h
@@ -121,7 +121,7 @@ public:
   // vc_push or vc_query. ClearAllTables is where that discarding happens, so
   // that is where this is cleared; vc_query_with_timeout sets it again when
   // the query comes back decided, and leaves it clear when the answer was a
-  // timeout or an error, because neither leaves a model behind.
+  // unknown or an error, because neither leaves a model behind.
   //
   // The SMT-LIB2 frontend has always kept the equivalent (model_valid) and
   // answers "unsupported" without it. Nothing on the C API side did, so a

--- a/include/stp/STPManager/STPManager.h
+++ b/include/stp/STPManager/STPManager.h
@@ -115,6 +115,17 @@ private:
   ExtensionalityContext* extensionality = nullptr;
   UFContext* uninterpretedFunctions = nullptr;
 
+  // Why the last solve had no answer, and the sentence to give a caller who
+  // asks. Recorded rather than derived because the reasons are produced in
+  // different places -- a spent search budget wherever the solver was asked
+  // to run, an abandoned encoding before it ever was -- and only one of them
+  // has anything to say beyond its name. The SMT-LIB frontend clears this at
+  // the top of every check-sat and on reset / reset-assertions. SMT-LIB reads
+  // it through (get-info :reason-unknown), and the C API through
+  // vc_getReasonUnknown.
+  UnknownReason unknown_reason = UnknownReason::None;
+  std::string unknown_detail;
+
   // Table to uniquefy bvconst
   ASTBVConstSet _bvconst_unique_table;
 
@@ -151,16 +162,6 @@ public:
 
   bool soft_timeout_expired;
 
-  // Why the last solve had no answer, and the sentence to give a caller who
-  // asks. Recorded rather than derived because the reasons are produced in
-  // different places -- a spent search budget wherever the solver was asked
-  // to run, an abandoned encoding before it ever was -- and only one of them
-  // has anything to say beyond its name. The SMT-LIB frontend clears this at
-  // the top of every check-sat and on reset / reset-assertions, which is
-  // where (get-info :reason-unknown) reads it; no other caller can.
-  UnknownReason unknown_reason = UnknownReason::None;
-  std::string unknown_detail;
-
   // One named element of a declared sort: the sort, the name the model gives
   // it, and the carrier pattern it stands for.
   struct UninterpretedElement
@@ -177,9 +178,14 @@ public:
 
   void noteUnknown(UnknownReason reason, const std::string& detail = "")
   {
+    assert(reason != UnknownReason::None);
     unknown_reason = reason;
     unknown_detail = detail;
   }
+
+  UnknownReason getUnknownReason() const { return unknown_reason; }
+
+  const std::string& getUnknownReasonDetail() const { return unknown_detail; }
 
   // Called by whoever just watched this solver give up. Two budgets share the
   // no-answer exit and they are not the same claim to a caller: the wall
@@ -205,6 +211,17 @@ public:
   {
     unknown_reason = UnknownReason::None;
     unknown_detail.clear();
+  }
+
+  // The verdict deliberately says only that there was no answer; the reason
+  // is a separate, mandatory part of that result. Keeping the invariant at
+  // the point an unknown is returned prevents a new producer from silently
+  // resurrecting an unexplained timeout-shaped result.
+  SOLVER_RETURN_TYPE unknownResult() const
+  {
+    if (unknown_reason == UnknownReason::None)
+      FatalError("solver returned SOLVER_UNKNOWN without recording why");
+    return SOLVER_UNKNOWN;
   }
 
   // How much injectivity --uf-inject-args put into the encoding this solve is
@@ -361,9 +378,9 @@ public:
                     "may be an artefact of that assumption rather than a "
                     "refutation; re-run without --uf-inject-args to decide the "
                     "query");
-    // SOLVER_TIMEOUT is what every way of giving up returns; which cause it
-    // was is a question for (get-info :reason-unknown), recorded just above.
-    return SOLVER_TIMEOUT;
+    // SOLVER_UNKNOWN says only that there is no answer; the cause was
+    // recorded just above for the reason API.
+    return unknownResult();
   }
 
   // No nodes should already have the iteration number that is returned from

--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -343,8 +343,8 @@ public:
   // who transfers their intuition here must not get the opposite of what
   // they asked for. Exceeding the cap abandons the query through the
   // soft-timeout path, so the answer is the same one a `--max-time` expiry
-  // gives -- `unknown` on stdout in SMT-LIB mode (`Timed Out.` in the CVC
-  // language) with exit status 0, and SOLVER_TIMEOUT from the library.
+  // gives -- `unknown` on stdout in SMT-LIB mode (`Unknown.` in the CVC
+  // language) with exit status 0, and SOLVER_UNKNOWN from the library.
   // (get-info :reason-unknown) is what tells this budget from the clock.
   //
   // The cap governs the two AIGs a batch solve builds -- the bit-blast in

--- a/include/stp/c_interface.h
+++ b/include/stp/c_interface.h
@@ -360,7 +360,7 @@ enum ifaceflag_t
   //!
   //! Exceeding it ends the query without an answer: vc_query returns 3, the
   //! value every way of giving up returns, and vc_getReasonUnknown returns
-  //! REASON_UNKNOWN_INCOMPLETE with a sentence naming this budget and the
+  //! REASON_UNKNOWN_AIG_BUDGET with a sentence naming this budget and the
   //! count it stopped at -- the same sentence SMT-LIB2 reads through
   //! (get-info :reason-unknown).
   //!
@@ -544,11 +544,10 @@ enum reason_unknown_t
   //! Something stopped before an answer and has no value of its own here yet.
   //! vc_getReasonUnknownToBuffer gives the sentence, which says what.
   //!
-  //! The two below were this until they were named, and are appended rather
-  //! than inserted so that nothing already reporting as incomplete moves. A
-  //! caller that has not heard of a later addition compares unequal to every
-  //! value it knows and still has the sentence to fall back on, which is what
-  //! makes naming a cause a safe change to make.
+  //! Later named causes are appended rather than inserted so that nothing
+  //! already reporting as incomplete moves. A caller that has not heard of a
+  //! later addition compares unequal to every value it knows and still has the
+  //! sentence to fall back on, which makes naming a cause safe.
   REASON_UNKNOWN_INCOMPLETE,
 
   //! A sort introduced by (declare-sort S 0) had a carrier too narrow for the
@@ -573,7 +572,13 @@ enum reason_unknown_t
   //! for what it is because it is the floor those drivers would fall to, and
   //! because a caller reading a value it does not recognise is better served
   //! than one reading `unsat`.
-  REASON_UNKNOWN_ASSUMED_INJECTIVITY
+  REASON_UNKNOWN_ASSUMED_INJECTIVITY,
+
+  //! AIG_NODE_BUDGET stopped bit-blasting before the AIG exhausted memory.
+  //! Deterministic: re-running reproduces it exactly, so what is worth doing
+  //! is raising that budget. vc_getReasonUnknownToBuffer says how many AND
+  //! gates had been built when it stopped.
+  REASON_UNKNOWN_AIG_BUDGET
 };
 
 //! \brief Returns why the last query had no answer.
@@ -591,10 +596,10 @@ DLL_PUBLIC enum reason_unknown_t vc_getReasonUnknown(VC vc);
 //! 'len'. It is the responsibility of the caller to free the memory
 //! afterwards.
 //!
-//! REASON_UNKNOWN_INCOMPLETE, REASON_UNKNOWN_CARRIER_EXHAUSTED and
-//! REASON_UNKNOWN_ASSUMED_INJECTIVITY carry a sentence, saying what was
-//! reached or what was assumed; the causes their name alone is enough to act
-//! on write an empty string. Prose for a person to read: a caller deciding
+//! REASON_UNKNOWN_INCOMPLETE, REASON_UNKNOWN_CARRIER_EXHAUSTED,
+//! REASON_UNKNOWN_ASSUMED_INJECTIVITY and REASON_UNKNOWN_AIG_BUDGET carry a
+//! sentence, saying what was reached or what was assumed; the AIG sentence
+//! also gives the gate count. Prose is for a person to read: a caller deciding
 //! what to do next wants vc_getReasonUnknown, which is why the two are
 //! separate.
 DLL_PUBLIC void vc_getReasonUnknownToBuffer(VC vc, char** buf, size_t* len);
@@ -893,7 +898,7 @@ DLL_PUBLIC Expr vc_simplify(VC vc, Expr e);
 //!   0: if 'e' is INVALID
 //!   1: if 'e' is VALID
 //!   2: if errors occured
-//!   3: if the timeout was reached
+//!   3: if the query could not be answered; call vc_getReasonUnknown for why
 //!
 //! Note: only the cryptominisat and cadical solvers can abandon a search that
 //!       is already running. With the other solvers 'timeout_max_time' is
@@ -920,7 +925,7 @@ DLL_PUBLIC int vc_query(VC vc, Expr e);
 //! well sorted, and asserting it pins 'e' to the value.
 //!
 //! There has to be a model to read. A query must have been answered -- VALID
-//! or INVALID, not a timeout or an error -- and it must still be the last
+//! or INVALID, not UNKNOWN or an error -- and it must still be the last
 //! thing to have happened: as vc_pop and vc_push document, a counterexample
 //! survives vc_pop and is discarded by the next vc_push or vc_query. Called
 //! with no model behind it, this reports a nonfatal diagnostic through

--- a/include/stp/fp.hpp
+++ b/include/stp/fp.hpp
@@ -280,7 +280,7 @@ public:
   }
 
   // Solving. check() is true iff the assertions are satisfiable; a solver
-  // error or timeout throws rather than masquerading as unsatisfiable.
+  // unknown result or error throws rather than masquerading as unsatisfiable.
   void add(const Bool& b) { vc_assertFormula(vc_, b.raw()); }
   bool check()
   {
@@ -290,7 +290,8 @@ public:
     if (r == 1)
       return false;
     throw std::runtime_error(
-        "stp::fp::Solver::check: solver error or timeout (vc_query returned " +
+        "stp::fp::Solver::check: solver error or unknown result (vc_query "
+        "returned " +
         std::to_string(r) + ")");
   }
 

--- a/lib/AbsRefineCounterExample/CounterExample.cpp
+++ b/lib/AbsRefineCounterExample/CounterExample.cpp
@@ -2962,7 +2962,7 @@ AbsRefine_CounterExample::CallSAT_ResultCheck(SATSolver& SatSolver,
       ufTheoryAdapter != NULL && ufTheoryAdapter->active();
 
   if (bm->soft_timeout_expired)
-    return SOLVER_TIMEOUT;
+    return bm->unknownResult();
 
   if (!sat)
   {

--- a/lib/Incremental/IncrementalExactStack.cpp
+++ b/lib/Incremental/IncrementalExactStack.cpp
@@ -216,9 +216,9 @@ SOLVER_RETURN_TYPE IncrementalSolver::Impl::solvePlainExactStack(
     bm->GetRunTimes()->stop(RunTimes::Solving);
   }
 
-  // As in IncrementalSolver::checkSat: the SOLVER_TIMEOUT below is the same
-  // value a clock expiry returns, so which budget it was has to be taken from
-  // the solver here or not at all.
+  // As in IncrementalSolver::checkSat, the verdict below deliberately does
+  // not identify the exhausted budget, so the reason has to be taken from the
+  // solver here or not at all.
   if (bm->soft_timeout_expired)
     bm->noteBudgetExhausted(*solver);
 
@@ -238,7 +238,7 @@ SOLVER_RETURN_TYPE IncrementalSolver::Impl::solvePlainExactStack(
     solver->printStats();
 
   if (bm->soft_timeout_expired)
-    return SOLVER_TIMEOUT;
+    return bm->unknownResult();
 
   if (!sat)
   {

--- a/lib/Incremental/IncrementalSolver.cpp
+++ b/lib/Incremental/IncrementalSolver.cpp
@@ -612,8 +612,8 @@ IncrementalSolver::checkSatBody(const ASTVec& assertionsSMT2,
 
   // Say which budget stopped the search while the solver is still here to be
   // asked, the way the batch pipeline does in ToSATAIG::runSolver. The
-  // SOLVER_TIMEOUT below is all that survives this frame, and it is the same
-  // value a clock expiry returns, so a reason not taken here is one
+  // SOLVER_UNKNOWN below is all that survives this frame, so a reason not
+  // taken here is one
   // (get-info :reason-unknown) can never give.
   if (bm->soft_timeout_expired)
     bm->noteBudgetExhausted(*impl->solver);
@@ -640,7 +640,7 @@ IncrementalSolver::checkSatBody(const ASTVec& assertionsSMT2,
     impl->solver->printStats();
 
   if (bm->soft_timeout_expired)
-    return SOLVER_TIMEOUT;
+    return bm->unknownResult();
 
   if (!sat)
   {

--- a/lib/Interface/c_interface.cpp
+++ b/lib/Interface/c_interface.cpp
@@ -368,10 +368,12 @@ Expr wrap(const stp::ASTNode& n)
 // Whether the query that just returned this leaves anything to read. VALID
 // counts: there is no counterexample to a valid query, but that is the
 // decided answer to the question rather than an absence of one, and
-// GetCounterExample has its own arm for saying so. A timeout or an error
+// GetCounterExample has its own arm for saying so. An unknown or an error
 // decided nothing and cleared the tables on the way in.
 static int recordQueryOutcome(stp::STP* stp_i, int outcome)
 {
+  if (outcome == stp::SOLVER_UNKNOWN)
+    outcome = stp_i->bm->unknownResult();
   stp_i->queryAnswered = (outcome == stp::SOLVER_INVALID ||
                           outcome == stp::SOLVER_VALID);
   return outcome;
@@ -832,7 +834,7 @@ void vc_printCounterExampleToBuffer(VC vc, char** buf, size_t* len)
 
 enum reason_unknown_t vc_getReasonUnknown(VC vc)
 {
-  switch (mgr(vc)->unknown_reason)
+  switch (mgr(vc)->getUnknownReason())
   {
     case stp::UnknownReason::Timeout:
       return REASON_UNKNOWN_TIMEOUT;
@@ -844,6 +846,8 @@ enum reason_unknown_t vc_getReasonUnknown(VC vc)
       return REASON_UNKNOWN_CARRIER_EXHAUSTED;
     case stp::UnknownReason::AssumedInjectivity:
       return REASON_UNKNOWN_ASSUMED_INJECTIVITY;
+    case stp::UnknownReason::AIGBudget:
+      return REASON_UNKNOWN_AIG_BUDGET;
     case stp::UnknownReason::None:
       break;
   }
@@ -854,7 +858,7 @@ void vc_getReasonUnknownToBuffer(VC vc, char** buf, size_t* len)
 {
   // Empty rather than absent when there is nothing to say, so that a caller
   // has one shape to handle and always something to free.
-  const std::string& detail = mgr(vc)->unknown_detail;
+  const std::string& detail = mgr(vc)->getUnknownReasonDetail();
   const size_t size = detail.size() + 1; // chars plus the terminating null
   *buf = (char*)malloc(size);
   *len = size;

--- a/lib/Interface/cpp_interface.cpp
+++ b/lib/Interface/cpp_interface.cpp
@@ -1085,7 +1085,7 @@ void Cpp_interface::checkSat(const ASTVec& assertionsSMT2,
       last_result = GlobalSTP->TopLevelSTP(query, bm.ASTFalse);
     }
 
-    // Store away the answer. Might be timeout, or error though..
+    // Store away the answer. It may also be unknown or an error.
     last_run = Entry(last_result);
     last_run.node_number = assertionsSMT2.back().GetNodeNum();
 
@@ -1113,8 +1113,8 @@ void Cpp_interface::checkSat(const ASTVec& assertionsSMT2,
   // this way is a genuine one whatever the carrier's width.
   if (carrierMayBeShort && last_run.result == SOLVER_UNSATISFIABLE)
   {
-    last_run.result = SOLVER_TIMEOUT;
     bm.noteUnknown(UnknownReason::CarrierExhausted, carrierExhausted);
+    last_run.result = bm.unknownResult();
   }
 
   // A model exists exactly when this check concluded SAT and the solve
@@ -1477,7 +1477,7 @@ void Cpp_interface::getInfo(std::string flag)
     // an error response, for the reason :all-statistics gives above: under an
     // immediate-exit error behaviour, raising one would kill the session over
     // a diagnostic query.
-    switch (bm.unknown_reason)
+    switch (bm.getUnknownReason())
     {
       case UnknownReason::Timeout:
         cout << "(:reason-unknown timeout)" << endl;
@@ -1491,35 +1491,23 @@ void Cpp_interface::getInfo(std::string flag)
         break;
       case UnknownReason::CarrierExhausted:
       case UnknownReason::AssumedInjectivity:
+      case UnknownReason::AIGBudget:
       case UnknownReason::Incomplete:
         // The predefined SMT-LIB spelling, followed by what was incomplete:
         // the flag admits an s-expression, and a bare "incomplete" tells a
-        // caller nothing they can act on. All three share it because the
+        // caller nothing they can act on. All four share it because the
         // sentence is what says which, and SMT-LIB2 has no spelling that
         // would say it better.
-        cout << "(:reason-unknown (incomplete \"" << bm.unknown_detail
+        cout << "(:reason-unknown (incomplete \""
+             << bm.getUnknownReasonDetail()
              << "\"))" << endl;
         break;
       case UnknownReason::None:
-        // Two shapes reach here: no unknown to explain, and an unknown whose
-        // producer recorded no reason. Told apart by the verdict, because
-        // answering "not unknown" after an unknown would be a plain lie.
-        //
-        // SOLVER_TIMEOUT is the verdict every no-answer carries, whichever
-        // budget ran out, and PrintOutput answers `unknown` for all of them --
-        // so a check-sat that gave up and recorded nothing lands here holding
-        // exactly that, and saying "not unknown" would contradict the line
-        // above it. Every producer of that verdict does record a reason today;
-        // this arm is what keeps a future one that forgets from turning a
-        // missing explanation into a false statement. SOLVER_UNDECIDED is
-        // deliberately not here: it is what the cache holds before a level has
-        // been solved and what a stale entry is reset to, so admitting it
-        // would answer for a check-sat that never ran.
-        if (cache.size() > 0 && cache.back().result == SOLVER_TIMEOUT)
-          cout << "(:reason-unknown unknown)" << endl;
-        else
-          cout << "(:reason-unknown (error \"the last answer was not "
-                  "unknown\"))" << endl;
+        // SOLVER_UNKNOWN cannot reach the frontend without a reason: both
+        // output boundaries enforce that invariant. None therefore means
+        // there was no unknown result to explain.
+        cout << "(:reason-unknown (error \"the last answer was not "
+                "unknown\"))" << endl;
         break;
     }
   }

--- a/lib/Parser/smt2.y
+++ b/lib/Parser/smt2.y
@@ -248,7 +248,7 @@ namespace stp
   using stp::SOLVER_INVALID;
   using stp::SOLVER_VALID;
   using stp::SOLVER_UNDECIDED;
-  using stp::SOLVER_TIMEOUT;
+  using stp::SOLVER_UNKNOWN;
   using stp::SOLVER_ERROR;
   using stp::SOLVER_UNSATISFIABLE;
   using stp::SOLVER_SATISFIABLE;

--- a/lib/STPManager/STP.cpp
+++ b/lib/STPManager/STP.cpp
@@ -714,7 +714,7 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
     tmp_inputToSAT = inputToSat;
 
     if (bm->soft_timeout_expired)
-      return SOLVER_TIMEOUT;
+      return bm->unknownResult();
 
     if (bm->UserFlags.optimize_flag)
     {
@@ -818,7 +818,7 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
   }
 
   if (bm->soft_timeout_expired)
-    return SOLVER_TIMEOUT;
+    return bm->unknownResult();
 
   if (bm->UserFlags.enable_ite_context)
   {
@@ -1021,7 +1021,7 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
   ToSATBase* satBase = &toSATAIG;
 
   if (bm->soft_timeout_expired)
-    return SOLVER_TIMEOUT;
+    return bm->unknownResult();
 
   NewSolver.enableRefinement(maybeRefinement);
 
@@ -1050,7 +1050,7 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
     if (toSATAIG.cbIsDestructed())
       cleaner.release();
 
-    return SOLVER_TIMEOUT;
+    return bm->unknownResult();
   }
 
   if (SOLVER_UNDECIDED != res)
@@ -1152,7 +1152,7 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
     {
       if (toSATAIG.cbIsDestructed())
         cleaner.release();
-      return SOLVER_TIMEOUT;
+      return bm->unknownResult();
     }
 
     if (!toSATAIG.hasBVEQAbstractions() && !toSATAIG.hasBVTermAbstractions() &&

--- a/lib/ToSat/ToSATAIG.cpp
+++ b/lib/ToSat/ToSATAIG.cpp
@@ -78,7 +78,7 @@ bool ToSATAIG::CallSAT(SATSolver& satSolver, const ASTNode& input,
 
   // Only an exhausted AIG budget returns NULL: the query has no answer, and
   // `false` alone would be read as UNSAT. Raising the soft-timeout flag is
-  // what makes CallSAT_ResultCheck report SOLVER_TIMEOUT instead -- it tests
+  // what makes CallSAT_ResultCheck report SOLVER_UNKNOWN instead -- it tests
   // that flag before it tests this return value.
   if (cnfData == NULL)
   {
@@ -247,7 +247,7 @@ Cnf_Dat_t* ToSATAIG::bitblast(const ASTNode& input, bool needAbsRef)
     detail << "the AIG node budget set by --aig-node-budget ("
            << bm->UserFlags.aig_node_budget << ") ran out at " << e.nodeCount
            << " AND gates; raise it, or set it to -1 for no limit";
-    bm->noteUnknown(UnknownReason::Incomplete, detail.str());
+    bm->noteUnknown(UnknownReason::AIGBudget, detail.str());
     delete cb;
     cb = NULL;
     bb.cb = NULL;

--- a/lib/ToSat/ToSATBase.cpp
+++ b/lib/ToSat/ToSATBase.cpp
@@ -33,24 +33,28 @@ using std::endl;
 // This function prints the output of the STP solver
 void ToSATBase::PrintOutput(STPMgr* bm, SOLVER_RETURN_TYPE ret)
 {
-  if (ret == SOLVER_TIMEOUT || ret == SOLVER_UNDECIDED)
+  if (ret == SOLVER_UNDECIDED)
+    FatalError("SOLVER_UNDECIDED escaped the solver's refinement loop");
+
+  if (ret == SOLVER_UNKNOWN)
   {
-    // SMT-LIB has a word for this and it is not "Timed Out.": a caller cannot
-    // act on prose, and the clock is only one of the reasons there may be no
-    // answer. Which reason it was is (get-info :reason-unknown)'s job. The
-    // legacy CVC output keeps its own wording, where no such command exists.
+    // The verdict says only that there is no answer. Which reason it was is
+    // (get-info :reason-unknown)'s job in SMT-LIB and the reason API's job for
+    // library callers; calling every such result a timeout would misdescribe
+    // deterministic conflict and AIG budgets.
     //
     // Gated like the two verdicts below it, rather than printed
     // unconditionally as this arm used to be: a caller that did not ask for
     // output does not want the no-answer narrated either, and a library that
     // stays quiet about sat and unsat has no business narrating this one.
+    bm->unknownResult();
     if (bm->UserFlags.print_output_flag)
     {
       if (bm->UserFlags.smtlib1_parser_flag ||
           bm->UserFlags.smtlib2_parser_flag)
         cout << "unknown" << endl;
       else
-        cout << "Timed Out." << endl;
+        cout << "Unknown." << endl;
     }
     return;
   }

--- a/tests/api/C/example_broken.cpp
+++ b/tests/api/C/example_broken.cpp
@@ -74,7 +74,7 @@ void handleQuery(VC handle, Expr queryExpr)
       printf("Could not answer query\n");
       break;
     case 3:
-      printf("Timeout.\n");
+      printf("Could not answer query (UNKNOWN).\n");
       break;
     default:
       printf("Unhandled error\n");

--- a/tests/api/C/model-read-with-no-solve.cpp
+++ b/tests/api/C/model-read-with-no-solve.cpp
@@ -182,7 +182,7 @@ TEST(model_read_with_no_solve, incremental_is_refused_too)
 //
 // The budget is zero conflicts, which is a budget rather than the absence of
 // one, so the give-up is decided before the search rather than by the clock.
-TEST(model_read_with_no_solve, a_timed_out_query_leaves_no_model)
+TEST(model_read_with_no_solve, an_unknown_query_leaves_no_model)
 {
   VC vc = vc_createValidityChecker();
 
@@ -211,7 +211,8 @@ TEST(model_read_with_no_solve, a_timed_out_query_leaves_no_model)
   vc_assertFormula(vc, vc_bvLtExpr(vc, b, limit));
   vc_assertFormula(vc, vc_bvLeExpr(vc, a, b));
 
-  ASSERT_EQ(3, vc_query_with_timeout(vc, vc_falseExpr(vc), 0, -1)); // 3 == timeout
+  ASSERT_EQ(3, vc_query_with_timeout(vc, vc_falseExpr(vc), 0, -1));
+  ASSERT_EQ(REASON_UNKNOWN_CONFLICT_BUDGET, vc_getReasonUnknown(vc));
 
   EXPECT_EQ((Expr)NULL, vc_getCounterExample(vc, x));
 

--- a/tests/api/C/reason-unknown.cpp
+++ b/tests/api/C/reason-unknown.cpp
@@ -104,16 +104,16 @@ TEST(reason_unknown, TheClockAndTheConflictBudgetAreToldApartByTheReason)
   vc_Destroy(conflicts);
 }
 
-// The AIG budget is neither of those two, so the clock's name is not what it
-// reports: it is an encoding STP abandoned, and the sentence behind the value
-// names the flag and the count it stopped at -- which the value alone cannot.
+// The AIG budget is neither of those two and has a value of its own rather
+// than the catch-all it used to report as. A caller sets this budget in order
+// to act on it firing; the sentence still supplies the count the value cannot.
 TEST(reason_unknown, TheAigBudgetIsNotReportedAsAClock)
 {
   VC vc = vc_createValidityChecker();
   vc_setInterfaceFlags(vc, AIG_NODE_BUDGET, 50);
   assertFactoring(vc);
   EXPECT_EQ(3, vc_query_with_timeout(vc, vc_falseExpr(vc), -1, -1));
-  EXPECT_EQ(REASON_UNKNOWN_INCOMPLETE, vc_getReasonUnknown(vc));
+  EXPECT_EQ(REASON_UNKNOWN_AIG_BUDGET, vc_getReasonUnknown(vc));
 
   const std::string why = detail(vc);
   EXPECT_NE(std::string::npos, why.find("--aig-node-budget")) << why;

--- a/tests/api/C/timeout-budget.cpp
+++ b/tests/api/C/timeout-budget.cpp
@@ -41,7 +41,7 @@ namespace
 const int QUERY_INVALID = 0;
 const int QUERY_VALID = 1;
 const int QUERY_ERROR = 2;
-const int QUERY_TIMEOUT = 3;
+const int QUERY_UNKNOWN = 3;
 
 const int NO_LIMIT = -1;
 
@@ -153,7 +153,7 @@ TEST(timeout_budget, zero_time_budget_gives_up_immediately)
         std::chrono::steady_clock::now();
 
     EXPECT_EQ(vc_query_with_timeout(vc, vc_falseExpr(vc), NO_LIMIT, 0),
-              QUERY_TIMEOUT);
+              QUERY_UNKNOWN);
     EXPECT_LT(seconds_since(start), 30.0);
 
     vc_Destroy(vc);
@@ -171,7 +171,7 @@ TEST(timeout_budget, zero_conflict_budget_gives_up_immediately)
     assert_hard_instance(vc);
 
     EXPECT_EQ(vc_query_with_timeout(vc, vc_falseExpr(vc), 0, NO_LIMIT),
-              QUERY_TIMEOUT);
+              QUERY_UNKNOWN);
 
     vc_Destroy(vc);
   }
@@ -202,7 +202,7 @@ TEST(timeout_budget, time_budget_covers_the_whole_query)
         std::chrono::steady_clock::now();
 
     EXPECT_EQ(vc_query_with_timeout(vc, vc_falseExpr(vc), NO_LIMIT, 2),
-              QUERY_TIMEOUT);
+              QUERY_UNKNOWN);
     EXPECT_LT(seconds_since(start), 30.0);
 
     vc_Destroy(vc);
@@ -226,7 +226,7 @@ TEST(timeout_budget, no_limit_reaches_the_solver)
 
     // 60491 == 251 * 241, factored in milliseconds, but still an answer
     // that has to come out of the SAT solver: give this same instance a
-    // budget of zero conflicts and every backend reports a timeout.
+    // budget of zero conflicts and every backend reports unknown.
     const int width = 32;
     Expr a = vc_varExpr(vc, "a", vc_bvType(vc, width));
     Expr b = vc_varExpr(vc, "b", vc_bvType(vc, width));

--- a/tests/api/C/timeout.cpp
+++ b/tests/api/C/timeout.cpp
@@ -74,7 +74,7 @@ void test_timeout(bool test_with_time, uint32_t max_value, bool use_cms)
     }
     std::cout << timeout_type << " : " << limit << " : result " << std::flush;
 
-    // returns 3 on timeout
+    // returns unknown (3), with timeout available through the reason API
     int query = vc_query_with_timeout(vc, vc_falseExpr(vc), max_conflicts, max_time);
     ASSERT_TRUE(query == 3);
 

--- a/tests/api/python/tests.py.in
+++ b/tests/api/python/tests.py.in
@@ -1337,11 +1337,11 @@ class TestSTP(unittest.TestCase):
         """
         An unlimited query must still reach the SAT solver and come back with
         an answer: a backend that mistook "no budget configured" for a budget
-        of zero would report a timeout here.
+        of zero would report unknown here.
 
         60491 == 251 * 241, factored in milliseconds. Given a budget of zero
-        conflicts this same instance times out, so the answer really does
-        come from the SAT solver.
+        conflicts this same instance returns unknown, so the answer really
+        does come from the SAT solver.
         """
         s = self.s
         a = s.bitvec('a', 32)

--- a/tests/query-files/smt2-command-tests/reason-unknown-names-the-budget.smt2
+++ b/tests/query-files/smt2-command-tests/reason-unknown-names-the-budget.smt2
@@ -1,7 +1,7 @@
 ; Both drivers name the budget that stopped them, and name the same one.
 ;
-; A no-answer leaves either driver as SOLVER_TIMEOUT, which is the same value
-; whichever budget ran out, so which one it was has to be taken from the SAT
+; A no-answer leaves either driver as SOLVER_UNKNOWN, which deliberately says
+; nothing about which budget ran out, so that has to be taken from the SAT
 ; solver while it is still there to be asked. The batch pipeline did that in
 ; ToSATAIG::runSolver and the incremental driver did not, so the same query
 ; stopped by the same flag was named through one and denied through the other:

--- a/tests/query-files/smt2-command-tests/unknown-on-budget.cvc
+++ b/tests/query-files/smt2-command-tests/unknown-on-budget.cvc
@@ -1,16 +1,15 @@
-% The legacy CVC output says "Timed Out." where SMT-LIB says "unknown".
+% A CVC query with no answer reports that verdict without guessing why.
 %
-% That wording is kept deliberately rather than unified: this input language
-% has no (get-info :reason-unknown) to carry a reason, so the sentence is the
-% whole of what a caller gets, and it is what every existing consumer of this
-% mode reads. The parser is selected by file extension, so this is the only
-% kind of file that can exercise it.
+% This input language has no (get-info :reason-unknown), but calling every
+% no-answer a timeout would still be wrong: a deterministic conflict or AIG
+% budget reaches the same verdict. The parser is selected by file extension,
+% so this is the only kind of file that can exercise the CVC rendering.
 %
 % A zero-second budget, so the result does not depend on the machine.
 %
 % RUN: %solver -k 0 %s 2>&1 | %OutputCheck %s
-% CHECK: Timed Out
-% CHECK-NOT: ^unknown$
+% CHECK: ^Unknown\.$
+% CHECK-NOT: Timed Out
 
 a, b, c : BITVECTOR(32);
 

--- a/tests/query-files/smt2-command-tests/unknown-on-timeout.smt2
+++ b/tests/query-files/smt2-command-tests/unknown-on-timeout.smt2
@@ -12,10 +12,10 @@
 ; version of this fixture ran -g and pinned `timeout`, in a run that finished
 ; in a tenth of a second.
 ;
-; The legacy CVC wording is pinned in unknown-on-budget.cvc rather than here:
-; the parser is chosen by file extension, so a .smt2 file cannot produce it and
-; a leg claiming to test it would be testing the SMT-LIB path under another
-; name.
+; The CVC rendering is pinned in unknown-on-budget.cvc rather than here: that
+; language has no reason command, so it reports the generic verdict as
+; `Unknown.`. The parser is chosen by file extension, so a .smt2 file cannot
+; exercise that path.
 ;
 ; The clock leg asks for zero seconds. That is deterministic -- the budget is
 ; spent before the solver is entered, which is the case the pre-check exists

--- a/tests/unit-tests/UFLowering_Test.cpp
+++ b/tests/unit-tests/UFLowering_Test.cpp
@@ -360,18 +360,18 @@ TEST(UFLowering, InjectArgsInstallsARetractableAssumptionAndCountsIt)
       guarded++;
   EXPECT_EQ(viewWith.eagerStats.emittedInjectivity(), guarded);
 
-  EXPECT_EQ(SOLVER_TIMEOUT,
+  EXPECT_EQ(SOLVER_UNKNOWN,
             manager.withholdAssumedUnsat(SOLVER_UNSATISFIABLE));
-  EXPECT_EQ(UnknownReason::AssumedInjectivity, manager.unknown_reason);
+  EXPECT_EQ(UnknownReason::AssumedInjectivity, manager.getUnknownReason());
   EXPECT_NE(std::string::npos,
-            manager.unknown_detail.find("--uf-inject-args"))
-      << manager.unknown_detail;
+            manager.getUnknownReasonDetail().find("--uf-inject-args"))
+      << manager.getUnknownReasonDetail();
 
   manager.clearUnknown();
   EXPECT_EQ(SOLVER_SATISFIABLE,
             manager.withholdAssumedUnsat(SOLVER_SATISFIABLE))
       << "a model of the strengthened formula is a model of the query";
-  EXPECT_EQ(UnknownReason::None, manager.unknown_reason);
+  EXPECT_EQ(UnknownReason::None, manager.getUnknownReason());
 
   // A driver that established whose refutation it holds says so by clearing
   // the record, and then the same unsat is reported rather than withheld.
@@ -379,7 +379,7 @@ TEST(UFLowering, InjectArgsInstallsARetractableAssumptionAndCountsIt)
   manager.uf_injectivity_assumed = 0;
   EXPECT_EQ(SOLVER_UNSATISFIABLE,
             manager.withholdAssumedUnsat(SOLVER_UNSATISFIABLE));
-  EXPECT_EQ(UnknownReason::None, manager.unknown_reason);
+  EXPECT_EQ(UnknownReason::None, manager.getUnknownReason());
 
   // Nothing assumed, no guard, nothing to retract, nothing withheld. The rule
   // keys on what was installed rather than on the flag.
@@ -397,5 +397,5 @@ TEST(UFLowering, InjectArgsInstallsARetractableAssumptionAndCountsIt)
   EXPECT_EQ(0u, manager.uf_injectivity_assumed);
   EXPECT_EQ(SOLVER_UNSATISFIABLE,
             manager.withholdAssumedUnsat(SOLVER_UNSATISFIABLE));
-  EXPECT_EQ(UnknownReason::None, manager.unknown_reason);
+  EXPECT_EQ(UnknownReason::None, manager.getUnknownReason());
 }

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -484,7 +484,7 @@ void ExtraMain::create_options()
             "it abandons the query through the soft-timeout path, so the "
             "answer is the one --max-time gives -- \"unknown\" in SMT-LIB "
             "mode, with (get-info :reason-unknown) naming this budget, and "
-            "\"Timed Out.\" in the CVC language. "
+            "\"Unknown.\" in the CVC language. "
             "Batch solves only: the incremental encoder's AIG outlives the "
             "check that grew it and is never capped, so engaging it with a "
             "budget set warns once instead. Bounds the blast, not the "


### PR DESCRIPTION
## Summary

- replace `SOLVER_TIMEOUT` with `SOLVER_UNKNOWN`, retaining result value 3
- represent timeout as one typed unknown reason rather than a separate solver verdict
- require no-answer producers to record a reason and expose C++ reason/detail accessors
- add the AIG-budget reason internally and append it to the C API reason enum
- update the frontends and regressions to report unknown results consistently

## Testing

- GCC 11.5 with `WERROR=ON`: build at `--parallel 24`; 151/151 tests passed
- Clang 21.1.6 with `WERROR=ON`: build at `--parallel 24`; 151/151 tests passed
- all four CI `rewrite_rule_gen` smoke checks passed