### PR TITLE
Remove dead code from AST, NodeFactory, STPManager and Util

### DIFF
--- a/include/stp/AST/AST.h
+++ b/include/stp/AST/AST.h
@@ -37,7 +37,6 @@ DLL_PUBLIC ATTR_NORETURN void FatalError(const char* str, const ASTNode& a,
 DLL_PUBLIC ATTR_NORETURN void FatalError(const char* str);
 void SortByExprNum(ASTVec& c);
 void SortByArith(ASTVec& c);
-bool exprless(const ASTNode& n1, const ASTNode& n2);
 bool arithless(const ASTNode& n1, const ASTNode& n2);
 
 // Functor form of exprless. Passing a free function to std::sort/is_sorted
@@ -219,22 +218,6 @@ typedef std::unordered_map<ASTNode, ASTVec, ASTNode::ASTNodeHasher,
 void FlattenKindNoDuplicates(const Kind k, const ASTChildren& children,
                              ASTVec& flat_children,
                              ASTNodeSet& alreadyFlattened);
-
-// Needed for defining the MAP below
-struct ltint
-{
-  bool operator()(int s1, int s2) const { return s1 < s2; }
-};
-
-class ClauseList;
-
-// Datatype for ClauseLists
-typedef std::map<int, ClauseList*, ltint> ClauseBuckets;
-
-typedef std::map<int, ASTVec*, ltint> IntToASTVecMap;
-
-// Function to dump contents of ASTNodeMap
-ostream& operator<<(ostream& os, const ASTNodeMap& nmap);
 
 void buildListOfSymbols(const ASTNode& n, ASTNodeSet& visited,
                         ASTNodeSet& symbols);

--- a/include/stp/AST/ASTBVConst.h
+++ b/include/stp/AST/ASTBVConst.h
@@ -38,8 +38,6 @@ class ASTBVConst : public ASTInternal
   friend class ASTNode;
   friend class ASTFPConst;
   friend class ASTRMConst;
-  friend class ASTNodeHasher;
-  friend class ASTNodeEqual;
 
 private:
   // CBV is actually an unsigned*. The bitvector constant is
@@ -60,7 +58,6 @@ private:
     bool operator()(const ASTBVConst* bvc1, const ASTBVConst* bvc2) const;
   };
 
-  ASTBVConst(CBV bv, unsigned int width);
   ASTBVConst(STPMgr* mgr, CBV bv, unsigned int /*width*/,
              bool managed_outside = false)
       : ASTInternal(mgr, BVCONST)

