### PR TITLE
Say why the SymFPU submodule is nested a level down

### DIFF
--- a/docs/code-guide.rst
+++ b/docs/code-guide.rst
@@ -80,6 +80,14 @@ Third-party code that is compiled into STP also lives under ``lib/``:
    is pinned to -- carries STP's changes as commits on top. They are four
    correctness fixes for the narrowest formats SMT-LIB permits, none of
    which the common formats reach.
+
+   This is the one submodule that sits a level down from its ``extlib-``
+   directory, at ``extlib-symfpu/symfpu``. SymFPU's headers include each
+   other as ``symfpu/core/...``, so the include root has to be a directory
+   *containing* one named ``symfpu``; ``extlib-symfpu`` is that root, and is
+   what ``SYMFPU_INCLUDE_DIRS`` names. ``extlib-libbf`` needs no such wrapper
+   because its header is included as ``<libbf.h>``, so the submodule
+   directory is itself the include root.
 -  ``extlib-mimalloc``:
    `mimalloc <https://github.com/microsoft/mimalloc>`__, the allocator
    the STP executables link against by default. A git submodule; see


### PR DESCRIPTION
`lib/extlib-symfpu/symfpu` is the one submodule that does not sit directly at its `extlib-` directory, which reads as an inconsistency next to `lib/extlib-libbf` until you know why: SymFPU's headers include each other as `symfpu/core/...`, so the include root has to be a directory *containing* one named `symfpu`. `extlib-symfpu` is that root, and is what `SYMFPU_INCLUDE_DIRS` names.

LibBF needs no such wrapper because its header is included as `<libbf.h>`, so the submodule directory is itself the include root.

This was part of #958, but that merged into #957's branch before I pushed it, so it did not reach master with the rest. Documentation only.