### PR TITLE
Stop CI keeping the MiniSat pin in two places

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1017,6 +1017,46 @@ jobs:
         echo "simplifying-minisat output: '$out'"
         [ "$out" = "sat" ]
 
+    # Rung 0 of the ladder in cmake/deps-helper.cmake: a MiniSat that is
+    # already built, named by MINISAT_INCLUDE_DIRS and MINISAT_LIBDIR. It is
+    # the only rung that decides MINISAT_HAS_TERMINATOR by compiling against
+    # the headers rather than deriving it from the pin, so it is the only one
+    # that would notice the probe going wrong -- and no job takes it since the
+    # MSVC leg moved onto the ExternalProject. The build above installed a
+    # MiniSat into deps/install; point a second configure straight at it.
+    #
+    # Configure only. What is under test is settled during configure, and
+    # rebuilding STP against the same archive it just linked would prove
+    # nothing the job has not already proved.
+    - name: Probe an already-built MiniSat
+      run: |
+        cmake -S . -B build-minisat-probe -G Ninja \
+          -DSTP_DEP_DIR:PATH="$GITHUB_WORKSPACE/deps/install" \
+          -DFETCHCONTENT_BASE_DIR:PATH="$GITHUB_WORKSPACE/deps/fetch" \
+          -DENABLE_AUTO_DOWNLOAD:BOOL=ON \
+          -DUSE_MINISAT:BOOL=ON \
+          -DUSE_CRYPTOMINISAT:STRING=OFF \
+          -DUSE_CADICAL:BOOL=OFF \
+          -DMINISAT_INCLUDE_DIRS:PATH="$GITHUB_WORKSPACE/deps/install/include" \
+          -DMINISAT_LIBDIR:PATH="$GITHUB_WORKSPACE/deps/install/lib" \
+          > probe.log 2>&1 || { cat probe.log; exit 1; }
+        grep -i minisat probe.log || true
+
+        # Without this the check below is vacuous: a configure that fell
+        # through to the ExternalProject would report the terminator too,
+        # having derived it from the pin rather than probed for it.
+        want="$GITHUB_WORKSPACE/deps/install/lib/libminisat.a"
+        if ! grep -qF "Found MiniSat: $want" probe.log; then
+          echo "::error::rung 0 did not resolve to $want, so nothing was probed"
+          cat probe.log
+          exit 1
+        fi
+        if ! grep -q "MiniSat can be stopped mid-search" probe.log; then
+          echo "::error::the terminator probe did not fire against the pinned MiniSat"
+          cat probe.log
+          exit 1
+        fi
+
   # USE_RISS is an advertised option -- the "no SAT backend" configure error
   # names it as one of the ways to get a solver, and --riss and vc_useRiss are
   # both wired up -- but no job built it, so nothing noticed when it stopped
@@ -1134,13 +1174,14 @@ jobs:
     runs-on: windows-2025
 
     env:
-      MINISAT_ROOT: ${{ github.workspace }}\minisat\install
       # Build ABC single-threaded: its pthread/atomics code paths don't
       # compile with MSVC. ABC's Makefile (run during CMake configure to
       # extract flags) reads this from the environment.
       ABC_USE_NO_PTHREADS: 1
-      # minisat and STP both predate CMP0074, so ZLIB_ROOT is ignored;
-      # pass the include dir and library explicitly instead.
+      # STP predates CMP0074, so ZLIB_ROOT is ignored; pass the include dir
+      # and library explicitly instead. cmake/FindMiniSat.cmake hands both on
+      # to MiniSat's own build, which searches the default paths only and so
+      # would never find the vcpkg copy by itself.
       # ZLIB_LIBRARY is located after the vcpkg install (see below).
       ZLIB_INCLUDE_DIR: C:\vcpkg\installed\x64-windows-static\include
       # Turns on sccache's GitHub Actions storage backend. It has to be set for
@@ -1287,14 +1328,13 @@ jobs:
     # cl. cmake/FindLibBF.cmake supplies LibBF with a CMakeLists of its own, so
     # the configure step below builds it with whatever compiler this build is
     # using -- cl included -- and there is nothing Windows-specific left to do.
-
-    - name: Build minisat
-      run: |
-        git clone https://github.com/stp/minisat
-        cd minisat
-        git checkout 74c4aa2e450ef4eb6eb159e984d64d86a2a35058
-        cmake -B build -A x64 -DSTATICCOMPILE=ON "-DCMAKE_POLICY_VERSION_MINIMUM=3.12" "-DCMAKE_INSTALL_PREFIX=$env:MINISAT_ROOT" "-DZLIB_INCLUDE_DIR=$env:ZLIB_INCLUDE_DIR" "-DZLIB_LIBRARY=$env:ZLIB_LIBRARY" .
-        cmake --build build --config Release --target install
+    #
+    # MiniSat was the last of those hand-built dependencies, and the only one
+    # whose pinned commit had to be written out twice -- once here and once in
+    # cmake/FindMiniSat.cmake, where the two drifting apart would have left
+    # this leg quietly testing a MiniSat no other job builds. It is an
+    # ExternalProject like the rest now: the configure step below fetches and
+    # builds it, with this job's compiler, flags and sccache.
 
     # Ninja rather than the Visual Studio generator, for two reasons. MSBuild
     # invoked without /m builds one project at a time, and its ClCompile task
