### PR TITLE
Spell the in-house CNF rungs with hyphens, like every other rung

### DIFF
--- a/lib/ToSat/ToCNFTseitin.cpp
+++ b/lib/ToSat/ToCNFTseitin.cpp
@@ -76,9 +76,9 @@ void ToCNFTseitin::toCNF(const BBNodeLit& top, CNF& cnf,
   }
 
   if (uf.stats_flag)
-    std::cerr << (recover == aig::Recover::Nothing    ? "new_very_low CNF"
-                  : recover == aig::Recover::Patterns ? "new_low CNF"
-                                                      : "new_medium CNF")
+    std::cerr << (recover == aig::Recover::Nothing    ? "new-very-low CNF"
+                  : recover == aig::Recover::Patterns ? "new-low CNF"
+                                                      : "new-medium CNF")
               << std::endl;
 }
 

--- a/tests/query-files/misc-tests/cnf-generation-effort-auto.smt2
+++ b/tests/query-files/misc-tests/cnf-generation-effort-auto.smt2
@@ -31,25 +31,25 @@
 ;
 ; RUN: not %solver --SMTLIB2 --cnf-generation-effort nonsense %s 2>&1 | %OutputCheck --check-prefix=BADLEVEL %s
 ;
-; BADLEVEL: Unknown --cnf-generation-effort value 'nonsense'\. Expected one of: auto, very-low, low, medium, high, very-high, new_very_low, new_low, new_medium, gia-low, gia-high, gia-very-high\.
+; BADLEVEL: Unknown --cnf-generation-effort value 'nonsense'\. Expected one of: auto, very-low, low, medium, high, very-high, new-very-low, new-low, new-medium, gia-low, gia-high, gia-very-high\.
 ;
-; The new_* rungs are a different generator over a different AIG, so they
-; says so rather than printing one of the ABC lines, and auto never reaches it:
+; The new-* rungs are a different generator over a different AIG, so they
+; say so rather than printing one of the ABC lines, and auto never reaches it:
 ; auto decides from ABC's node count, which means blasting through ABC first.
 ;
-; RUN: %solver --SMTLIB2 -s --cnf-generation-effort new_very_low %s 2>&1 | %OutputCheck --check-prefix=NEWVERYLOW %s
-; RUN: %solver --SMTLIB2 -s --cnf-generation-effort new_low %s 2>&1 | %OutputCheck --check-prefix=NEWLOW %s
-; RUN: %solver --SMTLIB2 -s --cnf-generation-effort new_medium %s 2>&1 | %OutputCheck --check-prefix=NEWMEDIUM %s
+; RUN: %solver --SMTLIB2 -s --cnf-generation-effort new-very-low %s 2>&1 | %OutputCheck --check-prefix=NEWVERYLOW %s
+; RUN: %solver --SMTLIB2 -s --cnf-generation-effort new-low %s 2>&1 | %OutputCheck --check-prefix=NEWLOW %s
+; RUN: %solver --SMTLIB2 -s --cnf-generation-effort new-medium %s 2>&1 | %OutputCheck --check-prefix=NEWMEDIUM %s
 ;
 ; NEWVERYLOW-NOT: cnf-auto:
 ; NEWVERYLOW-NOT: advanced CNF
-; NEWVERYLOW: ^new_very_low CNF$
+; NEWVERYLOW: ^new-very-low CNF$
 ; NEWVERYLOW: sat
 ;
-; NEWLOW: ^new_low CNF$
+; NEWLOW: ^new-low CNF$
 ; NEWLOW: sat
 ;
-; NEWMEDIUM: ^new_medium CNF$
+; NEWMEDIUM: ^new-medium CNF$
 ; NEWMEDIUM: sat
 ;
 ; The gia-* rungs reach Mf_ManGenerateCnf, the same generator low, high and

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -732,14 +732,14 @@ void ExtraMain::create_options()
       ->group(misc_group);
   app.add_option("--cnf-generation-effort", cnf_effort,
                  "effort spent minimising the CNF: auto, very-low, low, "
-                 "medium, high, very-high, new_very_low, new_low, new_medium. "
+                 "medium, high, very-high, new-very-low, new-low, new-medium. "
                  "Higher is slower to "
                  "generate but yields a smaller CNF; auto picks between "
                  "very-low and medium from the size of the AIG, since "
                  "minimising a large one costs more than the solver saves. "
-                 "The new_* rungs blast through STP's own AIG instead of "
-                 "ABC's and write the CNF directly: new_very_low is plain "
-                 "Tseitin, new_low recovers XOR and if-then-else, new_medium "
+                 "The new-* rungs blast through STP's own AIG instead of "
+                 "ABC's and write the CNF directly: new-very-low is plain "
+                 "Tseitin, new-low recovers XOR and if-then-else, new-medium "
                  "also collapses n-ary ANDs and ORs. The gia-* rungs are low, "
                  "high and very-high again, reaching the same generator over "
                  "a Gia the blaster built rather than one converted from an "
@@ -1057,11 +1057,11 @@ int ExtraMain::parse_options(int argc, char** argv)
     bm->UserFlags.cnf_effort = UserDefinedFlags::CNF_EFFORT_VERY_HIGH;
   else if (cnf_effort == "auto")
     bm->UserFlags.cnf_effort = UserDefinedFlags::CNF_EFFORT_AUTO;
-  else if (cnf_effort == "new_very_low")
+  else if (cnf_effort == "new-very-low")
     bm->UserFlags.cnf_effort = UserDefinedFlags::CNF_EFFORT_NEW_VERY_LOW;
-  else if (cnf_effort == "new_low")
+  else if (cnf_effort == "new-low")
     bm->UserFlags.cnf_effort = UserDefinedFlags::CNF_EFFORT_NEW_LOW;
-  else if (cnf_effort == "new_medium")
+  else if (cnf_effort == "new-medium")
     bm->UserFlags.cnf_effort = UserDefinedFlags::CNF_EFFORT_NEW_MEDIUM;
   else if (cnf_effort == "gia-low")
     bm->UserFlags.cnf_effort = UserDefinedFlags::CNF_EFFORT_GIA_LOW;
@@ -1073,7 +1073,7 @@ int ExtraMain::parse_options(int argc, char** argv)
   {
     std::cerr << "Unknown --cnf-generation-effort value '" << cnf_effort
               << "'. Expected one of: auto, very-low, low, medium, high, "
-                 "very-high, new_very_low, new_low, new_medium, gia-low, "
+                 "very-high, new-very-low, new-low, new-medium, gia-low, "
                  "gia-high, gia-very-high."
               << std::endl;
     return -1;


### PR DESCRIPTION
`--cnf-generation-effort` takes `very-low`, `gia-very-high` and the rest with hyphens. The three rungs that write the CNF from STP's own AIG arrived as `new_very_low`, `new_low` and `new_medium`, so the option now answers to two spelling conventions at once. This makes them `new-very-low`, `new-low` and `new-medium`.

The stats line the Tseitin writer prints names the rung it took, so it moves with them, and so does the test that pins both the names and the list the parser offers when it refuses an unknown one.

No alias for the old spellings. The rungs are days old and nothing outside the tree has had the chance to depend on them; carrying two names for a week-old option costs more than it saves.

Checked: the query-file test for the option passes, the unit tests over the encoders pass, `--cnf-generation-effort new_low` is now refused with the corrected list, and `new-medium` prints its own stats line.