### PR TITLE
Fuse SymFPU add-zero predicates directly

### DIFF
--- a/include/stp/FloatBlaster/FloatBlast.h
+++ b/include/stp/FloatBlaster/FloatBlast.h
@@ -82,6 +82,10 @@ public:
     // arithmetic entry is the operation's final, rounded SymFPU result.
     size_t unpacked_operation_builds = 0;
     size_t unpacked_cache_hits = 0;
+
+    // Predicates built directly from two unpacked operands, without
+    // constructing the rounded fp.add result they observe.
+    size_t add_iszero_builds = 0;
   };
 
   FloatBlast(STPMgr* bm_);

--- a/include/stp/FloatBlaster/symbolic_fp.h
+++ b/include/stp/FloatBlaster/symbolic_fp.h
@@ -344,6 +344,12 @@ ASTNode lessThan(const floatingPointTypeInfo& size, const uf& lhs,
                  const uf& rhs);
 ASTNode lessThanOrEqual(const floatingPointTypeInfo& size, const uf& lhs,
                         const uf& rhs);
+// Whether adding two already-rounded values of `size` can produce either
+// signed zero.  This deliberately consumes the operands rather than an
+// unpacked addition result, so callers that observe only zero magnitude do
+// not have to construct the complete rounded sum.
+ASTNode addIsZero(const floatingPointTypeInfo& size, const uf& lhs,
+                  const uf& rhs);
 ASTNode isNormal(const floatingPointTypeInfo& size, const uf& value);
 ASTNode isSubnormal(const floatingPointTypeInfo& size, const uf& value);
 ASTNode isZero(const floatingPointTypeInfo& size, const uf& value);

--- a/lib/FloatBlaster/FloatBlast.cpp
+++ b/lib/FloatBlaster/FloatBlast.cpp
@@ -940,6 +940,14 @@ private:
         const ASTNode survivor = nativeClassificationSurvivor(n);
         if (!survivor.IsNull())
           return survivor;
+        if (bm->UserFlags.fp_native_add_iszero &&
+            n[0].GetKind() == FP_ADD && n[0].Degree() == 3)
+        {
+          requireSameFormat(n[0][1], n[0][2]);
+          ++stats.add_iszero_builds;
+          return symbolic_fp::unpacked::addIsZero(
+              formatOf(n[0]), asUnpacked(n[0][1]), asUnpacked(n[0][2]));
+        }
         return symbolic_fp::unpacked::isZero(formatOf(n[0]),
                                              asUnpacked(n[0]));
       }

--- a/lib/FloatBlaster/FpEncodingContext.cpp
+++ b/lib/FloatBlaster/FpEncodingContext.cpp
@@ -84,7 +84,8 @@ ASTNode FpEncodingContext::lowerPrepared(const ASTNode& prepared)
         s.unpacked_operation_builds + s.unpack_builds + s.pack_builds == 0;
     std::cerr << "FloatBlast: " << s.unpacked_operation_builds
               << " SymFPU operations, " << s.unpack_builds << " unpacks, "
-              << s.pack_builds << " packs"
+              << s.pack_builds << " packs, " << s.add_iszero_builds
+              << " direct add-isZero predicates"
               << (noop ? " (no-op: everything passed through natively)" : "")
               << std::endl;
   }

--- a/lib/FloatBlaster/symbolic_fp.cpp
+++ b/lib/FloatBlaster/symbolic_fp.cpp
@@ -882,6 +882,34 @@ ASTNode lessThanOrEqual(const floatingPointTypeInfo& size, const uf& lhs,
   return symfpu::lessThanOrEqual<traits>(size, lhs, rhs);
 }
 
