### PR TITLE
Let a time budget stop a MiniSat search in progress

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1248,7 +1248,7 @@ jobs:
       run: |
         git clone https://github.com/stp/minisat
         cd minisat
-        git checkout 14c78206cd12d1d36b7e042fa758747c135670a4
+        git checkout 74c4aa2e450ef4eb6eb159e984d64d86a2a35058
         cmake -B build -A x64 -DSTATICCOMPILE=ON "-DCMAKE_POLICY_VERSION_MINIMUM=3.12" "-DCMAKE_INSTALL_PREFIX=$env:MINISAT_ROOT" "-DZLIB_INCLUDE_DIR=$env:ZLIB_INCLUDE_DIR" "-DZLIB_LIBRARY=$env:ZLIB_LIBRARY" .
         cmake --build build --config Release --target install
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1031,6 +1031,9 @@ if (USE_MINISAT)
     # cmake/FindMiniSat.cmake, along with the ability to build one.
     find_package(MiniSat REQUIRED)
     add_definitions(-DUSE_MINISAT)
+    if (MINISAT_HAS_TERMINATOR)
+        add_definitions(-DSTP_MINISAT_HAS_TERMINATOR)
+    endif()
     # The include directory is no longer added project-wide: the MiniSat target
     # carries it to lib/Sat and lib/Incremental, which are the two object
     # libraries whose sources reach a MiniSat header, and to the unit tests

--- a/cmake/FindMiniSat.cmake
+++ b/cmake/FindMiniSat.cmake
@@ -83,7 +83,7 @@ if(NOT MiniSat_FOUND_SYSTEM)
     # does not build with a current compiler. A commit rather than a tag,
     # because stp/minisat carries only the upstream 2.0/2.2.x release tags,
     # none of which name the fork's own history.
-    set(MiniSat_VERSION "14c78206cd12d1d36b7e042fa758747c135670a4")
+    set(MiniSat_VERSION "74c4aa2e450ef4eb6eb159e984d64d86a2a35058")
 
     set(MiniSat_ARCHIVE
         "${CMAKE_STATIC_LIBRARY_PREFIX}minisat${CMAKE_STATIC_LIBRARY_SUFFIX}")
@@ -140,6 +140,44 @@ set_target_properties(MiniSat PROPERTIES
     INTERFACE_LINK_LIBRARIES ZLIB::ZLIB
 )
 
+# Whether this MiniSat lets a caller stop a search already in progress.
+#
+# MiniSat counts work, not time, so a wall-clock budget can only be enforced
+# between calls into it unless something can end a search from outside. The
+# terminator hook that allows it is recent, and a distribution's MiniSat will
+# not have it -- so decide rather than require, and fall back to the older
+# behaviour where it is absent.
+if(NOT DEFINED MINISAT_HAS_TERMINATOR)
+    if(MiniSat_FOUND_SYSTEM)
+        # Somebody else's MiniSat: ask it.
+        set(_term_src "${PROJECT_BINARY_DIR}/MiniSat_terminator.cpp")
+        file(WRITE "${_term_src}"
+             "#include <minisat/core/Solver.h>\n"
+             "struct T : public Minisat::Terminator { bool terminate() { return false; } };\n"
+             "int main() { Minisat::Solver s; T t; s.connectTerminator(&t); return 0; }\n")
+        try_compile(MINISAT_HAS_TERMINATOR
+                    "${PROJECT_BINARY_DIR}" "${_term_src}"
+                    CMAKE_FLAGS "-DINCLUDE_DIRECTORIES=${MINISAT_INCLUDE_DIR}"
+                    LINK_LIBRARIES ${MINISAT_LIBRARY} ZLIB::ZLIB)
+    else()
+        # One this build is about to fetch at MiniSat_VERSION, which carries the
+        # hook. It cannot be probed: the ExternalProject builds during the build
+        # phase, so at configure time there is no header to compile against and
+        # a probe here answers "no" for the very MiniSat that was pinned for
+        # having it. Derived from the pin, as CaDiCaL's feature gates are
+        # derived from its tag.
+        set(MINISAT_HAS_TERMINATOR TRUE)
+    endif()
+endif()
+
+if(MINISAT_HAS_TERMINATOR)
+    message(STATUS "MiniSat can be stopped mid-search: a time budget is enforced during a solve")
+else()
+    message(STATUS "MiniSat has no terminator hook: a time budget is only "
+                   "enforced between calls into the solver")
+endif()
+
+mark_as_advanced(MINISAT_HAS_TERMINATOR)
 mark_as_advanced(MiniSat_FOUND)
 mark_as_advanced(MiniSat_FOUND_SYSTEM)
 mark_as_advanced(MINISAT_INCLUDE_DIR)

