### PR TITLE
Propagate extremal FP selector values

### DIFF
--- a/include/stp/FloatBlaster/FpDomainSimplify.h
+++ b/include/stp/FloatBlaster/FpDomainSimplify.h
@@ -27,6 +27,10 @@ public:
     size_t derived_bounds = 0;
     size_t zero_add_bounds = 0;
     size_t inconsistent_boxes = 0;
+    size_t extremal_selector_domains = 0;
+    size_t extremal_selector_predicates = 0;
+    size_t extremal_selector_facts = 0;
+    size_t extremal_selector_rewrites = 0;
     size_t sound_zero_rows = 0;
     size_t sound_zero_facts = 0;
     size_t row_bound_rows = 0;

--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -584,6 +584,14 @@ public:
   // emitted as additional constraints.
   bool fp_domain_derived_bounds = false;
 
+  // Experimental propagation through an objective over semantic {0, 1}
+  // floating-point selector symbols. Replace the objective only when
+  // interval exclusion proves each selected endpoint necessary and their
+  // conjunction sufficient. Exact extrema are the primary case. Kept
+  // separate from the interval-bound experiment so their solver effects can
+  // be ablated.
+  bool fp_domain_extremal_selectors = false;
+
   // Sound zero-fact extraction for boxed nonnegative FP symbols. It only
   // derives zero facts from same-sign rows whose terms are +/- one boxed
   // symbol. Two-term differences may propagate an already-established zero,

--- a/lib/FloatBlaster/FpDomainSimplify.cpp
+++ b/lib/FloatBlaster/FpDomainSimplify.cpp
@@ -79,11 +79,22 @@ struct RelationalBound
   bool strict = false;
 };
 
+struct SelectorDomain
+{
+  ASTNode zero;
+  ASTNode one;
+  Interval zeroValue;
+  Interval oneValue;
+};
+
 using BoundsMap =
     std::unordered_map<ASTNode, Bounds, ASTNode::ASTNodeHasher,
                        ASTNode::ASTNodeEqual>;
 using IntervalMap =
     std::unordered_map<ASTNode, Interval, ASTNode::ASTNodeHasher,
+                       ASTNode::ASTNodeEqual>;
+using SelectorDomainMap =
+    std::unordered_map<ASTNode, SelectorDomain, ASTNode::ASTNodeHasher,
                        ASTNode::ASTNodeEqual>;
 
 using SignedTerms = std::vector<std::pair<ASTNode, int>>;
@@ -537,6 +548,13 @@ public:
     if (bm->UserFlags.fp_domain_derived_bounds && contradictoryBox())
       return bm->ASTFalse;
 
+    if (bm->UserFlags.fp_domain_extremal_selectors)
+    {
+      collectSelectorDomains(root);
+      intervals.clear();
+      collectExtremalRewrites(root);
+    }
+
     // Zero-fact extraction is an independent strengthening. Enabling it must
     // not also select the general domain-rewrite prepass. The inferred facts
     // are conjoined below with the original formula unless one of the rewrite
@@ -544,6 +562,7 @@ public:
     ASTNode out = root;
     if (bm->UserFlags.fp_domain_simplify ||
         bm->UserFlags.fp_domain_derived_bounds ||
+        bm->UserFlags.fp_domain_extremal_selectors ||
         bm->UserFlags.fp_domain_row_bounds)
       out = rewrite(root);
     if (!soundZeroSymbols.empty())
@@ -844,6 +863,111 @@ private:
     return false;
   }
 