--- a/include/stp/AST/ASTInterior.h
+++ b/include/stp/AST/ASTInterior.h
@@ -34,7 +34,6 @@ namespace stp
 {
 class ASTNode;
 class STPMgr;
-typedef vector<ASTNode> ASTVec;
 
 /******************************************************************
  * Internal representation of an interior ASTNode.Generally, these*
@@ -44,8 +43,6 @@ class ASTInterior : public ASTInternal
 {
 
   friend class STPMgr;
-  friend class ASTNodeHasher;
-  friend class ASTNodeEqual;
   friend stp::ASTNode HashingNodeFactory::CreateNode(
       Kind kind, stp::ASTChildren back_children);
 

--- a/include/stp/AST/ASTInternal.h
+++ b/include/stp/AST/ASTInternal.h
@@ -154,9 +154,6 @@ protected:
    * Protected Member Functions                                   *
    ****************************************************************/
 
-  // Copying assign operator.  Also copies contents of children.
-  ASTInternal& operator=(const ASTInternal& int_node);
-
   // Cleanup function for removing from hash table
   virtual void CleanUp() = 0;
 

--- a/include/stp/AST/ASTNode.h
+++ b/include/stp/AST/ASTNode.h
@@ -50,7 +50,6 @@ class ASTNode
   friend class vector<ASTNode>;
   friend ASTNode HashingNodeFactory::CreateNode(
       stp::Kind kind, stp::ASTChildren back_children);
-  friend bool exprless(const ASTNode& n1, const ASTNode& n2);
   friend bool arithless(const ASTNode& n1, const ASTNode& n2);
 
   // Ptr to the read data
@@ -144,12 +143,6 @@ public:
   {
     const Kind k = GetKind();
     return k == BVCONST || k == TRUE || k == FALSE;
-  }
-
-  bool isITE() const
-  {
-    Kind k = GetKind();
-    return k == ITE;
   }
 
   bool isAtom() const
@@ -311,8 +304,6 @@ public:
 
   // Hash is the node's unique id. Inlined: used by every ==/</hash lookup.
   size_t Hash() const { return _int_node_ptr ? _int_node_ptr->node_uid : 0; }
-
-  void NFASTPrint(int l, int max, int prefix) const;
 
   // Lisp-form printer
   ostream& LispPrint(ostream& os, int indentation = 0) const;

--- a/include/stp/AST/ASTSymbol.h
+++ b/include/stp/AST/ASTSymbol.h
@@ -37,8 +37,6 @@ class ASTSymbol : public ASTInternal
 {
   friend class STPMgr;
   friend class ASTNode;
-  friend class ASTNodeHasher;
-  friend class ASTNodeEqual;
 
   const static ASTVec empty_children;
 

--- a/include/stp/STPManager/STP.h
+++ b/include/stp/STPManager/STP.h
@@ -140,7 +140,6 @@ public:
   DLL_PUBLIC IncrementalSolver* getIncrementalSolver();
   DLL_PUBLIC void resetIncrementalSolver();
   bool hasIncrementalSolver() const { return incrementalSolver != nullptr; }
-  const LoweredApplicationView& lastBatchUFView() const;
 
 public:
   // Out of line so the UF implementation types above remain incomplete here.

--- a/include/stp/STPManager/STPManager.h
+++ b/include/stp/STPManager/STPManager.h
@@ -443,10 +443,6 @@ private:
   // Create unique ASTSymbol node.
   ASTSymbol* LookupOrCreateSymbol(ASTSymbol& s);
 
-  // Called whenever we want to make sure that the Symbol is
-  // declared during semantic analysis
-  bool LookupSymbol(ASTSymbol& s);
-
   // Called by ASTNode constructors to uniqueify ASTBVConst
   ASTBVConst* LookupOrCreateBVConst(ASTBVConst& s);
 
@@ -806,15 +802,6 @@ public:
 
   const ASTVec GetAsserts();
   const ASTVec getVectorOfAsserts();
-
-  // Every assertion currently on the stack, appended to out. Unlike
-  // getVectorOfAsserts() this does not collapse each level into a
-  // single conjunct, so it is safe to call outside a solve.
-  void collectAsserts(ASTVec& out) const
-  {
-    for (size_t i = 0; i < _asserts.size(); i++)
-      out.insert(out.end(), _asserts[i]->begin(), _asserts[i]->end());
-  }
 
   // add a query/assertion to the current logical context
   void AddAssert(const ASTNode& assert);

--- a/include/stp/Util/DagWalk.h
+++ b/include/stp/Util/DagWalk.h
@@ -177,7 +177,6 @@ public:
     return out.str();
   }
 
-  size_t depth() const { return deepest; }
 
   void clear() { deepest = 0; }
 

--- a/include/stp/Util/RunTimes.h
+++ b/include/stp/Util/RunTimes.h
@@ -146,9 +146,7 @@ public:
 
   std::string getDifference();
 
-  void resetDifference() { getDifference(); }
 
-  void difference() { std::cout << getDifference() << std::endl << std::endl; }
 
   RunTimes() { lastTime = stp::getCurrentTime(); }
 

--- a/lib/AST/ASTNode.cpp
+++ b/lib/AST/ASTNode.cpp
@@ -704,39 +704,6 @@ unsigned int ASTNode::GetUnsignedConst() const
 
 // Hash() is now inlined in ASTNode.h.
 
-void ASTNode::NFASTPrint(int l, int max, int prefix) const
-{
-  //****************************************
-  // stop
-  //****************************************
-  if (l > max)
-  {
-    return;
-  }
-
-  //****************************************
-  // print
-  //****************************************
-  printf("[%10d]", 0);
-  for (int i = 0; i < prefix; i++)
-  {
-    printf("    ");
-  }
-  std::cout << GetKind();
-  printf("\n");
-
-  //****************************************
-  // recurse
-  //****************************************
-
-  const ASTChildren children = GetChildren();
-  auto it = children.begin();
-  for (; it != children.end(); it++)
-  {
-    it->NFASTPrint(l + 1, max, prefix + 1);
-  }
-}
-
 bool ASTNode::isSimplfied() const
 {
   return _int_node_ptr->isSimplified();

--- a/lib/AST/ASTmisc.cpp
+++ b/lib/AST/ASTmisc.cpp
@@ -47,12 +47,6 @@ THREAD_LOCAL_IE uint64_t ASTInternal::node_uid_cntr = 0;
  * Universal Helper Functions                                   *
  ****************************************************************/
 
-// Sort ASTNodes by expression numbers
-bool exprless(const ASTNode& n1, const ASTNode& n2)
-{
-  return (n1.GetNodeNum() < n2.GetNodeNum());
-}
-
 // This is for sorting by arithmetic expressions (for
 // combining like terms, etc.)
 bool arithless(const ASTNode& n1, const ASTNode& n2)
@@ -380,8 +374,6 @@ bool isCommutative(const Kind k)
     default:
       return false;
   }
-
-  return false;
 }
 
 ATTR_NORETURN void FatalError(const char* str, const ASTNode& a, int w)

