### PR TITLE
Collapse n-ary ANDs, and give the in-house writer three rungs

### DIFF
--- a/include/stp/AIG/CNF.h
+++ b/include/stp/AIG/CNF.h
@@ -27,6 +27,7 @@ THE SOFTWARE.
 
 #include <cassert>
 #include <cstdint>
+#include <cstddef>
 #include <iosfwd>
 #include <utility>
 #include <vector>
@@ -148,6 +149,14 @@ public:
     lits_.push_back(a);
     lits_.push_back(b);
     lits_.push_back(c);
+    closeClause();
+  }
+  // A clause of any length, for the n-ary ANDs: a query's top-level
+  // conjunction reaches a thousand leaves, so this one cannot be an overload
+  // set over fixed arities like the three above.
+  void clause(const int* lits, size_t n)
+  {
+    lits_.insert(lits_.end(), lits, lits + n);
     closeClause();
   }
   void emptyClause()

--- a/include/stp/AIG/Tseitin.h
+++ b/include/stp/AIG/Tseitin.h
@@ -55,6 +55,33 @@ namespace aig
 // isAnd() has agreed, so c, t and e always name real nodes.
 bool matchIte(const Manager& m, Node n, Lit& c, Lit& t, Lit& e);
 
+// The leaves of the maximal AND rooted at `n`, appended to `into`.
+//
+// An AIG has no OR node: `a | b` is `!(!a & !b)`, one AND with the
+// complements on the edges. So an n-ary OR *is* an n-ary AND over negated
+// leaves, with the output polarity carried by the edge above it -- and one
+// collector recovers both. Nothing here looks at the sign above `n`.
+//
+// Descends through an uncomplemented fanin whose node `absorbed` marks, and
+// stops everywhere else. Stopping at a complemented edge is what keeps a
+// conjunction from swallowing a disjunction: an alternation of the two shows
+// up as a complemented edge and cuts the collection there.
+//
+// Iterative: a query's top-level conjunction reaches a thousand leaves, and
+// this runs once per root over the whole cone.
+void collectAndLeaves(const Manager& m, Node n, const std::vector<uint64_t>& absorbed,
+                      std::vector<Lit>& into, std::vector<Lit>& stack);
+
+// What the writer recovers from the AIG before emitting. Each rung adds to
+// the one above it, and each is a strict size reduction -- see the report in
+// bench-hard for what each is worth.
+enum class Recover
+{
+  Nothing,        // plain Tseitin: three clauses for every AND node
+  Patterns,       // + XOR and if-then-else, four clauses instead of nine
+  PatternsAndAnds // + maximal n-ary ANDs, and so n-ary ORs, collapsed
+};
+
 // Which nodes the CNF will talk about, and how many clauses that will take.
 //
 // Pass A of the writer, split out because it is the same work whatever the
@@ -73,7 +100,8 @@ public:
   // variable of their own instead of being asserted. That is the split
   // Cnf_DeriveSimple takes, and the two callers want its ends: a formula
   // asserts its single output, a fragment names all of them.
-  Cone(const Manager& m, unsigned namedOutputs = 0, bool matchPatterns = true);
+  Cone(const Manager& m, unsigned namedOutputs = 0,
+       Recover recover = Recover::PatternsAndAnds);
 
   // In the cone, so it gets a variable and its defining clauses.
   bool live(Node n) const { return (live_[n >> 6] >> (n & 63)) & 1u; }
@@ -89,7 +117,17 @@ public:
   uint64_t clauseCount() const { return nClauses_; }
   uint64_t literalCount() const { return nLiterals_; }
   // Live AND nodes, which is how many variables the cone itself needs.
+  // Absorbed into the n-ary AND of its parent: no variable, no clauses of
+  // its own, and its leaves appear in the parent's big clause instead.
+  bool absorbed(Node n) const
+  {
+    return (absorbed_[n >> 6] >> (n & 63)) & 1u;
+  }
+
   uint64_t liveAndCount() const { return nAnds_; }
+
+  // For the emit pass, which has to collect the same leaves this counted.
+  const std::vector<uint64_t>& absorbedBits() const { return absorbed_; }
 
   // Variable layout, closed form and no lookup table:
   //   1 .. nCi                      the CIs, in ordinal order
