### PR TITLE
Evaluate packed floating-point operations exactly

### DIFF
--- a/include/stp/FloatBlaster/DecimalLiteral.h
+++ b/include/stp/FloatBlaster/DecimalLiteral.h
@@ -72,6 +72,25 @@ bool rationalToPackedFPBits(const std::string& numerator,
                             unsigned rounding_mode, std::string& bits,
                             std::string& err);
 
+enum class PackedFpBinaryOp
+{
+  Add,
+  Subtract,
+  Multiply
+};
+
+// Evaluate one binary operation on two finite packed values exactly in the
+// target format. Inputs and output use the same MSB-first packed-bit spelling
+// as decimalToPackedFPBits. LibBF first reconstructs each input as an exact
+// dyadic value, then performs a single target-format rounding under
+// `rounding_mode`; host floating-point arithmetic is never involved. An
+// IEEE overflow result may be infinity. NaN/infinity inputs, malformed bit
+// strings, unsupported formats, and allocation failures return false.
+bool packedFPBinaryOp(const std::string& left, const std::string& right,
+                      unsigned exp_width, unsigned sig_width,
+                      unsigned rounding_mode, PackedFpBinaryOp operation,
+                      std::string& bits, std::string& err);
+
 } // namespace stp
 
 #endif

--- a/lib/FloatBlaster/DecimalLiteral.cpp
+++ b/lib/FloatBlaster/DecimalLiteral.cpp
@@ -184,6 +184,78 @@ void packToBits(const bf_t* v, unsigned exp_width, unsigned sig_width,
   }
 }
 
