### PR TITLE
Resolve auto to gia-low only when the SAT backend is CaDiCaL

### DIFF
--- a/lib/ToSat/ToSATAIG.cpp
+++ b/lib/ToSat/ToSATAIG.cpp
@@ -234,8 +234,13 @@ bool ToSATAIG::bitblast(const ASTNode& input, bool needAbsRef, CNF& cnf)
   // Written back rather than resolved locally so that the splices the
   // refinement adds later convert at the same rung; an explicit level is
   // left alone.
+  // Only under CaDiCaL: the corpus that justified this rung was solved
+  // with it, no other backend was measured, and MiniSat demonstrably
+  // cannot finish some escalated division proofs on the gia-low CNF that
+  // it finishes at the size-based rung.
   if (bm->UserFlags.cnf_effort == UserDefinedFlags::CNF_EFFORT_AUTO &&
-      allowAbstraction_ && bm->UserFlags.bv_term_abstraction)
+      allowAbstraction_ && bm->UserFlags.bv_term_abstraction &&
+      bm->UserFlags.solver_to_use == UserDefinedFlags::CADICAL_SOLVER)
   {
     bm->UserFlags.cnf_effort = UserDefinedFlags::CNF_EFFORT_GIA_LOW;
     if (bm->UserFlags.stats_flag)

--- a/tests/query-files/misc-tests/cnf-auto-under-bv-abstraction.smt2
+++ b/tests/query-files/misc-tests/cnf-auto-under-bv-abstraction.smt2
@@ -2,8 +2,12 @@
 ; lowest rung before the size-based choice is made, and says so; an explicit
 ; level is left alone, and so is a query the abstraction is not on for.
 ;
-; RUN: %solver -s --bv-term-abstraction=1 %s 2>&1 | %OutputCheck --check-prefix=ABS %s
-; RUN: %solver -s --bv-term-abstraction=1 --cnf-generation-effort auto %s 2>&1 | %OutputCheck --check-prefix=ABS %s
+; The resolution below requires the CaDiCaL backend, so the test does too:
+; a build without it keeps the size-based choice and has nothing to say, and
+; a build whose default backend is CryptoMiniSat must ask for CaDiCaL.
+; REQUIRES: cadical
+; RUN: %solver --cadical -s --bv-term-abstraction=1 %s 2>&1 | %OutputCheck --check-prefix=ABS %s
+; RUN: %solver --cadical -s --bv-term-abstraction=1 --cnf-generation-effort auto %s 2>&1 | %OutputCheck --check-prefix=ABS %s
 ; RUN: %solver -s --bv-term-abstraction=1 --cnf-generation-effort very-low %s 2>&1 | %OutputCheck --check-prefix=EXPLICIT %s
 ; RUN: %solver -s %s 2>&1 | %OutputCheck --check-prefix=OFF %s
 ;


### PR DESCRIPTION
The `gcc (minisat only)` leg hangs on every run since #1056 -- `bv-division-refinement/dividend-below-divisor.smt2` never returns. The cause is the one place #1056 changed behaviour for backends it never measured: with `--bv-term-abstraction` on, `auto` resolves the CNF effort to the Gia backend's low rung, and that resolution was justified by a corpus solved entirely with CaDiCaL. MiniSat pays for the difference on exactly one shape: the escalated 256-bit remainder proof in that test takes 0.04 s at the size-based rung and does not finish on the gia-low CNF (capped at 30 s locally; the CI leg just sits there).

The resolution now also requires the CaDiCaL backend, so MiniSat and CryptoMiniSat keep the size-based choice that was always theirs, and the test that asserts the resolution (`misc-tests/cnf-auto-under-bv-abstraction.smt2`) gains `REQUIRES: cadical` since a MiniSat-only build now has nothing to say there.

Verified on a MiniSat-only build of master: the hanging test passes in a fraction of a second, and the five abstraction-heavy lit directories run clean under a 90 s per-test cap that previously caught the hang. A CaDiCaL build of the same tree passes the full suite, with the resolution still reporting `chose gia-low`.

The mechanism, isolated with `--simplifying-minisat`: the gia-low CNF of that proof is actually smaller than the size-based one (2,989 clauses against 3,280), but its LUT3 mapping leaves chains of three-input definition variables that bounded variable elimination folds away by resolution -- MiniSat's simplifying variant solves the same instance in 0.05 s, and CaDiCaL runs that elimination as inprocessing. STP's plain MiniSat core has no elimination, and on this proof it has to branch through the definition chains instead. The size-based rungs never expose the problem because their wider cuts do the merging at CNF-generation time.
