### PR TITLE
Make FP domain conjunction scans stack-safe

### DIFF
--- a/lib/FloatBlaster/FpDomainSimplify.cpp
+++ b/lib/FloatBlaster/FpDomainSimplify.cpp
@@ -477,6 +477,25 @@ ASTNode rebuild(NodeFactory* nf, const ASTNode& n, const ASTVec& children)
   return nf->CreateTerm(n.GetKind(), n.GetValueWidth(), children);
 }
 
+template <typename Visitor>
+void forEachConjunct(const ASTNode& root, Visitor visitor)
+{
+  ASTVec pending(1, root);
+  while (!pending.empty())
+  {
+    const ASTNode current = pending.back();
+    pending.pop_back();
+    if (current.GetKind() == AND)
+    {
+      // Reverse-push to preserve recursive left-to-right visitation order.
+      for (auto it = current.end(); it != current.begin();)
+        pending.push_back(*--it);
+      continue;
+    }
+    visitor(current);
+  }
+}
+
 class DomainPass
 {
 public:
@@ -522,50 +541,46 @@ public:
   }
 
 private:
-  void collectConjunctiveBounds(const ASTNode& n)
+  void collectConjunctiveBounds(const ASTNode& root)
   {
-    if (n.GetKind() == AND)
-    {
-      for (const ASTNode& child : n)
-        collectConjunctiveBounds(child);
-      return;
-    }
+    forEachConjunct(root, [&](const ASTNode& n) {
+      ASTNode symbol;
+      ASTNode constant;
+      long double value = 0.0L;
+      bool lowerBound = false;
+      bool strict = false;
+      if (!boundPredicate(n, symbol, constant, value, lowerBound, strict))
+        return;
 
-    ASTNode symbol;
-    ASTNode constant;
-    long double value = 0.0L;
-    bool lowerBound = false;
-    bool strict = false;
-    if (!boundPredicate(n, symbol, constant, value, lowerBound, strict))
-      return;
-
-    // These predicates are both the proof source for this pass and the facts
-    // consumed later by native lowering. Do not fold them away merely because
-    // the interval assembled from the complete conjunction proves them.
-    boxPredicates.insert(n);
-    Bounds& b = bounds[symbol];
-    if (lowerBound)
-    {
-      if (!b.hasLower || value >= b.lower)
+      // These predicates are both the proof source for this pass and the
+      // facts consumed later by native lowering. Do not fold them away merely
+      // because the interval assembled from the complete conjunction proves
+      // them.
+      boxPredicates.insert(n);
+      Bounds& b = bounds[symbol];
+      if (lowerBound)
       {
-        b.lower = value;
-        b.lowerConst = constant;
-        b.lowerStrict = strict;
-        b.lowerExact = fpConstantBits(constant, b.lowerBits);
+        if (!b.hasLower || value >= b.lower)
+        {
+          b.lower = value;
+          b.lowerConst = constant;
+          b.lowerStrict = strict;
+          b.lowerExact = fpConstantBits(constant, b.lowerBits);
+        }
+        b.hasLower = true;
       }
-      b.hasLower = true;
-    }
-    else
-    {
-      if (!b.hasUpper || value <= b.upper)
+      else
       {
-        b.upper = value;
-        b.upperConst = constant;
-        b.upperStrict = strict;
-        b.upperExact = fpConstantBits(constant, b.upperBits);
+        if (!b.hasUpper || value <= b.upper)
+        {
+          b.upper = value;
+          b.upperConst = constant;
+          b.upperStrict = strict;
+          b.upperExact = fpConstantBits(constant, b.upperBits);
+        }
+        b.hasUpper = true;
       }
-      b.hasUpper = true;
-    }
+    });
   }
 
   Interval interval(const ASTNode& n)
@@ -903,18 +918,13 @@ private:
     return true;
   }
 
-  void collectSoundRows(const ASTNode& n)
+  void collectSoundRows(const ASTNode& root)
   {
-    if (n.GetKind() == AND)
-    {
-      for (const ASTNode& child : n)
-        collectSoundRows(child);
-      return;
-    }
-
-    SignedTerms terms;
-    if (parseSoundZeroRow(n, terms))
-      soundRows.push_back(terms);
+    forEachConjunct(root, [&](const ASTNode& n) {
+      SignedTerms terms;
+      if (parseSoundZeroRow(n, terms))
+        soundRows.push_back(terms);
+    });
   }
 
   void normalizeSoundZeros()

