### PR TITLE
Compare widths, not their unsigned difference, in BVZX

### DIFF
--- a/lib/NodeFactory/SimplifyingNodeFactory.cpp
+++ b/lib/NodeFactory/SimplifyingNodeFactory.cpp
@@ -3409,7 +3409,11 @@ ASTNode SimplifyingNodeFactory::CreateTerm(Kind kind, unsigned int width,
   {
     case stp::BVZX:
     {
-      if (width - children[0].GetValueWidth() > 0)
+      // Compared as widths, not as a difference: both are unsigned, so
+      // width - GetValueWidth() > 0 held whenever the two differed at all,
+      // and a narrowing BVZX reached CreateZeroConst() with a wrapped length
+      // instead of the FatalError below.
+      if (width > children[0].GetValueWidth())
       {
         ASTNode zero = bm.CreateZeroConst(width - children[0].GetValueWidth());
         result = NodeFactory::CreateTerm(BVCONCAT, width, zero, children[0]);


### PR DESCRIPTION
CodeQL reports nine open alerts. One of them is a real bug; the other eight cannot be closed by anything, for a reason worth knowing about.

## The real one

`lib/NodeFactory/SimplifyingNodeFactory.cpp`, `cpp/unsigned-difference-expression-compared-zero`:

```cpp
if (width - children[0].GetValueWidth() > 0)
{
  ASTNode zero = bm.CreateZeroConst(width - children[0].GetValueWidth());
  ...
}
else if (width == children[0].GetValueWidth()) { result = children[0]; }
else { FatalError("Negative zero extend", children[0]); }
```

`width` is `unsigned int` and `GetValueWidth()` returns `unsigned int`, so the difference wraps rather than going negative and the first test holds whenever the two widths differ *at all*. Two consequences:

- `FatalError("Negative zero extend")` is unreachable.
- A BVZX asked to narrow reaches `CreateZeroConst()` with a length near 2³² instead of being rejected.

Fixed by comparing the widths — `width > children[0].GetValueWidth()` — which is what the three branches were shaped to express. Whether a narrowing BVZX can be constructed today, the guard was not doing its job.

Checked for the pattern elsewhere: this is the only `x - y > 0` on widths in `lib/`, `include/` or `tools/`.

## The other eight are unclosable, not unfixed

They point at code that no longer exists:

- three in `lib/extlib-abc/**`, a path deleted with the submodules in `4f9356cc`;
- five `cpp/alloca-in-loop`, in `ConstantBitP_Multiplication.cpp` and `MutableASTNode.h` — neither of which contains an `alloca`. The first uses a fixed stack buffer with a `std::vector` fallback, the second `std::vector<RebuildFrame>`.

They survive because of a category mismatch:

| | category |
| --- | --- |
| alerts #1–#9 | `.github/workflows/codeql-analysis.yml:analyze/language:cpp` |
| alert #10, and every analysis run today | `/language:cpp` |

GitHub closes an alert when a later analysis **in the same category** stops reporting it. Once the workflow began setting `category:` explicitly, it started a new lineage, and the old alerts became orphans that no future scan can retire regardless of the code. Alert #9 was created 2020-08-31 and last updated 2023-07-17; master was analysed today and did not touch it.

That the one alert in the live category is a real bug, and all eight in the dead category are ghosts, is a good sign for the scanner and a bad one for the alert list.

**This PR does not clear them** — that is a repository-state change, not a code change, and there are three ways to do it with different consequences (dismiss them, delete the dead analyses, or set `category:` back to the old string so the next scan closes them itself). Worth deciding deliberately rather than as a side effect of a bug fix.

## Verified

Release build with `ENABLE_TESTING=ON`: 167/167 pass.