### PR TITLE
Enable sound FP zero facts by default

### DIFF
--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -439,9 +439,10 @@ public:
   // derives zero facts from same-sign rows whose terms are +/- one boxed
   // symbol. Two-term differences may propagate an already-established zero,
   // but terms are never algebraically cancelled through a rounded row. Zero
-  // is encoded as zero magnitude bits so +0/-0 remain distinct. This does not
-  // enable the general floating-point domain rewrite prepass.
-  bool fp_domain_sound_zero_facts = false;
+  // is encoded as zero magnitude bits so +0/-0 remain distinct. Enabled by
+  // default; this does not enable the general floating-point domain rewrite
+  // prepass.
+  bool fp_domain_sound_zero_facts = true;
 
   // Sound row-level FP zero refutation. It recognises linear FP expressions
   // over boxed finite variables and rewrites a zero-row to false only when a

--- a/tests/query-files/fp-tests/fp-domain-native-nonnegative-arith.smt2
+++ b/tests/query-files/fp-tests/fp-domain-native-nonnegative-arith.smt2
@@ -1,10 +1,11 @@
 ; Finite semantic-sign facts let native add/mul omit sign-controlled
 ; cancellation and rounding circuitry. The nonnegative lower bounds
 ; intentionally admit -0, so the specialized paths must retain explicit
-; signed-zero handling.
+; signed-zero handling. Disable the independent zero-fact pass so this test's
+; counters continue to isolate known-sign lowering.
 ;
-; RUN: %solver --bb.fp-native-arith=1 --fp-domain-simplify=1 --bb.fp-native-domain=1 --bb.fp-native-known-sign=1 -s %s 2>&1 | %OutputCheck --check-prefix=NATIVE %s
-; RUN: %solver --bb.fp-native-arith=1 --fp-domain-simplify=1 --bb.fp-native-domain=1 --bb.fp-native-known-sign=1 -s %s 2>&1 | %OutputCheck --check-prefix=COUNTERS %s
+; RUN: %solver --bb.fp-native-arith=1 --fp-domain-simplify=1 --fp-domain-sound-zero-facts=0 --bb.fp-native-domain=1 --bb.fp-native-known-sign=1 -s %s 2>&1 | %OutputCheck --check-prefix=NATIVE %s
+; RUN: %solver --bb.fp-native-arith=1 --fp-domain-simplify=1 --fp-domain-sound-zero-facts=0 --bb.fp-native-domain=1 --bb.fp-native-known-sign=1 -s %s 2>&1 | %OutputCheck --check-prefix=COUNTERS %s
 ; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck --check-prefix=SYMFPU %s
 ;
 ; NATIVE: ^unsat

--- a/tests/query-files/fp-tests/fp-domain-sound-zero-facts.smt2
+++ b/tests/query-files/fp-tests/fp-domain-sound-zero-facts.smt2
@@ -1,5 +1,13 @@
+; RUN: %solver -s %s 2>&1 | %OutputCheck --check-prefix=DEFAULT %s
+; RUN: %solver --fp-domain-sound-zero-facts=0 -s %s 2>&1 | %OutputCheck --check-prefix=DISABLED %s
 ; RUN: %solver --fp-domain-sound-zero-facts=1 -s %s 2>&1 | %OutputCheck --check-prefix=ZERO-ONLY %s
 ; RUN: %solver --fp-domain-simplify=1 --fp-domain-sound-zero-facts=1 -s %s 2>&1 | %OutputCheck --check-prefix=COMBINED %s
+;
+; DEFAULT: FpDomainSimplify: 3 boxed symbols, 0 interval-true, 0 interval-false, 0 classifier-false, 0 diff-zero-eq, 0 nonnegative-zero-sum, 2 sound-zero-rows, 3 sound-zero-facts
+; DEFAULT: sat
+;
+; DISABLED-NOT: FpDomainSimplify:
+; DISABLED: sat
 ;
 ; ZERO-ONLY: FpDomainSimplify: 3 boxed symbols, 0 interval-true, 0 interval-false, 0 classifier-false, 0 diff-zero-eq, 0 nonnegative-zero-sum, 2 sound-zero-rows, 3 sound-zero-facts
 ; ZERO-ONLY: sat

--- a/tests/query-files/fp-tests/fp-native-domain-default.smt2
+++ b/tests/query-files/fp-tests/fp-native-domain-default.smt2
@@ -1,9 +1,10 @@
 ; Native-domain fact collection is enabled by default and remains independent
 ; of the domain rewrite prepass and known-sign arithmetic specialization. The
-; explicit false value remains available as an opt-out.
+; explicit false value remains available as an opt-out. Disable the independent
+; zero-fact default in both runs so the negative checks isolate this flag.
 ;
