### PR TITLE
BV abstraction (1/6): give every abstraction an identity the lowering preserves

### DIFF
--- a/include/stp/ToSat/BVAbstractionRefiner.h
+++ b/include/stp/ToSat/BVAbstractionRefiner.h
@@ -49,10 +49,12 @@ THE SOFTWARE.
 
 #include "stp/AST/AST.h"
 #include "stp/STPManager/STPManager.h"
+#include "stp/ToSat/BVAbstractionTypes.h"
 #include "stp/ToSat/BVExactEncoder.h"
 #include "stp/ToSat/ToSATBase.h"
 
 #include <cstdint>
+#include <map>
 #include <vector>
 
 namespace stp
@@ -72,6 +74,8 @@ const unsigned BV_ABSTRACTION_NO_VAR = ~((unsigned)0);
 // equality and the record is never revisited.
 struct BVEQAbstraction
 {
+  BVAbstractionId id;
+  std::vector<BVAbstractionId> dependencies;
   ASTNode eqNode;
   unsigned abstractionSATVar = BV_ABSTRACTION_NO_VAR;
   ASTNode leftSymbol;
@@ -311,6 +315,8 @@ DLL_PUBLIC unsigned valueLemmaAllowance(const UserDefinedFlags& uf,
 
 struct BVTermAbstraction
 {
+  BVAbstractionId id;
+  std::vector<BVAbstractionId> dependencies;
   ASTNode termNode;
   Kind opKind;
   ASTNode operands[3];
@@ -353,6 +359,14 @@ class DLL_PUBLIC BVAbstractionRefiner
   std::vector<BVEQAbstraction> eqs_;
   std::vector<BVTermAbstraction> terms_;
 
+  struct RecordLocation
+  {
+    bool equality;
+    size_t index;
+  };
+  std::map<BVAbstractionId, RecordLocation> recordOfId_;
+  size_t indexedRecords_ = 0;
+
   // Monotone across the session, including across a clear(): a driver
   // compares it either side of a round to learn whether that round found
   // anything, and a counter that went backwards would read as no progress.
@@ -362,6 +376,7 @@ class DLL_PUBLIC BVAbstractionRefiner
                             const ToSATBase::ASTNodeToSATVar& nodeToSATVar);
   unsigned refineTerms(SATSolver& solver,
                        const ToSATBase::ASTNodeToSATVar& nodeToSATVar);
+  void rebuildRecordIndex();
 
 public:
   explicit BVAbstractionRefiner(STPMgr* bm_) : bm(bm_) {}
@@ -373,13 +388,21 @@ public:
   // The records, for whoever mints them. Everything a refinement round
   // learns is written back into them, so an owner that discards its SAT
   // solver or its bit-blast has to discard these too.
-  std::vector<BVEQAbstraction>& equalities() { return eqs_; }
-  std::vector<BVTermAbstraction>& terms() { return terms_; }
+  const std::vector<BVEQAbstraction>& equalities() const { return eqs_; }
+  const std::vector<BVTermAbstraction>& terms() const { return terms_; }
+
+  // File a record. The identity a producer minted travels with it, so
+  // everything downstream can name the operation a record came from rather
+  // than the position it happens to occupy in these vectors.
+  void appendEquality(BVEQAbstraction record);
+  void appendTerm(BVTermAbstraction record);
 
   void clear()
   {
     eqs_.clear();
     terms_.clear();
+    recordOfId_.clear();
+    indexedRecords_ = 0;
   }
 
   uint64_t refinements() const { return refinements_; }

--- a/include/stp/ToSat/BVAbstractionTypes.h
+++ b/include/stp/ToSat/BVAbstractionTypes.h
@@ -1,0 +1,68 @@
+/********************************************************************
+ * AUTHORS: Andrew Teylu
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#ifndef BVABSTRACTIONTYPES_H
+#define BVABSTRACTIONTYPES_H
+
+#include <cstdint>
+
+namespace stp
+{
+
+// Identity of one Boolean or bit-vector result introduced by BV abstraction.
+//
+// This is deliberately not a record-vector index. Records are copied from the
+// bit-blaster into more than one consumer, and the incremental SAT backend can
+// be rebuilt while the bit-blaster remains alive. The ID stays attached to the
+// producer for the lifetime of that word-to-AIG encoding epoch. A memory-relief
+// epoch rotation destroys every producer and every consumer together, after
+// which numbering may start over safely.
+class BVAbstractionId
+{
+  uint64_t value_;
+
+public:
+  BVAbstractionId() : value_(0) {}
+  explicit BVAbstractionId(uint64_t value) : value_(value) {}
+
+  bool valid() const { return value_ != 0; }
+  uint64_t value() const { return value_; }
+
+  bool operator==(const BVAbstractionId& other) const
+  {
+    return value_ == other.value_;
+  }
+  bool operator!=(const BVAbstractionId& other) const
+  {
+    return !(*this == other);
+  }
+  bool operator<(const BVAbstractionId& other) const
+  {
+    return value_ < other.value_;
+  }
+};
+
+} // namespace stp
+
+#endif

--- a/include/stp/ToSat/BitBlaster.h
+++ b/include/stp/ToSat/BitBlaster.h
@@ -28,6 +28,7 @@ THE SOFTWARE.
 #include "stp/STPManager/STPManager.h"
 #include "stp/Simplifier/constantBitP/MultiplicationStats.h"
 #include "stp/ToSat/BBNodeManagerAIG.h"
+#include "stp/ToSat/BVAbstractionTypes.h"
 #include "stp/Util/DagWalk.h"
 #include <cassert>
 #include <cmath>
@@ -419,6 +420,7 @@ class BitBlaster
   size_t fpNativeKnownPositiveMulPaths = 0;
   size_t fpNativeKnownNegativeMulPaths = 0;
   UserDefinedFlags* uf;
+  const bool allowAbstraction_ = true;
   NodeFactory* ASTNF;
   Simplifier* simp;
   BBNodeManagerAIG* nf;
@@ -426,8 +428,27 @@ class BitBlaster
   ASTNodeSet booth_recoded; // Nodes that have been recoded.
 
 public:
+  // The two result shapes are deliberately different types. An entry in one
+  // of these registries is proof that the returned AIG input was minted by an
+  // abstraction, and carries the producer identity with it; symbolToBBNode is
+  // still the general symbol/proxy compatibility registry and is not such
+  // proof.
+  struct BooleanAbstractionResult
+  {
+    BVAbstractionId producer;
+    BBNodeAIG bit;
+  };
+
+  struct BitVectorAbstractionResult
+  {
+    BVAbstractionId producer;
+    BBNodeVec bits;
+  };
+
   struct RawBVEQAbstraction
   {
+    BVAbstractionId id;
+    std::vector<BVAbstractionId> dependencies;
     ASTNode eqNode;
     BBNodeAIG abstractionCI;
     ASTNode leftSymbol;
@@ -445,6 +466,8 @@ public:
 
   struct RawBVTermAbstraction
   {
+    BVAbstractionId id;
+    std::vector<BVAbstractionId> dependencies;
     ASTNode termNode;
     Kind opKind;
     ASTNode operands[3];
@@ -461,6 +484,75 @@ public:
 
 private:
   std::vector<RawBVTermAbstraction> abstractedTerms_;
+  // The Boolean each abstracted equality and comparison was replaced by, so
+  // that a second occurrence of the same predicate reuses it.
+  //
+  // The term families get this from symbolToBBNode, which the node manager
+  // owns and which outlives a piece; a predicate is one Boolean rather than a
+  // vector and has no place there, so it has its own map. It is kept for the
+  // same reason and the reason is the incremental driver: BBForm clears its
+  // memo on every new root, so two conjuncts sharing a predicate ask for it
+  // independently, and minting a second Boolean for the second ask leaves two
+  // records over two inputs that are free to disagree. A predicate has one
+  // truth value wherever it occurs.
+  //
+  // Not cleared by ClearAllTables, which is deliberate and is what the raw
+  // record vectors beside it do: the abstraction state outlives the memos and
+  // is dropped only when the blaster is.
+  std::unordered_map<ASTNode, BooleanAbstractionResult,
+                     ASTNode::ASTNodeHasher,
+                     ASTNode::ASTNodeEqual>
+      abstractedFormulas_;
+  // Nodes whose blasted vector IS an abstraction's own result inputs.
+  //
+  // Constant-bit propagation must not rewrite one of these. The record was
+  // filed against those inputs and resolves them through the registry, while
+  // updateTerm rewrites the term MEMO -- so a bit it replaced with a constant
+  // would leave every parent that reads the term using a bit the record does
+  // not name, and the refinement pinning an input nothing reads.
+  //
+  // Nothing is lost by declining. Refinement pins the abstraction to the
+  // operands underneath it, which is a stronger statement than any single bit
+  // constant-bit propagation could fix, and the operands keep their own
+  // propagation either way.
+  std::unordered_map<ASTNode, BitVectorAbstractionResult,
+                     ASTNode::ASTNodeHasher, ASTNode::ASTNodeEqual>
+      abstractedResults_;
+
+  // Provenance is attached to AIG inputs because those are what survive all
+  // of the lowering's generated ASTs, memo aliases and proxy boundaries. An
+  // abstraction result input names exactly its producer. A proxy input names
+  // the producers reachable in the AIG bit it aliases. Internal-node results
+  // are memoised after an iterative walk; CI provenance never changes after
+  // that input is exposed to a parent.
+  uint64_t nextAbstractionId_ = 1;
+  std::unordered_map<unsigned, std::vector<BVAbstractionId>>
+      ciAbstractionSources_;
+  std::unordered_map<unsigned, std::vector<BVAbstractionId>>
+      aigAbstractionSourcesMemo_;
+
+  BVAbstractionId newAbstractionId();
+  void tagAbstractionSources(const BBNodeAIG& ci,
+                             const std::vector<BVAbstractionId>& sources);
+  BBNodeVec ensureProxyCIs(const ASTNode& node, const BBNodeVec& bits);
+  bool reuseRegisteredTerm(const ASTNode& term, unsigned width,
+                           BBNodeVec& reused) const;
+  // Operations already counted as abstraction candidates.
+  //
+  // bv_candidates says it counts operations reaching the bit-blaster at or
+  // above the width floor, and exists so that a flag which reached nothing
+  // eligible can be told from a flag that is broken. It was counted at the top
+  // of each abstraction arm, which is a bit-blaster VISIT: the incremental
+  // driver clears its term memo on every new root, so one operation is
+  // re-entered once per check-sat while bv_abstracted -- correctly -- counts
+  // the one record. Ten solves over one multiplication read mult=10->1, which
+  // says the abstraction took a tenth of what it could have.
+  //
+  // Counted once per node, so the ratio means what it is documented to mean
+  // and abstracted can never exceed candidates. In the batch pipeline the
+  // blaster lives for one query with one root, so nothing there moves.
+  std::unordered_set<ASTNode, ASTNode::ASTNodeHasher, ASTNode::ASTNodeEqual>
+      countedCandidates_;
   std::vector<BBNode> sideConstraints_;
 
 public:
@@ -472,6 +564,12 @@ public:
   {
     return sideConstraints_;
   }
+
+  // Direct producer IDs reachable from an AIG result. Walking the committed
+  // root gives assertion ownership; walking the operands before a new result
+  // is tagged gives that producer's parent-to-child dependencies.
+  std::vector<BVAbstractionId> abstractionSourcesOf(const BBNodeAIG& root);
+  std::vector<BVAbstractionId> abstractionSourcesOf(const BBNodeVec& bits);
   BitBlaster& operator=(const BitBlaster& other) = delete;
   BitBlaster(const BitBlaster& other) = delete;
   ~BitBlaster() { ClearAllTables(); }
@@ -520,10 +618,18 @@ public:
   std::unordered_map<ASTNode, BBNodeVec, ASTNode::ASTNodeHasher, ASTNode::ASTNodeEqual>::iterator
   simplify_during_bb(ASTNode& term, BBNodeSet& support);
 
+  // `allowAbstraction` is false for a blast whose circuit is itself the
+  // answer to an abstraction -- an exact escalation, or a lemma spliced onto
+  // an abstraction's own variables. Such a blast must not abstract anything:
+  // the record it minted would be against an AIG thrown away at the end of
+  // the call, so nothing could ever refine it. This used to be done by
+  // clearing the flags on the shared UserDefinedFlags for the duration, which
+  // meant one blast could see another's policy.
   BitBlaster(BBNodeManagerAIG* bnm, Simplifier* _simp, NodeFactory* astNodeF,
              UserDefinedFlags* _uf,
-             simplifier::constantBitP::ConstantBitPropagation* cb_ = NULL)
-      : uf(_uf)
+             simplifier::constantBitP::ConstantBitPropagation* cb_ = NULL,
+             bool allowAbstraction = true)
+      : uf(_uf), allowAbstraction_(allowAbstraction)
   {
     nf = bnm;
     cb = cb_;
@@ -531,6 +637,23 @@ public:
     BBFalse = nf->getFalse();
     simp = _simp;
     ASTNF = astNodeF;
+  }
+
+  // Whether this blast may replace a term or an equality with free inputs.
+  // Whether this operation has not been counted as a candidate before; see
+  // countedCandidates_.
+  bool firstCandidateSighting(const ASTNode& n)
+  {
+    return countedCandidates_.insert(n).second;
+  }
+
+  bool termAbstractionAllowed() const
+  {
+    return allowAbstraction_ && uf->bv_term_abstraction;
+  }
+  bool eqAbstractionAllowed() const
+  {
+    return allowAbstraction_ && uf->bv_eq_abstraction;
   }
 
   void ClearAllTables()

--- a/include/stp/ToSat/ToSATAIG.h
+++ b/include/stp/ToSat/ToSATAIG.h
@@ -84,6 +84,8 @@ private:
   // refines them. Both live here for the batch pipeline's lifetime of one
   // query; the incremental driver keeps its own across a session.
   BVAbstractionRefiner abstraction_;
+  // Whether this lowering may abstract at all; see the constructors.
+  bool allowAbstraction_ = true;
 
   void init() { first = true; }
 
@@ -101,8 +103,22 @@ public:
 
   bool cbIsDestructed() { return cb == NULL; }
 
-  ToSATAIG(STPMgr* bm, ArrayTransformer* at)
-      : ToSATBase(bm), toCNF(bm->UserFlags), abstraction_(bm)
+  // `allowAbstraction` is false for a lowering whose query must be encoded
+  // exactly whatever the session's flags say -- the same argument BitBlaster
+  // takes, reaching it from here so that a caller does not have to clear the
+  // manager's flags and put them back.
+  //
+  // maxPrecision is the one such caller: it drives this class over auxiliary
+  // queries a few bits wide, which gain nothing from abstracting, and its
+  // result handling reads the SOLVER_UNDECIDED a refinement round returns as
+  // an error from the backend. It used to save the two feature flags, clear
+  // them and restore them around its loop, which is a manager-wide write for
+  // a decision belonging to one encoding, invisible to anything else sharing
+  // the manager, and undone only on the paths that reach the bottom of the
+  // function.
+  ToSATAIG(STPMgr* bm, ArrayTransformer* at, bool allowAbstraction = true)
+      : ToSATBase(bm), toCNF(bm->UserFlags), abstraction_(bm),
+        allowAbstraction_(allowAbstraction)
   {
     cb = NULL;
     init();
@@ -110,8 +126,9 @@ public:
   }
 
   ToSATAIG(STPMgr* bm, simplifier::constantBitP::ConstantBitPropagation* cb_,
-           ArrayTransformer* at)
-      : ToSATBase(bm), cb(cb_), toCNF(bm->UserFlags), abstraction_(bm)
+           ArrayTransformer* at, bool allowAbstraction = true)
+      : ToSATBase(bm), cb(cb_), toCNF(bm->UserFlags), abstraction_(bm),
+        allowAbstraction_(allowAbstraction)
   {
     init();
     arrayTransformer = at;
@@ -129,6 +146,17 @@ public:
 
   bool hasBVEQAbstractions() const { return abstraction_.hasEqualities(); }
   bool hasBVTermAbstractions() const { return abstraction_.hasTerms(); }
+
+  // Test-only inspection: the term records this lowering filed. The invariant
+  // under test is that each carries its own result variables rather than
+  // relying on the AST-keyed registry, which holds one vector per node and so
+  // can name only the newest result registered for it. Nothing observable
+  // changes while canonical reuse holds, which is why it needs pinning here
+  // rather than by a query that would answer the same either way.
+  const std::vector<BVTermAbstraction>& termRecordsForTesting() const
+  {
+    return abstraction_.terms();
+  }
 
   unsigned refineAbstractions(SATSolver& solver) override;
   uint64_t abstractionRefinements() const override

--- a/lib/Incremental/IncrementalSolverImpl.h
+++ b/lib/Incremental/IncrementalSolverImpl.h
@@ -3698,6 +3698,8 @@ struct IncrementalSolver::Impl
       const BitBlaster::RawBVEQAbstraction& raw =
           rawEQs[harvestedEQAbstractions];
       BVEQAbstraction a;
+      a.id = raw.id;
+      a.dependencies = raw.dependencies;
       a.eqNode = raw.eqNode;
       a.abstractionSATVar = abstractionVarOf(raw.abstractionCI.symbol_index);
       a.leftSymbol = raw.leftSymbol;
@@ -3705,7 +3707,7 @@ struct IncrementalSolver::Impl
       a.width = std::max(1u, raw.leftSymbol.GetValueWidth());
       encodeAbstractionNode(a.leftSymbol);
       encodeAbstractionNode(a.rightSymbol);
-      bvAbstraction.equalities().push_back(std::move(a));
+      bvAbstraction.appendEquality(std::move(a));
     }
 
     const std::vector<BitBlaster::RawBVTermAbstraction>& rawTerms =
@@ -3716,6 +3718,8 @@ struct IncrementalSolver::Impl
       const BitBlaster::RawBVTermAbstraction& raw =
           rawTerms[harvestedTermAbstractions];
       BVTermAbstraction a;
+      a.id = raw.id;
+      a.dependencies = raw.dependencies;
       a.termNode = raw.termNode;
       a.opKind = raw.opKind;
       for (unsigned i = 0; i < raw.numOperands; i++)
@@ -3735,7 +3739,7 @@ struct IncrementalSolver::Impl
       if (raw.condCISymbolIndex >= 0)
         a.condSATVar = abstractionVarOf(raw.condCISymbolIndex);
       encodeAbstractionNode(a.termNode);
-      bvAbstraction.terms().push_back(std::move(a));
+      bvAbstraction.appendTerm(std::move(a));
     }
   }
 

--- a/lib/Simplifier/constantBitP/ConstantBitP_MaxPrecision.cpp
+++ b/lib/Simplifier/constantBitP/ConstantBitP_MaxPrecision.cpp
@@ -160,9 +160,6 @@ bool maxPrecision(vector<FixedBits*> children, FixedBits& output, Kind kind,
   bool printOutput = beev->UserFlags.print_output_flag;
   bool checkCounter = beev->UserFlags.check_counterexample_flag;
   bool constructCounter = beev->UserFlags.construct_counterexample_flag;
-  bool eqAbstraction = beev->UserFlags.bv_eq_abstraction;
-  bool termAbstraction = beev->UserFlags.bv_term_abstraction;
-
   beev->UserFlags.bitConstantProp_flag = false;
   beev->UserFlags.print_output_flag = false;
   beev->UserFlags.check_counterexample_flag = false;
@@ -170,15 +167,6 @@ bool maxPrecision(vector<FixedBits*> children, FixedBits& output, Kind kind,
   // without this flag CallSAT_ResultCheck never constructs the model, every
   // "model" reads as all-zero, and the loop cannot terminate.
   beev->UserFlags.construct_counterexample_flag = true;
-  // The BV abstraction turns CallSAT_ResultCheck into a refinement
-  // producer: it can answer SOLVER_UNDECIDED (2) with no arrays involved,
-  // returning before the model this loop is about to read is constructed.
-  // The result handling below reads 2 as "error from solver" and aborts --
-  // a refinement round taken for a broken backend. These auxiliary
-  // queries are a few bits wide and gain nothing from abstracting anyway,
-  // so run them exact.
-  beev->UserFlags.bv_eq_abstraction = false;
-  beev->UserFlags.bv_term_abstraction = false;
 
   ASTVec initialFixing;
 
@@ -246,7 +234,18 @@ bool maxPrecision(vector<FixedBits*> children, FixedBits& output, Kind kind,
   std::unique_ptr<SATSolver> newS_owner(createSATSolver(beev->UserFlags));
   SATSolver& newS = *newS_owner;
 
-  ToSATAIG tosat(beev, &at);
+  // Exactly, whatever the session's abstraction flags say. The BV abstraction
+  // turns CallSAT_ResultCheck into a refinement producer: it can answer
+  // SOLVER_UNDECIDED (2) with no arrays involved, returning before the model
+  // this loop is about to read is constructed, and the result handling below
+  // reads 2 as "error from solver" and aborts. These auxiliary queries are a
+  // few bits wide and gain nothing from abstracting anyway.
+  //
+  // Said to this encoding rather than by clearing the manager's flags and
+  // putting them back: that was a manager-wide write for a decision belonging
+  // to one lowering, invisible to anything else sharing the manager, and
+  // restored only on the paths that reach the bottom of this function.
+  ToSATAIG tosat(beev, &at, /*allowAbstraction=*/false);
 
   SATSolver::vec_literals satSolverClause;
 
@@ -325,8 +324,6 @@ bool maxPrecision(vector<FixedBits*> children, FixedBits& output, Kind kind,
   beev->UserFlags.print_output_flag = printOutput;
   beev->UserFlags.check_counterexample_flag = checkCounter;
   beev->UserFlags.construct_counterexample_flag = constructCounter;
-  beev->UserFlags.bv_eq_abstraction = eqAbstraction;
-  beev->UserFlags.bv_term_abstraction = termAbstraction;
 
   return first;
 }

--- a/lib/ToSat/BVAbstractionRefiner.cpp
+++ b/lib/ToSat/BVAbstractionRefiner.cpp
@@ -39,6 +39,54 @@ namespace stp
 // without reading a single bit. A round that refined an equality stops
 // there rather than going on to the terms -- the term scan reads the same
 // model, and what it would find in it has already been ruled out.
+void BVAbstractionRefiner::rebuildRecordIndex()
+{
+  recordOfId_.clear();
+  for (size_t i = 0; i < eqs_.size(); ++i)
+  {
+    if (!eqs_[i].id.valid())
+      continue;
+    [[maybe_unused]] const bool inserted =
+        recordOfId_.insert({eqs_[i].id, {true, i}}).second;
+    assert(inserted && "two BV abstraction records share one producer ID");
+  }
+  for (size_t i = 0; i < terms_.size(); ++i)
+  {
+    if (!terms_[i].id.valid())
+      continue;
+    [[maybe_unused]] const bool inserted =
+        recordOfId_.insert({terms_[i].id, {false, i}}).second;
+    assert(inserted && "two BV abstraction records share one producer ID");
+  }
+  indexedRecords_ = eqs_.size() + terms_.size();
+}
+
+void BVAbstractionRefiner::appendEquality(BVEQAbstraction record)
+{
+  assert(record.id.valid());
+  if (indexedRecords_ != eqs_.size() + terms_.size())
+    rebuildRecordIndex();
+  const size_t index = eqs_.size();
+  [[maybe_unused]] const bool inserted =
+      recordOfId_.insert({record.id, {true, index}}).second;
+  assert(inserted && "two BV abstraction records share one producer ID");
+  eqs_.push_back(std::move(record));
+  ++indexedRecords_;
+}
+
+void BVAbstractionRefiner::appendTerm(BVTermAbstraction record)
+{
+  assert(record.id.valid());
+  if (indexedRecords_ != eqs_.size() + terms_.size())
+    rebuildRecordIndex();
+  const size_t index = terms_.size();
+  [[maybe_unused]] const bool inserted =
+      recordOfId_.insert({record.id, {false, index}}).second;
+  assert(inserted && "two BV abstraction records share one producer ID");
+  terms_.push_back(std::move(record));
+  ++indexedRecords_;
+}
+
 unsigned BVAbstractionRefiner::refine(
     SATSolver& solver, const ToSATBase::ASTNodeToSATVar& nodeToSATVar)
 {

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -64,11 +64,109 @@ static std::vector<int> ciSymbolIndices(const BBNodeVec& bits)
 // For operands that contain internal AIG nodes (e.g. BVAND results),
 // create fresh proxy CIs with biconditional side constraints so that
 // downstream abstraction can proceed.
-static BBNodeVec ensureProxyCIs(
-    BBNodeManagerAIG* nf,
-    const ASTNode& node,
-    const BBNodeVec& bits,
-    std::vector<BBNode>& sideConstraints)
+static void appendAbstractionSources(
+    std::vector<BVAbstractionId>& into,
+    const std::vector<BVAbstractionId>& from)
+{
+  into.insert(into.end(), from.begin(), from.end());
+  std::sort(into.begin(), into.end());
+  into.erase(std::unique(into.begin(), into.end()), into.end());
+}
+
+BVAbstractionId BitBlaster::newAbstractionId()
+{
+  assert(nextAbstractionId_ != 0 &&
+         "the BV abstraction identity space wrapped");
+  return BVAbstractionId(nextAbstractionId_++);
+}
+
+void BitBlaster::tagAbstractionSources(
+    const BBNodeAIG& ci, const std::vector<BVAbstractionId>& sources)
+{
+  assert(!ci.IsNull());
+  Aig_Obj_t* regular = Aig_Regular(ci.n);
+  assert(Aig_ObjIsCi(regular));
+
+  std::vector<BVAbstractionId> normalized = sources;
+  std::sort(normalized.begin(), normalized.end());
+  normalized.erase(std::unique(normalized.begin(), normalized.end()),
+                   normalized.end());
+  for ([[maybe_unused]] const BVAbstractionId id : normalized)
+    assert(id.valid());
+
+  const unsigned aigId = Aig_ObjId(regular);
+  [[maybe_unused]] const auto inserted =
+      ciAbstractionSources_.insert(std::make_pair(aigId, normalized));
+  assert((inserted.second || inserted.first->second == normalized) &&
+         "an AIG input acquired two abstraction provenances");
+}
+
+std::vector<BVAbstractionId>
+BitBlaster::abstractionSourcesOf(const BBNodeAIG& root)
+{
+  if (root.IsNull())
+    return {};
+
+  Aig_Obj_t* rootRegular = Aig_Regular(root.n);
+  if (Aig_ObjIsConst1(rootRegular))
+    return {};
+  if (Aig_ObjIsCi(rootRegular))
+  {
+    const auto it = ciAbstractionSources_.find(Aig_ObjId(rootRegular));
+    return it == ciAbstractionSources_.end()
+               ? std::vector<BVAbstractionId>()
+               : it->second;
+  }
+
+  const unsigned rootId = Aig_ObjId(rootRegular);
+  const auto rootMemo = aigAbstractionSourcesMemo_.find(rootId);
+  if (rootMemo != aigAbstractionSourcesMemo_.end())
+    return rootMemo->second;
+
+  // Deep input terms reach tens of thousands of AIG levels in practice.
+  // Run the recursive two-visit post-order explicitly on the heap, computing
+  // each union only after both fanins. Memo hits also collapse shared cones.
+  typedef std::pair<Aig_Obj_t*, bool> PendingAig;
+  std::vector<PendingAig> pending(1, PendingAig(rootRegular, false));
+  while (!pending.empty())
+  {
+    Aig_Obj_t* node = Aig_Regular(pending.back().first);
+    const bool expanded = pending.back().second;
+    pending.pop_back();
+    if (Aig_ObjIsConst1(node) || Aig_ObjIsCi(node) ||
+        aigAbstractionSourcesMemo_.find(Aig_ObjId(node)) !=
+            aigAbstractionSourcesMemo_.end())
+      continue;
+    assert(Aig_ObjIsAnd(node));
+    if (!expanded)
+    {
+      pending.push_back(PendingAig(node, true));
+      pending.push_back(PendingAig(Aig_ObjFanin0(node), false));
+      pending.push_back(PendingAig(Aig_ObjFanin1(node), false));
+      continue;
+    }
+
+    std::vector<BVAbstractionId> sources =
+        abstractionSourcesOf(BBNodeAIG(Aig_ObjFanin0(node)));
+    appendAbstractionSources(
+        sources, abstractionSourcesOf(BBNodeAIG(Aig_ObjFanin1(node))));
+    aigAbstractionSourcesMemo_[Aig_ObjId(node)] = std::move(sources);
+  }
+
+  return aigAbstractionSourcesMemo_.at(rootId);
+}
+
+std::vector<BVAbstractionId>
+BitBlaster::abstractionSourcesOf(const BBNodeVec& bits)
+{
+  std::vector<BVAbstractionId> sources;
+  for (const BBNodeAIG& bit : bits)
+    appendAbstractionSources(sources, abstractionSourcesOf(bit));
+  return sources;
+}
+
+BBNodeVec BitBlaster::ensureProxyCIs(const ASTNode& node,
+                                     const BBNodeVec& bits)
 {
   auto it = nf->symbolToBBNode.find(node);
   if (it != nf->symbolToBBNode.end())
@@ -84,11 +182,14 @@ static BBNodeVec ensureProxyCIs(
   BBNodeVec proxies(width);
   for (unsigned i = 0; i < width; i++)
   {
+    const std::vector<BVAbstractionId> sources =
+        abstractionSourcesOf(bits[i]);
     proxies[i] = BBNodeAIG(Aig_ObjCreateCi(nf->aigMgr));
     proxies[i].symbol_index = nf->aigMgr->vCis->nSize - 1;
+    tagAbstractionSources(proxies[i], sources);
     Aig_Obj_t* bicond = Aig_Not(orderedAigExor(
         nf->aigMgr, proxies[i].n, bits[i].n));
-    sideConstraints.push_back(BBNodeAIG(bicond));
+    sideConstraints_.push_back(BBNodeAIG(bicond));
   }
   nf->symbolToBBNode[node] = proxies;
   return proxies;
@@ -115,9 +216,18 @@ static BBNodeVec ensureProxyCIs(
 // Incremental records also retain their own result variables, so a duplicate
 // that ever did arise would cost work rather than a verdict; canonicalising
 // here is the invariant, not the only line of defence.
-static bool reuseRegisteredTerm(BBNodeManagerAIG* nf, const ASTNode& term,
-                                unsigned width, BBNodeVec& reused)
+bool BitBlaster::reuseRegisteredTerm(const ASTNode& term, unsigned width,
+                                     BBNodeVec& reused) const
 {
+  const auto abstraction = abstractedResults_.find(term);
+  if (abstraction != abstractedResults_.end())
+  {
+    if (abstraction->second.bits.size() != width)
+      return false;
+    reused = abstraction->second.bits;
+    return true;
+  }
+
   const BBNodeManagerAIG::SymbolToBBNode::const_iterator it =
       nf->symbolToBBNode.find(term);
   if (it == nf->symbolToBBNode.end() || it->second.size() != width)
@@ -614,6 +724,29 @@ void BitBlaster::updateTerm(const ASTNode& n,
     return;
   }
 
+  // Never over an abstraction's own result inputs.
+  //
+  // The record was filed against those inputs and resolves them through
+  // symbolToBBNode, while this rewrites the term MEMO -- so a bit replaced
+  // here with a constant would leave every parent that reads the term using a
+  // bit the record does not name, and the refinement pinning an input nothing
+  // reads. The two would still agree about the value, because constant-bit
+  // propagation is sound, but the record would have stopped describing what
+  // the CNF computes, which is the property everything else in the refiner is
+  // written to preserve.
+  //
+  // This is a guard on an ordering, not a repair of an observed fault: on
+  // every query I could build, this function IS reached for abstracted
+  // results and constant-bit propagation DOES hold a FixedBits record for
+  // them, but that record has no fixed bit in it, so no rewrite ever
+  // happened. What the guard removes is the dependence on that staying true.
+  //
+  // Nothing is lost by declining. Refinement pins the abstraction to the
+  // operands underneath it, which is a stronger statement than any single bit
+  // this could fix, and the operands keep their own propagation regardless.
+  if (abstractedResults_.count(n) != 0)
+    return;
+
   bool bbFixed = false;
   for (int i = 0; i < (int)bb.size(); i++)
   {
@@ -1069,40 +1202,57 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term, BBNodeSet& support,
       const BBNodeVec& thn = BBTerm(term[1], support);
       const BBNodeVec& els = BBTerm(term[2], support);
 
-      if (num_bits >= uf->bv_abstraction_width)
+      if (num_bits >= uf->bv_abstraction_width &&
+          firstCandidateSighting(term))
         uf->coverage.bv_candidates[UserDefinedFlags::ABSTRACT_ITE]++;
 
-      if (uf->bv_term_abstraction && uf->bv_term_abstraction_ite &&
+      if (termAbstractionAllowed() && uf->bv_term_abstraction_ite &&
           num_bits >= uf->bv_abstraction_width)
       {
         {
           BBNodeVec reused;
-          if (reuseRegisteredTerm(nf, term, num_bits, reused))
+          if (reuseRegisteredTerm(term, num_bits, reused))
           {
             result = reused;
             break;
           }
         }
         uf->coverage.bv_abstracted[UserDefinedFlags::ABSTRACT_ITE]++;
-        ensureProxyCIs(nf, term[1], thn, sideConstraints_);
-        ensureProxyCIs(nf, term[2], els, sideConstraints_);
+        const BBNodeVec thnInputs = ensureProxyCIs(term[1], thn);
+        const BBNodeVec elsInputs = ensureProxyCIs(term[2], els);
+
+        std::vector<BVAbstractionId> dependencies =
+            abstractionSourcesOf(cond);
+        appendAbstractionSources(dependencies,
+                                 abstractionSourcesOf(thnInputs));
+        appendAbstractionSources(dependencies,
+                                 abstractionSourcesOf(elsInputs));
+        const BVAbstractionId id = newAbstractionId();
 
         BBNodeVec abstracted(num_bits);
         for (unsigned i = 0; i < num_bits; i++)
         {
           abstracted[i] = BBNodeAIG(Aig_ObjCreateCi(nf->aigMgr));
           abstracted[i].symbol_index = nf->aigMgr->vCis->nSize - 1;
+          tagAbstractionSources(abstracted[i], {id});
         }
         BBNodeAIG condCI(Aig_ObjCreateCi(nf->aigMgr));
         condCI.symbol_index = nf->aigMgr->vCis->nSize - 1;
+        // This is an operand proxy, not the ITE abstraction's answer. Keep
+        // the condition's producers on it so a future AIG alias does not
+        // turn the dependency cut into an unlabelled CI.
+        tagAbstractionSources(condCI, abstractionSourcesOf(cond));
 
         Aig_Obj_t* bicond = Aig_Not(orderedAigExor(
             nf->aigMgr, condCI.n, cond.n));
         sideConstraints_.push_back(BBNodeAIG(bicond));
 
         nf->symbolToBBNode[term] = abstracted;
+        abstractedResults_[term] = {id, abstracted};
 
         RawBVTermAbstraction raw;
+        raw.id = id;
+        raw.dependencies = std::move(dependencies);
         raw.termNode = term;
         raw.opKind = ITE;
         raw.operands[0] = term[0];
@@ -1208,8 +1358,7 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term, BBNodeSet& support,
       // keeps the n-ary adder it had. Addition is associative and commutative
       // modulo 2^n, so the tree computes the same value; the sort keeps the
       // shape it takes deterministic.
-      if (uf->bv_term_abstraction && uf->bv_term_abstraction_plus &&
-          uf->bvplus_variant &&
+      if (termAbstractionAllowed() && uf->bv_term_abstraction_plus &&
           term.Degree() > 2 && num_bits >= uf->bv_abstraction_width)
       {
         std::deque<ASTNode> names(term.begin(), term.end());
@@ -1226,7 +1375,8 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term, BBNodeSet& support,
         break;
       }
 
-      if (term.Degree() == 2 && num_bits >= uf->bv_abstraction_width)
+      if (term.Degree() == 2 && num_bits >= uf->bv_abstraction_width &&
+          firstCandidateSighting(term))
         uf->coverage.bv_candidates[UserDefinedFlags::ABSTRACT_PLUS]++;
 
       // A wide n-ary addition that was not decomposed above -- because the
@@ -1235,21 +1385,34 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term, BBNodeSet& support,
       // number comparable between a run with the flag and a run without,
       // which is the whole use of it: a zero has to mean "no wide addition
       // here", not "the flag that lowers them was off".
+      //
+      // Exactly the negation of the gate above, so the two cannot disagree
+      // about which additions the decomposition took. Restated in different
+      // terms they did: this one omitted bv_term_abstraction_plus, so turning
+      // that off alone gave the unreadable zero the count exists to prevent.
       if (term.Degree() > 2 && num_bits >= uf->bv_abstraction_width &&
-          !(uf->bv_term_abstraction && uf->bvplus_variant))
+          !(termAbstractionAllowed() && uf->bv_term_abstraction_plus) &&
+          firstCandidateSighting(term))
       {
         uf->coverage.bv_candidates[UserDefinedFlags::ABSTRACT_PLUS] +=
             term.Degree() - 1;
       }
 
-      if (uf->bv_term_abstraction && uf->bv_term_abstraction_plus &&
-          uf->bvplus_variant &&
+      // Not conditioned on bvplus_variant. That flag chooses between the two
+      // adder lowerings below -- pairwise BBPlus2 accumulation and the
+      // addition network -- and the abstraction reaches neither: it returns
+      // before them, and what it escalates to is spliced in at CNF level
+      // through BVExactEncoder. It sat in this condition by adjacency to the
+      // `if (uf->bvplus_variant)` block underneath, and the effect was that
+      // --bb.add-v2=0 silently abstracted no additions at all, which the fuzz
+      // harness draws often enough to have stopped covering this family.
+      if (termAbstractionAllowed() && uf->bv_term_abstraction_plus &&
           term.Degree() == 2 &&
           num_bits >= uf->bv_abstraction_width)
       {
         {
           BBNodeVec reused;
-          if (reuseRegisteredTerm(nf, term, num_bits, reused))
+          if (reuseRegisteredTerm(term, num_bits, reused))
           {
             result = reused;
             break;
@@ -1280,18 +1443,32 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term, BBNodeSet& support,
 
         if (!(negated[0] && negated[1]))
         {
+          // Constants included, as every other abstracted family does it: a
+          // constant operand gets a vector of inputs pinned to it. Left out,
+          // it is not in the registry refinement reads, and every round that
+          // touches the record has to mint a fresh pinned vector for it.
+          const BBNodeVec operandInputs[2] = {
+              ensureProxyCIs(realOp[0], *opVecs[0]),
+              ensureProxyCIs(realOp[1], *opVecs[1])};
+          std::vector<BVAbstractionId> dependencies =
+              abstractionSourcesOf(operandInputs[0]);
+          appendAbstractionSources(dependencies,
+                                   abstractionSourcesOf(operandInputs[1]));
+          const BVAbstractionId id = newAbstractionId();
+
           BBNodeVec abstracted(num_bits);
           for (unsigned i = 0; i < num_bits; i++)
           {
             abstracted[i] = BBNodeAIG(Aig_ObjCreateCi(nf->aigMgr));
             abstracted[i].symbol_index = nf->aigMgr->vCis->nSize - 1;
+            tagAbstractionSources(abstracted[i], {id});
           }
           uf->coverage.bv_abstracted[UserDefinedFlags::ABSTRACT_PLUS]++;
           nf->symbolToBBNode[term] = abstracted;
-          for (int i = 0; i < 2; i++)
-            if (realOp[i].GetKind() != BVCONST)
-              ensureProxyCIs(nf, realOp[i], *opVecs[i], sideConstraints_);
+          abstractedResults_[term] = {id, abstracted};
           RawBVTermAbstraction raw;
+          raw.id = id;
+          raw.dependencies = std::move(dependencies);
           raw.termNode = term;
           raw.opKind = BVPLUS;
           raw.operands[0] = realOp[0];
@@ -1388,33 +1565,42 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term, BBNodeSet& support,
       updateTerm(term[0], mpcd1, support);
       assert(mpcd1.size() == mpcd2.size());
 
-      if (num_bits >= uf->bv_abstraction_width)
+      if (num_bits >= uf->bv_abstraction_width &&
+          firstCandidateSighting(term))
         uf->coverage.bv_candidates[UserDefinedFlags::ABSTRACT_MULT]++;
 
-      if (uf->bv_term_abstraction && uf->bv_term_abstraction_mult &&
+      if (termAbstractionAllowed() && uf->bv_term_abstraction_mult &&
           num_bits >= uf->bv_abstraction_width)
       {
         {
           BBNodeVec reused;
-          if (reuseRegisteredTerm(nf, term, num_bits, reused))
+          if (reuseRegisteredTerm(term, num_bits, reused))
           {
             result = reused;
             break;
           }
         }
         uf->coverage.bv_abstracted[UserDefinedFlags::ABSTRACT_MULT]++;
-        BBNodeVec op0 = ensureProxyCIs(nf, term[0], mpcd1, sideConstraints_);
-        BBNodeVec op1 = ensureProxyCIs(nf, term[1], mpcd2, sideConstraints_);
+        const BBNodeVec op0 = ensureProxyCIs(term[0], mpcd1);
+        const BBNodeVec op1 = ensureProxyCIs(term[1], mpcd2);
+        std::vector<BVAbstractionId> dependencies =
+            abstractionSourcesOf(op0);
+        appendAbstractionSources(dependencies, abstractionSourcesOf(op1));
+        const BVAbstractionId id = newAbstractionId();
 
         BBNodeVec abstracted(num_bits);
         for (unsigned i = 0; i < num_bits; i++)
         {
           abstracted[i] = BBNodeAIG(Aig_ObjCreateCi(nf->aigMgr));
           abstracted[i].symbol_index = nf->aigMgr->vCis->nSize - 1;
+          tagAbstractionSources(abstracted[i], {id});
         }
         nf->symbolToBBNode[term] = abstracted;
+        abstractedResults_[term] = {id, abstracted};
 
         RawBVTermAbstraction raw;
+        raw.id = id;
+        raw.dependencies = std::move(dependencies);
         raw.termNode = term;
         raw.opKind = BVMULT;
         raw.operands[0] = term[0];
@@ -1448,33 +1634,43 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term, BBNodeSet& support,
       assert(dvdd.size() == num_bits);
       assert(dvsr.size() == num_bits);
 
-      if (num_bits >= uf->bv_abstraction_width)
+      if (num_bits >= uf->bv_abstraction_width &&
+          firstCandidateSighting(term))
         uf->coverage.bv_candidates[UserDefinedFlags::ABSTRACT_DIVMOD]++;
 
-      if (uf->bv_term_abstraction && uf->bv_term_abstraction_mult &&
+      if (termAbstractionAllowed() && uf->bv_term_abstraction_mult &&
           num_bits >= uf->bv_abstraction_width)
       {
         {
           BBNodeVec reused;
-          if (reuseRegisteredTerm(nf, term, num_bits, reused))
+          if (reuseRegisteredTerm(term, num_bits, reused))
           {
             result = reused;
             break;
           }
         }
         uf->coverage.bv_abstracted[UserDefinedFlags::ABSTRACT_DIVMOD]++;
-        ensureProxyCIs(nf, term[0], dvdd, sideConstraints_);
-        ensureProxyCIs(nf, term[1], dvsr, sideConstraints_);
+        const BBNodeVec dividendInputs = ensureProxyCIs(term[0], dvdd);
+        const BBNodeVec divisorInputs = ensureProxyCIs(term[1], dvsr);
+        std::vector<BVAbstractionId> dependencies =
+            abstractionSourcesOf(dividendInputs);
+        appendAbstractionSources(dependencies,
+                                 abstractionSourcesOf(divisorInputs));
+        const BVAbstractionId id = newAbstractionId();
 
         BBNodeVec abstracted(num_bits);
         for (unsigned i = 0; i < num_bits; i++)
         {
           abstracted[i] = BBNodeAIG(Aig_ObjCreateCi(nf->aigMgr));
           abstracted[i].symbol_index = nf->aigMgr->vCis->nSize - 1;
+          tagAbstractionSources(abstracted[i], {id});
         }
         nf->symbolToBBNode[term] = abstracted;
+        abstractedResults_[term] = {id, abstracted};
 
         RawBVTermAbstraction raw;
+        raw.id = id;
+        raw.dependencies = std::move(dependencies);
         raw.termNode = term;
         raw.opKind = k;
         raw.operands[0] = term[0];
@@ -1956,18 +2152,42 @@ const BBNode BitBlaster::BBForm(const ASTNode& form, BBNodeSet& support,
       const BBNodeVec right = BBTerm(form[1], support);
       assert(left.size() == right.size());
 
-      if (left.size() >= uf->bv_abstraction_width)
+      if (left.size() >= uf->bv_abstraction_width &&
+          firstCandidateSighting(form))
         uf->coverage.bv_candidates[UserDefinedFlags::ABSTRACT_EQ]++;
 
-      if (uf->bv_eq_abstraction &&
+      if (eqAbstractionAllowed() &&
           left.size() >= uf->bv_abstraction_width)
       {
+        // One Boolean per predicate, not per occurrence: see
+        // abstractedFormulas_ for why the term families' registry does not
+        // serve here and what two independent Booleans for one equality cost.
+        const auto reused = abstractedFormulas_.find(form);
+        if (reused != abstractedFormulas_.end())
+        {
+          result = reused->second.bit;
+          break;
+        }
         uf->coverage.bv_abstracted[UserDefinedFlags::ABSTRACT_EQ]++;
-        ensureProxyCIs(nf, form[0], left, sideConstraints_);
-        ensureProxyCIs(nf, form[1], right, sideConstraints_);
+        const BBNodeVec leftInputs = ensureProxyCIs(form[0], left);
+        const BBNodeVec rightInputs = ensureProxyCIs(form[1], right);
+        std::vector<BVAbstractionId> dependencies =
+            abstractionSourcesOf(leftInputs);
+        appendAbstractionSources(dependencies,
+                                 abstractionSourcesOf(rightInputs));
+        const BVAbstractionId id = newAbstractionId();
         BBNodeAIG abstractCI(Aig_ObjCreateCi(nf->aigMgr));
         abstractCI.symbol_index = nf->aigMgr->vCis->nSize - 1;
-        abstractedEQs_.push_back({form, abstractCI, form[0], form[1]});
+        tagAbstractionSources(abstractCI, {id});
+        RawBVEQAbstraction raw;
+        raw.id = id;
+        raw.dependencies = std::move(dependencies);
+        raw.eqNode = form;
+        raw.abstractionCI = abstractCI;
+        raw.leftSymbol = form[0];
+        raw.rightSymbol = form[1];
+        abstractedEQs_.push_back(std::move(raw));
+        abstractedFormulas_[form] = {id, abstractCI};
         result = abstractCI;
       }
       else
@@ -1986,22 +2206,39 @@ const BBNode BitBlaster::BBForm(const ASTNode& form, BBNodeSet& support,
     case BVSGT:
     case BVSLT:
     {
-      if (form[0].GetValueWidth() >= uf->bv_abstraction_width)
+      if (form[0].GetValueWidth() >= uf->bv_abstraction_width &&
+          firstCandidateSighting(form))
         uf->coverage.bv_candidates[UserDefinedFlags::ABSTRACT_COMPARE]++;
 
-      if (uf->bv_term_abstraction && uf->bv_term_abstraction_compare)
+      if (termAbstractionAllowed() && uf->bv_term_abstraction_compare)
       {
         const BBNodeVec& left = BBTerm(form[0], support);
         const BBNodeVec& right = BBTerm(form[1], support);
         if (left.size() >= uf->bv_abstraction_width)
         {
+          // One Boolean per predicate, as the equality above; the comparison
+          // families were the other half of the same gap.
+          const auto reused = abstractedFormulas_.find(form);
+          if (reused != abstractedFormulas_.end())
+          {
+            result = reused->second.bit;
+            break;
+          }
           uf->coverage.bv_abstracted[UserDefinedFlags::ABSTRACT_COMPARE]++;
-          ensureProxyCIs(nf, form[0], left, sideConstraints_);
-          ensureProxyCIs(nf, form[1], right, sideConstraints_);
+          const BBNodeVec leftInputs = ensureProxyCIs(form[0], left);
+          const BBNodeVec rightInputs = ensureProxyCIs(form[1], right);
+          std::vector<BVAbstractionId> dependencies =
+              abstractionSourcesOf(leftInputs);
+          appendAbstractionSources(dependencies,
+                                   abstractionSourcesOf(rightInputs));
+          const BVAbstractionId id = newAbstractionId();
           BBNodeAIG abstractCI(Aig_ObjCreateCi(nf->aigMgr));
           abstractCI.symbol_index = nf->aigMgr->vCis->nSize - 1;
+          tagAbstractionSources(abstractCI, {id});
 
           RawBVTermAbstraction raw;
+          raw.id = id;
+          raw.dependencies = std::move(dependencies);
           raw.termNode = form;
           raw.opKind = k;
           raw.operands[0] = form[0];
@@ -2010,6 +2247,7 @@ const BBNode BitBlaster::BBForm(const ASTNode& form, BBNodeSet& support,
           raw.width = left.size();
           raw.condCISymbolIndex = abstractCI.symbol_index;
           abstractedTerms_.push_back(raw);
+          abstractedFormulas_[form] = {id, abstractCI};
           result = abstractCI;
           break;
         }

--- a/lib/ToSat/ToSATAIG.cpp
+++ b/lib/ToSat/ToSATAIG.cpp
@@ -182,7 +182,8 @@ Cnf_Dat_t* ToSATAIG::bitblast(const ASTNode& input, bool needAbsRef)
 
   BBNodeManagerAIG mgr;
   mgr.nodeBudget = bm->UserFlags.aig_node_budget;
-  BitBlaster bb(&mgr, &simp, bm->defaultNodeFactory, &bm->UserFlags, cb);
+  BitBlaster bb(&mgr, &simp, bm->defaultNodeFactory, &bm->UserFlags, cb,
+                allowAbstraction_);
 
   BBNodeAIG BBFormula;
 
@@ -269,6 +270,8 @@ Cnf_Dat_t* ToSATAIG::bitblast(const ASTNode& input, bool needAbsRef)
   for (const auto& raw : bb.abstractedEQs())
   {
     BVEQAbstraction a;
+    a.id = raw.id;
+    a.dependencies = raw.dependencies;
     a.eqNode = raw.eqNode;
     Aig_Obj_t* pObj = (Aig_Obj_t*)Vec_PtrEntry(
         mgr.aigMgr->vCis, raw.abstractionCI.symbol_index);
@@ -276,12 +279,14 @@ Cnf_Dat_t* ToSATAIG::bitblast(const ASTNode& input, bool needAbsRef)
     a.leftSymbol = raw.leftSymbol;
     a.rightSymbol = raw.rightSymbol;
     a.width = std::max(1u, raw.leftSymbol.GetValueWidth());
-    abstraction_.equalities().push_back(std::move(a));
+    abstraction_.appendEquality(std::move(a));
   }
 
   for (const auto& raw : bb.abstractedTerms())
   {
     BVTermAbstraction a;
+    a.id = raw.id;
+    a.dependencies = raw.dependencies;
     a.termNode = raw.termNode;
     a.opKind = raw.opKind;
     for (unsigned i = 0; i < raw.numOperands; i++)
@@ -297,7 +302,26 @@ Cnf_Dat_t* ToSATAIG::bitblast(const ASTNode& input, bool needAbsRef)
           mgr.aigMgr->vCis, raw.condCISymbolIndex);
       a.condSATVar = cnfData->pVarNums[condObj->Id];
     }
-    abstraction_.terms().push_back(std::move(a));
+    // The record's own result inputs, resolved the same way the condition
+    // above is. The blaster files them for every term family; the persistent
+    // incremental lowering has always carried them across and this one used
+    // to drop them, leaving the AST-keyed registry as the only answer to
+    // which variables a result is.
+    //
+    // That registry holds one vector per node, so it names only the newest
+    // one registered. Canonical reuse normally means there is only ever one,
+    // and nothing here relies on that any more: an unmapped input reads back
+    // as ~0u exactly as fill_node_to_var records it, so the values are the
+    // ones refinement would have found anyway, and a duplicate that ever did
+    // arise costs work rather than a verdict.
+    a.resultSATVars.reserve(raw.resultCISymbolIndices.size());
+    for (const int index : raw.resultCISymbolIndices)
+    {
+      Aig_Obj_t* resultObj =
+          (Aig_Obj_t*)Vec_PtrEntry(mgr.aigMgr->vCis, index);
+      a.resultSATVars.push_back(cnfData->pVarNums[resultObj->Id]);
+    }
+    abstraction_.appendTerm(std::move(a));
   }
 
   // Free the memory in the AIGs.
@@ -471,8 +495,8 @@ void ToSATAIG::mark_variables_as_frozen(SATSolver& satSolver)
 // that spreading unconstrained scalars out is worth anything, so its default
 // phase puts many of them on the same value at once and each collision is
 // paid for with a lemma and another full solve. Counting the scalars off
-// against an increasing value is the same trick Bitwuzla plays for DISTINCT,
-// applied to what the congruence checker reads.
+// against an increasing value is the ordinary way to seed a distinctness
+// constraint, pointed here at what the congruence checker reads.
 //
 // This is only a hint: it reorders the search and cannot change which answers
 // are reachable, so no soundness argument rests on the choice being good. A

--- a/tests/query-files/incremental-tests/bv-abstraction-candidates-count-operations.smt2
+++ b/tests/query-files/incremental-tests/bv-abstraction-candidates-count-operations.smt2
@@ -1,0 +1,78 @@
+; The candidate counter counts operations, not bit-blaster visits.
+;
+; bv_candidates is documented as the operations that reached the bit-blaster at
+; or above the width floor -- what the abstraction COULD have taken -- and it
+; exists so that a flag which found nothing eligible can be told from a flag
+; that is broken. It was incremented at the top of each abstraction arm, which
+; is a visit: this driver clears its term memo on every new root, so one
+; operation is re-entered once per check-sat, while bv_abstracted correctly
+; counts the one record that was minted for it.
+;
+; Ten solves over the one multiplication below therefore read mult=10->1, which
+; says the abstraction took a tenth of what it could have. It took all of it.
+; The ratio reaches vc_getCounter and every profile comparison run over an
+; incremental corpus, so a number that degrades linearly with session length is
+; not a number those comparisons can use.
+;
+; Counted once per operation, the ratio means what it says and carries an
+; invariant with it: abstracted can never exceed candidates, so a second record
+; for one operation shows as 1->2 rather than hiding inside a larger left
+; number. That is what the sibling fixture on predicate canonicalisation now
+; checks.
+;
+; Only the multiplication's field is pinned. The pushed assertions are eight
+; bits wide and below the abstraction floor, but the driver's own encoding puts
+; one wide equality in front of the counters, and what that equality is is not
+; what this fixture is about; pinning the whole line would make it a test of
+; the encoding's shape.
+;
+; RUN: %solver --incremental=on -d -t --bv-term-abstraction=1 --bv-term-abstraction-compare=0 %s 2>&1 | %OutputCheck --check-prefix=ONCE %s
+;
+; ONCE: Abstraction coverage \(candidates -> abstracted\):.* mult=1->1
+; ONCE: ^sat$
+(set-logic QF_BV)
+(declare-fun x () (_ BitVec 64))
+(declare-fun y () (_ BitVec 64))
+(declare-fun w () (_ BitVec 8))
+(assert (bvult (bvmul x y) (_ bv18446744073709551615 64)))
+(push 1)
+(assert (= w (_ bv1 8)))
+(check-sat)
+(pop 1)
+(push 1)
+(assert (= w (_ bv2 8)))
+(check-sat)
+(pop 1)
+(push 1)
+(assert (= w (_ bv3 8)))
+(check-sat)
+(pop 1)
+(push 1)
+(assert (= w (_ bv4 8)))
+(check-sat)
+(pop 1)
+(push 1)
+(assert (= w (_ bv5 8)))
+(check-sat)
+(pop 1)
+(push 1)
+(assert (= w (_ bv6 8)))
+(check-sat)
+(pop 1)
+(push 1)
+(assert (= w (_ bv7 8)))
+(check-sat)
+(pop 1)
+(push 1)
+(assert (= w (_ bv8 8)))
+(check-sat)
+(pop 1)
+(push 1)
+(assert (= w (_ bv9 8)))
+(check-sat)
+(pop 1)
+(push 1)
+(assert (= w (_ bv10 8)))
+(check-sat)
+(pop 1)
+(exit)

--- a/tests/query-files/incremental-tests/bv-abstraction-predicates-are-canonical.smt2
+++ b/tests/query-files/incremental-tests/bv-abstraction-predicates-are-canonical.smt2
@@ -1,0 +1,43 @@
+; One Boolean per abstracted predicate, not one per occurrence.
+;
+; The term families are canonicalised by the blaster: a second ask for a term
+; it has already abstracted reuses the vector it registered, and the reason
+; given for doing so is this driver. BBForm clears its memo on every new root,
+; so two conjuncts sharing a subterm ask for it independently, and minting a
+; second set of inputs for the second ask leaves two records over two sets that
+; are free to disagree.
+;
+; Equalities and comparisons had the same exposure and none of the guard. Each
+; occurrence minted a fresh Boolean and pushed a fresh record, so the same
+; predicate was refined twice over two inputs -- and the refinement paid for
+; both, once per occurrence, for the whole session.
+;
+; Here each predicate is written into two conjuncts, so the driver blasts each
+; one twice. The coverage line counts operations on the left and records on the
+; right, so one predicate abstracted once reads 1->1 -- and a second record for
+; it reads 1->2, which is the shape of the defect: more records than there are
+; operations to have them. Without the guard the equality leg reports exactly
+; that.
+;
+; -d re-derives the answer under the published model, which is the check that
+; matters if the reuse were wrong: a Boolean shared between two predicates that
+; are not the same predicate would report sat on a model the raw stack rejects.
+;
+; RUN: %solver --incremental=on -d -t --bv-eq-abstraction=1 --bv-term-abstraction=1 %s 2>&1 | %OutputCheck --check-prefix=SHARED %s
+; RUN: %solver --incremental=on -d %s 2>&1 | %OutputCheck --check-prefix=PLAIN %s
+;
+; SHARED: Abstraction coverage \(candidates -> abstracted\): eq=1->1 compare=1->1
+; SHARED: ^sat$
+;
+; PLAIN: ^sat$
+(set-logic QF_BV)
+(declare-fun a () (_ BitVec 64))
+(declare-fun b () (_ BitVec 64))
+(declare-fun p () Bool)
+(declare-fun q () Bool)
+(assert (or p (= a b)))
+(assert (or (not p) (= a b)))
+(assert (or q (bvule a b)))
+(assert (or (not q) (bvule a b)))
+(check-sat)
+(exit)

--- a/tests/query-files/misc-tests/bv-abstraction-plus-is-not-gated-by-the-adder-variant.smt2
+++ b/tests/query-files/misc-tests/bv-abstraction-plus-is-not-gated-by-the-adder-variant.smt2
@@ -1,0 +1,36 @@
+; Which adder the bit-blaster would have used does not decide whether an
+; addition is abstracted.
+;
+; --bb.add-v2 chooses between the two lowerings BBTerm has for BVPLUS:
+; pairwise BBPlus2 accumulation, and the addition network. The abstraction
+; reaches neither. It returns before both of them, and the exact encoding it
+; escalates to is spliced in at CNF level through BVExactEncoder rather than
+; built by either adder. The flag sat in the abstraction's gate by adjacency to
+; the `if (uf->bvplus_variant)` block underneath it, and the effect was that
+; --bb.add-v2=0 abstracted no additions at all -- silently, and often, because
+; the fuzz harness draws that flag from its bit-blast group.
+;
+; The third leg is the other half of the same condition. A wide n-ary addition
+; that the abstraction did not decompose is counted as the binary additions the
+; decomposition would have made, so that a zero means "no wide addition here"
+; rather than "the flag that lowers them was off". That compensating count was
+; written in different terms from the gate it compensates for and omitted
+; --bv-term-abstraction-plus, so turning that off alone produced exactly the
+; unreadable number it exists to prevent: one candidate rather than three.
+;
+; RUN: %solver --incremental=off -t --bv-term-abstraction=1 --bv-term-abstraction-compare=0 %s 2>&1 | %OutputCheck --check-prefix=DEFAULT %s
+; RUN: %solver --incremental=off -t --bv-term-abstraction=1 --bv-term-abstraction-compare=0 --bb.add-v2 0 %s 2>&1 | %OutputCheck --check-prefix=ADDV1 %s
+; RUN: %solver --incremental=off -t --bv-term-abstraction=1 --bv-term-abstraction-compare=0 --bv-term-abstraction-plus 0 %s 2>&1 | %OutputCheck --check-prefix=NOPLUS %s
+;
+; DEFAULT: plus=2->2
+; ADDV1: plus=2->2
+; NOPLUS: plus=3->0
+(set-logic QF_BV)
+(declare-fun a () (_ BitVec 64))
+(declare-fun b () (_ BitVec 64))
+(declare-fun c () (_ BitVec 64))
+(assert (bvult (bvadd a b c) (_ bv100 64)))
+(assert (bvugt (bvadd a b) (_ bv5 64)))
+(assert (distinct a c))
+(check-sat)
+(exit)

--- a/tests/query-files/uf/phase-hints-round-count.smt2
+++ b/tests/query-files/uf/phase-hints-round-count.smt2
@@ -6,7 +6,8 @@
 ; spreading unconstrained scalars out is worth anything, so its default phase
 ; puts many on the same value at once and each collision costs a lemma and
 ; another full solve. Counting them off against an increasing value is the
-; trick Bitwuzla plays for DISTINCT, pointed at what the checker reads.
+; ordinary way to seed a distinctness constraint, pointed at what the checker
+; reads.
 ;
 ; Here every argument is unconstrained and the results are forced apart, so
 ; the hint is exactly right: with it the first candidate already has distinct

--- a/tests/unit-tests/BVEQAbstraction_Test.cpp
+++ b/tests/unit-tests/BVEQAbstraction_Test.cpp
@@ -41,6 +41,23 @@ using namespace stp;
 namespace
 {
 
+void appendEqualityRecord(BVAbstractionRefiner& refiner,
+                          BVEQAbstraction record)
+{
+  static uint64_t nextId = 1;
+  record.id = BVAbstractionId(nextId++);
+  refiner.appendEquality(record);
+}
+
+void appendTermRecord(BVAbstractionRefiner& refiner,
+                      BVTermAbstraction record)
+{
+  static uint64_t nextId = UINT64_C(1) << 32;
+  record.id = BVAbstractionId(nextId++);
+  refiner.appendTerm(record);
+}
+
+
 class BVEQAbstractionTest : public ::testing::Test
 {
 protected:
@@ -632,12 +649,12 @@ TEST_F(BVEQAbstractionTest, FreezeVariablesCoversEveryLemmaVariable)
   eq.leftSymbol = x;
   eq.rightSymbol = y;
   eq.width = 4;
-  refiner.equalities().push_back(eq);
+  appendEqualityRecord(refiner, eq);
 
   // Harvested with no variable yet: legal before the first solve, skipped.
   BVEQAbstraction pending = eq;
   pending.abstractionSATVar = BV_ABSTRACTION_NO_VAR;
-  refiner.equalities().push_back(pending);
+  appendEqualityRecord(refiner, pending);
 
   BVTermAbstraction term;
   term.termNode = sum;
@@ -646,7 +663,7 @@ TEST_F(BVEQAbstractionTest, FreezeVariablesCoversEveryLemmaVariable)
   term.operands[1] = y;
   term.numOperands = 2;
   term.width = 4;
-  refiner.terms().push_back(term);
+  appendTermRecord(refiner, term);
 
   // A record that owns its result, as the persistent incremental lowering
   // files them. Freezing has to reach 40..43 and not whatever the node map
@@ -655,7 +672,7 @@ TEST_F(BVEQAbstractionTest, FreezeVariablesCoversEveryLemmaVariable)
   // nothing and keeps the map fallback covered.
   BVTermAbstraction owned = term;
   owned.resultSATVars = std::vector<unsigned>{40, 41, 42, 43};
-  refiner.terms().push_back(owned);
+  appendTermRecord(refiner, owned);
 
   ToSATBase::ASTNodeToSATVar bits;
   bits[x] = std::vector<unsigned>{10, 11, 12, 13};
@@ -691,11 +708,11 @@ TEST_F(BVEQAbstractionTest, DuplicateTermsKeepTheirOwnResultVariables)
   older.numOperands = 2;
   older.width = 4;
   older.resultSATVars = std::vector<unsigned>{40, 41, 42, 43};
-  refiner.terms().push_back(older);
+  appendTermRecord(refiner, older);
 
   BVTermAbstraction newer = older;
   newer.resultSATVars = std::vector<unsigned>{30, 31, 32, 33};
-  refiner.terms().push_back(newer);
+  appendTermRecord(refiner, newer);
 
   ToSATBase::ASTNodeToSATVar bits;
   bits[a] = std::vector<unsigned>{10, 11, 12, 13};
@@ -746,7 +763,7 @@ TEST_F(BVEQAbstractionTest, SaidUnequalRoundBlocksTheCandidate)
   record.leftSymbol = x;
   record.rightSymbol = y;
   record.width = 4;
-  refiner.equalities().push_back(record);
+  appendEqualityRecord(refiner, record);
 
   ToSATBase::ASTNodeToSATVar bits;
   bits[x] = std::vector<unsigned>{10, 11, 12, 13};
@@ -797,7 +814,7 @@ TEST_F(BVEQAbstractionTest, CongruenceChainsRunThroughDefinedEqualities)
   xy.width = 4;
   xy.defined = true;
   xy.refinedBits = 4;
-  refiner.equalities().push_back(xy);
+  appendEqualityRecord(refiner, xy);
 
   BVEQAbstraction yz;
   yz.eqNode = factory->CreateNode(EQ, y, z);
@@ -805,7 +822,7 @@ TEST_F(BVEQAbstractionTest, CongruenceChainsRunThroughDefinedEqualities)
   yz.leftSymbol = y;
   yz.rightSymbol = z;
   yz.width = 4;
-  refiner.equalities().push_back(yz);
+  appendEqualityRecord(refiner, yz);
 
   BVEQAbstraction xz;
   xz.eqNode = factory->CreateNode(EQ, x, z);
@@ -813,7 +830,7 @@ TEST_F(BVEQAbstractionTest, CongruenceChainsRunThroughDefinedEqualities)
   xz.leftSymbol = x;
   xz.rightSymbol = z;
   xz.width = 4;
-  refiner.equalities().push_back(xz);
+  appendEqualityRecord(refiner, xz);
 
   ToSATBase::ASTNodeToSATVar bits;
   bits[x] = std::vector<unsigned>{10, 11, 12, 13};
@@ -860,7 +877,7 @@ TEST_F(BVEQAbstractionTest, BlockingRoundReusesTheRegisteredConstant)
   record.operands[1] = three;
   record.numOperands = 2;
   record.width = 4;
-  refiner.terms().push_back(record);
+  appendTermRecord(refiner, record);
 
   ToSATBase::ASTNodeToSATVar bits;
   bits[a] = std::vector<unsigned>{10, 11, 12, 13};
@@ -914,7 +931,7 @@ TEST_F(BVEQAbstractionTest, ASchemaRoundIsSpentWhereTheCandidateContradictsOne)
   record.operands[1] = three;
   record.numOperands = 2;
   record.width = 4;
-  refiner.terms().push_back(record);
+  appendTermRecord(refiner, record);
 
   ToSATBase::ASTNodeToSATVar bits;
   bits[a] = std::vector<unsigned>{10, 11, 12, 13};
@@ -965,7 +982,7 @@ TEST_F(BVEQAbstractionTest, OnePassCanInstallBothKindsOfMultiplicationLemma)
   first.operands[1] = b;
   first.numOperands = 2;
   first.width = 4;
-  refiner.terms().push_back(first);
+  appendTermRecord(refiner, first);
 
   BVTermAbstraction second;
   second.termNode = secondProduct;
@@ -974,7 +991,7 @@ TEST_F(BVEQAbstractionTest, OnePassCanInstallBothKindsOfMultiplicationLemma)
   second.operands[1] = d;
   second.numOperands = 2;
   second.width = 4;
-  refiner.terms().push_back(second);
+  appendTermRecord(refiner, second);
 
   ToSATBase::ASTNodeToSATVar bits;
   bits[a] = std::vector<unsigned>{10, 11, 12, 13};
@@ -1078,7 +1095,7 @@ TEST_F(BVEQAbstractionTest, RefusesAnEqualityWhoseOperandsAreNotEncoded)
   record.leftSymbol = x;
   record.rightSymbol = y;
   record.width = 8;
-  refiner.equalities().push_back(record);
+  appendEqualityRecord(refiner, record);
 
   NoModelSolver solver;
   ToSATBase::ASTNodeToSATVar empty;
@@ -1097,7 +1114,7 @@ TEST_F(BVEQAbstractionTest, RefusesAnEqualityRecordedWiderThanItsOperands)
   record.leftSymbol = x;
   record.rightSymbol = y;
   record.width = 8;
-  refiner.equalities().push_back(record);
+  appendEqualityRecord(refiner, record);
 
   NoModelSolver solver;
   ToSATBase::ASTNodeToSATVar bits;
@@ -1118,7 +1135,7 @@ TEST_F(BVEQAbstractionTest, RefusesAnEqualityBitThatNeverReachedTheCNF)
   record.leftSymbol = x;
   record.rightSymbol = y;
   record.width = 8;
-  refiner.equalities().push_back(record);
+  appendEqualityRecord(refiner, record);
 
   NoModelSolver solver;
   ToSATBase::ASTNodeToSATVar bits;
@@ -1143,7 +1160,7 @@ TEST_F(BVEQAbstractionTest, RefusesAnAdditionWhoseOperandsAreNotEncoded)
   record.operands[1] = y;
   record.numOperands = 2;
   record.width = 8;
-  refiner.terms().push_back(record);
+  appendTermRecord(refiner, record);
 
   NoModelSolver solver;
   ToSATBase::ASTNodeToSATVar bits;
@@ -1169,7 +1186,7 @@ TEST_F(BVEQAbstractionTest, RefusesAComparisonWithNoInputOfItsOwn)
   record.width = 8;
   // condSATVar left at BV_ABSTRACTION_NO_VAR: the comparison's answer has
   // nowhere to be read from, so nothing about this candidate can be checked.
-  refiner.terms().push_back(record);
+  appendTermRecord(refiner, record);
 
   NoModelSolver solver;
   ToSATBase::ASTNodeToSATVar bits;


### PR DESCRIPTION
# BV abstraction (1/6): give every abstraction an identity the lowering preserves

The first of six PRs splitting one development branch, which extends the lazy bit-vector abstraction already in the tree. Each builds on the one before it, so they want merging bottom-up; nothing here changes what a default run does.

The bit-blaster mints an abstraction by replacing an operation with fresh AIG inputs and filing a record about it. Everything downstream then has to find its way back from those inputs to the record, and the only route was the AST-keyed registry the node manager keeps — which holds one vector per node, and so can name only the most recently registered result for it.

Give each record a producer ID instead, minted where the abstraction is, attached to the AIG inputs it introduces, and carried on the record. Proxy inputs carry the producers of the bit they alias, so a dependency cut never becomes an unlabelled input. Records are filed through `appendEquality` and `appendTerm`, which keep an ID-to-record index; the accessors become const, because a record's identity is not something a caller should be able to overwrite after the fact.

Four things the same pass fixes, all of them the registry being asked a question it cannot answer:

- An abstracted predicate got one Boolean per occurrence. `BBForm` clears its memo on every new root, so two conjuncts sharing an equality asked for it independently and got two inputs free to disagree; a predicate has one truth value wherever it occurs. A term's result vector lives in `symbolToBBNode`, but a Boolean is not a vector and had nowhere to go, so it gets its own map.
- Constant-bit propagation could rewrite an abstraction's own result bits. `updateTerm` rewrites the term memo while the record names the inputs, so a bit replaced with a constant would leave parents reading a bit the record does not name. Nothing is lost by declining: refinement pins the abstraction to the operands, which is stronger than any single bit.
- Candidates were counted per bit-blaster visit rather than per operation. The incremental driver re-enters one operation once per check-sat while the abstracted count — correctly — counts the one record, so ten solves over one multiplication read `mult=10->1`.
- `BVPLUS` abstraction was gated on `bvplus_variant`, which chooses between the two adder lowerings the abstraction reaches neither of. `--bb.add-v2=0` silently abstracted no additions at all.

A lowering can also now be told not to abstract, rather than clearing the session's flags around it: `maxPrecision` drives `ToSATAIG` over auxiliary queries a few bits wide, reads `SOLVER_UNDECIDED` as a backend error, and used to save the two feature flags, clear them and put them back — a manager-wide write for a decision belonging to one encoding, restored only on the paths that reach the bottom of the function.

## Tests

Three query files pin the behavioural fixes: that one operation is counted once however many times the incremental driver re-enters it, that a predicate occurring twice gets one Boolean, and that `--bb.add-v2=0` no longer suppresses addition abstraction. `BVEQAbstraction_Test` files its records through the new appenders, which is what exercises the ID index.
