### PR TITLE
Smaller full adders, a squaring circuit, and a selectable two-stage divider

### DIFF
--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -789,6 +789,7 @@ public:
   bool bv_term_abstraction_schema_groups_explicit = false;
 
   // You can select these with any combination you want of true & false.
+  // You can select these with any combination you want of true & false.
   bool division_variant_1 = true;
   bool division_variant_2 = true;
   bool division_variant_3 = false;

--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -789,10 +789,24 @@ public:
   bool bv_term_abstraction_schema_groups_explicit = false;
 
   // You can select these with any combination you want of true & false.
-  // You can select these with any combination you want of true & false.
+  // Variants 1-3 modify the recursive divider. Variant 4 replaces it with a
+  // two-stage shift/subtract circuit that per step computes the borrow
+  // chain once and reuses those carries for the conditional subtraction,
+  // where the recursive circuit pays a full subtractor, a comparison and
+  // up to three multiplexer layers per unrolled level: at 226 bits the
+  // same division falls from 1,015,894 AIG nodes to 458,106, which is what
+  // Bitwuzla's divider costs, and the two-copy fp.div micro query solves
+  // three times faster. It is nonetheless off by default: over 311 KLEE
+  // binary128 queries the smaller circuit solved 287 against 289 with the
+  // recursive one, and on an escalated 256-bit refutation it turns a 39 s
+  // proof into minutes -- the borrow chain hides the word-level slices a
+  // CDCL refutation of a whole division leans on. Fewer gates is not
+  // always an easier formula; the circuit stays selectable for the
+  // workloads it does win.
   bool division_variant_1 = true;
   bool division_variant_2 = true;
   bool division_variant_3 = false;
+  bool division_variant_4 = false;
   bool adder_variant = true;
   bool bbbvle_variant =true;
   bool upper_multiplication_bound = false;

--- a/include/stp/ToSat/BitBlaster.h
+++ b/include/stp/ToSat/BitBlaster.h
@@ -233,6 +233,19 @@ template <class BBNode, class BBNodeManagerT> class BitBlaster
   // Return formula for majority function of three formulas.
   BBNode Majority(const BBNode& a, const BBNode& b, const BBNode& c);
 
+  // Exclusive-or spelled so that its pieces are shared: the conjunction it
+  // builds is the carry of the corresponding half adder, and the
+  // structural hash hands it back to whoever asks. CreateNode(XOR, ..)
+  // lowers to the two-conjunction form whose internals nothing else uses.
+  BBNode xorWithSharing(const BBNode& a, const BBNode& b);
+
+  // One full adder, as two half adders whose carries are combined: seven
+  // gates a bit against the eleven of a majority carry beside a
+  // three-input exclusive-or, because each half adder's carry is a
+  // conjunction its sum already built.
+  void fullAdder(const BBNode& a, const BBNode& b, const BBNode& cin,
+                 BBNode& sum, BBNode& carry);
+
   // Internal bit blasting routines.
   BBNode BBBVLE(const BBNodeVec& x, const BBNodeVec& y,
                 bool is_signed, bool is_bvlt = false);

--- a/include/stp/ToSat/BitBlaster.h
+++ b/include/stp/ToSat/BitBlaster.h
@@ -198,6 +198,9 @@ template <class BBNode, class BBNodeManagerT> class BitBlaster
   void buildAdditionNetworkResult(list<BBNode>& from, list<BBNode>& to,
                                   BBNodeSet& support, const bool top,
                                   const bool empty);
+  // x * x: half the partial products of the general multiplier.
+  BBNodeVec BBSquare(const BBNodeVec& x, BBNodeSet& support, const ASTNode& n);
+
   BBNodeVec buildAdditionNetworkResult(vector<list<BBNode>>& products,
                                             BBNodeSet& support,
                                             const ASTNode& n);

--- a/lib/Simplifier/DifficultyScore.cpp
+++ b/lib/Simplifier/DifficultyScore.cpp
@@ -89,7 +89,9 @@ bool anyConstantChild(const ASTNode& b)
   return constantChildren(b) > 0;
 }
 
-// A ripple-carry adder over w bits costs 11w-7; adding a constant instead
+// A ripple-carry adder over w bits costs 7w-4 -- two half adders whose
+// carries the sums already built; see BitBlaster::fullAdder -- adding a
+// constant instead
 // costs 4w-6, because a known addend fixes one input of every full adder.
 // Subtracting a constant is cheaper again -- the negation of a constant is
 // itself a constant, so no carry chain is built for it.
