### PR TITLE
Size the blasting managers from the difficulty score

### DIFF
--- a/include/stp/STPManager/STPManager.h
+++ b/include/stp/STPManager/STPManager.h
@@ -146,6 +146,13 @@ public:
 
   bool soft_timeout_expired;
 
+  // Fitted estimate of the AND nodes bit-blasting the formula will build,
+  // recorded by the top level from the difficulty score it computes anyway.
+  // The blasting managers use it to size their node and hash storage once
+  // instead of growing by doubling. 0 means no estimate; the score errs
+  // high, by up to about 2x on the hard set.
+  int64_t expected_blast_ands = 0;
+
   // One named element of a declared sort: the sort, the name the model gives
   // it, and the carrier pattern it stands for.
   struct UninterpretedElement

--- a/include/stp/ToSat/BBNodeManagerAIG.h
+++ b/include/stp/ToSat/BBNodeManagerAIG.h
@@ -262,6 +262,31 @@ public:
     aigMgr->fAddStrash = 1;
   }
 
+  // Swap in a strash table sized for the whole blast, before anything is
+  // built. Only the table: restarting the manager at the hinted size would
+  // also make its node-page chunk that large, which costs real memory --
+  // measured at +5-9% peak on large blasts -- while the table alone retires
+  // Aig_TableResize and runs at load factor <= 1 where the growth policy
+  // oscillates between 0.5 and 2. The table holds only AND nodes and none
+  // exist yet, so an empty replacement is the same table, larger.
+  void hintExpectedAnds(uint64_t n)
+  {
+    assert(Aig_ManNodeNum(aigMgr) == 0);
+    const uint64_t cap = 1ull << 26;
+    const uint64_t want = n + (n >> 4) + 1024;
+    // Half the expected count: the resize trigger is load factor 2, so this
+    // still never resizes, and it matches the table size the growth policy
+    // would have ended at (its jumps are 4x, landing near load 1.2) instead
+    // of paying ~60 MB over it for shorter chains.
+    const int slots = Abc_PrimeCudd((unsigned)((want < cap ? want : cap) / 2));
+    if (slots <= aigMgr->nTableSize)
+      return;
+    ABC_FREE(aigMgr->pTable);
+    aigMgr->nTableSize = slots;
+    aigMgr->pTable = ABC_ALLOC(Aig_Obj_t*, slots);
+    memset(aigMgr->pTable, 0, sizeof(Aig_Obj_t*) * slots);
+  }
+
   void stop()
   {
     if (aigMgr != NULL)

--- a/include/stp/ToSat/BBNodeManagerGia.h
+++ b/include/stp/ToSat/BBNodeManagerGia.h
@@ -100,6 +100,24 @@ public:
     giaMgr->fAddStrash = 1;
   }
 
+  // Restart at a hinted size, before anything is built: Gia_ManStart's
+  // object array is calloc'd so untouched pages cost nothing, and
+  // Gia_ManHashAlloc sizes the hash from nObjsAlloc, so one hint removes
+  // both resize ladders. Objects are ANDs plus CIs, hence the margin.
+  void hintExpectedAnds(uint64_t n)
+  {
+    assert(Gia_ManObjNum(giaMgr) == 1);
+    const uint64_t cap = 1ull << 26;
+    const uint64_t want = n + (n >> 4) + 1024;
+    const int objs = (int)(want < cap ? want : cap);
+    if (objs <= giaMgr->nObjsAlloc)
+      return;
+    Gia_ManStop(giaMgr);
+    giaMgr = Gia_ManStart(objs);
+    Gia_ManHashAlloc(giaMgr);
+    giaMgr->fAddStrash = 1;
+  }
+
   BBNodeManagerGia(const BBNodeManagerGia&) = delete;
   BBNodeManagerGia& operator=(const BBNodeManagerGia&) = delete;
 

