### PR TITLE
Hand the CNF around as one class instead of ABC's Cnf_Dat_t

### DIFF
--- a/include/stp/AIG/CNF.h
+++ b/include/stp/AIG/CNF.h
@@ -28,20 +28,20 @@ THE SOFTWARE.
 #include <cassert>
 #include <cstdint>
 #include <iosfwd>
+#include <utility>
 #include <vector>
 
 namespace stp
 {
 
-// A CNF formula and the projection back to the circuit it came from.
+// A CNF formula and the projection back to the circuit it came from. The one
+// currency the CNF generators hand back, whichever of them ran.
 //
-// Clauses live in one flat literal arena with an offsets array beside it, so
-// clause i is [lits_[offsets_[i]], lits_[offsets_[i+1]]) -- the layout
-// Cnf_Dat_t uses, kept because add_cnf_to_solver() walks it a clause at a
-// time and nothing is gained by a different one.
-//
-// A literal is `2*variable + negated`, again as in Cnf_Dat_t, so `^1` negates
-// and `>>1` recovers the variable.
+// Clauses live in one flat literal arena, indexed a clause at a time. A
+// literal is `2*variable + negated`, so `^1` negates and `>>1` recovers the
+// variable. That is Cnf_Dat_t's layout and encoding, and keeping it is what
+// lets an ABC-generated formula be adopted rather than copied -- see adopt()
+// below.
 //
 // Variables number from 1. Variable 0 does not exist, and that is not a
 // convention worth trading away: SATSolver::newVar() hands out 0 first and
@@ -54,32 +54,59 @@ namespace stp
 // Cnf_Dat_t's pVarNums is one int per AIG object and it outlives the
 // derivation, held for the whole solve so that a handful of CIs can be looked
 // up. Only the inputs and outputs are ever asked about, so only those are
-// kept.
+// kept -- varOfCi()/varOfCo() below, filled by whoever built the formula.
+//
+// Move-only. It owns either its own arena or somebody else's, and neither is
+// worth duplicating by accident.
 class CNF
 {
 public:
-  uint32_t varCount() const { return nVars_; }
-  uint64_t clauseCount() const
+  CNF() = default;
+  ~CNF() { discard(); }
+  CNF(CNF&& o) noexcept { steal(o); }
+  CNF& operator=(CNF&& o) noexcept
   {
-    return offsets_.empty() ? 0 : offsets_.size() - 1;
+    if (this != &o)
+    {
+      discard();
+      steal(o);
+    }
+    return *this;
   }
-  uint64_t literalCount() const { return lits_.size(); }
+  CNF(const CNF&) = delete;
+  CNF& operator=(const CNF&) = delete;
 
-  const int* clauseBegin(uint64_t i) const { return lits_.data() + offsets_[i]; }
+  uint32_t varCount() const { return nVars_; }
+  uint64_t clauseCount() const { return nClauses_; }
+  uint64_t literalCount() const { return nLiterals_; }
+
+  const int* clauseBegin(uint64_t i) const
+  {
+    return adopted_ ? adopted_[i] : lits_.data() + offsets_[i];
+  }
   const int* clauseEnd(uint64_t i) const
   {
-    return lits_.data() + offsets_[i + 1];
+    return adopted_ ? adopted_[i + 1] : lits_.data() + offsets_[i + 1];
   }
 
   // The variable holding the value of combinational input `ordinal`, or of
-  // combinational output `ordinal`. Zero means "no variable": an output that
-  // was asserted rather than named has none. Zero rather than some positive
-  // sentinel because a caller that forgets to check writes out of bounds on a
-  // sentinel that is a plausible index, and does not on this one.
+  // combinational output `ordinal`. Zero means "no variable": an input the
+  // formula never mentions has none, and neither does an output that was
+  // asserted rather than named. Zero rather than some positive sentinel
+  // because a caller that forgets to check writes out of bounds on a sentinel
+  // that is a plausible index, and does not on this one.
   uint32_t ciCount() const { return static_cast<uint32_t>(ciVar_.size()); }
   uint32_t coCount() const { return static_cast<uint32_t>(coVar_.size()); }
-  uint32_t varOfCi(uint32_t ordinal) const { return ciVar_[ordinal]; }
-  uint32_t varOfCo(uint32_t ordinal) const { return coVar_[ordinal]; }
+  uint32_t varOfCi(uint32_t ordinal) const
+  {
+    assert(ordinal < ciVar_.size());
+    return ciVar_[ordinal];
+  }
+  uint32_t varOfCo(uint32_t ordinal) const
+  {
+    assert(ordinal < coVar_.size());
+    return coVar_[ordinal];
+  }
 
   // Set when an empty clause was emitted, which is the only way this class
   // says "unsatisfiable before the solver has seen it".
@@ -87,11 +114,16 @@ public:
 
   void writeDimacs(std::ostream& out) const;
 
-  // ---- the sink the AIG's Tseitin writer emits into ----
+  // Give the formula back now rather than at the end of the scope. Worth
+  // saying explicitly where the next thing to run is the SAT search, which
+  // wants the memory this is holding.
+  void clear() { discard(); }
+
+  // ---- the sink a generator that builds its own arena emits into ----
   //
-  // Ordinary member functions rather than an interface: the writer is a
-  // template over its sink, so a DIMACS or straight-to-solver sink is a
-  // different type with these same names and costs no indirection.
+  // Ordinary member functions rather than an interface: the AIG's Tseitin
+  // writer is a template over its sink, so a DIMACS or straight-to-solver
+  // sink is a different type with these same names and costs no indirection.
 
   // Exact counts, not estimates -- the writer's first pass produces them and
   // end() checks that the second pass emitted precisely that many.
@@ -103,36 +135,70 @@ public:
   void clause(int a)
   {
     lits_.push_back(a);
-    offsets_.push_back(lits_.size());
+    closeClause();
   }
   void clause(int a, int b)
   {
     lits_.push_back(a);
     lits_.push_back(b);
-    offsets_.push_back(lits_.size());
+    closeClause();
   }
   void clause(int a, int b, int c)
   {
     lits_.push_back(a);
     lits_.push_back(b);
     lits_.push_back(c);
-    offsets_.push_back(lits_.size());
+    closeClause();
   }
   void emptyClause()
   {
     emptyClause_ = true;
-    offsets_.push_back(lits_.size());
+    closeClause();
   }
   void end();
 
+  // ---- taking over a formula built elsewhere ----
+
+  // Adopt a clause store this class did not build, without copying it. The
+  // ABC generators already produce exactly this layout -- an arena of
+  // literals with an array of nClauses+1 pointers indexing it -- so the whole
+  // seam between them and here is the projection of the CI and CO variables,
+  // filled with mapCi()/mapCo() afterwards.
+  //
+  // `release(owner)` is called when this CNF dies. It is a function pointer
+  // rather than a std::function so that this header stays free of the type it
+  // is adopting: the AIG package must not learn what a Cnf_Dat_t is.
+  void adopt(void* owner, void (*release)(void*), const int* const* clauses,
+             uint64_t nClauses, uint64_t nLiterals, uint32_t nVars,
+             uint32_t nCi, uint32_t nCo);
+
 private:
+  void closeClause()
+  {
+    offsets_.push_back(lits_.size());
+    ++nClauses_;
+    nLiterals_ = lits_.size();
+  }
+  void discard();
+  void steal(CNF& o);
+
+  // Ours, when we built it.
   std::vector<int> lits_;
   std::vector<uint64_t> offsets_;
+
+  // Somebody else's, when we adopted it. Non-null selects it over the two
+  // vectors above; the two are never both populated.
+  const int* const* adopted_ = nullptr;
+  void* owner_ = nullptr;
+  void (*release_)(void*) = nullptr;
+
   std::vector<uint32_t> ciVar_;
   std::vector<uint32_t> coVar_;
-  uint32_t nVars_ = 1;
+  uint64_t nClauses_ = 0;
+  uint64_t nLiterals_ = 0;
   uint64_t expectedClauses_ = 0;
   uint64_t expectedLiterals_ = 0;
+  uint32_t nVars_ = 1;
   bool emptyClause_ = false;
 };
 

--- a/include/stp/ToSat/BBNodeManagerAIG.h
+++ b/include/stp/ToSat/BBNodeManagerAIG.h
@@ -151,8 +151,10 @@ public:
   }
 
   // How many combinational inputs exist, and the object id of one of them by
