### PR TITLE
Freeze the chain-read anchors the refinement lemmas are written over

### DIFF
--- a/lib/ToSat/ToSATAIG.cpp
+++ b/lib/ToSat/ToSATAIG.cpp
@@ -338,6 +338,23 @@ void ToSATAIG::add_cnf_to_solver(SATSolver& satSolver, Cnf_Dat_t* cnfData)
 
 void ToSATAIG::mark_variables_as_frozen(SATSolver& satSolver)
 {
+  // A bit that reached no SAT variable is marked with ~0u rather than
+  // omitted, so freezing has to skip it: the sentinel is not a variable
+  // index, and a backend that acts on setFrozen() writes out of bounds when
+  // handed it. A leaf with no mapping at all -- a constant anchor, or a
+  // symbol the blast never reached -- simply has no variables to keep.
+  const auto freezeLeaf = [&](const ASTNode& leaf) {
+    if (leaf.IsNull())
+      return;
+    ASTNodeToSATVar::const_iterator it = nodeToSATVar.find(leaf);
+    if (it == nodeToSATVar.end())
+      return;
+    const vector<unsigned>& v = it->second;
+    for (size_t i = 0, size = v.size(); i < size; ++i)
+      if (v[i] != ~((unsigned)0))
+        satSolver.setFrozen(v[i]);
+  };
+
   for (ArrayTransformer::ArrType::iterator it =
            arrayTransformer->arrayToIndexToRead.begin();
        it != arrayTransformer->arrayToIndexToRead.end(); it++)
@@ -347,27 +364,37 @@ void ToSATAIG::mark_variables_as_frozen(SATSolver& satSolver)
     for (ArrayTransformer::arrTypeMap::const_iterator arr_it = atm.begin();
          arr_it != atm.end(); arr_it++)
     {
-      // A bit that reached no SAT variable is marked with ~0u rather than
-      // omitted, so freezing has to skip it: the sentinel is not a variable
-      // index, and a backend that acts on setFrozen() writes out of bounds
-      // when handed it. The extensionality loop below already guards this.
       const ArrayTransformer::ArrayRead& ar = arr_it->second;
-      ASTNodeToSATVar::iterator it = nodeToSATVar.find(ar.index_symbol);
-      if (it != nodeToSATVar.end())
-      {
-        const vector<unsigned>& v = it->second;
-        for (size_t i = 0, size = v.size(); i < size; ++i)
-          if (v[i] != ~((unsigned)0))
-            satSolver.setFrozen(v[i]);
-      }
+      freezeLeaf(ar.index_symbol);
+      freezeLeaf(ar.symbol);
+    }
+  }
 
-      ASTNodeToSATVar::iterator it2 = nodeToSATVar.find(ar.symbol);
-      if (it2 != nodeToSATVar.end())
+  // The abstracted write-chain reads refine through their own table, and
+  // emitChainReadLemmas() writes its path lemmas over the same leaves the
+  // incremental driver totalises: the row symbol, the read index anchor,
+  // the fall-through base read symbol, and both anchors of every level.
+  // Those lemmas are added in later solve calls, so a backend that
+  // eliminates one of these leaves in the meantime is then handed a clause
+  // over an eliminated variable -- the simplifying MiniSat asserts on
+  // exactly that. Freezing the congruence rows above is not enough: a chain
+  // row's anchors need not appear in arrayToIndexToRead at all.
+  for (ArrayTransformer::ChainReadsMap::const_iterator cit =
+           arrayTransformer->chainReads.begin();
+       cit != arrayTransformer->chainReads.end(); cit++)
+  {
+    for (ArrayTransformer::ChainIndexMap::const_iterator rit =
+             cit->second.begin();
+         rit != cit->second.end(); rit++)
+    {
+      const ArrayTransformer::ChainRow& row = rit->second;
+      freezeLeaf(row.symbol);
+      freezeLeaf(row.indexAnchor);
+      freezeLeaf(row.baseReadSymbol);
+      for (const ArrayTransformer::ChainLevel& lvl : row.levels)
       {
-        const vector<unsigned>& v = it2->second;
-        for (size_t i = 0, size = v.size(); i < size; ++i)
-          if (v[i] != ~((unsigned)0))
-            satSolver.setFrozen(v[i]);
+        freezeLeaf(lvl.indexAnchor);
+        freezeLeaf(lvl.valueAnchor);
       }
     }
   }

