### PR TITLE
Report what the abstraction took, and let its scope be narrowed

### DIFF
--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -392,6 +392,33 @@ public:
   // abstracted with everything else, and this turns just those three off for a
   // query that would rather not pay for the rounds at all.
   bool bv_term_abstraction_mult = true;
+
+  // Which of the other abstractable kinds --bv-term-abstraction takes.
+  //
+  // It has always taken all of them, and the reason to doubt that looked
+  // strong: an ITE, an addition and a comparison each bit-blast in a number
+  // of gates linear in the width, where a multiplication is quadratic and a
+  // division worse, so abstracting a linear operation saves little and costs
+  // a free variable the refinement then has to pin down. On one 256-bit
+  // industrial query the blaster was handed 82 comparisons, 79 if-then-elses
+  // and 15 additions against 2 multiplications and 6 divisions: 184 free
+  // variables to avoid encoding 8 operations.
+  //
+  // Turning the three off changes nothing. On that query the refinement ran
+  // 35 rounds either way -- the same rounds, over the same 8 arithmetic
+  // abstractions -- and over 400 files of the same family it solved 245
+  // against 247, which is inside the run-to-run spread. The 176 cheap
+  // abstractions are not what the refinement loop is spent on, and the loop
+  // is not what separates this from a solver that decides these queries
+  // without refining at all.
+  //
+  // Kept because the question is a reasonable one to ask again of another
+  // workload, and because the answer above is worth more written down than
+  // rediscovered. Default true, which is what this did before the flags
+  // existed.
+  bool bv_term_abstraction_ite = true;
+  bool bv_term_abstraction_plus = true;
+  bool bv_term_abstraction_compare = true;
   // The ceiling on how many times one of those three may be blocked before
   // its refinement stops enumerating and encodes the operation exactly
   // instead. Measured: through about thirty rounds the abstraction is still

