### PR TITLE
Fix duplicate BV abstractions in incremental solving

### DIFF
--- a/include/stp/ToSat/BVAbstractionRefiner.h
+++ b/include/stp/ToSat/BVAbstractionRefiner.h
@@ -316,6 +316,11 @@ struct BVTermAbstraction
   ASTNode operands[3];
   unsigned numOperands;
   unsigned width;
+  // Direct variables for this record's free result bits. The batch path may
+  // leave this empty and use nodeToSATVar. The persistent incremental path
+  // fills it so correctness does not depend on the canonical-reuse invariant:
+  // if duplicate records ever arise, each still owns distinct inputs.
+  std::vector<unsigned> resultSATVars;
   bool operandNegated[3] = {false, false, false};
   unsigned condSATVar = BV_ABSTRACTION_NO_VAR;
   bool defined = false;

--- a/include/stp/ToSat/BitBlaster.h
+++ b/include/stp/ToSat/BitBlaster.h
@@ -459,6 +459,11 @@ public:
     unsigned width;
     bool operandNegated[3] = {false, false, false};
     int condCISymbolIndex = -1;
+    // The result inputs belonging to this record. Canonical reuse normally
+    // prevents duplicate records for one term, but ownership here keeps the
+    // lowering sound if another producer or a future memo boundary creates
+    // them: symbolToBBNode can identify only the latest registered vector.
+    std::vector<int> resultCISymbolIndices;
   };
 
 private:

--- a/lib/Incremental/IncrementalSolverImpl.h
+++ b/lib/Incremental/IncrementalSolverImpl.h
@@ -3715,6 +3715,12 @@ struct IncrementalSolver::Impl
       }
       a.numOperands = raw.numOperands;
       a.width = raw.width;
+      a.resultSATVars.reserve(raw.resultCISymbolIndices.size());
+      for (const int index : raw.resultCISymbolIndices)
+      {
+        assert(index >= 0);
+        a.resultSATVars.push_back(abstractionVarOf(index));
+      }
       if (raw.condCISymbolIndex >= 0)
         a.condSATVar = abstractionVarOf(raw.condCISymbolIndex);
       encodeAbstractionNode(a.termNode);

--- a/lib/ToSat/BVAbstractionRefiner.cpp
+++ b/lib/ToSat/BVAbstractionRefiner.cpp
@@ -193,6 +193,31 @@ encodedBitsOf(const ASTNode& node, unsigned width,
   return vars;
 }
 
+// A term record's own free result, rather than whichever result was most
+// recently registered under the same AST node. Whole-formula batch blasting
+// creates one result per term and retains its historical node map. The
+// incremental blaster also canonicalises repeated terms, but direct ownership
+// keeps the refiner sound if that producer-side invariant is ever broken.
+static const std::vector<unsigned>& encodedResultBitsOf(
+    const BVTermAbstraction& abstraction,
+    const ToSATBase::ASTNodeToSATVar& nodeToSATVar)
+{
+  if (abstraction.resultSATVars.empty())
+    return encodedBitsOf(abstraction.termNode, abstraction.width,
+                         nodeToSATVar);
+
+  if (abstraction.resultSATVars.size() < abstraction.width)
+    FatalError("BV abstraction: a term record has fewer direct result "
+               "variables than its width: ",
+               abstraction.termNode, (int)abstraction.width);
+  for (unsigned i = 0; i < abstraction.width; ++i)
+    if (abstraction.resultSATVars[i] == BV_ABSTRACTION_NO_VAR)
+      FatalError("BV abstraction: a term record's direct result bit never "
+                 "reached the CNF: ",
+                 abstraction.termNode, (int)i);
+  return abstraction.resultSATVars;
+}
+
 // A record's own variable: the Boolean an equality became, or the condition
 // input of a comparison or an if-then-else. ~0u is both "the family has none"
 // and "the one it has never reached the solver", and neither is a state any
@@ -1285,7 +1310,7 @@ unsigned BVAbstractionRefiner::refineTerms(
     }
 
     const std::vector<unsigned>& resultVars =
