### PR TITLE
Run CodeQL weekly, cover the Python that ships, and fail on findings

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -161,3 +161,58 @@ jobs:
       with:
         category: "/language:${{ matrix.language }}"
         sarif_file: sarif-results/${{ matrix.language }}.sarif
+        # So the alerts are queryable by the step below rather than still
+        # being processed when it looks.
+        wait-for-processing: true
+
+    # A scan that finds something still exits 0: upload is failure-only, so
+    # findings do not fail the analysis, and the run is green either way. On a
+    # weekly schedule there is no pull request to annotate and nothing that
+    # says so out loud -- the alerts appear in the Security tab and wait to be
+    # noticed. Fail the job instead, so a new finding arrives as a broken
+    # scheduled run, which GitHub mails to whoever last edited the cron.
+    #
+    # Dismissed alerts are not open, so anything already triaged does not hold
+    # this red; only something new does.
+    - name: Report any open alerts
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        case "${{ matrix.language }}" in
+          cpp)    prefix=cpp/ ;;
+          python) prefix=py/  ;;
+          *)      echo "no rule-id prefix known for ${{ matrix.language }}"; exit 1 ;;
+        esac
+
+        # The upload waits for processing, but the alerts API can still lag it.
+        # Retrying is not optional: if every attempt failed and this treated
+        # that as "nothing found", the step would be silent in exactly the case
+        # it exists for.
+        body=""
+        for attempt in 1 2 3 4 5; do
+          if body=$(gh api \
+              "repos/${{ github.repository }}/code-scanning/alerts?state=open&per_page=100&ref=${{ github.ref }}"); then
+            break
+          fi
+          body=""
+          sleep 15
+        done
+        if [ -z "$body" ]; then
+          echo "Could not read the code scanning alerts API; not treating that as a clean scan."
+          exit 1
+        fi
+
+        open=$(printf '%s' "$body" | jq -r \
+          "[.[] | select(.rule.id | startswith(\"$prefix\"))]
+           | .[]
+           | \"  \(.rule.security_severity_level // .rule.severity)  \(.rule.id)\n      \(.most_recent_instance.location.path):\(.most_recent_instance.location.start_line)\"")
+
+        if [ -n "$open" ]; then
+          echo "Open ${{ matrix.language }} alerts on ${{ github.ref }}:"
+          echo "$open"
+          echo
+          echo "Fix them, or dismiss with a reason in the Security tab; a dismissed"
+          echo "alert does not count as open and will not keep this job red."
+          exit 1
+        fi
+        echo "ok: no open ${{ matrix.language }} alerts"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,13 +1,18 @@
 name: "CodeQL"
 
+# Weekly, not per-change. The C++ half builds STP with every backend, the unit
+# tests and the extra tools, then analyses the result, which made it the
+# longest job on every pull request -- for findings that are about the state of
+# the tree rather than about the change under review, and that are read in the
+# code scanning tab rather than in the pull request. Alerts are dated by the
+# scan that found them, so a week's lag is visible rather than silent.
+#
+# Not on the hour: GitHub delays scheduled runs when the minute is congested,
+# and midnight UTC is the worst of them.
 on:
-  push:
-    branches: [master]
-  pull_request:
-    branches: [master]
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * 1'
+    - cron: '37 3 * * 1'
 
 jobs:
   analyze:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -79,6 +79,31 @@ jobs:
         # fetched by the configure step below.
         ./scripts/deps/setup-cms.sh -DBUILD_SHARED_LIBS=ON
 
