### PR TITLE
Check the install tree with the build tree deleted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -666,6 +666,60 @@ jobs:
         "$stp" --version > /dev/null
         echo "ok: ignored the decoy ./lib/$soname"
 
+    # Everything above ran with the build tree still there, so nothing had
+    # established that the install tree stands on its own: a RUNPATH, a
+    # generated path or an exported target could point back into build/ and
+    # every check would still have passed. Delete it and use only what was
+    # installed. CMAKE_INSTALL_PREFIX is $GITHUB_WORKSPACE/install, set at
+    # configure time, so this is also the not-in-/usr/local case.
+    #
+    # This is the last step in the job; nothing after it may use build/.
+    - name: Use the install tree with the build tree deleted
+      run: |
+        rm -rf build
+        prefix="$GITHUB_WORKSPACE/install"
+
+        printf '%s\n' \
+          '(set-logic QF_BV)' \
+          '(declare-fun x () (_ BitVec 8))' \
+          '(assert (= (bvadd x x) (bvmul (_ bv2 8) x)))' \
+          '(check-sat)' \
+          '(exit)' > query.smt2
+
+        "$prefix/bin/stp" query.smt2 | grep -qx sat
+        echo "ok: installed stp solves a query"
+
+        # A find_package(STP) that cannot see this prefix does not fail: it
+        # keeps searching and settles on any other STP present, so the step
+        # would report on a package this job did not build. Pinning STP_DIR
+        # and switching the registries off is not enough on its own -- the
+        # system prefixes are still searched, and a stale /usr/local/lib/cmake/STP
+        # answers -- so the check that matters is asserting afterwards which
+        # package was actually resolved.
+        cmake -S tests/api/install/uf-public-header-consumer -B consumer \
+          -DSTP_DIR:PATH="$prefix/lib/cmake/STP" \
+          -DCMAKE_FIND_USE_PACKAGE_REGISTRY=OFF \
+          -DCMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY=OFF \
+          -G Ninja
+        grep -qx "STP_DIR:PATH=$prefix/lib/cmake/STP" consumer/CMakeCache.txt
+        cmake --build consumer --parallel "$(nproc)"
+        ctest --test-dir consumer --output-on-failure
+        echo "ok: consumer builds and runs against the installed package"
+
+        # The installed Python package, whose library_path.py comes from
+        # library_path.py.in_install and names the install prefix. The
+        # build-tree template is a different file, and it is the only one the
+        # ctest suite imports, so this is the first time the installed one is
+        # loaded at all.
+        PYTHONPATH="$prefix/pylib" python3 -c "
+        import stp
+        s = stp.Solver()
+        x = s.bitvec('x', width=8)
+        s.add(x + x != 2 * x)
+        assert s.check() is False, 'installed python module gave the wrong answer'
+        "
+        echo "ok: installed python module solves a query"
+
   # CryptoMiniSat and CaDiCaL in one binary. Every other Linux job enables
   # exactly one of them, so until this job existed nothing established that
   # the combination works -- the exclusions elsewhere were about build time,


### PR DESCRIPTION
The `gcc (cadical ...)` job already installs to a custom prefix (`$GITHUB_WORKSPACE/install`, set at configure time) and checks the installed binary runs from an unrelated directory. But all of that happened with the build tree still sitting there, so nothing established that the install tree stands on its own — a RUNPATH, a generated path or an exported target could point back into `build/` and every check would still pass.

This deletes `build/` and then uses only what was installed:

1. solve a query with the installed `stp`;
2. configure, build and run the install-tree consumer against the installed package;
3. import the installed Python module and solve with it.

No new job — one step appended to the job that was already the install-focused one. It is now last; nothing after it may use `build/`.

## Why the Python check is new coverage

`bindings/python/stp/library_path.py` is generated from two different templates: `library_path.py.in` for the build tree, which searches `CMAKE_LIBRARY_OUTPUT_DIRECTORY` and `$LD_LIBRARY_PATH`, and `library_path.py.in_install` for the install tree, which names `CMAKE_INSTALL_PREFIX` directly. The ctest suite runs against the build tree, so only the first was ever imported. The installed one had never been loaded by anything.

## Why the step asserts which package it resolved

`find_package(STP)` does not fail when the directory you pin has no package in it — it carries on through the system prefixes and takes any other STP it finds. I hit this while developing the step: with an install tree that was missing `lib/cmake/STP`, the consumer silently resolved `STP_DIR=/usr/local/lib/cmake/STP` — a stale STP from an unrelated build — and then failed on a path belonging to *that* build. The failure looked like a real result and was not.

Switching the two package registries off does not close it either; the system prefixes are still searched. So the step greps `CMakeCache.txt` afterwards for the `STP_DIR` it expected. Verified both ways: pointed at a bogus prefix, the configure still succeeds and resolves to `/usr/local/lib/cmake/STP`, and the assertion is what aborts the step.

On a clean runner there is no other STP, so this is insurance rather than a live problem — but it is the difference between a step that reports on our install tree and one that reports on whatever is lying around.

## Verified

Ran the step's script verbatim — extracted from the YAML, not retyped — against a shared build installed to a custom prefix with the build tree deleted:

```
ok: installed stp solves a query
ok: consumer builds and runs against the installed package
ok: installed python module solves a query
```

## Notes

Two things this step deliberately does not do, both of which fail today and are separate from it:

- **Relocating** the install tree afterwards. `CMakeLists.txt:224` sets `CMAKE_INSTALL_RPATH` to the absolute `CMAKE_INSTALL_FULL_LIBDIR` rather than `$ORIGIN/../lib` (macOS gets `@loader_path/../lib` at line 238, so this is ELF-only). Move the tree and the binary no longer finds its own `libstp` — on a machine with another one installed it loads that instead and crashes. `STPConfig.cmake`'s `STP_INCLUDE_DIRS` is absolute for the same reason.
- **`cmake --install --prefix`**, which does not relocate the headers, already noted in a comment in this job.

Both are worth fixing; neither belongs in this change.