### PR TITLE
Fuse native floating-point add zero predicates

### DIFF
--- a/include/stp/FloatBlaster/DecimalLiteral.h
+++ b/include/stp/FloatBlaster/DecimalLiteral.h
@@ -72,6 +72,25 @@ bool rationalToPackedFPBits(const std::string& numerator,
                             unsigned rounding_mode, std::string& bits,
                             std::string& err);
 
+enum class PackedFpBinaryOp
+{
+  Add,
+  Subtract,
+  Multiply
+};
+
+// Evaluate one binary operation on two finite packed values exactly in the
+// target format. Inputs and output use the same MSB-first packed-bit spelling
+// as decimalToPackedFPBits. LibBF first reconstructs each input as an exact
+// dyadic value, then performs a single target-format rounding under
+// `rounding_mode`; host floating-point arithmetic is never involved. An
+// IEEE overflow result may be infinity. NaN/infinity inputs, malformed bit
+// strings, unsupported formats, and allocation failures return false.
+bool packedFPBinaryOp(const std::string& left, const std::string& right,
+                      unsigned exp_width, unsigned sig_width,
+                      unsigned rounding_mode, PackedFpBinaryOp operation,
+                      std::string& bits, std::string& err);
+
 } // namespace stp
 
 #endif

--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -281,6 +281,11 @@ public:
   // circuits. Experimental; off by default.
   bool fp_native_arith = false;
 
+  // Recognise fp.isZero(fp.add ...) and encode only the observed zero-result
+  // condition instead of constructing and packing every result bit.
+  // Experimental; requires native arithmetic and is off by default.
+  bool fp_native_add_iszero = false;
+
   int64_t multiplication_variant = 1;
 
   // If the bit-blaster discovers new constants, should the term simplifier be

--- a/include/stp/ToSat/BitBlaster.h
+++ b/include/stp/ToSat/BitBlaster.h
@@ -222,7 +222,10 @@ class BitBlaster
   // (--bb.fp-native-arith)
   BBNodeVec BBfpMul(const ASTNode& term, BBNodeSet& support);
   BBNodeVec BBfpAdd(const ASTNode& term, BBNodeSet& support);
+  BBNode BBfpAddIsZero(const ASTNode& term, BBNodeSet& support);
   BBNodeVec BBfpToFp(const ASTNode& term, BBNodeSet& support);
+
+  size_t fpNativeAddIsZeroFusions = 0;
 
   // A packed operand split for the native arithmetic circuits: fields,
   // classification, and the significand with its hidden bit made explicit
@@ -398,6 +401,7 @@ public:
   {
     BBTermMemo.clear();
     BBFormMemo.clear();
+    fpNativeAddIsZeroFusions = 0;
   }
 
   // Bitblast a formula

--- a/lib/FloatBlaster/DecimalLiteral.cpp
+++ b/lib/FloatBlaster/DecimalLiteral.cpp
@@ -184,6 +184,78 @@ void packToBits(const bf_t* v, unsigned exp_width, unsigned sig_width,
   }
 }
 
