### PR TITLE
Export include directories, not targets, for SymFPU and ABC

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -286,24 +286,29 @@ target_link_libraries(stp
     PRIVATE ${stp_export_libs}
 )
 
-# SymFPU reaches further than the sources that name it. It is header-only, and
-# stp/FloatBlaster/symbolic_fp.h -- an internal header, but one any part of the
-# tree may include -- includes symfpu/core/unpackedFloat.h. So the tools and
-# tests that include it need SymFPU's include directory too, and listing them
-# one by one is a list that rots: it was already wrong by two targets when
-# first written.
+# SymFPU and ABC reach further than the sources that name them. SymFPU is
+# header-only, and stp/FloatBlaster/symbolic_fp.h -- an internal header, but one
+# any part of the tree may include -- includes symfpu/core/unpackedFloat.h; ABC
+# is reached the same way through stp/ToSat/BBNodeAIG.h. So the tools and tests
+# that include either need its include directory too, and listing them one by
+# one is a list that rots: it was already wrong by two targets when first
+# written.
 #
-# BUILD_INTERFACE, so it reaches everything in this build that links stp and
-# nothing at all in the exported STPTargets.cmake -- SymFPU is a target no
-# consumer of an installed STP has, and none of them need it: the headers STP
-# installs (c_interface.h, fp.hpp, uf.hpp) do not include it.
-target_link_libraries(stp INTERFACE $<BUILD_INTERFACE:SymFPU>)
-
-# And ABC, for the tools and tests that include stp/ToSat/BBNodeAIG.h. Only the
-# include directory travels this way; the archive is named on stp's own link
-# line above, and the handful of tests that call into ABC directly link it
+# The directories, not the targets. BUILD_INTERFACE means "when consumed from
+# the build tree", not "never exported": install(EXPORT) drops it, export()
+# keeps it. SymFPU and ABC are IMPORTED targets, which CMake exports as bare
+# names without complaint, so naming them here left the build-tree
+# STPTargets.cmake asking a consumer for -lSymFPU -lABC.
+#
+# An installed STP needs neither -- c_interface.h, fp.hpp and uf.hpp include
+# neither library. SYSTEM keeps the warning suppression both find modules set.
+# Only the include directory travels this way: ABC's archive is named on stp's
+# own link line above, and the tests that call into ABC directly link it
 # themselves because a shared libstp localises its symbols.
-target_link_libraries(stp INTERFACE $<BUILD_INTERFACE:ABC>)
+target_include_directories(stp SYSTEM INTERFACE
+    $<BUILD_INTERFACE:${SYMFPU_INCLUDE_DIRS}>
+    $<BUILD_INTERFACE:${ABC_INCLUDE_DIR}>
+)
 
 # ABC is interconnected enough that satisfying our ~30 entry points transitively
 # drags in most of the archive, including its vendored zlib and bzlib (gzopen,

--- a/tests/api/install/CMakeLists.txt
+++ b/tests/api/install/CMakeLists.txt
@@ -4,13 +4,20 @@ configure_file(
   @ONLY
 )
 
-add_test(
-  NAME uf-install-tree-public-header-consumer
-  COMMAND ${CMAKE_COMMAND}
-          -DSTP_TEST_CONFIG=$<CONFIG>
-          -P ${CMAKE_CURRENT_BINARY_DIR}/run-uf-public-header-consumer.cmake
-)
-set_tests_properties(
-  uf-install-tree-public-header-consumer
-  PROPERTIES LABELS "api;install;uf" TIMEOUT 300
-)
+# One consumer, both exported STPTargets.cmake files. export() and
+# install(EXPORT) write different content -- $<BUILD_INTERFACE:> survives in the
+# first and is dropped from the second -- so passing against one says nothing
+# about the other.
+foreach(_stp_export IN ITEMS install-tree build-tree)
+  add_test(
+    NAME uf-${_stp_export}-public-header-consumer
+    COMMAND ${CMAKE_COMMAND}
+            -DSTP_TEST_CONFIG=$<CONFIG>
+            -DSTP_CONSUMER_EXPORT=${_stp_export}
+            -P ${CMAKE_CURRENT_BINARY_DIR}/run-uf-public-header-consumer.cmake
+  )
+  set_tests_properties(
+    uf-${_stp_export}-public-header-consumer
+    PROPERTIES LABELS "api;install;uf" TIMEOUT 300
+  )
+endforeach()