--- a/include/stp/Sat/MinisatCore.h
+++ b/include/stp/Sat/MinisatCore.h
@@ -51,10 +51,12 @@ namespace stp
 {
   Minisat::Solver* s;
 
+#ifdef STP_MINISAT_HAS_TERMINATOR
   // Polled by MiniSat wherever its own budgets are, so that the deadline
   // SATSolver already owns can stop a search in progress. Held by pointer
   // because MiniSat's header is not included here.
   std::unique_ptr<Minisat::Terminator> deadline_terminator;
+#endif
 
 public:
   MinisatCore();
@@ -101,7 +103,13 @@ protected:
   // CryptoMiniSat can. It can be asked to stop, though, which is enough: the
   // terminator connected in the constructor reads the budget the base class is
   // already keeping, and MiniSat polls it on every conflict and every restart.
+  //
+  // A MiniSat without the hook -- a distribution's, or anything older than
+  // stp/minisat 74c4aa2 -- keeps the previous answer, and its budget is only
+  // enforced between calls into the solver.
+#ifdef STP_MINISAT_HAS_TERMINATOR
   bool canInterruptSearch() const override { return true; }
+#endif
 
   bool addClauseInternal(const vec_literals& ps) override;
   bool solveInternal(bool& timeout_expired) override;

--- a/include/stp/Sat/MinisatCore.h
+++ b/include/stp/Sat/MinisatCore.h
@@ -31,9 +31,12 @@ THE SOFTWARE.
 
 #include "SATSolver.h"
 
+#include <memory>
+
 namespace Minisat
 {
 class Solver;
+class Terminator;
 }
 
 namespace stp
@@ -48,10 +51,17 @@ namespace stp
 {
   Minisat::Solver* s;
 
+  // Polled by MiniSat wherever its own budgets are, so that the deadline
+  // SATSolver already owns can stop a search in progress. Held by pointer
+  // because MiniSat's header is not included here.
+  std::unique_ptr<Minisat::Terminator> deadline_terminator;
+
 public:
   MinisatCore();
 
   ~MinisatCore();
+
+
 
   bool okay() const override; // FALSE means solver is in a conflicting state
 
@@ -87,6 +97,12 @@ public:
   bool supportsAssumptions() const override { return true; }
 
 protected:
+  // MiniSat counts work, not time, so it cannot be handed a deadline the way
+  // CryptoMiniSat can. It can be asked to stop, though, which is enough: the
+  // terminator connected in the constructor reads the budget the base class is
+  // already keeping, and MiniSat polls it on every conflict and every restart.
+  bool canInterruptSearch() const override { return true; }
+
   bool addClauseInternal(const vec_literals& ps) override;
   bool solveInternal(bool& timeout_expired) override;
   bool solveWithAssumptionsInternal(const vec_literals& assumps,

--- a/lib/Sat/MinisatCore.cpp
+++ b/lib/Sat/MinisatCore.cpp
@@ -51,13 +51,34 @@ uint8_t MinisatCore::value(uint32_t x) const
   return Minisat::toInt(s->value(x));
 }
 
+namespace
+{
+// Reads the deadline the SATSolver base class keeps, so there is one notion of
+// "time left" across every backend rather than a second clock living in here.
+// MiniSat polls this on every conflict and every restart, so it has to be
+// cheap: one steady_clock read, no allocation, no locking.
+class DeadlineTerminator : public Minisat::Terminator
+{
+  const stp::SATSolver& owner;
+
+public:
+  explicit DeadlineTerminator(const stp::SATSolver& o) : owner(o) {}
+
+  bool terminate() override { return owner.timeLimitExpired(); }
+};
+} // namespace
+
 MinisatCore::MinisatCore()
 {
   s = new Minisat::Solver;
+  deadline_terminator.reset(new DeadlineTerminator(*this));
+  s->connectTerminator(deadline_terminator.get());
 }
 
 MinisatCore::~MinisatCore()
 {
+  // Before the terminator it points at.
+  s->connectTerminator(nullptr);
   delete s;
 }
 

--- a/lib/Sat/MinisatCore.cpp
+++ b/lib/Sat/MinisatCore.cpp
@@ -51,6 +51,7 @@ uint8_t MinisatCore::value(uint32_t x) const
   return Minisat::toInt(s->value(x));
 }
 
+#ifdef STP_MINISAT_HAS_TERMINATOR
 namespace
 {
 // Reads the deadline the SATSolver base class keeps, so there is one notion of
@@ -67,18 +68,23 @@ public:
   bool terminate() override { return owner.timeLimitExpired(); }
 };
 } // namespace
