### PR TITLE
Generate the scanners with flex's uncompressed tables

### DIFF
--- a/lib/Parser/CMakeLists.txt
+++ b/lib/Parser/CMakeLists.txt
@@ -49,7 +49,11 @@ foreach(_file ${TOLEX})
 
     COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/parse${_file}.tab.c ${CMAKE_CURRENT_BINARY_DIR}/parse${_file}.tab.cpp
 
-        COMMAND ${FLEX_EXECUTABLE} ${FLEX_COMPATIBILITY_ARGS} -Ce -8 --header-file=${CMAKE_CURRENT_BINARY_DIR}/${_file}_flex_header.h -o${CMAKE_CURRENT_BINARY_DIR}/lex${_file}.cpp --prefix=${_file} ${CMAKE_CURRENT_SOURCE_DIR}/${_file}.lex
+        # -Cf, not -Ce: an uncompressed scanner table indexes one array per
+        # character, where the compressed one walks equivalence-class and
+        # default-state tables per character. The tables are larger and the
+        # tokens are identical.
+        COMMAND ${FLEX_EXECUTABLE} ${FLEX_COMPATIBILITY_ARGS} -Cf -8 --header-file=${CMAKE_CURRENT_BINARY_DIR}/${_file}_flex_header.h -o${CMAKE_CURRENT_BINARY_DIR}/lex${_file}.cpp --prefix=${_file} ${CMAKE_CURRENT_SOURCE_DIR}/${_file}.lex
 
         DEPENDS ${_file}.lex ${_file}.y ASTKind_header
     )


### PR DESCRIPTION
The three lexers are generated with `flex -Ce`, which is flex's most compressed table representation and its slowest. Every input character goes through an equivalence-class lookup and then a walk of the default-state chain before the next state is known. `-Cf` indexes one table directly by character instead.

Flex builds the same automaton from the same rules either way. The token stream, the actions, and the error messages are identical; only the table representation and its size change. That makes this cheap to accept: the acceptance test is a byte comparison of the generated CNF, not an argument.

### Measurements

Uniform random 4,000-file sample of the non-incremental SMT-LIB benchmarks STP supports (10 logics, ~138k files), measured as retired user-space instructions to the point where the CNF is complete (`--exit-after-CNF`). Wall clock on the measuring machine has a ±4% noise floor, which is wider than this change; instruction counts are reproducible to about 0.001%.

| | |
|---|---|
| total instructions to CNF, 4,000 files | **−2.59%** |
| files whose emitted CNF is byte-identical | **4,000 / 4,000** |
| best file | −15.4% |
| worst file | +0.008% (noise; every other file is negative) |
| median file | −0.42% |

The win is concentrated where it should be. Parsing is 61% of the time to reach a CNF across that corpus — the benchmarks are 39GB of text, and most queries are small enough that scanning dominates everything downstream. Restricted to the files that spend under 200ms reaching a CNF, parsing is 86% of the accounted time.

### Cost

The generated scanner source grows from 125KB to 1.3MB, and the linked binary by about 685KB.

### Why not `-CF`

`-Cf` and `-CF` are both uncompressed; `-CF` differs in how it represents the accepting states. `-Cf` was measured and taken; `-CF` was not separately measured, and there is no reason to expect it to matter here.

An earlier round of parser work (#800) took the same corpus 15.5% faster by replacing the symbol table and dropping `%option yylineno`. This is orthogonal to all of it: it changes no rule and no action, only how flex encodes the automaton it already builds.