+ASTNode addIsZero(const floatingPointTypeInfo& size, const uf& lhs,
+                  const uf& rhs)
+{
+  assertUnpackedFormat(size, lhs);
+  assertUnpackedFormat(size, rhs);
+
+  // Every finite value in one binary IEEE format is an integer multiple of
+  // that format's minimum subnormal.  Consequently the exact sum of two
+  // values in the format is either zero or has magnitude at least one
+  // minimum subnormal: rounding cannot turn a nonzero sum into zero, in any
+  // rounding mode.  Apart from two signed zeros, exact cancellation is
+  // therefore precisely opposite signs and equal normalized magnitudes.
+  //
+  // Keep the class tests explicit.  The exponent and significand fields of
+  // a SymFPU special value are harmless defaults, not part of that value's
+  // semantics, and must never make an infinity or NaN look cancellable.
+  const proposition finite =
+      !lhs.getNaN() && !lhs.getInf() && !rhs.getNaN() && !rhs.getInf();
+  const proposition bothZero = lhs.getZero() && rhs.getZero();
+  const proposition neitherZero = !lhs.getZero() && !rhs.getZero();
+  const proposition sameMagnitude =
+      (lhs.getExponent() == rhs.getExponent()) &&
+      (lhs.getSignificand() == rhs.getSignificand());
+  const proposition cancellation =
+      neitherZero && (lhs.getSign() ^ rhs.getSign()) && sameMagnitude;
+  return finite && (bothZero || cancellation);
+}
+
 #define STP_UNPACKED_CLASSIFY(name, symfpu_fn)                                 \
   ASTNode name(const floatingPointTypeInfo& size, const uf& value)             \
   {                                                                            \

--- a/tests/query-files/fp-tests/fp-native-add-iszero.smt2
+++ b/tests/query-files/fp-tests/fp-native-add-iszero.smt2
@@ -1,13 +1,21 @@
 ; A binary-format addition can round to zero only when its finite operands
 ; have an exact real sum of zero. Exhaust the small (3,4) format and all five
-; rounding modes by asking for a disagreement with that packed-value law.
+; rounding modes by asking for a disagreement with that law. The direct
+; predicate has an unpacked SymFPU-operand path in the default configuration
+; and a packed-operand path when native arithmetic is selected; disabling it
+; checks the ordinary full-addition SymFPU circuit independently.
 ;
-; RUN: %solver --disable-equality --unconstrained-variable-elimination=0 --bb.fp-native-arith=1 -s %s 2>&1 | %OutputCheck --check-prefix=FUSED %s
-; RUN: %solver --disable-equality --unconstrained-variable-elimination=0 --bb.fp-native-arith=1 --bb.fp-native-add-iszero=0 %s | %OutputCheck --check-prefix=RESULT %s
-; RUN: %solver --bb.fp-native-cmp=false %s | %OutputCheck --check-prefix=RESULT %s
+; RUN: %solver --disable-equality --unconstrained-variable-elimination=0 -s %s 2>&1 | %OutputCheck --check-prefix=DIRECT %s
+; RUN: %solver --disable-equality --unconstrained-variable-elimination=0 --bb.fp-native-cmp=false -s %s 2>&1 | %OutputCheck --check-prefix=REFERENCE %s
+; RUN: %solver --disable-equality --unconstrained-variable-elimination=0 --bb.fp-native-cmp=false --bb.fp-native-add-iszero=0 %s | %OutputCheck --check-prefix=RESULT %s
+; RUN: %solver --disable-equality --unconstrained-variable-elimination=0 --bb.fp-native-arith=1 -s %s 2>&1 | %OutputCheck --check-prefix=NATIVE %s
 ;
-; FUSED: FP native add-isZero fused predicates: 1
-; FUSED: ^unsat
+; DIRECT: FloatBlast: 0 SymFPU operations, 2 unpacks, 0 packs, 1 direct add-isZero predicates
+; DIRECT: ^unsat
+; REFERENCE: FloatBlast: 2 SymFPU operations, 2 unpacks, 0 packs, 1 direct add-isZero predicates
+; REFERENCE: ^unsat
+; NATIVE: FP native add-isZero fused predicates: 1
+; NATIVE: ^unsat
 ; RESULT: ^unsat
 ;
 (set-logic QF_FP)

--- a/tests/unit-tests/FloatBlast_Test.cpp
+++ b/tests/unit-tests/FloatBlast_Test.cpp
@@ -151,6 +151,46 @@ TEST(FloatBlast, shared_chain_stays_unpacked_until_a_carrier_boundary)
   EXPECT_EQ(1u, lower.statistics().pack_builds);
 }
 
