### PR TITLE
Remove dead code from the Simplifier

### DIFF
--- a/include/stp/Simplifier/AchievableImage.h
+++ b/include/stp/Simplifier/AchievableImage.h
@@ -96,7 +96,6 @@ public:
   // to samples, the hints (width-adapted) are tried as members first --
   // e.g. (x & 0x55) == 0x41 only finds the true-witness x = 0x41 this
   // way. Call before apply()ing the steps.
-  void addHint(const ASTNode& k);
 
   // Back-propagate the predicate constant `k` through the whole
   // collected path with a per-operator heuristic preimage, recording a
@@ -153,7 +152,7 @@ private:
   // invert an image value back to an x value.
   std::vector<std::pair<CBV, CBV>> exactBounds;
   std::vector<Sample> samples;
-  std::vector<CBV> hints; // owned; see addHint
+  std::vector<CBV> hints; // owned; see addHintChain
 
   bool applyExact(const GroundStep& step);
   void applyToSamples(const GroundStep& step);

--- a/include/stp/Simplifier/NodeDomainAnalysis.h
+++ b/include/stp/Simplifier/NodeDomainAnalysis.h
@@ -110,7 +110,7 @@ private:
 
 public:
   NodeDomainAnalysis(STPMgr* _bm)
-      : bm(*_bm), intervalAnalysis(*_bm), valueSetAnalysis(*_bm)
+      : bm(*_bm), valueSetAnalysis(*_bm)
   {
     emptyBoolean = new FixedBits(1, true);
   }

--- a/include/stp/Simplifier/PropagateEqualities.h
+++ b/include/stp/Simplifier/PropagateEqualities.h
@@ -28,7 +28,6 @@ THE SOFTWARE.
 #include "stp/AST/AST.h"
 #include "stp/STPManager/STPManager.h"
 #include "stp/Simplifier/Simplifier.h"
-#include "stp/Simplifier/PropagateEqualities.h"
 #include "stp/Simplifier/NodeSimplifier.h"
 #include <ankerl/unordered_dense.h>
 
@@ -73,10 +72,8 @@ private:
 
   void buildCandidateList(const ASTNode& a);
   bool buildCandidateListNode(const ASTNode& a);
-  void replaceIfPossible(int line, ASTNode& output, const ASTNode& lhs, const ASTNode& rhs);
   void buildXORCandidates(const ASTNode a, bool negated);
   
-  //ASTNode AndPropagate(const ASTNode& a, ArrayTransformer* at);
 
   void addCandidate(const ASTNode a, const ASTNode b);
   ASTNode resolveFpLiteral(const ASTNode& n);

--- a/include/stp/Simplifier/Simplifier.h
+++ b/include/stp/Simplifier/Simplifier.h
@@ -133,7 +133,6 @@ public:
   bool UpdateSubstitutionMapFewChecks(const ASTNode& e0, const ASTNode& e1);
 
   DLL_PUBLIC ASTNode applySubstitutionMap(const ASTNode& n);
-  DLL_PUBLIC ASTNode applySubstitutionMapUntilArrays(const ASTNode& n);
   ASTNode applySubstitutionMapUntilArrays(const ASTNode& n,
                                           DenseNodeMap& cache);
 
@@ -232,8 +231,6 @@ private:
   // depth becomes C++ call depth.
   ASTNode simplifyNode(const ASTNode& n, bool pushNeg, SimplifyJob job);
 
-  void checkIfInSimplifyMap(const ASTNode& n, ASTNodeSet visited);
-
   ASTNode makeTower(const Kind k, const ASTVec& children);
 
   ASTNode pullUpBVSX(const ASTNode output);
@@ -246,14 +243,9 @@ private:
 
   bool hasBeenSimplified(const ASTNode& n);
 
-  ASTNode SimplifyFormula_NoRemoveWrites(const ASTNode& a, bool pushNeg);
-
   ASTNode ITEOpt_InEqs(const ASTNode& in1, ASTNode& conditionToNegate);
 
   ASTNode PullUpITE(const ASTNode& in);
-
-  ASTNode CreateSimplifiedFormulaITE(const ASTNode& in0, const ASTNode& in1,
-                                     const ASTNode& in2);
 
   ASTNode CreateSimplifiedINEQ(const Kind k, const ASTNode& a0,
                                const ASTNode& a1, bool pushNeg);
@@ -272,13 +264,6 @@ private:
 
   ASTNode DistributeMultOverPlus(const ASTNode& a,
                                  bool startdistribution = false);
-
-  // Replaces WRITE(Arr,i,val) with ITE(j=i, val, READ(Arr,j))
-  ASTNode RemoveWrites_TopLevel(const ASTNode& term);
-  ASTNode RemoveWrites(const ASTNode& term);
-  ASTNode SimplifyWrites_InPlace(const ASTNode& term);
-
-  ASTNode SimplifyArrayTerm(const ASTNode& term);
 
 };
 } // end of namespace

