### PR TITLE
Remove dead code from the Parser front ends and interfaces

### DIFF
--- a/include/stp/Parser/LetMgr.h
+++ b/include/stp/Parser/LetMgr.h
@@ -37,8 +37,6 @@ using std::string;
 class LetMgr
 {
 private:
-  const ASTNode ASTUndefined;
-
   typedef ankerl::unordered_dense::map<string, ASTNode, TransparentStringHash,
                                        std::equal_to<>>
       MapType;
@@ -72,7 +70,7 @@ public:
   
   bool frameMode = true;
 
-  LetMgr(ASTNode undefined) : ASTUndefined(undefined)
+  LetMgr([[maybe_unused]] ASTNode undefined)
   {
     assert(!undefined.IsNull());
     push(); // CVC format has a global let scope.
@@ -89,14 +87,10 @@ public:
 
   void CleanupLetIDMap(void);
 
-  // Has a let with this name has already been declared.
-  bool isLetDeclared(const string& s) const;
-
   // The expression the innermost binding of s maps to, or nullptr.
   // The pointer is invalidated by any change to the bindings.
   const ASTNode* lookupLet(std::string_view s) const;
 
-  ASTNode resolveLet(const string& s) const;
   ASTNode ResolveID(const ASTNode& var);
 
   // Functions that are used to create LET expressions

--- a/include/stp/Parser/parser.h
+++ b/include/stp/Parser/parser.h
@@ -35,7 +35,6 @@ THE SOFTWARE.
 namespace stp
 {
 // external parser table for declared symbols.
-// extern ASTNodeSet _parser_symbol_table;
 
 // Symbols in generated  files used by tools/stp
 void SMTScanString(const char* yy_str);

--- a/include/stp/cpp_interface.h
+++ b/include/stp/cpp_interface.h
@@ -182,7 +182,6 @@ private:
     vector<std::string>& getFunctions();
 
     // Obtain the symbols for the current frame
-    ASTVec& getSymbols();
 
     void addSortAlias(const std::string& name);
     void addSymbol(const ASTNode& symbol);
@@ -225,7 +224,6 @@ private:
   std::vector< SolverFrame* > frames;
 
   // Obtain the symbols/functions for the current frame
-  ASTVec& getCurrentSymbols();
   vector<std::string>& getCurrentFunctions();
 
   // What the most recent check-sat charged to each pipeline stage: the
@@ -407,7 +405,6 @@ public:
 
   DLL_PUBLIC ASTNode CreateBVConst(std::string& strval, int base,
                                    int bit_width);
-  DLL_PUBLIC ASTNode CreateBVConst(const char* const strval, int base);
   DLL_PUBLIC ASTNode CreateBVConst(unsigned int width,
                                    uint64_t bvconst);
   DLL_PUBLIC ASTNode CreateRMConst(unsigned mode);
@@ -444,12 +441,6 @@ public:
   // Apply an already-resolved function, skipping the by-name map probe.
   DLL_PUBLIC ASTNode applyFunction(const Function& f, const ASTVec& params);
 
-  // Classify a name by its carrier return type in a single map probe:
-  // BITVECTOR_TYPE or BOOLEAN_TYPE, or UNKNOWN_TYPE when the name is not a
-  // stored function. Source-only distinctions are available from
-  // functionReturnSourceSort().
-  DLL_PUBLIC types functionReturnType(const std::string& name);
-  DLL_PUBLIC SourceSort functionReturnSourceSort(const std::string& name);
   bool hasFunctions() const { return !functions.empty(); }
 
   // Context-owned uninterpreted declarations are distinct from stored
@@ -476,7 +467,6 @@ public:
   DLL_PUBLIC ASTNode LookupOrCreateSymbol(std::string name);
   DLL_PUBLIC bool LookupSymbol(const char* const name, ASTNode& output);
   DLL_PUBLIC bool LookupTemporarySymbol(const char* name, ASTNode& output);
-  DLL_PUBLIC bool isSymbolAlreadyDeclared(char* name);
   DLL_PUBLIC void setPrintSuccess(bool ps);
   DLL_PUBLIC bool isSymbolAlreadyDeclared(std::string name);
 
@@ -499,7 +489,6 @@ public:
                               const ASTNode& n1);
 
   // Create the node, then "new" it.
-  DLL_PUBLIC ASTNode* newNode(const Kind k, const int width, const ASTVec& v);
 
   // On testcase20 it took about 4.2 seconds to parse using the standard
   // allocator and the pool allocator.

--- a/lib/Interface/c_interface.cpp
+++ b/lib/Interface/c_interface.cpp
@@ -443,9 +443,6 @@ std::pair<unsigned int, unsigned int> getTypeSizes(Type type)
       break;
     default:
       stp::FatalError("CInterface: vc_varExpr: Unsupported type", *a);
-      assert(false);
-      exit(-1);
-      break;
   }
   return std::make_pair(valueWidth, indexWidth);
 }