+  bool selectorEquality(const ASTNode& n, ASTNode& symbol,
+                        ASTNode& constant, bool& one)
+  {
+    // The simplifying factory canonicalises fp.eq(x, +/-0) to isZero(x),
+    // and fp.eq(x, nonzero-constant) to structural FP equality. Recover that
+    // source-level semantic {0, 1} disjunction here. Structural equality is
+    // sound for the one endpoint; it is deliberately not used for zero.
+    if (n.GetKind() == FP_ISZERO && n.Degree() == 1 &&
+        n[0].GetKind() == SYMBOL && fpSort(n[0]))
+    {
+      symbol = n[0];
+      const SourceSort sort = symbol.GetSourceSort();
+      constant = bm->CreateFPSpecialConst(
+          FPSpecial::PlusZero, sort.exponentWidth(), sort.significandWidth());
+      one = false;
+      return true;
+    }
+
+    if ((n.GetKind() != FP_EQ && n.GetKind() != FP_SMT_EQ) ||
+        n.Degree() != 2)
+      return false;
+
+    if (n[0].GetKind() == SYMBOL && fpSort(n[0]))
+    {
+      symbol = n[0];
+      constant = n[1];
+    }
+    else if (n[1].GetKind() == SYMBOL && fpSort(n[1]))
+    {
+      symbol = n[1];
+      constant = n[0];
+    }
+    else
+      return false;
+
+    long double value = 0.0L;
+    if (!fpConstantValue(constant, value))
+      return false;
+    if (value == 0.0L)
+    {
+      if (n.GetKind() == FP_SMT_EQ)
+        return false;
+      one = false;
+      return true;
+    }
+    if (value == 1.0L)
+    {
+      one = true;
+      return true;
+    }
+    return false;
+  }
+
+  void collectSelectorDomains(const ASTNode& root)
+  {
+    forEachConjunct(root, [&](const ASTNode& n) {
+      if (n.GetKind() != OR || n.Degree() != 2)
+        return;
+
+      ASTNode firstSymbol;
+      ASTNode firstConstant;
+      ASTNode secondSymbol;
+      ASTNode secondConstant;
+      bool firstOne = false;
+      bool secondOne = false;
+      if (!selectorEquality(n[0], firstSymbol, firstConstant, firstOne) ||
+          !selectorEquality(n[1], secondSymbol, secondConstant, secondOne) ||
+          firstSymbol != secondSymbol || firstOne == secondOne)
+        return;
+
+      SelectorDomain domain;
+      domain.zero = firstOne ? secondConstant : firstConstant;
+      domain.one = firstOne ? firstConstant : secondConstant;
+      domain.zeroValue = interval(domain.zero);
+      domain.oneValue = interval(domain.one);
+      if (!domain.zeroValue.known || !domain.zeroValue.finite ||
+          !domain.zeroValue.exact || !domain.oneValue.known ||
+          !domain.oneValue.finite || !domain.oneValue.exact)
+        return;
+      selectorDomains[firstSymbol] = domain;
+      stats.extremal_selector_domains = selectorDomains.size();
+    });
+  }
+
+  void collectPredicateSelectors(const ASTNode& predicate,
+                                 ASTNodeSet& selectors) const
+  {
+    ASTVec pending(1, predicate);
+    ASTNodeSet visited;
+    while (!pending.empty())
+    {
+      const ASTNode current = pending.back();
+      pending.pop_back();
+      if (!visited.insert(current).second)
+        continue;
+      if (selectorDomains.find(current) != selectorDomains.end())
+      {
+        selectors.insert(current);
+        continue;
+      }
+      for (const ASTNode& child : current)
+        pending.push_back(child);
+    }
+  }
+
   int compareIntervalEndpoints(const Interval& left, bool leftUpper,
                                const Interval& right,
                                bool rightUpper) const
@@ -925,6 +1049,100 @@ private:
     return false;
   }
 
