### PR TITLE
Move the query-file tests to lit 23 and its internal shell

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,13 @@ jobs:
           python3-pip \
           python3-setuptools \
           zlib1g-dev
-        sudo pip3 install -U lit
+        # Pinned to the 23 series. lit is installed unpinned nowhere else,
+        # and an unpinned -U picks up whatever is newest: 23.1.0 landed on
+        # 2026-08-25 after fourteen months without a release and broke every
+        # job that runs this suite, because lit 23 refuses the external shell
+        # the config asked for. A major version of a test runner should be
+        # something this repository moves to deliberately.
+        sudo pip3 install -U 'lit~=23.1'
 
     # Every dependency is pinned in the file that fetches it, so this hashes
     # those files and nothing else -- it used to have to resolve a revision

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,15 +32,40 @@
 #   LIT_TOOL              rung 0, an absolute path to a lit
 #   an installed lit      rung 1
 #   ENABLE_AUTO_DOWNLOAD  rung 3, pip install into ${CMAKE_BINARY_DIR}/venv
-set(LIT_VERSION "18.1.8" CACHE STRING "lit version to install when one has to be")
+# 23.1.0, not 18.1.8. lit 23 rejects the external shell this suite used to ask
+# for, so the two have to move together; pinning the venv to 18 while CI
+# installed whatever pip called latest is what let a lit release break every
+# job that runs these tests.
+set(LIT_VERSION "23.1.0" CACHE STRING "lit version to install when one has to be")
 mark_as_advanced(LIT_VERSION)
 
 find_program(LIT_TOOL lit DOC "Path to lit tool")
 
 if(NOT LIT_TOOL AND ENABLE_AUTO_DOWNLOAD)
     set(STP_VENV_DIR "${PROJECT_BINARY_DIR}/venv")
