### PR TITLE
Abstract additions by their width, and count what the abstraction took

### DIFF
--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -578,6 +578,48 @@ public:
      difficulty_reversion = false;
   }
 
+  // What the encoding options above actually did, as against what they were
+  // allowed to do. Not settings: a caller that turns an abstraction on wants
+  // to know it engaged, and a flag that reached no eligible operation and a
+  // flag that is broken both abstract nothing -- only the candidate count
+  // tells them apart. Cumulative over the manager's lifetime, and read
+  // through vc_getCounter.
+  //
+  // Lives here rather than in STPMgr because the bit-blaster holds only these
+  // flags, and the sites that would have to be counted are all inside it.
+  struct EncodingCoverage
+  {
+    // One per abstractable node kind, indexed by AbstractionKind below.
+    static const unsigned KINDS = 6;
+    // Operations reaching the bit-blaster at or above bv_abstraction_width:
+    // what the abstraction could have taken, whether or not it was on.
+    uint64_t bv_candidates[KINDS] = {};
+    // ... and what it did take.
+    uint64_t bv_abstracted[KINDS] = {};
+    // Rounds the CEGAR refiner ran, and blocking lemmas it installed.
+    uint64_t bv_refinement_rounds = 0;
+    uint64_t bv_blocking_lemmas = 0;
+    // Uninterpreted-function applications the lowering decided, and the
+    // constraints it installed for them.
+    uint64_t uf_applications_lowered = 0;
+    uint64_t uf_constraints_installed = 0;
+    // Queries that reached bit-blasting at all: the denominator, without
+    // which a zero above cannot be told from a query the simplifier settled.
+    uint64_t queries_bitblasted = 0;
+  };
+
+  enum AbstractionKind
+  {
+    ABSTRACT_EQ = 0,
+    ABSTRACT_COMPARE,
+    ABSTRACT_ITE,
+    ABSTRACT_PLUS,
+    ABSTRACT_MULT,
+    ABSTRACT_DIVMOD
+  };
+
+  EncodingCoverage coverage;
+
   UserDefinedFlags()
   {
 #ifdef USE_CADICAL

--- a/include/stp/c_interface.h
+++ b/include/stp/c_interface.h
@@ -641,6 +641,58 @@ enum reason_unknown_t
   REASON_UNKNOWN_AIG_BUDGET
 };
 
+//! What the encoding options did to the queries this checker has run, as
+//! against what they were allowed to do. Cumulative over the checker's
+//! lifetime, so a caller samples the difference across a solve, or reads the
+//! totals once at the end of a session.
+//!
+//! A caller that enables an abstraction and wants to know it engaged needs
+//! both halves: CANDIDATES counts the operations that reached bit-blasting at
+//! or above BV_ABSTRACTION_WIDTH -- what the abstraction could have taken,
+//! whether or not it was on -- and ABSTRACTED counts what it did take. Zero
+//! of both means the query never built an operation wide enough, or never
+//! reached the bit-blaster at all, which QUERIES_BITBLASTED tells apart.
+enum stp_counter_t
+{
+  //! Queries that reached bit-blasting. A query the simplifier settled never
+  //! gets there, and none of the counters below can move for it.
+  STP_COUNTER_QUERIES_BITBLASTED = 0,
+
+  //! Wide operations reaching the bit-blaster, by kind.
+  STP_COUNTER_BV_CANDIDATES_EQ,
+  STP_COUNTER_BV_CANDIDATES_COMPARE,
+  STP_COUNTER_BV_CANDIDATES_ITE,
+  STP_COUNTER_BV_CANDIDATES_PLUS,
+  STP_COUNTER_BV_CANDIDATES_MULT,
+  STP_COUNTER_BV_CANDIDATES_DIVMOD,
+
+  //! ... and the ones actually replaced by a fresh input.
+  STP_COUNTER_BV_ABSTRACTED_EQ,
+  STP_COUNTER_BV_ABSTRACTED_COMPARE,
+  STP_COUNTER_BV_ABSTRACTED_ITE,
+  STP_COUNTER_BV_ABSTRACTED_PLUS,
+  STP_COUNTER_BV_ABSTRACTED_MULT,
+  STP_COUNTER_BV_ABSTRACTED_DIVMOD,
+
+  //! Rounds the CEGAR refiner ran, and blocking lemmas it installed for an
+  //! abstracted BVMULT, BVDIV or BVMOD.
+  STP_COUNTER_BV_REFINEMENT_ROUNDS,
+  STP_COUNTER_BV_BLOCKING_LEMMAS,
+
+  //! Uninterpreted-function applications the lowering decided, and the
+  //! constraints installed for them -- eagerly during lowering, or by the
+  //! refinement that a refuted candidate earned.
+  STP_COUNTER_UF_APPLICATIONS_LOWERED,
+  STP_COUNTER_UF_CONSTRAINTS_INSTALLED
+};
+
+//! \brief Reads one of the counters above.
+//!
+//! An unrecognised counter reads 0 and reports a nonfatal diagnostic, so a
+//! caller built against a later header keeps working against an earlier
+//! library.
+DLL_PUBLIC unsigned long long vc_getCounter(VC vc, enum stp_counter_t counter);
+
 //! \brief Returns why the last query had no answer.
 //!
 //! Meaningful after vc_query returns 3; REASON_UNKNOWN_NONE at any other

