### PR TITLE
Keep the AST hash-cons tables usable after a failed allocation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -903,10 +903,12 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(unordereddense)
 message(STATUS "ankerl::unordered_dense ${UNORDERED_DENSE_VERSION}: ${unordereddense_SOURCE_DIR}")
 
+include(cmake/PrepareUnorderedDense.cmake)
+
 # SYSTEM, and project-wide because stp/AST/AST.h reaches it: upstream code
 # whose warnings STP does not control, compiled into nearly every translation
 # unit here.
-include_directories(SYSTEM ${unordereddense_SOURCE_DIR}/include)
+include_directories(SYSTEM ${STP_UNORDERED_DENSE_INCLUDE_DIR})
 
 # -----------------------------------------------------------------------------
 # ABC

--- a/cmake/PrepareUnorderedDense.cmake
+++ b/cmake/PrepareUnorderedDense.cmake
@@ -1,0 +1,120 @@
+# Prepare the exact pinned unordered_dense header used by STP.  STP's
+# allocation-failure contract needs two narrowly scoped fixes: a non-allocating
+# same-allocator swap and access to the container's integral insertion
+# threshold.  Generate the derived header in the build tree so the current
+# upstream FetchContent dependency remains authoritative and pristine.
+
+set(_stp_unordered_dense_source_header
+    "${unordereddense_SOURCE_DIR}/include/ankerl/unordered_dense.h")
+set(_stp_unordered_dense_source_sha256
+    "b5f67c6895a58e059273cf24bae16cb07e6c72f0e3f88bbebecaddd987b102b3")
+
+if(NOT EXISTS "${_stp_unordered_dense_source_header}")
+  message(FATAL_ERROR
+      "Pinned ankerl::unordered_dense header is absent: "
+      "${_stp_unordered_dense_source_header}")
+endif()
+file(SHA256 "${_stp_unordered_dense_source_header}"
+     _stp_unordered_dense_observed_sha256)
+if(NOT _stp_unordered_dense_observed_sha256 STREQUAL
+       _stp_unordered_dense_source_sha256)
+  message(FATAL_ERROR
+      "ankerl::unordered_dense ${UNORDERED_DENSE_VERSION} header identity "
+      "mismatch: expected ${_stp_unordered_dense_source_sha256}, observed "
+      "${_stp_unordered_dense_observed_sha256}")
+endif()
+
+file(READ "${_stp_unordered_dense_source_header}"
+     _stp_unordered_dense_content)
+
+set(_stp_unordered_dense_swap_anchor [=[
+    void swap(table& other) noexcept(noexcept(std::is_nothrow_swappable_v<value_container_type> &&
+                                              std::is_nothrow_swappable_v<Hash> && std::is_nothrow_swappable_v<KeyEqual>)) {
+        using std::swap;
+        swap(other, *this);
+    }
+]=])
+set(_stp_unordered_dense_swap_replacement [=[
+    void swap(table& other) noexcept(noexcept(std::is_nothrow_swappable_v<value_container_type> &&
+                                              std::is_nothrow_swappable_v<Hash> && std::is_nothrow_swappable_v<KeyEqual>)) {
+        using std::swap;
+        if (get_allocator() == other.get_allocator()) {
+            // Swapping the table object through std::swap selects the generic
+            // move-construction path. table's move assignment reinitializes
+            // the moved-from bucket array, which allocates and can therefore
+            // terminate inside this noexcept function. Swap the complete
+            // representation directly when the allocators agree; this is the
+            // ordinary/default-allocator case and performs no allocation.
+            swap(m_values, other.m_values);
+            swap(m_buckets, other.m_buckets);
+            swap(m_max_bucket_capacity, other.m_max_bucket_capacity);
+            swap(m_max_load_factor, other.m_max_load_factor);
+            swap(m_hash, other.m_hash);
+            swap(m_equal, other.m_equal);
+            swap(m_shifts, other.m_shifts);
+            return;
+        }
+        swap(other, *this);
+    }
+]=])
+
+set(_stp_unordered_dense_bucket_anchor [=[
+    auto bucket_count() const noexcept -> size_t { // NOLINT(modernize-use-nodiscard)
+        return m_buckets.size();
+    }
+
+    static constexpr auto max_bucket_count() noexcept -> size_t { // NOLINT(modernize-use-nodiscard)
+]=])
+set(_stp_unordered_dense_bucket_replacement [=[
+    auto bucket_count() const noexcept -> size_t { // NOLINT(modernize-use-nodiscard)
+        return m_buckets.size();
+    }
+
+    // STP's hash-cons tables need to know whether the next insert can rebuild
+    // the bucket array. Expose the container's already-computed integral
+    // threshold so callers never reconstruct it through the floating
+    // load-factor API.
+    [[nodiscard]] auto stp_insertion_may_rehash() const noexcept -> bool {
+        return 0 == bucket_count() ||
+               size() >= static_cast<size_t>(m_max_bucket_capacity);
+    }
+
+    static constexpr auto max_bucket_count() noexcept -> size_t { // NOLINT(modernize-use-nodiscard)
+]=])
+
+foreach(_stp_anchor IN ITEMS swap bucket)
+  string(FIND "${_stp_unordered_dense_content}"
+         "${_stp_unordered_dense_${_stp_anchor}_anchor}" _stp_anchor_first)
+  string(FIND "${_stp_unordered_dense_content}"
+         "${_stp_unordered_dense_${_stp_anchor}_anchor}" _stp_anchor_last
+         REVERSE)
+  if(_stp_anchor_first LESS 0 OR NOT _stp_anchor_first EQUAL _stp_anchor_last)
+    message(FATAL_ERROR
+        "Pinned unordered_dense ${_stp_anchor} patch anchor is not unique")
+  endif()
+  string(REPLACE "${_stp_unordered_dense_${_stp_anchor}_anchor}"
+                 "${_stp_unordered_dense_${_stp_anchor}_replacement}"
+                 _stp_unordered_dense_content
+                 "${_stp_unordered_dense_content}")
+endforeach()
+
+set(STP_UNORDERED_DENSE_INCLUDE_DIR
+    "${PROJECT_BINARY_DIR}/generated-extlib-unordered-dense/include")
+set(_stp_unordered_dense_output_header
+    "${STP_UNORDERED_DENSE_INCLUDE_DIR}/ankerl/unordered_dense.h")
+file(MAKE_DIRECTORY "${STP_UNORDERED_DENSE_INCLUDE_DIR}/ankerl")
+file(WRITE "${_stp_unordered_dense_output_header}"
+     "${_stp_unordered_dense_content}")
+
+unset(_stp_unordered_dense_content)
+unset(_stp_unordered_dense_observed_sha256)
+unset(_stp_unordered_dense_output_header)
+unset(_stp_unordered_dense_source_header)
+unset(_stp_unordered_dense_source_sha256)
+unset(_stp_unordered_dense_swap_anchor)
+unset(_stp_unordered_dense_swap_replacement)
+unset(_stp_unordered_dense_bucket_anchor)
+unset(_stp_unordered_dense_bucket_replacement)
+unset(_stp_anchor)
+unset(_stp_anchor_first)
+unset(_stp_anchor_last)

--- a/lib/STPManager/STPManager.cpp
+++ b/lib/STPManager/STPManager.cpp
@@ -30,6 +30,7 @@ THE SOFTWARE.
 #include "stp/Printer/SMTLIBPrinter.h"
 #include "stp/Util/CBVOps.h"
 #include "stp/Util/NodeIterator.h"
+#include <algorithm>
 #include <cmath>
 #include <cstdint>
 #include <sstream>
@@ -49,6 +50,29 @@ void STPMgr::noteAIGBudgetExhausted(int nodeCount)
   soft_timeout_expired = true;
 }
 
+namespace
+{
+// unordered_dense grows its value array before it grows/rebuilds the bucket
+// array.  An allocation failure while rebuilding the latter leaves the
+// container valid for destruction but not for another lookup.  AST hash-cons
+// tables must remain usable after a caught allocation failure, so perform a
+// potentially-growing reserve on a copy and publish it only after every
+// allocation succeeds.  This is paid only at geometric growth boundaries;
+// ordinary inserts retain the normal constant-time path.
+template <class DenseTable>
+void prepareStrongDenseInsert(DenseTable& table)
+{
+  if (!table.stp_insertion_may_rehash())
+    return;
+
+  DenseTable grown(table);
+  const std::size_t requested =
+      std::max<std::size_t>(table.size() + 1, table.size() * 2 + 8);
+  grown.reserve(requested);
+  table.swap(grown);
+}
+} // namespace
+
 // Probe the unique table with a non-owning (kind, borrowed children) key. On
 // a hit nothing is built; only on a miss is the tail-allocated node created.
 ASTInterior* STPMgr::LookupOrCreateInterior(Kind kind, ASTChildren children)
@@ -66,9 +90,28 @@ ASTInterior* STPMgr::LookupOrCreateInterior(Kind kind, ASTChildren children)
     assert(children[0].GetKind() != NOT);
   }
 
