### PR TITLE
Totalise the chain-read rows the refinement lemmas are written over

### DIFF
--- a/lib/Incremental/IncrementalExactStack.cpp
+++ b/lib/Incremental/IncrementalExactStack.cpp
@@ -652,10 +652,10 @@ IncrementalSolver::Impl::exactStackCheckSat(
   IncrementalToSAT* tosat = static_cast<IncrementalToSAT*>(ensureAdapter());
   tosat->setAssumptions(&assumptions);
 
-  // Congruence axioms are encoded straight over the bit variables of the
-  // round registry's read symbols, and the block's cone may have needed
-  // only some of a symbol's bits (the frozen/lemma-only totalisation
-  // above covers the checker's symbols, not the registry rows). This
+  // Congruence and chain path axioms are encoded straight over the bit
+  // variables of the round registry's read and chain rows, and the block's
+  // cone may have needed only some of a symbol's bits (the frozen/lemma-only
+  // totalisation above covers the checker's symbols, not the rows). This
   // matters most for the hybrid below: a round routed here for an array
   // equality that simplified away runs ordinary read refinement with the
   // checker inactive.

--- a/lib/Incremental/IncrementalSolverImpl.h
+++ b/lib/Incremental/IncrementalSolverImpl.h
@@ -2718,6 +2718,33 @@ struct IncrementalSolver::Impl
     }
   }
 
+  // Every leaf emitChainReadLemmas() writes a path lemma over, for one
+  // chain table: the row symbol, the read index anchor, the fall-through
+  // base read symbol and both anchors of every level. They need whole
+  // encodings for the same reason the read rows do -- a
+  // partially-propagated-away symbol cannot carry an axiom -- and
+  // totalizeSymbol() drops the constants among them.
+  void totalizeChainTable(const ArrayTransformer::ChainReadsMap& table)
+  {
+    ScopedProfileTimer registryTimer(profile.enabled, profile.registryNs);
+    for (ArrayTransformer::ChainReadsMap::const_iterator it = table.begin();
+         it != table.end(); ++it)
+      for (ArrayTransformer::ChainIndexMap::const_iterator rit =
+               it->second.begin();
+           rit != it->second.end(); ++rit)
+      {
+        const ArrayTransformer::ChainRow& row = rit->second;
+        totalizeSymbol(row.symbol);
+        totalizeSymbol(row.indexAnchor);
+        totalizeSymbol(row.baseReadSymbol);
+        for (const ArrayTransformer::ChainLevel& lvl : row.levels)
+        {
+          totalizeSymbol(lvl.indexAnchor);
+          totalizeSymbol(lvl.valueAnchor);
+        }
+      }
+  }
+
   void totalizeRegistrySymbols()
   {
     // Only the refinement machinery encodes axioms over registry symbols,
@@ -2725,31 +2752,7 @@ struct IncrementalSolver::Impl
     if (bm->UserFlags.ackermannisation)
       return;
     totalizeReadTable(arrayRegistry.reads);
-
-    // The chain rows' lemma leaves need whole encodings for the same
-    // reason: a partially-propagated-away symbol cannot carry an axiom.
-    for (ArrayTransformer::ChainReadsMap::const_iterator it =
-             arrayRegistry.chains.begin();
-         it != arrayRegistry.chains.end(); ++it)
-      for (ArrayTransformer::ChainIndexMap::const_iterator rit =
-               it->second.begin();
-           rit != it->second.end(); ++rit)
-      {
-        const ArrayTransformer::ChainRow& row = rit->second;
-        totalizeSymbol(row.symbol);
-        if (row.indexAnchor.GetKind() == SYMBOL)
-          totalizeSymbol(row.indexAnchor);
-        if (!row.baseReadSymbol.IsNull() &&
-            row.baseReadSymbol.GetKind() == SYMBOL)
-          totalizeSymbol(row.baseReadSymbol);
-        for (const ArrayTransformer::ChainLevel& lvl : row.levels)
-        {
-          if (lvl.indexAnchor.GetKind() == SYMBOL)
-            totalizeSymbol(lvl.indexAnchor);
-          if (lvl.valueAnchor.GetKind() == SYMBOL)
-            totalizeSymbol(lvl.valueAnchor);
-        }
-      }
+    totalizeChainTable(arrayRegistry.chains);
   }
 
   // The same guarantee for the rows an extensionality round refines over.