@@ -1322,31 +1319,6 @@ int vc_query_with_timeout(VC vc, Expr e, int timeout_max_conflicts, int timeout_
 
   return recordQueryOutcome(stp_i, output);
 }
-
-// int vc_absRefineQuery(VC vc, Expr e) {
-//   stp::STP* stp_i = (stp::STP*)vc;
-//   stp::ASTNode* a = (stp::ASTNode*)e;
-//   stp::STPMgr* b   = stp_i->bm;
-
-//   if(!stp::is_Form_kind(a->GetKind()))
-//     stp::FatalError("CInterface: Trying to QUERY a NON formula: ",*a);
-
-//   //a->LispPrint(cout, 0);
-//   //printf("##################################################\n");
-//   BVTypeCheck(*a);
-//   b->AddQuery(*a);
-
-//   const stp::ASTVec v = b->GetAsserts();
-//   stp::ASTNode o;
-//   if(!v.empty()) {
-//     if(v.size()==1)
-//       return b->TopLevelSTP(v[0],*a);
-//     else
-//       return b->TopLevelSTP(b->CreateNode(stp::AND,v),*a);
-//   }
-//   else
-//     return b->TopLevelSTP(b->CreateNode(stp::TRUE),*a);
-// }
 
 void vc_push(VC vc)
 {
@@ -3619,22 +3591,6 @@ Expr vc_bv32ConstExprFromInt(VC vc, unsigned int value)
   return vc_bvConstExprFromInt(vc, 32, value);
 }
 
-#if 0
-static char *val_to_binary_str(unsigned nbits, unsigned long long val) {
-  char s[65];
-
-  assert(nbits < sizeof s);
-  strcpy(s, "");
-  while(nbits-- > 0) {
-    if((val >> nbits) & 1)
-      strcat(s, "1");
-    else
-      strcat(s, "0");
-  }
-  return strdup(s);
-}
-#endif
-
 Expr vc_parseExpr(VC vc, const char* infile)
 {
   stp::STP* stp_i = (stp::STP*)vc;
@@ -3732,7 +3688,6 @@ Expr getChild(Expr e, int i)
                     "in expression: ",
                     *a);
   }
-  return a;
 }
 
 void vc_registerErrorHandler(void (*error_hdlr)(const char* err_msg))
@@ -4093,40 +4048,25 @@ int vc_parseMemExpr(VC vc, const char* s, Expr* oquery, Expr* oasserts)
   stp::STP* stp_i = (stp::STP*)vc;
   stp::STPMgr* b = stp_i->bm;
 