+// Reconstruct a finite packed IEEE value as an exact LibBF dyadic. Parsing
+// the significand as a base-two integer and applying its power-of-two scale
+// avoids both host precision and a decimal round trip.
+bool unpackFiniteBits(const std::string& bits, unsigned exp_width,
+                      unsigned sig_width, bf_t* value, std::string& err)
+{
+  const unsigned width = exp_width + sig_width;
+  if (bits.size() != width)
+  {
+    err = "a packed floating-point operand has the wrong width";
+    return false;
+  }
+  for (const char c : bits)
+    if (c != '0' && c != '1')
+    {
+      err = "a packed floating-point operand contains a non-bit character";
+      return false;
+    }
+
+  uint64_t exponent = 0;
+  for (unsigned i = 0; i < exp_width; i++)
+    exponent = (exponent << 1) | static_cast<uint64_t>(bits[1 + i] - '0');
+  const uint64_t max_exponent =
+      (static_cast<uint64_t>(1) << exp_width) - 1;
+  if (exponent == max_exponent)
+  {
+    err = "packedFPBinaryOp requires finite operands";
+    return false;
+  }
+
+  const std::string fraction = bits.substr(1 + exp_width);
+  bool fraction_nonzero = false;
+  for (const char c : fraction)
+    fraction_nonzero = fraction_nonzero || c == '1';
+  if (exponent == 0 && !fraction_nonzero)
+  {
+    bf_set_zero(value, bits[0] == '1');
+    return true;
+  }
+
+  std::string significand;
+  if (bits[0] == '1')
+    significand.push_back('-');
+  significand.push_back(exponent == 0 ? '0' : '1');
+  significand += fraction;
+
+  const char* next = nullptr;
+  int status = bf_atof(value, significand.c_str(), &next, 2, BF_PREC_INF,
+                       BF_RNDZ | BF_ATOF_NO_NAN_INF);
+  if ((status & (BF_ST_MEM_ERROR | BF_ST_INEXACT)) != 0 ||
+      next != significand.c_str() + significand.size())
+  {
+    err = "failed to reconstruct a packed floating-point operand";
+    return false;
+  }
+
+  const int64_t bias =
+      (static_cast<int64_t>(1) << (exp_width - 1)) - 1;
+  const int64_t unbiased = exponent == 0
+                               ? 1 - bias
+                               : static_cast<int64_t>(exponent) - bias;
+  const int64_t scale = unbiased - static_cast<int64_t>(sig_width - 1);
+  status = bf_mul_2exp(value, static_cast<slimb_t>(scale), BF_PREC_INF,
+                       BF_RNDZ);
+  if ((status & (BF_ST_MEM_ERROR | BF_ST_INEXACT)) != 0)
+  {
+    err = "failed to scale a packed floating-point operand";
+    return false;
+  }
+  return true;
+}
+
 } // namespace
 
 bool decimalToPackedFPBits(const std::string& decimal, unsigned exp_width,
@@ -365,6 +437,63 @@ bool rationalToPackedFPBits(const std::string& numerator,
   bf_delete(&v);
   bf_delete(&d);
   bf_delete(&n);
+  bf_context_end(&ctx);
+  return ok;
+}
+
+bool packedFPBinaryOp(const std::string& left, const std::string& right,
+                      unsigned exp_width, unsigned sig_width,
+                      unsigned rounding_mode, PackedFpBinaryOp operation,
+                      std::string& bits, std::string& err)
+{
+  if (!checkFormat(exp_width, sig_width, err))
+    return false;
+
+  bf_context_t ctx;
+  bf_context_init(&ctx, bfRealloc, nullptr);
+  bf_t a, b, result;
+  bf_init(&ctx, &a);
+  bf_init(&ctx, &b);
+  bf_init(&ctx, &result);
+
+  bool ok = unpackFiniteBits(left, exp_width, sig_width, &a, err) &&
+            unpackFiniteBits(right, exp_width, sig_width, &b, err);
+  if (ok)
+  {
+    const bf_flags_t flags = (bf_flags_t)bfRounding(rounding_mode) |
+                             bf_set_exp_bits((int)exp_width) |
+                             BF_FLAG_SUBNORMAL;
+    int status = 0;
+    switch (operation)
+    {
+      case PackedFpBinaryOp::Add:
+        status = bf_add(&result, &a, &b, (limb_t)sig_width, flags);
+        break;
+      case PackedFpBinaryOp::Subtract:
+        status = bf_sub(&result, &a, &b, (limb_t)sig_width, flags);
+        break;
+      case PackedFpBinaryOp::Multiply:
+        status = bf_mul(&result, &a, &b, (limb_t)sig_width, flags);
+        break;
+    }
+
+    if ((status & BF_ST_MEM_ERROR) != 0)
+    {
+      err = "out of memory while evaluating a packed floating-point operation";
+      ok = false;
+    }
+    else if (bf_is_nan(&result))
+    {
+      err = "a finite packed floating-point operation produced NaN";
+      ok = false;
+    }
+    else
+      packToBits(&result, exp_width, sig_width, bits);
+  }
+
+  bf_delete(&result);
+  bf_delete(&b);
+  bf_delete(&a);
   bf_context_end(&ctx);
   return ok;
 }

--- a/lib/Sat/Cadical.cpp
+++ b/lib/Sat/Cadical.cpp
@@ -139,10 +139,22 @@ Cadical::~Cadical()
 
 void Cadical::printStats() const
 {
-    // The newline matters: without it this stderr fragment glues onto the
-    // next stdout line (the check-sat verdict) in a combined stream, which
-    // is exactly what line-anchored test checks read.
-    std::cerr << "print stats not yet implemented." << std::endl;
+#if defined(CADICAL_MAJOR) && CADICAL_MAJOR >= 3
+  // These counters remain available in the UNKNOWN state produced by our
+  // Terminator. Keep this compact: CaDiCaL's full reporter is several hundred
+  // lines, while these are the search quantities benchmark logs consume.
+  std::cerr << "CaDiCaL conflicts: "
+            << s->get_statistic_value("conflicts") << std::endl;
+  std::cerr << "CaDiCaL decisions: "
+            << s->get_statistic_value("decisions") << std::endl;
+  std::cerr << "CaDiCaL search propagations: "
+            << s->get_statistic_value("propagations") << std::endl;
+  std::cerr << "CaDiCaL search ticks: "
+            << s->get_statistic_value("ticks") << std::endl;
+#else
+  // get_statistic_value() is unavailable in the oldest supported releases.
+  s->statistics();
+#endif
 }
 
 uint32_t Cadical::newVar()

--- a/lib/Sat/MinisatCore.cpp
+++ b/lib/Sat/MinisatCore.cpp
@@ -25,6 +25,7 @@ THE SOFTWARE.
 #define __STDC_FORMAT_MACROS
 #include "stp/Sat/MinisatCore.h"
 #include "minisat/core/Solver.h"
+#include <iostream>
 //#include "utils/System.h"
 //#include "simp/SimpSolver.h"
 
@@ -151,7 +152,35 @@ uint32_t MinisatCore::nVars() const
 
 void MinisatCore::printStats() const
 {
-  //s->printStats();
+  // MiniSat's periodic table is useful while a long search is running, but
+  // fixed-conflict profiles also need exact final totals. In particular,
+  // propagations/conflict distinguishes SAT-search work from front-end time.
+  std::cerr << "MiniSat starts: " << s->starts << '\n';
+  std::cerr << "MiniSat conflicts: " << s->conflicts << '\n';
+  std::cerr << "MiniSat decisions: " << s->decisions << '\n';
+  std::cerr << "MiniSat propagations: " << s->propagations << '\n';
+  std::cerr << "MiniSat variables: " << s->nVars() << '\n';
+  if (s->conflicts != 0)
+  {
+    std::cerr << "MiniSat decisions per conflict: "
+              << static_cast<double>(s->decisions) / s->conflicts << '\n';
+    std::cerr << "MiniSat propagations per conflict: "
+              << static_cast<double>(s->propagations) / s->conflicts << '\n';
+  }
+  std::cerr << "MiniSat active original clauses: " << s->nClauses() << '\n';
+  std::cerr << "MiniSat active original literals: " << s->clauses_literals
+            << '\n';
+  std::cerr << "MiniSat active learnt clauses: " << s->nLearnts() << '\n';
+  std::cerr << "MiniSat active learnt literals: " << s->learnts_literals
+            << '\n';
+  if (s->nLearnts() != 0)
+    std::cerr << "MiniSat active learnt literals per clause: "
+              << static_cast<double>(s->learnts_literals) / s->nLearnts()
+              << '\n';
+  std::cerr << "MiniSat learnt literals before minimization: "
+            << s->max_literals << '\n';
+  std::cerr << "MiniSat learnt literals after minimization: "
+            << s->tot_literals << '\n';
 }
 
 int MinisatCore::nClauses()

--- a/lib/Sat/SimplifyingMinisat.cpp
+++ b/lib/Sat/SimplifyingMinisat.cpp
@@ -25,6 +25,7 @@ THE SOFTWARE.
 #define __STDC_FORMAT_MACROS
 #include "stp/Sat/SimplifyingMinisat.h"
 #include "minisat/simp/SimpSolver.h"
+#include <iostream>
 
 namespace MiniSat
 {
@@ -113,7 +114,32 @@ uint32_t SimplifyingMinisat::nVars() const
 
 void SimplifyingMinisat::printStats() const
 {
-  //s->printStats();
+  std::cerr << "MiniSat starts: " << s->starts << '\n';
+  std::cerr << "MiniSat conflicts: " << s->conflicts << '\n';
+  std::cerr << "MiniSat decisions: " << s->decisions << '\n';
+  std::cerr << "MiniSat propagations: " << s->propagations << '\n';
+  std::cerr << "MiniSat variables: " << s->nVars() << '\n';
+  if (s->conflicts != 0)
+  {
+    std::cerr << "MiniSat decisions per conflict: "
+              << static_cast<double>(s->decisions) / s->conflicts << '\n';
+    std::cerr << "MiniSat propagations per conflict: "
+              << static_cast<double>(s->propagations) / s->conflicts << '\n';
+  }
+  std::cerr << "MiniSat active original clauses: " << s->nClauses() << '\n';
+  std::cerr << "MiniSat active original literals: " << s->clauses_literals
+            << '\n';
+  std::cerr << "MiniSat active learnt clauses: " << s->nLearnts() << '\n';
+  std::cerr << "MiniSat active learnt literals: " << s->learnts_literals
+            << '\n';
+  if (s->nLearnts() != 0)
+    std::cerr << "MiniSat active learnt literals per clause: "
+              << static_cast<double>(s->learnts_literals) / s->nLearnts()
+              << '\n';
+  std::cerr << "MiniSat learnt literals before minimization: "
+            << s->max_literals << '\n';
+  std::cerr << "MiniSat learnt literals after minimization: "
+            << s->tot_literals << '\n';
 }
 
 void SimplifyingMinisat::setFrozen(uint32_t x)

--- a/tests/query-files/misc-tests/cadical-statistics.smt2
+++ b/tests/query-files/misc-tests/cadical-statistics.smt2
@@ -1,0 +1,22 @@
+; REQUIRES: cadical-inprobing
+; RUN: %solver --cadical -s %s 2>&1 | %OutputCheck %s
+; CHECK: CaDiCaL conflicts: {{[0-9]+}}
+; CHECK: CaDiCaL decisions: {{[0-9]+}}
+; CHECK: CaDiCaL search propagations: {{[0-9]+}}
+; CHECK: CaDiCaL search ticks: {{[0-9]+}}
+; CHECK-NOT: print stats not yet implemented
+; CHECK: ^sat
+; Keep enough coupled structure to reach the SAT backend instead of being
+; discharged by unconstrained-variable elimination.
+(set-logic QF_FP)
+(declare-const x (_ FloatingPoint 8 24))
+(declare-const y (_ FloatingPoint 8 24))
+(define-fun one () (_ FloatingPoint 8 24)
+  ((_ to_fp 8 24) #x3f800000))
+(assert (fp.lt one x))
+(assert (fp.lt one y))
+(assert (not (fp.isInfinite x)))
+(assert (not (fp.isInfinite y)))
+(assert (fp.gt (fp.mul RNE x y) x))
+(assert (fp.gt (fp.mul RNE x y) y))
+(check-sat)

--- a/tests/query-files/misc-tests/cadical-statistics.smt2
+++ b/tests/query-files/misc-tests/cadical-statistics.smt2
@@ -1,9 +1,9 @@
 ; REQUIRES: cadical-inprobing
 ; RUN: %solver --cadical -s %s 2>&1 | %OutputCheck %s
-; CHECK: CaDiCaL conflicts: {{[0-9]+}}
-; CHECK: CaDiCaL decisions: {{[0-9]+}}
-; CHECK: CaDiCaL search propagations: {{[0-9]+}}
-; CHECK: CaDiCaL search ticks: {{[0-9]+}}
+; CHECK: CaDiCaL conflicts: [0-9]+
+; CHECK: CaDiCaL decisions: [0-9]+
+; CHECK: CaDiCaL search propagations: [0-9]+
+; CHECK: CaDiCaL search ticks: [0-9]+
 ; CHECK-NOT: print stats not yet implemented
 ; CHECK: ^sat
 ; Keep enough coupled structure to reach the SAT backend instead of being

--- a/tests/query-files/misc-tests/minisat-statistics.smt2
+++ b/tests/query-files/misc-tests/minisat-statistics.smt2
@@ -1,17 +1,17 @@
 ; REQUIRES: minisat
 ; RUN: %solver --minisat -s %s 2>&1 | %OutputCheck --check-prefix=STATS %s
 ; RUN: %solver --simplifying-minisat -s %s 2>&1 | %OutputCheck --check-prefix=STATS %s
-; STATS: MiniSat starts: {{[0-9]+}}
-; STATS: MiniSat conflicts: {{[0-9]+}}
-; STATS: MiniSat decisions: {{[0-9]+}}
-; STATS: MiniSat propagations: {{[0-9]+}}
-; STATS: MiniSat variables: {{[0-9]+}}
-; STATS: MiniSat active original clauses: {{[0-9]+}}
-; STATS: MiniSat active original literals: {{[0-9]+}}
-; STATS: MiniSat active learnt clauses: {{[0-9]+}}
-; STATS: MiniSat active learnt literals: {{[0-9]+}}
-; STATS: MiniSat learnt literals before minimization: {{[0-9]+}}
-; STATS: MiniSat learnt literals after minimization: {{[0-9]+}}
+; STATS: MiniSat starts: [0-9]+
+; STATS: MiniSat conflicts: [0-9]+
+; STATS: MiniSat decisions: [0-9]+
+; STATS: MiniSat propagations: [0-9]+
+; STATS: MiniSat variables: [0-9]+
+; STATS: MiniSat active original clauses: [0-9]+
+; STATS: MiniSat active original literals: [0-9]+
+; STATS: MiniSat active learnt clauses: [0-9]+
+; STATS: MiniSat active learnt literals: [0-9]+
+; STATS: MiniSat learnt literals before minimization: [0-9]+
+; STATS: MiniSat learnt literals after minimization: [0-9]+
 ; STATS: ^sat
 ; Keep enough coupled structure to reach the SAT backend instead of being
 ; discharged by unconstrained-variable elimination.

--- a/tests/query-files/misc-tests/minisat-statistics.smt2
+++ b/tests/query-files/misc-tests/minisat-statistics.smt2
@@ -1,0 +1,29 @@
+; REQUIRES: minisat
+; RUN: %solver --minisat -s %s 2>&1 | %OutputCheck --check-prefix=STATS %s
+; RUN: %solver --simplifying-minisat -s %s 2>&1 | %OutputCheck --check-prefix=STATS %s
+; STATS: MiniSat starts: {{[0-9]+}}
+; STATS: MiniSat conflicts: {{[0-9]+}}
+; STATS: MiniSat decisions: {{[0-9]+}}
+; STATS: MiniSat propagations: {{[0-9]+}}
+; STATS: MiniSat variables: {{[0-9]+}}
+; STATS: MiniSat active original clauses: {{[0-9]+}}
+; STATS: MiniSat active original literals: {{[0-9]+}}
+; STATS: MiniSat active learnt clauses: {{[0-9]+}}
+; STATS: MiniSat active learnt literals: {{[0-9]+}}
+; STATS: MiniSat learnt literals before minimization: {{[0-9]+}}
+; STATS: MiniSat learnt literals after minimization: {{[0-9]+}}
+; STATS: ^sat
+; Keep enough coupled structure to reach the SAT backend instead of being
+; discharged by unconstrained-variable elimination.
+(set-logic QF_FP)
+(declare-const x (_ FloatingPoint 8 24))
+(declare-const y (_ FloatingPoint 8 24))
+(define-fun one () (_ FloatingPoint 8 24)
+  ((_ to_fp 8 24) #x3f800000))
+(assert (fp.lt one x))
+(assert (fp.lt one y))
+(assert (not (fp.isInfinite x)))
+(assert (not (fp.isInfinite y)))
+(assert (fp.gt (fp.mul RNE x y) x))
+(assert (fp.gt (fp.mul RNE x y) y))
+(check-sat)

--- a/tests/unit-tests/DecimalToFP_Test.cpp
+++ b/tests/unit-tests/DecimalToFP_Test.cpp
@@ -64,6 +64,17 @@ std::string bitsOfU64(uint64_t v, unsigned width)
   return s;
 }
 
+std::string binary(const std::string& left, const std::string& right,
+                   unsigned eb, unsigned sb, unsigned rm,
+                   PackedFpBinaryOp operation)
+{
+  std::string bits, err;
+  const bool ok = packedFPBinaryOp(left, right, eb, sb, rm, operation, bits,
+                                   err);
+  EXPECT_TRUE(ok) << "(" << eb << "," << sb << "): " << err;
+  return ok ? bits : "";
+}
+
 std::string hostFloatBits(const std::string& dec)
 {
   const float f = strtof(dec.c_str(), nullptr);
@@ -376,6 +387,107 @@ TEST(DecimalToFP, unsupportedExponentWidths)
   EXPECT_FALSE(decimalToPackedFPBits("1.5", 62, 8,
                                      ROUND_NEAREST_TIES_TO_EVEN, bits, err));
   EXPECT_NE(err.find("exponent widths"), std::string::npos) << err;
+}
+
+TEST(PackedFpBinaryOp, exactArithmeticAndCancellation)
+{
+  const std::string one = bitsOfU64(0x3c00, 16);
+  const std::string onePointFive = bitsOfU64(0x3e00, 16);
+  const std::string two = bitsOfU64(0x4000, 16);
+
+  EXPECT_EQ(binary(onePointFive, two, 5, 11, ROUND_NEAREST_TIES_TO_EVEN,
+                   PackedFpBinaryOp::Add),
+            bitsOfU64(0x4300, 16)); // 3.5
+  EXPECT_EQ(binary(two, onePointFive, 5, 11,
+                   ROUND_NEAREST_TIES_TO_EVEN,
+                   PackedFpBinaryOp::Subtract),
+            bitsOfU64(0x3800, 16)); // 0.5
+  EXPECT_EQ(binary(onePointFive, two, 5, 11,
+                   ROUND_NEAREST_TIES_TO_EVEN,
+                   PackedFpBinaryOp::Multiply),
+            bitsOfU64(0x4200, 16)); // 3.0
+
+  EXPECT_EQ(binary(one, one, 5, 11, ROUND_NEAREST_TIES_TO_EVEN,
+                   PackedFpBinaryOp::Subtract),
+            bitsOfU64(0x0000, 16));
+  EXPECT_EQ(binary(one, one, 5, 11, ROUND_TOWARD_NEGATIVE,
+                   PackedFpBinaryOp::Subtract),
+            bitsOfU64(0x8000, 16));
+}
+
+TEST(PackedFpBinaryOp, underflowUsesTheRequestedRoundingMode)
+{
+  const std::string minSub = bitsOfU64(0x0001, 16);
+  const std::string minusMinSub = bitsOfU64(0x8001, 16);
+  const std::string half = bitsOfU64(0x3800, 16);
+
+  EXPECT_EQ(binary(minSub, half, 5, 11, ROUND_NEAREST_TIES_TO_EVEN,
+                   PackedFpBinaryOp::Multiply),
+            bitsOfU64(0x0000, 16));
+  EXPECT_EQ(binary(minSub, half, 5, 11, ROUND_NEAREST_TIES_TO_AWAY,
+                   PackedFpBinaryOp::Multiply),
+            minSub);
+  EXPECT_EQ(binary(minSub, half, 5, 11, ROUND_TOWARD_POSITIVE,
+                   PackedFpBinaryOp::Multiply),
+            minSub);
+  EXPECT_EQ(binary(minusMinSub, half, 5, 11, ROUND_TOWARD_POSITIVE,
+                   PackedFpBinaryOp::Multiply),
+            bitsOfU64(0x8000, 16));
+  EXPECT_EQ(binary(minusMinSub, half, 5, 11, ROUND_TOWARD_NEGATIVE,
+                   PackedFpBinaryOp::Multiply),
+            minusMinSub);
+}
+
+TEST(PackedFpBinaryOp, overflowUsesTheRequestedRoundingMode)
+{
+  const std::string maxFinite = bitsOfU64(0x7bff, 16);
+  const std::string two = bitsOfU64(0x4000, 16);
+  EXPECT_EQ(binary(maxFinite, two, 5, 11, ROUND_NEAREST_TIES_TO_EVEN,
+                   PackedFpBinaryOp::Multiply),
+            bitsOfU64(0x7c00, 16));
+  EXPECT_EQ(binary(maxFinite, two, 5, 11, ROUND_TOWARD_POSITIVE,
+                   PackedFpBinaryOp::Multiply),
+            bitsOfU64(0x7c00, 16));
+  EXPECT_EQ(binary(maxFinite, two, 5, 11, ROUND_TOWARD_NEGATIVE,
+                   PackedFpBinaryOp::Multiply),
+            maxFinite);
+  EXPECT_EQ(binary(maxFinite, two, 5, 11, ROUND_TOWARD_ZERO,
+                   PackedFpBinaryOp::Multiply),
+            maxFinite);
+}
+
+TEST(PackedFpBinaryOp, signedZerosArePreserved)
+{
+  const std::string minusZero = bitsOfU64(0x8000, 16);
+  const std::string two = bitsOfU64(0x4000, 16);
+  const std::string minusTwo = bitsOfU64(0xc000, 16);
+  EXPECT_EQ(binary(minusZero, two, 5, 11, ROUND_NEAREST_TIES_TO_EVEN,
+                   PackedFpBinaryOp::Multiply),
+            minusZero);
+  EXPECT_EQ(binary(minusZero, minusTwo, 5, 11,
+                   ROUND_NEAREST_TIES_TO_EVEN,
+                   PackedFpBinaryOp::Multiply),
+            bitsOfU64(0x0000, 16));
+}
+
+TEST(PackedFpBinaryOp, rejectsMalformedAndNonfiniteInputs)
+{
+  const std::string one = bitsOfU64(0x3c00, 16);
+  std::string bits, err;
+  EXPECT_FALSE(packedFPBinaryOp(bitsOfU64(0x7c00, 16), one, 5, 11,
+                                ROUND_NEAREST_TIES_TO_EVEN,
+                                PackedFpBinaryOp::Add, bits, err));
+  EXPECT_NE(err.find("finite operands"), std::string::npos) << err;
+  err.clear();
+  EXPECT_FALSE(packedFPBinaryOp("000000000000000x", one, 5, 11,
+                                ROUND_NEAREST_TIES_TO_EVEN,
+                                PackedFpBinaryOp::Add, bits, err));
+  EXPECT_NE(err.find("non-bit"), std::string::npos) << err;
+  err.clear();
+  EXPECT_FALSE(packedFPBinaryOp("0", one, 5, 11,
+                                ROUND_NEAREST_TIES_TO_EVEN,
+                                PackedFpBinaryOp::Add, bits, err));
+  EXPECT_NE(err.find("wrong width"), std::string::npos) << err;
 }
 
 } // namespace


### PR DESCRIPTION
## Summary

- add an exact packed floating-point binary-operation helper for finite constants
- reconstruct packed operands as exact LibBF dyadics, perform one target-format add/subtract/multiply rounding, and repack the result
- cover cancellation, signed zero, underflow, overflow, malformed encodings, and every rounding mode

The implementation does not use host floating-point arithmetic, so endpoint evaluation follows the target format rather than the host format or an enlarged intermediate format.

## Testing

- `cmake --build build -j24`
- focused exact-arithmetic, cancellation, signed-zero, underflow, overflow, non-finite, and malformed-input tests
- validated as part of the complete five-branch stack: all 649 supported query tests and all 140 compiled/API/unit tests passed

## Stack

This is PR 2 of 5 and depends on #961.

GitHub cannot use the fork-only predecessor branch as the base of an `stp/stp` PR, so the displayed diff is cumulative until #961 merges. The intended layer-only diff is [fp-pr-01-sat-statistics...fp-pr-02-exact-endpoints](https://github.com/aytey/stp/compare/fp-pr-01-sat-statistics...fp-pr-02-exact-endpoints).
