### PR TITLE
Correct the count of Windows CI jobs in the visibility note

### DIFF
--- a/include/stp/Util/Attributes.h
+++ b/include/stp/Util/Attributes.h
@@ -56,7 +56,7 @@ THE SOFTWARE.
 // compiled and dllimport for everyone else.
 //
 // The mechanism is currently dormant -- no shared MSVC build of STP is produced
-// (the only Windows CI job is STATICCOMPILE=ON, which forces BUILD_SHARED_LIBS
+// (both Windows CI jobs are STATICCOMPILE=ON, which forces BUILD_SHARED_LIBS
 // OFF), so neither __declspec arm is ever taken. It is kept correct so that
 // enabling a Windows DLL build later works.
 #if defined(STP_SHARED_LIB) && defined(STP_EXPORTS)


### PR DESCRIPTION
The note in `include/stp/Util/Attributes.h` explaining why the `__declspec` arms are dormant says the only Windows CI job is `STATICCOMPILE=ON`. There are two of them now — the MSVC MiniSat leg and the MinGW CaDiCaL leg — and both are static.

The conclusion is unchanged: neither arm is ever taken, because neither job produces a shared library. But the reason given should count the jobs that actually exist. Comment only.