### PR TITLE
Allow the test suite in static builds

### DIFF
--- a/.github/actions/build-static-linux/action.yml
+++ b/.github/actions/build-static-linux/action.yml
@@ -38,10 +38,10 @@ runs:
 
   steps:
 
-  # No lit and no gtest here: STATICCOMPILE turns BUILD_SHARED_LIBS off, and
-  # the top-level CMakeLists forces ENABLE_TESTING off when it is off (the
-  # Python bindings and the test harness both want a shared libstp), so a
-  # static build has no tests to run. See the smoke test at the end.
+  # No lit and no gtest here: this job leaves ENABLE_TESTING off, so there is
+  # no test harness to install or build. A static build can run the suite --
+  # nothing forces the option off any more -- but what this job exists to cover
+  # is the static link itself. See the smoke test at the end.
   - name: Packages
     shell: bash
     run: |
@@ -201,8 +201,8 @@ runs:
   # to resolve them itself -- which means an installed static STP has to ship
   # them and its STPTargets.cmake has to name them somewhere that still exists
   # on the machine doing the consuming. Nothing else checks that: the
-  # install-tree consumer test in the suite runs only in shared builds, because
-  # ENABLE_TESTING is forced off when BUILD_SHARED_LIBS is.
+  # install-tree consumer test in the suite runs only where ENABLE_TESTING is
+  # on, and this job leaves it off.
   #
   # The build tree and the dependency directory are moved out of the way first.
   # Without that this passes on paths that happen to still be there, which is

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1615,11 +1615,12 @@ if(ENABLE_TESTING AND NOT PYTHON_EXECUTABLE)
     set(ENABLE_TESTING OFF)
 endif()
 
-if(ENABLE_TESTING)
-    if (NOT BUILD_SHARED_LIBS)
-        set(ENABLE_TESTING OFF)
-    endif()
-endif()
+# Nothing forces ENABLE_TESTING off for a static build. The unit tests link
+# against a static libstp: the archives libstp does not absorb are on their own
+# link line, and the --exclude-libs localisation that would hide them from a
+# test is a shared-library link step that a static build never reaches. The
+# guard that used to sit here dated from 2016, and the per-target static link
+# handling it stood in for was deleted from AddSTPGTest.cmake in 2019.
 
 if(ENABLE_TESTING)
   enable_testing()


### PR DESCRIPTION
`ENABLE_TESTING` is forced off whenever `BUILD_SHARED_LIBS` is off, and `STATICCOMPILE` always turns `BUILD_SHARED_LIBS` off. The option is flipped silently, so a static configure that asks for tests gets none and still reports success — the same silent-no-op family as the unset `PYTHON_EXECUTABLE` case immediately above it. `scripts/build/build_static.sh` and `scripts/build/build_clang_static.sh` have both been passing `-DENABLE_TESTING=ON` into that for years.

#452 asks whether the restriction is real. It is not, any more.

### Where it came from

- `541f1883` (2016, "Don't test when building static binaries") introduced it, with a `message(STATUS "Cannot enable testing if shared libs are not built.")`. The same commit made `build_static.sh` pass `-DENABLE_TESTING=ON` and run `make check`, so the guard's job was to make that request a no-op rather than a build failure.
- `fd5e7435` (2019, "Fixing the mess that staticcompile was causing") deleted the static link handling from `AddSTPGTest.cmake` — the `LINK_SEARCH_START_STATIC` and `LINK_SEARCH_END_STATIC` properties set on each test target — instead of repairing it. The guard stayed, so nothing noticed.
- `d52dcf02` (2019) renamed the condition from `if (STATICCOMPILE)` to `if (NOT BUILD_SHARED_LIBS)`.

The explanatory `STATUS` message was dropped somewhere along the way, so today the option is flipped with nothing printed at all.

### Why it holds no longer

gtest is fetched and built as part of the tree, so it is a static library in either configuration. The `--exclude-libs` localisation in `lib/CMakeLists.txt` that hides libstp's absorbed archives from a test is a shared-library link step a static build never reaches — a static libstp exposes more to the tests, not less. And the `-fvisibility=hidden` exemption for test builds is orthogonal to shared versus static, firing correctly either way.

### Measured

Static `RelWithDebInfo`, CaDiCaL only, gcc 12.3.0, configured `-DSTATICCOMPILE=ON -DENABLE_TESTING=ON`:

- everything links, including all 160 gtest executables against a static `libstp.a`
- **165 of 165 ctest targets pass**, in 30 seconds

### CI

No job changes behaviour: none of the static jobs set `ENABLE_TESTING`, so they still build without tests. Two comments in the static Linux action gave the removed rule as the reason there are no tests there; they now give the actual one.

Closes #452