### PR TITLE
Have the ABC build write a compile-commands database

### DIFF
--- a/cmake/FindABC.cmake
+++ b/cmake/FindABC.cmake
@@ -118,6 +118,7 @@ if(NOT ABC_FOUND_SYSTEM)
 
     set(ABC_CMAKE_ARGS
         ${STP_EP_COMMON_CMAKE_ARGS}
+        -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
         "-DCMAKE_C_FLAGS=${CMAKE_C_FLAGS} ${ABC_EXTRA_FLAGS}"
         "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS} ${ABC_EXTRA_FLAGS}"
         # A static archive: it is linked into libstp.so, which is


### PR DESCRIPTION
Every other part of the build can be indexed by a clangd or clang-tidy that reads `compile_commands.json`, but ABC is configured as an external project with its own CMake invocation, and that invocation did not ask for one. Tooling pointed at the dependency tree therefore saw nothing for ABC.

This passes `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON` through with the rest of the forwarded configuration. One line, and it changes nothing about what gets built.