### PR TITLE
Rename the parser types bison's api.prefix leaves behind

### DIFF
--- a/lib/Parser/CMakeLists.txt
+++ b/lib/Parser/CMakeLists.txt
@@ -66,6 +66,14 @@ foreach(_file ${TOLEX})
         ${CMAKE_CURRENT_BINARY_DIR}/lex${_file}.cpp
         ${CMAKE_CURRENT_BINARY_DIR}/parse${_file}.tab.cpp
     )
+    # api.prefix renames what a grammar exports, not the types it declares,
+    # so three grammars in one program leave three different `union yyalloc`
+    # and `yysymbol_kind_t` for LTO to report as ODR violations. Neither name
+    # reaches parse${_file}.tab.h, so the rename stays in this one file.
+    set_source_files_properties(parse${_file}.tab.cpp
+        PROPERTIES COMPILE_DEFINITIONS
+        "yyalloc=${_file}_yyalloc;yysymbol_kind_t=${_file}_yysymbol_kind_t")
+
     if (NOT MSVC)
         set_source_files_properties(lex${_file}.cpp
             PROPERTIES COMPILE_FLAGS


### PR DESCRIPTION
`lib/Parser/CMakeLists.txt` generates each grammar with `-Dapi.prefix={cvc|smt|smt2}`. That renames the symbols a parser exports — `yyparse` becomes `cvcparse`, and so on — but bison does not apply the prefix to two types it declares in the generated file: `yysymbol_kind_t`, whose enumerators differ per grammar, and `union yyalloc`, whose members do.

The generated `.tab.c` is copied to `.tab.cpp` and compiled as C++, where a namespace-scope type name has external linkage. Linking all three grammars into one program therefore leaves three mutually incompatible definitions of each of those two names.

No single translation unit can see the clash, so it is only diagnosed when building with LTO:

```
parsecvc.tab.c:555:7: warning: type 'union yyalloc' violates the C++ One Definition Rule [-Wodr]
  555 | union yyalloc
      |       ^
parsesmt2.tab.c:2004:7: note: a different type is defined in another translation unit
```

Neither name reaches `parse<grammar>.tab.h`, so renaming them per grammar is confined to the file that declares them and is invisible to every other translation unit.

Worth noting for anyone reading the generated output: flex already prefixes a `yyalloc` of its own. That one is a function in the generated scanner and is unrelated to bison's union, which is why these are spelled `<grammar>_yyalloc` rather than `<grammar>alloc` — the latter would have collided with it.

### Testing

A release build with `-DENABLE_LTO=ON` goes from four `-Wodr` warnings to none. Without LTO there is no observable change, since the warning cannot be diagnosed there in the first place.

Behaviour is unchanged. Every file in `tests/query-files` — 838 of them, 831 `.smt2`, 5 `.cvc` and 2 `.smt`, so all three grammars are exercised — was run through a binary built before and after the change with `--parse-only`. All 838 exit codes are identical, and the parser output matches; the only differing lines were the reported peak-memory figures, which is an artefact of the two binaries having been built with different options rather than anything to do with this change.