+  bool objectivePredicate(const ASTNode& n) const
+  {
+    if (n.Degree() != 2 ||
+        (!isOrderedComparison(n.GetKind()) && n.GetKind() != FP_EQ &&
+         n.GetKind() != FP_SMT_EQ))
+      return false;
+
+    long double target = 0.0L;
+    const bool leftConstant = fpConstantValue(n[0], target);
+    long double rightTarget = 0.0L;
+    const bool rightConstant = fpConstantValue(n[1], rightTarget);
+    if (leftConstant == rightConstant)
+      return false;
+    if (!leftConstant)
+      target = rightTarget;
+
+    // Zero-result predicates have separate signed-zero-sensitive machinery.
+    // Keeping this experiment to nonzero extrema also prevents it from
+    // consuming a bound derived from the predicate it is considering.
+    return target != 0.0L;
+  }
+
+  void setSelectorOverride(const ASTNode& symbol, bool one)
+  {
+    const SelectorDomainMap::const_iterator it = selectorDomains.find(symbol);
+    assert(it != selectorDomains.end());
+    selectorOverrides[symbol] = one ? it->second.oneValue
+                                    : it->second.zeroValue;
+    intervals.clear();
+  }
+
+  void clearSelectorOverrides()
+  {
+    selectorOverrides.clear();
+    intervals.clear();
+  }
+
+  void collectExtremalRewrites(const ASTNode& root)
+  {
+    forEachConjunct(root, [&](const ASTNode& predicate) {
+      if (!objectivePredicate(predicate) ||
+          boxPredicates.find(predicate) != boxPredicates.end())
+        return;
+
+      ASTNodeSet selectors;
+      collectPredicateSelectors(predicate, selectors);
+      if (selectors.empty())
+        return;
+      ++stats.extremal_selector_predicates;
+
+      std::vector<std::pair<ASTNode, bool>> forced;
+      for (const ASTNode& selector : selectors)
+      {
+        setSelectorOverride(selector, false);
+        bool zeroValue = false;
+        const bool zeroDecided = predicateDecision(predicate, zeroValue);
+        clearSelectorOverrides();
+
+        setSelectorOverride(selector, true);
+        bool oneValue = false;
+        const bool oneDecided = predicateDecision(predicate, oneValue);
+        clearSelectorOverrides();
+
+        const bool zeroImpossible = zeroDecided && !zeroValue;
+        const bool oneImpossible = oneDecided && !oneValue;
+        if (zeroImpossible != oneImpossible)
+          forced.push_back(std::make_pair(selector, zeroImpossible));
+      }
+      if (forced.empty())
+        return;
+
+      for (const auto& fact : forced)
+        setSelectorOverride(fact.first, fact.second);
+      bool sufficientValue = false;
+      const bool sufficient =
+          predicateDecision(predicate, sufficientValue) && sufficientValue;
+      clearSelectorOverrides();
+      if (!sufficient)
+        return;
+
+      ASTVec facts;
+      facts.reserve(forced.size());
+      for (const auto& fact : forced)
+      {
+        const SelectorDomain& domain = selectorDomains.at(fact.first);
+        facts.push_back(nf->CreateNode(FP_EQ, fact.first,
+                                       fact.second ? domain.one : domain.zero));
+      }
+      extremalRewrites[predicate] = nf->CreateNode(AND, facts);
+      stats.extremal_selector_facts += facts.size();
+      ++stats.extremal_selector_rewrites;
+    });
+  }
+
   Interval interval(const ASTNode& n)
   {
     const IntervalMap::const_iterator cached = intervals.find(n);
@@ -949,6 +1167,10 @@ private:
 
     if (n.GetKind() == SYMBOL && fpSort(n))
     {
+      const IntervalMap::const_iterator overridden = selectorOverrides.find(n);
+      if (overridden != selectorOverrides.end())
+        return overridden->second;
+
       const BoundsMap::const_iterator it = bounds.find(n);
       if (it != bounds.end() && it->second.hasLower && it->second.hasUpper)
       {
@@ -960,6 +1182,15 @@ private:
               it->second.upperBits);
         return Interval::finiteRange(it->second.lower, it->second.upper);
       }
+
+      const SelectorDomainMap::const_iterator selector =
+          selectorDomains.find(n);
+      if (selector != selectorDomains.end())
+        return Interval::exactFiniteRange(
+            selector->second.zeroValue.lower,
+            selector->second.oneValue.upper,
+            selector->second.zeroValue.lowerBits,
+            selector->second.oneValue.upperBits);
       return Interval::unknown();
     }
 
@@ -1456,7 +1687,10 @@ private:
     ASTNode out;
     const bool legacyRewrite = bm->UserFlags.fp_domain_simplify ||
                                bm->UserFlags.fp_domain_row_bounds;
-    if (boxPredicates.find(n) != boxPredicates.end())
+    const ASTNodeMap::const_iterator extremal = extremalRewrites.find(n);
+    if (extremal != extremalRewrites.end())
+      out = extremal->second;
+    else if (boxPredicates.find(n) != boxPredicates.end())
       out = n;
     else if (n.GetKind() == FP_ISZERO && legacyRewrite)
     {
@@ -1536,6 +1770,8 @@ private:
   std::vector<RelationalBound> relationalBounds;
   ASTVec zeroAddRelations;
   ASTNodeSet derivedDecisionPredicates;
+  SelectorDomainMap selectorDomains;
+  IntervalMap selectorOverrides;
   std::vector<SignedTerms> soundRows;
   ASTNodeSet boxed;
   ASTNodeSet boxPredicates;
@@ -1543,6 +1779,7 @@ private:
   ASTNodeSet soundZeroSymbols;
   ASTNodeMap soundParent;
   IntervalMap intervals;
+  ASTNodeMap extremalRewrites;
   ASTNodeMap rewriteCache;
 };
 

