### PR TITLE
Let the build turn on LTO and profile-guided optimisation

### DIFF
--- a/.github/workflows/pgo.yml
+++ b/.github/workflows/pgo.yml
@@ -1,0 +1,127 @@
+# The profile-guided build, once a night.
+#
+# Not on pull requests. What this protects is machinery rather than STP's own
+# behaviour -- that the LTO and profile flags still reach every translation
+# unit including the dependencies', that ExternalProject still lets the second
+# pass recompile what the first one instrumented, that llvm-profdata still
+# reads what this clang wrote -- and that rots on the scale of a CMake release
+# or a runner image moving its compiler, not on the scale of a commit. A
+# nightly notices within a day; a per-pull-request job would cost the whole
+# two-pass build every time and notice nothing sooner.
+#
+# It cannot tell you the optimisation is still worth having. A shared runner
+# is nowhere near quiet enough to resolve the few per cent this is for --
+# measuring it took pinned cores, interleaved configurations and a best-of-N,
+# and cross-run drift was larger than the effect even then. A green tick here
+# means the build works and the answers are right, and nothing about speed.
+#
+# The first run of this is the night after it lands on master, and there is no
+# way to bring that forward: GitHub registers a workflow from the default
+# branch alone, so schedule does not fire for a branch and workflow_dispatch
+# cannot reach one either -- dispatching it answers "workflow pgo.yml not found
+# on the default branch". Until then it is verified by running
+# scripts/pgo-build.sh by hand, which is the whole of what this job does.
+# workflow_dispatch is here for re-running it on demand once it has landed.
+on:
+  schedule:
+    - cron: '17 3 * * *'
+  workflow_dispatch:
+name: PGO
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  pgo:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: clang
+            cc: clang
+            cxx: clang++
+          - name: gcc
+            cc: gcc
+            cxx: g++
+    name: ${{ matrix.name }} (lto+pgo)
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+
+    - uses: actions/checkout@v7
+
+    # llvm for llvm-profdata, which merges the raw counters clang writes, and
+    # lld because clang cannot link the instrumented build without it: the
+    # counters live in sections that do not exist until the ThinLTO backend
+    # has run, and GNU ld resolves __start___llvm_prf_* before that, so every
+    # unit test -- whose inputs are all bytecode -- fails to link.
+    - name: Packages
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          bison \
+          build-essential \
+          clang \
+          cmake \
+          flex \
+          git \
+          lld \
+          llvm \
+          ninja-build \
+          python3 \
+          python3-pip \
+          python3-setuptools \
+          zlib1g-dev
+        sudo pip3 install -U lit
+
+    # No ccache and no dependency cache, deliberately. The second pass
+    # compiles with -fprofile-use, whose cache key includes the profile, and
+    # the profile changes with almost any edit to the tree -- so a compiler
+    # cache would mostly miss while still competing for the repository's cache
+    # budget. The dependencies cannot be shared either: they are compiled with
+    # the profile too, which is why pgo-build.sh keeps them inside the build
+    # directory and rebuilds them between the passes. A cold build is also the
+    # more honest test of the thing being tested.
+    - name: Build, train, and build again
+      run: |
+        CC=${{ matrix.cc }} CXX=${{ matrix.cxx }} \
+          ./scripts/pgo-build.sh release --lto --ninja --auto-download --testing
+
+    # A pass that quietly dropped a flag would build, test and pass while
+    # checking nothing -- which is not hypothetical: check_cxx_compiler_flag()
+    # reports -flto=thin as unsupported, because it puts the flag on the
+    # compile line and not on the link, and the first end-to-end build of this
+    # was silently PGO-only for that reason. Confirm both flags reached STP's
+    # own translation units and a dependency's before trusting the tests.
+    - name: The build really is optimised
+      run: |
+        set -u
+        stp_flags=$(python3 -c '
+        import json, sys
+        for e in json.load(open("build/compile_commands.json")):
+            if e["file"].endswith("ASTNode.cpp"):
+                print(e["command"]); break
+        else:
+            sys.exit("ASTNode.cpp is not in compile_commands.json")
+        ')
+        dep_flags=$(sed -n 's/^CMAKE_CXX_FLAGS:STRING=//p' \
+                      build/deps/src/CaDiCaL-EP-build/CMakeCache.txt)
+        for what in "STP:$stp_flags" "CaDiCaL:$dep_flags"; do
+          who=${what%%:*}
+          flags=${what#*:}
+          echo "$who: $flags"
+          case $flags in
+            *-flto*) ;;
+            *) echo "::error::$who was compiled without LTO"; exit 1;;
+          esac
+          case $flags in
+            *-fprofile-use*) ;;
+            *) echo "::error::$who was compiled without the profile"; exit 1;;
+          esac
+        done
+
+    - name: Test
+      run: ctest --parallel "$(nproc)" -VV --output-on-failure
+      working-directory: build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -424,7 +424,8 @@ if(NOT MSVC)
 
         set(CMAKE_EXE_LINKER_FLAGS " ${CMAKE_EXE_LINKER_FLAGS} -Wl,--discard-all -Wl,--build-id=sha1")
     endif()
-    # add_cxx_flag_if_supported("-flto") # slow compile and not enough benefits
+    # LTO is not decided here any more; see ENABLE_LTO below, which has to set
+    # it late enough that cmake/deps-helper.cmake can forward it.
     set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 endif()
 
@@ -453,6 +454,255 @@ if(USE_POPCNT)
   if(HAVE_FLAG_-mpopcnt)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mpopcnt")
   endif()
