### PR TITLE
A third bit-blasting backend, over ABC's Gia

### DIFF
--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -894,8 +894,27 @@ public:
     // little effort it spends. AUTO never picks it -- AUTO chooses from the
     // AIG's node count, which means blasting through ABC first, so reaching
     // this rung has to be an explicit request.
-    CNF_EFFORT_NEW_VERY_LOW
+    CNF_EFFORT_NEW_VERY_LOW,
+
+    // Mf_ManGenerateCnf again -- the same generator low, high and very-high
+    // reach -- but over a Gia the blaster built itself rather than one
+    // converted from an ABC Aig. Same LUT sizes, 3, 6 and 8, so gia-low
+    // against low is a comparison of the two backends and nothing else.
+    //
+    // AUTO never picks these, for the reason it never picks the rung above:
+    // it decides from ABC's Aig node count, which means blasting through ABC
+    // first, and the point of these is that no ABC Aig is built at all.
+    CNF_EFFORT_GIA_LOW,
+    CNF_EFFORT_GIA_HIGH,
+    CNF_EFFORT_GIA_VERY_HIGH
   };
+
+  // Whether a level blasts through the Gia backend rather than ABC's Aig.
+  static bool isGiaEffort(enum CNFEffort e)
+  {
+    return e == CNF_EFFORT_GIA_LOW || e == CNF_EFFORT_GIA_HIGH ||
+           e == CNF_EFFORT_GIA_VERY_HIGH;
+  }
 
   enum CNFEffort cnf_effort = CNF_EFFORT_AUTO;
 

--- a/include/stp/ToSat/AbcCnfAdopt.h
+++ b/include/stp/ToSat/AbcCnfAdopt.h
@@ -1,0 +1,69 @@
+/********************************************************************
+ * AUTHORS: Trevor Hansen
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#ifndef ABCCNFADOPT_H_
+#define ABCCNFADOPT_H_
+
+// From ABC
+#include "sat/cnf/cnf.h"
+
+#include "stp/AIG/CNF.h"
+
+#include <functional>
+
+namespace stp
+{
+
+// Take over an ABC-generated formula, projecting its per-object pVarNums down
+// to the CI and CO variables that are the only ones anybody asks for. The
+// clauses are adopted, not copied: ABC's layout is already the one CNF
+// exposes.
+//
+// `objectVar` reads pVarNums for one object, which is the only thing that
+// differs between the Aig-based generators and the Gia-based one -- each
+// indexes that array by ids of its own manager. Shared by ToCNFAIG and
+// ToCNFGia, which is why it lives here rather than on either of them.
+inline CNF adoptAbcCnf(Cnf_Dat_t* cnfData, unsigned nCi, unsigned nCo,
+                       const std::function<int(bool isCo, unsigned)>& objectVar)
+{
+  assert(cnfData != NULL);
+  CNF cnf;
+  cnf.adopt(cnfData, [](void* p) { Cnf_DataFree((Cnf_Dat_t*)p); },
+            cnfData->pClauses, (uint64_t)cnfData->nClauses,
+            (uint64_t)cnfData->nLiterals, (uint32_t)cnfData->nVars, nCi, nCo);
+
+  // -1 is ABC's "this object has no variable" -- a CI outside the cone of the
+  // outputs, or a CO that was asserted rather than named. CNF spells that 0,
+  // for the reason its header gives.
+  const auto var = [](int v) { return v < 0 ? 0u : (uint32_t)v; };
+  for (unsigned i = 0; i < nCi; i++)
+    cnf.mapCi(i, var(objectVar(false, i)));
+  for (unsigned i = 0; i < nCo; i++)
+    cnf.mapCo(i, var(objectVar(true, i)));
+  return cnf;
+}
+
+} // namespace stp
+
+#endif /* ABCCNFADOPT_H_ */

