### PR TITLE
Enable extremal FP selectors by default

### DIFF
--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -584,13 +584,12 @@ public:
   // additional constraints. Enabled by default; retain the flag for ablation.
   bool fp_domain_derived_bounds = true;
 
-  // Experimental propagation through an objective over semantic {0, 1}
-  // floating-point selector symbols. Replace the objective only when
-  // interval exclusion proves each selected endpoint necessary and their
-  // conjunction sufficient. Exact extrema are the primary case. Kept
-  // separate from the interval-bound experiment so their solver effects can
-  // be ablated.
-  bool fp_domain_extremal_selectors = false;
+  // Propagation through an objective over semantic {0, 1} floating-point
+  // selector symbols. Replace the objective only when interval exclusion
+  // proves each selected endpoint necessary and their conjunction sufficient.
+  // Exact extrema are the primary case. Enabled by default; retain the flag
+  // so its solver effects can be ablated independently.
+  bool fp_domain_extremal_selectors = true;
 
   // Sound zero-fact extraction for boxed nonnegative FP symbols. It only
   // derives zero facts from same-sign rows whose terms are +/- one boxed

--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -577,12 +577,12 @@ public:
   // decide them.
   bool fp_domain_simplify = false;
 
-  // Experimental decision-only extension of the FP domain prepass. Derive
-  // symbol endpoints from top-level symbol/expression inequalities and from
-  // a narrowly recognised zero-result addition. The derived facts may
-  // discharge comparisons or expose contradictory boxes, but are not
-  // emitted as additional constraints.
-  bool fp_domain_derived_bounds = false;
+  // Decision-only extension of the FP domain prepass. Derive symbol endpoints
+  // from top-level symbol/expression inequalities and from a narrowly
+  // recognised zero-result addition. The derived facts may discharge
+  // comparisons or expose contradictory boxes, but are not emitted as
+  // additional constraints. Enabled by default; retain the flag for ablation.
+  bool fp_domain_derived_bounds = true;
 
   // Experimental propagation through an objective over semantic {0, 1}
   // floating-point selector symbols. Replace the objective only when

--- a/lib/FloatBlaster/FpDomainSimplify.cpp
+++ b/lib/FloatBlaster/FpDomainSimplify.cpp
@@ -5,13 +5,16 @@
 
 #include "stp/FloatBlaster/DecimalLiteral.h"
 #include "stp/FloatBlaster/rounding_modes.h"
+#include "stp/Util/DagWalk.h"
 
 #include "extlib-constbv/constantbv.h"
 
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <deque>
 #include <iostream>
+#include <iterator>
 #include <limits>
 #include <unordered_map>
 #include <vector>
@@ -1145,9 +1148,69 @@ private:
 
   Interval interval(const ASTNode& n)
   {
+    PrimeAudit::Running running(intervalAudit, n);
+
     const IntervalMap::const_iterator cached = intervals.find(n);
     if (cached != intervals.end())
       return cached->second;
+
+    // intervalUncached is memoised by node alone and reaches only the
+    // expression operands described below. Fill those answers bottom-up so
+    // its calls on children stop at the cache instead of consuming one C++
+    // frame per FP operation. In particular, an ITE condition and an
+    // arithmetic rounding-mode operand are deliberately not interval
+    // expressions and must not be visited here.
+    primeMemo(
+        n,
+        [this](const ASTNode& current)
+        {
+          if (intervals.find(current) != intervals.end())
+            return Walk::Skip;
+
+          switch (current.GetKind())
+          {
+            case ITE:
+              return current.Degree() == 3 && fpSort(current)
+                         ? Walk::Descend
+                         : Walk::Visit;
+            case FP_ABS:
+            case FP_NEG:
+              return current.Degree() == 1 ? Walk::Descend : Walk::Visit;
+            case FP_ADD:
+            case FP_SUB:
+            case FP_MUL:
+              return current.Degree() == 3 ? Walk::Descend : Walk::Visit;
+            default: return Walk::Visit;
+          }
+        },
+        [](const ASTNode& current)
+        {
+          switch (current.GetKind())
+          {
+            case ITE: return WalkOperands::range(1, 3);
+            case FP_ABS:
+            case FP_NEG: return WalkOperands::range(0, 1);
+            case FP_ADD:
+            case FP_SUB:
+            case FP_MUL: return WalkOperands::range(1, 3);
+            default:
+              assert(false && "interval walk descended an unsupported node");
+              return WalkOperands();
+          }
+        },
+        [this](const ASTNode& current, PrimeMemoReady)
+        {
+          const bool inserted =
+              intervals.emplace(current, intervalUncached(current)).second;
+          assert(inserted);
+          (void)inserted;
+        });
+
+    // primeMemo leaves an uncached leaf or unsupported top-level node for
+    // its caller. Supported compound expressions were recorded by the walk.
+    const IntervalMap::const_iterator primed = intervals.find(n);
+    if (primed != intervals.end())
+      return primed->second;
 
     Interval out = intervalUncached(n);
     intervals.emplace(n, out);
@@ -1678,12 +1741,8 @@ private:
     return nf->CreateNode(AND, conjuncts);
   }
 
