### PR TITLE
Point the ABC pin at the linear leaf collection

### DIFF
--- a/cmake/FindABC.cmake
+++ b/cmake/FindABC.cmake
@@ -82,7 +82,7 @@ if(NOT ABC_FOUND_SYSTEM)
     # stp/abc is a fork: master tracks upstream untouched and the `stp` branch
     # carries STP's changes as commits on top. To work on those, clone it and
     # point -DABC_DIR at a build of the clone. See docs/code-guide.rst.
-    set(ABC_GIT_TAG "c8920763e91c5fb7427444b6cd97d580224ae88b" CACHE STRING
+    set(ABC_GIT_TAG "bdacd898845aa91b2e2d650272b2ca35c1d4539f" CACHE STRING
         "ABC revision to build when one has to be built")
     mark_as_advanced(ABC_GIT_TAG)
 


### PR DESCRIPTION
Moves `ABC_GIT_TAG` from `c8920763` to `bdacd8988` — the same ABC revision plus two commits: stp/abc#7 (the leaf collection change) and stp/abc#8 (`Aig_And` operand canonicalisation). Held by the tag `stp-at-953930643-pr1051`, alongside `stp-at-953930643-pr971` which holds the revision pinned until now.

`Cnf_CollectLeaves()` suppressed duplicate leaves with `Vec_PtrPushUnique()`, which rescans the whole vector on every push, so collecting an n-leaf gate cost O(n^2). The widest gate in the benchmark set has 2.4M leaves: about 3x10^12 comparisons before, about 5x10^7 after.

Measured through STP as retired user-space instructions to `--exit-after-CNF`, over a tail-weighted 1,251-file subset of the non-incremental benchmarks, with ABC built exactly as STP builds it:

| | |
|---|---:|
| summed instructions | **−60.75%** |
| `QF_BV/20210312-Bouvier/vlsat3_a95.smt2` wall clock | **32.8s → 0.53s** |
| worst file | +0.61% |
| median file | −0.000% |
| CNF byte-identical | 1,138 / 1,251 |
| CNF changed | 113 |

### On the CNF changes

Two independent causes. The leaves of a gate past the cut-off now come out sorted rather than in discovery order, which reorders the emitted clauses without changing the clause set — nothing structural can move, because every consumer that is sensitive to leaf order needs fewer leaves than the cut-off. And #8 canonicalises `Aig_And`'s operands, which changes the AIG itself; that accounts for the difference between the 68 files that reorder from the leaf change alone and the 113 seen here.

Solve times on the reordered files show no regression: worst 1.01x, best 0.09x, verdicts unchanged throughout. That sample was taken against a build carrying the same `cnfFast.c` on a newer ABC base, so it characterises the reordering rather than this exact pin.

Full solves over `tests/query-files`: identical output except for files differing only in a reported memory or timing statistic.

Raised upstream as berkeley-abc/abc#555.
