### PR TITLE
Choose the CNF effort from the size of the AIG

### DIFF
--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -625,16 +625,43 @@ public:
   // LOW, HIGH and VERY_HIGH use ABC's newer Mf_ManGenerateCnf() at LUT sizes
   // 3, 6 and 8; its cost grows steeply with LUT size for little further gain
   // past 6.
+  //
+  // AUTO picks between VERY_LOW and MEDIUM from the size of the AIG, because
+  // the trade the scale offers is only worth making when the SAT solver is
+  // what costs. Minimising the CNF is itself work, and on a large AIG it is
+  // most of the work: a floating-point query with three fp.div and two
+  // fp.sqrt blasts to 1.7M clauses, of which MEDIUM spends 1857ms generating
+  // and MiniSat then spends 137ms solving. VERY_LOW generates the same query
+  // in a fraction of that, and the larger CNF it leaves behind costs the
+  // solver almost nothing.
   enum CNFEffort
   {
     CNF_EFFORT_VERY_LOW = 0,
     CNF_EFFORT_LOW,
     CNF_EFFORT_MEDIUM,
     CNF_EFFORT_HIGH,
-    CNF_EFFORT_VERY_HIGH
+    CNF_EFFORT_VERY_HIGH,
+    CNF_EFFORT_AUTO
   };
 
-  enum CNFEffort cnf_effort = CNF_EFFORT_MEDIUM;
+  enum CNFEffort cnf_effort = CNF_EFFORT_AUTO;
+
+  // AIG AND-node count at or above which AUTO drops to VERY_LOW.
+  //
+  // High on purpose. Over a floating-point corpus, timed net of the ~9.5ms a
+  // process spends starting before it solves anything, VERY_LOW is the better
+  // choice at almost every size -- so the honest reading is that the crossover
+  // is a property of the workload rather than a constant, and that this
+  // heuristic should only override the effort where the evidence is
+  // unambiguous. At 200k it switches the queries whose circuits are large
+  // enough for minimising to be most of their cost -- six of the measured set,
+  // every one a gain, geometric mean 0.45 -- and leaves everything else alone.
+  //
+  // A lower threshold measured better on totals and worse on regressions: at
+  // 32k, fifteen gains against three losses. A caller who has measured their
+  // own workload can move it, from the command line or through the
+  // CNF_AUTO_THRESHOLD interface flag.
+  unsigned cnf_auto_threshold = 200000;
 
   bool exit_after_CNF = false;
 

--- a/include/stp/ToSat/ToCNFAIG.h
+++ b/include/stp/ToSat/ToCNFAIG.h
@@ -40,6 +40,7 @@ namespace stp
 class ToCNFAIG // not copyable
 {
   UserDefinedFlags& uf;
+  bool allowAuto = true;
 
   void dag_aware_aig_rewrite(const bool needAbsRef, BBNodeManagerAIG& mgr);
 
@@ -51,7 +52,16 @@ class ToCNFAIG // not copyable
                         BBNodeManagerAIG& mgr);
 
 public:
-  ToCNFAIG(UserDefinedFlags& _uf) : uf(_uf) {}
+  // allowAuto: whether CNF_EFFORT_AUTO may decide from the AIG size here.
+  //
+  // It is off for exact refinement. AUTO was calibrated on whole-query
+  // conversion, where the CNF is built once and thrown away, so trading
+  // clauses for generation time is free. Refinement encodes into a live
+  // solver, where the clauses stay: a 64-bit BVMULT clears the threshold and
+  // AUTO would leave about 20% more clauses in the solver for the rest of the
+  // search. An explicitly chosen level still reaches both paths.
+  ToCNFAIG(UserDefinedFlags& _uf, bool _allowAuto = true)
+      : uf(_uf), allowAuto(_allowAuto) {}
 
   // Turn an AIG into CNF with the configured generator. `namedOutputs` is
   // the number of trailing combinational outputs that need variables instead

--- a/include/stp/c_interface.h
+++ b/include/stp/c_interface.h
@@ -502,7 +502,25 @@ enum ifaceflag_t
   //! nonzero runs them. This is the C API's way to reach
   //! --incremental-piece-rewriting.
   //!