-  ASTNode rewrite(const ASTNode& n)
+  ASTNode localRewrite(const ASTNode& n)
   {
-    const ASTNodeMap::const_iterator cached = rewriteCache.find(n);
-    if (cached != rewriteCache.end())
-      return cached->second;
-
     ASTNode out;
     const bool legacyRewrite = bm->UserFlags.fp_domain_simplify ||
                                bm->UserFlags.fp_domain_row_bounds;
@@ -1740,27 +1799,117 @@ private:
       }
     }
 
-    if (out.IsNull())
-    {
-      if (n.Degree() == 0)
-        out = n;
-      else
-      {
-        ASTVec children;
-        children.reserve(n.Degree());
-        bool changed = false;
-        for (const ASTNode& child : n)
-        {
-          const ASTNode r = rewrite(child);
-          changed = changed || r != child;
-          children.push_back(r);
-        }
-        out = changed ? rebuild(nf, n, children) : n;
-      }
-    }
-
-    rewriteCache[n] = out;
     return out;
+  }
+
+  ASTNode rewrite(const ASTNode& n)
+  {
+    ASTNode result;
+
+    // Match the recursive implementation's entry sequence exactly: consult
+    // the memo, try a node-local replacement (which also prunes boxed
+    // predicates), and only then consider children. Keeping this decision
+    // ahead of descent avoids both unnecessary work below proof predicates
+    // and changes to node-factory/counter ordering.
+    auto known = [this, &result](const ASTNode& current)
+    {
+      const ASTNodeMap::const_iterator cached = rewriteCache.find(current);
+      if (cached != rewriteCache.end())
+      {
+        result = cached->second;
+        return true;
+      }
+
+      result = localRewrite(current);
+      if (result.IsNull() && current.Degree() == 0)
+        result = current;
+      if (result.IsNull())
+        return false;
+
+      rewriteCache[current] = result;
+      return true;
+    };
+
+    if (known(n))
+      return result;
+
+    struct Frame
+    {
+      ASTNode node;
+      size_t childrenBegin;
+      size_t nextChild = 0;
+      bool waiting = false;
+      bool changed = false;
+
+      Frame(const ASTNode& n_, size_t begin)
+          : node(n_), childrenBegin(begin)
+      {
+      }
+    };
+
+    // Results for all suspended parents share one arena. This keeps a deep
+    // unary FP chain to O(depth) compact frames instead of one separately
+    // allocated child vector per level.
+    ASTVec activeChildren;
+    ASTVec rebuiltChildren;
+    std::deque<Frame> stack;
+    stack.emplace_back(n, 0);
+
+    while (true)
+    {
+      Frame& current = stack.back();
+      if (current.waiting)
+      {
+        current.waiting = false;
+        current.changed =
+            current.changed || result != current.node[current.nextChild];
+        activeChildren.push_back(result);
+        ++current.nextChild;
+      }
+
+      bool descended = false;
+      while (current.nextChild < current.node.Degree())
+      {
+        const ASTNode child = current.node[current.nextChild];
+        if (known(child))
+        {
+          current.changed = current.changed || result != child;
+          activeChildren.push_back(result);
+          ++current.nextChild;
+          continue;
+        }
+
+        // A deque keeps `current` valid across the push, but no reference to
+        // it is used until the next loop iteration regardless.
+        current.waiting = true;
+        stack.emplace_back(child, activeChildren.size());
+        descended = true;
+        break;
+      }
+      if (descended)
+        continue;
+
+      assert(activeChildren.size() - current.childrenBegin ==
+             current.node.Degree());
+      if (current.changed)
+      {
+        rebuiltChildren.clear();
+        rebuiltChildren.insert(
+            rebuiltChildren.end(),
+            std::make_move_iterator(activeChildren.begin() +
+                                    current.childrenBegin),
+            std::make_move_iterator(activeChildren.end()));
+        result = rebuild(nf, current.node, rebuiltChildren);
+      }
+      else
+        result = current.node;
+      activeChildren.resize(current.childrenBegin);
+
+      rewriteCache[current.node] = result;
+      stack.pop_back();
+      if (stack.empty())
+        return result;
+    }
   }
 
   STPMgr* bm;