--- a/tests/api/install/run-uf-public-header-consumer.cmake.in
+++ b/tests/api/install/run-uf-public-header-consumer.cmake.in
@@ -1,45 +1,61 @@
+# STP_CONSUMER_EXPORT picks which of the two exported STPTargets.cmake files
+# the consumer is pointed at. They are different files with different contents,
+# and only the install-tree one used to be tested: a build tree exports the
+# build interface, so anything wrapped in $<BUILD_INTERFACE:> that install()
+# would have dropped is still in it.
+if(NOT DEFINED STP_CONSUMER_EXPORT OR STP_CONSUMER_EXPORT STREQUAL "")
+  set(STP_CONSUMER_EXPORT "install-tree")
+endif()
+
 set(stp_build_dir "@PROJECT_BINARY_DIR@")
 set(consumer_source_dir
     "@CMAKE_CURRENT_SOURCE_DIR@/uf-public-header-consumer")
-set(scratch_dir "@CMAKE_CURRENT_BINARY_DIR@/uf-public-header-consumer-run")
+# Per export, so the two tests can run concurrently under ctest --parallel.
+set(scratch_dir
+    "@CMAKE_CURRENT_BINARY_DIR@/uf-consumer-run-${STP_CONSUMER_EXPORT}")
 set(stage_dir "${scratch_dir}/stage")
 set(consumer_build_dir "${scratch_dir}/build")
 
 file(REMOVE_RECURSE "${scratch_dir}")
-file(MAKE_DIRECTORY "${stage_dir}")
 
-set(install_command "@CMAKE_COMMAND@" --install "${stp_build_dir}")
-if(DEFINED STP_TEST_CONFIG AND NOT STP_TEST_CONFIG STREQUAL "")
-  list(APPEND install_command --config "${STP_TEST_CONFIG}")
-endif()
-execute_process(
-  COMMAND "@CMAKE_COMMAND@" -E env "DESTDIR=${stage_dir}" ${install_command}
-  RESULT_VARIABLE install_result
-  OUTPUT_VARIABLE install_stdout
-  ERROR_VARIABLE install_stderr
-)
-if(NOT install_result EQUAL 0)
-  message(FATAL_ERROR
-    "STP install failed (${install_result})\n${install_stdout}\n${install_stderr}")
-endif()
+if(STP_CONSUMER_EXPORT STREQUAL "build-tree")
+  set(stp_cmake_dir "${stp_build_dir}")
+else()
+  file(MAKE_DIRECTORY "${stage_dir}")
 
-# DESTDIR prepends the configured absolute prefix on Unix. Strip its leading
-# slash before joining so this remains a path below the test scratch tree.
-set(configured_prefix "@CMAKE_INSTALL_PREFIX@")
-string(REGEX REPLACE "^/+" "" relative_prefix "${configured_prefix}")
-set(staged_prefix "${stage_dir}/${relative_prefix}")
-
-function(staged_install_path output configured_path)
-  if(IS_ABSOLUTE "${configured_path}")
-    string(REGEX REPLACE "^/+" "" relative_path "${configured_path}")
-    set(result "${stage_dir}/${relative_path}")
-  else()
-    set(result "${staged_prefix}/${configured_path}")
+  set(install_command "@CMAKE_COMMAND@" --install "${stp_build_dir}")
+  if(DEFINED STP_TEST_CONFIG AND NOT STP_TEST_CONFIG STREQUAL "")
+    list(APPEND install_command --config "${STP_TEST_CONFIG}")
   endif()