--- a/include/stp/ToSat/BBNodeGia.h
+++ b/include/stp/ToSat/BBNodeGia.h
@@ -1,0 +1,100 @@
+/********************************************************************
+ * AUTHORS: Trevor Hansen
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#ifndef BBNODEGIA_H
+#define BBNODEGIA_H
+
+#include <cstddef>
+#include <functional>
+#include <ostream>
+
+namespace stp
+{
+
+// The blaster's handle on a node of an ABC Gia: one literal, four bytes.
+//
+// A Gia literal is 2*id + complement, and the id indexes Gia_Man_t::pObjs --
+// an array that reallocs as it grows, so a Gia_Obj_t* would dangle the moment
+// the next gate is built. That is why this backend cannot reuse BBNodeAIG's
+// pointer handle. It is also why the literal needs no ordinal beside it the
+// way BBNodeAIG does: nothing renumbers a Gia in place, and a CI carries its
+// own ordinal in the object, so ciOrdinal() is a field read rather than
+// something the handle has to remember.
+//
+// Null is negative. Gia literals are non-negative, so no real node can be
+// mistaken for null -- and neither can the negation of one, since `^1` of a
+// negative int stays negative. A null that survived a negation would
+// otherwise alias literal 0 or 1, which are the two constants.
+class BBNodeGia
+{
+public:
+  int n = -1;
+
+  BBNodeGia() = default;
+  explicit BBNodeGia(int lit) : n(lit) {}
+
+  bool IsNull() const { return n < 0; }
+
+  // The whole literal, complement bit included, which is what the blaster's
+  // memo tables need to distinguish x from !x.
+  int GetNodeNum() const { return n; }
+
+  bool operator==(const BBNodeGia& o) const { return n == o.n; }
+  bool operator!=(const BBNodeGia& o) const { return n != o.n; }
+
+  // Not dead, whatever a grep suggests: mult_Booth sorts each column of
+  // partial products with it, and that ordering decides which products
+  // combine first, so it reaches the emitted formula. Both other handles
+  // carry the same operator for the same reason.
+  bool operator<(const BBNodeGia& o) const { return n < o.n; }
+};
+
+static_assert(sizeof(BBNodeGia) == 4, "the point of this class is its size");
+
+// For the --debug-multiply tracing, as BBNodeLit does. The ABC-Aig side
+// answers this with a FatalError because an Aig_Obj_t* has nothing short to
+// say; a literal does.
+inline std::ostream& operator<<(std::ostream& out, const BBNodeGia& n)
+{
+  if (n.IsNull())
+    return out << "null";
+  if (n.n & 1)
+    out << '!';
+  return out << (n.n >> 1);
+}
+
+} // namespace stp
+
+namespace std
+{
+template <> struct hash<stp::BBNodeGia>
+{
+  size_t operator()(const stp::BBNodeGia& n) const
+  {
+    return std::hash<int>()(n.n);
+  }
+};
+} // namespace std
+
+#endif

--- a/include/stp/ToSat/BBNodeManagerGia.h
+++ b/include/stp/ToSat/BBNodeManagerGia.h
@@ -1,0 +1,355 @@
+/********************************************************************
+ * AUTHORS: Trevor Hansen
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#ifndef BBNODEMANAGERGIA_H
+#define BBNODEMANAGERGIA_H
+
+#include "stp/AST/AST.h"
+#include "stp/ToSat/AIGBudget.h"
+#include "stp/ToSat/BBNodeGia.h"
+
+// From ABC
+#include "aig/gia/gia.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <deque>
+#include <iostream>
+#include <map>
+#include <vector>
+
+namespace stp
+{
+
+// The blaster's third backend: the same gate builders again, over ABC's Gia
+// instead of ABC's Aig or the in-house package.
+//
+// The reason this one exists is the CNF generator on the other side.
+// Mf_ManGenerateCnf -- the LUT-cut generator behind --cnf-generation-effort
+// low, high and very-high -- takes a Gia_Man_t, and ToCNFAIG reaches it by
+// building an Aig and calling Gia_ManFromAig, so both graphs are live at the
+// moment the mapper runs. Blasting into the Gia directly deletes the Aig from
+// that path: 12 bytes an object against 48, and no conversion.
+//
+// Two things are *easier* here than on ABC's Aig, and both are worth knowing
+// before anyone tries to keep the three managers in step:
+//
+//   * No ordered-gate wrappers. orderedAigExor and orderedAigMux exist
+//     because Aig_Exor and Aig_Mux2 build two Aig_And nodes inside one
+//     Aig_Or argument list, where the evaluation order is unspecified and
+//     therefore compiler-dependent -- and the node ids it decides reach the
+//     CNF. Gia_ManHashXor and Gia_ManHashMux assign their two intermediates
+//     in separate statements, so the question does not arise.
+//
+//   * ciOrdinal is O(1). Gia_ManAppendCi stores the ordinal in the object
+//     (Gia_ObjCioId reads it back), so unlike BBNodeAIG this handle carries
+//     no symbol_index, and unlike BBNodeManagerLit there is no binary search
+//     over the input list.
+//
+// One thing is harder, and it is a correctness matter rather than a
+// convenience: the CIs of this manager are *not* objects 1..nCi. See
+// ToCNFGia for what depends on that and what is done about it.
+class BBNodeManagerGia
+{
+public:
+  Gia_Man_t* giaMgr;
+
+  // Hard cap on AND gates; -1 (the default) is no limit, 0 permits none.
+  int64_t nodeBudget = -1;
+
+  // Map from symbols to their nodes. std::map rather than a hash map for the
+  // same reason the other two managers use one: the lowering walks it, and
+  // the order it walks in reaches the emitted formula.
+  typedef std::map<ASTNode, std::vector<BBNodeGia>> SymbolToBBNode;
+  SymbolToBBNode symbolToBBNode;
+
+  int totalNumberOfNodes() { return Gia_ManAndNum(giaMgr); }
+
+  BBNodeManagerGia() : giaMgr(NULL)
+  {
+    // The initial object array, which Gia_ManAppendObj doubles as it fills.
+    // Gia_ManStart also sizes the CI and CO vectors at a twentieth of this
+    // and the hash table at the whole of it, so a large opening bid is not
+    // free -- 64k objects is under a megabyte all told and covers a small
+    // query without a single resize.
+    giaMgr = Gia_ManStart(1 << 16);
+    Gia_ManHashAlloc(giaMgr);
+
+    // The two-level rewriting that BBNodeManagerAIG asks Aig_And for.
+    giaMgr->fAddStrash = 1;
+  }
+
+  BBNodeManagerGia(const BBNodeManagerGia&) = delete;
+  BBNodeManagerGia& operator=(const BBNodeManagerGia&) = delete;
+
+  void stop()
+  {
+    if (giaMgr != NULL)
+      Gia_ManStop(giaMgr);
+    giaMgr = NULL;
+    symbolToBBNode.clear();
+  }
+
+  ~BBNodeManagerGia() { stop(); }
+
+  // Gia literal 0 is constant false and 1 is constant true, both being node 0
+  // with and without the complement bit.
+  BBNodeGia getTrue() { return BBNodeGia(1); }
+  BBNodeGia getFalse() { return BBNodeGia(0); }
+
+  // An input that stands for no symbol. The BV abstraction machinery mints
+  // these for proxies and for abstracted results, which is why it does not go
+  // through CreateSymbol.
+  BBNodeGia CreateFreshInput() { return BBNodeGia(Gia_ManAppendCi(giaMgr)); }
+
+  // The same symbol always has to come back as the same node.
+  BBNodeGia CreateSymbol(const ASTNode& n, unsigned i)
+  {
+    assert(n.GetKind() == SYMBOL);
+
+    // booleans have width 0.
+    const unsigned width = std::max((unsigned)1, n.GetValueWidth());
+
+    SymbolToBBNode::iterator it = symbolToBBNode.find(n);
+    if (symbolToBBNode.end() == it)
+    {
+      symbolToBBNode[n] = std::vector<BBNodeGia>(width);
+      it = symbolToBBNode.find(n);
+    }
+    assert(it->second.size() == width);
+    assert(i < width);
+
+    if (!it->second[i].IsNull())
+      return it->second[i];
+
+    it->second[i] = BBNodeGia(Gia_ManAppendCi(giaMgr));
+    return it->second[i];
+  }
+
+  // --- the queries BitBlaster asks about a node ---------------------------
+  //
+  // Members rather than statics, as on BBNodeManagerLit: a Gia handle is an
+  // index, so answering any of these needs the array it indexes into.
+
+  bool isCI(const BBNodeGia& n) const { return Gia_ObjIsCi(obj(n)); }
+  bool isConstant(const BBNodeGia& n) const { return Abc_Lit2Var(n.n) == 0; }
+  bool isAnd(const BBNodeGia& n) const { return Gia_ObjIsAnd(obj(n)); }
+  unsigned nodeId(const BBNodeGia& n) const
+  {
+    return (unsigned)Abc_Lit2Var(n.n);
+  }
+
+  // The fanins of an AND, with the sign stripped, as the other two managers
+  // do: provenance and traversal are both sign-insensitive, and returning the
+  // signed edge would key two memo entries per node.
+  BBNodeGia fanin0(const BBNodeGia& n) const
+  {
+    const int id = Abc_Lit2Var(n.n);
+    return BBNodeGia(Abc_LitRegular(Gia_ObjFaninLit0(obj(n), id)));
+  }
+  BBNodeGia fanin1(const BBNodeGia& n) const
+  {
+    const int id = Abc_Lit2Var(n.n);
+    return BBNodeGia(Abc_LitRegular(Gia_ObjFaninLit1(obj(n), id)));
+  }
+
+  // An uncomplemented input this manager minted, and its ordinal.
+  //
+  // Not the same question as isCI(), which ignores the complement bit: a
+  // complemented input is still an input, but it is not one the blaster can
+  // name, and an abstraction record that stored its ordinal would be
+  // recording the wrong polarity.
+  bool isNamedCI(const BBNodeGia& n) const
+  {
+    return !n.IsNull() && !Abc_LitIsCompl(n.n) && isCI(n);
+  }
+  int ciOrdinal(const BBNodeGia& n) const
+  {
+    assert(isNamedCI(n));
+    return Gia_ObjCioId(obj(n));
+  }
+
+  // --- the gate builders --------------------------------------------------
+
+  BBNodeGia CreateNode(Kind kind, std::vector<BBNodeGia>& children)
+  {
+    assert(children.size() != 0);
+    for (size_t i = 0, size = children.size(); i < size; ++i)
+      assert(!children[i].IsNull());
+
+    int r;
+    switch (kind)
+    {
+      case AND:
+        r = tower(Gia_ManHashAnd, children);
+        break;
+
+      case NAND:
+        r = Abc_LitNot(tower(Gia_ManHashAnd, children));
+        break;
+
+      case OR:
+        r = tower(Gia_ManHashOr, children);
+        break;
+
+      case NOR:
+        r = Abc_LitNot(tower(Gia_ManHashOr, children));
+        break;
+
+      case NOT:
+        assert(children.size() == 1);
+        r = Abc_LitNot(children[0].n);
+        break;
+
+      case XOR:
+        r = tower(Gia_ManHashXor, children);
+        break;
+
+      case IFF:
+        assert(children.size() == 2);
+        r = Abc_LitNot(Gia_ManHashXor(giaMgr, children[0].n, children[1].n));
+        break;
+
+      case IMPLIES:
+        assert(children.size() == 2);
+        r = Gia_ManHashOr(giaMgr, Abc_LitNot(children[0].n), children[1].n);
+        break;
+
+      case ITE:
+        assert(children.size() == 3);
+        r = Gia_ManHashMux(giaMgr, children[0].n, children[1].n,
+                           children[2].n);
+        break;
+
+      default:
+        std::cerr << "Not handled::!!" << _kind_names[kind];
+        FatalError("Never here");
+        exit(-1);
+    }
+    checkBudget();
+    return BBNodeGia(r);
+  }
+
+  BBNodeGia CreateNode(Kind kind, const BBNodeGia& child0,
+                       const std::vector<BBNodeGia>& back_children =
+                           std::vector<BBNodeGia>())
+  {
+    std::vector<BBNodeGia> front;
+    front.reserve(1 + back_children.size());
+    front.push_back(child0);
+    front.insert(front.end(), back_children.begin(), back_children.end());
+    return CreateNode(kind, front);
+  }
+
+  BBNodeGia CreateNode(Kind kind, const BBNodeGia& child0,
+                       const BBNodeGia& child1,
+                       const std::vector<BBNodeGia>& back_children =
+                           std::vector<BBNodeGia>())
+  {
+    std::vector<BBNodeGia> front;
+    front.reserve(2 + back_children.size());
+    front.push_back(child0);
+    front.push_back(child1);
+    front.insert(front.end(), back_children.begin(), back_children.end());
+    return CreateNode(kind, front);
+  }
+
+  BBNodeGia CreateNode(Kind kind, const BBNodeGia& child0,
+                       const BBNodeGia& child1, const BBNodeGia& child2,
+                       const std::vector<BBNodeGia>& back_children =
+                           std::vector<BBNodeGia>())
+  {
+    std::vector<BBNodeGia> front;
+    front.reserve(3 + back_children.size());
+    front.push_back(child0);
+    front.push_back(child1);
+    front.push_back(child2);
+    front.insert(front.end(), back_children.begin(), back_children.end());
+    return CreateNode(kind, front);
+  }
+
+  // Called after every CreateNode(). One node can add a whole fan-in tower
+  // before this runs, so the count at the throw can overshoot the budget by
+  // the width of one operator -- as with the other two managers, the cap
+  // bounds the order of magnitude rather than being an exact ceiling.
+  //
+  // The second clause is not a budget at all. Gia_ManAppendObj prints a line
+  // and calls exit(1) when the object count reaches 2^29, which would take
+  // the process out with no answer and nothing to catch. Stopping short of it
+  // turns that into the same AIGBudgetExhausted every other over-large blast
+  // raises, which unwinds and reports.
+  void checkBudget() const
+  {
+    const int64_t ands = Gia_ManAndNum(giaMgr);
+    if (nodeBudget >= 0 && ands > nodeBudget)
+      throw AIGBudgetExhausted(ands);
+
+    if (Gia_ManObjNum(giaMgr) >= GIA_OBJECT_CEILING)
+      throw AIGBudgetExhausted(ands);
+  }
+
+private:
+  // ABC's hard limit is 1 << 29 objects. Leave room for the fan-in tower that
+  // may still be in flight when this fires.
+  static const int GIA_OBJECT_CEILING = (1 << 29) - (1 << 16);
+
+  Gia_Obj_t* obj(const BBNodeGia& n) const
+  {
+    assert(!n.IsNull());
+    return Gia_ManObj(giaMgr, Abc_Lit2Var(n.n));
+  }
+
+  // A two-input gate takes two operands, so a wide one becomes a log-height
+  // tower. Built the same way as the other two managers -- front two off,
+  // result to the back -- because which operands end up paired decides which
+  // subterms are shared, and so decides the gate count.
+  int tower(int (*op)(Gia_Man_t*, int, int),
+            const std::vector<BBNodeGia>& children)
+  {
+    if (children.size() == 1)
+      return children[0].n;
+
+    std::deque<int> names;
+    for (size_t i = 0, size = children.size(); i < size; ++i)
+      names.push_back(children[i].n);
+
+    while (names.size() > 2)
+    {
+      const int a = names.front();
+      names.pop_front();
+      const int b = names.front();
+      names.pop_front();
+      names.push_back(op(giaMgr, a, b));
+    }
+
+    const int a = names.front();
+    names.pop_front();
+    const int b = names.front();
+    return op(giaMgr, a, b);
+  }
+};
+
+} // namespace stp
+
+#endif

--- a/include/stp/ToSat/BitBlaster.h
+++ b/include/stp/ToSat/BitBlaster.h
@@ -28,6 +28,7 @@ THE SOFTWARE.
 #include "stp/STPManager/STPManager.h"
 #include "stp/Simplifier/constantBitP/MultiplicationStats.h"
 #include "stp/ToSat/BBNodeManagerAIG.h"
+#include "stp/ToSat/BBNodeManagerGia.h"
 #include "stp/ToSat/BBNodeManagerLit.h"
 #include "stp/ToSat/BVAbstractionTypes.h"
 #include "stp/Util/DagWalk.h"
@@ -841,6 +842,13 @@ using BBNodeSetAIG = BBNodeOrderedSet<BBNodeAIG>;
 using BitBlasterLit = BitBlaster<BBNodeLit, BBNodeManagerLit>;
 using BBNodeVecLit = std::vector<BBNodeLit>;
 using BBNodeSetLit = BBNodeOrderedSet<BBNodeLit>;
+
+// The third, over ABC's Gia. It exists for the CNF generator on the far side
+// rather than for the graph itself -- Mf_ManGenerateCnf takes a Gia, and this
+// is how it is reached without building an ABC Aig first.
+using BitBlasterGia = BitBlaster<BBNodeGia, BBNodeManagerGia>;
+using BBNodeVecGia = std::vector<BBNodeGia>;
+using BBNodeSetGia = BBNodeOrderedSet<BBNodeGia>;
 
 } // end of namespace
 

--- a/include/stp/ToSat/ToCNFAIG.h
+++ b/include/stp/ToSat/ToCNFAIG.h
@@ -35,6 +35,7 @@ THE SOFTWARE.
 #include <functional>
 
 #include "stp/AIG/CNF.h"
+#include "stp/ToSat/AbcCnfAdopt.h"
 #include "stp/ToSat/BBNodeManagerAIG.h"
 #include "stp/ToSat/ToSATBase.h"
 
@@ -49,15 +50,6 @@ class ToCNFAIG // not copyable
 
   CNF derive_cnf_mf(BBNodeManagerAIG& mgr, int nLutSize,
                     unsigned namedOutputs);
-
-  // Take over an ABC-generated formula, projecting its per-object pVarNums
-  // down to the CI and CO variables that are the only ones anybody asks for.
-  // The clauses are adopted, not copied: ABC's layout is already the one CNF
-  // exposes. `objectVar` reads pVarNums for one object id, which is the only
-  // thing that differs between the Aig-based generators and the Gia-based
-  // one -- they index it by ids of their own manager.
-  static CNF adopt(Cnf_Dat_t* cnfData, unsigned nCi, unsigned nCo,
-                   const std::function<int(bool isCo, unsigned)>& objectVar);
 
   void fill_node_to_var(const CNF& cnf,
                         ToSATBase::ASTNodeToSATVar& nodeToVars,

--- a/include/stp/ToSat/ToCNFGia.h
+++ b/include/stp/ToSat/ToCNFGia.h
@@ -1,0 +1,101 @@
+/********************************************************************
+ * AUTHORS: Trevor Hansen
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#ifndef TOCNFGIA_H_
+#define TOCNFGIA_H_
+
+// From ABC
+#include "aig/gia/gia.h"
+
+#include "stp/AIG/CNF.h"
+#include "stp/STPManager/UserDefinedFlags.h"
+#include "stp/ToSat/BBNodeManagerGia.h"
+#include "stp/ToSat/ToSATBase.h"
+
+namespace stp
+{
+
+// The Gia backend's route to CNF, and the whole of it: assert the formula as
+// the manager's one output, hand the graph to Mf_ManGenerateCnf, and project
+// the inputs back to the symbols they came from.
+//
+// Mf_ManGenerateCnf is the generator behind --cnf-generation-effort low, high
+// and very-high, and it takes a Gia. ToCNFAIG reaches it by building an ABC
+// Aig and calling Gia_ManFromAig, so a graph at 48 bytes an object and a
+// graph at 12 are both live when the mapper runs. Here the blaster built the
+// Gia, so there is no Aig and no conversion -- nothing between the manager
+// and the generator at all.
+//
+// ToCNFAIG also has a dag-aware rewriting loop and a manager-to-manager copy
+// to re-index after. Neither applies: Dar rewriting is an Aig pass with no
+// Gia equivalent that does not convert, and nothing else here renumbers.
+class ToCNFGia
+{
+  UserDefinedFlags& uf;
+
+  // The LUT size Mf enumerates cuts up to, which is what the effort level
+  // selects. 3, 6 and 8 are the sizes ToCNFAIG uses for low, high and
+  // very-high, and the gia- levels mirror them so that an A/B between the two
+  // backends is one word on the command line.
+  int nLutSize;
+
+  static int lutSizeOf(const UserDefinedFlags& uf)
+  {
+    switch (uf.cnf_effort)
+    {
+      case UserDefinedFlags::CNF_EFFORT_GIA_LOW:
+        return 3;
+      case UserDefinedFlags::CNF_EFFORT_GIA_VERY_HIGH:
+        return 8;
+      case UserDefinedFlags::CNF_EFFORT_GIA_HIGH:
+      default:
+        return 6;
+    }
+  }
+
+public:
+  // One argument, like the other two lowerings, so that the templated body in
+  // ToSATAIG constructs any of them the same way. The LUT size is not a
+  // second knob -- it is the effort level, read back off the flags.
+  explicit ToCNFGia(UserDefinedFlags& _uf) : uf(_uf), nLutSize(lutSizeOf(_uf))
+  {
+    assert(nLutSize >= 3 && nLutSize <= 8);
+  }
+
+  // The same signature as ToCNFAIG::toCNF and ToCNFTseitin::toCNF, so one
+  // templated body drives any of them.
+  //
+  // needAbsRef is taken and ignored, as it is by the Tseitin writer. It
+  // exists on the ABC-Aig path to suppress Aig_ManCleanup, because a cleanup
+  // renumbers and refinement has to be able to name an input afterwards.
+  // Nothing here removes an object, so there is nothing for the flag to
+  // protect.
+  void toCNF(const BBNodeGia& top, CNF& cnf,
+             ToSATBase::ASTNodeToSATVar& nodeToVars, bool needAbsRef,
+             BBNodeManagerGia& mgr);
+};
+
+} // namespace stp
+
+#endif /* TOCNFGIA_H_ */

