### PR TITLE
Add a Tseitin writer over the in-house AIG

### DIFF
--- a/include/stp/AIG/CNF.h
+++ b/include/stp/AIG/CNF.h
@@ -1,0 +1,141 @@
+/********************************************************************
+ * AUTHORS: Trevor Hansen
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#ifndef STP_AIG_CNF_H
+#define STP_AIG_CNF_H
+
+#include <cassert>
+#include <cstdint>
+#include <iosfwd>
+#include <vector>
+
+namespace stp
+{
+
+// A CNF formula and the projection back to the circuit it came from.
+//
+// Clauses live in one flat literal arena with an offsets array beside it, so
+// clause i is [lits_[offsets_[i]], lits_[offsets_[i+1]]) -- the layout
+// Cnf_Dat_t uses, kept because add_cnf_to_solver() walks it a clause at a
+// time and nothing is gained by a different one.
+//
+// A literal is `2*variable + negated`, again as in Cnf_Dat_t, so `^1` negates
+// and `>>1` recovers the variable.
+//
+// Variables number from 1. Variable 0 does not exist, and that is not a
+// convention worth trading away: SATSolver::newVar() hands out 0 first and
+// `add(0)` is CaDiCaL's clause terminator, so a literal naming variable 0
+// truncates a clause rather than failing. varCount() is one past the highest
+// variable used, which is the number of solver variables a consumer has to
+// allocate before adding these clauses.
+//
+// What the class does *not* carry is a map from circuit node to variable.
+// Cnf_Dat_t's pVarNums is one int per AIG object and it outlives the
+// derivation, held for the whole solve so that a handful of CIs can be looked
+// up. Only the inputs and outputs are ever asked about, so only those are
+// kept.
+class CNF
+{
+public:
+  uint32_t varCount() const { return nVars_; }
+  uint64_t clauseCount() const
+  {
+    return offsets_.empty() ? 0 : offsets_.size() - 1;
+  }
+  uint64_t literalCount() const { return lits_.size(); }
+
+  const int* clauseBegin(uint64_t i) const { return lits_.data() + offsets_[i]; }
+  const int* clauseEnd(uint64_t i) const
+  {
+    return lits_.data() + offsets_[i + 1];
+  }
+
+  // The variable holding the value of combinational input `ordinal`, or of
+  // combinational output `ordinal`. Zero means "no variable": an output that
+  // was asserted rather than named has none. Zero rather than some positive
+  // sentinel because a caller that forgets to check writes out of bounds on a
+  // sentinel that is a plausible index, and does not on this one.
+  uint32_t ciCount() const { return static_cast<uint32_t>(ciVar_.size()); }
+  uint32_t coCount() const { return static_cast<uint32_t>(coVar_.size()); }
+  uint32_t varOfCi(uint32_t ordinal) const { return ciVar_[ordinal]; }
+  uint32_t varOfCo(uint32_t ordinal) const { return coVar_[ordinal]; }
+
+  // Set when an empty clause was emitted, which is the only way this class
+  // says "unsatisfiable before the solver has seen it".
+  bool hasEmptyClause() const { return emptyClause_; }
+
+  void writeDimacs(std::ostream& out) const;
+
+  // ---- the sink the AIG's Tseitin writer emits into ----
+  //
+  // Ordinary member functions rather than an interface: the writer is a
+  // template over its sink, so a DIMACS or straight-to-solver sink is a
+  // different type with these same names and costs no indirection.
+
+  // Exact counts, not estimates -- the writer's first pass produces them and
+  // end() checks that the second pass emitted precisely that many.
+  void begin(uint32_t nVars, uint64_t nClauses, uint64_t nLiterals,
+             uint32_t nCi, uint32_t nCo);
+  void mapCi(uint32_t ordinal, uint32_t var) { ciVar_[ordinal] = var; }
+  void mapCo(uint32_t ordinal, uint32_t var) { coVar_[ordinal] = var; }
+
+  void clause(int a)
+  {
+    lits_.push_back(a);
+    offsets_.push_back(lits_.size());
+  }
+  void clause(int a, int b)
+  {
+    lits_.push_back(a);
+    lits_.push_back(b);
+    offsets_.push_back(lits_.size());
+  }
+  void clause(int a, int b, int c)
+  {
+    lits_.push_back(a);
+    lits_.push_back(b);
+    lits_.push_back(c);
+    offsets_.push_back(lits_.size());
+  }
+  void emptyClause()
+  {
+    emptyClause_ = true;
+    offsets_.push_back(lits_.size());
+  }
+  void end();
+
+private:
+  std::vector<int> lits_;
+  std::vector<uint64_t> offsets_;
+  std::vector<uint32_t> ciVar_;
+  std::vector<uint32_t> coVar_;
+  uint32_t nVars_ = 1;
+  uint64_t expectedClauses_ = 0;
+  uint64_t expectedLiterals_ = 0;
+  bool emptyClause_ = false;
+};
+
+} // namespace stp
+
+#endif

--- a/include/stp/AIG/Tseitin.h
+++ b/include/stp/AIG/Tseitin.h
@@ -1,0 +1,226 @@
+/********************************************************************
+ * AUTHORS: Trevor Hansen
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#ifndef STP_AIG_TSEITIN_H
+#define STP_AIG_TSEITIN_H
+
+#include "stp/AIG/CNF.h"
+#include "stp/AIG/Manager.h"
+
+#include <cassert>
+#include <cstdint>
+#include <vector>
+
+namespace stp
+{
+namespace aig
+{
+
+// Is node `n` an if-then-else, and over what?
+//
+// An AIG spells `ITE(c,t,e)` as `!(!(c & t) & !(!c & e))`, so the node one
+// level above that -- the one with both fanins inverted -- computes the
+// negation of an ITE, which is itself an ITE with both arms inverted. Written
+// out: if the two fanin nodes are (A,B) and (C,D) and any one of the four
+// cross pairs is complementary, say A == !C, then
+//
+//     n = !(A & B) & !(C & D) = ITE(A, !B, !D)
+//
+// Exclusive-or needs no separate case. It is this same shape with a second
+// complementary pair, and the clauses below degenerate into the four an XOR
+// wants when `t == !e` -- so one test and one emitter cover both.
+//
+// Fanins are never constants (And() folds those away) and never LIT_NULL once
+// isAnd() has agreed, so c, t and e always name real nodes.
+bool matchIte(const Manager& m, Node n, Lit& c, Lit& t, Lit& e);
+
+// Which nodes the CNF will talk about, and how many clauses that will take.
+//
+// Pass A of the writer, split out because it is the same work whatever the
+// clauses get written into, and because the counts have to be known before
+// the first clause is emitted if the arena is to be sized exactly once.
+//
+// Its sweeps run *down* the node array. Fanins always have smaller ids than
+// their node, so descending order visits every reference to a node before the
+// node itself -- no recursion, no explicit stack, and no visited set beyond
+// the bitmap. That retires the Cnf_ManScanMapping_rec stack-overflow class
+// outright rather than raising a limit.
+class Cone
+{
+public:
+  // namedOutputs: how many of the *trailing* combinational outputs get a
+  // variable of their own instead of being asserted. That is the split
+  // Cnf_DeriveSimple takes, and the two callers want its ends: a formula
+  // asserts its single output, a fragment names all of them.
+  Cone(const Manager& m, unsigned namedOutputs = 0, bool matchPatterns = true);
+
+  // In the cone, so it gets a variable and its defining clauses.
+  bool live(Node n) const { return (live_[n >> 6] >> (n & 63)) & 1u; }
+
+  // Encoded as one four-clause ITE over its grandchildren rather than as
+  // three ANDs. Its two fanin nodes are then not live at all.
+  bool patterned(Node n) const
+  {
+    return (pattern_[n >> 6] >> (n & 63)) & 1u;
+  }
+
+  uint32_t varCount() const { return nVars_; }
+  uint64_t clauseCount() const { return nClauses_; }
+  uint64_t literalCount() const { return nLiterals_; }
+  // Live AND nodes, which is how many variables the cone itself needs.
+  uint64_t liveAndCount() const { return nAnds_; }
+
+  // Variable layout, closed form and no lookup table:
+  //   1 .. nCi                      the CIs, in ordinal order
+  //   nCi+1 .. nCi+nNamed           the named outputs, in output order
+  //   the rest                      the cone's AND nodes, ascending by id
+  static constexpr uint32_t ciVarBase() { return 1; }
+  uint32_t coVarBase() const { return 1 + nCi_; }
+  uint32_t andVarBase() const { return 1 + nCi_ + nNamed_; }
+
+  // Outputs at or above this index are named; the ones below are asserted.
+  uint32_t firstNamedOutput() const { return firstNamed_; }
+
+private:
+  void setLive(Node n) { live_[n >> 6] |= 1ull << (n & 63); }
+  void setPatterned(Node n) { pattern_[n >> 6] |= 1ull << (n & 63); }
+
+  std::vector<uint64_t> live_;
+  std::vector<uint64_t> pattern_;
+  uint64_t nClauses_ = 0;
+  uint64_t nLiterals_ = 0;
+  uint64_t nAnds_ = 0;
+  uint32_t nVars_ = 1;
+  uint32_t nCi_ = 0;
+  uint32_t nNamed_ = 0;
+  uint32_t firstNamed_ = 0;
+};
+
+// Pass B: emit. Ascending is automatically topological, so a fanin's variable
+// is always a smaller index that was written a moment ago.
+//
+// Templated over the sink although only CNF implements it today, so that a
+// DIMACS writer or one that feeds a live solver costs no indirection when it
+// arrives.
+template <class Sink>
+void writeTseitin(const Manager& m, const Cone& cone, Sink& sink)
+{
+  const uint32_t nCi = m.ciCount();
+  const uint32_t nCo = m.outputCount();
+  const uint32_t firstNamed = cone.firstNamedOutput();
+
+  sink.begin(cone.varCount(), cone.clauseCount(), cone.literalCount(), nCi,
+             nCo);
+
+  // Four bytes a node, and it dies with this function. The CNF that outlives
+  // it carries no node map at all -- which is the whole difference from
+  // Cnf_Dat_t::pVarNums, held for the length of the solve.
+  std::vector<uint32_t> var(m.nodeCount(), 0);
+
+  for (uint32_t i = 0; i < nCi; i++)
+  {
+    var[m.ciNode(i)] = Cone::ciVarBase() + i;
+    sink.mapCi(i, Cone::ciVarBase() + i);
+  }
+  for (uint32_t i = 0; i < nCo; i++)
+    sink.mapCo(i, i < firstNamed ? 0 : cone.coVarBase() + (i - firstNamed));
+
+  const auto cnfLit = [&var](Lit l) -> int {
+    assert(!isConst(l));
+    assert(var[nodeOf(l)] != 0);
+    return static_cast<int>(2 * var[nodeOf(l)] + (l & 1u));
+  };
+
+  uint32_t next = cone.andVarBase();
+  for (Node n = 1; n < m.nodeCount(); ++n)
+  {
+    if (!m.isAnd(n) || !cone.live(n))
+      continue;
+    const uint32_t x = next++;
+    var[n] = x;
+    const int px = static_cast<int>(2 * x), nx = px | 1;
+
+    if (cone.patterned(n))
+    {
+      Lit c, t, e;
+      const bool matched = matchIte(m, n, c, t, e);
+      assert(matched);
+      (void)matched;
+      const int lc = cnfLit(c), lt = cnfLit(t), le = cnfLit(e);
+      sink.clause(nx, lc ^ 1, lt);
+      sink.clause(px, lc ^ 1, lt ^ 1);
+      sink.clause(nx, lc, le);
+      sink.clause(px, lc, le ^ 1);
+    }
+    else
+    {
+      const int a = cnfLit(m.fanin0(n)), b = cnfLit(m.fanin1(n));
+      sink.clause(px, a ^ 1, b ^ 1);
+      sink.clause(nx, a);
+      sink.clause(nx, b);
+    }
+  }
+  assert(next == cone.varCount());
+
+  for (uint32_t i = 0; i < nCo; i++)
+  {
+    const Lit o = m.output(i);
+    if (i < firstNamed)
+    {
+      // Asserted. A constant here is the one place a constant literal can
+      // reach: And() folds every other. True asserts nothing at all, and
+      // false is the empty clause -- neither needs a variable, which is why
+      // there is no constant variable and no constant unit clause anywhere in
+      // this encoding.
+      if (o == LIT_TRUE)
+        continue;
+      if (o == LIT_FALSE)
+        sink.emptyClause();
+      else
+        sink.clause(cnfLit(o));
+    }
+    else
+    {
+      const int pv = static_cast<int>(2 * (cone.coVarBase() + (i - firstNamed)));
+      if (isConst(o))
+        sink.clause(o == LIT_TRUE ? pv : (pv | 1));
+      else
+      {
+        const int d = cnfLit(o);
+        sink.clause(pv, d ^ 1);
+        sink.clause(pv | 1, d);
+      }
+    }
+  }
+  sink.end();
+}
+
+// Both passes, into a materialised CNF.
+CNF deriveTseitin(const Manager& m, unsigned namedOutputs = 0,
+                  bool matchPatterns = true);
+
+} // namespace aig
+} // namespace stp
+
+#endif

--- a/lib/AIG/CMakeLists.txt
+++ b/lib/AIG/CMakeLists.txt
@@ -23,4 +23,6 @@
 # add_dependencies(aig ASTKind_header), something has leaked into it.
 add_library(aig OBJECT
     Manager.cpp
+    CNF.cpp
+    Tseitin.cpp
 )

--- a/lib/AIG/CNF.cpp
+++ b/lib/AIG/CNF.cpp
@@ -1,0 +1,80 @@
+/********************************************************************
+ * AUTHORS: Trevor Hansen
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#include "stp/AIG/CNF.h"
+
+#include <ostream>
+
+namespace stp
+{
+
+void CNF::begin(uint32_t nVars, uint64_t nClauses, uint64_t nLiterals,
+                uint32_t nCi, uint32_t nCo)
+{
+  lits_.clear();
+  offsets_.clear();
+  emptyClause_ = false;
+
+  nVars_ = nVars;
+  expectedClauses_ = nClauses;
+  expectedLiterals_ = nLiterals;
+
+  // Exact, from the counting pass, so neither vector ever reallocates and
+  // neither ends up holding spare capacity for the life of the solve.
+  lits_.reserve(nLiterals);
+  offsets_.reserve(nClauses + 1);
+  offsets_.push_back(0);
+
+  ciVar_.assign(nCi, 0);
+  coVar_.assign(nCo, 0);
+}
+
+void CNF::end()
+{
+  assert(clauseCount() == expectedClauses_);
+  assert(literalCount() == expectedLiterals_);
+  (void)expectedClauses_;
+  (void)expectedLiterals_;
+}
+
+// DIMACS numbers variables 1..N, which is ours minus the variable 0 that does
+// not exist -- so N is one less than varCount(), not equal to it. ABC writes
+// its nVars here and therefore declares one variable more than it uses; that
+// is harmless but it is not the file the formula asks for.
+void CNF::writeDimacs(std::ostream& out) const
+{
+  out << "p cnf " << (nVars_ == 0 ? 0 : nVars_ - 1) << ' ' << clauseCount()
+      << '\n';
+  for (uint64_t i = 0, n = clauseCount(); i < n; i++)
+  {
+    for (const int *p = clauseBegin(i), *stop = clauseEnd(i); p < stop; p++)
+    {
+      const int var = *p >> 1;
+      out << ((*p & 1) ? -var : var) << ' ';
+    }
+    out << "0\n";
+  }
+}
+
+} // namespace stp

--- a/lib/AIG/Tseitin.cpp
+++ b/lib/AIG/Tseitin.cpp
@@ -1,0 +1,196 @@
+/********************************************************************
+ * AUTHORS: Trevor Hansen
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#include "stp/AIG/Tseitin.h"
+
+#include <limits>
+#include <stdexcept>
+
+namespace stp
+{
+namespace aig
+{
+
+bool matchIte(const Manager& m, Node n, Lit& c, Lit& t, Lit& e)
+{
+  if (!m.isAnd(n))
+    return false;
+  const Lit f0 = m.fanin0(n), f1 = m.fanin1(n);
+  if (!isNeg(f0) || !isNeg(f1))
+    return false;
+  const Node u = nodeOf(f0), v = nodeOf(f1);
+  if (!m.isAnd(u) || !m.isAnd(v))
+    return false;
+
+  const Lit a = m.fanin0(u), b = m.fanin1(u);
+  const Lit cc = m.fanin0(v), d = m.fanin1(v);
+
+  if (a == neg(cc))
+  {
+    c = a;
+    t = neg(b);
+    e = neg(d);
+  }
+  else if (a == neg(d))
+  {
+    c = a;
+    t = neg(b);
+    e = neg(cc);
+  }
+  else if (b == neg(cc))
+  {
+    c = b;
+    t = neg(a);
+    e = neg(d);
+  }
+  else if (b == neg(d))
+  {
+    c = b;
+    t = neg(a);
+    e = neg(cc);
+  }
+  else
+    return false;
+  return true;
+}
+
+Cone::Cone(const Manager& m, unsigned namedOutputs, bool matchPatterns)
+{
+  const uint32_t nCo = m.outputCount();
+  assert(namedOutputs <= nCo);
+
+  nCi_ = m.ciCount();
+  nNamed_ = namedOutputs;
+  firstNamed_ = nCo - namedOutputs;
+
+  const uint64_t nNodes = m.nodeCount();
+  const size_t words = static_cast<size_t>((nNodes + 63) / 64);
+  live_.assign(words, 0);
+  pattern_.assign(words, 0);
+
+  // A pattern is only taken when it removes its two intermediates outright,
+  // which needs to know whether anything else uses them. Nothing does if they
+  // have one reference apiece, and that is what this first sweep counts --
+  // over the plain cone, before any pattern is taken.
+  //
+  // Counting on the plain cone rather than the final one over-counts, since
+  // taking a pattern only ever removes references. Over-counting can lose an
+  // opportunity; it cannot take one that does not pay. Deciding it exactly
+  // would be a fixed point, and the reason it cannot be decided in one sweep
+  // is that a node's references are not all above the node that would absorb
+  // it -- they are only all above the node itself.
+  //
+  // One byte each, saturating at two, and it is gone when this constructor
+  // returns.
+  std::vector<uint8_t> refs;
+  if (matchPatterns)
+  {
+    refs.assign(nNodes, 0);
+    const auto bump = [&refs](Node x) {
+      if (x != 0 && refs[x] < 2)
+        refs[x]++;
+    };
+    for (uint32_t i = 0; i < nCo; i++)
+      bump(nodeOf(m.output(i)));
+    for (Node n = static_cast<Node>(nNodes); n-- > 1;)
+    {
+      if (refs[n] == 0 || !m.isAnd(n))
+        continue;
+      bump(nodeOf(m.fanin0(n)));
+      bump(nodeOf(m.fanin1(n)));
+    }
+  }
+
+  for (uint32_t i = 0; i < nCo; i++)
+    if (!isConst(m.output(i)))
+      setLive(nodeOf(m.output(i)));
+
+  for (Node n = static_cast<Node>(nNodes); n-- > 1;)
+  {
+    if (!live(n) || !m.isAnd(n))
+      continue;
+    ++nAnds_;
+
+    Lit c, t, e;
+    if (matchPatterns && refs[nodeOf(m.fanin0(n))] == 1 &&
+        refs[nodeOf(m.fanin1(n))] == 1 && matchIte(m, n, c, t, e))
+    {
+      setPatterned(n);
+      setLive(nodeOf(c));
+      setLive(nodeOf(t));
+      setLive(nodeOf(e));
+      nClauses_ += 4;
+      nLiterals_ += 12;
+    }
+    else
+    {
+      setLive(nodeOf(m.fanin0(n)));
+      setLive(nodeOf(m.fanin1(n)));
+      nClauses_ += 3;
+      nLiterals_ += 7;
+    }
+  }
+
+  for (uint32_t i = 0; i < nCo; i++)
+  {
+    const Lit o = m.output(i);
+    if (i < firstNamed_)
+    {
+      if (o == LIT_TRUE)
+        continue; // asserting true says nothing
+      nClauses_ += 1;
+      if (o != LIT_FALSE)
+        nLiterals_ += 1; // asserting false is the empty clause
+    }
+    else if (isConst(o))
+    {
+      nClauses_ += 1;
+      nLiterals_ += 1;
+    }
+    else
+    {
+      nClauses_ += 2;
+      nLiterals_ += 4;
+    }
+  }
+
+  // Counted in 64 bits and narrowed here, which is the check ABC does not
+  // do: Cnf_DeriveSimple computes 1 + 7*nodes + ... in an int, and overflows
+  // silently at around 306M AND nodes.
+  const uint64_t vars = 1ull + nCi_ + nNamed_ + nAnds_;
+  if (vars > static_cast<uint64_t>(std::numeric_limits<int>::max()) / 2)
+    throw std::overflow_error("CNF variable space exhausted");
+  nVars_ = static_cast<uint32_t>(vars);
+}
+
+CNF deriveTseitin(const Manager& m, unsigned namedOutputs, bool matchPatterns)
+{
+  const Cone cone(m, namedOutputs, matchPatterns);
+  CNF cnf;
+  writeTseitin(m, cone, cnf);
+  return cnf;
+}
+
+} // namespace aig
+} // namespace stp

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -58,6 +58,9 @@ AddSTPGTest(SourceSortMemo_Test.cpp)
 # same reason the tests below do.
 AddSTPGTest(AIG_Test.cpp)
 target_link_libraries(AIG_TestTests ABC)
+# The Tseitin writer over that AIG. Needs no ABC: it checks the CNF against
+# the circuit it came from, by simulation and unit propagation.
+AddSTPGTest(Tseitin_Test.cpp)
 AddSTPGTest(BBNodeManagerAIG_Test.cpp)
 target_link_libraries(BBNodeManagerAIG_TestTests ABC)
 AddSTPGTest(AIGBudget_Test.cpp)

--- a/tests/unit-tests/Tseitin_Test.cpp
+++ b/tests/unit-tests/Tseitin_Test.cpp
@@ -1,0 +1,549 @@
+/********************************************************************
+ * AUTHORS: Trevor Hansen
+ *
+ * BEGIN DATE: Aug, 2026
+ *
+ * LICENSE: Please view LICENSE file in the home dir of this Program
+ ********************************************************************/
+
+// The Tseitin writer over the in-house AIG.
+//
+// The central test needs no SAT solver, and is stronger than one would give.
+// A Tseitin encoding claims two things: that every assignment the circuit
+// admits satisfies the clauses, and that the clauses admit nothing else.  The
+// first is checked directly.  The second is checked by unit propagation: this
+// encoding is propagation-complete from the inputs -- fixing the CIs forces
+// every other variable, by construction -- so BCP deriving exactly the
+// simulated value for every variable says the clauses pin the circuit and
+// nothing looser.  A solver would answer only "satisfiable", which a
+// one-sided bug survives.
+
+#include "stp/AIG/Tseitin.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <random>
+#include <sstream>
+#include <vector>
+
+using namespace stp;
+
+namespace
+{
+
+// Node values under one assignment of the CIs.  Ascending is topological, so
+// this is a single forward sweep -- the same property the writer's second
+// pass leans on.
+std::vector<uint8_t> simulate(const aig::Manager& m,
+                              const std::vector<uint8_t>& ciValues)
+{
+  std::vector<uint8_t> value(m.nodeCount(), 0);
+  unsigned seen = 0;
+  for (aig::Node n = 1; n < m.nodeCount(); ++n)
+  {
+    if (m.isCi(n))
+      value[n] = ciValues[seen++];
+    else
+    {
+      const aig::Lit a = m.fanin0(n), b = m.fanin1(n);
+      const uint8_t va = value[aig::nodeOf(a)] ^ (aig::isNeg(a) ? 1 : 0);
+      const uint8_t vb = value[aig::nodeOf(b)] ^ (aig::isNeg(b) ? 1 : 0);
+      value[n] = va & vb;
+    }
+  }
+  return value;
+}
+
+uint8_t valueOf(const std::vector<uint8_t>& value, aig::Lit l)
+{
+  return value[aig::nodeOf(l)] ^ (aig::isNeg(l) ? 1 : 0);
+}
+
+// The writer's variable numbering, recomputed here rather than read out of
+// the CNF, so that a change to the layout has to be made deliberately in two
+// places instead of silently agreeing with itself.
+struct Layout
+{
+  std::vector<uint32_t> nodeVar; // node -> variable, 0 for none
+  std::vector<uint32_t> coVar;   // output -> variable, 0 when asserted
+  uint32_t nVars = 1;
+};
+
+Layout layoutOf(const aig::Manager& m, const aig::Cone& cone)
+{
+  Layout l;
+  l.nodeVar.assign(m.nodeCount(), 0);
+  for (uint32_t i = 0; i < m.ciCount(); i++)
+    l.nodeVar[m.ciNode(i)] = aig::Cone::ciVarBase() + i;
+
+  l.coVar.assign(m.outputCount(), 0);
+  for (uint32_t i = cone.firstNamedOutput(); i < m.outputCount(); i++)
+    l.coVar[i] = cone.coVarBase() + (i - cone.firstNamedOutput());
+
+  uint32_t next = cone.andVarBase();
+  for (aig::Node n = 1; n < m.nodeCount(); ++n)
+    if (m.isAnd(n) && cone.live(n))
+      l.nodeVar[n] = next++;
+  l.nVars = next;
+  return l;
+}
+
+// What every variable is supposed to hold, given the CIs.  -1 for a variable
+// the layout never handed out, which is only ever variable 0.
+std::vector<int8_t> intendedValues(const aig::Manager& m,
+                                   const aig::Cone& cone, const Layout& l,
+                                   const std::vector<uint8_t>& value)
+{
+  std::vector<int8_t> want(l.nVars, -1);
+  for (aig::Node n = 1; n < m.nodeCount(); ++n)
+    if (l.nodeVar[n] != 0)
+      want[l.nodeVar[n]] = static_cast<int8_t>(value[n]);
+  for (uint32_t i = 0; i < m.outputCount(); i++)
+    if (l.coVar[i] != 0)
+      want[l.coVar[i]] = static_cast<int8_t>(valueOf(value, m.output(i)));
+  (void)cone;
+  return want;
+}
+
+bool clauseSatisfied(const CNF& cnf, uint64_t i, const std::vector<int8_t>& a)
+{
+  for (const int *p = cnf.clauseBegin(i), *stop = cnf.clauseEnd(i); p < stop;
+       p++)
+  {
+    const uint32_t v = static_cast<uint32_t>(*p) >> 1;
+    const int8_t want = (*p & 1) ? 0 : 1;
+    if (a[v] == want)
+      return true;
+  }
+  return false;
+}
+
+// Textbook BCP.  Quadratic and proud of it: the formulas here have tens of
+// clauses, and a watched-literal scheme would be a second implementation to
+// get wrong.  Returns false on a conflict.
+bool propagate(const CNF& cnf, std::vector<int8_t>& a)
+{
+  bool changed = true;
+  while (changed)
+  {
+    changed = false;
+    for (uint64_t i = 0, n = cnf.clauseCount(); i < n; i++)
+    {
+      int unassigned = 0, lastLit = 0;
+      bool sat = false;
+      for (const int *p = cnf.clauseBegin(i), *stop = cnf.clauseEnd(i);
+           p < stop; p++)
+      {
+        const uint32_t v = static_cast<uint32_t>(*p) >> 1;
+        const int8_t want = (*p & 1) ? 0 : 1;
+        if (a[v] < 0)
+        {
+          unassigned++;
+          lastLit = *p;
+        }
+        else if (a[v] == want)
+        {
+          sat = true;
+          break;
+        }
+      }
+      if (sat)
+        continue;
+      if (unassigned == 0)
+        return false;
+      if (unassigned == 1)
+      {
+        a[static_cast<uint32_t>(lastLit) >> 1] = (lastLit & 1) ? 0 : 1;
+        changed = true;
+      }
+    }
+  }
+  return true;
+}
+
+// A circuit with XORs and MUXes in it, since those are what the pattern
+// matcher exists for and a pure-AND generator would never produce one.
+void buildRandom(aig::Manager& m, std::mt19937& rng, unsigned nCi,
+                 unsigned nGates, std::vector<aig::Lit>& pool)
+{
+  for (unsigned i = 0; i < nCi; i++)
+    pool.push_back(m.createCi());
+
+  for (unsigned g = 0; g < nGates; g++)
+  {
+    const auto pick = [&]() {
+      const aig::Lit l = pool[rng() % pool.size()];
+      return (rng() & 1) ? aig::neg(l) : l;
+    };
+    const unsigned which = rng() % 100;
+    aig::Lit r;
+    if (which < 25)
+      r = m.Xor(pick(), pick());
+    else if (which < 40)
+      r = m.Mux(pick(), pick(), pick());
+    else
+      r = m.And(pick(), pick());
+    if (!aig::isConst(r))
+      pool.push_back(r);
+  }
+}
+
+// Exhaustive over the CIs: every clause holds under the circuit's own values,
+// and BCP from the CIs reproduces every one of them.
+void checkExact(const aig::Manager& m, unsigned namedOutputs,
+                bool matchPatterns)
+{
+  const aig::Cone cone(m, namedOutputs, matchPatterns);
+  const CNF cnf = aig::deriveTseitin(m, namedOutputs, matchPatterns);
+  const Layout l = layoutOf(m, cone);
+
+  ASSERT_EQ(cnf.varCount(), l.nVars);
+  ASSERT_EQ(cnf.varCount(), cone.varCount());
+  for (uint32_t i = 0; i < m.ciCount(); i++)
+    ASSERT_EQ(cnf.varOfCi(i), 1u + i);
+  for (uint32_t i = 0; i < m.outputCount(); i++)
+    ASSERT_EQ(cnf.varOfCo(i), l.coVar[i]);
+
+  const unsigned nCi = m.ciCount();
+  ASSERT_LE(nCi, 12u);
+  for (uint32_t bits = 0; bits < (1u << nCi); bits++)
+  {
+    std::vector<uint8_t> ci(nCi);
+    for (unsigned i = 0; i < nCi; i++)
+      ci[i] = (bits >> i) & 1;
+
+    const std::vector<uint8_t> value = simulate(m, ci);
+    const std::vector<int8_t> want = intendedValues(m, cone, l, value);
+
+    // Are the asserted outputs all true under this assignment?  If not the
+    // formula is unsatisfiable here, and the two directions swap over.
+    bool assertedHold = true;
+    for (uint32_t i = 0; i < cone.firstNamedOutput(); i++)
+      if (!valueOf(value, m.output(i)))
+        assertedHold = false;
+
+    if (assertedHold)
+    {
+      for (uint64_t c = 0, n = cnf.clauseCount(); c < n; c++)
+        ASSERT_TRUE(clauseSatisfied(cnf, c, want))
+            << "clause " << c << " unsatisfied by the circuit's own values";
+    }
+
+    std::vector<int8_t> a(cnf.varCount(), -1);
+    for (unsigned i = 0; i < nCi; i++)
+      a[cnf.varOfCi(i)] = static_cast<int8_t>(ci[i]);
+    const bool ok = propagate(cnf, a);
+
+    ASSERT_EQ(ok, assertedHold)
+        << "propagation should conflict exactly when an asserted output is 0";
+    if (!ok)
+      continue;
+    for (uint32_t v = 1; v < cnf.varCount(); v++)
+    {
+      ASSERT_GE(a[v], 0) << "variable " << v << " left unforced";
+      ASSERT_EQ(a[v], want[v]) << "variable " << v << " forced to the wrong value";
+    }
+  }
+}
+
+} // namespace
+
+// The headline: on random circuits, with every output named, the CNF says
+// exactly what the AIG says -- no assignment lost and none admitted.
+TEST(Tseitin, NamedOutputsEncodeTheCircuitExactly)
+{
+  for (unsigned seed = 0; seed < 120; seed++)
+  {
+    std::mt19937 rng(seed);
+    aig::Manager m;
+    std::vector<aig::Lit> pool;
+    buildRandom(m, rng, 3 + (seed % 6), 30, pool);
+    for (unsigned i = 0; i < 3; i++)
+      m.createOutput(pool[rng() % pool.size()]);
+
+    ASSERT_NO_FATAL_FAILURE(checkExact(m, m.outputCount(), true)) << seed;
+    ASSERT_NO_FATAL_FAILURE(checkExact(m, m.outputCount(), false)) << seed;
+  }
+}
+
+// The other end of the namedOutputs split: an asserted output has no variable
+// and no defining clauses, only a unit -- so the formula must be
+// unsatisfiable under exactly the assignments the circuit rejects.
+TEST(Tseitin, AssertedOutputIsUnsatWhereTheCircuitIsFalse)
+{
+  for (unsigned seed = 0; seed < 120; seed++)
+  {
+    std::mt19937 rng(seed);
+    aig::Manager m;
+    std::vector<aig::Lit> pool;
+    buildRandom(m, rng, 3 + (seed % 6), 25, pool);
+    m.createOutput(pool[rng() % pool.size()]);
+
+    ASSERT_NO_FATAL_FAILURE(checkExact(m, 0, true)) << seed;
+    ASSERT_NO_FATAL_FAILURE(checkExact(m, 0, false)) << seed;
+  }
+}
+
+// A mixture: some outputs asserted, the trailing ones named.
+TEST(Tseitin, MixedAssertedAndNamedOutputs)
+{
+  for (unsigned seed = 0; seed < 60; seed++)
+  {
+    std::mt19937 rng(seed);
+    aig::Manager m;
+    std::vector<aig::Lit> pool;
+    buildRandom(m, rng, 3 + (seed % 4), 20, pool);
+    for (unsigned i = 0; i < 4; i++)
+      m.createOutput(pool[rng() % pool.size()]);
+
+    ASSERT_NO_FATAL_FAILURE(checkExact(m, 2, true)) << seed;
+  }
+}
+
+// The saving the matcher exists for, on the smallest circuit that has one.
+// A MUX is three AND nodes; encoded as an ITE it is one variable and four
+// clauses, and its two intermediates disappear entirely.
+TEST(Tseitin, MuxCostsFourClausesInsteadOfNine)
+{
+  aig::Manager m;
+  const aig::Lit c = m.createCi(), t = m.createCi(), e = m.createCi();
+  m.createOutput(m.Mux(c, t, e));
+  ASSERT_EQ(m.andCount(), 3u);
+
+  const CNF plain = aig::deriveTseitin(m, 1, false);
+  const CNF folded = aig::deriveTseitin(m, 1, true);
+
+  // Three ANDs at 3 clauses / 7 literals each, plus the named output's two.
+  EXPECT_EQ(plain.clauseCount(), 11u);
+  EXPECT_EQ(plain.literalCount(), 25u);
+  EXPECT_EQ(plain.varCount(), 1u + 3u + 1u + 3u);
+
+  EXPECT_EQ(folded.clauseCount(), 6u);
+  EXPECT_EQ(folded.literalCount(), 16u);
+  EXPECT_EQ(folded.varCount(), 1u + 3u + 1u + 1u);
+}
+
+// Exclusive-or is the same shape with a second complementary pair, and gets
+// the same four clauses out of the same emitter.
+TEST(Tseitin, XorCostsFourClausesInsteadOfNine)
+{
+  aig::Manager m;
+  const aig::Lit a = m.createCi(), b = m.createCi();
+  m.createOutput(m.Xor(a, b));
+  ASSERT_EQ(m.andCount(), 3u);
+
+  EXPECT_EQ(aig::deriveTseitin(m, 1, false).clauseCount(), 11u);
+  EXPECT_EQ(aig::deriveTseitin(m, 1, true).clauseCount(), 6u);
+}
+
+// The guard on the merge.  If one of the intermediates is wanted elsewhere it
+// stays, and folding the parent would then add a clause rather than remove
+// five -- so the matcher must decline.
+TEST(Tseitin, SharedIntermediateDeclinesTheMerge)
+{
+  aig::Manager m;
+  const aig::Lit c = m.createCi(), t = m.createCi(), e = m.createCi();
+  const aig::Lit mux = m.Mux(c, t, e);
+  m.createOutput(mux);
+  m.createOutput(m.And(c, t)); // the MUX's own then-branch, hash-consed
+
+  const CNF plain = aig::deriveTseitin(m, 2, false);
+  const CNF folded = aig::deriveTseitin(m, 2, true);
+  EXPECT_EQ(plain.clauseCount(), folded.clauseCount());
+  EXPECT_EQ(plain.varCount(), folded.varCount());
+}
+
+// Over random circuits the matcher must never make a formula bigger, on any
+// of the three measures, and must sometimes make it smaller.
+TEST(Tseitin, MatchingNeverCostsAnything)
+{
+  uint64_t savedClauses = 0, savedLiterals = 0, savedVars = 0;
+  for (unsigned seed = 0; seed < 200; seed++)
+  {
+    std::mt19937 rng(seed);
+    aig::Manager m;
+    std::vector<aig::Lit> pool;
+    buildRandom(m, rng, 6, 80, pool);
+    for (unsigned i = 0; i < 2; i++)
+      m.createOutput(pool[rng() % pool.size()]);
+
+    const CNF plain = aig::deriveTseitin(m, 0, false);
+    const CNF folded = aig::deriveTseitin(m, 0, true);
+    ASSERT_LE(folded.clauseCount(), plain.clauseCount()) << seed;
+    ASSERT_LE(folded.literalCount(), plain.literalCount()) << seed;
+    ASSERT_LE(folded.varCount(), plain.varCount()) << seed;
+    savedClauses += plain.clauseCount() - folded.clauseCount();
+    savedLiterals += plain.literalCount() - folded.literalCount();
+    savedVars += plain.varCount() - folded.varCount();
+  }
+  EXPECT_GT(savedClauses, 0u);
+  EXPECT_GT(savedLiterals, 0u);
+  EXPECT_GT(savedVars, 0u);
+}
+
+// Only the cone of the outputs is encoded.  Nothing hashes the graph into the
+// CNF, so gates nobody asked about cost nothing at all.
+TEST(Tseitin, DeadNodesAreNotEncoded)
+{
+  aig::Manager m;
+  const aig::Lit a = m.createCi(), b = m.createCi();
+  const aig::Lit live = m.And(a, b);
+  m.createOutput(live);
+
+  const CNF before = aig::deriveTseitin(m);
+  const uint32_t varsBefore = before.varCount();
+
+  const aig::Lit c = m.createCi();
+  for (unsigned i = 0; i < 50; i++)
+    m.And(m.Xor(a, c), m.Or(b, aig::neg(c)));
+
+  const CNF after = aig::deriveTseitin(m);
+  EXPECT_EQ(after.clauseCount(), before.clauseCount());
+  EXPECT_EQ(after.literalCount(), before.literalCount());
+  // One more CI, and CIs are numbered whether or not they are reachable --
+  // refinement names them after the fact and the numbering must not move.
+  EXPECT_EQ(after.varCount(), varsBefore + 1);
+  EXPECT_EQ(after.varOfCi(2), 3u);
+}
+
+// Both passes are sweeps over the node array.  A chain this deep overflows a
+// default stack many times over if either of them recurses.
+TEST(Tseitin, DeepChainNeedsNoStack)
+{
+  aig::Manager m;
+  aig::Lit acc = m.createCi();
+  for (unsigned i = 0; i < 1000000; i++)
+    acc = m.And(acc, m.createCi());
+  m.createOutput(acc);
+
+  const CNF cnf = aig::deriveTseitin(m);
+  EXPECT_EQ(cnf.clauseCount(), 3ull * 1000000 + 1);
+  EXPECT_EQ(cnf.literalCount(), 7ull * 1000000 + 1);
+  EXPECT_EQ(cnf.varCount(), 1u + 1000001u + 1000000u);
+}
+
+// The four constant cases.  There is no constant variable and no unit clause
+// asserting one, which is the one place this encoding differs from
+// Cnf_DeriveSimple on a formula neither of them can simplify further.
+TEST(Tseitin, ConstantOutputs)
+{
+  {
+    aig::Manager m;
+    m.createCi();
+    m.createOutput(m.constTrue());
+    const CNF cnf = aig::deriveTseitin(m, 0);
+    EXPECT_EQ(cnf.clauseCount(), 0u);
+    EXPECT_FALSE(cnf.hasEmptyClause());
+  }
+  {
+    aig::Manager m;
+    m.createCi();
+    m.createOutput(m.constFalse());
+    const CNF cnf = aig::deriveTseitin(m, 0);
+    EXPECT_EQ(cnf.clauseCount(), 1u);
+    EXPECT_EQ(cnf.literalCount(), 0u);
+    EXPECT_TRUE(cnf.hasEmptyClause());
+  }
+  {
+    aig::Manager m;
+    m.createCi();
+    m.createOutput(m.constTrue());
+    const CNF cnf = aig::deriveTseitin(m, 1);
+    ASSERT_EQ(cnf.clauseCount(), 1u);
+    EXPECT_FALSE(cnf.hasEmptyClause());
+    const uint32_t v = cnf.varOfCo(0);
+    EXPECT_EQ(v, 2u); // one CI, then the named output
+    EXPECT_EQ(*cnf.clauseBegin(0), static_cast<int>(2 * v));
+  }
+  {
+    aig::Manager m;
+    m.createCi();
+    m.createOutput(m.constFalse());
+    const CNF cnf = aig::deriveTseitin(m, 1);
+    ASSERT_EQ(cnf.clauseCount(), 1u);
+    EXPECT_EQ(*cnf.clauseBegin(0), static_cast<int>(2 * cnf.varOfCo(0) + 1));
+  }
+}
+
+// No variable 0 anywhere.  SATSolver::newVar() hands out 0 first and add(0)
+// terminates a clause, so a literal naming it truncates rather than fails.
+TEST(Tseitin, NoLiteralNamesVariableZero)
+{
+  std::mt19937 rng(7);
+  aig::Manager m;
+  std::vector<aig::Lit> pool;
+  buildRandom(m, rng, 5, 60, pool);
+  for (unsigned i = 0; i < 3; i++)
+    m.createOutput(pool[rng() % pool.size()]);
+
+  const CNF cnf = aig::deriveTseitin(m, 1);
+  ASSERT_GT(cnf.clauseCount(), 0u);
+  for (uint64_t i = 0, n = cnf.clauseCount(); i < n; i++)
+    for (const int *p = cnf.clauseBegin(i), *stop = cnf.clauseEnd(i); p < stop;
+         p++)
+    {
+      ASSERT_GE(*p, 2) << "literal names variable 0";
+      ASSERT_LT(static_cast<uint32_t>(*p) >> 1, cnf.varCount());
+    }
+}
+
+// Same circuit, two fresh managers, byte-identical arena.  Nothing in the
+// writer reads an address, an allocator or a container's bucket order.
+TEST(Tseitin, IsDeterministic)
+{
+  const auto build = [](aig::Manager& m) {
+    std::mt19937 rng(99);
+    std::vector<aig::Lit> pool;
+    buildRandom(m, rng, 6, 200, pool);
+    for (unsigned i = 0; i < 5; i++)
+      m.createOutput(pool[rng() % pool.size()]);
+  };
+
+  aig::Manager a, b;
+  build(a);
+  build(b);
+  const CNF ca = aig::deriveTseitin(a, 2);
+  const CNF cb = aig::deriveTseitin(b, 2);
+
+  ASSERT_EQ(ca.clauseCount(), cb.clauseCount());
+  ASSERT_EQ(ca.literalCount(), cb.literalCount());
+  ASSERT_EQ(ca.varCount(), cb.varCount());
+  for (uint64_t i = 0, n = ca.clauseCount(); i < n; i++)
+  {
+    ASSERT_EQ(ca.clauseEnd(i) - ca.clauseBegin(i),
+              cb.clauseEnd(i) - cb.clauseBegin(i));
+    for (const int *p = ca.clauseBegin(i), *q = cb.clauseBegin(i),
+                   *stop = ca.clauseEnd(i);
+         p < stop; p++, q++)
+      ASSERT_EQ(*p, *q);
+  }
+}
+
+// The DIMACS header names the highest variable, not one past it.
+TEST(Tseitin, WritesDimacs)
+{
+  aig::Manager m;
+  const aig::Lit a = m.createCi(), b = m.createCi();
+  m.createOutput(m.And(a, b));
+
+  const CNF cnf = aig::deriveTseitin(m);
+  std::ostringstream out;
+  cnf.writeDimacs(out);
+
+  std::istringstream in(out.str());
+  std::string p, fmt;
+  int vars = 0, clauses = 0;
+  in >> p >> fmt >> vars >> clauses;
+  EXPECT_EQ(p, "p");
+  EXPECT_EQ(fmt, "cnf");
+  EXPECT_EQ(vars, static_cast<int>(cnf.varCount()) - 1);
+  EXPECT_EQ(clauses, static_cast<int>(cnf.clauseCount()));
+
+  unsigned terminators = 0;
+  int token = 0;
+  while (in >> token)
+    if (token == 0)
+      terminators++;
+  EXPECT_EQ(terminators, cnf.clauseCount());
+}


