### PR TITLE
Remove dead code from FloatBlaster, Extensionality, UF and Incremental

### DIFF
--- a/include/stp/Extensionality/ExtChecker.h
+++ b/include/stp/Extensionality/ExtChecker.h
@@ -337,14 +337,11 @@ struct ExtEvent
     CONFLICT,
     WITNESS_CHECK
   };
-  int seq;
   Kind kind;
   const char* rule;
   ASTNode source; // null for seeds / witness checks
   ASTNode destination;
   size_t access;
-  ASTNode indexValue;  // null on SKIP_SEEN
-  ASTNode accessValue; // null on SKIP_SEEN
 };
 
 struct ExtCheckResult

--- a/include/stp/Extensionality/ExtensionalityContext.h
+++ b/include/stp/Extensionality/ExtensionalityContext.h
@@ -291,7 +291,6 @@ public:
 
   // How many lemmas instantiateEagerAckermann would conjoin for that
   // inventory: one per active record per index of the record's shape.
-  uint64_t eagerLemmaCount(const IndexInventory& indexesByShape) const;
 
   // True when a record's construction operands quotient their bit patterns
   // (float or RoundingMode cells or indexes), which the eager arm cannot

--- a/include/stp/FloatBlaster/FloatBlaster.h
+++ b/include/stp/FloatBlaster/FloatBlaster.h
@@ -40,24 +40,6 @@ namespace stp
 class FloatBlaster
 {
 public:
-  // The format of an operation's floating-point *operands*, which is what
-  // symfpu needs to unpack them, and which is not always the result's format:
-  // fp.to_ubv yields a bitvector, and to_fp's four-argument form converts
-  // between two formats.
-  //
-  // Read it off the node the input built, before blasting has replaced its
-  // children with bits. Taking it from a blasted operand is what made the
-  // blaster depend on the format being stamped onto those bits -- a stamp
-  // that lands on a hash-consed node the input may still be using as a plain
-  // bitvector, which is a whole family of wrong answers and aborts.
-  //
-  // Follows the same rule as deriveFPFormat: the first child that carries a
-  // format. The others are rounding modes, widths and to_fp's format
-  // arguments, none of which do.
-  static std::pair<unsigned int, unsigned int> operandFormat(const ASTNode& n);
-  static std::pair<unsigned int, unsigned int>
-  operandFormat(const ASTVec& children);
-
   // Return `n` carrying the floating-point format (exp_width, sig_width).
   //
   // A float's format is per-node state, so it is lost whenever a node is
@@ -70,9 +52,8 @@ public:
 
   // The canonical packed bits of a float: pack(unpack(f)). Collapses the NaN
   // payloads, which SMT-LIB equality does not distinguish, while keeping +0
-  // and -0 apart. The format-taking form serves callers holding a term that
-  // does not carry the format itself.
-  static ASTNode canonicalBits(STPMgr* bm, const ASTNode& f);
+  // and -0 apart. Takes the format from the caller, for terms that do not
+  // carry it themselves.
   static ASTNode canonicalBits(STPMgr* bm, const ASTNode& f,
                                unsigned int exp_width, unsigned int sig_width);
 

--- a/include/stp/Incremental/IncrementalScopeState.h
+++ b/include/stp/Incremental/IncrementalScopeState.h
@@ -199,7 +199,6 @@ public:
   void commitLevel(size_t level,
                    const PreprocessingTransaction& transaction);
   void commitWholeStack(const PreprocessingTransaction& transaction);
-  bool hasWholeStackTransaction() const { return wholeStackActive; }
 
   const std::vector<ScopedElimination>& activeEliminations() const
   {

--- a/include/stp/Incremental/IncrementalSolver.h
+++ b/include/stp/Incremental/IncrementalSolver.h
@@ -197,7 +197,6 @@ public:
     size_t rootEncodings = 0;
     size_t bitBlastedSymbols = 0;
     size_t semanticCacheEntries = 0;
-    size_t arrayReadRows = 0;
   };
 
   // Test-only inspection of the resettable encoding store. A relief test

--- a/include/stp/UninterpretedFunctions/UFChecker.h
+++ b/include/stp/UninterpretedFunctions/UFChecker.h
@@ -112,8 +112,6 @@ struct DLL_PUBLIC UFCongruenceConflict
   const UFDecl* declaration = NULL;
   ASTNode representativeHandle;
   ASTNode conflictingHandle;
-  size_t representativeOrder = 0;
-  size_t conflictingOrder = 0;
   std::vector<UFCongruenceArgument> arguments;
   ASTNode leftResult;
   ASTNode rightResult;
@@ -145,8 +143,6 @@ struct DLL_PUBLIC UFFunctionModelSeedSet
 
 struct DLL_PUBLIC UFCheckStats
 {
-  size_t functions = 0;
-  size_t activeApplications = 0;
   size_t insertions = 0;
   size_t comparisons = 0;
 };

--- a/include/stp/UninterpretedFunctions/UFContext.h
+++ b/include/stp/UninterpretedFunctions/UFContext.h
@@ -57,7 +57,6 @@ public:
                                 const SourceSort& codomain,
                                 std::string* error = NULL);
   bool deactivate(const UFDecl* decl, std::string* error = NULL);