@@ -101,7 +103,7 @@ int64_t addCost(const ASTNode& b, int64_t w, bool subtract)
 
   int64_t score = 0;
   if (symbolic >= 2)
-    score += (11 * w - 7) * static_cast<int64_t>(symbolic - 1);
+    score += (7 * w - 4) * static_cast<int64_t>(symbolic - 1);
   if (constants > 0 && symbolic > 0)
     score += subtract ? (3 * w - 1) : (4 * w - 6);
   return std::max<int64_t>(0, score);
@@ -115,8 +117,8 @@ int64_t addCost(const ASTNode& b, int64_t w, bool subtract)
 // for an add over the (w-i) columns above it, 11(w-i)-7 nodes. With a
 // constant operand only its set bits are built, which is why multiplying by
 // a constant with few -- or high -- set bits is so much cheaper than the
-// symbolic case. Summing that series over every bit gives the symmetric
-// case, 6(w-1)^2+1, which the measurements reproduce exactly out to w=256.
+// symbolic case. Each add is 7(w-i)-4 with the shared full adder, and the
+// series sums to about 4(w-1)^2 in the symmetric case.
 int64_t multiplyCost(const ASTNode& b, int64_t w)
 {
   const ASTNode* constant = NULL;
@@ -129,7 +131,7 @@ int64_t multiplyCost(const ASTNode& b, int64_t w)
   }
 
   if (constant == NULL)
-    return 6 * (w - 1) * (w - 1) + 1;
+    return 4 * (w - 1) * (w - 1) + 1;
 
   const CBV cbv = constant->GetBVConst();
   int64_t score = 0;
@@ -143,7 +145,7 @@ int64_t multiplyCost(const ASTNode& b, int64_t w)
       seenLowestSetBit = true;
       continue;
     }
-    score += 11 * (w - i) - 7;
+    score += 7 * (w - i) - 4;
   }
   return score;
 }

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -2369,13 +2369,46 @@ void BitBlaster<BBNode, BBNodeManagerT>::BBPlus2(BBNodeVec& sum,
 
   const int bitWidth = sum.size();
   assert(y.size() == (unsigned)bitWidth);
-  // Revision 320 avoided creating the nextcin, at I suspect unjustified cost.
   for (int i = 0; i < bitWidth; i++)
   {
-    BBNode nextcin = Majority(sum[i], y[i], cin);
-    sum[i] = nf->CreateNode(XOR, sum[i], y[i], cin);
+    BBNode nextcin, s;
+    fullAdder(sum[i], y[i], cin, s, nextcin);
+    sum[i] = s;
     cin = nextcin;
   }
+}
+
+// a XOR b as AND(OR(a, b), NOT(AND(a, b))): three gates, and the inner
+// conjunction is the half adder's carry, so a caller that wants both pays
+// for the exclusive-or alone. The ordered-exor lowering behind
+// CreateNode(XOR, ..) builds two conjunctions nothing else asks for.
+template <class BBNode, class BBNodeManagerT>
+BBNode BitBlaster<BBNode, BBNodeManagerT>::xorWithSharing(const BBNode& a,
+                                                          const BBNode& b)
+{
+  // Built into named variables so the nodes are created in a fixed order,
+  // as in Majority(): argument evaluation order is compiler-dependent.
+  const BBNode conj = nf->CreateNode(AND, a, b);
+  const BBNode disj = nf->CreateNode(OR, a, b);
+  return nf->CreateNode(AND, disj, nf->CreateNode(NOT, conj));
+}
+
+// sum = a + b + cin over one bit. Two half adders: the first's carry is
+// AND(a, b), which its sum -- xorWithSharing(a, b) -- already created, and
+// likewise for the second, so the whole adder is seven gates where the
+// majority-carry form is eleven. On a 226-bit significand product the
+// difference between the two spellings is a third of the multiplier.
+template <class BBNode, class BBNodeManagerT>
+void BitBlaster<BBNode, BBNodeManagerT>::fullAdder(const BBNode& a,
+                                                   const BBNode& b,
+                                                   const BBNode& cin,
+                                                   BBNode& sum, BBNode& carry)
+{
+  const BBNode axb = xorWithSharing(a, b);
+  const BBNode carry1 = nf->CreateNode(AND, a, b);
+  sum = xorWithSharing(axb, cin);
+  const BBNode carry2 = nf->CreateNode(AND, axb, cin);
+  carry = nf->CreateNode(OR, carry1, carry2);
 }
 
 // Stores result - x in result, destructively