--- a/include/stp/ToSat/BBNodeManagerLit.h
+++ b/include/stp/ToSat/BBNodeManagerLit.h
@@ -63,6 +63,16 @@ public:
 
   int totalNumberOfNodes() { return static_cast<int>(mgr.andCount()); }
 
+  // Size the node array and strash table before anything is built. The
+  // estimate errs high, which the power-of-two table rounding mostly absorbs;
+  // the margin covers the CIs, which the estimate does not count.
+  void hintExpectedAnds(uint64_t n)
+  {
+    const uint64_t cap = 1ull << 26;
+    const uint64_t want = n + (n >> 4) + 1024;
+    mgr.reserveNodes(want < cap ? want : cap);
+  }
+
   BBNodeManagerLit() = default;
   BBNodeManagerLit(const BBNodeManagerLit&) = delete;
   BBNodeManagerLit& operator=(const BBNodeManagerLit&) = delete;

--- a/lib/STPManager/STP.cpp
+++ b/lib/STPManager/STP.cpp
@@ -913,6 +913,7 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
   bm->TermsAlreadySeenMap_Clear();
 
   int64_t final_difficulty_score = difficulty.score(inputToSat, bm);
+  bm->expected_blast_ands = final_difficulty_score;
 
   // Simplification has to have taken a fifth off the score to count as having
   // helped. Written as an assignment now that the AIG node count is gone: it
@@ -946,6 +947,7 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
         keptConstants.insert(e);
 
     inputToSat = revert->toRevertTo;
+    bm->expected_blast_ands = initial_difficulty_score;
 
     // I do this to clear the substitution/solver map.
     // Not sure what would happen if it contained simplifications

--- a/lib/ToSat/ToSATAIG.cpp
+++ b/lib/ToSat/ToSATAIG.cpp
@@ -268,6 +268,13 @@ bool ToSATAIG::bitblastWith(const ASTNode& input, bool needAbsRef, CNF& cnf)
 
   ManagerT mgr;
   mgr.nodeBudget = bm->UserFlags.aig_node_budget;
+  if (bm->expected_blast_ands > 0)
+  {
+    mgr.hintExpectedAnds((uint64_t)bm->expected_blast_ands);
+    if (bm->UserFlags.stats_flag)
+      cerr << "blast-hint: " << bm->expected_blast_ands << " AND nodes"
+           << endl;
+  }
   BlasterT bb(&mgr, &simp, bm->defaultNodeFactory, &bm->UserFlags, cb,
                 allowAbstraction_);
 


### PR DESCRIPTION
The top level computes a fitted AND-node estimate of the formula it hands the bit-blaster (the difficulty score, for the reversion decision) and then discards it. Record it, and let each backend size its node and hash storage once, before the first gate, instead of growing by doubling.

The in-house manager's reserveNodes() gets its first production caller: on the largest hard-set blast the whole run drops 10.8% of its instructions and 4.6% of peak RSS, table growth having been 26% of blasting there. The native-Gia backend restarts at the hinted size, which Gia_ManHashAlloc then sizes its hash from, so both of its resize ladders go. The ABC-Aig backend swaps in a pre-sized strash table only, at half the hint: restarting the whole manager at the hint measured +5-9% peak, because Aig_ManStart scales its node-page chunk along with the table, and a load-factor-1 table sits well above the growth policy's final size, which lands near load 1.2 - half the hint matches it.

The estimate errs high by 1.0-2.2x on the hard set, which the power-of-two rounding in the in-house table mostly absorbs. A hint at or below a manager's starting size is ignored, so small queries are untouched.

Verified: CNF byte-identical against master on hard-set files under new-medium, gia-low, medium, very-low and gia-high; speedups measured as retired instructions (deterministic where wall clock has a ±4% floor); full test suite green.

A side effect worth naming: the estimate now exists before a backend is chosen, which is what a follow-up needs to let AUTO reach the non-ABC rungs without blasting through ABC first.