### PR TITLE
Make BitBlaster a template again, over the node and its manager

### DIFF
--- a/include/stp/AIG/CNF.h
+++ b/include/stp/AIG/CNF.h
@@ -28,20 +28,20 @@ THE SOFTWARE.
 #include <cassert>
 #include <cstdint>
 #include <iosfwd>
+#include <utility>
 #include <vector>
 
 namespace stp
 {
 
-// A CNF formula and the projection back to the circuit it came from.
+// A CNF formula and the projection back to the circuit it came from. The one
+// currency the CNF generators hand back, whichever of them ran.
 //
-// Clauses live in one flat literal arena with an offsets array beside it, so
-// clause i is [lits_[offsets_[i]], lits_[offsets_[i+1]]) -- the layout
-// Cnf_Dat_t uses, kept because add_cnf_to_solver() walks it a clause at a
-// time and nothing is gained by a different one.
-//
-// A literal is `2*variable + negated`, again as in Cnf_Dat_t, so `^1` negates
-// and `>>1` recovers the variable.
+// Clauses live in one flat literal arena, indexed a clause at a time. A
+// literal is `2*variable + negated`, so `^1` negates and `>>1` recovers the
+// variable. That is Cnf_Dat_t's layout and encoding, and keeping it is what
+// lets an ABC-generated formula be adopted rather than copied -- see adopt()
+// below.
 //
 // Variables number from 1. Variable 0 does not exist, and that is not a
 // convention worth trading away: SATSolver::newVar() hands out 0 first and
@@ -54,32 +54,59 @@ namespace stp
 // Cnf_Dat_t's pVarNums is one int per AIG object and it outlives the
 // derivation, held for the whole solve so that a handful of CIs can be looked
 // up. Only the inputs and outputs are ever asked about, so only those are
-// kept.
+// kept -- varOfCi()/varOfCo() below, filled by whoever built the formula.
+//
+// Move-only. It owns either its own arena or somebody else's, and neither is
+// worth duplicating by accident.
 class CNF
 {
 public:
-  uint32_t varCount() const { return nVars_; }
-  uint64_t clauseCount() const
+  CNF() = default;
+  ~CNF() { discard(); }
+  CNF(CNF&& o) noexcept { steal(o); }
+  CNF& operator=(CNF&& o) noexcept
   {
-    return offsets_.empty() ? 0 : offsets_.size() - 1;
+    if (this != &o)
+    {
+      discard();
+      steal(o);
+    }
+    return *this;
   }
-  uint64_t literalCount() const { return lits_.size(); }
+  CNF(const CNF&) = delete;
+  CNF& operator=(const CNF&) = delete;
 
-  const int* clauseBegin(uint64_t i) const { return lits_.data() + offsets_[i]; }
+  uint32_t varCount() const { return nVars_; }
+  uint64_t clauseCount() const { return nClauses_; }
+  uint64_t literalCount() const { return nLiterals_; }
+
+  const int* clauseBegin(uint64_t i) const
+  {
+    return adopted_ ? adopted_[i] : lits_.data() + offsets_[i];
+  }
   const int* clauseEnd(uint64_t i) const
   {
-    return lits_.data() + offsets_[i + 1];
+    return adopted_ ? adopted_[i + 1] : lits_.data() + offsets_[i + 1];
   }
 
   // The variable holding the value of combinational input `ordinal`, or of
-  // combinational output `ordinal`. Zero means "no variable": an output that
-  // was asserted rather than named has none. Zero rather than some positive
-  // sentinel because a caller that forgets to check writes out of bounds on a
-  // sentinel that is a plausible index, and does not on this one.
+  // combinational output `ordinal`. Zero means "no variable": an input the
+  // formula never mentions has none, and neither does an output that was
+  // asserted rather than named. Zero rather than some positive sentinel
+  // because a caller that forgets to check writes out of bounds on a sentinel
+  // that is a plausible index, and does not on this one.
   uint32_t ciCount() const { return static_cast<uint32_t>(ciVar_.size()); }
   uint32_t coCount() const { return static_cast<uint32_t>(coVar_.size()); }
-  uint32_t varOfCi(uint32_t ordinal) const { return ciVar_[ordinal]; }
-  uint32_t varOfCo(uint32_t ordinal) const { return coVar_[ordinal]; }
+  uint32_t varOfCi(uint32_t ordinal) const
+  {
+    assert(ordinal < ciVar_.size());
+    return ciVar_[ordinal];
+  }
+  uint32_t varOfCo(uint32_t ordinal) const
+  {
+    assert(ordinal < coVar_.size());
+    return coVar_[ordinal];
+  }
 
   // Set when an empty clause was emitted, which is the only way this class
   // says "unsatisfiable before the solver has seen it".
@@ -87,11 +114,16 @@ public:
 
   void writeDimacs(std::ostream& out) const;
 
-  // ---- the sink the AIG's Tseitin writer emits into ----
+  // Give the formula back now rather than at the end of the scope. Worth
+  // saying explicitly where the next thing to run is the SAT search, which
+  // wants the memory this is holding.
+  void clear() { discard(); }
+
+  // ---- the sink a generator that builds its own arena emits into ----
   //
-  // Ordinary member functions rather than an interface: the writer is a
-  // template over its sink, so a DIMACS or straight-to-solver sink is a
-  // different type with these same names and costs no indirection.
+  // Ordinary member functions rather than an interface: the AIG's Tseitin
+  // writer is a template over its sink, so a DIMACS or straight-to-solver
+  // sink is a different type with these same names and costs no indirection.
 
   // Exact counts, not estimates -- the writer's first pass produces them and
   // end() checks that the second pass emitted precisely that many.
@@ -103,36 +135,70 @@ public:
   void clause(int a)
   {
     lits_.push_back(a);
-    offsets_.push_back(lits_.size());
+    closeClause();
   }
   void clause(int a, int b)
   {
     lits_.push_back(a);
     lits_.push_back(b);
-    offsets_.push_back(lits_.size());
+    closeClause();
   }
   void clause(int a, int b, int c)
   {
     lits_.push_back(a);
     lits_.push_back(b);
     lits_.push_back(c);
-    offsets_.push_back(lits_.size());
+    closeClause();
   }
   void emptyClause()
   {
     emptyClause_ = true;
-    offsets_.push_back(lits_.size());
+    closeClause();
   }
   void end();
 
+  // ---- taking over a formula built elsewhere ----
+
+  // Adopt a clause store this class did not build, without copying it. The
+  // ABC generators already produce exactly this layout -- an arena of
+  // literals with an array of nClauses+1 pointers indexing it -- so the whole
+  // seam between them and here is the projection of the CI and CO variables,
+  // filled with mapCi()/mapCo() afterwards.
+  //
+  // `release(owner)` is called when this CNF dies. It is a function pointer
+  // rather than a std::function so that this header stays free of the type it
+  // is adopting: the AIG package must not learn what a Cnf_Dat_t is.
+  void adopt(void* owner, void (*release)(void*), const int* const* clauses,
+             uint64_t nClauses, uint64_t nLiterals, uint32_t nVars,
+             uint32_t nCi, uint32_t nCo);
+
 private:
+  void closeClause()
+  {
+    offsets_.push_back(lits_.size());
+    ++nClauses_;
+    nLiterals_ = lits_.size();
+  }
+  void discard();
+  void steal(CNF& o);
+
+  // Ours, when we built it.
   std::vector<int> lits_;
   std::vector<uint64_t> offsets_;
+
+  // Somebody else's, when we adopted it. Non-null selects it over the two
+  // vectors above; the two are never both populated.
+  const int* const* adopted_ = nullptr;
+  void* owner_ = nullptr;
+  void (*release_)(void*) = nullptr;
+
   std::vector<uint32_t> ciVar_;
   std::vector<uint32_t> coVar_;
-  uint32_t nVars_ = 1;
+  uint64_t nClauses_ = 0;
+  uint64_t nLiterals_ = 0;
   uint64_t expectedClauses_ = 0;
   uint64_t expectedLiterals_ = 0;
+  uint32_t nVars_ = 1;
   bool emptyClause_ = false;
 };
 

--- a/include/stp/ToSat/BBNodeManagerAIG.h
+++ b/include/stp/ToSat/BBNodeManagerAIG.h
@@ -175,6 +175,25 @@ public:
   // Node-level queries, all on the uncomplemented node: a literal and its
   // negation answer these identically.
   static bool isCI(const BBNodeAIG& n) { return Aig_ObjIsCi(Aig_Regular(n.n)); }
+
+  // Whether this handle is an input of this manager's own making, held
+  // uncomplemented so that its ordinal is meaningful -- and that ordinal.
+  //
+  // Not the same question as isCI(), which strips the complement bit before
+  // asking: a complemented input is still an input, but it is not one the
+  // blaster can name, and an abstraction record that stored its ordinal would
+  // be recording the wrong polarity. The blaster asks these rather than
+  // reading BBNodeAIG::symbol_index, so that the shared blasting code does
+  // not depend on one backend's handle carrying an ordinal at all.
+  static bool isNamedCI(const BBNodeAIG& n)
+  {
+    return !n.IsNull() && n.symbol_index >= 0;
+  }
+  static int ciOrdinal(const BBNodeAIG& n)
+  {
+    assert(isNamedCI(n));
+    return n.symbol_index;
+  }
   static bool isConstant(const BBNodeAIG& n)
   {
     return Aig_ObjIsConst1(Aig_Regular(n.n));

--- a/include/stp/ToSat/BBNodeManagerAIG.h
+++ b/include/stp/ToSat/BBNodeManagerAIG.h
@@ -151,8 +151,10 @@ public:
   }
 
   // How many combinational inputs exist, and the object id of one of them by
-  // creation order. Callers index Cnf_Dat_t::pVarNums by that id; when the
-  // CNF seam lands they ask the CNF for the variable instead and this goes.
+  // creation order. The CNF seam left one caller for the id -- the
+  // propositional core's map back to the AIG it rewrote -- and everything
+  // that wanted a SAT variable now asks CNF::varOfCi() for it by the same
+  // ordinal.
   //
   // Positional rather than by node, because dag-aware rewriting replaces the
   // manager wholesale and only the position in vCis survives it.

--- a/include/stp/ToSat/BitBlaster.h
+++ b/include/stp/ToSat/BitBlaster.h
@@ -56,39 +56,41 @@ class ASTNode;
 
 using ASTVec = vector<ASTNode>;
 
-// BitBlaster used to be a template over the node representation and its
-// manager. The AIG backend is the only one that remains, so these are the
-// only types it is ever used with.
-using BBNode = BBNodeAIG;
-using BBNodeVec = std::vector<BBNodeAIG>;
-// Alongside the other two rather than inside the class, because
-// BBExactBinaryOp takes one and its callers are outside.
-//
-// Insertion-ordered rather than a bare std::unordered_set. Its iteration
-// order reaches the emitted formula in two places -- the support conjunction
-// under --conjoin-to-top, and the combinational-output order BVExactEncoder
-// gives the circuit it splices into a live solver -- and an unordered_set's
-// order is a property of the standard library's bucket policy and of
-// std::hash<BBNodeAIG>, not of the query. So the CNF depended on which
-// library STP was built against. Insertion order depends on the blast alone.
+// The support set a blast accumulates, insertion-ordered rather than a bare
+// std::unordered_set. Its iteration order reaches the emitted formula in two
+// places -- the support conjunction under --conjoin-to-top, and the
+// combinational-output order BVExactEncoder gives the circuit it splices into
+// a live solver -- and an unordered_set's order is a property of the standard
+// library's bucket policy and of std::hash, not of the query. So the CNF
+// depended on which library STP was built against. Insertion order depends on
+// the blast alone.
 //
 // The set is small (it holds side conditions, not gates), so the vector is
 // the cheap part; the hash set is only here to keep insert() a set operation.
-class BBNodeSet
+//
+// At namespace scope rather than inside the blaster because BBExactBinaryOp
+// takes one and its callers are outside.
+template <class BBNode> class BBNodeOrderedSet
 {
-  std::vector<BBNodeAIG> order_;
-  std::unordered_set<BBNodeAIG> seen_;
+  std::vector<BBNode> order_;
+  std::unordered_set<BBNode> seen_;
 
 public:
-  void insert(const BBNodeAIG& n)
+  void insert(const BBNode& n)
   {
     if (seen_.insert(n).second)
       order_.push_back(n);
   }
   size_t size() const { return order_.size(); }
   bool empty() const { return order_.empty(); }
-  std::vector<BBNodeAIG>::const_iterator begin() const { return order_.begin(); }
-  std::vector<BBNodeAIG>::const_iterator end() const { return order_.end(); }
+  typename std::vector<BBNode>::const_iterator begin() const
+  {
+    return order_.begin();
+  }
+  typename std::vector<BBNode>::const_iterator end() const
+  {
+    return order_.end();
+  }
 };
 
 enum class DivLemma;
@@ -96,8 +98,16 @@ enum class RemLemma;
 enum class MulLemma;
 enum class AddLemma;
 
-class BitBlaster
+// Templated over the node representation and the manager that mints them.
+// One instantiation exists -- BitBlasterAIG, at the bottom of this file --
+// and the parameters are here so that a second can arrive without the 6900
+// lines of blasting logic learning anything about it. Nothing in this class
+// may name a backend's own types: BBNodeAIG appears nowhere in the class
+// body, only in the alias under it.
+template <class BBNode, class BBNodeManagerT> class BitBlaster
 {
+  using BBNodeVec = std::vector<BBNode>;
+  using BBNodeSet = BBNodeOrderedSet<BBNode>;
 
   BBNode BBTrue, BBFalse;
 
@@ -454,7 +464,7 @@ class BitBlaster
   const bool allowAbstraction_ = true;
   NodeFactory* ASTNF;
   Simplifier* simp;
-  BBNodeManagerAIG* nf;
+  BBNodeManagerT* nf;
 
   ASTNodeSet booth_recoded; // Nodes that have been recoded.
 
@@ -467,7 +477,7 @@ public:
   struct BooleanAbstractionResult
   {
     BVAbstractionId producer;
-    BBNodeAIG bit;
+    BBNode bit;
   };
 
   struct BitVectorAbstractionResult
@@ -481,7 +491,7 @@ public:
     BVAbstractionId id;
     std::vector<BVAbstractionId> dependencies;
     ASTNode eqNode;
-    BBNodeAIG abstractionCI;
+    BBNode abstractionCI;
     ASTNode leftSymbol;
     ASTNode rightSymbol;
   };
@@ -617,7 +627,7 @@ private:
   }
 
   BVAbstractionId newAbstractionId();
