### PR TITLE
Stop the lit cache entry disabling the check that maintains it

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,10 +39,38 @@
 set(LIT_VERSION "23.1.0" CACHE STRING "lit version to install when one has to be")
 mark_as_advanced(LIT_VERSION)
 
+set(STP_VENV_DIR "${PROJECT_BINARY_DIR}/venv")
+
+# find_program caches its answer, and the auto-download branch below ends by
+# FORCEing its own into that same cache entry. Left alone the two self-disable:
+# every reconfigure after the first finds LIT_TOOL already set, skips the
+# branch whole, and takes the version check inside it along too. Both failures
+# are quiet ones. A venv removed under a surviving cache -- a cleaned build
+# tree, a pruned scratch disk -- reaches the "path does not seem to exist"
+# error below and asks the user to edit a cache variable by hand, when
+# recreating what we put there ourselves is plainly what was wanted. And a
+# bumped LIT_VERSION goes unread, which is the one thing the check exists to
+# stop.
+#
+# So discard the cached answer before searching, when it no longer resolves or
+# when it is the one we installed. A lit named by the user or found on PATH is
+# left alone in both respects: it sits on a higher rung, and its version is
+# deliberately not our business -- see tests/query-files/lit.cfg, which is
+# written to parse on whatever lit is already installed rather than only the
+# newest.
+if(LIT_TOOL AND NOT EXISTS "${LIT_TOOL}")
+    message(STATUS
+        "Discarding LIT_TOOL (${LIT_TOOL}): the path no longer exists")
+    unset(LIT_TOOL CACHE)
+elseif(LIT_TOOL AND LIT_TOOL STREQUAL "${STP_VENV_DIR}/bin/lit")
+    # Ours from a previous configure. Re-derived below so that LIT_VERSION
+    # still governs; the venv itself survives when it already holds it.
+    unset(LIT_TOOL CACHE)
+endif()
+
 find_program(LIT_TOOL lit DOC "Path to lit tool")
 
 if(NOT LIT_TOOL AND ENABLE_AUTO_DOWNLOAD)
-    set(STP_VENV_DIR "${PROJECT_BINARY_DIR}/venv")
     # Created once and reused: pip is slow, and reconfiguring is not rare. But
     # reused only while it holds the version asked for -- a bumped LIT_VERSION
     # against an existing build tree used to be ignored in silence, and the


### PR DESCRIPTION
`find_program` caches its answer, and the `ENABLE_AUTO_DOWNLOAD` branch below it ends by `FORCE`ing its own into the same cache entry. The pair self-disables: every reconfigure after the first finds `LIT_TOOL` already set, skips that branch whole, and takes the version check living inside it along too.

So the check added in #999 only ever runs on a build tree that has never been configured — which is not where it was needed.

### Two failures follow, both quiet

**A venv removed under a surviving cache** — a cleaned build tree, a pruned scratch disk — reaches

```
CMake Error at tests/CMakeLists.txt:94 (message):
  LIT_TOOL is set but the path does not seem to exist.  Try deleting the
  LIT_TOOL cache variable and reconfiguring
```

and asks the user to edit a cache variable by hand, when recreating what we put there ourselves is plainly what was wanted.

**A bumped `LIT_VERSION` goes unread.** Against an existing tree the build keeps running whatever the venv happens to hold, and the `Using lit ${LIT_VERSION}` status line does not print at all. That is the exact silence #999 claimed to have ended:

> reused only while it holds the version asked for -- a bumped LIT_VERSION against an existing build tree used to be ignored in silence

### The fix

Discard the cached answer before searching, when it no longer resolves or when it is the one we installed.

A lit the user named with `-DLIT_TOOL`, or one found on `PATH`, is left alone in both respects. It sits on a higher rung of the ladder, and its version is deliberately not this build's business — `tests/query-files/lit.cfg` is written to parse on whatever lit is already installed rather than only the newest:

> rung 1 of the ladder in tests/CMakeLists.txt uses whatever lit is already installed, whatever version that is, and a config only the newest lit can parse would break it

so gating that on a version would defeat it on purpose. This PR does not do that.

### Verified in the tree, not only in the abstract

| | before | after |
| --- | --- | --- |
| fresh tree | creates venv | creates venv |
| plain reconfigure | reuses, quiet | reuses, quiet — no pip, no spurious message |
| **venv deleted, cache kept** | **fatal error** | discards the dead entry, recreates, `lit 23.1.0` |
| **`-DLIT_VERSION=18.1.8`** | **silently still 23.1.0** | replaces the venv, `lit 18.1.8` |
| `-DLIT_VERSION=23.1.0` back again | silently still 18.1.8 | replaces the venv, `lit 23.1.0` |

`ctest -R query` passes: `query-files`, `query-files-cadical-factor-off`, `incremental-query`, `multi-query-bug`, `fp-model-no-fp-in-query` — 5/5.

https://claude.ai/code/session_016VNCxfwhxtu6qbMpdZbsc1