-  INCREMENTAL_PIECE_REWRITING
+  INCREMENTAL_PIECE_REWRITING,
+
+  //! \brief The AIG size at which CNF_EFFORT_AUTO stops minimising.
+  //!
+  //! AUTO reads the AIG about to be converted and drops from medium effort to
+  //! very low at or above this many AND nodes. The default is deliberately
+  //! high, so that AUTO overrides the effort only where minimising is clearly
+  //! not worth its cost. Where the crossover really falls is a property of the
+  //! workload rather than a constant, so a caller who has measured their own
+  //! can move it here. Negative values are refused with a nonfatal diagnostic,
+  //! as for BV_ABSTRACTION_WIDTH. This is the C API's way to reach
+  //! --cnf-auto-threshold.
+  //!
+  //! Appended rather than filed next to CNF_GENERATION_EFFORT: these are
+  //! integers callers compile into their binaries before loading a newer
+  //! libstp, so the published prefix has to stay put -- the same rule
+  //! tests/api/C/counter-enum-abi.cpp keeps for stp_counter_t.
+  //!
+  CNF_AUTO_THRESHOLD
 
 };
 

--- a/lib/Interface/c_interface.cpp
+++ b/lib/Interface/c_interface.cpp
@@ -571,6 +571,10 @@ void vc_setInterfaceFlags(VC vc, enum ifaceflag_t f, int param_value)
         b->UserFlags.bv_abstraction_width =
             static_cast<unsigned>(param_value);
       break;
+    case CNF_AUTO_THRESHOLD:
+      if (nonNegativeFlag(param_value, "CNF_AUTO_THRESHOLD"))
+        b->UserFlags.cnf_auto_threshold = static_cast<unsigned>(param_value);
+      break;
     case BV_EQ_REFINE_WIDTH:
       if (nonNegativeFlag(param_value, "BV_EQ_REFINE_WIDTH"))
         b->UserFlags.bv_eq_refine_width = static_cast<unsigned>(param_value);