### PR DESCRIPTION
CNF from the AIG package that landed in #1043, and the class the two backends will hand around. Nothing calls it yet, so it lands with its tests the way the package did. The seam that rewires the ABC path onto the same class is the next step and is not here — only the class itself, because the writer has to return something.

### Two sweeps, no depth-first search

Fanins always have smaller ids than their node, so a descending sweep sees every reference to a node before the node itself — that is the marking pass — and an ascending one is topological, so a fanin's variable was written a moment ago. Neither recurses, which retires the `Cnf_ManScanMapping_rec` stack-overflow class rather than raising a limit.

The variable layout is closed form: the CIs are `1..nCi` in ordinal order, the named outputs follow, then the cone's AND nodes ascending. So the node-to-variable map is a local that dies with the writer, where `Cnf_Dat_t::pVarNums` is one `int` per object held for the whole solve so that a handful of inputs can be looked up. Only the inputs and the outputs are ever asked about, so only those are kept.

### Freedoms taken over `Cnf_DeriveSimple`

* **No constant variable and no unit clause asserting it.** `And()` folds constants, so a constant literal can only be an output: asserting true emits nothing, asserting false emits the empty clause. A *named* constant output still gets a variable and a unit clause.
* **The cone of the outputs only, always.** CIs are numbered whether or not they are reachable, so refinement can still name one afterwards.
* **XOR and if-then-else matched structurally.** An AIG spells `ITE(c,t,e)` as three AND nodes; recognised, it is one variable and four clauses instead of three and nine. XOR needs no separate case — it is the same shape with a second complementary pair, and the four clauses degenerate into the ones an XOR wants.
* **Counts in `uint64_t`, narrowed with a check.** `Cnf_DeriveSimple` computes `1 + 7*nodes + …` in an `int`, which overflows near 306M AND nodes.