-  set(${output} "${result}" PARENT_SCOPE)
-endfunction()
+  execute_process(
+    COMMAND "@CMAKE_COMMAND@" -E env "DESTDIR=${stage_dir}" ${install_command}
+    RESULT_VARIABLE install_result
+    OUTPUT_VARIABLE install_stdout
+    ERROR_VARIABLE install_stderr
+  )
+  if(NOT install_result EQUAL 0)
+    message(FATAL_ERROR
+      "STP install failed (${install_result})\n${install_stdout}\n${install_stderr}")
+  endif()
 
-staged_install_path(stp_cmake_dir "@STP_INSTALL_CMAKE_DIR@")
+  # DESTDIR prepends the configured absolute prefix on Unix. Strip its leading
+  # slash before joining so this remains a path below the test scratch tree.
+  set(configured_prefix "@CMAKE_INSTALL_PREFIX@")
+  string(REGEX REPLACE "^/+" "" relative_prefix "${configured_prefix}")
+  set(staged_prefix "${stage_dir}/${relative_prefix}")
+
+  function(staged_install_path output configured_path)
+    if(IS_ABSOLUTE "${configured_path}")
+      string(REGEX REPLACE "^/+" "" relative_path "${configured_path}")
+      set(result "${stage_dir}/${relative_path}")
+    else()
+      set(result "${staged_prefix}/${configured_path}")
+    endif()
+    set(${output} "${result}" PARENT_SCOPE)
+  endfunction()
+
+  staged_install_path(stp_cmake_dir "@STP_INSTALL_CMAKE_DIR@")
+endif()
 
 # CMAKE_PREFIX_PATH is a list, and all of it has to reach the consumer inside
 # one -D argument. execute_process() splits each element of its command on
@@ -87,7 +103,7 @@ execute_process(
 )
 if(NOT configure_result EQUAL 0)
   message(FATAL_ERROR
-    "UF install-tree consumer configure failed (${configure_result})\n"
+    "UF ${STP_CONSUMER_EXPORT} consumer configure failed (${configure_result})\n"
     "${configure_stdout}\n${configure_stderr}")
 endif()
 
@@ -103,7 +119,7 @@ execute_process(
 )
 if(NOT build_result EQUAL 0)
   message(FATAL_ERROR
-    "UF install-tree consumer build failed (${build_result})\n"
+    "UF ${STP_CONSUMER_EXPORT} consumer build failed (${build_result})\n"
     "${build_stdout}\n${build_stderr}")
 endif()
 
@@ -121,6 +137,6 @@ execute_process(
 )
 if(NOT test_result EQUAL 0)
   message(FATAL_ERROR
-    "UF install-tree consumer tests failed (${test_result})\n"
+    "UF ${STP_CONSUMER_EXPORT} consumer tests failed (${test_result})\n"
     "${test_stdout}\n${test_stderr}")
 endif()


### PR DESCRIPTION
`find_package(STP)` against a **build tree** could not link. A five-line consumer:

```cmake
cmake_minimum_required(VERSION 3.18)
project(bt C)
find_package(STP REQUIRED)
add_executable(bt main.c)
target_link_libraries(bt stp)
```

configures cleanly with `-DSTP_DIR=<build>`, then:

```
/usr/bin/ld: cannot find -lSymFPU: No such file or directory
/usr/bin/ld: cannot find -lABC: No such file or directory
```

## What was wrong

`lib/CMakeLists.txt` named the two targets in libstp's interface:

```cmake
target_link_libraries(stp INTERFACE $<BUILD_INTERFACE:SymFPU>)
target_link_libraries(stp INTERFACE $<BUILD_INTERFACE:ABC>)
```