@@ -2759,9 +2762,17 @@ struct IncrementalSolver::Impl
   // creation is memoised), so calling it before every refinement entry is
   // cheap, and necessary: the checker's lemma encodings can add rows
   // mid-round.
+  //
+  // The chain rows are covered here too, and not only in the registry pass:
+  // an exact-stack round reaches read refinement without ever running that
+  // pass, and a chain read's symbol is routinely only half-encoded (a read
+  // whose result is used through an extract blasts just the bits the
+  // extract takes). emitChainReadLemmas() then hands getEquals() a ~0u bit
+  // and refinement fails on a leaf it could have valued freely.
   void totalizeBatchRegistrySymbols()
   {
     totalizeReadTable(batchAT->arrayToIndexToRead);
+    totalizeChainTable(batchAT->chainReads);
   }
 
   size_t semanticCacheEntryCount() const

--- a/tests/query-files/array-write-chain-tests/chain-read-partial-encoding.smt2
+++ b/tests/query-files/array-write-chain-tests/chain-read-partial-encoding.smt2
@@ -1,0 +1,118 @@
+; RUN: %solver --array-equality -d %s | %OutputCheck %s
+;
+; A chain read whose value only reaches the encoding through an extract:
+; the bits the extract does not take are never bit-blasted, so the row
+; symbol's SAT binding has holes. The array-equality route reaches read
+; refinement through the exact-stack driver, which totalised the batch
+; table's READ rows only -- emitChainReadLemmas then handed getEquals a
+; bit with no SAT variable and the solve died on "Incremental array
+; refinement has an incomplete SAT binding for an axiom leaf". The chain
+; rows have to be totalised there too; an unencoded bit is unconstrained,
+; and a fresh variable is exactly what the blasted formula means by it.
+;
+; Reduced from a fuzzsmt QF_ABVFP query. The push/pop cycle matters: the
+; row is only half-encoded once the chain has been folded and unfolded
+; across levels, so the failure lands several check-sats in.
+;
+; CHECK: ^sat
+; CHECK: ^sat
+; CHECK: ^sat
+; CHECK: ^sat
+; CHECK: ^sat
+; CHECK: ^sat
+; CHECK: ^sat
+; CHECK: ^sat
+; CHECK: ^sat
+; CHECK: ^sat
+(set-logic  QF_ABVFP)
+(set-info :status unknown)
+(declare-fun v0 () Float128)
+(declare-fun v1 () (_ FloatingPoint 15 113))
+(declare-fun v2 () (_ FloatingPoint 15 113))
+(declare-fun v3 () (_ FloatingPoint 15 113))
+(declare-fun v4 () (_ FloatingPoint 8 24))
+(declare-fun rm5 () RoundingMode)
+(declare-fun v6 () (_ BitVec 14))
+(declare-fun a7 () (Array (_ FloatingPoint 15 113) (_ BitVec 1)))
+(declare-fun a8 () (Array (_ FloatingPoint 15 113) (_ FloatingPoint 15 113)))
+(declare-fun a9 () (Array (_ BitVec 6) (_ FloatingPoint 15 113)))
+(define-fun __fuzz_q () Bool
+(let ((e0 ((_ to_fp 15 113) #b00001011110000000111101111111111010011000001101011010111101101011000001110101010001101011001110000111110011011001010010010111100)))
+(let ((e1 ((_ to_fp 15 113) rm5 (_ bv1 1))))
+(let ((e2 (_ bv0 4)))
+(let ((e3 (bvlshr v6 ((_ zero_extend 10) e2))))
+(let ((e4 (store a9 ((_ extract 11 6) v6) e1)))
+(let ((e5 (store a8 v2 e0)))
+(let ((e6 (store e5 e0 v0)))
+(let ((e7 (select a9 ((_ extract 5 0) v6))))
+(let ((e8 (select e6 e0)))
+(let ((e9 (select e4 ((_ sign_extend 2) e2))))
+(let ((e10 (select a8 v2)))
+(let ((e11 (store e6 v2 e7)))
+(let ((e12 (store e11 v1 e8)))
+(let ((e13 ((_ to_fp_unsigned 5 11) roundTowardNegative e3)))
+(let ((e14 (fp.sub RTZ e9 ((_ to_fp 15 113) RNA v4))))
+(let ((e15 (fp.max e10 ((_ to_fp 15 113) RTZ e13))))
+(let ((e16 (fp.abs e0)))
+(let ((e17 (store e12 e14 e16)))
+(let ((e18 (store e17 v3 e0)))
+(let ((e19 (store e6 e15 e1)))
+(let ((e20 (select e18 e15)))
+(let ((e21 true))
+(let ((e22 (fp.isNormal e20)))
+(let ((e23 true))
+(let ((e24 true))
+(let ((e25 true))
+(let ((e26 false))
+(let ((e27 true))
+(let ((e28 true))
+(let ((e29 (distinct e19 e5)))
+(let ((e30 (and e22 e27 e25)))
+(let ((e31 (ite e29 e29 e26)))
+(let ((e32 true))
+(let ((e33 (not e30)))
+(let ((e34 (= e23 e33 e21)))
+(let ((e35 (xor e24 e32 e34)))
+(let ((e36 (=> e28 e31)))
+(let ((e37 false))
+(let ((e38 (or e36 e37)))
+(let ((e39 true))
+(let ((e40 (xor e39 e35)))
+(let ((e41 (= e40 e38 e38)))
+e41
+)))))))))))))))))))))))))))))))))))))))))))
+(check-sat)
+(push 1)
+(assert __fuzz_q)
+(check-sat)
+(pop 1)
+(push 1)
+(assert (not __fuzz_q))
+(check-sat)
+(pop 1)
+(push 1)
+(assert __fuzz_q)
+(check-sat)
+(pop 1)
+(push 1)
+(assert (not __fuzz_q))
+(check-sat)
+(pop 1)
+(push 1)
+(assert __fuzz_q)
+(check-sat)
+(pop 1)
+(push 1)
+(assert (not __fuzz_q))
+(check-sat)
+(pop 1)
+(push 1)
+(assert __fuzz_q)
+(check-sat)
+(pop 1)
+(push 1)
+(assert (not __fuzz_q))
+(check-sat)
+(pop 1)
+(assert __fuzz_q)
+(check-sat)


### PR DESCRIPTION
## The bug

`emitChainReadLemmas()` writes its path lemmas straight over the bit variables of a chain row's leaves — the row symbol, the read index anchor, the fall-through base read symbol and each level's anchors — via `getEquals()`, which has no notion of *"this bit never reached the solver"*.

A chain read's symbol is routinely only half-encoded. A read whose result is consumed through an extract leaves the remaining bits outside the block's cone, and `buildSymbolMap()` reports those as the `~0u` sentinel:

```
DBGLEAF [7844:@chain_read_k1014_k7820] width=7 present=1 bits=[2547 2551 2543 X X X X]
```

The incremental driver already totalises for exactly this reason, but only the registry pass covered the chain rows. An exact-stack round reaches read refinement without ever running that pass — it calls `totalizeBatchRegistrySymbols()`, which walked the read table alone — so the round died on its own guard instead of refining:

```
Fatal Error: Incremental array refinement has an incomplete SAT binding
for an axiom leaf: @chain_read_k1014_k7820
```

## The fix

Pull the chain walk out as `totalizeChainTable()` and call it from both totalisers, so the batch table's chain rows get the guarantee its read rows already had.

An unencoded bit is unconstrained — nothing in the CNF mentions it — so a fresh variable is exactly the meaning the blasted formula gives it. That is the same argument the read rows and the lemma-only extensionality symbols already rest on. The per-leaf `SYMBOL`/null tests are dropped because `totalizeSymbol()` makes them itself.

## Testing

Found by the fuzzer. Ten saved failures — QF_ABVFP and QF_AUFBV, spread across the array-equality, bv-abstraction and uf-ackermann option sets, with and without `push`/`pop` — are all this one bug. All ten now answer, and agree with bitwuzla.

`tests/query-files/array-write-chain-tests/chain-read-partial-encoding.smt2` is reduced from one of them (192 → 42 let-bindings). It fails against a pre-fix build and passes after. The push/pop cycle is load-bearing: the row is only half-encoded once the chain has folded and unfolded across levels, so the failure lands several `check-sat`s in.

Full suites pass: 821 query-file tests (9 unsupported, 0 failed) and 165/165 ctest.

The batch pipeline looks structurally immune to the same shape — it blasts the whole formula at once and `BVEXTRACT` blasts all of its child's bits — and a probe query built to trigger it there comes back `sat`.