@@ -1779,6 +1928,7 @@ private:
   ASTNodeSet soundZeroSymbols;
   ASTNodeMap soundParent;
   IntervalMap intervals;
+  PrimeAudit intervalAudit{"FpDomainSimplify::interval", 2};
   ASTNodeMap extremalRewrites;
   ASTNodeMap rewriteCache;
 };

--- a/tests/query-files/fp-tests/fp-domain-derived-relational.smt2
+++ b/tests/query-files/fp-tests/fp-domain-derived-relational.smt2
@@ -3,9 +3,12 @@
 ; resulting [0,4] box only to refute the separate objective.
 ;
 ; RUN: %solver --fp-domain-sound-zero-facts=0 --fp-domain-derived-bounds=1 -s %s 2>&1 | %OutputCheck --check-prefix=DERIVED %s
-; RUN: %solver --fp-domain-sound-zero-facts=0 %s | %OutputCheck --check-prefix=BASE %s
+; RUN: %solver --fp-domain-sound-zero-facts=0 -s %s 2>&1 | %OutputCheck --check-prefix=DEFAULT %s
+; RUN: %solver --fp-domain-sound-zero-facts=0 --fp-domain-derived-bounds=0 %s | %OutputCheck --check-prefix=BASE %s
 ; DERIVED: FpDomainSimplify: 2 boxed symbols, 0 interval-true, 1 interval-false, .* 2 derived-relations, 2 derived-bounds
 ; DERIVED: unsat
+; DEFAULT: FpDomainSimplify: 2 boxed symbols, 0 interval-true, 1 interval-false, .* 2 derived-relations, 2 derived-bounds
+; DEFAULT: unsat
 ; BASE: unsat
 
 (set-logic QF_FP)

--- a/tests/query-files/fp-tests/fp-domain-derived-relational.smt2
+++ b/tests/query-files/fp-tests/fp-domain-derived-relational.smt2
@@ -2,9 +2,9 @@
 ; experiment is decision-only: it keeps both source relations and uses the
 ; resulting [0,4] box only to refute the separate objective.
 ;
-; RUN: %solver --fp-domain-sound-zero-facts=0 --fp-domain-derived-bounds=1 -s %s 2>&1 | %OutputCheck --check-prefix=DERIVED %s
+; RUN: %solver --fp-domain-sound-zero-facts=0 --fp-domain-derived-bounds=1 --fp-domain-extremal-selectors=0 -s %s 2>&1 | %OutputCheck --check-prefix=DERIVED %s
 ; RUN: %solver --fp-domain-sound-zero-facts=0 -s %s 2>&1 | %OutputCheck --check-prefix=DEFAULT %s
-; RUN: %solver --fp-domain-sound-zero-facts=0 --fp-domain-derived-bounds=0 %s | %OutputCheck --check-prefix=BASE %s
+; RUN: %solver --fp-domain-sound-zero-facts=0 --fp-domain-derived-bounds=0 --fp-domain-extremal-selectors=0 %s | %OutputCheck --check-prefix=BASE %s
 ; DERIVED: FpDomainSimplify: 2 boxed symbols, 0 interval-true, 1 interval-false, .* 2 derived-relations, 2 derived-bounds
 ; DERIVED: unsat
 ; DEFAULT: FpDomainSimplify: 2 boxed symbols, 0 interval-true, 1 interval-false, .* 2 derived-relations, 2 derived-bounds

--- a/tests/query-files/fp-tests/fp-domain-derived-zero-add-minsub.smt2
+++ b/tests/query-files/fp-tests/fp-domain-derived-zero-add-minsub.smt2
@@ -3,9 +3,9 @@
 ; at x = minSub, so the strict upper endpoint is contradictory. The inner
 ; addition uses -zero to ensure the rule is numeric, not packed-zero equality.
 ;
-; RUN: %solver --fp-domain-sound-zero-facts=0 --fp-domain-derived-bounds=1 -s %s 2>&1 | %OutputCheck --check-prefix=DERIVED %s
+; RUN: %solver --fp-domain-sound-zero-facts=0 --fp-domain-derived-bounds=1 --fp-domain-extremal-selectors=0 -s %s 2>&1 | %OutputCheck --check-prefix=DERIVED %s
 ; RUN: %solver --fp-domain-sound-zero-facts=0 -s %s 2>&1 | %OutputCheck --check-prefix=DEFAULT %s
-; RUN: %solver --fp-domain-sound-zero-facts=0 --fp-domain-derived-bounds=0 %s | %OutputCheck --check-prefix=BASE %s
+; RUN: %solver --fp-domain-sound-zero-facts=0 --fp-domain-derived-bounds=0 --fp-domain-extremal-selectors=0 %s | %OutputCheck --check-prefix=BASE %s
 ; DERIVED: 1 zero-add-bounds, 1 inconsistent-boxes
 ; DERIVED: unsat
 ; DEFAULT: 1 zero-add-bounds, 1 inconsistent-boxes

