### PR TITLE
Reach the AIG through the node manager, not through ABC

### DIFF
--- a/include/stp/Simplifier/AIGSimplifyPropositionalCore.h
+++ b/include/stp/Simplifier/AIGSimplifyPropositionalCore.h
@@ -66,7 +66,11 @@ private:
   // Convert theory nodes to fresh variables.
   ASTNode theoryToFresh(const ASTNode& n, ASTNodeMap& fromTo);
 
-  typedef std::map<Aig_Obj_t*, ASTNode> cacheType;
+  // Keyed by AIG literal -- 2*id + complement -- rather than by Aig_Obj_t*.
+  // A pointer-keyed container is one iteration away from ordering the pass by
+  // address, and the literal also lets the complemented form be cached, which
+  // the pointer key could not do without conflating x with !x.
+  typedef std::unordered_map<unsigned, ASTNode> cacheType;
 
   // Convert the AIG back to an ASTNode.
   ASTNode convert(BBNodeManagerAIG& mgr, Aig_Obj_t* obj, cacheType& cache);

--- a/include/stp/ToSat/BBNodeAIG.h
+++ b/include/stp/ToSat/BBNodeAIG.h
@@ -110,12 +110,16 @@ public:
   bool operator==(const BBNodeAIG& other) const { return n == other.n; }
   bool operator!=(const BBNodeAIG& other) const { return !(n == other.n); }
 
-
   /*
   Negative AIG nodes are indicated by being odd.
   Each AIG node has a unique id.
   The negative, and non-negative of the same node, have the same ID.
-  We use this in a set, so we need the negative and non-negative to evaluate as different.  
+  We use this in a set, so we need the negative and non-negative to evaluate as different.
+
+  Not dead: mult_Booth sorts each column of partial products with it
+  (BitBlaster.cpp, "sort(t_products[i]...")), so this ordering decides which
+  products are combined first and therefore reaches the CNF. Any change to it
+  is a change to the emitted formula, not a refactor.
   */
   bool operator<(const BBNodeAIG& other) const 
   { 
@@ -124,6 +128,8 @@ public:
 
     return Aig_Regular(n)->Id < Aig_Regular(other.n)->Id; 
   }
+
+
 
   void print() const { print(n); }
 };

--- a/include/stp/ToSat/BBNodeManagerAIG.h
+++ b/include/stp/ToSat/BBNodeManagerAIG.h
@@ -36,9 +36,6 @@ THE SOFTWARE.
 #include "sat/cnf/cnf.h"
 #include "opt/dar/dar.h"
 
