### PR TITLE
Let installed headers pick the SAT backend the library was built with

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -839,14 +839,9 @@ MESSAGE(STATUS "PROJECT_VERSION_MAJOR: ${PROJECT_VERSION_MAJOR}")
 MESSAGE(STATUS "PROJECT_VERSION_MINOR: ${PROJECT_VERSION_MINOR}")
 MESSAGE(STATUS "PROJECT_VERSION_PATCH: ${PROJECT_VERSION_PATCH}")
 
-# -----------------------------------------------------------------------------
-# Write out the config.h
-# -----------------------------------------------------------------------------
-
-configure_file(
-  "${CMAKE_CURRENT_SOURCE_DIR}/include/stp/config.h.in"
-  "${CMAKE_CURRENT_BINARY_DIR}/include/stp/config.h"
-)
+# config.h is materialized after SAT-backend discovery below.  Public C++
+# headers use its backend capability values, so generating it here would leave
+# installed clients with incomplete information.
 
 # -----------------------------------------------------------------------------
 # Set up includes
@@ -1029,6 +1024,7 @@ if (USE_CADICAL)
     # (--cadical-factor) can be compiled in.
     find_package(CaDiCaL REQUIRED)
     add_definitions(-DUSE_CADICAL)
+    set(STP_BUILD_WITH_CADICAL ON)
     if (CADICAL_HAS_FACTOR)
         add_definitions(-DSTP_CADICAL_HAS_FACTOR)
     endif()
@@ -1228,6 +1224,7 @@ if (NOT USE_CRYPTOMINISAT STREQUAL "OFF")
   # it whether or not the package was found.
   if (CryptoMiniSat_FOUND AND HAVE_FLAG_STD_CPP11)
     add_definitions(-DUSE_CRYPTOMINISAT)
+    set(STP_BUILD_WITH_CRYPTOMINISAT ON)
     set(USE_CRYPTOMINISAT ON)
   else()
     set(USE_CRYPTOMINISAT OFF)
@@ -1414,6 +1411,7 @@ if (USE_MINISAT)
     # cmake/FindMiniSat.cmake, along with the ability to build one.
     find_package(MiniSat REQUIRED)
     add_definitions(-DUSE_MINISAT)
+    set(STP_BUILD_WITH_MINISAT ON)
     if (MINISAT_HAS_TERMINATOR)
         add_definitions(-DSTP_MINISAT_HAS_TERMINATOR)
     endif()
@@ -1423,6 +1421,13 @@ if (USE_MINISAT)
     # through AddSTPGTest. (There used to be a `set(LIBS ...)` here too, whose
     # value nothing ever read.)
 endif()
+
+# Materialize config.h now that backend discovery is final so an installed C++
+# client gets the same inline UserDefinedFlags constructor as libstp itself.
+configure_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/include/stp/config.h.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/include/stp/config.h"
+)
 
 # -----------------------------------------------------------------------------
 # Find Parser and Lexer generators

--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -26,6 +26,7 @@ THE SOFTWARE.
 
 #include "stp/Sat/SearchBias.h"
 #include "stp/Util/Attributes.h"
+#include "stp/config.h"
 #include <cstdint>
 #include <iosfwd>
 #include <string>
@@ -1176,14 +1177,12 @@ public:
     // MiniSat is the last resort and is not guarded: CMakeLists.txt refuses
     // a build with no backend at all, so the fall-through is only reached
     // when MiniSat is the one that is there.
-#ifdef USE_CRYPTOMINISAT
+#if STP_BUILD_WITH_CRYPTOMINISAT
     solver_to_use = CRYPTOMINISAT5_SOLVER;
-#else
-#ifdef USE_CADICAL
+#elif STP_BUILD_WITH_CADICAL
     solver_to_use = CADICAL_SOLVER;
 #else
     solver_to_use = MINISAT_SOLVER;
-#endif
 #endif
   }
 };

--- a/include/stp/config.h.in
+++ b/include/stp/config.h.in
@@ -52,6 +52,13 @@ OUT OF OR IN CONNECT
 #define STP_VERSION_MINOR ${PROJECT_VERSION_MINOR}
 #define STP_VERSION "${PROJECT_VERSION}"
 
+/* Public C++ headers construct the same default SAT-backend selection as the
+ * library, including when compiled by an installed-package client.  These are
+ * build capabilities, not runtime backend selectors. */
+#cmakedefine01 STP_BUILD_WITH_CADICAL
+#cmakedefine01 STP_BUILD_WITH_CRYPTOMINISAT
+#cmakedefine01 STP_BUILD_WITH_MINISAT
+
 
 #cmakedefine01 USE_THREAD_LOCAL
 


### PR DESCRIPTION
`UserDefinedFlags::UserDefinedFlags()` chooses its default solver from `USE_CRYPTOMINISAT` / `USE_CADICAL`. Those are private build definitions: they are set while STP itself compiles, and they are absent when a client compiles against the installed headers. Such a client therefore constructs `UserDefinedFlags` with `MINISAT_SOLVER` whatever the library was actually built with, and then disagrees with it about the default backend — including on a build where MiniSat was never compiled in.

This publishes the backends as build capabilities in the configured `config.h`, which is installed, and selects on those instead. The private `-DUSE_*` switches keep their existing meaning for STP’s own sources; the new values record what the build produced, not what a run should choose. The order of preference is unchanged: CryptoMiniSat, then CaDiCaL, then MiniSat.

One structural change comes with it, and it is load-bearing rather than tidying: `config.h` is generated near the top of the top-level `CMakeLists.txt`, before any `find_package` for a solver, so writing the capabilities there would emit `0` for every one of them and send every client to MiniSat. The `configure_file` therefore moves down to the point where the backend set is final. That is the larger part of the diff, and the reason the change is not a three-line edit.

Full suite passes.