@@ -105,9 +143,11 @@ public:
 private:
   void setLive(Node n) { live_[n >> 6] |= 1ull << (n & 63); }
   void setPatterned(Node n) { pattern_[n >> 6] |= 1ull << (n & 63); }
+  void setAbsorbed(Node n) { absorbed_[n >> 6] |= 1ull << (n & 63); }
 
   std::vector<uint64_t> live_;
   std::vector<uint64_t> pattern_;
+  std::vector<uint64_t> absorbed_;
   uint64_t nClauses_ = 0;
   uint64_t nLiterals_ = 0;
   uint64_t nAnds_ = 0;
@@ -133,6 +173,12 @@ void writeTseitin(const Manager& m, const Cone& cone, Sink& sink)
   sink.begin(cone.varCount(), cone.clauseCount(), cone.literalCount(), nCi,
              nCo);
 
+  // Scratch for the n-ary AND collection, hoisted so the whole emit pass
+  // reuses one allocation rather than one per root.
+  std::vector<Lit> leaves;
+  std::vector<Lit> stack;
+  std::vector<int> clause;
+
   // Four bytes a node, and it dies with this function. The CNF that outlives
   // it carries no node map at all -- which is the whole difference from
   // Cnf_Dat_t::pVarNums, held for the length of the solve.
@@ -155,7 +201,7 @@ void writeTseitin(const Manager& m, const Cone& cone, Sink& sink)
   uint32_t next = cone.andVarBase();
   for (Node n = 1; n < m.nodeCount(); ++n)
   {
-    if (!m.isAnd(n) || !cone.live(n))
+    if (!m.isAnd(n) || !cone.live(n) || cone.absorbed(n))
       continue;
     const uint32_t x = next++;
     var[n] = x;
@@ -175,10 +221,20 @@ void writeTseitin(const Manager& m, const Cone& cone, Sink& sink)
     }
     else
     {
-      const int a = cnfLit(m.fanin0(n)), b = cnfLit(m.fanin1(n));
-      sink.clause(px, a ^ 1, b ^ 1);
-      sink.clause(nx, a);
-      sink.clause(nx, b);
+      // The n-ary AND. Collected exactly as Cone counted it -- same
+      // function, same bitmap -- because the arena was reserved from that
+      // count and CNF::end() checks the two agree.
+      leaves.clear();
+      collectAndLeaves(m, n, cone.absorbedBits(), leaves, stack);
+
+      // x -> every leaf, and every leaf together -> x.
+      clause.clear();
+      clause.push_back(px);
+      for (const Lit l : leaves)
+        clause.push_back(cnfLit(l) ^ 1);
+      sink.clause(clause.data(), clause.size());
+      for (const Lit l : leaves)
+        sink.clause(nx, cnfLit(l));
     }
   }
   assert(next == cone.varCount());
@@ -218,7 +274,7 @@ void writeTseitin(const Manager& m, const Cone& cone, Sink& sink)
 
 // Both passes, into a materialised CNF.
 CNF deriveTseitin(const Manager& m, unsigned namedOutputs = 0,
-                  bool matchPatterns = true);
+                  Recover recover = Recover::PatternsAndAnds);
 
 } // namespace aig
 } // namespace stp

--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -894,7 +894,9 @@ public:
     // little effort it spends. AUTO never picks it -- AUTO chooses from the
     // AIG's node count, which means blasting through ABC first, so reaching
     // this rung has to be an explicit request.
-    CNF_EFFORT_NEW_VERY_LOW
+    CNF_EFFORT_NEW_VERY_LOW,
+    CNF_EFFORT_NEW_LOW,
+    CNF_EFFORT_NEW_MEDIUM
   };
 
   enum CNFEffort cnf_effort = CNF_EFFORT_AUTO;

--- a/include/stp/ToSat/ToCNFTseitin.h
+++ b/include/stp/ToSat/ToCNFTseitin.h
@@ -26,6 +26,7 @@ THE SOFTWARE.
 #define TOCNFTSEITIN_H_
 
 #include "stp/AIG/CNF.h"
+#include "stp/AIG/Tseitin.h"
 #include "stp/STPManager/UserDefinedFlags.h"
 #include "stp/ToSat/BBNodeManagerLit.h"
 #include "stp/ToSat/ToSATBase.h"