with a comment saying `BUILD_INTERFACE` makes this reach everything in the build "and nothing at all in the exported STPTargets.cmake". That is not what it does. `BUILD_INTERFACE` means *when consumed from the build tree*: `install(EXPORT)` drops it, `export()` keeps it, because the build tree **is** the build interface. STP's two export files, from one shared build:

```
build/STPTargets.cmake:50     INTERFACE_LINK_LIBRARIES "SymFPU;ABC"
installed STPTargets.cmake    (no INTERFACE_LINK_LIBRARIES at all)
```

In a shared build those two names were not part of the build-tree interface — they were all of it.

## Why CMake did not object

`export()` refuses to write a link to a **non-imported** target that is missing from the export set, but writes an **imported** one through as a bare name with no diagnostic. Confirmed on a synthetic project:

| link interface holds | result |
| --- | --- |
| `add_library(RealHelper STATIC ...)` | `CMake Error ... export called with target "mylib" which requires target "RealHelper" that is not in any export set.` |
| `add_library(FakeImported INTERFACE IMPORTED GLOBAL)` | Configuring done / Generating done, `INTERFACE_LINK_LIBRARIES "FakeImported"` written |

`FindABC.cmake:185` is `add_library(ABC UNKNOWN IMPORTED GLOBAL)`; `FindSymFPU.cmake:94` is `add_library(SymFPU INTERFACE IMPORTED GLOBAL)`. The leniency assumes an imported target is one the consumer can recreate via `find_dependency()`, as `STPConfig.cmake.in` does for `cryptominisat5`. Nothing recreates these two, so the consumer fell through to the "assume it is a system library" rule and emitted `-lSymFPU -lABC`.

## Where it came from

Both lines arrived with the submodule removal:

```
23b27370 2026-08-23 Fetch SymFPU and CLI11 rather than carrying them as submodules
7bcde9b3 2026-08-23 Build ABC separately, so it is built once and not once per build directory
```

Before that, ABC's headers reached every target through a directory-scoped global (`7bcde9b3^:CMakeLists.txt:594`):

```cmake
include_directories(SYSTEM ${abc_SOURCE_DIR}/src)
```

which put nothing in any link interface. Moving off the global onto target properties is the right direction — the comment's point about a hand-maintained list of consumers rotting is a real one. Attaching to an *imported* target is what disabled the export check at the same moment.

## The fix

Only the include directories were ever wanted: ABC's archive is already named on `stp`'s own link line, and SymFPU is header-only.

```cmake
target_include_directories(stp SYSTEM INTERFACE
    $<BUILD_INTERFACE:${SYMFPU_INCLUDE_DIRS}>
    $<BUILD_INTERFACE:${ABC_INCLUDE_DIR}>
)
```

Same guard, wrapping a path instead of a target name. In-tree tools and tests still get the headers with no per-target list to maintain; the build-tree export gets real directories; the install export still gets nothing. `SYSTEM` preserves the warning suppression both find modules set via `INTERFACE_SYSTEM_INCLUDE_DIRECTORIES`.

## Test

The consumer test is parameterised by `STP_CONSUMER_EXPORT` and now runs against both exports. Previously only the install tree was covered — the half that worked. The two legs use separate scratch directories so they can run under `ctest --parallel`.

## Verified

- **The new test fails without the fix.** On the unfixed build: `uf-install-tree-... Passed`, `uf-build-tree-... ***Failed` with exactly `cannot find -lSymFPU` / `-lABC`. With the fix, both pass.
- `INTERFACE_LINK_LIBRARIES` is gone from the shared build-tree export entirely.
- The **static** build-tree export, where CMake must propagate private dependencies, now names only real archive paths — no `SymFPU`/`ABC`.
- Consuming translation units still receive `-isystem` (checked in `compile_commands.json`, 160 of them).
- Full suite green: 167/167.

## Not addressed

A static build's export still bakes absolute paths into whichever machine's dependency directory produced the package, and `cmake --install --prefix` still does not relocate the headers. Both are pre-existing and separate; the second is already noted in a CI comment.