--- a/lib/FloatBlaster/FpEncodingContext.cpp
+++ b/lib/FloatBlaster/FpEncodingContext.cpp
@@ -29,6 +29,7 @@ ASTNode FpEncodingContext::prepare(const ASTNode& source)
   ASTNode out = totalise.topLevel(source);
   if (bm->UserFlags.fp_domain_simplify ||
       bm->UserFlags.fp_domain_derived_bounds ||
+      bm->UserFlags.fp_domain_extremal_selectors ||
       bm->UserFlags.fp_domain_sound_zero_facts ||
       bm->UserFlags.fp_domain_row_bounds)
   {
@@ -50,7 +51,14 @@ ASTNode FpEncodingContext::prepare(const ASTNode& source)
                 << " derived-relations, " << s.derived_bounds
                 << " derived-bounds, " << s.zero_add_bounds
                 << " zero-add-bounds, " << s.inconsistent_boxes
-                << " inconsistent-boxes" << std::endl;
+                << " inconsistent-boxes, " << s.extremal_selector_domains
+                << " extremal-selector-domains, "
+                << s.extremal_selector_predicates
+                << " extremal-selector-predicates, "
+                << s.extremal_selector_facts
+                << " extremal-selector-facts, "
+                << s.extremal_selector_rewrites
+                << " extremal-selector-rewrites" << std::endl;
     }
   }
   return out;