-#if 0
- stp::GlobalSTP = (stp::STP*)vc;
-  CONSTANTBV::ErrCode c = CONSTANTBV::BitVector_Boot();
-  if(0 != c) {
-    cout << CONSTANTBV::BitVector_Error(c) << endl;
-    return 0;
-  }
-#endif
-
   stp::Cpp_interface pi(*b, b->defaultNodeFactory);
   stp::GlobalParserInterface = &pi;
 
   stp::ASTVec AssertsQuery;
   if (b->UserFlags.smtlib1_parser_flag)
   {
-    // YY_BUFFER_STATE bstat = smt_scan_string(s);
-    // smt_switch_to_buffer(bstat);
     stp::GlobalSTP = stp_i;
     stp::GlobalParserBM = b;
     stp::SMTScanString(s);
     smtparse((void*)&AssertsQuery);
-    // smt_delete_buffer(bstat);
     stp::GlobalSTP = NULL;
     stp::GlobalParserBM = NULL;
   }
   else
   {
-    // YY_BUFFER_STATE bstat = cvc_scan_string(s);
-    // cvc_switch_to_buffer(bstat);
     stp::GlobalSTP = stp_i;
     stp::GlobalParserBM = b;
     stp::CVCScanString(s);
     cvcparse((void*)&AssertsQuery);
-    // cvc_delete_buffer(bstat);
     stp::GlobalSTP = NULL;
     stp::GlobalParserBM = NULL;
   }

--- a/lib/Interface/cpp_interface.cpp
+++ b/lib/Interface/cpp_interface.cpp
@@ -127,11 +127,6 @@ Cpp_interface::~Cpp_interface()
     GlobalParserBM = NULL;
 }
 
-ASTVec& Cpp_interface::getCurrentSymbols()
-{
-  return frames.back()->getSymbols();
-}
-
 vector<std::string>& Cpp_interface::getCurrentFunctions()
 {
   return frames.back()->getFunctions();
@@ -312,11 +307,6 @@ ASTNode Cpp_interface::CreateBVConst(string& strval, int base, int bit_width)
   return bm.CreateBVConst(strval, base, bit_width);
 }
 
-ASTNode Cpp_interface::CreateBVConst(const char* const strval, int base)
-{
-  return bm.CreateBVConst(strval, base);
-}
-
 // FIXME: unsigned long long int is wong. Use intN_t from cstdint
 ASTNode Cpp_interface::CreateBVConst(unsigned int width,
                                      uint64_t bvconst)
@@ -437,22 +427,6 @@ ASTNode Cpp_interface::applyFunction(const Function& f, const ASTVec& params)
 
   ASTNodeMap cache;
   return SubstitutionMap::replace(f.function, fromTo, cache, nf);