-  void deactivateAll();
 
   const UFDecl* lookup(const std::string& name) const;
   const UFDecl* lookupIdentity(const ASTNode& identity) const;
@@ -136,7 +135,6 @@ private:
   uint64_t nextDeclarationId_ = 0;
   std::vector<std::unique_ptr<UFDecl>> declarations_;
   std::map<std::string, const UFDecl*> activeByName_;
-  std::map<uint64_t, const UFDecl*> allById_;
   std::map<ASTNode, const UFDecl*> byIdentity_;
   std::set<const UFDecl*> owned_;
   ASTNodeSet applications_;

--- a/include/stp/UninterpretedFunctions/UFRefinement.h
+++ b/include/stp/UninterpretedFunctions/UFRefinement.h
@@ -73,7 +73,6 @@ public:
                                           UFConcreteValue& value) const = 0;
   virtual const LoweredApplicationView* applicationView() const = 0;
   virtual const std::string& diagnostic() const = 0;
-  virtual uint64_t candidateChecks() const = 0;
   virtual uint64_t lemmasEmitted() const = 0;
 };
 
@@ -103,7 +102,6 @@ public:
                                   UFConcreteValue& value) const override;
   const LoweredApplicationView* applicationView() const override;
   const std::string& diagnostic() const override;
-  uint64_t candidateChecks() const override;
   uint64_t lemmasEmitted() const override;
 
 private:
@@ -143,7 +141,6 @@ public:
                                   UFConcreteValue& value) const override;
   const LoweredApplicationView* applicationView() const override;
   const std::string& diagnostic() const override;
-  uint64_t candidateChecks() const override;
   uint64_t lemmasEmitted() const override;
 
 private:

--- a/lib/AST/ASTNode.cpp
+++ b/lib/AST/ASTNode.cpp
@@ -374,7 +374,7 @@ unsigned int ASTNode::GetExpWidth() const
 // start reporting FLOATINGPOINT_TYPE solver-wide, bitvector operations over
 // them stop type checking, and to_fp reads an integer as a float. Lowering
 // therefore hands its format to the blaster as an argument instead (see
-// FloatBlaster::operandFormat and FloatBlast).
+// ASTNode::deriveFPFormat and FloatBlast).
 bool ASTNode::canStoreFPFormat() const
 {
   return Degree() == 0 || is_FP_kind(GetKind()) || GetKind() == FLOATINGPOINT ||

--- a/lib/Extensionality/ExtChecker.cpp
+++ b/lib/Extensionality/ExtChecker.cpp
@@ -74,12 +74,10 @@ struct CheckerState
   std::map<ASTNode, std::vector<size_t>> rho; // insertion order preserved
   std::deque<PairKey> worklist;
   ExtCheckResult result;
-  int seq;
   size_t materializedGuardCount;
 
   CheckerState(const ExtGraph& g, ExtModelView& m, bool ev)
-      : graph(g), model(m), recordEvents(ev), seq(0),
-        materializedGuardCount(0)
+      : graph(g), model(m), recordEvents(ev), materializedGuardCount(0)
   {
   }
 
@@ -94,23 +92,16 @@ struct CheckerState
   }
 
   void event(ExtEvent::Kind kind, const char* rule, const ASTNode& source,
-             const ASTNode& destination, size_t access,
-             const ASTNode& indexValue, const ASTNode& accessValue)
+             const ASTNode& destination, size_t access)
   {
     if (!recordEvents)
-    {
-      seq++;
       return;
-    }
     ExtEvent e;
-    e.seq = seq++;
     e.kind = kind;
     e.rule = rule;
     e.source = source;
     e.destination = destination;
     e.access = access;
-    e.indexValue = indexValue;
-    e.accessValue = accessValue;
     result.events.push_back(e);
   }
 