--- a/tests/unit-tests/DeepDag_Test.cpp
+++ b/tests/unit-tests/DeepDag_Test.cpp
@@ -56,6 +56,7 @@ THE SOFTWARE.
 #include "stp/AbsRefineCounterExample/ArrayTransformer.h"
 #include "stp/AbsRefineCounterExample/AbsRefine_CounterExample.h"
 #include "stp/FloatBlaster/FpEncodingContext.h"
+#include "stp/FloatBlaster/FpDomainSimplify.h"
 #include "stp/FloatBlaster/FpTotalise.h"
 #include "stp/Extensionality/ExtensionalityContext.h"
 #include "stp/Printer/printers.h"
@@ -1195,6 +1196,29 @@ bool nodeDomainOk(Context& c, unsigned depth)
   NodeDomainAnalysis nda(&c.mgr);
   nda.buildMap(f);
   return true;
+}
+
+// FpDomainSimplify scans the top-level conjunction once for finite bounds and
+// again for sound zero rows. Zero-fact inference is opt-in today, but enabling
+// it must not put an input-controlled AND depth back on the C++ call stack.
+bool fpDomainZeroFactsOk(Context& c, unsigned depth)
+{
+  ASTNode f = c.mgr.CreateSymbol("fp-domain-conjunct-0", 0, 0);
+  for (unsigned i = 1; i < depth; ++i)
+  {
+    const std::string name = "fp-domain-conjunct-" + std::to_string(i);
+    f = c.hf->CreateNode(
+        AND, c.mgr.CreateSymbol(name.c_str(), 0, 0), f);
+  }
+  c.roots.push_back(f);
+
+  c.mgr.UserFlags.fp_domain_sound_zero_facts = true;
+  FpDomainSimplify domain(&c.mgr);
+  const ASTNode result = domain.topLevel(f);
+  c.roots.push_back(result);
+  const FpDomainSimplify::Statistics& stats = domain.statistics();
+  return result == f && stats.boxed_symbols == 0 &&
+         stats.sound_zero_rows == 0 && stats.sound_zero_facts == 0;
 }
 
 // NodeIterator historically visits children right-to-left. Put the deep
@@ -2838,6 +2862,10 @@ TEST(DeepDag, deep_mutable_dag_walks)
 }
 TEST(DeepDag, DISABLED_deep_use_ite_context)    { EXPECT_STACK_SAFE(useITEContextOk, 20000); }
 TEST(DeepDag, deep_node_domain)        { EXPECT_STACK_SAFE(nodeDomainOk, 20000); }
+TEST(DeepDag, deep_fp_domain_zero_facts)
+{
+  EXPECT_STACK_SAFE(fpDomainZeroFactsOk, 20000);
+}
 TEST(DeepDag, deep_node_iterator)      { EXPECT_STACK_SAFE(nodeIteratorOk, 20000); }
 TEST(DeepDag, deep_vars_in_expression) { EXPECT_STACK_SAFE(varsInExpressionOk, 20000); }
 TEST(DeepDag, deep_propagate_equalities) { EXPECT_STACK_SAFE(propagateEqualitiesOk, 20000); }


### PR DESCRIPTION
`FpDomainSimplify` scans the top-level conjunction once for finite bounds and, when sound zero-fact inference is enabled, again for candidate zero rows. Both scans recursively followed nested `and` spines, so opting into zero facts could overflow the C++ stack on an input-controlled formula depth.

This replaces the two recursive scans with one shared explicit worklist. Children are reverse-pushed to retain the old left-to-right visitation order, including deterministic bound tie handling and zero-row representative selection.

The change does not alter any FP inference, rewrite, or default flag.

Tests:

- `cmake --build build -j24`
- `DeepDag.deep_fp_domain_zero_facts`: both scans over a 20,000-deep conjunction under a 1 MiB stack
- `DeepDag.deep_bit_blast`
- all query-file tests: 793 passed, 8 unsupported