-        encodedBitsOf(abs.termNode, abs.width, nodeToSATVar);
+        encodedResultBitsOf(abs, nodeToSATVar);
 
     if (abs.opKind == BVPLUS)
     {
@@ -1507,7 +1532,7 @@ unsigned BVAbstractionRefiner::refineTerms(
     getOperandVars(abs.operands[0], abs.width, nodeToSATVar, solver, leftVars);
     getOperandVars(abs.operands[1], abs.width, nodeToSATVar, solver, rightVars);
     const std::vector<unsigned>& resultVars =
-        encodedBitsOf(abs.termNode, abs.width, nodeToSATVar);
+        encodedResultBitsOf(abs, nodeToSATVar);
     const bool lNeg = abs.operandNegated[0];
     const bool rNeg = abs.operandNegated[1];
     const bool carryInit = (lNeg != rNeg);
@@ -1585,7 +1610,7 @@ unsigned BVAbstractionRefiner::refineTerms(
     getOperandVars(abs.operands[1], abs.width, nodeToSATVar, solver, thenVars);
     getOperandVars(abs.operands[2], abs.width, nodeToSATVar, solver, elseVars);
     const std::vector<unsigned>& resultVars =
-        encodedBitsOf(abs.termNode, abs.width, nodeToSATVar);
+        encodedResultBitsOf(abs, nodeToSATVar);
     unsigned c = abs.condSATVar;
 
     for (unsigned bit = 0; bit < abs.width; ++bit)
@@ -1613,7 +1638,7 @@ unsigned BVAbstractionRefiner::refineTerms(
     getOperandVars(abs.operands[0], abs.width, nodeToSATVar, solver, aVars);
     getOperandVars(abs.operands[1], abs.width, nodeToSATVar, solver, bVars);
     const std::vector<unsigned>& resultVars =
-        encodedBitsOf(abs.termNode, abs.width, nodeToSATVar);
+        encodedResultBitsOf(abs, nodeToSATVar);
     unsigned W = abs.width;
 
     // An algebraic fact the candidate contradicts, where there is one.

--- a/lib/ToSat/BVAbstractionRefiner.cpp
+++ b/lib/ToSat/BVAbstractionRefiner.cpp
@@ -71,6 +71,28 @@ unsigned BVAbstractionRefiner::refine(
   return refined;
 }
 
+// Which variables carry a term record's result: its own, where the lowering
+// filed them, and otherwise whatever the AST-keyed map holds for its term.
+// NULL when neither has an answer.
+//
+// Both readers of a result go through here, and that is the point. They are
+// entitled to different things -- freezing runs before the first solve and
+// tolerates a record whose bits are not encoded yet, refinement runs after it
+// and does not -- but neither is entitled to its own opinion about WHICH
+// variables the result is. A record frozen at one set and checked at another
+// is the shape of the bug the record-owned result exists to close, rebuilt
+// inside this file.
+static const std::vector<unsigned>*
+resultVarsOf(const BVTermAbstraction& abstraction,
+             const ToSATBase::ASTNodeToSATVar& nodeToSATVar)
+{
+  if (!abstraction.resultSATVars.empty())
+    return &abstraction.resultSATVars;
+
+  const auto it = nodeToSATVar.find(abstraction.termNode);
+  return it == nodeToSATVar.end() ? NULL : &it->second;
+}
+
 void BVAbstractionRefiner::freezeVariables(
     SATSolver& satSolver,
     const ToSATBase::ASTNodeToSATVar& nodeToSATVar) const
@@ -107,9 +129,9 @@ void BVAbstractionRefiner::freezeVariables(
 
   for (const auto& a : terms_)
   {
-    auto resultIt = nodeToSATVar.find(a.termNode);
-    if (resultIt != nodeToSATVar.end())
-      for (unsigned v : resultIt->second)
+    const std::vector<unsigned>* result = resultVarsOf(a, nodeToSATVar);
+    if (result != NULL)
+      for (unsigned v : *result)
         if (v != BV_ABSTRACTION_NO_VAR)
           satSolver.setFrozen(v);
     for (unsigned i = 0; i < a.numOperands; i++)
@@ -125,9 +147,10 @@ void BVAbstractionRefiner::freezeVariables(
   }
 }
 
-// The SAT variables one node of a record -- an operand, or the abstraction's
-// own result -- was encoded into, ready to be read out of a candidate or
-// written into a clause.
+// The SAT variables one operand of a record was encoded into, ready to be
+// read out of a candidate or written into a clause. A record's own result
+// does not come through here: it is the record's to name, and resultVarsOf
+// answers for it.
 //
 // Three things have to hold for the record to be checkable at all, and all
 // three hold by construction.
@@ -193,29 +216,33 @@ encodedBitsOf(const ASTNode& node, unsigned width,
   return vars;
 }
 
-// A term record's own free result, rather than whichever result was most
-// recently registered under the same AST node. Whole-formula batch blasting
-// creates one result per term and retains its historical node map. The
-// incremental blaster also canonicalises repeated terms, but direct ownership
-// keeps the refiner sound if that producer-side invariant is ever broken.
-static const std::vector<unsigned>& encodedResultBitsOf(
-    const BVTermAbstraction& abstraction,
-    const ToSATBase::ASTNodeToSATVar& nodeToSATVar)
+// The same result, for refinement: every bit a variable the CNF has, or the
+// call does not come back. The three things checked here are the three
+// encodedBitsOf checks for an operand, and hold for the same reasons.
+static const std::vector<unsigned>&
+encodedResultBitsOf(const BVTermAbstraction& abstraction,
+                    const ToSATBase::ASTNodeToSATVar& nodeToSATVar)
 {
-  if (abstraction.resultSATVars.empty())
-    return encodedBitsOf(abstraction.termNode, abstraction.width,
-                         nodeToSATVar);
+  const std::vector<unsigned>* vars = resultVarsOf(abstraction, nodeToSATVar);
+  if (vars == NULL)
+    FatalError("BV abstraction: an abstracted operation has no result the "
+               "bit-blast encoded, so no candidate can be checked against "
+               "it: ",
+               abstraction.termNode);
 
-  if (abstraction.resultSATVars.size() < abstraction.width)
-    FatalError("BV abstraction: a term record has fewer direct result "
-               "variables than its width: ",
+  if (vars->size() < abstraction.width)
+    FatalError("BV abstraction: an abstracted operation is recorded wider "
+               "than the result the bit-blast gave it; the record's width "
+               "is: ",
                abstraction.termNode, (int)abstraction.width);
+
   for (unsigned i = 0; i < abstraction.width; ++i)
-    if (abstraction.resultSATVars[i] == BV_ABSTRACTION_NO_VAR)
-      FatalError("BV abstraction: a term record's direct result bit never "
-                 "reached the CNF: ",
+    if ((*vars)[i] == BV_ABSTRACTION_NO_VAR)
+      FatalError("BV abstraction: an abstracted operation's result names a "
+                 "bit that never reached the CNF; the bit is: ",
                  abstraction.termNode, (int)i);
-  return abstraction.resultSATVars;
+
+  return *vars;
 }
 
 // A record's own variable: the Boolean an equality became, or the condition

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -82,6 +82,41 @@ static BBNodeVec ensureProxyCIs(
   return proxies;
 }
 
+// An abstraction stands for its term with fresh inputs, and refinement later
+// constrains those inputs through the record the blaster files here.
+//
+// The incremental driver blasts each conjunct as its own piece, and its
+// ordinary term memo is cleared between pieces -- fp_native_domain, which is
+// on by default, clears it on every new root -- so two pieces sharing a
+// subterm ask for it independently. Minting a second, independent set of
+// inputs for the second ask leaves two sets that are free to disagree, and
+// symbolToBBNode -- the registry refinement resolves a record's result
+// through -- holds one vector per node, so the second registration hides the
+// first: both records are then defined over the second set, the first stays
+// unconstrained, and the search is free to answer from it.
+//
+// A term has one value wherever it occurs, so reuse the vector it is already
+// registered as. An existing entry can also be an exact result or a proxy
+// tied to one; reusing either is stronger than abstracting the term again
+// and remains semantically exact.
+static bool reuseRegisteredTerm(BBNodeManagerAIG* nf, const ASTNode& term,
+                                unsigned width, BBNodeVec& reused)
+{
+  const BBNodeManagerAIG::SymbolToBBNode::const_iterator it =
+      nf->symbolToBBNode.find(term);
+  if (it == nf->symbolToBBNode.end() || it->second.size() != width)
+    return false;
+
+  // A width-sized entry whose bits were never filled in is a placeholder,
+  // not an abstraction to reuse.
+  for (unsigned i = 0; i < width; i++)
+    if (it->second[i].IsNull())
+      return false;
+
+  reused = it->second;
+  return true;
+}
+
 /********************************************************************
  * BitBlast
  *
@@ -1024,6 +1059,14 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term, BBNodeSet& support,
       if (uf->bv_term_abstraction && uf->bv_term_abstraction_ite &&
           num_bits >= uf->bv_abstraction_width)
       {
+        {
+          BBNodeVec reused;
+          if (reuseRegisteredTerm(nf, term, num_bits, reused))
+          {
+            result = reused;
+            break;
+          }
+        }
         uf->coverage.bv_abstracted[UserDefinedFlags::ABSTRACT_ITE]++;
         ensureProxyCIs(nf, term[1], thn, sideConstraints_);
         ensureProxyCIs(nf, term[2], els, sideConstraints_);
@@ -1187,6 +1230,14 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term, BBNodeSet& support,
           term.Degree() == 2 &&
           num_bits >= uf->bv_abstraction_width)
       {
+        {
+          BBNodeVec reused;
+          if (reuseRegisteredTerm(nf, term, num_bits, reused))
+          {
+            result = reused;
+            break;
+          }
+        }
         const BBNodeVec& left = BBTerm(term[0], support);
         const BBNodeVec& right = BBTerm(term[1], support);
 
@@ -1325,6 +1376,14 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term, BBNodeSet& support,
       if (uf->bv_term_abstraction && uf->bv_term_abstraction_mult &&
           num_bits >= uf->bv_abstraction_width)
       {
+        {
+          BBNodeVec reused;
+          if (reuseRegisteredTerm(nf, term, num_bits, reused))
+          {
+            result = reused;
+            break;
+          }
+        }
         uf->coverage.bv_abstracted[UserDefinedFlags::ABSTRACT_MULT]++;
         BBNodeVec op0 = ensureProxyCIs(nf, term[0], mpcd1, sideConstraints_);
         BBNodeVec op1 = ensureProxyCIs(nf, term[1], mpcd2, sideConstraints_);
@@ -1376,6 +1435,14 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term, BBNodeSet& support,
       if (uf->bv_term_abstraction && uf->bv_term_abstraction_mult &&
           num_bits >= uf->bv_abstraction_width)
       {
+        {
+          BBNodeVec reused;
+          if (reuseRegisteredTerm(nf, term, num_bits, reused))
+          {
+            result = reused;
+            break;
+          }
+        }
         uf->coverage.bv_abstracted[UserDefinedFlags::ABSTRACT_DIVMOD]++;
         ensureProxyCIs(nf, term[0], dvdd, sideConstraints_);
         ensureProxyCIs(nf, term[1], dvsr, sideConstraints_);

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -49,6 +49,18 @@ static bool allBBNodesAreCIs(const BBNodeVec& vec)
   return !vec.empty();
 }
 
+static std::vector<int> ciSymbolIndices(const BBNodeVec& bits)
+{
+  std::vector<int> indices;
+  indices.reserve(bits.size());
+  for (const BBNode& bit : bits)
+  {
+    assert(!bit.IsNull() && bit.symbol_index >= 0);
+    indices.push_back(bit.symbol_index);
+  }
+  return indices;
+}
+
 // For operands that contain internal AIG nodes (e.g. BVAND results),
 // create fresh proxy CIs with biconditional side constraints so that
 // downstream abstraction can proceed.
@@ -99,6 +111,10 @@ static BBNodeVec ensureProxyCIs(
 // registered as. An existing entry can also be an exact result or a proxy
 // tied to one; reusing either is stronger than abstracting the term again
 // and remains semantically exact.
+//
+// Incremental records also retain their own result variables, so a duplicate
+// that ever did arise would cost work rather than a verdict; canonicalising
+// here is the invariant, not the only line of defence.
 static bool reuseRegisteredTerm(BBNodeManagerAIG* nf, const ASTNode& term,
                                 unsigned width, BBNodeVec& reused)
 {
@@ -1095,6 +1111,7 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term, BBNodeSet& support,
         raw.numOperands = 3;
         raw.width = num_bits;
         raw.condCISymbolIndex = condCI.symbol_index;
+        raw.resultCISymbolIndices = ciSymbolIndices(abstracted);
         abstractedTerms_.push_back(raw);
         result = abstracted;
       }
@@ -1284,6 +1301,7 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term, BBNodeSet& support,
           raw.width = num_bits;
           raw.operandNegated[0] = negated[0];
           raw.operandNegated[1] = negated[1];
+          raw.resultCISymbolIndices = ciSymbolIndices(abstracted);
           abstractedTerms_.push_back(raw);
           result = abstracted;
           break;
@@ -1403,6 +1421,7 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term, BBNodeSet& support,
         raw.operands[1] = term[1];
         raw.numOperands = 2;
         raw.width = num_bits;
+        raw.resultCISymbolIndices = ciSymbolIndices(abstracted);
         abstractedTerms_.push_back(raw);
         result = abstracted;
       }
@@ -1462,6 +1481,7 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term, BBNodeSet& support,
         raw.operands[1] = term[1];
         raw.numOperands = 2;
         raw.width = num_bits;
+        raw.resultCISymbolIndices = ciSymbolIndices(abstracted);
         abstractedTerms_.push_back(raw);
         result = abstracted;
       }

--- a/tests/query-files/incremental-tests/abstraction-shared-subterm.smt2
+++ b/tests/query-files/incremental-tests/abstraction-shared-subterm.smt2
@@ -1,0 +1,29 @@
+; A term the abstraction replaces has to be replaced exactly once, however
+; many pieces the driver blasts it in.
+;
+; The driver prepares and encodes each conjunct of a pushed level as its own
+; piece, so a subterm two conjuncts share is offered to the blaster twice.
+; An abstraction is a set of fresh inputs standing for the term, constrained
+; by nothing until refinement writes clauses over the record the blaster
+; files; mint a second, independent set for the second ask and the two are
+; free to disagree. The registry the refiner resolves a record's result
+; through holds one vector per node, so the second registration hid the
+; first: both records were then defined over the second set and the first
+; was left unconstrained, which is an assignment the search may answer from.
+;
+; Here `t` occurs in both conjuncts and its expansion is all if-then-else,
+; so the width floor of 1 abstracts it. `bvsrem 1 x` is 1 for every x except
+; 1 and -1, where it is 0; no x satisfies both `t <=s x` and `t >=u x`, and
+; the query is unsatisfiable at every width. With the duplicate abstraction
+; live, STP answered sat -- the wrong verdict outright, not merely a model
+; that fails --check-sanity.
+; RUN: %solver --incremental --bv-term-abstraction=1 --bv-abstraction-width=1 %s | %OutputCheck %s
+; CHECK: ^unsat
+(set-logic QF_BV)
+(declare-fun x () (_ BitVec 4))
+(define-fun t () (_ BitVec 4) (bvsrem (_ bv1 4) x))
+(push 1)
+(assert (bvsle t x))
+(assert (bvuge t x))
+(check-sat)
+(exit)

--- a/tests/query-files/incremental-tests/abstraction-shared-subterm.smt2
+++ b/tests/query-files/incremental-tests/abstraction-shared-subterm.smt2
@@ -10,6 +10,8 @@
 ; through holds one vector per node, so the second registration hid the
 ; first: both records were then defined over the second set and the first
 ; was left unconstrained, which is an assignment the search may answer from.
+; The blaster now abstracts the term once; the refiner reads each record's
+; own result variables, so it does not rest on that alone.
 ;
 ; Here `t` occurs in both conjuncts and its expansion is all if-then-else,
 ; so the width floor of 1 abstracts it. `bvsrem 1 x` is 1 for every x except

--- a/tests/unit-tests/BVEQAbstraction_Test.cpp
+++ b/tests/unit-tests/BVEQAbstraction_Test.cpp
@@ -443,6 +443,61 @@ TEST_F(BVEQAbstractionTest, ITEAbstractionUnsatResult)
   EXPECT_EQ(SOLVER_VALID, result);
 }
 
+// Incremental pieces do not necessarily share the ordinary BBTerm memo. The
+// long-lived node registry is the canonical name of a term across that
+// boundary: revisiting an abstractable operation must return the first result
+// vector without filing another record. Per-record result ownership remains a
+// backstop, but the normal path should not pay for duplicate abstractions.
+TEST_F(BVEQAbstractionTest, ReusesTermAbstractionsAcrossMemoBoundaries)
+{
+  mgr.UserFlags.bv_term_abstraction = true;
+  mgr.UserFlags.bv_term_abstraction_ite = true;
+  mgr.UserFlags.bv_term_abstraction_plus = true;
+  mgr.UserFlags.bv_term_abstraction_mult = true;
+  mgr.UserFlags.bv_term_abstraction_compare = false;
+  mgr.UserFlags.bv_eq_abstraction = false;
+  mgr.UserFlags.bv_abstraction_width = 1;
+  mgr.UserFlags.fp_native_domain = true;
+
+  ASTNode condition = makeSymbol("reuse_abs_condition", 0);
+  ASTNode left = makeSymbol("reuse_abs_left", 8);
+  ASTNode right = makeSymbol("reuse_abs_right", 8);
+
+  BBNodeManagerAIG aigMgr;
+  stp::SubstitutionMap sm(&mgr);
+  Simplifier simp(&mgr, &sm);
+  BitBlaster bb(&aigMgr, &simp, factory, &mgr.UserFlags);
+
+  const auto expectReused = [&](const ASTNode& term, Kind expectedKind)
+  {
+    const size_t recordsBefore = bb.abstractedTerms().size();
+    const ASTNode firstRoot = factory->CreateNode(EQ, term, left);
+    const ASTNode secondRoot = factory->CreateNode(EQ, term, right);
+
+    bb.BBForm(firstRoot);
+
+    ASSERT_EQ(recordsBefore + 1, bb.abstractedTerms().size());
+    EXPECT_EQ(expectedKind, bb.abstractedTerms().back().opKind);
+    const auto firstRegistration = aigMgr.symbolToBBNode.find(term);
+    ASSERT_TRUE(firstRegistration != aigMgr.symbolToBBNode.end());
+    const BBNodeVec first = firstRegistration->second;
+
+    // A different FP-domain root clears BBTermMemo before this visit, as the
+    // incremental per-piece route does for distinct conjuncts.
+    bb.BBForm(secondRoot);
+
+    const auto secondRegistration = aigMgr.symbolToBBNode.find(term);
+    ASSERT_TRUE(secondRegistration != aigMgr.symbolToBBNode.end());
+    EXPECT_EQ(first, secondRegistration->second);
+    EXPECT_EQ(recordsBefore + 1, bb.abstractedTerms().size());
+  };
+
+  expectReused(factory->CreateTerm(ITE, 8, condition, left, right), ITE);
+  expectReused(factory->CreateTerm(BVPLUS, 8, left, right), BVPLUS);
+  expectReused(factory->CreateTerm(BVMULT, 8, left, right), BVMULT);
+  expectReused(factory->CreateTerm(BVDIV, 8, left, right), BVDIV);
+}
+
 // A candidate is only an assignment of the query once every abstraction in it
 // has been checked against the operands it stands for. Refinement checks them
 // by reading the operands' bits out of one map from node to SAT variables, and

--- a/tests/unit-tests/BVEQAbstraction_Test.cpp
+++ b/tests/unit-tests/BVEQAbstraction_Test.cpp
@@ -648,6 +648,15 @@ TEST_F(BVEQAbstractionTest, FreezeVariablesCoversEveryLemmaVariable)
   term.width = 4;
   refiner.terms().push_back(term);
 
+  // A record that owns its result, as the persistent incremental lowering
+  // files them. Freezing has to reach 40..43 and not whatever the node map
+  // says for the same term, or the backend is free to eliminate the very
+  // variables refinement will write its lemmas over. The record above owns
+  // nothing and keeps the map fallback covered.
+  BVTermAbstraction owned = term;
+  owned.resultSATVars = std::vector<unsigned>{40, 41, 42, 43};
+  refiner.terms().push_back(owned);
+
   ToSATBase::ASTNodeToSATVar bits;
   bits[x] = std::vector<unsigned>{10, 11, 12, 13};
   bits[y] = std::vector<unsigned>{20, 21, BV_ABSTRACTION_NO_VAR, 23};
@@ -656,8 +665,8 @@ TEST_F(BVEQAbstractionTest, FreezeVariablesCoversEveryLemmaVariable)
   RecordingSolver solver;
   refiner.freezeVariables(solver, bits);
 
-  const std::set<uint32_t> expected = {5,  10, 11, 12, 13, 20,
-                                       21, 23, 30, 31, 32, 33};
+  const std::set<uint32_t> expected = {5,  10, 11, 12, 13, 20, 21, 23,
+                                       30, 31, 32, 33, 40, 41, 42, 43};
   EXPECT_EQ(expected, solver.frozen);
 }
 

--- a/tests/unit-tests/BVEQAbstraction_Test.cpp
+++ b/tests/unit-tests/BVEQAbstraction_Test.cpp
@@ -478,6 +478,8 @@ TEST_F(BVEQAbstractionTest, ReusesTermAbstractionsAcrossMemoBoundaries)
 
     ASSERT_EQ(recordsBefore + 1, bb.abstractedTerms().size());
     EXPECT_EQ(expectedKind, bb.abstractedTerms().back().opKind);
+    EXPECT_EQ(term.GetValueWidth(),
+              bb.abstractedTerms().back().resultCISymbolIndices.size());
     const auto firstRegistration = aigMgr.symbolToBBNode.find(term);
     ASSERT_TRUE(firstRegistration != aigMgr.symbolToBBNode.end());
     const BBNodeVec first = firstRegistration->second;
@@ -657,6 +659,61 @@ TEST_F(BVEQAbstractionTest, FreezeVariablesCoversEveryLemmaVariable)
   const std::set<uint32_t> expected = {5,  10, 11, 12, 13, 20,
                                        21, 23, 30, 31, 32, 33};
   EXPECT_EQ(expected, solver.frozen);
+}
+
+// Canonical bit-blaster reuse normally prevents more than one abstraction
+// record for the same rewritten term. The refiner must not rely on that
+// producer-side invariant, though: the AST-keyed registry names only the
+// newest result, so every record must retain and refine its own free inputs.
+TEST_F(BVEQAbstractionTest, DuplicateTermsKeepTheirOwnResultVariables)
+{
+  mgr.UserFlags.bv_term_abstraction_schemas = false;
+
+  ASTNode a = makeSymbol("duplicate_result_a", 4);
+  ASTNode b = makeSymbol("duplicate_result_b", 4);
+  ASTNode product = factory->CreateTerm(BVMULT, 4, a, b);
+
+  BVAbstractionRefiner refiner(&mgr);
+  BVTermAbstraction older;
+  older.termNode = product;
+  older.opKind = BVMULT;
+  older.operands[0] = a;
+  older.operands[1] = b;
+  older.numOperands = 2;
+  older.width = 4;
+  older.resultSATVars = std::vector<unsigned>{40, 41, 42, 43};
+  refiner.terms().push_back(older);
+
+  BVTermAbstraction newer = older;
+  newer.resultSATVars = std::vector<unsigned>{30, 31, 32, 33};
+  refiner.terms().push_back(newer);
+
+  ToSATBase::ASTNodeToSATVar bits;
+  bits[a] = std::vector<unsigned>{10, 11, 12, 13};
+  bits[b] = std::vector<unsigned>{20, 21, 22, 23};
+  // The historical map has necessarily been overwritten by the newer
+  // record. It cannot identify the result still used by the older root.
+  bits[product] = newer.resultSATVars;
+
+  RecordingSolver solver;
+  // Both operands are 3, so their four-bit product is 9. The newer result is
+  // correct while the older result says zero. Looking up both records by AST
+  // would call the whole candidate consistent; record-owned variables expose
+  // and block the older inconsistency.
+  const bool operand[4] = {true, true, false, false};
+  const bool expected[4] = {true, false, false, true};
+  for (unsigned i = 0; i < 4; ++i)
+  {
+    solver.model[10 + i] = operand[i];
+    solver.model[20 + i] = operand[i];
+    solver.model[30 + i] = expected[i];
+    solver.model[40 + i] = false;
+  }
+
+  EXPECT_EQ(1u, refiner.refine(solver, bits));
+  EXPECT_EQ(1u, refiner.terms()[0].blockedRounds);
+  EXPECT_EQ(0u, refiner.terms()[1].blockedRounds);
+  EXPECT_TRUE(solver.someClauseBlocksModel());
 }
 
 // A partial prefix says nothing to a candidate that called the equality


### PR DESCRIPTION
## Summary

- Reuse an existing abstraction when a shared bit-vector term is blasted as separate incremental roots, avoiding duplicate unconstrained inputs and incorrect `sat` answers.
- Store result variables on term records as a defensive backstop and use one accessor for both refinement and variable freezing.
- Add an end-to-end SMT regression and unit coverage for reuse across memo boundaries, record ownership, and freezing.

## Background

The incremental driver blasts each conjunct as its own root while the term memo is cleared between roots. Re-abstracting the same AST node created fresh combinational inputs and overwrote the AST-keyed result registration. Refinement then constrained the newer result twice and left the original inputs free, which could make an unsatisfiable query appear satisfiable.

## Testing

- `cmake --build build --parallel 8`
- `ctest --test-dir build --output-on-failure --parallel 8` (167/167 passed)
- Focused BVEQ abstraction tests for canonical reuse, duplicate record ownership, and freezing all passed.
- The incremental regression reports `ite=4->2` and `unsat`.