### PR TITLE
Pin the MSVC job's MiniSat clone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1254,10 +1254,14 @@ jobs:
     # stale hit is not expressible.
     - uses: mozilla-actions/sccache-action@v0.0.11
 
+    # The commit scripts/deps/setup-minisat.sh pins, so this leg builds the
+    # same MiniSat as every other one; the two move together. Not --depth 1:
+    # a shallow clone fetches only the tip, which the checkout cannot resolve.
     - name: Build minisat
       run: |
-        git clone --depth 1 https://github.com/stp/minisat
+        git clone https://github.com/stp/minisat
         cd minisat
+        git checkout 14c78206cd12d1d36b7e042fa758747c135670a4
         cmake -B build -A x64 -DSTATICCOMPILE=ON "-DCMAKE_POLICY_VERSION_MINIMUM=3.12" "-DCMAKE_INSTALL_PREFIX=$env:MINISAT_ROOT" "-DZLIB_INCLUDE_DIR=$env:ZLIB_INCLUDE_DIR" "-DZLIB_LIBRARY=$env:ZLIB_LIBRARY" .
         cmake --build build --config Release --target install
 


### PR DESCRIPTION
Every other consumer of `stp/minisat` goes through `scripts/deps/setup-minisat.sh`, which pins commit `14c78206` and says why: this is what a released binary links against, so it should move because someone chose to move it. The MSVC job is the exception. It cannot use the script — that builds for a Unix prefix and calls `nproc` — so it open-codes the clone, and open-coded it without a revision. The one leg whose backend is not a choice but a necessity, MSVC compiling neither CryptoMiniSat nor CaDiCaL, was the one building whatever the fork's default branch held that morning.

Check the same commit out. It is what `stp/minisat`'s `master` points at today, so nothing changes now; it stops changing the day the fork moves, which is the point. A full clone rather than `--depth 1`, since a shallow clone fetches only the tip and leaves the checkout nothing to resolve against, and the repository is small enough that the difference does not show up in the job's time. The pin now lives in two places, so the comment says so.

Nothing else needed adjusting. The MSVC leg runs no setup script and caches no `deps` tree — it uses sccache, whose keys derive from the compilation itself — so `cache-key.sh`, which hashes the setup scripts for the `actions/cache` steps in the Linux jobs, does not cover this clone and does not need to.

## Audit of the other fetched dependencies

No second instance. Recorded here so the question does not have to be re-asked:

| Dependency | Pin | Where |
| --- | --- | --- |
| MiniSat | commit `14c78206` | `setup-minisat.sh`; now also the MSVC job |
| CaDiCaL | `${CADICAL_TAG:-rel-3.0.1}` | `setup-cadical.sh`; the MinGW leg hard-codes the same tag |
| CryptoMiniSat | tag `release/v5.14.7` | `setup-cms.sh`, never overridden |
| GTest | `v1.17.0` | `setup-gtest.sh` |
| Riss | `${RISS_COMMIT:-41342f15…}` | `setup-riss.sh` |
| OutputCheck | unpinned by design | remote `HEAD` folded into `cache-key.sh` |

`CADICAL_TAG` is the only pin a workflow can override, and it is set in exactly one place: the CaDiCaL matrix, over `rel-3.0.1` and `rel-2.1.3`. Because `cache-key.sh` hashes script *contents*, an env-var override does not change the key on its own — that job folds the tag in itself. The four cache steps holding `deps/cadical` use disjoint key prefixes and none declares `restore-keys`, so no prefix fallback can reach across the tag segment, and the gcc/clang matrix rebuilds CaDiCaL unconditionally with it left out of the cached paths. No job can be served a tree built with the other tag.

CryptoMiniSat's own tag is pinned, but from 5.14 it fetches its bundled CaDiCaL and cadiback from default branches. That gap is already documented in `cache-key.sh` along with the reason it is priced in, and is left alone.

Outside the class of "a dependency STP fetches", and not touched here: `vcpkg install zlib` takes the runner image's baseline, `i386/debian:bookworm` is a floating tag, the actions are major-tag rather than SHA pinned, and `pip3 install -U lit` always takes latest.