--- a/tests/query-files/fp-tests/fp-domain-derived-zero-add-minsub.smt2
+++ b/tests/query-files/fp-tests/fp-domain-derived-zero-add-minsub.smt2
@@ -4,9 +4,12 @@
 ; addition uses -zero to ensure the rule is numeric, not packed-zero equality.
 ;
 ; RUN: %solver --fp-domain-sound-zero-facts=0 --fp-domain-derived-bounds=1 -s %s 2>&1 | %OutputCheck --check-prefix=DERIVED %s
-; RUN: %solver --fp-domain-sound-zero-facts=0 %s | %OutputCheck --check-prefix=BASE %s
+; RUN: %solver --fp-domain-sound-zero-facts=0 -s %s 2>&1 | %OutputCheck --check-prefix=DEFAULT %s
+; RUN: %solver --fp-domain-sound-zero-facts=0 --fp-domain-derived-bounds=0 %s | %OutputCheck --check-prefix=BASE %s
 ; DERIVED: 1 zero-add-bounds, 1 inconsistent-boxes
 ; DERIVED: unsat
+; DEFAULT: 1 zero-add-bounds, 1 inconsistent-boxes
+; DEFAULT: unsat
 ; BASE: unsat
 
 (set-logic QF_FP)

--- a/tests/query-files/fp-tests/fp-domain-derived-zero-add.smt2
+++ b/tests/query-files/fp-tests/fp-domain-derived-zero-add.smt2
@@ -4,9 +4,12 @@
 ; contradicting the asserted upper bound 49.
 ;
 ; RUN: %solver --fp-domain-sound-zero-facts=0 --fp-domain-derived-bounds=1 -s %s 2>&1 | %OutputCheck --check-prefix=DERIVED %s
-; RUN: %solver --fp-domain-sound-zero-facts=0 %s | %OutputCheck --check-prefix=BASE %s
+; RUN: %solver --fp-domain-sound-zero-facts=0 -s %s 2>&1 | %OutputCheck --check-prefix=DEFAULT %s
+; RUN: %solver --fp-domain-sound-zero-facts=0 --fp-domain-derived-bounds=0 %s | %OutputCheck --check-prefix=BASE %s
 ; DERIVED: 1 zero-add-bounds, 1 inconsistent-boxes
 ; DERIVED: unsat
+; DEFAULT: 1 zero-add-bounds, 1 inconsistent-boxes
+; DEFAULT: unsat
 ; BASE: unsat
 
 (set-logic QF_FP)

--- a/tests/query-files/fp-tests/fp-domain-derived-zero-add.smt2
+++ b/tests/query-files/fp-tests/fp-domain-derived-zero-add.smt2
@@ -3,9 +3,9 @@
 ; subnormal. Thus this association-preserving row gives obj = 10*r = 50,
 ; contradicting the asserted upper bound 49.
 ;
-; RUN: %solver --fp-domain-sound-zero-facts=0 --fp-domain-derived-bounds=1 -s %s 2>&1 | %OutputCheck --check-prefix=DERIVED %s
+; RUN: %solver --fp-domain-sound-zero-facts=0 --fp-domain-derived-bounds=1 --fp-domain-extremal-selectors=0 -s %s 2>&1 | %OutputCheck --check-prefix=DERIVED %s
 ; RUN: %solver --fp-domain-sound-zero-facts=0 -s %s 2>&1 | %OutputCheck --check-prefix=DEFAULT %s
-; RUN: %solver --fp-domain-sound-zero-facts=0 --fp-domain-derived-bounds=0 %s | %OutputCheck --check-prefix=BASE %s
+; RUN: %solver --fp-domain-sound-zero-facts=0 --fp-domain-derived-bounds=0 --fp-domain-extremal-selectors=0 %s | %OutputCheck --check-prefix=BASE %s
 ; DERIVED: 1 zero-add-bounds, 1 inconsistent-boxes
 ; DERIVED: unsat
 ; DEFAULT: 1 zero-add-bounds, 1 inconsistent-boxes

--- a/tests/query-files/fp-tests/fp-domain-extremal-selectors.smt2
+++ b/tests/query-files/fp-tests/fp-domain-extremal-selectors.smt2
@@ -8,8 +8,8 @@
 ; The structural {+0,1} disjunction for w is deliberately not treated as a
 ; semantic selector domain.
 ;