--- a/lib/AIG/Tseitin.cpp
+++ b/lib/AIG/Tseitin.cpp
@@ -75,7 +75,29 @@ bool matchIte(const Manager& m, Node n, Lit& c, Lit& t, Lit& e)
   return true;
 }
 
-Cone::Cone(const Manager& m, unsigned namedOutputs, bool matchPatterns)
+void collectAndLeaves(const Manager& m, Node n,
+                      const std::vector<uint64_t>& absorbed,
+                      std::vector<Lit>& into, std::vector<Lit>& stack)
+{
+  stack.clear();
+  stack.push_back(m.fanin1(n));
+  stack.push_back(m.fanin0(n));
+  while (!stack.empty())
+  {
+    const Lit f = stack.back();
+    stack.pop_back();
+    const Node x = nodeOf(f);
+    if (!isNeg(f) && ((absorbed[x >> 6] >> (x & 63)) & 1u))
+    {
+      stack.push_back(m.fanin1(x));
+      stack.push_back(m.fanin0(x));
+    }
+    else
+      into.push_back(f);
+  }
+}
+
+Cone::Cone(const Manager& m, unsigned namedOutputs, Recover recover)
 {
   const uint32_t nCo = m.outputCount();
   assert(namedOutputs <= nCo);
@@ -88,6 +110,7 @@ Cone::Cone(const Manager& m, unsigned namedOutputs, bool matchPatterns)
   const size_t words = static_cast<size_t>((nNodes + 63) / 64);
   live_.assign(words, 0);
   pattern_.assign(words, 0);
+  absorbed_.assign(words, 0);
 
   // A pattern is only taken when it removes its two intermediates outright,
   // which needs to know whether anything else uses them. Nothing does if they
@@ -103,6 +126,9 @@ Cone::Cone(const Manager& m, unsigned namedOutputs, bool matchPatterns)
   //
   // One byte each, saturating at two, and it is gone when this constructor
   // returns.
+  const bool matchPatterns = recover != Recover::Nothing;
+  const bool collapseAnds = recover == Recover::PatternsAndAnds;
+
   std::vector<uint8_t> refs;
   if (matchPatterns)
   {
@@ -126,30 +152,72 @@ Cone::Cone(const Manager& m, unsigned namedOutputs, bool matchPatterns)
     if (!isConst(m.output(i)))
       setLive(nodeOf(m.output(i)));
 
+  // Would this node be folded as an ITE?  Asked in two places -- of the node
+  // being decided, and of a fanin about to be absorbed -- so it is written
+  // once. An ITE-shaped node must not be absorbed into its parent's
+  // conjunction: absorbing it saves the parent two clauses, while folding it
+  // saves five by removing both of its intermediates, and the two are
+  // mutually exclusive.
+  const auto wouldPattern = [&](Node x) {
+    Lit c, t, e;
+    return matchPatterns && m.isAnd(x) &&
+           refs[nodeOf(m.fanin0(x))] == 1 && refs[nodeOf(m.fanin1(x))] == 1 &&
+           matchIte(m, x, c, t, e);
+  };
+
   for (Node n = static_cast<Node>(nNodes); n-- > 1;)
   {
     if (!live(n) || !m.isAnd(n))
       continue;
-    ++nAnds_;
 
     Lit c, t, e;
-    if (matchPatterns && refs[nodeOf(m.fanin0(n))] == 1 &&
-        refs[nodeOf(m.fanin1(n))] == 1 && matchIte(m, n, c, t, e))
+    if (wouldPattern(n))
     {
+      const bool matched = matchIte(m, n, c, t, e);
+      assert(matched);
+      (void)matched;
       setPatterned(n);
       setLive(nodeOf(c));
       setLive(nodeOf(t));
       setLive(nodeOf(e));
+      continue;
+    }
+
+    // Otherwise this is an AND, and each uncomplemented fanin that nothing
+    // else needs folds into it. Marking the fanin absorbed rather than only
+    // live is what makes the collection transitive: the sweep reaches that
+    // fanin later, finds it absorbed, and marks *its* private fanins in
+    // turn, so a whole chain collapses in one descending pass.
+    for (const Lit f : {m.fanin0(n), m.fanin1(n)})
+    {
+      const Node x = nodeOf(f);
+      setLive(x);
+      if (collapseAnds && !isNeg(f) && m.isAnd(x) && refs[x] == 1 &&
+          !wouldPattern(x))
+        setAbsorbed(x);
+    }
+  }
+
+  // Now price it. Absorbed nodes cost nothing; every other live AND node is
+  // either an ITE or the root of an n-ary AND whose leaves have to be
+  // counted, and counted the same way pass B will collect them.
+  std::vector<Lit> leaves, stack;
+  for (Node n = 1; n < nNodes; ++n)
+  {
+    if (!live(n) || !m.isAnd(n) || absorbed(n))
+      continue;
+    ++nAnds_;
+    if (patterned(n))
+    {
       nClauses_ += 4;
       nLiterals_ += 12;
+      continue;
     }
-    else
-    {
-      setLive(nodeOf(m.fanin0(n)));
-      setLive(nodeOf(m.fanin1(n)));
-      nClauses_ += 3;
-      nLiterals_ += 7;
-    }
+    leaves.clear();
+    collectAndLeaves(m, n, absorbed_, leaves, stack);
+    const uint64_t k = leaves.size();
+    nClauses_ += k + 1;      // one big clause, and k implications
+    nLiterals_ += 3 * k + 1; // (k+1) + 2k
   }
 
   for (uint32_t i = 0; i < nCo; i++)
@@ -184,9 +252,9 @@ Cone::Cone(const Manager& m, unsigned namedOutputs, bool matchPatterns)
   nVars_ = static_cast<uint32_t>(vars);
 }
 
-CNF deriveTseitin(const Manager& m, unsigned namedOutputs, bool matchPatterns)
+CNF deriveTseitin(const Manager& m, unsigned namedOutputs, Recover recover)
 {
-  const Cone cone(m, namedOutputs, matchPatterns);
+  const Cone cone(m, namedOutputs, recover);
   CNF cnf;
   writeTseitin(m, cone, cnf);
   return cnf;

--- a/lib/ToSat/ToCNFTseitin.cpp
+++ b/lib/ToSat/ToCNFTseitin.cpp
@@ -42,7 +42,15 @@ void ToCNFTseitin::toCNF(const BBNodeLit& top, CNF& cnf,
   // which is the point in the pipeline where the process is largest.
   mgr.mgr.freeStrash();
 
-  cnf = aig::deriveTseitin(mgr.mgr, 0);
+  // The three in-house rungs differ only in what the writer recovers before
+  // emitting; the blast above them is the same either way.
+  aig::Recover recover = aig::Recover::PatternsAndAnds;
+  if (uf.cnf_effort == UserDefinedFlags::CNF_EFFORT_NEW_VERY_LOW)
+    recover = aig::Recover::Nothing;
+  else if (uf.cnf_effort == UserDefinedFlags::CNF_EFFORT_NEW_LOW)
+    recover = aig::Recover::Patterns;
+
+  cnf = aig::deriveTseitin(mgr.mgr, 0, recover);
 
   // Each symbol maps to the variables its bits carry. ~0u for a bit that
   // reached no variable, which is the same sentinel fill_node_to_var writes
@@ -68,7 +76,10 @@ void ToCNFTseitin::toCNF(const BBNodeLit& top, CNF& cnf,
   }
 
   if (uf.stats_flag)
-    std::cerr << "new_very_low CNF" << std::endl;
+    std::cerr << (recover == aig::Recover::Nothing    ? "new_very_low CNF"
+                  : recover == aig::Recover::Patterns ? "new_low CNF"
+                                                      : "new_medium CNF")
+              << std::endl;
 }
 
 } // namespace stp

--- a/lib/ToSat/ToSATAIG.cpp
+++ b/lib/ToSat/ToSATAIG.cpp
@@ -221,7 +221,10 @@ void ToSATAIG::handle_cnf_options(const CNF& cnf, bool needAbsRef)
 // knows there is more than one backend. Everything below is written once.
 bool ToSATAIG::bitblast(const ASTNode& input, bool needAbsRef, CNF& cnf)
 {
-  if (bm->UserFlags.cnf_effort == UserDefinedFlags::CNF_EFFORT_NEW_VERY_LOW)
+  const enum UserDefinedFlags::CNFEffort e = bm->UserFlags.cnf_effort;
+  if (e == UserDefinedFlags::CNF_EFFORT_NEW_VERY_LOW ||
+      e == UserDefinedFlags::CNF_EFFORT_NEW_LOW ||
+      e == UserDefinedFlags::CNF_EFFORT_NEW_MEDIUM)
     return bitblastWith<BBNodeLit, BBNodeManagerLit, BitBlasterLit,
                         ToCNFTseitin>(input, needAbsRef, cnf);
   return bitblastWith<BBNodeAIG, BBNodeManagerAIG, BitBlasterAIG, ToCNFAIG>(

--- a/tests/query-files/misc-tests/cnf-generation-effort-auto.smt2
+++ b/tests/query-files/misc-tests/cnf-generation-effort-auto.smt2
@@ -31,19 +31,26 @@
 ;
 ; RUN: not %solver --SMTLIB2 --cnf-generation-effort nonsense %s 2>&1 | %OutputCheck --check-prefix=BADLEVEL %s
 ;
-; BADLEVEL: Unknown --cnf-generation-effort value 'nonsense'\. Expected one of: auto, very-low, low, medium, high, very-high, new_very_low\.
+; BADLEVEL: Unknown --cnf-generation-effort value 'nonsense'\. Expected one of: auto, very-low, low, medium, high, very-high, new_very_low, new_low, new_medium\.
 ;
-; The new_very_low rung is a different generator over a different AIG, so it
+; The new_* rungs are a different generator over a different AIG, so they
 ; says so rather than printing one of the ABC lines, and auto never reaches it:
 ; auto decides from ABC's node count, which means blasting through ABC first.
 ;
 ; RUN: %solver --SMTLIB2 -s --cnf-generation-effort new_very_low %s 2>&1 | %OutputCheck --check-prefix=NEWVERYLOW %s
+; RUN: %solver --SMTLIB2 -s --cnf-generation-effort new_low %s 2>&1 | %OutputCheck --check-prefix=NEWLOW %s
+; RUN: %solver --SMTLIB2 -s --cnf-generation-effort new_medium %s 2>&1 | %OutputCheck --check-prefix=NEWMEDIUM %s
 ;
 ; NEWVERYLOW-NOT: cnf-auto:
 ; NEWVERYLOW-NOT: advanced CNF
 ; NEWVERYLOW: ^new_very_low CNF$
-; NEWVERYLOW: ^cnf: [0-9]+ clauses, [0-9]+ variables, [0-9]+ literals$
 ; NEWVERYLOW: sat
+;
+; NEWLOW: ^new_low CNF$
+; NEWLOW: sat
+;
+; NEWMEDIUM: ^new_medium CNF$
+; NEWMEDIUM: sat
 
 (set-logic QF_BV)
 (declare-fun a () (_ BitVec 8))

--- a/tests/unit-tests/Tseitin_Test.cpp
+++ b/tests/unit-tests/Tseitin_Test.cpp
@@ -84,7 +84,7 @@ Layout layoutOf(const aig::Manager& m, const aig::Cone& cone)
 
   uint32_t next = cone.andVarBase();
   for (aig::Node n = 1; n < m.nodeCount(); ++n)
-    if (m.isAnd(n) && cone.live(n))
+    if (m.isAnd(n) && cone.live(n) && !cone.absorbed(n))
       l.nodeVar[n] = next++;
   l.nVars = next;
   return l;
@@ -193,10 +193,10 @@ void buildRandom(aig::Manager& m, std::mt19937& rng, unsigned nCi,
 // Exhaustive over the CIs: every clause holds under the circuit's own values,
 // and BCP from the CIs reproduces every one of them.
 void checkExact(const aig::Manager& m, unsigned namedOutputs,
-                bool matchPatterns)
+                aig::Recover recover)
 {
-  const aig::Cone cone(m, namedOutputs, matchPatterns);
-  const CNF cnf = aig::deriveTseitin(m, namedOutputs, matchPatterns);
+  const aig::Cone cone(m, namedOutputs, recover);
+  const CNF cnf = aig::deriveTseitin(m, namedOutputs, recover);
   const Layout l = layoutOf(m, cone);
 
   ASSERT_EQ(cnf.varCount(), l.nVars);
@@ -263,8 +263,8 @@ TEST(Tseitin, NamedOutputsEncodeTheCircuitExactly)
     for (unsigned i = 0; i < 3; i++)
       m.createOutput(pool[rng() % pool.size()]);
 
-    ASSERT_NO_FATAL_FAILURE(checkExact(m, m.outputCount(), true)) << seed;
-    ASSERT_NO_FATAL_FAILURE(checkExact(m, m.outputCount(), false)) << seed;
+    ASSERT_NO_FATAL_FAILURE(checkExact(m, m.outputCount(), aig::Recover::PatternsAndAnds)) << seed;
+    ASSERT_NO_FATAL_FAILURE(checkExact(m, m.outputCount(), aig::Recover::Nothing)) << seed;
   }
 }
 
@@ -281,8 +281,8 @@ TEST(Tseitin, AssertedOutputIsUnsatWhereTheCircuitIsFalse)
     buildRandom(m, rng, 3 + (seed % 6), 25, pool);
     m.createOutput(pool[rng() % pool.size()]);
 
-    ASSERT_NO_FATAL_FAILURE(checkExact(m, 0, true)) << seed;
-    ASSERT_NO_FATAL_FAILURE(checkExact(m, 0, false)) << seed;
+    ASSERT_NO_FATAL_FAILURE(checkExact(m, 0, aig::Recover::PatternsAndAnds)) << seed;
+    ASSERT_NO_FATAL_FAILURE(checkExact(m, 0, aig::Recover::Nothing)) << seed;
   }
 }
 
