### PR TITLE
Look for libstp next to the installed Python package as well

### DIFF
--- a/bindings/python/stp/CMakeLists.txt
+++ b/bindings/python/stp/CMakeLists.txt
@@ -88,6 +88,32 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/stp.py
 # FIXME: the concrete binary filename should be obtained via generator
 #         expressions, but they can't be used for now due to bugs in older
 #         versions of CMake
+get_filename_component(STP_PYTHON_PACKAGE_INSTALL_DIR
+                       "${PYTHON_LIB_INSTALL_DIR}/stp" ABSOLUTE)
+if(IS_ABSOLUTE "${CMAKE_INSTALL_LIBDIR}")
+  set(STP_LIBRARY_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}")
+else()
+  set(STP_LIBRARY_INSTALL_DIR
+      "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
+endif()
+if(IS_ABSOLUTE "${CMAKE_INSTALL_BINDIR}")
+  set(STP_RUNTIME_INSTALL_DIR "${CMAKE_INSTALL_BINDIR}")
+else()
+  set(STP_RUNTIME_INSTALL_DIR
+      "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}")
+endif()
+get_filename_component(STP_LIBRARY_INSTALL_DIR
+                       "${STP_LIBRARY_INSTALL_DIR}" ABSOLUTE)
+get_filename_component(STP_RUNTIME_INSTALL_DIR
+                       "${STP_RUNTIME_INSTALL_DIR}" ABSOLUTE)
+file(RELATIVE_PATH STP_PYTHON_TO_INSTALL_LIBDIR
+     "${STP_PYTHON_PACKAGE_INSTALL_DIR}" "${STP_LIBRARY_INSTALL_DIR}")
+file(RELATIVE_PATH STP_PYTHON_TO_INSTALL_BINDIR
+     "${STP_PYTHON_PACKAGE_INSTALL_DIR}" "${STP_RUNTIME_INSTALL_DIR}")
+file(TO_CMAKE_PATH "${STP_PYTHON_TO_INSTALL_LIBDIR}"
+     STP_PYTHON_TO_INSTALL_LIBDIR)
+file(TO_CMAKE_PATH "${STP_PYTHON_TO_INSTALL_BINDIR}"
+     STP_PYTHON_TO_INSTALL_BINDIR)
 configure_file(library_path.py.in_install "${PROJECT_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/library_path.py" @ONLY)
 
 install(FILES "${PROJECT_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/library_path.py"

--- a/bindings/python/stp/library_path.py.in_install
+++ b/bindings/python/stp/library_path.py.in_install
@@ -27,7 +27,22 @@
 # a good idea.
 
 # Search paths for the stp shared library
+import os
+
+_PACKAGE_DIR = os.path.dirname(os.path.abspath(__file__))
+# Relative to this package first, so an installation that was moved, staged
+# under a different root, or relocated into a wheel or image still resolves.
+# Then the configured absolute locations, which is what answers the case where
+# the package and the library do not share a prefix -- a system site-packages
+# directory alongside a --prefix install -- and the relative route therefore
+# points out of one tree and into another.
 PATHS = [
+    os.path.normpath(os.path.join(
+        _PACKAGE_DIR, '@STP_PYTHON_TO_INSTALL_LIBDIR@',
+        '@LIBSTP_FILENAME@')),
+    os.path.normpath(os.path.join(
+        _PACKAGE_DIR, '@STP_PYTHON_TO_INSTALL_BINDIR@',
+        '@LIBSTP_FILENAME@')),
     '@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@/@LIBSTP_FILENAME@',
-    '@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_BINDIR@/@LIBSTP_FILENAME@'
+    '@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_BINDIR@/@LIBSTP_FILENAME@',
 ]


### PR DESCRIPTION
`library_path.py` is configured with the absolute paths libstp was installed to, baked in from `CMAKE_INSTALL_PREFIX` at configure time. That is correct only while the installation stays exactly where it was configured. Move the tree, stage it under a different root, or relocate it into a wheel or a container image, and the module looks for the library at a path that no longer exists on that machine.

The package already knows where it is, so this computes the library and runtime directories relative to the installed package at configure time and resolves them against `__file__` at import.

Those relative candidates go first, and the configured absolute paths stay behind them rather than being replaced. The two are not interchangeable, and this is the part worth reviewing: the package installs to the detected site-packages directory, which need not be under `CMAKE_INSTALL_PREFIX` at all. When it is not, the relative route leads out of one tree and into another and holds only while both stay put — so replacing the absolute entries outright would trade one fragile case for another. `PATHS` is a search list, so keeping both costs a missed `stat` on the way to the answer.

This deliberately does not touch where the bindings install to, which #1020 noted is a separate decision; it only makes the lookup work under either answer.

Full suite passes.