-}
-
-types Cpp_interface::functionReturnType(const string& name)
-{
-  const auto found = functions.find(name);
-  if (found == functions.end())
-    return UNKNOWN_TYPE;
-
-  return found->second.function.GetType();
-}
-
-SourceSort Cpp_interface::functionReturnSourceSort(const string& name)
-{
-  const auto found = functions.find(name);
-  return found == functions.end() ? SourceSort::unknown()
-                                  : found->second.function.GetSourceSort();
 }
 
 const UFDecl* Cpp_interface::declareUninterpretedFunction(
@@ -578,12 +552,6 @@ bool Cpp_interface::LookupTemporarySymbol(const char* const name,
   return false;
 }
 
-bool Cpp_interface::isSymbolAlreadyDeclared(char* name)
-{
-  ASTNode ignored;
-  return LookupSymbol(name, ignored);
-}
-
 void Cpp_interface::setPrintSuccess(bool ps)
 {
   print_success = ps;
@@ -607,12 +575,6 @@ ASTNode* Cpp_interface::newNode(const Kind k, const int width,
 {
   return newNode(nf->CreateTerm(k, width, n0, n1));
 }
-
-ASTNode* Cpp_interface::newNode(const Kind k, const int width, const ASTVec& v)
-{
-  return newNode(nf->CreateTerm(k, width, v));
-}
-
 
 ASTNode* Cpp_interface::newNode(const ASTNode& copyIn)
 {
@@ -2061,11 +2023,6 @@ Cpp_interface::SolverFrame::~SolverFrame()
 vector<std::string>& Cpp_interface::SolverFrame::getFunctions()
 {
   return _scoped_functions;
-}
-
-ASTVec& Cpp_interface::SolverFrame::getSymbols()
-{
-  return _scoped_symbols;
 }
 
 void Cpp_interface::SolverFrame::addSortAlias(const std::string& name)

--- a/lib/Parser/LetMgr.cpp
+++ b/lib/Parser/LetMgr.cpp
@@ -142,20 +142,7 @@ const ASTNode* LetMgr::lookupLet(std::string_view s) const
   return &found->second.back().second;
 }
 
-ASTNode LetMgr::resolveLet(const string& s) const
-{
-  const ASTNode* found = lookupLet(s);
-  if (found == nullptr)
-    FatalError("never here...");
-  return *found;
-}
-
-bool LetMgr::isLetDeclared(const string& s) const
-{
-  return lookupLet(s) != nullptr;
-}
-
-void LetMgr::cleanupParserSymbolTable() 
+void LetMgr::cleanupParserSymbolTable()
 {
   _parser_symbol_table.clear(); 
 }

--- a/lib/Parser/cvc.lex
+++ b/lib/Parser/cvc.lex
@@ -25,7 +25,6 @@
 %option noyymore
 %option yylineno
 %x    COMMENT
-%x    STRING_LITERAL
 LETTER    ([a-zA-Z])
 HEX       ([0-9a-fA-F])
 BITS      ([0-1])

--- a/lib/Parser/cvc.y
+++ b/lib/Parser/cvc.y
@@ -26,7 +26,6 @@ THE SOFTWARE.
 #include "stp/Parser/parser.h"
 #include "stp/cpp_interface.h"
 #include "stp/Parser/LetMgr.h"
-#include "stp/Parser/parser.h"
 #include <sstream>
 #include <string>
 
@@ -236,21 +235,7 @@ counterexample  :      COUNTEREXAMPLE_TOK ';'
 ;
 
 other_cmd       :
-/* other_cmd1 */
-/* { */
-/*   ASTVec aaa = GlobalParserInterface->GetAsserts(); */
-/*   if(aaa.size() == 0) */
-/*     { */
-/*       yyerror("GetAsserts() call: no assertions"); */
-/*     } */
-
-/*   ASTNode asserts =  */
-/*     aaa.size() == 1 ?  */
-/*     aaa[0] : */
-/*     GlobalParserInterface->CreateNode(AND, aaa); */
-/*   ((ASTVec*)AssertsQuery)->push_back(asserts);   */
-/* } */
-|      Query 
+       Query 
 { 
   ((ASTVec*)AssertsQuery)->push_back(GlobalParserInterface->CreateNode(TRUE));
   ((ASTVec*)AssertsQuery)->push_back(*$1);                       
@@ -293,20 +278,6 @@ other_cmd1      :     VarDecls Asserts
   delete $3;
 }
 ;
-
-/* push            :     PUSH_TOK */
-/*                       { */
-/*                      GlobalParserBM->Push(); */
-/*                       } */
-/*                 | */
-/*                 ; */
-
-/* pop             :     POP_TOK */
-/*                       { */
-/*                      GlobalParserBM->Pop(); */
-/*                       } */
-/*                 | */
-/*                 ; */
 
 Asserts         :      Assert 
 {

--- a/lib/Parser/smt.y
+++ b/lib/Parser/smt.y
@@ -87,9 +87,6 @@
   // FIXME: Why is this not an UNSIGNED int?
   int uintval;                  /* for numerals in types. */
 
-  // for BV32 BVCONST 
-  unsigned long long ullval;
-
   struct {
     //stores the indexwidth and valuewidth
     //indexwidth is 0 iff type is bitvector. positive iff type is
@@ -139,12 +136,9 @@
 %token OR_TOK
 %token XOR_TOK
 %token IFF_TOK
-%token EXISTS_TOK
-%token FORALL_TOK
 %token LET_TOK
 %token FLET_TOK
 %token NOTES_TOK
-%token CVC_COMMAND_TOK
 %token SORTS_TOK
 %token FUNS_TOK
 %token PREDS_TOK
@@ -171,16 +165,10 @@
 %token DOLLAR_TOK
 %token QUESTION_TOK
 %token DISTINCT_TOK
-%token SEMICOLON_TOK
-%token EOF_TOK
 %token EQ_TOK
  /*BV SPECIFIC TOKENS*/
 %token NAND_TOK
 %token NOR_TOK
-%token NEQ_TOK
-%token ASSIGN_TOK
-%token BV_TOK
-%token BOOLEAN_TOK
 %token BVLEFTSHIFT_1_TOK
 %token BVRIGHTSHIFT_1_TOK
 %token BVARITHRIGHTSHIFT_TOK
@@ -265,7 +253,6 @@ LPAREN_TOK BENCHMARK_TOK bench_name bench_attributes RPAREN_TOK
   }
   delete $3; //discard the benchmarkname.
 }
-/*   | EOF_TOK */
 /*     { */
 /*     } */
 ;

--- a/lib/Parser/smt2.lex
+++ b/lib/Parser/smt2.lex
@@ -367,7 +367,6 @@ namespace stp
 
 %x  COMMENT
 %x  STRING_LITERAL
-%x  SYMBOL
 %x  SKIP_SEXPR
 
 LETTER  ([a-zA-Z])

--- a/lib/Parser/smt2.y
+++ b/lib/Parser/smt2.y
@@ -81,63 +81,6 @@ namespace stp
   using std::cerr;
   using std::endl;
 
-  using stp::SYMBOL;       //!< Named expression (or variable), i.e. created via 'vc_varExpr'.
-  using stp::BVNOT;        //!< Bitvector bitwise-not
-  using stp::BVCONCAT;     //!< Bitvector concatenation
-  using stp::BVOR;         //!< Bitvector bitwise-or
-  using stp::BVAND;        //!< Bitvector bitwise-and
-  using stp::BVXOR;        //!< Bitvector bitwise-xor
-  using stp::BVNAND;       //!< Bitvector bitwise not-and; OR nand (TODO: does this still exist?)
-  using stp::BVNOR;        //!< Bitvector bitwise not-or; OR nor (TODO: does this still exist?)
-  using stp::BVXNOR;       //!< Bitvector bitwise not-xor; OR xnor (TODO: does this still exist?)
-  using stp::BVEXTRACT;    //!< Bitvector extraction, i.e. via 'vc_bvExtract'.
-  using stp::BVLEFTSHIFT;  //!< Bitvector left-shift
-  using stp::BVRIGHTSHIFT; //!< Bitvector right-right
-  using stp::BVSRSHIFT;    //!< Bitvector signed right-shift
-  using stp::BVPLUS;       //!< Bitvector addition
-  using stp::BVSUB;        //!< Bitvector subtraction
-  using stp::BVUMINUS;     //!< Bitvector unary minus; OR negate expression
-  using stp::BVMULT;       //!< Bitvector multiplication
-  using stp::BVDIV;        //!< Bitvector division
-  using stp::BVMOD;        //!< Bitvector modulo operation
-  using stp::SBVDIV;       //!< Signed bitvector division
-  using stp::SBVREM;       //!< Signed bitvector remainder
-  using stp::SBVMOD;       //!< Signed bitvector modulo operation
-  using stp::BVSX;         //!< Bitvector signed extend
-  using stp::BVZX;         //!< Bitvector zero extend
-  using stp::ITE;          //!< If-then-else
-  using stp::BOOLEXTRACT;  //!< Bitvector boolean extraction
-  using stp::BVLT;         //!< Bitvector less-than
-  using stp::BVLE;         //!< Bitvector less-equals
-  using stp::BVGT;         //!< Bitvector greater-than
-  using stp::BVGE;         //!< Bitvector greater-equals
-  using stp::BVSLT;        //!< Signed bitvector less-than
-  using stp::BVSLE;        //!< Signed bitvector less-equals
-  using stp::BVSGT;        //!< Signed bitvector greater-than
-  using stp::BVSGE;        //!< Signed bitvector greater-equals
-  using stp::BVUADDO;      //!< Unsigned addition overflow predicate
-  using stp::BVSADDO;      //!< Signed addition overflow predicate
-  using stp::BVUMULO;      //!< Unsigned multiplication overflow predicate
-  using stp::BVSMULO;      //!< Signed multiplication overflow predicate
-  using stp::BVUSUBO;      //!< Unsigned subtraction overflow predicate
-  using stp::BVSSUBO;      //!< Signed subtraction overflow predicate
-  using stp::EQ;           //!< Equality comparator
-  using stp::FALSE;        //!< Constant false boolean expression
-  using stp::TRUE;         //!< Constant true boolean expression
-  using stp::NOT;          //!< Logical-not boolean expression
-  using stp::AND;          //!< Logical-and boolean expression
-  using stp::OR;           //!< Logical-or boolean expression
-  using stp::NAND;         //!< Logical-not-and boolean expression (TODO: Does this still exist?)
-  using stp::NOR;          //!< Logical-not-or boolean expression (TODO: Does this still exist?)
-  using stp::XOR;          //!< Logical-xor (either-or) boolean expression
-  using stp::IFF;          //!< If-and-only-if boolean expression
-  using stp::IMPLIES;      //!< Implication boolean expression
-  using stp::READ;         //!< Array read expression
-  using stp::WRITE;        //!< Array write expression
-  using stp::ARRAY;        //!< Array creation expression
-  using stp::BITVECTOR;    //!< Bitvector creation expression
-  using stp::BOOLEAN;      //!< Boolean creation expression
-
   using stp::UNDEFINED;    //!< An undefined expression.
   using stp::SYMBOL;       //!< Named expression (or variable), i.e. created via 'vc_varExpr'.
   using stp::BVCONST;      //!< Bitvector constant expression, i.e. created via 'vc_bvConstExprFromInt'.
@@ -1495,7 +1438,6 @@ namespace stp
      pointer is named; the struct itself lives in the parser prologue. */
   struct ParsedRealConstant* realc;
   unsigned uintval; /* for numerals in types. */
-  stp::Kind kind;
   stp::float_size* fp_size;
   stp::array_sort_component* arr_component;
   stp::array_sort* arr_sort;


### PR DESCRIPTION
Continues #991–#995, same method. ~180 lines. The input language is deliberately unchanged: grammar edits are limited to things bison itself proves inert.

Highlights:

- `smt2.y` carried a 56-line block of `using stp::...` declarations duplicated verbatim immediately below itself (the second block is a superset; redundant using-declarations are legal, so nothing ever complained).
- `smt.y` declared nine tokens the lexer can never produce (`EXISTS_TOK`, `FORALL_TOK`, `CVC_COMMAND_TOK`, …) — remnants of the CVC grammar it was copied from. A terminal that appears in no rule and is never returned cannot affect the parse, and bison regenerates without any change to the conflict count.
- `LetMgr::resolveLet` was dead and also broken: its failure path called the noreturn `FatalError` and then dereferenced a null pointer it had just tested. `lookupLet` replaced it and `isLetDeclared`.
- `Cpp_interface::isSymbolAlreadyDeclared(char*)` could never be selected by overload resolution — the only call site passes `std::string`, which conversion-ranks to the `std::string` overload and cannot implicitly become `char*`.
- `getChild` ended with an unreachable `return a;` after a noreturn `FatalError` — unreachable, and semantically wrong (it would have returned the parent node as its own child).
- Not touched: the eleven SMT-LIB1 lexer keywords that return tokens no production accepts (`notes`, `sorts`, `nand`, …). Removing those changes the input language (keyword → identifier), so that's flagged in the audit notes as a decision rather than done here. Same for the `cvc.y` rule bison reports as "useless in parser due to conflicts" on every build — untangling it changes the conflict count.

Full test suite passes (166/166).