-; RUN: %solver --fp-domain-sound-zero-facts=0 --fp-domain-extremal-selectors=1 -s %s 2>&1 | %OutputCheck --check-prefix=SELECTOR %s
-; RUN: %solver --fp-domain-sound-zero-facts=0 %s | %OutputCheck --check-prefix=BASE %s
+; RUN: %solver --fp-domain-sound-zero-facts=0 --fp-domain-derived-bounds=0 --fp-domain-extremal-selectors=1 -s %s 2>&1 | %OutputCheck --check-prefix=SELECTOR %s
+; RUN: %solver --fp-domain-sound-zero-facts=0 --fp-domain-derived-bounds=0 --fp-domain-extremal-selectors=0 %s | %OutputCheck --check-prefix=BASE %s
 ; SELECTOR: 4 extremal-selector-domains, 3 extremal-selector-predicates, 3 extremal-selector-facts, 2 extremal-selector-rewrites
 ; SELECTOR: sat
 ; BASE: sat

--- a/tests/query-files/fp-tests/fp-domain-extremal-selectors.smt2
+++ b/tests/query-files/fp-tests/fp-domain-extremal-selectors.smt2
@@ -9,9 +9,12 @@
 ; semantic selector domain.
 ;
 ; RUN: %solver --fp-domain-sound-zero-facts=0 --fp-domain-derived-bounds=0 --fp-domain-extremal-selectors=1 -s %s 2>&1 | %OutputCheck --check-prefix=SELECTOR %s
+; RUN: %solver --fp-domain-sound-zero-facts=0 -s %s 2>&1 | %OutputCheck --check-prefix=DEFAULT %s
 ; RUN: %solver --fp-domain-sound-zero-facts=0 --fp-domain-derived-bounds=0 --fp-domain-extremal-selectors=0 %s | %OutputCheck --check-prefix=BASE %s
 ; SELECTOR: 4 extremal-selector-domains, 3 extremal-selector-predicates, 3 extremal-selector-facts, 2 extremal-selector-rewrites
 ; SELECTOR: sat
+; DEFAULT: 4 extremal-selector-domains, 3 extremal-selector-predicates, 3 extremal-selector-facts, 2 extremal-selector-rewrites
+; DEFAULT: sat
 ; BASE: sat
 
 (set-logic QF_FP)

--- a/tests/query-files/fp-tests/fp-domain-row-bounds-false.smt2
+++ b/tests/query-files/fp-tests/fp-domain-row-bounds-false.smt2
@@ -1,4 +1,4 @@
-; RUN: %solver --fp-domain-derived-bounds=0 --fp-domain-row-bounds=1 -s %s 2>&1 | %OutputCheck %s
+; RUN: %solver --fp-domain-derived-bounds=0 --fp-domain-extremal-selectors=0 --fp-domain-row-bounds=1 -s %s 2>&1 | %OutputCheck %s
 ; CHECK: row-bound-rows, 1 row-bound-false
 ; CHECK: unsat
 (set-logic QF_FP)

--- a/tests/query-files/fp-tests/fp-domain-row-bounds-false.smt2
+++ b/tests/query-files/fp-tests/fp-domain-row-bounds-false.smt2
@@ -1,4 +1,4 @@
-; RUN: %solver --fp-domain-row-bounds=1 -s %s 2>&1 | %OutputCheck %s
+; RUN: %solver --fp-domain-derived-bounds=0 --fp-domain-row-bounds=1 -s %s 2>&1 | %OutputCheck %s
 ; CHECK: row-bound-rows, 1 row-bound-false
 ; CHECK: unsat
 (set-logic QF_FP)

--- a/tests/query-files/fp-tests/fp-domain-sound-zero-facts.smt2
+++ b/tests/query-files/fp-tests/fp-domain-sound-zero-facts.smt2
@@ -1,7 +1,7 @@
 ; RUN: %solver -s %s 2>&1 | %OutputCheck --check-prefix=DEFAULT %s
-; RUN: %solver --fp-domain-derived-bounds=0 --fp-domain-sound-zero-facts=0 -s %s 2>&1 | %OutputCheck --check-prefix=DISABLED %s
-; RUN: %solver --fp-domain-derived-bounds=0 --fp-domain-sound-zero-facts=1 -s %s 2>&1 | %OutputCheck --check-prefix=ZERO-ONLY %s
-; RUN: %solver --fp-domain-derived-bounds=0 --fp-domain-simplify=1 --fp-domain-sound-zero-facts=1 -s %s 2>&1 | %OutputCheck --check-prefix=COMBINED %s
+; RUN: %solver --fp-domain-derived-bounds=0 --fp-domain-extremal-selectors=0 --fp-domain-sound-zero-facts=0 -s %s 2>&1 | %OutputCheck --check-prefix=DISABLED %s
+; RUN: %solver --fp-domain-derived-bounds=0 --fp-domain-extremal-selectors=0 --fp-domain-sound-zero-facts=1 -s %s 2>&1 | %OutputCheck --check-prefix=ZERO-ONLY %s
+; RUN: %solver --fp-domain-derived-bounds=0 --fp-domain-extremal-selectors=0 --fp-domain-simplify=1 --fp-domain-sound-zero-facts=1 -s %s 2>&1 | %OutputCheck --check-prefix=COMBINED %s
 ;
 ; DEFAULT: FpDomainSimplify: 3 boxed symbols, 0 interval-true, 0 interval-false, 0 classifier-false, 0 diff-zero-eq, 0 nonnegative-zero-sum, 2 sound-zero-rows, 3 sound-zero-facts
 ; DEFAULT: sat