@@ -298,7 +298,7 @@ TEST(Tseitin, MixedAssertedAndNamedOutputs)
     for (unsigned i = 0; i < 4; i++)
       m.createOutput(pool[rng() % pool.size()]);
 
-    ASSERT_NO_FATAL_FAILURE(checkExact(m, 2, true)) << seed;
+    ASSERT_NO_FATAL_FAILURE(checkExact(m, 2, aig::Recover::PatternsAndAnds)) << seed;
   }
 }
 
@@ -312,8 +312,8 @@ TEST(Tseitin, MuxCostsFourClausesInsteadOfNine)
   m.createOutput(m.Mux(c, t, e));
   ASSERT_EQ(m.andCount(), 3u);
 
-  const CNF plain = aig::deriveTseitin(m, 1, false);
-  const CNF folded = aig::deriveTseitin(m, 1, true);
+  const CNF plain = aig::deriveTseitin(m, 1, aig::Recover::Nothing);
+  const CNF folded = aig::deriveTseitin(m, 1, aig::Recover::PatternsAndAnds);
 
   // Three ANDs at 3 clauses / 7 literals each, plus the named output's two.
   EXPECT_EQ(plain.clauseCount(), 11u);
@@ -334,8 +334,8 @@ TEST(Tseitin, XorCostsFourClausesInsteadOfNine)
   m.createOutput(m.Xor(a, b));
   ASSERT_EQ(m.andCount(), 3u);
 