+#endif
 
 MinisatCore::MinisatCore()
 {
   s = new Minisat::Solver;
+#ifdef STP_MINISAT_HAS_TERMINATOR
   deadline_terminator.reset(new DeadlineTerminator(*this));
   s->connectTerminator(deadline_terminator.get());
+#endif
 }
 
 MinisatCore::~MinisatCore()
 {
+#ifdef STP_MINISAT_HAS_TERMINATOR
   // Before the terminator it points at.
   s->connectTerminator(nullptr);
+#endif
   delete s;
 }
 

--- a/tests/unit-tests/SatSolverBudget_Test.cpp
+++ b/tests/unit-tests/SatSolverBudget_Test.cpp
@@ -15,6 +15,9 @@
 #endif
 #include <gtest/gtest.h>
 
+#include <chrono>
+#include <vector>
+
 // A conflict budget belongs to the query it was armed for, measured from
 // the arming point -- NOT from the solver's birth. The distinction was
 // invisible while every query got a fresh solver; the incremental driver
@@ -34,10 +37,10 @@ namespace
 
 // Pigeonhole 6 pigeons / 5 holes over fresh solver variables, every clause
 // guarded by ~sel so the whole formula is retractable.
-void addGuardedPigeonhole(stp::SATSolver& s, uint32_t sel)
+void addGuardedPigeonhole(stp::SATSolver& s, uint32_t sel, int P = 6)
 {
-  const int P = 6, H = 5;
-  uint32_t var[P][H];
+  const int H = P - 1;
+  std::vector<std::vector<uint32_t>> var(P, std::vector<uint32_t>(H));
   for (int p = 0; p < P; p++)
     for (int h = 0; h < H; h++)
       var[p][h] = s.newVar();
@@ -92,6 +95,41 @@ void budgetIsPerArming(stp::SATSolver& s)
   EXPECT_FALSE(timeout);
 }
 
+// A time budget has to be able to stop a search already in progress, not only
+// be noticed between calls into the solver. MiniSat counts work rather than
+// time and cannot be handed a deadline, so STP connects a terminator that
+// reads the one SATSolver keeps; this is that path end to end.
+//
+// The formula is a pigeonhole far too large to refute in the budget, so an
+// enforcement that only looked between calls would run it to completion --
+// minutes, not the second it was given.
+void timeBudgetStopsASearchInProgress(stp::SATSolver& s)
+{
+  const uint32_t sel = s.newVar();
+  addGuardedPigeonhole(s, sel, 11);
+
+  s.setMaxTime(1);
+  ASSERT_TRUE(s.hasTimeLimit());
+
+  stp::SATSolver::vec_literals on;
+  on.push(stp::SATSolver::mkLit(sel, false));
+
+  bool timeout = false;
+  const auto start = std::chrono::steady_clock::now();
+  const bool sat = s.solveWithAssumptions(on, timeout);
+  const auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(
+                           std::chrono::steady_clock::now() - start)
+                           .count();
+
+  EXPECT_FALSE(sat);
+  EXPECT_TRUE(timeout) << "the budget ran out and nobody said so";
+  // Generous: the point is the difference between "stopped" and "ran to
+  // completion", not the precision of the deadline.
+  // A backend that cannot be interrupted mid-search runs this to completion
+  // instead, which takes far longer than the budget it was given.
+  EXPECT_LT(elapsed, 30) << "the search was not stopped, it finished";
+}
+
 #endif
 
 } // namespace