--- a/tests/query-files/fp-tests/fp-domain-sound-zero-facts.smt2
+++ b/tests/query-files/fp-tests/fp-domain-sound-zero-facts.smt2
@@ -1,7 +1,7 @@
 ; RUN: %solver -s %s 2>&1 | %OutputCheck --check-prefix=DEFAULT %s
-; RUN: %solver --fp-domain-sound-zero-facts=0 -s %s 2>&1 | %OutputCheck --check-prefix=DISABLED %s
-; RUN: %solver --fp-domain-sound-zero-facts=1 -s %s 2>&1 | %OutputCheck --check-prefix=ZERO-ONLY %s
-; RUN: %solver --fp-domain-simplify=1 --fp-domain-sound-zero-facts=1 -s %s 2>&1 | %OutputCheck --check-prefix=COMBINED %s
+; RUN: %solver --fp-domain-derived-bounds=0 --fp-domain-sound-zero-facts=0 -s %s 2>&1 | %OutputCheck --check-prefix=DISABLED %s
+; RUN: %solver --fp-domain-derived-bounds=0 --fp-domain-sound-zero-facts=1 -s %s 2>&1 | %OutputCheck --check-prefix=ZERO-ONLY %s
+; RUN: %solver --fp-domain-derived-bounds=0 --fp-domain-simplify=1 --fp-domain-sound-zero-facts=1 -s %s 2>&1 | %OutputCheck --check-prefix=COMBINED %s
 ;
 ; DEFAULT: FpDomainSimplify: 3 boxed symbols, 0 interval-true, 0 interval-false, 0 classifier-false, 0 diff-zero-eq, 0 nonnegative-zero-sum, 2 sound-zero-rows, 3 sound-zero-facts
 ; DEFAULT: sat

--- a/tests/query-files/fp-tests/fp-native-domain-default.smt2
+++ b/tests/query-files/fp-tests/fp-native-domain-default.smt2
@@ -1,11 +1,11 @@
 ; Native-domain fact collection is enabled by default and remains independent
 ; of the domain rewrite prepass and known-sign arithmetic specialization. The
 ; explicit false value remains available as an opt-out. Disable the independent
-; zero-fact and derived-bound defaults in both runs so the negative checks
-; isolate this flag.
+; zero-fact, derived-bound, and selector defaults in both runs so the negative
+; checks isolate this flag.
 ;
-; RUN: %solver --disable-equality --unconstrained-variable-elimination=0 --fp-domain-derived-bounds=0 --fp-domain-sound-zero-facts=0 -s %s 2>&1 | %OutputCheck --check-prefix=DEFAULT %s
-; RUN: %solver --disable-equality --unconstrained-variable-elimination=0 --fp-domain-derived-bounds=0 --fp-domain-sound-zero-facts=0 --bb.fp-native-domain=false -s %s 2>&1 | %OutputCheck --check-prefix=OFF %s
+; RUN: %solver --disable-equality --unconstrained-variable-elimination=0 --fp-domain-derived-bounds=0 --fp-domain-extremal-selectors=0 --fp-domain-sound-zero-facts=0 -s %s 2>&1 | %OutputCheck --check-prefix=DEFAULT %s
+; RUN: %solver --disable-equality --unconstrained-variable-elimination=0 --fp-domain-derived-bounds=0 --fp-domain-extremal-selectors=0 --fp-domain-sound-zero-facts=0 --bb.fp-native-domain=false -s %s 2>&1 | %OutputCheck --check-prefix=OFF %s
 ;
 ; DEFAULT: FP native domain finite terms: [1-9][0-9]*
 ; DEFAULT: FP native domain classifications: [1-9][0-9]*

--- a/tests/query-files/fp-tests/fp-native-domain-default.smt2
+++ b/tests/query-files/fp-tests/fp-native-domain-default.smt2
@@ -1,10 +1,11 @@
 ; Native-domain fact collection is enabled by default and remains independent
 ; of the domain rewrite prepass and known-sign arithmetic specialization. The
 ; explicit false value remains available as an opt-out. Disable the independent
