### PR TITLE
Decouple sound FP zero facts from domain rewriting

### DIFF
--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -438,7 +438,8 @@ public:
   // derives zero facts from same-sign rows whose terms are +/- one boxed
   // symbol. Two-term differences may propagate an already-established zero,
   // but terms are never algebraically cancelled through a rounded row. Zero
-  // is encoded as zero magnitude bits so +0/-0 remain distinct.
+  // is encoded as zero magnitude bits so +0/-0 remain distinct. This does not
+  // enable the general floating-point domain rewrite prepass.
   bool fp_domain_sound_zero_facts = false;
 
   // Sound row-level FP zero refutation. It recognises linear FP expressions

--- a/lib/FloatBlaster/FpDomainSimplify.cpp
+++ b/lib/FloatBlaster/FpDomainSimplify.cpp
@@ -499,7 +499,14 @@ public:
     if (bm->UserFlags.fp_domain_sound_zero_facts)
       inferSoundZeroRows(root);
 
-    ASTNode out = rewrite(root);
+    // Zero-fact extraction is an independent strengthening. Enabling it must
+    // not also select the general domain-rewrite prepass. The inferred facts
+    // are conjoined below with the original formula unless one of the rewrite
+    // passes was explicitly requested as well.
+    ASTNode out = root;
+    if (bm->UserFlags.fp_domain_simplify ||
+        bm->UserFlags.fp_domain_row_bounds)
+      out = rewrite(root);
     if (!soundZeroSymbols.empty())
     {
       ASTVec conjuncts;

--- a/tests/query-files/fp-tests/fp-domain-sound-zero-facts.smt2
+++ b/tests/query-files/fp-tests/fp-domain-sound-zero-facts.smt2
@@ -1,6 +1,11 @@
-; RUN: %solver --fp-domain-sound-zero-facts=1 -s %s 2>&1 | %OutputCheck %s
-; CHECK: FpDomainSimplify: 3 boxed symbols, 0 interval-true, 0 interval-false, 0 classifier-false, 1 diff-zero-eq, 1 nonnegative-zero-sum, 2 sound-zero-rows, 3 sound-zero-facts
-; CHECK: sat
+; RUN: %solver --fp-domain-sound-zero-facts=1 -s %s 2>&1 | %OutputCheck --check-prefix=ZERO-ONLY %s
+; RUN: %solver --fp-domain-simplify=1 --fp-domain-sound-zero-facts=1 -s %s 2>&1 | %OutputCheck --check-prefix=COMBINED %s
+;
+; ZERO-ONLY: FpDomainSimplify: 3 boxed symbols, 0 interval-true, 0 interval-false, 0 classifier-false, 0 diff-zero-eq, 0 nonnegative-zero-sum, 2 sound-zero-rows, 3 sound-zero-facts
+; ZERO-ONLY: sat
+;
+; COMBINED: FpDomainSimplify: 3 boxed symbols, 0 interval-true, 0 interval-false, 0 classifier-false, 1 diff-zero-eq, 1 nonnegative-zero-sum, 2 sound-zero-rows, 3 sound-zero-facts
+; COMBINED: sat
 (set-logic QF_FP)
 (declare-fun x () (_ FloatingPoint 8 24))
 (declare-fun y () (_ FloatingPoint 8 24))

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -506,7 +506,8 @@ void ExtraMain::create_options()
            bm->UserFlags.fp_domain_sound_zero_facts,
            "Experimental FP prepass: derive sound zero facts from "
            "association-safe same-sign boxed +/-1 rows and encode them as "
-           "zero magnitude bits, preserving the +0/-0 distinction",
+           "zero magnitude bits, preserving the +0/-0 distinction; does not "
+           "enable --fp-domain-simplify",
            bb_group);
 
   bool_arg("--fp-domain-row-bounds", bm->UserFlags.fp_domain_row_bounds,


### PR DESCRIPTION
This makes `--fp-domain-sound-zero-facts` an independent, still-default-off strengthening instead of implicitly running the general `--fp-domain-simplify` rewrite pass.

The implementation change is intentionally small:

- zero-fact-only mode keeps the original formula and conjoins only the inferred magnitude-zero constraints;
- explicitly selecting both flags retains the previous combined behavior;
- help text and a query regression pin that separation;
- `--fp-domain-sound-zero-facts`, `--fp-domain-simplify`, `--fp-domain-row-bounds`, and native known-sign specialization all remain off by default.

Soundness
---------

The inference accepts only boxed, finite, semantically nonnegative FP symbols and association-preserving rows made from those symbols, unary negation, and `fp.add`/`fp.sub`:

- a rounded sum whose remaining terms all have the same mathematical sign has zero magnitude only if every term has zero magnitude;
- a two-term difference can propagate an independently established zero only through IEEE value equality;
- no algebraic cancellation through a longer rounded row and no coefficient-product inference is performed;
- inferred constraints set only exponent/significand bits to zero, leaving the sign unconstrained, so `+0` and `-0` remain distinct structurally.

The source bounds also exclude NaN and infinities. The reasoning does not assume real arithmetic across FP associations and remains valid for every rounding mode and subnormal result.

Qualification
-------------

A coverage-only sweep over 36 biological FBA instances (16 E. coli, 16 glycerol, and 4 Shewanella; FP32/FP64 and multiple thresholds) found no general-domain rewrites in zero-only mode. Coverage was stable within each family:

- Shewanella: 699 rows, 303 facts;
- E. coli: 917 rows, 319 facts;
- glycerol: 909 rows, 319 facts.

Three-run interleaved FP32 CNF-generation measurements, with known-sign, domain simplification, and row bounds explicitly disabled:

| family | AIG nodes | clauses | median wall | median RSS |
|---|---:|---:|---:|---:|
| Shewanella | -21.74% | -20.88% | -20.35% | about -21.2% |
| E. coli | -15.09% | -14.24% | -15.25% | about -14.8% |
| glycerol | -13.13% | -9.41% | -12.98% | about -12.6% |

The native consumer counters increased as expected: inferred facts were consumed by add, multiply, comparison, classifier, and conversion lowering.

Fixed-5,000-conflict checks showed good or mixed search behavior on five of six representatives, but the high-threshold E. coli case regressed from 89,718 to 102,064 decisions and from 9,994,182 to 14,139,009 propagations. That solver-order sensitivity is why this PR deliberately does **not** enable row-zero inference by default despite the broad structural wins.

Tests
-----

- `cmake --build build -j24`
- all query-file tests: 792 passed, 8 unsupported
- zero-only and explicitly combined counter checks
- nonzero-underflow and association-loss counterexamples remain satisfiable and infer no zero facts
- native/SymFPU focused comparisons agree; native zero-fact consumers are exercised