-typedef Cnf_Dat_t_ CNFData;
-typedef Aig_Obj_t AIGNode;
-
 namespace stp
 {
 class ASTNode;
@@ -86,6 +83,23 @@ inline Aig_Obj_t* orderedAigMux(Aig_Man_t* p, Aig_Obj_t* pC, Aig_Obj_t* p1,
   return Aig_Or(p, thn, els);
 }
 
+// The DAR 4-input subgraph library is a process-global that costs roughly
+// 150M instructions to build, and all three of its users -- AIG rewriting
+// inside CNF conversion, the exact-encoder's rewrite, and the propositional
+// core simplifier -- share the one copy.
+//
+// It used to have three callers of Dar_LibStart() and a single Dar_LibStop(),
+// so the core simplifier tore down the library the other two were still
+// relying on and the next rewrite re-paid the build. Dar_LibStop() also
+// asserts the library is live, making a second call an abort rather than a
+// no-op. One owner, started on demand and kept for the process: Dar_LibStart()
+// is already idempotent, so the cost is paid once however many callers there
+// are.
+inline void ensureDarLibrary()
+{
+  Dar_LibStart();
+}
+
 // Thrown by BBNodeManagerAIG::checkBudget() when the AND-gate count passes
 // the manager's nodeBudget. Whoever set the budget owns the abandonment
 // policy, so this escapes CreateNode() and every BitBlaster frame above it;
@@ -117,6 +131,68 @@ public:
   int totalNumberOfNodes()
   {
     return aigMgr->nObjs[AIG_OBJ_AND]; // without having removed non-reachable.
+  }
+
+  // --- the interface everything above the manager is allowed to use --------
+  //
+  // These exist so that no caller reaches through `aigMgr` into ABC. That is
+  // not tidiness: BitBlaster cannot be instantiated over a second node
+  // representation while it names Aig_Obj_t directly, and every one of these
+  // is a method that representation would have to provide anyway.
+
+  // A combinational input that stands for no symbol. The BV abstraction
+  // machinery mints these for proxies and for abstracted results, which is
+  // why it does not go through CreateSymbol.
+  BBNodeAIG CreateFreshInput()
+  {
+    BBNodeAIG fresh(Aig_ObjCreateCi(aigMgr));
+    fresh.symbol_index = aigMgr->vCis->nSize - 1;
+    return fresh;
+  }
+
+  // How many combinational inputs exist, and the object id of one of them by
+  // creation order. Callers index Cnf_Dat_t::pVarNums by that id; when the
+  // CNF seam lands they ask the CNF for the variable instead and this goes.
+  //
+  // Positional rather than by node, because dag-aware rewriting replaces the
+  // manager wholesale and only the position in vCis survives it.
+  int ciCount() const { return aigMgr->vCis->nSize; }
+
+  int ciObjectId(int ordinal) const
+  {
+    assert(ordinal >= 0 && ordinal < ciCount());
+    return Aig_ObjId((Aig_Obj_t*)Vec_PtrEntry(aigMgr->vCis, ordinal));
+  }
+
+  BBNodeAIG ciNode(int ordinal) const
+  {
+    assert(ordinal >= 0 && ordinal < ciCount());
+    return BBNodeAIG((Aig_Obj_t*)Vec_PtrEntry(aigMgr->vCis, ordinal));
+  }
+
+  // Node-level queries, all on the uncomplemented node: a literal and its
+  // negation answer these identically.
+  static bool isCI(const BBNodeAIG& n) { return Aig_ObjIsCi(Aig_Regular(n.n)); }
+  static bool isConstant(const BBNodeAIG& n)
+  {
+    return Aig_ObjIsConst1(Aig_Regular(n.n));
+  }
+  static bool isAnd(const BBNodeAIG& n) { return Aig_ObjIsAnd(Aig_Regular(n.n)); }
+  static unsigned nodeId(const BBNodeAIG& n)
+  {
+    return Aig_ObjId(Aig_Regular(n.n));
+  }
+
+  // The fanins of an AND, with the sign stripped. Provenance and traversal
+  // are both sign-insensitive; returning the signed edge here would key two
+  // memo entries per node.
+  static BBNodeAIG fanin0(const BBNodeAIG& n)
+  {
+    return BBNodeAIG(Aig_ObjFanin0(Aig_Regular(n.n)));
+  }
+  static BBNodeAIG fanin1(const BBNodeAIG& n)
+  {
+    return BBNodeAIG(Aig_ObjFanin1(Aig_Regular(n.n)));
   }
 
   // Called after every CreateNode(). A single node can add a whole fan-in

--- a/include/stp/ToSat/BitBlaster.h
+++ b/include/stp/ToSat/BitBlaster.h
@@ -548,10 +548,47 @@ private:
   // are memoised after an iterative walk; CI provenance never changes after
   // that input is exposed to a parent.
   uint64_t nextAbstractionId_ = 1;
-  std::unordered_map<unsigned, std::vector<BVAbstractionId>>
-      ciAbstractionSources_;
-  std::unordered_map<unsigned, std::vector<BVAbstractionId>>
-      aigAbstractionSourcesMemo_;
+  // Both are indexed by AIG node id, which is dense and never reused within a
+  // manager, so a vector beats a hash map: the second is walked once per
+  // abstracted bit, and this removes a hash from every node of every visit.
+  // An empty entry means "nothing recorded", which is the same answer the
+  // maps gave by not finding the key.
+  std::vector<std::vector<BVAbstractionId>> ciAbstractionSources_;
+  std::vector<std::vector<BVAbstractionId>> aigAbstractionSourcesMemo_;
+  // "this id's union has been computed", which an empty entry cannot say on
+  // its own -- and a node whose cone holds no abstraction has an empty union,
+  // which is the common case because abstraction is off by default. Keeping
+  // this separate from the memo is what stops those cones being re-walked on
+  // every visit. It must live here rather than in the walk: the walk recurses
+  // into itself for the fanins, so a local marker is void at each descent.
+  std::vector<bool> aigAbstractionSourcesComputed_;
+
+  // Grow-on-demand accessors for the two above; `at` returns the empty vector
+  // for an id past the end rather than resizing, so a read never allocates.
+  static const std::vector<BVAbstractionId>& noSources();
+  static const std::vector<BVAbstractionId>&
+  sourcesAt(const std::vector<std::vector<BVAbstractionId>>& table, unsigned id)
+  {
+    return id < table.size() ? table[id] : noSources();
+  }
+  static void setSourcesAt(std::vector<std::vector<BVAbstractionId>>& table,
+                           unsigned id, std::vector<BVAbstractionId> sources)
+  {
+    if (id >= table.size())
+      table.resize(id + 1);
+    table[id] = std::move(sources);
+  }
+  bool aigSourcesComputed(unsigned id) const
+  {
+    return id < aigAbstractionSourcesComputed_.size() &&
+           aigAbstractionSourcesComputed_[id];
+  }
+  void markAigSourcesComputed(unsigned id)
+  {
+    if (id >= aigAbstractionSourcesComputed_.size())
+      aigAbstractionSourcesComputed_.resize(id + 1, false);
+    aigAbstractionSourcesComputed_[id] = true;
+  }
 
   BVAbstractionId newAbstractionId();
   void tagAbstractionSources(const BBNodeAIG& ci,

--- a/include/stp/ToSat/ToSATAIG.h
+++ b/include/stp/ToSat/ToSATAIG.h
@@ -89,8 +89,6 @@ private:
 
   void init() { first = true; }
 
-  static THREAD_LOCAL_IE int cnf_calls;
-
 public:
   void add_cnf_to_solver(SATSolver& satSolver, Cnf_Dat_t* cnfData);
 

--- a/include/stp/cpp_interface.h
+++ b/include/stp/cpp_interface.h
@@ -608,11 +608,6 @@ public:
   DLL_PUBLIC void getModel();
   DLL_PUBLIC void getValue(const ASTVec& v);
 };
-
-// Functions used by C++ clients of STP. TODO: either export abc cleanly or don't use this in clients.
-
-/// Export version of Cnf_ClearMemory.
-DLL_PUBLIC void CNFClearMemory();
 }
 
 #endif

--- a/lib/Incremental/IncrementalSolverImpl.h
+++ b/lib/Incremental/IncrementalSolverImpl.h
@@ -3750,8 +3750,7 @@ struct IncrementalSolver::Impl
   // where a later simplification kept the record but not the cone.
   unsigned abstractionVarOf(int ciSymbolIndex)
   {
-    Aig_Obj_t* ci = (Aig_Obj_t*)Vec_PtrEntry(
-        encoding.nodes().aigMgr->vCis, ciSymbolIndex);
+    Aig_Obj_t* ci = encoding.nodes().ciNode(ciSymbolIndex).n;
     ensureEncoded(ci);
     return (unsigned)varOfAig(ci);
   }

--- a/lib/Interface/c_interface.cpp
+++ b/lib/Interface/c_interface.cpp
@@ -3913,7 +3913,6 @@ void vc_Destroy(VC vc)
     b->persist.clear();
   }
 
-  Cnf_ManFree();
   vc_clearDecls(vc);
   retireCContext(vc);
   stp_i->deleteObjects();

--- a/lib/Interface/cpp_interface.cpp
+++ b/lib/Interface/cpp_interface.cpp
@@ -1942,11 +1942,6 @@ void Cpp_interface::getModel()
   cout << ")" << std::endl;
 }
 
