### PR TITLE
Remove the CNF's dependence on the standard library's hash order

### DIFF
--- a/include/stp/ToSat/BBNodeAIG.h
+++ b/include/stp/ToSat/BBNodeAIG.h
@@ -136,12 +136,21 @@ public:
 }
 
 namespace std {
+    // The AIG literal: 2*id + complement. Hashing the id alone put x and !x
+    // in the same bucket, which they never are under operator==, so every
+    // set holding both ran at twice the collision rate it needed.
+    //
+    // This is only a hash-quality change. It used to decide the iteration
+    // order of BBNodeSet, and that order reached the emitted CNF -- but
+    // BBNodeSet is insertion-ordered now, so nothing observable depends on
+    // the bucket layout any more.
     template <>
         class hash<stp::BBNodeAIG>{
         public :
             size_t operator()(const stp::BBNodeAIG & node ) const
             {
-                return Aig_Regular(node.n)->Id ;
+                return 2 * (size_t)Aig_Regular(node.n)->Id +
+                       (Aig_IsComplement(node.n) ? 1 : 0);
             }
     };
 }

--- a/include/stp/ToSat/BitBlaster.h
+++ b/include/stp/ToSat/BitBlaster.h
@@ -63,7 +63,33 @@ using BBNode = BBNodeAIG;
 using BBNodeVec = std::vector<BBNodeAIG>;
 // Alongside the other two rather than inside the class, because
 // BBExactBinaryOp takes one and its callers are outside.
-using BBNodeSet = std::unordered_set<BBNodeAIG>;
+//
+// Insertion-ordered rather than a bare std::unordered_set. Its iteration
+// order reaches the emitted formula in two places -- the support conjunction
+// under --conjoin-to-top, and the combinational-output order BVExactEncoder
+// gives the circuit it splices into a live solver -- and an unordered_set's
+// order is a property of the standard library's bucket policy and of
+// std::hash<BBNodeAIG>, not of the query. So the CNF depended on which
+// library STP was built against. Insertion order depends on the blast alone.
+//
+// The set is small (it holds side conditions, not gates), so the vector is
+// the cheap part; the hash set is only here to keep insert() a set operation.
+class BBNodeSet
+{
+  std::vector<BBNodeAIG> order_;
+  std::unordered_set<BBNodeAIG> seen_;
+
+public:
+  void insert(const BBNodeAIG& n)
+  {
+    if (seen_.insert(n).second)
+      order_.push_back(n);
+  }
+  size_t size() const { return order_.size(); }
+  bool empty() const { return order_.empty(); }
+  std::vector<BBNodeAIG>::const_iterator begin() const { return order_.begin(); }
+  std::vector<BBNodeAIG>::const_iterator end() const { return order_.end(); }
+};
 
 enum class DivLemma;
 enum class RemLemma;

--- a/lib/ToSat/BVExactEncoder.cpp
+++ b/lib/ToSat/BVExactEncoder.cpp
@@ -173,7 +173,13 @@ void encodeNaryLemma(
     cnfToSolver[var] = (*liveVars[i / width])[i % width];
   }
 
