### PR TITLE
A second bit-blasting backend, and the CNF route that goes with it

### DIFF
--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -887,7 +887,14 @@ public:
     CNF_EFFORT_MEDIUM,
     CNF_EFFORT_HIGH,
     CNF_EFFORT_VERY_HIGH,
-    CNF_EFFORT_AUTO
+    CNF_EFFORT_AUTO,
+    // The in-house Tseitin writer, over the in-house AIG. Below very-low on
+    // the scale and last in the enum, which are different facts: the ordinals
+    // are the C interface's contract, so a new rung goes on the end however
+    // little effort it spends. AUTO never picks it -- AUTO chooses from the
+    // AIG's node count, which means blasting through ABC first, so reaching
+    // this rung has to be an explicit request.
+    CNF_EFFORT_NEW_VERY_LOW
   };
 
   enum CNFEffort cnf_effort = CNF_EFFORT_AUTO;

--- a/include/stp/ToSat/AIGBudget.h
+++ b/include/stp/ToSat/AIGBudget.h
@@ -1,0 +1,51 @@
+/********************************************************************
+ * AUTHORS: Trevor Hansen
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#ifndef AIGBUDGET_H
+#define AIGBUDGET_H
+
+#include <stdexcept>
+
+namespace stp
+{
+
+// Thrown by a node manager's checkBudget() when the AND-gate count passes its
+// nodeBudget. Whoever set the budget owns the abandonment policy, so this
+// escapes CreateNode() and every BitBlaster frame above it; only a caller
+// that set a budget can see it.
+//
+// In its own header because both node managers throw it and the callers catch
+// one type, while only one of the two managers knows what ABC is.
+struct AIGBudgetExhausted : public std::runtime_error
+{
+  // The AND-gate count reached, always strictly greater than the budget.
+  int nodeCount;
+
+  explicit AIGBudgetExhausted(int n)
+      : std::runtime_error("AIG node budget exhausted"), nodeCount(n) {}
+};
+
+} // namespace stp
+
+#endif

--- a/include/stp/ToSat/BBNodeLit.h
+++ b/include/stp/ToSat/BBNodeLit.h
@@ -1,0 +1,103 @@
+/********************************************************************
+ * AUTHORS: Trevor Hansen
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#ifndef BBNODELIT_H
+#define BBNODELIT_H
+
+#include "stp/AIG/Literal.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <ostream>
+
+namespace stp
+{
+
+// The blaster's handle on a node of the in-house AIG: one literal, four
+// bytes, no pointer.
+//
+// BBNodeAIG is sixteen -- an Aig_Obj_t* and an int symbol_index -- and the
+// ordinal is what most of that pays for. It exists because dag-aware
+// rewriting replaces ABC's manager wholesale and renumbers everything, so a
+// symbol has to be found again by its position among the inputs. Nothing
+// renumbers here: the id is the array index and the array only ever grows,
+// so the literal *is* the identity and no ordinal has to be carried beside
+// it.
+//
+// Null is aig::LIT_NULL, which is outside the literal space and closed under
+// negation there -- so a null handle cannot be mistaken for a real node, and
+// neither can its complement.
+class BBNodeLit
+{
+public:
+  aig::Lit n = aig::LIT_NULL;
+
+  BBNodeLit() = default;
+  explicit BBNodeLit(aig::Lit l) : n(l) {}
+
+  bool IsNull() const { return n == aig::LIT_NULL; }
+
+  // The whole literal, complement bit included, which is what the blaster's
+  // memo tables need to distinguish x from !x. BBNodeAIG's own hash had to be
+  // fixed to do the same.
+  unsigned GetNodeNum() const { return n; }
+
+  bool operator==(const BBNodeLit& o) const { return n == o.n; }
+  bool operator!=(const BBNodeLit& o) const { return n != o.n; }
+
+  // Not dead, whatever a grep suggests: mult_Booth sorts each column of
+  // partial products with it, and that ordering decides which products
+  // combine first, so it reaches the emitted formula. BBNodeAIG carries the
+  // same operator for the same reason.
+  bool operator<(const BBNodeLit& o) const { return n < o.n; }
+};
+
+static_assert(sizeof(BBNodeLit) == 4, "the point of this class is its size");
+
+// For the --debug-multiply tracing. The AIG side answers this with a
+// FatalError because an Aig_Obj_t* has nothing short to say; a literal does.
+inline std::ostream& operator<<(std::ostream& out, const BBNodeLit& n)
+{
+  if (n.IsNull())
+    return out << "null";
+  if (aig::isNeg(n.n))
+    out << '!';
+  return out << aig::nodeOf(n.n);
+}
+
+} // namespace stp
+
+namespace std
+{
+template <> struct hash<stp::BBNodeLit>
+{
+  size_t operator()(const stp::BBNodeLit& n) const
+  {
+    return std::hash<stp::aig::Lit>()(n.n);
+  }
+};
+} // namespace std
+
+#endif

--- a/include/stp/ToSat/BBNodeManagerAIG.h
+++ b/include/stp/ToSat/BBNodeManagerAIG.h
@@ -29,6 +29,7 @@ THE SOFTWARE.
 #include <stdexcept>
 
 #include "BBNodeAIG.h"
+#include "stp/ToSat/AIGBudget.h"
 #include "stp/ToSat/ToSATBase.h"
 
 // From ABC
@@ -99,19 +100,6 @@ inline void ensureDarLibrary()
 {
   Dar_LibStart();
 }
-
-// Thrown by BBNodeManagerAIG::checkBudget() when the AND-gate count passes
-// the manager's nodeBudget. Whoever set the budget owns the abandonment
-// policy, so this escapes CreateNode() and every BitBlaster frame above it;
-// only a caller that set a budget can see it.
-struct AIGBudgetExhausted : public std::runtime_error
-{
-  // The AND-gate count reached, always strictly greater than the budget.
-  int nodeCount;
-
-  explicit AIGBudgetExhausted(int n)
-      : std::runtime_error("AIG node budget exhausted"), nodeCount(n) {}
-};
 
 // Creates AIG nodes with ABC and wraps them in BBNodeAIG's.
 class BBNodeManagerAIG

--- a/include/stp/ToSat/BBNodeManagerLit.h
+++ b/include/stp/ToSat/BBNodeManagerLit.h
@@ -259,9 +259,9 @@ public:
 
 private:
   // A two-input gate takes two operands, so a wide one becomes a log-height
-  // tower. Same shape as BBNodeManagerAIG::makeTower -- front two off, result
-  // to the back -- because the shape decides which operands share subterms
-  // and so decides the gate count.
+  // tower. Built the same way as BBNodeManagerAIG::makeTower -- front two
+  // off, result to the back -- because which operands end up paired decides
+  // which subterms are shared, and so decides the gate count.
   aig::Lit tower(aig::Lit (aig::Manager::*op)(aig::Lit, aig::Lit),
                  const std::vector<BBNodeLit>& children)
   {

--- a/include/stp/ToSat/BBNodeManagerLit.h
+++ b/include/stp/ToSat/BBNodeManagerLit.h
@@ -1,0 +1,293 @@
+/********************************************************************
+ * AUTHORS: Trevor Hansen
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#ifndef BBNODEMANAGERLIT_H
+#define BBNODEMANAGERLIT_H
+
+#include "stp/AIG/Manager.h"
+#include "stp/AST/AST.h"
+#include "stp/ToSat/AIGBudget.h"
+#include "stp/ToSat/BBNodeLit.h"
+
+#include <algorithm>
+#include <iostream>
+#include <deque>
+#include <map>
+#include <vector>
+
+namespace stp
+{
+
+// The blaster's second backend: the same gate builders as BBNodeManagerAIG,
+// over the in-house AIG instead of ABC's.
+//
+// Every method here answers a question BitBlaster asks. Where the two
+// managers differ is not in the questions but in whether they can be answered
+// without the manager: ABC's object carries its own kind and its own fanins,
+// so isCI() and friends are static there. A node here is an index into an
+// array, so they are ordinary members and the blaster asks through `nf`.
+class BBNodeManagerLit
+{
+public:
+  aig::Manager mgr;
+
+  // Hard cap on AND gates; -1 (the default) is no limit, 0 permits none.
+  int64_t nodeBudget = -1;
+
+  // Map from symbols to their nodes. std::map rather than a hash map for the
+  // same reason BBNodeManagerAIG uses one: fill_node_to_var walks it, and the
+  // order it walks in reaches the emitted formula.
+  typedef std::map<ASTNode, std::vector<BBNodeLit>> SymbolToBBNode;
+  SymbolToBBNode symbolToBBNode;
+
+  int totalNumberOfNodes() { return static_cast<int>(mgr.andCount()); }
+
+  BBNodeManagerLit() = default;
+  BBNodeManagerLit(const BBNodeManagerLit&) = delete;
+  BBNodeManagerLit& operator=(const BBNodeManagerLit&) = delete;
+
+  void stop()
+  {
+    mgr.reset();
+    symbolToBBNode.clear();
+  }
+
+  BBNodeLit getTrue() { return BBNodeLit(aig::LIT_TRUE); }
+  BBNodeLit getFalse() { return BBNodeLit(aig::LIT_FALSE); }
+
+  // An input that stands for no symbol. The BV abstraction machinery mints
+  // these for proxies and for abstracted results.
+  BBNodeLit CreateFreshInput() { return BBNodeLit(mgr.createCi()); }
+
+  // The same symbol always has to come back as the same node.
+  BBNodeLit CreateSymbol(const ASTNode& n, unsigned i)
+  {
+    assert(n.GetKind() == SYMBOL);
+    const unsigned width = std::max((unsigned)1, n.GetValueWidth());
+
+    SymbolToBBNode::iterator it = symbolToBBNode.find(n);
+    if (symbolToBBNode.end() == it)
+    {
+      symbolToBBNode[n] = std::vector<BBNodeLit>(width);
+      it = symbolToBBNode.find(n);
+    }
+    assert(it->second.size() == width);
+    assert(i < width);
+
+    if (!it->second[i].IsNull())
+      return it->second[i];
+
+    it->second[i] = BBNodeLit(mgr.createCi());
+    return it->second[i];
+  }
+
+  // --- the queries BitBlaster asks about a node ---------------------------
+
+  bool isCI(const BBNodeLit& n) const { return mgr.isCi(aig::nodeOf(n.n)); }
+  bool isConstant(const BBNodeLit& n) const { return aig::isConst(n.n); }
+  bool isAnd(const BBNodeLit& n) const { return mgr.isAnd(aig::nodeOf(n.n)); }
+  unsigned nodeId(const BBNodeLit& n) const { return aig::nodeOf(n.n); }
+
+  // The fanins of an AND, with the sign stripped, as BBNodeManagerAIG does:
+  // provenance and traversal are both sign-insensitive, and returning the
+  // signed edge would key two memo entries per node.
+  BBNodeLit fanin0(const BBNodeLit& n) const
+  {
+    return BBNodeLit(mgr.fanin0(aig::nodeOf(n.n)) & ~aig::Lit(1));
+  }
+  BBNodeLit fanin1(const BBNodeLit& n) const
+  {
+    return BBNodeLit(mgr.fanin1(aig::nodeOf(n.n)) & ~aig::Lit(1));
+  }
+
+  // An uncomplemented input this manager minted, and its ordinal.
+  //
+  // BBNodeAIG answers by carrying the ordinal in the handle. Nothing here
+  // renumbers, so the ordinal can be recovered instead: inputs are appended
+  // in creation order, so the manager's input list ascends by node id and a
+  // binary search over it finds the position. Asked once per abstraction
+  // record, never on a blasting path.
+  bool isNamedCI(const BBNodeLit& n) const
+  {
+    return !n.IsNull() && !aig::isNeg(n.n) && isCI(n);
+  }
+  int ciOrdinal(const BBNodeLit& n) const
+  {
+    assert(isNamedCI(n));
+    const aig::Node want = aig::nodeOf(n.n);
+    uint32_t lo = 0, hi = mgr.ciCount();
+    while (lo < hi)
+    {
+      const uint32_t mid = lo + (hi - lo) / 2;
+      if (mgr.ciNode(mid) < want)
+        lo = mid + 1;
+      else
+        hi = mid;
+    }
+    assert(lo < mgr.ciCount() && mgr.ciNode(lo) == want);
+    return static_cast<int>(lo);
+  }
+
+  // --- the gate builders --------------------------------------------------
+
+  BBNodeLit CreateNode(Kind kind, std::vector<BBNodeLit>& children)
+  {
+    assert(children.size() != 0);
+    for (size_t i = 0, size = children.size(); i < size; ++i)
+      assert(!children[i].IsNull());
+
+    aig::Lit r;
+    switch (kind)
+    {
+      case AND:
+        r = tower(&aig::Manager::And, children);
+        break;
+
+      case NAND:
+        r = aig::neg(tower(&aig::Manager::And, children));
+        break;
+
+      case OR:
+        r = tower(&aig::Manager::Or, children);
+        break;
+
+      case NOR:
+        r = aig::neg(tower(&aig::Manager::Or, children));
+        break;
+
+      case NOT:
+        assert(children.size() == 1);
+        r = aig::neg(children[0].n);
+        break;
+
+      case XOR:
+        r = tower(&aig::Manager::Xor, children);
+        break;
+
+      case IFF:
+        assert(children.size() == 2);
+        r = mgr.Iff(children[0].n, children[1].n);
+        break;
+
+      case IMPLIES:
+        assert(children.size() == 2);
+        r = mgr.Or(aig::neg(children[0].n), children[1].n);
+        break;
+
+      case ITE:
+        assert(children.size() == 3);
+        r = mgr.Mux(children[0].n, children[1].n, children[2].n);
+        break;
+
+      default:
+        std::cerr << "Not handled::!!" << _kind_names[kind];
+        FatalError("Never here");
+        exit(-1);
+    }
+    checkBudget();
+    return BBNodeLit(r);
+  }
+
+  BBNodeLit CreateNode(Kind kind, const BBNodeLit& child0,
+                       const std::vector<BBNodeLit>& back_children =
+                           std::vector<BBNodeLit>())
+  {
+    std::vector<BBNodeLit> front;
+    front.reserve(1 + back_children.size());
+    front.push_back(child0);
+    front.insert(front.end(), back_children.begin(), back_children.end());
+    return CreateNode(kind, front);
+  }
+
+  BBNodeLit CreateNode(Kind kind, const BBNodeLit& child0,
+                       const BBNodeLit& child1,
+                       const std::vector<BBNodeLit>& back_children =
+                           std::vector<BBNodeLit>())
+  {
+    std::vector<BBNodeLit> front;
+    front.reserve(2 + back_children.size());
+    front.push_back(child0);
+    front.push_back(child1);
+    front.insert(front.end(), back_children.begin(), back_children.end());
+    return CreateNode(kind, front);
+  }
+
+  BBNodeLit CreateNode(Kind kind, const BBNodeLit& child0,
+                       const BBNodeLit& child1, const BBNodeLit& child2,
+                       const std::vector<BBNodeLit>& back_children =
+                           std::vector<BBNodeLit>())
+  {
+    std::vector<BBNodeLit> front;
+    front.reserve(3 + back_children.size());
+    front.push_back(child0);
+    front.push_back(child1);
+    front.push_back(child2);
+    front.insert(front.end(), back_children.begin(), back_children.end());
+    return CreateNode(kind, front);
+  }
+
+  // Called after every CreateNode(). One node can add a whole fan-in tower
+  // before this runs, so the count at the throw can overshoot the budget by
+  // the width of one operator -- as with the AIG manager, the cap bounds the
+  // order of magnitude rather than being an exact ceiling.
+  void checkBudget() const
+  {
+    if (nodeBudget >= 0 && static_cast<int64_t>(mgr.andCount()) > nodeBudget)
+      throw AIGBudgetExhausted(static_cast<int>(mgr.andCount()));
+  }
+
+private:
+  // A two-input gate takes two operands, so a wide one becomes a log-height
+  // tower. Same shape as BBNodeManagerAIG::makeTower -- front two off, result
+  // to the back -- because the shape decides which operands share subterms
+  // and so decides the gate count.
+  aig::Lit tower(aig::Lit (aig::Manager::*op)(aig::Lit, aig::Lit),
+                 const std::vector<BBNodeLit>& children)
+  {
+    if (children.size() == 1)
+      return children[0].n;
+
+    std::deque<aig::Lit> names;
+    for (size_t i = 0, size = children.size(); i < size; ++i)
+      names.push_back(children[i].n);
+
+    while (names.size() > 2)
+    {
+      const aig::Lit a = names.front();
+      names.pop_front();
+      const aig::Lit b = names.front();
+      names.pop_front();
+      names.push_back((mgr.*op)(a, b));
+    }
+
+    const aig::Lit a = names.front();
+    names.pop_front();
+    const aig::Lit b = names.front();
+    return (mgr.*op)(a, b);
+  }
+};
+
+} // namespace stp
+
+#endif

--- a/include/stp/ToSat/BitBlaster.h
+++ b/include/stp/ToSat/BitBlaster.h
@@ -28,6 +28,7 @@ THE SOFTWARE.
 #include "stp/STPManager/STPManager.h"
 #include "stp/Simplifier/constantBitP/MultiplicationStats.h"
 #include "stp/ToSat/BBNodeManagerAIG.h"
+#include "stp/ToSat/BBNodeManagerLit.h"
 #include "stp/ToSat/BVAbstractionTypes.h"
 #include "stp/Util/DagWalk.h"
 #include <cassert>
@@ -835,6 +836,11 @@ public:
 using BitBlasterAIG = BitBlaster<BBNodeAIG, BBNodeManagerAIG>;
 using BBNodeVecAIG = std::vector<BBNodeAIG>;
 using BBNodeSetAIG = BBNodeOrderedSet<BBNodeAIG>;
+
+// The second, over the in-house AIG.
+using BitBlasterLit = BitBlaster<BBNodeLit, BBNodeManagerLit>;
+using BBNodeVecLit = std::vector<BBNodeLit>;
+using BBNodeSetLit = BBNodeOrderedSet<BBNodeLit>;
 
 } // end of namespace
 

--- a/include/stp/ToSat/ToCNFTseitin.h
+++ b/include/stp/ToSat/ToCNFTseitin.h
@@ -49,7 +49,8 @@ class ToCNFTseitin
 public:
   explicit ToCNFTseitin(UserDefinedFlags& _uf) : uf(_uf) {}
 
-  // Same shape as ToCNFAIG::toCNF so that one templated body drives either.
+  // The same signature as ToCNFAIG::toCNF, so one templated body drives
+  // either.
   //
   // needAbsRef is taken and ignored. It exists on the ABC side to suppress
   // Aig_ManCleanup, because a cleanup renumbers and refinement has to be able

--- a/include/stp/ToSat/ToCNFTseitin.h
+++ b/include/stp/ToSat/ToCNFTseitin.h
@@ -1,0 +1,66 @@
+/********************************************************************
+ * AUTHORS: Trevor Hansen
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#ifndef TOCNFTSEITIN_H_
+#define TOCNFTSEITIN_H_
+
+#include "stp/AIG/CNF.h"
+#include "stp/STPManager/UserDefinedFlags.h"
+#include "stp/ToSat/BBNodeManagerLit.h"
+#include "stp/ToSat/ToSATBase.h"
+
+namespace stp
+{
+
+// The in-house AIG's route to CNF, and the whole of it: assert the formula as
+// the manager's one output, run the Tseitin writer over it, and project the
+// inputs back to the symbols they came from.
+//
+// ToCNFAIG has to do more than this because ABC's route does more: a
+// dag-aware rewriting loop, a manager-to-manager copy, and a per-object
+// variable map that has to be re-indexed after each of them. None of that
+// applies here -- no pass rewrites this AIG, so nothing renumbers, so the
+// node a symbol was blasted to is the node it still is.
+class ToCNFTseitin
+{
+  UserDefinedFlags& uf;
+
+public:
+  explicit ToCNFTseitin(UserDefinedFlags& _uf) : uf(_uf) {}
+
+  // Same shape as ToCNFAIG::toCNF so that one templated body drives either.
+  //
+  // needAbsRef is taken and ignored. It exists on the ABC side to suppress
+  // Aig_ManCleanup, because a cleanup renumbers and refinement has to be able
+  // to name an input afterwards. This writer encodes the cone of the output
+  // unconditionally and numbers every input whether it is reachable or not,
+  // so there is nothing for the flag to protect.
+  void toCNF(const BBNodeLit& top, CNF& cnf,
+             ToSATBase::ASTNodeToSATVar& nodeToVars, bool needAbsRef,
+             BBNodeManagerLit& mgr);
+};
+
+} // namespace stp
+
+#endif

--- a/include/stp/ToSat/ToSATAIG.h
+++ b/include/stp/ToSat/ToSATAIG.h
@@ -31,6 +31,7 @@ THE SOFTWARE.
 #include "stp/STPManager/STPManager.h"
 #include "stp/ToSat/BBNodeManagerAIG.h"
 #include "stp/ToSat/ToCNFAIG.h"
+#include "stp/ToSat/ToCNFTseitin.h"
 #include "stp/ToSat/BitBlaster.h"
 #include "stp/ToSat/BVAbstractionRefiner.h"
 #include "stp/Util/RunTimes.h"
@@ -78,7 +79,6 @@ private:
 
   bool first;
 
-  ToCNFAIG toCNF;
 
   // The abstractions this lowering minted, and the CEGAR loop that
   // refines them. Both live here for the batch pipeline's lifetime of one
@@ -99,6 +99,15 @@ public:
   // the absence as unsatisfiable.
   bool bitblast(const ASTNode& input, bool needAbsRef, CNF& cnf);
 
+private:
+  // The body of bitblast(), over whichever node representation, manager and
+  // lowering the flags selected. Defined in the .cpp; both instantiations are
+  // used there and nowhere else.
+  template <class BBNodeT, class ManagerT, class BlasterT, class LoweringT>
+  bool bitblastWith(const ASTNode& input, bool needAbsRef, CNF& cnf);
+
+public:
+
   bool cbIsDestructed() { return cb == NULL; }
 
   // `allowAbstraction` is false for a lowering whose query must be encoded
@@ -115,7 +124,7 @@ public:
   // the manager, and undone only on the paths that reach the bottom of the
   // function.
   ToSATAIG(STPMgr* bm, ArrayTransformer* at, bool allowAbstraction = true)
-      : ToSATBase(bm), toCNF(bm->UserFlags), abstraction_(bm),
+      : ToSATBase(bm), abstraction_(bm),
         allowAbstraction_(allowAbstraction)
   {
     cb = NULL;
@@ -125,7 +134,7 @@ public:
 
   ToSATAIG(STPMgr* bm, simplifier::constantBitP::ConstantBitPropagation* cb_,
            ArrayTransformer* at, bool allowAbstraction = true)
-      : ToSATBase(bm), cb(cb_), toCNF(bm->UserFlags), abstraction_(bm),
+      : ToSATBase(bm), cb(cb_), abstraction_(bm),
         allowAbstraction_(allowAbstraction)
   {
     init();

--- a/lib/ToSat/BVLemmaCircuits.cpp
+++ b/lib/ToSat/BVLemmaCircuits.cpp
@@ -670,4 +670,22 @@ template BBNodeAIG BitBlaster<BBNodeAIG, BBNodeManagerAIG>::BBDivRemIdentity(
     const ASTNode&, const BBNodeVecAIG&, const BBNodeVecAIG&,
     const BBNodeVecAIG&, const BBNodeVecAIG&, BBNodeSetAIG&);
 
+template BBNodeLit BitBlaster<BBNodeLit, BBNodeManagerLit>::BBFitsExactlyOnce(
+    const BBNodeVecLit&, const BBNodeVecLit&);
+template BBNodeLit BitBlaster<BBNodeLit, BBNodeManagerLit>::BBDivLemma(
+    DivLemma, const BBNodeVecLit&, const BBNodeVecLit&, const BBNodeVecLit&,
+    BBNodeSetLit&);
+template BBNodeLit BitBlaster<BBNodeLit, BBNodeManagerLit>::BBRemLemma(
+    RemLemma, const BBNodeVecLit&, const BBNodeVecLit&, const BBNodeVecLit&,
+    BBNodeSetLit&);
+template BBNodeLit BitBlaster<BBNodeLit, BBNodeManagerLit>::BBMulLemma(
+    MulLemma, const BBNodeVecLit&, const BBNodeVecLit&, const BBNodeVecLit&,
+    BBNodeSetLit&);
+template BBNodeLit BitBlaster<BBNodeLit, BBNodeManagerLit>::BBAddLemma(
+    AddLemma, const BBNodeVecLit&, const BBNodeVecLit&, const BBNodeVecLit&,
+    BBNodeSetLit&);
+template BBNodeLit BitBlaster<BBNodeLit, BBNodeManagerLit>::BBDivRemIdentity(
+    const ASTNode&, const BBNodeVecLit&, const BBNodeVecLit&,
+    const BBNodeVecLit&, const BBNodeVecLit&, BBNodeSetLit&);
+
 } // namespace stp

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -118,7 +118,7 @@ void BitBlaster<BBNode, BBNodeManagerT>::tagAbstractionSources(
     const BBNode& ci, const std::vector<BVAbstractionId>& sources)
 {
   assert(!ci.IsNull());
-  assert(BBNodeManagerT::isCI(ci));
+  assert(nf->isCI(ci));
 
   std::vector<BVAbstractionId> normalized = sources;
   std::sort(normalized.begin(), normalized.end());
@@ -127,7 +127,7 @@ void BitBlaster<BBNode, BBNodeManagerT>::tagAbstractionSources(
   for ([[maybe_unused]] const BVAbstractionId id : normalized)
     assert(id.valid());
 
-  const unsigned aigId = BBNodeManagerT::nodeId(ci);
+  const unsigned aigId = nf->nodeId(ci);
   assert((sourcesAt(ciAbstractionSources_, aigId).empty() ||
           sourcesAt(ciAbstractionSources_, aigId) == normalized) &&
          "an AIG input acquired two abstraction provenances");
@@ -141,12 +141,12 @@ BitBlaster<BBNode, BBNodeManagerT>::abstractionSourcesOf(const BBNode& root)
   if (root.IsNull())
     return {};
 
-  if (BBNodeManagerT::isConstant(root))
+  if (nf->isConstant(root))
     return {};
-  if (BBNodeManagerT::isCI(root))
-    return sourcesAt(ciAbstractionSources_, BBNodeManagerT::nodeId(root));
+  if (nf->isCI(root))
+    return sourcesAt(ciAbstractionSources_, nf->nodeId(root));
 
-  const unsigned rootId = BBNodeManagerT::nodeId(root);
+  const unsigned rootId = nf->nodeId(root);
   if (aigSourcesComputed(rootId))
     return sourcesAt(aigAbstractionSourcesMemo_, rootId);
 
@@ -160,23 +160,23 @@ BitBlaster<BBNode, BBNodeManagerT>::abstractionSourcesOf(const BBNode& root)
     const BBNode node = pending.back().first;
     const bool expanded = pending.back().second;
     pending.pop_back();
-    const unsigned id = BBNodeManagerT::nodeId(node);
-    if (BBNodeManagerT::isConstant(node) || BBNodeManagerT::isCI(node) ||
+    const unsigned id = nf->nodeId(node);
+    if (nf->isConstant(node) || nf->isCI(node) ||
         aigSourcesComputed(id))
       continue;
-    assert(BBNodeManagerT::isAnd(node));
+    assert(nf->isAnd(node));
     if (!expanded)
     {
       pending.push_back(PendingAig(node, true));
-      pending.push_back(PendingAig(BBNodeManagerT::fanin0(node), false));
-      pending.push_back(PendingAig(BBNodeManagerT::fanin1(node), false));
+      pending.push_back(PendingAig(nf->fanin0(node), false));
+      pending.push_back(PendingAig(nf->fanin1(node), false));
       continue;
     }
 
     std::vector<BVAbstractionId> sources =
-        abstractionSourcesOf(BBNodeManagerT::fanin0(node));
+        abstractionSourcesOf(nf->fanin0(node));
     appendAbstractionSources(
-        sources, abstractionSourcesOf(BBNodeManagerT::fanin1(node)));
+        sources, abstractionSourcesOf(nf->fanin1(node)));
     setSourcesAt(aigAbstractionSourcesMemo_, id, std::move(sources));
     markAigSourcesComputed(id);
   }
@@ -7019,8 +7019,8 @@ std::ostream& operator<<(std::ostream& output, const BBNodeAIG& /*h*/)
   return output;
 }
 
