### PR TITLE
Report final SAT backend statistics

### DIFF
--- a/lib/Sat/Cadical.cpp
+++ b/lib/Sat/Cadical.cpp
@@ -139,10 +139,22 @@ Cadical::~Cadical()
 
 void Cadical::printStats() const
 {
-    // The newline matters: without it this stderr fragment glues onto the
-    // next stdout line (the check-sat verdict) in a combined stream, which
-    // is exactly what line-anchored test checks read.
-    std::cerr << "print stats not yet implemented." << std::endl;
+#if defined(CADICAL_MAJOR) && CADICAL_MAJOR >= 3
+  // These counters remain available in the UNKNOWN state produced by our
+  // Terminator. Keep this compact: CaDiCaL's full reporter is several hundred
+  // lines, while these are the search quantities benchmark logs consume.
+  std::cerr << "CaDiCaL conflicts: "
+            << s->get_statistic_value("conflicts") << std::endl;
+  std::cerr << "CaDiCaL decisions: "
+            << s->get_statistic_value("decisions") << std::endl;
+  std::cerr << "CaDiCaL search propagations: "
+            << s->get_statistic_value("propagations") << std::endl;
+  std::cerr << "CaDiCaL search ticks: "
+            << s->get_statistic_value("ticks") << std::endl;
+#else
+  // get_statistic_value() is unavailable in the oldest supported releases.
+  s->statistics();
+#endif
 }
 
 uint32_t Cadical::newVar()

--- a/lib/Sat/MinisatCore.cpp
+++ b/lib/Sat/MinisatCore.cpp
@@ -25,6 +25,7 @@ THE SOFTWARE.
 #define __STDC_FORMAT_MACROS
 #include "stp/Sat/MinisatCore.h"
 #include "minisat/core/Solver.h"
+#include <iostream>
 //#include "utils/System.h"
 //#include "simp/SimpSolver.h"
 
@@ -151,7 +152,35 @@ uint32_t MinisatCore::nVars() const
 
 void MinisatCore::printStats() const
 {
-  //s->printStats();
+  // MiniSat's periodic table is useful while a long search is running, but
+  // fixed-conflict profiles also need exact final totals. In particular,
+  // propagations/conflict distinguishes SAT-search work from front-end time.
+  std::cerr << "MiniSat starts: " << s->starts << '\n';
+  std::cerr << "MiniSat conflicts: " << s->conflicts << '\n';
+  std::cerr << "MiniSat decisions: " << s->decisions << '\n';
+  std::cerr << "MiniSat propagations: " << s->propagations << '\n';
+  std::cerr << "MiniSat variables: " << s->nVars() << '\n';
+  if (s->conflicts != 0)
+  {
+    std::cerr << "MiniSat decisions per conflict: "
+              << static_cast<double>(s->decisions) / s->conflicts << '\n';
+    std::cerr << "MiniSat propagations per conflict: "
+              << static_cast<double>(s->propagations) / s->conflicts << '\n';
+  }
+  std::cerr << "MiniSat active original clauses: " << s->nClauses() << '\n';
+  std::cerr << "MiniSat active original literals: " << s->clauses_literals
+            << '\n';
+  std::cerr << "MiniSat active learnt clauses: " << s->nLearnts() << '\n';
+  std::cerr << "MiniSat active learnt literals: " << s->learnts_literals
+            << '\n';
+  if (s->nLearnts() != 0)
+    std::cerr << "MiniSat active learnt literals per clause: "
+              << static_cast<double>(s->learnts_literals) / s->nLearnts()
+              << '\n';
+  std::cerr << "MiniSat learnt literals before minimization: "
+            << s->max_literals << '\n';
+  std::cerr << "MiniSat learnt literals after minimization: "
+            << s->tot_literals << '\n';
 }
 
 int MinisatCore::nClauses()

--- a/lib/Sat/SimplifyingMinisat.cpp
+++ b/lib/Sat/SimplifyingMinisat.cpp
@@ -25,6 +25,7 @@ THE SOFTWARE.
 #define __STDC_FORMAT_MACROS
 #include "stp/Sat/SimplifyingMinisat.h"
 #include "minisat/simp/SimpSolver.h"