--- a/include/stp/ToSat/ToSATAIG.h
+++ b/include/stp/ToSat/ToSATAIG.h
@@ -31,6 +31,7 @@ THE SOFTWARE.
 #include "stp/STPManager/STPManager.h"
 #include "stp/ToSat/BBNodeManagerAIG.h"
 #include "stp/ToSat/ToCNFAIG.h"
+#include "stp/ToSat/ToCNFGia.h"
 #include "stp/ToSat/ToCNFTseitin.h"
 #include "stp/ToSat/BitBlaster.h"
 #include "stp/ToSat/BVAbstractionRefiner.h"

--- a/lib/ToSat/BVLemmaCircuits.cpp
+++ b/lib/ToSat/BVLemmaCircuits.cpp
@@ -688,4 +688,22 @@ template BBNodeLit BitBlaster<BBNodeLit, BBNodeManagerLit>::BBDivRemIdentity(
     const ASTNode&, const BBNodeVecLit&, const BBNodeVecLit&,
     const BBNodeVecLit&, const BBNodeVecLit&, BBNodeSetLit&);
 
+template BBNodeGia BitBlaster<BBNodeGia, BBNodeManagerGia>::BBFitsExactlyOnce(
+    const BBNodeVecGia&, const BBNodeVecGia&);
+template BBNodeGia BitBlaster<BBNodeGia, BBNodeManagerGia>::BBDivLemma(
+    DivLemma, const BBNodeVecGia&, const BBNodeVecGia&, const BBNodeVecGia&,
+    BBNodeSetGia&);
+template BBNodeGia BitBlaster<BBNodeGia, BBNodeManagerGia>::BBRemLemma(
+    RemLemma, const BBNodeVecGia&, const BBNodeVecGia&, const BBNodeVecGia&,
+    BBNodeSetGia&);
+template BBNodeGia BitBlaster<BBNodeGia, BBNodeManagerGia>::BBMulLemma(
+    MulLemma, const BBNodeVecGia&, const BBNodeVecGia&, const BBNodeVecGia&,
+    BBNodeSetGia&);
+template BBNodeGia BitBlaster<BBNodeGia, BBNodeManagerGia>::BBAddLemma(
+    AddLemma, const BBNodeVecGia&, const BBNodeVecGia&, const BBNodeVecGia&,
+    BBNodeSetGia&);
+template BBNodeGia BitBlaster<BBNodeGia, BBNodeManagerGia>::BBDivRemIdentity(
+    const ASTNode&, const BBNodeVecGia&, const BBNodeVecGia&,
+    const BBNodeVecGia&, const BBNodeVecGia&, BBNodeSetGia&);
+
 } // namespace stp

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -7022,5 +7022,6 @@ std::ostream& operator<<(std::ostream& output, const BBNodeAIG& /*h*/)
 // Every specialisation that exists.
 template class BitBlaster<BBNodeAIG, BBNodeManagerAIG>;
 template class BitBlaster<BBNodeLit, BBNodeManagerLit>;