@@ -173,8 +164,7 @@ struct CheckerState
     if (paths.find(key) != paths.end())
     {
       result.stats["skipped_seen"]++;
-      event(ExtEvent::SKIP_SEEN, rule, source, destination, accessId,
-            ASTNode(), ASTNode());
+      event(ExtEvent::SKIP_SEEN, rule, source, destination, accessId);
       return;
     }
 
@@ -218,8 +208,7 @@ struct CheckerState
         c.leftGuards = materializeGuards(otherPath->second);
         c.rightGuards = materializeGuards(candidatePath);
         result.stats["conflicts"]++;
-        event(ExtEvent::CONFLICT, rule, source, destination, accessId, idx,
-              val);
+        event(ExtEvent::CONFLICT, rule, source, destination, accessId);
         result.conflicts.push_back(std::move(c));
 
         // Record the pair as visited so a later path to it cannot report
@@ -242,8 +231,8 @@ struct CheckerState
         return;
       }
       result.stats["skipped_represented"]++;
-      event(ExtEvent::SKIP_REPRESENTED, rule, source, destination, accessId,
-            idx, val);
+      event(ExtEvent::SKIP_REPRESENTED, rule, source, destination,
+            accessId);
       return;
     }
 
@@ -264,7 +253,7 @@ struct CheckerState
       result.stats[std::string("rule_") + rule]++;
       kind = ExtEvent::PROPAGATE;
     }
-    event(kind, rule, source, destination, accessId, idx, val);
+    event(kind, rule, source, destination, accessId);
   }
 };
 
@@ -636,7 +625,7 @@ ExtCheckResult ExtChecker::check(const ExtGraph& graph, ExtModelView& model,
     const ASTNode leftVal = model.bvValue(w.leftValue);
     const ASTNode rightVal = model.bvValue(w.rightValue);
     st.event(ExtEvent::WITNESS_CHECK, "WITNESS", ASTNode(), ASTNode(),
-             w.record, model.bvValue(w.index), leftVal);
+             w.record);
     st.result.stats["witness_checks"]++;
     if (!proxyVal && leftVal == rightVal)
     {

--- a/lib/Extensionality/ExtensionalityContext.cpp
+++ b/lib/Extensionality/ExtensionalityContext.cpp
@@ -928,21 +928,6 @@ void ExtensionalityContext::collectIndexInventory(
   }
 }
 
-uint64_t ExtensionalityContext::eagerLemmaCount(
-    const IndexInventory& indexesByShape) const
-{
-  uint64_t lemmas = 0;
-  for (size_t i = 0; i < activeRecordIds.size(); i++)
-  {
-    const Record& r = records[activeRecordIds[i]];
-    const IndexInventory::const_iterator it = indexesByShape.find(ArrayShape(
-        r.constructionLeft.GetIndexWidth(), r.constructionLeft.GetValueWidth()));
-    if (it != indexesByShape.end())
-      lemmas += it->second.size();
-  }
-  return lemmas;
-}
-
 // The reads instantiation is about to create, and what they cost the read
 // side afterwards.
 //

--- a/lib/FloatBlaster/FloatBlast.cpp
+++ b/lib/FloatBlaster/FloatBlast.cpp
@@ -706,7 +706,6 @@ private:
         // one packed carrier: decode that instead.
         if (n[1].GetSourceSort() != n[2].GetSourceSort())
           return decodeCarrier(n, asPacked(n));
-        requireSameFormat(n[1], n[2]);
         result.reset(new symbolic_fp::uf(symbolic_fp::unpacked::select(
             lower(n[0]), asUnpacked(n[1]), asUnpacked(n[2]))));
         break;
@@ -724,7 +723,6 @@ private:
       case FP_SUB:
       case FP_MUL:
       case FP_DIV:
-        requireSameFormat(n[1], n[2]);
         if (kind == FP_ADD)
           result.reset(new symbolic_fp::uf(symbolic_fp::unpacked::add(
               result_format, lower(n[0]), asUnpacked(n[1]),
@@ -744,7 +742,6 @@ private:
         break;
 
       case FP_FMA:
-        requireSameFormat(n[1], n[2]);
         requireSameFormat(n[1], n[3]);
         result.reset(new symbolic_fp::uf(symbolic_fp::unpacked::fma(
             result_format, lower(n[0]), asUnpacked(n[1]), asUnpacked(n[2]),

--- a/lib/FloatBlaster/FloatBlaster.cpp
+++ b/lib/FloatBlaster/FloatBlaster.cpp
@@ -87,34 +87,6 @@ ASTNode FloatBlaster::withFormat(STPMgr* bm, const ASTNode& n,
   return out;
 }
 
-// Reads widths only; no SymFPU circuit is involved.
-std::pair<unsigned int, unsigned int>
-FloatBlaster::operandFormat(const ASTVec& children)
-{
-  for (size_t i = 0; i < children.size(); i++)
-  {
-    const unsigned int exp_width = children[i].GetExpWidth();
-    if (exp_width != 0)
-      return std::make_pair(exp_width, children[i].GetSigWidth());
-  }
-
-  // No float operand: ((_ to_fp e s) bits) and ((_ to_fp_unsigned e s) rm bv)
-  // read their source as bits, and name the only format they need in their
-  // own e/s children.
-  return std::make_pair(0u, 0u);
-}
-
-std::pair<unsigned int, unsigned int>
-FloatBlaster::operandFormat(const ASTNode& n)
-{
-  return operandFormat(toASTVec(n.GetChildren()));
-}
-
-ASTNode FloatBlaster::canonicalBits(STPMgr* bm, const ASTNode& f)
-{
-  return canonicalBits(bm, f, f.GetExpWidth(), f.GetSigWidth());
-}
-
 // The format-taking form, for callers that know the format but hold a term
 // that does not carry it -- a plain bitvector standing where a float-sorted
 // value belongs (an array index over a float-indexed array, say).

--- a/lib/Incremental/IncrementalSolver.cpp
+++ b/lib/Incremental/IncrementalSolver.cpp
@@ -63,10 +63,6 @@ IncrementalSolver::encodingEpochStatsForTesting() const
   out.bitBlastedSymbols =
       impl->encoding.nodes().symbolToBBNode.size();
   out.semanticCacheEntries = impl->semanticCacheEntryCount();
-  for (ArrayTransformer::ArrType::const_iterator it =
-           impl->arrayRegistry.reads.begin();
-       it != impl->arrayRegistry.reads.end(); ++it)
-    out.arrayReadRows += it->second.size();
   return out;
 }
 

--- a/lib/Simplifier/BVSolver.cpp
+++ b/lib/Simplifier/BVSolver.cpp
@@ -66,7 +66,7 @@ const bool debug_bvsolver = false;
 // unlowered while the solver runs: FloatBlast comes after the size-reducing
 // passes, and it reads an operation's format off its operands, because by
 // then they are the only thing that still says what sort they are (see
-// FloatBlaster::operandFormat). So a float-typed variable rewritten into a
+// ASTNode::deriveFPFormat). So a float-typed variable rewritten into a
 // concatenation leaves fp.isZero and friends blasting against a format of
 // (0, 0) -- a packed width of zero against a 64-bit operand.
 //

--- a/lib/UninterpretedFunctions/UFChecker.cpp
+++ b/lib/UninterpretedFunctions/UFChecker.cpp
@@ -487,8 +487,6 @@ UFCheckResult UFChecker::check(const UFCheckPlan& plan,
                          : plan.diagnostic_;
     return out;
   }
-  out.stats.activeApplications = plan.view_->applications.size();
-  out.stats.functions = plan.declarations_.size();
 
   size_t conflictOrder = 0;
   for (size_t declarationIndex = 0;
@@ -575,8 +573,6 @@ UFCheckResult UFChecker::check(const UFCheckPlan& plan,
       conflict.declaration = declaration;
       conflict.representativeHandle = representative.durableHandle;
       conflict.conflictingHandle = record->durableHandle;
-      conflict.representativeOrder = representative.stableOrder;
-      conflict.conflictingOrder = record->stableOrder;
       conflict.leftResult = representative.resultSymbol;
       conflict.rightResult = record->resultSymbol;
       conflict.leftResultValue = previousResult;

--- a/lib/UninterpretedFunctions/UFContext.cpp
+++ b/lib/UninterpretedFunctions/UFContext.cpp
@@ -60,7 +60,6 @@ UFContext::~UFContext()
   byIdentity_.clear();
   activeByName_.clear();
   owned_.clear();
-  allById_.clear();
   declarations_.clear();
 }
 
@@ -123,7 +122,6 @@ UFContext::declareFunction(const std::string& name,
   const UFDecl* result = record.get();
   declarations_.push_back(std::move(record));
   activeByName_.insert(std::make_pair(name, result));
-  allById_.insert(std::make_pair(id, result));
   byIdentity_.insert(std::make_pair(identity, result));
   owned_.insert(result);
   return result;
@@ -146,11 +144,6 @@ bool UFContext::deactivate(const UFDecl* decl, std::string* error)
   }
   activeByName_.erase(found);
   return true;
-}
-
-void UFContext::deactivateAll()
-{
-  activeByName_.clear();
 }
 
 const UFDecl* UFContext::lookup(const std::string& name) const

--- a/lib/UninterpretedFunctions/UFRefinement.cpp
+++ b/lib/UninterpretedFunctions/UFRefinement.cpp
@@ -164,7 +164,6 @@ struct MutableAdapterState
   std::map<ASTNode, UFConcreteValue> handleValues;
   std::string diagnostic;
   uint64_t nextCandidateVersion = 0;
-  uint64_t candidateCheckCount = 0;
   uint64_t emittedLemmaCount = 0;
 
   void clearRound()
@@ -227,7 +226,6 @@ UFCandidateOutcome checkOneCandidate(
   }
 
   const uint64_t version = ++state.nextCandidateVersion;
-  state.candidateCheckCount++;
   CounterExampleCandidate candidate(counterexample, *context, version);
   UFCheckResult result = UFChecker::check(
       state.checkPlan, candidate,
@@ -823,10 +821,6 @@ const std::string& UFBatchAdapter::diagnostic() const
 {
   return impl_->state.diagnostic;
 }
-uint64_t UFBatchAdapter::candidateChecks() const
-{
-  return impl_->state.candidateCheckCount;
-}
 uint64_t UFBatchAdapter::lemmasEmitted() const
 {
   return impl_->state.emittedLemmaCount;
@@ -938,10 +932,6 @@ const LoweredApplicationView* UFPersistentAdapter::applicationView() const
 const std::string& UFPersistentAdapter::diagnostic() const
 {
   return impl_->state.diagnostic;
-}
-uint64_t UFPersistentAdapter::candidateChecks() const
-{
-  return impl_->state.candidateCheckCount;
 }
 uint64_t UFPersistentAdapter::lemmasEmitted() const
 {


### PR DESCRIPTION
Continues #991–#996, same method. ~120 lines, mostly write-only state:

- `ExtEvent` carried three fields (`seq`, `indexValue`, `accessValue`) that every event write filled in and nothing — including the extensionality unit tests, which read the other five fields — ever read. The `event()` helper loses two parameters, and the `!recordEvents` fast path stops maintaining a sequence counter nothing sees.
- `UFContext::allById_` was a per-declaration `std::map` that was inserted into and cleared but never probed (`byIdentity_` and `activeByName_` are the lookups actually used).
- `UFTheoryAdapter::candidateChecks()` was a pure virtual forcing both adapters to carry an override, plus a counter incremented per candidate check — with no caller through the base or on either adapter.
- `FloatBlaster::operandFormat` (both overloads) survived only in two comments after `deriveFPFormat` replaced the mechanism; the comments now name the replacement.
- One provably-unreachable `requireSameFormat` call in `FloatBlast`'s ITE arm: the line directly above returns when the sorts differ, which is the exact condition the check re-tests.

One near-miss worth recording: `UFConcreteValue::scalar` looked dead under a qualified-name search but is called unqualified by the other factory functions in the same class — it stays.

No reachable code changes. Full test suite passes (166/166).