+#include <iostream>
 
 namespace MiniSat
 {
@@ -113,7 +114,32 @@ uint32_t SimplifyingMinisat::nVars() const
 
 void SimplifyingMinisat::printStats() const
 {
-  //s->printStats();
+  std::cerr << "MiniSat starts: " << s->starts << '\n';
+  std::cerr << "MiniSat conflicts: " << s->conflicts << '\n';
+  std::cerr << "MiniSat decisions: " << s->decisions << '\n';
+  std::cerr << "MiniSat propagations: " << s->propagations << '\n';
+  std::cerr << "MiniSat variables: " << s->nVars() << '\n';
+  if (s->conflicts != 0)
+  {
+    std::cerr << "MiniSat decisions per conflict: "
+              << static_cast<double>(s->decisions) / s->conflicts << '\n';
+    std::cerr << "MiniSat propagations per conflict: "
+              << static_cast<double>(s->propagations) / s->conflicts << '\n';
+  }
+  std::cerr << "MiniSat active original clauses: " << s->nClauses() << '\n';
+  std::cerr << "MiniSat active original literals: " << s->clauses_literals
+            << '\n';
+  std::cerr << "MiniSat active learnt clauses: " << s->nLearnts() << '\n';
+  std::cerr << "MiniSat active learnt literals: " << s->learnts_literals
+            << '\n';
+  if (s->nLearnts() != 0)
+    std::cerr << "MiniSat active learnt literals per clause: "
+              << static_cast<double>(s->learnts_literals) / s->nLearnts()
+              << '\n';
+  std::cerr << "MiniSat learnt literals before minimization: "
+            << s->max_literals << '\n';
+  std::cerr << "MiniSat learnt literals after minimization: "
+            << s->tot_literals << '\n';
 }
 
 void SimplifyingMinisat::setFrozen(uint32_t x)

--- a/tests/query-files/misc-tests/cadical-statistics.smt2
+++ b/tests/query-files/misc-tests/cadical-statistics.smt2
@@ -1,0 +1,22 @@
+; REQUIRES: cadical-inprobing
+; RUN: %solver --cadical -s %s 2>&1 | %OutputCheck %s
+; CHECK: CaDiCaL conflicts: {{[0-9]+}}
+; CHECK: CaDiCaL decisions: {{[0-9]+}}
+; CHECK: CaDiCaL search propagations: {{[0-9]+}}
+; CHECK: CaDiCaL search ticks: {{[0-9]+}}
+; CHECK-NOT: print stats not yet implemented
+; CHECK: ^sat
+; Keep enough coupled structure to reach the SAT backend instead of being
+; discharged by unconstrained-variable elimination.
+(set-logic QF_FP)
+(declare-const x (_ FloatingPoint 8 24))
+(declare-const y (_ FloatingPoint 8 24))
+(define-fun one () (_ FloatingPoint 8 24)
+  ((_ to_fp 8 24) #x3f800000))
+(assert (fp.lt one x))
+(assert (fp.lt one y))
+(assert (not (fp.isInfinite x)))
+(assert (not (fp.isInfinite y)))
+(assert (fp.gt (fp.mul RNE x y) x))
+(assert (fp.gt (fp.mul RNE x y) y))
+(check-sat)

--- a/tests/query-files/misc-tests/cadical-statistics.smt2
+++ b/tests/query-files/misc-tests/cadical-statistics.smt2
@@ -1,9 +1,9 @@
 ; REQUIRES: cadical-inprobing
 ; RUN: %solver --cadical -s %s 2>&1 | %OutputCheck %s
-; CHECK: CaDiCaL conflicts: {{[0-9]+}}
-; CHECK: CaDiCaL decisions: {{[0-9]+}}
-; CHECK: CaDiCaL search propagations: {{[0-9]+}}
-; CHECK: CaDiCaL search ticks: {{[0-9]+}}
+; CHECK: CaDiCaL conflicts: [0-9]+
+; CHECK: CaDiCaL decisions: [0-9]+
+; CHECK: CaDiCaL search propagations: [0-9]+
+; CHECK: CaDiCaL search ticks: [0-9]+
 ; CHECK-NOT: print stats not yet implemented
 ; CHECK: ^sat
 ; Keep enough coupled structure to reach the SAT backend instead of being

--- a/tests/query-files/misc-tests/minisat-statistics.smt2
+++ b/tests/query-files/misc-tests/minisat-statistics.smt2
@@ -1,17 +1,17 @@
 ; REQUIRES: minisat
 ; RUN: %solver --minisat -s %s 2>&1 | %OutputCheck --check-prefix=STATS %s
 ; RUN: %solver --simplifying-minisat -s %s 2>&1 | %OutputCheck --check-prefix=STATS %s
-; STATS: MiniSat starts: {{[0-9]+}}
-; STATS: MiniSat conflicts: {{[0-9]+}}
-; STATS: MiniSat decisions: {{[0-9]+}}
-; STATS: MiniSat propagations: {{[0-9]+}}
-; STATS: MiniSat variables: {{[0-9]+}}
-; STATS: MiniSat active original clauses: {{[0-9]+}}
-; STATS: MiniSat active original literals: {{[0-9]+}}
-; STATS: MiniSat active learnt clauses: {{[0-9]+}}
-; STATS: MiniSat active learnt literals: {{[0-9]+}}
-; STATS: MiniSat learnt literals before minimization: {{[0-9]+}}
-; STATS: MiniSat learnt literals after minimization: {{[0-9]+}}
+; STATS: MiniSat starts: [0-9]+
+; STATS: MiniSat conflicts: [0-9]+
+; STATS: MiniSat decisions: [0-9]+
+; STATS: MiniSat propagations: [0-9]+
+; STATS: MiniSat variables: [0-9]+
+; STATS: MiniSat active original clauses: [0-9]+
+; STATS: MiniSat active original literals: [0-9]+
+; STATS: MiniSat active learnt clauses: [0-9]+
+; STATS: MiniSat active learnt literals: [0-9]+
+; STATS: MiniSat learnt literals before minimization: [0-9]+
+; STATS: MiniSat learnt literals after minimization: [0-9]+
 ; STATS: ^sat
 ; Keep enough coupled structure to reach the SAT backend instead of being
 ; discharged by unconstrained-variable elimination.

--- a/tests/query-files/misc-tests/minisat-statistics.smt2
+++ b/tests/query-files/misc-tests/minisat-statistics.smt2
@@ -1,0 +1,29 @@
+; REQUIRES: minisat
+; RUN: %solver --minisat -s %s 2>&1 | %OutputCheck --check-prefix=STATS %s
+; RUN: %solver --simplifying-minisat -s %s 2>&1 | %OutputCheck --check-prefix=STATS %s
+; STATS: MiniSat starts: {{[0-9]+}}
+; STATS: MiniSat conflicts: {{[0-9]+}}
+; STATS: MiniSat decisions: {{[0-9]+}}
+; STATS: MiniSat propagations: {{[0-9]+}}
+; STATS: MiniSat variables: {{[0-9]+}}
+; STATS: MiniSat active original clauses: {{[0-9]+}}
+; STATS: MiniSat active original literals: {{[0-9]+}}
+; STATS: MiniSat active learnt clauses: {{[0-9]+}}
+; STATS: MiniSat active learnt literals: {{[0-9]+}}
+; STATS: MiniSat learnt literals before minimization: {{[0-9]+}}
+; STATS: MiniSat learnt literals after minimization: {{[0-9]+}}
+; STATS: ^sat
+; Keep enough coupled structure to reach the SAT backend instead of being
+; discharged by unconstrained-variable elimination.
+(set-logic QF_FP)
+(declare-const x (_ FloatingPoint 8 24))
+(declare-const y (_ FloatingPoint 8 24))
+(define-fun one () (_ FloatingPoint 8 24)
+  ((_ to_fp 8 24) #x3f800000))
+(assert (fp.lt one x))
+(assert (fp.lt one y))
+(assert (not (fp.isInfinite x)))
+(assert (not (fp.isInfinite y)))
+(assert (fp.gt (fp.mul RNE x y) x))
+(assert (fp.gt (fp.mul RNE x y) y))
+(check-sat)


### PR DESCRIPTION
## Summary

- report final MiniSat search and clause-database statistics from both MiniSat wrappers
- report compact final CaDiCaL counters through the CaDiCaL 3.x statistics API, while retaining the existing fallback for older versions
- add backend-gated regression coverage for the emitted statistics

These counters make fixed-conflict solver comparisons reproducible and help separate circuit/CNF improvements from changes in SAT search behavior.

## Testing

- `cmake --build build -j24`
- MiniSat core and simplifying-wrapper statistics query tests
- CaDiCaL statistics query test, gated on CaDiCaL support
- validated as part of the complete five-branch stack: all 649 supported query tests and all 140 compiled/API/unit tests passed

## Stack

This is PR 1 of 5. The later PRs are intentionally ordered on top of this one.