+template class BitBlaster<BBNodeGia, BBNodeManagerGia>;
 
 } // stp namespace

--- a/lib/ToSat/CMakeLists.txt
+++ b/lib/ToSat/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(tosat OBJECT
     ToSATBase.cpp
     ToCNFAIG.cpp
     ToCNFTseitin.cpp
+    ToCNFGia.cpp
     ToSATAIG.cpp
     BVAbstractionRefiner.cpp
     BVExactEncoder.cpp

--- a/lib/ToSat/ToCNFAIG.cpp
+++ b/lib/ToSat/ToCNFAIG.cpp
@@ -114,26 +114,6 @@ void ToCNFAIG::toCNF(const BBNodeAIG& top, CNF& cnf,
   fill_node_to_var(cnf, nodeToVars, mgr);
 }
 
-CNF ToCNFAIG::adopt(Cnf_Dat_t* cnfData, unsigned nCi, unsigned nCo,
-                    const std::function<int(bool, unsigned)>& objectVar)
-{
-  assert(cnfData != NULL);
-  CNF cnf;
-  cnf.adopt(cnfData, [](void* p) { Cnf_DataFree((Cnf_Dat_t*)p); },
-            cnfData->pClauses, (uint64_t)cnfData->nClauses,
-            (uint64_t)cnfData->nLiterals, (uint32_t)cnfData->nVars, nCi, nCo);
-
-  // -1 is ABC's "this object has no variable" -- a CI outside the cone of the
-  // outputs, or a CO that was asserted rather than named. CNF spells that 0,
-  // for the reason its header gives.
-  const auto var = [](int v) { return v < 0 ? 0u : (uint32_t)v; };
-  for (unsigned i = 0; i < nCi; i++)
-    cnf.mapCi(i, var(objectVar(false, i)));
-  for (unsigned i = 0; i < nCo; i++)
-    cnf.mapCo(i, var(objectVar(true, i)));
-  return cnf;
-}
-
 // ABC's newer CNF generator. It works on a Gia_Man_t, so the AIG is converted
 // first. nLutSize bounds the cuts it considers: larger means a smaller CNF for
 // steeply more work.
@@ -165,7 +145,7 @@ CNF ToCNFAIG::derive_cnf_mf(BBNodeManagerAIG& mgr, int nLutSize,
   // over a coarsened copy of the Gia (Gia_ManDupMuxes, when fCnfObjIds is 0):
   // both managers append CIs before any AND node, so CI ids are 1..nCi in
   // each, and pVarNums is sized by an object count that includes them.
-  CNF cnf = adopt(
+  CNF cnf = adoptAbcCnf(
       cnfData, (unsigned)Aig_ManCiNum(mgr.aigMgr),
       (unsigned)Aig_ManCoNum(mgr.aigMgr), [&](bool isCo, unsigned i) {
         Gia_Obj_t* o = isCo ? Gia_ManCo(pGia, (int)i) : Gia_ManCi(pGia, (int)i);
@@ -187,13 +167,13 @@ CNF ToCNFAIG::derive_cnf(BBNodeManagerAIG& mgr, unsigned namedOutputs)
 
   // Every generator below one indexes pVarNums by Aig object id.
   const auto fromAig = [&](Cnf_Dat_t* d) {
-    return adopt(d, (unsigned)Aig_ManCiNum(mgr.aigMgr),
-                 (unsigned)Aig_ManCoNum(mgr.aigMgr),
-                 [&](bool isCo, unsigned i) {
-                   Aig_Obj_t* o = isCo ? Aig_ManCo(mgr.aigMgr, (int)i)
-                                       : Aig_ManCi(mgr.aigMgr, (int)i);
-                   return d->pVarNums[Aig_ObjId(o)];
-                 });
+    return adoptAbcCnf(d, (unsigned)Aig_ManCiNum(mgr.aigMgr),
+                       (unsigned)Aig_ManCoNum(mgr.aigMgr),
+                       [&](bool isCo, unsigned i) {
+                         Aig_Obj_t* o = isCo ? Aig_ManCo(mgr.aigMgr, (int)i)
+                                             : Aig_ManCi(mgr.aigMgr, (int)i);
+                         return d->pVarNums[Aig_ObjId(o)];
+                       });
   };
 
   if (uf.simple_cnf)

--- a/lib/ToSat/ToCNFGia.cpp
+++ b/lib/ToSat/ToCNFGia.cpp
@@ -1,0 +1,123 @@
+/********************************************************************
+ * AUTHORS: Trevor Hansen
+ *
+ * BEGIN DATE: August, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+#include "stp/ToSat/ToCNFGia.h"
+
+#include "stp/ToSat/AbcCnfAdopt.h"
+
+#include <iostream>
+#include <vector>
+
+namespace stp
+{
+
+void ToCNFGia::toCNF(const BBNodeGia& top, CNF& cnf,
+                     ToSATBase::ASTNodeToSATVar& nodeToVars,
+                     bool /*needAbsRef*/, BBNodeManagerGia& mgr)
+{
+  assert(cnf.clauseCount() == 0);
+  assert(nodeToVars.size() == 0);
+  assert(!top.IsNull());
+
+  Gia_Man_t* const p = mgr.giaMgr;
+  assert(Gia_ManCoNum(p) == 0);
+  Gia_ManAppendCo(p, top.n);
+
+  // The structural-hash table has done its work and is two int arrays over
+  // the objects. Hand it back before the mapper allocates, which is the point
+  // in the pipeline where the process is largest. Nothing builds a gate after
+  // this; Gia_ManHashAnd asserts if anything tries.
+  Gia_ManHashStop(p);
+
+  if (uf.stats_flag)
+    std::cerr << "gia: " << Gia_ManAndNum(p) << " AND nodes, "
+              << Gia_ManCiNum(p) << " inputs, LUT" << nLutSize << std::endl;
+
+  // fAddOrCla, the fourth argument, is what asserts the outputs. Cnf_Derive
+  // does that itself; this generator only on request, by adding a single
+  // clause OR-ing every CO -- and there is exactly one.
+  //
+  // No cleanup first. The ABC-Aig path runs Aig_ManCleanup here, but a node
+  // outside the cone of the output is one Mf never maps, and so never gives a
+  // variable or a clause to; all it costs is its share of cut enumeration,
+  // measured at 2.1% of the AND nodes on the largest query in the hard set.
+  // Removing them means copying the graph, and a second Gia at 12 bytes an
+  // object costs more than the 2.1% is worth.
+  Cnf_Dat_t* const cnfData =
+      (Cnf_Dat_t*)Mf_ManGenerateCnf(p, nLutSize, 0, 1, 0, 0);
+
+  // pVarNums is indexed by the object ids of the graph passed in -- this one.
+  //
+  // That holds even though the generator derives the CNF over a coarsened
+  // copy (Gia_ManDupMuxes, which strashes and then cleans up, so ids do not
+  // survive it). Mf_ManDeriveCnf notices the two managers differ and rebuilds
+  // pVarNums against the original, bridging by CI and CO *ordinal*, which is
+  // what the copy does preserve. Only the input and output entries are
+  // filled; every other object reads back as ABC's -1.
+  //
+  // Worth knowing, because it is what makes this backend possible at all. An
+  // input here is not object 1..nCi the way it is on the converted path:
+  // CreateSymbol mints one the first time a symbol bit is touched and
+  // CreateFreshInput mints one mid-blast per abstraction proxy, so inputs
+  // land interleaved with gates -- on 375 of 388 fuzz corpus files, and with
+  // an input moved by the coarsening on 186 of 193. None of it matters,
+  // because no id read here is one the coarsening had a chance to move.
+  cnf = adoptAbcCnf(cnfData, (unsigned)Gia_ManCiNum(p),
+                    (unsigned)Gia_ManCoNum(p), [&](bool isCo, unsigned i) {
+                      Gia_Obj_t* const o =
+                          isCo ? Gia_ManCo(p, (int)i) : Gia_ManCi(p, (int)i);
+                      return cnfData->pVarNums[Gia_ObjId(p, o)];
+                    });
+
+  // Mf leaves pMan pointing at the graph it derived over, cast to Aig_Man_t*,
+  // and when it coarsened, that graph is a copy it has already stopped.
+  // Nothing in STP reads pMan and Cnf_DataFree does not touch it; null the
+  // pointer so a dangling one cannot be followed.
+  cnfData->pMan = NULL;
+
+  // Each symbol maps to the variables its bits carry. ~0u for a bit that
+  // reached no variable, which is the same sentinel the other two lowerings
+  // write and what the freezing pass and the model builder expect.
+  for (const auto& entry : mgr.symbolToBBNode)
+  {
+    const ASTNode& n = entry.first;
+    const std::vector<BBNodeGia>& bits = entry.second;
+    assert(nodeToVars.find(n) == nodeToVars.end());
+
+    const int width = (n.GetType() == BOOLEAN_TYPE) ? 1 : n.GetValueWidth();
+    std::vector<unsigned> v(width, ~((unsigned)0));
+
+    for (unsigned i = 0; i < bits.size(); i++)
+    {
+      if (bits[i].IsNull())
+        continue;
+      const uint32_t var = cnf.varOfCi((uint32_t)mgr.ciOrdinal(bits[i]));
+      if (var != 0)
+        v[i] = var;
+    }
+    nodeToVars.insert(std::make_pair(n, v));
+  }
+}
+
+} // namespace stp

--- a/lib/ToSat/ToSATAIG.cpp
+++ b/lib/ToSat/ToSATAIG.cpp
@@ -224,6 +224,9 @@ bool ToSATAIG::bitblast(const ASTNode& input, bool needAbsRef, CNF& cnf)
   if (bm->UserFlags.cnf_effort == UserDefinedFlags::CNF_EFFORT_NEW_VERY_LOW)
     return bitblastWith<BBNodeLit, BBNodeManagerLit, BitBlasterLit,
                         ToCNFTseitin>(input, needAbsRef, cnf);
+  if (UserDefinedFlags::isGiaEffort(bm->UserFlags.cnf_effort))
+    return bitblastWith<BBNodeGia, BBNodeManagerGia, BitBlasterGia, ToCNFGia>(
+        input, needAbsRef, cnf);
   return bitblastWith<BBNodeAIG, BBNodeManagerAIG, BitBlasterAIG, ToCNFAIG>(
       input, needAbsRef, cnf);
 }

--- a/tests/query-files/misc-tests/cnf-generation-effort-auto.smt2
+++ b/tests/query-files/misc-tests/cnf-generation-effort-auto.smt2
@@ -31,7 +31,7 @@
 ;
 ; RUN: not %solver --SMTLIB2 --cnf-generation-effort nonsense %s 2>&1 | %OutputCheck --check-prefix=BADLEVEL %s
 ;
-; BADLEVEL: Unknown --cnf-generation-effort value 'nonsense'\. Expected one of: auto, very-low, low, medium, high, very-high, new_very_low\.
+; BADLEVEL: Unknown --cnf-generation-effort value 'nonsense'\. Expected one of: auto, very-low, low, medium, high, very-high, new_very_low, gia-low, gia-high, gia-very-high\.
 ;
 ; The new_very_low rung is a different generator over a different AIG, so it
 ; says so rather than printing one of the ABC lines, and auto never reaches it:
@@ -44,6 +44,28 @@
 ; NEWVERYLOW: ^new_very_low CNF$
 ; NEWVERYLOW: ^cnf: [0-9]+ clauses, [0-9]+ variables, [0-9]+ literals$
 ; NEWVERYLOW: sat
+;
+; The gia- rungs reach Mf_ManGenerateCnf, the same generator low, high and
+; very-high reach, over a Gia the blaster built rather than one converted from
+; an ABC AIG. They print the graph they hand over -- which is how a reader
+; tells the two backends apart at the same LUT size -- and auto never picks
+; one, for the same reason it never picks the rung above.
+;
+; RUN: %solver --SMTLIB2 -s --cnf-generation-effort gia-low %s 2>&1 | %OutputCheck --check-prefix=GIALOW %s
+; RUN: %solver --SMTLIB2 -s --cnf-generation-effort gia-high %s 2>&1 | %OutputCheck --check-prefix=GIAHIGH %s
+; RUN: %solver --SMTLIB2 -s --cnf-generation-effort gia-very-high %s 2>&1 | %OutputCheck --check-prefix=GIAVHIGH %s
+;
+; GIALOW-NOT: cnf-auto:
+; GIALOW-NOT: Nodes before AIG rewrite:
+; GIALOW: ^gia: [0-9]+ AND nodes, [0-9]+ inputs, LUT3$
+; GIALOW: ^cnf: [0-9]+ clauses, [0-9]+ variables, [0-9]+ literals$
+; GIALOW: sat
+;
+; GIAHIGH: ^gia: [0-9]+ AND nodes, [0-9]+ inputs, LUT6$
+; GIAHIGH: sat
+;
+; GIAVHIGH: ^gia: [0-9]+ AND nodes, [0-9]+ inputs, LUT8$
+; GIAVHIGH: sat
 
 (set-logic QF_BV)
 (declare-fun a () (_ BitVec 8))

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -737,7 +737,10 @@ void ExtraMain::create_options()
                  "very-low and medium from the size of the AIG, since "
                  "minimising a large one costs more than the solver saves. "
                  "new_very_low blasts through STP's own AIG instead of ABC's "
-                 "and writes the CNF directly")
+                 "and writes the CNF directly. gia-low, gia-high and "
+                 "gia-very-high are low, high and very-high again, reaching "
+                 "the same generator over a Gia the blaster built rather than "
+                 "one converted from an ABC AIG")
       ->capture_default_str()
       ->group(misc_group);
 