+    # The Python that ships is generated. bindings/python/stp/*.py.in become
+    # build/bindings/python/stp/*.py through configure_file, so a checkout
+    # contains no copy of them and the analysis saw only docs/conf.py, the AST
+    # kind generator and the fuzz scripts -- about 2500 lines, none of which
+    # ship -- while missing the ~1900-line ctypes module that users import.
+    # It had never produced an alert.
+    #
+    # configure_file runs at configure time, so this needs no compilation.
+    # bison and flex are here because find_package(... REQUIRED) for them runs
+    # before CMake reaches anything Python-related.
+    - name: Generate the Python bindings
+      if: matrix.language == 'python'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y bison cmake flex python3
+        cmake -S . -B build \
+          -DENABLE_AUTO_DOWNLOAD:BOOL=ON \
+          -DSTP_DEP_DIR:PATH="$GITHUB_WORKSPACE/deps/install" \
+          -DFETCHCONTENT_BASE_DIR:PATH="$GITHUB_WORKSPACE/deps/fetch" \
+          -DPYTHON_EXECUTABLE:PATH="$(which python3)"
+        # The point of the step; a silent skip would leave the analysis
+        # looking healthy while covering nothing that ships.
+        test -s build/bindings/python/stp/stp.py
+        echo "ok: generated $(wc -l < build/bindings/python/stp/stp.py) lines of bindings"
+
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4
       with:


### PR DESCRIPTION
Three changes to `codeql-analysis.yml`, in order of why.

## 1. Weekly, not per-change

The C++ leg builds STP with all three backends, the unit tests and the extra tools before analysing anything, which made CodeQL the longest job on every pull request. What it produces is a view of the tree rather than a verdict on the change, read in the Security tab rather than in the pull request.

The weekly cron was already there; this removes the `push` and `pull_request` triggers and keeps `workflow_dispatch`. Moved off the hour too — GitHub delays scheduled runs on congested minutes and midnight UTC is the worst of them.

Checked first that this cannot block merges: `master` has no branch protection, and its ruleset carries only `deletion` and `non_fast_forward`, so there are no required status checks.

## 2. The Python leg was analysing the wrong Python

The bindings are generated — `bindings/python/stp/*.py.in` become `build/bindings/python/stp/*.py` via `configure_file` — so a checkout contains no copy of them.

| | lines | ships? |
| --- | --- | --- |
| analysed before | 2476 — `docs/conf.py`, the AST kind generator, four fuzz scripts, two test helpers | no |
| never analysed | 1944 — the `ctypes` module users `import stp` to get | yes |

Consistent with that, the python leg has produced **zero alerts, ever**, open or closed.

`configure_file` runs at configure time, so generating them needs no compilation — just `cmake -S . -B build` before `init`. Verified locally: 1944 lines produced, no `@PLACEHOLDER@` left unsubstituted, and it passes `py_compile`. The step asserts the file exists rather than assuming it, because a silent skip would leave the analysis looking healthy while still covering nothing that ships.

## 3. You would not have heard about a finding

This is the part that matters most, and it was already true before this PR.

`upload: failure-only` means findings do not fail the analysis. The job exits 0 whether it found three critical alerts or none. Removing the pull request trigger takes away the one place that used to say otherwise, so a weekly scan would have deposited alerts in the Security tab and gone green.

So the job now queries the alerts after upload and fails if any are open. A new finding becomes a broken scheduled run, which GitHub mails to whoever last edited the cron — this PR edits it, so that will be whoever merges this.

Properties worth stating:

- **Dismissed alerts are not open**, so the eight already triaged do not hold it red. Only something new does.
- **Each language checks its own rule-id prefix**, so a Python finding does not fail the C++ leg, and the message names the leg that found it.
- **It fails if it cannot read the API**, rather than reporting a clean scan. Silence is the one answer this step must never give by accident.

Verified by running the extracted script against the live repository:

```
=== cpp gate ===
Open cpp alerts on refs/heads/master:
  critical  cpp/unsigned-difference-expression-compared-zero
      lib/NodeFactory/SimplifyingNodeFactory.cpp:3412
exit=1

=== python gate ===          ok: no open python alerts     exit=0
=== API unreachable ===      Could not read ... not treating that as a clean scan.   exit=1
=== unknown language ===     no rule-id prefix known for ruby   exit=1
```

The cpp case is a live demonstration rather than a contrived one: that alert is #10, fixed in #1018 and still open only because the scan of the fixed tree had not finished when I ran this.

## Trade-off

A regression introduced on a Monday afternoon is now found the following Monday rather than in review. That seems right for this analysis — its alerts are dated by the scan that found them, so the lag is visible rather than silent, and `workflow_dispatch` covers a change that deserves a scan before it lands.