### PR TITLE
Six defects from an audit of the three-backend bit-blasting work

### DIFF
--- a/include/stp/ToSat/BBNodeManagerGia.h
+++ b/include/stp/ToSat/BBNodeManagerGia.h
@@ -330,6 +330,12 @@ private:
     if (children.size() == 1)
       return children[0].n;
 
+    // Two is the overwhelming majority of what a blast emits, and the deque
+    // below would allocate twice to pair them. The tower reduces to the same
+    // call.
+    if (children.size() == 2)
+      return op(giaMgr, children[0].n, children[1].n);
+
     std::deque<int> names;
     for (size_t i = 0, size = children.size(); i < size; ++i)
       names.push_back(children[i].n);

--- a/include/stp/ToSat/BBNodeManagerLit.h
+++ b/include/stp/ToSat/BBNodeManagerLit.h
@@ -268,6 +268,12 @@ private:
     if (children.size() == 1)
       return children[0].n;
 
+    // Two is the overwhelming majority of what a blast emits, and the deque
+    // below would allocate twice to pair them. The tower reduces to the same
+    // call.
+    if (children.size() == 2)
+      return (mgr.*op)(children[0].n, children[1].n);
+
     std::deque<aig::Lit> names;
     for (size_t i = 0, size = children.size(); i < size; ++i)
       names.push_back(children[i].n);

--- a/include/stp/c_interface.h
+++ b/include/stp/c_interface.h
@@ -481,9 +481,17 @@ enum ifaceflag_t
   BV_TERM_ABSTRACTION_INC_BITBLAST,
 
   //! How much effort the CNF generator spends minimising the formula it
-  //! hands the SAT solver, as an ordinal: 0 very low, 1 low, 2 medium (the
-  //! default), 3 high, 4 very high. Higher is slower to generate and yields
-  //! a smaller CNF.
+  //! hands the SAT solver, as an ordinal: 0 very low, 1 low, 2 medium,
+  //! 3 high, 4 very high. Higher is slower to generate and yields a smaller
+  //! CNF.
+  //!
+  //! 5 is auto, and is the default: it picks between very low and medium
+  //! from the size of the circuit, on the reasoning below. Ordinals 6 to 11
+  //! name rungs that blast the query with a different backend rather than
+  //! spending a different amount of effort -- 6, 7 and 8 the in-house
+  //! writer, 9, 10 and 11 the same generator as 1, 3 and 4 over a circuit
+  //! built without ABC. Auto never selects those; asking for one is an
+  //! explicit choice of backend.
   //!
   //! It is a real trade and not a quality dial. A query whose search is
   //! trivial but whose circuit is large -- a floating-point square root over

--- a/lib/Interface/c_interface.cpp
+++ b/lib/Interface/c_interface.cpp
@@ -600,10 +600,14 @@ void vc_setInterfaceFlags(VC vc, enum ifaceflag_t f, int param_value)
       b->UserFlags.incremental_scoped_preprocessing = param_value != 0;
       break;
     case CNF_GENERATION_EFFORT:
+      // Every rung, up to and including the last enumerator. AUTO in
+      // particular: it is the default, so refusing it leaves a caller that
+      // has set any other level with no way back to the one it started with.
+      // The bound tracks the enum, and the numbers in the message with it.
       if (param_value < 0 ||
-          param_value > stp::UserDefinedFlags::CNF_EFFORT_VERY_HIGH)
+          param_value > stp::UserDefinedFlags::CNF_EFFORT_GIA_VERY_HIGH)
         reportCAPIError("CNF_GENERATION_EFFORT takes an effort ordinal from "
-                        "0 (very low) to 4 (very high)");
+                        "0 (very low) to 11 (gia very high)");
       else
         b->UserFlags.cnf_effort =
             static_cast<stp::UserDefinedFlags::CNFEffort>(param_value);

--- a/lib/Simplifier/AIGSimplifyPropositionalCore.cpp
+++ b/lib/Simplifier/AIGSimplifyPropositionalCore.cpp
@@ -260,7 +260,10 @@ ASTNode AIGSimplifyPropositionalCore::topLevel(const ASTNode& top)
   Dar_RwrPar_t Pars, *pPars = &Pars;
   Dar_ManDefaultRwrParams(pPars);
 
