### PR TITLE
Enable add-isZero fusion with native FP arithmetic

### DIFF
--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -401,8 +401,8 @@ public:
 
   // Recognise fp.isZero(fp.add ...) and encode the observed zero-result
   // condition directly instead of constructing and packing every result bit.
-  // Experimental; requires native arithmetic and is off by default.
-  bool fp_native_add_iszero = false;
+  // Enabled by default, but only active when native arithmetic is selected.
+  bool fp_native_add_iszero = true;
 
   // Experimental strengthening for the native FP bit-blaster: mine simple
   // top-level finite box bounds and use them to omit NaN/infinity cases from

--- a/tests/query-files/fp-tests/fp-native-add-iszero.smt2
+++ b/tests/query-files/fp-tests/fp-native-add-iszero.smt2
@@ -2,7 +2,7 @@
 ; have an exact real sum of zero. Exhaust the small (3,4) format and all five
 ; rounding modes by asking for a disagreement with that packed-value law.
 ;
-; RUN: %solver --disable-equality --unconstrained-variable-elimination=0 --bb.fp-native-arith=1 --bb.fp-native-add-iszero=1 -s %s 2>&1 | %OutputCheck --check-prefix=FUSED %s
+; RUN: %solver --disable-equality --unconstrained-variable-elimination=0 --bb.fp-native-arith=1 -s %s 2>&1 | %OutputCheck --check-prefix=FUSED %s
 ; RUN: %solver --disable-equality --unconstrained-variable-elimination=0 --bb.fp-native-arith=1 --bb.fp-native-add-iszero=0 %s | %OutputCheck --check-prefix=RESULT %s
 ; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck --check-prefix=RESULT %s
 ;

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -473,8 +473,8 @@ void ExtraMain::create_options()
   bool_arg("--bb.fp-native-add-iszero",
            bm->UserFlags.fp_native_add_iszero,
            "Encode fp.isZero(fp.add ...) directly from the packed operands "
-           "without constructing the complete rounded sum (experimental; "
-           "requires --bb.fp-native-arith)",
+           "without constructing the complete rounded sum (enabled by "
+           "default; requires --bb.fp-native-arith)",
            bb_group);
 
   bool_arg("--bb.fp-native-domain", bm->UserFlags.fp_native_domain,


### PR DESCRIPTION
## Summary

- enable the existing `fp.isZero(fp.add ...)` packed-operand fusion by default whenever experimental native FP arithmetic is selected;
- retain `--bb.fp-native-add-iszero=0` as an explicit opt-out;
- make the focused regression exercise both the new default and the opt-out.

No circuit implementation changes in this PR.

## Soundness

The fused predicate is the already-reviewed implementation from #964. It tests the exact finite zero-sum condition over packed operands and does not construct or observe a rounded result. This preserves NaN/infinity behavior, underflow, every rounding mode, and both signed-zero encodings. The path is gated by `--bb.fp-native-arith`; with native arithmetic disabled, the default-on flag is dormant.

## Verification

- `cmake --build build -j24`
- MiniSat and integrated CaDiCaL builds
- exhaustive FP(3,4) add-zero equivalence test in default-fused, explicit-off native, and SymFPU modes under both backends: all `unsat`
- 26 native-arithmetic query files / 29 verdicts: zero differences among default-fused, explicit-off native, and SymFPU

## Post-merge qualification

The 144-file SyntheticFBA corpus was measured with domain/sign specialization disabled, isolating this fusion on top of generic native arithmetic.

- coverage: exactly 36 `pin_exact` files fuse; the other 108 have zero eligible predicates
- across those 36 files: AIG nodes -19.98%, variables -19.69%, clauses -19.40%, literals -19.55%
- three alternating MiniSat 5,000-conflict passes: median whole wall improves on 35/36 files; aggregate median wall -16.30%, mean peak RSS -19.73%
- three alternating integrated-CaDiCaL 15-second whole-query passes over an adversarial 18-case precision/size/seed sample: no solve-rate difference, median RSS -17.86%, aggregate search ticks +39.45%, conflicts +8.64%; 15/18 cases receive more search ticks

The CaDiCaL sample deliberately includes the sole MiniSat wall regression and the largest MiniSat decision/propagation trajectory changes.
