### PR TITLE
Fail rather than silently skip the query-file tests without an executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1603,6 +1603,11 @@ if (BUILD_EXECUTABLES)
     find_package(CLI11 REQUIRED)
 endif()
 add_subdirectory(tools)
+include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/STPExecutableTargetGuard.cmake")
+stp_resolve_option_target_availability(
+  TARGET stp-bin
+  OPTION BUILD_EXECUTABLES
+  OUT_VAR STP_EXECUTABLE_AVAILABLE)
 add_subdirectory(bindings)
 add_feature_info(Executables BUILD_EXECUTABLES "Enables executables compilation")
 

--- a/cmake/modules/STPExecutableTargetGuard.cmake
+++ b/cmake/modules/STPExecutableTargetGuard.cmake
@@ -1,0 +1,41 @@
+# Resolve an option-controlled executable target exactly once, after the target
+# producer has been visited.  A supported option-OFF profile yields FALSE;
+# either inconsistent state is a configure error rather than a silent test
+# omission.
+function(stp_resolve_option_target_availability)
+  set(options)
+  set(one_value_args TARGET OPTION OUT_VAR)
+  cmake_parse_arguments(PARSE_ARGV 0 STP_TARGET_GUARD
+    "${options}" "${one_value_args}" "")
+
+  if(STP_TARGET_GUARD_UNPARSED_ARGUMENTS OR
+     NOT STP_TARGET_GUARD_TARGET OR
+     NOT STP_TARGET_GUARD_OPTION OR
+     NOT STP_TARGET_GUARD_OUT_VAR)
+    message(FATAL_ERROR
+      "stp_resolve_option_target_availability requires TARGET, OPTION, and OUT_VAR")
+  endif()
+  if(NOT DEFINED ${STP_TARGET_GUARD_OPTION})
+    message(FATAL_ERROR
+      "STP target availability guard: option ${STP_TARGET_GUARD_OPTION} is undefined")
+  endif()
+
+  set(stp_target_guard_option_value "${${STP_TARGET_GUARD_OPTION}}")
+  if(stp_target_guard_option_value)
+    if(NOT TARGET ${STP_TARGET_GUARD_TARGET})
+      message(FATAL_ERROR
+        "STP target availability mismatch: ${STP_TARGET_GUARD_OPTION} is enabled "
+        "but target ${STP_TARGET_GUARD_TARGET} is absent")
+    endif()
+    set(stp_target_guard_available TRUE)
+  else()
+    if(TARGET ${STP_TARGET_GUARD_TARGET})
+      message(FATAL_ERROR
+        "STP target availability mismatch: ${STP_TARGET_GUARD_OPTION} is disabled "
+        "but target ${STP_TARGET_GUARD_TARGET} exists")
+    endif()
+    set(stp_target_guard_available FALSE)
+  endif()
+
+  set(${STP_TARGET_GUARD_OUT_VAR} "${stp_target_guard_available}" PARENT_SCOPE)
+endfunction()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -355,7 +355,7 @@ option(TEST_QUERY_FILES
        ON
       )
 
-if(TEST_QUERY_FILES)
+if(TEST_QUERY_FILES AND STP_EXECUTABLE_AVAILABLE)
     add_subdirectory(query-files)
 endif()
 


### PR DESCRIPTION
`TEST_QUERY_FILES` drives every test that runs the `stp` binary against a query file. With `BUILD_EXECUTABLES=OFF` there is no binary to run, and the suite did not notice: the tests were still registered, and CTest reported the run as green, because `add_test` with a missing command is not an error the default configuration surfaces. A configuration that looked like it was testing the query files was testing nothing.

A profile that builds no executable is supported, so the answer is not to force one — it is to know which case we are in.

This resolves the target once, after the directory that would have produced it has been visited, and gates the query-file suite on the result. A supported option-OFF profile yields FALSE and the suite is skipped deliberately. Anything inconsistent — the option on with no target, or off with one — is a configure error, because it means the build no longer matches what this file assumes about it.

Full suite passes with the guard in place.