### PR TITLE
Drop the export(PACKAGE STP) call, which has been a no-op

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1659,10 +1659,14 @@ configure_file(STPConfigVersion.cmake.in
   "${PROJECT_BINARY_DIR}/${STP_CONFIG_VERSION_FILENAME}" @ONLY
 )
 
-# Export this package to the CMake user package registry
-# Now the user can just use find_package(STP) on their system
-export(PACKAGE STP)
-
+# No export(PACKAGE STP) here. Under CMP0090, NEW since the 3.18 baseline, it
+# writes nothing unless CMAKE_EXPORT_PACKAGE_REGISTRY is on, so the comment it
+# used to carry -- that find_package(STP) would then just work -- had not been
+# true for some time. Switching it back on would not be an improvement: a
+# registry entry lets find_package(STP) resolve to a build tree the caller
+# never named, which is hard to notice and harder to attribute. Point
+# CMAKE_PREFIX_PATH at an installation, or STP_DIR at the directory holding
+# STPConfig.cmake.
 
 # -----------------------------------------------------------------------------
 # Install the licences


### PR DESCRIPTION
`CMakeLists.txt` called `export(PACKAGE STP)` with the comment *"Now the user can just use find_package(STP) on their system"*. That has not been true since the CMake baseline rose: CMP0090 is `NEW` at 3.18, so `export(PACKAGE)` writes to the user package registry only when `CMAKE_EXPORT_PACKAGE_REGISTRY` is on.

Removed rather than re-enabled, and the replacement comment says why. A registry entry lets `find_package(STP)` resolve to a build tree the caller never named. That is easy to miss — configure succeeds, and whatever goes wrong later points at the package rather than at where it came from. I hit exactly this shape of problem while working on the install tree: a consumer silently resolved a stale STP from elsewhere on the machine and then failed on a path belonging to that build, which read as a real failure of the tree under test. `CMAKE_PREFIX_PATH` and `STP_DIR` name the STP you mean.

Only the write side goes. Reading the registry is the caller-side default and is untouched, so entries an earlier build already left in `~/.cmake/packages/STP` still answer — removing this stops new ones being added, it does not clean up old ones.

## Verified

- The build-tree package files are still generated: `STPConfig.cmake`, `STPConfigVersion.cmake` and `STPTargets.cmake` all appear in the build directory as before. `export(PACKAGE)` never produced those — `export(TARGETS ...)` and the two `configure_file()` calls just above it do.
- Reconfiguring adds no registry entry (22 before, 22 after), confirming the call was already doing nothing.