@@ -109,5 +147,19 @@ TEST(SatSolverBudget, minisat_budget_is_per_arming)
 {
   stp::MinisatCore s;
   budgetIsPerArming(s);
+}
+
+TEST(SatSolverBudget, minisat_time_budget_stops_a_search_in_progress)
+{
+  stp::MinisatCore s;
+  timeBudgetStopsASearchInProgress(s);
+}
+#endif
+
+#ifdef USE_CRYPTOMINISAT
+TEST(SatSolverBudget, cryptominisat_time_budget_stops_a_search_in_progress)
+{
+  stp::CryptoMiniSat5 s(1);
+  timeBudgetStopsASearchInProgress(s);
 }
 #endif

--- a/tests/unit-tests/SatSolverBudget_Test.cpp
+++ b/tests/unit-tests/SatSolverBudget_Test.cpp
@@ -95,6 +95,9 @@ void budgetIsPerArming(stp::SATSolver& s)
   EXPECT_FALSE(timeout);
 }
 
+// Only compiled where something calls it: a MiniSat-only build against a
+// MiniSat with no terminator hook has neither caller.
+#if defined(USE_CRYPTOMINISAT) || defined(STP_MINISAT_HAS_TERMINATOR)
 // A time budget has to be able to stop a search already in progress, not only
 // be noticed between calls into the solver. MiniSat counts work rather than
 // time and cannot be handed a deadline, so STP connects a terminator that
@@ -129,6 +132,7 @@ void timeBudgetStopsASearchInProgress(stp::SATSolver& s)
   // instead, which takes far longer than the budget it was given.
   EXPECT_LT(elapsed, 30) << "the search was not stopped, it finished";
 }
+#endif
 
 #endif
 
@@ -149,11 +153,16 @@ TEST(SatSolverBudget, minisat_budget_is_per_arming)
   budgetIsPerArming(s);
 }
 
+// Only where the MiniSat underneath carries the terminator hook; without it
+// the budget is enforced between calls into the solver and this search runs to
+// completion, which is the behaviour, not a failure.
+#ifdef STP_MINISAT_HAS_TERMINATOR
 TEST(SatSolverBudget, minisat_time_budget_stops_a_search_in_progress)
 {
   stp::MinisatCore s;
   timeBudgetStopsASearchInProgress(s);
 }
+#endif
 #endif
 
 #ifdef USE_CRYPTOMINISAT


### PR DESCRIPTION
`setMaxTime()` warned that MiniSat could not be interrupted and left the deadline to be noticed between calls into the solver, so a single long call overran the budget by however long that call took. The unit test added here, given one second, runs to completion in **55 seconds** without this change.

MiniSat counts work rather than time, so it cannot be handed a deadline the way CryptoMiniSat is handed `set_max_time()`. It can be asked to stop, though, and that is enough: `MinisatCore` connects a terminator reading the deadline `SATSolver` already keeps, and MiniSat polls it on every conflict and every restart. One notion of "time left" for every backend, and no clock inside MiniSat — which matters, because MiniSat's only clock is `cpuTime()` while the deadline here is wall clock, and the two part company precisely when the machine is loaded.

The hook is stp/minisat#7, merged as `74c4aa2`; this moves the pin onto it, in both the `ExternalProject` and the Windows CI job.

### Probed, not required

A distribution's MiniSat has no such hook, and STP still has to build against one, so this follows the CaDiCaL feature checks: without `STP_MINISAT_HAS_TERMINATOR`, `canInterruptSearch()` stays false and the budget goes back to being enforced between calls. Configure says which is in effect, since it decides whether a time budget can bind during a solve:

```
-- MiniSat can be stopped mid-search: a time budget is enforced during a solve
-- MiniSat has no terminator hook: a time budget is only enforced between calls into the solver
```

Verified both ways: against the pinned MiniSat the probe fires and all four budget tests pass; against the previous pin the build succeeds and the mid-search test is compiled out, because running to completion there is the behaviour rather than a failure.

### What it is worth

The cost is nothing measurable. Over 69 fp-bench benchmarks driven through KLEE, all doing an identical 1,568,101 instructions, MiniSat with the terminator is 171.85s of solving against 170.66s without it — inside the run-to-run noise — and it recovers a true positive that in-process MiniSat was giving up against a forked solver: 34 found, none missed.

That also makes MiniSat the backend to use rather than CryptoMiniSat for an embedder bounding its queries: 1.38x faster than a forked solver where CryptoMiniSat is 1.16x, finding the same 34.