--- a/tests/query-files/array-write-chain-tests/chain-reads-on-a-simplifying-backend.smt2
+++ b/tests/query-files/array-write-chain-tests/chain-reads-on-a-simplifying-backend.smt2
@@ -1,0 +1,77 @@
+; REQUIRES: minisat
+; RUN: %solver -d --simplifying-minisat %s | %OutputCheck %s
+; CHECK: ^sat
+; The chain-read refinement loop on a SAT backend that eliminates
+; variables. Same query as deep-chain-reads-sat, which the default
+; backend decides either way; on the simplifying Minisat this aborted in
+; SimpSolver::addClause_ on `!isEliminated(var(ps[i]))'.
+;
+; emitChainReadLemmas() writes its path lemmas in later solve calls, over
+; the row symbol, the read index anchor, the base read symbol and both
+; anchors of every level. ToSATAIG::mark_variables_as_frozen() froze only
+; the congruence rows in arrayToIndexToRead, and a chain row's anchors
+; need not appear there at all, so elimination was free to take one out
+; from under a lemma that had not been written yet.
+(set-logic QF_ABV)
+(declare-fun a () (Array (_ BitVec 8) (_ BitVec 8)))
+(declare-fun i0 () (_ BitVec 8))
+(declare-fun v0 () (_ BitVec 8))
+(assert (bvult v0 #xf0))
+(assert (bvult i0 #xfe))
+(declare-fun i1 () (_ BitVec 8))
+(declare-fun v1 () (_ BitVec 8))
+(assert (bvult v1 #xf0))
+(assert (bvult i1 #xfe))
+(declare-fun i2 () (_ BitVec 8))
+(declare-fun v2 () (_ BitVec 8))
+(assert (bvult v2 #xf0))
+(assert (bvult i2 #xfe))
+(declare-fun i3 () (_ BitVec 8))
+(declare-fun v3 () (_ BitVec 8))
+(assert (bvult v3 #xf0))
+(assert (bvult i3 #xfe))
+(declare-fun i4 () (_ BitVec 8))
+(declare-fun v4 () (_ BitVec 8))
+(assert (bvult v4 #xf0))
+(assert (bvult i4 #xfe))
+(declare-fun i5 () (_ BitVec 8))
+(declare-fun v5 () (_ BitVec 8))
+(assert (bvult v5 #xf0))
+(assert (bvult i5 #xfe))
+(declare-fun i6 () (_ BitVec 8))
+(declare-fun v6 () (_ BitVec 8))
+(assert (bvult v6 #xf0))
+(assert (bvult i6 #xfe))
+(declare-fun i7 () (_ BitVec 8))
+(declare-fun v7 () (_ BitVec 8))
+(assert (bvult v7 #xf0))
+(assert (bvult i7 #xfe))
+(declare-fun j0 () (_ BitVec 8))
+(declare-fun j1 () (_ BitVec 8))
+(declare-fun j2 () (_ BitVec 8))
+(declare-fun j3 () (_ BitVec 8))
+(declare-fun j4 () (_ BitVec 8))
+(declare-fun j5 () (_ BitVec 8))
+(declare-fun j6 () (_ BitVec 8))
+(declare-fun j7 () (_ BitVec 8))
+(declare-fun j8 () (_ BitVec 8))
+(declare-fun j9 () (_ BitVec 8))
+(declare-fun j10 () (_ BitVec 8))
+(declare-fun j11 () (_ BitVec 8))
+(declare-fun j12 () (_ BitVec 8))
+(declare-fun j13 () (_ BitVec 8))
+(assert (= (bvadd (select (store (store (store (store (store (store (store (store a i0 v0) i1 v1) i2 v2) i3 v3) i4 v4) i5 v5) i6 v6) i7 v7) j0) (select (store (store (store (store (store (store (store (store a i0 v0) i1 v1) i2 v2) i3 v3) i4 v4) i5 v5) i6 v6) i7 v7) j1) (select (store (store (store (store (store (store (store (store a i0 v0) i1 v1) i2 v2) i3 v3) i4 v4) i5 v5) i6 v6) i7 v7) j2) (select (store (store (store (store (store (store (store (store a i0 v0) i1 v1) i2 v2) i3 v3) i4 v4) i5 v5) i6 v6) i7 v7) j3) (select (store (store (store (store (store (store (store (store a i0 v0) i1 v1) i2 v2) i3 v3) i4 v4) i5 v5) i6 v6) i7 v7) j4) (select (store (store (store (store (store (store (store (store a i0 v0) i1 v1) i2 v2) i3 v3) i4 v4) i5 v5) i6 v6) i7 v7) j5) (select (store (store (store (store (store (store (store (store a i0 v0) i1 v1) i2 v2) i3 v3) i4 v4) i5 v5) i6 v6) i7 v7) j6) (select (store (store (store (store (store (store (store (store a i0 v0) i1 v1) i2 v2) i3 v3) i4 v4) i5 v5) i6 v6) i7 v7) j7) (select (store (store (store (store (store (store (store (store a i0 v0) i1 v1) i2 v2) i3 v3) i4 v4) i5 v5) i6 v6) i7 v7) j8) (select (store (store (store (store (store (store (store (store a i0 v0) i1 v1) i2 v2) i3 v3) i4 v4) i5 v5) i6 v6) i7 v7) j9) (select (store (store (store (store (store (store (store (store a i0 v0) i1 v1) i2 v2) i3 v3) i4 v4) i5 v5) i6 v6) i7 v7) j10) (select (store (store (store (store (store (store (store (store a i0 v0) i1 v1) i2 v2) i3 v3) i4 v4) i5 v5) i6 v6) i7 v7) j11) (select (store (store (store (store (store (store (store (store a i0 v0) i1 v1) i2 v2) i3 v3) i4 v4) i5 v5) i6 v6) i7 v7) j12) (select (store (store (store (store (store (store (store (store a i0 v0) i1 v1) i2 v2) i3 v3) i4 v4) i5 v5) i6 v6) i7 v7) j13)) #x54))
+(assert (bvult j0 j1))
+(assert (bvult j1 j2))
+(assert (bvult j2 j3))
+(assert (bvult j3 j4))
+(assert (bvult j4 j5))
+(assert (bvult j5 j6))
+(assert (bvult j6 j7))
+(assert (bvult j7 j8))
+(assert (bvult j8 j9))
+(assert (bvult j9 j10))
+(assert (bvult j10 j11))
+(assert (bvult j11 j12))
+(assert (bvult j12 j13))
+(check-sat)


### PR DESCRIPTION
`--simplifying-minisat` aborts on a query whose reads are abstracted over write chains:

```
stp: minisat/simp/SimpSolver.cc:152: bool Minisat::SimpSolver::addClause_(...):
     Assertion `!isEliminated(var(ps[i]))' failed.
```

