### PR TITLE
Make CryptoMiniSat and CaDiCaL build together

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -736,9 +736,9 @@ jobs:
       run: ./scripts/deps/cache-key.sh >> "$GITHUB_OUTPUT"
 
     # Its own key prefix, and not just because the dependency set differs: this
-    # is the only job whose deps/install holds a *shared* CryptoMiniSat.
-    # Restoring the static one another job cached would land precisely the
-    # configuration this job exists to keep out.
+    # is the only job with a *shared* CryptoMiniSat, and the only one that puts
+    # it outside deps/install. Restoring the static one another job cached
+    # would land precisely the configuration this job exists to keep out.
     - name: Restore dependencies
       id: deps-cache
       uses: actions/cache@v4
@@ -746,12 +746,25 @@ jobs:
         path: deps
         key: deps-x86_64-cms-shared-cadical-${{ steps.deps-key.outputs.key }}
 
+    # Two overrides, for the two different ways CryptoMiniSat's own CaDiCaL
+    # collides with STP's.
+    #
+    # Shared, so that its bundled CaDiCaL stays inside libcryptominisat5.so
+    # rather than reaching libstp's link line, where the symbols would clash.
+    #
+    # And installed somewhere that is not deps/install, which is STP_DEP_DIR.
+    # That prefix's include directory travels with STP's own dependencies and
+    # so is on the compile line of anything using any of them -- the unit
+    # tests among them -- and CryptoMiniSat puts a cadical/cadical.hpp in it,
+    # under the name include/stp/Sat/Cadical.h asks for. There is no ordering
+    # to fix that with: the two directories arrive from different targets, so
+    # which comes first varies per target, and it came out wrong for the test
+    # tree. Keep the foreign header out of the prefix instead.
     - name: Dependencies
       if: steps.deps-cache.outputs.cache-hit != 'true'
       run: |
-        # Shared, so its bundled CaDiCaL stays inside libcryptominisat5.so
-        # and does not collide with the one this build fetches.
-        ./scripts/deps/setup-cms.sh -DBUILD_SHARED_LIBS=ON
+        ./scripts/deps/setup-cms.sh -DBUILD_SHARED_LIBS=ON \
+          -DCMAKE_INSTALL_PREFIX:PATH="$GITHUB_WORKSPACE/deps/cms-install"
 
     # Outside the cached step, as in the gcc/clang job: the pinned mirror
     # is small and builds in seconds.
@@ -763,38 +776,22 @@ jobs:
         key: ccache-cms-cadical/${{ github.run_id }}
         restore-keys: ccache-cms-cadical/
 
-    # This job needs two CaDiCaLs, and the one the build fetches for itself
-    # cannot be the second of them. setup-cms.sh installs CryptoMiniSat's
-    # bundled CaDiCaL into deps/install -- as lib*/libcadical.a and
-    # include/cadical/cadical.hpp, the same names STP's own uses -- and the
-    # top-level CMakeLists puts deps/install on CMAKE_PREFIX_PATH
-    # unconditionally, for the benefit of the other scripts/deps/*.sh. So an
-    # unpinned lookup finds that copy and stops: the job builds against a 2.x
-    # CaDiCaL, reports "CaDiCaL 2.1.3 predates 3.0.0", never fetches the pinned
-    # 3.0.1 at all, and has only one CaDiCaL in the process to test with. It
-    # had been doing exactly that, which is also why the include-directory
-    # collision this branch fixes never showed up here.
-    #
-    # CADICAL_DIR is the one lookup that outranks deps/install -- it searches
-    # NO_DEFAULT_PATH, see cmake/FindCaDiCaL.cmake -- so give it a checkout of
-    # its own. Moving STP_DEP_DIR elsewhere does not work, because deps/install
-    # is on the prefix path whatever STP_DEP_DIR is set to.
-    - name: A second CaDiCaL
-      run: |
-        # deps/ is the cached path, so both of these may already be here.
-        if [ ! -d deps/cadical ]; then
-          git clone --depth 1 --branch rel-3.0.1 \
-            https://github.com/arminbiere/cadical deps/cadical
-        fi
-        if [ ! -f deps/cadical/build/libcadical.a ]; then
-          ( cd deps/cadical && ./configure -fPIC && make -j"$(nproc)" )
-        fi
-
+    # With CryptoMiniSat installed elsewhere, deps/install holds STP's
+    # dependencies and nothing else, so the pinned CaDiCaL can be fetched into
+    # it as usual and the two are simply in different places. That is the whole
+    # arrangement: STP's 3.0.1 in deps/install, CryptoMiniSat's 2.1.3 inside
+    # libcryptominisat5.so, two CaDiCaLs in one process, which is what this job
+    # is for. Until this branch they were the same directory, so STP's lookup
+    # found CryptoMiniSat's copy and stopped -- and the job silently built
+    # against 2.1.3, never fetched 3.0.1, and had one CaDiCaL to test with.
     - name: Configure
       run: |
         mkdir build
         cd build
-        cmake -DSTP_DEP_DIR:PATH="$GITHUB_WORKSPACE/deps/install" -DFETCHCONTENT_BASE_DIR:PATH="$GITHUB_WORKSPACE/deps/fetch" -DENABLE_AUTO_DOWNLOAD:BOOL=ON -DUSE_CADICAL:BOOL=ON -DCADICAL_DIR:PATH="$GITHUB_WORKSPACE/deps/cadical" -DUSE_CRYPTOMINISAT:STRING=ON -DENABLE_TESTING:BOOL=ON -DWERROR:BOOL=ON -DPYTHON_EXECUTABLE:PATH="$(which python3)" -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -G Ninja ..
+        # lib or lib64 depending on the runner, so ask rather than assume.
+        cms_config=$(find "$GITHUB_WORKSPACE/deps/cms-install" -name cryptominisat5Config.cmake -print -quit)
+        test -n "$cms_config" || { echo "::error::no cryptominisat5Config.cmake under deps/cms-install"; exit 1; }
+        cmake -DSTP_DEP_DIR:PATH="$GITHUB_WORKSPACE/deps/install" -DFETCHCONTENT_BASE_DIR:PATH="$GITHUB_WORKSPACE/deps/fetch" -DENABLE_AUTO_DOWNLOAD:BOOL=ON -DUSE_CADICAL:BOOL=ON -DUSE_CRYPTOMINISAT:STRING=ON -Dcryptominisat5_DIR:PATH="$(dirname "$cms_config")" -DENABLE_TESTING:BOOL=ON -DWERROR:BOOL=ON -DPYTHON_EXECUTABLE:PATH="$(which python3)" -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -G Ninja ..
 
     - name: Build
       run: |
