### PR TITLE
Stop pinning the interface-flag ordinal that Riss used to hold

### DIFF
--- a/tests/api/C/refinement-flags.cpp
+++ b/tests/api/C/refinement-flags.cpp
@@ -53,7 +53,10 @@ static_assert(EXPRDELETE == 0, "published interface-flag ordinal changed");
 static_assert(MS == 1, "published interface-flag ordinal changed");
 static_assert(SMS == 2, "published interface-flag ordinal changed");
 static_assert(CMS4 == 3, "published interface-flag ordinal changed");
-static_assert(RISS == 4, "published interface-flag ordinal changed");
+// 4 was RISS, removed with the Riss backend. The value is retired rather than
+// reused -- c_interface.h writes `MSP = 5` out explicitly to keep this flag and
+// the ones below at the values they had while Riss existed -- so there is
+// nothing to pin at 4, and the run of ordinals below is deliberately unbroken.
 static_assert(MSP == 5, "published interface-flag ordinal changed");
 static_assert(CADICAL == 6, "published interface-flag ordinal changed");
 static_assert(INCREMENTAL_AUTO_ENGAGE_AT == 7,


### PR DESCRIPTION
# Stop pinning the interface-flag ordinal that Riss used to hold

`master` does not currently compile. `tests/api/C/refinement-flags.cpp` pins the whole published prefix of `ifaceflag_t`, one `static_assert` per ordinal, so that an insertion or a reorder earlier in the enum cannot go unnoticed. That block was written while `RISS` was still ordinal 4, and #1022 removed the backend.

The two changes are textually disjoint — #1022 never touched this file, and the block landed in #1033 — so they merged clean and the result stopped building:

```
tests/api/C/refinement-flags.cpp:56:15: error: 'RISS' was not declared in this scope
```

Nothing else needs adjusting, and in particular no published value moved. #1022 retired the ordinal rather than reusing it, writing `MSP = 5` out explicitly with a note saying that 4 was `RISS` and that the flags below keep the values they had. So every remaining assertion in the block still holds; only the one naming a flag that no longer exists has to go, with a comment at the gap recording why there is nothing to pin at 4.

## Tests

`ctest` is 174/174 with this applied, against 173 failures without it (the library does not link, so nearly everything fails). Verified with gcc at the default build type, `WERROR=ON`, CryptoMiniSat and MiniSat.