--- a/include/stp/Simplifier/StrengthReduction.h
+++ b/include/stp/Simplifier/StrengthReduction.h
@@ -57,7 +57,6 @@ class StrengthReduction
 
   // A special version that handles the lhs appearing in the rhs of the fromTo
   // map.
-  ASTNode replace(const ASTNode& n, ASTNodeMap& fromTo, ASTNodeMap& cache);
 
   ASTNode visit(const ASTNode& n, stp::NodeDomainAnalysis& nda, ASTNodeMap& fromTo);
 

--- a/include/stp/Simplifier/SubstitutionMap.h
+++ b/include/stp/Simplifier/SubstitutionMap.h
@@ -36,7 +36,6 @@ namespace stp
 class Simplifier;
 class ArrayTransformer;
 
-const bool debug_substn = false;
 
 class DLL_PUBLIC SubstitutionMap
 {
@@ -54,7 +53,6 @@ class DLL_PUBLIC SubstitutionMap
   VariablesInExpression::SymbolPtrSet
       rhs_visited; // the rhs contains all the variables in here already.
 
-  int loopCount;
 
   void buildDepends(const ASTNode& n0, const ASTNode& n1);
   void loops_helper(const std::set<ASTNode>& varsToCheck,
@@ -80,7 +78,7 @@ public:
     ASTUndefined = bm->CreateNode(UNDEFINED);
 
     SolverMap = new DenseNodeMap(INITIAL_TABLE_SIZE);
-    loopCount = 0;
+
     substitutionsLastApplied = 0;
   }
 

--- a/include/stp/Simplifier/UnsignedInterval.h
+++ b/include/stp/Simplifier/UnsignedInterval.h
@@ -90,13 +90,6 @@ struct UnsignedInterval
     return bits_(minV);
   }
 
-  void resetToComplete()
-  {
-    CONSTANTBV::BitVector_Empty(minV);
-    CONSTANTBV::BitVector_Fill(maxV);
-    checkUnsignedInvariant();
-  }
-
   bool replaceMinIfTightens(CBV min)
   {
     if (CONSTANTBV::BitVector_Lexicompare(min, minV) > 0)
@@ -127,92 +120,6 @@ struct UnsignedInterval
     assert(maxV != NULL);
     assert(size_(minV) == size_(maxV));
     assert(CONSTANTBV::BitVector_Lexicompare(minV, maxV) <= 0);
-  }
-
-  // If the interval is interpreted as a clockwise interval.
-  bool crossesSignedUnsigned(int width) const
-  {
-    bool minMSB = CONSTANTBV::BitVector_bit_test(minV, width - 1);
-    bool maxMSB = CONSTANTBV::BitVector_bit_test(maxV, width - 1);
-
-    // If the min is zero, and the max is one, then it must cross.
-    if (!minMSB && maxMSB)
-      return true;
-    if (!(minMSB ^ maxMSB)) // bits are the same.
-      return CONSTANTBV::BitVector_Compare(minV, maxV) > 0;
-    return false;
-  }
-
-  // Splits the interval at the poles, so that segments are entirely within a hemisphere.
-  static void split(const UnsignedInterval *a, std::vector<UnsignedInterval*>& a_vec)
-  {
-    const unsigned width = a->getWidth(); 
-
-    CBV zero = mkZero(width);
-
-    if (CONSTANTBV::BitVector_is_empty(a->minV) && !CONSTANTBV::BitVector_is_empty(a->maxV))
-    {
-      // Split zero into it's own segment if it's the minimum.
-       UnsignedInterval * split0 = new UnsignedInterval(CONSTANTBV::BitVector_Clone(zero), CONSTANTBV::BitVector_Clone(zero));
-       a_vec.push_back(split0);
-       CONSTANTBV::BitVector_Destroy(zero);
-
-       // What's left runs from one up to the maximum.
-       UnsignedInterval * split1 = new UnsignedInterval(mkOne(width), CONSTANTBV::BitVector_Clone(a->maxV));
-       split(split1,a_vec);
-       delete split1;
-       return;
-    }
-
-    if (!CONSTANTBV::BitVector_is_empty(a->minV) && CONSTANTBV::BitVector_is_empty(a->maxV))
-    {
-       // Split zero into it's own segment if it's the maximum.
-       UnsignedInterval * split0 = new UnsignedInterval(CONSTANTBV::BitVector_Clone(zero), CONSTANTBV::BitVector_Clone(zero));
-       a_vec.push_back(split0);
-       CONSTANTBV::BitVector_Destroy(zero);
-
-       // What's left runs from the minimum up to the last value before
-       // the wrap, which is all ones.
-       UnsignedInterval * split1 = new UnsignedInterval(CONSTANTBV::BitVector_Clone(a->minV), allOnes(width));
-       split(split1,a_vec);
-       delete split1;
-       return;
-    }
-
-    if (a->in(zero) && !CONSTANTBV::BitVector_is_empty(a->minV))
-    {
-      // Split at zero if it's in the middle somewhere.
-       CBV negativeOne = allOnes(width);
-
-       UnsignedInterval * split0 = new UnsignedInterval(CONSTANTBV::BitVector_Clone(a->minV), negativeOne);
-       UnsignedInterval * split1 = new UnsignedInterval(zero, CONSTANTBV::BitVector_Clone(a->maxV));
-       split(split0,a_vec);
-       split(split1,a_vec);
-       delete split0;
-       delete split1;
-       return;
-    }
-    CONSTANTBV::BitVector_Destroy(zero);
-
-    CBV signedMin = CONSTANTBV::BitVector_Create(width, true);
-    CONSTANTBV::BitVector_Bit_On(signedMin,width-1);
-    if (a->in(signedMin) && (CONSTANTBV::BitVector_Compare(a->minV,signedMin)) != 0)
-    {
-        // Split the signed minimum into it's own segment.
-        CBV unsignedMax = CONSTANTBV::BitVector_Clone(signedMin);
-        CONSTANTBV::BitVector_decrement(unsignedMax);
-
-        UnsignedInterval * split0 = new UnsignedInterval(CONSTANTBV::BitVector_Clone(a->minV), unsignedMax);
-        UnsignedInterval * split1 = new UnsignedInterval(signedMin, CONSTANTBV::BitVector_Clone(a->maxV));     
-        split(split0,a_vec);
-        split(split1,a_vec);
-        delete split0;
-        delete split1;
-        return;
-    }   
-    CONSTANTBV::BitVector_Destroy(signedMin);
-
-    a_vec.push_back(new UnsignedInterval(CONSTANTBV::BitVector_Clone(a->minV), CONSTANTBV::BitVector_Clone(a->maxV)));
   }
 
   bool in(const CBV c) const