-; zero-fact default in both runs so the negative checks isolate this flag.
+; zero-fact and derived-bound defaults in both runs so the negative checks
+; isolate this flag.
 ;
-; RUN: %solver --disable-equality --unconstrained-variable-elimination=0 --fp-domain-sound-zero-facts=0 -s %s 2>&1 | %OutputCheck --check-prefix=DEFAULT %s
-; RUN: %solver --disable-equality --unconstrained-variable-elimination=0 --fp-domain-sound-zero-facts=0 --bb.fp-native-domain=false -s %s 2>&1 | %OutputCheck --check-prefix=OFF %s
+; RUN: %solver --disable-equality --unconstrained-variable-elimination=0 --fp-domain-derived-bounds=0 --fp-domain-sound-zero-facts=0 -s %s 2>&1 | %OutputCheck --check-prefix=DEFAULT %s
+; RUN: %solver --disable-equality --unconstrained-variable-elimination=0 --fp-domain-derived-bounds=0 --fp-domain-sound-zero-facts=0 --bb.fp-native-domain=false -s %s 2>&1 | %OutputCheck --check-prefix=OFF %s
 ;
 ; DEFAULT: FP native domain finite terms: [1-9][0-9]*
 ; DEFAULT: FP native domain classifications: [1-9][0-9]*

--- a/tests/unit-tests/DeepDag_Test.cpp
+++ b/tests/unit-tests/DeepDag_Test.cpp
@@ -1198,9 +1198,10 @@ bool nodeDomainOk(Context& c, unsigned depth)
   return true;
 }
 
-// FpDomainSimplify scans the top-level conjunction once for finite bounds and
-// again for sound zero rows. Zero-fact inference is opt-in today, but enabling
-// it must not put an input-controlled AND depth back on the C++ call stack.
+// FpDomainSimplify scans the top-level conjunction for finite bounds and sound
+// zero rows, then its default derived-bound pass rewrites the formula. Neither
+// scan nor that rewrite may put an input-controlled AND depth back on the C++
+// call stack.
 bool fpDomainZeroFactsOk(Context& c, unsigned depth)
 {
   ASTNode f = c.mgr.CreateSymbol("fp-domain-conjunct-0", 0, 0);
@@ -1219,6 +1220,41 @@ bool fpDomainZeroFactsOk(Context& c, unsigned depth)
   const FpDomainSimplify::Statistics& stats = domain.statistics();
   return result == f && stats.boxed_symbols == 0 &&
          stats.sound_zero_rows == 0 && stats.sound_zero_facts == 0;
+}
+
+// Derived relational bounds evaluate an FP expression from its boxed leaves.
+// A nested expression used to recurse once per FP operation in interval(), so
+// exercise that path independently of the Boolean rewrite above. Negation is
+// enough to retain exact target-format endpoints while making the requested
+// interval depth entirely input-controlled.
+bool fpDomainDerivedIntervalsOk(Context& c, unsigned depth)
+{
+  const SourceSort fp16 = SourceSort::floatingPoint(5, 11);
+  const ASTNode x = c.mgr.CreateSourceSymbol("fp-domain-deep-x", fp16);
+  const ASTNode y = c.mgr.CreateSourceSymbol("fp-domain-deep-y", fp16);
+  const ASTNode negativeOne =
+      c.mgr.CreateFPConst(c.mgr.CreateBVConst(16, 0xbc00), 5, 11);
+  const ASTNode positiveOne =
+      c.mgr.CreateFPConst(c.mgr.CreateBVConst(16, 0x3c00), 5, 11);
+
+  ASTNode expression = x;
+  for (unsigned i = 0; i < depth; ++i)
+    expression = c.hf->CreateTerm(FP_NEG, 16, expression);
+
+  const ASTNode lower = c.hf->CreateNode(FP_GEQ, x, negativeOne);
+  const ASTNode upper = c.hf->CreateNode(FP_LEQ, x, positiveOne);
+  const ASTNode derived = c.hf->CreateNode(FP_LEQ, y, expression);
+  const ASTNode formula =
+      c.hf->CreateNode(AND, ASTVec{lower, upper, derived});
+  c.roots.push_back(formula);
+
+  c.mgr.UserFlags.fp_domain_derived_bounds = true;
+  FpDomainSimplify domain(&c.mgr);
+  const ASTNode result = domain.topLevel(formula);
+  c.roots.push_back(result);
+  const FpDomainSimplify::Statistics& stats = domain.statistics();
+  return result == formula && stats.boxed_symbols == 1 &&
+         stats.derived_relations == 1 && stats.derived_bounds == 1;
 }
 
 // NodeIterator historically visits children right-to-left. Put the deep