-// Every specialisation that exists. A second backend adds a line here, which
-// is the point of the whole file being a template again.
+// Every specialisation that exists.
 template class BitBlaster<BBNodeAIG, BBNodeManagerAIG>;
+template class BitBlaster<BBNodeLit, BBNodeManagerLit>;
 
 } // stp namespace

--- a/lib/ToSat/CMakeLists.txt
+++ b/lib/ToSat/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(tosat OBJECT
     BitBlaster.cpp
     ToSATBase.cpp
     ToCNFAIG.cpp
+    ToCNFTseitin.cpp
     ToSATAIG.cpp
     BVAbstractionRefiner.cpp
     BVExactEncoder.cpp

--- a/lib/ToSat/ToCNFTseitin.cpp
+++ b/lib/ToSat/ToCNFTseitin.cpp
@@ -1,0 +1,74 @@
+/********************************************************************
+ * AUTHORS: Trevor Hansen
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#include "stp/ToSat/ToCNFTseitin.h"
+
+#include "stp/AIG/Tseitin.h"
+
+namespace stp
+{
+
+void ToCNFTseitin::toCNF(const BBNodeLit& top, CNF& cnf,
+                         ToSATBase::ASTNodeToSATVar& nodeToVars,
+                         bool /*needAbsRef*/, BBNodeManagerLit& mgr)
+{
+  assert(nodeToVars.size() == 0);
+  assert(mgr.mgr.outputCount() == 0);
+  mgr.mgr.createOutput(top.n);
+
+  // The structural-hash table has done its work and is about half the
+  // manager's memory. Hand it back before the clause arena is allocated,
+  // which is the point in the pipeline where the process is largest.
+  mgr.mgr.freeStrash();
+
+  cnf = aig::deriveTseitin(mgr.mgr, 0);
+
+  // Each symbol maps to the variables its bits carry. ~0u for a bit that
+  // reached no variable, which is the same sentinel fill_node_to_var writes
+  // and what the freezing pass and the model builder expect.
+  for (const auto& entry : mgr.symbolToBBNode)
+  {
+    const ASTNode& n = entry.first;
+    const std::vector<BBNodeLit>& bits = entry.second;
+    assert(nodeToVars.find(n) == nodeToVars.end());
+
+    const int width = (n.GetType() == BOOLEAN_TYPE) ? 1 : n.GetValueWidth();
+    std::vector<unsigned> v(width, ~((unsigned)0));
+
+    for (unsigned i = 0; i < bits.size(); i++)
+    {
+      if (bits[i].IsNull())
+        continue;
+      const uint32_t var = cnf.varOfCi(mgr.ciOrdinal(bits[i]));
+      if (var != 0)
+        v[i] = var;
+    }
+    nodeToVars.insert(std::make_pair(n, v));
+  }
+
+  if (uf.stats_flag)
+    std::cerr << "new_very_low CNF" << std::endl;
+}
+
+} // namespace stp