--- a/lib/NodeFactory/SimplifyingNodeFactory.cpp
+++ b/lib/NodeFactory/SimplifyingNodeFactory.cpp
@@ -1574,19 +1574,14 @@ ASTNode SimplifyingNodeFactory::CreateSimpleAndOr(bool IsAnd,
   {
     case 0:
       return identity;
-      break;
 
     case 1:
       return out[0];
-      break;
 
     default:
       // 2 or more children.  Create a new node.
       return hashing.CreateNode(IsAnd ? stp::AND : stp::OR, out);
-      break;
   }
-  assert(false);
-  exit(-1);
 }
 
 // Tries to simplify the input to TRUE/FALSE. if it fails, then

--- a/lib/STPManager/STP.cpp
+++ b/lib/STPManager/STP.cpp
@@ -59,7 +59,6 @@ namespace stp
 
 const static string cb_message = "After Constant Bit Propagation. ";
 const static string uc_message = "After Removing Unconstrained. ";
-const static string int_message = "After Unsigned Interval Analysis. ";
 const static string pl_message = "After Pure Literals. ";
 const static string bitvec_message = "After Bit-vector Solving. ";
 const static string size_inc_message = "After Speculative Simplifications. ";
@@ -83,11 +82,6 @@ STP::~STP()
 {
   ClearAllTables();
   deleteObjects();
-}
-
-const LoweredApplicationView& STP::lastBatchUFView() const
-{
-  return *batchUFView;
 }
 
 void STP::ClearAllTables(void)

--- a/lib/STPManager/STPManager.cpp
+++ b/lib/STPManager/STPManager.cpp
@@ -71,17 +71,6 @@ ASTInterior* STPMgr::LookupOrCreateInterior(Kind kind, ASTChildren children)
   return n_ptr;
 }
 
-ostream& operator<<(ostream& os, const ASTNodeMap& nmap)
-{
-  ASTNodeMap::const_iterator iend = nmap.end();
-  for (ASTNodeMap::const_iterator i = nmap.begin(); i != iend; i++)
-  {
-    os << "Key: " << i->first << endl;
-    os << "Value: " << i->second << endl;
-  }
-  return os;
-}
-
 ////////////////////////////////////////////////////////////////
 // STPMgr member functions to create ASTSymbol and ASTBVConst
 ////////////////////////////////////////////////////////////////
@@ -241,16 +230,6 @@ void STPMgr::unindexSymbolName(ASTSymbol* symbol)
 
   if (declared.empty())
     _symbol_name_index.erase(entry);
-}
-
-bool STPMgr::LookupSymbol(ASTSymbol& s)
-{
-  ASTSymbol* s_ptr = &s; // it's a temporary key.
-
-  if (_symbol_unique_table.find(s_ptr) == _symbol_unique_table.end())
-    return false;
-  else
-    return true;
 }
 
 // The two name-only lookups. A symbol's sort is part of its identity, so


### PR DESCRIPTION
Continues #991–#994; same method (linker-assisted dead-symbol analysis on a static `--gc-sections` build, plus whole-repo reference checks including tools, tests, bindings and the .y/.lex grammar sources). ~120 lines.

The more interesting finds:

- `AST.h` forward-declared `class ClauseList` — a class defined **nowhere** in the tree — plus two typedefs over it (`ClauseBuckets`, `IntToASTVecMap`) and their comparator `ltint`, all unreferenced. Residue of the removed direct-CNF path.
- `ASTBVConst.h`, `ASTInterior.h` and `ASTSymbol.h` each declared `friend class ASTNodeHasher; friend class ASTNodeEqual;` at namespace scope. Those classes are *nested* in `ASTNode`, so these lines declared two brand-new, never-defined `stp::` classes and befriended them — six lines granting access to nothing.
- Two declared-but-never-defined members (`ASTInternal::operator=`, a two-argument `ASTBVConst` constructor) — latent link errors for any future caller.
- `exprless` was superseded by the `ExprLess` functor; `NFASTPrint` was only self-recursive and printed a hardcoded 0 where a node number was presumably meant, so it was already broken when abandoned.
- `PrimeAudit::depth()` existed only in the assertions-on variant of the class (the NDEBUG stub never had it), so any caller would have compiled in Debug and broken in Release.

No reachable code changes. Full test suite passes (166/166).