-  void tagAbstractionSources(const BBNodeAIG& ci,
+  void tagAbstractionSources(const BBNode& ci,
                              const std::vector<BVAbstractionId>& sources);
   BBNodeVec ensureProxyCIs(const ASTNode& node, const BBNodeVec& bits);
   bool reuseRegisteredTerm(const ASTNode& term, unsigned width,
@@ -653,7 +663,7 @@ public:
   // Direct producer IDs reachable from an AIG result. Walking the committed
   // root gives assertion ownership; walking the operands before a new result
   // is tagged gives that producer's parent-to-child dependencies.
-  std::vector<BVAbstractionId> abstractionSourcesOf(const BBNodeAIG& root);
+  std::vector<BVAbstractionId> abstractionSourcesOf(const BBNode& root);
   std::vector<BVAbstractionId> abstractionSourcesOf(const BBNodeVec& bits);
   BitBlaster& operator=(const BitBlaster& other) = delete;
   BitBlaster(const BitBlaster& other) = delete;
@@ -727,7 +737,8 @@ public:
   BBNode BBFitsExactlyOnce(const BBNodeVec& dividend,
                            const BBNodeVec& divisor);
 
-  std::unordered_map<ASTNode, BBNodeVec, ASTNode::ASTNodeHasher, ASTNode::ASTNodeEqual>::iterator
+  typename std::unordered_map<ASTNode, BBNodeVec, ASTNode::ASTNodeHasher,
+                              ASTNode::ASTNodeEqual>::iterator
   simplify_during_bb(ASTNode& term, BBNodeSet& support);
 
   // `allowAbstraction` is false for a blast whose circuit is itself the
@@ -737,7 +748,7 @@ public:
   // the call, so nothing could ever refine it. This used to be done by
   // clearing the flags on the shared UserDefinedFlags for the duration, which
   // meant one blast could see another's policy.
-  BitBlaster(BBNodeManagerAIG* bnm, Simplifier* _simp, NodeFactory* astNodeF,
+  BitBlaster(BBNodeManagerT* bnm, Simplifier* _simp, NodeFactory* astNodeF,
              UserDefinedFlags* _uf,
              simplifier::constantBitP::ConstantBitPropagation* cb_ = NULL,
              bool allowAbstraction = true)
@@ -817,6 +828,13 @@ public:
 
   void getConsts(const ASTNode& n, ASTNodeMap& fromTo, ASTNodeMap& equivs);
 };
+
+// The one instantiation the tree has, and the name everything outside the
+// blaster uses. A second backend adds an alias beside this one rather than an
+// edit at every use.
+using BitBlasterAIG = BitBlaster<BBNodeAIG, BBNodeManagerAIG>;
+using BBNodeVecAIG = std::vector<BBNodeAIG>;
+using BBNodeSetAIG = BBNodeOrderedSet<BBNodeAIG>;
 
 } // end of namespace
 

--- a/include/stp/ToSat/ToCNFAIG.h
+++ b/include/stp/ToSat/ToCNFAIG.h
@@ -32,6 +32,9 @@ THE SOFTWARE.
 #include "sat/cnf/cnf.h"
 #include "opt/dar/dar.h"
 
+#include <functional>
+
+#include "stp/AIG/CNF.h"
 #include "stp/ToSat/BBNodeManagerAIG.h"
 #include "stp/ToSat/ToSATBase.h"
 
@@ -44,10 +47,19 @@ class ToCNFAIG // not copyable
 
   void dag_aware_aig_rewrite(const bool needAbsRef, BBNodeManagerAIG& mgr);
 
-  Cnf_Dat_t* derive_cnf_mf(BBNodeManagerAIG& mgr, int nLutSize,
-                            unsigned namedOutputs);
+  CNF derive_cnf_mf(BBNodeManagerAIG& mgr, int nLutSize,
+                    unsigned namedOutputs);
 
-  void fill_node_to_var(Cnf_Dat_t* cnfData,
+  // Take over an ABC-generated formula, projecting its per-object pVarNums
+  // down to the CI and CO variables that are the only ones anybody asks for.
+  // The clauses are adopted, not copied: ABC's layout is already the one CNF
+  // exposes. `objectVar` reads pVarNums for one object id, which is the only
+  // thing that differs between the Aig-based generators and the Gia-based
+  // one -- they index it by ids of their own manager.
+  static CNF adopt(Cnf_Dat_t* cnfData, unsigned nCi, unsigned nCo,
+                   const std::function<int(bool isCo, unsigned)>& objectVar);
+
+  void fill_node_to_var(const CNF& cnf,
                         ToSATBase::ASTNodeToSATVar& nodeToVars,
                         BBNodeManagerAIG& mgr);
 
@@ -67,10 +79,9 @@ public:
   // the number of trailing combinational outputs that need variables instead
   // of being asserted; passing every output is how a fragment such as
   // BVExactEncoder obtains values to splice into an existing solver.
-  Cnf_Dat_t* derive_cnf(BBNodeManagerAIG& mgr,
-                        unsigned namedOutputs = 0);
+  CNF derive_cnf(BBNodeManagerAIG& mgr, unsigned namedOutputs = 0);
 
-  void toCNF(const BBNodeAIG& top, Cnf_Dat_t*& cnfData,
+  void toCNF(const BBNodeAIG& top, CNF& cnf,
              ToSATBase::ASTNodeToSATVar& nodeToVars, bool needAbsRef,
              BBNodeManagerAIG& _mgr);
 };

--- a/include/stp/ToSat/ToSATAIG.h
+++ b/include/stp/ToSat/ToSATAIG.h
@@ -62,7 +62,7 @@ private:
   void suggest_uf_scalar_phases(SATSolver& satSolver);
 
   bool runSolver(SATSolver& satSolver);
-  void handle_cnf_options(Cnf_Dat_t* cnfData, bool needAbsRef);
+  void handle_cnf_options(const CNF& cnf, bool needAbsRef);
 
   // Resolve the injectivity guard to a SAT variable and decide how it is
   // held: assumed (and so retractable) on a backend that can assume, and
@@ -90,14 +90,14 @@ private:
   void init() { first = true; }
 
 public:
-  void add_cnf_to_solver(SATSolver& satSolver, Cnf_Dat_t* cnfData);
+  void add_cnf_to_solver(SATSolver& satSolver, const CNF& cnf);
 
-  // Blast `input` and convert it to CNF. Returns NULL, having freed the AIG
-  // and the constant-bit propagator, when UserFlags::aig_node_budget is set
-  // and the blast exceeds it -- there is no CNF in that case, and the caller
-  // must abandon the query rather than treat the absence as unsatisfiable.
-  Cnf_Dat_t* bitblast(const ASTNode& input, bool needAbsRef);
-  void release_cnf_memory(Cnf_Dat_t* cnfData);
+  // Blast `input` and convert it to CNF. Returns false, having freed the AIG
+  // and the constant-bit propagator and left `cnf` untouched, when
+  // UserFlags::aig_node_budget is set and the blast exceeds it -- there is no
+  // CNF in that case, and the caller must abandon the query rather than treat
+  // the absence as unsatisfiable.
+  bool bitblast(const ASTNode& input, bool needAbsRef, CNF& cnf);
 
   bool cbIsDestructed() { return cb == NULL; }
 

--- a/lib/AIG/CNF.cpp
+++ b/lib/AIG/CNF.cpp
@@ -32,9 +32,7 @@ namespace stp
 void CNF::begin(uint32_t nVars, uint64_t nClauses, uint64_t nLiterals,
                 uint32_t nCi, uint32_t nCo)
 {
-  lits_.clear();
-  offsets_.clear();
-  emptyClause_ = false;
+  discard();
 
   nVars_ = nVars;
   expectedClauses_ = nClauses;
@@ -52,29 +50,101 @@ void CNF::begin(uint32_t nVars, uint64_t nClauses, uint64_t nLiterals,
 
 void CNF::end()
 {
-  assert(clauseCount() == expectedClauses_);
-  assert(literalCount() == expectedLiterals_);
-  (void)expectedClauses_;
-  (void)expectedLiterals_;
+  assert(nClauses_ == expectedClauses_);
+  assert(nLiterals_ == expectedLiterals_);
 }
 
-// DIMACS numbers variables 1..N, which is ours minus the variable 0 that does
-// not exist -- so N is one less than varCount(), not equal to it. ABC writes
-// its nVars here and therefore declares one variable more than it uses; that
-// is harmless but it is not the file the formula asks for.
+void CNF::adopt(void* owner, void (*release)(void*), const int* const* clauses,
+                uint64_t nClauses, uint64_t nLiterals, uint32_t nVars,
+                uint32_t nCi, uint32_t nCo)
+{
+  discard();
+
+  adopted_ = clauses;
+  owner_ = owner;
+  release_ = release;
+  nClauses_ = nClauses;
+  nLiterals_ = nLiterals;
+  nVars_ = nVars;
+  ciVar_.assign(nCi, 0);
+  coVar_.assign(nCo, 0);
+}
+
+void CNF::discard()
+{
+  if (release_ != nullptr)
+    release_(owner_);
+  adopted_ = nullptr;
+  owner_ = nullptr;
+  release_ = nullptr;
+
+  // Actually give the memory back rather than clearing: a CNF is reset only
+  // when it is about to hold a different formula, and the two must not be
+  // resident at once.
+  std::vector<int>().swap(lits_);
+  std::vector<uint64_t>().swap(offsets_);
+  ciVar_.clear();
+  coVar_.clear();
+
+  nClauses_ = 0;
+  nLiterals_ = 0;
+  expectedClauses_ = 0;
+  expectedLiterals_ = 0;
+  nVars_ = 1;
+  emptyClause_ = false;
+}
+
+void CNF::steal(CNF& o)
+{
+  lits_ = std::move(o.lits_);
+  offsets_ = std::move(o.offsets_);
+  adopted_ = o.adopted_;
+  owner_ = o.owner_;
+  release_ = o.release_;
+  ciVar_ = std::move(o.ciVar_);
+  coVar_ = std::move(o.coVar_);
+  nClauses_ = o.nClauses_;
+  nLiterals_ = o.nLiterals_;
+  expectedClauses_ = o.expectedClauses_;
+  expectedLiterals_ = o.expectedLiterals_;
+  nVars_ = o.nVars_;
+  emptyClause_ = o.emptyClause_;
+
+  // The source must not free what we now own.
+  o.adopted_ = nullptr;
+  o.owner_ = nullptr;
+  o.release_ = nullptr;
+  o.nClauses_ = 0;
+  o.nLiterals_ = 0;
+  o.nVars_ = 1;
+  o.emptyClause_ = false;
+}
+
+// Byte for byte what Cnf_DataWriteIntoFile() produced, because --output-CNF
+// is a user-facing file and an internal reshuffle is no reason for it to
+// change -- and because CNF byte-identity across a refactor is only evidence
+// if the bytes are of the formula rather than of the writer.
+//
+// Two things are ABC's rather than ours, and are kept deliberately. The
+// banner names the package that used to write this. And the variable numbers
+// are one *above* the formula's, so a file declaring N variables uses 2..N
+// and leaves 1 unused: ABC numbered from 1 internally and then added another
+// 1 on the way out. Both are worth revisiting when the ABC generators go, and
+// neither before.
 void CNF::writeDimacs(std::ostream& out) const
 {
-  out << "p cnf " << (nVars_ == 0 ? 0 : nVars_ - 1) << ' ' << clauseCount()
-      << '\n';
+  out << "c Result of efficient AIG-to-CNF conversion using package CNF\n";
+  out << "p cnf " << nVars_ << ' ' << clauseCount() << '\n';
   for (uint64_t i = 0, n = clauseCount(); i < n; i++)
   {
     for (const int *p = clauseBegin(i), *stop = clauseEnd(i); p < stop; p++)
     {
-      const int var = *p >> 1;
+      const int var = (*p >> 1) + 1;
       out << ((*p & 1) ? -var : var) << ' ';
     }
     out << "0\n";
   }
+  out << '\n';
 }
 
 } // namespace stp

--- a/lib/Incremental/IncrementalSolverImpl.h
+++ b/lib/Incremental/IncrementalSolverImpl.h
@@ -118,7 +118,7 @@ class AigEncodingEpoch
   std::unique_ptr<SubstitutionMap> substitutionMap;
   std::unique_ptr<Simplifier> simplifier;
   std::unique_ptr<BBNodeManagerAIG> nodeManager;
-  std::unique_ptr<BitBlaster> bitBlaster;
+  std::unique_ptr<BitBlasterAIG> bitBlaster;
 
 public:
   explicit AigEncodingEpoch(STPMgr* bm_) : bm(bm_) { reset(); }
@@ -133,14 +133,14 @@ public:
     substitutionMap.reset(new SubstitutionMap(bm));
     simplifier.reset(new Simplifier(bm, substitutionMap.get()));
     nodeManager.reset(new BBNodeManagerAIG());
-    bitBlaster.reset(new BitBlaster(nodeManager.get(), simplifier.get(),
+    bitBlaster.reset(new BitBlasterAIG(nodeManager.get(), simplifier.get(),
                                     bm->defaultNodeFactory,
                                     &bm->UserFlags, NULL));
   }
 
   BBNodeManagerAIG& nodes() { return *nodeManager; }
   const BBNodeManagerAIG& nodes() const { return *nodeManager; }
-  BitBlaster& blaster() { return *bitBlaster; }
+  BitBlasterAIG& blaster() { return *bitBlaster; }
   size_t aigAndNodes() const
   {
     return static_cast<size_t>(nodeManager->totalNumberOfNodes());
@@ -3768,7 +3768,7 @@ struct IncrementalSolver::Impl
   // simplifying MiniSat -- makeBackend refuses for this driver.
   void syncAbstractions()
   {
-    BitBlaster& bb = encoding.blaster();
+    BitBlasterAIG& bb = encoding.blaster();
 
     // An abstraction reads its operands through proxy inputs, tied to the
     // real bits by one biconditional each -- the blaster mints them
@@ -3794,11 +3794,11 @@ struct IncrementalSolver::Impl
       permanentUnitMass = addMass(permanentUnitMass, 1);
     }
 
-    const std::vector<BitBlaster::RawBVEQAbstraction>& rawEQs =
+    const std::vector<BitBlasterAIG::RawBVEQAbstraction>& rawEQs =
         bb.abstractedEQs();
     for (; harvestedEQAbstractions < rawEQs.size(); harvestedEQAbstractions++)
     {
-      const BitBlaster::RawBVEQAbstraction& raw =
+      const BitBlasterAIG::RawBVEQAbstraction& raw =
           rawEQs[harvestedEQAbstractions];
       BVEQAbstraction a;
       a.id = raw.id;
@@ -3813,12 +3813,12 @@ struct IncrementalSolver::Impl
       bvAbstraction.appendEquality(std::move(a));
     }
 
-    const std::vector<BitBlaster::RawBVTermAbstraction>& rawTerms =
+    const std::vector<BitBlasterAIG::RawBVTermAbstraction>& rawTerms =
         bb.abstractedTerms();
     for (; harvestedTermAbstractions < rawTerms.size();
          harvestedTermAbstractions++)
     {
-      const BitBlaster::RawBVTermAbstraction& raw =
+      const BitBlasterAIG::RawBVTermAbstraction& raw =
           rawTerms[harvestedTermAbstractions];
       BVTermAbstraction a;
       a.id = raw.id;

--- a/lib/Simplifier/AIGSimplifyPropositionalCore.cpp
+++ b/lib/Simplifier/AIGSimplifyPropositionalCore.cpp
@@ -227,7 +227,7 @@ ASTNode AIGSimplifyPropositionalCore::topLevel(const ASTNode& top)
   Simplifier simplifier(bm, &sm );
   BBNodeManagerAIG mgr;
   mgr.nodeBudget = bm->UserFlags.aig_node_budget;
-  BitBlaster bb(&mgr, &simplifier, bm->defaultNodeFactory, &bm->UserFlags);
+  BitBlasterAIG bb(&mgr, &simplifier, bm->defaultNodeFactory, &bm->UserFlags);
 
   // This pass is an optimisation, so an exhausted budget costs nothing but
   // the work already done: hand back the formula that came in and let the

--- a/lib/ToSat/BVExactEncoder.cpp
+++ b/lib/ToSat/BVExactEncoder.cpp
@@ -160,26 +160,25 @@ void encodeNaryLemma(
   // search. The paired DIV/REM identity is a full-width multiplier, which is
   // exactly the circuit that argument is about. An explicitly chosen level
   // still reaches here.
-  Cnf_Dat_t* cnf =
+  const CNF cnf =
       ToCNFAIG(bm->UserFlags, /*allowAuto=*/false).derive_cnf(mgr, outputs);
-  assert(cnf != NULL);
 
-  std::vector<unsigned> cnfToSolver(cnf->nVars, ~((unsigned)0));
+  std::vector<unsigned> cnfToSolver(cnf.varCount(), ~((unsigned)0));
   for (unsigned i = 0; i < liveVars.size() * width; ++i)
   {
-    const int var = cnf->pVarNums[mgr.ciObjectId((int)i)];
-    if (var < 0)
+    const uint32_t var = cnf.varOfCi(i);
+    if (var == 0)
       continue;
     cnfToSolver[var] = (*liveVars[i / width])[i % width];
   }
 
-  // From 1: every ABC CNF generator numbers variables from 1 and reports
-  // nVars as one past the last, so index 0 names nothing. Allocating a solver
-  // variable for it, and freezing it, left one unreachable variable in the
-  // live solver per splice. The assertion in the clause loop below is what
+  // From 1: every CNF generator numbers variables from 1 and reports
+  // varCount() as one past the last, so index 0 names nothing. Allocating a
+  // solver variable for it, and freezing it, left one unreachable variable in
+  // the live solver per splice. The assertion in the clause loop below is what
   // holds this: a literal over variable 0 would mean a generator numbered
   // from 0 after all.
-  for (int var = 1; var < cnf->nVars; var++)
+  for (uint32_t var = 1; var < cnf.varCount(); var++)
     if (cnfToSolver[var] == ~((unsigned)0))
     {
       const unsigned fresh = solver.newVar();
@@ -188,10 +187,10 @@ void encodeNaryLemma(
     }
 
   SATSolver::vec_literals cl;
-  for (int i = 0; i < cnf->nClauses; i++)
+  for (uint64_t i = 0; i < cnf.clauseCount(); i++)
   {
     cl.clear();
-    for (int *pLit = cnf->pClauses[i], *pStop = cnf->pClauses[i + 1];
+    for (const int *pLit = cnf.clauseBegin(i), *pStop = cnf.clauseEnd(i);
          pLit < pStop; pLit++)
     {
       assert(((*pLit) >> 1) != 0 && "a CNF generator numbered variables from 0");
@@ -204,14 +203,12 @@ void encodeNaryLemma(
   // wanted conjoined to it.
   for (unsigned i = 0; i < outputs; i++)
   {
-    const unsigned var =
-        cnfToSolver[cnf->pVarNums[Aig_ManCo(mgr.aigMgr, (int)i)->Id]];
+    assert(cnf.varOfCo(i) != 0 && "a named output with no variable");
+    const unsigned var = cnfToSolver[cnf.varOfCo(i)];
     cl.clear();
     cl.push(SATSolver::mkLit(var, false));
     solver.addClause(cl);
   }
-
-  Cnf_DataFree(cnf);
 }
 
 template <typename BuildClaim>
@@ -404,8 +401,8 @@ void BVExactEncoder::encode(SATSolver& solver, const ASTNode& term,
   // Use the query's selected CNF strategy. All outputs are named rather than
   // asserted because the splice below connects each result bit explicitly
   // and asserts only the side constraints.
-  Cnf_Dat_t* cnf = ToCNFAIG(bm->UserFlags, /*allowAuto=*/false).derive_cnf(mgr, outputs);
-  assert(cnf != NULL);
+  const CNF cnf =
+      ToCNFAIG(bm->UserFlags, /*allowAuto=*/false).derive_cnf(mgr, outputs);
 
   // The splice. Every variable of the derived CNF becomes a variable of the
   // live solver: the inputs become the ones the operands are already
@@ -413,25 +410,25 @@ void BVExactEncoder::encode(SATSolver& solver, const ASTNode& term,
   // operands' own variables rather than minting a copy and equating it is
   // the whole point -- the clauses have to talk about the bits the rest of
   // the query talks about.
-  std::vector<unsigned> cnfToSolver(cnf->nVars, ~((unsigned)0));
+  std::vector<unsigned> cnfToSolver(cnf.varCount(), ~((unsigned)0));
 
   for (unsigned i = 0; i < ciVars.size(); i++)
   {
-    const int var = cnf->pVarNums[mgr.ciObjectId((int)i)];
+    const uint32_t var = cnf.varOfCi(i);
     // An input the circuit never reads is given no variable, and needs
     // none: nothing the CNF says mentions it.
-    if (var < 0)
+    if (var == 0)
       continue;
     cnfToSolver[var] = ciVars[i];
   }
 
-  // From 1: every ABC CNF generator numbers variables from 1 and reports
-  // nVars as one past the last, so index 0 names nothing. Allocating a solver
-  // variable for it, and freezing it, left one unreachable variable in the
-  // live solver per splice. The assertion in the clause loop below is what
+  // From 1: every CNF generator numbers variables from 1 and reports
+  // varCount() as one past the last, so index 0 names nothing. Allocating a
+  // solver variable for it, and freezing it, left one unreachable variable in
+  // the live solver per splice. The assertion in the clause loop below is what
   // holds this: a literal over variable 0 would mean a generator numbered
   // from 0 after all.
-  for (int var = 1; var < cnf->nVars; var++)
+  for (uint32_t var = 1; var < cnf.varCount(); var++)
     if (cnfToSolver[var] == ~((unsigned)0))
     {
       const unsigned fresh = solver.newVar();
@@ -440,10 +437,10 @@ void BVExactEncoder::encode(SATSolver& solver, const ASTNode& term,
     }
 
   SATSolver::vec_literals cl;
-  for (int i = 0; i < cnf->nClauses; i++)
+  for (uint64_t i = 0; i < cnf.clauseCount(); i++)
   {
     cl.clear();
-    for (int *pLit = cnf->pClauses[i], *pStop = cnf->pClauses[i + 1];
+    for (const int *pLit = cnf.clauseBegin(i), *pStop = cnf.clauseEnd(i);
          pLit < pStop; pLit++)
     {
       assert(((*pLit) >> 1) != 0 && "a CNF generator numbered variables from 0");
@@ -454,8 +451,8 @@ void BVExactEncoder::encode(SATSolver& solver, const ASTNode& term,
 
   for (unsigned i = 0; i < outputs; i++)
   {
-    const unsigned var =
-        cnfToSolver[cnf->pVarNums[Aig_ManCo(mgr.aigMgr, (int)i)->Id]];
+    assert(cnf.varOfCo(i) != 0 && "a named output with no variable");
+    const unsigned var = cnfToSolver[cnf.varOfCo(i)];
     if (i < width)
     {
       addEquiv(solver, resultVars[i], var);
@@ -465,8 +462,6 @@ void BVExactEncoder::encode(SATSolver& solver, const ASTNode& term,
     cl.push(SATSolver::mkLit(var, false));
     solver.addClause(cl);
   }
-
-  Cnf_DataFree(cnf);
 }
 
 } // namespace stp

--- a/lib/ToSat/BVExactEncoder.cpp
+++ b/lib/ToSat/BVExactEncoder.cpp
@@ -121,19 +121,19 @@ void encodeNaryLemma(
   // Nothing this blast produces may itself be abstracted: the record would
   // be minted against an AIG thrown away when this returns, so nothing could
   // ever refine it.
-  BitBlaster bb(&mgr, scratch, bm->defaultNodeFactory, &bm->UserFlags, NULL,
-                /*allowAbstraction=*/false);
+  BitBlasterAIG bb(&mgr, scratch, bm->defaultNodeFactory, &bm->UserFlags,
+                   NULL, /*allowAbstraction=*/false);
 
   // Every live vector is an input here. Abstract results are not circuit
   // outputs: the theorem constrains them without defining the operations.
-  std::vector<BBNodeVec> inputs(liveVars.size(), BBNodeVec(width));
+  std::vector<BBNodeVecAIG> inputs(liveVars.size(), BBNodeVecAIG(width));
   for (unsigned v = 0; v < inputs.size(); ++v)
     for (unsigned i = 0; i < width; i++)
     {
       inputs[v][i] = mgr.CreateFreshInput();
     }
 
-  BBNodeSet support;
+  BBNodeSetAIG support;
   const BBNodeAIG claim = buildClaim(bb, inputs, support);
 
   Aig_ObjCreateCo(mgr.aigMgr, claim.n);
@@ -224,8 +224,8 @@ void encodeTernaryLemma(STPMgr* bm, Simplifier* scratch, SATSolver& solver,
   liveVars.push_back(&tVars);
   encodeNaryLemma(
       bm, scratch, solver, width, liveVars,
-      [&buildClaim](BitBlaster& bb, const std::vector<BBNodeVec>& inputs,
-                    BBNodeSet& support) {
+      [&buildClaim](BitBlasterAIG& bb, const std::vector<BBNodeVecAIG>& inputs,
+                    BBNodeSetAIG& support) {
         return buildClaim(bb, inputs[0], inputs[1], inputs[2], support);
       });
 }
@@ -240,8 +240,8 @@ void BVExactEncoder::encodeDivLemma(SATSolver& solver, DivLemma lemma,
 {
   encodeTernaryLemma(
       bm, scratch_.get(), solver, width, dividendVars, divisorVars, resultVars,
-      [lemma](BitBlaster& bb, const BBNodeVec& x, const BBNodeVec& s,
-              const BBNodeVec& t, BBNodeSet& support) {
+      [lemma](BitBlasterAIG& bb, const BBNodeVecAIG& x, const BBNodeVecAIG& s,
+              const BBNodeVecAIG& t, BBNodeSetAIG& support) {
         return bb.BBDivLemma(lemma, x, s, t, support);
       });
 }
@@ -254,8 +254,8 @@ void BVExactEncoder::encodeRemLemma(SATSolver& solver, RemLemma lemma,
 {
   encodeTernaryLemma(
       bm, scratch_.get(), solver, width, dividendVars, divisorVars, resultVars,
-      [lemma](BitBlaster& bb, const BBNodeVec& x, const BBNodeVec& s,
-              const BBNodeVec& t, BBNodeSet& support) {
+      [lemma](BitBlasterAIG& bb, const BBNodeVecAIG& x, const BBNodeVecAIG& s,
+              const BBNodeVecAIG& t, BBNodeSetAIG& support) {
         return bb.BBRemLemma(lemma, x, s, t, support);
       });
 }
@@ -268,8 +268,8 @@ void BVExactEncoder::encodeMulLemma(SATSolver& solver, MulLemma lemma,
 {
   encodeTernaryLemma(
       bm, scratch_.get(), solver, width, xVars, sVars, resultVars,
-      [lemma](BitBlaster& bb, const BBNodeVec& x, const BBNodeVec& s,
-              const BBNodeVec& t, BBNodeSet& support) {
+      [lemma](BitBlasterAIG& bb, const BBNodeVecAIG& x, const BBNodeVecAIG& s,
+              const BBNodeVecAIG& t, BBNodeSetAIG& support) {
         return bb.BBMulLemma(lemma, x, s, t, support);
       });
 }
@@ -282,8 +282,8 @@ void BVExactEncoder::encodeAddLemma(SATSolver& solver, AddLemma lemma,
 {
   encodeTernaryLemma(
       bm, scratch_.get(), solver, width, xVars, sVars, resultVars,
-      [lemma](BitBlaster& bb, const BBNodeVec& x, const BBNodeVec& s,
-              const BBNodeVec& t, BBNodeSet& support) {
+      [lemma](BitBlasterAIG& bb, const BBNodeVecAIG& x, const BBNodeVecAIG& s,
+              const BBNodeVecAIG& t, BBNodeSetAIG& support) {
         return bb.BBAddLemma(lemma, x, s, t, support);
       });
 }
@@ -302,8 +302,8 @@ void BVExactEncoder::encodeDivRemIdentity(
   liveVars.push_back(&remainderVars);
   encodeNaryLemma(
       bm, scratch_.get(), solver, width, liveVars,
-      [&product](BitBlaster& bb, const std::vector<BBNodeVec>& inputs,
-                 BBNodeSet& support) {
+      [&product](BitBlasterAIG& bb, const std::vector<BBNodeVecAIG>& inputs,
+                 BBNodeSetAIG& support) {
         return bb.BBDivRemIdentity(product, inputs[0], inputs[1], inputs[2],
                                    inputs[3], support);
       });
@@ -328,8 +328,8 @@ void BVExactEncoder::encode(SATSolver& solver, const ASTNode& term,
   // asks for them only through statsFound(), which answers no without it.
   // And no abstraction: this circuit is what the refinement gave up in
   // favour of, so re-abstracting it would put the record straight back.
-  BitBlaster bb(&mgr, scratch_.get(), bm->defaultNodeFactory, &bm->UserFlags, NULL,
-                /*allowAbstraction=*/false);
+  BitBlasterAIG bb(&mgr, scratch_.get(), bm->defaultNodeFactory,
+                   &bm->UserFlags, NULL, /*allowAbstraction=*/false);
 
   // The operand bits: a constant where the query's own blast had one, and a
   // combinational input everywhere else.
@@ -359,7 +359,7 @@ void BVExactEncoder::encode(SATSolver& solver, const ASTNode& term,
 
   const std::vector<signed char>* known[2] = {&knownA, &knownB};
   const std::vector<unsigned>* opVars[2] = {&aVars, &bVars};
-  BBNodeVec operands[2] = {BBNodeVec(width), BBNodeVec(width)};
+  BBNodeVecAIG operands[2] = {BBNodeVecAIG(width), BBNodeVecAIG(width)};
 
   for (unsigned op = 0; op < 2; op++)
     for (unsigned i = 0; i < width; i++)
@@ -374,11 +374,11 @@ void BVExactEncoder::encode(SATSolver& solver, const ASTNode& term,
       ciVars.push_back((*opVars[op])[i]);
     }
 
-  const BBNodeVec& x = operands[0];
-  const BBNodeVec& y = operands[1];
+  const BBNodeVecAIG& x = operands[0];
+  const BBNodeVecAIG& y = operands[1];
 
-  BBNodeSet support;
-  const BBNodeVec result = bb.BBExactBinaryOp(term, x, y, support);
+  BBNodeSetAIG support;
+  const BBNodeVecAIG result = bb.BBExactBinaryOp(term, x, y, support);
   assert(result.size() == width);
 
   // Outputs, then whatever the circuit wants conjoined to the top. Both are

--- a/lib/ToSat/BVLemmaCircuits.cpp
+++ b/lib/ToSat/BVLemmaCircuits.cpp
@@ -58,8 +58,9 @@ namespace stp
 // `s <=u x <u 2s`, with doubling interpreted in the integers. A divisor
 // whose top bit is set doubles past the vector width, making the upper test
 // automatic. A zero divisor cannot satisfy both halves of the premise.
-BBNode BitBlaster::BBFitsExactlyOnce(const BBNodeVec& x,
-                                     const BBNodeVec& s)
+template <class BBNode, class BBNodeManagerT>
+BBNode BitBlaster<BBNode, BBNodeManagerT>::BBFitsExactlyOnce(const BBNodeVec& x,
+                                                             const BBNodeVec& s)
 {
   const unsigned width = (unsigned)x.size();
   BBNodeVec twice = s;
@@ -70,9 +71,12 @@ BBNode BitBlaster::BBFitsExactlyOnce(const BBNodeVec& x,
                      nf->CreateNode(NOT, BBBVLE(twice, x, false))));
 }
 
-BBNode BitBlaster::BBDivLemma(DivLemma lemma, const BBNodeVec& x,
-                              const BBNodeVec& s, const BBNodeVec& t,
-                              BBNodeSet& support)
+template <class BBNode, class BBNodeManagerT>
+BBNode BitBlaster<BBNode, BBNodeManagerT>::BBDivLemma(DivLemma lemma,
+                                                      const BBNodeVec& x,
+                                                      const BBNodeVec& s,
+                                                      const BBNodeVec& t,
+                                                      BBNodeSet& support)
 {
   const unsigned width = (unsigned)x.size();
   assert(s.size() == width);
@@ -320,9 +324,12 @@ BBNode BitBlaster::BBDivLemma(DivLemma lemma, const BBNodeVec& x,
   return BBFalse;
 }
 
-BBNode BitBlaster::BBRemLemma(RemLemma lemma, const BBNodeVec& x,
-                              const BBNodeVec& s, const BBNodeVec& t,
-                              BBNodeSet& support)
+template <class BBNode, class BBNodeManagerT>
+BBNode BitBlaster<BBNode, BBNodeManagerT>::BBRemLemma(RemLemma lemma,
+                                                      const BBNodeVec& x,
+                                                      const BBNodeVec& s,
+                                                      const BBNodeVec& t,
+                                                      BBNodeSet& support)
 {
   const unsigned width = (unsigned)x.size();
   assert(s.size() == width);
@@ -398,9 +405,12 @@ BBNode BitBlaster::BBRemLemma(RemLemma lemma, const BBNodeVec& x,
   return BBFalse;
 }
 
-BBNode BitBlaster::BBMulLemma(MulLemma lemma, const BBNodeVec& x,
-                              const BBNodeVec& s, const BBNodeVec& t,
-                              BBNodeSet& support)
+template <class BBNode, class BBNodeManagerT>
+BBNode BitBlaster<BBNode, BBNodeManagerT>::BBMulLemma(MulLemma lemma,
+                                                      const BBNodeVec& x,
+                                                      const BBNodeVec& s,
+                                                      const BBNodeVec& t,
+                                                      BBNodeSet& support)
 {
   const unsigned width = (unsigned)x.size();
   assert(s.size() == width);
@@ -529,12 +539,10 @@ BBNode BitBlaster::BBMulLemma(MulLemma lemma, const BBNodeVec& x,
   return BBFalse;
 }
 
-BBNode BitBlaster::BBDivRemIdentity(const ASTNode& product,
-                                    const BBNodeVec& x,
-                                    const BBNodeVec& s,
-                                    const BBNodeVec& q,
-                                    const BBNodeVec& r,
-                                    BBNodeSet& support)
+template <class BBNode, class BBNodeManagerT>
+BBNode BitBlaster<BBNode, BBNodeManagerT>::BBDivRemIdentity(
+    const ASTNode& product, const BBNodeVec& x, const BBNodeVec& s,
+    const BBNodeVec& q, const BBNodeVec& r, BBNodeSet& support)
 {
   [[maybe_unused]] const unsigned width = (unsigned)x.size();
   assert(s.size() == width);
@@ -548,9 +556,12 @@ BBNode BitBlaster::BBDivRemIdentity(const ASTNode& product,
   return BBEQ(x, sum);
 }
 
-BBNode BitBlaster::BBAddLemma(AddLemma lemma, const BBNodeVec& x,
-                              const BBNodeVec& s, const BBNodeVec& t,
-                              BBNodeSet& /*support*/)
+template <class BBNode, class BBNodeManagerT>
+BBNode BitBlaster<BBNode, BBNodeManagerT>::BBAddLemma(AddLemma lemma,
+                                                      const BBNodeVec& x,
+                                                      const BBNodeVec& s,
+                                                      const BBNodeVec& t,
+                                                      BBNodeSet& /*support*/)
 {
   const unsigned width = (unsigned)x.size();
   assert(width > 0);
@@ -630,5 +641,33 @@ BBNode BitBlaster::BBAddLemma(AddLemma lemma, const BBNodeVec& x,
   FatalError("BBAddLemma: unknown lemma");
   return BBFalse;
 }
+
+// These six are the blaster's only members defined outside BitBlaster.cpp, so
+// the explicit instantiation there cannot reach them -- an explicit
+// instantiation only instantiates what its own translation unit can see.
+// Named one at a time rather than repeating `template class BitBlaster<...>`
+// here, which would be a second explicit instantiation of one specialisation.
+//
+// Spelled out rather than through the BitBlasterAIG alias: the qualifier of
+// an explicit instantiation has to be a template-id, and a typedef naming the
+// same specialisation is not one. gcc takes the alias; clang -pedantic is
+// right to refuse it.
+template BBNodeAIG BitBlaster<BBNodeAIG, BBNodeManagerAIG>::BBFitsExactlyOnce(
+    const BBNodeVecAIG&, const BBNodeVecAIG&);
+template BBNodeAIG BitBlaster<BBNodeAIG, BBNodeManagerAIG>::BBDivLemma(
+    DivLemma, const BBNodeVecAIG&, const BBNodeVecAIG&, const BBNodeVecAIG&,
+    BBNodeSetAIG&);
+template BBNodeAIG BitBlaster<BBNodeAIG, BBNodeManagerAIG>::BBRemLemma(
+    RemLemma, const BBNodeVecAIG&, const BBNodeVecAIG&, const BBNodeVecAIG&,
+    BBNodeSetAIG&);
+template BBNodeAIG BitBlaster<BBNodeAIG, BBNodeManagerAIG>::BBMulLemma(
+    MulLemma, const BBNodeVecAIG&, const BBNodeVecAIG&, const BBNodeVecAIG&,
+    BBNodeSetAIG&);
+template BBNodeAIG BitBlaster<BBNodeAIG, BBNodeManagerAIG>::BBAddLemma(
+    AddLemma, const BBNodeVecAIG&, const BBNodeVecAIG&, const BBNodeVecAIG&,
+    BBNodeSetAIG&);
+template BBNodeAIG BitBlaster<BBNodeAIG, BBNodeManagerAIG>::BBDivRemIdentity(
+    const ASTNode&, const BBNodeVecAIG&, const BBNodeVecAIG&,
+    const BBNodeVecAIG&, const BBNodeVecAIG&, BBNodeSetAIG&);
 
 } // namespace stp

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -41,10 +41,11 @@ THE SOFTWARE.
 namespace stp
 {
 
-static bool allBBNodesAreCIs(const BBNodeVec& vec)
+template <class BBNode, class BBNodeManagerT>
+static bool allBBNodesAreCIs(BBNodeManagerT* nf, const std::vector<BBNode>& vec)
 {
   for (const auto& node : vec)
-    if (node.IsNull() || node.symbol_index < 0)
+    if (!nf->isNamedCI(node))
       return false;
   return !vec.empty();
 }
@@ -53,11 +54,12 @@ static bool allBBNodesAreCIs(const BBNodeVec& vec)
 // the form BVExactEncoder reads back: -1 for a live node, 0 or 1 for a
 // constant. Read off the same vector ensureProxyCIs is about to replace, so
 // what is recorded is what the query's own encoding knew.
-static std::vector<signed char> knownBitsOf(BBNodeManagerAIG* nf,
-                                            const BBNodeVec& bits)
+template <class BBNode, class BBNodeManagerT>
+static std::vector<signed char> knownBitsOf(BBNodeManagerT* nf,
+                                            const std::vector<BBNode>& bits)
 {
-  const BBNodeAIG constTrue = nf->getTrue();
-  const BBNodeAIG constFalse = nf->getFalse();
+  const BBNode constTrue = nf->getTrue();
+  const BBNode constFalse = nf->getFalse();
 
   std::vector<signed char> known(bits.size(), -1);
   for (unsigned i = 0; i < bits.size(); i++)
@@ -72,15 +74,14 @@ static std::vector<signed char> knownBitsOf(BBNodeManagerAIG* nf,
   return known;
 }
 
-static std::vector<int> ciSymbolIndices(const BBNodeVec& bits)
+template <class BBNode, class BBNodeManagerT>
+static std::vector<int> ciSymbolIndices(BBNodeManagerT* nf,
+                                        const std::vector<BBNode>& bits)
 {
   std::vector<int> indices;
   indices.reserve(bits.size());
   for (const BBNode& bit : bits)
-  {
-    assert(!bit.IsNull() && bit.symbol_index >= 0);
-    indices.push_back(bit.symbol_index);
-  }
+    indices.push_back(nf->ciOrdinal(bit));
   return indices;
 }
 
@@ -96,24 +97,28 @@ static void appendAbstractionSources(
   into.erase(std::unique(into.begin(), into.end()), into.end());
 }
 
-BVAbstractionId BitBlaster::newAbstractionId()
+template <class BBNode, class BBNodeManagerT>
+BVAbstractionId BitBlaster<BBNode, BBNodeManagerT>::newAbstractionId()
 {
   assert(nextAbstractionId_ != 0 &&
          "the BV abstraction identity space wrapped");
   return BVAbstractionId(nextAbstractionId_++);
 }
 
-const std::vector<BVAbstractionId>& BitBlaster::noSources()
+template <class BBNode, class BBNodeManagerT>
+const std::vector<BVAbstractionId>&
+BitBlaster<BBNode, BBNodeManagerT>::noSources()
 {
   static const std::vector<BVAbstractionId> empty;
   return empty;
 }
 
-void BitBlaster::tagAbstractionSources(
-    const BBNodeAIG& ci, const std::vector<BVAbstractionId>& sources)
+template <class BBNode, class BBNodeManagerT>
+void BitBlaster<BBNode, BBNodeManagerT>::tagAbstractionSources(
+    const BBNode& ci, const std::vector<BVAbstractionId>& sources)
 {
   assert(!ci.IsNull());
-  assert(BBNodeManagerAIG::isCI(ci));
+  assert(BBNodeManagerT::isCI(ci));
 
   std::vector<BVAbstractionId> normalized = sources;
   std::sort(normalized.begin(), normalized.end());
@@ -122,55 +127,56 @@ void BitBlaster::tagAbstractionSources(
   for ([[maybe_unused]] const BVAbstractionId id : normalized)
     assert(id.valid());
 
-  const unsigned aigId = BBNodeManagerAIG::nodeId(ci);
+  const unsigned aigId = BBNodeManagerT::nodeId(ci);
   assert((sourcesAt(ciAbstractionSources_, aigId).empty() ||
           sourcesAt(ciAbstractionSources_, aigId) == normalized) &&
          "an AIG input acquired two abstraction provenances");
   setSourcesAt(ciAbstractionSources_, aigId, std::move(normalized));
 }
 
+template <class BBNode, class BBNodeManagerT>
 std::vector<BVAbstractionId>
-BitBlaster::abstractionSourcesOf(const BBNodeAIG& root)
+BitBlaster<BBNode, BBNodeManagerT>::abstractionSourcesOf(const BBNode& root)
 {
   if (root.IsNull())
     return {};
 
-  if (BBNodeManagerAIG::isConstant(root))
+  if (BBNodeManagerT::isConstant(root))
     return {};
-  if (BBNodeManagerAIG::isCI(root))
-    return sourcesAt(ciAbstractionSources_, BBNodeManagerAIG::nodeId(root));
+  if (BBNodeManagerT::isCI(root))
+    return sourcesAt(ciAbstractionSources_, BBNodeManagerT::nodeId(root));
 
-  const unsigned rootId = BBNodeManagerAIG::nodeId(root);
+  const unsigned rootId = BBNodeManagerT::nodeId(root);
   if (aigSourcesComputed(rootId))
     return sourcesAt(aigAbstractionSourcesMemo_, rootId);
 
   // Deep input terms reach tens of thousands of AIG levels in practice.
   // Run the recursive two-visit post-order explicitly on the heap, computing
   // each union only after both fanins. Memo hits also collapse shared cones.
-  typedef std::pair<BBNodeAIG, bool> PendingAig;
+  typedef std::pair<BBNode, bool> PendingAig;
   std::vector<PendingAig> pending(1, PendingAig(root, false));
   while (!pending.empty())
   {
-    const BBNodeAIG node = pending.back().first;
+    const BBNode node = pending.back().first;
     const bool expanded = pending.back().second;
     pending.pop_back();
-    const unsigned id = BBNodeManagerAIG::nodeId(node);
-    if (BBNodeManagerAIG::isConstant(node) || BBNodeManagerAIG::isCI(node) ||
+    const unsigned id = BBNodeManagerT::nodeId(node);
+    if (BBNodeManagerT::isConstant(node) || BBNodeManagerT::isCI(node) ||
         aigSourcesComputed(id))
       continue;
-    assert(BBNodeManagerAIG::isAnd(node));
+    assert(BBNodeManagerT::isAnd(node));
     if (!expanded)
     {
       pending.push_back(PendingAig(node, true));
-      pending.push_back(PendingAig(BBNodeManagerAIG::fanin0(node), false));
-      pending.push_back(PendingAig(BBNodeManagerAIG::fanin1(node), false));
+      pending.push_back(PendingAig(BBNodeManagerT::fanin0(node), false));
+      pending.push_back(PendingAig(BBNodeManagerT::fanin1(node), false));
       continue;
     }
 
     std::vector<BVAbstractionId> sources =
-        abstractionSourcesOf(BBNodeManagerAIG::fanin0(node));
+        abstractionSourcesOf(BBNodeManagerT::fanin0(node));
     appendAbstractionSources(
-        sources, abstractionSourcesOf(BBNodeManagerAIG::fanin1(node)));
+        sources, abstractionSourcesOf(BBNodeManagerT::fanin1(node)));
     setSourcesAt(aigAbstractionSourcesMemo_, id, std::move(sources));
     markAigSourcesComputed(id);
   }
@@ -178,23 +184,26 @@ BitBlaster::abstractionSourcesOf(const BBNodeAIG& root)
   return sourcesAt(aigAbstractionSourcesMemo_, rootId);
 }
 
+template <class BBNode, class BBNodeManagerT>
 std::vector<BVAbstractionId>
-BitBlaster::abstractionSourcesOf(const BBNodeVec& bits)
+BitBlaster<BBNode, BBNodeManagerT>::abstractionSourcesOf(const BBNodeVec& bits)
 {
   std::vector<BVAbstractionId> sources;
-  for (const BBNodeAIG& bit : bits)
+  for (const BBNode& bit : bits)
     appendAbstractionSources(sources, abstractionSourcesOf(bit));
   return sources;
 }
 
-BBNodeVec BitBlaster::ensureProxyCIs(const ASTNode& node,
-                                     const BBNodeVec& bits)
+template <class BBNode, class BBNodeManagerT>
+vector<BBNode>
+BitBlaster<BBNode, BBNodeManagerT>::ensureProxyCIs(const ASTNode& node,
+                                                   const BBNodeVec& bits)
 {
   auto it = nf->symbolToBBNode.find(node);
   if (it != nf->symbolToBBNode.end())
     return it->second;
 
-  if (allBBNodesAreCIs(bits))
+  if (allBBNodesAreCIs(nf, bits))
   {
     nf->symbolToBBNode[node] = bits;
     return bits;
@@ -235,8 +244,9 @@ BBNodeVec BitBlaster::ensureProxyCIs(const ASTNode& node,
 // Incremental records also retain their own result variables, so a duplicate
 // that ever did arise would cost work rather than a verdict; canonicalising
 // here is the invariant, not the only line of defence.
-bool BitBlaster::reuseRegisteredTerm(const ASTNode& term, unsigned width,
-                                     BBNodeVec& reused) const
+template <class BBNode, class BBNodeManagerT>
+bool BitBlaster<BBNode, BBNodeManagerT>::reuseRegisteredTerm(
+    const ASTNode& term, unsigned width, BBNodeVec& reused) const
 {
   const auto abstraction = abstractedResults_.find(term);
   if (abstraction != abstractedResults_.end())
@@ -247,7 +257,7 @@ bool BitBlaster::reuseRegisteredTerm(const ASTNode& term, unsigned width,
     return true;
   }
 
-  const BBNodeManagerAIG::SymbolToBBNode::const_iterator it =
+  const typename BBNodeManagerT::SymbolToBBNode::const_iterator it =
       nf->symbolToBBNode.find(term);
   if (it == nf->symbolToBBNode.end() || it->second.size() != width)
     return false;
@@ -458,7 +468,7 @@ static ASTNode TranslateSignedDivModRem(const ASTNode& in, NodeFactory* nf)
 
 //"Hash" (=add) first 5 node IDs together
 //TODO pretty bad hash
-class BBVecHasher
+template <class BBNode> class BBVecHasher
 {
 public:
   size_t operator()(const vector<BBNode>& n) const
@@ -472,7 +482,7 @@ public:
   }
 };
 
-class BBVecEquals
+template <class BBNode> class BBVecEquals
 {
 public:
   bool operator()(const vector<BBNode>& n0, const vector<BBNode>& n1) const
@@ -492,9 +502,10 @@ public:
 // Look through the maps to see what the bitblaster has discovered (if anything)
 // is constant.
 // Then look through for AIGS that are mapped to from different ASTNodes.
-void BitBlaster::getConsts(const ASTNode& form,
-                           ASTNodeMap& fromTo,
-                           ASTNodeMap& equivs)
+template <class BBNode, class BBNodeManagerT>
+void BitBlaster<BBNode, BBNodeManagerT>::getConsts(const ASTNode& form,
+                                                   ASTNodeMap& fromTo,
+                                                   ASTNodeMap& equivs)
 {
   assert(form.GetType() == BOOLEAN_TYPE);
 
@@ -601,7 +612,8 @@ void BitBlaster::getConsts(const ASTNode& form,
 
   if (true) //(uf->isSet("bb-equiv", "1"))
   {
-    typedef std::unordered_map<vector<BBNode>, ASTNode, BBVecHasher, BBVecEquals>
+    typedef std::unordered_map<vector<BBNode>, ASTNode, BBVecHasher<BBNode>,
+                               BBVecEquals<BBNode>>
         M;
     M lookup;
     for (auto it = BBTermMemo.begin(); it != BBTermMemo.end(); it++)
@@ -644,7 +656,8 @@ void BitBlaster::getConsts(const ASTNode& form,
   }
 }
 
-void BitBlaster::commonCheck(const ASTNode& n)
+template <class BBNode, class BBNodeManagerT>
+void BitBlaster<BBNode, BBNodeManagerT>::commonCheck(const ASTNode& n)
 {
   cerr << "Non constant is constant:";
   cerr << n << endl;
@@ -660,8 +673,9 @@ void BitBlaster::commonCheck(const ASTNode& n)
 
 // If x isn't a constant, and the bit-blasted version is. Print out the
 // AST nodes and the fixed bits.
-void BitBlaster::check(const BBNode& x,
-                       const ASTNode& n)
+template <class BBNode, class BBNodeManagerT>
+void BitBlaster<BBNode, BBNodeManagerT>::check(const BBNode& x,
+                                               const ASTNode& n)
 {
   if (n.isConstant())
     return;
@@ -672,8 +686,9 @@ void BitBlaster::check(const BBNode& x,
   commonCheck(n);
 }
 
-void BitBlaster::check(const vector<BBNode>& x,
-                       const ASTNode& n)
+template <class BBNode, class BBNodeManagerT>
+void BitBlaster<BBNode, BBNodeManagerT>::check(const vector<BBNode>& x,
+                                               const ASTNode& n)
 {
   if (n.isConstant())
     return;
@@ -687,7 +702,8 @@ void BitBlaster::check(const vector<BBNode>& x,
   commonCheck(n);
 }
 
-bool BitBlaster::update(
+template <class BBNode, class BBNodeManagerT>
+bool BitBlaster<BBNode, BBNodeManagerT>::update(
     const ASTNode& n, const int i, simplifier::constantBitP::FixedBits* b,
     BBNode& bb, BBNodeSet& support)
 {
@@ -715,9 +731,10 @@ bool BitBlaster::update(
   return false;
 }
 
-void BitBlaster::updateForm(const ASTNode& n,
-                            BBNode& bb,
-                            BBNodeSet& support)
+template <class BBNode, class BBNodeManagerT>
+void BitBlaster<BBNode, BBNodeManagerT>::updateForm(const ASTNode& n,
+                                                    BBNode& bb,
+                                                    BBNodeSet& support)
 {
   if (cb == NULL || n.isConstant())
     return;
@@ -727,9 +744,10 @@ void BitBlaster::updateForm(const ASTNode& n,
   bb = v[0];
 }
 
-void BitBlaster::updateTerm(const ASTNode& n,
-                            BBNodeVec& bb,
-                            BBNodeSet& support)
+template <class BBNode, class BBNodeManagerT>
+void BitBlaster<BBNode, BBNodeManagerT>::updateTerm(const ASTNode& n,
+                                                    BBNodeVec& bb,
+                                                    BBNodeSet& support)
 {
 
   if (cb == NULL)
@@ -834,7 +852,8 @@ void BitBlaster::updateTerm(const ASTNode& n,
     }
 }
 
-bool BitBlaster::isConstant(const BBNodeVec& v)
+template <class BBNode, class BBNodeManagerT>
+bool BitBlaster<BBNode, BBNodeManagerT>::isConstant(const BBNodeVec& v)
 {
   for (unsigned i = 0; i < v.size(); i++)
   {
@@ -845,8 +864,9 @@ bool BitBlaster::isConstant(const BBNodeVec& v)
   return true;
 }
 
-ASTNode BitBlaster::getConstant(const BBNodeVec& v,
-                                const ASTNode& n)
+template <class BBNode, class BBNodeManagerT>
+ASTNode BitBlaster<BBNode, BBNodeManagerT>::getConstant(const BBNodeVec& v,
+                                                        const ASTNode& n)
 {
   if (n.GetType() == BOOLEAN_TYPE)
   {
@@ -884,9 +904,11 @@ ASTNode BitBlaster::getConstant(const BBNodeVec& v,
 // call SimplifyTerm on ite(true,y,z), which will do the expected
 // simplification.
 // Then the term that we bitblast will by "y".
-std::unordered_map<ASTNode, vector<BBNode>, ASTNode::ASTNodeHasher, ASTNode::ASTNodeEqual>::iterator
-BitBlaster::simplify_during_bb(ASTNode& term,
-                               BBNodeSet& support)
+template <class BBNode, class BBNodeManagerT>
+typename std::unordered_map<ASTNode, vector<BBNode>, ASTNode::ASTNodeHasher,
+                            ASTNode::ASTNodeEqual>::iterator
+BitBlaster<BBNode, BBNodeManagerT>::simplify_during_bb(ASTNode& term,
+                                                       BBNodeSet& support)
 {
   const int numberOfChildren = term.Degree();
   vector<BBNodeVec> ch;
@@ -1029,13 +1051,17 @@ BitBlaster::simplify_during_bb(ASTNode& term,
   return BBTermMemo.end();
 }
 
-const BBNodeVec BitBlaster::BBTerm(const ASTNode& term, BBNodeSet& support)
+template <class BBNode, class BBNodeManagerT>
+const vector<BBNode>
+BitBlaster<BBNode, BBNodeManagerT>::BBTerm(const ASTNode& term,
+                                           BBNodeSet& support)
 {
   return BBTerm(term, support, false);
 }
 
-const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term, BBNodeSet& support,
-                                   const bool knownMissing)
+template <class BBNode, class BBNodeManagerT>
+const vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::BBTerm(
+    const ASTNode& _term, BBNodeSet& support, const bool knownMissing)
 {
   ASTNode term = _term; // mutable local copy.
 
@@ -1254,7 +1280,7 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term, BBNodeSet& support,
           abstracted[i] = nf->CreateFreshInput();
           tagAbstractionSources(abstracted[i], {id});
         }
-        BBNodeAIG condCI = nf->CreateFreshInput();
+        BBNode condCI = nf->CreateFreshInput();
         // This is an operand proxy, not the ITE abstraction's answer. Keep
         // the condition's producers on it so a future AIG alias does not
         // turn the dependency cut into an unlabelled CI.
@@ -1275,8 +1301,8 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term, BBNodeSet& support,
         raw.operands[2] = term[2];
         raw.numOperands = 3;
         raw.width = num_bits;
-        raw.condCISymbolIndex = condCI.symbol_index;
-        raw.resultCISymbolIndices = ciSymbolIndices(abstracted);
+        raw.condCISymbolIndex = nf->ciOrdinal(condCI);
+        raw.resultCISymbolIndices = ciSymbolIndices(nf, abstracted);
         abstractedTerms_.push_back(raw);
         result = abstracted;
       }
@@ -1310,11 +1336,11 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term, BBNodeSet& support,
 
         BBNodeVec tmp_res(result_width);
 
-        BBNodeVec::const_iterator bb_it = bbarg.begin();
-        BBNodeVec::iterator res_it = tmp_res.begin();
-        BBNodeVec::iterator res_ext =
+        typename BBNodeVec::const_iterator bb_it = bbarg.begin();
+        typename BBNodeVec::iterator res_it = tmp_res.begin();
+        typename BBNodeVec::iterator res_ext =
             res_it + arg_width; // first bit of extended part
-        BBNodeVec::iterator res_end = tmp_res.end();
+        typename BBNodeVec::iterator res_end = tmp_res.end();
 
         // copy LSBs directly from bbvec
         for (; res_it < res_ext; (res_it++, bb_it++))
@@ -1343,7 +1369,7 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term, BBNodeSet& support,
       const unsigned int high = term[1].GetUnsignedConst();
       const unsigned int low = term[2].GetUnsignedConst();
 
-      BBNodeVec::const_iterator bbkfit = bbkids.begin();
+      typename BBNodeVec::const_iterator bbkfit = bbkids.begin();
       // I should have used pointers to BBNodeVec, to avoid this crock
 
       result = BBNodeVec(bbkfit + low, bbkfit + high + 1);
@@ -1492,7 +1518,7 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term, BBNodeSet& support,
           raw.width = num_bits;
           raw.operandNegated[0] = negated[0];
           raw.operandNegated[1] = negated[1];
-          raw.resultCISymbolIndices = ciSymbolIndices(abstracted);
+          raw.resultCISymbolIndices = ciSymbolIndices(nf, abstracted);
           abstractedTerms_.push_back(raw);
           result = abstracted;
           break;
@@ -1620,7 +1646,7 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term, BBNodeSet& support,
         raw.operands[1] = term[1];
         raw.numOperands = 2;
         raw.width = num_bits;
-        raw.resultCISymbolIndices = ciSymbolIndices(abstracted);
+        raw.resultCISymbolIndices = ciSymbolIndices(nf, abstracted);
         raw.operandKnownBits[0] = knownBitsOf(nf, mpcd1);
         raw.operandKnownBits[1] = knownBitsOf(nf, mpcd2);
         abstractedTerms_.push_back(raw);
@@ -1691,7 +1717,7 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term, BBNodeSet& support,
         raw.operands[1] = term[1];
         raw.numOperands = 2;
         raw.width = num_bits;
-        raw.resultCISymbolIndices = ciSymbolIndices(abstracted);
+        raw.resultCISymbolIndices = ciSymbolIndices(nf, abstracted);
         raw.operandKnownBits[0] = knownBitsOf(nf, dvdd);
         raw.operandKnownBits[1] = knownBitsOf(nf, dvsr);
         abstractedTerms_.push_back(raw);
@@ -1845,7 +1871,8 @@ const BBNodeVec BitBlaster::BBTerm(const ASTNode& _term, BBNodeSet& support,
   return (BBTermMemo[term] = result);
 }
 
-const BBNode BitBlaster::BBForm(const ASTNode& form)
+template <class BBNode, class BBNodeManagerT>
+const BBNode BitBlaster<BBNode, BBNodeManagerT>::BBForm(const ASTNode& form)
 {
   fpNativeAddIsZeroFusions = 0;
 
@@ -1999,7 +2026,9 @@ static WalkOperands bbOperands(const ASTNode& n)
 // is load-bearing -- the CNF must not depend on the order operands happen to
 // be evaluated in, which is why BBForm blasts an ITE's arms into named
 // variables -- and it is what `bbOperands` above exists for.
-void BitBlaster::primeMemos(const ASTNode& n, BBNodeSet& support)
+template <class BBNode, class BBNodeManagerT>
+void BitBlaster<BBNode, BBNodeManagerT>::primeMemos(const ASTNode& n,
+                                                    BBNodeSet& support)
 {
   primeMemo(
       n,
@@ -2033,13 +2062,17 @@ void BitBlaster::primeMemos(const ASTNode& n, BBNodeSet& support)
 }
 
 // bit blast a formula (boolean term).  Result is one bit wide,
-const BBNode BitBlaster::BBForm(const ASTNode& form, BBNodeSet& support)
+template <class BBNode, class BBNodeManagerT>
+const BBNode BitBlaster<BBNode, BBNodeManagerT>::BBForm(const ASTNode& form,
+                                                        BBNodeSet& support)
 {
   return BBForm(form, support, false);
 }
 
-const BBNode BitBlaster::BBForm(const ASTNode& form, BBNodeSet& support,
-                                const bool knownMissing)
+template <class BBNode, class BBNodeManagerT>
+const BBNode BitBlaster<BBNode, BBNodeManagerT>::BBForm(const ASTNode& form,
+                                                        BBNodeSet& support,
+                                                        const bool knownMissing)
 {
   // The other half of the audit above: the two memos are primed by one walk,
   // so the walk is held to both functions at once.
@@ -2192,7 +2225,7 @@ const BBNode BitBlaster::BBForm(const ASTNode& form, BBNodeSet& support,
         appendAbstractionSources(dependencies,
                                  abstractionSourcesOf(rightInputs));
         const BVAbstractionId id = newAbstractionId();
-        BBNodeAIG abstractCI = nf->CreateFreshInput();
+        BBNode abstractCI = nf->CreateFreshInput();
         tagAbstractionSources(abstractCI, {id});
         RawBVEQAbstraction raw;
         raw.id = id;
@@ -2247,7 +2280,7 @@ const BBNode BitBlaster::BBForm(const ASTNode& form, BBNodeSet& support,
           appendAbstractionSources(dependencies,
                                    abstractionSourcesOf(rightInputs));
           const BVAbstractionId id = newAbstractionId();
-          BBNodeAIG abstractCI = nf->CreateFreshInput();
+          BBNode abstractCI = nf->CreateFreshInput();
           tagAbstractionSources(abstractCI, {id});
 
           RawBVTermAbstraction raw;
@@ -2259,7 +2292,7 @@ const BBNode BitBlaster::BBForm(const ASTNode& form, BBNodeSet& support,
           raw.operands[1] = form[1];
           raw.numOperands = 2;
           raw.width = left.size();
-          raw.condCISymbolIndex = abstractCI.symbol_index;
+          raw.condCISymbolIndex = nf->ciOrdinal(abstractCI);
           abstractedTerms_.push_back(raw);
           abstractedFormulas_[form] = {id, abstractCI};
           result = abstractCI;
@@ -2329,8 +2362,9 @@ const BBNode BitBlaster::BBForm(const ASTNode& form, BBNodeSet& support,
 
 // Bit blast a sum of two equal length BVs.
 // Update sum vector destructively with new sum.
-void BitBlaster::BBPlus2(BBNodeVec& sum,
-                         const BBNodeVec& y, BBNode cin)
+template <class BBNode, class BBNodeManagerT>
+void BitBlaster<BBNode, BBNodeManagerT>::BBPlus2(BBNodeVec& sum,
+                                                 const BBNodeVec& y, BBNode cin)
 {
 
   const int bitWidth = sum.size();
@@ -2345,22 +2379,24 @@ void BitBlaster::BBPlus2(BBNodeVec& sum,
 }
 
 // Stores result - x in result, destructively
-void BitBlaster::BBSub(BBNodeVec& result,
-                       const BBNodeVec& y,
-                       BBNodeSet& /*support*/)
+template <class BBNode, class BBNodeManagerT>
+void BitBlaster<BBNode, BBNodeManagerT>::BBSub(BBNodeVec& result,
+                                               const BBNodeVec& y,
+                                               BBNodeSet& /*support*/)
 {
   BBNodeVec compsubtrahend = BBNeg(y);
   BBPlus2(result, compsubtrahend, nf->getTrue());
 }
 
 // Add one bit
-BBNodeVec BitBlaster::BBAddOneBit(const BBNodeVec& x,
-                                  BBNode cin)
+template <class BBNode, class BBNodeManagerT>
+vector<BBNode>
+BitBlaster<BBNode, BBNodeManagerT>::BBAddOneBit(const BBNodeVec& x, BBNode cin)
 {
   BBNodeVec result;
   result.reserve(x.size());
-  const BBNodeVec::const_iterator itend = x.end();
-  for (BBNodeVec::const_iterator it = x.begin(); it < itend; it++)
+  const typename BBNodeVec::const_iterator itend = x.end();
+  for (typename BBNodeVec::const_iterator it = x.begin(); it < itend; it++)
   {
     BBNode nextcin = nf->CreateNode(AND, *it, cin);
     result.push_back(nf->CreateNode(XOR, *it, cin));
@@ -2370,16 +2406,18 @@ BBNodeVec BitBlaster::BBAddOneBit(const BBNodeVec& x,
 }
 
 // Increment bit-blasted vector and return result.
-BBNodeVec BitBlaster::BBInc(const BBNodeVec& x)
+template <class BBNode, class BBNodeManagerT>
+vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::BBInc(const BBNodeVec& x)
 {
   return BBAddOneBit(x, nf->getTrue());
 }
 
 // Return formula for majority function of three bits.
 // Pass arguments by reference to reduce refcounting.
-BBNode BitBlaster::Majority(const BBNode& a,
-                            const BBNode& b,
-                            const BBNode& c)
+template <class BBNode, class BBNodeManagerT>
+BBNode BitBlaster<BBNode, BBNodeManagerT>::Majority(const BBNode& a,
+                                                    const BBNode& b,
+                                                    const BBNode& c)
 {
   // Checking explicitly for constant a, b and c could
   // be more efficient, because they are repeated in the logic.
@@ -2422,20 +2460,23 @@ BBNode BitBlaster::Majority(const BBNode& a,
 }
 
 // Bitwise complement
-BBNodeVec BitBlaster::BBNeg(const BBNodeVec& x)
+template <class BBNode, class BBNodeManagerT>
+vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::BBNeg(const BBNodeVec& x)
 {
   BBNodeVec result;
   result.reserve(x.size());
   // Negate each bit.
-  const BBNodeVec::const_iterator& xend = x.end();
-  for (BBNodeVec::const_iterator it = x.begin(); it < xend; it++)
+  const typename BBNodeVec::const_iterator& xend = x.end();
+  for (typename BBNodeVec::const_iterator it = x.begin(); it < xend; it++)
   {
     result.push_back(nf->CreateNode(NOT, *it));
   }
   return result;
 }
 
-BBNodeVec BitBlaster::BBAnd(const BBNodeVec& x, const BBNodeVec& y)
+template <class BBNode, class BBNodeManagerT>
+vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::BBAnd(const BBNodeVec& x,
+                                                         const BBNodeVec& y)
 {
   assert(x.size() == y.size());
   BBNodeVec result(x.size());
@@ -2444,7 +2485,9 @@ BBNodeVec BitBlaster::BBAnd(const BBNodeVec& x, const BBNodeVec& y)
   return result;
 }
 
-BBNodeVec BitBlaster::BBOr(const BBNodeVec& x, const BBNodeVec& y)
+template <class BBNode, class BBNodeManagerT>
+vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::BBOr(const BBNodeVec& x,
+                                                        const BBNodeVec& y)
 {
   assert(x.size() == y.size());
   BBNodeVec result(x.size());
@@ -2453,7 +2496,9 @@ BBNodeVec BitBlaster::BBOr(const BBNodeVec& x, const BBNodeVec& y)
   return result;
 }
 
-BBNodeVec BitBlaster::BBXor(const BBNodeVec& x, const BBNodeVec& y)
+template <class BBNode, class BBNodeManagerT>
+vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::BBXor(const BBNodeVec& x,
+                                                         const BBNodeVec& y)
 {
   assert(x.size() == y.size());
   BBNodeVec result(x.size());
@@ -2462,7 +2507,9 @@ BBNodeVec BitBlaster::BBXor(const BBNodeVec& x, const BBNodeVec& y)
   return result;
 }
 
-BBNodeVec BitBlaster::BBAdd(const BBNodeVec& x, const BBNodeVec& y)
+template <class BBNode, class BBNodeManagerT>
+vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::BBAdd(const BBNodeVec& x,
+                                                         const BBNodeVec& y)
 {
   assert(x.size() == y.size());
   BBNodeVec result = x;
@@ -2471,15 +2518,17 @@ BBNodeVec BitBlaster::BBAdd(const BBNodeVec& x, const BBNodeVec& y)
 }
 
 // Compute unary minus
-BBNodeVec BitBlaster::BBUminus(const BBNodeVec& x)
+template <class BBNode, class BBNodeManagerT>
+vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::BBUminus(const BBNodeVec& x)
 {
   BBNodeVec xneg = BBNeg(x);
   return BBInc(xneg);
 }
 
 // AND each bit of vector y with single bit b and return the result.
-BBNodeVec BitBlaster::BBAndBit(const BBNodeVec& y,
-                               BBNode b)
+template <class BBNode, class BBNodeManagerT>
+vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::BBAndBit(const BBNodeVec& y,
+                                                            BBNode b)
 {
   if (nf->getTrue() == b)
   {
@@ -2489,8 +2538,8 @@ BBNodeVec BitBlaster::BBAndBit(const BBNodeVec& y,
   BBNodeVec result;
   result.reserve(y.size());
 
-  const BBNodeVec::const_iterator yend = y.end();
-  for (BBNodeVec::const_iterator yit = y.begin(); yit < yend; yit++)
+  const typename BBNodeVec::const_iterator yend = y.end();
+  for (typename BBNodeVec::const_iterator yit = y.begin(); yit < yend; yit++)
   {
     result.push_back(nf->CreateNode(AND, *yit, b));
   }
@@ -2514,7 +2563,9 @@ void printP(mult_type* m, int width)
   }
 }
 
-void convert(const BBNodeVec& v, BBNodeManagerAIG* nf, mult_type* result)
+template <class BBNode, class BBNodeManagerT>
+void convert(const std::vector<BBNode>& v, BBNodeManagerT* nf,
+             mult_type* result)
 {
   const BBNode& BBTrue = nf->getTrue();
   const BBNode& BBFalse = nf->getFalse();
@@ -2579,7 +2630,8 @@ void convert(const BBNodeVec& v, BBNodeManagerAIG* nf, mult_type* result)
 // This asks convert(), so it sees whatever the bit-blasted vector actually
 // holds -- bits that constant bit propagation or simplification fixed count
 // just as much as the bits of a BVCONST term.
-int boothRows(const BBNodeVec& v, BBNodeManagerAIG* nf, int& recoded,
+template <class BBNode, class BBNodeManagerT>
+int boothRows(const std::vector<BBNode>& v, BBNodeManagerT* nf, int& recoded,
               int& symbolic)
 {
   recoded = 0;
@@ -2610,8 +2662,10 @@ int boothRows(const BBNodeVec& v, BBNodeManagerAIG* nf, int& recoded,
 }
 
 // Multiply "multiplier" by y[start ... bitWidth].
+template <class BBNode, class BBNodeManagerT>
 void pushP(vector<vector<BBNode>>& products, const int start,
-           const BBNodeVec& y, const BBNode& multiplier, BBNodeManagerAIG* nf)
+           const std::vector<BBNode>& y, const BBNode& multiplier,
+           BBNodeManagerT* nf)
 {
   const int bitWidth = y.size();
 
@@ -2627,7 +2681,8 @@ void pushP(vector<vector<BBNode>>& products, const int start,
 
 const bool debug_multiply = false;
 
-BBNodeVec BitBlaster::buildAdditionNetworkResult(
+template <class BBNode, class BBNodeManagerT>
+vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::buildAdditionNetworkResult(
     vector<list<BBNode>>& products, BBNodeSet& support, const ASTNode& n)
 {
   const int bitWidth = n.GetValueWidth();
@@ -2659,9 +2714,10 @@ BBNodeVec BitBlaster::buildAdditionNetworkResult(
 // Use full adders to create an addition network that adds together each of the
 // partial products. Puts the carries into the "to" list.
 
-void BitBlaster::buildAdditionNetworkResult(
-    list<BBNode>& from, list<BBNode>& to, BBNodeSet& support,
-    const bool at_end, const bool all_false)
+template <class BBNode, class BBNodeManagerT>
+void BitBlaster<BBNode, BBNodeManagerT>::buildAdditionNetworkResult(
+    list<BBNode>& from, list<BBNode>& to, BBNodeSet& support, const bool at_end,
+    const bool all_false)
 {
 
   while (from.size() >= 2)
@@ -2734,7 +2790,8 @@ void BitBlaster::buildAdditionNetworkResult(
 
 const bool debug_bounds = false;
 
-bool BitBlaster::statsFound(const ASTNode& n)
+template <class BBNode, class BBNodeManagerT>
+bool BitBlaster<BBNode, BBNodeManagerT>::statsFound(const ASTNode& n)
 {
   if (NULL == cb)
     return false;
@@ -2754,7 +2811,8 @@ bool BitBlaster::statsFound(const ASTNode& n)
 
 // Make sure x and y are the parameters in the correct order. THIS ISNT
 // COMMUTATIVE.
-BBNodeVec BitBlaster::multWithBounds(
+template <class BBNode, class BBNodeManagerT>
+vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::multWithBounds(
     const ASTNode& n, vector<list<BBNode>>& products, BBNodeSet& toConjoinToTop)
 {
   const int bitWidth = n.GetValueWidth();
@@ -2812,7 +2870,8 @@ BBNodeVec BitBlaster::multWithBounds(
   return result;
 }
 
-void BitBlaster::mult_Booth(
+template <class BBNode, class BBNodeManagerT>
+void BitBlaster<BBNode, BBNodeManagerT>::mult_Booth(
     const BBNodeVec& x_i, const BBNodeVec& y_i, BBNodeSet& /*support*/,
     const ASTNode& xN, const ASTNode& yN, vector<list<BBNode>>& products,
     const ASTNode& n)
@@ -2920,9 +2979,10 @@ void BitBlaster::mult_Booth(
 // Truncation keeps the negative digits honest: BVMULT is same-width, so bits
 // above the width are dropped and each row only needs to be right modulo
 // 2^width.
-void BitBlaster::mult_Booth_radix4(const BBNodeVec& x, const BBNodeVec& y,
-                                   vector<list<BBNode>>& products,
-                                   const ASTNode& n)
+template <class BBNode, class BBNodeManagerT>
+void BitBlaster<BBNode, BBNodeManagerT>::mult_Booth_radix4(
+    const BBNodeVec& x, const BBNodeVec& y, vector<list<BBNode>>& products,
+    const ASTNode& n)
 {
   const unsigned bitWidth = x.size();
   const BBNode& BBFalse = nf->getFalse();
@@ -2963,7 +3023,8 @@ void BitBlaster::mult_Booth_radix4(const BBNodeVec& x, const BBNodeVec& y,
   }
 }
 
-void BitBlaster::mult_allPairs(
+template <class BBNode, class BBNodeManagerT>
+void BitBlaster<BBNode, BBNodeManagerT>::mult_allPairs(
     const BBNodeVec& x, const BBNodeVec& y, BBNodeSet& /*support*/,
     vector<list<BBNode>>& products)
 {
@@ -2993,8 +3054,9 @@ void BitBlaster::mult_allPairs(
   }
 }
 
-MultiplicationStats* BitBlaster::getMS(const ASTNode& n,
-                                       int& highestZero)
+template <class BBNode, class BBNodeManagerT>
+MultiplicationStats* BitBlaster<BBNode, BBNodeManagerT>::getMS(const ASTNode& n,
+                                                               int& highestZero)
 {
   MultiplicationStats* ms = NULL;
   highestZero = -1;
@@ -3023,10 +3085,10 @@ MultiplicationStats* BitBlaster::getMS(const ASTNode& n,
 }
 
 // Each bit of 'x' is taken in turn and multiplied by a shifted y.
-BBNodeVec BitBlaster::mult_normal(const BBNodeVec& x,
-                                  const BBNodeVec& y,
-                                  BBNodeSet& support,
-                                  const ASTNode& n)
+template <class BBNode, class BBNodeManagerT>
+vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::mult_normal(
+    const BBNodeVec& x, const BBNodeVec& y, BBNodeSet& support,
+    const ASTNode& n)
 {
   const int bitWidth = n.GetValueWidth();
 
@@ -3079,7 +3141,8 @@ BBNodeVec BitBlaster::mult_normal(const BBNodeVec& x,
 }
 
 // assumes the prior column is sorted.
-void BitBlaster::mult_BubbleSorterWithBounds(
+template <class BBNode, class BBNodeManagerT>
+void BitBlaster<BBNode, BBNodeManagerT>::mult_BubbleSorterWithBounds(
     BBNodeSet& support, list<BBNode>& current, vector<BBNode>& currentSorted,
     vector<BBNode>& priorSorted, const int minTrue, const int maxTrue)
 {
@@ -3169,7 +3232,8 @@ void BitBlaster::mult_BubbleSorterWithBounds(
 // then set that all the partial products must be zero.
 // For this to do anything constant bit propagation must be
 // turned on, and upper_multiplication_bound must be set.
-void BitBlaster::setColumnsToZero(
+template <class BBNode, class BBNodeManagerT>
+void BitBlaster<BBNode, BBNodeManagerT>::setColumnsToZero(
     vector<list<BBNode>>& products, BBNodeSet& support, const ASTNode& n)
 {
   const int bitWidth = n.GetValueWidth();
@@ -3222,10 +3286,10 @@ void BitBlaster::setColumnsToZero(
 //
 // Returns false, leaving products untouched, when neither operand recodes.
 // That is the symbolic x symbolic case, and the caller picks the fallback.
-bool BitBlaster::mult_Booth_constant(const BBNodeVec& x, const BBNodeVec& y,
-                                     BBNodeSet& support,
-                                     vector<list<BBNode>>& products,
-                                     const ASTNode& n)
+template <class BBNode, class BBNodeManagerT>
+bool BitBlaster<BBNode, BBNodeManagerT>::mult_Booth_constant(
+    const BBNodeVec& x, const BBNodeVec& y, BBNodeSet& support,
+    vector<list<BBNode>>& products, const ASTNode& n)
 {
   int xRecoded = 0, yRecoded = 0, xSymbolic = 0, ySymbolic = 0;
   const int xRows = boothRows(x, nf, xRecoded, xSymbolic);
@@ -3276,9 +3340,9 @@ bool BitBlaster::mult_Booth_constant(const BBNodeVec& x, const BBNodeVec& y,
 // amount at or above the width clears the vector, which is handled once
 // after the stages rather than inside them -- past log2(width) every
 // remaining bit of the amount means "at least the width".
-BBNodeVec BitBlaster::BBShiftRightByVariable(const BBNodeVec& value,
-                                             const BBNodeVec& amount,
-                                             unsigned width)
+template <class BBNode, class BBNodeManagerT>
+vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::BBShiftRightByVariable(
+    const BBNodeVec& value, const BBNodeVec& amount, unsigned width)
 {
   assert(value.size() == width);
   BBNodeVec result = value;
@@ -3302,8 +3366,10 @@ BBNodeVec BitBlaster::BBShiftRightByVariable(const BBNodeVec& value,
   return result;
 }
 
-BBNodeVec BitBlaster::BBExactBinaryOp(const ASTNode& term, const BBNodeVec& x,
-                                      const BBNodeVec& y, BBNodeSet& support)
+template <class BBNode, class BBNodeManagerT>
+vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::BBExactBinaryOp(
+    const ASTNode& term, const BBNodeVec& x, const BBNodeVec& y,
+    BBNodeSet& support)
 {
   const Kind k = term.GetKind();
   const unsigned width = term.GetValueWidth();
@@ -3327,10 +3393,11 @@ BBNodeVec BitBlaster::BBExactBinaryOp(const ASTNode& term, const BBNodeVec& x,
   return BBITE(BBEQ(zero, y), max, q);
 }
 
-BBNodeVec BitBlaster::BBMult(const BBNodeVec& _x,
-                             const BBNodeVec& _y,
-                             BBNodeSet& support,
-                             const ASTNode& n)
+template <class BBNode, class BBNodeManagerT>
+vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::BBMult(const BBNodeVec& _x,
+                                                          const BBNodeVec& _y,
+                                                          BBNodeSet& support,
+                                                          const ASTNode& n)
 {
 
   //  if (uf->isSet("print_on_mult", "0"))
@@ -3489,7 +3556,9 @@ BBNodeVec BitBlaster::BBMult(const BBNodeVec& _x,
 }
 
 // Takes an unsorted array, and returns a sorted array.
-BBNodeVec BitBlaster::batcher(const vector<BBNode>& in)
+template <class BBNode, class BBNodeManagerT>
+vector<BBNode>
+BitBlaster<BBNode, BBNodeManagerT>::batcher(const vector<BBNode>& in)
 {
   assert(in.size() != 0);
 
@@ -3519,9 +3588,10 @@ BBNodeVec BitBlaster::batcher(const vector<BBNode>& in)
 }
 
 // assumes that the prior column is sorted.
-void BitBlaster::sortingNetworkAdd(
-    BBNodeSet& /*support*/, list<BBNode>& current, vector<BBNode>& currentSorted,
-    vector<BBNode>& priorSorted)
+template <class BBNode, class BBNodeManagerT>
+void BitBlaster<BBNode, BBNodeManagerT>::sortingNetworkAdd(
+    BBNodeSet& /*support*/, list<BBNode>& current,
+    vector<BBNode>& currentSorted, vector<BBNode>& priorSorted)
 {
 
   vector<BBNode> toSort;
@@ -3575,9 +3645,10 @@ void BitBlaster::sortingNetworkAdd(
   current.push_back(resultNode);
 }
 
-BBNodeVec BitBlaster::v6(vector<list<BBNode>>& products,
-                         BBNodeSet& support,
-                         const ASTNode& n)
+template <class BBNode, class BBNodeManagerT>
+vector<BBNode>
+BitBlaster<BBNode, BBNodeManagerT>::v6(vector<list<BBNode>>& products,
+                                       BBNodeSet& support, const ASTNode& n)
 {
   const int bitWidth = n.GetValueWidth();
 
@@ -3595,9 +3666,10 @@ BBNodeVec BitBlaster::v6(vector<list<BBNode>>& products,
   return buildAdditionNetworkResult(products, support, n);
 }
 
-BBNodeVec
-BitBlaster::v13(vector<list<BBNode>>& products,
-                BBNodeSet& support, const ASTNode& n)
+template <class BBNode, class BBNodeManagerT>
+vector<BBNode>
+BitBlaster<BBNode, BBNodeManagerT>::v13(vector<list<BBNode>>& products,
+                                        BBNodeSet& support, const ASTNode& n)
 {
   const int bitWidth = n.GetValueWidth();
 
@@ -3671,9 +3743,10 @@ BitBlaster::v13(vector<list<BBNode>>& products,
 // Sorting network that delivers carries directly to the correct column.
 // For instance, if there are 6 true in a column, then a carry will flow to
 // column+1, and column+2.
-BBNodeVec BitBlaster::v9(vector<list<BBNode>>& products,
-                         BBNodeSet& support,
-                         const ASTNode& n)
+template <class BBNode, class BBNodeManagerT>
+vector<BBNode>
+BitBlaster<BBNode, BBNodeManagerT>::v9(vector<list<BBNode>>& products,
+                                       BBNodeSet& support, const ASTNode& n)
 {
   const unsigned bitWidth = n.GetValueWidth();
 
@@ -3746,9 +3819,10 @@ BBNodeVec BitBlaster::v9(vector<list<BBNode>>& products,
   return buildAdditionNetworkResult(products, support, n);
 }
 
-BBNodeVec BitBlaster::v7(vector<list<BBNode>>& products,
-                         BBNodeSet& support,
-                         const ASTNode& n)
+template <class BBNode, class BBNodeManagerT>
+vector<BBNode>
+BitBlaster<BBNode, BBNodeManagerT>::v7(vector<list<BBNode>>& products,
+                                       BBNodeSet& support, const ASTNode& n)
 {
   const int bitWidth = n.GetValueWidth();
 
@@ -3815,9 +3889,10 @@ BBNodeVec BitBlaster::v7(vector<list<BBNode>>& products,
   return results;
 }
 
-BBNodeVec BitBlaster::v8(vector<list<BBNode>>& products,
-                         BBNodeSet& support,
-                         const ASTNode& n)
+template <class BBNode, class BBNodeManagerT>
+vector<BBNode>
+BitBlaster<BBNode, BBNodeManagerT>::v8(vector<list<BBNode>>& products,
+                                       BBNodeSet& support, const ASTNode& n)
 {
   const int bitWidth = n.GetValueWidth();
 
@@ -3884,8 +3959,9 @@ BBNodeVec BitBlaster::v8(vector<list<BBNode>>& products,
 }
 
 // compare element 1 with 2, 3 with 4, and so on.
+template <class BBNode, class BBNodeManagerT>
 vector<BBNode>
-BitBlaster::compareOddEven(const vector<BBNode>& in)
+BitBlaster<BBNode, BBNodeManagerT>::compareOddEven(const vector<BBNode>& in)
 {
   vector<BBNode> result(in);
 
@@ -3900,9 +3976,10 @@ BitBlaster::compareOddEven(const vector<BBNode>& in)
   return result;
 }
 
+template <class BBNode, class BBNodeManagerT>
 vector<BBNode>
-BitBlaster::mergeSorted(const vector<BBNode>& in1,
-                        const vector<BBNode>& in2)
+BitBlaster<BBNode, BBNodeManagerT>::mergeSorted(const vector<BBNode>& in1,
+                                                const vector<BBNode>& in2)
 {
 
   assert(in1.size() >= in2.size());
@@ -3966,11 +4043,12 @@ BitBlaster::mergeSorted(const vector<BBNode>& in1,
 // This implements a variant of binary long division.
 // q and r are "out" parameters.  rwidth puts a bound on the
 // recursion depth.
-void BitBlaster::BBDivMod(const BBNodeVec& y,
-                          const BBNodeVec& x,
-                          BBNodeVec& q, BBNodeVec& r,
-                          unsigned int rwidth,
-                          BBNodeSet& support)
+template <class BBNode, class BBNodeManagerT>
+void BitBlaster<BBNode, BBNodeManagerT>::BBDivMod(const BBNodeVec& y,
+                                                  const BBNodeVec& x,
+                                                  BBNodeVec& q, BBNodeVec& r,
+                                                  unsigned int rwidth,
+                                                  BBNodeSet& support)
 {
   const unsigned int width = y.size();
   const BBNodeVec zero = BBfill(width, nf->getFalse());
@@ -4090,9 +4168,10 @@ void BitBlaster::BBDivMod(const BBNodeVec& y,
 }
 
 // build ITE's (ITE cond then[i] else[i]) for each i.
-BBNodeVec BitBlaster::BBITE(const BBNode& cond,
-                            const BBNodeVec& thn,
-                            const BBNodeVec& els)
+template <class BBNode, class BBNodeManagerT>
+vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::BBITE(const BBNode& cond,
+                                                         const BBNodeVec& thn,
+                                                         const BBNodeVec& els)
 {
   // Fast exits.
   if (cond == nf->getTrue())
@@ -4106,9 +4185,9 @@ BBNodeVec BitBlaster::BBITE(const BBNode& cond,
 
   BBNodeVec result;
   result.reserve(els.size());
-  const BBNodeVec::const_iterator th_it_end = thn.end();
-  BBNodeVec::const_iterator el_it = els.begin();
-  for (BBNodeVec::const_iterator th_it = thn.begin();
+  const typename BBNodeVec::const_iterator th_it_end = thn.end();
+  typename BBNodeVec::const_iterator el_it = els.begin();
+  for (typename BBNodeVec::const_iterator th_it = thn.begin();
        th_it < th_it_end; th_it++, el_it++)
   {
     result.push_back(nf->CreateNode(ITE, cond, *th_it, *el_it));
@@ -4119,9 +4198,10 @@ BBNodeVec BitBlaster::BBITE(const BBNode& cond,
 // Workhorse for comparison routines.  This does a signed BVLE if is_signed
 // is true, else it's unsigned.  All other comparison operators can be reduced
 // to this by swapping args or complementing the result bit.
-BBNode BitBlaster::BBBVLE(const BBNodeVec& left,
-                          const BBNodeVec& right,
-                          bool is_signed, bool is_bvlt)
+template <class BBNode, class BBNodeManagerT>
+BBNode BitBlaster<BBNode, BBNodeManagerT>::BBBVLE(const BBNodeVec& left,
+                                                  const BBNodeVec& right,
+                                                  bool is_signed, bool is_bvlt)
 {
   if (uf->bbbvle_variant)
     return BBBVLE_variant1(left, right, is_signed, is_bvlt);
@@ -4129,7 +4209,8 @@ BBNode BitBlaster::BBBVLE(const BBNodeVec& left,
     return BBBVLE_variant2(left, right, is_signed, is_bvlt);
 }
 
-BBNode BitBlaster::BBBVLE_variant1(
+template <class BBNode, class BBNodeManagerT>
+BBNode BitBlaster<BBNode, BBNodeManagerT>::BBBVLE_variant1(
     const BBNodeVec& left_, const BBNodeVec& right_, bool is_signed,
     bool is_bvlt)
 {
@@ -4142,9 +4223,9 @@ BBNode BitBlaster::BBBVLE_variant1(
   // treated separately, because signed comparison is done by
   // complementing the MSB of each BV, then doing an unsigned
   // comparison.
-  BBNodeVec::const_iterator lit = left.begin();
-  BBNodeVec::const_iterator litend = left.end();
-  BBNodeVec::const_iterator rit = right.begin();
+  typename BBNodeVec::const_iterator lit = left.begin();
+  typename BBNodeVec::const_iterator litend = left.end();
+  typename BBNodeVec::const_iterator rit = right.begin();
   BBNode prevbit = nf->getTrue();
   for (; lit < litend - 1; lit++, rit++)
   {
@@ -4172,12 +4253,13 @@ BBNode BitBlaster::BBBVLE_variant1(
   return msb;
 }
 
-BBNode BitBlaster::BBBVLE_variant2(
+template <class BBNode, class BBNodeManagerT>
+BBNode BitBlaster<BBNode, BBNodeManagerT>::BBBVLE_variant2(
     const BBNodeVec& left, const BBNodeVec& right, bool is_signed, bool is_bvlt)
 {
-  BBNodeVec::const_reverse_iterator lit = left.rbegin();
-  const BBNodeVec::const_reverse_iterator litend = left.rend();
-  BBNodeVec::const_reverse_iterator rit = right.rbegin();
+  typename BBNodeVec::const_reverse_iterator lit = left.rbegin();
+  const typename BBNodeVec::const_reverse_iterator litend = left.rend();
+  typename BBNodeVec::const_reverse_iterator rit = right.rbegin();
 
   BBNode this_compare_bit =
       is_signed ? nf->CreateNode(AND, *lit, nf->CreateNode(NOT, *rit))
@@ -4216,8 +4298,9 @@ BBNode BitBlaster::BBBVLE_variant2(
 
 // Left shift  within fixed field inserting zeros at LSB.
 // Writes result into first argument.
-void BitBlaster::BBLShift(BBNodeVec& x,
-                          unsigned int shift)
+template <class BBNode, class BBNodeManagerT>
+void BitBlaster<BBNode, BBNodeManagerT>::BBLShift(BBNodeVec& x,
+                                                  unsigned int shift)
 {
   // left shift x (destructively) within width.
   // loop backwards so that copy to self works correctly. (DON'T use STL
@@ -4233,12 +4316,13 @@ void BitBlaster::BBLShift(BBNodeVec& x,
 
 // Right shift within fixed field inserting zeros at MSB.
 // Writes result into first argument.
-void BitBlaster::BBRShift(BBNodeVec& x,
-                          unsigned int shift)
+template <class BBNode, class BBNodeManagerT>
+void BitBlaster<BBNode, BBNodeManagerT>::BBRShift(BBNodeVec& x,
+                                                  unsigned int shift)
 {
   // right shift x (destructively) within width.
-  const BBNodeVec::iterator xend = x.end();
-  BBNodeVec::iterator xit = x.begin();
+  const typename BBNodeVec::iterator xend = x.end();
+  typename BBNodeVec::iterator xit = x.begin();
   for (; xit < xend; xit++)
   {
     if (xit + shift < xend)
@@ -4249,8 +4333,9 @@ void BitBlaster::BBRShift(BBNodeVec& x,
 }
 
 // Return bit-blasted form for BVLE, BVGE, BVGT, SBLE, etc.
-BBNode BitBlaster::BBcompare(const ASTNode& form,
-                             BBNodeSet& support)
+template <class BBNode, class BBNodeManagerT>
+BBNode BitBlaster<BBNode, BBNodeManagerT>::BBcompare(const ASTNode& form,
+                                                     BBNodeSet& support)
 {
   const BBNodeVec& left = BBTerm(form[0], support);
   const BBNodeVec& right = BBTerm(form[1], support);
@@ -4309,7 +4394,9 @@ BBNode BitBlaster::BBcompare(const ASTNode& form,
 // canonical pattern is assumed. Bit i is bit i of the IEEE encoding:
 // significand field in bits [0, sb-2], exponent field in bits [sb-1, w-2],
 // sign at w-1.
-BBNode BitBlaster::BBfpIsNaN(const BBNodeVec& p, unsigned sb, unsigned w)
+template <class BBNode, class BBNodeManagerT>
+BBNode BitBlaster<BBNode, BBNodeManagerT>::BBfpIsNaN(const BBNodeVec& p,
+                                                     unsigned sb, unsigned w)
 {
   BBNodeVec expField(p.begin() + (sb - 1), p.begin() + (w - 1));
   BBNodeVec sigField(p.begin(), p.begin() + (sb - 1));
@@ -4320,7 +4407,9 @@ BBNode BitBlaster::BBfpIsNaN(const BBNodeVec& p, unsigned sb, unsigned w)
 
 // Zero iff the whole magnitude (everything below the sign bit) is zero, so
 // both +0 and -0 satisfy it.
-BBNode BitBlaster::BBfpIsZero(const BBNodeVec& p, unsigned w)
+template <class BBNode, class BBNodeManagerT>
+BBNode BitBlaster<BBNode, BBNodeManagerT>::BBfpIsZero(const BBNodeVec& p,
+                                                      unsigned w)
 {
   BBNodeVec magnitude(p.begin(), p.begin() + (w - 1));
   return nf->CreateNode(NOR, magnitude);
@@ -4460,7 +4549,9 @@ bool fpNativeExactBinaryEndpoint(const SourceSort& sort, const Kind kind,
 
 } // namespace
 
-bool BitBlaster::fpNativeConstantZeroMagnitude(const ASTNode& n) const
+template <class BBNode, class BBNodeManagerT>
+bool BitBlaster<BBNode, BBNodeManagerT>::fpNativeConstantZeroMagnitude(
+    const ASTNode& n) const
 {
   const SourceSort sort = n.GetSourceSort();
   if (n.GetKind() != BVCONST ||
@@ -4477,8 +4568,9 @@ bool BitBlaster::fpNativeConstantZeroMagnitude(const ASTNode& n) const
   return true;
 }
 
-bool BitBlaster::fpNativeConstantValue(const ASTNode& n,
-                                       long double& out) const
+template <class BBNode, class BBNodeManagerT>
+bool BitBlaster<BBNode, BBNodeManagerT>::fpNativeConstantValue(
+    const ASTNode& n, long double& out) const
 {
   const SourceSort sort = n.GetSourceSort();
   if (n.GetKind() != BVCONST ||
@@ -4532,8 +4624,9 @@ bool BitBlaster::fpNativeConstantValue(const ASTNode& n,
          (out != 0.0L || (exponent == 0 && significand == 0.0L));
 }
 
-bool BitBlaster::fpNativeConstantBits(const ASTNode& n,
-                                     std::string& out) const
+template <class BBNode, class BBNodeManagerT>
+bool BitBlaster<BBNode, BBNodeManagerT>::fpNativeConstantBits(
+    const ASTNode& n, std::string& out) const
 {
   const SourceSort sort = n.GetSourceSort();
   if (n.GetKind() != BVCONST ||
@@ -4549,8 +4642,9 @@ bool BitBlaster::fpNativeConstantBits(const ASTNode& n,
   return true;
 }
 
-bool BitBlaster::fpNativeMaxFiniteValue(const SourceSort& sort,
-                                        long double& out) const
+template <class BBNode, class BBNodeManagerT>
+bool BitBlaster<BBNode, BBNodeManagerT>::fpNativeMaxFiniteValue(
+    const SourceSort& sort, long double& out) const
 {
   if (sort.kind() != SourceSort::Kind::FloatingPoint)
     return false;
@@ -4568,7 +4662,9 @@ bool BitBlaster::fpNativeMaxFiniteValue(const SourceSort& sort,
   return std::isfinite(out);
 }
 
-BitBlaster::FpNativeInterval BitBlaster::fpNativeRoundedRange(
+template <class BBNode, class BBNodeManagerT>
+typename BitBlaster<BBNode, BBNodeManagerT>::FpNativeInterval
+BitBlaster<BBNode, BBNodeManagerT>::fpNativeRoundedRange(
     const SourceSort& sort, const long double lower,
     const long double upper) const
 {
@@ -4598,7 +4694,9 @@ BitBlaster::FpNativeInterval BitBlaster::fpNativeRoundedRange(
   return out;
 }
 
-BitBlaster::FpNativeInterval BitBlaster::fpNativeExactRoundedRange(
+template <class BBNode, class BBNodeManagerT>
+typename BitBlaster<BBNode, BBNodeManagerT>::FpNativeInterval
+BitBlaster<BBNode, BBNodeManagerT>::fpNativeExactRoundedRange(
     const SourceSort& sort, const Kind kind, const ASTNode& roundingMode,
     const FpNativeInterval& a, const FpNativeInterval& b) const
 {
@@ -4681,7 +4779,9 @@ BitBlaster::FpNativeInterval BitBlaster::fpNativeExactRoundedRange(
   return out;
 }
 
-BitBlaster::FpNativeInterval BitBlaster::fpNativeInterval(const ASTNode& n)
+template <class BBNode, class BBNodeManagerT>
+typename BitBlaster<BBNode, BBNodeManagerT>::FpNativeInterval
+BitBlaster<BBNode, BBNodeManagerT>::fpNativeInterval(const ASTNode& n)
 {
   const auto cached = fpNativeIntervals.find(n);
   if (cached != fpNativeIntervals.end())
@@ -4692,8 +4792,9 @@ BitBlaster::FpNativeInterval BitBlaster::fpNativeInterval(const ASTNode& n)
   return out;
 }
 
-BitBlaster::FpNativeInterval BitBlaster::fpNativeIntervalUncached(
-    const ASTNode& n)
+template <class BBNode, class BBNodeManagerT>
+typename BitBlaster<BBNode, BBNodeManagerT>::FpNativeInterval
+BitBlaster<BBNode, BBNodeManagerT>::fpNativeIntervalUncached(const ASTNode& n)
 {
   FpNativeInterval out;
   if (!uf->fp_native_domain)
@@ -4874,12 +4975,15 @@ BitBlaster::FpNativeInterval BitBlaster::fpNativeIntervalUncached(
   }
 }
 
-bool BitBlaster::fpNativeKnownFinite(const ASTNode& n)
+template <class BBNode, class BBNodeManagerT>
+bool BitBlaster<BBNode, BBNodeManagerT>::fpNativeKnownFinite(const ASTNode& n)
 {
   return fpNativeInterval(n).known;
 }
 
-bool BitBlaster::fpNativeKnownZeroMagnitude(const ASTNode& n)
+template <class BBNode, class BBNodeManagerT>
+bool BitBlaster<BBNode, BBNodeManagerT>::fpNativeKnownZeroMagnitude(
+    const ASTNode& n)
 {
   if (!uf->fp_native_domain ||
       n.GetSourceSort().kind() != SourceSort::Kind::FloatingPoint)
@@ -4945,7 +5049,9 @@ bool BitBlaster::fpNativeKnownZeroMagnitude(const ASTNode& n)
   return knownZero;
 }
 
-bool BitBlaster::fpNativeKnownFiniteNonnegative(const ASTNode& n)
+template <class BBNode, class BBNodeManagerT>
+bool BitBlaster<BBNode, BBNodeManagerT>::fpNativeKnownFiniteNonnegative(
+    const ASTNode& n)
 {
   if (!uf->fp_native_domain ||
       n.GetSourceSort().kind() != SourceSort::Kind::FloatingPoint)
@@ -5050,7 +5156,9 @@ bool BitBlaster::fpNativeKnownFiniteNonnegative(const ASTNode& n)
   return known;
 }
 
-bool BitBlaster::fpNativeKnownFiniteNonpositive(const ASTNode& n)
+template <class BBNode, class BBNodeManagerT>
+bool BitBlaster<BBNode, BBNodeManagerT>::fpNativeKnownFiniteNonpositive(
+    const ASTNode& n)
 {
   if (!uf->fp_native_domain ||
       n.GetSourceSort().kind() != SourceSort::Kind::FloatingPoint)
@@ -5149,11 +5257,10 @@ bool BitBlaster::fpNativeKnownFiniteNonpositive(const ASTNode& n)
   return known;
 }
 
-
-bool BitBlaster::fpNativeBoundPredicate(const ASTNode& n, ASTNode& symbol,
-                                        ASTNode& constant,
-                                        long double& value,
-                                        bool& lowerBound) const
+template <class BBNode, class BBNodeManagerT>
+bool BitBlaster<BBNode, BBNodeManagerT>::fpNativeBoundPredicate(
+    const ASTNode& n, ASTNode& symbol, ASTNode& constant, long double& value,
+    bool& lowerBound) const
 {
   const Kind k = n.GetKind();
   if ((k != FP_LT && k != FP_LEQ && k != FP_GT && k != FP_GEQ) ||
@@ -5187,8 +5294,9 @@ bool BitBlaster::fpNativeBoundPredicate(const ASTNode& n, ASTNode& symbol,
   return false;
 }
 
-bool BitBlaster::fpNativeMagnitudeZeroPredicate(const ASTNode& n,
-                                                ASTNode& term) const
+template <class BBNode, class BBNodeManagerT>
+bool BitBlaster<BBNode, BBNodeManagerT>::fpNativeMagnitudeZeroPredicate(
+    const ASTNode& n, ASTNode& term) const
 {
   if (n.GetKind() == FP_ISZERO && n.Degree() == 1 &&
       n[0].GetKind() == FP_MUL &&
@@ -5227,7 +5335,9 @@ bool BitBlaster::fpNativeMagnitudeZeroPredicate(const ASTNode& n,
   return match(n[0], n[1]) || match(n[1], n[0]);
 }
 
-void BitBlaster::collectFpNativeDomainBounds(const ASTNode& n)
+template <class BBNode, class BBNodeManagerT>
+void BitBlaster<BBNode, BBNodeManagerT>::collectFpNativeDomainBounds(
+    const ASTNode& n)
 {
   // Bounds are useful only when they occur in the top-level conjunction.
   // Walk that conjunction explicitly: native-domain collection is enabled
@@ -5283,7 +5393,9 @@ void BitBlaster::collectFpNativeDomainBounds(const ASTNode& n)
   }
 }
 
-void BitBlaster::collectFpNativeDomainFacts(const ASTNode& root)
+template <class BBNode, class BBNodeManagerT>
+void BitBlaster<BBNode, BBNodeManagerT>::collectFpNativeDomainFacts(
+    const ASTNode& root)
 {
   fpNativeFiniteTerms.clear();
   fpNativeZeroMagnitudeFacts.clear();
@@ -5365,7 +5477,9 @@ void BitBlaster::collectFpNativeDomainFacts(const ASTNode& root)
 // non-strictly, key(-0) >= key(+0) must be granted (the both-zero
 // disjunct). isNaN tests the exponent and significand fields, so operands
 // with arbitrary NaN payloads compare as NaN.
-BBNode BitBlaster::BBcompareFP(const ASTNode& form, BBNodeSet& support)
+template <class BBNode, class BBNodeManagerT>
+BBNode BitBlaster<BBNode, BBNodeManagerT>::BBcompareFP(const ASTNode& form,
+                                                       BBNodeSet& support)
 {
   const Kind k = form.GetKind();
   assert(k == FP_GT || k == FP_LT || k == FP_GEQ || k == FP_LEQ);
@@ -5486,7 +5600,9 @@ BBNode BitBlaster::BBcompareFP(const ASTNode& form, BBNodeSet& support)
 //   SMT =: the SMT domain has one abstract NaN, so all NaN payloads are
 //   equal, and two distinct zeros, so +0 and -0 are not.
 //     a = b = (isNaN(a) and isNaN(b)) or bits(a) = bits(b)
-BBNode BitBlaster::BBeqFP(const ASTNode& form, BBNodeSet& support)
+template <class BBNode, class BBNodeManagerT>
+BBNode BitBlaster<BBNode, BBNodeManagerT>::BBeqFP(const ASTNode& form,
+                                                  BBNodeSet& support)
 {
   const Kind k = form.GetKind();
   assert(k == FP_EQ || k == FP_SMT_EQ);
@@ -5596,7 +5712,9 @@ BBNode BitBlaster::BBeqFP(const ASTNode& form, BBNodeSet& support)
 // NaN is neither, because its sign bit carries no meaning. isNormal has to
 // exclude the all-ones exponent as well as the zero one, or infinities and
 // NaNs count as normal.
-BBNode BitBlaster::BBclassifyFP(const ASTNode& form, BBNodeSet& support)
+template <class BBNode, class BBNodeManagerT>
+BBNode BitBlaster<BBNode, BBNodeManagerT>::BBclassifyFP(const ASTNode& form,
+                                                        BBNodeSet& support)
 {
   const Kind k = form.GetKind();
 
@@ -5755,7 +5873,9 @@ BBNode BitBlaster::BBclassifyFP(const ASTNode& form, BBNodeSet& support)
 // binary vector of countWidth bits. An all-zero v counts v.size(). Built as
 // a priority chain: scanning positions from the LSB up, each set bit
 // overrides the count implied by the lower ones, so the MSB wins.
-BBNodeVec BitBlaster::BBfpCLZ(const BBNodeVec& v, unsigned countWidth)
+template <class BBNode, class BBNodeManagerT>
+vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::BBfpCLZ(const BBNodeVec& v,
+                                                           unsigned countWidth)
 {
   const unsigned n = v.size();
   auto constVec = [&](unsigned value) {
@@ -5776,8 +5896,9 @@ BBNodeVec BitBlaster::BBfpCLZ(const BBNodeVec& v, unsigned countWidth)
 // the stage number bounded by the host unsigned width now that BV lemmas may
 // hand it an amount as wide as the value: every still-higher amount bit is
 // necessarily a shift past any vector whose size fits in unsigned.
-BBNodeVec BitBlaster::BBShiftLeftByVariable(const BBNodeVec& value,
-                                            const BBNodeVec& amount)
+template <class BBNode, class BBNodeManagerT>
+vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::BBShiftLeftByVariable(
+    const BBNodeVec& value, const BBNodeVec& amount)
 {
   BBNodeVec result = value;
   unsigned stage = 0;
@@ -5801,9 +5922,9 @@ BBNodeVec BitBlaster::BBShiftLeftByVariable(const BBNodeVec& value,
 
 // Logarithmic right shifter that ORs every shifted-out bit into sticky --
 // the rounding circuits must not lose shifted-out precision.
-BBNodeVec BitBlaster::BBfpShiftRightSticky(const BBNodeVec& v,
-                                           const BBNodeVec& amt,
-                                           BBNode& sticky)
+template <class BBNode, class BBNodeManagerT>
+vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::BBfpShiftRightSticky(
+    const BBNodeVec& v, const BBNodeVec& amt, BBNode& sticky)
 {
   BBNodeVec r = v;
   for (unsigned s = 0; s < amt.size(); s++)
@@ -5831,7 +5952,10 @@ BBNodeVec BitBlaster::BBfpShiftRightSticky(const BBNodeVec& v,
 
 // v + inc (a single carry-in bit), one bit wider than v -- the rounding
 // increment, whose carry-out is the significand overflowing to 10...0.
-BBNodeVec BitBlaster::BBfpIncrement(const BBNodeVec& v, const BBNode& inc)
+template <class BBNode, class BBNodeManagerT>
+vector<BBNode>
+BitBlaster<BBNode, BBNodeManagerT>::BBfpIncrement(const BBNodeVec& v,
+                                                  const BBNode& inc)
 {
   BBNodeVec r(v.size() + 1);
   BBNode carry = inc;
@@ -5844,7 +5968,9 @@ BBNodeVec BitBlaster::BBfpIncrement(const BBNodeVec& v, const BBNode& inc)
   return r;
 }
 
-unsigned BitBlaster::BBfpExpWidth(unsigned eb, unsigned sb)
+template <class BBNode, class BBNodeManagerT>
+unsigned BitBlaster<BBNode, BBNodeManagerT>::BBfpExpWidth(unsigned eb,
+                                                          unsigned sb)
 {
   const unsigned bias = (1u << (eb - 1)) - 1;
   unsigned E = eb + 2;
@@ -5853,11 +5979,13 @@ unsigned BitBlaster::BBfpExpWidth(unsigned eb, unsigned sb)
   return E;
 }
 
-BitBlaster::FpOperand BitBlaster::BBfpUnpack(const BBNodeVec& p, unsigned sb,
-                                             unsigned w, unsigned E,
-                                             BBNodeSet& support,
-                                             const bool knownFinite,
-                                             const bool knownZeroMagnitude)
+template <class BBNode, class BBNodeManagerT>
+typename BitBlaster<BBNode, BBNodeManagerT>::FpOperand
+BitBlaster<BBNode, BBNodeManagerT>::BBfpUnpack(const BBNodeVec& p, unsigned sb,
+                                               unsigned w, unsigned E,
+                                               BBNodeSet& support,
+                                               const bool knownFinite,
+                                               const bool knownZeroMagnitude)
 {
   const unsigned eb = w - sb;
   const unsigned bias = (1u << (eb - 1)) - 1;
@@ -5905,13 +6033,11 @@ BitBlaster::FpOperand BitBlaster::BBfpUnpack(const BBNodeVec& p, unsigned sb,
   return o;
 }
 
-BBNodeVec BitBlaster::BBfpRoundPack(const BBNodeVec& rm, const BBNode& sgn,
-                                    const BBNodeVec& rsigIn,
-                                    const BBNode& guardIn,
-                                    const BBNode& stickyIn,
-                                    const BBNodeVec& beIn, unsigned sb,
-                                    unsigned eb, BBNodeSet& support,
-                                    const bool resultKnownFinite)
+template <class BBNode, class BBNodeManagerT>
+vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::BBfpRoundPack(
+    const BBNodeVec& rm, const BBNode& sgn, const BBNodeVec& rsigIn,
+    const BBNode& guardIn, const BBNode& stickyIn, const BBNodeVec& beIn,
+    unsigned sb, unsigned eb, BBNodeSet& support, const bool resultKnownFinite)
 {
   const unsigned w = eb + sb;
   const unsigned maxbe = (1u << eb) - 2;
@@ -6055,7 +6181,9 @@ BBNodeVec BitBlaster::BBfpRoundPack(const BBNodeVec& rm, const BBNode& sgn,
 //      or zero times infinity), then infinity, then zero. The NaN produced
 //      is the canonical quiet NaN (positive, significand MSB set), the
 //      same value the SymFPU path packs.
-BBNodeVec BitBlaster::BBfpMul(const ASTNode& term, BBNodeSet& support)
+template <class BBNode, class BBNodeManagerT>
+vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::BBfpMul(const ASTNode& term,
+                                                           BBNodeSet& support)
 {
   assert(term.GetKind() == FP_MUL);
   assert(term.Degree() == 3);
@@ -6272,7 +6400,9 @@ BBNodeVec BitBlaster::BBfpMul(const ASTNode& term, BBNodeSet& support)
 // zero iff the exact real sum is zero. For nonzero operands that means equal
 // packed magnitudes and opposite signs; every combination of signed zeros is
 // also zero. NaNs and infinities are excluded explicitly.
-BBNode BitBlaster::BBfpAddIsZero(const ASTNode& term, BBNodeSet& support)
+template <class BBNode, class BBNodeManagerT>
+BBNode BitBlaster<BBNode, BBNodeManagerT>::BBfpAddIsZero(const ASTNode& term,
+                                                         BBNodeSet& support)
 {
   assert(term.GetKind() == FP_ADD);
   assert(term.Degree() == 3);
@@ -6326,7 +6456,9 @@ BBNode BitBlaster::BBfpAddIsZero(const ASTNode& term, BBNodeSet& support)
   return nf->CreateNode(AND, finite(pa), finite(pb), exactZero);
 }
 
-BBNodeVec BitBlaster::BBfpAdd(const ASTNode& term, BBNodeSet& support)
+template <class BBNode, class BBNodeManagerT>
+vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::BBfpAdd(const ASTNode& term,
+                                                           BBNodeSet& support)
 {
   assert(term.GetKind() == FP_ADD);
   assert(term.Degree() == 3);
@@ -6635,7 +6767,9 @@ BBNodeVec BitBlaster::BBfpAdd(const ASTNode& term, BBNodeSet& support)
 // covering the source's, so the rounder never fires. The internal
 // exponent covers BOTH formats' ranges: a double's subnormal scale is far
 // outside a half's eb+2 bits.
-BBNodeVec BitBlaster::BBfpToFp(const ASTNode& term, BBNodeSet& support)
+template <class BBNode, class BBNodeManagerT>
+vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::BBfpToFp(const ASTNode& term,
+                                                            BBNodeSet& support)
 {
   assert(term.GetKind() == FP_TOFP);
   assert(term.Degree() == 4);
@@ -6748,8 +6882,9 @@ BBNodeVec BitBlaster::BBfpToFp(const ASTNode& term, BBNodeSet& support)
 
 // Return bit-blasted form for the overflow predicates BVUADDO, BVSADDO,
 // BVUMULO, BVSMULO. Each returns a single boolean.
-BBNode BitBlaster::BBOverflow(const ASTNode& form,
-                              BBNodeSet& support)
+template <class BBNode, class BBNodeManagerT>
+BBNode BitBlaster<BBNode, BBNodeManagerT>::BBOverflow(const ASTNode& form,
+                                                      BBNodeSet& support)
 {
   const Kind k = form.GetKind();
   const unsigned w = form[0].GetValueWidth();
@@ -6838,21 +6973,23 @@ BBNode BitBlaster::BBOverflow(const ASTNode& form,
 }
 
 // return a vector with n copies of fillval
-BBNodeVec BitBlaster::BBfill(unsigned int width,
-                             BBNode fillval)
+template <class BBNode, class BBNodeManagerT>
+vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::BBfill(unsigned int width,
+                                                          BBNode fillval)
 {
   BBNodeVec zvec(width, fillval);
   return zvec;
 }
 
-BBNode BitBlaster::BBEQ(const BBNodeVec& left,
-                        const BBNodeVec& right)
+template <class BBNode, class BBNodeManagerT>
+BBNode BitBlaster<BBNode, BBNodeManagerT>::BBEQ(const BBNodeVec& left,
+                                                const BBNodeVec& right)
 {
   BBNodeVec andvec;
   andvec.reserve(left.size());
-  BBNodeVec::const_iterator lit = left.begin();
-  const BBNodeVec::const_iterator litend = left.end();
-  BBNodeVec::const_iterator rit = right.begin();
+  typename BBNodeVec::const_iterator lit = left.begin();
+  const typename BBNodeVec::const_iterator litend = left.end();
+  typename BBNodeVec::const_iterator rit = right.begin();
 
   if (left.size() > 1)
   {
@@ -6881,5 +7018,9 @@ std::ostream& operator<<(std::ostream& output, const BBNodeAIG& /*h*/)
   FatalError("This isn't implemented  yet sorry;");
   return output;
 }
+
+// Every specialisation that exists. A second backend adds a line here, which
+// is the point of the whole file being a template again.
+template class BitBlaster<BBNodeAIG, BBNodeManagerAIG>;
 
 } // stp namespace

--- a/lib/ToSat/ToCNFAIG.cpp
+++ b/lib/ToSat/ToCNFAIG.cpp
@@ -80,11 +80,11 @@ void ToCNFAIG::dag_aware_aig_rewrite(const bool needAbsRef,
   }
 }
 
-void ToCNFAIG::toCNF(const BBNodeAIG& top, Cnf_Dat_t*& cnfData,
+void ToCNFAIG::toCNF(const BBNodeAIG& top, CNF& cnf,
                      ToSATBase::ASTNodeToSATVar& nodeToVars, bool needAbsRef,
                      BBNodeManagerAIG& mgr)
 {
-  assert(cnfData == NULL);
+  assert(cnf.clauseCount() == 0);
 
   Aig_ObjCreateCo(mgr.aigMgr, top.n);
   if (!needAbsRef)
@@ -107,19 +107,38 @@ void ToCNFAIG::toCNF(const BBNodeAIG& top, Cnf_Dat_t*& cnfData,
 
   dag_aware_aig_rewrite(needAbsRef, mgr);
 
-  cnfData = derive_cnf(mgr);
+  cnf = derive_cnf(mgr);
   if (uf.stats_flag)
     cerr << (uf.simple_cnf ? "simple CNF" : "advanced CNF") << endl;
-  assert(cnfData != NULL);
 
-  fill_node_to_var(cnfData, nodeToVars, mgr);
+  fill_node_to_var(cnf, nodeToVars, mgr);
+}
+
+CNF ToCNFAIG::adopt(Cnf_Dat_t* cnfData, unsigned nCi, unsigned nCo,
+                    const std::function<int(bool, unsigned)>& objectVar)
+{
+  assert(cnfData != NULL);
+  CNF cnf;
+  cnf.adopt(cnfData, [](void* p) { Cnf_DataFree((Cnf_Dat_t*)p); },
+            cnfData->pClauses, (uint64_t)cnfData->nClauses,
+            (uint64_t)cnfData->nLiterals, (uint32_t)cnfData->nVars, nCi, nCo);
+
+  // -1 is ABC's "this object has no variable" -- a CI outside the cone of the
+  // outputs, or a CO that was asserted rather than named. CNF spells that 0,
+  // for the reason its header gives.
+  const auto var = [](int v) { return v < 0 ? 0u : (uint32_t)v; };
+  for (unsigned i = 0; i < nCi; i++)
+    cnf.mapCi(i, var(objectVar(false, i)));
+  for (unsigned i = 0; i < nCo; i++)
+    cnf.mapCo(i, var(objectVar(true, i)));
+  return cnf;
 }
 
 // ABC's newer CNF generator. It works on a Gia_Man_t, so the AIG is converted
 // first. nLutSize bounds the cuts it considers: larger means a smaller CNF for
 // steeply more work.
-Cnf_Dat_t* ToCNFAIG::derive_cnf_mf(BBNodeManagerAIG& mgr, int nLutSize,
-                                    unsigned namedOutputs)
+CNF ToCNFAIG::derive_cnf_mf(BBNodeManagerAIG& mgr, int nLutSize,
+                            unsigned namedOutputs)
 {
   // The two callers need either a formula (one asserted CO) or a fragment
   // (all COs named). Mf_ManGenerateCnf can express those two forms directly;
@@ -138,36 +157,20 @@ Cnf_Dat_t* ToCNFAIG::derive_cnf_mf(BBNodeManagerAIG& mgr, int nLutSize,
   Cnf_Dat_t* cnfData = (Cnf_Dat_t*)Mf_ManGenerateCnf(
       pGia, nLutSize, 0, assertOutputs, 0, 0);
 
-  // pVarNums comes back indexed by Gia object id, but the users of this class
-  // index it by Aig object id. Rebuild it over the Aig id space for the CIs
-  // and COs they can ask for; everything else stays -1.
-  //
-  // Aig_ManObjNumMax(), not Aig_ManObjNum(): the latter subtracts nDeleted, and
-  // the Aig_ManCleanup() in toCNF() deletes nodes, so ids run past the count of
-  // live objects. Sizing by the count under-allocates by exactly nDeleted, and
-  // fill_node_to_var() then reads off the end of the array.
+  // pVarNums comes back indexed by Gia object id, and the only entries anyone
+  // wants are the CIs' and the COs'. Project those out here; the per-object
+  // array goes with the Cnf_Dat_t.
   //
   // Reading Gia CI ids is safe even though this generator may derive the CNF
   // over a coarsened copy of the Gia (Gia_ManDupMuxes, when fCnfObjIds is 0):
-  // both managers append CIs before any AND node, so CI ids are 1..nCi in each,
-  // and pVarNums is sized by an object count that includes them.
-  const int nAigObjs = Aig_ManObjNumMax(mgr.aigMgr);
-  int* pRemap = ABC_ALLOC(int, nAigObjs);
-  for (int i = 0; i < nAigObjs; i++)
-    pRemap[i] = -1;
-
-  Aig_Obj_t* pCi;
-  int ci;
-  Aig_ManForEachCi(mgr.aigMgr, pCi, ci)
-    pRemap[pCi->Id] = cnfData->pVarNums[Gia_ObjId(pGia, Gia_ManCi(pGia, ci))];
-
-  Aig_Obj_t* pCo;
-  int co;
-  Aig_ManForEachCo(mgr.aigMgr, pCo, co)
-    pRemap[pCo->Id] = cnfData->pVarNums[Gia_ObjId(pGia, Gia_ManCo(pGia, co))];
-
-  ABC_FREE(cnfData->pVarNums);
-  cnfData->pVarNums = pRemap;
+  // both managers append CIs before any AND node, so CI ids are 1..nCi in
+  // each, and pVarNums is sized by an object count that includes them.
+  CNF cnf = adopt(
+      cnfData, (unsigned)Aig_ManCiNum(mgr.aigMgr),
+      (unsigned)Aig_ManCoNum(mgr.aigMgr), [&](bool isCo, unsigned i) {
+        Gia_Obj_t* o = isCo ? Gia_ManCo(pGia, (int)i) : Gia_ManCi(pGia, (int)i);
+        return cnfData->pVarNums[Gia_ObjId(pGia, o)];
+      });
 
   // Mf_ManGenerateCnf leaves pMan pointing at the Gia, cast to Aig_Man_t*.
   // Nothing in STP reads pMan and Cnf_DataFree() does not touch it, so the Gia
@@ -175,15 +178,26 @@ Cnf_Dat_t* ToCNFAIG::derive_cnf_mf(BBNodeManagerAIG& mgr, int nLutSize,
   cnfData->pMan = NULL;
   Gia_ManStop(pGia);
 
-  return cnfData;
+  return cnf;
 }
 
-Cnf_Dat_t* ToCNFAIG::derive_cnf(BBNodeManagerAIG& mgr,
-                                 unsigned namedOutputs)
+CNF ToCNFAIG::derive_cnf(BBNodeManagerAIG& mgr, unsigned namedOutputs)
 {
   assert(namedOutputs <= (unsigned)Aig_ManCoNum(mgr.aigMgr));
+
+  // Every generator below one indexes pVarNums by Aig object id.
+  const auto fromAig = [&](Cnf_Dat_t* d) {
+    return adopt(d, (unsigned)Aig_ManCiNum(mgr.aigMgr),
+                 (unsigned)Aig_ManCoNum(mgr.aigMgr),
+                 [&](bool isCo, unsigned i) {
+                   Aig_Obj_t* o = isCo ? Aig_ManCo(mgr.aigMgr, (int)i)
+                                       : Aig_ManCi(mgr.aigMgr, (int)i);
+                   return d->pVarNums[Aig_ObjId(o)];
+                 });
+  };
+
   if (uf.simple_cnf)
-    return Cnf_DeriveSimple(mgr.aigMgr, (int)namedOutputs);
+    return fromAig(Cnf_DeriveSimple(mgr.aigMgr, (int)namedOutputs));
 
   // AUTO: decide from the size of the AIG about to be converted.
   //
@@ -224,7 +238,7 @@ Cnf_Dat_t* ToCNFAIG::derive_cnf(BBNodeManagerAIG& mgr,
       // Cnf_DeriveSimple buys about 12% off generation time for roughly 1.9x
       // the clauses -- measured on one input at 51.7M clauses against 27.6M
       // here. That trade is not worth a level.
-      return Cnf_DeriveFast(mgr.aigMgr, (int)namedOutputs);
+      return fromAig(Cnf_DeriveFast(mgr.aigMgr, (int)namedOutputs));
 
     case UserDefinedFlags::CNF_EFFORT_LOW:
       return derive_cnf_mf(mgr, 3, namedOutputs);
@@ -248,12 +262,12 @@ Cnf_Dat_t* ToCNFAIG::derive_cnf(BBNodeManagerAIG& mgr,
       Cnf_Dat_t* result =
           Cnf_DeriveWithMan(cnfMan, mgr.aigMgr, (int)namedOutputs);
       Cnf_ManStop(cnfMan);
-      return result;
+      return fromAig(result);
     }
   }
 }
 
-void ToCNFAIG::fill_node_to_var(Cnf_Dat_t* cnfData,
+void ToCNFAIG::fill_node_to_var(const CNF& cnf,
                                 ToSATBase::ASTNodeToSATVar& nodeToVars,
                                 BBNodeManagerAIG& mgr)
 {
@@ -276,7 +290,13 @@ void ToCNFAIG::fill_node_to_var(Cnf_Dat_t* cnfData,
     {
       if (!b[i].IsNull())
       {
-        v[i] = cnfData->pVarNums[mgr.ciObjectId(b[i].symbol_index)];
+        // 0 is CNF's "no variable"; ~0u is this map's, and the two have to be
+        // translated rather than assumed equal. pVarNums said -1, which
+        // became ~0u by the conversion into an unsigned, so nothing here
+        // used to need saying.
+        const uint32_t var = cnf.varOfCi((uint32_t)b[i].symbol_index);
+        if (var != 0)
+          v[i] = var;
       }
     }
 

--- a/lib/ToSat/ToSATAIG.cpp
+++ b/lib/ToSat/ToSATAIG.cpp
@@ -218,7 +218,7 @@ bool ToSATAIG::bitblast(const ASTNode& input, bool needAbsRef, CNF& cnf)
 
   BBNodeManagerAIG mgr;
   mgr.nodeBudget = bm->UserFlags.aig_node_budget;
-  BitBlaster bb(&mgr, &simp, bm->defaultNodeFactory, &bm->UserFlags, cb,
+  BitBlasterAIG bb(&mgr, &simp, bm->defaultNodeFactory, &bm->UserFlags, cb,
                 allowAbstraction_);
 
   BBNodeAIG BBFormula;

--- a/lib/ToSat/ToSATAIG.cpp
+++ b/lib/ToSat/ToSATAIG.cpp
@@ -27,6 +27,7 @@ THE SOFTWARE.
 #include "stp/UninterpretedFunctions/UFContext.h"
 #include "stp/Simplifier/Simplifier.h"
 #include "stp/Simplifier/constantBitP/ConstantBitPropagation.h"
+#include <fstream>
 #include <sstream>
 
 namespace stp
@@ -73,24 +74,30 @@ bool ToSATAIG::CallSAT(SATSolver& satSolver, const ASTNode& input,
   }
 
   first = false;
-  Cnf_Dat_t* cnfData = bitblast(input, needAbsRef);
+  CNF cnf;
 
-  // Only an exhausted AIG budget returns NULL: the query has no answer, and
+  // Only an exhausted AIG budget returns false: the query has no answer, and
   // `false` alone would be read as UNSAT. Raising the soft-timeout flag is
   // what makes CallSAT_ResultCheck report SOLVER_UNKNOWN instead -- it tests
   // that flag before it tests this return value.
-  if (cnfData == NULL)
+  if (!bitblast(input, needAbsRef, cnf))
   {
     bm->soft_timeout_expired = true;
     return false;
   }
 
-  handle_cnf_options(cnfData, needAbsRef);
+  handle_cnf_options(cnf, needAbsRef);
 
   assert(satSolver.nVars() == 0);
-  add_cnf_to_solver(satSolver, cnfData);
+  add_cnf_to_solver(satSolver, cnf);
 
-  release_cnf_memory(cnfData);
+  // The clauses are in the solver now; give the formula back before the
+  // search allocates. Cnf_ManFree() used to be called here too, to release
+  // ABC's precomputed clause-cost tables -- it only ever freed the manager
+  // that Cnf_Derive() lazily creates, and STP calls Cnf_DeriveWithMan() with
+  // a manager of its own instead, so ABC's global was always NULL and the
+  // call always a no-op.
+  cnf.clear();
 
   mark_variables_as_frozen(satSolver);
   bind_injectivity_guard(satSolver);
@@ -135,17 +142,7 @@ void ToSATAIG::bind_injectivity_guard(SATSolver& satSolver)
   satSolver.addClause(unit);
 }
 
-void ToSATAIG::release_cnf_memory(Cnf_Dat_t* cnfData)
-{
-  // Cnf_ManFree() used to be called here on the first conversion, to release
-  // ABC's precomputed clause-cost tables. It only ever freed the manager that
-  // Cnf_Derive() lazily creates, and STP calls Cnf_DeriveWithMan() with a
-  // manager of its own instead -- so ABC's global was always NULL and the call
-  // always a no-op. The counter that guarded it went with it.
-  Cnf_DataFree(cnfData);
-}
-
-void ToSATAIG::handle_cnf_options(Cnf_Dat_t* cnfData, bool needAbsRef)
+void ToSATAIG::handle_cnf_options(const CNF& cnf, bool needAbsRef)
 {
   // What makes this CNF partial, named so a reader can act on it.
   //
@@ -181,8 +178,15 @@ void ToSATAIG::handle_cnf_options(Cnf_Dat_t* cnfData, bool needAbsRef)
   {
     std::stringstream fileName;
     fileName << "output_" << bm->CNFFileNameCounter++ << ".cnf";
-    Cnf_DataWriteIntoFile(cnfData, (char*)fileName.str().c_str(), 0,0,0);
-    sayWhyPartial("the CNF written by --output-CNF");
+    std::ofstream out(fileName.str().c_str());
+    if (!out)
+      cerr << "Warning: could not open " << fileName.str() << " for writing."
+           << endl;
+    else
+    {
+      cnf.writeDimacs(out);
+      sayWhyPartial("the CNF written by --output-CNF");
+    }
   }
 
   if (bm->UserFlags.exit_after_CNF)
@@ -207,7 +211,7 @@ void ToSATAIG::handle_cnf_options(Cnf_Dat_t* cnfData, bool needAbsRef)
   }
 }
 
-Cnf_Dat_t* ToSATAIG::bitblast(const ASTNode& input, bool needAbsRef)
+bool ToSATAIG::bitblast(const ASTNode& input, bool needAbsRef, CNF& cnf)
 {
   stp::SubstitutionMap sm(bm);
   Simplifier simp(bm, &sm);
@@ -282,7 +286,7 @@ Cnf_Dat_t* ToSATAIG::bitblast(const ASTNode& input, bool needAbsRef)
     cb = NULL;
     bb.cb = NULL;
     mgr.stop();
-    return NULL;
+    return false;
   }
 
   bm->GetRunTimes()->stop(RunTimes::BitBlasting);
@@ -292,9 +296,18 @@ Cnf_Dat_t* ToSATAIG::bitblast(const ASTNode& input, bool needAbsRef)
   bb.cb = NULL;
 
   bm->GetRunTimes()->start(RunTimes::CNFConversion);
-  Cnf_Dat_t* cnfData = NULL;
-  toCNF.toCNF(BBFormula, cnfData, nodeToSATVar, needAbsRef, mgr);
+  toCNF.toCNF(BBFormula, cnf, nodeToSATVar, needAbsRef, mgr);
   bm->GetRunTimes()->stop(RunTimes::CNFConversion);
+
+  // The abstraction records below name their combinational inputs by ordinal,
+  // which is what the CI projection is indexed by. 0 is CNF's "no variable"
+  // and BV_ABSTRACTION_NO_VAR is theirs; pVarNums said -1, which became the
+  // latter by the conversion into an unsigned, so the translation used to be
+  // invisible.
+  const auto satVarOfCi = [&cnf](int ordinal) {
+    const uint32_t v = cnf.varOfCi((uint32_t)ordinal);
+    return v == 0 ? BV_ABSTRACTION_NO_VAR : v;
+  };
 
   // Record what each abstraction stands for, now that CNF conversion has
   // assigned the SAT variable its combinational input carries. Refinement
@@ -305,8 +318,7 @@ Cnf_Dat_t* ToSATAIG::bitblast(const ASTNode& input, bool needAbsRef)
     a.id = raw.id;
     a.dependencies = raw.dependencies;
     a.eqNode = raw.eqNode;
-    a.abstractionSATVar =
-        cnfData->pVarNums[mgr.ciObjectId(raw.abstractionCI.symbol_index)];
+    a.abstractionSATVar = satVarOfCi(raw.abstractionCI.symbol_index);
     a.leftSymbol = raw.leftSymbol;
     a.rightSymbol = raw.rightSymbol;
     a.width = std::max(1u, raw.leftSymbol.GetValueWidth());
@@ -331,7 +343,7 @@ Cnf_Dat_t* ToSATAIG::bitblast(const ASTNode& input, bool needAbsRef)
     a.width = raw.width;
     if (raw.condCISymbolIndex >= 0)
     {
-      a.condSATVar = cnfData->pVarNums[mgr.ciObjectId(raw.condCISymbolIndex)];
+      a.condSATVar = satVarOfCi(raw.condCISymbolIndex);
     }
     // The record's own result inputs, resolved the same way the condition
     // above is. The blaster files them for every term family; the persistent
@@ -348,7 +360,7 @@ Cnf_Dat_t* ToSATAIG::bitblast(const ASTNode& input, bool needAbsRef)
     a.resultSATVars.reserve(raw.resultCISymbolIndices.size());
     for (const int index : raw.resultCISymbolIndices)
     {
-      a.resultSATVars.push_back(cnfData->pVarNums[mgr.ciObjectId(index)]);
+      a.resultSATVars.push_back(satVarOfCi(index));
     }
     abstraction_.appendTerm(std::move(a));
   }
@@ -357,23 +369,23 @@ Cnf_Dat_t* ToSATAIG::bitblast(const ASTNode& input, bool needAbsRef)
   BBFormula = BBNodeAIG(); // null node
   mgr.stop();
 
-  return cnfData;
+  return true;
 }
 
-void ToSATAIG::add_cnf_to_solver(SATSolver& satSolver, Cnf_Dat_t* cnfData)
+void ToSATAIG::add_cnf_to_solver(SATSolver& satSolver, const CNF& cnf)
 {
   bm->GetRunTimes()->start(RunTimes::SendingToSAT);
 
   // Create a new sat variable for each of the variables in the CNF.
   int satV = satSolver.nVars();
-  for (int i = 0; i < cnfData->nVars - satV; i++)
+  for (int i = 0; i < (int)cnf.varCount() - satV; i++)
     satSolver.newVar();
 
   SATSolver::vec_literals satSolverClause;
-  for (int i = 0; i < cnfData->nClauses; i++)
+  for (uint64_t i = 0; i < cnf.clauseCount(); i++)
   {
     satSolverClause.clear();
-    for (int *pLit = cnfData->pClauses[i], *pStop = cnfData->pClauses[i + 1];
+    for (const int *pLit = cnf.clauseBegin(i), *pStop = cnf.clauseEnd(i);
          pLit < pStop; pLit++)
     {
       uint32_t var = (*pLit) >> 1;

--- a/tests/unit-tests/BVEQAbstraction_Test.cpp
+++ b/tests/unit-tests/BVEQAbstraction_Test.cpp
@@ -89,7 +89,7 @@ TEST_F(BVEQAbstractionTest, AbstractsWideSymbolEquality)
   BBNodeManagerAIG aigMgr;
   stp::SubstitutionMap sm(&mgr);
   Simplifier simp(&mgr, &sm);
-  BitBlaster bb(&aigMgr, &simp, factory, &mgr.UserFlags);
+  BitBlasterAIG bb(&aigMgr, &simp, factory, &mgr.UserFlags);
 
   bb.BBForm(eq);
 
@@ -110,7 +110,7 @@ TEST_F(BVEQAbstractionTest, NoAbstractionWhenDisabled)
   BBNodeManagerAIG aigMgr;
   stp::SubstitutionMap sm(&mgr);
   Simplifier simp(&mgr, &sm);
-  BitBlaster bb(&aigMgr, &simp, factory, &mgr.UserFlags);
+  BitBlasterAIG bb(&aigMgr, &simp, factory, &mgr.UserFlags);
 
   bb.BBForm(eq);
 
@@ -129,7 +129,7 @@ TEST_F(BVEQAbstractionTest, NoAbstractionBelowWidthThreshold)
   BBNodeManagerAIG aigMgr;
   stp::SubstitutionMap sm(&mgr);
   Simplifier simp(&mgr, &sm);
-  BitBlaster bb(&aigMgr, &simp, factory, &mgr.UserFlags);
+  BitBlasterAIG bb(&aigMgr, &simp, factory, &mgr.UserFlags);
 
   bb.BBForm(eq);
 
@@ -150,7 +150,7 @@ TEST_F(BVEQAbstractionTest, AbstractionWithNonSymbolOperandsViaProxyCIs)
   BBNodeManagerAIG aigMgr;
   stp::SubstitutionMap sm(&mgr);
   Simplifier simp(&mgr, &sm);
-  BitBlaster bb(&aigMgr, &simp, factory, &mgr.UserFlags);
+  BitBlasterAIG bb(&aigMgr, &simp, factory, &mgr.UserFlags);
 
   bb.BBForm(eq);
 
@@ -172,7 +172,7 @@ TEST_F(BVEQAbstractionTest, BooleanSkeletonContradictionIsUnsatWithoutRefinement
   BBNodeManagerAIG aigMgr;
   stp::SubstitutionMap sm(&mgr);
   Simplifier simp(&mgr, &sm);
-  BitBlaster bb(&aigMgr, &simp, factory, &mgr.UserFlags);
+  BitBlasterAIG bb(&aigMgr, &simp, factory, &mgr.UserFlags);
 
   BBNodeAIG result = bb.BBForm(conj);
 
@@ -195,7 +195,7 @@ TEST_F(BVEQAbstractionTest, MultipleEqualitiesAbstracted)
   BBNodeManagerAIG aigMgr;
   stp::SubstitutionMap sm(&mgr);
   Simplifier simp(&mgr, &sm);
-  BitBlaster bb(&aigMgr, &simp, factory, &mgr.UserFlags);
+  BitBlasterAIG bb(&aigMgr, &simp, factory, &mgr.UserFlags);
 
   bb.BBForm(conj);
 
@@ -215,7 +215,7 @@ TEST_F(BVEQAbstractionTest, DagSharingReusesAbstraction)
   BBNodeManagerAIG aigMgr;
   stp::SubstitutionMap sm(&mgr);
   Simplifier simp(&mgr, &sm);
-  BitBlaster bb(&aigMgr, &simp, factory, &mgr.UserFlags);
+  BitBlasterAIG bb(&aigMgr, &simp, factory, &mgr.UserFlags);
 
   bb.BBForm(conj);
 
@@ -289,7 +289,7 @@ TEST_F(BVEQAbstractionTest, BVPLUSAbstractionCreatesAbstraction)
   BBNodeManagerAIG aigMgr;
   stp::SubstitutionMap sm(&mgr);
   Simplifier simp(&mgr, &sm);
-  BitBlaster bb(&aigMgr, &simp, factory, &mgr.UserFlags);
+  BitBlasterAIG bb(&aigMgr, &simp, factory, &mgr.UserFlags);
 
   bb.BBForm(eq);
 
@@ -412,7 +412,7 @@ TEST_F(BVEQAbstractionTest, ITEAbstractionCreatesAbstraction)
   BBNodeManagerAIG aigMgr;
   stp::SubstitutionMap sm(&mgr);
   Simplifier simp(&mgr, &sm);
-  BitBlaster bb(&aigMgr, &simp, factory, &mgr.UserFlags);
+  BitBlasterAIG bb(&aigMgr, &simp, factory, &mgr.UserFlags);
 
   bb.BBForm(eq);
 
@@ -488,7 +488,7 @@ TEST_F(BVEQAbstractionTest, ReusesTermAbstractionsAcrossMemoBoundaries)
   BBNodeManagerAIG aigMgr;
   stp::SubstitutionMap sm(&mgr);
   Simplifier simp(&mgr, &sm);
-  BitBlaster bb(&aigMgr, &simp, factory, &mgr.UserFlags);
+  BitBlasterAIG bb(&aigMgr, &simp, factory, &mgr.UserFlags);
 
   const auto expectReused = [&](const ASTNode& term, Kind expectedKind)
   {
@@ -506,7 +506,7 @@ TEST_F(BVEQAbstractionTest, ReusesTermAbstractionsAcrossMemoBoundaries)
               bb.abstractedTerms().back().resultCISymbolIndices.size());
     const auto firstRegistration = aigMgr.symbolToBBNode.find(term);
     ASSERT_TRUE(firstRegistration != aigMgr.symbolToBBNode.end());
-    const BBNodeVec first = firstRegistration->second;
+    const BBNodeVecAIG first = firstRegistration->second;
 
     // A different FP-domain root clears BBTermMemo before this visit, as the
     // incremental per-piece route does for distinct conjuncts.
@@ -544,12 +544,12 @@ TEST_F(BVEQAbstractionTest,
   BBNodeManagerAIG aigMgr;
   stp::SubstitutionMap sm(&mgr);
   Simplifier simp(&mgr, &sm);
-  BitBlaster bb(&aigMgr, &simp, factory, &mgr.UserFlags);
+  BitBlasterAIG bb(&aigMgr, &simp, factory, &mgr.UserFlags);
 
   const BBNodeAIG rootAig = bb.BBForm(root);
 
-  const BitBlaster::RawBVTermAbstraction* childRecord = NULL;
-  const BitBlaster::RawBVTermAbstraction* parentRecord = NULL;
+  const BitBlasterAIG::RawBVTermAbstraction* childRecord = NULL;
+  const BitBlasterAIG::RawBVTermAbstraction* parentRecord = NULL;
   for (const auto& record : bb.abstractedTerms())
   {
     if (record.termNode == child)
@@ -596,13 +596,13 @@ TEST_F(BVEQAbstractionTest,
   BBNodeManagerAIG aigMgr;
   stp::SubstitutionMap sm(&mgr);
   Simplifier simp(&mgr, &sm);
-  BitBlaster bb(&aigMgr, &simp, factory, &mgr.UserFlags);
+  BitBlasterAIG bb(&aigMgr, &simp, factory, &mgr.UserFlags);
 
   const BBNodeAIG rootAig = bb.BBForm(root);
 
-  const BitBlaster::RawBVTermAbstraction* highRecord = NULL;
-  const BitBlaster::RawBVTermAbstraction* lowRecord = NULL;
-  const BitBlaster::RawBVTermAbstraction* parentRecord = NULL;
+  const BitBlasterAIG::RawBVTermAbstraction* highRecord = NULL;
+  const BitBlasterAIG::RawBVTermAbstraction* lowRecord = NULL;
+  const BitBlasterAIG::RawBVTermAbstraction* parentRecord = NULL;
   for (const auto& record : bb.abstractedTerms())
   {
     if (record.termNode == high)

--- a/tests/unit-tests/DeepDag_Test.cpp
+++ b/tests/unit-tests/DeepDag_Test.cpp
@@ -814,8 +814,8 @@ bool abstractionSideConstraintsOk(Context& c, unsigned depth)
 
   // Every conjunct has to reach the CNF, and each brings clauses of its
   // own, so fewer clauses than conjuncts would not be this formula.
-  Cnf_Dat_t* cnf = toSAT.bitblast(top, false);
-  return cnf != NULL && cnf->nClauses > static_cast<int>(depth);
+  CNF cnf;
+  return toSAT.bitblast(top, false, cnf) && cnf.clauseCount() > depth;
 }
 
 // Simplifier's term side. The job machine must use the same flattened operand

--- a/tests/unit-tests/DeepDag_Test.cpp
+++ b/tests/unit-tests/DeepDag_Test.cpp
@@ -702,7 +702,7 @@ bool bitBlastTermOk(Context& c, unsigned depth)
   SubstitutionMap sm(&c.mgr);
   Simplifier simp(&c.mgr, &sm);
   BBNodeManagerAIG nm;
-  BitBlaster bb(&nm, &simp, c.nf, &c.mgr.UserFlags);
+  BitBlasterAIG bb(&nm, &simp, c.nf, &c.mgr.UserFlags);
   bb.BBForm(f);
 
   // Every xor in the chain is 8 bits of AIG, so this cannot pass without
@@ -735,7 +735,7 @@ bool bitBlastNestedOk(Context& c, unsigned depth)
   SubstitutionMap sm(&c.mgr);
   Simplifier simp(&c.mgr, &sm);
   BBNodeManagerAIG nm;
-  BitBlaster bb(&nm, &simp, c.nf, &c.mgr.UserFlags);
+  BitBlasterAIG bb(&nm, &simp, c.nf, &c.mgr.UserFlags);
   bb.BBForm(f);
 
   // The chain is under the condition, so it cannot have been blasted
@@ -760,7 +760,7 @@ bool bitBlastOk(Context& c, unsigned depth)
   SubstitutionMap sm(&c.mgr);
   Simplifier simp(&c.mgr, &sm);
   BBNodeManagerAIG nm;
-  BitBlaster bb(&nm, &simp, c.nf, &c.mgr.UserFlags);
+  BitBlasterAIG bb(&nm, &simp, c.nf, &c.mgr.UserFlags);
   bb.BBForm(f);
 
   // One AIG node per conjunct at the very least.

--- a/tests/unit-tests/DifficultyScore_Test.cpp
+++ b/tests/unit-tests/DifficultyScore_Test.cpp
@@ -52,12 +52,12 @@ public:
   int aigNodes(const ASTNode& n)
   {
     BBNodeManagerAIG nm;
-    BitBlaster bb(&nm, &simp, mgr.defaultNodeFactory, &mgr.UserFlags);
+    BitBlasterAIG bb(&nm, &simp, mgr.defaultNodeFactory, &mgr.UserFlags);
     if (n.GetType() == BOOLEAN_TYPE)
       bb.BBForm(n);
     else
     {
-      BBNodeSet support;
+      BBNodeSetAIG support;
       bb.BBTerm(n, support);
     }
     return nm.totalNumberOfNodes();

--- a/tests/unit-tests/FloatBlast_Test.cpp
+++ b/tests/unit-tests/FloatBlast_Test.cpp
@@ -618,7 +618,7 @@ TEST(FloatBlast, native_comparison_agrees_with_symfpu_exhaustively)
   SubstitutionMap substitutions(&mgr);
   Simplifier simp(&mgr, &substitutions);
   BBNodeManagerAIG aig;
-  BitBlaster bb(&aig, &simp, mgr.defaultNodeFactory, &mgr.UserFlags);
+  BitBlasterAIG bb(&aig, &simp, mgr.defaultNodeFactory, &mgr.UserFlags);
 
   const unsigned eb = 3, sb = 4;
   const unsigned width = eb + sb;
@@ -642,7 +642,7 @@ TEST(FloatBlast, native_comparison_agrees_with_symfpu_exhaustively)
         const ASTNode reference = NonMemberBVConstEvaluator(&mgr, comparison);
         ASSERT_TRUE(reference == mgr.ASTTrue || reference == mgr.ASTFalse);
 
-        const BBNode native = bb.BBForm(comparison);
+        const BBNodeAIG native = bb.BBForm(comparison);
         ASSERT_TRUE(native == aig.getTrue() || native == aig.getFalse());
 
         ASSERT_EQ(reference == mgr.ASTTrue, native == aig.getTrue())
@@ -666,7 +666,7 @@ TEST(FloatBlast, native_comparison_agrees_with_symfpu_exhaustively)
       const ASTNode reference = NonMemberBVConstEvaluator(&mgr, classification);
       ASSERT_TRUE(reference == mgr.ASTTrue || reference == mgr.ASTFalse);
 
-      const BBNode native = bb.BBForm(classification);
+      const BBNodeAIG native = bb.BBForm(classification);
       ASSERT_TRUE(native == aig.getTrue() || native == aig.getFalse());
 
       ASSERT_EQ(reference == mgr.ASTTrue, native == aig.getTrue())
@@ -706,7 +706,7 @@ TEST(FloatBlast, native_comparison_agrees_with_symfpu_exhaustively)
             &mgr, mgr.CreateNode(FP_GT, selected, constants[j]));
         ASSERT_TRUE(reference == mgr.ASTTrue || reference == mgr.ASTFalse);
 
-        const BBNode native = bb.BBForm(comparison);
+        const BBNodeAIG native = bb.BBForm(comparison);
         ASSERT_TRUE(native == aig.getTrue() || native == aig.getFalse());
 
         ASSERT_EQ(reference == mgr.ASTTrue, native == aig.getTrue())

--- a/tests/unit-tests/Tseitin_Test.cpp
+++ b/tests/unit-tests/Tseitin_Test.cpp
@@ -23,6 +23,7 @@
 #include <gtest/gtest.h>
 
 #include <cstdint>
+#include <cstdlib>
 #include <random>
 #include <sstream>
 #include <vector>
@@ -520,7 +521,8 @@ TEST(Tseitin, IsDeterministic)
   }
 }
 
-// The DIMACS header names the highest variable, not one past it.
+// The DIMACS file is byte-compatible with the one Cnf_DataWriteIntoFile()
+// wrote, including its habit of numbering variables one above the formula's.
 TEST(Tseitin, WritesDimacs)
 {
   aig::Manager m;
@@ -531,19 +533,30 @@ TEST(Tseitin, WritesDimacs)
   std::ostringstream out;
   cnf.writeDimacs(out);
 
-  std::istringstream in(out.str());
+  const std::string text = out.str();
+  ASSERT_EQ(text.compare(0, 1, "c"), 0) << "the banner line is part of the format";
+
+  std::istringstream in(text.substr(text.find('\n') + 1));
   std::string p, fmt;
   int vars = 0, clauses = 0;
   in >> p >> fmt >> vars >> clauses;
   EXPECT_EQ(p, "p");
   EXPECT_EQ(fmt, "cnf");
-  EXPECT_EQ(vars, static_cast<int>(cnf.varCount()) - 1);
+  EXPECT_EQ(vars, static_cast<int>(cnf.varCount()));
   EXPECT_EQ(clauses, static_cast<int>(cnf.clauseCount()));
 
   unsigned terminators = 0;
   int token = 0;
   while (in >> token)
+  {
     if (token == 0)
       terminators++;
+    else
+    {
+      // Variables are one above the formula's, so 1 is never named.
+      EXPECT_GE(std::abs(token), 2);
+      EXPECT_LE(std::abs(token), static_cast<int>(cnf.varCount()));
+    }
+  }
   EXPECT_EQ(terminators, cnf.clauseCount());
 }

--- a/tools/difficulty_bench/main.cpp
+++ b/tools/difficulty_bench/main.cpp
@@ -80,12 +80,12 @@ ASTNode freshBool()
 int aigNodes(const ASTNode& n)
 {
   BBNodeManagerAIG nm;
-  BitBlaster bb(&nm, simp, mgr->defaultNodeFactory, &mgr->UserFlags);
+  BitBlasterAIG bb(&nm, simp, mgr->defaultNodeFactory, &mgr->UserFlags);
   if (n.GetType() == BOOLEAN_TYPE)
     bb.BBForm(n);
   else
   {
-    BBNodeSet support;
+    BBNodeSetAIG support;
     bb.BBTerm(n, support);
   }
   return nm.totalNumberOfNodes();

--- a/tools/propagator_bench/Bcp.cpp
+++ b/tools/propagator_bench/Bcp.cpp
@@ -75,7 +75,7 @@ struct BcpEncoding
 {
   BcpEncoding(STPMgr* mgr_, const OpSpec& op, const Layout& l)
       : mgr(mgr_), sm(mgr_), simp(mgr_, &sm), at(mgr_, &simp), aig(mgr_, &at),
-        cnf(NULL), ok(false)
+        ok(false)
   {
     const ASTNode node = buildNode(mgr, op, l);
 
@@ -93,13 +93,11 @@ struct BcpEncoding
     // sbvdiv, sbvrem and sbvmod reach the bit-blaster only after this.
     constraint = at.TransformFormula_TopLevel(constraint);
 
-    cnf = aig.bitblast(constraint, false);
+    if (!aig.bitblast(constraint, false, cnf))
+      return;
     // NULL means the AIG node budget stopped the blast. This tool never sets
     // one, so it cannot happen today -- but leaving `ok` false is the honest
     // answer for a layout with no CNF, and costs a single branch.
-    if (cnf == NULL)
-      return;
-
     const ToSATBase::ASTNodeToSATVar& map = aig.SATVar_to_SymbolIndexMap();
 
     // The varying children, in layout order, then the result. GetChildren()
@@ -117,12 +115,6 @@ struct BcpEncoding
       return;
 
     ok = true;
-  }
-
-  ~BcpEncoding()
-  {
-    if (cnf != NULL)
-      aig.release_cnf_memory(cnf);
   }
 
   // Counts the variables fixed at level zero once `bits` are asserted, or
@@ -162,8 +154,8 @@ struct BcpEncoding
   }
 
   bool usable() const { return ok; }
-  unsigned clauses() const { return cnf == NULL ? 0 : (unsigned)cnf->nClauses; }
-  unsigned variables() const { return cnf == NULL ? 0 : (unsigned)cnf->nVars; }
+  unsigned clauses() const { return (unsigned)cnf.clauseCount(); }
+  unsigned variables() const { return cnf.varCount(); }
 
 private:
   // constexpr, not const: resize() below binds it by reference, which needs
@@ -193,7 +185,7 @@ private:
   Simplifier simp;
   ArrayTransformer at;
   mutable ToSATAIG aig;
-  Cnf_Dat_t* cnf;
+  CNF cnf;
   vector<vector<unsigned>> vars; // one entry per varying child, then result
   std::unordered_set<unsigned> interesting;
   bool ok;

--- a/tools/rewrite_rule_gen/rewrite_rule_gen.cpp
+++ b/tools/rewrite_rule_gen/rewrite_rule_gen.cpp
@@ -644,7 +644,7 @@ int getDifficulty(const ASTNode& n_)
     return -1;
 
   BBNodeManagerAIG nm;
-  BitBlaster bb(&nm, simp, mgr->defaultNodeFactory, &mgr->UserFlags);
+  BitBlasterAIG bb(&nm, simp, mgr->defaultNodeFactory, &mgr->UserFlags);
 
   // equals fresh variable to convert to boolean type.
   ASTNode f = mgr->CreateFreshVariable(0, widen_to, "ffff");
@@ -3090,7 +3090,7 @@ ASTNode rewriteThroughWithAIGS(const ASTNode& n_)
   ASTNode n = create(EQ, n_, f);
 
   BBNodeManagerAIG nm;
-  BitBlaster bb(&nm, simp, mgr->defaultNodeFactory, &mgr->UserFlags);
+  BitBlasterAIG bb(&nm, simp, mgr->defaultNodeFactory, &mgr->UserFlags);
   ASTNodeMap fromTo;
   ASTNodeMap equivs;
   bb.getConsts(n, fromTo, equivs);

--- a/tools/rewrite_rule_gen/rewrite_rule_gen.cpp
+++ b/tools/rewrite_rule_gen/rewrite_rule_gen.cpp
@@ -654,7 +654,7 @@ int getDifficulty(const ASTNode& n_)
 
   clearSAT();
 
-  Cnf_Dat_t* cnfData = NULL;
+  CNF cnfData;
   ToCNFAIG toCNF(mgr->UserFlags);
   ToSATBase::ASTNodeToSATVar nodeToSATVar;
   toCNF.toCNF(BBFormula, cnfData, nodeToSATVar, false, nm);
@@ -668,14 +668,15 @@ int getDifficulty(const ASTNode& n_)
   {
     // Create a new sat variable for each of the variables in the CNF.
     assert(ss->nVars() == 0);
-    for (int i = 0; i < cnfData->nVars; i++)
+    for (uint32_t i = 0; i < cnfData.varCount(); i++)
       ss->newVar();
 
     SATSolver::vec_literals satSolverClause;
-    for (int i = 0; i < cnfData->nClauses; i++)
+    for (uint64_t i = 0; i < cnfData.clauseCount(); i++)
     {
       satSolverClause.clear();
-      for (int *pLit = cnfData->pClauses[i], *pStop = cnfData->pClauses[i + 1];
+      for (const int *pLit = cnfData.clauseBegin(i),
+                     *pStop = cnfData.clauseEnd(i);
            pLit < pStop; pLit++)
       {
         uint32_t var = (*pLit) >> 1;
@@ -693,17 +694,15 @@ int getDifficulty(const ASTNode& n_)
 
     // Why we go to all this trouble. The number of clauses.
     score = ss->nClauses();
-    assert(score <= cnfData->nClauses);
+    assert(score <= (int)cnfData.clauseCount());
   }
   else
   {
-    score = cnfData->nClauses;
+    score = (int)cnfData.clauseCount();
   }
   //////////////
 
-  // Cnf_ClearMemory();
-  Cnf_DataFree(cnfData);
-  cnfData = NULL;
+  cnfData.clear();
 
   // Free the memory in the AIGs.
   BBFormula = BBNodeAIG(); // null node


### PR DESCRIPTION
Stacked on #1045 — review that first; this PR's own diff is the second commit.

A revert of #714 in direction, not in text: the blaster goes back to `template <class BBNode, class BBNodeManagerT>` so that a second node representation can be instantiated over the same 6900 lines of blasting logic. #714 dropped the parameters because the ASTNode backend was gone and one instantiation was left, which was right at the time. A second one is now close enough to be worth the parameters again.

Everything outside the blaster names `BitBlasterAIG`, `BBNodeVecAIG` and `BBNodeSetAIG` rather than the template, so the second backend arrives as an alias beside those rather than an edit at forty use sites.

### The two changes that are not mechanical

The blaster no longer names a backend's own types anywhere in the class body — checked by script rather than by eye. Everything else in the diff is the template header, the qualification, and the re-wrapping that follows from it.

* **`BBNodeSet` becomes `BBNodeOrderedSet<BBNode>`** at namespace scope. It has to be template-dependent now, and it stays outside the class because `BBExactBinaryOp` takes one and its callers are outside.

* **The two reads of `BBNodeAIG::symbol_index` go through the manager**, as `BBNodeManagerAIG::isNamedCI()` and `::ciOrdinal()`. `isCI()` alone would not do: it strips the complement bit first, and the test being replaced meant "an uncomplemented input this manager minted, still carrying its ordinal". A complemented input is still an input, but it is not one the blaster can name, and an abstraction record that stored its ordinal would be recording the wrong polarity.

The four namespace-scope helpers in `BitBlaster.cpp` — `knownBitsOf`, `convert`, `boothRows`, `pushP` — become templates and take the manager, since `BBNodeVec` is no longer a namespace-scope name. The `typename` disambiguators on the iterator types come back, and so do the template parameters on `BBVecHasher` and `BBVecEquals`.

### The instantiation split

`BVLemmaCircuits.cpp` holds the blaster's only members defined outside `BitBlaster.cpp`, so the explicit instantiation there cannot reach them — an explicit instantiation only instantiates what its own translation unit can see. Its six are named one at a time rather than by a second `template class BitBlaster<...>`, which would be a second explicit instantiation of one specialisation.

They are spelled out in full rather than through the `BitBlasterAIG` alias: the qualifier of an explicit instantiation must be a template-id, and a typedef naming the same specialisation is not one. gcc takes the alias; clang `-pedantic` is right to refuse it.

### Gate

Still one instantiation, so nothing observable changes. `scripts/cnf-manifest.sh` against a binary built from the parent commit in its own build directory:

| configuration | inputs | produced CNF | differing |
|---|---|---|---|
| default | 882 | 349 | 0 |
| `--bb.conjoin-constant 1` | 882 | 349 | 0 |
| `--bv-eq-abstraction 1 --bv-term-abstraction 1` | 882 | 349 | 0 |
| `--disable-simplifications` | 882 | 679 | 0 |
| `--bb.mult-variant 9` | 882 | 349 | 0 |

176/176 ctest pass under gcc and under clang with `-Werror`.

**Compile time** for `BitBlaster.cpp`, the largest translation unit in the tree, three alternating rounds each: 12.5–13.0 s as a plain class, 13.7–14.5 s as a template — about 10% more. Recorded because wiring the second backend makes this file compile twice.