### PR TITLE
Stop the gcc leg restoring the release leg's compiler cache

### DIFF
--- a/.github/actions/build-static-linux/action.yml
+++ b/.github/actions/build-static-linux/action.yml
@@ -106,8 +106,8 @@ runs:
     uses: actions/cache@v4
     with:
       path: ~/.cache/ccache
-      key: ccache-static-${{ inputs.build-type || 'default' }}-${{ github.run_id }}
-      restore-keys: ccache-static-${{ inputs.build-type || 'default' }}-
+      key: ccache-static-${{ inputs.build-type || 'default' }}/${{ github.run_id }}
+      restore-keys: ccache-static-${{ inputs.build-type || 'default' }}/
 
   # CryptoMiniSat is linked in rather than disabled, because UserDefinedFlags
   # makes whichever solver is compiled in the default one, and MiniSat is not

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,12 +111,19 @@ jobs:
 
     # Keyed per run so every build writes a fresh entry; restore-keys picks
     # up the most recent one from this branch, or from the base branch.
+    #
+    # The separator before the run id is a slash rather than a hyphen, and
+    # has to be something a leg's name cannot contain. restore-keys matches
+    # by prefix, so while it was a hyphen `ccache-gcc-` also matched
+    # `ccache-gcc-release-...`: the gcc leg restored the release leg's cache
+    # every run, shared nothing with it, and recompiled all 311 files from
+    # cold while every other leg sat at 96-99% hits.
     - name: Compiler cache
       uses: actions/cache@v4
       with:
         path: ~/.cache/ccache
-        key: ccache-${{ matrix.name }}-${{ github.run_id }}
-        restore-keys: ccache-${{ matrix.name }}-
+        key: ccache-${{ matrix.name }}/${{ github.run_id }}
+        restore-keys: ccache-${{ matrix.name }}/
 
     - name: Configure
       run: |
@@ -435,8 +442,8 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ~/.cache/ccache
-        key: ccache-ubsan-${{ github.run_id }}
-        restore-keys: ccache-ubsan-
+        key: ccache-ubsan/${{ github.run_id }}
+        restore-keys: ccache-ubsan/
 
     # CMAKE_C_FLAGS is the half that matters most: ABC is C, and it is where
     # the CNF that every query is decided from is built.
@@ -592,8 +599,8 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ~/.cache/ccache
-        key: ccache-cadical-${{ matrix.cadical_tag }}-${{ github.run_id }}
-        restore-keys: ccache-cadical-${{ matrix.cadical_tag }}-
+        key: ccache-cadical-${{ matrix.cadical_tag }}/${{ github.run_id }}
+        restore-keys: ccache-cadical-${{ matrix.cadical_tag }}/
 
     # CMAKE_INSTALL_PREFIX and PYTHON_LIB_INSTALL_DIR are set so that the
     # install steps below land in the workspace rather than needing root.
@@ -753,8 +760,8 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ~/.cache/ccache
-        key: ccache-cms-cadical-${{ github.run_id }}
-        restore-keys: ccache-cms-cadical-
+        key: ccache-cms-cadical/${{ github.run_id }}
+        restore-keys: ccache-cms-cadical/
 
     - name: Configure
       run: |
@@ -1056,8 +1063,8 @@ jobs:
       uses: actions/cache@v4
       with:
         path: .ccache
-        key: ccache-i386-${{ github.run_id }}
-        restore-keys: ccache-i386-
+        key: ccache-i386/${{ github.run_id }}
+        restore-keys: ccache-i386/
 
     - name: Build and test in a 32-bit container
       run: |

--- a/scripts/prune-ci-caches.sh
+++ b/scripts/prune-ci-caches.sh
@@ -78,14 +78,20 @@ report() {
 }
 report "in the cache" "$work/all.tsv" 5
 
-# Superseded compiler caches. The key is <prefix>-<run id>; strip the run id to
+# Superseded compiler caches. The key is <prefix>/<run id>; strip the run id to
 # get the group, sort each group newest first, and mark everything after the
 # first. Restricted to ccache-* because that is the family whose key encodes
 # when it was written rather than what it contains -- applying this to a
 # content-keyed family would delete live entries.
-awk -F'\t' '$3 ~ /^ccache-.+-[0-9]+$/ {
+#
+# Either separator is accepted. The keys used to be <prefix>-<run id>, and a
+# hyphen there was what let one leg's restore-keys reach into another's
+# entries; entries written before that changed are still here, still worth
+# pruning, and group with their replacements because stripping either
+# separator leaves the same prefix.
+awk -F'\t' '$3 ~ /^ccache-.+[-\/][0-9]+$/ {
     prefix = $3
-    sub(/-[0-9]+$/, "", prefix)
+    sub(/[-\/][0-9]+$/, "", prefix)
     print $2 "\t" prefix "\t" $4 "\t" $1 "\t" $5
 }' "$work/all.tsv" |
     sort -t"$(printf '\t')" -k1,1 -k2,2 -k3,3r |


### PR DESCRIPTION
`restore-keys` matches by prefix, and the compiler caches were keyed `<leg>-<run id>`. `ccache-gcc-` is a prefix of `ccache-gcc-release-...`, so the gcc leg restored whichever of the two was written last — which is the release leg's cache about as often as its own. A Release build shares no objects with a default one, so it then recompiled the lot.

| leg | hits | duration |
| --- | --- | --- |
| clang | 308 / 311 (99.04%) | 3m18s |
| gcc-release | 308 / 311 (99.04%) | 3m19s |
| **gcc** | **0 / 311 (0.00%)** | **9m49s** |

The run log says it outright: `gcc | Cache restored from key: ccache-gcc-release-32716664636`. The gcc leg's own entry was written correctly every run — 285MB, right key, right ref — and read by nobody. This has been happening on every push and every pull request.

Not all of that 6½ minute gap is the cache; the gcc leg also builds the extra tools, runs the CaDiCaL clash check and builds the python bindings. But 311 cold compiles against 3 is the bulk of it.

A slash separates the two halves now, which a leg name cannot contain, so no prefix can reach past the name it names. I applied it to every ccache key rather than only the pair that collides: gcc and gcc-release are the only two that do today, but the property that keeps the others safe should not depend on what the legs happen to be called. The other families are unaffected — `deps-*` keys are content-addressed with no restore-keys, so `deps-x86_64-` cannot swallow `deps-x86_64-ubsan-`.

`scripts/prune-ci-caches.sh` had the old key shape written into it (`^ccache-.+-[0-9]+$`), so this change alone would have stopped it recognising the family at all, and the entries would have accumulated against the 10GB allowance — the exact thing `cache-cleanup.yml` exists to prevent. It now accepts either separator, which also means entries written before this change still group with their replacements and still get pruned.

One thing to expect: the first run after this merges will be at 0% hits in *every* leg, because the new keys name a namespace nothing has written yet. The run after that is the one to judge it by.