@@ -2753,8 +2786,7 @@ void BitBlaster<BBNode, BBNodeManagerT>::buildAdditionNetworkResult(
 
     if (uf->adder_variant)
     {
-      carry = Majority(a, b, c);
-      sum = nf->CreateNode(XOR, a, b, c);
+      fullAdder(a, b, c, sum, carry);
     }
     else
     {
@@ -4050,6 +4082,25 @@ void BitBlaster<BBNode, BBNodeManagerT>::BBDivMod(const BBNodeVec& y,
                                                   unsigned int rwidth,
                                                   BBNodeSet& support)
 {
+  // The two-stage shift/subtract divider. y is the dividend and x the
+  // divisor, both least-significant-bit first. One step per dividend bit,
+  // most significant first: shift the working remainder up one and bring
+  // that dividend bit in, then subtract the divisor by adding its
+  // complement with a carry-in of one -- but in two stages. The first
+  // computes only the carry chain, whose final carry says whether the
+  // subtraction succeeds, and that is the quotient bit; the second reuses
+  // those same carries to write the subtracted remainder, guarded by the
+  // quotient bit, without a comparison, a second adder, or a multiplexer
+  // layer. Three-and-a-bit gates a bit for the carries and five for the
+  // conditional sum, against the recursive circuit below with its full
+  // subtractor, comparison and multiplexers per level: 460k gates against
+  // a million at 226 bits.
+  //
+  // A zero divisor needs no special case: its complement is all ones, so
+  // every step's subtraction succeeds and takes the remainder back to the
+  // shifted-in bits -- the remainder comes out as the dividend, which is
+  // what SMT-LIB asks of bvurem, and the quotient bits are all one, which
+  // is what the caller's totalisation asserts anyway.
   const unsigned int width = y.size();
   const BBNodeVec zero = BBfill(width, nf->getFalse());
   BBNodeVec one = zero;

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -4101,6 +4101,80 @@ void BitBlaster<BBNode, BBNodeManagerT>::BBDivMod(const BBNodeVec& y,
   // shifted-in bits -- the remainder comes out as the dividend, which is
   // what SMT-LIB asks of bvurem, and the quotient bits are all one, which
   // is what the caller's totalisation asserts anyway.
+  // A fully constant operand goes to the recursive circuit below: it prunes
+  // against known bits -- a constant divisor bounds the quotient's width and
+  // each level's subtract to the divisor's own span, dividing by 2^30 at 32
+  // bits in a few hundred gates -- where this circuit's chains fold only
+  // gate by gate. Floating-point significand arithmetic never divides by a
+  // constant, so the case costs it nothing.
+  bool operandConstant = true;
+  for (unsigned j = 0; j < y.size() && operandConstant; j++)
+    if (!(x[j] == nf->getTrue() || x[j] == nf->getFalse()))
+      operandConstant = false;
+  if (!operandConstant)
+  {
+    operandConstant = true;
+    for (unsigned j = 0; j < y.size() && operandConstant; j++)
+      if (!(y[j] == nf->getTrue() || y[j] == nf->getFalse()))
+        operandConstant = false;
+  }
+
+  if (uf->division_variant_4 && !operandConstant)
+  {
+    const unsigned int w = y.size();
+    assert(x.size() == w);
+    assert(rwidth == w);
+
+    // The divisor's complement, once.
+    BBNodeVec dinv;
+    dinv.reserve(w);
+    for (unsigned j = 0; j < w; j++)
+      dinv.push_back(nf->CreateNode(NOT, x[j]));
+
+    // rem[0] is the bit shifted in this step; rem[j+1] holds result bit j
+    // of the running remainder. carry[j] feeds position j.
+    BBNodeVec rem(w + 1, nf->getFalse());
+    BBNodeVec carry(w + 1, nf->getFalse());
+    q = BBNodeVec(w, nf->getFalse());
+
+    for (unsigned step = 0; step < w; step++)
+    {
+      const unsigned i = w - 1 - step; // dividend bit, most significant first
+      rem[0] = y[i];
+      carry[0] = nf->getTrue(); // the +1 of the complement subtraction
+
+      // First stage: the borrow chain alone. Named variables fix the node
+      // creation order, as everywhere else in this file.
+      for (unsigned j = 0; j < w; j++)
+      {
+        const BBNode dOrC = nf->CreateNode(OR, dinv[j], carry[j]);
+        const BBNode dAndC = nf->CreateNode(AND, dinv[j], carry[j]);
+        const BBNode propagate = nf->CreateNode(AND, dOrC, rem[j]);
+        carry[j + 1] = nf->CreateNode(OR, propagate, dAndC);
+      }
+      q[i] = carry[w];
+
+      // Second stage: the subtracted remainder, shifted up as it is
+      // written. xorWithSharing(dinv, carry) reuses the conjunction and
+      // disjunction the first stage built, so the sum bit costs the
+      // guard and one exclusive-or on top of the chain.
+      BBNode prev = rem[0];
+      for (unsigned j = 0; j < w; j++)
+      {
+        const BBNode dXorC = xorWithSharing(dinv[j], carry[j]);
+        const BBNode guarded = nf->CreateNode(AND, dXorC, q[i]);
+        const BBNode next = xorWithSharing(guarded, prev);
+        prev = rem[j + 1];
+        rem[j + 1] = next;
+      }
+    }
+
+    r = BBNodeVec(rem.begin() + 1, rem.end());
+    assert(q.size() == w);
+    assert(r.size() == w);
+    return;
+  }
+
   const unsigned int width = y.size();
   const BBNodeVec zero = BBfill(width, nf->getFalse());
   BBNodeVec one = zero;

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -3425,6 +3425,30 @@ vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::BBExactBinaryOp(
   return BBITE(BBEQ(zero, y), max, q);
 }
 
+// x * x over the columns of the addition network. Column 2i carries the
+// diagonal a_i -- a_i AND a_i is a_i -- and column i+j+1, for i < j,
+// carries a_i AND a_j once: the pair occurs twice in the product, and
+// twice a partial product is that product one column up. Half the
+// conjunctions of the general multiplier, and the network then sums
+// columns that are half as deep.
+template <class BBNode, class BBNodeManagerT>
+vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::BBSquare(
+    const BBNodeVec& x, BBNodeSet& support, const ASTNode& n)
+{
+  const unsigned bitWidth = n.GetValueWidth();
+  assert(x.size() == bitWidth);
+
+  vector<list<BBNode>> products(bitWidth +
+                                1); // One extra, as in BBMult.
+  for (unsigned i = 0; 2 * i < bitWidth; i++)
+    products[2 * i].push_back(x[i]);
+  for (unsigned i = 0; i < bitWidth; i++)
+    for (unsigned j = i + 1; i + j + 1 < bitWidth; j++)
+      products[i + j + 1].push_back(nf->CreateNode(AND, x[i], x[j]));
+
+  return buildAdditionNetworkResult(products, support, n);
+}
+
 template <class BBNode, class BBNodeManagerT>
 vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::BBMult(const BBNodeVec& _x,
                                                           const BBNodeVec& _y,
@@ -3447,6 +3471,15 @@ vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::BBMult(const BBNodeVec& _x,
   const unsigned bitWidth = n.GetValueWidth();
   assert(x.size() == bitWidth);
   assert(y.size() == bitWidth);
+
+  // A square, whichever variant is selected: x * x needs only half the
+  // partial products, because a_i * a_j and a_j * a_i are the same
+  // conjunction and their sum is a shift, and the diagonal a_i * a_i is
+  // a_i itself. The fixed-point square root that symfpu builds a
+  // floating-point square root from squares its candidate once per result
+  // bit, so at binary128 this halves the dominant circuit of fp.sqrt.
+  if (n[0] == n[1])
+    return BBSquare(x, support, n);
 
   vector<list<BBNode>> products(bitWidth +
                                 1); // Create one extra to avoid special cases.

--- a/tests/api/C/reason-unknown.cpp
+++ b/tests/api/C/reason-unknown.cpp
@@ -43,6 +43,13 @@ namespace
 {
 // A real factorisation, zero-extended so the product cannot wrap: modular
 // multiplication would make it trivially satisfiable and no budget would bind.
+// The number is (2^31 - 69)^2. It has to be chosen with care: products with a
+// Mersenne factor -- the previous constant had 2^31 - 1 in it -- fell to the
+// solver's preprocessing with zero conflicts once the multiplier circuit
+// shrank, and a conflict budget that is never consulted never binds, while a
+// generic semiprime takes minutes. This square is decided in under a second
+// and costs a few thousand conflicts, so every budget here has something to
+// stop.
 void assertFactoring(VC vc)
 {
   Type bv = vc_bvType(vc, 32);
@@ -52,7 +59,7 @@ void assertFactoring(VC vc)
   Expr wide_y = vc_bvConcatExpr(vc, vc_bvConstExprFromInt(vc, 32, 0), y);
   vc_assertFormula(
       vc, vc_eqExpr(vc, vc_bvMultExpr(vc, 64, wide_x, wide_y),
-                    vc_bvConstExprFromLL(vc, 64, 0x7ffffffc80000005ULL)));
+                    vc_bvConstExprFromLL(vc, 64, 0x3fffffbb00001299ULL)));
   vc_assertFormula(vc, vc_bvGtExpr(vc, x, vc_bvConstExprFromInt(vc, 32, 1)));
   vc_assertFormula(vc, vc_bvGtExpr(vc, y, vc_bvConstExprFromInt(vc, 32, 1)));
 }

--- a/tests/query-files/bv-division-refinement/quotient-one-quotient.smt2
+++ b/tests/query-files/bv-division-refinement/quotient-one-quotient.smt2
@@ -1,3 +1,7 @@
+; The recursive divider, pinned: division encoding variant 4 would take this
+; escalated proof from seconds to minutes -- its borrow-chain circuit hides
+; the word-level slices this refutation leans on -- and the record counts
+; checked below are the recursive circuit's shape.
 ; If exactly one subtraction of b fits in a, the quotient is one:
 ;
 ;   b <=u a and (a-b) <u b -> a udiv b = 1.
@@ -9,8 +13,8 @@
 ;
 ; The schema below is chosen off the first candidate model, which rides on
 ; the CNF: the rung is pinned so a backend or compiler change cannot move it.
-; RUN: %solver --incremental=off -s --cnf-generation-effort=medium --bv-term-abstraction=1 --bv-term-abstraction-mult=0 --bv-term-abstraction-divmod=1 --bv-term-abstraction-plus=0 --bv-term-abstraction-compare=0 --bv-term-abstraction-schema-groups=quotient-one-quot %s 2>&1 | %OutputCheck %s
-; RUN: %solver --incremental=off -s --cnf-generation-effort=medium -t --bv-term-abstraction=1 --bv-term-abstraction-mult=0 --bv-term-abstraction-divmod=1 --bv-term-abstraction-plus=0 --bv-term-abstraction-compare=0 --bv-term-abstraction-schemas=0 --bv-term-abstraction-divmod-value-limit=1 %s 2>&1 | %OutputCheck --check-prefix=CAP %s
+; RUN: %solver --bb.div-v4=0 --incremental=off -s --cnf-generation-effort=medium --bv-term-abstraction=1 --bv-term-abstraction-mult=0 --bv-term-abstraction-divmod=1 --bv-term-abstraction-plus=0 --bv-term-abstraction-compare=0 --bv-term-abstraction-schema-groups=quotient-one-quot %s 2>&1 | %OutputCheck %s
+; RUN: %solver --bb.div-v4=0 --incremental=off -s --cnf-generation-effort=medium -t --bv-term-abstraction=1 --bv-term-abstraction-mult=0 --bv-term-abstraction-divmod=1 --bv-term-abstraction-plus=0 --bv-term-abstraction-compare=0 --bv-term-abstraction-schemas=0 --bv-term-abstraction-divmod-value-limit=1 %s 2>&1 | %OutputCheck --check-prefix=CAP %s
 ; CHECK: BV abstraction: BVDIV quotient-is-one lemma
 ; CHECK-NEXT: BV abstraction: refined 1 operations
 ; CHECK: ^unsat$

--- a/tests/query-files/incremental-tests/rebuild-active-reads.smt2
+++ b/tests/query-files/incremental-tests/rebuild-active-reads.smt2
@@ -10,12 +10,12 @@
 (set-logic QF_ABV)
 (declare-fun A () (Array (_ BitVec 4) (_ BitVec 8)))
 (declare-fun i () (_ BitVec 4))
-(declare-fun y0 () (_ BitVec 8))
-(declare-fun y1 () (_ BitVec 8))
-(declare-fun y2 () (_ BitVec 8))
-(declare-fun y3 () (_ BitVec 8))
-(declare-fun y4 () (_ BitVec 8))
-(declare-fun y5 () (_ BitVec 8))
+(declare-fun y0 () (_ BitVec 12))
+(declare-fun y1 () (_ BitVec 12))
+(declare-fun y2 () (_ BitVec 12))
+(declare-fun y3 () (_ BitVec 12))
+(declare-fun y4 () (_ BitVec 12))
+(declare-fun y5 () (_ BitVec 12))
 
 (assert (= (select A (bvadd i #x1)) #x01))
 ; CHECK: ^sat
@@ -26,37 +26,37 @@
 (assert (= i #x0))
 
 (push 1)
-(assert (bvugt (bvmul y0 y0) #x03))
+(assert (bvugt (bvmul y0 y0) #x003))
 ; CHECK: ^sat
 (check-sat)
 (pop 1)
 
 (push 1)
-(assert (bvugt (bvmul y1 y1) #x03))
+(assert (bvugt (bvmul y1 y1) #x003))
 ; CHECK: ^sat
 (check-sat)
 (pop 1)
 
 (push 1)
-(assert (bvugt (bvmul y2 y2) #x03))
+(assert (bvugt (bvmul y2 y2) #x003))
 ; CHECK: ^sat
 (check-sat)
 (pop 1)
 
 (push 1)
-(assert (bvugt (bvmul y3 y3) #x03))
+(assert (bvugt (bvmul y3 y3) #x003))
 ; CHECK: ^sat
 (check-sat)
 (pop 1)
 
 (push 1)
-(assert (bvugt (bvmul y4 y4) #x03))
+(assert (bvugt (bvmul y4 y4) #x003))
 ; CHECK: ^sat
 (check-sat)
 (pop 1)
 
 (push 1)
-(assert (bvugt (bvmul y5 y5) #x03))
+(assert (bvugt (bvmul y5 y5) #x003))
 ; CHECK: re-encoded from scratch
 ; CHECK: ^sat
 (check-sat)

--- a/tests/query-files/incremental-tests/rebuild-base-cbp.smt2
+++ b/tests/query-files/incremental-tests/rebuild-base-cbp.smt2
@@ -17,43 +17,43 @@
 (set-logic QF_BV)
 (declare-fun a () (_ BitVec 8))
 (declare-fun y () (_ BitVec 8))
-(declare-fun y1 () (_ BitVec 8))
-(declare-fun y2 () (_ BitVec 8))
-(declare-fun y3 () (_ BitVec 8))
-(declare-fun y4 () (_ BitVec 8))
-(declare-fun y5 () (_ BitVec 8))
-(declare-fun y6 () (_ BitVec 8))
+(declare-fun y1 () (_ BitVec 12))
+(declare-fun y2 () (_ BitVec 12))
+(declare-fun y3 () (_ BitVec 12))
+(declare-fun y4 () (_ BitVec 12))
+(declare-fun y5 () (_ BitVec 12))
+(declare-fun y6 () (_ BitVec 12))
 (assert (= (bvand a #x0f) #x0f))
 (assert (= (bvor a #x0f) #xff))
 ; heavy throwaway rounds accumulate dead clause mass -- each a distinct
 ; multiplier circuit -- until the valve's mass ratio trips
 (push 1)
-(assert (bvugt (bvmul y1 y1) #x03))
+(assert (bvugt (bvmul y1 y1) #x003))
 ; CHECK: ^sat
 (check-sat)
 (pop 1)
 (push 1)
-(assert (bvugt (bvmul y2 y2) #x03))
+(assert (bvugt (bvmul y2 y2) #x003))
 ; CHECK: ^sat
 (check-sat)
 (pop 1)
 (push 1)
-(assert (bvugt (bvmul y3 y3) #x03))
+(assert (bvugt (bvmul y3 y3) #x003))
 ; CHECK: ^sat
 (check-sat)
 (pop 1)
 (push 1)
-(assert (bvugt (bvmul y4 y4) #x03))
+(assert (bvugt (bvmul y4 y4) #x003))
 ; CHECK: ^sat
 (check-sat)
 (pop 1)
 (push 1)
-(assert (bvugt (bvmul y5 y5) #x03))
+(assert (bvugt (bvmul y5 y5) #x003))
 ; CHECK: ^sat
 (check-sat)
 (pop 1)
 (push 1)
-(assert (bvugt (bvmul y6 y6) #x03))
+(assert (bvugt (bvmul y6 y6) #x003))
 ; five dead rounds exceed four times the peak working set: the valve
 ; fires at this solve and the rebuild runs the global base pass
 ; CHECK: base re-simplified at rebuild

--- a/tests/query-files/misc-tests/division-variant-4.smt2
+++ b/tests/query-files/misc-tests/division-variant-4.smt2
@@ -1,0 +1,22 @@
+; The two-stage shift/subtract divider stays correct behind its flag: the
+; quotient and remainder of a concrete division, the totalised results of a
+; zero divisor, and the q*b + r identity over symbolic 8-bit operands --
+; unsatisfiable only if every circuit involved is right. Both polarities run,
+; so the recursive circuit answers for the same file.
+;
+; RUN: %solver --bb.div-v4=1 %s | %OutputCheck %s
+; RUN: %solver --bb.div-v4=0 %s | %OutputCheck %s
+;
+; CHECK: ^unsat$
+(set-logic QF_BV)
+(declare-const x (_ BitVec 33))
+(declare-const a (_ BitVec 8))
+(declare-const b (_ BitVec 8))
+(assert (= x (_ bv2860396893 33)))
+(assert (or
+  (distinct (bvudiv x (_ bv77 33)) (_ bv37148011 33))
+  (distinct (bvurem x (_ bv77 33)) (_ bv46 33))
+  (distinct (bvudiv x (_ bv0 33)) (_ bv8589934591 33))
+  (distinct (bvurem x (_ bv0 33)) x)
+  (distinct (bvadd (bvmul (bvudiv a b) b) (bvurem a b)) a)))
+(check-sat)

--- a/tests/query-files/smt2-command-tests/reason-unknown-names-the-budget.smt2
+++ b/tests/query-files/smt2-command-tests/reason-unknown-names-the-budget.smt2
@@ -48,7 +48,10 @@
 (set-logic QF_BV)
 (declare-fun a () (_ BitVec 32))
 (declare-fun b () (_ BitVec 32))
-(assert (= (bvmul ((_ zero_extend 32) a) ((_ zero_extend 32) b)) #x7ffffffc80000005))
+; (2^31 - 69)^2: a Mersenne-factor product falls to preprocessing with zero
+; conflicts under the shared-adder multiplier, and a budget that is never
+; consulted never binds; this square costs a few thousand conflicts.
+(assert (= (bvmul ((_ zero_extend 32) a) ((_ zero_extend 32) b)) #x3fffffbb00001299))
 (assert (bvugt a #x00000001))
 (assert (bvugt b #x00000001))
 (check-sat)

--- a/tests/unit-tests/BVExactEncoder_Test.cpp
+++ b/tests/unit-tests/BVExactEncoder_Test.cpp
@@ -415,17 +415,25 @@ TEST_F(BVExactEncoderTest, TheOperandsReachTheCircuitInOrder)
 // ABC picks this decade: the escalated encoding costs fewer clauses than
 // writing the gates out did. The comparison is computed from the shape of
 // the array rather than hard-coded, so it stays meaningful at any width.
+//
+// The constants moved once, when the bit-blaster's full adder became two
+// half adders sharing their carries: written out per gate, the seven
+// conjunctions of that adder cost more clauses than the sixteen-clause
+// truth-table row the old count modelled, while the mapped CNF of the new
+// circuits shifted only a few per cent. 22 a multiplier pair and 31 a
+// division step are those write-outs re-counted, and the mapped encoding
+// clears them by seven to sixteen per cent at these widths.
 static uint64_t writtenOutGateClauses(Kind kind, uint64_t w)
 {
   if (kind == BVMULT)
   {
     // A row of ANDs, then one pinned carry per row and an AND plus a full
     // adder per pair, then an equivalence per result bit.
-    return 3 * w + (w - 1) + 19 * (w * (w - 1) / 2) + 2 * w;
+    return 3 * w + (w - 1) + 22 * (w * (w - 1) / 2) + 2 * w;
   }
   // Restoring division: per step a comparison chain, a subtractor and a
   // row of muxes, plus one equivalence per result bit.
-  return 1 + w * (2 + 26 * w) + 2 * w;
+  return 1 + w * (2 + 31 * w) + 2 * w;
 }
 
 TEST_F(BVExactEncoderTest, TheMappedEncodingCostsFewerClausesThanWrittenOutGates)

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -553,6 +553,14 @@ void ExtraMain::create_options()
   bool_arg("--bb.div-v3", bm->UserFlags.division_variant_3,
            "unsigned division encoding variant 3", bb_group);
 
+  bool_arg("--bb.div-v4", bm->UserFlags.division_variant_4,
+           "unsigned division encoding variant 4: a two-stage shift/subtract "
+           "circuit at half the recursive one's size. Off by default -- "
+           "smaller measured slightly worse over a floating-point corpus and "
+           "much worse on whole-division refutations -- and variants 1 to 3 "
+           "modify the recursive circuit that runs instead",
+           bb_group);
+
   bool_arg("--bb.add-v1", bm->UserFlags.adder_variant,
            "addition encoding variant 1", bb_group);
 


### PR DESCRIPTION
Measuring the bit-blaster's arithmetic per operation against Bitwuzla's bit-blasting library at 113 and 226 bits put numbers on a gap that turns out to be three circuits: the divider was 2.2x Bitwuzla's AND-node count, subtraction 1.67x, multiplication 1.5x, with the shifters at parity and the comparisons already smaller. This PR closes it, one commit per circuit, each carrying its own measurements.

The full adder is the one everything else inherits. BBPlus2 built each bit as a majority carry beside a three-input exclusive-or -- eleven gates, nothing shared, because the ordered-exor lowering builds conjunctions nothing else asks for. Spelling the exclusive-or as `AND(OR(a,b), NOT(AND(a,b)))` makes the inner conjunction the half adder's carry, so a full adder is two half adders and an or: seven gates. A 226-bit symbolic multiply falls from 304,882 AIG nodes to 204,754, which is where Bitwuzla's multiplier sits (204,304) -- parity with no change to the multiplication algorithm. Radix-4 Booth recoding (`--bb.mult-variant 15`, or 16 for a per-multiply choice) was measured as a default at the same time and rejected: smaller again at 169k nodes, but 13 fewer solved over 311 wide-arithmetic queries, so the default stays at 1. The difficulty scorer's constants encoded the old adder and move with it, and two tests whose instances the smaller circuits now settle in preprocessing -- a factoring constant with a Mersenne factor, and two incremental rebuild tests calibrated to the old clause masses -- are recalibrated with the reasoning in comments.

The divider is the biggest single ratio, and the most instructive result. Variant 4, selectable as `--bb.div-v4`, is a two-stage shift/subtract circuit: per dividend bit the first stage computes only the borrow chain, whose final carry is the quotient bit, and the second reuses those carries to write the guarded, shifted remainder -- no comparison, no second adder, no multiplexer layers, and a zero divisor needs no special case. `bvudiv` at 226 bits falls from 1,015,894 AIG nodes to 458,106 (Bitwuzla: 457,199) and division-heavy micro queries solve about three times faster. It is nonetheless off by default, because fewer gates is not always an easier formula: over the 311-query corpus it measured 287 solved against 289 for the recursive circuit, and on one escalated 256-bit refutation that must reason about the division as a whole, the borrow-chain form hides the word-level slices the recursive circuit hands the SAT solver and a 39 s proof runs past two minutes. That test now pins `--bb.div-v4=0` against a future default change, a new test holds the variant to the evaluator's quotient, remainder and zero-divisor totalisation under both polarities, and fully constant operands keep the recursive circuit's pruning either way (dividing by 2^30 at 32 bits stays 40 nodes).

The square was hiding in plain sight. `x * x` needs half the partial products of a general multiply -- `a_i AND a_j` occurs once and its doubling is a column shift, the diagonal is `a_i` itself -- and symfpu's fixed-point square root squares a candidate once per result bit, so for `fp.sqrt` the squares are the whole circuit. BBMult now routes a multiply whose operands are the same node through those columns: `fp.sqrt` at binary128 falls from 5,590,978 AIG nodes, three times what Bitwuzla builds, to 1,503,289, under it.

Net effect at default flags over the 311 KLEE binary128 queries at 60 s: 280 solved / PAR2 5311 before, 289 / 4211 after. No answer differs anywhere, a 4,400-case oracle (exhaustive at widths 1-4, random at 7/8/13/16/33 bits, squares and zero divisors included) agrees with the constant evaluator on every case, and the suite is green at each commit.

A note on overlap: #1056, from the same measurement work, updates the expected counts in `bv-division-refinement/quotient-one-quotient.smt2`, whose RUN lines this PR pins. The edits are on adjacent lines and merge cleanly; whichever lands second just needs a rebase to rerun CI.