-  // Assertion errors occur with this enabled.
+  // The warning that stood here -- that assertion errors occur with this
+  // enabled -- was copied from ToCNFAIG.cpp, where the line is commented out.
+  // It is stale in both places: over 347 query files in an assertions build
+  // this path aborts on none of them and changes no answer.
   pPars->fUseZeros = 1;
 
   const int iterations = 3;

--- a/lib/ToSat/ToCNFAIG.cpp
+++ b/lib/ToSat/ToCNFAIG.cpp
@@ -234,9 +234,32 @@ CNF ToCNFAIG::derive_cnf(BBNodeManagerAIG& mgr, unsigned namedOutputs)
     case UserDefinedFlags::CNF_EFFORT_VERY_HIGH:
       return derive_cnf_mf(mgr, 8, namedOutputs);
 
+    // The rungs that name a different backend still have to answer here,
+    // because this conversion is reached from places that have an ABC Aig and
+    // nothing else -- the BV-abstraction refinement splices above all. Each
+    // maps to the level on this scale that spends comparable effort, so the
+    // splices track the level that was asked for instead of silently running
+    // whatever the default arm happened to be.
+    //
+    // The gia rungs drive the same generator at the same three LUT sizes, so
+    // the mapping is exact. The in-house rungs sit below very-low, and
+    // very-low is as far down as this scale goes.
+    case UserDefinedFlags::CNF_EFFORT_NEW_VERY_LOW:
+    case UserDefinedFlags::CNF_EFFORT_NEW_LOW:
+    case UserDefinedFlags::CNF_EFFORT_NEW_MEDIUM:
+      return fromAig(Cnf_DeriveFast(mgr.aigMgr, (int)namedOutputs));
+
+    case UserDefinedFlags::CNF_EFFORT_GIA_LOW:
+      return derive_cnf_mf(mgr, 3, namedOutputs);
+
+    case UserDefinedFlags::CNF_EFFORT_GIA_HIGH:
+      return derive_cnf_mf(mgr, 6, namedOutputs);
+
+    case UserDefinedFlags::CNF_EFFORT_GIA_VERY_HIGH:
+      return derive_cnf_mf(mgr, 8, namedOutputs);
+
     case UserDefinedFlags::CNF_EFFORT_AUTO: // resolved above; cannot reach here
     case UserDefinedFlags::CNF_EFFORT_MEDIUM:
-    default:
     {
       // Cut enumeration and technology mapping, as in ABC's Cnf_Derive().
       // That convenience wrapper reuses one process-global Cnf_Man_t, so two
@@ -250,6 +273,10 @@ CNF ToCNFAIG::derive_cnf(BBNodeManagerAIG& mgr, unsigned namedOutputs)
       return fromAig(result);
     }
   }