-void CNFClearMemory()
-{
-  Cnf_ManFree();
-}
-
 Cpp_interface::SolverFrame::SolverFrame(
     ankerl::unordered_dense::map<std::string, Function>*
         global_function_context,

--- a/lib/Simplifier/AIGSimplifyPropositionalCore.cpp
+++ b/lib/Simplifier/AIGSimplifyPropositionalCore.cpp
@@ -43,6 +43,7 @@ THE SOFTWARE.
 #include "opt/dar/dar.h"
 
 #include "stp/Simplifier/Simplifier.h"
+#include "stp/ToSat/BBNodeManagerAIG.h"
 #include "stp/ToSat/BitBlaster.h"
 
 #include <iostream>
@@ -130,42 +131,84 @@ ASTNode AIGSimplifyPropositionalCore::theoryToFresh(const ASTNode& n,
   return result;
 }
 
-// Convert the AIG back to an ASTNode.
-ASTNode AIGSimplifyPropositionalCore::convert(BBNodeManagerAIG& mgr,
-                                              Aig_Obj_t* obj, cacheType& cache)
+// The AIG literal an object stands for: 2*id + complement, so x and !x are
+// distinct keys and neither is a pointer.
+static inline unsigned aigLit(Aig_Obj_t* obj)
 {
-  cacheType::const_iterator it;
-  if ((it = cache.find(obj)) != cache.end())
-    return it->second;
+  return 2u * Aig_ObjId(Aig_Regular(obj)) + (Aig_IsComplement(obj) ? 1u : 0u);
+}
 
-  if (Aig_IsComplement(obj))
-    return nf->CreateNode(NOT, convert(mgr, Aig_Regular(obj), cache));
-  else if (Aig_ObjIsAnd(obj))
+// Convert the AIG back to an ASTNode.
+//
+// Iterative, two-visit post-order. The recursive form put one frame on the
+// stack for every AND node, and nothing bounds an AIG's depth: DeepDag_Test
+// covers the blaster and ABC's own CNF walks but has never reached this pass,
+// so the overflow here was latent rather than absent.
+//
+// Operands are pushed child1-then-child0 so that child0 is finished first,
+// which is the order the recursive form used. Node creation order decides
+// node_uid, and node_uid decides every sort that ties on node identity.
+ASTNode AIGSimplifyPropositionalCore::convert(BBNodeManagerAIG& mgr,
+                                              Aig_Obj_t* root, cacheType& cache)
+{
+  std::vector<std::pair<Aig_Obj_t*, bool>> pending(1,
+                                                   std::make_pair(root, false));
+  while (!pending.empty())
   {
-    // Argument evaluation order is unspecified, so convert each child into a
-    // named variable first, otherwise the nodes are built in a
-    // compiler-dependent order.
-    const ASTNode child0 = convert(mgr, Aig_ObjChild0(obj), cache);
-    const ASTNode child1 = convert(mgr, Aig_ObjChild1(obj), cache);
-    ASTNode result = nf->CreateNode(AND, child0, child1);
-    cache.insert(make_pair(obj, result));
-    return result;
+    Aig_Obj_t* obj = pending.back().first;
+    const bool expanded = pending.back().second;
+    pending.pop_back();
+
+    if (cache.find(aigLit(obj)) != cache.end())
+      continue;
+
+    if (Aig_IsComplement(obj))
+    {
+      Aig_Obj_t* regular = Aig_Regular(obj);
+      if (!expanded)
+      {
+        pending.push_back(std::make_pair(obj, true));
+        pending.push_back(std::make_pair(regular, false));
+        continue;
+      }
+      cache[aigLit(obj)] =
+          nf->CreateNode(NOT, cache.at(aigLit(regular)));
+    }
+    else if (Aig_ObjIsAnd(obj))
+    {
+      if (!expanded)
+      {
+        pending.push_back(std::make_pair(obj, true));
+        pending.push_back(std::make_pair(Aig_ObjChild1(obj), false));
+        pending.push_back(std::make_pair(Aig_ObjChild0(obj), false));
+        continue;
+      }
+      cache[aigLit(obj)] = nf->CreateNode(AND, cache.at(aigLit(Aig_ObjChild0(obj))),
+                                          cache.at(aigLit(Aig_ObjChild1(obj))));
+    }
+    else if (obj == Aig_ManConst1(mgr.aigMgr))
+      cache[aigLit(obj)] = bm->ASTTrue;
+    else if (obj == Aig_ManConst0(mgr.aigMgr))
+      cache[aigLit(obj)] = bm->ASTFalse;
+    else if (Aig_ObjIsCo(obj))
+    {
+      if (!expanded)
+      {
+        pending.push_back(std::make_pair(obj, true));
+        pending.push_back(std::make_pair(Aig_ObjChild0(obj), false));
+        continue;
+      }
+      cache[aigLit(obj)] = cache.at(aigLit(Aig_ObjChild0(obj)));
+    }
+    else
+    {
+      // Every combinational input was put into the cache by topLevel(), so
+      // reaching here means the symbol-to-input mapping is incomplete.
+      assert(!Aig_ObjIsCi(obj) && "AIG input missing from the symbol map");
+      FatalError("AIGSimplifyPropositionalCore: unhandled AIG object type");
+    }
   }
-  else if (obj == Aig_ManConst1(mgr.aigMgr))
-    return bm->ASTTrue;
-  else if (obj == Aig_ManConst0(mgr.aigMgr))
-    return bm->ASTFalse;
-  else if (Aig_ObjIsCo(obj))
-    return convert(mgr, Aig_ObjChild0(obj), cache);
-  else
-  {
-    // Every combinational input was put into the cache by topLevel(), so
-    // reaching here means the symbol-to-input mapping is incomplete.
-    assert(!Aig_ObjIsCi(obj) && "AIG input missing from the symbol map");
-    FatalError("AIGSimplifyPropositionalCore: unhandled AIG object type");
-  }
-  assert(false);
-  exit(-1);
+  return cache.at(aigLit(root));
 }
 
 ASTNode AIGSimplifyPropositionalCore::topLevel(const ASTNode& top)
@@ -210,10 +253,10 @@ ASTNode AIGSimplifyPropositionalCore::topLevel(const ASTNode& top)
 
   assert(Aig_ManCoNum(mgr.aigMgr) == 1);
 
-  int initial_nodeCount = mgr.aigMgr->nObjs[AIG_OBJ_AND];
+  int initial_nodeCount = mgr.totalNumberOfNodes();
   // cerr << "Nodes before AIG rewrite:" << initial_nodeCount << endl;
 
-  Dar_LibStart(); // About 150M instructions. Very expensive.
+  ensureDarLibrary();
   Dar_RwrPar_t Pars, *pPars = &Pars;
   Dar_ManDefaultRwrParams(pPars);
 
@@ -238,11 +281,11 @@ ASTNode AIGSimplifyPropositionalCore::topLevel(const ASTNode& top)
     Aig_ManStop(pTemp);
 
     // cerr << "After rewrite [" << i << "]  nodes:"
-    //		<< mgr.aigMgr->nObjs[AIG_OBJ_AND] << endl;
+    //		<< mgr.totalNumberOfNodes() << endl;
 
-    if (lastNodeCount == mgr.aigMgr->nObjs[AIG_OBJ_AND])
+    if (lastNodeCount == mgr.totalNumberOfNodes())
       break;
-    lastNodeCount = mgr.aigMgr->nObjs[AIG_OBJ_AND];
+    lastNodeCount = mgr.totalNumberOfNodes();
   }
 
   cacheType ptrToOrig;
