### PR TITLE
Stop every incremental build relinking libstp

### DIFF
--- a/cmake/deps-helper.cmake
+++ b/cmake/deps-helper.cmake
@@ -213,6 +213,25 @@ endif()
 set(STP_EP_COMMON_CONFIG
     PREFIX "${STP_DEPS_PREFIX}"
     INSTALL_DIR "${STP_DEP_DIR}"
+    # Every dependency here is pinned to an exact revision, so there is never
+    # anything for the update step to update. Left on, it is worse than
+    # useless: ExternalProject gives a git update step no stamp file, so the
+    # generator treats it as permanently out of date --
+    #
+    #   ninja explain: output deps/src/ABC-EP-stamp/ABC-EP-update doesn't exist
+    #
+    # and re-runs it, and then patch, configure, build and install behind it,
+    # on every incremental build. The archive it reinstalls looks newer than
+    # libstp, so libstp relinks, and so does everything that links libstp.
+    # Building twice in a row with nothing changed relinks the whole library
+    # the second time.
+    #
+    # Disconnecting it does not pin the pin any harder than it already is: a
+    # changed GIT_TAG still takes effect, because that changes the download
+    # step's own inputs rather than the update step's. The two dependencies
+    # fetched as tarballs never had this problem, having no update step at
+    # all, which is why only the git-fetched ones show up as dirty.
+    UPDATE_DISCONNECTED ON
     # Quiet by default, because a dependency's build is not what anyone
     # configuring STP is trying to read -- but printed in full if it fails,
     # which is the property the shell scripts had for free and an


### PR DESCRIPTION
Build twice in a row with nothing changed, and the second build relinks `libstp`, then `stp` and `extdiff` behind it. ninja says why if you ask it:

```
ninja explain: output deps/src/ABC-EP-stamp/ABC-EP-update doesn't exist
```

ExternalProject gives a git update step no stamp file, so the generator treats it as permanently out of date and runs it — and then patch, configure, build and install behind it. The archive it reinstalls is newer than the library that linked the previous one, so `libstp` relinks, and so does everything that links `libstp`.

Every dependency here is pinned to an exact revision, so there was never anything for that step to do.

Same tree, same flags, second build with nothing changed:

| | steps | last one |
| --- | --- | --- |
| before | 19 | `Linking CXX shared library lib/libstp.so.2.4` |
| after | 1 | `Running utility command for man_stp` |

The step that remains is a custom target with no output, so it always runs; it regenerates the man page and costs nothing.

The tell is *which* dependencies show up dirty: only the git-fetched ones. SymFPU and CLI11 are fetched as tarballs, have no update step, and never appear — which is also how cvc5 avoids this, by using tarballs for nearly everything rather than by disconnecting anything.

Two things I checked rather than assumed, since both would be bad to get wrong:

**A changed pin still takes effect.** `UPDATE_DISCONNECTED` skips the update step, so the obvious worry is that bumping a `GIT_TAG` would silently keep building the old revision. It does not: the pin is part of the download step's inputs, not the update step's. I built a throwaway two-commit repository, pinned an ExternalProject at the first commit, repointed it at the second, and the disconnected build picked up the new one.

**A new commit is still detected.** The version SHA comes from `configure_file()` on `.git/HEAD` and the branch's ref file, which are CMake configure dependencies — a different mechanism entirely from the ExternalProject step this touches. Committing on a local branch still triggers `Re-running CMake`, a fresh `GIT hash found:`, and a relink, and `stp --version` reports the new SHA. Verified with and without this change.

So it removes the relink you did not want and leaves the one you did.