--- a/lib/ToSat/ToSATAIG.cpp
+++ b/lib/ToSat/ToSATAIG.cpp
@@ -174,6 +174,12 @@ void ToSATAIG::handle_cnf_options(const CNF& cnf, bool needAbsRef)
            << " that is the whole query." << endl;
   };
 
+  // One line, whichever generator ran, so that a sweep over the levels can be
+  // read without knowing which of them prints what.
+  if (bm->UserFlags.stats_flag)
+    cerr << "cnf: " << cnf.clauseCount() << " clauses, " << cnf.varCount() - 1
+         << " variables, " << cnf.literalCount() << " literals" << endl;
+
   if (bm->UserFlags.output_CNF_flag)
   {
     std::stringstream fileName;
@@ -211,17 +217,29 @@ void ToSATAIG::handle_cnf_options(const CNF& cnf, bool needAbsRef)
   }
 }
 
+// One branch, at the top, and it is the only place in the pipeline that
+// knows there is more than one backend. Everything below is written once.
 bool ToSATAIG::bitblast(const ASTNode& input, bool needAbsRef, CNF& cnf)
+{
+  if (bm->UserFlags.cnf_effort == UserDefinedFlags::CNF_EFFORT_NEW_VERY_LOW)
+    return bitblastWith<BBNodeLit, BBNodeManagerLit, BitBlasterLit,
+                        ToCNFTseitin>(input, needAbsRef, cnf);
+  return bitblastWith<BBNodeAIG, BBNodeManagerAIG, BitBlasterAIG, ToCNFAIG>(
+      input, needAbsRef, cnf);
+}
+
+template <class BBNodeT, class ManagerT, class BlasterT, class LoweringT>
+bool ToSATAIG::bitblastWith(const ASTNode& input, bool needAbsRef, CNF& cnf)
 {
   stp::SubstitutionMap sm(bm);
   Simplifier simp(bm, &sm);
 
-  BBNodeManagerAIG mgr;
+  ManagerT mgr;
   mgr.nodeBudget = bm->UserFlags.aig_node_budget;
-  BitBlasterAIG bb(&mgr, &simp, bm->defaultNodeFactory, &bm->UserFlags, cb,
+  BlasterT bb(&mgr, &simp, bm->defaultNodeFactory, &bm->UserFlags, cb,
                 allowAbstraction_);
 
-  BBNodeAIG BBFormula;
+  BBNodeT BBFormula;
 
   bm->UserFlags.coverage.queries_bitblasted++;
   bm->GetRunTimes()->start(RunTimes::BitBlasting);
@@ -253,10 +271,10 @@ bool ToSATAIG::bitblast(const ASTNode& input, bool needAbsRef, CNF& cnf)
     // The incremental route never had this: syncAbstractions() asserts
     // each constraint as its own permanent unit clause and builds no
     // chain at all.
-    const std::vector<BBNodeAIG>& side = bb.sideConstraints();
+    const std::vector<BBNodeT>& side = bb.sideConstraints();
     if (!side.empty())
     {
-      std::vector<BBNodeAIG> conjuncts;
+      std::vector<BBNodeT> conjuncts;
       conjuncts.reserve(side.size() + 1);
       conjuncts.push_back(BBFormula);
       conjuncts.insert(conjuncts.end(), side.begin(), side.end());
@@ -296,7 +314,8 @@ bool ToSATAIG::bitblast(const ASTNode& input, bool needAbsRef, CNF& cnf)
   bb.cb = NULL;
 
   bm->GetRunTimes()->start(RunTimes::CNFConversion);
-  toCNF.toCNF(BBFormula, cnf, nodeToSATVar, needAbsRef, mgr);
+  LoweringT lowering(bm->UserFlags);
+  lowering.toCNF(BBFormula, cnf, nodeToSATVar, needAbsRef, mgr);
   bm->GetRunTimes()->stop(RunTimes::CNFConversion);
 
   // The abstraction records below name their combinational inputs by ordinal,
@@ -318,7 +337,7 @@ bool ToSATAIG::bitblast(const ASTNode& input, bool needAbsRef, CNF& cnf)
     a.id = raw.id;
     a.dependencies = raw.dependencies;
     a.eqNode = raw.eqNode;
-    a.abstractionSATVar = satVarOfCi(raw.abstractionCI.symbol_index);
+    a.abstractionSATVar = satVarOfCi(mgr.ciOrdinal(raw.abstractionCI));
     a.leftSymbol = raw.leftSymbol;
     a.rightSymbol = raw.rightSymbol;
     a.width = std::max(1u, raw.leftSymbol.GetValueWidth());
@@ -366,7 +385,7 @@ bool ToSATAIG::bitblast(const ASTNode& input, bool needAbsRef, CNF& cnf)
   }
 
   // Free the memory in the AIGs.
-  BBFormula = BBNodeAIG(); // null node
+  BBFormula = BBNodeT(); // null node
   mgr.stop();
 
   return true;

--- a/tests/query-files/misc-tests/cnf-generation-effort-auto.smt2
+++ b/tests/query-files/misc-tests/cnf-generation-effort-auto.smt2
@@ -13,6 +13,7 @@
 ; RUN: %solver --SMTLIB2 -s --cnf-generation-effort auto --cnf-auto-threshold 1 %s 2>&1 | %OutputCheck --check-prefix=BIG %s
 ;
 ; SMALL: ^cnf-auto: [0-9]+ AIG nodes, chose medium$
+; SMALL: ^cnf: [0-9]+ clauses, [0-9]+ variables, [0-9]+ literals$
 ; SMALL: sat
 ; BIG: ^cnf-auto: [0-9]+ AIG nodes, chose very-low$
 ; BIG: sat
@@ -30,7 +31,19 @@
 ;
 ; RUN: not %solver --SMTLIB2 --cnf-generation-effort nonsense %s 2>&1 | %OutputCheck --check-prefix=BADLEVEL %s
 ;
-; BADLEVEL: Unknown --cnf-generation-effort value 'nonsense'\. Expected one of: auto, very-low, low, medium, high, very-high\.
+; BADLEVEL: Unknown --cnf-generation-effort value 'nonsense'\. Expected one of: auto, very-low, low, medium, high, very-high, new_very_low\.
+;
+; The new_very_low rung is a different generator over a different AIG, so it
+; says so rather than printing one of the ABC lines, and auto never reaches it:
+; auto decides from ABC's node count, which means blasting through ABC first.
+;
+; RUN: %solver --SMTLIB2 -s --cnf-generation-effort new_very_low %s 2>&1 | %OutputCheck --check-prefix=NEWVERYLOW %s
+;
+; NEWVERYLOW-NOT: cnf-auto:
+; NEWVERYLOW-NOT: advanced CNF
+; NEWVERYLOW: ^new_very_low CNF$
+; NEWVERYLOW: ^cnf: [0-9]+ clauses, [0-9]+ variables, [0-9]+ literals$
+; NEWVERYLOW: sat
 
 (set-logic QF_BV)
 (declare-fun a () (_ BitVec 8))

--- a/tests/unit-tests/BitBlasterLit_Test.cpp
+++ b/tests/unit-tests/BitBlasterLit_Test.cpp
@@ -1,0 +1,313 @@
+/********************************************************************
+ * AUTHORS: Trevor Hansen
+ *
+ * BEGIN DATE: Aug, 2026
+ *
+ * LICENSE: Please view LICENSE file in the home dir of this Program
+ ********************************************************************/
+
+// The blaster's two backends, driven over the same formulas.
+//
+// The comparison is by *function*, never by node count or node id. The two
+// packages build different graphs on purpose -- ours orders operands before
+// applying the folding rules, so it lands on a slightly smaller AIG -- and a
+// test that pinned the counts would be pinning that difference rather than
+// the blasting. What has to agree is what the circuit computes.
+//
+// Six input bits, so a truth table is one 64-bit word and "same function" is
+// one comparison.
+
+#include "stp/AST/AST.h"
+#include "stp/STPManager/STPManager.h"
+#include "stp/Simplifier/Simplifier.h"
+#include "stp/ToSat/BBNodeManagerAIG.h"
+#include "stp/ToSat/BBNodeManagerLit.h"
+#include "stp/ToSat/BitBlaster.h"
+
+#include "aig/aig/aig.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <map>
+#include <string>
+#include <vector>
+
+using namespace stp;
+
+namespace
+{
+
+const uint64_t INPUT_TT[6] = {
+    0xAAAAAAAAAAAAAAAAull, 0xCCCCCCCCCCCCCCCCull, 0xF0F0F0F0F0F0F0F0ull,
+    0xFF00FF00FF00FF00ull, 0xFFFF0000FFFF0000ull, 0xFFFFFFFF00000000ull};
+
+// Simulate the in-house AIG. Ids ascend and fanins are always below their
+// node, so one forward sweep does it.
+uint64_t litTruthTable(const aig::Manager& m, aig::Lit top,
+                       const std::map<unsigned, uint64_t>& inputs)
+{
+  std::vector<uint64_t> tt(m.nodeCount(), 0);
+  for (aig::Node n = 1; n < m.nodeCount(); ++n)
+  {
+    if (m.isCi(n))
+    {
+      const auto it = inputs.find(n);
+      tt[n] = it == inputs.end() ? 0 : it->second;
+    }
+    else
+    {
+      const aig::Lit a = m.fanin0(n), b = m.fanin1(n);
+      const uint64_t va =
+          aig::isNeg(a) ? ~tt[aig::nodeOf(a)] : tt[aig::nodeOf(a)];
+      const uint64_t vb =
+          aig::isNeg(b) ? ~tt[aig::nodeOf(b)] : tt[aig::nodeOf(b)];
+      tt[n] = va & vb;
+    }
+  }
+  if (aig::isConst(top))
+    return top == aig::LIT_TRUE ? ~0ull : 0ull;
+  const uint64_t v = tt[aig::nodeOf(top)];
+  return aig::isNeg(top) ? ~v : v;
+}
+
+// The same for ABC's. Aig_ManForEachObj walks in id order, and ABC keeps
+// fanins below their node too.
+uint64_t abcTruthTable(Aig_Man_t* p, Aig_Obj_t* top,
+                       const std::map<int, uint64_t>& inputs)
+{
+  std::map<int, uint64_t> tt;
+  Aig_Obj_t* obj;
+  int i;
+  tt[Aig_ObjId(Aig_ManConst1(p))] = ~0ull;
+  Aig_ManForEachObj(p, obj, i)
+  {
+    if (Aig_ObjIsCi(obj))
+    {
+      const auto it = inputs.find(Aig_ObjId(obj));
+      tt[Aig_ObjId(obj)] = it == inputs.end() ? 0 : it->second;
+    }
+    else if (Aig_ObjIsAnd(obj))
+    {
+      const uint64_t a = tt[Aig_ObjId(Aig_ObjFanin0(obj))];
+      const uint64_t b = tt[Aig_ObjId(Aig_ObjFanin1(obj))];
+      tt[Aig_ObjId(obj)] = (Aig_ObjFaninC0(obj) ? ~a : a) &
+                           (Aig_ObjFaninC1(obj) ? ~b : b);
+    }
+  }
+  const uint64_t v = tt[Aig_ObjId(Aig_Regular(top))];
+  return Aig_IsComplement(top) ? ~v : v;
+}
+
+// Blast `form` through both backends and require that they compute the same
+// function of the same inputs.
+//
+// The input correspondence is not assumed: it is read out of each manager's
+// own symbol map, so a backend that numbered its inputs differently would be
+// compared correctly and would fail only if its circuit really differed.
+void expectSameFunction(STPMgr& mgr, const ASTNode& form,
+                        const std::string& what)
+{
+  SubstitutionMap subsAig(&mgr), subsLit(&mgr);
+  Simplifier simpAig(&mgr, &subsAig), simpLit(&mgr, &subsLit);
+
+  BBNodeManagerAIG aigMgr;
+  BitBlasterAIG bbAig(&aigMgr, &simpAig, mgr.defaultNodeFactory,
+                      &mgr.UserFlags);
+  BBNodeManagerLit litMgr;
+  BitBlasterLit bbLit(&litMgr, &simpLit, mgr.defaultNodeFactory,
+                      &mgr.UserFlags);
+
+  const BBNodeAIG topAig = bbAig.BBForm(form);
+  const BBNodeLit topLit = bbLit.BBForm(form);
+
+  // The two symbol maps have to name the same bits, in the same order, or
+  // the CNF's varOfCi(ordinal) would mean different things on the two
+  // backends. Assign each bit its truth-table column by walking them
+  // together.
+  std::map<int, uint64_t> abcInputs;
+  std::map<unsigned, uint64_t> litInputs;
+  unsigned column = 0;
+
+  auto itA = aigMgr.symbolToBBNode.begin();
+  auto itL = litMgr.symbolToBBNode.begin();
+  for (; itA != aigMgr.symbolToBBNode.end(); ++itA, ++itL)
+  {
+    ASSERT_NE(itL, litMgr.symbolToBBNode.end()) << what;
+    ASSERT_EQ(itA->first, itL->first) << what;
+    ASSERT_EQ(itA->second.size(), itL->second.size()) << what;
+
+    for (size_t i = 0; i < itA->second.size(); i++)
+    {
+      const bool nullA = itA->second[i].IsNull();
+      ASSERT_EQ(nullA, itL->second[i].IsNull()) << what << " bit " << i;
+      if (nullA)
+        continue;
+
+      // Same input ordinal on both sides. This is what the CNF seam relies
+      // on, and it holds because the blaster mints the inputs in one order.
+      ASSERT_EQ(aigMgr.ciOrdinal(itA->second[i]),
+                litMgr.ciOrdinal(itL->second[i]))
+          << what << " bit " << i;
+
+      ASSERT_LT(column, 6u) << what << ": too many input bits for one word";
+      abcInputs[Aig_ObjId(Aig_Regular(itA->second[i].n))] = INPUT_TT[column];
+      litInputs[aig::nodeOf(itL->second[i].n)] = INPUT_TT[column];
+      column++;
+    }
+  }
+  ASSERT_EQ(itL, litMgr.symbolToBBNode.end()) << what;
+
+  const uint64_t a = abcTruthTable(aigMgr.aigMgr, topAig.n, abcInputs);
+  const uint64_t l = litTruthTable(litMgr.mgr, topLit.n, litInputs);
+  EXPECT_EQ(a, l) << what << ": the two backends disagree";
+}
+
+} // namespace
+
+// One formula per bit-vector operator the blaster has a circuit for, over
+// two three-bit symbols. Three bits is enough to reach every branch of the
+// adders, the shifters and the multiplier that width-independent code has,
+// and small enough that the whole function fits in one word.
+TEST(BitBlasterLit, AgreesWithTheAIGBackend)
+{
+  STPMgr mgr;
+
+  const ASTNode x = mgr.CreateSymbol("x", 0, 3);
+  const ASTNode y = mgr.CreateSymbol("y", 0, 3);
+  const ASTNode three = mgr.CreateBVConst(3, 3);
+  const ASTNode one = mgr.CreateBVConst(3, 1);
+
+  const struct
+  {
+    const char* name;
+    ASTNode form;
+  } cases[] = {
+      {"eq", mgr.CreateNode(EQ, x, y)},
+      {"plus", mgr.CreateNode(EQ, mgr.CreateTerm(BVPLUS, 3, x, y), three)},
+      {"sub", mgr.CreateNode(EQ, mgr.CreateTerm(BVSUB, 3, x, y), one)},
+      {"mult", mgr.CreateNode(EQ, mgr.CreateTerm(BVMULT, 3, x, y), three)},
+      {"div", mgr.CreateNode(EQ, mgr.CreateTerm(BVDIV, 3, x, y), one)},
+      {"mod", mgr.CreateNode(EQ, mgr.CreateTerm(BVMOD, 3, x, y), one)},
+      {"and", mgr.CreateNode(EQ, mgr.CreateTerm(BVAND, 3, x, y), one)},
+      {"or", mgr.CreateNode(EQ, mgr.CreateTerm(BVOR, 3, x, y), one)},
+      {"xor", mgr.CreateNode(EQ, mgr.CreateTerm(BVXOR, 3, x, y), one)},
+      {"uminus", mgr.CreateNode(EQ, mgr.CreateTerm(BVUMINUS, 3, x), y)},
+      {"not", mgr.CreateNode(EQ, mgr.CreateTerm(BVNOT, 3, x), y)},
+      {"lt", mgr.CreateNode(BVLT, x, y)},
+      {"le", mgr.CreateNode(BVLE, x, y)},
+      {"slt", mgr.CreateNode(BVSLT, x, y)},
+      {"sle", mgr.CreateNode(BVSLE, x, y)},
+      {"shl", mgr.CreateNode(EQ, mgr.CreateTerm(BVLEFTSHIFT, 3, x, y), one)},
+      {"shr", mgr.CreateNode(EQ, mgr.CreateTerm(BVRIGHTSHIFT, 3, x, y), one)},
+      {"ashr", mgr.CreateNode(EQ, mgr.CreateTerm(BVSRSHIFT, 3, x, y), one)},
+      {"extract",
+       mgr.CreateNode(EQ, mgr.CreateTerm(BVEXTRACT, 1, x, mgr.CreateBVConst(32, 2),
+                                         mgr.CreateBVConst(32, 2)),
+                      mgr.CreateBVConst(1, 1))},
+      {"concat", mgr.CreateNode(EQ, mgr.CreateTerm(BVCONCAT, 6, x, y),
+                                mgr.CreateBVConst(6, 9))},
+      {"sx", mgr.CreateNode(EQ, mgr.CreateTerm(BVSX, 6, x, mgr.CreateBVConst(32, 6)),
+                            mgr.CreateBVConst(6, 63))},
+      {"ite", mgr.CreateNode(EQ, mgr.CreateTerm(ITE, 3, mgr.CreateNode(BVLT, x, y),
+                                                x, y),
+                             one)},
+      {"logical-not", mgr.CreateNode(NOT, mgr.CreateNode(EQ, x, y))},
+      {"nested", mgr.CreateNode(
+                     AND, mgr.CreateNode(BVLT, x, y),
+                     mgr.CreateNode(EQ, mgr.CreateTerm(BVPLUS, 3, x, y), three))},
+  };
+
+  for (const auto& c : cases)
+    ASSERT_NO_FATAL_FAILURE(expectSameFunction(mgr, c.form, c.name)) << c.name;
+}
+
+// The budget is the manager's, not ABC's: the literal backend has to raise
+// the same exception at the same place, because every caller that sets a
+// budget catches that one type.
+TEST(BitBlasterLit, HonoursTheNodeBudget)
+{
+  STPMgr mgr;
+
+  const ASTNode x = mgr.CreateSymbol("x", 0, 16);
+  const ASTNode y = mgr.CreateSymbol("y", 0, 16);
+  const ASTNode form =
+      mgr.CreateNode(EQ, mgr.CreateTerm(BVMULT, 16, x, y),
+                     mgr.CreateBVConst(16, 7));
+
+  SubstitutionMap subs(&mgr);
+  Simplifier simp(&mgr, &subs);
+  BBNodeManagerLit litMgr;
+  litMgr.nodeBudget = 10;
+  BitBlasterLit bb(&litMgr, &simp, mgr.defaultNodeFactory, &mgr.UserFlags);
+
+  bool thrown = false;
+  try
+  {
+    bb.BBForm(form);
+  }
+  catch (const AIGBudgetExhausted& e)
+  {
+    thrown = true;
+    EXPECT_GT(e.nodeCount, 10);
+  }
+  EXPECT_TRUE(thrown) << "a 16x16 multiplier is more than ten gates";
+}
+
+// Every gate kind the manager offers, at every arity it accepts.
+//
+// The formula-driven test above cannot reach all of them from bit-vector
+// operators alone, and the ones it misses are where a transcription slip
+// lives longest: breaking IMPLIES deliberately left that test green.
+//
+// NAND and IMPLIES look unreachable if you grep for CreateNode(NAND -- there
+// is no such call. They arrive as a *variable* kind instead, from BBForm's
+// pass-through of a formula node's own kind, so any AST carrying one reaches
+// the manager. Both are therefore live, whatever a grep says.
+TEST(BitBlasterLit, EveryGateKindMatches)
+{
+  const struct
+  {
+    Kind kind;
+    unsigned lo, hi;
+  } kinds[] = {{AND, 1, 5},  {OR, 1, 5},      {NAND, 1, 5}, {NOR, 1, 5},
+               {XOR, 1, 5},  {NOT, 1, 1},     {IFF, 2, 2},  {IMPLIES, 2, 2},
+               {ITE, 3, 3}};
+
+  for (const auto& k : kinds)
+  {
+    for (unsigned arity = k.lo; arity <= k.hi; arity++)
+    {
+      BBNodeManagerAIG aigMgr;
+      BBNodeManagerLit litMgr;
+
+      std::vector<BBNodeAIG> aigKids;
+      std::vector<BBNodeLit> litKids;
+      std::map<int, uint64_t> abcInputs;
+      std::map<unsigned, uint64_t> litInputs;
+      for (unsigned i = 0; i < arity; i++)
+      {
+        aigKids.push_back(aigMgr.CreateFreshInput());
+        litKids.push_back(litMgr.CreateFreshInput());
+        abcInputs[Aig_ObjId(Aig_Regular(aigKids.back().n))] = INPUT_TT[i];
+        litInputs[aig::nodeOf(litKids.back().n)] = INPUT_TT[i];
+      }
+
+      const BBNodeAIG a = aigMgr.CreateNode(k.kind, aigKids);
+      const BBNodeLit l = litMgr.CreateNode(k.kind, litKids);
+
+      EXPECT_EQ(abcTruthTable(aigMgr.aigMgr, a.n, abcInputs),
+                litTruthTable(litMgr.mgr, l.n, litInputs))
+          << _kind_names[k.kind] << " at arity " << arity;
+    }
+  }
+}
+
+// Four bytes, which is the reason this backend exists at all.
+TEST(BitBlasterLit, TheHandleIsOneLiteral)
+{
+  EXPECT_EQ(sizeof(BBNodeLit), 4u);
+  EXPECT_TRUE(BBNodeLit().IsNull());
+  EXPECT_FALSE(BBNodeLit(aig::LIT_TRUE).IsNull());
+  EXPECT_NE(BBNodeLit(aig::LIT_TRUE), BBNodeLit(aig::LIT_FALSE));
+}

--- a/tests/unit-tests/CMakeLists.txt
+++ b/tests/unit-tests/CMakeLists.txt
@@ -61,6 +61,10 @@ target_link_libraries(AIG_TestTests ABC)
 # The Tseitin writer over that AIG. Needs no ABC: it checks the CNF against
 # the circuit it came from, by simulation and unit propagation.
 AddSTPGTest(Tseitin_Test.cpp)
+# The blaster over its second backend, compared against its first by
+# simulating both circuits, so this one links ABC.
+AddSTPGTest(BitBlasterLit_Test.cpp)
+target_link_libraries(BitBlasterLit_TestTests ABC)
 AddSTPGTest(BBNodeManagerAIG_Test.cpp)
 target_link_libraries(BBNodeManagerAIG_TestTests ABC)
 AddSTPGTest(AIGBudget_Test.cpp)

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -732,10 +732,12 @@ void ExtraMain::create_options()
       ->group(misc_group);
   app.add_option("--cnf-generation-effort", cnf_effort,
                  "effort spent minimising the CNF: auto, very-low, low, "
-                 "medium, high, very-high. Higher is slower to generate but "
-                 "yields a smaller CNF; auto picks between very-low and medium "
-                 "from the size of the AIG, since minimising a large one costs "
-                 "more than the solver saves")
+                 "medium, high, very-high, new_very_low. Higher is slower to "
+                 "generate but yields a smaller CNF; auto picks between "
+                 "very-low and medium from the size of the AIG, since "
+                 "minimising a large one costs more than the solver saves. "
+                 "new_very_low blasts through STP's own AIG instead of ABC's "
+                 "and writes the CNF directly")
       ->capture_default_str()
       ->group(misc_group);
 
@@ -1049,11 +1051,13 @@ int ExtraMain::parse_options(int argc, char** argv)
     bm->UserFlags.cnf_effort = UserDefinedFlags::CNF_EFFORT_VERY_HIGH;
   else if (cnf_effort == "auto")
     bm->UserFlags.cnf_effort = UserDefinedFlags::CNF_EFFORT_AUTO;
+  else if (cnf_effort == "new_very_low")
+    bm->UserFlags.cnf_effort = UserDefinedFlags::CNF_EFFORT_NEW_VERY_LOW;
   else
   {
     std::cerr << "Unknown --cnf-generation-effort value '" << cnf_effort
               << "'. Expected one of: auto, very-low, low, medium, high, "
-                 "very-high."
+                 "very-high, new_very_low."
               << std::endl;
     return -1;
   }


### PR DESCRIPTION
#1046 has landed, so this now targets master directly. Three commits, and they are separable: the backend, the wiring, then a comment reword.

This is the milestone the previous four PRs were clearing the way for. A query can now be lowered through STP's own AIG and its own Tseitin writer, end to end, without ABC seeing it: `--cnf-generation-effort new_very_low`.

### The backend

`BBNodeLit` is four bytes against `BBNodeAIG`'s sixteen. The difference is `symbol_index`, and what that field pays for is renumbering: dag-aware rewriting replaces ABC's manager wholesale, so a symbol has to be found again by its position among the inputs. Nothing renumbers here — the id is the array index and the array only ever grows — so the literal is the identity, and the ordinal is recovered by a binary search over the input list on the rare paths that want one.

Two things the blaster had to stop assuming:

* The node queries — `isCI`, `isConstant`, `isAnd`, `nodeId`, `fanin0`, `fanin1` — are asked through `nf` rather than of `BBNodeManagerT`. ABC can answer them statically because its object carries its own kind and its own fanins. A node that is an index into the manager's array cannot.
* The budget exception moves to its own header. Both managers throw it and every caller catches the one type, but only one of the two knows what ABC is.

### The wiring

One branch, at the top of `bitblast()`, and it is the only place in the pipeline that knows there is more than one backend. The body below it is written once, over (node, manager, blaster, lowering).

`ToCNFTseitin` is the whole of the new route: assert the formula as the manager's one output, hand the strash table back, run the writer, project the inputs to the symbols they came from. `ToCNFAIG` has to do more because ABC's route does more — a dag-aware rewriting loop, a manager-to-manager copy, and a per-object variable map re-indexed after each. None of that applies when nothing renumbers.

The rung is last in the enum and lowest on the scale, which are different facts. The ordinals are the C interface's contract, so a new level goes on the end however little effort it spends; and AUTO never picks it, because AUTO decides from the AIG's node count, which means blasting through ABC first.

### Verification

All 864 lit cases and 177 ctest cases pass. Over `tests/query-files`, every input both routes answer gets the same answer: **455 agree, 0 differ**. The CNF byte-identity gate still holds on the ABC path across five configurations, which is what says the branch added here changed nothing on the way in. 400 fuzz-corpus files through both backends under AddressSanitizer and UndefinedBehaviorSanitizer: **zero reports**.

The cross-backend test compares by function, never by node count — our `And` orders operands before the folding rules, so it lands on a slightly smaller AIG, and a test that pinned counts would pin that difference rather than the blasting.

A note for whoever writes the third backend: the first version of that test passed with `IMPLIES` deliberately broken, because the blaster asks for whole bit-vector operators and no operator's circuit uses `IMPLIES`. There is now a second test that asks for every gate kind at every arity directly. `NAND` and `IMPLIES` look unreachable if you grep for `CreateNode(NAND` — there is no such call. They arrive as a *variable* kind from `BBForm`'s pass-through of a formula node's own kind, so any AST carrying one reaches the manager.

### Where it stands, measured

Over 57 hard queries (>10s), summed, generating CNF only:

| level | clauses | variables | literals | peak RSS |
|---|---|---|---|---|
| very-low | 99.4M | 25.4M | 283M | 10.0 GB |
| medium | 82.6M | 16.4M | 264M | 26.9 GB |
| very-high | 71.3M | 10.4M | 270M | 18.3 GB |
| **new_very_low** | **116.3M** | **33.9M** | **311M** | **6.3 GB** |

More clauses, much less memory — median 2.65x below medium, and on the largest query in the set the peak is **358 MB against medium's 2679 MB**.

And solved end to end, over nine unsatisfiable hard queries, the routes finish **within 1.5% of each other** (medium 527s, very-low 531s, new_very_low 523s), every query giving the same answer. So the 1.6x clause count costs approximately nothing in time, and the memory is the win.