@@ -268,16 +311,14 @@ ASTNode AIGSimplifyPropositionalCore::topLevel(const ASTNode& top)
     // symbol_index indexes vCis (see BBNodeManagerAIG::CreateSymbol), so this
     // is a combinational input. Not Aig_ManLi, which is the latch-input
     // accessor and reads past the end of vCos on a combinational AIG.
-    assert(index < Aig_ManCiNum(mgr.aigMgr));
-    Aig_Obj_t* pi = Aig_ManCi(mgr.aigMgr, index);
-    ptrToOrig.insert(make_pair(pi, result));
+    assert(index < mgr.ciCount());
+    ptrToOrig.insert(make_pair(2u * (unsigned)mgr.ciObjectId(index), result));
   }
 
-  Aig_Obj_t* pObj = (Aig_Obj_t*)Vec_PtrEntry(mgr.aigMgr->vCos, 0);
+  Aig_Obj_t* pObj = Aig_ManCo(mgr.aigMgr, 0);
 
   ASTNode result = convert(mgr, pObj, ptrToOrig);
 
-  Dar_LibStop();
 
   bm->GetRunTimes()->stop(RunTimes::AIGSimplifyCore);
   return result;

--- a/lib/ToSat/BVExactEncoder.cpp
+++ b/lib/ToSat/BVExactEncoder.cpp
@@ -68,13 +68,13 @@ void rewrite(BBNodeManagerAIG& mgr, int64_t iterations)
   if (iterations <= 0)
     return;
 
-  Dar_LibStart();
+  ensureDarLibrary();
   Dar_RwrPar_t Pars;
   Dar_ManDefaultRwrParams(&Pars);
 
   for (int64_t i = 0; i < iterations; i++)
   {
-    const int before = mgr.aigMgr->nObjs[AIG_OBJ_AND];
+    const int before = mgr.totalNumberOfNodes();
 
     Aig_Man_t* pTemp;
     mgr.aigMgr = Aig_ManDupDfs(pTemp = mgr.aigMgr);
@@ -88,7 +88,7 @@ void rewrite(BBNodeManagerAIG& mgr, int64_t iterations)
     mgr.aigMgr = Aig_ManDupDfs(pTemp = mgr.aigMgr);
     Aig_ManStop(pTemp);
 
-    if (before == mgr.aigMgr->nObjs[AIG_OBJ_AND])
+    if (before == mgr.totalNumberOfNodes())
       break;
   }
 }