-; RUN: %solver --disable-equality --unconstrained-variable-elimination=0 -s %s 2>&1 | %OutputCheck --check-prefix=DEFAULT %s
-; RUN: %solver --disable-equality --unconstrained-variable-elimination=0 --bb.fp-native-domain=false -s %s 2>&1 | %OutputCheck --check-prefix=OFF %s
+; RUN: %solver --disable-equality --unconstrained-variable-elimination=0 --fp-domain-sound-zero-facts=0 -s %s 2>&1 | %OutputCheck --check-prefix=DEFAULT %s
+; RUN: %solver --disable-equality --unconstrained-variable-elimination=0 --fp-domain-sound-zero-facts=0 --bb.fp-native-domain=false -s %s 2>&1 | %OutputCheck --check-prefix=OFF %s
 ;
 ; DEFAULT: FP native domain finite terms: [1-9][0-9]*
 ; DEFAULT: FP native domain classifications: [1-9][0-9]*

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -503,10 +503,10 @@ void ExtraMain::create_options()
 
   bool_arg("--fp-domain-sound-zero-facts",
            bm->UserFlags.fp_domain_sound_zero_facts,
-           "Experimental FP prepass: derive sound zero facts from "
+           "Derive sound zero facts from "
            "association-safe same-sign boxed +/-1 rows and encode them as "
-           "zero magnitude bits, preserving the +0/-0 distinction; does not "
-           "enable --fp-domain-simplify",
+           "zero magnitude bits, preserving the +0/-0 distinction (enabled "
+           "by default; does not enable --fp-domain-simplify)",
            bb_group);
 
   bool_arg("--fp-domain-row-bounds", bm->UserFlags.fp_domain_row_bounds,


### PR DESCRIPTION
## Summary

- enable sound row-derived FP zero-magnitude facts by default
- retain `--fp-domain-sound-zero-facts=0` as an explicit opt-out
- update the help text and add default-on/default-off regression coverage
- make known-sign and native-domain tests explicitly disable the independent zero-fact pass when isolating their own counters

This changes only the default. The inference and conjoined lowering were already reviewed and landed; #970 removed their input-depth recursion before this enablement.

## Soundness

The pass derives facts only for boxed finite, semantically nonnegative symbols in association-preserving same-sign `+/-1` rows. A same-sign rounded sum can have zero magnitude only when every representable term has zero magnitude. Two-term differences propagate an independently established zero fact but do not algebraically cancel terms through a rounded accumulator.

The derived constraint fixes exponent and significand bits while leaving the sign bit unconstrained, so `+0` and `-0` remain distinct. The existing underflow and association regressions continue to reject unsound deductions.

## Qualification

Coverage-only scans found:

- 0 facts on all 144 `20260821-SyntheticFBA-AndrewTeylu` instances across FP16, FP32, and FP64
- 303 facts on all four Shewanella instances
- 319 facts on every E. coli and glycerol instance, covering all 36 biological FP32/FP64 files

When no facts were found, three aggregate passes over all 144 synthetic instances measured 3.40 s control versus 3.41 s enabled median, with identical memory. The returned AST is unchanged, so AIG and CNF structure are identical.

Native-arithmetic CNF-only results (`--max-num-confl=0`):

| Workload | Format | AIG control -> enabled | clauses control -> enabled | wall control -> enabled |
|---|---|---:|---:|---:|
| Shewanella | FP32 | 12.30M -> 9.63M | 17.77M -> 14.06M | 26.68s -> 21.25s |
| E. coli | FP32 | 18.80M -> 15.97M | 27.23M -> 23.35M | 41.45s -> 35.13s |
| glycerol | FP32 | 35.66M -> 30.98M | 50.03M -> 45.32M | 77.37s -> 67.33s |
| Shewanella | FP64 | 28.19M -> 22.16M | 40.46M -> 32.10M | 56.04s -> 45.52s |
| E. coli | FP64 | 42.80M -> 36.42M | 61.57M -> 52.83M | 85.32s -> 72.30s |
| glycerol | FP64 | 100.62M -> 86.55M | 137.12M -> 124.83M | 203.17s -> 175.99s |

FP32 values are medians of three rotated runs; FP64 values are one sequential control/candidate pair per family because each family has identical row coverage and the largest build peaks near 41 GB.

The ordinary SymFPU-arithmetic path was neutral in CNF-only checks: Shewanella 44.50s -> 44.28s and E. coli 78.29s -> 78.39s. At 5,000 MiniSat conflicts, search effects were mixed by instance but showed no total-wall regression: repeated SymFPU Shewanella medians improved 53.77s -> 52.16s, while a single E. coli pair measured 82.21s -> 81.68s.

Full logs are retained locally under `/tmp/stp-fp-zero-qual.oraB3Z`.

## Testing

- `cmake --build build -j24`
- focused zero-fact, underflow, association, known-sign isolation, native-domain isolation, and incremental regressions
- all 801 query tests with lit internal shell: 793 passed, 8 unsupported
- all 153 non-query CTest targets passed, including `DeepDag_TestTests`, FP backend, rewrite, API, and exhaustive tests

The aggregate external-shell query target has the pre-existing local `OutputCheck/bin/not` Python-shebang issue; the same 801 tests pass directly with lit internal shell.