+endif()
+
+# -----------------------------------------------------------------------------
+# Link-time optimisation
+# -----------------------------------------------------------------------------
+# Off by default, and set through CMAKE_<LANG>_FLAGS rather than with
+# add_compile_options() or CMAKE_INTERPROCEDURAL_OPTIMIZATION, for one reason:
+# that string is what cmake/deps-helper.cmake hands to every dependency this
+# build compiles.  ABC and CaDiCaL are where most of a hard query's time goes
+# -- CaDiCaL's propagate() alone is a quarter of the instructions retired on a
+# ten-second QF_BV query -- so an optimisation that stops at libstp's edge
+# reaches the smaller half of the program.
+#
+# Measured over 726 SMT-LIB queries against the same compiler's -O3 build, LTO
+# on its own is worth about 1%: within a percent of nothing on wall time, and
+# -0.5% on instructions retired.  It earns its place next to PGO rather than
+# instead of it -- see the PGO block below -- because a profile is what tells
+# LTO which of the call sites it has newly made visible are worth inlining.
+option(ENABLE_LTO "Build with link-time optimisation" OFF)
+add_feature_info(LTO ENABLE_LTO
+                 "Optimises across translation units, and across STP and the dependencies it builds")
+
+# A flag that has to reach C as well as C++.  add_cxx_flag_if_supported() only
+# does the latter, and the rest of this file works around that one flag at a
+# time (see USE_POPCNT above); LTO and PGO need it a dozen times between them.
+#
+# Set rather than probed: which of these flags to use is already decided per
+# compiler below, and several of them carry a path, which
+# check_cxx_compiler_flag() would turn into a cache variable name with slashes
+# in it.  What is worth probing -- that the toolchain can actually link LTO
+# bytecode -- is probed on its own, below.
+macro(add_c_cxx_flag flagname)
+  string(APPEND CMAKE_C_FLAGS " ${flagname}")
+  string(APPEND CMAKE_CXX_FLAGS " ${flagname}")
+endmacro()
+
+if(ENABLE_LTO)
+  # The C and the C++ compiler have to be the same one.  Without LTO they only
+  # have to agree on an ABI, and a machine whose `cc` and `g++` are different
+  # GCC releases -- which is what a distribution that ships several of them
+  # looks like -- builds STP quite happily.  With LTO they exchange bytecode,
+  # and bytecode has a version:
+  #
+  #   lto1: fatal error: bytecode stream in file 'libabc-pic.a' generated with
+  #   LTO version 15.1 instead of the expected 11.3
+  #
+  # at the end of the build, naming a dependency rather than the mismatch.
+  # Said here instead, before anything is compiled.
+  if(NOT CMAKE_C_COMPILER_ID STREQUAL CMAKE_CXX_COMPILER_ID
+     OR NOT CMAKE_C_COMPILER_VERSION VERSION_EQUAL CMAKE_CXX_COMPILER_VERSION)
+    message(FATAL_ERROR
+            "ENABLE_LTO needs one compiler, and this is two: C is "
+            "${CMAKE_C_COMPILER_ID} ${CMAKE_C_COMPILER_VERSION} "
+            "(${CMAKE_C_COMPILER}), C++ is ${CMAKE_CXX_COMPILER_ID} "
+            "${CMAKE_CXX_COMPILER_VERSION} (${CMAKE_CXX_COMPILER}). They "
+            "exchange bytecode under LTO and will not agree on its version. "
+            "Name both, as in CC=gcc-13 CXX=g++-13, or build without --lto.")
+  endif()
+
+  if(MSVC)
+    add_compile_options(/GL)
+    foreach(_stp_lto_linker EXE SHARED STATIC MODULE)
+      string(APPEND CMAKE_${_stp_lto_linker}_LINKER_FLAGS " /LTCG")
+    endforeach()
+  else()
+    # The two compilers want to be told different things.  Clang has two
+    # schemes, and ThinLTO is the one to ask for: measured, it lands within
+    # 0.3% of its full LTO, for a fraction of the link time and the link-time
+    # memory.  GCC has one scheme, and =auto is how it is told to parallelise
+    # it across this machine; -fno-fat-lto-objects is what stops it compiling
+    # every object twice, once to bytecode and once to machine code that is
+    # then thrown away at link time.
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+      set(_stp_lto_flags "-flto=thin")
+    else()
+      set(_stp_lto_flags "-flto=auto -fno-fat-lto-objects")
+    endif()
+
+    # Probed through CMAKE_REQUIRED_FLAGS rather than with
+    # add_cxx_flag_if_supported(), because an LTO flag has to reach the link
+    # and not just the compile.  check_cxx_compiler_flag() puts it on the
+    # compile line alone, so the try_compile emits an object of bytecode and
+    # then links it with a plain driver invocation:
+    #
+    #   src.cxx.o: file not recognized: file format not recognized
+    #
+    # which reports a flag that works perfectly well as unsupported -- and
+    # then, silently, ENABLE_LTO builds without LTO in it.  Which is what this
+    # used to do.
+    include(CheckCXXSourceCompiles)
+    set(_stp_lto_saved_required "${CMAKE_REQUIRED_FLAGS}")
+    string(APPEND CMAKE_REQUIRED_FLAGS " ${_stp_lto_flags}")
+    check_cxx_source_compiles("int main() { return 0; }" STP_LTO_WORKS)
+    set(CMAKE_REQUIRED_FLAGS "${_stp_lto_saved_required}")
+    unset(_stp_lto_saved_required)
+    if(NOT STP_LTO_WORKS)
+      # Fatal rather than a quiet fall back to a non-LTO build: an
+      # optimisation that was asked for and did not happen is worth stopping
+      # for, and the two-pass PGO build below would otherwise spend a training
+      # run producing a binary that is not the one being measured.
+      message(FATAL_ERROR
+              "ENABLE_LTO is on, but ${CMAKE_CXX_COMPILER_ID} cannot compile "
+              "and link a program with '${_stp_lto_flags}'. The usual cause "
+              "is a linker with no plugin for this compiler's bytecode; lld "
+              "or mold will do for either, and GNU ld needs the plugin its "
+              "distribution installs in bfd-plugins.")
+    endif()
+    add_c_cxx_flag("${_stp_lto_flags}")
+
+    # Which linker finishes an LTO build is not only a build-time question.
+    # Measured over the same queries, with the same objects and a bytecode-for-
+    # bytecode identical .text, clang's ThinLTO through lld came out about 2%
+    # ahead of GNU ld and of mold on the heaviest ones -- the same code, laid
+    # out differently.  Said rather than done: which linker to use belongs to
+    # whoever is packaging this, and lld is not installed everywhere.
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang"
+       AND NOT CMAKE_CXX_FLAGS MATCHES "-fuse-ld="
+       AND NOT CMAKE_EXE_LINKER_FLAGS MATCHES "-fuse-ld="
+       AND NOT CMAKE_LINKER_TYPE)
+      find_program(STP_LTO_LLD NAMES ld.lld)
+      mark_as_advanced(STP_LTO_LLD)
+      if(STP_LTO_LLD)
+        message(STATUS
+                "ENABLE_LTO: ${STP_LTO_LLD} is installed, and clang's ThinLTO "
+                "through it measured about 2% faster on hard queries than "
+                "through the default linker. To use it, add -fuse-ld=lld to "
+                "CMAKE_EXE_LINKER_FLAGS and CMAKE_SHARED_LINKER_FLAGS -- or, "
+                "on CMake 3.29 or newer, -DCMAKE_LINKER_TYPE=LLD.")
+      endif()
+    endif()
+
+    # ar, nm and ranlib have to understand the compiler's IR to index an
+    # archive of it.  Binutils can, through the plugin in its bfd-plugins
+    # directory, but only if the distribution installed one there -- and STP
+    # builds several static dependencies, so an archive it cannot index is a
+    # link failure at the end of a long build.  The compiler ships wrappers
+    # that pass the plugin explicitly; prefer those when they exist.
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+      set(_stp_lto_tool_prefix llvm)
+    else()
+      set(_stp_lto_tool_prefix gcc)
+    endif()
+    foreach(_stp_lto_tool AR NM RANLIB)
+      string(TOLOWER "${_stp_lto_tool}" _stp_lto_tool_lc)
+      find_program(STP_LTO_${_stp_lto_tool}
+                   NAMES "${_stp_lto_tool_prefix}-${_stp_lto_tool_lc}")
+      mark_as_advanced(STP_LTO_${_stp_lto_tool})
+      if(STP_LTO_${_stp_lto_tool})
+        set(CMAKE_${_stp_lto_tool} "${STP_LTO_${_stp_lto_tool}}")
+      endif()
+    endforeach()
+  endif()
+  message(STATUS "Link-time optimisation enabled")
+endif()
+
+# -----------------------------------------------------------------------------
+# Profile-guided optimisation
+# -----------------------------------------------------------------------------
+# A two-pass build: -DPGO=generate produces a binary that writes a profile as
+# it runs, something is run through it, and -DPGO=use compiles again with what
+# that recorded.  scripts/pgo-build.sh drives the whole cycle; this is the part
+# of it the build system owns.
+#
+# Worth, over the same 726 SMT-LIB queries and trained on nothing but
+# tests/query-files -- so on the test suite that comes with the source, not on
+# the queries it was measured against:
+#
+#                                clang 21   gcc 13
+#   PGO alone                       -3.7%    -1.5%
+#   PGO with ENABLE_LTO             -5.4%    -3.8%
+#
+# (geometric mean of per-query wall time, against the same compiler at -O3.)
+# Instructions retired fall by rather more than that -- 6.2% for gcc with both
+# -- which is the honest shape of the result: PGO removes work, and what is
+# left is increasingly waiting on memory rather than executing.
+#
+# Two properties of that number are worth keeping in mind before changing what
+# the training run does.  The first is that a bigger corpus does not buy more:
+# trained on a disjoint sample of 443 SMT-LIB queries, on 60 deliberately hard
+# ones, or on both corpora together, the same build lands within half a percent
+# either way, and which is ahead changes with the compiler.  The profile is
+# being used to decide inlining and code layout, and the small queries in
+# tests/query-files exercise the same code as the large ones, just less of it.
+# The second is that GCC needs -fprofile-partial-training to get there.  Without
+# it, code the training run never reached is optimised for size, and since
+# tests/query-files leaves most of CaDiCaL's search cold that is most of what a
+# hard query then runs.
+set(PGO "off" CACHE STRING
+    "Profile-guided optimisation: off, generate (instrument), or use (optimise)")
+set_property(CACHE PGO PROPERTY STRINGS off generate use)
+set(PGO_DIR "${PROJECT_BINARY_DIR}/pgo-data" CACHE PATH
+    "Where PGO=generate writes profiles and PGO=use reads them")
+add_feature_info(PGO "NOT PGO STREQUAL off" "Profile-guided optimisation (${PGO})")
+
+if(NOT PGO STREQUAL "off")
+  if(MSVC)
+    message(FATAL_ERROR "PGO is not wired up for MSVC; configure with -DPGO=off")
+  endif()
+  if(NOT PGO MATCHES "^(generate|use)$")
+    message(FATAL_ERROR "PGO is '${PGO}'; it has to be off, generate or use")
+  endif()
+
+  # GCC names each .gcda after the absolute path of the object file it came
+  # from, so a profile generated in one build directory is invisible from
+  # another.  Both passes therefore have to run in the same build directory --
+  # which is what scripts/pgo-build.sh does, and what anyone driving the two
+  # passes by hand has to do as well.
+  if(PGO STREQUAL "generate")
+    add_c_cxx_flag("-fprofile-generate=${PGO_DIR}")
+    if(NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+      # STP is single-threaded, but the counters live in libstp, and a caller
+      # that is not gets counter updates from several threads at once.
+      add_c_cxx_flag("-fprofile-update=prefer-atomic")
+    endif()
+  elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    # Clang reads one merged file rather than a directory of raw counters;
+    # llvm-profdata produces it, and scripts/pgo-build.sh puts it here.
+    set(_stp_pgo_profdata "${PGO_DIR}/stp.profdata")
+    if(NOT EXISTS "${_stp_pgo_profdata}")
+      message(FATAL_ERROR
+              "PGO=use, but there is no profile at ${_stp_pgo_profdata}. Run "
+              "the generate pass first, or use scripts/pgo-build.sh, "
+              "runs both.")
+    endif()
+    add_c_cxx_flag("-fprofile-use=${_stp_pgo_profdata}")
+    # A profile is a snapshot of a source tree that has since been edited, and
+    # it is normal for some of it not to line up any more.  Say so once, here,
+    # rather than once per translation unit for the rest of the build.
+    add_c_cxx_flag("-Wno-profile-instr-out-of-date")
+    add_c_cxx_flag("-Wno-profile-instr-unprofiled")
+  else()
+    if(NOT EXISTS "${PGO_DIR}")
+      message(FATAL_ERROR
+              "PGO=use, but there is no profile in ${PGO_DIR}. Run the "
+              "generate pass first, or use scripts/pgo-build.sh, which "
+              "both -- from this same build directory, which is where GCC "
+              "looks for the counters it wrote.")
+    endif()
+    add_c_cxx_flag("-fprofile-use=${PGO_DIR}")
+    # Counters merged from many processes do not always add up to a consistent
+    # flow graph; without this, GCC discards such a function's profile rather
+    # than repairing it.
+    add_c_cxx_flag("-fprofile-correction")
+    # See the note above: without this, whatever the training run did not reach
+    # is optimised for size.
+    add_c_cxx_flag("-fprofile-partial-training")
+    add_c_cxx_flag("-Wno-missing-profile")
+  endif()
+  message(STATUS "Profile-guided optimisation: ${PGO} (${PGO_DIR})")
 endif()
 
 option(COVERAGE "Build with coverage check" OFF)

--- a/cmake/deps-helper.cmake
+++ b/cmake/deps-helper.cmake
@@ -134,6 +134,14 @@ set(STP_EP_COMMON_CMAKE_ARGS
     "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS} ${STP_EP_NO_WARNINGS} ${STP_EP_INHERITED_FLAGS}"
     -DCMAKE_C_COMPILER_LAUNCHER=${CMAKE_C_COMPILER_LAUNCHER}
     -DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}
+    # The archiver goes with the compiler, not with the machine. ENABLE_LTO
+    # switches these to the compiler's plugin-aware wrappers, because an
+    # archive of IR cannot be indexed by a plain ar -- and every dependency
+    # here is a static archive, so a sub-build left holding the plain one is a
+    # link failure at the end of the build rather than at the start.
+    -DCMAKE_AR=${CMAKE_AR}
+    -DCMAKE_NM=${CMAKE_NM}
+    -DCMAKE_RANLIB=${CMAKE_RANLIB}
     -DCMAKE_POSITION_INDEPENDENT_CODE=ON
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
     -DCMAKE_OSX_SYSROOT=${CMAKE_OSX_SYSROOT}

--- a/configure.sh
+++ b/configure.sh
@@ -49,6 +49,11 @@ Features (disable with --no-<name>):
   --werror            treat compiler warnings as errors
   --sanitize          build with Clang's sanitizers
   --coverage          build with coverage instrumentation
+  --lto               build with link-time optimisation
+  --pgo=STEP          profile-guided optimisation: generate or use. Both steps
+                      have to run in the same build directory.
+                      scripts/pgo-build.sh runs them in order, training on
+                      tests/query-files in between
   --tune-native       build with -mtune=native
   --allocator=NAME    mimalloc (default), tcmalloc or system
 
@@ -90,7 +95,9 @@ riss_dir=default
 allocator=default
 assertions=default
 coverage=default
+lto=default
 manpage=default
+pgo=default
 python_bindings=default
 sanitize=default
 static=default
@@ -156,6 +163,17 @@ do
     --coverage) coverage=ON;;
     --no-coverage) coverage=OFF;;
 