### Cause

`ToSATAIG::mark_variables_as_frozen()` froze the reads in `arrayToIndexToRead` — each row's `index_symbol` and `symbol`. The abstracted write-chain reads live in a second table, `ArrayTransformer::chainReads`, and nothing froze theirs.

`emitChainReadLemmas()` writes a row's path lemmas in **later solve calls**, over the row symbol, the read index anchor, the fall-through base read symbol, and both anchors of every level. `getEquals()` reuses whatever SAT variables those leaves already carry from the bit-blast, creating fresh frozen ones only for a leaf with no mapping at all. So variable elimination was free to remove one of those leaves during the first solve, before the lemma naming it had been written. A chain row's anchors need not appear in `arrayToIndexToRead` at all, so freezing the congruence rows never covered them.

Confirmed under gdb at the failing clause: the two literals are the index anchors of a chain-read guard equality, and both report `isEliminated() == true` with `frozen == 0`.

### Fix

Freeze the chain-table leaves too — the same set the incremental driver already totalises in `totalizeChainTable()`, for the same reason. The repeated "freeze a node's bits" block becomes a lambda, keeping the `~0u` sentinel skip in one place and adding the two cases the chain table needs and the read table does not: a null leaf (a row without a fall-through has no `baseReadSymbol`) and a leaf that is a constant rather than a symbol.

Only the simplifying MiniSat family is affected. `Cadical::setFrozen` is a deliberate no-op — CaDiCaL restores an eliminated variable the moment a clause mentions it — and `makeBackend` refuses the simplifying MiniSat for the incremental driver outright.

The assertion is also what makes this loud. With assertions off the clause is accepted over a variable elimination has already committed and nothing re-establishes it, so the round's lemma need not hold of the model that comes back. That path is untested here.

### Test

`deep-chain-reads-sat.smt2` is already in the suite and aborts on the unfixed tree — it had only ever been run on the default backend. The new test is that query on the simplifying backend, next to the array-equality procedure's equivalent in `48-refinement-on-a-simplifying-backend.smt2`. Measured against the unfixed tree it aborts; against this one it answers `sat`, with `-d` checking the model.

### Verification

- Clean A/B in one build: pre-fix aborts (rc 134), post-fix answers `sat` — on the original fuzz option string and on both minimal triggers.
- 200 array-heavy suite queries under `--simplifying-minisat --array-equality -d` agree with the same flags minus the backend, and 400 produce no aborts or segfaults.
- Found by the fuzzer on a QF_ABVFP query, but nothing about it is floating-point: `--simplifying-minisat` plus anything that shifts which variables elimination takes reaches it — `--bb.fp-native-arith=1` and `--cnf-generation-effort=very-high` both do.