@@ -2865,6 +2901,10 @@ TEST(DeepDag, deep_node_domain)        { EXPECT_STACK_SAFE(nodeDomainOk, 20000);
 TEST(DeepDag, deep_fp_domain_zero_facts)
 {
   EXPECT_STACK_SAFE(fpDomainZeroFactsOk, 20000);
+}
+TEST(DeepDag, deep_fp_domain_derived_intervals)
+{
+  EXPECT_STACK_SAFE(fpDomainDerivedIntervalsOk, 20000);
 }
 TEST(DeepDag, deep_node_iterator)      { EXPECT_STACK_SAFE(nodeIteratorOk, 20000); }
 TEST(DeepDag, deep_vars_in_expression) { EXPECT_STACK_SAFE(varsInExpressionOk, 20000); }

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -555,9 +555,10 @@ void ExtraMain::create_options()
 
   bool_arg("--fp-domain-derived-bounds",
            bm->UserFlags.fp_domain_derived_bounds,
-           "Experimental decision-only FP prepass: derive finite symbol "
-           "bounds from top-level symbol/expression relations and zero-result "
-           "additions, then discharge comparisons or contradictory boxes",
+           "Decision-only FP prepass (enabled by default): derive finite "
+           "symbol bounds from top-level symbol/expression relations and "
+           "zero-result additions, then discharge comparisons or "
+           "contradictory boxes",
            bb_group);
 
   bool_arg("--fp-domain-extremal-selectors",

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -563,9 +563,9 @@ void ExtraMain::create_options()
 
   bool_arg("--fp-domain-extremal-selectors",
            bm->UserFlags.fp_domain_extremal_selectors,
-           "Experimental FP prepass: replace an objective by necessary "
-           "semantic {0,1} selector values only after proving their "
-           "conjunction sufficient (primarily exact extrema)",
+           "FP prepass (enabled by default): replace an objective by "
+           "necessary semantic {0,1} selector values only after proving "
+           "their conjunction sufficient (primarily exact extrema)",
            bb_group);
 
   bool_arg("--fp-domain-sound-zero-facts",


### PR DESCRIPTION
## Summary

- Enable the extremal semantic `{0,1}` FP selector propagation introduced in #980 by default.
- Retain `--fp-domain-extremal-selectors=0` as an independent ablation and rollback switch.
- Test the combined derived-bound/selector default, while explicitly disabling both defaults in feature-isolation controls.

This PR is intentionally stacked on #982. Its unique diff is the selector default and test isolation; once #982 lands, only commit `4274c5e3` remains.

## Qualification

The same 494-file QF_FP sweep compared all four derived/selector combinations with MiniSat and CaDiCaL at matched wall budgets.

- Selector-only found 86 necessary selector facts and 10 rewrites in 10 Latendresse files.
- On top of derived bounds it found 90 facts and 14 rewrites in 14 files, including four additional Glycerol cases.
- Across those 14 combined-mode rewrites, the aggregate AIG-node ratio was 0.862 and the aggregate CNF-clause ratio was 0.661 relative to derived-only. Median ratios were 0.907 and 0.868 respectively.
- Latendresse solves at 20 seconds increased from 92 derived-only to 95 combined with MiniSat, and from 98 to 100 with CaDiCaL.
- Neither selector mode had any activity on the 144 SyntheticFBA or 130 AutoSMTGen files; their AIG counts were identical across modes.

The material wins reproduced in five isolated runs on both SAT backends:

- Glycerol fp8: derived-only solved 0/5 at the 20-second cap; combined solved 5/5 with a 1.87–1.88 second median. AIG nodes fell from 1,308,644 to 598,758 and MiniSat clauses from 1,103,974 to 429,675.
- Shewanella fp8: selector mode solved 5/5 with MiniSat at a 2.51 second median where control solved 0/5; CaDiCaL improved from 2.70 to 2.60 seconds.
- Shewanella fp4: MiniSat improved from 9.18 to 1.09 seconds and CaDiCaL from 1.41 to 1.10 seconds.

There were no contradictory answers in the 3,952-run sweep.

## Soundness

The already-reviewed propagation replaces an objective only after interval exclusion proves each selected endpoint necessary and proves the conjunction of all emitted facts sufficient. Selector zero is semantic IEEE zero, so `+0` and `-0` remain accepted where required; structural equality is not substituted for IEEE equality.

## Testing

- `cmake --build build -j24`
- `ctest --test-dir build -R '^(query-files|DeepDag_TestTests-gtest)$' --output-on-failure`
- `ctest --test-dir build -j24 --output-on-failure` — 162/162 passed
- Full two-backend, four-mode qualification sweep and isolated five-run checks described above