+  prepareStrongDenseInsert(_interior_unique_table);
   ASTInterior* n_ptr = ASTInterior::create(this, kind, children);
-  _interior_unique_table.insert(n_ptr);
-  return n_ptr;
+  try
+  {
+    const std::pair<ASTInteriorSet::iterator, bool> inserted =
+        _interior_unique_table.insert(n_ptr);
+    if (inserted.second)
+      return n_ptr;
+
+    // There is no concurrent construction, so the earlier lookup makes this
+    // unreachable.  Keep ownership correct if that invariant ever changes.
+    ASTInterior* const existing = *inserted.first;
+    delete n_ptr;
+    return existing;
+  }
+  catch (...)
+  {
+    // The node has not acquired a public ASTNode reference yet.  Destroying it
+    // directly releases the child references copied into its tail allocation.
+    delete n_ptr;
+    throw;
+  }
 }
 
 ////////////////////////////////////////////////////////////////


### PR DESCRIPTION
STP creates every interior node through a hash-consing table, and an allocation failure in that table is not recoverable in the way callers assume.

`unordered_dense` grows its value array before it grows or rebuilds its bucket array, so a `bad_alloc` from the second leaves the container valid for destruction but not for another lookup. The node just built also leaks, because nothing owns it until the insert returns.

Neither matters if allocation failure only ever ends the process. Both matter as soon as a caller catches `bad_alloc` and carries on, which is what an application embedding STP under a memory ceiling does.

This does the growth on a copy and publishes it only once every allocation has succeeded, so the live table is either replaced or untouched and never half-rebuilt. The copy is paid only at geometric growth boundaries — ordinary inserts keep the normal constant-time path. It also owns the new node across the insert, so the node is destroyed rather than leaked if that insert throws.

Two things upstream `unordered_dense` does not expose are needed for this. Knowing whether the next insert can rebuild the buckets needs the container's own integral threshold rather than a reconstruction of it from the floating load factor. And swapping two same-allocator tables without allocating needs a swap that does not route through move assignment, which reinitializes the moved-from bucket array, allocates, and can therefore terminate inside a `noexcept` function. Since neither is available, the build derives a patched header in the build tree and leaves the fetched dependency pristine; the source is pinned by checksum and the patch fails closed if it does not apply exactly.

Full suite passes.