+// Reconstruct a finite packed IEEE value as an exact LibBF dyadic. Parsing
+// the significand as a base-two integer and applying its power-of-two scale
+// avoids both host precision and a decimal round trip.
+bool unpackFiniteBits(const std::string& bits, unsigned exp_width,
+                      unsigned sig_width, bf_t* value, std::string& err)
+{
+  const unsigned width = exp_width + sig_width;
+  if (bits.size() != width)
+  {
+    err = "a packed floating-point operand has the wrong width";
+    return false;
+  }
+  for (const char c : bits)
+    if (c != '0' && c != '1')
+    {
+      err = "a packed floating-point operand contains a non-bit character";
+      return false;
+    }
+
+  uint64_t exponent = 0;
+  for (unsigned i = 0; i < exp_width; i++)
+    exponent = (exponent << 1) | static_cast<uint64_t>(bits[1 + i] - '0');
+  const uint64_t max_exponent =
+      (static_cast<uint64_t>(1) << exp_width) - 1;
+  if (exponent == max_exponent)
+  {
+    err = "packedFPBinaryOp requires finite operands";
+    return false;
+  }
+
+  const std::string fraction = bits.substr(1 + exp_width);
+  bool fraction_nonzero = false;
+  for (const char c : fraction)
+    fraction_nonzero = fraction_nonzero || c == '1';
+  if (exponent == 0 && !fraction_nonzero)
+  {
+    bf_set_zero(value, bits[0] == '1');
+    return true;
+  }
+
+  std::string significand;
+  if (bits[0] == '1')
+    significand.push_back('-');
+  significand.push_back(exponent == 0 ? '0' : '1');
+  significand += fraction;
+
+  const char* next = nullptr;
+  int status = bf_atof(value, significand.c_str(), &next, 2, BF_PREC_INF,
+                       BF_RNDZ | BF_ATOF_NO_NAN_INF);
+  if ((status & (BF_ST_MEM_ERROR | BF_ST_INEXACT)) != 0 ||
+      next != significand.c_str() + significand.size())
+  {
+    err = "failed to reconstruct a packed floating-point operand";
+    return false;
+  }
+
+  const int64_t bias =
+      (static_cast<int64_t>(1) << (exp_width - 1)) - 1;
+  const int64_t unbiased = exponent == 0
+                               ? 1 - bias
+                               : static_cast<int64_t>(exponent) - bias;
+  const int64_t scale = unbiased - static_cast<int64_t>(sig_width - 1);
+  status = bf_mul_2exp(value, static_cast<slimb_t>(scale), BF_PREC_INF,
+                       BF_RNDZ);
+  if ((status & (BF_ST_MEM_ERROR | BF_ST_INEXACT)) != 0)
+  {
+    err = "failed to scale a packed floating-point operand";
+    return false;
+  }
+  return true;
+}
+
 } // namespace
 
 bool decimalToPackedFPBits(const std::string& decimal, unsigned exp_width,
@@ -365,6 +437,63 @@ bool rationalToPackedFPBits(const std::string& numerator,
   bf_delete(&v);
   bf_delete(&d);
   bf_delete(&n);
+  bf_context_end(&ctx);
+  return ok;
+}
+
+bool packedFPBinaryOp(const std::string& left, const std::string& right,
+                      unsigned exp_width, unsigned sig_width,
+                      unsigned rounding_mode, PackedFpBinaryOp operation,
+                      std::string& bits, std::string& err)
+{
+  if (!checkFormat(exp_width, sig_width, err))
+    return false;
+
+  bf_context_t ctx;
+  bf_context_init(&ctx, bfRealloc, nullptr);
+  bf_t a, b, result;
+  bf_init(&ctx, &a);
+  bf_init(&ctx, &b);
+  bf_init(&ctx, &result);
+
+  bool ok = unpackFiniteBits(left, exp_width, sig_width, &a, err) &&
+            unpackFiniteBits(right, exp_width, sig_width, &b, err);
+  if (ok)
+  {
+    const bf_flags_t flags = (bf_flags_t)bfRounding(rounding_mode) |
+                             bf_set_exp_bits((int)exp_width) |
+                             BF_FLAG_SUBNORMAL;
+    int status = 0;
+    switch (operation)
+    {
+      case PackedFpBinaryOp::Add:
+        status = bf_add(&result, &a, &b, (limb_t)sig_width, flags);
+        break;
+      case PackedFpBinaryOp::Subtract:
+        status = bf_sub(&result, &a, &b, (limb_t)sig_width, flags);
+        break;
+      case PackedFpBinaryOp::Multiply:
+        status = bf_mul(&result, &a, &b, (limb_t)sig_width, flags);
+        break;
+    }
+
+    if ((status & BF_ST_MEM_ERROR) != 0)
+    {
+      err = "out of memory while evaluating a packed floating-point operation";
+      ok = false;
+    }
+    else if (bf_is_nan(&result))
+    {
+      err = "a finite packed floating-point operation produced NaN";
+      ok = false;
+    }
+    else
+      packToBits(&result, exp_width, sig_width, bits);
+  }
+
+  bf_delete(&result);
+  bf_delete(&b);
+  bf_delete(&a);
   bf_context_end(&ctx);
   return ok;
 }

--- a/lib/FloatBlaster/FloatBlast.cpp
+++ b/lib/FloatBlaster/FloatBlast.cpp
@@ -29,6 +29,8 @@ THE SOFTWARE.
 #include "stp/FloatBlaster/symbolic_fp.h"
 
 #include <cassert>
+#include <cstdint>
+#include <limits>
 #include <unordered_map>
 
 namespace stp
@@ -63,6 +65,86 @@ private:
   typedef std::unordered_map<ASTNode, std::unique_ptr<symbolic_fp::uf>,
                              ASTNode::ASTNodeHasher, ASTNode::ASTNodeEqual>
       UnpackedMap;
+
+  // The native arithmetic circuits currently materialise IEEE biases and
+  // exponent envelopes in `unsigned`, and their logarithmic-width helpers
+  // use `1u << bit`. Keep every such value strictly below unsigned's sign
+  // bit and every shift count within the host type. SMT-LIB admits wider
+  // formats; those remain supported through the ordinary SymFPU lowering.
+  static bool consumeNativeFpEnvelope(std::uintmax_t& remaining,
+                                      std::uintmax_t amount)
+  {
+    if (amount >= remaining)
+      return false;
+    remaining -= amount;
+    return true;
+  }
+
+  static bool nativeFpExponentIsSafe(unsigned eb)
+  {
+    const unsigned digits = std::numeric_limits<unsigned>::digits;
+    return eb >= 2 && eb <= digits - 2;
+  }
+
+  static std::uintmax_t nativeFpBias(unsigned eb)
+  {
+    assert(nativeFpExponentIsSafe(eb));
+    return (std::uintmax_t{1} << (eb - 1)) - 1;
+  }
+
+  static std::uintmax_t nativeFpEnvelopeLimit()
+  {
+    // 2^(digits - 1), without adding one to unsigned's maximum.
+    return static_cast<std::uintmax_t>(std::numeric_limits<unsigned>::max() /
+                                       2) +
+           1;
+  }
+
+  static bool nativeFpArithmeticFormatIsSafe(const SourceSort& sort)
+  {
+    if (sort.kind() != SourceSort::Kind::FloatingPoint)
+      return false;
+
+    const unsigned eb = sort.exponentWidth();
+    const unsigned sb = sort.significandWidth();
+    if (sb < 2 || !nativeFpExponentIsSafe(eb))
+      return false;
+
+    // BBfpExpWidth must represent bias + 2*sb + 4 without reaching a
+    // shift by numeric_limits<unsigned>::digits. This also bounds every
+    // doubled width and logarithmic shift amount used by BBfpAdd/BBfpMul.
+    std::uintmax_t remaining = nativeFpEnvelopeLimit();
+    return consumeNativeFpEnvelope(remaining, nativeFpBias(eb)) &&
+           consumeNativeFpEnvelope(remaining, sb) &&
+           consumeNativeFpEnvelope(remaining, sb) &&
+           consumeNativeFpEnvelope(remaining, 4);
+  }
+
+  static bool nativeFpToFpFormatsAreSafe(const SourceSort& source,
+                                         const SourceSort& target)
+  {
+    if (source.kind() != SourceSort::Kind::FloatingPoint ||
+        target.kind() != SourceSort::Kind::FloatingPoint)
+      return false;
+
+    const unsigned eb1 = source.exponentWidth();
+    const unsigned sb1 = source.significandWidth();
+    const unsigned eb2 = target.exponentWidth();
+    const unsigned sb2 = target.significandWidth();
+    if (sb1 < 2 || sb2 < 2 || !nativeFpExponentIsSafe(eb1) ||
+        !nativeFpExponentIsSafe(eb2))
+      return false;
+
+    // BBfpToFp sizes its signed exponent for the complete source/target
+    // envelope: bias1 + sb1 + bias2 + 2*sb2 + 4.
+    std::uintmax_t remaining = nativeFpEnvelopeLimit();
+    return consumeNativeFpEnvelope(remaining, nativeFpBias(eb1)) &&
+           consumeNativeFpEnvelope(remaining, sb1) &&
+           consumeNativeFpEnvelope(remaining, nativeFpBias(eb2)) &&
+           consumeNativeFpEnvelope(remaining, sb2) &&
+           consumeNativeFpEnvelope(remaining, sb2) &&
+           consumeNativeFpEnvelope(remaining, 4);
+  }
 
   symbolic_fp::floatingPointTypeInfo formatOf(const ASTNode& n) const
   {
@@ -162,15 +244,17 @@ private:
     // hand-written packed circuits (BBfpMul, BBfpAdd) take over from
     // SymFPU when both float operands resolve to packed views and the
     // rounding mode is immediate (a constant, or a declared symbol --
-    // whose one-hot validity is asserted at declaration). The rebuild
-    // goes through the factory, so constant operands fold (a fully
-    // constant operation never survives, keeping the lowering-must-change
-    // invariant of constant folding and model evaluation) and the
-    // identity rules still fire. fp.sub needs no arm: the factory already
-    // lowers it to fp.add of the negation.
+    // whose one-hot validity is asserted at declaration), and the format's
+    // host-sized intermediate calculations are safe. Wider legal formats
+    // fall back to SymFPU. The rebuild goes through the factory, so constant
+    // operands fold (a fully constant operation never survives, keeping the
+    // lowering-must-change invariant of constant folding and model
+    // evaluation) and the identity rules still fire. fp.sub needs no arm:
+    // the factory already lowers it to fp.add of the negation.
     if ((n.GetKind() == FP_MUL || n.GetKind() == FP_ADD) &&
         bm->UserFlags.fp_native_arith && n.Degree() == 3 &&
-        (n[0].GetKind() == SYMBOL || n[0].GetKind() == BVCONST))
+        (n[0].GetKind() == SYMBOL || n[0].GetKind() == BVCONST) &&
+        nativeFpArithmeticFormatIsSafe(n.GetSourceSort()))
     {
       const ASTNode left = comparisonLeaf(n[1]);
       if (left.IsNull())
@@ -202,7 +286,8 @@ private:
     if (n.GetKind() == FP_TOFP && bm->UserFlags.fp_native_arith &&
         n.Degree() == 4 &&
         (n[2].GetKind() == SYMBOL || n[2].GetKind() == BVCONST) &&
-        n[0].GetUnsignedConst() >= 3)
+        n[0].GetUnsignedConst() >= 3 &&
+        nativeFpToFpFormatsAreSafe(n[3].GetSourceSort(), n.GetSourceSort()))
     {
       const ASTNode operand = comparisonLeaf(n[3]);
       if (operand.IsNull())

--- a/lib/Sat/Cadical.cpp
+++ b/lib/Sat/Cadical.cpp
@@ -139,10 +139,22 @@ Cadical::~Cadical()
 
 void Cadical::printStats() const
 {
-    // The newline matters: without it this stderr fragment glues onto the
-    // next stdout line (the check-sat verdict) in a combined stream, which
-    // is exactly what line-anchored test checks read.
-    std::cerr << "print stats not yet implemented." << std::endl;
+#if defined(CADICAL_MAJOR) && CADICAL_MAJOR >= 3
+  // These counters remain available in the UNKNOWN state produced by our
+  // Terminator. Keep this compact: CaDiCaL's full reporter is several hundred
+  // lines, while these are the search quantities benchmark logs consume.
+  std::cerr << "CaDiCaL conflicts: "
+            << s->get_statistic_value("conflicts") << std::endl;
+  std::cerr << "CaDiCaL decisions: "
+            << s->get_statistic_value("decisions") << std::endl;
+  std::cerr << "CaDiCaL search propagations: "
+            << s->get_statistic_value("propagations") << std::endl;
+  std::cerr << "CaDiCaL search ticks: "
+            << s->get_statistic_value("ticks") << std::endl;
+#else
+  // get_statistic_value() is unavailable in the oldest supported releases.
+  s->statistics();
+#endif
 }
 
 uint32_t Cadical::newVar()

--- a/lib/Sat/MinisatCore.cpp
+++ b/lib/Sat/MinisatCore.cpp
@@ -25,6 +25,7 @@ THE SOFTWARE.
 #define __STDC_FORMAT_MACROS
 #include "stp/Sat/MinisatCore.h"
 #include "minisat/core/Solver.h"
+#include <iostream>
 //#include "utils/System.h"
 //#include "simp/SimpSolver.h"
 
@@ -151,7 +152,35 @@ uint32_t MinisatCore::nVars() const
 
 void MinisatCore::printStats() const
 {
-  //s->printStats();
+  // MiniSat's periodic table is useful while a long search is running, but
+  // fixed-conflict profiles also need exact final totals. In particular,
+  // propagations/conflict distinguishes SAT-search work from front-end time.
+  std::cerr << "MiniSat starts: " << s->starts << '\n';
+  std::cerr << "MiniSat conflicts: " << s->conflicts << '\n';
+  std::cerr << "MiniSat decisions: " << s->decisions << '\n';
+  std::cerr << "MiniSat propagations: " << s->propagations << '\n';
+  std::cerr << "MiniSat variables: " << s->nVars() << '\n';
+  if (s->conflicts != 0)
+  {
+    std::cerr << "MiniSat decisions per conflict: "
+              << static_cast<double>(s->decisions) / s->conflicts << '\n';
+    std::cerr << "MiniSat propagations per conflict: "
+              << static_cast<double>(s->propagations) / s->conflicts << '\n';
+  }
+  std::cerr << "MiniSat active original clauses: " << s->nClauses() << '\n';
+  std::cerr << "MiniSat active original literals: " << s->clauses_literals
+            << '\n';
+  std::cerr << "MiniSat active learnt clauses: " << s->nLearnts() << '\n';
+  std::cerr << "MiniSat active learnt literals: " << s->learnts_literals
+            << '\n';
+  if (s->nLearnts() != 0)
+    std::cerr << "MiniSat active learnt literals per clause: "
+              << static_cast<double>(s->learnts_literals) / s->nLearnts()
+              << '\n';
+  std::cerr << "MiniSat learnt literals before minimization: "
+            << s->max_literals << '\n';
+  std::cerr << "MiniSat learnt literals after minimization: "
+            << s->tot_literals << '\n';
 }
 
 int MinisatCore::nClauses()

--- a/lib/Sat/SimplifyingMinisat.cpp
+++ b/lib/Sat/SimplifyingMinisat.cpp
@@ -25,6 +25,7 @@ THE SOFTWARE.
 #define __STDC_FORMAT_MACROS
 #include "stp/Sat/SimplifyingMinisat.h"
 #include "minisat/simp/SimpSolver.h"
+#include <iostream>
 
 namespace MiniSat
 {
@@ -113,7 +114,32 @@ uint32_t SimplifyingMinisat::nVars() const
 
 void SimplifyingMinisat::printStats() const
 {
-  //s->printStats();
+  std::cerr << "MiniSat starts: " << s->starts << '\n';
+  std::cerr << "MiniSat conflicts: " << s->conflicts << '\n';
+  std::cerr << "MiniSat decisions: " << s->decisions << '\n';
+  std::cerr << "MiniSat propagations: " << s->propagations << '\n';
+  std::cerr << "MiniSat variables: " << s->nVars() << '\n';
+  if (s->conflicts != 0)
+  {
+    std::cerr << "MiniSat decisions per conflict: "
+              << static_cast<double>(s->decisions) / s->conflicts << '\n';
+    std::cerr << "MiniSat propagations per conflict: "
+              << static_cast<double>(s->propagations) / s->conflicts << '\n';
+  }
+  std::cerr << "MiniSat active original clauses: " << s->nClauses() << '\n';
+  std::cerr << "MiniSat active original literals: " << s->clauses_literals
+            << '\n';
+  std::cerr << "MiniSat active learnt clauses: " << s->nLearnts() << '\n';
+  std::cerr << "MiniSat active learnt literals: " << s->learnts_literals
+            << '\n';
+  if (s->nLearnts() != 0)
+    std::cerr << "MiniSat active learnt literals per clause: "
+              << static_cast<double>(s->learnts_literals) / s->nLearnts()
+              << '\n';
+  std::cerr << "MiniSat learnt literals before minimization: "
+            << s->max_literals << '\n';
+  std::cerr << "MiniSat learnt literals after minimization: "
+            << s->tot_literals << '\n';
 }
 
 void SimplifyingMinisat::setFrozen(uint32_t x)

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -4427,6 +4427,7 @@ BBNode BitBlaster::BBfpAddIsZero(const ASTNode& term, BBNodeSet& support)
   const unsigned sb = sort.significandWidth();
   const unsigned w = sort.packedWidth();
   const unsigned eb = sort.exponentWidth();
+  (void)eb;
   assert(sb >= 2 && eb >= 2 && w == sb + eb);
 
   const BBNodeVec pa = BBTerm(term[1], support);

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -1491,6 +1491,8 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term, BBNodeSet& support,
 const BBNode BitBlaster::BBForm(const ASTNode& form)
 {
 
+  fpNativeAddIsZeroFusions = 0;
+
   if (uf->conjoin_to_top && cb != NULL)
   {
     ASTNodeMap n = cb->getAllFixed();
@@ -1519,6 +1521,9 @@ const BBNode BitBlaster::BBForm(const ASTNode& form)
     ASTNodeSet visited;
     assert(cb->checkAtFixedPoint(form, visited));
   }
+  if (uf->stats_flag && uf->fp_native_add_iszero)
+    std::cerr << "FP native add-isZero fused predicates: "
+              << fpNativeAddIsZeroFusions << '\n';
   if (v.size() == 1)
     return v[0];
   else
@@ -3945,6 +3950,18 @@ BBNode BitBlaster::BBclassifyFP(const ASTNode& form, BBNodeSet& support)
   assert(form[0].GetValueWidth() == w);
   assert(sb >= 2 && w >= sb + 1);
 
+  // A complete packed sum is useful only when another consumer observes it.
+  // If it has already been memoised, retain the ordinary path so this
+  // predicate shares that result rather than building a second circuit.
+  if (k == FP_ISZERO && uf->fp_native_arith &&
+      uf->fp_native_add_iszero && form[0].GetKind() == FP_ADD &&
+      form[0].Degree() == 3 &&
+      BBTermMemo.find(form[0]) == BBTermMemo.end())
+  {
+    ++fpNativeAddIsZeroFusions;
+    return BBfpAddIsZero(form[0], support);
+  }
+
   const BBNodeVec p = BBTerm(form[0], support);
 
   switch (k)
@@ -4391,6 +4408,46 @@ BBNodeVec BitBlaster::BBfpMul(const ASTNode& term, BBNodeSet& support)
   res = BBITE(anyInf, packSpecial(false, true), res);
   res = BBITE(anyNaN, packSpecial(true, false), res);
   return res;
+}
+
+// fp.isZero needs much less than a packed result. Every finite value in a
+// binary IEEE format is an integer multiple of that format's minimum
+// subnormal, so a nonzero exact sum of two format values cannot round to
+// zero. The result is therefore a semantic zero exactly when both operands
+// are finite and their exact real sum is zero: equal magnitudes with opposite
+// signs, or any pair of signed zeros. The rounding mode cannot change this
+// predicate.
+BBNode BitBlaster::BBfpAddIsZero(const ASTNode& term, BBNodeSet& support)
+{
+  assert(term.GetKind() == FP_ADD);
+  assert(term.Degree() == 3);
+
+  const SourceSort sort = term.GetSourceSort();
+  assert(sort.kind() == SourceSort::Kind::FloatingPoint);
+  const unsigned sb = sort.significandWidth();
+  const unsigned w = sort.packedWidth();
+  const unsigned eb = sort.exponentWidth();
+  assert(sb >= 2 && eb >= 2 && w == sb + eb);
+
+  const BBNodeVec pa = BBTerm(term[1], support);
+  const BBNodeVec pb = BBTerm(term[2], support);
+  assert(pa.size() == w && pb.size() == w);
+
+  BBNodeVec aMagnitude(pa.begin(), pa.begin() + (w - 1));
+  const BBNodeVec bMagnitude(pb.begin(), pb.begin() + (w - 1));
+  const BBNode sameMagnitude = BBEQ(aMagnitude, bMagnitude);
+  const BBNode oppositeSigns = nf->CreateNode(XOR, pa[w - 1], pb[w - 1]);
+  // With equal magnitudes, testing either operand suffices to prove both are
+  // signed zeros.
+  const BBNode bothZero = nf->CreateNode(NOR, aMagnitude);
+  const BBNode exactZero = nf->CreateNode(
+      AND, sameMagnitude, nf->CreateNode(OR, oppositeSigns, bothZero));
+
+  auto finite = [&](const BBNodeVec& p) {
+    BBNodeVec exponent(p.begin() + (sb - 1), p.begin() + (w - 1));
+    return nf->CreateNode(NOT, nf->CreateNode(AND, exponent));
+  };
+  return nf->CreateNode(AND, finite(pa), finite(pb), exactZero);
 }
 
 // Bit-blasted fp.add over packed IEEE-754 operands, under the same flag

--- a/tests/query-files/fp-tests/fp-native-add-iszero.smt2
+++ b/tests/query-files/fp-tests/fp-native-add-iszero.smt2
@@ -1,0 +1,32 @@
+; A binary-format addition can round to zero only when its finite operands
+; have an exact real sum of zero. Exhaust the small (3,4) format and all five
+; rounding modes by asking for a disagreement with that packed-value law.
+;
+; RUN: %solver --disable-equality --unconstrained-variable-elimination=0 --bb.fp-native-arith=1 --bb.fp-native-add-iszero=1 -s %s 2>&1 | %OutputCheck --check-prefix=FUSED %s
+; RUN: %solver --disable-equality --unconstrained-variable-elimination=0 --bb.fp-native-arith=1 --bb.fp-native-add-iszero=0 %s | %OutputCheck --check-prefix=RESULT %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck --check-prefix=RESULT %s
+;
+; FUSED: FP native add-isZero fused predicates: 1
+; FUSED: ^unsat
+; RESULT: ^unsat
+;
+(set-logic QF_FP)
+(declare-fun rm () RoundingMode)
+(declare-fun a () (_ FloatingPoint 3 4))
+(declare-fun b () (_ FloatingPoint 3 4))
+
+(define-fun finite ((x (_ FloatingPoint 3 4))) Bool
+  (and (not (fp.isNaN x)) (not (fp.isInfinite x))))
+
+(define-fun exact-zero-sum ((x (_ FloatingPoint 3 4))
+                            (y (_ FloatingPoint 3 4))) Bool
+  (and (finite x) (finite y)
+       (or (and (fp.isZero x) (fp.isZero y))
+           (and (not (fp.isZero x)) (not (fp.isZero y))
+                (not (= (fp.isNegative x) (fp.isNegative y)))
+                (fp.eq (fp.abs x) (fp.abs y))))))
+
+(assert (not (= (fp.isZero (fp.add rm a b))
+                (exact-zero-sum a b))))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/native-arith-symfpu-equivalence.smt2
+++ b/tests/query-files/fp-tests/native-arith-symfpu-equivalence.smt2
@@ -1,0 +1,41 @@
+; Compare the native add and multiply circuits with independent SymFPU
+; encodings over every value of (3,4) and every rounding mode. FMA by a
+; symbolic value constrained to 1 expresses addition without being rewritten
+; to fp.add. The inner FMA with -0 similarly keeps the multiplication oracle
+; off the native packed path. Structural equality detects signed-zero
+; disagreements; NaN payloads are deliberately ignored.
+;
+; RUN: %solver --disable-equality --unconstrained-variable-elimination=0 --bb.fp-native-arith=true -s %s 2>&1 | %OutputCheck %s
+;
+; CHECK: FloatBlast: 3 SymFPU operations, 6 unpacks
+; CHECK: ^unsat
+;
+(set-logic QF_FP)
+(declare-fun a () (_ FloatingPoint 3 4))
+(declare-fun b () (_ FloatingPoint 3 4))
+(declare-fun unit () (_ FloatingPoint 3 4))
+(declare-fun minus-zero () (_ FloatingPoint 3 4))
+(declare-fun rm () RoundingMode)
+(declare-fun native-add () (_ FloatingPoint 3 4))
+(declare-fun oracle-add () (_ FloatingPoint 3 4))
+(declare-fun native-mul () (_ FloatingPoint 3 4))
+(declare-fun oracle-mul () (_ FloatingPoint 3 4))
+(define-fun one () (_ FloatingPoint 3 4) (fp #b0 #b011 #b000))
+
+(assert (fp.leq one unit))
+(assert (fp.leq unit one))
+(assert (fp.isZero minus-zero))
+(assert (fp.isNegative minus-zero))
+(assert (= native-add (fp.add rm a b)))
+(assert (= oracle-add (fp.fma rm a unit b)))
+(assert (= native-mul (fp.mul rm a b)))
+(assert (= oracle-mul
+           (fp.mul rm (fp.fma RNE a unit minus-zero) b)))
+(assert
+  (or
+    (not (or (= native-add oracle-add)
+             (and (fp.isNaN native-add) (fp.isNaN oracle-add))))
+    (not (or (= native-mul oracle-mul)
+             (and (fp.isNaN native-mul) (fp.isNaN oracle-mul))))))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/native-arith-wide-exponent-fallback.smt2
+++ b/tests/query-files/fp-tests/native-arith-wide-exponent-fallback.smt2
@@ -1,0 +1,26 @@
+; Native arithmetic currently forms exponent bounds in a host unsigned. A
+; legal format wider than that representation must stay on the SymFPU path.
+; The two operands are numerically 1, so both results below are finite; the
+; old unchecked native path incorrectly made this formula unsatisfiable.
+;
+; RUN: %solver --bb.fp-native-arith=true -s %s 2>&1 | %OutputCheck %s
+;
+; CHECK: FloatBlast: 2 SymFPU operations, 2 unpacks
+; CHECK: ^sat
+;
+(set-logic QF_FP)
+(declare-fun a () (_ FloatingPoint 33 2))
+(declare-fun b () (_ FloatingPoint 33 2))
+(define-fun one () (_ FloatingPoint 33 2)
+  (fp #b0 #b011111111111111111111111111111111 #b0))
+
+(assert (fp.leq one a))
+(assert (fp.leq a one))
+(assert (fp.leq one b))
+(assert (fp.leq b one))
+(assert (not (fp.isInfinite (fp.add RNE a b))))
+(assert (not (fp.isNaN (fp.add RNE a b))))
+(assert (not (fp.isInfinite (fp.mul RNE a b))))
+(assert (not (fp.isNaN (fp.mul RNE a b))))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/native-tofp-symfpu-equivalence.smt2
+++ b/tests/query-files/fp-tests/native-tofp-symfpu-equivalence.smt2
@@ -1,0 +1,32 @@
+; Compare the native (3,5)-to-(4,3) conversion with SymFPU for every source
+; value and rounding mode. The exact FMA wrapper preserves the source value
+; while preventing the oracle conversion from entering the native packed
+; path. Structural equality detects signed-zero disagreements; NaN payloads
+; are deliberately ignored.
+;
+; RUN: %solver --disable-equality --unconstrained-variable-elimination=0 --bb.fp-native-arith=true -s %s 2>&1 | %OutputCheck %s
+;
+; CHECK: FloatBlast: 2 SymFPU operations, 4 unpacks
+; CHECK: ^unsat
+;
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 3 5))
+(declare-fun unit () (_ FloatingPoint 3 5))
+(declare-fun minus-zero () (_ FloatingPoint 3 5))
+(declare-fun rm () RoundingMode)
+(declare-fun native () (_ FloatingPoint 4 3))
+(declare-fun oracle () (_ FloatingPoint 4 3))
+(define-fun one () (_ FloatingPoint 3 5) (fp #b0 #b011 #b0000))
+
+(assert (fp.leq one unit))
+(assert (fp.leq unit one))
+(assert (fp.isZero minus-zero))
+(assert (fp.isNegative minus-zero))
+(assert (= native ((_ to_fp 4 3) rm x)))
+(assert (= oracle
+           ((_ to_fp 4 3) rm (fp.fma RNE x unit minus-zero))))
+(assert
+  (not (or (= native oracle)
+           (and (fp.isNaN native) (fp.isNaN oracle)))))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/native-tofp-wide-exponent-fallback.smt2
+++ b/tests/query-files/fp-tests/native-tofp-wide-exponent-fallback.smt2
@@ -1,0 +1,29 @@
+; Both the source and target exponent widths participate in the native
+; float-to-float exponent envelope. Exercise each unsafe side and require the
+; conversions to fall back to SymFPU while preserving the exact value 1.
+;
+; RUN: %solver --disable-equality --unconstrained-variable-elimination=0 --bb.fp-native-arith=true -s %s 2>&1 | %OutputCheck %s
+;
+; CHECK: FloatBlast: 2 SymFPU operations
+; CHECK: ^sat
+;
+(set-logic QF_FP)
+(declare-fun wide () (_ FloatingPoint 33 2))
+(declare-fun single () (_ FloatingPoint 8 24))
+(declare-fun narrowed () (_ FloatingPoint 8 24))
+(declare-fun widened () (_ FloatingPoint 33 2))
+(define-fun one-wide () (_ FloatingPoint 33 2)
+  (fp #b0 #b011111111111111111111111111111111 #b0))
+(define-fun one-single () (_ FloatingPoint 8 24)
+  (fp #b0 #b01111111 #b00000000000000000000000))
+
+(assert (fp.leq one-wide wide))
+(assert (fp.leq wide one-wide))
+(assert (fp.leq one-single single))
+(assert (fp.leq single one-single))
+(assert (= narrowed ((_ to_fp 8 24) RNE wide)))
+(assert (= widened ((_ to_fp 33 2) RNE single)))
+(assert (fp.eq narrowed one-single))
+(assert (fp.eq widened one-wide))
+(check-sat)
+(exit)

--- a/tests/query-files/misc-tests/cadical-statistics.smt2
+++ b/tests/query-files/misc-tests/cadical-statistics.smt2
@@ -1,0 +1,22 @@
+; REQUIRES: cadical-inprobing
+; RUN: %solver --cadical -s %s 2>&1 | %OutputCheck %s
+; CHECK: CaDiCaL conflicts: {{[0-9]+}}
+; CHECK: CaDiCaL decisions: {{[0-9]+}}
+; CHECK: CaDiCaL search propagations: {{[0-9]+}}
+; CHECK: CaDiCaL search ticks: {{[0-9]+}}
+; CHECK-NOT: print stats not yet implemented
+; CHECK: ^sat
+; Keep enough coupled structure to reach the SAT backend instead of being
+; discharged by unconstrained-variable elimination.
+(set-logic QF_FP)
+(declare-const x (_ FloatingPoint 8 24))
+(declare-const y (_ FloatingPoint 8 24))
+(define-fun one () (_ FloatingPoint 8 24)
+  ((_ to_fp 8 24) #x3f800000))
+(assert (fp.lt one x))
+(assert (fp.lt one y))
+(assert (not (fp.isInfinite x)))
+(assert (not (fp.isInfinite y)))
+(assert (fp.gt (fp.mul RNE x y) x))
+(assert (fp.gt (fp.mul RNE x y) y))
+(check-sat)

--- a/tests/query-files/misc-tests/cadical-statistics.smt2
+++ b/tests/query-files/misc-tests/cadical-statistics.smt2
@@ -1,9 +1,9 @@
 ; REQUIRES: cadical-inprobing
 ; RUN: %solver --cadical -s %s 2>&1 | %OutputCheck %s
-; CHECK: CaDiCaL conflicts: {{[0-9]+}}
-; CHECK: CaDiCaL decisions: {{[0-9]+}}
-; CHECK: CaDiCaL search propagations: {{[0-9]+}}
-; CHECK: CaDiCaL search ticks: {{[0-9]+}}
+; CHECK: CaDiCaL conflicts: [0-9]+
+; CHECK: CaDiCaL decisions: [0-9]+
+; CHECK: CaDiCaL search propagations: [0-9]+
+; CHECK: CaDiCaL search ticks: [0-9]+
 ; CHECK-NOT: print stats not yet implemented
 ; CHECK: ^sat
 ; Keep enough coupled structure to reach the SAT backend instead of being

--- a/tests/query-files/misc-tests/minisat-statistics.smt2
+++ b/tests/query-files/misc-tests/minisat-statistics.smt2
@@ -1,17 +1,17 @@
 ; REQUIRES: minisat
 ; RUN: %solver --minisat -s %s 2>&1 | %OutputCheck --check-prefix=STATS %s
 ; RUN: %solver --simplifying-minisat -s %s 2>&1 | %OutputCheck --check-prefix=STATS %s
-; STATS: MiniSat starts: {{[0-9]+}}
-; STATS: MiniSat conflicts: {{[0-9]+}}
-; STATS: MiniSat decisions: {{[0-9]+}}
-; STATS: MiniSat propagations: {{[0-9]+}}
-; STATS: MiniSat variables: {{[0-9]+}}
-; STATS: MiniSat active original clauses: {{[0-9]+}}
-; STATS: MiniSat active original literals: {{[0-9]+}}
-; STATS: MiniSat active learnt clauses: {{[0-9]+}}
-; STATS: MiniSat active learnt literals: {{[0-9]+}}
-; STATS: MiniSat learnt literals before minimization: {{[0-9]+}}
-; STATS: MiniSat learnt literals after minimization: {{[0-9]+}}
+; STATS: MiniSat starts: [0-9]+
+; STATS: MiniSat conflicts: [0-9]+
+; STATS: MiniSat decisions: [0-9]+
+; STATS: MiniSat propagations: [0-9]+
+; STATS: MiniSat variables: [0-9]+
+; STATS: MiniSat active original clauses: [0-9]+
+; STATS: MiniSat active original literals: [0-9]+
+; STATS: MiniSat active learnt clauses: [0-9]+
+; STATS: MiniSat active learnt literals: [0-9]+
+; STATS: MiniSat learnt literals before minimization: [0-9]+
+; STATS: MiniSat learnt literals after minimization: [0-9]+
 ; STATS: ^sat
 ; Keep enough coupled structure to reach the SAT backend instead of being
 ; discharged by unconstrained-variable elimination.

--- a/tests/query-files/misc-tests/minisat-statistics.smt2
+++ b/tests/query-files/misc-tests/minisat-statistics.smt2
@@ -1,0 +1,29 @@
+; REQUIRES: minisat
+; RUN: %solver --minisat -s %s 2>&1 | %OutputCheck --check-prefix=STATS %s
+; RUN: %solver --simplifying-minisat -s %s 2>&1 | %OutputCheck --check-prefix=STATS %s
+; STATS: MiniSat starts: {{[0-9]+}}
+; STATS: MiniSat conflicts: {{[0-9]+}}
+; STATS: MiniSat decisions: {{[0-9]+}}
+; STATS: MiniSat propagations: {{[0-9]+}}
+; STATS: MiniSat variables: {{[0-9]+}}
+; STATS: MiniSat active original clauses: {{[0-9]+}}
+; STATS: MiniSat active original literals: {{[0-9]+}}
+; STATS: MiniSat active learnt clauses: {{[0-9]+}}
+; STATS: MiniSat active learnt literals: {{[0-9]+}}
+; STATS: MiniSat learnt literals before minimization: {{[0-9]+}}
+; STATS: MiniSat learnt literals after minimization: {{[0-9]+}}
+; STATS: ^sat
+; Keep enough coupled structure to reach the SAT backend instead of being
+; discharged by unconstrained-variable elimination.
+(set-logic QF_FP)
+(declare-const x (_ FloatingPoint 8 24))
+(declare-const y (_ FloatingPoint 8 24))
+(define-fun one () (_ FloatingPoint 8 24)
+  ((_ to_fp 8 24) #x3f800000))
+(assert (fp.lt one x))
+(assert (fp.lt one y))
+(assert (not (fp.isInfinite x)))
+(assert (not (fp.isInfinite y)))
+(assert (fp.gt (fp.mul RNE x y) x))
+(assert (fp.gt (fp.mul RNE x y) y))
+(check-sat)

--- a/tests/unit-tests/DecimalToFP_Test.cpp
+++ b/tests/unit-tests/DecimalToFP_Test.cpp
@@ -64,6 +64,17 @@ std::string bitsOfU64(uint64_t v, unsigned width)
   return s;
 }
 
+std::string binary(const std::string& left, const std::string& right,
+                   unsigned eb, unsigned sb, unsigned rm,
+                   PackedFpBinaryOp operation)
+{
+  std::string bits, err;
+  const bool ok = packedFPBinaryOp(left, right, eb, sb, rm, operation, bits,
+                                   err);
+  EXPECT_TRUE(ok) << "(" << eb << "," << sb << "): " << err;
+  return ok ? bits : "";
+}
+
 std::string hostFloatBits(const std::string& dec)
 {
   const float f = strtof(dec.c_str(), nullptr);
@@ -376,6 +387,107 @@ TEST(DecimalToFP, unsupportedExponentWidths)
   EXPECT_FALSE(decimalToPackedFPBits("1.5", 62, 8,
                                      ROUND_NEAREST_TIES_TO_EVEN, bits, err));
   EXPECT_NE(err.find("exponent widths"), std::string::npos) << err;
+}
+
+TEST(PackedFpBinaryOp, exactArithmeticAndCancellation)
+{
+  const std::string one = bitsOfU64(0x3c00, 16);
+  const std::string onePointFive = bitsOfU64(0x3e00, 16);
+  const std::string two = bitsOfU64(0x4000, 16);
+
+  EXPECT_EQ(binary(onePointFive, two, 5, 11, ROUND_NEAREST_TIES_TO_EVEN,
+                   PackedFpBinaryOp::Add),
+            bitsOfU64(0x4300, 16)); // 3.5
+  EXPECT_EQ(binary(two, onePointFive, 5, 11,
+                   ROUND_NEAREST_TIES_TO_EVEN,
+                   PackedFpBinaryOp::Subtract),
+            bitsOfU64(0x3800, 16)); // 0.5
+  EXPECT_EQ(binary(onePointFive, two, 5, 11,
+                   ROUND_NEAREST_TIES_TO_EVEN,
+                   PackedFpBinaryOp::Multiply),
+            bitsOfU64(0x4200, 16)); // 3.0
+
+  EXPECT_EQ(binary(one, one, 5, 11, ROUND_NEAREST_TIES_TO_EVEN,
+                   PackedFpBinaryOp::Subtract),
+            bitsOfU64(0x0000, 16));
+  EXPECT_EQ(binary(one, one, 5, 11, ROUND_TOWARD_NEGATIVE,
+                   PackedFpBinaryOp::Subtract),
+            bitsOfU64(0x8000, 16));
+}
+
+TEST(PackedFpBinaryOp, underflowUsesTheRequestedRoundingMode)
+{
+  const std::string minSub = bitsOfU64(0x0001, 16);
+  const std::string minusMinSub = bitsOfU64(0x8001, 16);
+  const std::string half = bitsOfU64(0x3800, 16);
+
+  EXPECT_EQ(binary(minSub, half, 5, 11, ROUND_NEAREST_TIES_TO_EVEN,
+                   PackedFpBinaryOp::Multiply),
+            bitsOfU64(0x0000, 16));
+  EXPECT_EQ(binary(minSub, half, 5, 11, ROUND_NEAREST_TIES_TO_AWAY,
+                   PackedFpBinaryOp::Multiply),
+            minSub);
+  EXPECT_EQ(binary(minSub, half, 5, 11, ROUND_TOWARD_POSITIVE,
+                   PackedFpBinaryOp::Multiply),
+            minSub);
+  EXPECT_EQ(binary(minusMinSub, half, 5, 11, ROUND_TOWARD_POSITIVE,
+                   PackedFpBinaryOp::Multiply),
+            bitsOfU64(0x8000, 16));
+  EXPECT_EQ(binary(minusMinSub, half, 5, 11, ROUND_TOWARD_NEGATIVE,
+                   PackedFpBinaryOp::Multiply),
+            minusMinSub);
+}
+
+TEST(PackedFpBinaryOp, overflowUsesTheRequestedRoundingMode)
+{
+  const std::string maxFinite = bitsOfU64(0x7bff, 16);
+  const std::string two = bitsOfU64(0x4000, 16);
+  EXPECT_EQ(binary(maxFinite, two, 5, 11, ROUND_NEAREST_TIES_TO_EVEN,
+                   PackedFpBinaryOp::Multiply),
+            bitsOfU64(0x7c00, 16));
+  EXPECT_EQ(binary(maxFinite, two, 5, 11, ROUND_TOWARD_POSITIVE,
+                   PackedFpBinaryOp::Multiply),
+            bitsOfU64(0x7c00, 16));
+  EXPECT_EQ(binary(maxFinite, two, 5, 11, ROUND_TOWARD_NEGATIVE,
+                   PackedFpBinaryOp::Multiply),
+            maxFinite);
+  EXPECT_EQ(binary(maxFinite, two, 5, 11, ROUND_TOWARD_ZERO,
+                   PackedFpBinaryOp::Multiply),
+            maxFinite);
+}
+
+TEST(PackedFpBinaryOp, signedZerosArePreserved)
+{
+  const std::string minusZero = bitsOfU64(0x8000, 16);
+  const std::string two = bitsOfU64(0x4000, 16);
+  const std::string minusTwo = bitsOfU64(0xc000, 16);
+  EXPECT_EQ(binary(minusZero, two, 5, 11, ROUND_NEAREST_TIES_TO_EVEN,
+                   PackedFpBinaryOp::Multiply),
+            minusZero);
+  EXPECT_EQ(binary(minusZero, minusTwo, 5, 11,
+                   ROUND_NEAREST_TIES_TO_EVEN,
+                   PackedFpBinaryOp::Multiply),
+            bitsOfU64(0x0000, 16));
+}
+
+TEST(PackedFpBinaryOp, rejectsMalformedAndNonfiniteInputs)
+{
+  const std::string one = bitsOfU64(0x3c00, 16);
+  std::string bits, err;
+  EXPECT_FALSE(packedFPBinaryOp(bitsOfU64(0x7c00, 16), one, 5, 11,
+                                ROUND_NEAREST_TIES_TO_EVEN,
+                                PackedFpBinaryOp::Add, bits, err));
+  EXPECT_NE(err.find("finite operands"), std::string::npos) << err;
+  err.clear();
+  EXPECT_FALSE(packedFPBinaryOp("000000000000000x", one, 5, 11,
+                                ROUND_NEAREST_TIES_TO_EVEN,
+                                PackedFpBinaryOp::Add, bits, err));
+  EXPECT_NE(err.find("non-bit"), std::string::npos) << err;
+  err.clear();
+  EXPECT_FALSE(packedFPBinaryOp("0", one, 5, 11,
+                                ROUND_NEAREST_TIES_TO_EVEN,
+                                PackedFpBinaryOp::Add, bits, err));
+  EXPECT_NE(err.find("wrong width"), std::string::npos) << err;
 }
 
 } // namespace

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -401,6 +401,13 @@ void ExtraMain::create_options()
            "SymFPU unpacking circuits (experimental)",
            bb_group);
 
+  bool_arg("--bb.fp-native-add-iszero",
+           bm->UserFlags.fp_native_add_iszero,
+           "Encode fp.isZero(fp.add ...) directly from the packed operands "
+           "without constructing the complete rounded sum (experimental; "
+           "requires --bb.fp-native-arith)",
+           bb_group);
+
   bool_arg("--bb.simplify-during-bb", bm->UserFlags.simplify_during_BB_flag,
            "When bit-blasting discovers that a non-constant child of a term "
            "blasts to an all-constant vector, rebuild the term with that "


### PR DESCRIPTION
## Summary

- add the off-by-default `--bb.fp-native-add-iszero` experiment
- fuse `fp.isZero(fp.add(...))` when the sum is not otherwise memoized
- test zero magnitude directly without constructing the complete rounded packed result
- compare the fused predicate against native control lowering and ordinary SymFPU

For operands in one IEEE format, every finite value is an integer multiple of the minimum subnormal. A nonzero exact finite sum therefore has magnitude at least one minimum subnormal and cannot round to zero in that same format. The fused circuit separately handles NaNs, infinities, exact cancellation, and zero operands. It observes only zero magnitude, so it does not conflate structural `+0` and `-0` equality.

## Testing

- `cmake --build build -j24`
- exhaustive FP `(3, 4)` fused/native-control/SymFPU comparisons
- symbolic coverage of all rounding modes, specials, cancellation, and signed zeros
- all 20 focused native arithmetic/fusion tests passed
- validated as part of the complete five-branch stack: all 649 supported query tests and all 140 compiled/API/unit tests passed

## Measurements

| Workload | Metric | Control | Fused | Change |
| --- | ---: | ---: | ---: | ---: |
| Shewanella compact2 FP8/24 | AIG nodes | 9,812,445 | 9,437,684 | -3.82% |
| Shewanella compact2 FP8/24 | median CNF generation | 23.75 s | 22.14 s | -6.8% |
| Shewanella compact2 FP8/24 | matched fixed-conflict wall | 49.11 s | 49.04 s | effectively tied |
| E. coli | AIG nodes | 16,712,803 | 15,756,333 | -5.72% |
| E. coli | median CNF generation | 41.03 s | 38.50 s | -6.2% |
| E. coli | matched fixed-conflict wall | 51.68 s | 46.64 s | -9.8% |

The flag remains disabled by default while solver robustness is evaluated on more workloads.

## Stack

This is PR 4 of 5 and depends on #963 (after #962 and #961).

GitHub cannot use the fork-only predecessor branch as the base of an `stp/stp` PR, so the displayed diff is cumulative until the preceding PRs merge. The intended layer-only diff is [fp-pr-03-native-arithmetic...fp-pr-04-add-iszero](https://github.com/aytey/stp/compare/fp-pr-03-native-arithmetic...fp-pr-04-add-iszero).