-  // creation order. Callers index Cnf_Dat_t::pVarNums by that id; when the
-  // CNF seam lands they ask the CNF for the variable instead and this goes.
+  // creation order. The CNF seam left one caller for the id -- the
+  // propositional core's map back to the AIG it rewrote -- and everything
+  // that wanted a SAT variable now asks CNF::varOfCi() for it by the same
+  // ordinal.
   //
   // Positional rather than by node, because dag-aware rewriting replaces the
   // manager wholesale and only the position in vCis survives it.

--- a/include/stp/ToSat/ToCNFAIG.h
+++ b/include/stp/ToSat/ToCNFAIG.h
@@ -32,6 +32,9 @@ THE SOFTWARE.
 #include "sat/cnf/cnf.h"
 #include "opt/dar/dar.h"
 
+#include <functional>
+
+#include "stp/AIG/CNF.h"
 #include "stp/ToSat/BBNodeManagerAIG.h"
 #include "stp/ToSat/ToSATBase.h"
 
@@ -44,10 +47,19 @@ class ToCNFAIG // not copyable
 
   void dag_aware_aig_rewrite(const bool needAbsRef, BBNodeManagerAIG& mgr);
 
-  Cnf_Dat_t* derive_cnf_mf(BBNodeManagerAIG& mgr, int nLutSize,
-                            unsigned namedOutputs);
+  CNF derive_cnf_mf(BBNodeManagerAIG& mgr, int nLutSize,
+                    unsigned namedOutputs);
 