+TEST(FloatBlast, add_iszero_omits_only_the_observed_outer_addition)
+{
+  STPMgr mgr;
+  const SourceSort fp16 = SourceSort::floatingPoint(5, 11);
+  const ASTNode x = mgr.CreateSourceSymbol("x", fp16);
+  const ASTNode y = mgr.CreateSourceSymbol("y", fp16);
+  const ASTNode z = mgr.CreateSourceSymbol("z", fp16);
+  const ASTNode rounding_mode = rne(mgr);
+
+  // This is the accumulator shape the FBA rows use.  The inner addition is
+  // an operand value and still has to be rounded.  Only the outer result is
+  // unobserved: its sole consumer asks whether its magnitude is zero.
+  const ASTNode inner =
+      mgr.CreateTerm(FP_ADD, 16, ASTVec{rounding_mode, x, y});
+  const ASTNode outer =
+      mgr.CreateTerm(FP_ADD, 16, ASTVec{rounding_mode, inner, z});
+  const ASTNode predicate = mgr.CreateNode(FP_ISZERO, outer);
+
+  FloatBlast direct(&mgr);
+  const ASTNode direct_result = direct.topLevel(predicate);
+
+  EXPECT_FALSE(containsFloatingPointKind(direct_result));
+  EXPECT_EQ(3u, direct.statistics().unpack_builds);
+  EXPECT_EQ(1u, direct.statistics().unpacked_operation_builds);
+  EXPECT_EQ(0u, direct.statistics().pack_builds);
+  EXPECT_EQ(1u, direct.statistics().add_iszero_builds);
+
+  // Disabling the predicate specialization restores the ordinary SymFPU
+  // construction of both rounded additions.
+  mgr.UserFlags.fp_native_add_iszero = false;
+  FloatBlast generic(&mgr);
+  const ASTNode generic_result = generic.topLevel(predicate);
+
+  EXPECT_FALSE(containsFloatingPointKind(generic_result));
+  EXPECT_EQ(3u, generic.statistics().unpack_builds);
+  EXPECT_EQ(2u, generic.statistics().unpacked_operation_builds);
+  EXPECT_EQ(0u, generic.statistics().pack_builds);
+  EXPECT_EQ(0u, generic.statistics().add_iszero_builds);
+}
+
 TEST(FloatBlast, format_conversion_feeds_the_next_operation_unpacked)
 {
   STPMgr mgr;

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -530,9 +530,9 @@ void ExtraMain::create_options()
 
   bool_arg("--bb.fp-native-add-iszero",
            bm->UserFlags.fp_native_add_iszero,
-           "Encode fp.isZero(fp.add ...) directly from the packed operands "
-           "without constructing the complete rounded sum (enabled by "
-           "default; requires --bb.fp-native-arith)",
+           "Encode fp.isZero(fp.add ...) directly from its operands without "
+           "constructing the complete rounded sum (enabled by default; "
+           "works with both SymFPU and native arithmetic)",
            bb_group);
 
   bool_arg("--bb.fp-native-domain", bm->UserFlags.fp_native_domain,


### PR DESCRIPTION
## Summary

- extend the existing `--bb.fp-native-add-iszero` specialization to the ordinary SymFPU lowering path;
- derive `fp.isZero(fp.add rm a b)` directly from the two unpacked operands, without constructing the complete rounded outer sum;
- retain the existing packed-native path and expose a direct-predicate counter;
- add accumulator-shaped and exhaustive small-format regression coverage.

## Why this is sound

Every finite value in one binary format is an integer multiple of that format's minimum subnormal. Consequently, the exact sum of two same-format values is either zero or has magnitude at least one minimum subnormal; no IEEE rounding mode can turn a nonzero such sum into zero.

The direct predicate therefore accepts exactly:

- two finite signed zeros; or
- two finite nonzero values with opposite signs and identical normalized exponent/significand magnitudes.

NaN and infinity are excluded explicitly. Both `+0` and `-0` are preserved semantically. Structural equality is unchanged and continues to distinguish the two zero encodings.

## Verification

- `cmake --build build -j24`
- `ctest --test-dir build -j24 --output-on-failure`: 163/163 passed
- MiniSat and CaDiCaL builds
- exhaustive symbolic `(3,4)` differential over both operands and all five rounding modes, covering:
  - the new direct SymFPU path;
  - an all-SymFPU reference;
  - the ordinary complete-addition SymFPU path;
  - the existing packed-native path.

No solver errors or contradictory decisive answers occurred in the qualification sweeps.

## Benchmark qualification

Natural 20-second budgets across 532 biological FBA files:

| Backend | Control solves | Direct solves | Gains / losses |
|---|---:|---:|---:|
| MiniSat | 174 | 183 | +9 / -0 |
| CaDiCaL | 185 | 195 | +13 / -3 |

Typical active AIG reduction was 8-10%. Of 278 active files with paired structural measurements, 277 became smaller.

On `shewanella-compact2.fp8_24`, the direct path reduced:

- AIG nodes: 12,974,609 -> 12,107,036;
- CNF-generation wall time: 41.48s -> 39.11s;
- peak RSS: 5,868,576 KiB -> 5,507,440 KiB.

Repeated MiniSat examples:

- glycerol beyond fp4: 18.90s -> 10.83s;
- Shewanella small-flux fp4: five 20s timeouts -> approximately 0.90s SAT;
- pin-exact fp5: five 20s timeouts -> 13.83s SAT.

Repeated CaDiCaL measurements do show encoding-sensitive reversals on three files, including one 5.4s -> 33.0s case. A targeted matched 60-second follow-up reached solve parity on all 16 cutoff-sensitive CaDiCaL pairs; aggregate time improved from 97.87s to 69.41s on the selected Latendresse cases and from 279.39s to 185.73s on the independent profile cases. No format/family gate was added because the same shapes also contain the largest wins.