@@ -1334,8 +1374,6 @@ jobs:
         -DENABLE_AUTO_DOWNLOAD=ON
         -DSTATICCOMPILE=ON -DUSE_MINISAT=ON -DUSE_CRYPTOMINISAT=OFF -DUSE_CADICAL=OFF
         -DENABLE_PYTHON_INTERFACE=OFF
-        "-DMINISAT_LIBDIR=$env:MINISAT_ROOT"
-        "-DMINISAT_INCLUDE_DIRS=$env:MINISAT_ROOT\include"
         "-DZLIB_INCLUDE_DIR=$env:ZLIB_INCLUDE_DIR"
         "-DZLIB_LIBRARY=$env:ZLIB_LIBRARY"
         .

--- a/cmake/FindMiniSat.cmake
+++ b/cmake/FindMiniSat.cmake
@@ -101,11 +101,23 @@ if(NOT MiniSat_FOUND_SYSTEM)
                    # build tree. STP_EP_COMMON_CMAKE_ARGS supplies the -fPIC
                    # this then needs; MiniSat's own CMake never sets it.
                    -DSTATICCOMPILE=ON
+                   # Somewhere other than the top of the build tree, which is
+                   # what stops the BUILD_COMMAND below meaning the wrong
+                   # thing. MiniSat gives minisat_simp an OUTPUT_NAME of
+                   # "minisat", so with the executables at the top the build
+                   # tree holds a *file* called minisat next to a *target*
+                   # called minisat, and Ninja resolves the name to the file:
+                   # asking for the library builds the program instead. The
+                   # Makefile generators have no such ambiguity, and neither
+                   # has Windows, where the file is minisat.exe -- so this was
+                   # every Ninja build on a Unix host, which is all of CI.
+                   -DCMAKE_RUNTIME_OUTPUT_DIRECTORY=<BINARY_DIR>/bin
         # Only the library. MiniSat also builds two command-line programs that
         # STP never runs, and STATICCOMPILE puts -static on them, which needs a
         # static libz, libstdc++ and libc on the build machine -- a requirement
         # STP has no business imposing, and one a distribution that ships no
-        # libz.a cannot meet at all.
+        # libz.a cannot meet at all. Ubuntu ships one, which is why CI built
+        # those programs for as long as it did without saying so.
         BUILD_COMMAND ${CMAKE_COMMAND} --build . --config ${CMAKE_BUILD_TYPE}
                       --target minisat
         # ...which means upstream's install rule, which names those programs

--- a/cmake/FindMiniSat.cmake
+++ b/cmake/FindMiniSat.cmake
@@ -88,12 +88,85 @@ if(NOT MiniSat_FOUND_SYSTEM)
     set(MiniSat_ARCHIVE
         "${CMAKE_STATIC_LIBRARY_PREFIX}minisat${CMAKE_STATIC_LIBRARY_SUFFIX}")
 