The match is only taken when both intermediates have a single reference, so they disappear rather than being encoded twice; a shared one costs a clause instead of saving five, and is declined. The reference counts come from a sweep over the unfolded cone, which over-counts — taking a match only ever removes references — so the guard can lose an opportunity but never take one that does not pay.

### Measurements

200 64-bit array multipliers, 4.81M AND nodes, with the same graph replayed into ABC node for node so both generators see one circuit. Our nodes are already a fixed point of the folding rules and are handed to `Aig_And` in our canonical operand order, so ABC rewrites nothing and the AND counts agree exactly — without that, the comparison would be measuring the gate-count difference between the two packages rather than the generators.

| generator | clauses | literals | variables | derive |
|---|---|---|---|---|
| `Cnf_DeriveSimple` | 14,442,599 | 33,699,395 | 4,852,601 | 150 ms |
| ours, matching off | 14,255,998 | 33,263,994 | 4,790,400 | 174 ms |
| **ours** | **10,222,998** | **26,004,594** | **3,177,200** | **165 ms** |
| `Cnf_DeriveFast` | 8,796,003 | 23,944,803 | 2,445,003 | 930 ms |

29.2% fewer clauses and 34.5% fewer variables than `Cnf_DeriveSimple` for 10% more generation time; 5.6x faster than `Cnf_DeriveFast` for 16% more clauses. Put the other way, matching covers 75% of the distance between the two ABC generators for 10% of the extra cost — which matters because `cnf-auto` reaches for `Cnf_DeriveFast` on exactly the large AIGs where cut enumeration is expensive.

The marking sweeps are 13 ms of the 165, or 33 when the reference counting runs; the rest is writing the clauses, which is memory bandwidth and nothing else.

### The tests do not use a SAT solver

A Tseitin encoding claims two things — that every assignment the circuit admits satisfies the clauses, and that the clauses admit nothing else — and "satisfiable" only ever answers the first. A one-sided bug that leaves a clause out survives a satisfiability check on every input.

This encoding is propagation-complete from the inputs, so the tests fix the CIs and run unit propagation: every other variable must be forced, and forced to exactly its simulated value. Exhaustive over the inputs of random circuits, with matching on and off, for named outputs, asserted outputs and a mixture of the two. BCP is twenty lines and quadratic, deliberately — a watched-literal scheme would be a second implementation to get wrong.

13 tests; 176/176 ctest pass.