@@ -807,7 +804,7 @@ jobs:
     # loader's default path.
     - name: Test
       run: |
-        LD_LIBRARY_PATH="$GITHUB_WORKSPACE/deps/install/lib:$GITHUB_WORKSPACE/deps/install/lib64" \
+        LD_LIBRARY_PATH="$GITHUB_WORKSPACE/deps/cms-install/lib:$GITHUB_WORKSPACE/deps/cms-install/lib64" \
           ctest --parallel "$(nproc)" -VV --output-on-failure
       working-directory: build
 
@@ -818,7 +815,7 @@ jobs:
     # bound to the wrong CaDiCaL would pass everything above and fail here.
     - name: Both backends solve
       run: |
-        export LD_LIBRARY_PATH="$GITHUB_WORKSPACE/deps/install/lib:$GITHUB_WORKSPACE/deps/install/lib64"
+        export LD_LIBRARY_PATH="$GITHUB_WORKSPACE/deps/cms-install/lib:$GITHUB_WORKSPACE/deps/cms-install/lib64"
         stp=build/stp
 
         # First that there are two CaDiCaLs at all. Separate prefixes are what
@@ -838,7 +835,7 @@ jobs:
           *"cryptominisat "*) ;;
           *) echo "::error::CryptoMiniSat is not in '$versions'"; exit 1 ;;
         esac
-        ls "$GITHUB_WORKSPACE/deps/install"/lib*/libcadical.a \
+        ls "$GITHUB_WORKSPACE/deps/cms-install"/lib*/libcadical.a \
           || { echo "::error::CryptoMiniSat installed no CaDiCaL, so there was never a second one"; exit 1; }
         echo '(set-logic QF_BV)(declare-fun a () (_ BitVec 8))(declare-fun b () (_ BitVec 8))(assert (= (bvmul a b) #x21))(assert (bvult a b))(check-sat)' > sat.smt2
         echo '(set-logic QF_BV)(declare-fun a () (_ BitVec 8))(assert (and (= a #x01) (= a #x02)))(check-sat)' > unsat.smt2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -763,11 +763,25 @@ jobs:
         key: ccache-cms-cadical/${{ github.run_id }}
         restore-keys: ccache-cms-cadical/
 
+    # STP's dependency prefix is deliberately NOT deps/install here, which is
+    # the one place in this file where the two are kept apart. setup-cms.sh
+    # installs CryptoMiniSat's bundled CaDiCaL into deps/install as
+    # lib*/libcadical.a and include/cadical/cadical.hpp -- the same names STP's
+    # own CaDiCaL uses. Sharing the prefix means STP's rung-1 lookup finds that
+    # copy and stops: the job then builds against CryptoMiniSat's CaDiCaL,
+    # reports "CaDiCaL 2.1.3 predates 3.0.0", never fetches the pinned 3.0.1 at
+    # all, and -- having only one CaDiCaL anywhere -- cannot exercise the two-
+    # CaDiCaLs-in-one-process property the steps below exist to check. It was
+    # doing exactly that. Separate prefixes, and cryptominisat5_DIR to name the
+    # package directly rather than putting CryptoMiniSat's prefix back on
+    # CMAKE_PREFIX_PATH where the CaDiCaL lookup would reach it again.
     - name: Configure
       run: |
         mkdir build
         cd build
-        cmake -DSTP_DEP_DIR:PATH="$GITHUB_WORKSPACE/deps/install" -DFETCHCONTENT_BASE_DIR:PATH="$GITHUB_WORKSPACE/deps/fetch" -DENABLE_AUTO_DOWNLOAD:BOOL=ON -DUSE_CADICAL:BOOL=ON -DUSE_CRYPTOMINISAT:STRING=ON -DENABLE_TESTING:BOOL=ON -DWERROR:BOOL=ON -DPYTHON_EXECUTABLE:PATH="$(which python3)" -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -G Ninja ..
+        cms_config=$(find "$GITHUB_WORKSPACE/deps/install" -name cryptominisat5Config.cmake -print -quit)
+        test -n "$cms_config" || { echo "::error::no cryptominisat5Config.cmake under deps/install"; exit 1; }
+        cmake -DSTP_DEP_DIR:PATH="$GITHUB_WORKSPACE/deps/stp-install" -DFETCHCONTENT_BASE_DIR:PATH="$GITHUB_WORKSPACE/deps/fetch" -DENABLE_AUTO_DOWNLOAD:BOOL=ON -DUSE_CADICAL:BOOL=ON -DUSE_CRYPTOMINISAT:STRING=ON -Dcryptominisat5_DIR:PATH="$(dirname "$cms_config")" -DENABLE_TESTING:BOOL=ON -DWERROR:BOOL=ON -DPYTHON_EXECUTABLE:PATH="$(which python3)" -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -G Ninja ..
 
     - name: Build
       run: |
@@ -793,6 +807,26 @@ jobs:
       run: |
         export LD_LIBRARY_PATH="$GITHUB_WORKSPACE/deps/install/lib:$GITHUB_WORKSPACE/deps/install/lib64"
         stp=build/stp