+    # MiniSat looks for zlib itself -- in the default paths only, and without
+    # REQUIRED, so nothing this build was told about zlib reaches it and a
+    # miss is silent there: it arrives later as a missing zlib.h from inside
+    # minisat/utils/ParseUtils.h. On a Linux runner the default paths are
+    # where zlib is, which is why nothing noticed; the MSVC job's zlib comes
+    # from vcpkg and is found only because it was named. So hand over what the
+    # find_package(ZLIB REQUIRED) above resolved, in the spelling MiniSat's
+    # own find_package reads -- FindZLIB honours a ZLIB_LIBRARY it is given
+    # rather than searching again, so the two agree by construction.
+    #
+    # ZLIB_ROOT would be the tidier channel and does nothing: MiniSat's
+    # cmake_minimum_required is 2.6, so CMP0074 is OLD in that build and
+    # <PackageName>_ROOT is ignored.
+    #
+    # Both go through file(TO_CMAKE_PATH) first. ExternalProject writes its
+    # configure command into a generated .cmake script as a quoted string, so
+    # a native Windows path arrives there as a string literal and its
+    # separators as escape sequences -- and the MSVC job's zlib lives in
+    # C:\vcpkg, where the first one is the invalid escape \v:
+    #
+    #     Syntax error in cmake code ... Invalid character escape '\v'.
+    #
+    # A -D<var>:PATH= is normalised on the way into the cache and never shows
+    # this; a plain -D<var>= is not, and that is how a library path is
+    # usually given.
+    set(MiniSat_ZLIB_ARGS "")
+    if(ZLIB_INCLUDE_DIR)
+        file(TO_CMAKE_PATH "${ZLIB_INCLUDE_DIR}" _zlib_include_dir)
+        list(APPEND MiniSat_ZLIB_ARGS "-DZLIB_INCLUDE_DIR=${_zlib_include_dir}")
+        unset(_zlib_include_dir)
+    endif()
+    # select_library_configurations() can leave ZLIB_LIBRARY as an
+    # optimized/debug pair rather than one path, and a list does not survive
+    # the trip through CMAKE_ARGS. Take the release half when it does.
+    set(_zlib_library "${ZLIB_LIBRARY}")
+    list(LENGTH _zlib_library _zlib_library_count)
+    if(_zlib_library_count GREATER 1)
+        set(_zlib_library "${ZLIB_LIBRARY_RELEASE}")
+    endif()
+    if(_zlib_library)
+        file(TO_CMAKE_PATH "${_zlib_library}" _zlib_library)
+        list(APPEND MiniSat_ZLIB_ARGS "-DZLIB_LIBRARY=${_zlib_library}")
+    endif()
+    unset(_zlib_library)
+    unset(_zlib_library_count)
+
+    # The configuration MiniSat is built in. STP's own, except under MSVC,
+    # where MiniSat's CMakeLists puts
+    #
+    #     add_compile_options("$<$<CONFIG:RELWITHDEBINFO>:/ZI>")
+    #
+    # on the compile line after the /Z7 that
+    # CMAKE_MSVC_DEBUG_INFORMATION_FORMAT contributes, so /ZI is what cl
+    # reads: one program database shared by four translation units compiling
+    # in parallel, which is the race the MSVC block in deps-helper.cmake
+    # exists to prevent, and uncacheable besides -- sccache declines /ZI.
+    # Release carries no such option, and is the configuration the Windows CI
+    # job built by hand before this became an ExternalProject.
+    #
+    # Named twice deliberately: CMAKE_BUILD_TYPE is what a single-config
+    # generator reads and --config is what a multi-config one reads, and the
+    # sub-build inherits whichever generator this build is using.
+    if(MSVC)
+        set(MiniSat_BUILD_TYPE "Release")
+    else()
+        set(MiniSat_BUILD_TYPE "${CMAKE_BUILD_TYPE}")
+    endif()
+
     ExternalProject_Add(
         MiniSat-EP
         ${STP_EP_COMMON_CONFIG}
         GIT_REPOSITORY https://github.com/stp/minisat
         GIT_TAG ${MiniSat_VERSION}
         CMAKE_ARGS ${STP_EP_COMMON_CMAKE_ARGS}
+                   ${MiniSat_ZLIB_ARGS}
+                   # After STP_EP_COMMON_CMAKE_ARGS, which names it too: a
+                   # later -D wins, which is how a dependency that needs
+                   # something different says so.
+                   -DCMAKE_BUILD_TYPE=${MiniSat_BUILD_TYPE}
                    -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
                    -DCMAKE_INSTALL_LIBDIR=lib
                    # The archive is linked into libstp, so that an installed
@@ -118,7 +191,7 @@ if(NOT MiniSat_FOUND_SYSTEM)
         # STP has no business imposing, and one a distribution that ships no
         # libz.a cannot meet at all. Ubuntu ships one, which is why CI built
         # those programs for as long as it did without saying so.
-        BUILD_COMMAND ${CMAKE_COMMAND} --build . --config ${CMAKE_BUILD_TYPE}
+        BUILD_COMMAND ${CMAKE_COMMAND} --build . --config ${MiniSat_BUILD_TYPE}
                       --target minisat
         # ...which means upstream's install rule, which names those programs
         # too, cannot be used either.


### PR DESCRIPTION
#985 moved the MiniSat pin, and had to move it in two places: `cmake/FindMiniSat.cmake`, where the `ExternalProject` reads it, and the MSVC job, which clones `stp/minisat` and builds it by hand. This deletes the second copy by putting that job on the `ExternalProject` like every other dependency.

The hand-built step is a leftover. It existed because `scripts/deps/setup-minisat.sh` existed; when the setup scripts were retired in 9d67c8b, the LibBF half of the Windows job went with them and the MiniSat half stayed. ABC, CaDiCaL, CLI11, LibBF, Riss and SymFPU are each pinned in exactly one file. MiniSat was the exception, and the two pins drifting apart would have left the MSVC leg quietly testing a MiniSat no other job builds, with nothing to say so.

The job already configures with `-DENABLE_AUTO_DOWNLOAD=ON`, so it only missed the `ExternalProject` because `MINISAT_LIBDIR` and `MINISAT_INCLUDE_DIRS` put it on rung 0 of the ladder in `cmake/deps-helper.cmake`. Two things had to be handed to the sub-build first.

### zlib

MiniSat looks for zlib itself, in the default paths only and without `REQUIRED`, so nothing this build was told about zlib reaches it and a miss is silent there — it arrives later as a missing `zlib.h` from inside `minisat/utils/ParseUtils.h`. On a Linux runner the default paths are where zlib is, which is why nothing has ever noticed; the MSVC job's zlib comes from vcpkg and is found only because `-DZLIB_INCLUDE_DIR` and `-DZLIB_LIBRARY` named it. `FindMiniSat.cmake` now forwards what its own `find_package(ZLIB REQUIRED)` resolved, and `FindZLIB` honours a `ZLIB_LIBRARY` it is handed rather than searching again, so the two sides agree by construction rather than by both happening to find the same copy.

Both values go through `file(TO_CMAKE_PATH)` on the way out, which the first CI run is what caught: `ExternalProject` writes its configure command into a generated `.cmake` script as a quoted string, so a native Windows path lands there as a string literal and its separators as escape sequences — and the MSVC job's zlib lives in `C:\vcpkg`, whose first separator is the invalid escape `\v`. A `-D<var>:PATH=` is normalised into the cache and never shows this; a plain `-D<var>=`, which is how a library path is usually given, is not.

`ZLIB_ROOT` would be the tidier channel and does nothing: MiniSat's `cmake_minimum_required` is 2.6, so `CMP0074` is `OLD` in that build and `<PackageName>_ROOT` is ignored.

### The configuration MiniSat is built in

MiniSat puts `add_compile_options("$<$<CONFIG:RELWITHDEBINFO>:/ZI>")` on the compile line *after* the `/Z7` that `CMAKE_MSVC_DEBUG_INFORMATION_FORMAT` contributes, so `/ZI` is what `cl` reads: one program database shared by four translation units compiling in parallel, which is the race the MSVC block in `deps-helper.cmake` exists to prevent, and uncacheable besides, since sccache declines `/ZI`. Release carries no such option and is what the Windows job built by hand, so MiniSat is built Release under MSVC and in STP's own configuration everywhere else.

### The rung nobody tests any more

Rung 0 — a MiniSat that is already built, named by `MINISAT_LIBDIR` and `MINISAT_INCLUDE_DIRS` — is the only rung that settles `MINISAT_HAS_TERMINATOR` by compiling against the headers rather than deriving it from the pin, and the MSVC job was the only job taking it. So `gcc (minisat only)` now points a second configure at the MiniSat the first one installed, and checks both halves: that rung 0 resolved to that archive, without which the second check is vacuous, and that the probe fired. Configure only, since everything under test is settled by then.

### A defect found on the way

`MiniSat-EP` builds `--target minisat` and explains why at some length: MiniSat's two command-line programs are of no use to STP, and `STATICCOMPILE` puts `-static` on them, so building them needs a static libz, libstdc++ and libc that a distribution need not have. Under Ninja that target has been the wrong one — MiniSat gives `minisat_simp` an `OUTPUT_NAME` of `minisat`, so with the executables at the top of the build tree there is a *file* called `minisat` beside a *target* called `minisat`, and Ninja resolves the name to the file. Asking for the library built the program.

Ubuntu's `zlib1g-dev` ships `libz.a`, so the `-static` link found what it needed and CI stayed green while building two programs it then threw away. On a machine whose zlib package carries no `libz.a` — openSUSE, where this surfaced — `-DUSE_MINISAT=ON -DENABLE_AUTO_DOWNLOAD=ON` fails outright, in a link nobody asked for:

```
ld: attempted static link of dynamic object `/usr/lib64/libz.so'
```

Moving the executables out of the build tree's root makes the name unambiguous again and leaves the archive where the install step already looks for it. Verified on both generators, both ways round: with the executables at the top, Ninja links `minisat_simp` and Make does not; with them under `bin/`, neither does.

### What is verified, and what CI has to settle

Everything above is checked on Linux: the `ExternalProject` now builds on a host with no `libz.a`, the forwarded zlib values are the ones the sub-build uses, and the new probe leg was run by hand — rung 0 resolves to the installed archive and `MINISAT_HAS_TERMINATOR` comes back true from a `try_compile` rather than from the pin.

What cannot be checked from here is MiniSat under Ninja and `cl`: the proven Windows path is the Visual Studio generator at `--config Release`, and this asks the MSVC job to build it the way it builds everything else. That is what the Windows leg is for.