@@ -1053,11 +1056,17 @@ int ExtraMain::parse_options(int argc, char** argv)
     bm->UserFlags.cnf_effort = UserDefinedFlags::CNF_EFFORT_AUTO;
   else if (cnf_effort == "new_very_low")
     bm->UserFlags.cnf_effort = UserDefinedFlags::CNF_EFFORT_NEW_VERY_LOW;
+  else if (cnf_effort == "gia-low")
+    bm->UserFlags.cnf_effort = UserDefinedFlags::CNF_EFFORT_GIA_LOW;
+  else if (cnf_effort == "gia-high")
+    bm->UserFlags.cnf_effort = UserDefinedFlags::CNF_EFFORT_GIA_HIGH;
+  else if (cnf_effort == "gia-very-high")
+    bm->UserFlags.cnf_effort = UserDefinedFlags::CNF_EFFORT_GIA_VERY_HIGH;
   else
   {
     std::cerr << "Unknown --cnf-generation-effort value '" << cnf_effort
               << "'. Expected one of: auto, very-low, low, medium, high, "
-                 "very-high, new_very_low."
+                 "very-high, new_very_low, gia-low, gia-high, gia-very-high."
               << std::endl;
     return -1;
   }


### PR DESCRIPTION
`Mf_ManGenerateCnf` is the generator behind `--cnf-generation-effort low`, `high` and `very-high`, and it takes a `Gia_Man_t`. `ToCNFAIG` reaches it by building an ABC Aig and calling `Gia_ManFromAig`, so a graph at 48 bytes an object and a graph at 12 are both live when the mapper runs.