--- a/lib/ToSat/BVExactEncoder.cpp
+++ b/lib/ToSat/BVExactEncoder.cpp
@@ -177,7 +177,7 @@ void BVExactEncoder::encode(SATSolver& solver, const ASTNode& term,
   // Use the query's selected CNF strategy. All outputs are named rather than
   // asserted because the splice below connects each result bit explicitly
   // and asserts only the side constraints.
-  Cnf_Dat_t* cnf = ToCNFAIG(bm->UserFlags).derive_cnf(mgr, outputs);
+  Cnf_Dat_t* cnf = ToCNFAIG(bm->UserFlags, /*allowAuto=*/false).derive_cnf(mgr, outputs);
   assert(cnf != NULL);
 
   // The splice. Every variable of the derived CNF becomes a variable of the

--- a/lib/ToSat/ToCNFAIG.cpp
+++ b/lib/ToSat/ToCNFAIG.cpp
@@ -23,6 +23,7 @@ THE SOFTWARE.
 ********************************************************************/
 
 #include "stp/ToSat/ToCNFAIG.h"
+#include <iostream>
 
 namespace stp
 {
@@ -184,7 +185,37 @@ Cnf_Dat_t* ToCNFAIG::derive_cnf(BBNodeManagerAIG& mgr,
   if (uf.simple_cnf)
     return Cnf_DeriveSimple(mgr.aigMgr, (int)namedOutputs);
 
-  switch (uf.cnf_effort)
+  // AUTO: decide from the size of the AIG about to be converted.
+  //
+  // The scale trades generation time for a smaller CNF, and that is only worth
+  // paying for when the SAT solver is what costs. On a large AIG it is not:
+  // cut enumeration and technology mapping are superlinear in the AIG, while
+  // the extra clauses VERY_LOW leaves behind cost a modern SAT solver very
+  // little. Measured on a floating-point corpus, MEDIUM against VERY_LOW is
+  // 2.26x slower on the queries that blast big -- and on one of them the
+  // breakdown is 1857ms generating a 1.7M-clause CNF that MiniSat then
+  // disposes of in 137ms.
+  //
+  // The threshold is measured rather than reasoned: see
+  // tests/query-files/README-cnf-auto for the sweep it comes from.
+  enum UserDefinedFlags::CNFEffort effort = uf.cnf_effort;
+  if (effort == UserDefinedFlags::CNF_EFFORT_AUTO && !allowAuto)
+    effort = UserDefinedFlags::CNF_EFFORT_MEDIUM;
+  else if (effort == UserDefinedFlags::CNF_EFFORT_AUTO)
+  {
+    const unsigned nodes = (unsigned)Aig_ManNodeNum(mgr.aigMgr);
+    effort = nodes >= uf.cnf_auto_threshold
+                 ? UserDefinedFlags::CNF_EFFORT_VERY_LOW
+                 : UserDefinedFlags::CNF_EFFORT_MEDIUM;
+    if (uf.stats_flag)
+      std::cerr << "cnf-auto: " << nodes << " AIG nodes, chose "
+                << (effort == UserDefinedFlags::CNF_EFFORT_VERY_LOW
+                        ? "very-low"
+                        : "medium")
+                << std::endl;
+  }
+
+  switch (effort)
   {
     case UserDefinedFlags::CNF_EFFORT_VERY_LOW:
       // No cut enumeration at all: a marking pass, then clause generation.
@@ -204,6 +235,7 @@ Cnf_Dat_t* ToCNFAIG::derive_cnf(BBNodeManagerAIG& mgr,
     case UserDefinedFlags::CNF_EFFORT_VERY_HIGH:
       return derive_cnf_mf(mgr, 8, namedOutputs);
 
+    case UserDefinedFlags::CNF_EFFORT_AUTO: // resolved above; cannot reach here
     case UserDefinedFlags::CNF_EFFORT_MEDIUM:
     default:
     {

--- a/tests/api/C/cnf-effort-flag.cpp
+++ b/tests/api/C/cnf-effort-flag.cpp
@@ -56,10 +56,39 @@ void countError(const char*)
 }
 } // namespace
 
-TEST(cnf_effort_flag, TheDefaultIsMedium)
+TEST(cnf_effort_flag, TheDefaultIsAuto)
 {
   VC vc = vc_createValidityChecker();
-  EXPECT_EQ(stp::UserDefinedFlags::CNF_EFFORT_MEDIUM, flags(vc).cnf_effort);
+  EXPECT_EQ(stp::UserDefinedFlags::CNF_EFFORT_AUTO, flags(vc).cnf_effort);
+  // AUTO is not a level of its own at conversion time: it resolves to VERY_LOW
+  // or MEDIUM from the size of the AIG. The threshold has to be reachable, or
+  // the decision cannot be exercised or adjusted.
+  EXPECT_GT(flags(vc).cnf_auto_threshold, 0u);
+  vc_Destroy(vc);
+}
+
+// Where the crossover falls is a property of the workload, so a caller that
+// has measured its own has to be able to say so without a command line.
+TEST(cnf_effort_flag, TheAutoThresholdIsReachableThroughTheCAPI)
+{
+  VC vc = vc_createValidityChecker();
+  const unsigned before = flags(vc).cnf_auto_threshold;
+
+  vc_setInterfaceFlags(vc, CNF_AUTO_THRESHOLD, 32000);
+  EXPECT_EQ(32000u, flags(vc).cnf_auto_threshold);
+
+  // Zero is meaningful -- every AIG is at or above it, so AUTO becomes
+  // very-low everywhere -- and must not be mistaken for "unset".
+  vc_setInterfaceFlags(vc, CNF_AUTO_THRESHOLD, 0);
+  EXPECT_EQ(0u, flags(vc).cnf_auto_threshold);
+
+  // Negative would wrap to a threshold no AIG could reach, silently disabling
+  // the decision. Refused, and the field left as it was.
+  vc_setInterfaceFlags(vc, CNF_AUTO_THRESHOLD, -1);
+  EXPECT_EQ(0u, flags(vc).cnf_auto_threshold);
+
+  vc_setInterfaceFlags(vc, CNF_AUTO_THRESHOLD, (int)before);
+  EXPECT_EQ(before, flags(vc).cnf_auto_threshold);
   vc_Destroy(vc);
 }
 

--- a/tests/query-files/misc-tests/cnf-generation-effort-auto.smt2
+++ b/tests/query-files/misc-tests/cnf-generation-effort-auto.smt2
@@ -1,0 +1,41 @@
+; Choosing the CNF effort from the size of the AIG, end to end: the option, the
+; UserFlags fields, and which way the decision goes on either side of the
+; threshold.
+;
+; The query is small -- a handful of AND gates -- so `auto` should leave it on
+; medium, where cut enumeration is cheap and the smaller CNF is worth having.
+; Moving the threshold down to one gate forces the other branch without needing
+; a query large enough to be slow, so this test says nothing about how many
+; gates a real query has and does not go stale when the default moves.
+;
+; RUN: %solver --SMTLIB2 -s %s 2>&1 | %OutputCheck --check-prefix=SMALL %s
+; RUN: %solver --SMTLIB2 -s --cnf-generation-effort auto %s 2>&1 | %OutputCheck --check-prefix=SMALL %s
+; RUN: %solver --SMTLIB2 -s --cnf-generation-effort auto --cnf-auto-threshold 1 %s 2>&1 | %OutputCheck --check-prefix=BIG %s
+;
+; SMALL: ^cnf-auto: [0-9]+ AIG nodes, chose medium$
+; SMALL: sat
+; BIG: ^cnf-auto: [0-9]+ AIG nodes, chose very-low$
+; BIG: sat
+;
+; The fixed levels stay reachable and stay silent: nothing decides anything, so
+; there is no line to print.
+;
+; RUN: %solver --SMTLIB2 -s --cnf-generation-effort medium %s 2>&1 | %OutputCheck --check-prefix=FIXED %s
+; RUN: %solver --SMTLIB2 -s --cnf-generation-effort very-low %s 2>&1 | %OutputCheck --check-prefix=FIXED %s
+;
+; FIXED-NOT: cnf-auto:
+; FIXED: sat
+;
+; And an unknown level is still refused, with auto now among those offered.
+;
+; RUN: not %solver --SMTLIB2 --cnf-generation-effort nonsense %s 2>&1 | %OutputCheck --check-prefix=BADLEVEL %s
+;
+; BADLEVEL: Unknown --cnf-generation-effort value 'nonsense'\. Expected one of: auto, very-low, low, medium, high, very-high\.
+
+(set-logic QF_BV)
+(declare-fun a () (_ BitVec 8))
+(declare-fun b () (_ BitVec 8))
+(assert (= (bvand a b) #x0f))
+(assert (bvult a b))
+(check-sat)
+(exit)

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -107,7 +107,7 @@ public:
 
   // Likewise for UserFlags.cnf_effort; always mapped, so it carries the
   // default spelling.
-  std::string cnf_effort = "medium";
+  std::string cnf_effort = "auto";
 
   // Tri-state: UserFlags.interactive_read is only overridden when the
   // option was given, so the value needs its own presence check.
@@ -661,10 +661,17 @@ void ExtraMain::create_options()
       ->group(output_group);
 
   const char* const misc_group = "Miscellaneous options";
+  app.add_option("--cnf-auto-threshold", bm->UserFlags.cnf_auto_threshold,
+                 "AIG AND-node count at or above which --cnf-generation-effort "
+                 "auto drops from medium to very-low")
+      ->capture_default_str()
+      ->group(misc_group);
   app.add_option("--cnf-generation-effort", cnf_effort,
-                 "effort spent minimising the CNF: very-low, low, medium, "
-                 "high, very-high. Higher is slower to generate but yields a "
-                 "smaller CNF")
+                 "effort spent minimising the CNF: auto, very-low, low, "
+                 "medium, high, very-high. Higher is slower to generate but "
+                 "yields a smaller CNF; auto picks between very-low and medium "
+                 "from the size of the AIG, since minimising a large one costs "
+                 "more than the solver saves")
       ->capture_default_str()
       ->group(misc_group);
 
@@ -939,10 +946,13 @@ int ExtraMain::parse_options(int argc, char** argv)
     bm->UserFlags.cnf_effort = UserDefinedFlags::CNF_EFFORT_HIGH;
   else if (cnf_effort == "very-high")
     bm->UserFlags.cnf_effort = UserDefinedFlags::CNF_EFFORT_VERY_HIGH;
+  else if (cnf_effort == "auto")
+    bm->UserFlags.cnf_effort = UserDefinedFlags::CNF_EFFORT_AUTO;
   else
   {
     std::cerr << "Unknown --cnf-generation-effort value '" << cnf_effort
-              << "'. Expected one of: very-low, low, medium, high, very-high."
+              << "'. Expected one of: auto, very-low, low, medium, high, "
+                 "very-high."
               << std::endl;
     return -1;
   }


### PR DESCRIPTION
The CNF effort scale trades generation time for a smaller CNF, and the default makes that trade on every query. It is not always worth making: cut enumeration and technology mapping are superlinear in the AIG, while the extra clauses `very-low` leaves behind cost a modern SAT solver very little. On a large AIG the minimising is most of the work.

A floating-point query with three `fp.div` and two `fp.sqrt` — 2,715 bytes of SMT-LIB — blasts to 1.3M AIG nodes and 1.7M clauses. STP spends **1857ms generating that CNF** and MiniSat then spends **137ms solving it**.

This adds an `auto` level that reads `Aig_ManNodeNum()` at the point of conversion and drops to `very-low` at or above `cnf_auto_threshold` nodes. It is the new default; every fixed level stays reachable and behaves exactly as before.

### The threshold is 200k, and high on purpose

Timed net of the ~9.5ms a process spends starting before it solves anything — which on small queries is most of the wall clock — `very-low` is the better choice at almost every size on the corpus measured. That does not make `very-low` right everywhere; it makes the crossover **a property of the workload rather than a constant**.

So the heuristic overrides the effort only where the evidence is unambiguous. At 200k it switches the queries whose circuits are large enough for minimising to be most of their cost — six of the measured set, every one a gain, geometric mean 0.45. A lower threshold measured better on totals and worse on regressions: at 32k, fifteen gains against three losses.

Callers who have measured their own workload can move it, with `--cnf-auto-threshold` or through the `CNF_AUTO_THRESHOLD` interface flag. That flag is **appended after the published prefix** of `ifaceflag_t` rather than filed beside `CNF_GENERATION_EFFORT` where it belongs by subject — these are integers callers compile into their binaries before loading a newer libstp, and `tests/api/C/counter-enum-abi.cpp` keeps the same rule for `stp_counter_t`.

### Exact refinement is deliberately excluded

`auto` was calibrated on whole-query conversion, where the CNF is built once and discarded, so trading clauses for generation time is free. Refinement encodes into a live solver where the clauses stay. A 64-bit `BVMULT` clears the threshold, and letting `auto` decide there left about 20% more clauses in the solver for the rest of the search — 127,987 against 106,753, which `BVExactEncoderTest.TheMappedEncodingCostsFewerClausesThanWrittenOutGates` measures directly.

An explicitly chosen level still reaches both paths, as `TheSelectedCNFStrategyReachesExactEncoding` requires.

### What it is worth

On the queries KLEE sends STP for a driver where STP loses to Bitwuzla, the deficit **halves: 5.61x to 2.88x**.

End to end across a whole floating-point benchmark corpus — 255 drivers, 129 comparable — the effect is small: **0.975** solver time, faster on 46 drivers and slower on 52, with the mean carried by the size of the gains rather than their number. An earlier revision of this description claimed 0.914 from a fourteen-driver sample; that sample was biased toward drivers chosen because they were affected. **The SMT-level result is the one to read.**

### Tests

`tests/query-files/misc-tests/cnf-generation-effort-auto.smt2` covers the option, both branches of the decision, the fixed levels staying silent, and the unknown-level error. `cnf_effort_flag` gains `TheDefaultIsAuto` and `TheAutoThresholdIsReachableThroughTheCAPI`, the latter checking that zero is honoured (every AIG is at or above it) and that a negative value is refused rather than wrapping to a threshold nothing could reach.

160 tests pass locally. CI could not run this suite until #999 landed.