+
+  // No default arm above: -Wswitch is what makes a new rung choose what this
+  // conversion does with it, rather than inheriting an arm by accident.
+  FatalError("ToCNFAIG: unhandled CNF generation effort");
 }
 
 void ToCNFAIG::fill_node_to_var(const CNF& cnf,

--- a/lib/ToSat/ToCNFAIG.cpp
+++ b/lib/ToSat/ToCNFAIG.cpp
@@ -37,7 +37,12 @@ void ToCNFAIG::dag_aware_aig_rewrite(const bool needAbsRef,
     Dar_RwrPar_t Pars, *pPars = &Pars;
     Dar_ManDefaultRwrParams(pPars);
 
-    // Assertion errors occur with this enabled.
+    // Left off because it is slower, not because it is unsound. The comment
+    // that stood here said assertion errors occur with it enabled; measured
+    // over 250 query files in an assertions build, none do -- the abort it
+    // described is the dangling-node one the Aig_ManCleanup below now
+    // handles. Enabling it did cost three files that finish in under a
+    // minute without it, so it stays off until someone measures the trade.
     // pPars->fUseZeros = 1;
 
     // For mul63bit.smt2 with iterations =3 & nCutsMax = 8

--- a/lib/ToSat/ToCNFGia.cpp
+++ b/lib/ToSat/ToCNFGia.cpp
@@ -96,6 +96,12 @@ void ToCNFGia::toCNF(const BBNodeGia& top, CNF& cnf,
   // pointer so a dangling one cannot be followed.
   cnfData->pMan = NULL;
 
+  // Mf also hangs the CNF off the graph it was given. Here that graph is the
+  // blaster's own manager, which outlives this call, while the CNF is about
+  // to belong to `cnf` and be freed with it -- and Gia_ManStop frees pData2
+  // but never pData, so nothing else clears it. Same reason as pMan above.
+  p->pData = NULL;
+
   // Each symbol maps to the variables its bits carry. ~0u for a bit that
   // reached no variable, which is the same sentinel the other two lowerings
   // write and what the freezing pass and the model builder expect.

--- a/tests/api/C/cnf-effort-flag.cpp
+++ b/tests/api/C/cnf-effort-flag.cpp
@@ -108,13 +108,37 @@ TEST(cnf_effort_flag, EveryLevelIsReachable)
   vc_setInterfaceFlags(vc, CNF_GENERATION_EFFORT, 4);
   EXPECT_EQ(stp::UserDefinedFlags::CNF_EFFORT_VERY_HIGH, flags(vc).cnf_effort);
 
+  // Auto is a level like the others here, and the only one that matters to a
+  // caller that has already set another: it is the default, so without it
+  // there is no way back to where the checker started.
+  vc_setInterfaceFlags(vc, CNF_GENERATION_EFFORT, 5);
+  EXPECT_EQ(stp::UserDefinedFlags::CNF_EFFORT_AUTO, flags(vc).cnf_effort);
+
+  // The rungs that name a backend rather than an effort. They are on the same
+  // ordinal scale by construction -- a new rung goes on the end -- so an
+  // embedder reaches them the same way.
+  vc_setInterfaceFlags(vc, CNF_GENERATION_EFFORT, 6);
+  EXPECT_EQ(stp::UserDefinedFlags::CNF_EFFORT_NEW_VERY_LOW,
+            flags(vc).cnf_effort);
+  vc_setInterfaceFlags(vc, CNF_GENERATION_EFFORT, 7);
+  EXPECT_EQ(stp::UserDefinedFlags::CNF_EFFORT_NEW_LOW, flags(vc).cnf_effort);
+  vc_setInterfaceFlags(vc, CNF_GENERATION_EFFORT, 8);
+  EXPECT_EQ(stp::UserDefinedFlags::CNF_EFFORT_NEW_MEDIUM, flags(vc).cnf_effort);
+  vc_setInterfaceFlags(vc, CNF_GENERATION_EFFORT, 9);
+  EXPECT_EQ(stp::UserDefinedFlags::CNF_EFFORT_GIA_LOW, flags(vc).cnf_effort);
+  vc_setInterfaceFlags(vc, CNF_GENERATION_EFFORT, 10);
+  EXPECT_EQ(stp::UserDefinedFlags::CNF_EFFORT_GIA_HIGH, flags(vc).cnf_effort);
+  vc_setInterfaceFlags(vc, CNF_GENERATION_EFFORT, 11);
+  EXPECT_EQ(stp::UserDefinedFlags::CNF_EFFORT_GIA_VERY_HIGH,
+            flags(vc).cnf_effort);
+
   vc_Destroy(vc);
 }
 
 // Out of range is refused and leaves the level alone. The field is an enum,
-// so an accepted 5 or -1 would be a value no switch in the generator handles
-// -- it would fall to whichever arm happens to be the default and the caller
-// would never learn that what they asked for did not happen.
+// so an accepted value past the end would be one no switch in the generator
+// handles -- it would fall to whichever arm happens to be first and the
+// caller would never learn that what they asked for did not happen.
 TEST(cnf_effort_flag, OutOfRangeIsRefusedAndLeavesTheLevelAlone)
 {
   vc_registerErrorHandler(countError);
@@ -124,7 +148,8 @@ TEST(cnf_effort_flag, OutOfRangeIsRefusedAndLeavesTheLevelAlone)
   vc_setInterfaceFlags(vc, CNF_GENERATION_EFFORT, 3);
   EXPECT_EQ(stp::UserDefinedFlags::CNF_EFFORT_HIGH, flags(vc).cnf_effort);
 
-  vc_setInterfaceFlags(vc, CNF_GENERATION_EFFORT, 5);
+  // One past the last enumerator.
+  vc_setInterfaceFlags(vc, CNF_GENERATION_EFFORT, 12);
   EXPECT_EQ(stp::UserDefinedFlags::CNF_EFFORT_HIGH, flags(vc).cnf_effort);
   vc_setInterfaceFlags(vc, CNF_GENERATION_EFFORT, -1);
   EXPECT_EQ(stp::UserDefinedFlags::CNF_EFFORT_HIGH, flags(vc).cnf_effort);
@@ -136,10 +161,12 @@ TEST(cnf_effort_flag, OutOfRangeIsRefusedAndLeavesTheLevelAlone)
 
 // The level reaches the solve, and every one of them answers the same
 // question the same way. A level that changed a verdict would be a bug in
-// the generator, not a setting.
+// the generator, not a setting -- and since six of the twelve pick a whole
+// bit-blasting backend rather than an effort, this is where a backend that
+// encoded the query wrongly would be caught.
 TEST(cnf_effort_flag, EveryLevelDecidesTheSameQuery)
 {
-  for (int effort = 0; effort <= 4; ++effort)
+  for (int effort = 0; effort <= 11; ++effort)
   {
     VC vc = vc_createValidityChecker();
     vc_setInterfaceFlags(vc, CNF_GENERATION_EFFORT, effort);

--- a/tests/query-files/misc-tests/cnf-generation-effort-auto.smt2
+++ b/tests/query-files/misc-tests/cnf-generation-effort-auto.smt2
@@ -14,9 +14,9 @@
 ;
 ; SMALL: ^cnf-auto: [0-9]+ AIG nodes, chose medium$
 ; SMALL: ^cnf: [0-9]+ clauses, [0-9]+ variables, [0-9]+ literals$
-; SMALL: sat
+; SMALL: ^sat$
 ; BIG: ^cnf-auto: [0-9]+ AIG nodes, chose very-low$
-; BIG: sat
+; BIG: ^sat$
 ;
 ; The fixed levels stay reachable and stay silent: nothing decides anything, so
 ; there is no line to print.
@@ -25,7 +25,7 @@
 ; RUN: %solver --SMTLIB2 -s --cnf-generation-effort very-low %s 2>&1 | %OutputCheck --check-prefix=FIXED %s
 ;
 ; FIXED-NOT: cnf-auto:
-; FIXED: sat
+; FIXED: ^sat$
 ;
 ; And an unknown level is still refused, with auto now among those offered.
 ;
@@ -44,13 +44,13 @@
 ; NEWVERYLOW-NOT: cnf-auto:
 ; NEWVERYLOW-NOT: advanced CNF
 ; NEWVERYLOW: ^new-very-low CNF$
-; NEWVERYLOW: sat
+; NEWVERYLOW: ^sat$
 ;
 ; NEWLOW: ^new-low CNF$
-; NEWLOW: sat
+; NEWLOW: ^sat$
 ;
 ; NEWMEDIUM: ^new-medium CNF$
-; NEWMEDIUM: sat
+; NEWMEDIUM: ^sat$
 ;
 ; The gia-* rungs reach Mf_ManGenerateCnf, the same generator low, high and
 ; very-high reach, over a Gia the blaster built rather than one converted from
@@ -66,13 +66,13 @@
 ; GIALOW-NOT: Nodes before AIG rewrite:
 ; GIALOW: ^gia: [0-9]+ AND nodes, [0-9]+ inputs, LUT3$
 ; GIALOW: ^cnf: [0-9]+ clauses, [0-9]+ variables, [0-9]+ literals$
-; GIALOW: sat
+; GIALOW: ^sat$
 ;
 ; GIAHIGH: ^gia: [0-9]+ AND nodes, [0-9]+ inputs, LUT6$
-; GIAHIGH: sat
+; GIAHIGH: ^sat$
 ;
 ; GIAVHIGH: ^gia: [0-9]+ AND nodes, [0-9]+ inputs, LUT8$
-; GIAVHIGH: sat
+; GIAVHIGH: ^sat$
 
 (set-logic QF_BV)
 (declare-fun a () (_ BitVec 8))


### PR DESCRIPTION
An audit of the five commits that made `BitBlaster` a template again and added the second and third bit-blasting backends turned up a list of cleanups. These are the six that are defects rather than tidying; the dead code, the duplication and the stale comments are left for a follow-up.

Each commit stands alone and none of them changes what the default configuration does.

### Let the C API reach every CNF-generation level

The setter refused any ordinal above `CNF_EFFORT_VERY_HIGH` (4). `CNF_EFFORT_AUTO` is 5 and is the default, so an embedder that set any level could never get back to the one it started with, and the six rungs added since were unreachable. The enum's own comment says new rungs go on the end *because* the ordinals are the C interface's contract, so the bound was simply left behind. `include/stp/c_interface.h` also still documented "2 medium (the default)".

The three tests grow to match. `EveryLevelDecidesTheSameQuery` now covers all twelve rather than the first five, which matters more than it did: six of the twelve select a whole bit-blasting backend rather than an amount of effort, so that loop is where a backend that encoded a query wrongly would surface.

### Anchor the CNF-effort test's answer checks

All nine answer checks were the bare string `sat`, and OutputCheck matches with `re.search`, so each was equally satisfied by `unsat`. The route-identifying lines were anchored; the correctness half was not, which left three bit-blasting backends with no end-to-end check that they agree on an answer. Anchored to the form 70 other query files already use.

### Say why fUseZeros is off, having measured it

Both copies of the Dar rewrite loop carried the same comment — that assertion errors occur with the setting enabled — above a line that is commented out in one copy and live in the other. One of the two had to be wrong.

Measured, in an assertions build: the live one aborts on none of 347 query files and changes no answer, and enabling the disabled one aborts on none of 250. The abort the comment describes is the dangling-node one that the `Aig_ManCleanup` call in the same loop now handles.

Enabling it in the CNF path is still a bad trade — three files that finish inside a minute without it did not finish with it — so the line stays off and only the reason changes. No behaviour change in either copy.

### Give the new CNF levels an arm of their own in ToCNFAIG

A `default:` label absorbed all six rungs added since that switch was written, so they ran the medium arm silently. That is reachable rather than theoretical: the BV-abstraction refinement splices convert through this function carrying the user's level, so `--bv-term-abstraction --cnf-generation-effort gia-low` blasted the query with one backend and every splice with another at a level nobody asked for. The same `default:` is why adding six enumerators produced no `-Wswitch` warning anywhere in the tree.

The gia rungs drive the same generator at the same three LUT sizes, so they map exactly onto low, high and very-high — on the effort test query all three pairs produce byte-identical CNF, which is what makes the mapping a fact rather than a guess. The in-house rungs sit below very-low, and very-low is as far down as this scale goes. The `default:` is gone, so the next rung has to choose.

### Pair two-input gates without a deque

`tower()` short-circuited at one child and built a `std::deque` for anything above it, so every two-input gate cost a map array and a 512-byte node. Two-input gates are most of what an adder or a comparator blasts to. `BBNodeManagerAIG` has special-cased the pair since it was written; the two newer managers did not.

For two children the deque path evaluates `op(children[0], children[1])` and nothing else, so this is the same call. Confirmed against a purpose-built pre-change binary: identical CNF over 172 measured conversions.

### Null the CNF that Mf hangs off the blaster's graph

`Mf_ManGenerateCnf` does not only return the CNF, it stores it on the graph it was given — here the blaster's own manager, which outlives the call, while the CNF becomes the property of a `CNF` object and is freed with it. `Gia_ManStop` frees `pData2` and never `pData`, so nothing clears the pointer and it dangles. Not a leak and not a double free, but the line directly above already nulls `pMan` for exactly this reason.

### Testing

`ctest` is 178/178 on a debug build with assertions and CaDiCaL. The two changes that could have moved the encoding were checked against a pre-change build and produce identical CNF.