### PR TITLE
Use sound floating-point domain facts in native lowering

### DIFF
--- a/include/stp/FloatBlaster/DecimalLiteral.h
+++ b/include/stp/FloatBlaster/DecimalLiteral.h
@@ -72,6 +72,25 @@ bool rationalToPackedFPBits(const std::string& numerator,
                             unsigned rounding_mode, std::string& bits,
                             std::string& err);
 
+enum class PackedFpBinaryOp
+{
+  Add,
+  Subtract,
+  Multiply
+};
+
+// Evaluate one binary operation on two finite packed values exactly in the
+// target format. Inputs and output use the same MSB-first packed-bit spelling
+// as decimalToPackedFPBits. LibBF first reconstructs each input as an exact
+// dyadic value, then performs a single target-format rounding under
+// `rounding_mode`; host floating-point arithmetic is never involved. An
+// IEEE overflow result may be infinity. NaN/infinity inputs, malformed bit
+// strings, unsupported formats, and allocation failures return false.
+bool packedFPBinaryOp(const std::string& left, const std::string& right,
+                      unsigned exp_width, unsigned sig_width,
+                      unsigned rounding_mode, PackedFpBinaryOp operation,
+                      std::string& bits, std::string& err);
+
 } // namespace stp
 
 #endif

--- a/include/stp/FloatBlaster/FpDomainSimplify.h
+++ b/include/stp/FloatBlaster/FpDomainSimplify.h
@@ -1,0 +1,46 @@
+/********************************************************************
+ * Experimental floating-point domain simplification.
+ ********************************************************************/
+#ifndef FPDOMAINSIMPLIFY_H
+#define FPDOMAINSIMPLIFY_H
+
+#include "stp/AST/AST.h"
+#include "stp/STPManager/STPManager.h"
+
+#include <cstddef>
+
+namespace stp
+{
+
+class FpDomainSimplify final
+{
+public:
+  struct Statistics
+  {
+    size_t boxed_symbols = 0;
+    size_t interval_true = 0;
+    size_t interval_false = 0;
+    size_t classifier_false = 0;
+    size_t difference_zero_equalities = 0;
+    size_t nonnegative_zero_sums = 0;
+    size_t sound_zero_rows = 0;
+    size_t sound_zero_facts = 0;
+    size_t row_bound_rows = 0;
+    size_t row_bound_false = 0;
+  };
+
+  explicit FpDomainSimplify(STPMgr* bm_);
+
+  ASTNode topLevel(const ASTNode& source);
+
+  const Statistics& statistics() const noexcept { return stats; }
+
+private:
+  STPMgr* bm;
+  NodeFactory* node_factory;
+  Statistics stats;
+};
+
+} // namespace stp
+
+#endif

--- a/include/stp/FloatBlaster/FpEncodingContext.h
+++ b/include/stp/FloatBlaster/FpEncodingContext.h
@@ -6,6 +6,7 @@
 
 #include "stp/AST/AST.h"
 #include "stp/FloatBlaster/FloatBlast.h"
+#include "stp/FloatBlaster/FpDomainSimplify.h"
 #include "stp/FloatBlaster/FpTotalise.h"
 #include "stp/STPManager/STPManager.h"
 
@@ -47,6 +48,7 @@ private:
   STPMgr* bm;
   NodeFactory* node_factory;
   FpTotalise totalise;
+  FpDomainSimplify domain;
   FloatBlast blast;
 };
 

--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -281,10 +281,39 @@ public:
   // circuits. Experimental; off by default.
   bool fp_native_arith = false;
 
-  // Recognise fp.isZero(fp.add ...) and encode only the observed zero-result
-  // condition instead of constructing and packing every result bit.
+  // Recognise fp.isZero(fp.add ...) and encode the observed zero-result
+  // condition directly instead of constructing and packing every result bit.
   // Experimental; requires native arithmetic and is off by default.
   bool fp_native_add_iszero = false;
+
+  // Experimental strengthening for the native FP bit-blaster: mine simple
+  // top-level finite box bounds and use them to omit NaN/infinity cases from
+  // native packed-field circuits when those cases are already impossible.
+  bool fp_native_domain = false;
+
+  // Experimental native-domain arithmetic specialization. A known finite
+  // semantic sign removes fp.add's opposite-sign cancellation datapath and
+  // fp.mul's sign-dependent rounding, while explicit muxes retain signed zero.
+  bool fp_native_known_sign = false;
+
+  // Experimental floating-point domain prepass. It mines simple boxed
+  // variable bounds from ordered FP comparisons and uses them to discharge
+  // non-box ordered comparisons and zero-sum rows whose interval/domain facts
+  // decide them.
+  bool fp_domain_simplify = false;
+
+  // Sound zero-fact extraction for boxed nonnegative FP symbols. It only
+  // derives zero facts from same-sign rows whose terms are +/- one boxed
+  // symbol. Two-term differences may propagate an already-established zero,
+  // but terms are never algebraically cancelled through a rounded row. Zero
+  // is encoded as zero magnitude bits so +0/-0 remain distinct.
+  bool fp_domain_sound_zero_facts = false;
+
+  // Sound row-level FP zero refutation. It recognises linear FP expressions
+  // over boxed finite variables and rewrites a zero-row to false only when a
+  // conservative target-format interval, evaluated in the original AST
+  // association with rounding at every operation, excludes zero.
+  bool fp_domain_row_bounds = false;
 
   int64_t multiplication_variant = 1;
 

--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -281,6 +281,11 @@ public:
   // circuits. Experimental; off by default.
   bool fp_native_arith = false;
 
+  // Recognise fp.isZero(fp.add ...) and encode only the observed zero-result
+  // condition instead of constructing and packing every result bit.
+  // Experimental; requires native arithmetic and is off by default.
+  bool fp_native_add_iszero = false;
+
   int64_t multiplication_variant = 1;
 
   // If the bit-blaster discovers new constants, should the term simplifier be

--- a/include/stp/ToSat/BitBlaster.h
+++ b/include/stp/ToSat/BitBlaster.h
@@ -33,6 +33,7 @@ THE SOFTWARE.
 #include <cmath>
 #include <list>
 #include <map>
+#include <string>
 
 namespace simplifier
 {
@@ -217,6 +218,53 @@ class BitBlaster
   BBNode BBfpIsNaN(const BBNodeVec& p, unsigned sb, unsigned w);
   BBNode BBfpIsZero(const BBNodeVec& p, unsigned w);
 
+  struct FpNativeBounds
+  {
+    bool hasLower = false;
+    bool hasUpper = false;
+    long double lower = 0.0L;
+    long double upper = 0.0L;
+    bool lowerExact = false;
+    bool upperExact = false;
+    std::string lowerBits;
+    std::string upperBits;
+  };
+
+  struct FpNativeInterval
+  {
+    bool known = false;
+    bool exact = false;
+    long double lower = 0.0L;
+    long double upper = 0.0L;
+    std::string lowerBits;
+    std::string upperBits;
+  };
+
+  void collectFpNativeDomainFacts(const ASTNode& root);
+  void collectFpNativeDomainBounds(const ASTNode& n);
+  bool fpNativeBoundPredicate(const ASTNode& n, ASTNode& symbol,
+                              ASTNode& constant, long double& value,
+                              bool& lowerBound) const;
+  bool fpNativeMagnitudeZeroPredicate(const ASTNode& n,
+                                      ASTNode& term) const;
+  bool fpNativeConstantZeroMagnitude(const ASTNode& n) const;
+  bool fpNativeConstantFinite(const ASTNode& n) const;
+  bool fpNativeConstantValue(const ASTNode& n, long double& out) const;
+  bool fpNativeConstantBits(const ASTNode& n, std::string& out) const;
+  bool fpNativeMaxFiniteValue(const SourceSort& sort, long double& out) const;
+  FpNativeInterval fpNativeRoundedRange(const SourceSort& sort,
+                                        long double lower,
+                                        long double upper) const;
+  FpNativeInterval fpNativeInterval(const ASTNode& n);
+  FpNativeInterval fpNativeIntervalUncached(const ASTNode& n);
+  FpNativeInterval fpNativeExactRoundedRange(
+      const SourceSort& sort, Kind kind, const ASTNode& roundingMode,
+      const FpNativeInterval& a, const FpNativeInterval& b) const;
+  bool fpNativeKnownFinite(const ASTNode& n);
+  bool fpNativeKnownZeroMagnitude(const ASTNode& n);
+  bool fpNativeKnownFiniteNonnegative(const ASTNode& n);
+  bool fpNativeKnownFiniteNonpositive(const ASTNode& n);
+
   // bit blast fp.mul / fp.add / float-to-float to_fp over packed operands:
   // hand-written unpack/compute/round/pack circuits, no SymFPU
   // (--bb.fp-native-arith)
@@ -225,6 +273,8 @@ class BitBlaster
   BBNode BBfpAddIsZero(const ASTNode& term, BBNodeSet& support);
   BBNodeVec BBfpToFp(const ASTNode& term, BBNodeSet& support);
 
+  // Kept separate from the native-domain profiling counters so the stacked
+  // add-isZero optimization retains its standalone statistics contract.
   size_t fpNativeAddIsZeroFusions = 0;
 
   // A packed operand split for the native arithmetic circuits: fields,
@@ -238,7 +288,9 @@ class BitBlaster
     BBNodeVec eUnb; // E bits, signed, unbiased (subnormals read exp as 1)
   };
   FpOperand BBfpUnpack(const BBNodeVec& p, unsigned sb, unsigned w,
-                       unsigned E, BBNodeSet& support);
+                       unsigned E, BBNodeSet& support,
+                       bool knownFinite = false,
+                       bool knownZeroMagnitude = false);
 
   // The shared tail of the native arithmetic circuits: denormalise into
   // the subnormal range when the biased exponent be is <= 0, round rsig
@@ -248,7 +300,8 @@ class BitBlaster
   BBNodeVec BBfpRoundPack(const BBNodeVec& rm, const BBNode& sgn,
                           const BBNodeVec& rsig, const BBNode& guard,
                           const BBNode& sticky, const BBNodeVec& be,
-                          unsigned sb, unsigned eb, BBNodeSet& support);
+                          unsigned sb, unsigned eb, BBNodeSet& support,
+                          bool resultKnownFinite = false);
 
   // Width of the internal signed exponent for format (eb, sb): eb+2
   // widened until the subnormal shift distance (up to bias + 2sb + 3,
@@ -320,7 +373,54 @@ class BitBlaster
   // Nodes in this set can be replaced by their constant values, without being
   // conjoined to the top..
   ASTNodeSet fixedFromBottom;
-
+  ASTNodeSet fpNativeFiniteTerms;
+  ASTNodeSet fpNativeZeroMagnitudeFacts;
+  ASTNodeSet fpNativeZeroMagnitudeTerms;
+  // Negative lookup cache only: membership means "not currently proven
+  // zero", not that the term is known nonzero.
+  ASTNodeSet fpNativeUnknownZeroMagnitudeTerms;
+  ASTNodeSet fpNativeFiniteNonnegativeTerms;
+  // As above, this is a proof-failure cache, not a proof that a term is
+  // negative or non-finite.
+  ASTNodeSet fpNativeUnknownFiniteNonnegativeTerms;
+  ASTNodeSet fpNativeFiniteNonpositiveTerms;
+  // As above, this records only failure to prove semantic nonpositivity.
+  ASTNodeSet fpNativeUnknownFiniteNonpositiveTerms;
+  std::unordered_map<ASTNode, FpNativeBounds, ASTNode::ASTNodeHasher,
+                     ASTNode::ASTNodeEqual>
+      fpNativeBounds;
+  std::unordered_map<ASTNode, FpNativeInterval, ASTNode::ASTNodeHasher,
+                     ASTNode::ASTNodeEqual>
+      fpNativeIntervals;
+  std::unordered_map<ASTNode, size_t, ASTNode::ASTNodeHasher,
+                     ASTNode::ASTNodeEqual>
+      fpNativeParentUses;
+  ASTNode fpNativeDomainRoot;
+  size_t fpNativeFiniteCmpOperands = 0;
+  size_t fpNativeFiniteEqOperands = 0;
+  size_t fpNativeFiniteClassifications = 0;
+  size_t fpNativeFiniteArithOperands = 0;
+  size_t fpNativeFiniteRoundPacks = 0;
+  size_t fpNativeZeroCmpOperands = 0;
+  size_t fpNativeZeroEqOperands = 0;
+  size_t fpNativeZeroClassifications = 0;
+  size_t fpNativeIsZeroPredicates = 0;
+  size_t fpNativeIsZeroAddPredicates = 0;
+  size_t fpNativeIsZeroAddFusedPredicates = 0;
+  size_t fpNativeIsZeroAddExclusiveResults = 0;
+  size_t fpNativeIsZeroAddMemoizedResults = 0;
+  size_t fpNativeIsZeroAddKnownZeroResults = 0;
+  size_t fpNativeIsZeroAddBothFiniteOperands = 0;
+  size_t fpNativeIsZeroAddKnownSameSignOperands = 0;
+  size_t fpNativeIsZeroAddKnownOppositeSignOperands = 0;
+  size_t fpNativeIsZeroAddOneKnownSignOperand = 0;
+  size_t fpNativeZeroAddFastPaths = 0;
+  size_t fpNativeZeroMulFastPaths = 0;
+  size_t fpNativeZeroToFpFastPaths = 0;
+  size_t fpNativeKnownPositiveAddPaths = 0;
+  size_t fpNativeKnownNegativeAddPaths = 0;
+  size_t fpNativeKnownPositiveMulPaths = 0;
+  size_t fpNativeKnownNegativeMulPaths = 0;
   UserDefinedFlags* uf;
   NodeFactory* ASTNF;
   Simplifier* simp;
@@ -401,7 +501,44 @@ public:
   {
     BBTermMemo.clear();
     BBFormMemo.clear();
+    fpNativeFiniteTerms.clear();
+    fpNativeZeroMagnitudeFacts.clear();
+    fpNativeZeroMagnitudeTerms.clear();
+    fpNativeUnknownZeroMagnitudeTerms.clear();
+    fpNativeFiniteNonnegativeTerms.clear();
+    fpNativeUnknownFiniteNonnegativeTerms.clear();
+    fpNativeFiniteNonpositiveTerms.clear();
+    fpNativeUnknownFiniteNonpositiveTerms.clear();
+    fpNativeBounds.clear();
+    fpNativeIntervals.clear();
+    fpNativeParentUses.clear();
+    fpNativeDomainRoot = ASTNode();
     fpNativeAddIsZeroFusions = 0;
+    fpNativeFiniteCmpOperands = 0;
+    fpNativeFiniteEqOperands = 0;
+    fpNativeFiniteClassifications = 0;
+    fpNativeFiniteArithOperands = 0;
+    fpNativeFiniteRoundPacks = 0;
+    fpNativeZeroCmpOperands = 0;
+    fpNativeZeroEqOperands = 0;
+    fpNativeZeroClassifications = 0;
+    fpNativeIsZeroPredicates = 0;
+    fpNativeIsZeroAddPredicates = 0;
+    fpNativeIsZeroAddFusedPredicates = 0;
+    fpNativeIsZeroAddExclusiveResults = 0;
+    fpNativeIsZeroAddMemoizedResults = 0;
+    fpNativeIsZeroAddKnownZeroResults = 0;
+    fpNativeIsZeroAddBothFiniteOperands = 0;
+    fpNativeIsZeroAddKnownSameSignOperands = 0;
+    fpNativeIsZeroAddKnownOppositeSignOperands = 0;
+    fpNativeIsZeroAddOneKnownSignOperand = 0;
+    fpNativeZeroAddFastPaths = 0;
+    fpNativeZeroMulFastPaths = 0;
+    fpNativeZeroToFpFastPaths = 0;
+    fpNativeKnownPositiveAddPaths = 0;
+    fpNativeKnownNegativeAddPaths = 0;
+    fpNativeKnownPositiveMulPaths = 0;
+    fpNativeKnownNegativeMulPaths = 0;
   }
 
   // Bitblast a formula

--- a/include/stp/ToSat/BitBlaster.h
+++ b/include/stp/ToSat/BitBlaster.h
@@ -222,7 +222,10 @@ class BitBlaster
   // (--bb.fp-native-arith)
   BBNodeVec BBfpMul(const ASTNode& term, BBNodeSet& support);
   BBNodeVec BBfpAdd(const ASTNode& term, BBNodeSet& support);
+  BBNode BBfpAddIsZero(const ASTNode& term, BBNodeSet& support);
   BBNodeVec BBfpToFp(const ASTNode& term, BBNodeSet& support);
+
+  size_t fpNativeAddIsZeroFusions = 0;
 
   // A packed operand split for the native arithmetic circuits: fields,
   // classification, and the significand with its hidden bit made explicit
@@ -398,6 +401,7 @@ public:
   {
     BBTermMemo.clear();
     BBFormMemo.clear();
+    fpNativeAddIsZeroFusions = 0;
   }
 
   // Bitblast a formula

--- a/lib/FloatBlaster/CMakeLists.txt
+++ b/lib/FloatBlaster/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(floatblaster OBJECT
     DecimalLiteral.cpp
     FloatBlaster.cpp
     FloatBlast.cpp
+    FpDomainSimplify.cpp
     FpEncodingContext.cpp
     FpTotalise.cpp
     literal_fp.cpp

--- a/lib/FloatBlaster/DecimalLiteral.cpp
+++ b/lib/FloatBlaster/DecimalLiteral.cpp
@@ -184,6 +184,78 @@ void packToBits(const bf_t* v, unsigned exp_width, unsigned sig_width,
   }
 }
 