-  void fill_node_to_var(Cnf_Dat_t* cnfData,
+  // Take over an ABC-generated formula, projecting its per-object pVarNums
+  // down to the CI and CO variables that are the only ones anybody asks for.
+  // The clauses are adopted, not copied: ABC's layout is already the one CNF
+  // exposes. `objectVar` reads pVarNums for one object id, which is the only
+  // thing that differs between the Aig-based generators and the Gia-based
+  // one -- they index it by ids of their own manager.
+  static CNF adopt(Cnf_Dat_t* cnfData, unsigned nCi, unsigned nCo,
+                   const std::function<int(bool isCo, unsigned)>& objectVar);
+
+  void fill_node_to_var(const CNF& cnf,
                         ToSATBase::ASTNodeToSATVar& nodeToVars,
                         BBNodeManagerAIG& mgr);
 
@@ -67,10 +79,9 @@ public:
   // the number of trailing combinational outputs that need variables instead
   // of being asserted; passing every output is how a fragment such as
   // BVExactEncoder obtains values to splice into an existing solver.
-  Cnf_Dat_t* derive_cnf(BBNodeManagerAIG& mgr,
-                        unsigned namedOutputs = 0);
+  CNF derive_cnf(BBNodeManagerAIG& mgr, unsigned namedOutputs = 0);
 
-  void toCNF(const BBNodeAIG& top, Cnf_Dat_t*& cnfData,
+  void toCNF(const BBNodeAIG& top, CNF& cnf,
              ToSATBase::ASTNodeToSATVar& nodeToVars, bool needAbsRef,
              BBNodeManagerAIG& _mgr);
 };

--- a/include/stp/ToSat/ToSATAIG.h
+++ b/include/stp/ToSat/ToSATAIG.h
@@ -62,7 +62,7 @@ private:
   void suggest_uf_scalar_phases(SATSolver& satSolver);
 
   bool runSolver(SATSolver& satSolver);
-  void handle_cnf_options(Cnf_Dat_t* cnfData, bool needAbsRef);
+  void handle_cnf_options(const CNF& cnf, bool needAbsRef);
 
   // Resolve the injectivity guard to a SAT variable and decide how it is
   // held: assumed (and so retractable) on a backend that can assume, and
@@ -90,14 +90,14 @@ private:
   void init() { first = true; }
 
 public:
-  void add_cnf_to_solver(SATSolver& satSolver, Cnf_Dat_t* cnfData);
+  void add_cnf_to_solver(SATSolver& satSolver, const CNF& cnf);
 
-  // Blast `input` and convert it to CNF. Returns NULL, having freed the AIG
-  // and the constant-bit propagator, when UserFlags::aig_node_budget is set
-  // and the blast exceeds it -- there is no CNF in that case, and the caller
-  // must abandon the query rather than treat the absence as unsatisfiable.
-  Cnf_Dat_t* bitblast(const ASTNode& input, bool needAbsRef);
-  void release_cnf_memory(Cnf_Dat_t* cnfData);
+  // Blast `input` and convert it to CNF. Returns false, having freed the AIG
+  // and the constant-bit propagator and left `cnf` untouched, when
+  // UserFlags::aig_node_budget is set and the blast exceeds it -- there is no
+  // CNF in that case, and the caller must abandon the query rather than treat
+  // the absence as unsatisfiable.
+  bool bitblast(const ASTNode& input, bool needAbsRef, CNF& cnf);
 
   bool cbIsDestructed() { return cb == NULL; }
 

--- a/lib/AIG/CNF.cpp
+++ b/lib/AIG/CNF.cpp
@@ -32,9 +32,7 @@ namespace stp
 void CNF::begin(uint32_t nVars, uint64_t nClauses, uint64_t nLiterals,
                 uint32_t nCi, uint32_t nCo)
 {
-  lits_.clear();
-  offsets_.clear();
-  emptyClause_ = false;
+  discard();
 
   nVars_ = nVars;
   expectedClauses_ = nClauses;
@@ -52,29 +50,101 @@ void CNF::begin(uint32_t nVars, uint64_t nClauses, uint64_t nLiterals,
 
 void CNF::end()
 {
-  assert(clauseCount() == expectedClauses_);
-  assert(literalCount() == expectedLiterals_);
-  (void)expectedClauses_;
-  (void)expectedLiterals_;
+  assert(nClauses_ == expectedClauses_);
+  assert(nLiterals_ == expectedLiterals_);
 }
 
-// DIMACS numbers variables 1..N, which is ours minus the variable 0 that does
-// not exist -- so N is one less than varCount(), not equal to it. ABC writes
-// its nVars here and therefore declares one variable more than it uses; that
-// is harmless but it is not the file the formula asks for.
+void CNF::adopt(void* owner, void (*release)(void*), const int* const* clauses,
+                uint64_t nClauses, uint64_t nLiterals, uint32_t nVars,
+                uint32_t nCi, uint32_t nCo)
+{
+  discard();
+
+  adopted_ = clauses;
+  owner_ = owner;
+  release_ = release;
+  nClauses_ = nClauses;
+  nLiterals_ = nLiterals;
+  nVars_ = nVars;
+  ciVar_.assign(nCi, 0);
+  coVar_.assign(nCo, 0);
+}
+
+void CNF::discard()
+{
+  if (release_ != nullptr)
+    release_(owner_);
+  adopted_ = nullptr;
+  owner_ = nullptr;
+  release_ = nullptr;
+
+  // Actually give the memory back rather than clearing: a CNF is reset only
+  // when it is about to hold a different formula, and the two must not be
+  // resident at once.
+  std::vector<int>().swap(lits_);
+  std::vector<uint64_t>().swap(offsets_);
+  ciVar_.clear();
+  coVar_.clear();
+
+  nClauses_ = 0;
+  nLiterals_ = 0;
+  expectedClauses_ = 0;
+  expectedLiterals_ = 0;
+  nVars_ = 1;
+  emptyClause_ = false;
+}
+
+void CNF::steal(CNF& o)
+{
+  lits_ = std::move(o.lits_);
+  offsets_ = std::move(o.offsets_);
+  adopted_ = o.adopted_;
+  owner_ = o.owner_;
+  release_ = o.release_;
+  ciVar_ = std::move(o.ciVar_);
+  coVar_ = std::move(o.coVar_);
+  nClauses_ = o.nClauses_;
+  nLiterals_ = o.nLiterals_;
+  expectedClauses_ = o.expectedClauses_;
+  expectedLiterals_ = o.expectedLiterals_;
+  nVars_ = o.nVars_;
+  emptyClause_ = o.emptyClause_;
+
+  // The source must not free what we now own.
+  o.adopted_ = nullptr;
+  o.owner_ = nullptr;
+  o.release_ = nullptr;
+  o.nClauses_ = 0;
+  o.nLiterals_ = 0;
+  o.nVars_ = 1;
+  o.emptyClause_ = false;
+}
+
+// Byte for byte what Cnf_DataWriteIntoFile() produced, because --output-CNF
+// is a user-facing file and an internal reshuffle is no reason for it to
+// change -- and because CNF byte-identity across a refactor is only evidence
+// if the bytes are of the formula rather than of the writer.
+//
+// Two things are ABC's rather than ours, and are kept deliberately. The
+// banner names the package that used to write this. And the variable numbers
+// are one *above* the formula's, so a file declaring N variables uses 2..N
+// and leaves 1 unused: ABC numbered from 1 internally and then added another
+// 1 on the way out. Both are worth revisiting when the ABC generators go, and
+// neither before.
 void CNF::writeDimacs(std::ostream& out) const
 {
-  out << "p cnf " << (nVars_ == 0 ? 0 : nVars_ - 1) << ' ' << clauseCount()
-      << '\n';
+  out << "c Result of efficient AIG-to-CNF conversion using package CNF\n";
+  out << "p cnf " << nVars_ << ' ' << clauseCount() << '\n';
   for (uint64_t i = 0, n = clauseCount(); i < n; i++)
   {
     for (const int *p = clauseBegin(i), *stop = clauseEnd(i); p < stop; p++)
     {
-      const int var = *p >> 1;
+      const int var = (*p >> 1) + 1;
       out << ((*p & 1) ? -var : var) << ' ';
     }
     out << "0\n";
   }
+  out << '\n';
 }
 
 } // namespace stp

--- a/lib/ToSat/BVExactEncoder.cpp
+++ b/lib/ToSat/BVExactEncoder.cpp
@@ -160,26 +160,25 @@ void encodeNaryLemma(
   // search. The paired DIV/REM identity is a full-width multiplier, which is
   // exactly the circuit that argument is about. An explicitly chosen level
   // still reaches here.
-  Cnf_Dat_t* cnf =
+  const CNF cnf =
       ToCNFAIG(bm->UserFlags, /*allowAuto=*/false).derive_cnf(mgr, outputs);
-  assert(cnf != NULL);
 
-  std::vector<unsigned> cnfToSolver(cnf->nVars, ~((unsigned)0));
+  std::vector<unsigned> cnfToSolver(cnf.varCount(), ~((unsigned)0));
   for (unsigned i = 0; i < liveVars.size() * width; ++i)
   {
-    const int var = cnf->pVarNums[mgr.ciObjectId((int)i)];
-    if (var < 0)
+    const uint32_t var = cnf.varOfCi(i);
+    if (var == 0)
       continue;
     cnfToSolver[var] = (*liveVars[i / width])[i % width];
   }
 
-  // From 1: every ABC CNF generator numbers variables from 1 and reports
-  // nVars as one past the last, so index 0 names nothing. Allocating a solver
-  // variable for it, and freezing it, left one unreachable variable in the
-  // live solver per splice. The assertion in the clause loop below is what
+  // From 1: every CNF generator numbers variables from 1 and reports
+  // varCount() as one past the last, so index 0 names nothing. Allocating a
+  // solver variable for it, and freezing it, left one unreachable variable in
+  // the live solver per splice. The assertion in the clause loop below is what
   // holds this: a literal over variable 0 would mean a generator numbered
   // from 0 after all.
-  for (int var = 1; var < cnf->nVars; var++)
+  for (uint32_t var = 1; var < cnf.varCount(); var++)
     if (cnfToSolver[var] == ~((unsigned)0))
     {
       const unsigned fresh = solver.newVar();
@@ -188,10 +187,10 @@ void encodeNaryLemma(
     }
 
   SATSolver::vec_literals cl;
-  for (int i = 0; i < cnf->nClauses; i++)
+  for (uint64_t i = 0; i < cnf.clauseCount(); i++)
   {
     cl.clear();
-    for (int *pLit = cnf->pClauses[i], *pStop = cnf->pClauses[i + 1];
+    for (const int *pLit = cnf.clauseBegin(i), *pStop = cnf.clauseEnd(i);
          pLit < pStop; pLit++)
     {
       assert(((*pLit) >> 1) != 0 && "a CNF generator numbered variables from 0");
@@ -204,14 +203,12 @@ void encodeNaryLemma(
   // wanted conjoined to it.
   for (unsigned i = 0; i < outputs; i++)
   {
-    const unsigned var =
-        cnfToSolver[cnf->pVarNums[Aig_ManCo(mgr.aigMgr, (int)i)->Id]];
+    assert(cnf.varOfCo(i) != 0 && "a named output with no variable");
+    const unsigned var = cnfToSolver[cnf.varOfCo(i)];
     cl.clear();
     cl.push(SATSolver::mkLit(var, false));
     solver.addClause(cl);
   }
-
-  Cnf_DataFree(cnf);
 }
 
 template <typename BuildClaim>
@@ -404,8 +401,8 @@ void BVExactEncoder::encode(SATSolver& solver, const ASTNode& term,
   // Use the query's selected CNF strategy. All outputs are named rather than
   // asserted because the splice below connects each result bit explicitly
   // and asserts only the side constraints.
-  Cnf_Dat_t* cnf = ToCNFAIG(bm->UserFlags, /*allowAuto=*/false).derive_cnf(mgr, outputs);
-  assert(cnf != NULL);
+  const CNF cnf =
+      ToCNFAIG(bm->UserFlags, /*allowAuto=*/false).derive_cnf(mgr, outputs);
 
   // The splice. Every variable of the derived CNF becomes a variable of the
   // live solver: the inputs become the ones the operands are already
@@ -413,25 +410,25 @@ void BVExactEncoder::encode(SATSolver& solver, const ASTNode& term,
   // operands' own variables rather than minting a copy and equating it is
   // the whole point -- the clauses have to talk about the bits the rest of
   // the query talks about.
-  std::vector<unsigned> cnfToSolver(cnf->nVars, ~((unsigned)0));
+  std::vector<unsigned> cnfToSolver(cnf.varCount(), ~((unsigned)0));
 
   for (unsigned i = 0; i < ciVars.size(); i++)
   {
-    const int var = cnf->pVarNums[mgr.ciObjectId((int)i)];
+    const uint32_t var = cnf.varOfCi(i);
     // An input the circuit never reads is given no variable, and needs
     // none: nothing the CNF says mentions it.
-    if (var < 0)
+    if (var == 0)
       continue;
     cnfToSolver[var] = ciVars[i];
   }
 
-  // From 1: every ABC CNF generator numbers variables from 1 and reports
-  // nVars as one past the last, so index 0 names nothing. Allocating a solver
-  // variable for it, and freezing it, left one unreachable variable in the
-  // live solver per splice. The assertion in the clause loop below is what
+  // From 1: every CNF generator numbers variables from 1 and reports
+  // varCount() as one past the last, so index 0 names nothing. Allocating a
+  // solver variable for it, and freezing it, left one unreachable variable in
+  // the live solver per splice. The assertion in the clause loop below is what
   // holds this: a literal over variable 0 would mean a generator numbered
   // from 0 after all.
-  for (int var = 1; var < cnf->nVars; var++)
+  for (uint32_t var = 1; var < cnf.varCount(); var++)
     if (cnfToSolver[var] == ~((unsigned)0))
     {
       const unsigned fresh = solver.newVar();
@@ -440,10 +437,10 @@ void BVExactEncoder::encode(SATSolver& solver, const ASTNode& term,
     }
 
   SATSolver::vec_literals cl;
-  for (int i = 0; i < cnf->nClauses; i++)
+  for (uint64_t i = 0; i < cnf.clauseCount(); i++)
   {
     cl.clear();
-    for (int *pLit = cnf->pClauses[i], *pStop = cnf->pClauses[i + 1];
+    for (const int *pLit = cnf.clauseBegin(i), *pStop = cnf.clauseEnd(i);
          pLit < pStop; pLit++)
     {
       assert(((*pLit) >> 1) != 0 && "a CNF generator numbered variables from 0");
@@ -454,8 +451,8 @@ void BVExactEncoder::encode(SATSolver& solver, const ASTNode& term,
 
   for (unsigned i = 0; i < outputs; i++)
   {
-    const unsigned var =
-        cnfToSolver[cnf->pVarNums[Aig_ManCo(mgr.aigMgr, (int)i)->Id]];
+    assert(cnf.varOfCo(i) != 0 && "a named output with no variable");
+    const unsigned var = cnfToSolver[cnf.varOfCo(i)];
     if (i < width)
     {
       addEquiv(solver, resultVars[i], var);
@@ -465,8 +462,6 @@ void BVExactEncoder::encode(SATSolver& solver, const ASTNode& term,
     cl.push(SATSolver::mkLit(var, false));
     solver.addClause(cl);
   }
-
-  Cnf_DataFree(cnf);
 }
 
 } // namespace stp

--- a/lib/ToSat/ToCNFAIG.cpp
+++ b/lib/ToSat/ToCNFAIG.cpp
@@ -80,11 +80,11 @@ void ToCNFAIG::dag_aware_aig_rewrite(const bool needAbsRef,
   }
 }
 
-void ToCNFAIG::toCNF(const BBNodeAIG& top, Cnf_Dat_t*& cnfData,
+void ToCNFAIG::toCNF(const BBNodeAIG& top, CNF& cnf,
                      ToSATBase::ASTNodeToSATVar& nodeToVars, bool needAbsRef,
                      BBNodeManagerAIG& mgr)
 {
-  assert(cnfData == NULL);
+  assert(cnf.clauseCount() == 0);
 
   Aig_ObjCreateCo(mgr.aigMgr, top.n);
   if (!needAbsRef)
@@ -107,19 +107,38 @@ void ToCNFAIG::toCNF(const BBNodeAIG& top, Cnf_Dat_t*& cnfData,
 
   dag_aware_aig_rewrite(needAbsRef, mgr);
 
-  cnfData = derive_cnf(mgr);
+  cnf = derive_cnf(mgr);
   if (uf.stats_flag)
     cerr << (uf.simple_cnf ? "simple CNF" : "advanced CNF") << endl;
-  assert(cnfData != NULL);
 
-  fill_node_to_var(cnfData, nodeToVars, mgr);
+  fill_node_to_var(cnf, nodeToVars, mgr);
+}
+
+CNF ToCNFAIG::adopt(Cnf_Dat_t* cnfData, unsigned nCi, unsigned nCo,
+                    const std::function<int(bool, unsigned)>& objectVar)
+{
+  assert(cnfData != NULL);
+  CNF cnf;
+  cnf.adopt(cnfData, [](void* p) { Cnf_DataFree((Cnf_Dat_t*)p); },
+            cnfData->pClauses, (uint64_t)cnfData->nClauses,
+            (uint64_t)cnfData->nLiterals, (uint32_t)cnfData->nVars, nCi, nCo);
+
+  // -1 is ABC's "this object has no variable" -- a CI outside the cone of the
+  // outputs, or a CO that was asserted rather than named. CNF spells that 0,
+  // for the reason its header gives.
+  const auto var = [](int v) { return v < 0 ? 0u : (uint32_t)v; };
+  for (unsigned i = 0; i < nCi; i++)
+    cnf.mapCi(i, var(objectVar(false, i)));
+  for (unsigned i = 0; i < nCo; i++)
+    cnf.mapCo(i, var(objectVar(true, i)));
+  return cnf;
 }
 
 // ABC's newer CNF generator. It works on a Gia_Man_t, so the AIG is converted
 // first. nLutSize bounds the cuts it considers: larger means a smaller CNF for
 // steeply more work.
-Cnf_Dat_t* ToCNFAIG::derive_cnf_mf(BBNodeManagerAIG& mgr, int nLutSize,
-                                    unsigned namedOutputs)
+CNF ToCNFAIG::derive_cnf_mf(BBNodeManagerAIG& mgr, int nLutSize,
+                            unsigned namedOutputs)
 {
   // The two callers need either a formula (one asserted CO) or a fragment
   // (all COs named). Mf_ManGenerateCnf can express those two forms directly;
@@ -138,36 +157,20 @@ Cnf_Dat_t* ToCNFAIG::derive_cnf_mf(BBNodeManagerAIG& mgr, int nLutSize,
   Cnf_Dat_t* cnfData = (Cnf_Dat_t*)Mf_ManGenerateCnf(
       pGia, nLutSize, 0, assertOutputs, 0, 0);
 
-  // pVarNums comes back indexed by Gia object id, but the users of this class
-  // index it by Aig object id. Rebuild it over the Aig id space for the CIs
-  // and COs they can ask for; everything else stays -1.
-  //
-  // Aig_ManObjNumMax(), not Aig_ManObjNum(): the latter subtracts nDeleted, and
-  // the Aig_ManCleanup() in toCNF() deletes nodes, so ids run past the count of
-  // live objects. Sizing by the count under-allocates by exactly nDeleted, and
-  // fill_node_to_var() then reads off the end of the array.
+  // pVarNums comes back indexed by Gia object id, and the only entries anyone
+  // wants are the CIs' and the COs'. Project those out here; the per-object
+  // array goes with the Cnf_Dat_t.
   //
   // Reading Gia CI ids is safe even though this generator may derive the CNF
   // over a coarsened copy of the Gia (Gia_ManDupMuxes, when fCnfObjIds is 0):
-  // both managers append CIs before any AND node, so CI ids are 1..nCi in each,
-  // and pVarNums is sized by an object count that includes them.
-  const int nAigObjs = Aig_ManObjNumMax(mgr.aigMgr);
-  int* pRemap = ABC_ALLOC(int, nAigObjs);
-  for (int i = 0; i < nAigObjs; i++)
-    pRemap[i] = -1;
-
-  Aig_Obj_t* pCi;
-  int ci;
-  Aig_ManForEachCi(mgr.aigMgr, pCi, ci)
-    pRemap[pCi->Id] = cnfData->pVarNums[Gia_ObjId(pGia, Gia_ManCi(pGia, ci))];
-
-  Aig_Obj_t* pCo;
-  int co;
-  Aig_ManForEachCo(mgr.aigMgr, pCo, co)
-    pRemap[pCo->Id] = cnfData->pVarNums[Gia_ObjId(pGia, Gia_ManCo(pGia, co))];
-
-  ABC_FREE(cnfData->pVarNums);
-  cnfData->pVarNums = pRemap;
+  // both managers append CIs before any AND node, so CI ids are 1..nCi in
+  // each, and pVarNums is sized by an object count that includes them.
+  CNF cnf = adopt(
+      cnfData, (unsigned)Aig_ManCiNum(mgr.aigMgr),
+      (unsigned)Aig_ManCoNum(mgr.aigMgr), [&](bool isCo, unsigned i) {
+        Gia_Obj_t* o = isCo ? Gia_ManCo(pGia, (int)i) : Gia_ManCi(pGia, (int)i);
+        return cnfData->pVarNums[Gia_ObjId(pGia, o)];
+      });
 
   // Mf_ManGenerateCnf leaves pMan pointing at the Gia, cast to Aig_Man_t*.
   // Nothing in STP reads pMan and Cnf_DataFree() does not touch it, so the Gia
@@ -175,15 +178,26 @@ Cnf_Dat_t* ToCNFAIG::derive_cnf_mf(BBNodeManagerAIG& mgr, int nLutSize,
   cnfData->pMan = NULL;
   Gia_ManStop(pGia);
 
-  return cnfData;
+  return cnf;
 }
 
-Cnf_Dat_t* ToCNFAIG::derive_cnf(BBNodeManagerAIG& mgr,
-                                 unsigned namedOutputs)
+CNF ToCNFAIG::derive_cnf(BBNodeManagerAIG& mgr, unsigned namedOutputs)
 {
   assert(namedOutputs <= (unsigned)Aig_ManCoNum(mgr.aigMgr));
+
+  // Every generator below one indexes pVarNums by Aig object id.
+  const auto fromAig = [&](Cnf_Dat_t* d) {
+    return adopt(d, (unsigned)Aig_ManCiNum(mgr.aigMgr),
+                 (unsigned)Aig_ManCoNum(mgr.aigMgr),
+                 [&](bool isCo, unsigned i) {
+                   Aig_Obj_t* o = isCo ? Aig_ManCo(mgr.aigMgr, (int)i)
+                                       : Aig_ManCi(mgr.aigMgr, (int)i);
+                   return d->pVarNums[Aig_ObjId(o)];
+                 });
+  };
+
   if (uf.simple_cnf)
-    return Cnf_DeriveSimple(mgr.aigMgr, (int)namedOutputs);
+    return fromAig(Cnf_DeriveSimple(mgr.aigMgr, (int)namedOutputs));
 
   // AUTO: decide from the size of the AIG about to be converted.
   //
@@ -224,7 +238,7 @@ Cnf_Dat_t* ToCNFAIG::derive_cnf(BBNodeManagerAIG& mgr,
       // Cnf_DeriveSimple buys about 12% off generation time for roughly 1.9x
       // the clauses -- measured on one input at 51.7M clauses against 27.6M
       // here. That trade is not worth a level.
-      return Cnf_DeriveFast(mgr.aigMgr, (int)namedOutputs);
+      return fromAig(Cnf_DeriveFast(mgr.aigMgr, (int)namedOutputs));
 
     case UserDefinedFlags::CNF_EFFORT_LOW:
       return derive_cnf_mf(mgr, 3, namedOutputs);
@@ -248,12 +262,12 @@ Cnf_Dat_t* ToCNFAIG::derive_cnf(BBNodeManagerAIG& mgr,
       Cnf_Dat_t* result =
           Cnf_DeriveWithMan(cnfMan, mgr.aigMgr, (int)namedOutputs);
       Cnf_ManStop(cnfMan);
-      return result;
+      return fromAig(result);
     }
   }
 }
 
-void ToCNFAIG::fill_node_to_var(Cnf_Dat_t* cnfData,
+void ToCNFAIG::fill_node_to_var(const CNF& cnf,
                                 ToSATBase::ASTNodeToSATVar& nodeToVars,
                                 BBNodeManagerAIG& mgr)
 {
@@ -276,7 +290,13 @@ void ToCNFAIG::fill_node_to_var(Cnf_Dat_t* cnfData,
     {
       if (!b[i].IsNull())
       {
-        v[i] = cnfData->pVarNums[mgr.ciObjectId(b[i].symbol_index)];
+        // 0 is CNF's "no variable"; ~0u is this map's, and the two have to be
+        // translated rather than assumed equal. pVarNums said -1, which
+        // became ~0u by the conversion into an unsigned, so nothing here
+        // used to need saying.
+        const uint32_t var = cnf.varOfCi((uint32_t)b[i].symbol_index);
+        if (var != 0)
+          v[i] = var;
       }
     }
 

--- a/lib/ToSat/ToSATAIG.cpp
+++ b/lib/ToSat/ToSATAIG.cpp
@@ -27,6 +27,7 @@ THE SOFTWARE.
 #include "stp/UninterpretedFunctions/UFContext.h"
 #include "stp/Simplifier/Simplifier.h"
 #include "stp/Simplifier/constantBitP/ConstantBitPropagation.h"
+#include <fstream>
 #include <sstream>
 
 namespace stp
@@ -73,24 +74,30 @@ bool ToSATAIG::CallSAT(SATSolver& satSolver, const ASTNode& input,
   }
 
   first = false;
-  Cnf_Dat_t* cnfData = bitblast(input, needAbsRef);
+  CNF cnf;
 
-  // Only an exhausted AIG budget returns NULL: the query has no answer, and
+  // Only an exhausted AIG budget returns false: the query has no answer, and
   // `false` alone would be read as UNSAT. Raising the soft-timeout flag is
   // what makes CallSAT_ResultCheck report SOLVER_UNKNOWN instead -- it tests
   // that flag before it tests this return value.
-  if (cnfData == NULL)
+  if (!bitblast(input, needAbsRef, cnf))
   {
     bm->soft_timeout_expired = true;
     return false;
   }
 
-  handle_cnf_options(cnfData, needAbsRef);
+  handle_cnf_options(cnf, needAbsRef);
 
   assert(satSolver.nVars() == 0);
-  add_cnf_to_solver(satSolver, cnfData);
+  add_cnf_to_solver(satSolver, cnf);
 
-  release_cnf_memory(cnfData);
+  // The clauses are in the solver now; give the formula back before the
+  // search allocates. Cnf_ManFree() used to be called here too, to release
+  // ABC's precomputed clause-cost tables -- it only ever freed the manager
+  // that Cnf_Derive() lazily creates, and STP calls Cnf_DeriveWithMan() with
+  // a manager of its own instead, so ABC's global was always NULL and the
+  // call always a no-op.
+  cnf.clear();
 
   mark_variables_as_frozen(satSolver);
   bind_injectivity_guard(satSolver);
@@ -135,17 +142,7 @@ void ToSATAIG::bind_injectivity_guard(SATSolver& satSolver)
   satSolver.addClause(unit);
 }
 
-void ToSATAIG::release_cnf_memory(Cnf_Dat_t* cnfData)
-{
-  // Cnf_ManFree() used to be called here on the first conversion, to release
-  // ABC's precomputed clause-cost tables. It only ever freed the manager that
-  // Cnf_Derive() lazily creates, and STP calls Cnf_DeriveWithMan() with a
-  // manager of its own instead -- so ABC's global was always NULL and the call
-  // always a no-op. The counter that guarded it went with it.
-  Cnf_DataFree(cnfData);
-}
-
-void ToSATAIG::handle_cnf_options(Cnf_Dat_t* cnfData, bool needAbsRef)
+void ToSATAIG::handle_cnf_options(const CNF& cnf, bool needAbsRef)
 {
   // What makes this CNF partial, named so a reader can act on it.
   //
@@ -181,8 +178,15 @@ void ToSATAIG::handle_cnf_options(Cnf_Dat_t* cnfData, bool needAbsRef)
   {
     std::stringstream fileName;
     fileName << "output_" << bm->CNFFileNameCounter++ << ".cnf";
-    Cnf_DataWriteIntoFile(cnfData, (char*)fileName.str().c_str(), 0,0,0);
-    sayWhyPartial("the CNF written by --output-CNF");
+    std::ofstream out(fileName.str().c_str());
+    if (!out)
+      cerr << "Warning: could not open " << fileName.str() << " for writing."
+           << endl;
+    else
+    {
+      cnf.writeDimacs(out);
+      sayWhyPartial("the CNF written by --output-CNF");
+    }
   }
 
   if (bm->UserFlags.exit_after_CNF)
@@ -207,7 +211,7 @@ void ToSATAIG::handle_cnf_options(Cnf_Dat_t* cnfData, bool needAbsRef)
   }
 }
 
-Cnf_Dat_t* ToSATAIG::bitblast(const ASTNode& input, bool needAbsRef)
+bool ToSATAIG::bitblast(const ASTNode& input, bool needAbsRef, CNF& cnf)
 {
   stp::SubstitutionMap sm(bm);
   Simplifier simp(bm, &sm);
@@ -282,7 +286,7 @@ Cnf_Dat_t* ToSATAIG::bitblast(const ASTNode& input, bool needAbsRef)
     cb = NULL;
     bb.cb = NULL;
     mgr.stop();
-    return NULL;
+    return false;
   }
 
   bm->GetRunTimes()->stop(RunTimes::BitBlasting);
@@ -292,9 +296,18 @@ Cnf_Dat_t* ToSATAIG::bitblast(const ASTNode& input, bool needAbsRef)
   bb.cb = NULL;
 
   bm->GetRunTimes()->start(RunTimes::CNFConversion);
-  Cnf_Dat_t* cnfData = NULL;
-  toCNF.toCNF(BBFormula, cnfData, nodeToSATVar, needAbsRef, mgr);
+  toCNF.toCNF(BBFormula, cnf, nodeToSATVar, needAbsRef, mgr);
   bm->GetRunTimes()->stop(RunTimes::CNFConversion);
+
+  // The abstraction records below name their combinational inputs by ordinal,
+  // which is what the CI projection is indexed by. 0 is CNF's "no variable"
+  // and BV_ABSTRACTION_NO_VAR is theirs; pVarNums said -1, which became the
+  // latter by the conversion into an unsigned, so the translation used to be
+  // invisible.
+  const auto satVarOfCi = [&cnf](int ordinal) {
+    const uint32_t v = cnf.varOfCi((uint32_t)ordinal);
+    return v == 0 ? BV_ABSTRACTION_NO_VAR : v;
+  };
 
   // Record what each abstraction stands for, now that CNF conversion has
   // assigned the SAT variable its combinational input carries. Refinement
@@ -305,8 +318,7 @@ Cnf_Dat_t* ToSATAIG::bitblast(const ASTNode& input, bool needAbsRef)
     a.id = raw.id;
     a.dependencies = raw.dependencies;
     a.eqNode = raw.eqNode;
-    a.abstractionSATVar =
-        cnfData->pVarNums[mgr.ciObjectId(raw.abstractionCI.symbol_index)];
+    a.abstractionSATVar = satVarOfCi(raw.abstractionCI.symbol_index);
     a.leftSymbol = raw.leftSymbol;
     a.rightSymbol = raw.rightSymbol;
     a.width = std::max(1u, raw.leftSymbol.GetValueWidth());
@@ -331,7 +343,7 @@ Cnf_Dat_t* ToSATAIG::bitblast(const ASTNode& input, bool needAbsRef)
     a.width = raw.width;
     if (raw.condCISymbolIndex >= 0)
     {
-      a.condSATVar = cnfData->pVarNums[mgr.ciObjectId(raw.condCISymbolIndex)];
+      a.condSATVar = satVarOfCi(raw.condCISymbolIndex);
     }
     // The record's own result inputs, resolved the same way the condition
     // above is. The blaster files them for every term family; the persistent
@@ -348,7 +360,7 @@ Cnf_Dat_t* ToSATAIG::bitblast(const ASTNode& input, bool needAbsRef)
     a.resultSATVars.reserve(raw.resultCISymbolIndices.size());
     for (const int index : raw.resultCISymbolIndices)
     {
-      a.resultSATVars.push_back(cnfData->pVarNums[mgr.ciObjectId(index)]);
+      a.resultSATVars.push_back(satVarOfCi(index));
     }
     abstraction_.appendTerm(std::move(a));
   }
@@ -357,23 +369,23 @@ Cnf_Dat_t* ToSATAIG::bitblast(const ASTNode& input, bool needAbsRef)
   BBFormula = BBNodeAIG(); // null node
   mgr.stop();
 
-  return cnfData;
+  return true;
 }
 
-void ToSATAIG::add_cnf_to_solver(SATSolver& satSolver, Cnf_Dat_t* cnfData)
+void ToSATAIG::add_cnf_to_solver(SATSolver& satSolver, const CNF& cnf)
 {
   bm->GetRunTimes()->start(RunTimes::SendingToSAT);
 
   // Create a new sat variable for each of the variables in the CNF.
   int satV = satSolver.nVars();
-  for (int i = 0; i < cnfData->nVars - satV; i++)
+  for (int i = 0; i < (int)cnf.varCount() - satV; i++)
     satSolver.newVar();
 
   SATSolver::vec_literals satSolverClause;
-  for (int i = 0; i < cnfData->nClauses; i++)
+  for (uint64_t i = 0; i < cnf.clauseCount(); i++)
   {
     satSolverClause.clear();
-    for (int *pLit = cnfData->pClauses[i], *pStop = cnfData->pClauses[i + 1];
+    for (const int *pLit = cnf.clauseBegin(i), *pStop = cnf.clauseEnd(i);
          pLit < pStop; pLit++)
     {
       uint32_t var = (*pLit) >> 1;

--- a/tests/unit-tests/DeepDag_Test.cpp
+++ b/tests/unit-tests/DeepDag_Test.cpp
@@ -814,8 +814,8 @@ bool abstractionSideConstraintsOk(Context& c, unsigned depth)
 
   // Every conjunct has to reach the CNF, and each brings clauses of its
   // own, so fewer clauses than conjuncts would not be this formula.
-  Cnf_Dat_t* cnf = toSAT.bitblast(top, false);
-  return cnf != NULL && cnf->nClauses > static_cast<int>(depth);
+  CNF cnf;
+  return toSAT.bitblast(top, false, cnf) && cnf.clauseCount() > depth;
 }
 
 // Simplifier's term side. The job machine must use the same flattened operand

--- a/tests/unit-tests/Tseitin_Test.cpp
+++ b/tests/unit-tests/Tseitin_Test.cpp
@@ -23,6 +23,7 @@
 #include <gtest/gtest.h>
 
 #include <cstdint>
+#include <cstdlib>
 #include <random>
 #include <sstream>
 #include <vector>
@@ -520,7 +521,8 @@ TEST(Tseitin, IsDeterministic)
   }
 }
 
-// The DIMACS header names the highest variable, not one past it.
+// The DIMACS file is byte-compatible with the one Cnf_DataWriteIntoFile()
+// wrote, including its habit of numbering variables one above the formula's.
 TEST(Tseitin, WritesDimacs)
 {
   aig::Manager m;
@@ -531,19 +533,30 @@ TEST(Tseitin, WritesDimacs)
   std::ostringstream out;
   cnf.writeDimacs(out);
 
-  std::istringstream in(out.str());
+  const std::string text = out.str();
+  ASSERT_EQ(text.compare(0, 1, "c"), 0) << "the banner line is part of the format";
+
+  std::istringstream in(text.substr(text.find('\n') + 1));
   std::string p, fmt;
   int vars = 0, clauses = 0;
   in >> p >> fmt >> vars >> clauses;
   EXPECT_EQ(p, "p");
   EXPECT_EQ(fmt, "cnf");
-  EXPECT_EQ(vars, static_cast<int>(cnf.varCount()) - 1);
+  EXPECT_EQ(vars, static_cast<int>(cnf.varCount()));
   EXPECT_EQ(clauses, static_cast<int>(cnf.clauseCount()));
 
   unsigned terminators = 0;
   int token = 0;
   while (in >> token)
+  {
     if (token == 0)
       terminators++;
+    else
+    {
+      // Variables are one above the formula's, so 1 is never named.
+      EXPECT_GE(std::abs(token), 2);
+      EXPECT_LE(std::abs(token), static_cast<int>(cnf.varCount()));
+    }
+  }
   EXPECT_EQ(terminators, cnf.clauseCount());
 }

--- a/tools/propagator_bench/Bcp.cpp
+++ b/tools/propagator_bench/Bcp.cpp
@@ -75,7 +75,7 @@ struct BcpEncoding
 {
   BcpEncoding(STPMgr* mgr_, const OpSpec& op, const Layout& l)
       : mgr(mgr_), sm(mgr_), simp(mgr_, &sm), at(mgr_, &simp), aig(mgr_, &at),
-        cnf(NULL), ok(false)
+        ok(false)
   {
     const ASTNode node = buildNode(mgr, op, l);
 
@@ -93,13 +93,11 @@ struct BcpEncoding
     // sbvdiv, sbvrem and sbvmod reach the bit-blaster only after this.
     constraint = at.TransformFormula_TopLevel(constraint);
 
-    cnf = aig.bitblast(constraint, false);
+    if (!aig.bitblast(constraint, false, cnf))
+      return;
     // NULL means the AIG node budget stopped the blast. This tool never sets
     // one, so it cannot happen today -- but leaving `ok` false is the honest
     // answer for a layout with no CNF, and costs a single branch.
-    if (cnf == NULL)
-      return;
-
     const ToSATBase::ASTNodeToSATVar& map = aig.SATVar_to_SymbolIndexMap();
 
     // The varying children, in layout order, then the result. GetChildren()
@@ -117,12 +115,6 @@ struct BcpEncoding
       return;
 
     ok = true;
-  }
-
-  ~BcpEncoding()
-  {
-    if (cnf != NULL)
-      aig.release_cnf_memory(cnf);
   }
 
   // Counts the variables fixed at level zero once `bits` are asserted, or
@@ -162,8 +154,8 @@ struct BcpEncoding
   }
 
   bool usable() const { return ok; }
-  unsigned clauses() const { return cnf == NULL ? 0 : (unsigned)cnf->nClauses; }
-  unsigned variables() const { return cnf == NULL ? 0 : (unsigned)cnf->nVars; }
+  unsigned clauses() const { return (unsigned)cnf.clauseCount(); }
+  unsigned variables() const { return cnf.varCount(); }
 
 private:
   // constexpr, not const: resize() below binds it by reference, which needs
@@ -193,7 +185,7 @@ private:
   Simplifier simp;
   ArrayTransformer at;
   mutable ToSATAIG aig;
-  Cnf_Dat_t* cnf;
+  CNF cnf;
   vector<vector<unsigned>> vars; // one entry per varying child, then result
   std::unordered_set<unsigned> interesting;
   bool ok;

--- a/tools/rewrite_rule_gen/rewrite_rule_gen.cpp
+++ b/tools/rewrite_rule_gen/rewrite_rule_gen.cpp
@@ -654,7 +654,7 @@ int getDifficulty(const ASTNode& n_)
 
   clearSAT();
 
-  Cnf_Dat_t* cnfData = NULL;
+  CNF cnfData;
   ToCNFAIG toCNF(mgr->UserFlags);
   ToSATBase::ASTNodeToSATVar nodeToSATVar;
   toCNF.toCNF(BBFormula, cnfData, nodeToSATVar, false, nm);
@@ -668,14 +668,15 @@ int getDifficulty(const ASTNode& n_)
   {
     // Create a new sat variable for each of the variables in the CNF.
     assert(ss->nVars() == 0);
-    for (int i = 0; i < cnfData->nVars; i++)
+    for (uint32_t i = 0; i < cnfData.varCount(); i++)
       ss->newVar();
 
     SATSolver::vec_literals satSolverClause;
-    for (int i = 0; i < cnfData->nClauses; i++)
+    for (uint64_t i = 0; i < cnfData.clauseCount(); i++)
     {
       satSolverClause.clear();
-      for (int *pLit = cnfData->pClauses[i], *pStop = cnfData->pClauses[i + 1];
+      for (const int *pLit = cnfData.clauseBegin(i),
+                     *pStop = cnfData.clauseEnd(i);
            pLit < pStop; pLit++)
       {
         uint32_t var = (*pLit) >> 1;
@@ -693,17 +694,15 @@ int getDifficulty(const ASTNode& n_)
 
     // Why we go to all this trouble. The number of clauses.
     score = ss->nClauses();
-    assert(score <= cnfData->nClauses);
+    assert(score <= (int)cnfData.clauseCount());
   }
   else
   {
-    score = cnfData->nClauses;
+    score = (int)cnfData.clauseCount();
   }
   //////////////
 
-  // Cnf_ClearMemory();
-  Cnf_DataFree(cnfData);
-  cnfData = NULL;
+  cnfData.clear();
 
   // Free the memory in the AIGs.
   BBFormula = BBNodeAIG(); // null node


### PR DESCRIPTION
The currency both generators will produce, and the last thing between the AIG package and being able to wire a second backend behind it. Nothing new generates anything yet — ABC still writes every clause here — so this is a refactor, gated on the CNF being byte-identical.

### Nothing is copied

ABC's layout is an arena of literals with an array of `nClauses+1` pointers indexing it, which is the layout `CNF` exposes. So the formula is adopted and freed through a function pointer when the `CNF` dies, rather than copied into vectors. That also keeps the AIG package from learning what a `Cnf_Dat_t` is, which is the one rule that package has.

### What goes is the node-to-variable map

`Cnf_Dat_t::pVarNums` is one `int` per AIG object and it outlives the derivation, held for the whole solve so that a handful of combinational inputs can be looked up. Only the inputs and the outputs are ever asked about, so the projection down to those now happens inside `derive_cnf()` and the per-object array is freed with the rest of the ABC formula.

Two things fall out of that:

* **The Gia path's `pRemap` block goes** — 25 lines that allocated a *second* per-object array to translate Gia object ids into Aig ones, together with the `Aig_ManObjNumMax`-versus-`Aig_ManObjNum` trap it needed a five-line comment about. Indexing by ordinal into a right-sized vector cannot read off the end.
* **`ToSATAIG` no longer reads the CNF through the AIG manager**, which it did while filling the abstraction records and only afterwards stopped. Correct as it stood, but it tied one backend's object ids to a record every backend has to fill.

### Sentinels had to be translated, not assumed equal

`pVarNums` said `-1` for "no variable", which became `~0u` by the conversion into an unsigned and so silently agreed with both `BV_ABSTRACTION_NO_VAR` and the `~0u` that `fill_node_to_var` writes for an unencoded bit. `CNF` says `0`, because a caller that forgets to check writes out of bounds on a plausible-looking positive sentinel and does not on that one. Every crossing is explicit now.

### `--output-CNF` still writes the same bytes

Down to ABC's banner line and its habit of numbering variables one above the formula's. Not sentiment: a user-facing file should not change under a refactor, and byte-identity across the change is only evidence if the bytes are of the formula rather than of the writer. Both are worth revisiting when the ABC generators go.

### Gate

`scripts/cnf-manifest.sh` against a binary built from the parent commit in its own build directory, so it links its own `libstp`.

| configuration | inputs | produced CNF | differing |
|---|---|---|---|
| default | 882 | 349 | 0 |
| `--bb.conjoin-constant 1` | 882 | 349 | 0 |
| `--bv-eq-abstraction 1 --bv-term-abstraction 1` | 882 | 349 | 0 |
| `--disable-simplifications` | 882 | 679 | 0 |

The manifest cannot see `BVExactEncoder`'s splice — `--exit-after-CNF` stops at the first CNF and the splice happens during refinement — so the evidence for that file is `BVExactEncoder_Test` and the abstraction tests. 176/176 ctest pass. `propagator_bench` was compiled separately since it needs CryptoMiniSat, which this build does not have.