-    # Created once and reused: pip is slow, and reconfiguring is not rare.
-    if(NOT EXISTS "${STP_VENV_DIR}/bin/lit")
+    # Created once and reused: pip is slow, and reconfiguring is not rare. But
+    # reused only while it holds the version asked for -- a bumped LIT_VERSION
+    # against an existing build tree used to be ignored in silence, and the
+    # status line below would then report the version that was wanted rather
+    # than the one about to run the tests.
+    set(_venv_lit_ok FALSE)
+    if(EXISTS "${STP_VENV_DIR}/bin/lit")
+        execute_process(
+            COMMAND "${STP_VENV_DIR}/bin/lit" --version
+            OUTPUT_VARIABLE _venv_lit_version
+            ERROR_VARIABLE _venv_lit_version
+            OUTPUT_STRIP_TRAILING_WHITESPACE RESULT_VARIABLE _venv_lit_rc)
+        if(_venv_lit_rc EQUAL 0 AND
+           _venv_lit_version MATCHES "(^| )${LIT_VERSION}( |$)")
+            set(_venv_lit_ok TRUE)
+        else()
+            message(STATUS
+                "Replacing the lit virtual environment: wanted ${LIT_VERSION}, "
+                "found \"${_venv_lit_version}\"")
+            file(REMOVE_RECURSE "${STP_VENV_DIR}")
+        endif()
+    endif()
+    if(NOT _venv_lit_ok)
         message(STATUS "Creating a virtual environment for lit: ${STP_VENV_DIR}")
         execute_process(
             COMMAND "${PYTHON_EXECUTABLE}" -m venv "${STP_VENV_DIR}"

--- a/tests/query-files/lit.cfg
+++ b/tests/query-files/lit.cfg
@@ -13,19 +13,24 @@ import lit.formats
 # name: The name of this test suite.
 config.name = 'STP query-files'
 
-# Choose between lit's internal shell pipeline runner and a real shell.  If
-# LIT_USE_INTERNAL_SHELL is in the environment, we use that as an override.
-use_lit_shell = os.environ.get("LIT_USE_INTERNAL_SHELL")
-if use_lit_shell:
-    # 0 is external, "" is default, and everything else is internal.
-    execute_external = (use_lit_shell == "0")
-else:
-    # Otherwise we default to internal on Windows and external elsewhere, as
-    # bash on Windows is usually very slow.
-    execute_external = (not sys.platform in ['win32'])
+# lit's internal shell, unconditionally. A real shell is not an option from
+# LLVM-24: lit 23 answers execute_external=True with a deprecation error rather
+# than honouring it, and lit 24 removes the parameter. The RUN lines in this
+# suite invoke only %solver, %OutputCheck and lit's own `not`, joined by pipes
+# and redirections, so nothing here needed a shell that the internal one does
+# not provide.
+#
+# Written without force_execute_external, which lit 23 offers as a migration
+# escape hatch but lit 18 has never heard of: rung 1 of the ladder in
+# tests/CMakeLists.txt uses whatever lit is already installed, whatever version
+# that is, and a config only the newest lit can parse would break it.
+# execute_external=False is spelled the same in both.
+#
+# LIT_USE_INTERNAL_SHELL is no longer read. It selected between the two shells
+# and there is only one.
 
 # testFormat: The test format to use to interpret tests.
-config.test_format = lit.formats.ShTest(execute_external)
+config.test_format = lit.formats.ShTest(execute_external=False)
 
 # suffixes: A list of file extensions to treat as test files. This is overriden
 # by individual lit.local.cfg files in the test subdirectories.
@@ -155,6 +160,7 @@ config.substitutions.append( ('%OutputCheck', pythonExec + ' ' +OutputCheckTool)
 
 ### Features
 
-# Shell execution
-if execute_external:
-    config.available_features.add('shell')
+# The 'shell' feature is deliberately not declared. It meant "the RUN lines go
+# to a real shell", which is no longer true of any configuration, so a test
+# asking REQUIRES: shell should be reported unsupported rather than run against
+# an internal shell that may not do what it wanted. Nothing asks for it today.


### PR DESCRIPTION
`lit 23.1.0` was published on 2026-08-25, fourteen months after `18.1.8`, and broke every CI job that runs the query-file suite. Two things had to be true at once for that to happen, and both are fixed here.

### The suite asked for a real shell

lit 23 answers `execute_external=True` with a deprecation error rather than honouring it, and lit 24 removes the parameter altogether. So `lit.cfg` no longer parses and the entire suite errors out before a single test runs:

```
tests/query-files/lit.cfg:28
ValueError: execute_external=True is deprected as of LLVM-23 and the option
will be removed in LLVM-24. Please move to using the internal shell
```

It now uses lit's internal shell. Nothing needed the real one: across **1,351 RUN lines** the only commands invoked are `%solver`, `%OutputCheck` and lit's own `not`, joined by pipes and redirections — no command substitution, no backticks, no `&&` or `||`, no loops.

It is written **without** `force_execute_external`, which lit 23 offers as a migration escape hatch. Rung 1 of the ladder in `tests/CMakeLists.txt` uses whatever lit is already installed, whatever version that is, and lit 18 has never heard of that parameter — a config only the newest lit can parse would break that rung. `execute_external=False` is spelled the same in both, and the suite passes under 18.1.8 and 23.1.0 alike.

`LIT_USE_INTERNAL_SHELL` is no longer read; it chose between two shells and there is one.

### lit was pinned in one place and unpinned in another

`ci.yml` ran `pip3 install -U lit` while the build's own virtual environment pinned `18.1.8`. Both now say 23.1.0.

### Bumping that pin did not work

An existing build tree reused its venv whenever one existed, so a changed `LIT_VERSION` was never installed — and the status line then reported the version that had been *asked for* rather than the one about to run the tests:

```
-- Using lit 23.1.0 from .../build/venv     # while ./venv/bin/lit said 18.1.8
```

It now checks what is installed and replaces the environment when it does not match:

```
-- Replacing the lit virtual environment: wanted 23.1.0, found "lit 18.1.8"
```

### Testing

164 tests pass, including all 815 query-file tests not skipped for a backend this build lacks. The query-file suite was also run against lit 18.1.8 with the new config, to confirm the rung-1 case still works.
