### PR TITLE
Keep the word-size probe away from LTO as well

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -420,6 +420,37 @@ macro(stp_probe_with_linking_again)
   unset(_stp_saved_try_compile_target_type)
 endmacro()
 
+# And one probe needs the optimiser kept away from it as well.
+# check_type_size() does not read its answer off an exit status: it compiles a
+# program with the size written into a string constant, and then greps that
+# constant out of the artifact it copied back.  Stopping at a static library
+# means the artifact is whatever the compiler emits without a link, and under
+# clang's -flto that is bytecode, which does not hold the string in a form
+# file(STRINGS) can see.  The compile succeeded, so the probe reports "done"
+# and hands back an empty size -- which is worse than a failure, because
+# everything downstream reads "" as "not 8" and configures ABC's 32-bit ABI on
+# a 64-bit host.  (GCC's bytecode keeps the string, so only clang shows it.)
+#
+# A word size is decided by the target, not by whether the build is optimised
+# across translation units, so the flag comes off for the probe and stays on
+# for the build.  The pattern matches -flto and -flto=thin as well as GCC's
+# -fno-fat-lto-objects, and not a path that happens to contain those letters.
+#
+# Not nestable either: one saved value, one restore.
+macro(stp_probe_without_lto)
+  set(_stp_saved_c_flags "${CMAKE_C_FLAGS}")
+  set(_stp_saved_cxx_flags "${CMAKE_CXX_FLAGS}")
+  string(REGEX REPLACE "-f[a-z-]*lto[^ ]*" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+  string(REGEX REPLACE "-f[a-z-]*lto[^ ]*" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+endmacro()
+
+macro(stp_probe_with_lto_again)
+  set(CMAKE_C_FLAGS "${_stp_saved_c_flags}")
+  set(CMAKE_CXX_FLAGS "${_stp_saved_cxx_flags}")
+  unset(_stp_saved_c_flags)
+  unset(_stp_saved_cxx_flags)
+endmacro()
+
 macro(add_cxx_flag_if_supported flagname)
   stp_probe_without_linking()
   check_cxx_compiler_flag("${flagname}" HAVE_FLAG_${flagname})
@@ -915,12 +946,16 @@ include_directories(SYSTEM ${STP_UNORDERED_DENSE_INCLUDE_DIR})
 include(CheckTypeSize)
 
 # A word size is a property of the compiler, not of how the final binary will
-# be linked; see stp_probe_without_linking() above for what happens when these
-# are allowed to depend on a link that cannot be made.
+# be linked or how hard it is optimised; see stp_probe_without_linking() above
+# for what happens when these are allowed to depend on a link that cannot be
+# made, and stp_probe_without_lto() for what LTO does to the way this
+# particular probe reports its answer.
 stp_probe_without_linking()
+stp_probe_without_lto()
 CHECK_TYPE_SIZE("void*" SIZEOF_VOID_P)
 CHECK_TYPE_SIZE("long" SIZEOF_LONG)
 CHECK_TYPE_SIZE("int" SIZEOF_INT)
+stp_probe_with_lto_again()
 stp_probe_with_linking_again()
 
 # And if one of them still does not come back, stop here.  Everything below is


### PR DESCRIPTION
Last night's [PGO run](https://github.com/stp/stp/actions/runs/33185014810/job/98895644509) failed on clang before it compiled anything, three lines after the probe it complains about had reported success:

```
-- Check size of void*
-- Check size of void* - done
...
CMake Error at CMakeLists.txt:934 (message):
  check_type_size() could not determine SIZEOF_VOID_P, and ABC's ABI is
  selected from it -- so there is nothing safe to assume here.
```

Both lines are true. `check_type_size()` does not read the size off an exit status: it compiles a program with the size written into a string constant, and then greps that constant back out of the artifact it copied. Since #1003 the word-size probes stop at a static library and never link, so the artifact is whatever the compiler emits without a link -- and under clang's `-flto` that is bytecode, which does not hold the string anywhere `file(STRINGS)` can see it. The compile succeeded, so the probe reports `done` and hands back an empty size.

The error is the check added in #1003 doing its job: an empty `SIZEOF_VOID_P` reads as "not 8" everywhere below it, which configures ABC's 32-bit ABI on a 64-bit host. GCC's LTO objects do still carry the string, which is why the gcc leg of that build is green, and the profile flags have nothing to do with it -- `CC=clang CXX=clang++ ./configure.sh --lto` reproduces it on its own, with no PGO anywhere near it.

A word size is decided by the target, not by whether the build is optimised across translation units, so this takes the LTO flags off that one probe and leaves them on the build. The pattern matches `-flto` and `-flto=thin` as well as GCC's `-fno-fat-lto-objects`, and leaves alone a path that happens to contain those letters.

Verified with clang and with gcc, with `--lto` and without: `SIZEOF_VOID_P` is 8, ABC is configured `-DLIN64`, and `-flto=thin` / `-flto=auto` are still in the final flags. The two-pass cycle this broke -- `scripts/pgo-build.sh release --lto --ninja --auto-download --testing` under clang -- runs end to end again, second pass compiling with `-flto=thin -fprofile-use=...`, 175 of 175 tests passing.

One thing this does not address: nothing in `ci.yml` passes `--lto`, so the nightly is the only job that exercises any of it, and a configure-time break in an LTO build is invisible until the next night. Happy to add a configure-only leg if that is wanted, but it seemed a separate decision from fixing the probe.