-  for (int var = 0; var < cnf->nVars; var++)
+  // From 1: every ABC CNF generator numbers variables from 1 and reports
+  // nVars as one past the last, so index 0 names nothing. Allocating a solver
+  // variable for it, and freezing it, left one unreachable variable in the
+  // live solver per splice. The assertion in the clause loop below is what
+  // holds this: a literal over variable 0 would mean a generator numbered
+  // from 0 after all.
+  for (int var = 1; var < cnf->nVars; var++)
     if (cnfToSolver[var] == ~((unsigned)0))
     {
       const unsigned fresh = solver.newVar();
@@ -187,7 +193,10 @@ void encodeNaryLemma(
     cl.clear();
     for (int *pLit = cnf->pClauses[i], *pStop = cnf->pClauses[i + 1];
          pLit < pStop; pLit++)
+    {
+      assert(((*pLit) >> 1) != 0 && "a CNF generator numbered variables from 0");
       cl.push(SATSolver::mkLit(cnfToSolver[(*pLit) >> 1], ((*pLit) & 1) != 0));
+    }
     solver.addClause(cl);
   }
 
@@ -416,7 +425,13 @@ void BVExactEncoder::encode(SATSolver& solver, const ASTNode& term,
     cnfToSolver[var] = ciVars[i];
   }
 
-  for (int var = 0; var < cnf->nVars; var++)
+  // From 1: every ABC CNF generator numbers variables from 1 and reports
+  // nVars as one past the last, so index 0 names nothing. Allocating a solver
+  // variable for it, and freezing it, left one unreachable variable in the
+  // live solver per splice. The assertion in the clause loop below is what
+  // holds this: a literal over variable 0 would mean a generator numbered
+  // from 0 after all.
+  for (int var = 1; var < cnf->nVars; var++)
     if (cnfToSolver[var] == ~((unsigned)0))
     {
       const unsigned fresh = solver.newVar();
@@ -430,7 +445,10 @@ void BVExactEncoder::encode(SATSolver& solver, const ASTNode& term,
     cl.clear();
     for (int *pLit = cnf->pClauses[i], *pStop = cnf->pClauses[i + 1];
          pLit < pStop; pLit++)
+    {
+      assert(((*pLit) >> 1) != 0 && "a CNF generator numbered variables from 0");
       cl.push(SATSolver::mkLit(cnfToSolver[(*pLit) >> 1], ((*pLit) & 1) != 0));
+    }
     solver.addClause(cl);
   }
 

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -208,9 +208,7 @@ BBNodeVec BitBlaster::ensureProxyCIs(const ASTNode& node,
         abstractionSourcesOf(bits[i]);
     proxies[i] = nf->CreateFreshInput();
     tagAbstractionSources(proxies[i], sources);
-    Aig_Obj_t* bicond = Aig_Not(orderedAigExor(
-        nf->aigMgr, proxies[i].n, bits[i].n));
-    sideConstraints_.push_back(BBNodeAIG(bicond));
+    sideConstraints_.push_back(nf->CreateNode(IFF, proxies[i], bits[i]));
   }
   nf->symbolToBBNode[node] = proxies;
   return proxies;
@@ -1262,9 +1260,7 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term, BBNodeSet& support,
         // turn the dependency cut into an unlabelled CI.
         tagAbstractionSources(condCI, abstractionSourcesOf(cond));
 
-        Aig_Obj_t* bicond = Aig_Not(orderedAigExor(
-            nf->aigMgr, condCI.n, cond.n));
-        sideConstraints_.push_back(BBNodeAIG(bicond));
+        sideConstraints_.push_back(nf->CreateNode(IFF, condCI, cond));
 
         nf->symbolToBBNode[term] = abstracted;
         abstractedResults_[term] = {id, abstracted};

--- a/tests/unit-tests/DifficultyScore_Test.cpp
+++ b/tests/unit-tests/DifficultyScore_Test.cpp
@@ -57,7 +57,7 @@ public:
       bb.BBForm(n);
     else
     {
-      std::unordered_set<BBNodeAIG> support;
+      BBNodeSet support;
       bb.BBTerm(n, support);
     }
     return nm.totalNumberOfNodes();

--- a/tools/difficulty_bench/main.cpp
+++ b/tools/difficulty_bench/main.cpp
@@ -85,7 +85,7 @@ int aigNodes(const ASTNode& n)
     bb.BBForm(n);
   else
   {
-    std::unordered_set<BBNodeAIG> support;
+    BBNodeSet support;
     bb.BBTerm(n, support);
   }
   return nm.totalNumberOfNodes();


### PR DESCRIPTION
Follows #1041, which has landed. Four cleanups that were left out of it because each one changes what STP emits, so none of them can ride a byte-identical gate. One commit each, and every commit builds on its own.

## The order of the first two is the point

`BBNodeSet` was a `std::unordered_set`, and its iteration order reached the emitted formula in two places: the support conjunction folded into the top node under `--bb.conjoin-constant`, and the order `BVExactEncoder` creates combinational outputs in for the circuit it splices into a live solver. An `unordered_set`'s order is a property of the standard library's bucket policy and of `std::hash<BBNodeAIG>` — not of the query — so the CNF depended on which standard library STP was built against. That is exactly the class of bug `scripts/cnf-manifest.sh` exists to catch.

So: **make the set insertion-ordered first**. That is the commit that moves the CNF, visibly and for a stated reason.

**Then fix the hash**, at which point it is provably inert. `std::hash<BBNodeAIG>` returned the regular node's id, so a node and its negation shared a bucket while never comparing equal — any set holding both ran at twice the collision rate it needed. Hashing `2*id + complement` is now a pure collision-rate change, because nothing observable depends on the bucket layout any more. Done in the other order, this commit would have silently moved the emitted formula under a message that reads like a performance tweak.

## The other two

**Biconditionals through the node manager.** `ensureProxyCIs` and the ITE-abstraction path each built `Aig_Not(orderedAigExor(...))` by hand — the same circuit `CreateNode(IFF, a, b)` builds, so the CNF is unchanged. With these gone, `BitBlaster.cpp` no longer names ABC anywhere: raw `aigMgr`/`Aig_*`/`Vec_Ptr`/`nObjs` references go from 32 before this series to **0**. A side effect is that these nodes now pass through `checkBudget()`, which the hand-rolled form skipped. That is not presented as a bug fix — see the negative result below.

**Do not allocate a solver variable for CNF variable 0.** Every ABC generator numbers variables from 1 and reports `nVars` as one past the last, so index 0 names nothing; `BVExactEncoder`'s remapping loop started at 0 anyway, leaving one unreachable frozen variable in the live solver per splice. The clause loop now asserts no literal names variable 0 — that assertion is what holds the assumption, since a generator numbering from 0 would otherwise corrupt the splice silently rather than fail.

## Verification

CNF over `tests/query-files`, against the merge base:

| configuration | inputs producing CNF | result |
|---|---|---|
| default | 349 | identical |
| `--bb.conjoin-constant 1` | 349 | **differs on 172** — the intended change |
| `--bv-eq-abstraction 1 --bv-term-abstraction 1` | 349 | identical |
| `--disable-simplifications` | 679 | identical |

Byte-identity is the wrong gate where the CNF is meant to move, so answers were compared instead:

| configuration | files compared | answers differing |
|---|---|---|
| `--bb.conjoin-constant 1` | 637 | **0** |
| `--bv-eq-abstraction 1 --bv-term-abstraction 1` | 645 | **0** |

All 174 `ctest` cases pass, and each of the four commits builds independently.

## Two things a reviewer should know

**The manifest cannot see the exact-encoder splice.** The "identical" on the abstraction row above is not evidence about `BVExactEncoder`: `--exit-after-CNF` stops at the *first* CNF, which is the whole-query blast, while the splice happens later during refinement. The CO-ordering change on that path is real and this harness structurally cannot observe it. The evidence for those sites is `BVExactEncoder_Test`, which sweeps the simple generator and every `--cnf-generation-effort` level, plus the answer comparison above.

**Negative result on the node budget.** It is tempting to call the `checkBudget()` gap a bug fix. It cannot be demonstrated: the budget is already checked after every other `CreateNode`, so the window in which only these two sites matter is a few nodes wide. Sweeping 336 (file, budget) pairs over the abstraction corpus with both abstraction flags enabled produced no query whose answer changes. The accounting is now complete; nothing observable moved.
