### PR TITLE
Name the CryptoMiniSat flag the way the binary spells it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1233,7 +1233,7 @@ if (NOT USE_CRYPTOMINISAT STREQUAL "OFF")
 else()
   set(USE_CRYPTOMINISAT OFF)
 endif()
-add_feature_info(CryptoMiniSat USE_CRYPTOMINISAT "Enables CryptoMiniSat solver, allows --cryptominisat5 option")
+add_feature_info(CryptoMiniSat USE_CRYPTOMINISAT "Enables CryptoMiniSat solver, allows --cryptominisat option")
 
 # CryptoMiniSat >= 5.14 builds its own CaDiCaL -- the meelgroup fork, 2.1.3 as
 # of 5.14.7 -- and installs it beside itself, exported as an imported target


### PR DESCRIPTION
The feature summary printed at the end of a configure advertised `--cryptominisat5`:

```
 * CryptoMiniSat (required version >= 5.11), Enables CryptoMiniSat solver, allows --cryptominisat5 option
```

There is no such flag. `tools/stp/main.cpp` registers the backend as `--cryptominisat`, with no alias, so `stp --cryptominisat5 problem.smt2` is rejected by the argument parser. The one thing that line exists to tell you was the one thing it got wrong.

The name was correct once and outlived the option. This is the only occurrence left in the tree.

After:

```
 * CryptoMiniSat (required version >= 5.11), Enables CryptoMiniSat solver, allows --cryptominisat option
```