--- a/lib/Interface/cpp_interface.cpp
+++ b/lib/Interface/cpp_interface.cpp
@@ -1172,6 +1172,33 @@ void Cpp_interface::checkSat(const ASTVec& assertionsSMT2,
   if (bm.UserFlags.quick_statistics_flag)
   {
     bm.GetRunTimes()->print();
+    {
+      // What the bit-blaster was handed and what the abstraction took, per
+      // kind, and what the refinement then spent.
+      //
+      // The counters have always been kept; they had no route out but the C
+      // API, so the numbers that say how much wide arithmetic actually
+      // reached the blaster, and how many rounds were spent on it, could not
+      // be read off a run. That made them the numbers a comparison against
+      // another solver most wanted and least had: reading them off the query
+      // text instead over-counts, because it counts occurrences the
+      // simplifier has already retired.
+      const UserDefinedFlags::EncodingCoverage& c = bm.UserFlags.coverage;
+      // In AbstractionKind order; a kind added there needs a name here.
+      static const char* kindNames[] = {"eq",   "compare", "ite",
+                                        "plus", "mult",    "divmod"};
+      static_assert(sizeof(kindNames) / sizeof(kindNames[0]) ==
+                        UserDefinedFlags::EncodingCoverage::KINDS,
+                    "abstraction kind names are out of step with the counters");
+      std::cerr << "Abstraction coverage (candidates -> abstracted):";
+      for (unsigned i = 0; i < UserDefinedFlags::EncodingCoverage::KINDS; i++)
+        std::cerr << " " << kindNames[i] << "=" << c.bv_candidates[i] << "->"
+                  << c.bv_abstracted[i];
+      std::cerr << std::endl
+                << "Abstraction refinement: rounds=" << c.bv_refinement_rounds
+                << " blocking=" << c.bv_blocking_lemmas
+                << " schema=" << c.bv_schema_lemmas << std::endl;
+    }
   }
 
   ToSATBase::PrintOutput(&bm, last_run.result);

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -1020,7 +1020,7 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term, BBNodeSet& support,
       if (num_bits >= uf->bv_abstraction_width)
         uf->coverage.bv_candidates[UserDefinedFlags::ABSTRACT_ITE]++;
 
-      if (uf->bv_term_abstraction &&
+      if (uf->bv_term_abstraction && uf->bv_term_abstraction_ite &&
           num_bits >= uf->bv_abstraction_width)
       {
         uf->coverage.bv_abstracted[UserDefinedFlags::ABSTRACT_ITE]++;
@@ -1147,7 +1147,8 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term, BBNodeSet& support,
       // keeps the n-ary adder it had. Addition is associative and commutative
       // modulo 2^n, so the tree computes the same value; the sort keeps the
       // shape it takes deterministic.
-      if (uf->bv_term_abstraction && uf->bvplus_variant &&
+      if (uf->bv_term_abstraction && uf->bv_term_abstraction_plus &&
+          uf->bvplus_variant &&
           term.Degree() > 2 && num_bits >= uf->bv_abstraction_width)
       {
         std::deque<ASTNode> names(term.begin(), term.end());
@@ -1180,7 +1181,7 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term, BBNodeSet& support,
             term.Degree() - 1;
       }
 
-      if (uf->bv_term_abstraction &&
+      if (uf->bv_term_abstraction && uf->bv_term_abstraction_plus &&
           uf->bvplus_variant &&
           term.Degree() == 2 &&
           num_bits >= uf->bv_abstraction_width)
@@ -1900,7 +1901,7 @@ const BBNode BitBlaster::BBForm(const ASTNode& form, BBNodeSet& support,
       if (form[0].GetValueWidth() >= uf->bv_abstraction_width)
         uf->coverage.bv_candidates[UserDefinedFlags::ABSTRACT_COMPARE]++;
 
-      if (uf->bv_term_abstraction)
+      if (uf->bv_term_abstraction && uf->bv_term_abstraction_compare)
       {
         const BBNodeVec& left = BBTerm(form[0], support);
         const BBNodeVec& right = BBTerm(form[1], support);

--- a/tests/query-files/abstraction-coverage/coverage-follows-the-scope-flags.smt2
+++ b/tests/query-files/abstraction-coverage/coverage-follows-the-scope-flags.smt2
@@ -1,0 +1,17 @@
+; ... and that the three scope flags reach the blaster. The same query with
+; if-then-else, addition and comparison switched off: each is still counted
+; as a candidate and none is taken, while the multiplication is untouched.
+; The candidate counts staying put is the point -- they say what was on
+; offer, not what was accepted.
+; RUN: %solver -t --bv-term-abstraction=1 --bv-term-abstraction-ite=0 --bv-term-abstraction-plus=0 --bv-term-abstraction-compare=0 %s 2>&1 | %OutputCheck %s
+(set-logic QF_BV)
+(declare-fun a () (_ BitVec 128))
+(declare-fun b () (_ BitVec 128))
+(declare-fun c () (_ BitVec 128))
+(assert (= (bvmul a b) c))
+(assert (bvult a b))
+(assert (= (bvadd a b) (bvnot c)))
+(assert (= (ite (bvult b c) a b) c))
+; CHECK: Abstraction coverage \(candidates -> abstracted\): eq=2->0 compare=2->0 ite=1->0 plus=1->0 mult=1->1 divmod=0->0
+(check-sat)
+(exit)

--- a/tests/query-files/abstraction-coverage/coverage-reports-every-kind.smt2
+++ b/tests/query-files/abstraction-coverage/coverage-reports-every-kind.smt2
@@ -1,0 +1,17 @@
+; The counters exist so that what the abstraction actually took can be read
+; off a run. This pins the line they print: one query holding a wide
+; comparison, if-then-else, addition and multiplication, each of which the
+; abstraction takes at this width, and two equalities which it does not --
+; --bv-eq-abstraction is a separate switch and is off here.
+; RUN: %solver -t --bv-term-abstraction=1 %s 2>&1 | %OutputCheck %s
+(set-logic QF_BV)
+(declare-fun a () (_ BitVec 128))
+(declare-fun b () (_ BitVec 128))
+(declare-fun c () (_ BitVec 128))
+(assert (= (bvmul a b) c))
+(assert (bvult a b))
+(assert (= (bvadd a b) (bvnot c)))
+(assert (= (ite (bvult b c) a b) c))
+; CHECK: Abstraction coverage \(candidates -> abstracted\): eq=2->0 compare=2->2 ite=1->1 plus=1->1 mult=1->1 divmod=0->0
+(check-sat)
+(exit)

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -350,6 +350,14 @@ void ExtraMain::create_options()
            "BVDIV, BVMOD, ITE and the inequalities) during bit-blasting, "
            "refining lazily via CEGAR",
            refinement_group);
+  bool_arg("--bv-term-abstraction-ite", bm->UserFlags.bv_term_abstraction_ite,
+           "include wide if-then-else in BV term abstraction", refinement_group);
+  bool_arg("--bv-term-abstraction-plus", bm->UserFlags.bv_term_abstraction_plus,
+           "include wide BVPLUS in BV term abstraction", refinement_group);
+  bool_arg("--bv-term-abstraction-compare",
+           bm->UserFlags.bv_term_abstraction_compare,
+           "include wide inequalities in BV term abstraction",
+           refinement_group);
   bool_arg("--bv-term-abstraction-mult", bm->UserFlags.bv_term_abstraction_mult,
            "include BVMULT, BVDIV and BVMOD in BV term abstraction; they are "
            "the ones refined by ruling out one pair of operand values at a "


### PR DESCRIPTION
The abstraction keeps counters for what the bit-blaster was handed per kind, what the abstraction took, and what the refinement then spent. They have never had a route out but the C API, which made them the numbers a comparison most wants and least has. This prints them under `--print-quickstat`.

Reading the query text instead over-counts, and not by a little: on a 256-bit industrial query the text holds 5 multiplications and 9 divisions, while the blaster is handed 2 and 6. A conclusion drawn from the text count was wrong for exactly that reason, which is what prompted this.

What they say on that query: 82 comparisons, 79 if-then-elses and 15 additions abstracted, against 2 multiplications and 6 divisions — 184 free variables to avoid encoding 8 operations, and 35 refinement rounds spent recovering from it. That looks like something to fix, since an ITE, an addition and a comparison each blast in gates linear in the width where a multiplication is quadratic and a division worse.

It is not. `--bv-term-abstraction-ite`, `-plus` and `-compare` turn the three off, and turning them off changes nothing: 35 refinement rounds either way, over the same 8 arithmetic abstractions, and 245 files solved against 247 over 400 of the same family, which is inside the run-to-run spread. The 176 cheap abstractions are not what the loop is spent on.

The flags are kept anyway. The question is a reasonable one to ask of a different workload, and the answer is worth more written down where the options are than rediscovered. All three default true, which is what this did before they existed, so nothing changes for anyone who does not ask.

Two query-file tests pin the reported line and the flags' effect. The candidate counts staying put across the two is the part worth pinning: they say what was on offer rather than what was accepted, and telling those apart is the whole reason to print them.

163 tests pass.