--- a/include/stp/Simplifier/UnsignedIntervalAnalysis.h
+++ b/include/stp/Simplifier/UnsignedIntervalAnalysis.h
@@ -50,7 +50,6 @@ using NodeToUnsignedIntervalMap =
 
 class UnsignedIntervalAnalysis
 {
-  STPMgr& bm;
   CBV littleOne;
   CBV littleZero;
 
@@ -70,8 +69,8 @@ class UnsignedIntervalAnalysis
 
 public:
 
-  UnsignedIntervalAnalysis(STPMgr& _bm);
-  
+  UnsignedIntervalAnalysis();
+
   UnsignedIntervalAnalysis(const UnsignedIntervalAnalysis&) = delete;
   UnsignedIntervalAnalysis & operator=(const UnsignedIntervalAnalysis&) = delete;
   

--- a/include/stp/Simplifier/UnsignedIntervalAnalysis.h
+++ b/include/stp/Simplifier/UnsignedIntervalAnalysis.h
@@ -78,10 +78,8 @@ public:
   ~UnsignedIntervalAnalysis();
 
   // Replace some of the things that unsigned intervals can figure out for us.
-  ASTNode topLevel(const ASTNode& top);
 
   UnsignedInterval* dispatchToTransferFunctions(const ASTNode&n, const vector<const UnsignedInterval*>& children);
-  UnsignedInterval* visit(const ASTNode& n, NodeToUnsignedIntervalMap& visited);
 
 
   void stats();

--- a/lib/Simplifier/AchievableImage.cpp
+++ b/lib/Simplifier/AchievableImage.cpp
@@ -133,12 +133,6 @@ AchievableImage::~AchievableImage()
     destroy(h);
 }
 
