### PR TITLE
Mention stp.sh at the end of the worktree section

### DIFF
--- a/docs/building.rst
+++ b/docs/building.rst
@@ -446,6 +446,20 @@ point ``LIT_TOOL`` at one -- the warm build's copy will do:
 
     -DLIT_TOOL=$PWD/warm/venv/bin/lit
 
+Doing all of this by hand
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Nothing above needs a tool: the flags are the whole of it, and they are
+written out so that they can be typed, scripted or put in a
+``CMakeUserPresets.json``, whichever suits.
+
+If a shell function is what suits, `stp.sh <https://github.com/stp/stp.sh>`__
+is a set of bash and zsh helpers that apply exactly these flags -- one
+command to warm the caches, one to make a worktree, one to build it. It is a
+convenience kept alongside STP rather than part of it, and it is not what the
+rest of this page assumes: everything here works without it, and on the
+platforms it does not cover.
+
 
 Building a static library and binary
 ------------------------------------


### PR DESCRIPTION
The "Working across several worktrees" section tells you to put the same four flags into every worktree, and to set two ccache variables you would not have guessed at on your own. [stp.sh](https://github.com/stp/stp.sh) is a set of bash and zsh functions that apply exactly those — warm the caches once, make a worktree, build it — and the reader who has just been handed the flags is the one most likely to want it.

It is deliberately the last thing in the section, one paragraph, and deliberately *not* presented as the recommended path. The flags are the substance and they stay written out where they are: this page has to work for somebody building on Windows, somebody who would rather script it themselves, and somebody who would put it in a `CMakeUserPresets.json`. The paragraph says what stp.sh is, that it sits alongside STP rather than inside it, and that nothing on the page depends on it.

The two link in both directions now — stp.sh's README already points back at this section for what the flags mean and why.

Documentation only. `docs/building.rst` produces the same three docutils reports before and after, all pre-existing Sphinx-only roles.