--- a/lib/Incremental/IncrementalSolverImpl.h
+++ b/lib/Incremental/IncrementalSolverImpl.h
@@ -2274,6 +2274,7 @@ struct IncrementalSolver::Impl
     }
 
     const uint64_t clausesPre = solver->submittedClauses();
+    bm->UserFlags.coverage.queries_bitblasted++;
     bm->GetRunTimes()->start(RunTimes::BitBlasting);
     BBNodeAIG root = encoding.blaster().BBForm(toEncode);
     bm->GetRunTimes()->stop(RunTimes::BitBlasting);

--- a/lib/Interface/c_interface.cpp
+++ b/lib/Interface/c_interface.cpp
@@ -853,6 +853,52 @@ void vc_printCounterExampleToBuffer(VC vc, char** buf, size_t* len)
   memcpy(*buf, cstr, size);
 }
 
+unsigned long long vc_getCounter(VC vc, enum stp_counter_t counter)
+{
+  const stp::UserDefinedFlags::EncodingCoverage& c =
+      mgr(vc)->UserFlags.coverage;
+  typedef stp::UserDefinedFlags UF;
+  switch (counter)
+  {
+    case STP_COUNTER_QUERIES_BITBLASTED: return c.queries_bitblasted;
+
+    case STP_COUNTER_BV_CANDIDATES_EQ:
+      return c.bv_candidates[UF::ABSTRACT_EQ];
+    case STP_COUNTER_BV_CANDIDATES_COMPARE:
+      return c.bv_candidates[UF::ABSTRACT_COMPARE];
+    case STP_COUNTER_BV_CANDIDATES_ITE:
+      return c.bv_candidates[UF::ABSTRACT_ITE];
+    case STP_COUNTER_BV_CANDIDATES_PLUS:
+      return c.bv_candidates[UF::ABSTRACT_PLUS];
+    case STP_COUNTER_BV_CANDIDATES_MULT:
+      return c.bv_candidates[UF::ABSTRACT_MULT];
+    case STP_COUNTER_BV_CANDIDATES_DIVMOD:
+      return c.bv_candidates[UF::ABSTRACT_DIVMOD];
+
+    case STP_COUNTER_BV_ABSTRACTED_EQ:
+      return c.bv_abstracted[UF::ABSTRACT_EQ];
+    case STP_COUNTER_BV_ABSTRACTED_COMPARE:
+      return c.bv_abstracted[UF::ABSTRACT_COMPARE];
+    case STP_COUNTER_BV_ABSTRACTED_ITE:
+      return c.bv_abstracted[UF::ABSTRACT_ITE];
+    case STP_COUNTER_BV_ABSTRACTED_PLUS:
+      return c.bv_abstracted[UF::ABSTRACT_PLUS];
+    case STP_COUNTER_BV_ABSTRACTED_MULT:
+      return c.bv_abstracted[UF::ABSTRACT_MULT];
+    case STP_COUNTER_BV_ABSTRACTED_DIVMOD:
+      return c.bv_abstracted[UF::ABSTRACT_DIVMOD];
+
+    case STP_COUNTER_BV_REFINEMENT_ROUNDS: return c.bv_refinement_rounds;
+    case STP_COUNTER_BV_BLOCKING_LEMMAS: return c.bv_blocking_lemmas;
+    case STP_COUNTER_UF_APPLICATIONS_LOWERED:
+      return c.uf_applications_lowered;
+    case STP_COUNTER_UF_CONSTRAINTS_INSTALLED:
+      return c.uf_constraints_installed;
+  }
+  reportCAPIError("vc_getCounter: unrecognised counter");
+  return 0;
+}
+
 enum reason_unknown_t vc_getReasonUnknown(VC vc)
 {
   switch (mgr(vc)->getUnknownReason())

--- a/lib/ToSat/BVAbstractionRefiner.cpp
+++ b/lib/ToSat/BVAbstractionRefiner.cpp
@@ -48,6 +48,7 @@ unsigned BVAbstractionRefiner::refine(
   if (refined > 0)
   {
     refinements_ += refined;
+    bm->UserFlags.coverage.bv_refinement_rounds++;
     if (bm->UserFlags.stats_flag)
       std::cerr << "BV abstraction: refined " << refined << " operations"
                 << std::endl;
@@ -1147,6 +1148,7 @@ unsigned BVAbstractionRefiner::refineTerms(
       continue;
     }
     abs.blockedRounds++;
+    bm->UserFlags.coverage.bv_blocking_lemmas++;
 
     for (unsigned bit = 0; bit < W; ++bit)
     {

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -1013,9 +1013,13 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term, BBNodeSet& support,
       const BBNodeVec& thn = BBTerm(term[1], support);
       const BBNodeVec& els = BBTerm(term[2], support);
 
+      if (num_bits >= uf->bv_abstraction_width)
+        uf->coverage.bv_candidates[UserDefinedFlags::ABSTRACT_ITE]++;
+
       if (uf->bv_term_abstraction &&
           num_bits >= uf->bv_abstraction_width)
       {
+        uf->coverage.bv_abstracted[UserDefinedFlags::ABSTRACT_ITE]++;
         ensureProxyCIs(nf, term[1], thn, sideConstraints_);
         ensureProxyCIs(nf, term[2], els, sideConstraints_);
 
@@ -1129,6 +1133,49 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term, BBNodeSet& support,
     {
       assert(term.Degree() >= 1);
 
+      // The abstraction below takes two operands, and Flatten folds every
+      // chain of additions into one n-ary node, so an addition of three or
+      // more operands would reach the exact adder however wide it is -- the
+      // arity the front end happened to build would decide what gets
+      // abstracted, rather than the width floor that is meant to. Lower it to
+      // genuine two-operand nodes first, as BVMULT does, and only when the
+      // abstraction would take them, so a query that is not being abstracted
+      // keeps the n-ary adder it had. Addition is associative and commutative
+      // modulo 2^n, so the tree computes the same value; the sort keeps the
+      // shape it takes deterministic.
+      if (uf->bv_term_abstraction && uf->bvplus_variant &&
+          term.Degree() > 2 && num_bits >= uf->bv_abstraction_width)
+      {
+        std::deque<ASTNode> names(term.begin(), term.end());
+        std::sort(names.begin(), names.end(), stp::ExprLess{});
+        while (names.size() > 1)
+        {
+          ASTNode a = names.front();
+          names.pop_front();
+          ASTNode b = names.front();
+          names.pop_front();
+          names.push_back(ASTNF->CreateTerm(BVPLUS, num_bits, a, b));
+        }
+        result = BBTerm(names.front(), support);
+        break;
+      }
+
+      if (term.Degree() == 2 && num_bits >= uf->bv_abstraction_width)
+        uf->coverage.bv_candidates[UserDefinedFlags::ABSTRACT_PLUS]++;
+
+      // A wide n-ary addition that was not decomposed above -- because the
+      // abstraction is off -- still offered it the Degree-1 binary adds the
+      // decomposition would have made. Counting them keeps the candidate
+      // number comparable between a run with the flag and a run without,
+      // which is the whole use of it: a zero has to mean "no wide addition
+      // here", not "the flag that lowers them was off".
+      if (term.Degree() > 2 && num_bits >= uf->bv_abstraction_width &&
+          !(uf->bv_term_abstraction && uf->bvplus_variant))
+      {
+        uf->coverage.bv_candidates[UserDefinedFlags::ABSTRACT_PLUS] +=
+            term.Degree() - 1;
+      }
+
       if (uf->bv_term_abstraction &&
           uf->bvplus_variant &&
           term.Degree() == 2 &&
@@ -1165,6 +1212,7 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term, BBNodeSet& support,
             abstracted[i] = BBNodeAIG(Aig_ObjCreateCi(nf->aigMgr));
             abstracted[i].symbol_index = nf->aigMgr->vCis->nSize - 1;
           }
+          uf->coverage.bv_abstracted[UserDefinedFlags::ABSTRACT_PLUS]++;
           nf->symbolToBBNode[term] = abstracted;
           for (int i = 0; i < 2; i++)
             if (realOp[i].GetKind() != BVCONST)
@@ -1265,9 +1313,13 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term, BBNodeSet& support,
       updateTerm(term[0], mpcd1, support);
       assert(mpcd1.size() == mpcd2.size());
 
+      if (num_bits >= uf->bv_abstraction_width)
+        uf->coverage.bv_candidates[UserDefinedFlags::ABSTRACT_MULT]++;
+
       if (uf->bv_term_abstraction && uf->bv_term_abstraction_mult &&
           num_bits >= uf->bv_abstraction_width)
       {
+        uf->coverage.bv_abstracted[UserDefinedFlags::ABSTRACT_MULT]++;
         BBNodeVec op0 = ensureProxyCIs(nf, term[0], mpcd1, sideConstraints_);
         BBNodeVec op1 = ensureProxyCIs(nf, term[1], mpcd2, sideConstraints_);
 
@@ -1312,9 +1364,13 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term, BBNodeSet& support,
       assert(dvdd.size() == num_bits);
       assert(dvsr.size() == num_bits);
 
+      if (num_bits >= uf->bv_abstraction_width)
+        uf->coverage.bv_candidates[UserDefinedFlags::ABSTRACT_DIVMOD]++;
+
       if (uf->bv_term_abstraction && uf->bv_term_abstraction_mult &&
           num_bits >= uf->bv_abstraction_width)
       {
+        uf->coverage.bv_abstracted[UserDefinedFlags::ABSTRACT_DIVMOD]++;
         ensureProxyCIs(nf, term[0], dvdd, sideConstraints_);
         ensureProxyCIs(nf, term[1], dvsr, sideConstraints_);
 
@@ -1732,9 +1788,13 @@ const BBNode BitBlaster::BBForm(const ASTNode& form, BBNodeSet& support,
       const BBNodeVec right = BBTerm(form[1], support);
       assert(left.size() == right.size());
 
+      if (left.size() >= uf->bv_abstraction_width)
+        uf->coverage.bv_candidates[UserDefinedFlags::ABSTRACT_EQ]++;
+
       if (uf->bv_eq_abstraction &&
           left.size() >= uf->bv_abstraction_width)
       {
+        uf->coverage.bv_abstracted[UserDefinedFlags::ABSTRACT_EQ]++;
         ensureProxyCIs(nf, form[0], left, sideConstraints_);
         ensureProxyCIs(nf, form[1], right, sideConstraints_);
         BBNodeAIG abstractCI(Aig_ObjCreateCi(nf->aigMgr));
@@ -1758,12 +1818,16 @@ const BBNode BitBlaster::BBForm(const ASTNode& form, BBNodeSet& support,
     case BVSGT:
     case BVSLT:
     {
+      if (form[0].GetValueWidth() >= uf->bv_abstraction_width)
+        uf->coverage.bv_candidates[UserDefinedFlags::ABSTRACT_COMPARE]++;
+
       if (uf->bv_term_abstraction)
       {
         const BBNodeVec& left = BBTerm(form[0], support);
         const BBNodeVec& right = BBTerm(form[1], support);
         if (left.size() >= uf->bv_abstraction_width)
         {
+          uf->coverage.bv_abstracted[UserDefinedFlags::ABSTRACT_COMPARE]++;
           ensureProxyCIs(nf, form[0], left, sideConstraints_);
           ensureProxyCIs(nf, form[1], right, sideConstraints_);
           BBNodeAIG abstractCI(Aig_ObjCreateCi(nf->aigMgr));

--- a/lib/ToSat/ToSATAIG.cpp
+++ b/lib/ToSat/ToSATAIG.cpp
@@ -186,6 +186,7 @@ Cnf_Dat_t* ToSATAIG::bitblast(const ASTNode& input, bool needAbsRef)
 
   BBNodeAIG BBFormula;
 
+  bm->UserFlags.coverage.queries_bitblasted++;
   bm->GetRunTimes()->start(RunTimes::BitBlasting);
 
   // Only BBForm() and the side-constraint fold below create AIG nodes, so

--- a/lib/UninterpretedFunctions/UFLowering.cpp
+++ b/lib/UninterpretedFunctions/UFLowering.cpp
@@ -522,6 +522,7 @@ void UFLowering::installEagerCongruence(
                 : premise.size() == 1
                       ? premise[0]
                       : factory->CreateNode(AND, premise);
+        manager_->UserFlags.coverage.uf_constraints_installed++;
         view.congruenceConstraints.push_back(
             premise.empty()
                 ? conclusion
@@ -542,6 +543,7 @@ void UFLowering::installEagerCongruence(
           stat.emittedInjectivity++;
           const ASTNode converse =
               factory->CreateNode(IMPLIES, conclusion, premiseConj);
+          manager_->UserFlags.coverage.uf_constraints_installed++;
           view.congruenceConstraints.push_back(
               guard.IsNull() ? converse
                              : factory->CreateNode(IMPLIES, guard, converse));
@@ -870,6 +872,7 @@ UFLowering::lowerCompletedRoot(const ASTNode& publicRoot,
         view.handleToResult.insert(
             std::make_pair(application, record.resultSymbol));
         view.applications.push_back(record);
+        manager_->UserFlags.coverage.uf_applications_lowered++;
         // A float result is solved as a packed bit-vector but the formula it
         // replaces expects a float, so it goes back in through the exact
         // inverse of the boundary its arguments came through: the three-child

--- a/lib/UninterpretedFunctions/UFRefinement.cpp
+++ b/lib/UninterpretedFunctions/UFRefinement.cpp
@@ -696,6 +696,7 @@ void encodeOneLemma(MutableAdapterState& state, const PendingLemma& entry,
     body.push_back(conclusion);
   addGuardedClause(solver, body, guardLiteral);
   state.emittedLemmaCount++;
+  state.manager->UserFlags.coverage.uf_constraints_installed++;
   // Observability under -s: every lemma that reaches this path was earned by
   // a refuted candidate; constraints installed eagerly during lowering do not
   // pass through here. One line per installation names the declaration and

--- a/tests/api/C/CMakeLists.txt
+++ b/tests/api/C/CMakeLists.txt
@@ -25,6 +25,7 @@
 AddSTPGTest(array-cvcl-02.cpp)
 AddSTPGTest(array-equality-retired-after-pop.cpp)
 AddSTPGTest(bv-abstraction-array-candidate-is-bound.cpp)
+AddSTPGTest(bv-abstraction-nary-plus.cpp)
 AddSTPGTest(array-extensionality.cpp)
 AddSTPGTest(array-ite.cpp)
 AddSTPGTest(b4-c2.cpp)

--- a/tests/api/C/bv-abstraction-nary-plus.cpp
+++ b/tests/api/C/bv-abstraction-nary-plus.cpp
@@ -1,0 +1,163 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+// An addition of three or more operands, and the counters that say what the
+// abstraction did with it.
+//
+// BVPLUS is n-ary, and Flatten folds every chain of additions into one such
+// node, so an addition written a + b + c arrives at the bit-blaster as a
+// single node of degree three however it was built. The term abstraction
+// takes two operands, so before this it declined every one of them: which
+// additions got abstracted was decided by the arity the front end happened to
+// produce rather than by the width floor that is meant to decide it. They are
+// lowered to genuine two-operand nodes first now, as BVMULT already was.
+//
+// The counters are the other half: a caller that turns an abstraction on and
+// sees nothing abstracted cannot tell a flag that reached no eligible
+// operation from a flag that is broken, so the candidate count -- what the
+// abstraction was offered -- is kept alongside what it took, and both are
+// readable through vc_getCounter.
+#include "stp/c_interface.h"
+#include <gtest/gtest.h>
+
+namespace
+{
+// A satisfiable query that preprocessing cannot settle: the product pins both
+// factors, so nothing is unconstrained and the bit-blaster actually runs. The
+// sum is an operand of that product rather than equated to a constant, which
+// is what keeps a substitution from removing it before bit-blasting.
+VC checkerOverANAryAddition(int abstraction)
+{
+  VC vc = vc_createValidityChecker();
+  vc_setInterfaceFlags(vc, BV_TERM_ABSTRACTION, abstraction);
+  vc_setInterfaceFlags(vc, BV_EQ_ABSTRACTION, abstraction);
+  // Every operand qualifies, so the arity is the only thing under test here.
+  vc_setInterfaceFlags(vc, BV_ABSTRACTION_WIDTH, 1);
+
+  Type bv = vc_bvType(vc, 32);
+  Expr a = vc_varExpr(vc, "a", bv);
+  Expr b = vc_varExpr(vc, "b", bv);
+  Expr c = vc_varExpr(vc, "c", bv);
+  Expr operands[3] = {a, b, c};
+  Expr sum = vc_bvPlusExprN(vc, 32, operands, 3);
+
+  vc_assertFormula(vc, vc_eqExpr(vc, vc_bvMultExpr(vc, 32, sum, a),
+                                 vc_bvConstExprFromInt(vc, 32, 3037 * 3041)));
+  vc_assertFormula(vc, vc_bvGtExpr(vc, a, vc_bvConstExprFromInt(vc, 32, 1)));
+  vc_assertFormula(vc, vc_bvGtExpr(vc, b, vc_bvConstExprFromInt(vc, 32, 1)));
+  vc_assertFormula(vc, vc_bvGtExpr(vc, c, vc_bvConstExprFromInt(vc, 32, 1)));
+  return vc;
+}
+
+unsigned long long counter(VC vc, enum stp_counter_t c)
+{
+  return vc_getCounter(vc, c);
+}
+} // namespace
+
+// The addition reaches the abstraction, which is what the lowering above is
+// for: three operands become the two two-operand additions that the
+// abstraction takes. Nothing here is about the width -- the floor is 1, so a
+// declined abstraction can only be the arity.
+TEST(bv_abstraction_nary_plus, AnNAryAdditionIsAbstracted)
+{
+  VC vc = checkerOverANAryAddition(1);
+  vc_query(vc, vc_falseExpr(vc));
+
+  EXPECT_GT(counter(vc, STP_COUNTER_QUERIES_BITBLASTED), 0u);
+  EXPECT_EQ(2u, counter(vc, STP_COUNTER_BV_CANDIDATES_PLUS));
+  EXPECT_EQ(2u, counter(vc, STP_COUNTER_BV_ABSTRACTED_PLUS));
+  vc_Destroy(vc);
+}
+
+// With the abstraction off the same query offers the same two additions and
+// none of them is taken. The candidate count is what makes a zero readable:
+// it has to mean "no addition wide enough was here", not "the flag that
+// lowers them was off", or a caller cannot tell the two apart -- so it counts
+// what the lowering would have produced even when the lowering does not run.
+TEST(bv_abstraction_nary_plus, CandidatesAreCountedWithTheAbstractionOff)
+{
+  VC vc = checkerOverANAryAddition(0);
+  vc_query(vc, vc_falseExpr(vc));
+
+  EXPECT_GT(counter(vc, STP_COUNTER_QUERIES_BITBLASTED), 0u);
+  EXPECT_EQ(2u, counter(vc, STP_COUNTER_BV_CANDIDATES_PLUS));
+  EXPECT_EQ(0u, counter(vc, STP_COUNTER_BV_ABSTRACTED_PLUS));
+  vc_Destroy(vc);
+}
+
+// The abstraction is a way of searching, not a different question: the
+// lowering reassociates the addition, and reassociating is sound modulo 2^n,
+// so the verdict is the one the exact encoding gives.
+TEST(bv_abstraction_nary_plus, TheVerdictIsTheOneTheExactEncodingGives)
+{
+  VC off = checkerOverANAryAddition(0);
+  const int exact = vc_query(off, vc_falseExpr(off));
+  vc_Destroy(off);
+
+  VC on = checkerOverANAryAddition(1);
+  const int abstracted = vc_query(on, vc_falseExpr(on));
+  vc_Destroy(on);
+
+  EXPECT_EQ(exact, abstracted);
+}
+
+// A fresh checker has done nothing, and the counters say so rather than
+// carrying whatever the last one in this process reached.
+TEST(bv_abstraction_nary_plus, AFreshCheckerHasCountedNothing)
+{
+  VC vc = vc_createValidityChecker();
+  EXPECT_EQ(0u, counter(vc, STP_COUNTER_QUERIES_BITBLASTED));
+  EXPECT_EQ(0u, counter(vc, STP_COUNTER_BV_CANDIDATES_PLUS));
+  EXPECT_EQ(0u, counter(vc, STP_COUNTER_BV_ABSTRACTED_PLUS));
+  EXPECT_EQ(0u, counter(vc, STP_COUNTER_BV_REFINEMENT_ROUNDS));
+  EXPECT_EQ(0u, counter(vc, STP_COUNTER_UF_APPLICATIONS_LOWERED));
+  vc_Destroy(vc);
+}
+
+// The persistent driver bit-blasts through a BitBlaster of its own, so a
+// denominator taken only from the batch pipeline reads zero for a session
+// that never uses it -- and an engagement rate over a zero denominator is
+// worse than no rate at all.
+TEST(bv_abstraction_nary_plus, TheIncrementalRouteCountsItsBitBlasting)
+{
+  VC vc = vc_createValidityChecker();
+  vc_setFlag(vc, 'i');
+  vc_setInterfaceFlags(vc, BV_TERM_ABSTRACTION, 1);
+  vc_setInterfaceFlags(vc, BV_ABSTRACTION_WIDTH, 1);
+
+  Type bv = vc_bvType(vc, 32);
+  Expr a = vc_varExpr(vc, "a", bv);
+  Expr b = vc_varExpr(vc, "b", bv);
+  Expr c = vc_varExpr(vc, "c", bv);
+  Expr operands[3] = {a, b, c};
+  Expr sum = vc_bvPlusExprN(vc, 32, operands, 3);
+  vc_assertFormula(vc, vc_eqExpr(vc, vc_bvMultExpr(vc, 32, sum, a),
+                                 vc_bvConstExprFromInt(vc, 32, 3037 * 3041)));
+  vc_assertFormula(vc, vc_bvGtExpr(vc, a, vc_bvConstExprFromInt(vc, 32, 1)));
+  vc_query(vc, vc_falseExpr(vc));
+
+  EXPECT_GT(counter(vc, STP_COUNTER_QUERIES_BITBLASTED), 0u);
+  vc_Destroy(vc);
+}


### PR DESCRIPTION
Three related changes, found while fuzzing this branch with Murxla.

### The addition arity decided what got abstracted

`BVPLUS` is n-ary, and `Flatten` folds every chain of additions into one such
node, so `a + b + c` reaches the bit-blaster with three children however a
front end built it. The term abstraction takes two operands, so it declined
all of them: `--bv-term-abstraction` covered arithmetic only for the additions
that happened to arrive binary, and the width floor that is meant to decide
what gets abstracted did not get a say.

They are now lowered to genuine two-operand nodes first, as `BVMULT` already
was, and only when the abstraction would take them — a solve that is not
abstracting keeps the n-ary adder it had. Reassociating is sound modulo 2^n,
and the sort keeps the shape deterministic.

### Counters for what the encoding options actually did

A caller that turns an abstraction on and sees nothing abstracted cannot act
on it: a flag that reached no eligible operation and a flag that is broken
abstract the same nothing. Each site now records both halves — the operations
reaching it at or above `--bv-abstraction-width`, and the ones it took —
alongside refinement rounds, blocking lemmas, UF applications lowered and the
constraints installed for them. `vc_getCounter` reads them.

Queries that reached the bit-blaster are the denominator: without it a zero
cannot be told from a query preprocessing settled, and most small queries are
settled.

### Both bit-blasting routes count

An `--incremental` session bit-blasts through a `BitBlaster` of its own, so a
denominator taken from `ToSATAIG` alone reads zero for it. Counting both
routes is what keeps an engagement rate from being taken over a zero
denominator.

## Why it matters, measured

A Murxla campaign against Bitwuzla, 300 runs a side:

| | switches fuzzed, floor uniform 1..128 | switches pinned on, floor 1 |
|---|---|---|
| runs abstracting anything | 4.6% | 16.9% |
| abstractions taken | 112 | 2,654 |
| refinement rounds | 38 | 306 |
| blocking lemmas | 0 | 125 |
| wide multiplications abstracted | 0 | 52 |

The escalation an abstracted `BVMULT` reaches after
`--bv-term-abstraction-rounds` blocking lemmas had never fired at all. In the
campaign since, additions are 244k of the abstractions — before the arity fix
an addition of three operands could not be abstracted at any width.

## Test plan

`tests/api/C/bv-abstraction-nary-plus.cpp`, five cases: an addition of three
operands is abstracted (floor at 1, so nothing but the arity can explain a
decline); the same query with the abstraction off offers the same two
additions and takes none, so a zero is readable; the verdict is the one the
exact encoding gives; a fresh checker has counted nothing; the incremental
route counts its own bit-blasting.

Checked against a control library built with the decomposition removed: the
two arity cases fail there and pass here, and the three counter cases pass in
both — so they pin the change rather than passing either way.