-  EXPECT_EQ(aig::deriveTseitin(m, 1, false).clauseCount(), 11u);
-  EXPECT_EQ(aig::deriveTseitin(m, 1, true).clauseCount(), 6u);
+  EXPECT_EQ(aig::deriveTseitin(m, 1, aig::Recover::Nothing).clauseCount(), 11u);
+  EXPECT_EQ(aig::deriveTseitin(m, 1, aig::Recover::PatternsAndAnds).clauseCount(), 6u);
 }
 
 // The guard on the merge.  If one of the intermediates is wanted elsewhere it
@@ -349,8 +349,8 @@ TEST(Tseitin, SharedIntermediateDeclinesTheMerge)
   m.createOutput(mux);
   m.createOutput(m.And(c, t)); // the MUX's own then-branch, hash-consed
 
-  const CNF plain = aig::deriveTseitin(m, 2, false);
-  const CNF folded = aig::deriveTseitin(m, 2, true);
+  const CNF plain = aig::deriveTseitin(m, 2, aig::Recover::Nothing);
+  const CNF folded = aig::deriveTseitin(m, 2, aig::Recover::PatternsAndAnds);
   EXPECT_EQ(plain.clauseCount(), folded.clauseCount());
   EXPECT_EQ(plain.varCount(), folded.varCount());
 }
