### PR TITLE
Make the install RPATH relative, so an installation can be moved

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -720,6 +720,31 @@ jobs:
         "
         echo "ok: installed python module solves a query"
 
+        # And again from a different directory, which is what a packager
+        # staging into a temporary root or anyone unpacking a tarball
+        # elsewhere ends up with. This is what an absolute install RPATH
+        # breaks: the binary keeps looking where it was configured, and on a
+        # machine that has another libstp there it loads that one and crashes
+        # rather than reporting a missing library.
+        #
+        # The Python module is not retried here. Its library_path.py names
+        # ${prefix}/lib outright, so it is still tied to the configured
+        # prefix -- a separate matter from the RPATH.
+        mv "$prefix" "${prefix}-moved"
+        "${prefix}-moved/bin/stp" query.smt2 | grep -qx sat
+        ldd "${prefix}-moved/bin/stp" | grep -q "${prefix}-moved/bin/../lib/libstp"
+        echo "ok: relocated install tree runs and loads its own libstp"
+
+        cmake -S tests/api/install/uf-public-header-consumer -B consumer-moved \
+          -DSTP_DIR:PATH="${prefix}-moved/lib/cmake/STP" \
+          -DCMAKE_FIND_USE_PACKAGE_REGISTRY=OFF \
+          -DCMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY=OFF \
+          -G Ninja
+        grep -qx "STP_DIR:PATH=${prefix}-moved/lib/cmake/STP" consumer-moved/CMakeCache.txt
+        cmake --build consumer-moved --parallel "$(nproc)"
+        ctest --test-dir consumer-moved --output-on-failure
+        echo "ok: consumer builds against the relocated package"
+
   # CryptoMiniSat and CaDiCaL in one binary. Every other Linux job enables
   # exactly one of them, so until this job existed nothing established that
   # the combination works -- the exclusions elsewhere were about build time,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,17 +221,30 @@ else ()
     # (but later on when installing)
     SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
 
-    SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_FULL_LIBDIR}")
+    # Relative to the loading binary, so the installation can be moved. An
+    # absolute CMAKE_INSTALL_FULL_LIBDIR here means a relocated tree -- a
+    # packager's staging root, a tarball unpacked elsewhere -- has binaries
+    # looking for libstp where it was configured, not where it is. Where some
+    # other libstp is installed the loader finds that one instead, and the
+    # mismatch surfaces as a crash rather than as a missing library. macOS has
+    # always used @loader_path below; $ORIGIN is the ELF equivalent.
+    #
+    # The same expression serves executables in BINDIR and libraries in LIBDIR
+    # as long as the two are siblings: from LIBDIR, "../<libdir>" is LIBDIR.
+    #
+    # Nothing is set when LIBDIR is a system directory: the loader searches
+    # those anyway, and an RPATH into one is what distribution packaging
+    # checks object to.
+    LIST(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_FULL_LIBDIR}" isSystemDir)
+    IF("${isSystemDir}" STREQUAL "-1")
+        FILE(RELATIVE_PATH _stp_bindir_to_libdir
+             "${CMAKE_INSTALL_FULL_BINDIR}" "${CMAKE_INSTALL_FULL_LIBDIR}")
+        SET(CMAKE_INSTALL_RPATH "$ORIGIN/${_stp_bindir_to_libdir}")
+    ENDIF("${isSystemDir}" STREQUAL "-1")
 
     # add the automatically determined parts of the RPATH
     # which point to directories outside the build tree to the install RPATH
     SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-
-    # the RPATH to be used when installing, but only if it's not a system directory
-    LIST(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_FULL_LIBDIR}" isSystemDir)
-    IF("${isSystemDir}" STREQUAL "-1")
-        SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_FULL_LIBDIR}")
-    ENDIF("${isSystemDir}" STREQUAL "-1")
 
     if (APPLE)
       set(CMAKE_MACOSX_RPATH ON)


### PR DESCRIPTION
`CMAKE_INSTALL_RPATH` was the absolute `CMAKE_INSTALL_FULL_LIBDIR`, so a relocated install tree — a packager staging into a temporary root, a tarball unpacked somewhere other than where it was configured — left binaries looking for `libstp` at the configure-time path.

Observed before the change, on a tree installed to one prefix and then moved:

```
$ ldd <moved>/bin/stp | grep stp
	libstp.so.2.4 => /usr/local/lib/libstp.so.2.4      <-- not its own
$ <moved>/bin/stp query.smt2
Segmentation fault (core dumped)
```

Where no other `libstp` exists the symptom is a clean "not found" instead; where one does, the loader silently takes it and the version mismatch crashes.

## Change

```cmake
LIST(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_FULL_LIBDIR}" isSystemDir)
IF("${isSystemDir}" STREQUAL "-1")
    FILE(RELATIVE_PATH _stp_bindir_to_libdir
         "${CMAKE_INSTALL_FULL_BINDIR}" "${CMAKE_INSTALL_FULL_LIBDIR}")
    SET(CMAKE_INSTALL_RPATH "$ORIGIN/${_stp_bindir_to_libdir}")
ENDIF()
```

`$ORIGIN` is the ELF equivalent of the `@loader_path/../lib` macOS already uses a few lines below. The offset is computed rather than hardcoded so `lib64` layouts work, and one expression serves both executables and the library: from LIBDIR, `../<libdir>` is LIBDIR.

This also revives the `isSystemDir` test, which was dead. The unconditional `SET` above it assigned the same value for the non-system case and left it standing for the system case, so the test could not affect anything. Now a system LIBDIR gets no RPATH at all, which is what it was for — the loader searches those anyway, and an RPATH into one is what distribution packaging checks flag.

## Test

The step added in #1012 now also moves the tree and repeats.

**Running the binary is not by itself a test of this.** A relocated pre-fix binary still prints `sat`, because it loaded a `libstp` from the path it was built with. Verified:

```
does it still solve?  sat
which libstp:         .../scratchpad/vprefix/lib/libstp.so.2.4    <-- the old location
```

So the check that has teeth is asserting through `ldd` which library was actually resolved. With that in place, the whole step run verbatim against a pre-fix install exits 1 — the three non-relocated checks pass, the relocated one fails — and against a fixed install all five pass:

```
ok: installed stp solves a query
ok: consumer builds and runs against the installed package
ok: installed python module solves a query
ok: relocated install tree runs and loads its own libstp
ok: consumer builds against the relocated package
```

After the fix, `RUNPATH` is `[$ORIGIN/../lib]` on both `bin/stp` and `lib/libstp.so.2.4`, and the moved tree resolves `<moved>/bin/../lib/libstp.so.2.4`. The existing decoy check (a bogus `./lib/libstp.so.2.4` in the working directory) still passes.

## Not included

The installed Python module is left out of the relocated leg, and the PR comment says why: `bindings/python/stp/library_path.py` is generated from `library_path.py.in_install`, which writes `${prefix}/lib` literally, so it stays tied to the configured prefix. `PATHS` there is an ordered search list, so it is separately fixable — but the module may legitimately be installed outside the prefix (the default is the interpreter's site-packages), so a relative entry is only meaningful when it is not, and that is its own decision.