@@ -130,8 +130,7 @@ void encodeNaryLemma(
   for (unsigned v = 0; v < inputs.size(); ++v)
     for (unsigned i = 0; i < width; i++)
     {
-      inputs[v][i] = BBNodeAIG(Aig_ObjCreateCi(mgr.aigMgr));
-      inputs[v][i].symbol_index = mgr.aigMgr->vCis->nSize - 1;
+      inputs[v][i] = mgr.CreateFreshInput();
     }
 
   BBNodeSet support;
@@ -168,7 +167,7 @@ void encodeNaryLemma(
   std::vector<unsigned> cnfToSolver(cnf->nVars, ~((unsigned)0));
   for (unsigned i = 0; i < liveVars.size() * width; ++i)
   {
-    const int var = cnf->pVarNums[Aig_ManCi(mgr.aigMgr, (int)i)->Id];
+    const int var = cnf->pVarNums[mgr.ciObjectId((int)i)];
     if (var < 0)
       continue;
     cnfToSolver[var] = (*liveVars[i / width])[i % width];
@@ -365,8 +364,7 @@ void BVExactEncoder::encode(SATSolver& solver, const ASTNode& term,
         operands[op][i] = bit != 0 ? mgr.getTrue() : mgr.getFalse();
         continue;
       }
-      operands[op][i] = BBNodeAIG(Aig_ObjCreateCi(mgr.aigMgr));
-      operands[op][i].symbol_index = mgr.aigMgr->vCis->nSize - 1;
+      operands[op][i] = mgr.CreateFreshInput();
       ciVars.push_back((*opVars[op])[i]);
     }
 
@@ -410,7 +408,7 @@ void BVExactEncoder::encode(SATSolver& solver, const ASTNode& term,
 
   for (unsigned i = 0; i < ciVars.size(); i++)
   {
-    const int var = cnf->pVarNums[Aig_ManCi(mgr.aigMgr, (int)i)->Id];
+    const int var = cnf->pVarNums[mgr.ciObjectId((int)i)];
     // An input the circuit never reads is given no variable, and needs
     // none: nothing the CNF says mentions it.
     if (var < 0)

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -103,12 +103,17 @@ BVAbstractionId BitBlaster::newAbstractionId()
   return BVAbstractionId(nextAbstractionId_++);
 }
 
+const std::vector<BVAbstractionId>& BitBlaster::noSources()
+{
+  static const std::vector<BVAbstractionId> empty;
+  return empty;
+}
+
 void BitBlaster::tagAbstractionSources(
     const BBNodeAIG& ci, const std::vector<BVAbstractionId>& sources)
 {
   assert(!ci.IsNull());
-  Aig_Obj_t* regular = Aig_Regular(ci.n);
-  assert(Aig_ObjIsCi(regular));
+  assert(BBNodeManagerAIG::isCI(ci));
 
   std::vector<BVAbstractionId> normalized = sources;
   std::sort(normalized.begin(), normalized.end());
@@ -117,11 +122,11 @@ void BitBlaster::tagAbstractionSources(
   for ([[maybe_unused]] const BVAbstractionId id : normalized)
     assert(id.valid());
 
-  const unsigned aigId = Aig_ObjId(regular);
-  [[maybe_unused]] const auto inserted =
-      ciAbstractionSources_.insert(std::make_pair(aigId, normalized));
-  assert((inserted.second || inserted.first->second == normalized) &&
+  const unsigned aigId = BBNodeManagerAIG::nodeId(ci);
+  assert((sourcesAt(ciAbstractionSources_, aigId).empty() ||
+          sourcesAt(ciAbstractionSources_, aigId) == normalized) &&
          "an AIG input acquired two abstraction provenances");
+  setSourcesAt(ciAbstractionSources_, aigId, std::move(normalized));
 }
 
 std::vector<BVAbstractionId>
@@ -130,53 +135,47 @@ BitBlaster::abstractionSourcesOf(const BBNodeAIG& root)
   if (root.IsNull())
     return {};
 
-  Aig_Obj_t* rootRegular = Aig_Regular(root.n);
-  if (Aig_ObjIsConst1(rootRegular))
+  if (BBNodeManagerAIG::isConstant(root))
     return {};
-  if (Aig_ObjIsCi(rootRegular))
-  {
-    const auto it = ciAbstractionSources_.find(Aig_ObjId(rootRegular));
-    return it == ciAbstractionSources_.end()
-               ? std::vector<BVAbstractionId>()
-               : it->second;
-  }
+  if (BBNodeManagerAIG::isCI(root))
+    return sourcesAt(ciAbstractionSources_, BBNodeManagerAIG::nodeId(root));
 
-  const unsigned rootId = Aig_ObjId(rootRegular);
-  const auto rootMemo = aigAbstractionSourcesMemo_.find(rootId);
-  if (rootMemo != aigAbstractionSourcesMemo_.end())
-    return rootMemo->second;
+  const unsigned rootId = BBNodeManagerAIG::nodeId(root);
+  if (aigSourcesComputed(rootId))
+    return sourcesAt(aigAbstractionSourcesMemo_, rootId);
 
   // Deep input terms reach tens of thousands of AIG levels in practice.
   // Run the recursive two-visit post-order explicitly on the heap, computing
   // each union only after both fanins. Memo hits also collapse shared cones.
-  typedef std::pair<Aig_Obj_t*, bool> PendingAig;
-  std::vector<PendingAig> pending(1, PendingAig(rootRegular, false));
+  typedef std::pair<BBNodeAIG, bool> PendingAig;
+  std::vector<PendingAig> pending(1, PendingAig(root, false));
   while (!pending.empty())
   {
-    Aig_Obj_t* node = Aig_Regular(pending.back().first);
+    const BBNodeAIG node = pending.back().first;
     const bool expanded = pending.back().second;
     pending.pop_back();
-    if (Aig_ObjIsConst1(node) || Aig_ObjIsCi(node) ||
-        aigAbstractionSourcesMemo_.find(Aig_ObjId(node)) !=
-            aigAbstractionSourcesMemo_.end())
+    const unsigned id = BBNodeManagerAIG::nodeId(node);
+    if (BBNodeManagerAIG::isConstant(node) || BBNodeManagerAIG::isCI(node) ||
+        aigSourcesComputed(id))
       continue;
-    assert(Aig_ObjIsAnd(node));
+    assert(BBNodeManagerAIG::isAnd(node));
     if (!expanded)
     {
       pending.push_back(PendingAig(node, true));
-      pending.push_back(PendingAig(Aig_ObjFanin0(node), false));
-      pending.push_back(PendingAig(Aig_ObjFanin1(node), false));
+      pending.push_back(PendingAig(BBNodeManagerAIG::fanin0(node), false));
+      pending.push_back(PendingAig(BBNodeManagerAIG::fanin1(node), false));
       continue;
     }
 
     std::vector<BVAbstractionId> sources =
-        abstractionSourcesOf(BBNodeAIG(Aig_ObjFanin0(node)));
+        abstractionSourcesOf(BBNodeManagerAIG::fanin0(node));
     appendAbstractionSources(
-        sources, abstractionSourcesOf(BBNodeAIG(Aig_ObjFanin1(node))));
-    aigAbstractionSourcesMemo_[Aig_ObjId(node)] = std::move(sources);
+        sources, abstractionSourcesOf(BBNodeManagerAIG::fanin1(node)));
+    setSourcesAt(aigAbstractionSourcesMemo_, id, std::move(sources));
+    markAigSourcesComputed(id);
   }
 
-  return aigAbstractionSourcesMemo_.at(rootId);
+  return sourcesAt(aigAbstractionSourcesMemo_, rootId);
 }
 
 std::vector<BVAbstractionId>
@@ -207,8 +206,7 @@ BBNodeVec BitBlaster::ensureProxyCIs(const ASTNode& node,
   {
     const std::vector<BVAbstractionId> sources =
         abstractionSourcesOf(bits[i]);
-    proxies[i] = BBNodeAIG(Aig_ObjCreateCi(nf->aigMgr));
-    proxies[i].symbol_index = nf->aigMgr->vCis->nSize - 1;
+    proxies[i] = nf->CreateFreshInput();
     tagAbstractionSources(proxies[i], sources);
     Aig_Obj_t* bicond = Aig_Not(orderedAigExor(
         nf->aigMgr, proxies[i].n, bits[i].n));
@@ -1255,12 +1253,10 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term, BBNodeSet& support,
         BBNodeVec abstracted(num_bits);
         for (unsigned i = 0; i < num_bits; i++)
         {
-          abstracted[i] = BBNodeAIG(Aig_ObjCreateCi(nf->aigMgr));
-          abstracted[i].symbol_index = nf->aigMgr->vCis->nSize - 1;
+          abstracted[i] = nf->CreateFreshInput();
           tagAbstractionSources(abstracted[i], {id});
         }
-        BBNodeAIG condCI(Aig_ObjCreateCi(nf->aigMgr));
-        condCI.symbol_index = nf->aigMgr->vCis->nSize - 1;
+        BBNodeAIG condCI = nf->CreateFreshInput();
         // This is an operand proxy, not the ITE abstraction's answer. Keep
         // the condition's producers on it so a future AIG alias does not
         // turn the dependency cut into an unlabelled CI.
@@ -1482,8 +1478,7 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term, BBNodeSet& support,
           BBNodeVec abstracted(num_bits);
           for (unsigned i = 0; i < num_bits; i++)
           {
-            abstracted[i] = BBNodeAIG(Aig_ObjCreateCi(nf->aigMgr));
-            abstracted[i].symbol_index = nf->aigMgr->vCis->nSize - 1;
+            abstracted[i] = nf->CreateFreshInput();
             tagAbstractionSources(abstracted[i], {id});
           }
           uf->coverage.bv_abstracted[UserDefinedFlags::ABSTRACT_PLUS]++;
@@ -1614,8 +1609,7 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term, BBNodeSet& support,
         BBNodeVec abstracted(num_bits);
         for (unsigned i = 0; i < num_bits; i++)
         {
-          abstracted[i] = BBNodeAIG(Aig_ObjCreateCi(nf->aigMgr));
-          abstracted[i].symbol_index = nf->aigMgr->vCis->nSize - 1;
+          abstracted[i] = nf->CreateFreshInput();
           tagAbstractionSources(abstracted[i], {id});
         }
         nf->symbolToBBNode[term] = abstracted;
@@ -1686,8 +1680,7 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term, BBNodeSet& support,
         BBNodeVec abstracted(num_bits);
         for (unsigned i = 0; i < num_bits; i++)
         {
-          abstracted[i] = BBNodeAIG(Aig_ObjCreateCi(nf->aigMgr));
-          abstracted[i].symbol_index = nf->aigMgr->vCis->nSize - 1;
+          abstracted[i] = nf->CreateFreshInput();
           tagAbstractionSources(abstracted[i], {id});
         }
         nf->symbolToBBNode[term] = abstracted;
@@ -2203,8 +2196,7 @@ const BBNode BitBlaster::BBForm(const ASTNode& form, BBNodeSet& support,
         appendAbstractionSources(dependencies,
                                  abstractionSourcesOf(rightInputs));
         const BVAbstractionId id = newAbstractionId();
-        BBNodeAIG abstractCI(Aig_ObjCreateCi(nf->aigMgr));
-        abstractCI.symbol_index = nf->aigMgr->vCis->nSize - 1;
+        BBNodeAIG abstractCI = nf->CreateFreshInput();
         tagAbstractionSources(abstractCI, {id});
         RawBVEQAbstraction raw;
         raw.id = id;
@@ -2259,8 +2251,7 @@ const BBNode BitBlaster::BBForm(const ASTNode& form, BBNodeSet& support,
           appendAbstractionSources(dependencies,
                                    abstractionSourcesOf(rightInputs));
           const BVAbstractionId id = newAbstractionId();
-          BBNodeAIG abstractCI(Aig_ObjCreateCi(nf->aigMgr));
-          abstractCI.symbol_index = nf->aigMgr->vCis->nSize - 1;
+          BBNodeAIG abstractCI = nf->CreateFreshInput();
           tagAbstractionSources(abstractCI, {id});
 
           RawBVTermAbstraction raw;

--- a/lib/ToSat/ToCNFAIG.cpp
+++ b/lib/ToSat/ToCNFAIG.cpp
@@ -33,7 +33,7 @@ void ToCNFAIG::dag_aware_aig_rewrite(const bool needAbsRef,
 {
   if (!needAbsRef && uf.AIG_rewrites_iterations)
   {
-    Dar_LibStart();
+    ensureDarLibrary();
     Dar_RwrPar_t Pars, *pPars = &Pars;
     Dar_ManDefaultRwrParams(pPars);
 
@@ -47,7 +47,7 @@ void ToCNFAIG::dag_aware_aig_rewrite(const bool needAbsRef,
     // The rewriting doesn't remove as many nodes of course..
     for (int i = 0; i < uf.AIG_rewrites_iterations; i++)
     {
-      int nodeCount = mgr.aigMgr->nObjs[AIG_OBJ_AND];
+      int nodeCount = mgr.totalNumberOfNodes();
 
       Aig_Man_t* pTemp;
       mgr.aigMgr = Aig_ManDupDfs(pTemp = mgr.aigMgr);
@@ -71,10 +71,10 @@ void ToCNFAIG::dag_aware_aig_rewrite(const bool needAbsRef,
 
       if (uf.stats_flag)
         cerr << "After rewrite [" << i
-             << "]  nodes:" << mgr.aigMgr->nObjs[AIG_OBJ_AND] << endl;
+             << "]  nodes:" << mgr.totalNumberOfNodes() << endl;
 
       //Fixedpoint reached?
-      if (nodeCount == mgr.aigMgr->nObjs[AIG_OBJ_AND])
+      if (nodeCount == mgr.totalNumberOfNodes())
         break;
     }
   }
@@ -101,7 +101,7 @@ void ToCNFAIG::toCNF(const BBNodeAIG& top, Cnf_Dat_t*& cnfData,
 
   if (uf.stats_flag)
   {
-    cerr << "Nodes before AIG rewrite:" << mgr.aigMgr->nObjs[AIG_OBJ_AND]
+    cerr << "Nodes before AIG rewrite:" << mgr.totalNumberOfNodes()
          << endl;
   }
 
@@ -276,9 +276,7 @@ void ToCNFAIG::fill_node_to_var(Cnf_Dat_t* cnfData,
     {
       if (!b[i].IsNull())
       {
-        Aig_Obj_t* pObj;
-        pObj = (Aig_Obj_t*)Vec_PtrEntry(mgr.aigMgr->vCis, b[i].symbol_index);
-        v[i] = cnfData->pVarNums[pObj->Id];
+        v[i] = cnfData->pVarNums[mgr.ciObjectId(b[i].symbol_index)];
       }
     }
 

--- a/lib/ToSat/ToSATAIG.cpp
+++ b/lib/ToSat/ToSATAIG.cpp
@@ -32,7 +32,6 @@ THE SOFTWARE.
 namespace stp
 {
 
-THREAD_LOCAL_IE int ToSATAIG::cnf_calls = 0;
 
 bool ToSATAIG::CallSAT(SATSolver& satSolver, const ASTNode& input,
                        bool needAbsRef)
@@ -138,15 +137,12 @@ void ToSATAIG::bind_injectivity_guard(SATSolver& satSolver)
 
 void ToSATAIG::release_cnf_memory(Cnf_Dat_t* cnfData)
 {
-  // This releases the memory used by the CNF generator, particularly some data
-  // tables.
-  // If CNF generation is going to be called lots, we'd rather keep it around.
-  // because the datatables are expensive to generate.
-  if (cnf_calls == 0)
-    Cnf_ManFree();
-
+  // Cnf_ManFree() used to be called here on the first conversion, to release
+  // ABC's precomputed clause-cost tables. It only ever freed the manager that
+  // Cnf_Derive() lazily creates, and STP calls Cnf_DeriveWithMan() with a
+  // manager of its own instead -- so ABC's global was always NULL and the call
+  // always a no-op. The counter that guarded it went with it.
   Cnf_DataFree(cnfData);
-  cnf_calls++;
 }
 
 void ToSATAIG::handle_cnf_options(Cnf_Dat_t* cnfData, bool needAbsRef)
@@ -309,9 +305,8 @@ Cnf_Dat_t* ToSATAIG::bitblast(const ASTNode& input, bool needAbsRef)
     a.id = raw.id;
     a.dependencies = raw.dependencies;
     a.eqNode = raw.eqNode;
-    Aig_Obj_t* pObj = (Aig_Obj_t*)Vec_PtrEntry(
-        mgr.aigMgr->vCis, raw.abstractionCI.symbol_index);
-    a.abstractionSATVar = cnfData->pVarNums[pObj->Id];
+    a.abstractionSATVar =
+        cnfData->pVarNums[mgr.ciObjectId(raw.abstractionCI.symbol_index)];
     a.leftSymbol = raw.leftSymbol;
     a.rightSymbol = raw.rightSymbol;
     a.width = std::max(1u, raw.leftSymbol.GetValueWidth());
@@ -336,9 +331,7 @@ Cnf_Dat_t* ToSATAIG::bitblast(const ASTNode& input, bool needAbsRef)
     a.width = raw.width;
     if (raw.condCISymbolIndex >= 0)
     {
-      Aig_Obj_t* condObj = (Aig_Obj_t*)Vec_PtrEntry(
-          mgr.aigMgr->vCis, raw.condCISymbolIndex);
-      a.condSATVar = cnfData->pVarNums[condObj->Id];
+      a.condSATVar = cnfData->pVarNums[mgr.ciObjectId(raw.condCISymbolIndex)];
     }
     // The record's own result inputs, resolved the same way the condition
     // above is. The blaster files them for every term family; the persistent
@@ -355,9 +348,7 @@ Cnf_Dat_t* ToSATAIG::bitblast(const ASTNode& input, bool needAbsRef)
     a.resultSATVars.reserve(raw.resultCISymbolIndices.size());
     for (const int index : raw.resultCISymbolIndices)
     {
-      Aig_Obj_t* resultObj =
-          (Aig_Obj_t*)Vec_PtrEntry(mgr.aigMgr->vCis, index);
-      a.resultSATVars.push_back(cnfData->pVarNums[resultObj->Id]);
+      a.resultSATVars.push_back(cnfData->pVarNums[mgr.ciObjectId(index)]);
     }
     abstraction_.appendTerm(std::move(a));
   }

--- a/scripts/cnf-manifest.sh
+++ b/scripts/cnf-manifest.sh
@@ -27,13 +27,18 @@
 set -u -o pipefail
 
 if [ $# -lt 2 ]; then
-    echo "usage: $0 <stp binary> <corpus directory> [timeout seconds]" >&2
+    echo "usage: $0 <stp binary> <corpus directory> [timeout seconds] [stp arg ...]" >&2
     exit 2
 fi
 
 solver=$(readlink -f "$1")
 corpus=$(readlink -f "$2")
 per_file_timeout=${3:-60}
+# Anything further is handed to stp. The paths this pass touches are mostly
+# off by default -- --aig-core-simplification, --aig-rewrite-passes,
+# --disable-simplifications -- so a manifest taken without them proves nothing
+# about the code they reach.
+if [ $# -gt 3 ]; then shift 3; extra_args=("$@"); else extra_args=(); fi
 
 if [ ! -x "$solver" ]; then
     echo "$0: '$1' is not an executable" >&2
@@ -66,10 +71,15 @@ while IFS= read -r input; do
     rm -rf "$work/run"
     mkdir -p "$work/run"
 
-    if ! (cd "$work/run" && timeout "$per_file_timeout" \
-              "$solver" --array-equality --output-CNF --exit-after-CNF "$input" \
-              >/dev/null 2>&1); then
-        status=$?
+    # Run first and capture the status separately: inside `if ! cmd; then`,
+    # $? is the status of the negation -- always 0 there -- not the command's,
+    # so every timeout used to be recorded as an error.
+    (cd "$work/run" && timeout "$per_file_timeout" \
+         "$solver" --array-equality --output-CNF --exit-after-CNF \
+         ${extra_args+"${extra_args[@]}"} "$input" \
+         >/dev/null 2>&1)
+    status=$?
+    if [ "$status" -ne 0 ]; then
         # 124 is timeout(1) killing it. Anything else is stp declining the
         # input -- an unsupported logic, a deliberate error-path test. Both
         # are recorded rather than skipped: a build that starts timing out, or

--- a/tools/stp/main_common.cpp
+++ b/tools/stp/main_common.cpp
@@ -360,7 +360,6 @@ int Main::main(int argc, char** argv)
   delete AssertsQuery;
   _empty_ASTVec.clear();
   delete stp;
-  CNFClearMemory();
 
   return 0;
 }


### PR DESCRIPTION
`BitBlaster` names ABC directly in 32 places — 18 through `nf->aigMgr`, 8 reads of `vCis->nSize`, and 17 uses of `Aig_Regular`/`Aig_ObjId`/`Aig_ObjIs*`/`Aig_ObjFanin*` in the abstraction-provenance walk. None of it needs to be there, and while it is, the bit-blaster is welded to one node representation.

This gives the node manager the methods those sites actually want — `CreateFreshInput()`, `ciCount()`, `ciObjectId()`, `ciNode()`, and node-level `isCI`/`isConstant`/`isAnd`/`nodeId`/`fanin0`/`fanin1` — and routes every caller through them.

| file | ABC reaches before | after |
|---|---|---|
| `BitBlaster.cpp` | 32 | **4** |
| `ToSATAIG.cpp` | 6 | 1 (a comment) |
| `BVExactEncoder.cpp` | 26 | 18 |
| `ToCNFAIG.cpp` | 29 | 24 |
| `AIGSimplifyPropositionalCore.cpp` | 25 | 20 |
| `IncrementalSolverImpl.h` | 18 | 16 |

The four left in `BitBlaster.cpp` are the two hand-rolled biconditionals. They build the same circuit as `CreateNode(IFF, a, b)` but skip `checkBudget()`, so replacing them changes which queries give up under `--aig-node-budget` — that belongs in its own change, not this one. The remaining files legitimately drive ABC: CNF derivation, DAG-aware rewriting, and the incremental Tseitin encoder.

Two spellings of one operation are collapsed while here: CI lookup was `Vec_PtrEntry(vCis, i)` in six places and `Aig_ManCi(mgr, i)` in three.

The two abstraction-provenance tables are keyed by AIG node id, which is dense and never reused, so they become vectors rather than hash maps — the second is walked once per abstracted bit, and this removes a hash from every node of every visit. A dense table cannot use "has an entry" to mean "has been computed", because a cone containing no abstraction has an empty union and that is the common case; the computed marker is therefore explicit and lives beside the table.

## Three defects found on the way

**`Dar_LibStart()` had three callers and `Dar_LibStop()` one**, on a process-global that costs roughly 150M instructions to build. The propositional-core simplifier tore down the library the other two rely on, so the next rewrite re-paid the build. `Dar_LibStart` is idempotent; `Dar_LibStop` asserts the library is live, which makes a second call an abort rather than a no-op. There is now one owner that starts it on demand and does not stop it.

**`AIGSimplifyPropositionalCore::convert` recursed once per AND node** over an AIG of unbounded depth, and the deep-DAG regression test has never reached that pass — so the overflow was latent rather than absent. It is iterative now, and its cache is keyed by AIG literal rather than by `Aig_Obj_t*`, so `x` and `!x` are distinct keys and no container is ordered by address.

**`Cnf_ManFree()` was a no-op at all three call sites.** It only frees the manager `Cnf_Derive()` creates lazily, and STP calls `Cnf_DeriveWithMan()` with a manager of its own, so ABC's global was always NULL. The calls go, along with the counter that guarded one of them and the `CNFClearMemory()` wrapper that exported another. `cpp_interface.h` is not an installed header, so that is not an API break.

## `BBNodeAIG::operator<` stays

It looks dead — nothing declares a `std::set` or `std::map` over `BBNodeAIG` — but `mult_Booth` sorts each column of partial products with it, so the ordering reaches the emitted CNF. It gains a comment saying so, because the next reader will draw the same wrong conclusion.

## Harness fix

`scripts/cnf-manifest.sh` took its exit status from inside `if ! cmd; then`, where `$?` is the negation's status and never the command's. Every timeout was therefore recorded as `error`, conflating "this build times out on an input" with "this build rejects the input" — exactly the distinction the script's own comment claims to draw. It also gains a passthrough for further `stp` arguments, since the code paths this touches are mostly off by default and a manifest taken without them proves nothing about them.

## Verification

CNF is byte-identical over `tests/query-files` against a baseline built from the merge base in a separate build directory, on four configurations:

| configuration | inputs producing CNF | timeouts | |
|---|---|---|---|
| default | 349 | 0 | identical |
| `--aig-core-simplification 1` | 348 | 0 | identical |
| `--aig-rewrite-passes 1` | 337 | 12 | identical |
| `--disable-simplifications` | 679 | 0 | identical |

The count of inputs that actually produced CNF is reported because it is the check that a comparison is not vacuous: passing a value-taking option as a bare flag makes both binaries exit non-zero on every input, and the manifests then match perfectly while testing nothing. The 12 timeouts under `--aig-rewrite-passes` occur identically on both sides and are only visible as timeouts because of the harness fix above.

All 174 `ctest` cases pass.