This blasts into the Gia directly. No Aig, no conversion, and the structural-hash table is handed back before the mapper allocates. Three new levels — `gia-low`, `gia-high`, `gia-very-high` — mirror the LUT sizes of `low`, `high` and `very-high`, so comparing the two backends is one word on the command line.

## The pieces

The seam is the one #1046 and #1047 established, so this is a third instantiation of it rather than new machinery:

| | in-house (#1047) | this |
|---|---|---|
| handle | `BBNodeLit` | `BBNodeGia` — a 4-byte Gia literal |
| manager | `BBNodeManagerLit` | `BBNodeManagerGia` |
| lowering | `ToCNFTseitin` | `ToCNFGia` → `Mf_ManGenerateCnf` |

A Gia handle has to be a literal rather than a pointer because `Gia_Man_t::pObjs` reallocs as it grows.

Two things are easier here than on ABC's Aig. `ciOrdinal` is O(1), since `Gia_ManAppendCi` stores the ordinal in the object — the handle carries no `symbol_index` and there is no search over the input list. And no ordered-gate wrappers are needed: `orderedAigExor` and `orderedAigMux` exist because `Aig_Exor` and `Aig_Mux2` build two nodes inside one argument list, where the evaluation order is unspecified and the ids it decides reach the CNF, whereas `Gia_ManHashXor` and `Gia_ManHashMux` assign their intermediates in separate statements.

## Two things worth reading the comments for

**The inputs are not objects 1..nCi.** On the converted path they are, because `Gia_ManFromAig` appends every CI before any AND, and `derive_cnf_mf` says so. This manager cannot: `CreateSymbol` mints an input the first time a symbol bit is touched, so inputs land interleaved with gates — on 375 of 388 fuzz corpus files, with an input moved by Mf's coarsening on 186 of 193.

That turns out not to matter, and the reason is recorded because it is not obvious. Mf coarsens the graph before mapping and derives the CNF over the copy, but `Mf_ManDeriveCnf` notices the managers differ and rebuilds `pVarNums` against the original, bridging by input and output **ordinal** rather than by id. I built a hoisting pass to restore the 1..nCi invariant before finding this, then deleted it.

**No cleanup before generation.** The Aig path runs `Aig_ManCleanup` here. A node outside the cone of the output is one Mf never maps and never gives a variable to; it costs only its share of cut enumeration — 2.1% of the AND nodes on the largest query in the hard set — and removing them means copying the graph, which costs more than the 2.1% is worth.

`ToCNFAIG::adopt()` moves to a header as a free function, unchanged, so both lowerings share the one copy.

## Measurements

Largest query in the hard set, `--exit-after-CNF`, each level against the one it mirrors:

| level | clauses | variables | peak RSS | wall |
|---|---|---|---|---|
| low | 9,414,737 | 2,121,486 | 1331 MB | 9.5 s |
| **gia-low** | 9,414,733 | 2,121,654 | **906 MB** | 9.2 s |
| high | 8,054,120 | 1,151,136 | 1711 MB | 17.9 s |
| **gia-high** | 8,054,125 | 1,151,672 | **1257 MB** | 16.0 s |
| very-high | 7,997,033 | 1,128,315 | 1777 MB | 29.3 s |
| **gia-very-high** | 7,997,021 | 1,150,007 | **1288 MB** | 27.3 s |

−32%, −27% and −28% peak. Clause counts are within 5 of each other; the graphs differ slightly because Gia's structural hash is commutative and `Aig_And` is not (stp/abc#8).

## Verification

2501 fuzz corpus queries under `--check-sanity`, so every counterexample was constructed and checked against the formula — the direct test of the input-to-variable projection, which is what could plausibly break here. `gia-low` and `gia-high` agree with `low` and `high` on all 2501.

The check was itself validated: shifting the projection by one input made it fail on 41 of 200 files, so a green sweep means something. 175/175 ctest, with the effort-level query file extended to cover the new rungs.

## One open question

On four array queries of 250 (`--array-equality` with both abstractions on), `gia-low` is 3–18x slower than `low`. Every answer is still correct and CNF generation is *faster* in each case — the whole loss is SAT search, e.g. 1311 ms → 25378 ms on one, with an extra refinement round. A slightly different formula sending the solver down a worse path. Too few cases to call it a regression, too many to call it noise; it wants a proper A/B on a larger array corpus before these levels are recommended for anything but measurement.


---

*Rebased onto #1048. Three conflicts, all from the `new_low`/`new_medium` rungs it added: the `CNFEffort` ordinals (the `gia-*` ones now follow the `new_*` ones, since the ordinals are the C interface's contract), the CLI parse chain and its level list, and the effort-level query file, which now checks all twelve. The backend dispatch merged without conflict. Every number above and the 2501-query sweep were re-taken on the merged tree; 175/175 ctest.*