+    --lto) lto=ON;;
+    --no-lto) lto=OFF;;
+
+    --pgo) die "missing argument to $1 (try -h)";;
+    --pgo=*) pgo=${1##*=}
+        case $pgo in
+          generate|use) ;;
+          *) die "--pgo takes generate or use, not '$pgo'";;
+        esac
+        ;;
+
     --manpage) manpage=ON;;
     --no-manpage) manpage=OFF;;
 
@@ -211,6 +229,8 @@ add RISS_DIR               "$riss_dir"
 add STP_ALLOCATOR          "$allocator"
 add ENABLE_ASSERTIONS      "$assertions"
 add COVERAGE               "$coverage"
+add ENABLE_LTO             "$lto"
+add PGO                    "$pgo"
 add BUILD_MANPAGE          "$manpage"
 add ENABLE_PYTHON_INTERFACE "$python_bindings"
 add SANITIZE               "$sanitize"

--- a/docs/building.rst
+++ b/docs/building.rst
@@ -316,6 +316,14 @@ These apply to all generators:
 -  ``USE_MINISAT`` -- build the MiniSat backend
 -  ``USE_RISS`` -- build the Riss backend
 -  ``TUNE_NATIVE`` -- build with ``-mtune=native``
+-  ``ENABLE_LTO`` -- optimise across translation units, and across STP
+   and the dependencies it compiles. Off by default. On its own it is
+   worth about a percent; most of its value is in what it lets a profile
+   do, and the two are covered together in `Link-time and
+   profile-guided optimisation`_
+-  ``PGO`` and ``PGO_DIR`` -- ``generate`` or ``use``, and where the
+   profile lives. ``scripts/pgo-build.sh`` runs both passes with a
+   training run in between; the same section has the detail
 -  ``WERROR`` -- treat compiler warnings as errors
 -  ``BUILD_MANPAGE`` -- build and install the ``stp(1)`` manpage, which
    needs help2man. Three-valued: ``ON`` requires help2man and fails