+// Reconstruct a finite packed IEEE value as an exact LibBF dyadic. Parsing
+// the significand as a base-two integer and applying its power-of-two scale
+// avoids both host precision and a decimal round trip.
+bool unpackFiniteBits(const std::string& bits, unsigned exp_width,
+                      unsigned sig_width, bf_t* value, std::string& err)
+{
+  const unsigned width = exp_width + sig_width;
+  if (bits.size() != width)
+  {
+    err = "a packed floating-point operand has the wrong width";
+    return false;
+  }
+  for (const char c : bits)
+    if (c != '0' && c != '1')
+    {
+      err = "a packed floating-point operand contains a non-bit character";
+      return false;
+    }
+
+  uint64_t exponent = 0;
+  for (unsigned i = 0; i < exp_width; i++)
+    exponent = (exponent << 1) | static_cast<uint64_t>(bits[1 + i] - '0');
+  const uint64_t max_exponent =
+      (static_cast<uint64_t>(1) << exp_width) - 1;
+  if (exponent == max_exponent)
+  {
+    err = "packedFPBinaryOp requires finite operands";
+    return false;
+  }
+
+  const std::string fraction = bits.substr(1 + exp_width);
+  bool fraction_nonzero = false;
+  for (const char c : fraction)
+    fraction_nonzero = fraction_nonzero || c == '1';
+  if (exponent == 0 && !fraction_nonzero)
+  {
+    bf_set_zero(value, bits[0] == '1');
+    return true;
+  }
+
+  std::string significand;
+  if (bits[0] == '1')
+    significand.push_back('-');
+  significand.push_back(exponent == 0 ? '0' : '1');
+  significand += fraction;
+
+  const char* next = nullptr;
+  int status = bf_atof(value, significand.c_str(), &next, 2, BF_PREC_INF,
+                       BF_RNDZ | BF_ATOF_NO_NAN_INF);
+  if ((status & (BF_ST_MEM_ERROR | BF_ST_INEXACT)) != 0 ||
+      next != significand.c_str() + significand.size())
+  {
+    err = "failed to reconstruct a packed floating-point operand";
+    return false;
+  }
+
+  const int64_t bias =
+      (static_cast<int64_t>(1) << (exp_width - 1)) - 1;
+  const int64_t unbiased = exponent == 0
+                               ? 1 - bias
+                               : static_cast<int64_t>(exponent) - bias;
+  const int64_t scale = unbiased - static_cast<int64_t>(sig_width - 1);
+  status = bf_mul_2exp(value, static_cast<slimb_t>(scale), BF_PREC_INF,
+                       BF_RNDZ);
+  if ((status & (BF_ST_MEM_ERROR | BF_ST_INEXACT)) != 0)
+  {
+    err = "failed to scale a packed floating-point operand";
+    return false;
+  }
+  return true;
+}
+
 } // namespace
 
 bool decimalToPackedFPBits(const std::string& decimal, unsigned exp_width,
@@ -365,6 +437,63 @@ bool rationalToPackedFPBits(const std::string& numerator,
   bf_delete(&v);
   bf_delete(&d);
   bf_delete(&n);
+  bf_context_end(&ctx);
+  return ok;
+}
+
+bool packedFPBinaryOp(const std::string& left, const std::string& right,
+                      unsigned exp_width, unsigned sig_width,
+                      unsigned rounding_mode, PackedFpBinaryOp operation,
+                      std::string& bits, std::string& err)
+{
+  if (!checkFormat(exp_width, sig_width, err))
+    return false;
+
+  bf_context_t ctx;
+  bf_context_init(&ctx, bfRealloc, nullptr);
+  bf_t a, b, result;
+  bf_init(&ctx, &a);
+  bf_init(&ctx, &b);
+  bf_init(&ctx, &result);
+
+  bool ok = unpackFiniteBits(left, exp_width, sig_width, &a, err) &&
+            unpackFiniteBits(right, exp_width, sig_width, &b, err);
+  if (ok)
+  {
+    const bf_flags_t flags = (bf_flags_t)bfRounding(rounding_mode) |
+                             bf_set_exp_bits((int)exp_width) |
+                             BF_FLAG_SUBNORMAL;
+    int status = 0;
+    switch (operation)
+    {
+      case PackedFpBinaryOp::Add:
+        status = bf_add(&result, &a, &b, (limb_t)sig_width, flags);
+        break;
+      case PackedFpBinaryOp::Subtract:
+        status = bf_sub(&result, &a, &b, (limb_t)sig_width, flags);
+        break;
+      case PackedFpBinaryOp::Multiply:
+        status = bf_mul(&result, &a, &b, (limb_t)sig_width, flags);
+        break;
+    }
+
+    if ((status & BF_ST_MEM_ERROR) != 0)
+    {
+      err = "out of memory while evaluating a packed floating-point operation";
+      ok = false;
+    }
+    else if (bf_is_nan(&result))
+    {
+      err = "a finite packed floating-point operation produced NaN";
+      ok = false;
+    }
+    else
+      packToBits(&result, exp_width, sig_width, bits);
+  }
+
+  bf_delete(&result);
+  bf_delete(&b);
+  bf_delete(&a);
   bf_context_end(&ctx);
   return ok;
 }

--- a/lib/FloatBlaster/FloatBlast.cpp
+++ b/lib/FloatBlaster/FloatBlast.cpp
@@ -29,6 +29,8 @@ THE SOFTWARE.
 #include "stp/FloatBlaster/symbolic_fp.h"
 
 #include <cassert>
+#include <cstdint>
+#include <limits>
 #include <unordered_map>
 
 namespace stp
@@ -63,6 +65,86 @@ private:
   typedef std::unordered_map<ASTNode, std::unique_ptr<symbolic_fp::uf>,
                              ASTNode::ASTNodeHasher, ASTNode::ASTNodeEqual>
       UnpackedMap;
+
+  // The native arithmetic circuits currently materialise IEEE biases and
+  // exponent envelopes in `unsigned`, and their logarithmic-width helpers
+  // use `1u << bit`. Keep every such value strictly below unsigned's sign
+  // bit and every shift count within the host type. SMT-LIB admits wider
+  // formats; those remain supported through the ordinary SymFPU lowering.
+  static bool consumeNativeFpEnvelope(std::uintmax_t& remaining,
+                                      std::uintmax_t amount)
+  {
+    if (amount >= remaining)
+      return false;
+    remaining -= amount;
+    return true;
+  }
+
+  static bool nativeFpExponentIsSafe(unsigned eb)
+  {
+    const unsigned digits = std::numeric_limits<unsigned>::digits;
+    return eb >= 2 && eb <= digits - 2;
+  }
+
+  static std::uintmax_t nativeFpBias(unsigned eb)
+  {
+    assert(nativeFpExponentIsSafe(eb));
+    return (std::uintmax_t{1} << (eb - 1)) - 1;
+  }
+
+  static std::uintmax_t nativeFpEnvelopeLimit()
+  {
+    // 2^(digits - 1), without adding one to unsigned's maximum.
+    return static_cast<std::uintmax_t>(std::numeric_limits<unsigned>::max() /
+                                       2) +
+           1;
+  }
+
+  static bool nativeFpArithmeticFormatIsSafe(const SourceSort& sort)
+  {
+    if (sort.kind() != SourceSort::Kind::FloatingPoint)
+      return false;
+
+    const unsigned eb = sort.exponentWidth();
+    const unsigned sb = sort.significandWidth();
+    if (sb < 2 || !nativeFpExponentIsSafe(eb))
+      return false;
+
+    // BBfpExpWidth must represent bias + 2*sb + 4 without reaching a
+    // shift by numeric_limits<unsigned>::digits. This also bounds every
+    // doubled width and logarithmic shift amount used by BBfpAdd/BBfpMul.
+    std::uintmax_t remaining = nativeFpEnvelopeLimit();
+    return consumeNativeFpEnvelope(remaining, nativeFpBias(eb)) &&
+           consumeNativeFpEnvelope(remaining, sb) &&
+           consumeNativeFpEnvelope(remaining, sb) &&
+           consumeNativeFpEnvelope(remaining, 4);
+  }
+
+  static bool nativeFpToFpFormatsAreSafe(const SourceSort& source,
+                                         const SourceSort& target)
+  {
+    if (source.kind() != SourceSort::Kind::FloatingPoint ||
+        target.kind() != SourceSort::Kind::FloatingPoint)
+      return false;
+
+    const unsigned eb1 = source.exponentWidth();
+    const unsigned sb1 = source.significandWidth();
+    const unsigned eb2 = target.exponentWidth();
+    const unsigned sb2 = target.significandWidth();
+    if (sb1 < 2 || sb2 < 2 || !nativeFpExponentIsSafe(eb1) ||
+        !nativeFpExponentIsSafe(eb2))
+      return false;
+
+    // BBfpToFp sizes its signed exponent for the complete source/target
+    // envelope: bias1 + sb1 + bias2 + 2*sb2 + 4.
+    std::uintmax_t remaining = nativeFpEnvelopeLimit();
+    return consumeNativeFpEnvelope(remaining, nativeFpBias(eb1)) &&
+           consumeNativeFpEnvelope(remaining, sb1) &&
+           consumeNativeFpEnvelope(remaining, nativeFpBias(eb2)) &&
+           consumeNativeFpEnvelope(remaining, sb2) &&
+           consumeNativeFpEnvelope(remaining, sb2) &&
+           consumeNativeFpEnvelope(remaining, 4);
+  }
 
   symbolic_fp::floatingPointTypeInfo formatOf(const ASTNode& n) const
   {
@@ -162,15 +244,17 @@ private:
     // hand-written packed circuits (BBfpMul, BBfpAdd) take over from
     // SymFPU when both float operands resolve to packed views and the
     // rounding mode is immediate (a constant, or a declared symbol --
-    // whose one-hot validity is asserted at declaration). The rebuild
-    // goes through the factory, so constant operands fold (a fully
-    // constant operation never survives, keeping the lowering-must-change
-    // invariant of constant folding and model evaluation) and the
-    // identity rules still fire. fp.sub needs no arm: the factory already
-    // lowers it to fp.add of the negation.
+    // whose one-hot validity is asserted at declaration), and the format's
+    // host-sized intermediate calculations are safe. Wider legal formats
+    // fall back to SymFPU. The rebuild goes through the factory, so constant
+    // operands fold (a fully constant operation never survives, keeping the
+    // lowering-must-change invariant of constant folding and model
+    // evaluation) and the identity rules still fire. fp.sub needs no arm:
+    // the factory already lowers it to fp.add of the negation.
     if ((n.GetKind() == FP_MUL || n.GetKind() == FP_ADD) &&
         bm->UserFlags.fp_native_arith && n.Degree() == 3 &&
-        (n[0].GetKind() == SYMBOL || n[0].GetKind() == BVCONST))
+        (n[0].GetKind() == SYMBOL || n[0].GetKind() == BVCONST) &&
+        nativeFpArithmeticFormatIsSafe(n.GetSourceSort()))
     {
       const ASTNode left = comparisonLeaf(n[1]);
       if (left.IsNull())
@@ -202,7 +286,8 @@ private:
     if (n.GetKind() == FP_TOFP && bm->UserFlags.fp_native_arith &&
         n.Degree() == 4 &&
         (n[2].GetKind() == SYMBOL || n[2].GetKind() == BVCONST) &&
-        n[0].GetUnsignedConst() >= 3)
+        n[0].GetUnsignedConst() >= 3 &&
+        nativeFpToFpFormatsAreSafe(n[3].GetSourceSort(), n.GetSourceSort()))
     {
       const ASTNode operand = comparisonLeaf(n[3]);
       if (operand.IsNull())

--- a/lib/FloatBlaster/FpDomainSimplify.cpp
+++ b/lib/FloatBlaster/FpDomainSimplify.cpp
@@ -1,0 +1,1249 @@
+/********************************************************************
+ * Experimental floating-point domain simplification.
+ ********************************************************************/
+#include "stp/FloatBlaster/FpDomainSimplify.h"
+
+#include "stp/FloatBlaster/DecimalLiteral.h"
+#include "stp/FloatBlaster/rounding_modes.h"
+
+#include "extlib-constbv/constantbv.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <iostream>
+#include <limits>
+#include <unordered_map>
+#include <vector>
+
+namespace stp
+{
+namespace
+{
+
+struct Bounds
+{
+  bool hasLower = false;
+  bool hasUpper = false;
+  bool lowerStrict = false;
+  bool upperStrict = false;
+  long double lower = 0.0L;
+  long double upper = 0.0L;
+  ASTNode lowerConst;
+  ASTNode upperConst;
+  std::string lowerBits;
+  std::string upperBits;
+  bool lowerExact = false;
+  bool upperExact = false;
+};
+
+struct Interval
+{
+  bool known = false;
+  bool finite = false;
+  bool exact = false;
+  long double lower = 0.0L;
+  long double upper = 0.0L;
+  std::string lowerBits;
+  std::string upperBits;
+
+  static Interval unknown() { return Interval(); }
+
+  static Interval finiteRange(long double lo, long double hi)
+  {
+    Interval out;
+    out.known = true;
+    out.finite = true;
+    out.lower = lo;
+    out.upper = hi;
+    return out;
+  }
+
+  static Interval exactFiniteRange(long double lo, long double hi,
+                                   const std::string& loBits,
+                                   const std::string& hiBits)
+  {
+    Interval out = finiteRange(lo, hi);
+    out.exact = true;
+    out.lowerBits = loBits;
+    out.upperBits = hiBits;
+    return out;
+  }
+};
+
+using BoundsMap =
+    std::unordered_map<ASTNode, Bounds, ASTNode::ASTNodeHasher,
+                       ASTNode::ASTNodeEqual>;
+using IntervalMap =
+    std::unordered_map<ASTNode, Interval, ASTNode::ASTNodeHasher,
+                       ASTNode::ASTNodeEqual>;
+
+using SignedTerms = std::vector<std::pair<ASTNode, int>>;
+
+bool fpSort(const ASTNode& n)
+{
+  return n.GetSourceSort().kind() == SourceSort::Kind::FloatingPoint;
+}
+
+bool bit(const ASTNode& c, unsigned i)
+{
+  return CONSTANTBV::BitVector_bit_test(c.GetBVConst(), i);
+}
+
+bool fpConstantValue(const ASTNode& c, long double& out)
+{
+  if (c.GetKind() != BVCONST || c.GetSourceSort().kind() !=
+                                    SourceSort::Kind::FloatingPoint)
+    return false;
+
+  const unsigned eb = c.GetExpWidth();
+  const unsigned sb = c.GetSigWidth();
+  if (eb < 2 || sb < 2 || eb >= 31 ||
+      sb > static_cast<unsigned>(std::numeric_limits<long double>::digits))
+    return false;
+
+  const unsigned w = eb + sb;
+  const bool negative = bit(c, w - 1);
+
+  unsigned exponent = 0;
+  for (unsigned i = 0; i < eb; i++)
+    if (bit(c, sb - 1 + i))
+      exponent |= 1u << i;
+
+  const unsigned maxExponent = (1u << eb) - 1;
+  if (exponent == maxExponent)
+    return false; // NaN or infinity.
+
+  long double significand = 0.0L;
+  for (unsigned i = 0; i + 1 < sb; i++)
+    if (bit(c, i))
+      significand += std::ldexp(1.0L, static_cast<int>(i));
+
+  const int bias = static_cast<int>((1u << (eb - 1)) - 1);
+  if (exponent == 0)
+  {
+    out = std::ldexp(significand,
+                     static_cast<int>(1 - bias - (sb - 1)));
+  }
+  else
+  {
+    significand += std::ldexp(1.0L, static_cast<int>(sb - 1));
+    out = std::ldexp(significand,
+                     static_cast<int>(exponent) - bias -
+                         static_cast<int>(sb - 1));
+  }
+
+  if (negative)
+    out = -out;
+  return std::isfinite(out) &&
+         (out != 0.0L || (exponent == 0 && significand == 0.0L));
+}
+
+bool fpConstantBits(const ASTNode& c, std::string& out)
+{
+  if (c.GetKind() != BVCONST ||
+      c.GetSourceSort().kind() != SourceSort::Kind::FloatingPoint)
+    return false;
+
+  const unsigned width = c.GetValueWidth();
+  out.resize(width);
+  for (unsigned i = 0; i < width; i++)
+    out[width - 1 - i] = bit(c, i) ? '1' : '0';
+  return true;
+}
+
+bool fpPackedValue(const SourceSort& sort, const std::string& bits,
+                   long double& out)
+{
+  if (sort.kind() != SourceSort::Kind::FloatingPoint)
+    return false;
+  const unsigned eb = sort.exponentWidth();
+  const unsigned sb = sort.significandWidth();
+  if (bits.size() != eb + sb || eb < 2 || sb < 2 || eb >= 31 ||
+      sb > static_cast<unsigned>(std::numeric_limits<long double>::digits))
+    return false;
+
+  unsigned exponent = 0;
+  for (unsigned i = 0; i < eb; i++)
+    exponent = (exponent << 1) |
+               static_cast<unsigned>(bits[1 + i] == '1');
+  if (exponent == (1u << eb) - 1)
+    return false;
+
+  long double significand = 0.0L;
+  for (unsigned i = 0; i + 1 < sb; i++)
+    if (bits[1 + eb + i] == '1')
+      significand += std::ldexp(
+          1.0L, static_cast<int>(sb - 2 - i));
+
+  const int bias = static_cast<int>((1u << (eb - 1)) - 1);
+  if (exponent == 0)
+    out = std::ldexp(significand,
+                     1 - bias - static_cast<int>(sb - 1));
+  else
+  {
+    significand += std::ldexp(1.0L, static_cast<int>(sb - 1));
+    out = std::ldexp(significand,
+                     static_cast<int>(exponent) - bias -
+                         static_cast<int>(sb - 1));
+  }
+  if (bits[0] == '1')
+    out = -out;
+  return std::isfinite(out);
+}
+
+bool packedFinite(const std::string& bits, unsigned eb)
+{
+  if (bits.size() <= eb)
+    return false;
+  for (unsigned i = 0; i < eb; i++)
+    if (bits[1 + i] != '1')
+      return true;
+  return false;
+}
+
+bool packedZeroMagnitude(const std::string& bits)
+{
+  for (size_t i = 1; i < bits.size(); i++)
+    if (bits[i] != '0')
+      return false;
+  return !bits.empty();
+}
+
+// Numeric ordering for finite packed IEEE values. Signed zeros compare equal;
+// all other values use sign-magnitude order, reversed on the negative side.
+int packedCompare(const std::string& a, const std::string& b)
+{
+  assert(a.size() == b.size() && !a.empty());
+  if (packedZeroMagnitude(a) && packedZeroMagnitude(b))
+    return 0;
+  if (a[0] != b[0])
+    return a[0] == '1' ? -1 : 1;
+  const int magnitude = a.substr(1).compare(b.substr(1));
+  if (magnitude == 0)
+    return 0;
+  const int ordered = magnitude < 0 ? -1 : 1;
+  return a[0] == '1' ? -ordered : ordered;
+}
+
+std::string packedNegate(std::string bits)
+{
+  assert(!bits.empty());
+  bits[0] = bits[0] == '1' ? '0' : '1';
+  return bits;
+}
+
+std::string packedAbs(std::string bits)
+{
+  assert(!bits.empty());
+  bits[0] = '0';
+  return bits;
+}
+
+bool fixedRoundingMode(const ASTNode& n, unsigned& mode)
+{
+  if (n.GetKind() != BVCONST || n.GetValueWidth() != 5)
+    return false;
+  mode = static_cast<unsigned>(n.GetUnsignedConst());
+  switch (mode)
+  {
+    case symbolic_fp::ROUND_NEAREST_TIES_TO_EVEN:
+    case symbolic_fp::ROUND_NEAREST_TIES_TO_AWAY:
+    case symbolic_fp::ROUND_TOWARD_POSITIVE:
+    case symbolic_fp::ROUND_TOWARD_NEGATIVE:
+    case symbolic_fp::ROUND_TOWARD_ZERO: return true;
+    default: return false;
+  }
+}
+
+bool exactBinaryEndpoint(const SourceSort& sort, Kind kind,
+                         const std::string& left,
+                         const std::string& right, unsigned mode,
+                         std::string& result)
+{
+  PackedFpBinaryOp operation;
+  switch (kind)
+  {
+    case FP_ADD: operation = PackedFpBinaryOp::Add; break;
+    case FP_SUB: operation = PackedFpBinaryOp::Subtract; break;
+    case FP_MUL: operation = PackedFpBinaryOp::Multiply; break;
+    default: return false;
+  }
+
+  std::string error;
+  if (!packedFPBinaryOp(left, right, sort.exponentWidth(),
+                        sort.significandWidth(), mode, operation, result,
+                        error))
+    return false;
+  return packedFinite(result, sort.exponentWidth());
+}
+
+bool maxFiniteValue(const SourceSort& sort, long double& out)
+{
+  if (sort.kind() != SourceSort::Kind::FloatingPoint)
+    return false;
+
+  const unsigned eb = sort.exponentWidth();
+  const unsigned sb = sort.significandWidth();
+  if (eb < 2 || sb < 2 || eb >= 31 || sb > 113)
+    return false;
+
+  const int bias = static_cast<int>((1u << (eb - 1)) - 1);
+  const int maxExp = static_cast<int>((1u << eb) - 2) - bias;
+  const long double sig =
+      2.0L - std::ldexp(1.0L, -static_cast<int>(sb - 1));
+  out = std::ldexp(sig, maxExp);
+  return std::isfinite(out);
+}
+
+bool maxUlpValue(const SourceSort& sort, long double& out)
+{
+  if (sort.kind() != SourceSort::Kind::FloatingPoint)
+    return false;
+
+  const unsigned eb = sort.exponentWidth();
+  const unsigned sb = sort.significandWidth();
+  if (eb < 2 || sb < 2 || eb >= 31 || sb > 113)
+    return false;
+
+  const int bias = static_cast<int>((1u << (eb - 1)) - 1);
+  const int maxExp = static_cast<int>((1u << eb) - 2) - bias;
+  out = std::ldexp(1.0L, maxExp - static_cast<int>(sb - 1));
+  return std::isfinite(out) && out > 0.0L;
+}
+
+Interval roundedRange(const SourceSort& sort, long double lo, long double hi)
+{
+  if (!std::isfinite(lo) || !std::isfinite(hi))
+    return Interval::unknown();
+
+  long double maxFinite = 0.0L;
+  if (!maxFiniteValue(sort, maxFinite))
+    return Interval::unknown();
+
+  if (lo < -maxFinite || hi > maxFinite)
+    return Interval::unknown();
+  long double maxUlp = 0.0L;
+  if (!maxUlpValue(sort, maxUlp))
+    return Interval::unknown();
+  lo = std::max(-maxFinite, lo - maxUlp);
+  hi = std::min(maxFinite, hi + maxUlp);
+  return Interval::finiteRange(lo, hi);
+}
+
+Interval exactRoundedRange(const SourceSort& sort, Kind kind,
+                           const ASTNode& roundingMode, const Interval& a,
+                           const Interval& b)
+{
+  if (!a.exact || !b.exact)
+    return Interval::unknown();
+
+  unsigned fixedMode = 0;
+  const bool fixed = fixedRoundingMode(roundingMode, fixedMode);
+  const unsigned lowerMode =
+      fixed ? fixedMode
+            : static_cast<unsigned>(symbolic_fp::ROUND_TOWARD_NEGATIVE);
+  const unsigned upperMode =
+      fixed ? fixedMode
+            : static_cast<unsigned>(symbolic_fp::ROUND_TOWARD_POSITIVE);
+
+  using EndpointPair = std::pair<std::string, std::string>;
+  std::vector<EndpointPair> lowerInputs;
+  std::vector<EndpointPair> upperInputs;
+  if (kind == FP_ADD)
+  {
+    lowerInputs.emplace_back(a.lowerBits, b.lowerBits);
+    upperInputs.emplace_back(a.upperBits, b.upperBits);
+  }
+  else if (kind == FP_SUB)
+  {
+    lowerInputs.emplace_back(a.lowerBits, b.upperBits);
+    upperInputs.emplace_back(a.upperBits, b.lowerBits);
+  }
+  else if (kind == FP_MUL)
+  {
+    const std::string as[2] = {a.lowerBits, a.upperBits};
+    const std::string bs[2] = {b.lowerBits, b.upperBits};
+    for (const std::string& av : as)
+      for (const std::string& bv : bs)
+      {
+        lowerInputs.emplace_back(av, bv);
+        upperInputs.emplace_back(av, bv);
+      }
+  }
+  else
+    return Interval::unknown();
+
+  std::string lower;
+  for (const EndpointPair& input : lowerInputs)
+  {
+    std::string value;
+    if (!exactBinaryEndpoint(sort, kind, input.first, input.second,
+                             lowerMode, value))
+      return Interval::unknown();
+    if (lower.empty() || packedCompare(value, lower) < 0)
+      lower = value;
+  }
+
+  std::string upper;
+  for (const EndpointPair& input : upperInputs)
+  {
+    std::string value;
+    if (!exactBinaryEndpoint(sort, kind, input.first, input.second,
+                             upperMode, value))
+      return Interval::unknown();
+    if (upper.empty() || packedCompare(value, upper) > 0)
+      upper = value;
+  }
+
+  long double lo = 0.0L;
+  long double hi = 0.0L;
+  if (lower.empty() || upper.empty() || packedCompare(lower, upper) > 0 ||
+      !fpPackedValue(sort, lower, lo) ||
+      !fpPackedValue(sort, upper, hi))
+    return Interval::unknown();
+  return Interval::exactFiniteRange(lo, hi, lower, upper);
+}
+
+bool isOrderedComparison(Kind k)
+{
+  return k == FP_LT || k == FP_LEQ || k == FP_GT || k == FP_GEQ;
+}
+
+bool isFpZero(const ASTNode& n)
+{
+  long double value = 0.0L;
+  return fpConstantValue(n, value) && value == 0.0L;
+}
+
+bool relationAsLeq(const ASTNode& n, ASTNode& left, ASTNode& right)
+{
+  switch (n.GetKind())
+  {
+    case FP_LEQ:
+    case FP_LT:
+      left = n[0];
+      right = n[1];
+      return true;
+    case FP_GEQ:
+    case FP_GT:
+      left = n[1];
+      right = n[0];
+      return true;
+    default:
+      return false;
+  }
+}
+
+bool boundPredicate(const ASTNode& n, ASTNode& symbol, ASTNode& constant,
+                    long double& value, bool& lowerBound, bool& strict)
+{
+  if (!isOrderedComparison(n.GetKind()) || n.Degree() != 2)
+    return false;
+
+  strict = n.GetKind() == FP_LT || n.GetKind() == FP_GT;
+
+  ASTNode left;
+  ASTNode right;
+  if (!relationAsLeq(n, left, right))
+    return false;
+
+  if (left.GetKind() == SYMBOL && fpSort(left) && fpConstantValue(right, value))
+  {
+    symbol = left;
+    constant = right;
+    lowerBound = false;
+    return true;
+  }
+
+  if (right.GetKind() == SYMBOL && fpSort(right) && fpConstantValue(left, value))
+  {
+    symbol = right;
+    constant = left;
+    lowerBound = true;
+    return true;
+  }
+
+  return false;
+}
+
+ASTNode rebuild(NodeFactory* nf, const ASTNode& n, const ASTVec& children)
+{
+  if (n.GetType() == BOOLEAN_TYPE)
+    return nf->CreateNode(n.GetKind(), children);
+  if (n.GetIndexWidth() > 0)
+    return nf->CreateArrayTerm(n.GetKind(), n.GetIndexWidth(),
+                               n.GetValueWidth(), children);
+  return nf->CreateTerm(n.GetKind(), n.GetValueWidth(), children);
+}
+
+class DomainPass
+{
+public:
+  DomainPass(STPMgr* bm_, NodeFactory* nf_,
+             FpDomainSimplify::Statistics& stats_)
+      : bm(bm_), nf(nf_), stats(stats_)
+  {
+  }
+
+  ASTNode run(const ASTNode& root)
+  {
+    collectConjunctiveBounds(root);
+    for (const auto& entry : bounds)
+      if (entry.second.hasLower && entry.second.hasUpper &&
+          entry.second.lower <= entry.second.upper)
+        boxed.insert(entry.first);
+
+    stats.boxed_symbols = boxed.size();
+
+    if (bm->UserFlags.fp_domain_sound_zero_facts)
+      inferSoundZeroRows(root);
+
+    ASTNode out = rewrite(root);
+    if (!soundZeroSymbols.empty())
+    {
+      ASTVec conjuncts;
+      conjuncts.push_back(out);
+      for (const ASTNode& term : soundZeroSymbols)
+      {
+        assert(term.GetKind() == SYMBOL);
+        conjuncts.push_back(magnitudeZero(term));
+      }
+      out = nf->CreateNode(AND, conjuncts);
+    }
+    return out;
+  }
+
+private:
+  void collectConjunctiveBounds(const ASTNode& n)
+  {
+    if (n.GetKind() == AND)
+    {
+      for (const ASTNode& child : n)
+        collectConjunctiveBounds(child);
+      return;
+    }
+
+    ASTNode symbol;
+    ASTNode constant;
+    long double value = 0.0L;
+    bool lowerBound = false;
+    bool strict = false;
+    if (!boundPredicate(n, symbol, constant, value, lowerBound, strict))
+      return;
+
+    // These predicates are both the proof source for this pass and the facts
+    // consumed later by native lowering. Do not fold them away merely because
+    // the interval assembled from the complete conjunction proves them.
+    boxPredicates.insert(n);
+    Bounds& b = bounds[symbol];
+    if (lowerBound)
+    {
+      if (!b.hasLower || value >= b.lower)
+      {
+        b.lower = value;
+        b.lowerConst = constant;
+        b.lowerStrict = strict;
+        b.lowerExact = fpConstantBits(constant, b.lowerBits);
+      }
+      b.hasLower = true;
+    }
+    else
+    {
+      if (!b.hasUpper || value <= b.upper)
+      {
+        b.upper = value;
+        b.upperConst = constant;
+        b.upperStrict = strict;
+        b.upperExact = fpConstantBits(constant, b.upperBits);
+      }
+      b.hasUpper = true;
+    }
+  }
+
+  Interval interval(const ASTNode& n)
+  {
+    const IntervalMap::const_iterator cached = intervals.find(n);
+    if (cached != intervals.end())
+      return cached->second;
+
+    Interval out = intervalUncached(n);
+    intervals.emplace(n, out);
+    return out;
+  }
+
+  Interval intervalUncached(const ASTNode& n)
+  {
+    long double value = 0.0L;
+    if (fpConstantValue(n, value))
+    {
+      std::string bits;
+      if (fpConstantBits(n, bits))
+        return Interval::exactFiniteRange(value, value, bits, bits);
+      return Interval::finiteRange(value, value);
+    }
+
+    if (n.GetKind() == SYMBOL && fpSort(n))
+    {
+      const BoundsMap::const_iterator it = bounds.find(n);
+      if (it == bounds.end() || !it->second.hasLower || !it->second.hasUpper)
+        return Interval::unknown();
+      if (it->second.lower > it->second.upper)
+        return Interval::unknown();
+      if (it->second.lowerExact && it->second.upperExact)
+        return Interval::exactFiniteRange(
+            it->second.lower, it->second.upper, it->second.lowerBits,
+            it->second.upperBits);
+      return Interval::finiteRange(it->second.lower, it->second.upper);
+    }
+
+    switch (n.GetKind())
+    {
+      case ITE:
+      {
+        if (n.Degree() != 3 || !fpSort(n))
+          return Interval::unknown();
+        const Interval t = interval(n[1]);
+        const Interval e = interval(n[2]);
+        if (!t.known || !e.known || !t.finite || !e.finite)
+          return Interval::unknown();
+        const long double lower = std::min(t.lower, e.lower);
+        const long double upper = std::max(t.upper, e.upper);
+        if (t.exact && e.exact)
+        {
+          const std::string& lowerBits =
+              packedCompare(t.lowerBits, e.lowerBits) <= 0 ? t.lowerBits
+                                                           : e.lowerBits;
+          const std::string& upperBits =
+              packedCompare(t.upperBits, e.upperBits) >= 0 ? t.upperBits
+                                                           : e.upperBits;
+          return Interval::exactFiniteRange(lower, upper, lowerBits,
+                                            upperBits);
+        }
+        return Interval::finiteRange(lower, upper);
+      }
+
+      case FP_ABS:
+      {
+        const Interval x = interval(n[0]);
+        if (!x.known || !x.finite)
+          return Interval::unknown();
+        if (x.lower >= 0.0L)
+        {
+          if (!x.exact)
+            return x;
+          return Interval::exactFiniteRange(
+              x.lower, x.upper, packedAbs(x.lowerBits),
+              packedAbs(x.upperBits));
+        }
+        if (x.upper <= 0.0L)
+        {
+          if (x.exact)
+            return Interval::exactFiniteRange(
+                -x.upper, -x.lower, packedAbs(x.upperBits),
+                packedAbs(x.lowerBits));
+          return Interval::finiteRange(-x.upper, -x.lower);
+        }
+        const long double upper = std::max(-x.lower, x.upper);
+        if (x.exact)
+        {
+          std::string zero = x.lowerBits;
+          std::fill(zero.begin(), zero.end(), '0');
+          const std::string negativeMagnitude = packedAbs(x.lowerBits);
+          const std::string positiveMagnitude = packedAbs(x.upperBits);
+          const std::string& upperBits =
+              packedCompare(negativeMagnitude, positiveMagnitude) >= 0
+                  ? negativeMagnitude
+                  : positiveMagnitude;
+          return Interval::exactFiniteRange(0.0L, upper, zero, upperBits);
+        }
+        return Interval::finiteRange(0.0L, upper);
+      }
+
+      case FP_NEG:
+      {
+        const Interval x = interval(n[0]);
+        if (!x.known || !x.finite)
+          return Interval::unknown();
+        if (x.exact)
+          return Interval::exactFiniteRange(
+              -x.upper, -x.lower, packedNegate(x.upperBits),
+              packedNegate(x.lowerBits));
+        return Interval::finiteRange(-x.upper, -x.lower);
+      }
+
+      case FP_ADD:
+      case FP_SUB:
+      case FP_MUL:
+      {
+        if (n.Degree() != 3)
+          return Interval::unknown();
+        const Interval a = interval(n[1]);
+        const Interval b = interval(n[2]);
+        if (!a.known || !b.known || !a.finite || !b.finite)
+          return Interval::unknown();
+
+        const Interval exact =
+            exactRoundedRange(n.GetSourceSort(), n.GetKind(), n[0], a, b);
+        if (exact.known)
+          return exact;
+
+        if (n.GetKind() == FP_ADD)
+          return roundedRange(n.GetSourceSort(), a.lower + b.lower,
+                              a.upper + b.upper);
+        if (n.GetKind() == FP_SUB)
+          return roundedRange(n.GetSourceSort(), a.lower - b.upper,
+                              a.upper - b.lower);
+
+        long double vals[4] = {a.lower * b.lower, a.lower * b.upper,
+                               a.upper * b.lower, a.upper * b.upper};
+        return roundedRange(n.GetSourceSort(),
+                            *std::min_element(vals, vals + 4),
+                            *std::max_element(vals, vals + 4));
+      }
+
+      default:
+        return Interval::unknown();
+    }
+  }
+
+  bool knownFinite(const ASTNode& n)
+  {
+    const Interval x = interval(n);
+    return x.known && x.finite;
+  }
+
+  bool knownNonnegativeFinite(const ASTNode& n)
+  {
+    const Interval x = interval(n);
+    if (!x.known || !x.finite)
+      return false;
+    if (x.exact)
+      return x.lowerBits[0] == '0' || packedZeroMagnitude(x.lowerBits);
+    return x.lower >= 0.0L;
+  }
+
+  // Recognise the same restricted linear-row language as the former
+  // coefficient/error model, but do not flatten it. The actual endpoint
+  // evaluation below follows every FP operation in its original AST
+  // association and rounds after each operation in the target format.
+  bool linearRowExpression(const ASTNode& n)
+  {
+    long double value = 0.0L;
+    if (fpConstantValue(n, value))
+      return true;
+
+    if (n.GetKind() == SYMBOL && knownFinite(n))
+      return true;
+
+    if (n.GetKind() == FP_NEG)
+      return n.Degree() == 1 && linearRowExpression(n[0]);
+
+    if ((n.GetKind() == FP_ADD || n.GetKind() == FP_SUB) && n.Degree() == 3)
+      return linearRowExpression(n[1]) && linearRowExpression(n[2]);
+
+    if (n.GetKind() == FP_MUL && n.Degree() == 3)
+    {
+      long double c = 0.0L;
+      if (fpConstantValue(n[1], c) && n[2].GetKind() == SYMBOL &&
+          knownFinite(n[2]))
+        return true;
+      return fpConstantValue(n[2], c) && n[1].GetKind() == SYMBOL &&
+             knownFinite(n[1]);
+    }
+
+    return false;
+  }
+
+  ASTNode rowBoundZeroRewrite(const ASTNode& expr)
+  {
+    if (!bm->UserFlags.fp_domain_row_bounds)
+      return ASTNode();
+
+    if (!linearRowExpression(expr))
+      return ASTNode();
+
+    const Interval row = interval(expr);
+    if (!row.known || !row.finite)
+      return ASTNode();
+
+    ++stats.row_bound_rows;
+    bool excludesZero = row.lower > 0.0L || row.upper < 0.0L;
+    if (row.exact)
+    {
+      assert(row.lowerBits.size() == row.upperBits.size());
+      const std::string zero(row.lowerBits.size(), '0');
+      excludesZero = packedCompare(row.lowerBits, zero) > 0 ||
+                     packedCompare(row.upperBits, zero) < 0;
+    }
+    if (excludesZero)
+    {
+      ++stats.row_bound_false;
+      return bm->ASTFalse;
+    }
+    return ASTNode();
+  }
+
+  ASTNode magnitudeZero(const ASTNode& n)
+  {
+    const SourceSort sort = n.GetSourceSort();
+    if (sort.kind() != SourceSort::Kind::FloatingPoint)
+      return ASTNode();
+
+    const unsigned width = sort.packedWidth();
+    if (width <= 1)
+      return ASTNode();
+
+    const ASTNode high = bm->CreateBVConst(32, width - 2);
+    const ASTNode low = bm->CreateBVConst(32, 0);
+    const ASTNode magnitude =
+        nf->CreateTerm(BVEXTRACT, width - 1, n, high, low);
+    return nf->CreateNode(EQ, magnitude, bm->CreateZeroConst(width - 1));
+  }
+
+  ASTNode zeroTest(const ASTNode& n)
+  {
+    if (bm->UserFlags.fp_domain_sound_zero_facts && n.GetKind() == SYMBOL &&
+        knownNonnegativeFinite(n))
+    {
+      const ASTNode zero = magnitudeZero(n);
+      if (!zero.IsNull())
+        return zero;
+    }
+
+    return nf->CreateNode(FP_ISZERO, n);
+  }
+
+  bool parseSignedSymbolSum(const ASTNode& n, int sign, SignedTerms& terms)
+  {
+    if (n.GetKind() == FP_ADD && n.Degree() == 3)
+    {
+      return parseSignedSymbolSum(n[1], sign, terms) &&
+             parseSignedSymbolSum(n[2], sign, terms);
+    }
+
+    if (n.GetKind() == FP_SUB && n.Degree() == 3)
+    {
+      return parseSignedSymbolSum(n[1], sign, terms) &&
+             parseSignedSymbolSum(n[2], -sign, terms);
+    }
+
+    if (n.GetKind() == FP_NEG)
+      return parseSignedSymbolSum(n[0], -sign, terms);
+
+    if (isFpZero(n))
+      return true;
+
+    if (n.GetKind() != SYMBOL || !knownNonnegativeFinite(n))
+      return false;
+
+    terms.push_back(std::make_pair(n, sign));
+    return true;
+  }
+
+  bool parseSoundZeroRow(const ASTNode& n, SignedTerms& terms)
+  {
+    ASTNode expr;
+    if (n.GetKind() == FP_ISZERO && n.Degree() == 1)
+      expr = n[0];
+    else if (n.GetKind() == FP_EQ && n.Degree() == 2)
+    {
+      if (isFpZero(n[0]))
+        expr = n[1];
+      else if (isFpZero(n[1]))
+        expr = n[0];
+      else
+        return false;
+    }
+    else
+      return false;
+
+    return parseSignedSymbolSum(expr, 1, terms) && !terms.empty();
+  }
+
+  ASTNode soundRep(const ASTNode& n)
+  {
+    ASTNodeMap::iterator it = soundParent.find(n);
+    if (it == soundParent.end())
+    {
+      soundParent[n] = n;
+      return n;
+    }
+    if (it->second == n)
+      return n;
+    const ASTNode rep = soundRep(it->second);
+    it->second = rep;
+    return rep;
+  }
+
+  bool uniteSound(const ASTNode& a, const ASTNode& b)
+  {
+    ASTNode ra = soundRep(a);
+    ASTNode rb = soundRep(b);
+    if (ra == rb)
+      return false;
+    if (rb.GetNodeNum() < ra.GetNodeNum())
+      std::swap(ra, rb);
+    soundParent[rb] = ra;
+    return true;
+  }
+
+  bool markSoundZero(const ASTNode& n)
+  {
+    const ASTNode rep = soundRep(n);
+    if (!soundZeroReps.insert(rep).second)
+      return false;
+    return true;
+  }
+
+  void collectSoundRows(const ASTNode& n)
+  {
+    if (n.GetKind() == AND)
+    {
+      for (const ASTNode& child : n)
+        collectSoundRows(child);
+      return;
+    }
+
+    SignedTerms terms;
+    if (parseSoundZeroRow(n, terms))
+      soundRows.push_back(terms);
+  }
+
+  void normalizeSoundZeros()
+  {
+    ASTNodeSet normalized;
+    for (const ASTNode& z : soundZeroReps)
+      normalized.insert(soundRep(z));
+    soundZeroReps.swap(normalized);
+  }
+
+  void inferSoundZeroRows(const ASTNode& root)
+  {
+    collectSoundRows(root);
+    stats.sound_zero_rows = soundRows.size();
+    if (soundRows.empty())
+      return;
+
+    for (const SignedTerms& row : soundRows)
+      for (const auto& term : row)
+        soundRep(term.first);
+
+    bool changed = true;
+    unsigned rounds = 0;
+    while (changed && rounds++ < soundRows.size() + 1)
+    {
+      changed = false;
+      normalizeSoundZeros();
+
+      for (const SignedTerms& row : soundRows)
+      {
+        SignedTerms active;
+        for (const auto& term : row)
+        {
+          const ASTNode rep = soundRep(term.first);
+          if (soundZeroReps.find(rep) != soundZeroReps.end())
+            continue;
+          active.push_back(term);
+        }
+
+        if (active.empty())
+          continue;
+
+        bool allPositive = true;
+        bool allNegative = true;
+        for (const auto& term : active)
+        {
+          allPositive = allPositive && term.second > 0;
+          allNegative = allNegative && term.second < 0;
+        }
+
+        // A rounded sum of finite terms with one mathematical sign has zero
+        // magnitude only when every term has zero magnitude. Association and
+        // rounding cannot cancel a nonzero same-sign term.
+        if (allPositive || allNegative)
+        {
+          for (const auto& term : active)
+            changed = markSoundZero(term.first) || changed;
+          continue;
+        }
+
+        // For two representable operands, a rounded difference can have zero
+        // magnitude only when the operands have the same FP value. Keep that
+        // equality for propagating an independently established zero fact.
+        // Do not cancel equal/opposite terms inside a larger row: in
+        // (x + tiny) - x, `tiny` may be lost to rounding even though it is
+        // nonzero.
+        if (active.size() == 2 &&
+            active[0].second + active[1].second == 0)
+          changed = uniteSound(active[0].first, active[1].first) || changed;
+      }
+    }
+
+    normalizeSoundZeros();
+    for (const auto& entry : soundParent)
+      if (soundZeroReps.find(soundRep(entry.first)) != soundZeroReps.end())
+        soundZeroSymbols.insert(entry.first);
+    stats.sound_zero_facts = soundZeroSymbols.size();
+  }
+
+  bool differenceFromZero(const ASTNode& n, ASTNode& left, ASTNode& right)
+  {
+    if (n.GetKind() != FP_ADD || n.Degree() != 3)
+      return false;
+
+    if (n[1].GetKind() == FP_NEG)
+    {
+      left = n[2];
+      right = n[1][0];
+      return knownFinite(left) && knownFinite(right);
+    }
+
+    if (n[2].GetKind() == FP_NEG)
+    {
+      left = n[1];
+      right = n[2][0];
+      return knownFinite(left) && knownFinite(right);
+    }
+
+    return false;
+  }
+
+  void collectAddends(const ASTNode& n, ASTVec& out)
+  {
+    if (n.GetKind() == FP_ADD && n.Degree() == 3)
+    {
+      collectAddends(n[1], out);
+      collectAddends(n[2], out);
+      return;
+    }
+    out.push_back(n);
+  }
+
+  ASTNode zeroEqualityRewrite(const ASTNode& expr, const ASTNode& zero)
+  {
+    if (expr.GetKind() == FP_NEG)
+    {
+      ++stats.difference_zero_equalities;
+      return nf->CreateNode(FP_EQ, expr[0], zero);
+    }
+
+    ASTNode left;
+    ASTNode right;
+    if (differenceFromZero(expr, left, right))
+    {
+      ++stats.difference_zero_equalities;
+      return nf->CreateNode(FP_EQ, left, right);
+    }
+
+    ASTVec addends;
+    collectAddends(expr, addends);
+    if (addends.size() < 2)
+      return ASTNode();
+
+    for (const ASTNode& addend : addends)
+      if (!knownNonnegativeFinite(addend))
+        return ASTNode();
+
+    ASTVec conjuncts;
+    conjuncts.reserve(addends.size());
+    for (const ASTNode& addend : addends)
+      conjuncts.push_back(nf->CreateNode(FP_EQ, addend, zero));
+    ++stats.nonnegative_zero_sums;
+    return nf->CreateNode(AND, conjuncts);
+  }
+
+  ASTNode zeroPredicateRewrite(const ASTNode& expr)
+  {
+    if (expr.GetKind() == FP_NEG)
+    {
+      ++stats.difference_zero_equalities;
+      return zeroTest(expr[0]);
+    }
+
+    ASTNode left;
+    ASTNode right;
+    if (differenceFromZero(expr, left, right))
+    {
+      ++stats.difference_zero_equalities;
+      return nf->CreateNode(FP_EQ, left, right);
+    }
+
+    ASTVec addends;
+    collectAddends(expr, addends);
+    if (addends.size() < 2)
+      return ASTNode();
+
+    for (const ASTNode& addend : addends)
+      if (!knownNonnegativeFinite(addend))
+        return ASTNode();
+
+    ASTVec conjuncts;
+    conjuncts.reserve(addends.size());
+    for (const ASTNode& addend : addends)
+      conjuncts.push_back(zeroTest(addend));
+    ++stats.nonnegative_zero_sums;
+    return nf->CreateNode(AND, conjuncts);
+  }
+
+  ASTNode rewrite(const ASTNode& n)
+  {
+    const ASTNodeMap::const_iterator cached = rewriteCache.find(n);
+    if (cached != rewriteCache.end())
+      return cached->second;
+
+    ASTNode out;
+    if (boxPredicates.find(n) != boxPredicates.end())
+      out = n;
+    else if (n.GetKind() == FP_ISZERO)
+    {
+      out = rowBoundZeroRewrite(n[0]);
+      if (out.IsNull())
+        out = zeroPredicateRewrite(n[0]);
+    }
+    else if (n.GetKind() == FP_ISNAN || n.GetKind() == FP_ISINFINITE)
+    {
+      const Interval x = interval(n[0]);
+      if (x.known && x.finite)
+      {
+        ++stats.classifier_false;
+        out = bm->ASTFalse;
+      }
+    }
+    else if (isOrderedComparison(n.GetKind()) && n.Degree() == 2)
+    {
+      const Interval a = interval(n[0]);
+      const Interval b = interval(n[1]);
+      if (a.known && b.known && a.finite && b.finite)
+      {
+        const bool strict = n.GetKind() == FP_LT || n.GetKind() == FP_GT;
+        const auto compareEndpoints = [](const Interval& left,
+                                         bool leftUpper,
+                                         const Interval& right,
+                                         bool rightUpper) {
+          if (left.exact && right.exact)
+          {
+            const std::string& l =
+                leftUpper ? left.upperBits : left.lowerBits;
+            const std::string& r =
+                rightUpper ? right.upperBits : right.lowerBits;
+            return packedCompare(l, r);
+          }
+          const long double l = leftUpper ? left.upper : left.lower;
+          const long double r = rightUpper ? right.upper : right.lower;
+          return l < r ? -1 : (l > r ? 1 : 0);
+        };
+        const int upperLower =
+            compareEndpoints(a, true, b, false);
+        const int lowerUpper =
+            compareEndpoints(a, false, b, true);
+        bool decided = false;
+        bool value = false;
+        if (n.GetKind() == FP_LT || n.GetKind() == FP_LEQ)
+        {
+          if (strict ? upperLower < 0 : upperLower <= 0)
+          {
+            decided = true;
+            value = true;
+          }
+          else if (strict ? lowerUpper >= 0 : lowerUpper > 0)
+          {
+            decided = true;
+            value = false;
+          }
+        }
+        else
+        {
+          if (strict ? lowerUpper > 0 : lowerUpper >= 0)
+          {
+            decided = true;
+            value = true;
+          }
+          else if (strict ? upperLower <= 0 : upperLower < 0)
+          {
+            decided = true;
+            value = false;
+          }
+        }
+
+        if (decided)
+        {
+          if (value)
+            ++stats.interval_true;
+          else
+            ++stats.interval_false;
+          out = value ? bm->ASTTrue : bm->ASTFalse;
+        }
+      }
+    }
+    else if (n.GetKind() == FP_EQ && n.Degree() == 2)
+    {
+      if (isFpZero(n[0]))
+      {
+        out = rowBoundZeroRewrite(n[1]);
+        if (out.IsNull())
+          out = zeroEqualityRewrite(n[1], n[0]);
+      }
+      else if (isFpZero(n[1]))
+      {
+        out = rowBoundZeroRewrite(n[0]);
+        if (out.IsNull())
+          out = zeroEqualityRewrite(n[0], n[1]);
+      }
+    }
+
+    if (out.IsNull())
+    {
+      if (n.Degree() == 0)
+        out = n;
+      else
+      {
+        ASTVec children;
+        children.reserve(n.Degree());
+        bool changed = false;
+        for (const ASTNode& child : n)
+        {
+          const ASTNode r = rewrite(child);
+          changed = changed || r != child;
+          children.push_back(r);
+        }
+        out = changed ? rebuild(nf, n, children) : n;
+      }
+    }
+
+    rewriteCache[n] = out;
+    return out;
+  }
+
+  STPMgr* bm;
+  NodeFactory* nf;
+  FpDomainSimplify::Statistics& stats;
+  BoundsMap bounds;
+  std::vector<SignedTerms> soundRows;
+  ASTNodeSet boxed;
+  ASTNodeSet boxPredicates;
+  ASTNodeSet soundZeroReps;
+  ASTNodeSet soundZeroSymbols;
+  ASTNodeMap soundParent;
+  IntervalMap intervals;
+  ASTNodeMap rewriteCache;
+};
+
+} // namespace
+
+FpDomainSimplify::FpDomainSimplify(STPMgr* bm_)
+    : bm(bm_), node_factory(bm_->defaultNodeFactory)
+{
+}
+
+ASTNode FpDomainSimplify::topLevel(const ASTNode& source)
+{
+  if (bm->defaultNodeFactory != node_factory)
+    FatalError("FpDomainSimplify reused after the node factory changed");
+
+  stats = Statistics();
+  DomainPass pass(bm, node_factory, stats);
+  return pass.run(source);
+}
+
+} // namespace stp

--- a/lib/FloatBlaster/FpEncodingContext.cpp
+++ b/lib/FloatBlaster/FpEncodingContext.cpp
@@ -9,7 +9,8 @@ namespace stp
 {
 
 FpEncodingContext::FpEncodingContext(STPMgr* bm_)
-    : bm(bm_), node_factory(bm_->defaultNodeFactory), totalise(bm_), blast(bm_)
+    : bm(bm_), node_factory(bm_->defaultNodeFactory), totalise(bm_),
+      domain(bm_), blast(bm_)
 {
 }
 
@@ -25,7 +26,29 @@ void FpEncodingContext::requireOriginalNodeFactory() const
 ASTNode FpEncodingContext::prepare(const ASTNode& source)
 {
   requireOriginalNodeFactory();
-  return totalise.topLevel(source);
+  ASTNode out = totalise.topLevel(source);
+  if (bm->UserFlags.fp_domain_simplify ||
+      bm->UserFlags.fp_domain_sound_zero_facts ||
+      bm->UserFlags.fp_domain_row_bounds)
+  {
+    out = domain.topLevel(out);
+    if (bm->UserFlags.stats_flag)
+    {
+      const FpDomainSimplify::Statistics& s = domain.statistics();
+      std::cerr << "FpDomainSimplify: " << s.boxed_symbols
+                << " boxed symbols, " << s.interval_true
+                << " interval-true, " << s.interval_false
+                << " interval-false, " << s.classifier_false
+                << " classifier-false, " << s.difference_zero_equalities
+                << " diff-zero-eq, " << s.nonnegative_zero_sums
+                << " nonnegative-zero-sum, " << s.sound_zero_rows
+                << " sound-zero-rows, " << s.sound_zero_facts
+                << " sound-zero-facts, " << s.row_bound_rows
+                << " row-bound-rows, " << s.row_bound_false
+                << " row-bound-false" << std::endl;
+    }
+  }
+  return out;
 }
 
 void FpEncodingContext::copyArrayEqualityRewrites(ASTNodeMap& out) const

--- a/lib/Sat/Cadical.cpp
+++ b/lib/Sat/Cadical.cpp
@@ -139,10 +139,22 @@ Cadical::~Cadical()
 
 void Cadical::printStats() const
 {
-    // The newline matters: without it this stderr fragment glues onto the
-    // next stdout line (the check-sat verdict) in a combined stream, which
-    // is exactly what line-anchored test checks read.
-    std::cerr << "print stats not yet implemented." << std::endl;
+#if defined(CADICAL_MAJOR) && CADICAL_MAJOR >= 3
+  // These counters remain available in the UNKNOWN state produced by our
+  // Terminator. Keep this compact: CaDiCaL's full reporter is several hundred
+  // lines, while these are the search quantities benchmark logs consume.
+  std::cerr << "CaDiCaL conflicts: "
+            << s->get_statistic_value("conflicts") << std::endl;
+  std::cerr << "CaDiCaL decisions: "
+            << s->get_statistic_value("decisions") << std::endl;
+  std::cerr << "CaDiCaL search propagations: "
+            << s->get_statistic_value("propagations") << std::endl;
+  std::cerr << "CaDiCaL search ticks: "
+            << s->get_statistic_value("ticks") << std::endl;
+#else
+  // get_statistic_value() is unavailable in the oldest supported releases.
+  s->statistics();
+#endif
 }
 
 uint32_t Cadical::newVar()

--- a/lib/Sat/MinisatCore.cpp
+++ b/lib/Sat/MinisatCore.cpp
@@ -25,6 +25,7 @@ THE SOFTWARE.
 #define __STDC_FORMAT_MACROS
 #include "stp/Sat/MinisatCore.h"
 #include "minisat/core/Solver.h"
+#include <iostream>
 //#include "utils/System.h"
 //#include "simp/SimpSolver.h"
 
@@ -151,7 +152,35 @@ uint32_t MinisatCore::nVars() const
 
 void MinisatCore::printStats() const
 {
-  //s->printStats();
+  // MiniSat's periodic table is useful while a long search is running, but
+  // fixed-conflict profiles also need exact final totals. In particular,
+  // propagations/conflict distinguishes SAT-search work from front-end time.
+  std::cerr << "MiniSat starts: " << s->starts << '\n';
+  std::cerr << "MiniSat conflicts: " << s->conflicts << '\n';
+  std::cerr << "MiniSat decisions: " << s->decisions << '\n';
+  std::cerr << "MiniSat propagations: " << s->propagations << '\n';
+  std::cerr << "MiniSat variables: " << s->nVars() << '\n';
+  if (s->conflicts != 0)
+  {
+    std::cerr << "MiniSat decisions per conflict: "
+              << static_cast<double>(s->decisions) / s->conflicts << '\n';
+    std::cerr << "MiniSat propagations per conflict: "
+              << static_cast<double>(s->propagations) / s->conflicts << '\n';
+  }
+  std::cerr << "MiniSat active original clauses: " << s->nClauses() << '\n';
+  std::cerr << "MiniSat active original literals: " << s->clauses_literals
+            << '\n';
+  std::cerr << "MiniSat active learnt clauses: " << s->nLearnts() << '\n';
+  std::cerr << "MiniSat active learnt literals: " << s->learnts_literals
+            << '\n';
+  if (s->nLearnts() != 0)
+    std::cerr << "MiniSat active learnt literals per clause: "
+              << static_cast<double>(s->learnts_literals) / s->nLearnts()
+              << '\n';
+  std::cerr << "MiniSat learnt literals before minimization: "
+            << s->max_literals << '\n';
+  std::cerr << "MiniSat learnt literals after minimization: "
+            << s->tot_literals << '\n';
 }
 
 int MinisatCore::nClauses()

--- a/lib/Sat/SimplifyingMinisat.cpp
+++ b/lib/Sat/SimplifyingMinisat.cpp
@@ -25,6 +25,7 @@ THE SOFTWARE.
 #define __STDC_FORMAT_MACROS
 #include "stp/Sat/SimplifyingMinisat.h"
 #include "minisat/simp/SimpSolver.h"
+#include <iostream>
 
 namespace MiniSat
 {
@@ -113,7 +114,32 @@ uint32_t SimplifyingMinisat::nVars() const
 
 void SimplifyingMinisat::printStats() const
 {
-  //s->printStats();
+  std::cerr << "MiniSat starts: " << s->starts << '\n';
+  std::cerr << "MiniSat conflicts: " << s->conflicts << '\n';
+  std::cerr << "MiniSat decisions: " << s->decisions << '\n';
+  std::cerr << "MiniSat propagations: " << s->propagations << '\n';
+  std::cerr << "MiniSat variables: " << s->nVars() << '\n';
+  if (s->conflicts != 0)
+  {
+    std::cerr << "MiniSat decisions per conflict: "
+              << static_cast<double>(s->decisions) / s->conflicts << '\n';
+    std::cerr << "MiniSat propagations per conflict: "
+              << static_cast<double>(s->propagations) / s->conflicts << '\n';
+  }
+  std::cerr << "MiniSat active original clauses: " << s->nClauses() << '\n';
+  std::cerr << "MiniSat active original literals: " << s->clauses_literals
+            << '\n';
+  std::cerr << "MiniSat active learnt clauses: " << s->nLearnts() << '\n';
+  std::cerr << "MiniSat active learnt literals: " << s->learnts_literals
+            << '\n';
+  if (s->nLearnts() != 0)
+    std::cerr << "MiniSat active learnt literals per clause: "
+              << static_cast<double>(s->learnts_literals) / s->nLearnts()
+              << '\n';
+  std::cerr << "MiniSat learnt literals before minimization: "
+            << s->max_literals << '\n';
+  std::cerr << "MiniSat learnt literals after minimization: "
+            << s->tot_literals << '\n';
 }
 
 void SimplifyingMinisat::setFrozen(uint32_t x)

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -4427,6 +4427,7 @@ BBNode BitBlaster::BBfpAddIsZero(const ASTNode& term, BBNodeSet& support)
   const unsigned sb = sort.significandWidth();
   const unsigned w = sort.packedWidth();
   const unsigned eb = sort.exponentWidth();
+  (void)eb;
   assert(sb >= 2 && eb >= 2 && w == sb + eb);
 
   const BBNodeVec pa = BBTerm(term[1], support);

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -1491,6 +1491,8 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term, BBNodeSet& support,
 const BBNode BitBlaster::BBForm(const ASTNode& form)
 {
 
+  fpNativeAddIsZeroFusions = 0;
+
   if (uf->conjoin_to_top && cb != NULL)
   {
     ASTNodeMap n = cb->getAllFixed();
@@ -1519,6 +1521,9 @@ const BBNode BitBlaster::BBForm(const ASTNode& form)
     ASTNodeSet visited;
     assert(cb->checkAtFixedPoint(form, visited));
   }
+  if (uf->stats_flag && uf->fp_native_add_iszero)
+    std::cerr << "FP native add-isZero fused predicates: "
+              << fpNativeAddIsZeroFusions << '\n';
   if (v.size() == 1)
     return v[0];
   else
@@ -3945,6 +3950,18 @@ BBNode BitBlaster::BBclassifyFP(const ASTNode& form, BBNodeSet& support)
   assert(form[0].GetValueWidth() == w);
   assert(sb >= 2 && w >= sb + 1);
 
+  // A complete packed sum is useful only when another consumer observes it.
+  // If it has already been memoised, retain the ordinary path so this
+  // predicate shares that result rather than building a second circuit.
+  if (k == FP_ISZERO && uf->fp_native_arith &&
+      uf->fp_native_add_iszero && form[0].GetKind() == FP_ADD &&
+      form[0].Degree() == 3 &&
+      BBTermMemo.find(form[0]) == BBTermMemo.end())
+  {
+    ++fpNativeAddIsZeroFusions;
+    return BBfpAddIsZero(form[0], support);
+  }
+
   const BBNodeVec p = BBTerm(form[0], support);
 
   switch (k)
@@ -4391,6 +4408,46 @@ BBNodeVec BitBlaster::BBfpMul(const ASTNode& term, BBNodeSet& support)
   res = BBITE(anyInf, packSpecial(false, true), res);
   res = BBITE(anyNaN, packSpecial(true, false), res);
   return res;
+}
+
+// fp.isZero needs much less than a packed result. Every finite value in a
+// binary IEEE format is an integer multiple of that format's minimum
+// subnormal, so a nonzero exact sum of two format values cannot round to
+// zero. The result is therefore a semantic zero exactly when both operands
+// are finite and their exact real sum is zero: equal magnitudes with opposite
+// signs, or any pair of signed zeros. The rounding mode cannot change this
+// predicate.
+BBNode BitBlaster::BBfpAddIsZero(const ASTNode& term, BBNodeSet& support)
+{
+  assert(term.GetKind() == FP_ADD);
+  assert(term.Degree() == 3);
+
+  const SourceSort sort = term.GetSourceSort();
+  assert(sort.kind() == SourceSort::Kind::FloatingPoint);
+  const unsigned sb = sort.significandWidth();
+  const unsigned w = sort.packedWidth();
+  const unsigned eb = sort.exponentWidth();
+  assert(sb >= 2 && eb >= 2 && w == sb + eb);
+
+  const BBNodeVec pa = BBTerm(term[1], support);
+  const BBNodeVec pb = BBTerm(term[2], support);
+  assert(pa.size() == w && pb.size() == w);
+
+  BBNodeVec aMagnitude(pa.begin(), pa.begin() + (w - 1));
+  const BBNodeVec bMagnitude(pb.begin(), pb.begin() + (w - 1));
+  const BBNode sameMagnitude = BBEQ(aMagnitude, bMagnitude);
+  const BBNode oppositeSigns = nf->CreateNode(XOR, pa[w - 1], pb[w - 1]);
+  // With equal magnitudes, testing either operand suffices to prove both are
+  // signed zeros.
+  const BBNode bothZero = nf->CreateNode(NOR, aMagnitude);
+  const BBNode exactZero = nf->CreateNode(
+      AND, sameMagnitude, nf->CreateNode(OR, oppositeSigns, bothZero));
+
+  auto finite = [&](const BBNodeVec& p) {
+    BBNodeVec exponent(p.begin() + (sb - 1), p.begin() + (w - 1));
+    return nf->CreateNode(NOT, nf->CreateNode(AND, exponent));
+  };
+  return nf->CreateNode(AND, finite(pa), finite(pb), exactZero);
 }
 
 // Bit-blasted fp.add over packed IEEE-754 operands, under the same flag

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -22,16 +22,20 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ********************************************************************/
 #include "stp/ToSat/BitBlaster.h"
+#include "stp/FloatBlaster/DecimalLiteral.h"
 #include "stp/FloatBlaster/FloatBlaster.h"
+#include "stp/FloatBlaster/rounding_modes.h"
 #include "stp/Simplifier/Simplifier.h"
 #include "stp/Simplifier/constantBitP/ConstantBitPropagation.h"
 #include "stp/Simplifier/constantBitP/FixedBits.h"
 #include "stp/Simplifier/constantBitP/NodeToFixedBitsMap.h"
 #include "stp/ToSat/BBNodeManagerAIG.h"
 #include "stp/Util/DagWalk.h"
+#include <algorithm>
 #include <cassert>
 #include <deque>
 #include <cmath>
+#include <limits>
 
 namespace stp
 {
@@ -1490,8 +1494,19 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term, BBNodeSet& support,
 
 const BBNode BitBlaster::BBForm(const ASTNode& form)
 {
-
   fpNativeAddIsZeroFusions = 0;
+
+  if (uf->fp_native_domain &&
+      (fpNativeDomainRoot.IsNull() || !(fpNativeDomainRoot == form)))
+  {
+    if (!fpNativeDomainRoot.IsNull())
+    {
+      BBTermMemo.clear();
+      BBFormMemo.clear();
+    }
+    fpNativeDomainRoot = form;
+    collectFpNativeDomainFacts(form);
+  }
 
   if (uf->conjoin_to_top && cb != NULL)
   {
@@ -1521,9 +1536,73 @@ const BBNode BitBlaster::BBForm(const ASTNode& form)
     ASTNodeSet visited;
     assert(cb->checkAtFixedPoint(form, visited));
   }
+  if (uf->stats_flag && uf->fp_native_domain)
+  {
+    std::cerr << "FP native domain finite terms: "
+              << fpNativeFiniteTerms.size() << '\n';
+    std::cerr << "FP native domain cmp finite operands: "
+              << fpNativeFiniteCmpOperands << '\n';
+    std::cerr << "FP native domain eq finite operands: "
+              << fpNativeFiniteEqOperands << '\n';
+    std::cerr << "FP native domain classifications: "
+              << fpNativeFiniteClassifications << '\n';
+    std::cerr << "FP native domain arith finite operands: "
+              << fpNativeFiniteArithOperands << '\n';
+    std::cerr << "FP native domain finite round-packs: "
+              << fpNativeFiniteRoundPacks << '\n';
+    std::cerr << "FP native domain zero-magnitude facts: "
+              << fpNativeZeroMagnitudeFacts.size() << '\n';
+    std::cerr << "FP native domain zero-magnitude terms: "
+              << fpNativeZeroMagnitudeTerms.size() << '\n';
+    std::cerr << "FP native domain zero cmp operands: "
+              << fpNativeZeroCmpOperands << '\n';
+    std::cerr << "FP native domain zero eq operands: "
+              << fpNativeZeroEqOperands << '\n';
+    std::cerr << "FP native domain zero classifications: "
+              << fpNativeZeroClassifications << '\n';
+    std::cerr << "FP native domain isZero predicates: "
+              << fpNativeIsZeroPredicates << '\n';
+    std::cerr << "FP native domain isZero add predicates: "
+              << fpNativeIsZeroAddPredicates << '\n';
+    std::cerr << "FP native domain isZero add fused predicates: "
+              << fpNativeIsZeroAddFusedPredicates << '\n';
+    std::cerr << "FP native domain isZero add exclusive results: "
+              << fpNativeIsZeroAddExclusiveResults << '\n';
+    std::cerr << "FP native domain isZero add pre-memoized results: "
+              << fpNativeIsZeroAddMemoizedResults << '\n';
+    std::cerr << "FP native domain isZero add known-zero results: "
+              << fpNativeIsZeroAddKnownZeroResults << '\n';
+    std::cerr << "FP native domain isZero add both-finite operands: "
+              << fpNativeIsZeroAddBothFiniteOperands << '\n';
+    std::cerr << "FP native domain isZero add known-same-sign operands: "
+              << fpNativeIsZeroAddKnownSameSignOperands << '\n';
+    std::cerr << "FP native domain isZero add known-opposite-sign operands: "
+              << fpNativeIsZeroAddKnownOppositeSignOperands << '\n';
+    std::cerr << "FP native domain isZero add one-known-sign operand: "
+              << fpNativeIsZeroAddOneKnownSignOperand << '\n';
+    std::cerr << "FP native domain zero add fast-paths: "
+              << fpNativeZeroAddFastPaths << '\n';
+    std::cerr << "FP native domain zero mul fast-paths: "
+              << fpNativeZeroMulFastPaths << '\n';
+    std::cerr << "FP native domain zero to-fp fast-paths: "
+              << fpNativeZeroToFpFastPaths << '\n';
+    std::cerr << "FP native domain finite nonnegative terms: "
+              << fpNativeFiniteNonnegativeTerms.size() << '\n';
+    std::cerr << "FP native domain finite nonpositive terms: "
+              << fpNativeFiniteNonpositiveTerms.size() << '\n';
+    std::cerr << "FP native domain known-positive add paths: "
+              << fpNativeKnownPositiveAddPaths << '\n';
+    std::cerr << "FP native domain known-negative add paths: "
+              << fpNativeKnownNegativeAddPaths << '\n';
+    std::cerr << "FP native domain known-positive mul paths: "
+              << fpNativeKnownPositiveMulPaths << '\n';
+    std::cerr << "FP native domain known-negative mul paths: "
+              << fpNativeKnownNegativeMulPaths << '\n';
+  }
   if (uf->stats_flag && uf->fp_native_add_iszero)
     std::cerr << "FP native add-isZero fused predicates: "
               << fpNativeAddIsZeroFusions << '\n';
+
   if (v.size() == 1)
     return v[0];
   else
@@ -3780,6 +3859,1020 @@ BBNode BitBlaster::BBfpIsZero(const BBNodeVec& p, unsigned w)
   return nf->CreateNode(NOR, magnitude);
 }
 
+namespace
+{
+bool fpNativePackedFiniteBits(const std::string& bits, const unsigned eb)
+{
+  if (bits.size() <= eb)
+    return false;
+  for (unsigned i = 0; i < eb; ++i)
+    if (bits[1 + i] != '1')
+      return true;
+  return false;
+}
+
+bool fpNativePackedZeroMagnitudeBits(const std::string& bits)
+{
+  if (bits.empty())
+    return false;
+  for (size_t i = 1; i < bits.size(); ++i)
+    if (bits[i] != '0')
+      return false;
+  return true;
+}
+
+// Numeric ordering for finite packed IEEE values. The two signed zeros are
+// equal; otherwise the magnitude order reverses on the negative side.
+int fpNativePackedCompareBits(const std::string& a, const std::string& b)
+{
+  assert(a.size() == b.size() && !a.empty());
+  if (fpNativePackedZeroMagnitudeBits(a) &&
+      fpNativePackedZeroMagnitudeBits(b))
+    return 0;
+  if (a[0] != b[0])
+    return a[0] == '1' ? -1 : 1;
+  const int magnitude = a.substr(1).compare(b.substr(1));
+  if (magnitude == 0)
+    return 0;
+  const int ordered = magnitude < 0 ? -1 : 1;
+  return a[0] == '1' ? -ordered : ordered;
+}
+
+std::string fpNativePackedNegateBits(std::string bits)
+{
+  assert(!bits.empty());
+  bits[0] = bits[0] == '1' ? '0' : '1';
+  return bits;
+}
+
+std::string fpNativePackedAbsBits(std::string bits)
+{
+  assert(!bits.empty());
+  bits[0] = '0';
+  return bits;
+}
+
+bool fpNativePackedValueBits(const SourceSort& sort,
+                             const std::string& bits, long double& out)
+{
+  if (sort.kind() != SourceSort::Kind::FloatingPoint)
+    return false;
+  const unsigned eb = sort.exponentWidth();
+  const unsigned sb = sort.significandWidth();
+  if (bits.size() != eb + sb || eb < 2 || sb < 2 || eb >= 31 ||
+      sb > static_cast<unsigned>(std::numeric_limits<long double>::digits))
+    return false;
+
+  unsigned exponent = 0;
+  for (unsigned i = 0; i < eb; ++i)
+    exponent = (exponent << 1) |
+               static_cast<unsigned>(bits[1 + i] == '1');
+  if (exponent == (1u << eb) - 1)
+    return false;
+
+  long double significand = 0.0L;
+  for (unsigned i = 0; i + 1 < sb; ++i)
+    if (bits[1 + eb + i] == '1')
+      significand +=
+          std::ldexp(1.0L, static_cast<int>(sb - 2 - i));
+
+  const int bias = static_cast<int>((1u << (eb - 1)) - 1);
+  if (exponent == 0)
+    out = std::ldexp(significand,
+                     1 - bias - static_cast<int>(sb - 1));
+  else
+  {
+    significand += std::ldexp(1.0L, static_cast<int>(sb - 1));
+    out = std::ldexp(significand,
+                     static_cast<int>(exponent) - bias -
+                         static_cast<int>(sb - 1));
+  }
+  if (bits[0] == '1')
+    out = -out;
+  return std::isfinite(out) &&
+         (out != 0.0L || (exponent == 0 && significand == 0.0L));
+}
+
+bool fpNativeFixedRoundingMode(const ASTNode& n, unsigned& mode)
+{
+  if (n.GetKind() != BVCONST || n.GetValueWidth() != 5)
+    return false;
+  mode = static_cast<unsigned>(n.GetUnsignedConst());
+  switch (mode)
+  {
+    case symbolic_fp::ROUND_NEAREST_TIES_TO_EVEN:
+    case symbolic_fp::ROUND_NEAREST_TIES_TO_AWAY:
+    case symbolic_fp::ROUND_TOWARD_POSITIVE:
+    case symbolic_fp::ROUND_TOWARD_NEGATIVE:
+    case symbolic_fp::ROUND_TOWARD_ZERO: return true;
+    default: return false;
+  }
+}
+
+bool fpNativeExactBinaryEndpoint(const SourceSort& sort, const Kind kind,
+                                 const std::string& left,
+                                 const std::string& right,
+                                 const unsigned mode, std::string& result)
+{
+  PackedFpBinaryOp operation;
+  switch (kind)
+  {
+    case FP_ADD: operation = PackedFpBinaryOp::Add; break;
+    case FP_SUB: operation = PackedFpBinaryOp::Subtract; break;
+    case FP_MUL: operation = PackedFpBinaryOp::Multiply; break;
+    default: return false;
+  }
+
+  std::string error;
+  if (!packedFPBinaryOp(left, right, sort.exponentWidth(),
+                        sort.significandWidth(), mode, operation, result,
+                        error))
+    return false;
+  return fpNativePackedFiniteBits(result, sort.exponentWidth());
+}
+
+} // namespace
+
+bool BitBlaster::fpNativeConstantZeroMagnitude(const ASTNode& n) const
+{
+  const SourceSort sort = n.GetSourceSort();
+  if (n.GetKind() != BVCONST ||
+      sort.kind() != SourceSort::Kind::FloatingPoint)
+    return false;
+
+  const unsigned w = sort.packedWidth();
+  if (w < 2 || n.GetValueWidth() != w)
+    return false;
+
+  for (unsigned i = 0; i + 1 < w; ++i)
+    if (CONSTANTBV::BitVector_bit_test(n.GetBVConst(), i))
+      return false;
+  return true;
+}
+
+bool BitBlaster::fpNativeConstantFinite(const ASTNode& n) const
+{
+  long double ignored = 0.0L;
+  return fpNativeConstantValue(n, ignored);
+}
+
+bool BitBlaster::fpNativeConstantValue(const ASTNode& n,
+                                       long double& out) const
+{
+  const SourceSort sort = n.GetSourceSort();
+  if (n.GetKind() != BVCONST ||
+      sort.kind() != SourceSort::Kind::FloatingPoint)
+    return false;
+
+  const unsigned sb = sort.significandWidth();
+  const unsigned w = sort.packedWidth();
+  const unsigned eb = sort.exponentWidth();
+  if (sb < 2 || w <= sb || eb >= 31 ||
+      sb > static_cast<unsigned>(std::numeric_limits<long double>::digits))
+    return false;
+
+  CBV bv = n.GetBVConst();
+  bool expAllOnes = true;
+  for (unsigned i = sb - 1; i < w - 1; i++)
+    expAllOnes &= CONSTANTBV::BitVector_bit_test(bv, i);
+  if (expAllOnes)
+    return false;
+
+  const bool negative = CONSTANTBV::BitVector_bit_test(bv, w - 1);
+  unsigned exponent = 0;
+  for (unsigned i = 0; i < eb; i++)
+    if (CONSTANTBV::BitVector_bit_test(bv, sb - 1 + i))
+      exponent |= 1u << i;
+
+  long double significand = 0.0L;
+  for (unsigned i = 0; i + 1 < sb; i++)
+    if (CONSTANTBV::BitVector_bit_test(bv, i))
+      significand += std::ldexp(1.0L, static_cast<int>(i));
+
+  const int bias = static_cast<int>((1u << (eb - 1)) - 1);
+  if (exponent == 0)
+  {
+    out = std::ldexp(significand,
+                     static_cast<int>(1 - bias - (sb - 1)));
+  }
+  else
+  {
+    significand += std::ldexp(1.0L, static_cast<int>(sb - 1));
+    out = std::ldexp(significand,
+                     static_cast<int>(exponent) - bias -
+                         static_cast<int>(sb - 1));
+  }
+  if (negative)
+    out = -out;
+  // Reject a target nonzero that lies outside the host exponent range. In
+  // particular, decoding a negative tiny value as host -0 must never turn a
+  // negative lower bound into a semantic nonnegativity proof.
+  return std::isfinite(out) &&
+         (out != 0.0L || (exponent == 0 && significand == 0.0L));
+}
+
+bool BitBlaster::fpNativeConstantBits(const ASTNode& n,
+                                     std::string& out) const
+{
+  const SourceSort sort = n.GetSourceSort();
+  if (n.GetKind() != BVCONST ||
+      sort.kind() != SourceSort::Kind::FloatingPoint ||
+      n.GetValueWidth() != sort.packedWidth())
+    return false;
+
+  const unsigned width = n.GetValueWidth();
+  out.resize(width);
+  for (unsigned i = 0; i < width; ++i)
+    out[width - 1 - i] =
+        CONSTANTBV::BitVector_bit_test(n.GetBVConst(), i) ? '1' : '0';
+  return true;
+}
+
+bool BitBlaster::fpNativeMaxFiniteValue(const SourceSort& sort,
+                                        long double& out) const
+{
+  if (sort.kind() != SourceSort::Kind::FloatingPoint)
+    return false;
+
+  const unsigned eb = sort.exponentWidth();
+  const unsigned sb = sort.significandWidth();
+  if (eb < 2 || sb < 2 || eb >= 31 || sb > 113)
+    return false;
+
+  const int bias = static_cast<int>((1u << (eb - 1)) - 1);
+  const int maxExp = static_cast<int>((1u << eb) - 2) - bias;
+  const long double sig =
+      2.0L - std::ldexp(1.0L, -static_cast<int>(sb - 1));
+  out = std::ldexp(sig, maxExp);
+  return std::isfinite(out);
+}
+
+BitBlaster::FpNativeInterval BitBlaster::fpNativeRoundedRange(
+    const SourceSort& sort, const long double lower,
+    const long double upper) const
+{
+  FpNativeInterval out;
+  if (!std::isfinite(lower) || !std::isfinite(upper))
+    return out;
+
+  long double maxFinite = 0.0L;
+  if (!fpNativeMaxFiniteValue(sort, maxFinite))
+    return out;
+
+  if (lower < -maxFinite || upper > maxFinite)
+    return out;
+
+  const unsigned eb = sort.exponentWidth();
+  const unsigned sb = sort.significandWidth();
+  const int bias = static_cast<int>((1u << (eb - 1)) - 1);
+  const int maxExp = static_cast<int>((1u << eb) - 2) - bias;
+  const long double maxUlp =
+      std::ldexp(1.0L, maxExp - static_cast<int>(sb - 1));
+  const long double lo = std::max(-maxFinite, lower - maxUlp);
+  const long double hi = std::min(maxFinite, upper + maxUlp);
+
+  out.known = true;
+  out.lower = lo;
+  out.upper = hi;
+  return out;
+}
+
+BitBlaster::FpNativeInterval BitBlaster::fpNativeExactRoundedRange(
+    const SourceSort& sort, const Kind kind, const ASTNode& roundingMode,
+    const FpNativeInterval& a, const FpNativeInterval& b) const
+{
+  FpNativeInterval out;
+  if (!a.exact || !b.exact)
+    return out;
+
+  unsigned fixedMode = 0;
+  const bool fixed = fpNativeFixedRoundingMode(roundingMode, fixedMode);
+  const unsigned lowerMode =
+      fixed ? fixedMode
+            : static_cast<unsigned>(symbolic_fp::ROUND_TOWARD_NEGATIVE);
+  const unsigned upperMode =
+      fixed ? fixedMode
+            : static_cast<unsigned>(symbolic_fp::ROUND_TOWARD_POSITIVE);
+
+  using EndpointPair = std::pair<std::string, std::string>;
+  std::vector<EndpointPair> lowerInputs;
+  std::vector<EndpointPair> upperInputs;
+  if (kind == FP_ADD)
+  {
+    lowerInputs.emplace_back(a.lowerBits, b.lowerBits);
+    upperInputs.emplace_back(a.upperBits, b.upperBits);
+  }
+  else if (kind == FP_SUB)
+  {
+    lowerInputs.emplace_back(a.lowerBits, b.upperBits);
+    upperInputs.emplace_back(a.upperBits, b.lowerBits);
+  }
+  else if (kind == FP_MUL)
+  {
+    const std::string as[2] = {a.lowerBits, a.upperBits};
+    const std::string bs[2] = {b.lowerBits, b.upperBits};
+    for (const std::string& av : as)
+      for (const std::string& bv : bs)
+      {
+        lowerInputs.emplace_back(av, bv);
+        upperInputs.emplace_back(av, bv);
+      }
+  }
+  else
+    return out;
+
+  std::string lower;
+  for (const EndpointPair& input : lowerInputs)
+  {
+    std::string value;
+    if (!fpNativeExactBinaryEndpoint(sort, kind, input.first, input.second,
+                                     lowerMode, value))
+      return out;
+    if (lower.empty() || fpNativePackedCompareBits(value, lower) < 0)
+      lower = value;
+  }
+
+  std::string upper;
+  for (const EndpointPair& input : upperInputs)
+  {
+    std::string value;
+    if (!fpNativeExactBinaryEndpoint(sort, kind, input.first, input.second,
+                                     upperMode, value))
+      return out;
+    if (upper.empty() || fpNativePackedCompareBits(value, upper) > 0)
+      upper = value;
+  }
+
+  long double lo = 0.0L;
+  long double hi = 0.0L;
+  if (lower.empty() || upper.empty() ||
+      fpNativePackedCompareBits(lower, upper) > 0 ||
+      !fpNativePackedValueBits(sort, lower, lo) ||
+      !fpNativePackedValueBits(sort, upper, hi))
+    return out;
+
+  out.known = true;
+  out.exact = true;
+  out.lower = lo;
+  out.upper = hi;
+  out.lowerBits = lower;
+  out.upperBits = upper;
+  return out;
+}
+
+BitBlaster::FpNativeInterval BitBlaster::fpNativeInterval(const ASTNode& n)
+{
+  const auto cached = fpNativeIntervals.find(n);
+  if (cached != fpNativeIntervals.end())
+    return cached->second;
+
+  FpNativeInterval out = fpNativeIntervalUncached(n);
+  fpNativeIntervals.emplace(n, out);
+  return out;
+}
+
+BitBlaster::FpNativeInterval BitBlaster::fpNativeIntervalUncached(
+    const ASTNode& n)
+{
+  FpNativeInterval out;
+  if (!uf->fp_native_domain)
+    return out;
+
+  const SourceSort sort = n.GetSourceSort();
+  if (sort.kind() != SourceSort::Kind::FloatingPoint)
+    return out;
+
+  long double value = 0.0L;
+  if (fpNativeConstantValue(n, value))
+  {
+    out.known = true;
+    out.lower = value;
+    out.upper = value;
+    out.exact = fpNativeConstantBits(n, out.lowerBits);
+    if (out.exact)
+      out.upperBits = out.lowerBits;
+    return out;
+  }
+
+  if (fpNativeKnownZeroMagnitude(n))
+  {
+    out.known = true;
+    out.exact = true;
+    out.lower = 0.0L;
+    out.upper = 0.0L;
+    out.lowerBits.assign(sort.packedWidth(), '0');
+    out.upperBits = out.lowerBits;
+    return out;
+  }
+
+  if (n.GetKind() == SYMBOL)
+  {
+    const auto it = fpNativeBounds.find(n);
+    if (it != fpNativeBounds.end() && it->second.hasLower &&
+        it->second.hasUpper && it->second.lower <= it->second.upper)
+    {
+      out.known = true;
+      out.lower = it->second.lower;
+      out.upper = it->second.upper;
+      if (it->second.lowerExact && it->second.upperExact &&
+          fpNativePackedCompareBits(it->second.lowerBits,
+                                    it->second.upperBits) <= 0)
+      {
+        out.exact = true;
+        out.lowerBits = it->second.lowerBits;
+        out.upperBits = it->second.upperBits;
+      }
+    }
+    return out;
+  }
+
+  switch (n.GetKind())
+  {
+    case FP_NEG:
+    {
+      const FpNativeInterval x = fpNativeInterval(n[0]);
+      if (!x.known)
+        return out;
+      out.known = true;
+      out.lower = -x.upper;
+      out.upper = -x.lower;
+      if (x.exact)
+      {
+        out.exact = true;
+        out.lowerBits = fpNativePackedNegateBits(x.upperBits);
+        out.upperBits = fpNativePackedNegateBits(x.lowerBits);
+      }
+      return out;
+    }
+
+    case FP_ABS:
+    {
+      const FpNativeInterval x = fpNativeInterval(n[0]);
+      if (!x.known)
+        return out;
+      out.known = true;
+      if (x.lower >= 0.0L)
+      {
+        out.lower = x.lower;
+        out.upper = x.upper;
+        if (x.exact)
+        {
+          out.exact = true;
+          out.lowerBits = fpNativePackedAbsBits(x.lowerBits);
+          out.upperBits = fpNativePackedAbsBits(x.upperBits);
+        }
+      }
+      else if (x.upper <= 0.0L)
+      {
+        out.lower = -x.upper;
+        out.upper = -x.lower;
+        if (x.exact)
+        {
+          out.exact = true;
+          out.lowerBits = fpNativePackedAbsBits(x.upperBits);
+          out.upperBits = fpNativePackedAbsBits(x.lowerBits);
+        }
+      }
+      else
+      {
+        out.lower = 0.0L;
+        out.upper = std::max(-x.lower, x.upper);
+        if (x.exact)
+        {
+          out.exact = true;
+          out.lowerBits.assign(sort.packedWidth(), '0');
+          const std::string negativeMagnitude =
+              fpNativePackedAbsBits(x.lowerBits);
+          const std::string positiveMagnitude =
+              fpNativePackedAbsBits(x.upperBits);
+          out.upperBits =
+              fpNativePackedCompareBits(negativeMagnitude,
+                                        positiveMagnitude) >= 0
+                  ? negativeMagnitude
+                  : positiveMagnitude;
+        }
+      }
+      return out;
+    }
+
+    case ITE:
+    {
+      if (n.Degree() != 3)
+        return out;
+      const FpNativeInterval t = fpNativeInterval(n[1]);
+      const FpNativeInterval e = fpNativeInterval(n[2]);
+      if (!t.known || !e.known)
+        return out;
+      out.known = true;
+      out.lower = std::min(t.lower, e.lower);
+      out.upper = std::max(t.upper, e.upper);
+      if (t.exact && e.exact)
+      {
+        out.exact = true;
+        out.lowerBits = fpNativePackedCompareBits(t.lowerBits, e.lowerBits) <= 0
+                            ? t.lowerBits
+                            : e.lowerBits;
+        out.upperBits = fpNativePackedCompareBits(t.upperBits, e.upperBits) >= 0
+                            ? t.upperBits
+                            : e.upperBits;
+      }
+      return out;
+    }
+
+    case FP_ADD:
+    case FP_SUB:
+    case FP_MUL:
+    {
+      if (n.Degree() != 3)
+        return out;
+      const FpNativeInterval a = fpNativeInterval(n[1]);
+      const FpNativeInterval b = fpNativeInterval(n[2]);
+      if (!a.known || !b.known)
+        return out;
+
+      const FpNativeInterval exact =
+          fpNativeExactRoundedRange(sort, n.GetKind(), n[0], a, b);
+      if (exact.known)
+        return exact;
+
+      if (n.GetKind() == FP_ADD)
+        return fpNativeRoundedRange(sort, a.lower + b.lower,
+                                    a.upper + b.upper);
+      if (n.GetKind() == FP_SUB)
+        return fpNativeRoundedRange(sort, a.lower - b.upper,
+                                    a.upper - b.lower);
+
+      const long double vals[4] = {a.lower * b.lower, a.lower * b.upper,
+                                   a.upper * b.lower, a.upper * b.upper};
+      return fpNativeRoundedRange(sort, *std::min_element(vals, vals + 4),
+                                  *std::max_element(vals, vals + 4));
+    }
+
+    default:
+      return out;
+  }
+}
+
+bool BitBlaster::fpNativeKnownFinite(const ASTNode& n)
+{
+  return fpNativeInterval(n).known;
+}
+
+bool BitBlaster::fpNativeKnownZeroMagnitude(const ASTNode& n)
+{
+  if (!uf->fp_native_domain ||
+      n.GetSourceSort().kind() != SourceSort::Kind::FloatingPoint)
+    return false;
+
+  if (fpNativeZeroMagnitudeTerms.find(n) !=
+      fpNativeZeroMagnitudeTerms.end())
+    return true;
+  if (fpNativeUnknownZeroMagnitudeTerms.find(n) !=
+      fpNativeUnknownZeroMagnitudeTerms.end())
+    return false;
+
+  bool knownZero = fpNativeConstantZeroMagnitude(n);
+  if (!knownZero)
+  {
+    switch (n.GetKind())
+    {
+      case FP_NEG:
+      case FP_ABS:
+        knownZero = n.Degree() == 1 && fpNativeKnownZeroMagnitude(n[0]);
+        break;
+
+      case ITE:
+        knownZero = n.Degree() == 3 &&
+                    fpNativeKnownZeroMagnitude(n[1]) &&
+                    fpNativeKnownZeroMagnitude(n[2]);
+        break;
+
+      case FP_ADD:
+      case FP_SUB:
+        knownZero = n.Degree() == 3 &&
+                    fpNativeKnownZeroMagnitude(n[1]) &&
+                    fpNativeKnownZeroMagnitude(n[2]);
+        break;
+
+      case FP_MUL:
+        if (n.Degree() == 3)
+        {
+          const bool aZero = fpNativeKnownZeroMagnitude(n[1]);
+          knownZero =
+              (aZero && fpNativeKnownFinite(n[2])) ||
+              (fpNativeKnownZeroMagnitude(n[2]) &&
+               fpNativeKnownFinite(n[1]));
+        }
+        break;
+
+      case FP_TOFP:
+        knownZero = n.Degree() == 4 && fpNativeKnownZeroMagnitude(n[3]);
+        break;
+
+      default:
+        break;
+    }
+  }
+
+  if (knownZero)
+  {
+    if (n.GetKind() != BVCONST)
+      fpNativeZeroMagnitudeTerms.insert(n);
+  }
+  else
+    fpNativeUnknownZeroMagnitudeTerms.insert(n);
+  return knownZero;
+}
+
+bool BitBlaster::fpNativeKnownFiniteNonnegative(const ASTNode& n)
+{
+  if (!uf->fp_native_domain ||
+      n.GetSourceSort().kind() != SourceSort::Kind::FloatingPoint)
+    return false;
+
+  if (fpNativeFiniteNonnegativeTerms.find(n) !=
+      fpNativeFiniteNonnegativeTerms.end())
+    return true;
+  if (fpNativeUnknownFiniteNonnegativeTerms.find(n) !=
+      fpNativeUnknownFiniteNonnegativeTerms.end())
+    return false;
+
+  // A magnitude-zero fact proves semantic nonnegativity even for -0. It
+  // deliberately does not prove that the packed sign bit is clear.
+  bool known = fpNativeKnownZeroMagnitude(n);
+  if (!known)
+  {
+    long double value = 0.0L;
+    if (fpNativeConstantValue(n, value))
+      known = value >= 0.0L;
+    else
+    {
+      switch (n.GetKind())
+      {
+        case SYMBOL:
+        {
+          const auto it = fpNativeBounds.find(n);
+          known = it != fpNativeBounds.end() && it->second.hasLower &&
+                  it->second.hasUpper && it->second.lower >= 0.0L &&
+                  fpNativeKnownFinite(n);
+          break;
+        }
+
+        case FP_ABS:
+          known = n.Degree() == 1 && fpNativeKnownFinite(n[0]);
+          break;
+
+        case FP_NEG:
+          known = n.Degree() == 1 &&
+                  fpNativeKnownFiniteNonpositive(n[0]);
+          break;
+
+        case ITE:
+          known = n.Degree() == 3 &&
+                  fpNativeKnownFiniteNonnegative(n[1]) &&
+                  fpNativeKnownFiniteNonnegative(n[2]);
+          break;
+
+        case FP_ADD:
+          // The operands establish the result's mathematical sign. A
+          // separate finite-result proof is required before propagating the
+          // fact through this term: positive overflow is infinity.
+          known = n.Degree() == 3 &&
+                  fpNativeKnownFiniteNonnegative(n[1]) &&
+                  fpNativeKnownFiniteNonnegative(n[2]) &&
+                  fpNativeKnownFinite(n);
+          break;
+
+        case FP_SUB:
+          known = n.Degree() == 3 &&
+                  fpNativeKnownFiniteNonnegative(n[1]) &&
+                  fpNativeKnownFiniteNonpositive(n[2]) &&
+                  fpNativeKnownFinite(n);
+          break;
+
+        case FP_MUL:
+          if (n.Degree() == 3)
+          {
+            const bool aNonnegative =
+                fpNativeKnownFiniteNonnegative(n[1]);
+            const bool aNonpositive =
+                fpNativeKnownFiniteNonpositive(n[1]);
+            const bool bNonnegative =
+                fpNativeKnownFiniteNonnegative(n[2]);
+            const bool bNonpositive =
+                fpNativeKnownFiniteNonpositive(n[2]);
+            known = ((aNonnegative && bNonnegative) ||
+                     (aNonpositive && bNonpositive)) &&
+                    fpNativeKnownFinite(n);
+          }
+          break;
+
+        case FP_TOFP:
+          known = n.Degree() == 4 &&
+                  fpNativeKnownFiniteNonnegative(n[3]) &&
+                  fpNativeKnownFinite(n);
+          break;
+
+        default:
+          break;
+      }
+    }
+  }
+
+  if (known)
+  {
+    if (n.GetKind() != BVCONST)
+      fpNativeFiniteNonnegativeTerms.insert(n);
+  }
+  else
+    fpNativeUnknownFiniteNonnegativeTerms.insert(n);
+  return known;
+}
+
+bool BitBlaster::fpNativeKnownFiniteNonpositive(const ASTNode& n)
+{
+  if (!uf->fp_native_domain ||
+      n.GetSourceSort().kind() != SourceSort::Kind::FloatingPoint)
+    return false;
+
+  if (fpNativeFiniteNonpositiveTerms.find(n) !=
+      fpNativeFiniteNonpositiveTerms.end())
+    return true;
+  if (fpNativeUnknownFiniteNonpositiveTerms.find(n) !=
+      fpNativeUnknownFiniteNonpositiveTerms.end())
+    return false;
+
+  // Magnitude zero belongs to both semantic sign domains. In particular,
+  // neither this predicate nor its nonnegative twin constrains the packed
+  // sign bit of zero.
+  bool known = fpNativeKnownZeroMagnitude(n);
+  if (!known)
+  {
+    long double value = 0.0L;
+    if (fpNativeConstantValue(n, value))
+      known = value <= 0.0L;
+    else
+    {
+      switch (n.GetKind())
+      {
+        case SYMBOL:
+        {
+          const auto it = fpNativeBounds.find(n);
+          known = it != fpNativeBounds.end() && it->second.hasLower &&
+                  it->second.hasUpper && it->second.upper <= 0.0L &&
+                  fpNativeKnownFinite(n);
+          break;
+        }
+
+        case FP_NEG:
+          known = n.Degree() == 1 &&
+                  fpNativeKnownFiniteNonnegative(n[0]);
+          break;
+
+        case ITE:
+          known = n.Degree() == 3 &&
+                  fpNativeKnownFiniteNonpositive(n[1]) &&
+                  fpNativeKnownFiniteNonpositive(n[2]);
+          break;
+
+        case FP_ADD:
+          known = n.Degree() == 3 &&
+                  fpNativeKnownFiniteNonpositive(n[1]) &&
+                  fpNativeKnownFiniteNonpositive(n[2]) &&
+                  fpNativeKnownFinite(n);
+          break;
+
+        case FP_SUB:
+          known = n.Degree() == 3 &&
+                  fpNativeKnownFiniteNonpositive(n[1]) &&
+                  fpNativeKnownFiniteNonnegative(n[2]) &&
+                  fpNativeKnownFinite(n);
+          break;
+
+        case FP_MUL:
+          if (n.Degree() == 3)
+          {
+            const bool aNonnegative =
+                fpNativeKnownFiniteNonnegative(n[1]);
+            const bool aNonpositive =
+                fpNativeKnownFiniteNonpositive(n[1]);
+            const bool bNonnegative =
+                fpNativeKnownFiniteNonnegative(n[2]);
+            const bool bNonpositive =
+                fpNativeKnownFiniteNonpositive(n[2]);
+            known = ((aNonnegative && bNonpositive) ||
+                     (aNonpositive && bNonnegative)) &&
+                    fpNativeKnownFinite(n);
+          }
+          break;
+
+        case FP_TOFP:
+          known = n.Degree() == 4 &&
+                  fpNativeKnownFiniteNonpositive(n[3]) &&
+                  fpNativeKnownFinite(n);
+          break;
+
+        default:
+          break;
+      }
+    }
+  }
+
+  if (known)
+  {
+    if (n.GetKind() != BVCONST)
+      fpNativeFiniteNonpositiveTerms.insert(n);
+  }
+  else
+    fpNativeUnknownFiniteNonpositiveTerms.insert(n);
+  return known;
+}
+
+
+bool BitBlaster::fpNativeBoundPredicate(const ASTNode& n, ASTNode& symbol,
+                                        ASTNode& constant,
+                                        long double& value,
+                                        bool& lowerBound) const
+{
+  const Kind k = n.GetKind();
+  if ((k != FP_LT && k != FP_LEQ && k != FP_GT && k != FP_GEQ) ||
+      n.Degree() != 2)
+    return false;
+
+  const bool flipped = (k == FP_GT || k == FP_GEQ);
+  const ASTNode& left = flipped ? n[1] : n[0];
+  const ASTNode& right = flipped ? n[0] : n[1];
+
+  if (left.GetKind() == SYMBOL &&
+      left.GetSourceSort().kind() == SourceSort::Kind::FloatingPoint &&
+      fpNativeConstantValue(right, value))
+  {
+    symbol = left;
+    constant = right;
+    lowerBound = false;
+    return true;
+  }
+
+  if (right.GetKind() == SYMBOL &&
+      right.GetSourceSort().kind() == SourceSort::Kind::FloatingPoint &&
+      fpNativeConstantValue(left, value))
+  {
+    symbol = right;
+    constant = left;
+    lowerBound = true;
+    return true;
+  }
+
+  return false;
+}
+
+bool BitBlaster::fpNativeMagnitudeZeroPredicate(const ASTNode& n,
+                                                ASTNode& term) const
+{
+  if (n.GetKind() == FP_ISZERO && n.Degree() == 1 &&
+      n[0].GetKind() == FP_MUL &&
+      n[0].GetSourceSort().kind() == SourceSort::Kind::FloatingPoint)
+  {
+    term = n[0];
+    return true;
+  }
+
+  if (n.GetKind() != EQ || n.Degree() != 2)
+    return false;
+
+  auto match = [&](const ASTNode& extract, const ASTNode& zero) {
+    if (extract.GetKind() != BVEXTRACT || extract.Degree() != 3 ||
+        zero.GetKind() != BVCONST ||
+        !CONSTANTBV::BitVector_is_empty(zero.GetBVConst()))
+      return false;
+
+    const ASTNode& candidate = extract[0];
+    const SourceSort sort = candidate.GetSourceSort();
+    if (candidate.GetKind() != SYMBOL ||
+        sort.kind() != SourceSort::Kind::FloatingPoint)
+      return false;
+
+    const unsigned w = sort.packedWidth();
+    if (w < 2 || candidate.GetValueWidth() != w ||
+        extract.GetValueWidth() != w - 1 || zero.GetValueWidth() != w - 1 ||
+        extract[1].GetUnsignedConst() != w - 2 ||
+        extract[2].GetUnsignedConst() != 0)
+      return false;
+
+    term = candidate;
+    return true;
+  };
+
+  return match(n[0], n[1]) || match(n[1], n[0]);
+}
+
+void BitBlaster::collectFpNativeDomainBounds(const ASTNode& n)
+{
+  if (n.GetKind() == AND)
+  {
+    for (const ASTNode& child : n)
+      collectFpNativeDomainBounds(child);
+    return;
+  }
+
+  ASTNode zeroSymbol;
+  if (fpNativeMagnitudeZeroPredicate(n, zeroSymbol))
+  {
+    fpNativeZeroMagnitudeFacts.insert(zeroSymbol);
+    fpNativeZeroMagnitudeTerms.insert(zeroSymbol);
+    fpNativeFiniteTerms.insert(zeroSymbol);
+  }
+
+  ASTNode symbol;
+  ASTNode constant;
+  long double value = 0.0L;
+  bool lowerBound = false;
+  if (!fpNativeBoundPredicate(n, symbol, constant, value, lowerBound))
+    return;
+
+  FpNativeBounds& seen = fpNativeBounds[symbol];
+  if (lowerBound)
+  {
+    if (!seen.hasLower || value >= seen.lower)
+    {
+      seen.lower = value;
+      seen.lowerExact = fpNativeConstantBits(constant, seen.lowerBits);
+    }
+    seen.hasLower = true;
+  }
+  else
+  {
+    if (!seen.hasUpper || value <= seen.upper)
+    {
+      seen.upper = value;
+      seen.upperExact = fpNativeConstantBits(constant, seen.upperBits);
+    }
+    seen.hasUpper = true;
+  }
+}
+
+void BitBlaster::collectFpNativeDomainFacts(const ASTNode& root)
+{
+  fpNativeFiniteTerms.clear();
+  fpNativeZeroMagnitudeFacts.clear();
+  fpNativeZeroMagnitudeTerms.clear();
+  fpNativeUnknownZeroMagnitudeTerms.clear();
+  fpNativeFiniteNonnegativeTerms.clear();
+  fpNativeUnknownFiniteNonnegativeTerms.clear();
+  fpNativeFiniteNonpositiveTerms.clear();
+  fpNativeUnknownFiniteNonpositiveTerms.clear();
+  fpNativeBounds.clear();
+  fpNativeIntervals.clear();
+  fpNativeParentUses.clear();
+  fpNativeFiniteCmpOperands = 0;
+  fpNativeFiniteEqOperands = 0;
+  fpNativeFiniteClassifications = 0;
+  fpNativeFiniteArithOperands = 0;
+  fpNativeFiniteRoundPacks = 0;
+  fpNativeZeroCmpOperands = 0;
+  fpNativeZeroEqOperands = 0;
+  fpNativeZeroClassifications = 0;
+  fpNativeIsZeroPredicates = 0;
+  fpNativeIsZeroAddPredicates = 0;
+  fpNativeIsZeroAddFusedPredicates = 0;
+  fpNativeIsZeroAddExclusiveResults = 0;
+  fpNativeIsZeroAddMemoizedResults = 0;
+  fpNativeIsZeroAddKnownZeroResults = 0;
+  fpNativeIsZeroAddBothFiniteOperands = 0;
+  fpNativeIsZeroAddKnownSameSignOperands = 0;
+  fpNativeIsZeroAddKnownOppositeSignOperands = 0;
+  fpNativeIsZeroAddOneKnownSignOperand = 0;
+  fpNativeZeroAddFastPaths = 0;
+  fpNativeZeroMulFastPaths = 0;
+  fpNativeZeroToFpFastPaths = 0;
+  fpNativeKnownPositiveAddPaths = 0;
+  fpNativeKnownNegativeAddPaths = 0;
+  fpNativeKnownPositiveMulPaths = 0;
+  fpNativeKnownNegativeMulPaths = 0;
+  if (uf->stats_flag)
+  {
+    ASTNodeSet visited;
+    std::vector<ASTNode> pending(1, root);
+    while (!pending.empty())
+    {
+      const ASTNode n = pending.back();
+      pending.pop_back();
+      if (!visited.insert(n).second)
+        continue;
+      for (const ASTNode& child : n)
+      {
+        ++fpNativeParentUses[child];
+        pending.push_back(child);
+      }
+    }
+  }
+
+  collectFpNativeDomainBounds(root);
+  for (const auto& entry : fpNativeBounds)
+    if (entry.second.hasLower && entry.second.hasUpper)
+      fpNativeFiniteTerms.insert(entry.first);
+}
+
 // Bit-blasted form for the four ordering comparisons (FP_GT, FP_LT, FP_GEQ,
 // FP_LEQ) over packed IEEE-754 operands. FloatBlast leaves these comparisons
 // in place when both operands are packed views (symbols, interned
@@ -3823,6 +4916,48 @@ BBNode BitBlaster::BBcompareFP(const ASTNode& form, BBNodeSet& support)
   // w-1.
   const BBNodeVec aBits = BBTerm(a, support);
   const BBNodeVec bBits = BBTerm(b, support);
+  const bool aFinite = fpNativeKnownFinite(a);
+  const bool bFinite = fpNativeKnownFinite(b);
+  const bool aKnownZero = fpNativeKnownZeroMagnitude(a);
+  const bool bKnownZero = fpNativeKnownZeroMagnitude(b);
+  fpNativeFiniteCmpOperands += static_cast<size_t>(aFinite) +
+                               static_cast<size_t>(bFinite);
+  fpNativeZeroCmpOperands += static_cast<size_t>(aKnownZero) +
+                             static_cast<size_t>(bKnownZero);
+
+  // Once a top-level magnitude constraint establishes an operand as either
+  // signed zero, comparison with it only needs the other operand's sign,
+  // zero test, and (unless finite) NaN test. This retains the SMT-LIB rule
+  // that +0 and -0 compare equal.
+  if (aKnownZero && bKnownZero)
+    return strict ? nf->getFalse() : nf->getTrue();
+
+  if (aKnownZero || bKnownZero)
+  {
+    const bool zeroOnLeft = aKnownZero;
+    const BBNodeVec& otherBits = zeroOnLeft ? bBits : aBits;
+    const bool otherFinite = zeroOnLeft ? bFinite : aFinite;
+    const BBNode otherZero = BBfpIsZero(otherBits, w);
+    const BBNode sign = otherBits[w - 1];
+    BBNode ordered;
+    if (zeroOnLeft)
+      ordered = strict
+                    ? nf->CreateNode(AND, sign,
+                                     nf->CreateNode(NOT, otherZero))
+                    : nf->CreateNode(OR, sign, otherZero);
+    else
+      ordered = strict
+                    ? nf->CreateNode(AND, nf->CreateNode(NOT, sign),
+                                     nf->CreateNode(NOT, otherZero))
+                    : nf->CreateNode(OR, nf->CreateNode(NOT, sign),
+                                     otherZero);
+
+    if (otherFinite)
+      return ordered;
+    const BBNode notNaN =
+        nf->CreateNode(NOT, BBfpIsNaN(otherBits, sb, w));
+    return nf->CreateNode(AND, notNaN, ordered);
+  }
 
   auto key = [this](const BBNodeVec& p, unsigned width) {
     const BBNode& sign = p[width - 1];
@@ -3834,8 +4969,10 @@ BBNode BitBlaster::BBcompareFP(const ASTNode& form, BBNodeSet& support)
     return k;
   };
 
-  const BBNode aNotNaN = nf->CreateNode(NOT, BBfpIsNaN(aBits, sb, w));
-  const BBNode bNotNaN = nf->CreateNode(NOT, BBfpIsNaN(bBits, sb, w));
+  const BBNode aIsNaN = aFinite ? nf->getFalse() : BBfpIsNaN(aBits, sb, w);
+  const BBNode bIsNaN = bFinite ? nf->getFalse() : BBfpIsNaN(bBits, sb, w);
+  const BBNode aNotNaN = nf->CreateNode(NOT, aIsNaN);
+  const BBNode bNotNaN = nf->CreateNode(NOT, bIsNaN);
   // Both operands' circuits are built before they are combined. Written as
   // two statements because C++ does not sequence a call's arguments against
   // each other: as one expression, which operand's AIG nodes get built first
@@ -3851,6 +4988,9 @@ BBNode BitBlaster::BBcompareFP(const ASTNode& form, BBNodeSet& support)
   const BBNode zeroCorrected =
       strict ? nf->CreateNode(AND, nf->CreateNode(NOT, bothZero), ordered)
              : nf->CreateNode(OR, bothZero, ordered);
+
+  if (aFinite && bFinite)
+    return zeroCorrected;
 
   BBNodeVec conjuncts;
   conjuncts.reserve(3);
@@ -3889,10 +5029,52 @@ BBNode BitBlaster::BBeqFP(const ASTNode& form, BBNodeSet& support)
 
   const BBNodeVec aBits = BBTerm(form[0], support);
   const BBNodeVec bBits = BBTerm(form[1], support);
+  const bool aFinite = fpNativeKnownFinite(form[0]);
+  const bool bFinite = fpNativeKnownFinite(form[1]);
+  // A direct product-zero fact must retain one predicate that checks the
+  // product bits; otherwise simplifying that very predicate to true would
+  // discard the operand restriction the fact represents. Consumers can use
+  // the fact, while this witness equality keeps the producer relation live.
+  const bool aDirectProductZero =
+      form[0].GetKind() == FP_MUL &&
+      fpNativeZeroMagnitudeFacts.find(form[0]) !=
+          fpNativeZeroMagnitudeFacts.end();
+  const bool bDirectProductZero =
+      form[1].GetKind() == FP_MUL &&
+      fpNativeZeroMagnitudeFacts.find(form[1]) !=
+          fpNativeZeroMagnitudeFacts.end();
+  const bool aKnownZero =
+      fpNativeKnownZeroMagnitude(form[0]) && !aDirectProductZero;
+  const bool bKnownZero =
+      fpNativeKnownZeroMagnitude(form[1]) && !bDirectProductZero;
+  fpNativeFiniteEqOperands += static_cast<size_t>(aFinite) +
+                              static_cast<size_t>(bFinite);
+  fpNativeZeroEqOperands += static_cast<size_t>(aKnownZero) +
+                            static_cast<size_t>(bKnownZero);
+
+  if (aKnownZero || bKnownZero)
+  {
+    const BBNode otherZero =
+        (aKnownZero && bKnownZero)
+            ? nf->getTrue()
+            : BBfpIsZero(aKnownZero ? bBits : aBits, w);
+
+    // fp.eq identifies the two signed zeros. Structural SMT equality keeps
+    // them distinct, so it additionally compares the surviving sign bits.
+    if (k == FP_EQ)
+      return otherZero;
+    const BBNode signsEqual =
+        nf->CreateNode(IFF, aBits[w - 1], bBits[w - 1]);
+    return nf->CreateNode(AND, otherZero, signsEqual);
+  }
+
   const BBNode sameBits = BBEQ(aBits, bBits);
 
   if (k == FP_SMT_EQ)
   {
+    if (aFinite || bFinite)
+      return sameBits;
+
     // Sequenced deliberately; see the note in BBcompareFP.
     const BBNode aNaN = BBfpIsNaN(aBits, sb, w);
     const BBNode bNaN = BBfpIsNaN(bBits, sb, w);
@@ -3907,17 +5089,20 @@ BBNode BitBlaster::BBeqFP(const ASTNode& form, BBNodeSet& support)
   // computes the same Boolean function (the exhaustive differential
   // passes with either or both tests; no test CAN distinguish them, so
   // this comment is the argument that keeps the dropped test dropped).
-  // Test the constant side when there is one: its isNaN folds away
-  // entirely and the symbolic side's isNaN circuit is never built. The
-  // choice is per-node and deterministic.
-  const BBNodeVec& nanSide = form[0].isConstant() ? aBits : bBits;
-  const BBNode notNaN = nf->CreateNode(NOT, BBfpIsNaN(nanSide, sb, w));
   // Sequenced deliberately; see the note in BBcompareFP.
   const BBNode aZero = BBfpIsZero(aBits, w);
   const BBNode bZero = BBfpIsZero(bBits, w);
   const BBNode bothZero = nf->CreateNode(AND, aZero, bZero);
   const BBNode sameValue = nf->CreateNode(OR, sameBits, bothZero);
 
+  if (aFinite || bFinite)
+    return sameValue;
+
+  // Test the constant side when there is one: its isNaN folds away
+  // entirely and the symbolic side's isNaN circuit is never built. The
+  // choice is per-node and deterministic.
+  const BBNodeVec& nanSide = form[0].isConstant() ? aBits : bBits;
+  const BBNode notNaN = nf->CreateNode(NOT, BBfpIsNaN(nanSide, sb, w));
   return nf->CreateNode(AND, notNaN, sameValue);
 }
 
@@ -3950,16 +5135,74 @@ BBNode BitBlaster::BBclassifyFP(const ASTNode& form, BBNodeSet& support)
   assert(form[0].GetValueWidth() == w);
   assert(sb >= 2 && w >= sb + 1);
 
-  // A complete packed sum is useful only when another consumer observes it.
-  // If it has already been memoised, retain the ordinary path so this
-  // predicate shares that result rather than building a second circuit.
-  if (k == FP_ISZERO && uf->fp_native_arith &&
-      uf->fp_native_add_iszero && form[0].GetKind() == FP_ADD &&
-      form[0].Degree() == 3 &&
-      BBTermMemo.find(form[0]) == BBTermMemo.end())
+  const bool isZeroAdd =
+      k == FP_ISZERO && form[0].GetKind() == FP_ADD &&
+      form[0].Degree() == 3 && uf->fp_native_arith;
+  const bool addMemoizedBefore =
+      isZeroAdd && BBTermMemo.find(form[0]) != BBTermMemo.end();
+  // As in BBeqFP, a product's own asserted/derived zero predicate is the
+  // witness that must continue checking its computed magnitude.
+  const bool directProductZero =
+      form[0].GetKind() == FP_MUL &&
+      fpNativeZeroMagnitudeFacts.find(form[0]) !=
+          fpNativeZeroMagnitudeFacts.end();
+  const bool knownZero =
+      fpNativeKnownZeroMagnitude(form[0]) && !directProductZero;
+  const bool knownFinite = fpNativeKnownFinite(form[0]);
+  if (knownFinite)
+    ++fpNativeFiniteClassifications;
+  if (knownZero)
+    ++fpNativeZeroClassifications;
+
+  if (uf->stats_flag && k == FP_ISZERO)
+  {
+    ++fpNativeIsZeroPredicates;
+    if (isZeroAdd)
+    {
+      ++fpNativeIsZeroAddPredicates;
+      const auto uses = fpNativeParentUses.find(form[0]);
+      if (uses != fpNativeParentUses.end() && uses->second == 1)
+        ++fpNativeIsZeroAddExclusiveResults;
+      if (addMemoizedBefore)
+        ++fpNativeIsZeroAddMemoizedResults;
+      if (knownZero)
+        ++fpNativeIsZeroAddKnownZeroResults;
+
+      const bool aFinite = fpNativeKnownFinite(form[0][1]);
+      const bool bFinite = fpNativeKnownFinite(form[0][2]);
+      if (aFinite && bFinite)
+        ++fpNativeIsZeroAddBothFiniteOperands;
+
+      if (uf->fp_native_known_sign)
+      {
+        const bool aNonnegative =
+            fpNativeKnownFiniteNonnegative(form[0][1]);
+        const bool aNonpositive =
+            fpNativeKnownFiniteNonpositive(form[0][1]);
+        const bool bNonnegative =
+            fpNativeKnownFiniteNonnegative(form[0][2]);
+        const bool bNonpositive =
+            fpNativeKnownFiniteNonpositive(form[0][2]);
+        const bool aKnownSign = aNonnegative || aNonpositive;
+        const bool bKnownSign = bNonnegative || bNonpositive;
+        if ((aNonnegative && bNonnegative) ||
+            (aNonpositive && bNonpositive))
+          ++fpNativeIsZeroAddKnownSameSignOperands;
+        if ((aNonnegative && bNonpositive) ||
+            (aNonpositive && bNonnegative))
+          ++fpNativeIsZeroAddKnownOppositeSignOperands;
+        if (aKnownSign != bKnownSign)
+          ++fpNativeIsZeroAddOneKnownSignOperand;
+      }
+    }
+  }
+
+  if (isZeroAdd && uf->fp_native_add_iszero && !addMemoizedBefore)
   {
     ++fpNativeAddIsZeroFusions;
-    return BBfpAddIsZero(form[0], support);
+    if (uf->stats_flag)
+      ++fpNativeIsZeroAddFusedPredicates;
+    return knownZero ? nf->getTrue() : BBfpAddIsZero(form[0], support);
   }
 
   const BBNodeVec p = BBTerm(form[0], support);
@@ -3967,13 +5210,15 @@ BBNode BitBlaster::BBclassifyFP(const ASTNode& form, BBNodeSet& support)
   switch (k)
   {
     case FP_ISZERO:
-      return BBfpIsZero(p, w);
+      return knownZero ? nf->getTrue() : BBfpIsZero(p, w);
 
     case FP_ISNAN:
-      return BBfpIsNaN(p, sb, w);
+      return knownFinite ? nf->getFalse() : BBfpIsNaN(p, sb, w);
 
     case FP_ISSUBNORMAL:
     {
+      if (knownZero)
+        return nf->getFalse();
       BBNodeVec expField(p.begin() + (sb - 1), p.begin() + (w - 1));
       BBNodeVec sigField(p.begin(), p.begin() + (sb - 1));
       const BBNode expZero = nf->CreateNode(NOR, expField);
@@ -3983,10 +5228,14 @@ BBNode BitBlaster::BBclassifyFP(const ASTNode& form, BBNodeSet& support)
 
     case FP_ISNORMAL:
     {
+      if (knownZero)
+        return nf->getFalse();
       // Built as NOT(AND(e)) rather than NAND(e) so the all-ones test is
       // the same AIG node isNaN and isInfinite build over this operand.
       BBNodeVec expField(p.begin() + (sb - 1), p.begin() + (w - 1));
       const BBNode expNonZero = nf->CreateNode(OR, expField);
+      if (knownFinite)
+        return expNonZero;
       const BBNode expAllOnes = nf->CreateNode(AND, expField);
       const BBNode expNotOnes = nf->CreateNode(NOT, expAllOnes);
       return nf->CreateNode(AND, expNonZero, expNotOnes);
@@ -3994,6 +5243,8 @@ BBNode BitBlaster::BBclassifyFP(const ASTNode& form, BBNodeSet& support)
 
     case FP_ISINFINITE:
     {
+      if (knownFinite)
+        return nf->getFalse();
       BBNodeVec expField(p.begin() + (sb - 1), p.begin() + (w - 1));
       BBNodeVec sigField(p.begin(), p.begin() + (sb - 1));
       const BBNode expAllOnes = nf->CreateNode(AND, expField);
@@ -4003,14 +5254,18 @@ BBNode BitBlaster::BBclassifyFP(const ASTNode& form, BBNodeSet& support)
 
     case FP_ISNEGATIVE:
     {
+      if (knownFinite)
+        return p[w - 1];
       const BBNode notNaN = nf->CreateNode(NOT, BBfpIsNaN(p, sb, w));
       return nf->CreateNode(AND, p[w - 1], notNaN);
     }
 
     case FP_ISPOSITIVE:
     {
-      const BBNode notNaN = nf->CreateNode(NOT, BBfpIsNaN(p, sb, w));
       const BBNode signClear = nf->CreateNode(NOT, p[w - 1]);
+      if (knownFinite)
+        return signClear;
+      const BBNode notNaN = nf->CreateNode(NOT, BBfpIsNaN(p, sb, w));
       return nf->CreateNode(AND, signClear, notNaN);
     }
 
@@ -4121,21 +5376,37 @@ unsigned BitBlaster::BBfpExpWidth(unsigned eb, unsigned sb)
 
 BitBlaster::FpOperand BitBlaster::BBfpUnpack(const BBNodeVec& p, unsigned sb,
                                              unsigned w, unsigned E,
-                                             BBNodeSet& support)
+                                             BBNodeSet& support,
+                                             const bool knownFinite,
+                                             const bool knownZeroMagnitude)
 {
   const unsigned eb = w - sb;
   const unsigned bias = (1u << (eb - 1)) - 1;
   FpOperand o;
   o.sign = p[w - 1];
-  BBNodeVec exp(p.begin() + (sb - 1), p.begin() + (w - 1));
-  BBNodeVec sig(p.begin(), p.begin() + (sb - 1));
+  BBNodeVec exp = knownZeroMagnitude
+                      ? BBfill(eb, nf->getFalse())
+                      : BBNodeVec(p.begin() + (sb - 1), p.begin() + (w - 1));
+  BBNodeVec sig = knownZeroMagnitude
+                      ? BBfill(sb - 1, nf->getFalse())
+                      : BBNodeVec(p.begin(), p.begin() + (sb - 1));
   const BBNode expZero = nf->CreateNode(NOR, exp);
-  const BBNode expOnes = nf->CreateNode(AND, exp);
   const BBNode sigZero = nf->CreateNode(NOR, sig);
-  const BBNode sigNonzero = nf->CreateNode(OR, sig);
-  o.isZero = nf->CreateNode(AND, expZero, sigZero);
-  o.isInf = nf->CreateNode(AND, expOnes, sigZero);
-  o.isNaN = nf->CreateNode(AND, expOnes, sigNonzero);
+  o.isZero = knownZeroMagnitude
+                 ? nf->getTrue()
+                 : nf->CreateNode(AND, expZero, sigZero);
+  if (knownFinite || knownZeroMagnitude)
+  {
+    o.isInf = nf->getFalse();
+    o.isNaN = nf->getFalse();
+  }
+  else
+  {
+    const BBNode expOnes = nf->CreateNode(AND, exp);
+    const BBNode sigNonzero = nf->CreateNode(OR, sig);
+    o.isInf = nf->CreateNode(AND, expOnes, sigZero);
+    o.isNaN = nf->CreateNode(AND, expOnes, sigNonzero);
+  }
   const BBNode hidden = nf->CreateNode(NOT, expZero);
   o.msig = sig;
   o.msig.push_back(hidden);
@@ -4160,7 +5431,8 @@ BBNodeVec BitBlaster::BBfpRoundPack(const BBNodeVec& rm, const BBNode& sgn,
                                     const BBNode& guardIn,
                                     const BBNode& stickyIn,
                                     const BBNodeVec& beIn, unsigned sb,
-                                    unsigned eb, BBNodeSet& support)
+                                    unsigned eb, BBNodeSet& support,
+                                    const bool resultKnownFinite)
 {
   const unsigned w = eb + sb;
   const unsigned maxbe = (1u << eb) - 2;
@@ -4234,6 +5506,22 @@ BBNodeVec BitBlaster::BBfpRoundPack(const BBNodeVec& rm, const BBNode& sgn,
   BBNodeVec beF = beAfter;
   BBPlus2(beF, BBfill(E, nf->getFalse()), carry);
 
+  // Pack the finite result. A significand without its leading 1 is
+  // subnormal: exponent field 0 (beAfter is 1 there, the same scale).
+  const BBNode isNormRes = rsigF[sb - 1];
+  BBNodeVec res(w);
+  for (unsigned i = 0; i < sb - 1; i++)
+    res[i] = rsigF[i];
+  for (unsigned i = 0; i < eb; i++)
+    res[sb - 1 + i] = nf->CreateNode(AND, isNormRes, beF[i]);
+  res[w - 1] = sgn;
+
+  if (resultKnownFinite)
+  {
+    ++fpNativeFiniteRoundPacks;
+    return res;
+  }
+
   // Overflow, checked after rounding; saturation is mode- and sign-
   // dependent: to infinity for the nearest modes, to the largest finite
   // value for RTZ and for the directed mode pointing away from the sign.
@@ -4245,16 +5533,6 @@ BBNodeVec BitBlaster::BBfpRoundPack(const BBNodeVec& rm, const BBNode& sgn,
   infCases.push_back(nf->CreateNode(AND, rtp, nf->CreateNode(NOT, sgn)));
   infCases.push_back(nf->CreateNode(AND, rtn, sgn));
   const BBNode roundsToInf = nf->CreateNode(OR, infCases);
-
-  // Pack the finite result. A significand without its leading 1 is
-  // subnormal: exponent field 0 (beAfter is 1 there, the same scale).
-  const BBNode isNormRes = rsigF[sb - 1];
-  BBNodeVec res(w);
-  for (unsigned i = 0; i < sb - 1; i++)
-    res[i] = rsigF[i];
-  for (unsigned i = 0; i < eb; i++)
-    res[sb - 1 + i] = nf->CreateNode(AND, isNormRes, beF[i]);
-  res[w - 1] = sgn;
 
   BBNodeVec inf(w, nf->getFalse());
   BBNodeVec maxFin(w, nf->getFalse());
@@ -4318,6 +5596,50 @@ BBNodeVec BitBlaster::BBfpMul(const ASTNode& term, BBNodeSet& support)
   const BBNodeVec pb = BBTerm(term[2], support);
   assert(pa.size() == w && pb.size() == w);
 
+  const bool aKnownZero = fpNativeKnownZeroMagnitude(term[1]);
+  const bool bKnownZero = fpNativeKnownZeroMagnitude(term[2]);
+  const bool aFinite = fpNativeKnownFinite(term[1]);
+  const bool bFinite = fpNativeKnownFinite(term[2]);
+  const bool knownSignEnabled = uf->fp_native_known_sign;
+  const bool aNonnegative =
+      knownSignEnabled && fpNativeKnownFiniteNonnegative(term[1]);
+  const bool aNonpositive =
+      knownSignEnabled && fpNativeKnownFiniteNonpositive(term[1]);
+  const bool bNonnegative =
+      knownSignEnabled && fpNativeKnownFiniteNonnegative(term[2]);
+  const bool bNonpositive =
+      knownSignEnabled && fpNativeKnownFiniteNonpositive(term[2]);
+  const bool knownSignOperands =
+      (aNonnegative || aNonpositive) && (bNonnegative || bNonpositive);
+  // A term proved both nonnegative and nonpositive is semantically zero. Its
+  // core sign is immaterial because the exact packed zero sign is muxed below.
+  const bool knownNegativeProduct =
+      knownSignOperands &&
+      ((aNonpositive && !aNonnegative) !=
+       (bNonpositive && !bNonnegative));
+  fpNativeFiniteArithOperands += static_cast<size_t>(aFinite) +
+                                 static_cast<size_t>(bFinite);
+
+  // zero * finite is an exact signed zero in every rounding mode. Requiring
+  // the other operand to be finite is essential: zero * infinity and zero *
+  // NaN must still take the invalid/NaN special paths below.
+  if ((aKnownZero && bFinite) || (bKnownZero && aFinite))
+  {
+    ++fpNativeZeroMulFastPaths;
+    BBNodeVec zero(w, nf->getFalse());
+    zero[w - 1] = nf->CreateNode(XOR, pa[w - 1], pb[w - 1]);
+    return zero;
+  }
+
+  if (knownSignOperands)
+  {
+    assert(aFinite && bFinite);
+    if (knownNegativeProduct)
+      ++fpNativeKnownNegativeMulPaths;
+    else
+      ++fpNativeKnownPositiveMulPaths;
+  }
+
   auto constVec = [&](unsigned value, unsigned width) {
     BBNodeVec c(width);
     for (unsigned i = 0; i < width; i++)
@@ -4334,10 +5656,19 @@ BBNodeVec BitBlaster::BBfpMul(const ASTNode& term, BBNodeSet& support)
   // The un-normalised field split (see BBfpUnpack): consuming a packed
   // operand -- a leaf or a chained native result -- is only wiring and
   // four classification gates; normalisation is deferred to the product.
-  const FpOperand a = BBfpUnpack(pa, sb, w, E, support);
-  const FpOperand b = BBfpUnpack(pb, sb, w, E, support);
+  const FpOperand a =
+      BBfpUnpack(pa, sb, w, E, support, aFinite, aKnownZero);
+  const FpOperand b =
+      BBfpUnpack(pb, sb, w, E, support, bFinite, bKnownZero);
 
-  const BBNode sgn = nf->CreateNode(XOR, a.sign, b.sign);
+  // A semantic-sign fact does not fix the packed sign of zero. Raw operand
+  // signs therefore select an exact zero result, while every nonzero result
+  // rounds with the constant product sign proved above.
+  const BBNode zeroSign = nf->CreateNode(XOR, a.sign, b.sign);
+  const BBNode roundSign = knownSignOperands
+                               ? (knownNegativeProduct ? nf->getTrue()
+                                                       : nf->getFalse())
+                               : zeroSign;
 
   // Significand product, 2sb bits, of the raw hidden-bit significands --
   // in [0, 4) counting subnormal fractions.
@@ -4379,8 +5710,18 @@ BBNodeVec BitBlaster::BBfpMul(const ASTNode& term, BBNodeSet& support)
   BBNodeVec ellE = zext(ell, E);
   BBSub(be, ellE, support);
 
-  BBNodeVec res = BBfpRoundPack(rm, sgn, rsig, guard, sticky, be, sb, eb,
-                                support);
+  // A top-level magnitude constraint on this product is useful to consumers,
+  // but must not erase the producer relation that enforces the constraint.
+  // In particular, do not simplify this product's overflow path merely by
+  // assuming its own output is zero; the full product circuit remains the
+  // witness that restricts its operands.
+  const bool directlyConstrainedZero =
+      fpNativeZeroMagnitudeFacts.find(term) !=
+      fpNativeZeroMagnitudeFacts.end();
+  const bool resultFinite =
+      !directlyConstrainedZero && fpNativeKnownFinite(term);
+  BBNodeVec res = BBfpRoundPack(rm, roundSign, rsig, guard, sticky, be, sb, eb,
+                                support, resultFinite);
 
   // Specials, outermost first: NaN (any NaN operand, or zero times
   // infinity), then infinity, then zero.
@@ -4392,63 +5733,32 @@ BBNodeVec BitBlaster::BBfpMul(const ASTNode& term, BBNodeSet& support)
     if (isnan)
       s[sb - 2] = nf->getTrue(); // canonical quiet NaN, positive
     else
-      s[w - 1] = sgn;
+      s[w - 1] = zeroSign;
     return s;
   };
   BBNodeVec nanCases;
-  nanCases.push_back(a.isNaN);
-  nanCases.push_back(b.isNaN);
-  nanCases.push_back(nf->CreateNode(AND, a.isZero, b.isInf));
-  nanCases.push_back(nf->CreateNode(AND, a.isInf, b.isZero));
-  const BBNode anyNaN = nf->CreateNode(OR, nanCases);
-  const BBNode anyInf = nf->CreateNode(OR, a.isInf, b.isInf);
+  if (!aFinite)
+    nanCases.push_back(a.isNaN);
+  if (!bFinite)
+    nanCases.push_back(b.isNaN);
+  if (!bFinite)
+    nanCases.push_back(nf->CreateNode(AND, a.isZero, b.isInf));
+  if (!aFinite)
+    nanCases.push_back(nf->CreateNode(AND, a.isInf, b.isZero));
+  const BBNode anyNaN =
+      nanCases.empty() ? nf->getFalse() : nf->CreateNode(OR, nanCases);
+  const BBNode anyInf =
+      aFinite ? (bFinite ? nf->getFalse() : b.isInf)
+              : (bFinite ? a.isInf : nf->CreateNode(OR, a.isInf, b.isInf));
   const BBNode anyZero = nf->CreateNode(OR, a.isZero, b.isZero);
 
   res = BBITE(anyZero, packSpecial(false, false), res);
-  res = BBITE(anyInf, packSpecial(false, true), res);
-  res = BBITE(anyNaN, packSpecial(true, false), res);
+  if (!(aFinite && bFinite))
+  {
+    res = BBITE(anyInf, packSpecial(false, true), res);
+    res = BBITE(anyNaN, packSpecial(true, false), res);
+  }
   return res;
-}
-
-// fp.isZero needs much less than a packed result. Every finite value in a
-// binary IEEE format is an integer multiple of that format's minimum
-// subnormal, so a nonzero exact sum of two format values cannot round to
-// zero. The result is therefore a semantic zero exactly when both operands
-// are finite and their exact real sum is zero: equal magnitudes with opposite
-// signs, or any pair of signed zeros. The rounding mode cannot change this
-// predicate.
-BBNode BitBlaster::BBfpAddIsZero(const ASTNode& term, BBNodeSet& support)
-{
-  assert(term.GetKind() == FP_ADD);
-  assert(term.Degree() == 3);
-
-  const SourceSort sort = term.GetSourceSort();
-  assert(sort.kind() == SourceSort::Kind::FloatingPoint);
-  const unsigned sb = sort.significandWidth();
-  const unsigned w = sort.packedWidth();
-  const unsigned eb = sort.exponentWidth();
-  (void)eb;
-  assert(sb >= 2 && eb >= 2 && w == sb + eb);
-
-  const BBNodeVec pa = BBTerm(term[1], support);
-  const BBNodeVec pb = BBTerm(term[2], support);
-  assert(pa.size() == w && pb.size() == w);
-
-  BBNodeVec aMagnitude(pa.begin(), pa.begin() + (w - 1));
-  const BBNodeVec bMagnitude(pb.begin(), pb.begin() + (w - 1));
-  const BBNode sameMagnitude = BBEQ(aMagnitude, bMagnitude);
-  const BBNode oppositeSigns = nf->CreateNode(XOR, pa[w - 1], pb[w - 1]);
-  // With equal magnitudes, testing either operand suffices to prove both are
-  // signed zeros.
-  const BBNode bothZero = nf->CreateNode(NOR, aMagnitude);
-  const BBNode exactZero = nf->CreateNode(
-      AND, sameMagnitude, nf->CreateNode(OR, oppositeSigns, bothZero));
-
-  auto finite = [&](const BBNodeVec& p) {
-    BBNodeVec exponent(p.begin() + (sb - 1), p.begin() + (w - 1));
-    return nf->CreateNode(NOT, nf->CreateNode(AND, exponent));
-  };
-  return nf->CreateNode(AND, finite(pa), finite(pb), exactZero);
 }
 
 // Bit-blasted fp.add over packed IEEE-754 operands, under the same flag
@@ -4473,6 +5783,70 @@ BBNode BitBlaster::BBfpAddIsZero(const ASTNode& term, BBNodeSet& support)
 //      EXACT zero result is mode-dependent: -0 under RTN, else +0.
 //   6. Specials: NaN operands and infinity minus infinity give NaN;
 //      otherwise any infinite operand's infinity wins, keeping its sign.
+//
+// fp.isZero needs much less than this packed result. Every finite value in a
+// binary IEEE format is an integer multiple of that format's minimum
+// subnormal. The exact sum of two finite operands is therefore another such
+// multiple. If it is nonzero but smaller than the minimum normal it is itself
+// an exactly representable subnormal; if it is at least the minimum normal,
+// no rounding mode can turn it into zero. Thus fp.add rounds to either signed
+// zero iff the exact real sum is zero. For nonzero operands that means equal
+// packed magnitudes and opposite signs; every combination of signed zeros is
+// also zero. NaNs and infinities are excluded explicitly.
+BBNode BitBlaster::BBfpAddIsZero(const ASTNode& term, BBNodeSet& support)
+{
+  assert(term.GetKind() == FP_ADD);
+  assert(term.Degree() == 3);
+
+  const SourceSort sort = term.GetSourceSort();
+  assert(sort.kind() == SourceSort::Kind::FloatingPoint);
+  const unsigned sb = sort.significandWidth();
+  const unsigned w = sort.packedWidth();
+  const unsigned eb = sort.exponentWidth();
+  (void)eb;
+  assert(sb >= 2 && eb >= 2 && w == sb + eb);
+
+  const bool aKnownZero = fpNativeKnownZeroMagnitude(term[1]);
+  const bool bKnownZero = fpNativeKnownZeroMagnitude(term[2]);
+  if (aKnownZero && bKnownZero)
+    return nf->getTrue();
+
+  if (aKnownZero || bKnownZero)
+  {
+    const BBNodeVec other = BBTerm(aKnownZero ? term[2] : term[1], support);
+    return BBfpIsZero(other, w);
+  }
+
+  const BBNodeVec pa = BBTerm(term[1], support);
+  const BBNodeVec pb = BBTerm(term[2], support);
+  assert(pa.size() == w && pb.size() == w);
+
+  BBNodeVec aMagnitude(pa.begin(), pa.begin() + (w - 1));
+  const BBNodeVec bMagnitude(pb.begin(), pb.begin() + (w - 1));
+  const BBNode sameMagnitude = BBEQ(aMagnitude, bMagnitude);
+  const BBNode oppositeSigns = nf->CreateNode(XOR, pa[w - 1], pb[w - 1]);
+  // Under sameMagnitude, testing one side for magnitude zero proves that
+  // both operands are signed zeros.
+  const BBNode bothZero = nf->CreateNode(NOR, aMagnitude);
+  const BBNode exactZero = nf->CreateNode(
+      AND, sameMagnitude, nf->CreateNode(OR, oppositeSigns, bothZero));
+
+  const bool aFinite = fpNativeKnownFinite(term[1]);
+  const bool bFinite = fpNativeKnownFinite(term[2]);
+  if (aFinite && bFinite)
+    return exactZero;
+
+  auto finite = [&](const BBNodeVec& p) {
+    BBNodeVec exponent(p.begin() + (sb - 1), p.begin() + (w - 1));
+    return nf->CreateNode(NOT, nf->CreateNode(AND, exponent));
+  };
+  if (aFinite)
+    return nf->CreateNode(AND, finite(pb), exactZero);
+  if (bFinite)
+    return nf->CreateNode(AND, finite(pa), exactZero);
+  return nf->CreateNode(AND, finite(pa), finite(pb), exactZero);
+}
+
 BBNodeVec BitBlaster::BBfpAdd(const ASTNode& term, BBNodeSet& support)
 {
   assert(term.GetKind() == FP_ADD);
@@ -4492,6 +5866,66 @@ BBNodeVec BitBlaster::BBfpAdd(const ASTNode& term, BBNodeSet& support)
   const BBNodeVec pb = BBTerm(term[2], support);
   assert(pa.size() == w && pb.size() == w);
 
+  const bool aKnownZero = fpNativeKnownZeroMagnitude(term[1]);
+  const bool bKnownZero = fpNativeKnownZeroMagnitude(term[2]);
+  const bool aFinite = fpNativeKnownFinite(term[1]);
+  const bool bFinite = fpNativeKnownFinite(term[2]);
+  const bool knownSignEnabled = uf->fp_native_known_sign;
+  const bool aNonnegative =
+      knownSignEnabled && fpNativeKnownFiniteNonnegative(term[1]);
+  const bool aNonpositive =
+      knownSignEnabled && fpNativeKnownFiniteNonpositive(term[1]);
+  const bool bNonnegative =
+      knownSignEnabled && fpNativeKnownFiniteNonnegative(term[2]);
+  const bool bNonpositive =
+      knownSignEnabled && fpNativeKnownFiniteNonpositive(term[2]);
+  const bool sameNonnegative = aNonnegative && bNonnegative;
+  const bool sameNonpositive = aNonpositive && bNonpositive;
+  const bool knownSameSign = sameNonnegative || sameNonpositive;
+  // If both sides hold, both operands are semantic zeros; choose a positive
+  // core and let the explicit zero-sign mux below select the packed result.
+  const bool knownNegativeSum = sameNonpositive && !sameNonnegative;
+  fpNativeFiniteArithOperands += static_cast<size_t>(aFinite) +
+                                 static_cast<size_t>(bFinite);
+
+  // A signed zero is an additive identity for every nonzero finite value.
+  // When the other operand is also zero, IEEE-754 chooses the common sign,
+  // or -0 only under RTN when the signs differ.
+  if ((aKnownZero && bFinite) || (bKnownZero && aFinite))
+  {
+    ++fpNativeZeroAddFastPaths;
+    const bool zeroOnLeft = aKnownZero;
+    const BBNodeVec& zeroBits = zeroOnLeft ? pa : pb;
+    const BBNodeVec& otherBits = zeroOnLeft ? pb : pa;
+    const bool otherKnownZero = zeroOnLeft ? bKnownZero : aKnownZero;
+    const BBNode otherZero = otherKnownZero
+                                 ? nf->getTrue()
+                                 : BBfpIsZero(otherBits, w);
+    const BBNode oppositeSigns = nf->CreateNode(
+        XOR, zeroBits[w - 1], otherBits[w - 1]);
+    const BBNode bothNegative = nf->CreateNode(
+        AND, zeroBits[w - 1], otherBits[w - 1]);
+    const BBNode zeroSign = nf->CreateNode(
+        OR, bothNegative,
+        nf->CreateNode(AND, oppositeSigns, rm[2]));
+
+    BBNodeVec result = otherKnownZero
+                           ? BBfill(w, nf->getFalse())
+                           : otherBits;
+    result[w - 1] =
+        nf->CreateNode(ITE, otherZero, zeroSign, otherBits[w - 1]);
+    return result;
+  }
+
+  if (knownSameSign)
+  {
+    assert(aFinite && bFinite);
+    if (knownNegativeSum)
+      ++fpNativeKnownNegativeAddPaths;
+    else
+      ++fpNativeKnownPositiveAddPaths;
+  }
+
   auto constVec = [&](unsigned value, unsigned width) {
     BBNodeVec c(width);
     for (unsigned i = 0; i < width; i++)
@@ -4505,21 +5939,35 @@ BBNodeVec BitBlaster::BBfpAdd(const ASTNode& term, BBNodeSet& support)
     return c;
   };
 
-  const FpOperand a = BBfpUnpack(pa, sb, w, E, support);
-  const FpOperand b = BBfpUnpack(pb, sb, w, E, support);
-  const BBNode effSub = nf->CreateNode(XOR, a.sign, b.sign);
+  const FpOperand a =
+      BBfpUnpack(pa, sb, w, E, support, aFinite, aKnownZero);
+  const FpOperand b =
+      BBfpUnpack(pb, sb, w, E, support, bFinite, bKnownZero);
+  const BBNode effSub = knownSameSign
+                            ? nf->getFalse()
+                            : nf->CreateNode(XOR, a.sign, b.sign);
 
-  // Order by magnitude: (eUnb, msig) lexicographically.
+  // General addition orders by magnitude: (eUnb, msig)
+  // lexicographically. For finite operands with the same known semantic sign
+  // the operation is always magnitude addition; when exponents tie either
+  // operand may be aligned, so the significand comparison and cancellation
+  // logic are unnecessary.
   const BBNode eLess = BBBVLE(a.eUnb, b.eUnb, true /*signed*/, true);
-  const BBNode eEq = BBEQ(a.eUnb, b.eUnb);
-  const BBNode mLess = BBBVLE(a.msig, b.msig, false, true);
-  const BBNode swap =
-      nf->CreateNode(OR, eLess, nf->CreateNode(AND, eEq, mLess));
+  BBNode swap = eLess;
+  if (!knownSameSign)
+  {
+    const BBNode eEq = BBEQ(a.eUnb, b.eUnb);
+    const BBNode mLess = BBBVLE(a.msig, b.msig, false, true);
+    swap = nf->CreateNode(OR, eLess, nf->CreateNode(AND, eEq, mLess));
+  }
   const BBNodeVec msigBig = BBITE(swap, b.msig, a.msig);
   const BBNodeVec msigSmall = BBITE(swap, a.msig, b.msig);
   const BBNodeVec eBig = BBITE(swap, b.eUnb, a.eUnb);
   const BBNodeVec eSmall = BBITE(swap, a.eUnb, b.eUnb);
-  const BBNode signBig = nf->CreateNode(ITE, swap, b.sign, a.sign);
+  const BBNode signBig = knownSameSign
+                             ? (knownNegativeSum ? nf->getTrue()
+                                                 : nf->getFalse())
+                             : nf->CreateNode(ITE, swap, b.sign, a.sign);
 
   // Alignment distance, clamped into the frame.
   const unsigned dmaxA = sb + 3;
@@ -4557,44 +6005,108 @@ BBNodeVec BitBlaster::BBfpAdd(const ASTNode& term, BBNodeSet& support)
   // sticky tail: the true small operand is (aligned + fraction), so the
   // true difference is (big - aligned - 1) plus a nonzero fraction; the
   // borrowed carry-in and the kept sticky express exactly that.
-  BBNodeVec addend(W);
-  for (unsigned i = 0; i < W; i++)
-    addend[i] = nf->CreateNode(XOR, small[i], effSub);
-  const BBNode cin =
-      nf->CreateNode(AND, effSub, nf->CreateNode(NOT, stickyTail));
+  BBNodeVec addend = small;
+  BBNode cin = nf->getFalse();
+  if (!knownSameSign)
+  {
+    for (unsigned i = 0; i < W; i++)
+      addend[i] = nf->CreateNode(XOR, small[i], effSub);
+    cin = nf->CreateNode(AND, effSub,
+                         nf->CreateNode(NOT, stickyTail));
+  }
   BBNodeVec sum = big;
   BBPlus2(sum, addend, cin);
 
-  // One normalisation for carry and cancellation alike.
-  const unsigned lwA = [](unsigned x) {
-    unsigned bb = 1;
-    while ((1u << bb) <= x)
-      bb++;
-    return bb;
-  }(W);
-  const BBNodeVec ell = BBfpCLZ(sum, lwA);
-  const BBNodeVec sn = BBfpShiftLeft(sum, ell);
-  BBNodeVec rsig(sn.begin() + (W - sb), sn.end());
-  const BBNode guard = sn[W - sb - 1];
-  BBNodeVec lowBits(sn.begin(), sn.begin() + (W - sb - 1));
-  BBNode sticky = nf->CreateNode(OR, nf->CreateNode(OR, lowBits), stickyTail);
+  BBNodeVec rsig;
+  BBNode guard = nf->getFalse();
+  BBNode sticky = nf->getFalse();
+  BBNodeVec be;
+  if (knownSameSign)
+  {
+    // No cancellation means no arbitrary left normalisation. If the larger
+    // scale is normal, the leading bit either stays at W-2 or carries once to
+    // W-1. If both operands are subnormal (or one is the minimum normal at
+    // the shared exponent), their unshifted sum can be packed directly at
+    // biased exponent 1; a missing hidden bit then denotes a subnormal.
+    const BBNode carry = sum[W - 1];
+    const BBNodeVec rsigNoCarry(sum.begin() + dmaxA,
+                                sum.begin() + dmaxA + sb);
+    const BBNodeVec rsigCarry(sum.begin() + dmaxA + 1, sum.end());
+    rsig = BBITE(carry, rsigCarry, rsigNoCarry);
+    guard = nf->CreateNode(ITE, carry, sum[dmaxA], sum[dmaxA - 1]);
 
-  // be = eBig + bias + 1 - leading zeros, exactly as the multiplier.
-  BBNodeVec be = eBig;
-  BBPlus2(be, constVec(bias, E), nf->getTrue());
-  BBNodeVec ellE = zext(ell, E);
-  BBSub(be, ellE, support);
+    BBNodeVec lowNoCarry(sum.begin(), sum.begin() + dmaxA - 1);
+    BBNodeVec lowCarry(sum.begin(), sum.begin() + dmaxA);
+    const BBNode stickyNoCarry = nf->CreateNode(
+        OR, nf->CreateNode(OR, lowNoCarry), stickyTail);
+    const BBNode stickyCarry = nf->CreateNode(
+        OR, nf->CreateNode(OR, lowCarry), stickyTail);
+    sticky = nf->CreateNode(ITE, carry, stickyCarry, stickyNoCarry);
 
-  // An EXACT zero result (cancellation of equal values -- only possible
-  // unshifted, so the sticky tail is clear) is +0 in every mode but RTN.
-  const BBNode sumZero = nf->CreateNode(NOR, sum);
-  const BBNode exactZero = nf->CreateNode(
-      AND, effSub, sumZero, nf->CreateNode(NOT, stickyTail));
-  const BBNode& rtn = rm[2];
-  const BBNode sgn = nf->CreateNode(ITE, exactZero, rtn, signBig);
+    // eBig is unbiased. The direct subnormal scale gives 1 here; a normal
+    // carry increments the ordinary biased exponent once.
+    be = eBig;
+    BBPlus2(be, constVec(bias, E), carry);
+  }
+  else
+  {
+    // General opposite-sign addition needs a leading-zero count and shift for
+    // arbitrary cancellation.
+    const unsigned lwA = [](unsigned x) {
+      unsigned bb = 1;
+      while ((1u << bb) <= x)
+        bb++;
+      return bb;
+    }(W);
+    const BBNodeVec ell = BBfpCLZ(sum, lwA);
+    const BBNodeVec sn = BBfpShiftLeft(sum, ell);
+    rsig.assign(sn.begin() + (W - sb), sn.end());
+    guard = sn[W - sb - 1];
+    BBNodeVec lowBits(sn.begin(), sn.begin() + (W - sb - 1));
+    sticky =
+        nf->CreateNode(OR, nf->CreateNode(OR, lowBits), stickyTail);
 
+    // be = eBig + bias + 1 - leading zeros, exactly as the multiplier.
+    be = eBig;
+    BBPlus2(be, constVec(bias, E), nf->getTrue());
+    BBNodeVec ellE = zext(ell, E);
+    BBSub(be, ellE, support);
+  }
+
+  BBNode bothZero = nf->getFalse();
+  BBNode knownSignZeroSign = nf->getFalse();
+  BBNode sgn = signBig;
+  if (knownSameSign)
+  {
+    // Nonzero sums round with the proven constant sign. If both magnitudes
+    // are zero, equal signs are retained and opposite signs choose -0 only
+    // in RTN. The final result-sign mux keeps this exceptional packed sign
+    // out of the rounding and overflow circuitry.
+    bothZero = nf->CreateNode(AND, a.isZero, b.isZero);
+    const BBNode oppositeSigns = nf->CreateNode(XOR, a.sign, b.sign);
+    const BBNode bothNegative = nf->CreateNode(AND, a.sign, b.sign);
+    knownSignZeroSign = nf->CreateNode(
+        OR, bothNegative,
+        nf->CreateNode(AND, oppositeSigns, rm[2]));
+    sgn = knownNegativeSum ? nf->getTrue() : nf->getFalse();
+  }
+  else
+  {
+    // An EXACT zero result (cancellation of equal values -- only possible
+    // unshifted, so the sticky tail is clear) is +0 in every mode but RTN.
+    const BBNode sumZero = nf->CreateNode(NOR, sum);
+    const BBNode exactZero = nf->CreateNode(
+        AND, effSub, sumZero, nf->CreateNode(NOT, stickyTail));
+    sgn = nf->CreateNode(ITE, exactZero, rm[2], signBig);
+  }
+
+  const bool resultFinite = fpNativeKnownFinite(term);
   BBNodeVec res =
-      BBfpRoundPack(rm, sgn, rsig, guard, sticky, be, sb, eb, support);
+      BBfpRoundPack(rm, sgn, rsig, guard, sticky, be, sb, eb, support,
+                    resultFinite);
+
+  if (knownSameSign)
+    res[w - 1] = nf->CreateNode(ITE, bothZero, knownSignZeroSign, sgn);
 
   // Specials: NaN operands, or subtracting infinities; otherwise an
   // infinite operand's infinity, keeping that operand's sign.
@@ -4609,15 +6121,28 @@ BBNodeVec BitBlaster::BBfpAdd(const ASTNode& term, BBNodeSet& support)
     return s;
   };
   BBNodeVec nanCases;
-  nanCases.push_back(a.isNaN);
-  nanCases.push_back(b.isNaN);
-  nanCases.push_back(nf->CreateNode(AND, a.isInf, b.isInf, effSub));
-  const BBNode anyNaN = nf->CreateNode(OR, nanCases);
-  const BBNode anyInf = nf->CreateNode(OR, a.isInf, b.isInf);
-  const BBNode infSign = nf->CreateNode(ITE, a.isInf, a.sign, b.sign);
+  if (!aFinite)
+    nanCases.push_back(a.isNaN);
+  if (!bFinite)
+    nanCases.push_back(b.isNaN);
+  if (!aFinite && !bFinite)
+    nanCases.push_back(nf->CreateNode(AND, a.isInf, b.isInf, effSub));
+  const BBNode anyNaN =
+      nanCases.empty() ? nf->getFalse() : nf->CreateNode(OR, nanCases);
+  const BBNode anyInf =
+      aFinite ? (bFinite ? nf->getFalse() : b.isInf)
+              : (bFinite ? a.isInf : nf->CreateNode(OR, a.isInf, b.isInf));
 
-  res = BBITE(anyInf, packSpecial(false, infSign), res);
-  res = BBITE(anyNaN, packSpecial(true, nf->getFalse()), res);
+  if (!(aFinite && bFinite))
+  {
+    const BBNode infSign = aFinite ? b.sign
+                                   : (bFinite ? a.sign
+                                              : nf->CreateNode(ITE, a.isInf,
+                                                               a.sign,
+                                                               b.sign));
+    res = BBITE(anyInf, packSpecial(false, infSign), res);
+    res = BBITE(anyNaN, packSpecial(true, nf->getFalse()), res);
+  }
   return res;
 }
 
@@ -4656,6 +6181,15 @@ BBNodeVec BitBlaster::BBfpToFp(const ASTNode& term, BBNodeSet& support)
   const BBNodeVec p = BBTerm(term[3], support);
   assert(p.size() == w1);
 
+  const bool sourceKnownZero = fpNativeKnownZeroMagnitude(term[3]);
+  if (sourceKnownZero)
+  {
+    ++fpNativeZeroToFpFastPaths;
+    BBNodeVec zero(w2, nf->getFalse());
+    zero[w2 - 1] = p[w1 - 1];
+    return zero;
+  }
+
   auto constVec = [&](unsigned value, unsigned width) {
     BBNodeVec c(width);
     for (unsigned i = 0; i < width; i++)
@@ -4669,7 +6203,9 @@ BBNodeVec BitBlaster::BBfpToFp(const ASTNode& term, BBNodeSet& support)
     return c;
   };
 
-  const FpOperand s = BBfpUnpack(p, sb1, w1, E, support);
+  const bool sourceFinite = fpNativeKnownFinite(term[3]);
+  const FpOperand s =
+      BBfpUnpack(p, sb1, w1, E, support, sourceFinite, sourceKnownZero);
 
   // Normalise the source significand; the count also lets a subnormal
   // source become normal in a wider target range.

--- a/tests/query-files/fp-tests/fp-domain-native-nonnegative-arith.smt2
+++ b/tests/query-files/fp-tests/fp-domain-native-nonnegative-arith.smt2
@@ -1,0 +1,102 @@
+; Finite semantic-sign facts let native add/mul omit sign-controlled
+; cancellation and rounding circuitry. The nonnegative lower bounds
+; intentionally admit -0, so the specialized paths must retain explicit
+; signed-zero handling.
+;
+; RUN: %solver --bb.fp-native-arith=1 --fp-domain-simplify=1 --bb.fp-native-domain=1 --bb.fp-native-known-sign=1 -s %s 2>&1 | %OutputCheck --check-prefix=NATIVE %s
+; RUN: %solver --bb.fp-native-arith=1 --fp-domain-simplify=1 --bb.fp-native-domain=1 --bb.fp-native-known-sign=1 -s %s 2>&1 | %OutputCheck --check-prefix=COUNTERS %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck --check-prefix=SYMFPU %s
+;
+; NATIVE: ^unsat
+; SYMFPU: ^unsat
+; COUNTERS: FP native domain known-positive add paths: [1-9][0-9]*
+; COUNTERS: FP native domain known-positive mul paths: [1-9][0-9]*
+;
+(set-logic QF_FP)
+(declare-fun pz () (_ FloatingPoint 8 24))
+(declare-fun nz () (_ FloatingPoint 8 24))
+(declare-fun a () (_ FloatingPoint 8 24))
+(declare-fun b () (_ FloatingPoint 8 24))
+(declare-fun tiny () (_ FloatingPoint 8 24))
+(declare-fun half () (_ FloatingPoint 8 24))
+(declare-fun largest () (_ FloatingPoint 8 24))
+(declare-fun two () (_ FloatingPoint 8 24))
+
+(define-fun maxFinite () (_ FloatingPoint 8 24)
+  (fp #b0 #xfe #b11111111111111111111111))
+(define-fun one () (_ FloatingPoint 8 24)
+  (fp #b0 #x7f #b00000000000000000000000))
+(define-fun nextOne () (_ FloatingPoint 8 24)
+  (fp #b0 #x7f #b00000000000000000000001))
+(define-fun halfUlpAtOne () (_ FloatingPoint 8 24)
+  (fp #b0 #x67 #b00000000000000000000000))
+(define-fun minSub () (_ FloatingPoint 8 24)
+  (fp #b0 #x00 #b00000000000000000000001))
+
+; All variables are finite and semantically nonnegative. In particular, these
+; facts say neither that a value is nonzero nor that its sign bit is clear.
+(assert (and
+  (fp.leq (_ +zero 8 24) pz) (fp.leq pz maxFinite)
+  (fp.leq (_ +zero 8 24) nz) (fp.leq nz maxFinite)
+  (fp.leq (_ +zero 8 24) a) (fp.leq a maxFinite)
+  (fp.leq (_ +zero 8 24) b) (fp.leq b maxFinite)
+  (fp.leq (_ +zero 8 24) tiny) (fp.leq tiny maxFinite)
+  (fp.leq (_ +zero 8 24) half) (fp.leq half maxFinite)
+  (fp.leq (_ +zero 8 24) largest) (fp.leq largest maxFinite)
+  (fp.leq (_ +zero 8 24) two) (fp.leq two maxFinite)))
+
+; Pin values through FP predicates, leaving the arithmetic terms intact for
+; native lowering. The two zeros retain opposite packed signs.
+(assert (and
+  (fp.isZero pz) (fp.isPositive pz)
+  (fp.isZero nz) (fp.isNegative nz)
+  (fp.eq a one)
+  (fp.eq b halfUlpAtOne)
+  (fp.eq tiny minSub)
+  (fp.eq half (fp #b0 #x7e #b00000000000000000000000))
+  (fp.eq largest maxFinite)
+  (fp.eq two (fp #b0 #x80 #b00000000000000000000000))))
+
+; Refute all target results together. This covers the signed-zero exception,
+; every rounding direction at a halfway addition, exact subnormal addition,
+; positive overflow, positive underflow, and nested fact propagation.
+(assert
+  (not
+    (and
+      (= (fp.add RNE pz nz) (_ +zero 8 24))
+      (= (fp.add RNA pz nz) (_ +zero 8 24))
+      (= (fp.add RTP pz nz) (_ +zero 8 24))
+      (= (fp.add RTZ pz nz) (_ +zero 8 24))
+      (= (fp.add RTN pz nz) (_ -zero 8 24))
+      (= (fp.add RNE nz nz) (_ -zero 8 24))
+
+      (= (fp.add RNE a b) one)
+      (= (fp.add RNA a b) nextOne)
+      (= (fp.add RTP a b) nextOne)
+      (= (fp.add RTN a b) one)
+      (= (fp.add RTZ a b) one)
+      (= (fp.add RNE tiny tiny)
+         (fp #b0 #x00 #b00000000000000000000010))
+      (= (fp.add RNE largest largest) (_ +oo 8 24))
+      (= (fp.add RNA largest largest) (_ +oo 8 24))
+      (= (fp.add RTP largest largest) (_ +oo 8 24))
+      (= (fp.add RTN largest largest) maxFinite)
+      (= (fp.add RTZ largest largest) maxFinite)
+
+      (= (fp.mul RNE nz two) (_ -zero 8 24))
+      (= (fp.mul RTN nz nz) (_ +zero 8 24))
+      (= (fp.mul RNE tiny half) (_ +zero 8 24))
+      (= (fp.mul RTN tiny half) (_ +zero 8 24))
+      (= (fp.mul RTZ tiny half) (_ +zero 8 24))
+      (= (fp.mul RNA tiny half) minSub)
+      (= (fp.mul RTP tiny half) minSub)
+      (= (fp.mul RNE largest two) (_ +oo 8 24))
+      (= (fp.mul RNA largest two) (_ +oo 8 24))
+      (= (fp.mul RTP largest two) (_ +oo 8 24))
+      (= (fp.mul RTN largest two) maxFinite)
+      (= (fp.mul RTZ largest two) maxFinite)
+
+      (= (fp.add RNE (fp.mul RNE a two) a)
+         (fp #b0 #x80 #b10000000000000000000000)))))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/fp-domain-native-nonnegative-equivalence.smt2
+++ b/tests/query-files/fp-tests/fp-domain-native-nonnegative-equivalence.smt2
@@ -1,0 +1,68 @@
+; Exhaustive small-format equivalence checks for the specialized known-sign
+; datapaths. FMA is deliberately left on the ordinary SymFPU path and serves
+; as the oracle: a*1+b is fp.add with one rounding, while a*b+0 is fp.mul for
+; nonzero finite operands. Both semantic sign directions and all five IEEE
+; rounding modes are covered. The (3,5) format is small enough to prove this
+; exhaustively, including both packed encodings of zero in the additions.
+;
+; RUN: %solver --disable-equality --unconstrained-variable-elimination=0 --bb.fp-native-arith=1 --fp-domain-simplify=1 --bb.fp-native-domain=1 --bb.fp-native-known-sign=1 -s %s 2>&1 | %OutputCheck --check-prefix=NATIVE %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck --check-prefix=SYMFPU %s
+; NATIVE: FP native domain known-positive add paths: [1-9][0-9]*
+; NATIVE: FP native domain known-negative add paths: [1-9][0-9]*
+; NATIVE: FP native domain known-positive mul paths: [1-9][0-9]*
+; NATIVE: FP native domain known-negative mul paths: [1-9][0-9]*
+; NATIVE: ^unsat
+; SYMFPU: ^unsat
+;
+(set-logic QF_FP)
+(declare-fun a () (_ FloatingPoint 3 5))
+(declare-fun b () (_ FloatingPoint 3 5))
+(declare-fun m () (_ FloatingPoint 3 5))
+(declare-fun n () (_ FloatingPoint 3 5))
+(declare-fun c () (_ FloatingPoint 3 5))
+(declare-fun d () (_ FloatingPoint 3 5))
+(declare-fun p () (_ FloatingPoint 3 5))
+(declare-fun q () (_ FloatingPoint 3 5))
+(declare-fun nativeAdd () (_ FloatingPoint 3 5))
+(declare-fun oracleAdd () (_ FloatingPoint 3 5))
+(declare-fun nativeNegativeAdd () (_ FloatingPoint 3 5))
+(declare-fun oracleNegativeAdd () (_ FloatingPoint 3 5))
+(declare-fun nativeMul () (_ FloatingPoint 3 5))
+(declare-fun oracleMul () (_ FloatingPoint 3 5))
+(declare-fun nativeNegativeMul () (_ FloatingPoint 3 5))
+(declare-fun oracleNegativeMul () (_ FloatingPoint 3 5))
+(declare-fun rm () RoundingMode)
+
+(define-fun one () (_ FloatingPoint 3 5) (fp #b0 #b011 #b0000))
+(define-fun minSub () (_ FloatingPoint 3 5) (fp #b0 #b000 #b0001))
+(define-fun maxFinite () (_ FloatingPoint 3 5) (fp #b0 #b110 #b1111))
+(define-fun minusMinSub () (_ FloatingPoint 3 5) (fp #b1 #b000 #b0001))
+(define-fun minusMaxFinite () (_ FloatingPoint 3 5) (fp #b1 #b110 #b1111))
+
+(assert (and
+  (fp.leq (_ +zero 3 5) a) (fp.leq a maxFinite)
+  (fp.leq (_ +zero 3 5) b) (fp.leq b maxFinite)
+  (fp.leq minSub m) (fp.leq m maxFinite)
+  (fp.leq minSub n) (fp.leq n maxFinite)
+  (fp.leq minusMaxFinite c) (fp.leq c (_ -zero 3 5))
+  (fp.leq minusMaxFinite d) (fp.leq d (_ -zero 3 5))
+  (fp.leq minusMaxFinite p) (fp.leq p minusMinSub)
+  (fp.leq minSub q) (fp.leq q maxFinite)))
+
+; Each native result is named through a packed equality. The corresponding
+; FMA equation forces an ordinary SymFPU result, after which a packed mismatch
+; would witness a circuit error (including a wrong zero sign).
+(assert (= nativeAdd (fp.add rm a b)))
+(assert (= oracleAdd (fp.fma rm a one b)))
+(assert (= nativeNegativeAdd (fp.add rm c d)))
+(assert (= oracleNegativeAdd (fp.fma rm c one d)))
+(assert (= nativeMul (fp.mul rm m n)))
+(assert (= oracleMul (fp.fma rm m n (_ +zero 3 5))))
+(assert (= nativeNegativeMul (fp.mul rm p q)))
+(assert (= oracleNegativeMul (fp.fma rm p q (_ +zero 3 5))))
+(assert (or (not (= nativeAdd oracleAdd))
+            (not (= nativeNegativeAdd oracleNegativeAdd))
+            (not (= nativeMul oracleMul))
+            (not (= nativeNegativeMul oracleNegativeMul))))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/fp-domain-native-product-zero-witness.smt2
+++ b/tests/query-files/fp-tests/fp-domain-native-product-zero-witness.smt2
@@ -1,0 +1,23 @@
+; RUN: %solver --disable-equality --unconstrained-variable-elimination=0 --bb.fp-native-arith=1 --bb.fp-native-domain=1 --bb.fp-native-known-sign=1 -s %s 2>&1 | %OutputCheck --check-prefix=NATIVE %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck --check-prefix=SYMFPU %s
+;
+; NATIVE: FP native domain zero-magnitude facts: 1
+; NATIVE: ^unsat
+; SYMFPU: ^unsat
+;
+; A product's own isZero assertion is useful as a fact for consumers, but it
+; must remain a live witness that checks the computed magnitude. Treating the
+; fact as permission to replace its producer by zero would make this formula
+; spuriously satisfiable.
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 3 5))
+
+(define-fun one () (_ FloatingPoint 3 5)
+  (fp #b0 #b011 #b0000))
+(define-fun two () (_ FloatingPoint 3 5)
+  (fp #b0 #b100 #b0000))
+
+(assert (and (fp.leq one x) (fp.leq x one)))
+(assert (fp.isZero (fp.mul RNE two x)))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/fp-domain-native-zero-fastpaths.smt2
+++ b/tests/query-files/fp-tests/fp-domain-native-zero-fastpaths.smt2
@@ -1,0 +1,140 @@
+; Row-derived magnitude-zero facts must reach native FP lowering without
+; identifying -0 with +0. The first native run checks the answer, the second
+; checks that each specialized consumer actually fires, and the last run is
+; the ordinary SymFPU oracle for the same source formula.
+;
+; RUN: %solver --bb.fp-native-arith=1 --fp-domain-simplify=1 --fp-domain-sound-zero-facts=1 --bb.fp-native-domain=1 -s %s 2>&1 | %OutputCheck --check-prefix=NATIVE %s
+; RUN: %solver --bb.fp-native-arith=1 --fp-domain-simplify=1 --fp-domain-sound-zero-facts=1 --bb.fp-native-domain=1 -s %s 2>&1 | %OutputCheck --check-prefix=COUNTERS %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck --check-prefix=SYMFPU %s
+;
+; NATIVE: ^unsat
+;
+; SYMFPU: ^unsat
+;
+; COUNTERS: FP native domain zero-magnitude facts: 3
+; COUNTERS: FP native domain zero cmp operands: [1-9][0-9]*
+; COUNTERS: FP native domain zero classifications: [1-9][0-9]*
+; COUNTERS: FP native domain zero add fast-paths: [1-9][0-9]*
+; COUNTERS: FP native domain zero mul fast-paths: [1-9][0-9]*
+; COUNTERS: FP native domain zero to-fp fast-paths: [1-9][0-9]*
+;
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(declare-fun y () (_ FloatingPoint 8 24))
+(declare-fun n () (_ FloatingPoint 8 24))
+(declare-fun u () (_ FloatingPoint 8 24))
+(declare-fun q () (_ FloatingPoint 8 24))
+(declare-fun rm () RoundingMode)
+
+; All three variables are finite and semantically nonnegative; the lower
+; bound deliberately still admits -0.
+(assert (fp.leq (_ +zero 8 24) x))
+(assert (fp.leq x (fp #b0 #x80 #b00000000000000000000000)))
+(assert (fp.leq (_ +zero 8 24) y))
+(assert (fp.leq y (fp #b0 #x80 #b00000000000000000000000)))
+(assert (fp.leq (_ +zero 8 24) n))
+(assert (fp.leq n (fp #b0 #x80 #b00000000000000000000000)))
+(assert (fp.leq (_ +zero 8 24) u))
+(assert (fp.leq u (fp #b0 #x80 #b00000000000000000000000)))
+
+; A same-sign zero row soundly establishes zero magnitude for x and y. The
+; sign predicates then choose the two different zero encodings without using
+; structural equalities that preprocessing could substitute away.
+(assert (fp.eq (fp.add RNE x y) (_ +zero 8 24)))
+(assert (fp.eq (fp.add RNE u u) (_ +zero 8 24)))
+(assert (fp.isNegative x))
+(assert (fp.isPositive y))
+
+; Refute the conjunction of all required zero identities/corner cases. A
+; wrong result in any one specialized consumer makes this query satisfiable.
+(assert
+  (not
+    (and
+      ; Opposite signed zeros add to -0 only under RTN.
+      (= (fp.add RTN x y) (_ -zero 8 24))
+      (= (fp.add RNE x y) (_ +zero 8 24))
+      (= (fp.add RNA x y) (_ +zero 8 24))
+      (= (fp.add RTP x y) (_ +zero 8 24))
+      (= (fp.add RTZ x y) (_ +zero 8 24))
+      (= (= (fp.add rm x y) (_ -zero 8 24)) (= rm RTN))
+
+      ; Equal-sign zeros keep that sign under every rounding mode.
+      (= (fp.add RNE u u) u)
+      (= (fp.add RNA u u) u)
+      (= (fp.add RTP u u) u)
+      (= (fp.add RTN u u) u)
+      (= (fp.add RTZ u u) u)
+
+      ; A signed zero is an fp.eq identity for every finite operand,
+      ; including subnormals and either signed zero.
+      (fp.eq (fp.add RNE x n) n)
+      (fp.eq (fp.add RNA n y) n)
+      (fp.eq (fp.add RTP x n) n)
+      (fp.eq (fp.add RTN n y) n)
+      (fp.eq (fp.add RTZ x n) n)
+      (= (fp.add RNE x
+            (fp #b0 #x00 #b00000000000000000000001))
+         (fp #b0 #x00 #b00000000000000000000001))
+      (= (fp.add RNE x
+            (fp #b0 #xfe #b11111111111111111111111))
+         (fp #b0 #xfe #b11111111111111111111111))
+
+      ; Multiplication preserves sign XOR and is exact in every mode.
+      (= (fp.mul RNE x (fp #b0 #x80 #b00000000000000000000000))
+         (_ -zero 8 24))
+      (= (fp.mul RNA x (fp #b1 #x80 #b00000000000000000000000))
+         (_ +zero 8 24))
+      (= (fp.mul RTP x (fp #b0 #x80 #b00000000000000000000000))
+         (_ -zero 8 24))
+      (= (fp.mul RTN x (fp #b1 #x80 #b00000000000000000000000))
+         (_ +zero 8 24))
+      (= (fp.mul RTZ x (fp #b0 #x80 #b00000000000000000000000))
+         (_ -zero 8 24))
+      (= (fp.mul RNE x (fp #b0 #x00 #b00000000000000000000001))
+         (_ -zero 8 24))
+      (= (fp.mul RNE x (fp #b0 #xfe #b11111111111111111111111))
+         (_ -zero 8 24))
+
+      ; Float-to-float conversion retains the zero sign exactly.
+      (= ((_ to_fp 11 53) RTP x) (_ -zero 11 53))
+      (= ((_ to_fp 5 11) RTP u) ((_ to_fp 5 11) RTZ u))
+
+      ; Fast paths must not cross their finiteness guard.
+      (fp.isNaN (fp.mul RNE x (_ +oo 8 24)))
+      (fp.isNaN (fp.mul RNE x (_ NaN 8 24)))
+      (fp.isInfinite (fp.add RNE x (_ +oo 8 24)))
+      (fp.isNaN (fp.add RNE x (_ NaN 8 24)))
+
+      ; Ordered/fp equality identify signed zeros; SMT equality and sign
+      ; classifiers distinguish their encodings.
+      (fp.eq x y)
+      (not (= x y))
+      (fp.leq x y)
+      (fp.geq x y)
+      (not (fp.lt x y))
+      (not (fp.gt x y))
+      (fp.isZero x)
+      (fp.isZero y)
+      (not (fp.isNormal x))
+      (not (fp.isSubnormal y))
+      (not (fp.isInfinite x))
+      (not (fp.isNaN y))
+
+      ; The specialized zero comparator still guards an unconstrained NaN,
+      ; and orders either infinity on the correct side of zero.
+      (=> (fp.isNaN q)
+          (and (not (fp.lt q x))
+               (not (fp.leq q x))
+               (not (fp.gt q x))
+               (not (fp.geq q x))
+               (not (fp.lt x q))
+               (not (fp.leq x q))
+               (not (fp.gt x q))
+               (not (fp.geq x q))
+               (not (fp.eq x q))))
+      (=> (and (fp.isInfinite q) (fp.isPositive q))
+          (and (fp.gt q x) (fp.lt x q)))
+      (=> (and (fp.isInfinite q) (fp.isNegative q))
+          (and (fp.lt q x) (fp.gt x q))))))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/fp-domain-native-zero-multi-query.smt2
+++ b/tests/query-files/fp-tests/fp-domain-native-zero-multi-query.smt2
@@ -1,0 +1,46 @@
+; Zero-domain assumptions are solve-local and must be recollected as the root
+; changes. Check the same push/pop sequence in batch rebuilds, the persistent
+; incremental driver, and the ordinary SymFPU encoding.
+;
+; RUN: %solver --incremental=off --bb.fp-native-arith=1 --fp-domain-simplify=1 --fp-domain-sound-zero-facts=1 --bb.fp-native-domain=1 %s | %OutputCheck --check-prefix=NATIVE %s
+; RUN: %solver --incremental=on --bb.fp-native-arith=1 --fp-domain-simplify=1 --fp-domain-sound-zero-facts=1 --bb.fp-native-domain=1 %s | %OutputCheck --check-prefix=NATIVE %s
+; RUN: %solver --incremental=off --bb.fp-native-cmp=false %s | %OutputCheck --check-prefix=SYMFPU %s
+;
+; NATIVE: ^sat
+; NATIVE: ^unsat
+; NATIVE: ^unsat
+; NATIVE: ^sat
+; SYMFPU: ^sat
+; SYMFPU: ^unsat
+; SYMFPU: ^unsat
+; SYMFPU: ^sat
+;
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(declare-fun y () (_ FloatingPoint 8 24))
+(declare-fun n () (_ FloatingPoint 8 24))
+
+(assert (fp.leq (_ +zero 8 24) x))
+(assert (fp.leq x (fp #b0 #x80 #b00000000000000000000000)))
+(assert (fp.leq (_ +zero 8 24) y))
+(assert (fp.leq y (fp #b0 #x80 #b00000000000000000000000)))
+(assert (fp.leq (_ +zero 8 24) n))
+(assert (fp.leq n (fp #b0 #x80 #b00000000000000000000000)))
+(assert (fp.eq (fp.add RNE x y) (_ +zero 8 24)))
+(check-sat)
+
+(push 1)
+(assert (not (fp.eq (fp.add RTP x n) n)))
+(check-sat)
+(pop 1)
+
+(push 1)
+(assert
+  (not
+    (fp.isZero
+      (fp.mul RTN x (fp #b1 #x80 #b00000000000000000000000)))))
+(check-sat)
+(pop 1)
+
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/fp-domain-row-bounds-association.smt2
+++ b/tests/query-files/fp-tests/fp-domain-row-bounds-association.smt2
@@ -1,0 +1,27 @@
+; RUN: %solver --fp-domain-row-bounds=1 -s %s 2>&1 | %OutputCheck --check-prefix=DOMAIN %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck --check-prefix=SYMFPU %s
+;
+; DOMAIN: 1 row-bound-rows, 0 row-bound-false
+; DOMAIN: ^sat
+; SYMFPU: ^sat
+;
+; Endpoint evaluation must preserve the source association. Although the real
+; expression algebraically cancels x and leaves the nonzero z, RNE first loses
+; the minimum subnormal in x+z; the following addition therefore cancels to
+; +0. Flattening the row into real coefficients would miss that behavior.
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(declare-fun z () (_ FloatingPoint 8 24))
+
+(define-fun one () (_ FloatingPoint 8 24)
+  (fp #b0 #x7f #b00000000000000000000000))
+(define-fun minSub () (_ FloatingPoint 8 24)
+  (fp #b0 #x00 #b00000000000000000000001))
+
+(assert (and (fp.leq one x) (fp.leq x one)))
+(assert (and (fp.leq minSub z) (fp.leq z minSub)))
+(assert
+  (fp.eq (fp.add RNE (fp.add RNE x z) (fp.neg x))
+         (_ +zero 8 24)))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/fp-domain-row-bounds-exact-endpoints.smt2
+++ b/tests/query-files/fp-tests/fp-domain-row-bounds-exact-endpoints.smt2
@@ -1,0 +1,28 @@
+; RUN: %solver --fp-domain-row-bounds=1 -s %s 2>&1 | %OutputCheck --check-prefix=DOMAIN %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck --check-prefix=SYMFPU %s
+;
+; DOMAIN: 1 row-bound-rows, 1 row-bound-false
+; DOMAIN: ^unsat
+; SYMFPU: ^unsat
+;
+; Target-format endpoints retain the rounding at each associated operation.
+; RNE rounds x+minSub back to one, after which subtracting nextOne is exactly
+; one negative ulp. The old global ULP error envelope was too loose here.
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(declare-fun z () (_ FloatingPoint 8 24))
+
+(define-fun one () (_ FloatingPoint 8 24)
+  (fp #b0 #x7f #b00000000000000000000000))
+(define-fun nextOne () (_ FloatingPoint 8 24)
+  (fp #b0 #x7f #b00000000000000000000001))
+(define-fun minSub () (_ FloatingPoint 8 24)
+  (fp #b0 #x00 #b00000000000000000000001))
+
+(assert (and (fp.leq one x) (fp.leq x one)))
+(assert (and (fp.leq minSub z) (fp.leq z minSub)))
+(assert
+  (fp.eq (fp.add RNE (fp.add RNE x z) (fp.neg nextOne))
+         (_ +zero 8 24)))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/fp-domain-row-bounds-false.smt2
+++ b/tests/query-files/fp-tests/fp-domain-row-bounds-false.smt2
@@ -1,0 +1,11 @@
+; RUN: %solver --fp-domain-row-bounds=1 -s %s 2>&1 | %OutputCheck %s
+; CHECK: row-bound-rows, 1 row-bound-false
+; CHECK: unsat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(assert (and (fp.leq (_ +zero 8 24) x)
+             (fp.leq x (fp #b0 #b10000000 #b00000000000000000000000))))
+(assert (fp.eq (fp.add RNE x
+                       (fp #b1 #b10000001 #b00000000000000000000000))
+               (_ +zero 8 24)))
+(check-sat)

--- a/tests/query-files/fp-tests/fp-domain-simplify-diff-zero.smt2
+++ b/tests/query-files/fp-tests/fp-domain-simplify-diff-zero.smt2
@@ -1,0 +1,12 @@
+; RUN: %solver --fp-domain-simplify=1 -s %s 2>&1 | %OutputCheck %s
+; CHECK: FpDomainSimplify: 2 boxed symbols, 0 interval-true, 0 interval-false, 0 classifier-false, 1 diff-zero-eq
+; CHECK: sat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(declare-fun y () (_ FloatingPoint 8 24))
+(assert (and (fp.leq (_ +zero 8 24) x)
+             (fp.leq x (fp #b0 #b10000001 #b00000000000000000000000))
+             (fp.leq (_ +zero 8 24) y)
+             (fp.leq y (fp #b0 #b10000001 #b00000000000000000000000))
+             (fp.eq (fp.add RNE x (fp.neg y)) (_ +zero 8 24))))
+(check-sat)

--- a/tests/query-files/fp-tests/fp-domain-simplify-exact-endpoints.smt2
+++ b/tests/query-files/fp-tests/fp-domain-simplify-exact-endpoints.smt2
@@ -1,0 +1,79 @@
+; Exact packed endpoint evaluation must respect target rounding rather than a
+; host nextafter/max-ULP approximation. This exercises halfway rounding,
+; directed underflow, symbolic-mode outward bounds, and signed multiplication.
+;
+; RUN: %solver --fp-domain-simplify=1 -s %s 2>&1 | %OutputCheck --check-prefix=DOMAIN %s
+; RUN: %solver %s | %OutputCheck --check-prefix=BASE %s
+; DOMAIN: FpDomainSimplify: 8 boxed symbols, [1-9][0-9]* interval-true, [1-9][0-9]* interval-false
+; DOMAIN: ^sat
+; BASE: ^sat
+;
+(set-logic QF_FP)
+(declare-fun oneVar () (_ FloatingPoint 8 24))
+(declare-fun halfUlpVar () (_ FloatingPoint 8 24))
+(declare-fun minSubVar () (_ FloatingPoint 8 24))
+(declare-fun halfVar () (_ FloatingPoint 8 24))
+(declare-fun neg () (_ FloatingPoint 8 24))
+(declare-fun pos () (_ FloatingPoint 8 24))
+(declare-fun largest () (_ FloatingPoint 8 24))
+(declare-fun two () (_ FloatingPoint 8 24))
+(declare-fun rm () RoundingMode)
+
+(define-fun one () (_ FloatingPoint 8 24)
+  (fp #b0 #x7f #b00000000000000000000000))
+(define-fun nextOne () (_ FloatingPoint 8 24)
+  (fp #b0 #x7f #b00000000000000000000001))
+(define-fun halfUlp () (_ FloatingPoint 8 24)
+  (fp #b0 #x67 #b00000000000000000000000))
+(define-fun minSub () (_ FloatingPoint 8 24)
+  (fp #b0 #x00 #b00000000000000000000001))
+(define-fun half () (_ FloatingPoint 8 24)
+  (fp #b0 #x7e #b00000000000000000000000))
+(define-fun minusEight () (_ FloatingPoint 8 24)
+  (fp #b1 #x82 #b00000000000000000000000))
+(define-fun minusThree () (_ FloatingPoint 8 24)
+  (fp #b1 #x80 #b10000000000000000000000))
+(define-fun maxFinite () (_ FloatingPoint 8 24)
+  (fp #b0 #xfe #b11111111111111111111111))
+(define-fun twoValue () (_ FloatingPoint 8 24)
+  (fp #b0 #x80 #b00000000000000000000000))
+
+; Singleton boxes make the halfway and underflow endpoints exact while still
+; exercising the interval evaluator rather than constant folding.
+(assert (and
+  (fp.leq one oneVar) (fp.leq oneVar one)
+  (fp.leq halfUlp halfUlpVar) (fp.leq halfUlpVar halfUlp)
+  (fp.leq minSub minSubVar) (fp.leq minSubVar minSub)
+  (fp.leq half halfVar) (fp.leq halfVar half)
+  (fp.leq (fp #b1 #x80 #b00000000000000000000000) neg)
+  (fp.leq neg (fp #b1 #x7f #b00000000000000000000000))
+  (fp.leq (fp #b0 #x80 #b10000000000000000000000) pos)
+  (fp.leq pos (fp #b0 #x81 #b00000000000000000000000))
+  (fp.leq maxFinite largest) (fp.leq largest maxFinite)
+  (fp.leq twoValue two) (fp.leq two twoValue)))
+
+(assert (and
+  ; 1 + 2^-24 is halfway: RNE goes to one, RNA goes to nextOne.
+  (fp.leq (fp.add RNE oneVar halfUlpVar) one)
+  (not (fp.leq (fp.add RNA oneVar halfUlpVar) one))
+  ; Any legal symbolic mode lies between RTN and RTP.
+  (fp.leq (fp.add rm oneVar halfUlpVar) nextOne)
+  (not (fp.gt (fp.add rm oneVar halfUlpVar) nextOne))
+
+  ; Half of the minimum subnormal rounds down under RNE and up under RTP.
+  (fp.leq (fp.mul RNE minSubVar halfVar) (_ +zero 8 24))
+  (not (fp.gt (fp.mul RNE minSubVar halfVar) (_ +zero 8 24)))
+  (fp.geq (fp.mul RTP minSubVar halfVar) minSub)
+  (fp.leq (fp.mul rm minSubVar halfVar) minSub)
+  (fp.geq (fp.mul rm minSubVar halfVar) (_ +zero 8 24))
+
+  ; [-2,-1] * [3,4] has exact target interval [-8,-3].
+  (fp.geq (fp.mul RNE neg pos) minusEight)
+  (fp.leq (fp.mul RNE neg pos) minusThree)
+  (not (fp.gt (fp.mul RNE neg pos) minusThree))
+
+  ; A non-finite endpoint makes the interval unknown; it must not justify
+  ; erasing this genuine overflow classification.
+  (fp.isInfinite (fp.mul RNE largest two))))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/fp-domain-simplify-interval-false.smt2
+++ b/tests/query-files/fp-tests/fp-domain-simplify-interval-false.smt2
@@ -1,0 +1,10 @@
+; RUN: %solver --fp-domain-simplify=1 -s %s 2>&1 | %OutputCheck %s
+; CHECK: FpDomainSimplify: 1 boxed symbols, 0 interval-true, 1 interval-false
+; CHECK: unsat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(assert (and (fp.leq (_ +zero 8 24) x)
+             (fp.leq x (fp #b0 #b10000001 #b00000000000000000000000))))
+(assert (fp.gt (fp.add RNE x x)
+               (fp #b0 #b10000011 #b00000000000000000000000)))
+(check-sat)

--- a/tests/query-files/fp-tests/fp-domain-simplify-interval-true.smt2
+++ b/tests/query-files/fp-tests/fp-domain-simplify-interval-true.smt2
@@ -1,0 +1,10 @@
+; RUN: %solver --fp-domain-simplify=1 -s %s 2>&1 | %OutputCheck %s
+; CHECK: FpDomainSimplify: 1 boxed symbols, 1 interval-true
+; CHECK: sat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(assert (and (fp.leq (_ +zero 8 24) x)
+             (fp.leq x (fp #b0 #b10000001 #b00000000000000000000000))))
+(assert (fp.leq (fp.add RNE x x)
+                (fp #b0 #b10000100 #b00000000000000000000000)))
+(check-sat)

--- a/tests/query-files/fp-tests/fp-domain-simplify-nonnegative-zero-sum.smt2
+++ b/tests/query-files/fp-tests/fp-domain-simplify-nonnegative-zero-sum.smt2
@@ -1,0 +1,12 @@
+; RUN: %solver --fp-domain-simplify=1 -s %s 2>&1 | %OutputCheck %s
+; CHECK: FpDomainSimplify: 2 boxed symbols, 0 interval-true, 0 interval-false, 0 classifier-false, 0 diff-zero-eq, 1 nonnegative-zero-sum
+; CHECK: sat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(declare-fun y () (_ FloatingPoint 8 24))
+(assert (and (fp.leq (_ +zero 8 24) x)
+             (fp.leq x (fp #b0 #b10000001 #b00000000000000000000000))
+             (fp.leq (_ +zero 8 24) y)
+             (fp.leq y (fp #b0 #b10000001 #b00000000000000000000000))
+             (fp.eq (fp.add RNE x y) (_ +zero 8 24))))
+(check-sat)

--- a/tests/query-files/fp-tests/fp-domain-sound-zero-facts.smt2
+++ b/tests/query-files/fp-tests/fp-domain-sound-zero-facts.smt2
@@ -1,0 +1,16 @@
+; RUN: %solver --fp-domain-sound-zero-facts=1 -s %s 2>&1 | %OutputCheck %s
+; CHECK: FpDomainSimplify: 3 boxed symbols, 0 interval-true, 0 interval-false, 0 classifier-false, 1 diff-zero-eq, 1 nonnegative-zero-sum, 2 sound-zero-rows, 3 sound-zero-facts
+; CHECK: sat
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(declare-fun y () (_ FloatingPoint 8 24))
+(declare-fun z () (_ FloatingPoint 8 24))
+(assert (and (fp.leq (_ +zero 8 24) x)
+             (fp.leq x (fp #b0 #b10000001 #b00000000000000000000000))
+             (fp.leq (_ +zero 8 24) y)
+             (fp.leq y (fp #b0 #b10000001 #b00000000000000000000000))
+             (fp.leq (_ +zero 8 24) z)
+             (fp.leq z (fp #b0 #b10000001 #b00000000000000000000000))
+             (fp.eq (fp.add RNE x y) (_ +zero 8 24))
+             (fp.eq (fp.add RNE z (fp.neg y)) (_ +zero 8 24))))
+(check-sat)

--- a/tests/query-files/fp-tests/fp-domain-zero-facts-association.smt2
+++ b/tests/query-files/fp-tests/fp-domain-zero-facts-association.smt2
@@ -1,0 +1,32 @@
+; RUN: %solver --fp-domain-sound-zero-facts=1 -s %s 2>&1 | %OutputCheck --check-prefix=DOMAIN %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck --check-prefix=SYMFPU %s
+;
+; DOMAIN: 2 sound-zero-rows, 0 sound-zero-facts
+; DOMAIN: ^sat
+; SYMFPU: ^sat
+;
+; Equal/opposite terms may not be algebraically cancelled through a rounded
+; FP row. Here x = y = 1 and z is the minimum subnormal. RNE loses z in
+; x + z, so (x + z) - y is zero even though z is nonzero. The old inference
+; cancelled x/y and unsoundly emitted magnitude(z) = 0.
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(declare-fun y () (_ FloatingPoint 8 24))
+(declare-fun z () (_ FloatingPoint 8 24))
+
+(assert (fp.leq (_ +zero 8 24) x))
+(assert (fp.leq x (fp #b0 #x80 #b00000000000000000000000)))
+(assert (fp.leq (_ +zero 8 24) y))
+(assert (fp.leq y (fp #b0 #x80 #b00000000000000000000000)))
+(assert (fp.leq (_ +zero 8 24) z))
+(assert (fp.leq z (fp #b0 #x80 #b00000000000000000000000)))
+
+(assert (= x (fp #b0 #x7f #b00000000000000000000000)))
+(assert (= y (fp #b0 #x7f #b00000000000000000000000)))
+(assert (= z (fp #b0 #x00 #b00000000000000000000001)))
+(assert (fp.eq (fp.add RNE x (fp.neg y)) (_ +zero 8 24)))
+(assert
+  (fp.eq (fp.add RNE (fp.add RNE x z) (fp.neg y)) (_ +zero 8 24)))
+(assert (not (fp.isZero z)))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/fp-domain-zero-facts-underflow.smt2
+++ b/tests/query-files/fp-tests/fp-domain-zero-facts-underflow.smt2
@@ -1,0 +1,19 @@
+; RUN: %solver --bb.fp-native-arith=1 --fp-domain-sound-zero-facts=1 --bb.fp-native-domain=1 -s %s 2>&1 | %OutputCheck --check-prefix=NATIVE %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck --check-prefix=SYMFPU %s
+;
+; NATIVE: 0 sound-zero-rows, 0 sound-zero-facts
+; NATIVE: ^sat
+; SYMFPU: ^sat
+;
+; A zero rounded product does not imply a zero input. Half of the minimum
+; subnormal is the RNE tie between zero and that subnormal, and ties-to-even
+; selects zero while x itself remains nonzero.
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 8 24))
+(assert (= x (fp #b0 #x00 #b00000000000000000000001)))
+(assert
+  (fp.isZero
+    (fp.mul RNE x (fp #b0 #x7e #b00000000000000000000000))))
+(assert (not (fp.isZero x)))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/fp-native-add-iszero.smt2
+++ b/tests/query-files/fp-tests/fp-native-add-iszero.smt2
@@ -1,0 +1,32 @@
+; A binary-format addition can round to zero only when its finite operands
+; have an exact real sum of zero. Exhaust the small (3,4) format and all five
+; rounding modes by asking for a disagreement with that packed-value law.
+;
+; RUN: %solver --disable-equality --unconstrained-variable-elimination=0 --bb.fp-native-arith=1 --bb.fp-native-add-iszero=1 -s %s 2>&1 | %OutputCheck --check-prefix=FUSED %s
+; RUN: %solver --disable-equality --unconstrained-variable-elimination=0 --bb.fp-native-arith=1 --bb.fp-native-add-iszero=0 %s | %OutputCheck --check-prefix=RESULT %s
+; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck --check-prefix=RESULT %s
+;
+; FUSED: FP native add-isZero fused predicates: 1
+; FUSED: ^unsat
+; RESULT: ^unsat
+;
+(set-logic QF_FP)
+(declare-fun rm () RoundingMode)
+(declare-fun a () (_ FloatingPoint 3 4))
+(declare-fun b () (_ FloatingPoint 3 4))
+
+(define-fun finite ((x (_ FloatingPoint 3 4))) Bool
+  (and (not (fp.isNaN x)) (not (fp.isInfinite x))))
+
+(define-fun exact-zero-sum ((x (_ FloatingPoint 3 4))
+                            (y (_ FloatingPoint 3 4))) Bool
+  (and (finite x) (finite y)
+       (or (and (fp.isZero x) (fp.isZero y))
+           (and (not (fp.isZero x)) (not (fp.isZero y))
+                (not (= (fp.isNegative x) (fp.isNegative y)))
+                (fp.eq (fp.abs x) (fp.abs y))))))
+
+(assert (not (= (fp.isZero (fp.add rm a b))
+                (exact-zero-sum a b))))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/native-arith-symfpu-equivalence.smt2
+++ b/tests/query-files/fp-tests/native-arith-symfpu-equivalence.smt2
@@ -1,0 +1,41 @@
+; Compare the native add and multiply circuits with independent SymFPU
+; encodings over every value of (3,4) and every rounding mode. FMA by a
+; symbolic value constrained to 1 expresses addition without being rewritten
+; to fp.add. The inner FMA with -0 similarly keeps the multiplication oracle
+; off the native packed path. Structural equality detects signed-zero
+; disagreements; NaN payloads are deliberately ignored.
+;
+; RUN: %solver --disable-equality --unconstrained-variable-elimination=0 --bb.fp-native-arith=true -s %s 2>&1 | %OutputCheck %s
+;
+; CHECK: FloatBlast: 3 SymFPU operations, 6 unpacks
+; CHECK: ^unsat
+;
+(set-logic QF_FP)
+(declare-fun a () (_ FloatingPoint 3 4))
+(declare-fun b () (_ FloatingPoint 3 4))
+(declare-fun unit () (_ FloatingPoint 3 4))
+(declare-fun minus-zero () (_ FloatingPoint 3 4))
+(declare-fun rm () RoundingMode)
+(declare-fun native-add () (_ FloatingPoint 3 4))
+(declare-fun oracle-add () (_ FloatingPoint 3 4))
+(declare-fun native-mul () (_ FloatingPoint 3 4))
+(declare-fun oracle-mul () (_ FloatingPoint 3 4))
+(define-fun one () (_ FloatingPoint 3 4) (fp #b0 #b011 #b000))
+
+(assert (fp.leq one unit))
+(assert (fp.leq unit one))
+(assert (fp.isZero minus-zero))
+(assert (fp.isNegative minus-zero))
+(assert (= native-add (fp.add rm a b)))
+(assert (= oracle-add (fp.fma rm a unit b)))
+(assert (= native-mul (fp.mul rm a b)))
+(assert (= oracle-mul
+           (fp.mul rm (fp.fma RNE a unit minus-zero) b)))
+(assert
+  (or
+    (not (or (= native-add oracle-add)
+             (and (fp.isNaN native-add) (fp.isNaN oracle-add))))
+    (not (or (= native-mul oracle-mul)
+             (and (fp.isNaN native-mul) (fp.isNaN oracle-mul))))))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/native-arith-wide-exponent-fallback.smt2
+++ b/tests/query-files/fp-tests/native-arith-wide-exponent-fallback.smt2
@@ -1,0 +1,26 @@
+; Native arithmetic currently forms exponent bounds in a host unsigned. A
+; legal format wider than that representation must stay on the SymFPU path.
+; The two operands are numerically 1, so both results below are finite; the
+; old unchecked native path incorrectly made this formula unsatisfiable.
+;
+; RUN: %solver --bb.fp-native-arith=true -s %s 2>&1 | %OutputCheck %s
+;
+; CHECK: FloatBlast: 2 SymFPU operations, 2 unpacks
+; CHECK: ^sat
+;
+(set-logic QF_FP)
+(declare-fun a () (_ FloatingPoint 33 2))
+(declare-fun b () (_ FloatingPoint 33 2))
+(define-fun one () (_ FloatingPoint 33 2)
+  (fp #b0 #b011111111111111111111111111111111 #b0))
+
+(assert (fp.leq one a))
+(assert (fp.leq a one))
+(assert (fp.leq one b))
+(assert (fp.leq b one))
+(assert (not (fp.isInfinite (fp.add RNE a b))))
+(assert (not (fp.isNaN (fp.add RNE a b))))
+(assert (not (fp.isInfinite (fp.mul RNE a b))))
+(assert (not (fp.isNaN (fp.mul RNE a b))))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/native-tofp-symfpu-equivalence.smt2
+++ b/tests/query-files/fp-tests/native-tofp-symfpu-equivalence.smt2
@@ -1,0 +1,32 @@
+; Compare the native (3,5)-to-(4,3) conversion with SymFPU for every source
+; value and rounding mode. The exact FMA wrapper preserves the source value
+; while preventing the oracle conversion from entering the native packed
+; path. Structural equality detects signed-zero disagreements; NaN payloads
+; are deliberately ignored.
+;
+; RUN: %solver --disable-equality --unconstrained-variable-elimination=0 --bb.fp-native-arith=true -s %s 2>&1 | %OutputCheck %s
+;
+; CHECK: FloatBlast: 2 SymFPU operations, 4 unpacks
+; CHECK: ^unsat
+;
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 3 5))
+(declare-fun unit () (_ FloatingPoint 3 5))
+(declare-fun minus-zero () (_ FloatingPoint 3 5))
+(declare-fun rm () RoundingMode)
+(declare-fun native () (_ FloatingPoint 4 3))
+(declare-fun oracle () (_ FloatingPoint 4 3))
+(define-fun one () (_ FloatingPoint 3 5) (fp #b0 #b011 #b0000))
+
+(assert (fp.leq one unit))
+(assert (fp.leq unit one))
+(assert (fp.isZero minus-zero))
+(assert (fp.isNegative minus-zero))
+(assert (= native ((_ to_fp 4 3) rm x)))
+(assert (= oracle
+           ((_ to_fp 4 3) rm (fp.fma RNE x unit minus-zero))))
+(assert
+  (not (or (= native oracle)
+           (and (fp.isNaN native) (fp.isNaN oracle)))))
+(check-sat)
+(exit)

--- a/tests/query-files/fp-tests/native-tofp-wide-exponent-fallback.smt2
+++ b/tests/query-files/fp-tests/native-tofp-wide-exponent-fallback.smt2
@@ -1,0 +1,29 @@
+; Both the source and target exponent widths participate in the native
+; float-to-float exponent envelope. Exercise each unsafe side and require the
+; conversions to fall back to SymFPU while preserving the exact value 1.
+;
+; RUN: %solver --disable-equality --unconstrained-variable-elimination=0 --bb.fp-native-arith=true -s %s 2>&1 | %OutputCheck %s
+;
+; CHECK: FloatBlast: 2 SymFPU operations
+; CHECK: ^sat
+;
+(set-logic QF_FP)
+(declare-fun wide () (_ FloatingPoint 33 2))
+(declare-fun single () (_ FloatingPoint 8 24))
+(declare-fun narrowed () (_ FloatingPoint 8 24))
+(declare-fun widened () (_ FloatingPoint 33 2))
+(define-fun one-wide () (_ FloatingPoint 33 2)
+  (fp #b0 #b011111111111111111111111111111111 #b0))
+(define-fun one-single () (_ FloatingPoint 8 24)
+  (fp #b0 #b01111111 #b00000000000000000000000))
+
+(assert (fp.leq one-wide wide))
+(assert (fp.leq wide one-wide))
+(assert (fp.leq one-single single))
+(assert (fp.leq single one-single))
+(assert (= narrowed ((_ to_fp 8 24) RNE wide)))
+(assert (= widened ((_ to_fp 33 2) RNE single)))
+(assert (fp.eq narrowed one-single))
+(assert (fp.eq widened one-wide))
+(check-sat)
+(exit)

--- a/tests/query-files/misc-tests/cadical-statistics.smt2
+++ b/tests/query-files/misc-tests/cadical-statistics.smt2
@@ -1,0 +1,22 @@
+; REQUIRES: cadical-inprobing
+; RUN: %solver --cadical -s %s 2>&1 | %OutputCheck %s
+; CHECK: CaDiCaL conflicts: {{[0-9]+}}
+; CHECK: CaDiCaL decisions: {{[0-9]+}}
+; CHECK: CaDiCaL search propagations: {{[0-9]+}}
+; CHECK: CaDiCaL search ticks: {{[0-9]+}}
+; CHECK-NOT: print stats not yet implemented
+; CHECK: ^sat
+; Keep enough coupled structure to reach the SAT backend instead of being
+; discharged by unconstrained-variable elimination.
+(set-logic QF_FP)
+(declare-const x (_ FloatingPoint 8 24))
+(declare-const y (_ FloatingPoint 8 24))
+(define-fun one () (_ FloatingPoint 8 24)
+  ((_ to_fp 8 24) #x3f800000))
+(assert (fp.lt one x))
+(assert (fp.lt one y))
+(assert (not (fp.isInfinite x)))
+(assert (not (fp.isInfinite y)))
+(assert (fp.gt (fp.mul RNE x y) x))
+(assert (fp.gt (fp.mul RNE x y) y))
+(check-sat)

--- a/tests/query-files/misc-tests/cadical-statistics.smt2
+++ b/tests/query-files/misc-tests/cadical-statistics.smt2
@@ -1,9 +1,9 @@
 ; REQUIRES: cadical-inprobing
 ; RUN: %solver --cadical -s %s 2>&1 | %OutputCheck %s
-; CHECK: CaDiCaL conflicts: {{[0-9]+}}
-; CHECK: CaDiCaL decisions: {{[0-9]+}}
-; CHECK: CaDiCaL search propagations: {{[0-9]+}}
-; CHECK: CaDiCaL search ticks: {{[0-9]+}}
+; CHECK: CaDiCaL conflicts: [0-9]+
+; CHECK: CaDiCaL decisions: [0-9]+
+; CHECK: CaDiCaL search propagations: [0-9]+
+; CHECK: CaDiCaL search ticks: [0-9]+
 ; CHECK-NOT: print stats not yet implemented
 ; CHECK: ^sat
 ; Keep enough coupled structure to reach the SAT backend instead of being

--- a/tests/query-files/misc-tests/minisat-statistics.smt2
+++ b/tests/query-files/misc-tests/minisat-statistics.smt2
@@ -1,17 +1,17 @@
 ; REQUIRES: minisat
 ; RUN: %solver --minisat -s %s 2>&1 | %OutputCheck --check-prefix=STATS %s
 ; RUN: %solver --simplifying-minisat -s %s 2>&1 | %OutputCheck --check-prefix=STATS %s
-; STATS: MiniSat starts: {{[0-9]+}}
-; STATS: MiniSat conflicts: {{[0-9]+}}
-; STATS: MiniSat decisions: {{[0-9]+}}
-; STATS: MiniSat propagations: {{[0-9]+}}
-; STATS: MiniSat variables: {{[0-9]+}}
-; STATS: MiniSat active original clauses: {{[0-9]+}}
-; STATS: MiniSat active original literals: {{[0-9]+}}
-; STATS: MiniSat active learnt clauses: {{[0-9]+}}
-; STATS: MiniSat active learnt literals: {{[0-9]+}}
-; STATS: MiniSat learnt literals before minimization: {{[0-9]+}}
-; STATS: MiniSat learnt literals after minimization: {{[0-9]+}}
+; STATS: MiniSat starts: [0-9]+
+; STATS: MiniSat conflicts: [0-9]+
+; STATS: MiniSat decisions: [0-9]+
+; STATS: MiniSat propagations: [0-9]+
+; STATS: MiniSat variables: [0-9]+
+; STATS: MiniSat active original clauses: [0-9]+
+; STATS: MiniSat active original literals: [0-9]+
+; STATS: MiniSat active learnt clauses: [0-9]+
+; STATS: MiniSat active learnt literals: [0-9]+
+; STATS: MiniSat learnt literals before minimization: [0-9]+
+; STATS: MiniSat learnt literals after minimization: [0-9]+
 ; STATS: ^sat
 ; Keep enough coupled structure to reach the SAT backend instead of being
 ; discharged by unconstrained-variable elimination.

--- a/tests/query-files/misc-tests/minisat-statistics.smt2
+++ b/tests/query-files/misc-tests/minisat-statistics.smt2
@@ -1,0 +1,29 @@
+; REQUIRES: minisat
+; RUN: %solver --minisat -s %s 2>&1 | %OutputCheck --check-prefix=STATS %s
+; RUN: %solver --simplifying-minisat -s %s 2>&1 | %OutputCheck --check-prefix=STATS %s
+; STATS: MiniSat starts: {{[0-9]+}}
+; STATS: MiniSat conflicts: {{[0-9]+}}
+; STATS: MiniSat decisions: {{[0-9]+}}
+; STATS: MiniSat propagations: {{[0-9]+}}
+; STATS: MiniSat variables: {{[0-9]+}}
+; STATS: MiniSat active original clauses: {{[0-9]+}}
+; STATS: MiniSat active original literals: {{[0-9]+}}
+; STATS: MiniSat active learnt clauses: {{[0-9]+}}
+; STATS: MiniSat active learnt literals: {{[0-9]+}}
+; STATS: MiniSat learnt literals before minimization: {{[0-9]+}}
+; STATS: MiniSat learnt literals after minimization: {{[0-9]+}}
+; STATS: ^sat
+; Keep enough coupled structure to reach the SAT backend instead of being
+; discharged by unconstrained-variable elimination.
+(set-logic QF_FP)
+(declare-const x (_ FloatingPoint 8 24))
+(declare-const y (_ FloatingPoint 8 24))
+(define-fun one () (_ FloatingPoint 8 24)
+  ((_ to_fp 8 24) #x3f800000))
+(assert (fp.lt one x))
+(assert (fp.lt one y))
+(assert (not (fp.isInfinite x)))
+(assert (not (fp.isInfinite y)))
+(assert (fp.gt (fp.mul RNE x y) x))
+(assert (fp.gt (fp.mul RNE x y) y))
+(check-sat)

--- a/tests/unit-tests/DecimalToFP_Test.cpp
+++ b/tests/unit-tests/DecimalToFP_Test.cpp
@@ -64,6 +64,17 @@ std::string bitsOfU64(uint64_t v, unsigned width)
   return s;
 }
 
+std::string binary(const std::string& left, const std::string& right,
+                   unsigned eb, unsigned sb, unsigned rm,
+                   PackedFpBinaryOp operation)
+{
+  std::string bits, err;
+  const bool ok = packedFPBinaryOp(left, right, eb, sb, rm, operation, bits,
+                                   err);
+  EXPECT_TRUE(ok) << "(" << eb << "," << sb << "): " << err;
+  return ok ? bits : "";
+}
+
 std::string hostFloatBits(const std::string& dec)
 {
   const float f = strtof(dec.c_str(), nullptr);
@@ -376,6 +387,107 @@ TEST(DecimalToFP, unsupportedExponentWidths)
   EXPECT_FALSE(decimalToPackedFPBits("1.5", 62, 8,
                                      ROUND_NEAREST_TIES_TO_EVEN, bits, err));
   EXPECT_NE(err.find("exponent widths"), std::string::npos) << err;
+}
+
+TEST(PackedFpBinaryOp, exactArithmeticAndCancellation)
+{
+  const std::string one = bitsOfU64(0x3c00, 16);
+  const std::string onePointFive = bitsOfU64(0x3e00, 16);
+  const std::string two = bitsOfU64(0x4000, 16);
+
+  EXPECT_EQ(binary(onePointFive, two, 5, 11, ROUND_NEAREST_TIES_TO_EVEN,
+                   PackedFpBinaryOp::Add),
+            bitsOfU64(0x4300, 16)); // 3.5
+  EXPECT_EQ(binary(two, onePointFive, 5, 11,
+                   ROUND_NEAREST_TIES_TO_EVEN,
+                   PackedFpBinaryOp::Subtract),
+            bitsOfU64(0x3800, 16)); // 0.5
+  EXPECT_EQ(binary(onePointFive, two, 5, 11,
+                   ROUND_NEAREST_TIES_TO_EVEN,
+                   PackedFpBinaryOp::Multiply),
+            bitsOfU64(0x4200, 16)); // 3.0
+
+  EXPECT_EQ(binary(one, one, 5, 11, ROUND_NEAREST_TIES_TO_EVEN,
+                   PackedFpBinaryOp::Subtract),
+            bitsOfU64(0x0000, 16));
+  EXPECT_EQ(binary(one, one, 5, 11, ROUND_TOWARD_NEGATIVE,
+                   PackedFpBinaryOp::Subtract),
+            bitsOfU64(0x8000, 16));
+}
+
+TEST(PackedFpBinaryOp, underflowUsesTheRequestedRoundingMode)
+{
+  const std::string minSub = bitsOfU64(0x0001, 16);
+  const std::string minusMinSub = bitsOfU64(0x8001, 16);
+  const std::string half = bitsOfU64(0x3800, 16);
+
+  EXPECT_EQ(binary(minSub, half, 5, 11, ROUND_NEAREST_TIES_TO_EVEN,
+                   PackedFpBinaryOp::Multiply),
+            bitsOfU64(0x0000, 16));
+  EXPECT_EQ(binary(minSub, half, 5, 11, ROUND_NEAREST_TIES_TO_AWAY,
+                   PackedFpBinaryOp::Multiply),
+            minSub);
+  EXPECT_EQ(binary(minSub, half, 5, 11, ROUND_TOWARD_POSITIVE,
+                   PackedFpBinaryOp::Multiply),
+            minSub);
+  EXPECT_EQ(binary(minusMinSub, half, 5, 11, ROUND_TOWARD_POSITIVE,
+                   PackedFpBinaryOp::Multiply),
+            bitsOfU64(0x8000, 16));
+  EXPECT_EQ(binary(minusMinSub, half, 5, 11, ROUND_TOWARD_NEGATIVE,
+                   PackedFpBinaryOp::Multiply),
+            minusMinSub);
+}
+
+TEST(PackedFpBinaryOp, overflowUsesTheRequestedRoundingMode)
+{
+  const std::string maxFinite = bitsOfU64(0x7bff, 16);
+  const std::string two = bitsOfU64(0x4000, 16);
+  EXPECT_EQ(binary(maxFinite, two, 5, 11, ROUND_NEAREST_TIES_TO_EVEN,
+                   PackedFpBinaryOp::Multiply),
+            bitsOfU64(0x7c00, 16));
+  EXPECT_EQ(binary(maxFinite, two, 5, 11, ROUND_TOWARD_POSITIVE,
+                   PackedFpBinaryOp::Multiply),
+            bitsOfU64(0x7c00, 16));
+  EXPECT_EQ(binary(maxFinite, two, 5, 11, ROUND_TOWARD_NEGATIVE,
+                   PackedFpBinaryOp::Multiply),
+            maxFinite);
+  EXPECT_EQ(binary(maxFinite, two, 5, 11, ROUND_TOWARD_ZERO,
+                   PackedFpBinaryOp::Multiply),
+            maxFinite);
+}
+
+TEST(PackedFpBinaryOp, signedZerosArePreserved)
+{
+  const std::string minusZero = bitsOfU64(0x8000, 16);
+  const std::string two = bitsOfU64(0x4000, 16);
+  const std::string minusTwo = bitsOfU64(0xc000, 16);
+  EXPECT_EQ(binary(minusZero, two, 5, 11, ROUND_NEAREST_TIES_TO_EVEN,
+                   PackedFpBinaryOp::Multiply),
+            minusZero);
+  EXPECT_EQ(binary(minusZero, minusTwo, 5, 11,
+                   ROUND_NEAREST_TIES_TO_EVEN,
+                   PackedFpBinaryOp::Multiply),
+            bitsOfU64(0x0000, 16));
+}
+
+TEST(PackedFpBinaryOp, rejectsMalformedAndNonfiniteInputs)
+{
+  const std::string one = bitsOfU64(0x3c00, 16);
+  std::string bits, err;
+  EXPECT_FALSE(packedFPBinaryOp(bitsOfU64(0x7c00, 16), one, 5, 11,
+                                ROUND_NEAREST_TIES_TO_EVEN,
+                                PackedFpBinaryOp::Add, bits, err));
+  EXPECT_NE(err.find("finite operands"), std::string::npos) << err;
+  err.clear();
+  EXPECT_FALSE(packedFPBinaryOp("000000000000000x", one, 5, 11,
+                                ROUND_NEAREST_TIES_TO_EVEN,
+                                PackedFpBinaryOp::Add, bits, err));
+  EXPECT_NE(err.find("non-bit"), std::string::npos) << err;
+  err.clear();
+  EXPECT_FALSE(packedFPBinaryOp("0", one, 5, 11,
+                                ROUND_NEAREST_TIES_TO_EVEN,
+                                PackedFpBinaryOp::Add, bits, err));
+  EXPECT_NE(err.find("wrong width"), std::string::npos) << err;
 }
 
 } // namespace

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -408,6 +408,38 @@ void ExtraMain::create_options()
            "requires --bb.fp-native-arith)",
            bb_group);
 
+  bool_arg("--bb.fp-native-domain", bm->UserFlags.fp_native_domain,
+           "Experimental native FP bit-blaster strengthening: mine simple "
+           "finite box bounds and omit NaN/infinity cases that are impossible "
+           "under those top-level facts",
+           bb_group);
+
+  bool_arg("--bb.fp-native-known-sign",
+           bm->UserFlags.fp_native_known_sign,
+           "Use finite semantic-sign facts in native fp.add/fp.mul to omit "
+           "opposite-sign/sign-dependent circuitry while preserving signed "
+           "zero (experimental; requires --bb.fp-native-domain)",
+           bb_group);
+
+  bool_arg("--fp-domain-simplify", bm->UserFlags.fp_domain_simplify,
+           "Experimental FP prepass: mine boxed variable bounds, use boxed FP "
+           "domain facts, and discharge ordered FP "
+           "comparisons or zero-sum rows decided by those facts",
+           bb_group);
+
+  bool_arg("--fp-domain-sound-zero-facts",
+           bm->UserFlags.fp_domain_sound_zero_facts,
+           "Experimental FP prepass: derive sound zero facts from "
+           "association-safe same-sign boxed +/-1 rows and encode them as "
+           "zero magnitude bits, preserving the +0/-0 distinction",
+           bb_group);
+
+  bool_arg("--fp-domain-row-bounds", bm->UserFlags.fp_domain_row_bounds,
+           "Experimental FP prepass: recognise linear FP zero rows and "
+           "rewrite them to false when association-preserving target-format "
+           "interval endpoints exclude zero",
+           bb_group);
+
   bool_arg("--bb.simplify-during-bb", bm->UserFlags.simplify_during_BB_flag,
            "When bit-blasting discovers that a non-constant child of a term "
            "blasts to an all-constant vector, rebuild the term with that "

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -401,6 +401,13 @@ void ExtraMain::create_options()
            "SymFPU unpacking circuits (experimental)",
            bb_group);
 
+  bool_arg("--bb.fp-native-add-iszero",
+           bm->UserFlags.fp_native_add_iszero,
+           "Encode fp.isZero(fp.add ...) directly from the packed operands "
+           "without constructing the complete rounded sum (experimental; "
+           "requires --bb.fp-native-arith)",
+           bb_group);
+
   bool_arg("--bb.simplify-during-bb", bm->UserFlags.simplify_during_BB_flag,
            "When bit-blasting discovers that a non-constant child of a term "
            "blasts to an all-constant vector, rebuild the term with that "


### PR DESCRIPTION
## Summary

- add an experimental FP-domain prepass for boxed finite bounds and decided comparisons
- propagate sound row-derived zero-magnitude facts into native FP lowering
- use proven finiteness and semantic sign to omit unreachable NaN/infinity and opposite-sign circuitry
- preserve an explicit signed-zero choice in sign-specialized add/multiply lowering
- evaluate linear-row interval endpoints in target format while preserving the original association order
- add native-domain counters and focused differential regressions

All new behavior is off by default behind these flags:

- `--fp-domain-simplify`
- `--fp-domain-sound-zero-facts`
- `--fp-domain-row-bounds`
- `--bb.fp-native-domain`
- `--bb.fp-native-known-sign`

## Soundness boundary

The prepass derives zero facts only from association-safe, same-sign boxed rows with coefficients `+1` or `-1`. Those facts constrain magnitude bits only, retaining the distinction between `+0` and `-0`. Native lowering omits special-value paths only when top-level facts prove finiteness, and known-sign arithmetic retains explicit handling for IEEE signed-zero results. Interval endpoints are rounded after each source operation in the target format, so reassociation or excess intermediate precision cannot manufacture a proof.

The earlier canonical-zero and reassociated linear-row experiments are not part of this PR.

## Testing

- `cmake --build build -j24`
- exhaustive `(3, 5)` known-sign differential checks against ordinary SymFPU for every rounding mode
- focused signed-zero, cancellation, underflow, NaN/infinity, product-zero-witness, association, exact-endpoint, and multi-query regressions
- all 649 supported query tests passed (six existing unsupported tests skipped)
- all 140 compiled/API/unit tests passed

## Measurements

For the core sound zero-fact/domain stack:

| Workload | Metric | Control | Domain stack | Change |
| --- | ---: | ---: | ---: | ---: |
| Shewanella compact2 FP8/24 | AIG nodes | 12,744,148 | 10,006,050 | -21.5% |
| Shewanella compact2 FP8/24 | median CNF generation | 27.76 s | 21.98 s | -20.8% |
| E. coli | AIG nodes | 20,058,854 | 16,930,469 | -15.6% |
| E. coli | median CNF generation | 51.47 s | 42.12 s | -18.2% |

Known-sign lowering further reduced the Shewanella AIG from 10,006,050 to 9,815,741 nodes (-1.90%), but repeated timing distributions overlapped. Neither configuration solved these workloads within the 75-second search budget, so this PR deliberately makes no solver-runtime claim and leaves every optimization disabled by default.

## Stack

This is PR 5 of 5 and depends on #964 (after #963, #962, and #961).

GitHub cannot use the fork-only predecessor branch as the base of an `stp/stp` PR, so the displayed diff is cumulative until the preceding PRs merge. The intended layer-only diff is [fp-pr-04-add-iszero...fp-pr-05-native-domain-sign](https://github.com/aytey/stp/compare/fp-pr-04-add-iszero...fp-pr-05-native-domain-sign).