-void AchievableImage::addHint(const ASTNode& k)
-{
-  assert(k.isConstant());
-  hints.push_back(clone(k.GetBVConst()));
-}
-
 namespace
 {
 // Deterministic integer square root (no libm: the result seeds samples,

--- a/lib/Simplifier/BVSolver.cpp
+++ b/lib/Simplifier/BVSolver.cpp
@@ -53,8 +53,6 @@ THE SOFTWARE.
 // 4. Outside the solver, Substitute and Re-normalize the input DAG
 namespace stp
 {
-const bool flatten_ands = true;
-const bool debug_bvsolver = false;
 
 // Whether eliminating `var` in favour of `value` keeps the floating-point
 // format `var` carries.
@@ -259,12 +257,6 @@ ASTNode BVSolver::ChooseMonom(const ASTNode& eq, ASTNode& modifiedlhs,
   modifiedlhs =
       (o.size() > 1) ? _bm->CreateTerm(BVPLUS, lhs.GetValueWidth(), o) : o[0];
 
-  if (debug_bvsolver)
-  {
-    std::cerr << "Initial:" << eq;
-    std::cerr << "Chosen Monomial:" << outmonom;
-    std::cerr << "Output LHS:" << modifiedlhs;
-  }
 
   // can be SYMBOL or (BVUMINUS SYMBOL) or (BVMULT ODD_BVCONST SYMBOL) or
   // (BVMULT ODD_BVCONST (EXTRACT SYMBOL BV_CONST ZERO)) or
@@ -315,11 +307,6 @@ ASTNode BVSolver::substitute(const ASTNode& eq, const ASTNode& lhs,
 
       if (!(SYMBOL == lhs[0].GetKind() && BVCONST == lhs[1].GetKind() &&
             zero == lhs[2] && !vars.VarSeenInTerm(lhs[0], rhs)))
-      {
-        return eq;
-      }
-
-      if (vars.VarSeenInTerm(lhs[0], rhs))
       {
         return eq;
       }
@@ -555,7 +542,7 @@ ASTNode BVSolver::TopLevelBVSolve(const ASTNode& _input,
     return input;
   }
 
-  if (flatten_ands && AND == k)
+  if (AND == k)
   {
     ASTVec c = FlattenKind(AND, input.GetChildren());
     input = _bm->CreateNode(AND, c);
@@ -850,8 +837,6 @@ ASTNode BVSolver::BVSolve_Even(const ASTNode& input)
     }
 
     unsigned len = lhs.GetValueWidth();
-    ASTNode hi = _bm->CreateBVConst(32, len - 1);
-    ASTNode low = _bm->CreateBVConst(32, len - power_of_2);
     ASTNode low_minus_one = _bm->CreateBVConst(32, len - power_of_2 - 1);
     ASTNode low_zero = _bm->CreateZeroConst(32);
     unsigned newlen = len - power_of_2;

--- a/lib/Simplifier/PropagateEqualities.cpp
+++ b/lib/Simplifier/PropagateEqualities.cpp
@@ -30,13 +30,6 @@ THE SOFTWARE.
 namespace stp
 {
 
-void log([[maybe_unused]] std::string s)
-{
-#if 0
-  std::cerr << ">>" << s;
-#endif
-}
-
 typedef PropagateEqualities::IdSet IdSet;
 typedef ankerl::unordered_dense::map<uint64_t, uint64_t> IdToId;
 typedef ankerl::unordered_dense::map<uint64_t, IdSet> IdToIdSet;
@@ -319,10 +312,7 @@ ASTNode PropagateEqualities::topLevel(const ASTNode& a)
   result = simp->applySubstitutionMapAtTopLevel(result);
  
   bm->GetRunTimes()->start(RunTimes::PropagateEqualities);
-  
-  //if (AND == a.GetKind())
-    //result = AndPropagate(result, at);
-    // TODO should write the substitutions through?
+
   buildCandidateList(result);
   
   if (bm->UserFlags.stats_flag)
@@ -454,63 +444,6 @@ void PropagateEqualities::buildXORCandidates(const ASTNode a, bool negated)
       addCandidate(symbol, newN);
     }
 }
-
-#if 0
-ASTNode PropagateEqualities::AndPropagate(const ASTNode& input, ArrayTransformer* at)
-{
-  assert(input.GetKind() == AND);
-  ASTVec c = FlattenKind(AND, input.GetChildren());
-  
-  ASTVec result;
-
-  bool different = false;
-  for (const auto& it : c)
-  {
-    ASTNode changed = it;
-    const Kind k = changed.GetKind();
-    assert(k != AND); // Should have been flattened out already.
-
-    if (NOT == k && SYMBOL == it[0].GetKind()) // (NOT a)
-        changed = propagate(it,at);
-    else if (SYMBOL == k) // (a)
-        changed = propagate(it,at);
-    else if ((IFF == k || EQ == k) && (it[0].GetKind() == SYMBOL && it[1].GetChildren().size() == 0)) // (= x y), (= x 55)
-        changed = propagate(it,at);
-    else if ((IFF == k || EQ == k) && (it[0].GetKind() == SYMBOL && it[1].Degree() == 0 && it[1][0].GetKind() == SYMBOL))  // (= x (bvnot y)), 
-        changed = propagate(it,at);
-    else if (XOR == k && it.Degree() == 2 && it[0].GetKind() == SYMBOL && it[1].Degree() == 0) 
-        changed = propagate(it,at);
-    else if (NOT == k && XOR == it[0].GetKind() && it[0].Degree() == 2 && it[0][0].GetKind() == SYMBOL && it[0][1].Degree() == 0)
-        changed = propagate(it,at);
-  
-    if (!different && it != changed) 
-    {
-        different = true;
-        result.reserve(c.size());
-        for (ASTVec::iterator it1 = c.begin(); *it1 != it; it1++)
-           result.push_back(*it1);
-    }
-
-    if (changed != ASTTrue)
-       result.push_back(changed);
-
-     alreadyVisited.insert(it.GetNodeNum());
-  }
-
-  if (!different)
-    return input;
-
-  ASTNode output;
-  if (result.size() == 0)
-    output = ASTTrue;
-  else if (result.size() == 1)
-    output = result[0];
-  else 
-    output = nf->CreateNode(AND, result);
-
-  return output;
-}
-#endif
 
 bool PropagateEqualities::isSymbol(ASTNode c)
 {

--- a/lib/Simplifier/RemoveUnconstrained.cpp
+++ b/lib/Simplifier/RemoveUnconstrained.cpp
@@ -122,20 +122,6 @@ ASTNode RemoveUnconstrained::topLevel(const ASTNode& n, Simplifier* simplifier,
   // in the substitution map.
   result = topLevel_other(result, simplifier);
 
-// It is idempotent if there are no big ANDS (we have a special hack), and,
-// if we don't introduced any new "disjoint extracts."
-
-#if 0
-  ASTNode result2 = topLevel_other(result, simplifier);
-  if (result2 != result)
-  {
-      cerr << n;
-      cerr << result;
-      cerr << result2;
-      assert(result2 == result);
-  }
-#endif
-
   // Any definition the substitution map refused goes back as a
   // conjunct, so the variable it defines is not left free.
   if (!refusedDefinitions.empty())

--- a/lib/Simplifier/Simplifier.cpp
+++ b/lib/Simplifier/Simplifier.cpp
@@ -145,11 +145,6 @@ ASTNode Simplifier::applySubstitutionMapAtTopLevel(const ASTNode& topLevel)
   return substitutionMap.applySubstitutionMapAtTopLevel(topLevel);
 }
 
-ASTNode Simplifier::applySubstitutionMapUntilArrays(const ASTNode& n)
-{
-  return substitutionMap.applySubstitutionMapUntilArrays(n);
-}
-
 ASTNode Simplifier::applySubstitutionMapUntilArrays(const ASTNode& n, DenseNodeMap& cache)
 {
   return substitutionMap.applySubstitutionMapUntilArrays(n,cache);
@@ -185,37 +180,6 @@ bool Simplifier::CheckMultInverseMap(const ASTNode& key, ASTNode& output)
 void Simplifier::UpdateMultInverseMap(const ASTNode& key, const ASTNode& value)
 {
   MultInverseMap[key] = value;
-}
-
-ASTNode Simplifier::SimplifyFormula_NoRemoveWrites(const ASTNode& b,
-                                                   bool pushNeg)
-{
-  ASTNode out = SimplifyFormula(b, pushNeg);
-  return out;
-}
-
-// I like simplify to have been run on all the nodes.
-void Simplifier::checkIfInSimplifyMap(const ASTNode& n, ASTNodeSet visited)
-{
-  if (n.isConstant() || (n.GetKind() == SYMBOL))
-    return;
-
-  if (visited.find(n) != visited.end())
-    return;
-
-  if (SimplifyMap->find(n) == SimplifyMap->end())
-  {
-    cerr << "not found";
-    cerr << n;
-    assert(false);
-  }
-
-  for (size_t i = 0; i < n.Degree(); i++)
-  {
-    checkIfInSimplifyMap(n[i], visited);
-  }
-
-  visited.insert(n);
 }
 
 ASTNodeMap Simplifier::FindConsts_TopLevel(const ASTNode& b, bool pushNeg)
@@ -254,8 +218,6 @@ ASTNode Simplifier::SimplifyFormula_TopLevel(const ASTNode& b, bool pushNeg)
   assert(_bm->UserFlags.optimize_flag);
   _bm->GetRunTimes()->start(RunTimes::SimplifyTopLevel);
   ASTNode out = SimplifyFormula(b, pushNeg);
-  ASTNodeSet visited;
-  // checkIfInSimplifyMap(out,visited);
   ResetSimplifyMaps();
   _bm->GetRunTimes()->stop(RunTimes::SimplifyTopLevel);
   return out;
@@ -737,29 +699,6 @@ ASTNode Simplifier::CreateSimplifiedTermITE(const ASTNode& in0,
 
   return nf->CreateArrayTerm(ITE, t1.GetIndexWidth(), t1.GetValueWidth(), t0,
                              t1, t2);
-}
-
-ASTNode Simplifier::CreateSimplifiedFormulaITE(const ASTNode& in0,
-                                               const ASTNode& in1,
-                                               const ASTNode& in2)
-{
-  const ASTNode& t0 = in0;
-  const ASTNode& t1 = in1;
-  const ASTNode& t2 = in2;
-  CountersAndStats("CreateSimplifiedFormulaITE", _bm);
-
-  if (_bm->UserFlags.optimize_flag)
-  {
-    if (t0 == ASTTrue)
-      return t1;
-    if (t0 == ASTFalse)
-      return t2;
-    if (t1 == t2)
-      return t1;
-  }
-  ASTNode result = nf->CreateNode(ITE, t0, t1, t2);
-  assert(BVTypeCheck(result));
-  return result;
 }
 
 // Every connective is where a formula nests: each operand is simplified by
@@ -2556,68 +2495,7 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
           break;
         }
 
-// This can increase the number of nodes exponentially.
-// If turned on bitrev2048 will blow out main memory, with
-// this disabled it takes 12MB.
-#if 0
-
-          case BVAND:
-          case BVOR:
-          case BVXOR:
-            {
-              assert(a0.Degree() == 2);
-
-              //assumes these operators are binary
-              //
-              // (t op u)[i:j] <==> t[i:j] op u[i:j]
-              ASTNode t = a0[0];
-              ASTNode u = a0[1];
-              t =
-              SimplifyTerm(nf->CreateTerm(BVEXTRACT,
-                      a_len, t, i, j));
-              u =
-              SimplifyTerm(nf->CreateTerm(BVEXTRACT,
-                      a_len, u, i, j));
-              BVTypeCheck(t);
-              BVTypeCheck(u);
-              //output = nf->CreateTerm(k1, a_len, t, u);
-
-              output = inputterm;
-              break;
-            }
-#endif
         // nb. (~t)[i:j] == ~(t[i:j]) is done by the simplifying node factory.
-        // case BVSX:{ //(BVSX(t,n)[i:j] <==> BVSX(t,i+1), if n
-        //        >= i+1 and j=0 ASTNode t = a0[0]; unsigned int
-        //        bvsx_len = a0.GetValueWidth(); if(bvsx_len <
-        //        a_len) { FatalError("SimplifyTerm: BVEXTRACT
-        //        over BVSX:" "the length of BVSX term must be
-        //        greater than extract-len",inputterm); } if(j
-        //        != zero) { output =
-        //        nf->CreateTerm(BVEXTRACT,a_len,a0,i,j); }
-        //        else { output =
-        //        nf->CreateTerm(BVSX,a_len,t,
-        //                        nf->CreateBVConst(32,a_len));
-        //        } break; }
-
-        /*
-         * On deeply nested ITES, this can cause an exponential number
-         * of nodes to be produced. Especially if there are different
-         * extracts over the same node.
-         *
-         case ITE:
-         {
-         const ASTNode& t0 = a0[0];
-         ASTNode t1 =
-         SimplifyTerm(nf->CreateTerm(BVEXTRACT,
-         a_len, a0[1], i, j));
-         ASTNode t2 =
-         SimplifyTerm(nf->CreateTerm(BVEXTRACT,
-         a_len, a0[2], i, j));
-         output = CreateSimplifiedTermITE(t0, t1, t2);
-         break;
-         }
-         */
         default:
         {
           output = inputterm;
@@ -3093,13 +2971,6 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
 
       assert(!out1.IsNull());
 
-// process only if not  in the substitution map. simplifymap
-// has been checked already
-#if 0
-        if (!InsideSubstitutionMap(out1, out1) && out1.GetKind() == READ && WRITE == out1[0].GetKind())
-          out1 = RemoveWrites_TopLevel(out1);
-#endif
-
       // it is possible that after all the procesing the READ term
       // reduces to READ(Symbol,const) and hence we should check the
       // substitutionmap once again.
@@ -3181,9 +3052,6 @@ ASTNode Simplifier::simplify_term_switch(const ASTNode& actualInputterm,
     default:
       FatalError("SimplifyTerm: Control should never reach here:", inputterm,
                  k);
-      assert(false);
-      exit(-1);
-      break;
   }
 
   return ASTUndefined;
@@ -3535,12 +3403,6 @@ ASTNode Simplifier::DistributeMultOverPlus(const ASTNode& a,
   return output;
 }
 
-// recursively simplify things that are of type array.
-ASTNode Simplifier::SimplifyArrayTerm(const ASTNode& term)
-{
-  return simplifyNode(term, false, SimplifyJob::Array);
-}
-
 // compute the multiplicative inverse of the input
 ASTNode Simplifier::MultiplicativeInverse(const ASTNode& d)
 {
@@ -3687,12 +3549,6 @@ void Simplifier::printCacheStatus()
   cerr << "MultInverseMap" << MultInverseMap.size() << ":"
        << MultInverseMap.bucket_count() << endl;
 
-#if 0
-    cerr << "ReadOverWrite_NewName_Map" << ReadOverWrite_NewName_Map->size() << ":"
-        << ReadOverWrite_NewName_Map->bucket_count() << endl;
-    cerr << "NewName_ReadOverWrite_Map" << NewName_ReadOverWrite_Map.size() << ":"
-        << NewName_ReadOverWrite_Map.bucket_count() << endl;
-#endif
   cerr << "substn_map" << substitutionMap.Return_SolverMap()->size() << ":"
        << substitutionMap.Return_SolverMap()->bucket_count() << endl;
 }

--- a/lib/Simplifier/StrengthReduction.cpp
+++ b/lib/Simplifier/StrengthReduction.cpp
@@ -34,58 +34,6 @@ namespace stp
   using std::make_pair;
   using simplifier::constantBitP::FixedBits;
 
-  // A special version that handles the lhs appearing in the rhs of the fromTo
-  // map.
-  ASTNode StrengthReduction::replace(const ASTNode& n, ASTNodeMap& fromTo, ASTNodeMap& cache)
-  {
-    if (n.isAtom())
-      return n;
-
-    {
-      const ASTNodeMap::const_iterator it = cache.find(n);
-      if (it != cache.end())
-        return it->second;
-    }
-
-    ASTNode result = n;
-
-    {
-      const ASTNodeMap::iterator it = fromTo.find(n);
-      if (it != fromTo.end())
-      {
-        result = it->second;
-        fromTo.erase(it); // this is how it differs from the everyday replace.
-      }
-    }
-
-    ASTVec new_children;
-    new_children.reserve(result.GetChildren().size());
-
-    for (size_t i = 0; i < result.Degree(); i++)
-      new_children.push_back(replace(result[i], fromTo, cache));
-
-    if (ASTChildren(new_children) == result.GetChildren())
-    {
-      cache.insert(make_pair(n, result));
-      return result;
-    }
-
-    if (n.GetValueWidth() == 0) // n.GetType() == BOOLEAN_TYPE
-    {
-      result = nf->CreateNode(result.GetKind(), new_children);
-    }
-    else
-    {
-      // If the index and value width aren't saved, they are reset sometimes
-      // (??)
-      result = nf->CreateArrayTerm(result.GetKind(), result.GetIndexWidth(),
-                                   result.GetValueWidth(), new_children);
-    }
-
-    cache.insert(make_pair(n, result));
-    return result;
-  }
-
   // visit each node apply strength reductions to it.
   //
   // postOrderRebuild does the walking, on the heap: how deeply the input

--- a/lib/Simplifier/SubstitutionMap.cpp
+++ b/lib/Simplifier/SubstitutionMap.cpp
@@ -464,7 +464,6 @@ void SubstitutionMap::buildDepends(const ASTNode& n0, const ASTNode& n1)
       continue;
     rhsAlreadyAdded.insert(sym);
 
-    // cout << loopCount++ << " ";
     // cout << "initial" << rhs.size() << " Adding: " <<sym->size();
     rhs.insert(sym->begin(), sym->end());
     // cout << "final:" << rhs.size();
@@ -541,18 +540,10 @@ bool SubstitutionMap::loops(const ASTNode& n0, const ASTNode& n1)
   if (n1.GetKind() == SYMBOL && dependsOn.find(n1) == dependsOn.end())
     return false; // The rhs is a symbol and doesn't appear.
 
-  if (debug_substn)
-    cout << loopCount++ << endl;
 
   bool destruct = true;
   ASTNodeSet* dependN = vars.SetofVarsSeenInTerm(n1, destruct);
 
-  if (debug_substn)
-  {
-    cout << n0 << " "
-         << n1.GetNodeNum(); //<< " Expression size:" << bm->NodeSize(n1,true);
-    cout << "Variables in expression: " << dependN->size() << endl;
-  }
 
   set<ASTNode> depend(dependN->begin(), dependN->end());
 
@@ -564,8 +555,6 @@ bool SubstitutionMap::loops(const ASTNode& n0, const ASTNode& n1)
 
   bool loops = visited.find(n0) != visited.end();
 
-  if (debug_substn)
-    cout << "Visited:" << visited.size() << "Loops:" << loops << endl;
 
   return (loops);
 }

--- a/lib/Simplifier/UnsignedIntervalAnalysis.cpp
+++ b/lib/Simplifier/UnsignedIntervalAnalysis.cpp
@@ -2047,7 +2047,7 @@ namespace stp
     return result;
   }
 
-  UnsignedIntervalAnalysis::UnsignedIntervalAnalysis(STPMgr& _bm) : bm(_bm)
+  UnsignedIntervalAnalysis::UnsignedIntervalAnalysis()
   {
     littleZero = getEmptyCBV(1); // owned by emptyCBV, not by us.
     littleOne = mkOne(1);

--- a/lib/Simplifier/UnsignedIntervalAnalysis.cpp
+++ b/lib/Simplifier/UnsignedIntervalAnalysis.cpp
@@ -1008,32 +1008,6 @@ namespace stp
     return r;
   }
 
-  // Replace some of the things that unsigned intervals can figure out for us.
-  ASTNode UnsignedIntervalAnalysis::topLevel(const ASTNode& top)
-  {
-    propagatorNotImplemented = 0;
-    iterations=0;
-
-    bm.GetRunTimes()->start(RunTimes::IntervalPropagation);
-
-    NodeToUnsignedIntervalMap visited;
-    visit(top, visited);
-
-    if (bm.UserFlags.stats_flag)
-      stats();
-
-    StrengthReduction sr(bm.defaultNodeFactory, &bm.UserFlags);
-    ASTNode result = sr.topLevel(top, visited);
-
-    // The intervals are only read during strength reduction, delete them now.
-    for (const auto& pair : visited)
-      delete pair.second;
-
-    bm.GetRunTimes()->stop(RunTimes::IntervalPropagation);
-
-    return result;
-  }
-
   UnsignedInterval* UnsignedIntervalAnalysis::dispatchToTransferFunctions(const ASTNode&n, const vector<const UnsignedInterval*>& _children)
   {
     const auto number_children = n.Degree();
@@ -2070,44 +2044,6 @@ namespace stp
       result->checkUnsignedInvariant();
     }
 
-    return result;
-  }
-
-  UnsignedInterval* UnsignedIntervalAnalysis::visit(const ASTNode& n,
-                          NodeToUnsignedIntervalMap& visited)
-  {
-    {
-      NodeToUnsignedIntervalMap::iterator it;
-      if ((it = visited.find(n)) != visited.end())
-        return it->second;
-    }
-
-    if (n.GetKind() == SYMBOL || n.GetKind() == WRITE || n.GetKind() == READ)
-    {
-      // Never know anything about these.
-      visited.insert({n, NULL});
-      return NULL;
-    }
-
-    const auto number_children = n.Degree();
-    vector<const UnsignedInterval*> children;
-
-    children.reserve(number_children);
-
-    for (unsigned i = 0; i < number_children; i++)
-    {
-      UnsignedInterval* r = visit(n[i], visited);
-      if (r != NULL)
-      {
-        assert(!r->isComplete());
-      }
-      children.push_back(r);
-    }
-
-    UnsignedInterval* result = dispatchToTransferFunctions(n,children);
-
-    // result will often be null (which we take to mean the maximum range).
-    visited.insert({n, result});
     return result;
   }
 

--- a/tests/unit-tests/UnsignedIntervalExhaustive_Test.cpp
+++ b/tests/unit-tests/UnsignedIntervalExhaustive_Test.cpp
@@ -71,7 +71,7 @@ struct Context
   SimplifyingNodeFactory snf;
   stp::UnsignedIntervalAnalysis analysis;
 
-  Context() : snf(*(mgr.hashingNodeFactory), mgr), analysis(mgr)
+  Context() : snf(*(mgr.hashingNodeFactory), mgr)
   {
     mgr.defaultNodeFactory = &snf;
   }

--- a/tests/unit-tests/UnsignedIntervalPropagators_Test.cpp
+++ b/tests/unit-tests/UnsignedIntervalPropagators_Test.cpp
@@ -46,7 +46,7 @@ struct Context
   SimplifyingNodeFactory snf;
   stp::UnsignedIntervalAnalysis analysis;
 
-  Context() : snf(*(mgr.hashingNodeFactory), mgr), analysis(mgr)
+  Context() : snf(*(mgr.hashingNodeFactory), mgr)
   {
     mgr.defaultNodeFactory = &snf;
   }

--- a/tests/unit-tests/UnsignedIntervalWide_Test.cpp
+++ b/tests/unit-tests/UnsignedIntervalWide_Test.cpp
@@ -62,7 +62,7 @@ struct Context
   SimplifyingNodeFactory snf;
   stp::UnsignedIntervalAnalysis analysis;
 
-  Context() : snf(*(mgr.hashingNodeFactory), mgr), analysis(mgr)
+  Context() : snf(*(mgr.hashingNodeFactory), mgr)
   {
     mgr.defaultNodeFactory = &snf;
   }

--- a/tools/propagator_bench/Domains.cpp
+++ b/tools/propagator_bench/Domains.cpp
@@ -222,7 +222,7 @@ PrecisionResult intervalPrecision(STPMgr* mgr, const OpSpec& op,
   result.ran = true;
   result.width = width;
 
-  UnsignedIntervalAnalysis analysis(*mgr);
+  UnsignedIntervalAnalysis analysis;
   const ASTNode node = buildNode(mgr, op, l);
   const vector<uint64_t> table = semanticsTable(mgr, op, l);
   const vector<unsigned> varying = l.varying();
@@ -444,7 +444,7 @@ PrecisionResult valueSetPrecision(STPMgr* mgr, const OpSpec& op,
 
 void runInterval(STPMgr* mgr, const Config& cfg, vector<Row>& out)
 {
-  UnsignedIntervalAnalysis analysis(*mgr);
+  UnsignedIntervalAnalysis analysis;
 
   for (const OpSpec& op : allOps())
   {


### PR DESCRIPTION
Continues #991/#992/#993, same method (linker-assisted dead-symbol analysis plus whole-repo reference checks). ~330 lines across the Simplifier component.

Items worth a second look while reviewing:

- Three member declarations had no definition anywhere (`RemoveWrites_TopLevel`, `RemoveWrites`, `SimplifyWrites_InPlace`) — the only "call" sat inside an `#if 0` block, so enabling that block would have failed at link time.
- `checkIfInSimplifyMap` took its `visited` set **by value** and inserted into the copy, so even when it was called it never memoised — it was already broken when it was abandoned.
- The 1-argument `applySubstitutionMapUntilArrays` overloads (on both `Simplifier` and `SubstitutionMap`) are dead at overload granularity: the linker shows only the cache-taking 2-argument forms are referenced (from `BVSolver`).
- In `BVSolver`'s `BVEXTRACT` arm, the second `vars.VarSeenInTerm(lhs[0], rhs)` test was provably false — the condition three lines above already required its negation — and `VarSeenInTerm` walks the symbol graph, so this also removes a wasted traversal per extract equation.
- `UnsignedIntervalAnalysis::topLevel`/`visit` were bypassed everywhere: production runs `NodeDomainAnalysis` + `StrengthReduction::topLevel`, and the benchmark tools and unit tests call `dispatchToTransferFunctions` directly. (`NodeDomainAnalysis::topLevel` itself stays — a unit test drives it.)
- `UnsignedInterval::split` was ~70 lines in a widely-included header with no caller, which also `new`'d intervals into a caller-supplied vector nobody owned.
- `StrengthReduction::replace` and the removed `visit` were recursive DAG walks, so two stack hazards go with them.

No reachable code changes. Full test suite passes (166/166).