### PR TITLE
Enable native FP domain lowering by default

### DIFF
--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -418,10 +418,11 @@ public:
   // Enabled by default, but only active when native arithmetic is selected.
   bool fp_native_add_iszero = true;
 
-  // Experimental strengthening for the native FP bit-blaster: mine simple
-  // top-level finite box bounds and use them to omit NaN/infinity cases from
-  // native packed-field circuits when those cases are already impossible.
-  bool fp_native_domain = false;
+  // Mine simple top-level finite box bounds and use them to omit NaN/infinity
+  // cases from native packed-field circuits when those cases are already
+  // impossible. This does not enable the separate domain prepass or its
+  // known-sign arithmetic specialization.
+  bool fp_native_domain = true;
 
   // Experimental native-domain arithmetic specialization. A known finite
   // semantic sign removes fp.add's opposite-sign cancellation datapath and

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -4851,46 +4851,57 @@ bool BitBlaster::fpNativeMagnitudeZeroPredicate(const ASTNode& n,
 
 void BitBlaster::collectFpNativeDomainBounds(const ASTNode& n)
 {
-  if (n.GetKind() == AND)
+  // Bounds are useful only when they occur in the top-level conjunction.
+  // Walk that conjunction explicitly: native-domain collection is enabled
+  // for every query, including deep formulas with no floating-point terms.
+  // Recursing down a long AND spine would therefore reintroduce a stack limit
+  // into the otherwise stack-safe bit-blaster.
+  ASTVec pending(1, n);
+  while (!pending.empty())
   {
-    for (const ASTNode& child : n)
-      collectFpNativeDomainBounds(child);
-    return;
-  }
-
-  ASTNode zeroSymbol;
-  if (fpNativeMagnitudeZeroPredicate(n, zeroSymbol))
-  {
-    fpNativeZeroMagnitudeFacts.insert(zeroSymbol);
-    fpNativeZeroMagnitudeTerms.insert(zeroSymbol);
-    fpNativeFiniteTerms.insert(zeroSymbol);
-  }
-
-  ASTNode symbol;
-  ASTNode constant;
-  long double value = 0.0L;
-  bool lowerBound = false;
-  if (!fpNativeBoundPredicate(n, symbol, constant, value, lowerBound))
-    return;
-
-  FpNativeBounds& seen = fpNativeBounds[symbol];
-  if (lowerBound)
-  {
-    if (!seen.hasLower || value >= seen.lower)
+    const ASTNode current = pending.back();
+    pending.pop_back();
+    if (current.GetKind() == AND)
     {
-      seen.lower = value;
-      seen.lowerExact = fpNativeConstantBits(constant, seen.lowerBits);
+      for (auto it = current.end(); it != current.begin();)
+        pending.push_back(*--it);
+      continue;
     }
-    seen.hasLower = true;
-  }
-  else
-  {
-    if (!seen.hasUpper || value <= seen.upper)
+
+    ASTNode zeroSymbol;
+    if (fpNativeMagnitudeZeroPredicate(current, zeroSymbol))
     {
-      seen.upper = value;
-      seen.upperExact = fpNativeConstantBits(constant, seen.upperBits);
+      fpNativeZeroMagnitudeFacts.insert(zeroSymbol);
+      fpNativeZeroMagnitudeTerms.insert(zeroSymbol);
+      fpNativeFiniteTerms.insert(zeroSymbol);
     }
-    seen.hasUpper = true;
+
+    ASTNode symbol;
+    ASTNode constant;
+    long double value = 0.0L;
+    bool lowerBound = false;
+    if (!fpNativeBoundPredicate(current, symbol, constant, value, lowerBound))
+      continue;
+
+    FpNativeBounds& seen = fpNativeBounds[symbol];
+    if (lowerBound)
+    {
+      if (!seen.hasLower || value >= seen.lower)
+      {
+        seen.lower = value;
+        seen.lowerExact = fpNativeConstantBits(constant, seen.lowerBits);
+      }
+      seen.hasLower = true;
+    }
+    else
+    {
+      if (!seen.hasUpper || value <= seen.upper)
+      {
+        seen.upper = value;
+        seen.upperExact = fpNativeConstantBits(constant, seen.upperBits);
+      }
+      seen.hasUpper = true;
+    }
   }
 }
 

--- a/tests/query-files/fp-tests/fp-native-domain-default.smt2
+++ b/tests/query-files/fp-tests/fp-native-domain-default.smt2
@@ -1,0 +1,27 @@
+; Native-domain fact collection is enabled by default and remains independent
+; of the domain rewrite prepass and known-sign arithmetic specialization. The
+; explicit false value remains available as an opt-out.
+;
+; RUN: %solver --disable-equality --unconstrained-variable-elimination=0 -s %s 2>&1 | %OutputCheck --check-prefix=DEFAULT %s
+; RUN: %solver --disable-equality --unconstrained-variable-elimination=0 --bb.fp-native-domain=false -s %s 2>&1 | %OutputCheck --check-prefix=OFF %s
+;
+; DEFAULT: FP native domain finite terms: [1-9][0-9]*
+; DEFAULT: FP native domain classifications: [1-9][0-9]*
+; DEFAULT: FP native domain known-positive add paths: 0
+; DEFAULT-NOT: FpDomainSimplify:
+; DEFAULT: ^unsat
+;
+; OFF-NOT: FP native domain
+; OFF-NOT: FpDomainSimplify:
+; OFF: ^unsat
+;
+(set-logic QF_FP)
+(declare-fun x () (_ FloatingPoint 3 5))
+
+(define-fun one () (_ FloatingPoint 3 5) (fp #b0 #b011 #b0000))
+(define-fun two () (_ FloatingPoint 3 5) (fp #b0 #b100 #b0000))
+
+(assert (and (fp.leq one x) (fp.leq x two)))
+(assert (fp.isNaN x))
+(check-sat)
+(exit)

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -484,9 +484,8 @@ void ExtraMain::create_options()
            bb_group);
 
   bool_arg("--bb.fp-native-domain", bm->UserFlags.fp_native_domain,
-           "Experimental native FP bit-blaster strengthening: mine simple "
-           "finite box bounds and omit NaN/infinity cases that are impossible "
-           "under those top-level facts",
+           "Mine simple finite box bounds and omit NaN/infinity cases that "
+           "are impossible under those top-level facts (enabled by default)",
            bb_group);
 
   bool_arg("--bb.fp-native-known-sign",


### PR DESCRIPTION
This enables the native FP bit-blaster's finite-box domain lowering by default.

The change is deliberately narrow:

- collect simple top-level finite bounds and use them to remove impossible NaN/infinity circuitry;
- keep `--bb.fp-native-known-sign`, `--fp-domain-simplify`, and `--fp-domain-sound-zero-facts` off by default;
- retain `--bb.fp-native-domain=false` as an explicit opt-out;
- collect facts with an explicit worklist so deeply nested conjunctions remain stack-safe;
- add a regression proving the default/opt-out behavior and separation from the domain prepass and known-sign specialization.

Qualification before enabling the default:

- 36-instance stratified SyntheticFBA sweep: median AIG nodes -21.95%, clauses -22.74%, repeated MiniSat wall time -20.70%, with 36/36 median wins;
- 12-case, two-pass CaDiCaL wall-budget sweep: +55.35% conflicts and +39.85% ticks within the matched budget, -23.27% RSS, with 11/12 tick wins;
- repeated MiniSat fixed-conflict timing: Shewanella -5.51%, E. coli -12.88%.

The domain analysis is a circuit specialization only: it consumes finite facts already asserted by the formula and does not add or rewrite constraints.

Tests:

- `cmake --build build -j24`
- all query-file tests: 793 passed, 8 unsupported
- `DeepDag.deep_bit_blast`: 20,000-deep formula under a 1 MiB stack
- `fp-native-domain-default.smt2`, default and explicit-off paths
- prior exhaustive small-format native/SymFPU differential tests and stratified benchmark qualification