@@ -363,6 +371,135 @@ lets you pick the generator; run ``ccmake``, which is the same idea in an
 ncurses terminal interface; or pass ``-D<VARIABLE>=<VALUE>`` to ``cmake``,
 which is best kept for scripts. An already-configured build can be
 changed with ``make edit_cache``, which reconfigures and regenerates.
+
+Link-time and profile-guided optimisation
+-----------------------------------------
+
+Two optimisations that are off by default and want to be turned on
+together. Neither changes what STP computes; both change how long it
+takes to compute it.
+
+``-DENABLE_LTO=ON`` optimises across translation units. It reaches the
+dependencies as well as STP itself, which is the point: most of a hard
+query's time is not spent in ``libstp`` at all. On a ten-second QF_BV
+query, ``CaDiCaL::Internal::propagate()`` alone is a quarter of the
+instructions retired, and CaDiCaL as a whole is most of the rest.
+
+``-DPGO=generate`` then ``-DPGO=use`` compiles twice, with a run of the
+first build in between to record which branches are taken and which code
+is hot. ``scripts/pgo-build.sh`` does all of it -- configure, build,
+train, configure, build:
+
+.. code-block:: bash
+
+   CC=clang CXX=clang++ ./scripts/pgo-build.sh release --lto --ninja --auto-download
+
+Options it does not recognise go to ``configure.sh``, so the build is
+configured as usual. ``--train=PATH`` names what to train on, and may be
+repeated; it defaults to ``tests/query-files``, the query suite in the
+source tree.
+
+What it is worth
+~~~~~~~~~~~~~~~~
+
+Measured over 726 SMT-LIB queries (QF_BV, QF_ABV, QF_FP, QF_BVFP,
+QF_ABVFP; 20-core Xeon, each configuration run interleaved with the
+others on a pinned core, best of three), against the same compiler's
+plain ``release`` build:
+
+=====================  ==============  ==============
+Configuration          clang 21        gcc 13
+=====================  ==============  ==============
+``--lto``              -1.0%           -1.0%
+``--pgo``              -3.7%           -1.5%
+both                   -5.4%           -3.8%
+=====================  ==============  ==============
+
+as the geometric mean of the per-query change, which weights a
+millisecond query and a ten-second one alike. Summed instead, so that the
+hard queries dominate, clang with both is 7% faster and gcc with both is
+1% faster: gcc's profile pays off on the front end, where a small query
+spends its time, and hardly at all inside CaDiCaL's search, where a large
+one does.
+
+The split is sharper still on queries that are entirely CaDiCaL. Over 57
+of them taking 12 to 123 seconds each, clang with both keeps its 4% --
+4.2% on the geometric mean, 4.4% at the median query -- and gcc with both
+has nothing left, at 0.1% on the median query.
+
+Instructions retired fall by more than the time does -- 6.2% for gcc with
+both, over the same queries under callgrind. That gap is the honest shape
+of the result: PGO removes work, and what remains is increasingly waiting
+on memory rather than executing.
+
+Training on tests/query-files
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The default training set is the test suite, which takes about fifteen
+seconds to run and needs nothing downloaded. It is not a compromise.
+Trained instead on a disjoint sample of 443 SMT-LIB queries, on 60
+deliberately hard ones, or on both corpora together, the same build lands
+within half a percent of it either way -- and which of them is ahead
+changes with the compiler and with the run. The profile is being used to
+decide inlining and code layout, and a small query exercises the same
+code as a large one, just less of it.
+
+Two things do matter more than the training set:
+
+-  **GCC needs** ``-fprofile-partial-training``, which the build passes
+   for it. Without it, code the training run never reached is optimised
+   for size, and a run of ``tests/query-files`` leaves most of CaDiCaL's
+   search cold. Turning it off cost 0.8% of the 3.8% above.
+-  **Clang wants the IR instrumentation**, ``-fprofile-generate``, which
+   is what the build uses -- not the frontend's
+   ``-fprofile-instr-generate``, which measured 1.5% worse here.
+
+Which linker
+~~~~~~~~~~~~
+
+With clang, it makes a difference of its own. The same objects, a
+bytecode-for-bytecode identical ``.text`` and an identical exported
+symbol set, linked three ways: through lld the heaviest queries ran about
+2% faster than through GNU ld or mold -- 2% at the median of the queries
+over three seconds, up to 15% on individual ones. That is code layout,
+and it is the one part of this that nothing in the source tree controls.
+
+lld is also required rather than merely preferable for the ``generate``
+pass. Clang finds its counters through ``__start___llvm_prf_*`` symbols
+that the linker synthesises; under ThinLTO the sections they refer to do
+not exist until the LTO backend has run, and GNU ld decides the symbols
+before that, so a target whose inputs are all bytecode -- which, with
+``--testing``, several of the unit tests are -- fails to link:
+
+.. code-block:: text
+
+   undefined reference to `__start___llvm_prf_names'
+
+``pgo-build.sh`` therefore links with lld when the compiler is clang and
+``ld.lld`` is installed, unless a linker was named on its command line.
+
+Caveats
+~~~~~~~
+
+-  Both passes have to use the same build directory. GCC names each
+   ``.gcda`` after the absolute path of the object file it came from, so
+   a profile collected in one build directory is invisible from another.
+   ``pgo-build.sh`` reconfigures in place for exactly this reason.
+-  The dependencies are rebuilt between the passes, since they are
+   compiled with the profile too. ``pgo-build.sh`` therefore keeps them
+   in the build directory and refuses ``--dep-dir``.
+-  ``ENABLE_LTO`` requires that ``CC`` and ``CXX`` be the same compiler
+   at the same version. Without LTO a mismatched pair -- which is what a
+   machine whose ``cc`` is gcc 15 and whose ``g++`` is gcc 11 has --
+   builds STP quite happily; with it they exchange bytecode, and the
+   build fails at the end with ``bytecode stream ... generated with LTO
+   version 15.1 instead of the expected 11.3``. Configuration checks for
+   this and stops first.
+-  A profile is not portable and not reproducible: it belongs to one
+   source tree and one compiler version, and two training runs of the
+   same build do not produce byte-identical binaries. For a build that
+   has to be reproducible, leave ``PGO`` off. ``ENABLE_LTO`` on its own
+   is deterministic.
 
 Working across several worktrees
 --------------------------------

--- a/scripts/pgo-build.sh
+++ b/scripts/pgo-build.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+#
+# Configure, build, train, and build again: the whole profile-guided cycle.
+# configure.sh does the configuring, this decides what happens between the two
+# passes.
+#
+# They share a build directory on purpose. GCC names each .gcda after the
+# absolute path of the object file it came from, so a profile collected in one
+# build directory is invisible from another; there is no arrangement in which
+# the second pass can be a separate tree.
+
+set -e -o pipefail
+
+die () { echo "*** pgo-build.sh: $*" 1>&2; exit 1; }
+
+usage () {
+cat <<EOF
+Usage: $0 [<option> ...] [<configure.sh option> ...]
+
+Builds STP twice -- once instrumented, then again with what the first build
+recorded while solving a corpus of queries -- and leaves the optimised build
+in the build directory.
+
+Options:
+  -h, --help          display this help and exit
+  --name=STR          build directory to use (default: build)
+  --train=PATH        a directory to search for .smt2 queries, or one query.
+                      Repeatable. Defaults to tests/query-files
+  --jobs=N            parallel jobs for the builds and the training run
+
+Everything else is passed to configure.sh, so the usual options work:
+
+  ./scripts/pgo-build.sh release --lto --ninja --auto-download
+
+and the compiler is chosen the same way it is for configure.sh, through the
+environment. Measured, clang is the one worth using here -- its profile
+reaches CaDiCaL's search and gcc's does not:
+
+  CC=clang CXX=clang++ ./scripts/pgo-build.sh release --lto --ninja --auto-download
+
+See "Link-time and profile-guided optimisation" in docs/building.rst for what
+this is worth, what it costs, and what it does not do.
+EOF
+  exit 0
+}
+
+[ ! -e lib/AST ] && die "$0 not called from the STP source directory"
+
+build_dir=build
+train=()
+passthrough=()
+jobs=$( (nproc || sysctl -n hw.ncpu || echo 4) 2>/dev/null )
+
+while [ $# -gt 0 ]; do
+  case $1 in
+    -h|--help) usage;;
+    --name=*)  build_dir=${1##*=};;
+    --train=*) train+=("${1##*=}");;
+    --jobs=*)  jobs=${1##*=};;
+    --name|--train|--jobs) die "missing argument to $1 (try -h)";;
+    --pgo|--pgo=*) die "$1 is what this script is for: it runs both passes";;
+    *)         passthrough+=("$1");;
+  esac
+  shift
+done
+
+[ ${#train[@]} -eq 0 ] && train=(tests/query-files)
+
+root_dir=$(pwd)
+prof_dir=$root_dir/$build_dir/pgo-data
+
+# Clang's instrumentation puts its counters in their own sections and finds
+# them through the __start___llvm_prf_* symbols the linker is supposed to
+# synthesise.  Under ThinLTO those sections do not exist until after the LTO
+# backend has run, and GNU ld decides the symbols before that, so a target
+# whose inputs are all bytecode fails to link:
+#
+#   undefined reference to `__start___llvm_prf_names'
+#
+# lld creates them afterwards and links it.  It is also the linker this came
+# out fastest with -- about 2% on the heaviest queries, same objects, same
+# .text -- so when it is there and nobody has asked for another one, use it.
+linker_opts=()
+case " ${passthrough[*]} " in
+  *-fuse-ld=*|*CMAKE_LINKER_TYPE*) ;;
+  *)
+    if "${CXX:-c++}" --version 2>/dev/null | head -1 | grep -qi clang \
+       && command -v ld.lld >/dev/null 2>&1; then
+      echo "==> linking with lld (clang's instrumented ThinLTO needs it)"
+      linker_opts=(-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld
+                   -DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=lld)
+    fi
+    ;;
+esac
+
+# STP builds its dependencies as separate CMake projects, and most of a hard
+# query's time is spent inside two of them. A profile that covered only libstp
+# would be a profile of the smaller half, so the dependencies are compiled with
+# the same flags in both passes -- which means they have to be rebuilt between
+# the passes, and that in turn means this build directory needs a dependency
+# tree of its own rather than a shared one it would be rude to delete.
+dep_dir=$root_dir/$build_dir/deps/install
+for opt in "${passthrough[@]}"; do
+  case $opt in
+    --dep-dir=*) die "--dep-dir cannot be shared with a PGO build: the second"\
+                     "pass has to recompile the dependencies with the profile";;
+  esac
+done
+
+# Collect the training queries once, so both the count reported below and the
+# run itself see the same list.
+queries=$(mktemp)
+trap 'rm -f "$queries"' EXIT
+for t in "${train[@]}"; do
+  if [ -d "$t" ]; then
+    find "$t" -name '*.smt2' -type f
+  elif [ -f "$t" ]; then
+    echo "$t"
+  else
+    die "--train=$t is neither a file nor a directory"
+  fi
+done | sort > "$queries"
+n_queries=$(wc -l < "$queries")
+[ "$n_queries" -eq 0 ] && die "no .smt2 queries found in: ${train[*]}"
+
+echo "==> pass 1: instrumented build in $build_dir"
+rm -rf "$prof_dir"
+mkdir -p "$prof_dir"
+./configure.sh --name="$build_dir" --dep-dir="$dep_dir" --pgo=generate \
+               -DPGO_DIR="$prof_dir" "${linker_opts[@]}" "${passthrough[@]}"
+cmake --build "$build_dir" --parallel "$jobs"
+
+stp_bin=$build_dir/stp
+[ -x "$stp_bin" ] || die "no $stp_bin to train with"
+
+echo "==> training on $n_queries queries from: ${train[*]}"
+# Clang's runtime merges into one file per binary when the name contains %m,
+# which is what keeps this from leaving one raw profile per process behind.
+# GCC's runtime merges into the .gcda files whatever the name, and ignores it.
+export LLVM_PROFILE_FILE="$prof_dir/stp-%m.profraw"
+# A query that does not finish is a query that never writes its counters, so
+# the cap is generous: the point is to survive a pathological input, not to
+# bound the training run.
+xargs -a "$queries" -P "$jobs" -I{} \
+      sh -c 'timeout 300 "$0" --SMTLIB2 "$1" >/dev/null 2>&1 || true' \
+      "$root_dir/$stp_bin" {}
+
+# Which toolchain built it decides what shape the profile is in.  Asked of the
+# compiler rather than read out of CMakeCache.txt, which does not carry
+# CMAKE_CXX_COMPILER_ID: that one is worked out afresh on every configure and
+# never cached.
+cxx=$(sed -n 's/^CMAKE_CXX_COMPILER:.*=//p' "$build_dir/CMakeCache.txt")
+[ -n "$cxx" ] || die "no CMAKE_CXX_COMPILER in $build_dir/CMakeCache.txt"
+if "$cxx" --version 2>/dev/null | head -1 | grep -qi clang; then
+  raw=$(find "$prof_dir" -name '*.profraw' | wc -l)
+  [ "$raw" -eq 0 ] && die "the training run produced no profile"
+  # Prefer the llvm-profdata that goes with this clang: a profile written by
+  # one version is not always readable by another, and distributions install
+  # several side by side.
+  major=$("$cxx" -dumpversion 2>/dev/null | cut -d. -f1)
+  profdata=""
+  for cand in "llvm-profdata-$major" llvm-profdata; do
+    command -v "$cand" >/dev/null 2>&1 && { profdata=$cand; break; }
+  done
+  [ -z "$profdata" ] && die "llvm-profdata is needed to merge a clang profile"
+  echo "==> merging $raw raw profiles with $profdata"
+  find "$prof_dir" -name '*.profraw' -print0 \
+    | xargs -0 "$profdata" merge -output="$prof_dir/stp.profdata"
+  find "$prof_dir" -name '*.profraw' -delete
+else
+  gcda=$(find "$prof_dir" -name '*.gcda' | wc -l)
+  [ "$gcda" -eq 0 ] && die "the training run produced no profile"
+  echo "==> collected $gcda profiles"
+fi
+
+echo "==> pass 2: optimised build in $build_dir"
+# The dependencies were built instrumented too. ExternalProject remembers that
+# it has already configured, built and installed them, so drop those three
+# stamps -- and the tree they installed into -- to have them compiled again
+# with the profile. The download and patch stamps stay, so nothing is fetched
+# twice.
+rm -f "$build_dir"/deps/src/*-EP-stamp/*-configure \
+      "$build_dir"/deps/src/*-EP-stamp/*-build \
+      "$build_dir"/deps/src/*-EP-stamp/*-install
+rm -rf "$dep_dir"
+./configure.sh --name="$build_dir" --dep-dir="$dep_dir" --pgo=use \
+               -DPGO_DIR="$prof_dir" "${linker_opts[@]}" "${passthrough[@]}"
+cmake --build "$build_dir" --parallel "$jobs"
+
+echo "==> done: $build_dir/stp"


### PR DESCRIPTION
Two build options that have never been available -- `ENABLE_LTO` and `PGO` -- a `scripts/pgo-build.sh` that runs the two-pass cycle. Both are off by default: a build that names neither is flag-for-flag what it was.

## What it is worth

Measured over 726 SMT-LIB queries (QF_BV, QF_ABV, QF_FP, QF_BVFP, QF_ABVFP), against the same compiler's own `release` build, as the geometric mean of the per-query change:

| | clang 21 | gcc 13 |
|---|---|---|
| `--lto` | -1.0% | -1.0% |
| `--pgo` | -3.7% | -1.5% |
| both | -5.4% | -3.8% |

LTO on its own is worth 0.5% of the instructions retired and none of the time -- the comment where it used to be considered, "slow compile and not enough benefits", is right about LTO and wrong about the pair. It earns its place next to a profile rather than instead of one: LTO makes call sites visible across translation units, and a profile is what decides which of them are worth inlining.

The split between the two compilers is the part worth reading. Summed rather than averaged, so that hard queries dominate, clang with both is 7% faster and gcc with both is 1% faster; and on 57 queries taking 12 to 123 seconds each -- where the time is essentially all CaDiCaL -- clang keeps 4.2% and gcc has nothing left, at 0.1% on the median query. gcc's profile pays off on the front end, where a millisecond query spends its time, and hardly at all inside CaDiCaL's search. So the configuration worth using is clang.

## Using it

```
CC=clang CXX=clang++ ./scripts/pgo-build.sh release --lto --ninja --auto-download
```

Two minutes on 24 cores, of which fifteen seconds is the training run. `./scripts/pgo-build.sh --help` has the rest; everything it does not recognise goes to `configure.sh`, so the build is configured as usual. `configure.sh` also gains `--lto` and `--pgo=generate|use` for driving the passes by hand.

## Why the flags reach the dependencies

Both are set through `CMAKE_<LANG>_FLAGS` rather than with `CMAKE_INTERPROCEDURAL_OPTIMIZATION` or `add_compile_options()`, because that string is what `deps-helper` hands to every dependency this build compiles. That is not a detail: on a ten-second QF_BV query `CaDiCaL::Internal::propagate()` alone is a quarter of the instructions retired, and CaDiCaL as a whole is most of the rest, so an optimisation that stops at libstp's edge reaches the smaller half of the program. The archiver is forwarded alongside the compiler for the same reason -- a plain `ar` cannot index an archive of bytecode.

## Training on tests/query-files

The default training corpus is the query suite already in the tree. It takes fifteen seconds and needs nothing downloaded, and it is not a compromise: trained instead on a disjoint sample of 443 SMT-LIB queries, on 60 deliberately hard ones, or on both corpora together, the same build lands within half a percent either way, and which of them is ahead changes with the compiler and with the run. The profile is deciding inlining and code layout, and the small queries in the test suite exercise the same code as the large ones, just less of it. `--train=PATH` says otherwise.

Two knobs did matter, and both are set for you. gcc needs `-fprofile-partial-training` -- worth 0.8 of its 3.8 points, because without it whatever the training run never reached is optimised for size, and `tests/query-files` leaves most of CaDiCaL's search cold. And clang wants the IR instrumentation, `-fprofile-generate`, not the frontend's `-fprofile-instr-generate`, which measured 1.4 points worse.

## Three ways this quietly does nothing, now guarded

`check_cxx_compiler_flag("-flto=thin")` reports failure. It puts the flag on the compile line and not on the link, so its test program compiles to bytecode and is then linked by a driver that was never told to load the plugin -- `file format not recognized` -- and a flag that works perfectly well is dropped. Not hypothetical: the first end-to-end build here was silently PGO-only and measured two points short before I noticed. It is now probed through `CMAKE_REQUIRED_FLAGS`, and fatal rather than quiet if it genuinely fails.

`cc` and `g++` being different compilers. On a distribution shipping several gcc releases they often are -- here `cc` is gcc 15 and `g++` is gcc 11 -- which builds STP quite happily without LTO and dies with it at the very end, naming a dependency rather than the cause: `bytecode stream in file 'libabc-pic.a' generated with LTO version 15.1 instead of the expected 11.3`. Configuration now checks the pair and stops first, with the fix in the message.

Clang's instrumented ThinLTO does not link with GNU ld. Clang finds its counters through `__start___llvm_prf_*` symbols the linker synthesises; under ThinLTO the sections they refer to do not exist until the LTO backend has run, and GNU ld decides the symbols before that, so any target whose inputs are all bytecode fails with `undefined reference to __start___llvm_prf_names`. With `--testing`, several of the unit tests are exactly that. `pgo-build.sh` links with lld when the compiler is clang and `ld.lld` is installed, unless a linker was named on its command line.

lld is also the linker this came out fastest with, which is worth knowing separately. Same objects, a bytecode-for-bytecode identical `.text` and an identical exported symbol set, linked three ways: through lld the heaviest queries ran about 2% faster than through GNU ld or mold -- 2.0% at the median of the queries over three seconds, up to 15% on individual ones, and nothing at all below a second. That is code layout, and it is the one part of this that nothing in the source tree controls. `CMakeLists.txt` says so at configure time rather than choosing for you, since which linker to use belongs to whoever is packaging this.

## CI

`.github/workflows/pgo.yml` runs the whole cycle nightly, both toolchains, driven by the same `scripts/pgo-build.sh`. Not on pull requests: what it protects is machinery rather than STP's behaviour -- that the flags still reach every translation unit including the dependencies', that ExternalProject still lets the second pass recompile what the first one instrumented, that `llvm-profdata` still reads what this clang wrote -- and that rots on the scale of a CMake release or a runner image moving its compiler. A nightly notices in time; a per-PR job would cost the whole two-pass build on every push and notice nothing sooner.

It checks the flags rather than assuming them, against STP's own translation units and against CaDiCaL's, because a pass that quietly dropped one would build, test and pass while checking nothing. It carries no compiler cache and no dependency cache, for reasons in a comment. And it cannot tell you the optimisation is still worth having -- a shared runner is nowhere near quiet enough to resolve a few per cent -- which the job comment says too, so that a green tick is not read as a speedup still being intact.

## Verified

`ctest` passes 167 of 167 with the LTO+PGO build under both toolchains -- including with `CC=gcc CXX=g++` on gcc 11, which is the invocation the nightly uses -- and the 1,222 queries this was measured on return identical answers from every build.

One caveat on the measurements themselves: codegen perturbs the floating-point scores CaDiCaL sorts its heuristics by, so a hard query can take several times longer or shorter with the same answer. On `QF_FP/griggio/fmcad12/test_v5_r5_vr10_c1_s5379.smt2` three builds return `sat` after 2,465, 9,902 and 23,101 conflicts. Over a thousand queries this averages out, but it means the summed-time figure is the more fragile of the two and no single hard query proves anything. The figures above set aside the queries whose spread between builds exceeded 1.5x; leaving them in moves the totals by about a point and the geometric means not at all.

Each build was run on the same pinned core, back to back on the same query, best of three or four, on a 24-core Xeon Gold 6348 with 20 cores in use. A second copy of the baseline binary running under a different label came out 0.18% apart on total time and 0.04% on the geometric mean, which is the floor this can resolve. Everything above was measured at 7f4fd700 and re-confirmed after rebasing onto current master: -5.6% for clang and -4.4% for gcc on the geometric mean of a 439-query held-out set.