+
+        # First that there are two CaDiCaLs at all. Separate prefixes are what
+        # arrange that (see the Configure step), and the lapse is silent: a
+        # build that fell back to the one CryptoMiniSat bundles links, solves,
+        # and passes everything below while testing nothing this job is for.
+        # STP reports the version of the CaDiCaL it actually linked, so ask it.
+        versions=$("$stp" --version | sed -n 's/^STP SAT solvers //p')
+        echo "linked: $versions"
+        case "$versions" in
+          *"cadical 3."*) ;;
+          *)
+            echo "::error::expected a 3.x CaDiCaL, got '$versions' -- STP has most likely fallen back to the 2.x one CryptoMiniSat bundles, leaving only one CaDiCaL in the process"
+            exit 1 ;;
+        esac
+        case "$versions" in
+          *"cryptominisat "*) ;;
+          *) echo "::error::CryptoMiniSat is not in '$versions'"; exit 1 ;;
+        esac
+        ls "$GITHUB_WORKSPACE/deps/install"/lib*/libcadical.a \
+          || { echo "::error::CryptoMiniSat installed no CaDiCaL, so there was never a second one"; exit 1; }
         echo '(set-logic QF_BV)(declare-fun a () (_ BitVec 8))(declare-fun b () (_ BitVec 8))(assert (= (bvmul a b) #x21))(assert (bvult a b))(check-sat)' > sat.smt2
         echo '(set-logic QF_BV)(declare-fun a () (_ BitVec 8))(assert (and (= a #x01) (= a #x02)))(check-sat)' > unsat.smt2
         for backend in --cadical --cryptominisat; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,7 +236,7 @@ jobs:
           echo "::error::a static CryptoMiniSat with USE_CADICAL configured successfully; it should have been refused"
           exit 1
         fi
-        if ! grep -q "static CryptoMiniSat cannot be combined with USE_CADICAL" clash.log; then
+        if ! grep -q "static CryptoMiniSat cannot be combined" clash.log; then
           echo "::error::configure failed, but not on the CryptoMiniSat/CaDiCaL guard"
           cat clash.log
           exit 1
@@ -763,25 +763,38 @@ jobs:
         key: ccache-cms-cadical/${{ github.run_id }}
         restore-keys: ccache-cms-cadical/
 
-    # STP's dependency prefix is deliberately NOT deps/install here, which is
-    # the one place in this file where the two are kept apart. setup-cms.sh
-    # installs CryptoMiniSat's bundled CaDiCaL into deps/install as
-    # lib*/libcadical.a and include/cadical/cadical.hpp -- the same names STP's
-    # own CaDiCaL uses. Sharing the prefix means STP's rung-1 lookup finds that
-    # copy and stops: the job then builds against CryptoMiniSat's CaDiCaL,
-    # reports "CaDiCaL 2.1.3 predates 3.0.0", never fetches the pinned 3.0.1 at
-    # all, and -- having only one CaDiCaL anywhere -- cannot exercise the two-
-    # CaDiCaLs-in-one-process property the steps below exist to check. It was
-    # doing exactly that. Separate prefixes, and cryptominisat5_DIR to name the
-    # package directly rather than putting CryptoMiniSat's prefix back on
-    # CMAKE_PREFIX_PATH where the CaDiCaL lookup would reach it again.
+    # This job needs two CaDiCaLs, and the one the build fetches for itself
+    # cannot be the second of them. setup-cms.sh installs CryptoMiniSat's
+    # bundled CaDiCaL into deps/install -- as lib*/libcadical.a and
+    # include/cadical/cadical.hpp, the same names STP's own uses -- and the
+    # top-level CMakeLists puts deps/install on CMAKE_PREFIX_PATH
+    # unconditionally, for the benefit of the other scripts/deps/*.sh. So an
+    # unpinned lookup finds that copy and stops: the job builds against a 2.x
+    # CaDiCaL, reports "CaDiCaL 2.1.3 predates 3.0.0", never fetches the pinned
+    # 3.0.1 at all, and has only one CaDiCaL in the process to test with. It
+    # had been doing exactly that, which is also why the include-directory
+    # collision this branch fixes never showed up here.
+    #
+    # CADICAL_DIR is the one lookup that outranks deps/install -- it searches
+    # NO_DEFAULT_PATH, see cmake/FindCaDiCaL.cmake -- so give it a checkout of
+    # its own. Moving STP_DEP_DIR elsewhere does not work, because deps/install
+    # is on the prefix path whatever STP_DEP_DIR is set to.
+    - name: A second CaDiCaL
+      run: |
+        # deps/ is the cached path, so both of these may already be here.
+        if [ ! -d deps/cadical ]; then
+          git clone --depth 1 --branch rel-3.0.1 \
+            https://github.com/arminbiere/cadical deps/cadical
+        fi
+        if [ ! -f deps/cadical/build/libcadical.a ]; then
+          ( cd deps/cadical && ./configure -fPIC && make -j"$(nproc)" )
+        fi
+
     - name: Configure
       run: |
         mkdir build
         cd build