--- a/tests/query-files/fp-tests/fp-domain-extremal-selectors.smt2
+++ b/tests/query-files/fp-tests/fp-domain-extremal-selectors.smt2
@@ -1,0 +1,49 @@
+; The first objective is the exact maximum of 4*s-2*t and uniquely requires
+; s=1, t=semantic-zero. Structural t=-0 must remain satisfiable: the emitted
+; zero fact is IEEE equality/isZero, never packed equality to +0. The second
+; objective has an interior value. One endpoint is necessary, but the partial
+; facts are not sufficient, so that equality must not be replaced. The
+; matching ordered threshold is equivalent to u=1 and is safely replaced:
+; exact extrema are the primary case, not an artificial syntactic condition.
+; The structural {+0,1} disjunction for w is deliberately not treated as a
+; semantic selector domain.
+;
+; RUN: %solver --fp-domain-sound-zero-facts=0 --fp-domain-extremal-selectors=1 -s %s 2>&1 | %OutputCheck --check-prefix=SELECTOR %s
+; RUN: %solver --fp-domain-sound-zero-facts=0 %s | %OutputCheck --check-prefix=BASE %s
+; SELECTOR: 4 extremal-selector-domains, 3 extremal-selector-predicates, 3 extremal-selector-facts, 2 extremal-selector-rewrites
+; SELECTOR: sat
+; BASE: sat
+
+(set-logic QF_FP)
+(declare-fun s () (_ FloatingPoint 8 24))
+(declare-fun t () (_ FloatingPoint 8 24))
+(declare-fun u () (_ FloatingPoint 8 24))
+(declare-fun v () (_ FloatingPoint 8 24))
+(declare-fun w () (_ FloatingPoint 8 24))
+(define-fun one () (_ FloatingPoint 8 24)
+  (fp #b0 #x7f #b00000000000000000000000))
+(define-fun two () (_ FloatingPoint 8 24)
+  (fp #b0 #x80 #b00000000000000000000000))
+(define-fun minusTwo () (_ FloatingPoint 8 24)
+  (fp #b1 #x80 #b00000000000000000000000))
+(define-fun four () (_ FloatingPoint 8 24)
+  (fp #b0 #x81 #b00000000000000000000000))
+
+(assert (and
+  (or (fp.eq s (_ -zero 8 24)) (fp.eq s one))
+  (or (fp.eq t (_ +zero 8 24)) (fp.eq t one))
+  (or (fp.eq u (_ +zero 8 24)) (fp.eq u one))
+  (or (fp.eq v (_ +zero 8 24)) (fp.eq v one))
+  (or (= w (_ +zero 8 24)) (= w one))))
+
+(define-fun objective ((a (_ FloatingPoint 8 24))
+                       (b (_ FloatingPoint 8 24)))
+  (_ FloatingPoint 8 24)
+  (fp.add RNE (fp.mul RNE four a) (fp.mul RNE minusTwo b)))
+
+(assert (fp.eq (objective s t) four))
+(assert (= t (_ -zero 8 24)))
+(assert (fp.eq (objective u v) two))
+(assert (fp.geq (objective u v) two))
+(check-sat)
+(exit)

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -560,6 +560,13 @@ void ExtraMain::create_options()
            "additions, then discharge comparisons or contradictory boxes",
            bb_group);
 
+  bool_arg("--fp-domain-extremal-selectors",
+           bm->UserFlags.fp_domain_extremal_selectors,
+           "Experimental FP prepass: replace an objective by necessary "
+           "semantic {0,1} selector values only after proving their "
+           "conjunction sufficient (primarily exact extrema)",
+           bb_group);
+
   bool_arg("--fp-domain-sound-zero-facts",
            bm->UserFlags.fp_domain_sound_zero_facts,
            "Derive sound zero facts from "


### PR DESCRIPTION
## Summary

- add the default-off `--fp-domain-extremal-selectors` experiment
- recognise retained semantic `{0,1}` floating-point selector domains
- prove selector endpoint facts necessary by excluding the opposite endpoint
- replace a top-level objective only when the complete set of necessary facts is also sufficient
- keep structural zero equality outside the selector-domain rule
- add a focused regression covering exact extrema, a safely rejected partial implicant, an ordered threshold, signed zero, and structural equality

This builds on the derived interval machinery merged in #979.

## Soundness

Every selector-domain assertion remains in the formula. For each selector occurring in a candidate predicate, the pass fixes one endpoint while leaving every other operand overapproximated. It records a fact only when the opposite endpoint makes the predicate definitely false, proving necessity. It then applies all recorded facts together and rewrites the predicate only when interval evaluation proves the original predicate definitely true, proving sufficiency. Thus the replacement is equivalent under the retained domains.

Only exact finite zero and one endpoints are accepted. Candidate objectives must compare against a finite nonzero constant, keeping signed-zero-sensitive result predicates out of this rule. Emitted zero facts use IEEE equality, while structural zero equality is explicitly rejected as a source of semantic selector domains. Unknown values, NaNs, infinities, overflow, and insufficient interval proofs conservatively leave the formula unchanged.

The flag is off by default.

## Qualification

Across 132 core E. coli, Glycerol, and Shewanella instances, selector-only mode found 796 selector domains and 84 candidate predicates, proving 86 endpoint facts across 10 rewrites. With derived bounds enabled it proved 90 facts across 14 rewrites, adding four Glycerol small-flux objectives.

Representative repeated ordinary-SymFPU measurements:

| Instance | Control | Selector propagation |
| --- | ---: | ---: |
| Shewanella boundary-20 FP32 | 0.835 s median | 0.460 s |
| Shewanella boundary-100 FP32 | timed out at 25 s | 2.883 s median |
| Shewanella boundary-600 FP32 | timed out at 50 s | 21.70-24.96 s |
| Glycerol small-flux-100 FP32, with derived bounds | timed out at 35 s | 1.763 s median |

Structural effects:

- Shewanella-20: 156,664 to 138,032 AIG nodes; 186,822 to 160,349 clauses; 4,778 to zero conflicts
- Shewanella-100: 805,719 to 780,215 AIG nodes; 984,700 to 947,378 clauses; conflicts to zero
- Glycerol small-flux-100: 1,308,644 to 598,758 AIG nodes; 1,112,143 to 429,675 clauses; conflicts to zero

The benefit also survives native arithmetic: Shewanella-20 improves from 0.338 to 0.157 seconds, Shewanella-100 from a 25-second timeout to 0.909 seconds, and Glycerol small-flux-100 from a 25-second timeout to 0.434 seconds.

## Tests

- `cmake --build build -j24`
- all 162 post-merge tests passed, including the complete query-file suite
- deterministic small-format differential: 100/100 results matched ordinary SymFPU, with 46 actual rewrites
- `git range-diff` confirms the rebased commit is identical to the qualified stacked commit
