### PR TITLE
Let cmake --install --prefix relocate the headers and the package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1686,7 +1686,23 @@ install(FILES
 # -----------------------------------------------------------------------------
 # Create STPConfig file
 set(EXPORT_TYPE "installed")
-set(CONF_INCLUDE_DIRS "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
+# Relative to the config file, which knows where it is, rather than to the
+# prefix this build was configured with. STPConfig.cmake.in is configured
+# @ONLY, so ${STP_CMAKE_DIR} passes through and is evaluated by find_package()
+# in the installation the caller actually has. The imported target already
+# resolves its include directory this way through _IMPORT_PREFIX; this is the
+# variable half saying the same thing.
+# From wherever the config is actually installed: STP_INSTALL_CMAKE_DIR is a
+# cache variable, and is CMake/ rather than lib/cmake/STP on Windows.
+set(_stp_cmakedir "${STP_INSTALL_CMAKE_DIR}")
+if(NOT IS_ABSOLUTE "${_stp_cmakedir}")
+    set(_stp_cmakedir "${CMAKE_INSTALL_PREFIX}/${_stp_cmakedir}")
+endif()
+file(RELATIVE_PATH _stp_cmakedir_to_includedir
+     "${_stp_cmakedir}" "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
+set(CONF_INCLUDE_DIRS "\${STP_CMAKE_DIR}/${_stp_cmakedir_to_includedir}")
+unset(_stp_cmakedir)
+unset(_stp_cmakedir_to_includedir)
 configure_file(STPConfig.cmake.in
   "${PROJECT_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/${STP_CONFIG_FILENAME}" @ONLY
 )

--- a/STPConfig.cmake.in
+++ b/STPConfig.cmake.in
@@ -9,7 +9,11 @@
 
 # Compute paths
 get_filename_component(STP_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-set(STP_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@")
+# For an installed package this is written relative to this file, so that the
+# installation can be moved or staged under a different prefix than the one it
+# was configured with. get_filename_component resolves the ".." rather than
+# leaving them for the compiler command line.
+get_filename_component(STP_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@" ABSOLUTE)
 
 
 if ("@USE_CRYPTOMINISAT@" STREQUAL "ON")

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -336,5 +336,9 @@ install(TARGETS stp
     LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
     ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
     RUNTIME DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-    PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_FULL_INCLUDEDIR}/stp"
+    # Relative, like the three above it. An absolute destination is fixed when
+    # the cache is written, so `cmake --install --prefix` moved the libraries
+    # and left the headers behind -- and DESTDIR staging wrote them outside the
+    # staging root.
+    PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/stp"
 )

--- a/tests/api/install/CMakeLists.txt
+++ b/tests/api/install/CMakeLists.txt
@@ -4,11 +4,12 @@ configure_file(
   @ONLY
 )
 
-# One consumer, both exported STPTargets.cmake files. export() and
-# install(EXPORT) write different content -- $<BUILD_INTERFACE:> survives in the
-# first and is dropped from the second -- so passing against one says nothing
-# about the other.
-foreach(_stp_export IN ITEMS install-tree build-tree)
+# One consumer, three ways of producing the package it consumes: DESTDIR
+# staging, cmake --install --prefix, and the build tree. They fail differently
+# -- $<BUILD_INTERFACE:> survives export() and is dropped by install(EXPORT),
+# and an absolute install DESTINATION honours DESTDIR while ignoring --prefix
+# -- so passing under one says little about the others.
+foreach(_stp_export IN ITEMS install-tree install-prefix build-tree)
   add_test(
     NAME uf-${_stp_export}-public-header-consumer
     COMMAND ${CMAKE_COMMAND}

--- a/tests/api/install/run-uf-public-header-consumer.cmake.in
+++ b/tests/api/install/run-uf-public-header-consumer.cmake.in
@@ -1,8 +1,15 @@
-# STP_CONSUMER_EXPORT picks which of the two exported STPTargets.cmake files
-# the consumer is pointed at. They are different files with different contents,
-# and only the install-tree one used to be tested: a build tree exports the
-# build interface, so anything wrapped in $<BUILD_INTERFACE:> that install()
-# would have dropped is still in it.
+# STP_CONSUMER_EXPORT picks how the package the consumer is pointed at was
+# produced. Three ways, because they fail differently:
+#
+#   install-tree    DESTDIR staging, the packagers' route
+#   install-prefix  cmake --install --prefix, relocating at install time
+#   build-tree      export() rather than install(EXPORT)
+#
+# The two exported STPTargets.cmake files have different contents -- a build
+# tree exports the build interface, so anything wrapped in $<BUILD_INTERFACE:>
+# that install() would have dropped is still in it -- and an install(DESTINATION)
+# written as an absolute path honours DESTDIR while ignoring --prefix, so
+# passing under one of these says little about the others.
 if(NOT DEFINED STP_CONSUMER_EXPORT OR STP_CONSUMER_EXPORT STREQUAL "")
   set(STP_CONSUMER_EXPORT "install-tree")
 endif()
@@ -20,6 +27,58 @@ file(REMOVE_RECURSE "${scratch_dir}")
 
 if(STP_CONSUMER_EXPORT STREQUAL "build-tree")
   set(stp_cmake_dir "${stp_build_dir}")
+elseif(STP_CONSUMER_EXPORT STREQUAL "install-prefix")
+  # --prefix overrides CMAKE_INSTALL_PREFIX at install time, which only reaches
+  # destinations that were written relative to it. An absolute one -- as
+  # PUBLIC_HEADER used to be -- is fixed when the cache is written, so the
+  # libraries moved and the headers went to the configured prefix instead.
+  set(prefix_dir "${scratch_dir}/prefix")
+  file(MAKE_DIRECTORY "${prefix_dir}")
+  file(MAKE_DIRECTORY "${stage_dir}")
+  # DESTDIR prepends the whole prefix, leading slash and all.
+  string(REGEX REPLACE "^/+" "" _staged_prefix_rel "${prefix_dir}")
+  set(staged_prefix_dir "${stage_dir}/${_staged_prefix_rel}")
+
+  set(install_command
+      "@CMAKE_COMMAND@" --install "${stp_build_dir}" --prefix "${prefix_dir}")
+  if(DEFINED STP_TEST_CONFIG AND NOT STP_TEST_CONFIG STREQUAL "")
+    list(APPEND install_command --config "${STP_TEST_CONFIG}")
+  endif()
+  # DESTDIR as well, and not to weaken the check. --prefix only redirects
+  # destinations written relative to the prefix, and the Python bindings are
+  # deliberately not: PYTHON_LIB_INSTALL_DIR is the interpreter's
+  # site-packages, outside any prefix. Without a staging root that write needs
+  # root and the install dies there, before reaching anything this is about.
+  # Under DESTDIR it lands harmlessly beside the prefix instead, and what is
+  # asserted below is unchanged: the C and C++ package has to appear under the
+  # prefix that was asked for.
+  execute_process(
+    COMMAND "@CMAKE_COMMAND@" -E env "DESTDIR=${stage_dir}" ${install_command}
+    RESULT_VARIABLE install_result
+    OUTPUT_VARIABLE install_stdout
+    ERROR_VARIABLE install_stderr
+  )
+  if(NOT install_result EQUAL 0)
+    message(FATAL_ERROR
+      "STP install --prefix failed (${install_result})\n${install_stdout}\n${install_stderr}")
+  endif()
+
+  # Everything the package needs has to be under the prefix that was asked
+  # for. Searching rather than reconstructing the layout, so this checks where
+  # the files went instead of restating where they were meant to go.
+  file(GLOB_RECURSE _found_config "${staged_prefix_dir}/*/STPConfig.cmake")
+  file(GLOB_RECURSE _found_header "${staged_prefix_dir}/*/c_interface.h")
+  if(NOT _found_config)
+    message(FATAL_ERROR
+      "cmake --install --prefix put no STPConfig.cmake under ${staged_prefix_dir}")
+  endif()
+  if(NOT _found_header)
+    message(FATAL_ERROR
+      "cmake --install --prefix put no c_interface.h under ${staged_prefix_dir}; "
+      "an install DESTINATION is still absolute and ignored the new prefix")
+  endif()
+  list(GET _found_config 0 _found_config)
+  get_filename_component(stp_cmake_dir "${_found_config}" DIRECTORY)
 else()
   file(MAKE_DIRECTORY "${stage_dir}")
 


### PR DESCRIPTION
`cmake --install build --prefix /elsewhere` moved the libraries and left the headers behind, at the prefix the build was configured with. Without write access there it failed partway, leaving a half-populated tree with no `lib/cmake/STP` — and a consumer pointed at it then quietly resolved `find_package(STP)` to some other STP on the machine.

## Two absolute destinations

**`lib/CMakeLists.txt`** wrote `PUBLIC_HEADER` to `CMAKE_INSTALL_FULL_INCLUDEDIR`, fixed when the cache is written. The three destinations above it in the same call are relative:

```cmake
LIBRARY  DESTINATION "${CMAKE_INSTALL_LIBDIR}"                   # relative
ARCHIVE  DESTINATION "${CMAKE_INSTALL_LIBDIR}"                   # relative
RUNTIME  DESTINATION "${CMAKE_INSTALL_LIBDIR}"                   # relative
PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_FULL_INCLUDEDIR}/stp" # absolute
```

so this only ever made one of the four behave differently. It arrived in `fd3f0989` (2017-12-13), *"Using _FULL_ for dirs in CMakeLists"*:

```diff
-    PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_PREFIX}/${INCLUDEDIR}/stp"
+    PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_FULL_INCLUDEDIR}/stp"
```

— a swap of a hand-composed absolute path for the canonical spelling of the same one. Empty commit body; nothing suggests the absoluteness was the point.

**`CONF_INCLUDE_DIRS`** put the same path into the installed `STPConfig.cmake`, so `STP_INCLUDE_DIRS` named the prefix the package was built with rather than the one it is in. Now written relative to the config file, which knows where it is — the same way the imported target already resolves its include directory through `_IMPORT_PREFIX`. Derived from `STP_INSTALL_CMAKE_DIR` rather than an assumed `lib/cmake/STP`, since that is a cache variable and is `CMake/` on Windows.

## The test

A third leg on the install-tree consumer: install with `--prefix`, then require the package and the headers to appear under the prefix that was asked for — searching for them rather than reconstructing the expected layout, so it checks where files went instead of restating where they were meant to go.

Measured against the unfixed tree, which is what makes it a regression test:

```
uf-install-tree-public-header-consumer .....   Passed
uf-install-prefix-public-header-consumer ...***Failed
    cmake --install --prefix put no c_interface.h under ...
uf-build-tree-public-header-consumer .......   Passed
```

Reverting only the one `PUBLIC_HEADER` line reproduces exactly that, with the other two legs still green. With the fix, 3/3, and the full suite is 168/168.

Also verified by hand that the relocated `STPConfig.cmake` resolves `${STP_CMAKE_DIR}/../../../include` to a directory that really contains `stp/c_interface.h`, through both the prefix override and the staging root.

## Why the leg also sets DESTDIR

Not to weaken the check. The Python bindings install to the interpreter’s site-packages, which is outside any prefix by design (`PYTHON_LIB_INSTALL_DIR`), so `--prefix` leaves that write where it is — and without a staging root it needs root and the install dies there, before reaching anything this PR is about. Under `DESTDIR` it lands harmlessly beside the prefix, and the assertion is unchanged.

Worth stating plainly: **a whole-tree `cmake --install --prefix` still writes the Python module outside the prefix.** That is not fixed here. Making it follow the prefix would break the flow the README documents — `sudo cmake --install build` then `import stp` — unless the module also went somewhere on `sys.path`, so it is a decision about where the bindings belong rather than a typo.