@@ -369,8 +369,8 @@ TEST(Tseitin, MatchingNeverCostsAnything)
     for (unsigned i = 0; i < 2; i++)
       m.createOutput(pool[rng() % pool.size()]);
 
-    const CNF plain = aig::deriveTseitin(m, 0, false);
-    const CNF folded = aig::deriveTseitin(m, 0, true);
+    const CNF plain = aig::deriveTseitin(m, 0, aig::Recover::Nothing);
+    const CNF folded = aig::deriveTseitin(m, 0, aig::Recover::PatternsAndAnds);
     ASSERT_LE(folded.clauseCount(), plain.clauseCount()) << seed;
     ASSERT_LE(folded.literalCount(), plain.literalCount()) << seed;
     ASSERT_LE(folded.varCount(), plain.varCount()) << seed;
@@ -408,8 +408,13 @@ TEST(Tseitin, DeadNodesAreNotEncoded)
   EXPECT_EQ(after.varOfCi(2), 3u);
 }
 
-// Both passes are sweeps over the node array.  A chain this deep overflows a
-// default stack many times over if either of them recurses.
+// Both passes are sweeps over the node array, and the leaf collection is an
+// explicit stack. A chain this deep overflows a default stack many times over
+// if any of the three recurses.
+//
+// It is also the extreme case of the n-ary AND: every link is a private,
+// uncomplemented fanin of the next, so the whole million-node chain collapses
+// into a single conjunction of its inputs -- one variable, not a million.
 TEST(Tseitin, DeepChainNeedsNoStack)
 {
   aig::Manager m;
@@ -419,6 +424,25 @@ TEST(Tseitin, DeepChainNeedsNoStack)
   m.createOutput(acc);
 
   const CNF cnf = aig::deriveTseitin(m);
+  const uint64_t k = 1000001; // every input is a leaf of the one AND
+
+  EXPECT_EQ(cnf.clauseCount(), k + 1 + 1);   // k+1 defining, 1 asserted output
+  EXPECT_EQ(cnf.literalCount(), 3 * k + 1 + 1);
+  EXPECT_EQ(cnf.varCount(), 1u + 1000001u + 1u); // constant, inputs, one AND
+}
+
+// The same chain with matching off, which is what it used to cost: one
+// variable and three clauses per link. Also the guard that says the switch
+// really does turn the collection off, not just the ITE fold.
+TEST(Tseitin, DeepChainWithoutMatchingIsOneNodePerLink)
+{
+  aig::Manager m;
+  aig::Lit acc = m.createCi();
+  for (unsigned i = 0; i < 1000000; i++)
+    acc = m.And(acc, m.createCi());
+  m.createOutput(acc);
+
+  const CNF cnf = aig::deriveTseitin(m, 0, aig::Recover::Nothing);
   EXPECT_EQ(cnf.clauseCount(), 3ull * 1000000 + 1);
   EXPECT_EQ(cnf.literalCount(), 7ull * 1000000 + 1);
   EXPECT_EQ(cnf.varCount(), 1u + 1000001u + 1000000u);

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -732,11 +732,15 @@ void ExtraMain::create_options()
       ->group(misc_group);
   app.add_option("--cnf-generation-effort", cnf_effort,
                  "effort spent minimising the CNF: auto, very-low, low, "
-                 "medium, high, very-high, new_very_low. Higher is slower to "
+                 "medium, high, very-high, new_very_low, new_low, new_medium. "
+                 "Higher is slower to "
                  "generate but yields a smaller CNF; auto picks between "
                  "very-low and medium from the size of the AIG, since "
                  "minimising a large one costs more than the solver saves. "
-                 "new_very_low blasts through STP's own AIG instead of ABC's "
+                 "The new_* rungs blast through STP's own AIG instead of "
+                 "ABC's and write the CNF directly: new_very_low is plain "
+                 "Tseitin, new_low recovers XOR and if-then-else, new_medium "
+                 "also collapses n-ary ANDs and ORs. "
                  "and writes the CNF directly")
       ->capture_default_str()
       ->group(misc_group);
@@ -1053,11 +1057,15 @@ int ExtraMain::parse_options(int argc, char** argv)
     bm->UserFlags.cnf_effort = UserDefinedFlags::CNF_EFFORT_AUTO;
   else if (cnf_effort == "new_very_low")
     bm->UserFlags.cnf_effort = UserDefinedFlags::CNF_EFFORT_NEW_VERY_LOW;
+  else if (cnf_effort == "new_low")
+    bm->UserFlags.cnf_effort = UserDefinedFlags::CNF_EFFORT_NEW_LOW;
+  else if (cnf_effort == "new_medium")
+    bm->UserFlags.cnf_effort = UserDefinedFlags::CNF_EFFORT_NEW_MEDIUM;
   else
   {
     std::cerr << "Unknown --cnf-generation-effort value '" << cnf_effort
               << "'. Expected one of: auto, very-low, low, medium, high, "
-                 "very-high, new_very_low."
+                 "very-high, new_very_low, new_low, new_medium."
               << std::endl;
     return -1;
   }


### PR DESCRIPTION
An AND node whose uncomplemented fanin nothing else needs folds into it, transitively, so a chain of binary ANDs becomes one conjunction of its leaves. A k-input AND costs `k+1` clauses, `3k+1` literals and one variable against `3(k-1)`, `7(k-1)` and `k-1` for the binary tree it replaces.

### There is no separate n-ary OR

An AIG has no OR node — `a | b` is `!(!a & !b)`, one AND with the complements on the edges. So **an n-ary OR *is* an n-ary AND over negated leaves**, with the output polarity carried by the edge above it. One collector recovers both, which is the same reason XOR falls out of the ITE matcher.

A 5-input OR builds as four AND nodes with every internal edge uncomplemented and every leaf edge complemented; the collector descends the three internal edges, stops at the five leaf edges, and emits one 6-literal clause plus five binaries. 6 clauses and 1 variable, against 12 clauses and 4 variables.

Stopping at complemented edges is what keeps a conjunction from swallowing a disjunction: an alternation of the two shows up as a complemented edge and cuts the collection there. Flat AND trees flatten, flat OR trees flatten, AND-over-OR does not.

### Two guards, both on counts that already existed

* **A fanin is absorbed only when nothing else needs it**, on the same reference counts the ITE fold uses. A shared intermediate keeps its variable and its clauses, and the chain cuts there — merging through it would save nothing, because the parent still needs its own three clauses.
* **An ITE-shaped node is never absorbed.** Absorbing it saves its parent two clauses while forgoing the five that folding it saves by removing both intermediates, and the two are exclusive. The test is written once and asked in both places so they cannot drift.

The collection is an explicit stack in both passes — a query's top-level conjunction reaches a thousand leaves and the deep-chain test a million, so nothing here may recurse.

### Three rungs

The two recoveries are separable and worth measuring apart:

| rung | recovers |
|---|---|
| `new_very_low` | nothing — plain Tseitin, three clauses per AND node |
| `new_low` | + XOR and if-then-else, four clauses instead of nine |
| `new_medium` | + n-ary ANDs and ORs collapsed |

### Measured, 30 hard queries, summed

| level | clauses | variables | literals |
|---|---|---|---|
| `new_very_low` | 39,520,380 | 13,251,418 | 92,214,180 |
| `new_low` | 20,382,230 | 5,596,158 | 57,765,510 |
| **`new_medium`** | **19,391,920** | **5,101,003** | **55,784,890** |
| `very-low` (ABC) | 18,836,863 | 4,824,250 | 55,025,547 |
| `medium` (ABC) | 17,966,497 | 4,263,035 | 54,485,370 |

n-ary collection is worth **4.9% of clauses, 8.8% of variables, 3.4% of literals** over `new_low`, and closes the gap to ABC's `very-low` from **1.082x to 1.029x** — about two thirds of what was left.

That is the whole of what `Cnf_DeriveFast`'s supergate collection does. The rest of its advantage is the truth-table and ISOP path, which carries a hard `assert(leaves <= 6)` — it cannot absorb a thousand-input conjunction at all, which is why ABC needs the uncapped AND branch too.

### Verification

177 ctest and all 864 lit cases pass; clang with `-Werror` clean. Over `tests/query-files`, every input both routes answer gets the same answer: **637 agree, 0 differ**.

The exhaustive tests needed no change to cover this — they fix the inputs, run unit propagation, and require every variable to be forced to its simulated value, which a wrong n-ary encoding fails. That is the payoff from writing them structurally rather than against the patterns that existed at the time.

The deep-chain test is now the extreme case rather than a stack check alone: a million-link chain collapses to one variable and one clause of a million literals. Its old expectations move to a second test that runs with recovery off, which is also what says the switch turns the collection off rather than only the ITE fold.