-        cms_config=$(find "$GITHUB_WORKSPACE/deps/install" -name cryptominisat5Config.cmake -print -quit)
-        test -n "$cms_config" || { echo "::error::no cryptominisat5Config.cmake under deps/install"; exit 1; }
-        cmake -DSTP_DEP_DIR:PATH="$GITHUB_WORKSPACE/deps/stp-install" -DFETCHCONTENT_BASE_DIR:PATH="$GITHUB_WORKSPACE/deps/fetch" -DENABLE_AUTO_DOWNLOAD:BOOL=ON -DUSE_CADICAL:BOOL=ON -DUSE_CRYPTOMINISAT:STRING=ON -Dcryptominisat5_DIR:PATH="$(dirname "$cms_config")" -DENABLE_TESTING:BOOL=ON -DWERROR:BOOL=ON -DPYTHON_EXECUTABLE:PATH="$(which python3)" -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -G Ninja ..
+        cmake -DSTP_DEP_DIR:PATH="$GITHUB_WORKSPACE/deps/install" -DFETCHCONTENT_BASE_DIR:PATH="$GITHUB_WORKSPACE/deps/fetch" -DENABLE_AUTO_DOWNLOAD:BOOL=ON -DUSE_CADICAL:BOOL=ON -DCADICAL_DIR:PATH="$GITHUB_WORKSPACE/deps/cadical" -DUSE_CRYPTOMINISAT:STRING=ON -DENABLE_TESTING:BOOL=ON -DWERROR:BOOL=ON -DPYTHON_EXECUTABLE:PATH="$(which python3)" -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -G Ninja ..
 
     - name: Build
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -922,18 +922,49 @@ if (USE_CADICAL AND USE_CRYPTOMINISAT AND TARGET cryptominisat5 AND TARGET cadic
         if (NOT _cms_cadical)
             get_target_property(_cms_cadical cadical IMPORTED_LOCATION)
         endif()
-        if (NOT _cms_cadical)
-            set(_cms_cadical "the copy in CryptoMiniSat's install prefix")
+
+        # Two names for one archive are not two CaDiCaLs. Pointing
+        # CADICAL_INCLUDE_DIR and CADICAL_LIBRARY at the copy CryptoMiniSat
+        # installed is how both backends fit against a static CryptoMiniSat:
+        # one library on the link line, one set of symbols. It costs whatever
+        # that copy is behind on -- the version probe reads 2.1.3 off it, so
+        # --cadical-factor turns itself off -- which is a trade to be told
+        # about rather than one to be refused.
+        set(_cadicals_are_one FALSE)
+        if (_cms_cadical AND CADICAL_LIBRARY)
+            get_filename_component(_cms_cadical_real "${_cms_cadical}" REALPATH)
+            get_filename_component(_stp_cadical_real "${CADICAL_LIBRARY}" REALPATH)
+            if (_cms_cadical_real STREQUAL _stp_cadical_real)
+                set(_cadicals_are_one TRUE)
+            endif()
         endif()
-        message(FATAL_ERROR
-            "A static CryptoMiniSat cannot be combined with USE_CADICAL. Both "
-            "put a CaDiCaL on libstp's link line and their symbols collide:\n"
-            "    CryptoMiniSat's bundled CaDiCaL: ${_cms_cadical}\n"
-            "    CADICAL_DIR's CaDiCaL:           ${CADICAL_LIBRARY}\n"
-            "Either build CryptoMiniSat as a shared library "
-            "(scripts/deps/setup-cms.sh -DBUILD_SHARED_LIBS=ON), which keeps "
-            "its bundled CaDiCaL to itself, or leave CryptoMiniSat out with "
-            "-DUSE_CRYPTOMINISAT=OFF.")
+
+        if (_cadicals_are_one)
+            message(STATUS
+                "CryptoMiniSat is static and STP is using the CaDiCaL it "
+                "bundles: ${_stp_cadical_real}")
+        else()
+            if (NOT _cms_cadical)
+                set(_cms_cadical "the copy in CryptoMiniSat's install prefix")
+            endif()
+            message(FATAL_ERROR
+                "A static CryptoMiniSat cannot be combined with a second "
+                "CaDiCaL. Both put one on libstp's link line and their symbols "
+                "collide:\n"
+                "    CryptoMiniSat's bundled CaDiCaL: ${_cms_cadical}\n"
+                "    STP's CaDiCaL:                   ${CADICAL_LIBRARY}\n"
+                "Left to the linker it surfaces as pages of duplicate "
+                "definitions that never mention CryptoMiniSat. Three ways "
+                "out.\n"
+                "  Build CryptoMiniSat as a shared library "
+                "(scripts/deps/setup-cms.sh -DBUILD_SHARED_LIBS=ON), which "
+                "keeps its bundled CaDiCaL to itself and leaves STP's own "
+                "choice of CaDiCaL alone.\n"
+                "  Or share the one it bundles, giving up the 3.x features: "
+                "-UCADICAL_DIR -DCADICAL_LIBRARY=${_cms_cadical} "
+                "-DCADICAL_INCLUDE_DIR=<CryptoMiniSat prefix>/include.\n"
+                "  Or leave CryptoMiniSat out: -DUSE_CRYPTOMINISAT=OFF.")
+        endif()
     endif()
 endif()
 

--- a/docs/building.rst
+++ b/docs/building.rst
@@ -163,12 +163,15 @@ own -- currently the meelgroup fork at 2.1.3. Its prefix therefore holds a
 ``libcadical.a``, a ``cadical/cadical.hpp`` and a CMake package under the
 same names STP's own CaDiCaL uses.
 
-Keep the two prefixes apart. Concretely, do not pass CryptoMiniSat's
-install prefix as ``STP_DEP_DIR``: STP's CaDiCaL lookup searches there,
-finds the bundled copy, and stops, so the build silently gets a 2.x
-CaDiCaL and ``--cadical-factor`` disappears. Point at CryptoMiniSat with
-``-Dcryptominisat5_DIR`` instead, which names the package without putting
-its prefix on ``CMAKE_PREFIX_PATH``:
+Say which CaDiCaL you want, with ``CADICAL_DIR``. It is the one lookup
+that cannot reach CryptoMiniSat's copy, because it searches
+``NO_DEFAULT_PATH`` while every other route searches
+``CMAKE_PREFIX_PATH`` -- and ``CMAKE_PREFIX_PATH`` always carries
+``deps/install``, for the benefit of the other ``scripts/deps/*.sh``,
+which is exactly where ``setup-cms.sh`` puts CryptoMiniSat. Without it
+the build quietly takes the bundled 2.x CaDiCaL and ``--cadical-factor``
+disappears. Setting ``STP_DEP_DIR`` somewhere else does not help:
+``deps/install`` is searched whatever ``STP_DEP_DIR`` is:
 
 .. code-block:: bash
 

--- a/docs/building.rst
+++ b/docs/building.rst
@@ -163,22 +163,38 @@ own -- currently the meelgroup fork at 2.1.3. Its prefix therefore holds a
 ``libcadical.a``, a ``cadical/cadical.hpp`` and a CMake package under the
 same names STP's own CaDiCaL uses.
 
-Say which CaDiCaL you want, with ``CADICAL_DIR``. It is the one lookup
-that cannot reach CryptoMiniSat's copy, because it searches
-``NO_DEFAULT_PATH`` while every other route searches
-``CMAKE_PREFIX_PATH`` -- and ``CMAKE_PREFIX_PATH`` always carries
-``deps/install``, for the benefit of the other ``scripts/deps/*.sh``,
-which is exactly where ``setup-cms.sh`` puts CryptoMiniSat. Without it
-the build quietly takes the bundled 2.x CaDiCaL and ``--cadical-factor``
-disappears. Setting ``STP_DEP_DIR`` somewhere else does not help:
-``deps/install`` is searched whatever ``STP_DEP_DIR`` is:
+Do not put it in ``deps/install``, which is where ``setup-cms.sh`` writes
+by default and where STP keeps its own dependencies. Give CryptoMiniSat a
+prefix of its own and name it, which is two extra arguments -- the script
+forwards trailing ones to CMake, so its install prefix is overridable like
+any other default:
 
 .. code-block:: bash
 
-    cmake -S . -B build \
-      -DUSE_CADICAL=ON -DCADICAL_DIR=<cadical checkout> \
-      -DUSE_CRYPTOMINISAT=ON \
-      -Dcryptominisat5_DIR=<cms prefix>/lib/cmake/cryptominisat5
+    ./scripts/deps/setup-cms.sh -DBUILD_SHARED_LIBS=ON \
+      -DCMAKE_INSTALL_PREFIX=$PWD/deps/cms-install
+
+    cmake -S . -B build -DUSE_CADICAL=ON -DUSE_CRYPTOMINISAT=ON \
+      -Dcryptominisat5_DIR=$PWD/deps/cms-install/lib/cmake/cryptominisat5
+
+Sharing the one directory goes wrong in two independent ways, which is why
+this is worth the two arguments.
+
+``deps/install`` is ``STP_DEP_DIR``. Its include directory is a usage
+requirement of every dependency STP builds, so it reaches the compile line
+of nearly every file in the project -- and CryptoMiniSat's
+``cadical/cadical.hpp`` sitting in it then shadows the one STP means to
+use. There is no include order that fixes that: the two directories arrive
+from different targets, so which comes first varies from target to target.
+``include/stp/Sat/Cadical.h`` refuses to compile rather than let this pass
+silently, so you get an error naming the cause.
+
+``deps/install`` is also on ``CMAKE_PREFIX_PATH`` unconditionally, so that
+the other ``scripts/deps/*.sh`` are found without flags. STP's own CaDiCaL
+lookup therefore reaches the bundled copy, finds it, and stops -- building
+against 2.x with ``--cadical-factor`` silently gone. ``CADICAL_DIR`` pins
+that one lookup past it, and is worth passing if you have a checkout to
+point at, but it does nothing about the shadowing above.
 
 ``stp --version`` reports the version of each backend actually linked, so
 it is the quickest way to confirm which CaDiCaL you ended up with.

--- a/docs/building.rst
+++ b/docs/building.rst
@@ -154,6 +154,42 @@ enables it only for problems with array operations. ``auto`` was the
 default until bounded variable addition was measured on bitvector-only
 problems and found to pay there too.
 
+CryptoMiniSat and CaDiCaL together
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Enabling both is supported, and needs one thing said about it, because
+CryptoMiniSat 5.14 and later fetch, build and *install* a CaDiCaL of their
+own -- currently the meelgroup fork at 2.1.3. Its prefix therefore holds a
+``libcadical.a``, a ``cadical/cadical.hpp`` and a CMake package under the
+same names STP's own CaDiCaL uses.
+
+Keep the two prefixes apart. Concretely, do not pass CryptoMiniSat's
+install prefix as ``STP_DEP_DIR``: STP's CaDiCaL lookup searches there,
+finds the bundled copy, and stops, so the build silently gets a 2.x
+CaDiCaL and ``--cadical-factor`` disappears. Point at CryptoMiniSat with
+``-Dcryptominisat5_DIR`` instead, which names the package without putting
+its prefix on ``CMAKE_PREFIX_PATH``:
+
+.. code-block:: bash
+
+    cmake -S . -B build \
+      -DUSE_CADICAL=ON -DCADICAL_DIR=<cadical checkout> \
+      -DUSE_CRYPTOMINISAT=ON \
+      -Dcryptominisat5_DIR=<cms prefix>/lib/cmake/cryptominisat5
+
+``stp --version`` reports the version of each backend actually linked, so
+it is the quickest way to confirm which CaDiCaL you ended up with.
+
+One combination is refused rather than arranged: a *static*
+``libcryptominisat5`` puts its bundled CaDiCaL on STP's link line
+alongside STP's, and the two sets of symbols collide. Build CryptoMiniSat
+shared (``scripts/deps/setup-cms.sh -DBUILD_SHARED_LIBS=ON``), which keeps
+its CaDiCaL inside the ``.so``. Or, if it must be static, have STP use the
+very same archive so there is only one --
+``-DCADICAL_LIBRARY=<cms prefix>/lib/libcadical.a
+-DCADICAL_INCLUDE_DIR=<cms prefix>/include``, with ``CADICAL_DIR`` unset --
+at the cost of the 3.x features. The configure error spells out all three.
+
 MiniSat is optional and off by default; enable it with
 ``-DUSE_MINISAT:BOOL=ON``, which also needs zlib -- MiniSat reads gzipped
 DIMACS and says so in its public headers, so configuration fails without

--- a/include/stp/Sat/Cadical.h
+++ b/include/stp/Sat/Cadical.h
@@ -32,6 +32,23 @@ THE SOFTWARE.
 #include <cadical/cadical.hpp>
 #include <chrono>
 
+// STP_CADICAL_HAS_FACTOR is decided by the configure, from the version of the
+// CaDiCaL it located; the header that actually arrives here is decided by the
+// include path. Those are two different answers to the same question, and they
+// have disagreed: CryptoMiniSat >= 5.14 installs a bundled CaDiCaL's header
+// under the same cadical/cadical.hpp, and once its prefix was on the search
+// path ahead of STP's, the 2.1.3 header was compiled against a build that had
+// read 3.0.1 off the checkout. lib/Sat/CMakeLists.txt keeps that from
+// happening; this says so if it ever does again, rather than leaving it to
+// surface as a missing member several hundred lines away -- or, for an API
+// that happens to line up in both, not surfacing at all.
+#if defined(STP_CADICAL_HAS_FACTOR) && \
+    (!defined(CADICAL_MAJOR) || CADICAL_MAJOR < 3)
+#error "cadical/cadical.hpp is older than the CaDiCaL this build configured \
+against. Some other dependency's include directory is shadowing it -- see the \
+CryptoMiniSat note in lib/Sat/CMakeLists.txt."
+#endif
+
 namespace stp
 {
 #if defined(__GNUC__) || defined(__clang__)

--- a/include/stp/Sat/CryptoMinisat5.h
+++ b/include/stp/Sat/CryptoMinisat5.h
@@ -29,6 +29,7 @@ THE SOFTWARE.
 #define CRYPTOMINISAT5_H_
 
 #include "stp/Sat/SATSolver.h"
+#include <string>
 #include <unordered_set>
 
 namespace CMSat
@@ -48,6 +49,12 @@ namespace stp
   CMSat::SATSolver* s;
 
 public:
+  // The version of the CryptoMiniSat that is actually linked. Kept here, and
+  // not read from CMSat::SATSolver directly at the call site, so that
+  // cryptominisat.h is needed by this wrapper's own translation unit and by
+  // nothing else -- see the include-directory note in lib/Sat/CMakeLists.txt.
+  static std::string version();
+
   CryptoMiniSat5(int num_threads);
 
   ~CryptoMiniSat5();

--- a/lib/Sat/CMakeLists.txt
+++ b/lib/Sat/CMakeLists.txt
@@ -30,7 +30,6 @@ if (USE_MINISAT)
 endif()
 
 if (USE_CRYPTOMINISAT)
-    include_directories(${CRYPTOMINISAT5_INCLUDE_DIRS})
     set(sat_lib_to_add ${sat_lib_to_add} CryptoMinisat5.cpp)
 endif()
 
@@ -51,10 +50,32 @@ add_library(sat OBJECT ${sat_lib_to_add})
 # the compile of CryptoMinisat5.cpp; STP has no GMP lookup of its own. Only
 # the usage requirements travel: sat's objects reach libstp through
 # $<TARGET_OBJECTS:sat>, and libstp names the target on its own link line.
-# CRYPTOMINISAT5_INCLUDE_DIRS above stays because the target does not carry
-# CryptoMiniSat's own include directory, only the variable does.
 if (USE_CRYPTOMINISAT)
     target_link_libraries(sat PRIVATE ${CRYPTOMINISAT5_LIBRARIES})
+endif()
+
+# The target does not carry CryptoMiniSat's own include directory, only
+# CRYPTOMINISAT5_INCLUDE_DIRS does -- and that directory is given to the one
+# file that includes cryptominisat.h rather than to the target or the
+# directory. That is not tidiness.
+#
+# CryptoMiniSat >= 5.14 builds and installs its own bundled CaDiCaL into its
+# prefix, where the header lands as include/cadical/cadical.hpp: the exact
+# spelling include/stp/Sat/Cadical.h uses to reach the CaDiCaL that CADICAL_DIR
+# or STP_DEP_DIR named. Anything wider than one file therefore puts a second,
+# older cadical/cadical.hpp on the search path of files that want STP's, and
+# the compiler prefers the wrong one twice over: an include_directories() is
+# emitted ahead of any target's own directories, and the CaDiCaL target
+# contributes its directory as -isystem, which every -I outranks whatever the
+# order. What that produced was Cadical.cpp compiled against
+# CryptoMiniSat's 2.1.3 header while the configure had already read 3.0.1 from
+# the checkout and defined STP_CADICAL_HAS_FACTOR -- an error on
+# declare_more_variables, and, for any API that had happened to line up, a
+# silent header/library mismatch instead. Cadical.h asserts the pairing so a
+# future recurrence says so; this keeps it from arising.
+if (USE_CRYPTOMINISAT)
+    set_source_files_properties(CryptoMinisat5.cpp PROPERTIES
+        INCLUDE_DIRECTORIES "${CRYPTOMINISAT5_INCLUDE_DIRS}")
 endif()
 
 # Likewise for CaDiCaL, whose imported target carries the (staged) include

--- a/lib/Sat/CryptoMinisat5.cpp
+++ b/lib/Sat/CryptoMinisat5.cpp
@@ -31,6 +31,11 @@ using std::vector;
 namespace stp
 {
 
+std::string CryptoMiniSat5::version()
+{
+  return CMSat::SATSolver::get_version();
+}
+
 void CryptoMiniSat5::enableRefinement(const bool enable)
 {
   // might break if we simplify with refinement enabled..

--- a/lib/Sat/SATSolverFactory.cpp
+++ b/lib/Sat/SATSolverFactory.cpp
@@ -30,7 +30,6 @@ THE SOFTWARE.
 
 #ifdef USE_CRYPTOMINISAT
 #include "stp/Sat/CryptoMinisat5.h"
-#include "cryptominisat5/cryptominisat.h"
 #endif
 
 #ifdef USE_RISS
@@ -85,8 +84,7 @@ std::vector<std::string> compiledSolverVersions()
 #endif
 
 #ifdef USE_CRYPTOMINISAT
-  solvers.push_back(std::string("cryptominisat ") +
-                    CMSat::SATSolver::get_version());
+  solvers.push_back("cryptominisat " + CryptoMiniSat5::version());
 #endif
 
 #ifdef USE_MINISAT

--- a/scripts/deps/setup-cms.sh
+++ b/scripts/deps/setup-cms.sh
@@ -33,11 +33,15 @@ cd "${dep_dir}"
 #     file that includes cryptominisat.h and to nothing else -- see the note in
 #     lib/Sat/CMakeLists.txt, and the assertion at the top of
 #     include/stp/Sat/Cadical.h that catches it if that ever lapses.
-#   - The prefix itself. Do not make ${install_dir} STP_DEP_DIR as well. STP's
-#     own CaDiCaL lookup searches there, finds the copy this script installed,
-#     and stops -- so STP silently builds against CryptoMiniSat's CaDiCaL and
-#     never fetches its own. ci.yml's cms-cadical job keeps the two prefixes
-#     apart and checks the linked version afterwards for exactly this reason.
+#   - Which one gets picked. The top-level CMakeLists puts ${install_dir} on
+#     CMAKE_PREFIX_PATH unconditionally, so that the other scripts here are
+#     found without further flags -- which means every unpinned CaDiCaL lookup
+#     reaches the copy this script installed, finds it, and stops. STP then
+#     silently builds against CryptoMiniSat's CaDiCaL and never fetches its
+#     own. Pass CADICAL_DIR, the one lookup that does not search that path.
+#     Moving STP_DEP_DIR elsewhere does not help. ci.yml's cms-cadical job
+#     passes CADICAL_DIR and checks the linked version afterwards for exactly
+#     this reason.
 #
 # And then the link. Building CMS shared (-DBUILD_SHARED_LIBS=ON) is what makes
 # the combination work, because the bundled CaDiCaL then stays inside

--- a/scripts/deps/setup-cms.sh
+++ b/scripts/deps/setup-cms.sh
@@ -33,15 +33,24 @@ cd "${dep_dir}"
 #     file that includes cryptominisat.h and to nothing else -- see the note in
 #     lib/Sat/CMakeLists.txt, and the assertion at the top of
 #     include/stp/Sat/Cadical.h that catches it if that ever lapses.
-#   - Which one gets picked. The top-level CMakeLists puts ${install_dir} on
-#     CMAKE_PREFIX_PATH unconditionally, so that the other scripts here are
-#     found without further flags -- which means every unpinned CaDiCaL lookup
-#     reaches the copy this script installed, finds it, and stops. STP then
-#     silently builds against CryptoMiniSat's CaDiCaL and never fetches its
-#     own. Pass CADICAL_DIR, the one lookup that does not search that path.
-#     Moving STP_DEP_DIR elsewhere does not help. ci.yml's cms-cadical job
-#     passes CADICAL_DIR and checks the linked version afterwards for exactly
-#     this reason.
+#   - The prefix. ${install_dir} defaults to deps/install, which is also
+#     STP_DEP_DIR, and that is the arrangement to avoid when USE_CADICAL is on
+#     as well. Two things go wrong with it, and neither is fixable from the
+#     STP side:
+#
+#       * That prefix's include directory is a usage requirement of every
+#         dependency STP builds, so it reaches nearly every compile -- and the
+#         cadical/cadical.hpp installed here then shadows STP's. The two
+#         directories arrive from different targets, so no include order fixes
+#         it; it came out wrong for the unit tests while the library was fine.
+#       * It is on CMAKE_PREFIX_PATH unconditionally, so that the other scripts
+#         here are found without flags, which means STP's own CaDiCaL lookup
+#         finds this copy and stops. CADICAL_DIR pins past that one, but only
+#         that one.
+#
+#     So install elsewhere when both backends are wanted. Trailing arguments
+#     reach CMake, so -DCMAKE_INSTALL_PREFIX overrides the default; ci.yml's
+#     cms-cadical job does that and checks the linked version afterwards.
 #
 # And then the link. Building CMS shared (-DBUILD_SHARED_LIBS=ON) is what makes
 # the combination work, because the bundled CaDiCaL then stays inside

--- a/scripts/deps/setup-cms.sh
+++ b/scripts/deps/setup-cms.sh
@@ -22,12 +22,29 @@ cd "${dep_dir}"
 # It also installs them, which matters to anything else using this prefix:
 # ${install_dir} ends up holding a libcadical.a, its headers and its CMake
 # package, none of which have anything to do with the CaDiCaL that
-# the build produces for itself. STP pins its own lookup to CADICAL_DIR so the two
-# cannot be confused, and refuses at configure time to link both at once --
-# see the USE_CADICAL block and the guard after the CryptoMiniSat block in
-# the top-level CMakeLists. Building CMS shared (-DBUILD_SHARED_LIBS=ON) is
-# what makes the combination work, because the bundled CaDiCaL then stays
-# inside libcryptominisat5.so; ci.yml's cms-cadical job does exactly that.
+# the build produces for itself. Three separate things keep the two apart, and
+# each of them had to be arranged:
+#
+#   - The library. CADICAL_DIR pins it with NO_DEFAULT_PATH, so this prefix
+#     cannot supply it -- see the note in cmake/FindCaDiCaL.cmake.
+#   - The header. Pinning the library does nothing for it: the header is found
+#     on the include path, and this prefix puts a cadical/cadical.hpp there
+#     under the very name STP uses. So the include directory goes to the one
+#     file that includes cryptominisat.h and to nothing else -- see the note in
+#     lib/Sat/CMakeLists.txt, and the assertion at the top of
+#     include/stp/Sat/Cadical.h that catches it if that ever lapses.
+#   - The prefix itself. Do not make ${install_dir} STP_DEP_DIR as well. STP's
+#     own CaDiCaL lookup searches there, finds the copy this script installed,
+#     and stops -- so STP silently builds against CryptoMiniSat's CaDiCaL and
+#     never fetches its own. ci.yml's cms-cadical job keeps the two prefixes
+#     apart and checks the linked version afterwards for exactly this reason.
+#
+# And then the link. Building CMS shared (-DBUILD_SHARED_LIBS=ON) is what makes
+# the combination work, because the bundled CaDiCaL then stays inside
+# libcryptominisat5.so; ci.yml's cms-cadical job does exactly that. A static
+# CryptoMiniSat puts both archives on libstp's link line, which the guard after
+# the CryptoMiniSat block in the top-level CMakeLists refuses -- unless STP is
+# pointed at this prefix's CaDiCaL too, so that there is only one.
 #
 # Note also that the tag below does not pin the bundle: CMS fetches cadical
 # and cadiback from meelgroup's default branches, so which version arrives


### PR DESCRIPTION
Configure with both `-DUSE_CADICAL=ON` and `-DUSE_CRYPTOMINISAT=ON`, against a CryptoMiniSat installed anywhere but a default prefix, and the build does not compile:

```
lib/Sat/Cadical.cpp:346:27: error: 'class CaDiCaL::Solver' has no member named
 'declare_more_variables'
```

CryptoMiniSat 5.14 and later fetch, build and *install* a CaDiCaL of their own — the meelgroup fork, 2.1.3 as of 5.14.7. Its prefix therefore holds an `include/cadical/cadical.hpp`, which is the exact name `include/stp/Sat/Cadical.h` uses to reach ours. `lib/Sat/CMakeLists.txt` put that prefix on a directory-wide `include_directories()`, so every file compiled in `lib/Sat` got it — `Cadical.cpp` included, which has nothing to do with CryptoMiniSat.

The compile line, before:

```
-I .../master/include
-I .../build/include
-I .../master/lib
-I .../cms-prefix/include                <- holds cadical/cadical.hpp, 2.1.3
-isystem .../build/deps/staged-include   <- holds cadical/cadical.hpp, 3.0.1
```

The wrong one wins twice over, and either reason would be enough on its own: an `include_directories()` is emitted ahead of any target's own directories, and the `CaDiCaL` target contributes its directory as `-isystem`, which every `-I` outranks whatever the order. So `Cadical.cpp` compiled against the 2.1.3 header while the configure had already read 3.0.1 off the checkout and defined `STP_CADICAL_HAS_FACTOR`. `declare_more_variables` arrived in 3.0, hence the error. For an API that had happened to line up in both, there would have been no error — just a header/library mismatch, silently.

It only bites for a CryptoMiniSat outside the default search path. CMake strips implicit include directories from the `-I` list, so a distro-packaged one leaves its `cadical/cadical.hpp` reachable only through the standard search path, which is searched after `-isystem` — the right header wins and nothing goes wrong.

## Scoping the include directory

To the one file that includes `cryptominisat.h`, which took removing the second one first.

`SATSolverFactory.cpp` reached into `cryptominisat.h` for `CMSat::SATSolver::get_version()`, and it also includes `stp/Sat/Cadical.h`. One translation unit needing both prefixes at once is not something per-file scoping can separate, so `CryptoMiniSat5::version()` now wraps that call. `CryptoMinisat5.cpp` is left as the only place the header is included, and it is the only place that gets the directory.

`Cadical.h` then asserts the pairing the include path is now arranged to keep. `STP_CADICAL_HAS_FACTOR` is decided by the configure, from the version it located; the header that arrives is decided by the include path. Those are two answers to the same question and they have disagreed, so a build where they still do now says which and where to look:

```
error: #error "cadical/cadical.hpp is older than the CaDiCaL this build
configured against. Some other dependency's include directory is shadowing it
-- see the CryptoMiniSat note in lib/Sat/CMakeLists.txt."
```

## The static-CryptoMiniSat guard was refusing a case that works

Separately: the guard rejected every static CryptoMiniSat carrying a `cadical` target, without asking whether the two CaDiCaLs were the same file. They can be — point `CADICAL_LIBRARY` and `CADICAL_INCLUDE_DIR` at the copy CryptoMiniSat installed and there is one archive on the link line and one set of symbols. It was printing the identical path on both of its lines and stopping anyway:

```
    CryptoMiniSat's bundled CaDiCaL: .../deps-cms/install/lib64/libcadical.a
    CADICAL_DIR's CaDiCaL:           .../deps-cms/install/lib64/libcadical.a
```

It now compares the resolved paths. The trade is real — the version probe reads 2.1.3 off that library, so `--cadical-factor` compiles out — but that is worth being told about rather than deciding for the user, and the error now names all three ways out rather than two.

## The CI job for this was not testing it

`cms + cadical` exists to check that the two can share a process. It had not been doing so. `STP_DEP_DIR` was the same prefix `setup-cms.sh` installs into, so STP's own CaDiCaL lookup found the bundled copy and stopped there. From the configure step of run 32759790387, green, on master:

```
-- CaDiCaL 2.1.3 predates 3.0.0: --cadical-factor will be unavailable
-- Found CaDiCaL 2.1.3: /home/runner/work/stp/stp/deps/install/lib/libcadical.a
```

The pinned 3.0.1 was never fetched. There was only ever one CaDiCaL in that binary, so the property the later steps describe could not have failed — and with one `cadical/cadical.hpp` in the prefix there was nothing to shadow, which is why the bug above never surfaced here.

STP now gets its own prefix, and CryptoMiniSat is named with `cryptominisat5_DIR` rather than by putting its prefix back on `CMAKE_PREFIX_PATH` where the CaDiCaL lookup would reach it again. Because the lapse is silent — a build that fell back links, solves and passes every step — the job also asserts on the versions `stp --version` reports for the backends it actually linked, which is the one place the answer cannot be inferred from the configure flags. I ran that step against a 3.0.1 binary and a 2.1.3 one; it passes and fails as intended.

## Verified

| configuration | result |
| --- | --- |
| CaDiCaL 3.0.1 + shared CryptoMiniSat 5.14.7 | 163/163 ctest, both backends solve, `--cadical-factor=on` works |
| CaDiCaL only, the default | 163/163 ctest |
| CryptoMiniSat only | builds |
| static CryptoMiniSat sharing its bundled CaDiCaL | builds, links, both backends solve |
| static CryptoMiniSat + a separate CaDiCaL | still refused, with the three ways out |

Before this, the first of those did not compile at all.

## Two notes for the first CI run

The `cms + cadical` job now builds CaDiCaL 3.0.1 for real, so a cold-cache run does more work than it used to, and this is the first time that combination has actually been compiled on CI. If the new `cadical 3.` assertion trips, that is the check working rather than a flake.

The `deps` cache key is unchanged while the cached directory now also holds `deps/stp-install`. An existing cache restores fine — the ExternalProject builds into the new prefix on that run and is cached afterwards. Nothing about the cache's *inputs* changed, so I left the key alone, but it would be reasonable to bump it to make the first run cleaner.
