### PR TITLE
Clean the lemma AIG before rewriting it

### DIFF
--- a/lib/ToSat/BVExactEncoder.cpp
+++ b/lib/ToSat/BVExactEncoder.cpp
@@ -68,6 +68,15 @@ void rewrite(BBNodeManagerAIG& mgr, int64_t iterations)
   if (iterations <= 0)
     return;
 
+  // Blasting a claim leaves AND nodes behind that no CO reaches: a bit of an
+  // intermediate vector nothing reads, an operand a later structural-hash hit
+  // dropped the last reference to. Aig_ManDupDfs does not copy those, but it
+  // asserts that it copied everything, so it aborts an assertions build below.
+  // ToCNFAIG::toCNF cleans up before it rewrites for the same reason; these
+  // AIGs are built here, so clean up here. Only unreferenced AND nodes go, so
+  // the CI order the callers splice by is untouched.
+  Aig_ManCleanup(mgr.aigMgr);
+
   ensureDarLibrary();
   Dar_RwrPar_t Pars;
   Dar_ManDefaultRwrParams(&Pars);


### PR DESCRIPTION
`--bv-term-abstraction=1` together with `--aig-rewrite-passes` aborts an assertions build:

```
Aig_ManDupDfs: Assertion `p->pEquivs != NULL || Aig_ManBufNum(p) != 0
                          || Aig_ManNodeNum(p) == Aig_ManNodeNum(pNew)' failed.
```

Both flags have to be on. `--bv-term-abstraction` is the only thing that reaches `BVExactEncoder`, and `--aig-rewrite-passes` is `0` by default, so the default path never sees this.

## What happens

`BVExactEncoder` blasts a small lemma AIG, makes the claim and its support combinational outputs, and hands the manager to the file-local `rewrite()` helper. Blasting leaves AND nodes behind that no CO reaches — a bit of an intermediate vector nothing reads, an operand whose last reference a structural-hash hit dropped. `Aig_ManDupDfs` copies only the CO-reachable cone, and then asserts that it copied every node.

`ToCNFAIG::toCNF` calls `Aig_ManCleanup` before it rewrites for exactly this reason. The lemma path never did.

Reading the dangling count at the head of `rewrite()` over one input shows the distribution, and shows why the abort is not on the first lemma:

| lemma | AIG nodes | CIs | COs | dangling |
| --- | --- | --- | --- | --- |
| 1 | 71 | 36 | 1 | 0 |
| 2 | 41 | 24 | 1 | **1** |
| 3 | 95 | 48 | 1 | 0 |
| 4 | 139 | 24 | 1 | **4** |
| 5 | 66 | 24 | 1 | **9** |

Master aborts on lemma 2.

## The change

One `Aig_ManCleanup` at the top of `rewrite()`, which covers both call sites. The loop already cleans after each `Dar_ManRewrite`, and `Aig_ManDupDfs` cleans the manager it returns, so the manager is clean at the top of every later iteration — once before the loop is enough.

Cleaning inside the helper rather than where the COs are made keeps the default path byte-identical: `AIG_rewrites_iterations` is 0 by default and the helper returns immediately, whereas cleaning at CO creation would also shrink the AIG handed to `derive_cnf`, where cut enumeration can give a dangling node a variable and renumber the CNF.

CI ordinals and counts survive it — `Aig_ManCleanup` collects only objects satisfying `Aig_ObjIsNode`, and `Aig_ObjDelete_rec` returns early on CIs and const-1. That is what the `varOfCi` splices and the `Aig_ManCiNum` assertions in both callers depend on.

## Testing

Found by the differential fuzzer, which reported 136 `QF_UFBV` files under a single option draw:

```
--aig-rewrite-passes=1 --bb.mult-variant=5 --bb.div-v1=0
--bv-term-abstraction=1 --bv-abstraction-width=8
--cnf-generation-effort=new-very-low --search-bias unsat --interactive=1
```

- Unpatched, 25 of those inputs sampled at this base: 25/25 abort.
- Patched: all 136 answer, and every answer agrees with the checker. One is slow enough to need a raised timeout, but takes just as long with `--aig-rewrite-passes=0`, so it is an inherently slow instance rather than a regression.
- 40 of the inputs re-run at `--aig-rewrite-passes=2` and `=3`: 80 runs, no assertion and no segfault.
- `ctest`: full suite green.