### PR TITLE
Index stp::CNF by clause length rather than by offset

### DIFF
--- a/include/stp/AIG/CNF.h
+++ b/include/stp/AIG/CNF.h
@@ -38,11 +38,19 @@ namespace stp
 // A CNF formula and the projection back to the circuit it came from. The one
 // currency the CNF generators hand back, whichever of them ran.
 //
-// Clauses live in one flat literal arena, indexed a clause at a time. A
+// Clauses live in one flat literal arena, walked a clause at a time. A
 // literal is `2*variable + negated`, so `^1` negates and `>>1` recovers the
 // variable. That is Cnf_Dat_t's layout and encoding, and keeping it is what
 // lets an ABC-generated formula be adopted rather than copied -- see adopt()
 // below.
+//
+// The index into the arena is one *byte* per clause, not an offset. An
+// offsets array costs eight bytes a clause and on a 13M-clause formula that
+// was 100 MB of a 233 MB CNF -- more than the literals it indexed. Lengths
+// fit in a byte for every clause the Tseitin writer emits except the n-ary
+// ANDs, and those escape through longLens_. What that costs is random
+// access: a clause can only be reached by walking to it. Every consumer
+// already walked in order, so the API is a forward cursor -- see clauses().
 //
 // Variables number from 1. Variable 0 does not exist, and that is not a
 // convention worth trading away: SATSolver::newVar() hands out 0 first and
@@ -81,13 +89,68 @@ public:
   uint64_t clauseCount() const { return nClauses_; }
   uint64_t literalCount() const { return nLiterals_; }
 
-  const int* clauseBegin(uint64_t i) const
+  // One pass over the clauses, in the order they were emitted:
+  //
+  //   for (CNF::ClauseCursor c = cnf.clauses(); c.next(); )
+  //     for (const int* p = c.begin(); p < c.end(); p++) ...
+  //
+  // begin() and end() are the current clause and are only meaningful after
+  // next() has returned true. The cursor holds pointers into the CNF, so it
+  // does not outlive it, and it does not survive a further clause() either.
+  class ClauseCursor
   {
-    return adopted_ ? adopted_[i] : lits_.data() + offsets_[i];
-  }
-  const int* clauseEnd(uint64_t i) const
+  public:
+    bool next()
+    {
+      if (left_ == 0)
+        return false;
+      left_--;
+
+      if (adopted_ != nullptr)
+      {
+        // nClauses+1 pointers, so the next one is this clause's end.
+        begin_ = adopted_[0];
+        end_ = adopted_[1];
+        adopted_++;
+        return true;
+      }
+
+      begin_ = end_;
+      uint64_t len = *lens_++;
+      if (len == longMarker)
+        len = *longLens_++;
+      end_ = begin_ + len;
+      return true;
+    }
+
+    const int* begin() const { return begin_; }
+    const int* end() const { return end_; }
+    size_t size() const { return static_cast<size_t>(end_ - begin_); }
+
+  private:
+    friend class CNF;
+
+    const int* const* adopted_ = nullptr;
+    const uint8_t* lens_ = nullptr;
+    const uint64_t* longLens_ = nullptr;
+    const int* begin_ = nullptr;
+    const int* end_ = nullptr;
+    uint64_t left_ = 0;
+  };
+
+  ClauseCursor clauses() const
   {
-    return adopted_ ? adopted_[i + 1] : lits_.data() + offsets_[i + 1];
+    ClauseCursor c;
+    c.left_ = nClauses_;
+    if (adopted_ != nullptr)
+      c.adopted_ = adopted_;
+    else
+    {
+      c.lens_ = lens_.data();
+      c.longLens_ = longLens_.data();
+      c.begin_ = c.end_ = lits_.data();
+    }
+    return c;
   }
 
   // The variable holding the value of combinational input `ordinal`, or of
@@ -182,21 +245,39 @@ public:
              uint32_t nCi, uint32_t nCo);
 
 private:
+  // A lens_ entry of this value says the length is the next unread entry of
+  // longLens_ instead. 255 rather than 0, because 0 is a length a clause
+  // really has: the empty clause is the one that says "unsatisfiable".
+  //
+  // constexpr, not const: the cursor compares against it, which odr-uses a
+  // const member and then wants an out-of-line definition. A constexpr
+  // static member is implicitly inline in C++17.
+  static constexpr uint8_t longMarker = 255;
+
   void closeClause()
   {
-    offsets_.push_back(lits_.size());
+    const uint64_t len = lits_.size() - nLiterals_;
+    if (len < longMarker)
+      lens_.push_back(static_cast<uint8_t>(len));
+    else
+    {
+      lens_.push_back(longMarker);
+      longLens_.push_back(len);
+    }
     ++nClauses_;
     nLiterals_ = lits_.size();
   }
   void discard();
   void steal(CNF& o);
 
-  // Ours, when we built it.
+  // Ours, when we built it. One lens_ byte per clause; longLens_ holds, in
+  // clause order, the lengths of the clauses too long to fit in one.
   std::vector<int> lits_;
-  std::vector<uint64_t> offsets_;
+  std::vector<uint8_t> lens_;
+  std::vector<uint64_t> longLens_;
 
-  // Somebody else's, when we adopted it. Non-null selects it over the two
-  // vectors above; the two are never both populated.
+  // Somebody else's, when we adopted it. Non-null selects it over the
+  // vectors above; the two stores are never both populated.
   const int* const* adopted_ = nullptr;
   void* owner_ = nullptr;
   void (*release_)(void*) = nullptr;

--- a/lib/AIG/CNF.cpp
+++ b/lib/AIG/CNF.cpp
@@ -40,9 +40,10 @@ void CNF::begin(uint32_t nVars, uint64_t nClauses, uint64_t nLiterals,
 
   // Exact, from the counting pass, so neither vector ever reallocates and
   // neither ends up holding spare capacity for the life of the solve.
+  // longLens_ is not reserved: the counting pass does not say how many
+  // clauses are long, and on the formulas that have any there are a handful.
   lits_.reserve(nLiterals);
-  offsets_.reserve(nClauses + 1);
-  offsets_.push_back(0);
+  lens_.reserve(nClauses);
 
   ciVar_.assign(nCi, 0);
   coVar_.assign(nCo, 0);
@@ -82,7 +83,8 @@ void CNF::discard()
   // when it is about to hold a different formula, and the two must not be
   // resident at once.
   std::vector<int>().swap(lits_);
-  std::vector<uint64_t>().swap(offsets_);
+  std::vector<uint8_t>().swap(lens_);
+  std::vector<uint64_t>().swap(longLens_);
   ciVar_.clear();
   coVar_.clear();
 
@@ -97,7 +99,8 @@ void CNF::discard()
 void CNF::steal(CNF& o)
 {
   lits_ = std::move(o.lits_);
-  offsets_ = std::move(o.offsets_);
+  lens_ = std::move(o.lens_);
+  longLens_ = std::move(o.longLens_);
   adopted_ = o.adopted_;
   owner_ = o.owner_;
   release_ = o.release_;
@@ -135,9 +138,9 @@ void CNF::writeDimacs(std::ostream& out) const
 {
   out << "c Result of efficient AIG-to-CNF conversion using package CNF\n";
   out << "p cnf " << nVars_ << ' ' << clauseCount() << '\n';
-  for (uint64_t i = 0, n = clauseCount(); i < n; i++)
+  for (ClauseCursor c = clauses(); c.next();)
   {
-    for (const int *p = clauseBegin(i), *stop = clauseEnd(i); p < stop; p++)
+    for (const int *p = c.begin(), *stop = c.end(); p < stop; p++)
     {
       const int var = (*p >> 1) + 1;
       out << ((*p & 1) ? -var : var) << ' ';

--- a/lib/ToSat/BVExactEncoder.cpp
+++ b/lib/ToSat/BVExactEncoder.cpp
@@ -196,11 +196,10 @@ void encodeNaryLemma(
     }
 
   SATSolver::vec_literals cl;
-  for (uint64_t i = 0; i < cnf.clauseCount(); i++)
+  for (CNF::ClauseCursor c = cnf.clauses(); c.next();)
   {
     cl.clear();
-    for (const int *pLit = cnf.clauseBegin(i), *pStop = cnf.clauseEnd(i);
-         pLit < pStop; pLit++)
+    for (const int *pLit = c.begin(), *pStop = c.end(); pLit < pStop; pLit++)
     {
       assert(((*pLit) >> 1) != 0 && "a CNF generator numbered variables from 0");
       cl.push(SATSolver::mkLit(cnfToSolver[(*pLit) >> 1], ((*pLit) & 1) != 0));
@@ -446,11 +445,10 @@ void BVExactEncoder::encode(SATSolver& solver, const ASTNode& term,
     }
 
   SATSolver::vec_literals cl;
-  for (uint64_t i = 0; i < cnf.clauseCount(); i++)
+  for (CNF::ClauseCursor c = cnf.clauses(); c.next();)
   {
     cl.clear();
-    for (const int *pLit = cnf.clauseBegin(i), *pStop = cnf.clauseEnd(i);
-         pLit < pStop; pLit++)
+    for (const int *pLit = c.begin(), *pStop = c.end(); pLit < pStop; pLit++)
     {
       assert(((*pLit) >> 1) != 0 && "a CNF generator numbered variables from 0");
       cl.push(SATSolver::mkLit(cnfToSolver[(*pLit) >> 1], ((*pLit) & 1) != 0));

--- a/lib/ToSat/ToSATAIG.cpp
+++ b/lib/ToSat/ToSATAIG.cpp
@@ -433,11 +433,10 @@ void ToSATAIG::add_cnf_to_solver(SATSolver& satSolver, const CNF& cnf)
     satSolver.newVar();
 
   SATSolver::vec_literals satSolverClause;
-  for (uint64_t i = 0; i < cnf.clauseCount(); i++)
+  for (CNF::ClauseCursor c = cnf.clauses(); c.next();)
   {
     satSolverClause.clear();
-    for (const int *pLit = cnf.clauseBegin(i), *pStop = cnf.clauseEnd(i);
-         pLit < pStop; pLit++)
+    for (const int *pLit = c.begin(), *pStop = c.end(); pLit < pStop; pLit++)
     {
       uint32_t var = (*pLit) >> 1;
       assert((var < satSolver.nVars()));

--- a/tests/unit-tests/BitBlasterGia_Test.cpp
+++ b/tests/unit-tests/BitBlasterGia_Test.cpp
@@ -172,10 +172,10 @@ void expectSameFunction(STPMgr& mgr, const ASTNode& form,
 // Is `clauses` satisfied by `assignment`, a bitmask indexed by variable?
 bool satisfies(const CNF& cnf, uint32_t assignment)
 {
-  for (uint64_t c = 0; c < cnf.clauseCount(); c++)
+  for (CNF::ClauseCursor c = cnf.clauses(); c.next();)
   {
     bool ok = false;
-    for (const int* l = cnf.clauseBegin(c); l != cnf.clauseEnd(c) && !ok; ++l)
+    for (const int* l = c.begin(); l != c.end() && !ok; ++l)
     {
       // 2*variable + negated, which is both ABC's encoding and this class's.
       const uint32_t var = (uint32_t)(*l) >> 1;

--- a/tests/unit-tests/Tseitin_Test.cpp
+++ b/tests/unit-tests/Tseitin_Test.cpp
@@ -22,6 +22,7 @@
 
 #include <gtest/gtest.h>
 
+#include <cstddef>
 #include <cstdint>
 #include <cstdlib>
 #include <random>
@@ -107,10 +108,9 @@ std::vector<int8_t> intendedValues(const aig::Manager& m,
   return want;
 }
 
-bool clauseSatisfied(const CNF& cnf, uint64_t i, const std::vector<int8_t>& a)
+bool clauseSatisfied(const CNF::ClauseCursor& c, const std::vector<int8_t>& a)
 {
-  for (const int *p = cnf.clauseBegin(i), *stop = cnf.clauseEnd(i); p < stop;
-       p++)
+  for (const int *p = c.begin(), *stop = c.end(); p < stop; p++)
   {
     const uint32_t v = static_cast<uint32_t>(*p) >> 1;
     const int8_t want = (*p & 1) ? 0 : 1;
@@ -129,12 +129,11 @@ bool propagate(const CNF& cnf, std::vector<int8_t>& a)
   while (changed)
   {
     changed = false;
-    for (uint64_t i = 0, n = cnf.clauseCount(); i < n; i++)
+    for (CNF::ClauseCursor c = cnf.clauses(); c.next();)
     {
       int unassigned = 0, lastLit = 0;
       bool sat = false;
-      for (const int *p = cnf.clauseBegin(i), *stop = cnf.clauseEnd(i);
-           p < stop; p++)
+      for (const int *p = c.begin(), *stop = c.end(); p < stop; p++)
       {
         const uint32_t v = static_cast<uint32_t>(*p) >> 1;
         const int8_t want = (*p & 1) ? 0 : 1;
@@ -226,9 +225,10 @@ void checkExact(const aig::Manager& m, unsigned namedOutputs,
 
     if (assertedHold)
     {
-      for (uint64_t c = 0, n = cnf.clauseCount(); c < n; c++)
-        ASSERT_TRUE(clauseSatisfied(cnf, c, want))
-            << "clause " << c << " unsatisfied by the circuit's own values";
+      uint64_t at = 0;
+      for (CNF::ClauseCursor c = cnf.clauses(); c.next(); at++)
+        ASSERT_TRUE(clauseSatisfied(c, want))
+            << "clause " << at << " unsatisfied by the circuit's own values";
     }
 
     std::vector<int8_t> a(cnf.varCount(), -1);
@@ -479,7 +479,9 @@ TEST(Tseitin, ConstantOutputs)
     EXPECT_FALSE(cnf.hasEmptyClause());
     const uint32_t v = cnf.varOfCo(0);
     EXPECT_EQ(v, 2u); // one CI, then the named output
-    EXPECT_EQ(*cnf.clauseBegin(0), static_cast<int>(2 * v));
+    CNF::ClauseCursor c = cnf.clauses();
+    ASSERT_TRUE(c.next());
+    EXPECT_EQ(*c.begin(), static_cast<int>(2 * v));
   }
   {
     aig::Manager m;
@@ -487,7 +489,9 @@ TEST(Tseitin, ConstantOutputs)
     m.createOutput(m.constFalse());
     const CNF cnf = aig::deriveTseitin(m, 1);
     ASSERT_EQ(cnf.clauseCount(), 1u);
-    EXPECT_EQ(*cnf.clauseBegin(0), static_cast<int>(2 * cnf.varOfCo(0) + 1));
+    CNF::ClauseCursor c = cnf.clauses();
+    ASSERT_TRUE(c.next());
+    EXPECT_EQ(*c.begin(), static_cast<int>(2 * cnf.varOfCo(0) + 1));
   }
 }
 
@@ -504,13 +508,46 @@ TEST(Tseitin, NoLiteralNamesVariableZero)
 
   const CNF cnf = aig::deriveTseitin(m, 1);
   ASSERT_GT(cnf.clauseCount(), 0u);
-  for (uint64_t i = 0, n = cnf.clauseCount(); i < n; i++)
-    for (const int *p = cnf.clauseBegin(i), *stop = cnf.clauseEnd(i); p < stop;
-         p++)
+  for (CNF::ClauseCursor c = cnf.clauses(); c.next();)
+    for (const int *p = c.begin(), *stop = c.end(); p < stop; p++)
     {
       ASSERT_GE(*p, 2) << "literal names variable 0";
       ASSERT_LT(static_cast<uint32_t>(*p) >> 1, cnf.varCount());
     }
+}
+
+// The clause index is one byte per clause, escaping through a side table at
+// 255, so a clause of exactly 255 literals is the case a one-byte length gets
+// wrong.  The n-ary AND is the only clause that reaches there: L leaves emit
+// one clause of L+1 literals, then L binary ones, and a named output adds two
+// more.
+TEST(Tseitin, ClauseLengthsRoundTripAcrossTheOneByteLimit)
+{
+  for (const unsigned leaves : {2u, 253u, 254u, 255u, 256u, 1000u})
+  {
+    aig::Manager m;
+    aig::Lit acc = m.createCi();
+    for (unsigned i = 1; i < leaves; i++)
+      acc = m.And(acc, m.createCi());
+    m.createOutput(acc);
+
+    const CNF cnf = aig::deriveTseitin(m, 1);
+    ASSERT_EQ(cnf.clauseCount(), leaves + 3u) << leaves;
+
+    std::vector<size_t> sizes;
+    for (CNF::ClauseCursor c = cnf.clauses(); c.next();)
+      sizes.push_back(c.size());
+
+    ASSERT_EQ(sizes.size(), cnf.clauseCount()) << leaves;
+    EXPECT_EQ(sizes[0], leaves + 1u) << leaves; // the conjunction itself
+    uint64_t total = sizes[0];
+    for (size_t i = 1; i < sizes.size(); i++)
+    {
+      EXPECT_EQ(sizes[i], 2u) << leaves << ", clause " << i;
+      total += sizes[i];
+    }
+    EXPECT_EQ(total, cnf.literalCount()) << leaves;
+  }
 }
 
 // Same circuit, two fresh managers, byte-identical arena.  Nothing in the
@@ -534,15 +571,16 @@ TEST(Tseitin, IsDeterministic)
   ASSERT_EQ(ca.clauseCount(), cb.clauseCount());
   ASSERT_EQ(ca.literalCount(), cb.literalCount());
   ASSERT_EQ(ca.varCount(), cb.varCount());
-  for (uint64_t i = 0, n = ca.clauseCount(); i < n; i++)
+  CNF::ClauseCursor x = ca.clauses(), y = cb.clauses();
+  while (x.next())
   {
-    ASSERT_EQ(ca.clauseEnd(i) - ca.clauseBegin(i),
-              cb.clauseEnd(i) - cb.clauseBegin(i));
-    for (const int *p = ca.clauseBegin(i), *q = cb.clauseBegin(i),
-                   *stop = ca.clauseEnd(i);
-         p < stop; p++, q++)
+    ASSERT_TRUE(y.next());
+    ASSERT_EQ(x.size(), y.size());
+    for (const int *p = x.begin(), *q = y.begin(), *stop = x.end(); p < stop;
+         p++, q++)
       ASSERT_EQ(*p, *q);
   }
+  ASSERT_FALSE(y.next());
 }
 
 // The DIMACS file is byte-compatible with the one Cnf_DataWriteIntoFile()

--- a/tools/rewrite_rule_gen/rewrite_rule_gen.cpp
+++ b/tools/rewrite_rule_gen/rewrite_rule_gen.cpp
@@ -672,12 +672,10 @@ int getDifficulty(const ASTNode& n_)
       ss->newVar();
 
     SATSolver::vec_literals satSolverClause;
-    for (uint64_t i = 0; i < cnfData.clauseCount(); i++)
+    for (CNF::ClauseCursor c = cnfData.clauses(); c.next();)
     {
       satSolverClause.clear();
-      for (const int *pLit = cnfData.clauseBegin(i),
-                     *pStop = cnfData.clauseEnd(i);
-           pLit < pStop; pLit++)
+      for (const int *pLit = c.begin(), *pStop = c.end(); pLit < pStop; pLit++)
       {
         uint32_t var = (*pLit) >> 1;
         assert((var < ss->nVars()));


### PR DESCRIPTION
The per-clause index into the literal arena was an eight-byte offset, and on a 13M-clause formula those offsets were 100.8 MB of a 233 MB CNF - more than the literals they indexed. Every production consumer walks the formula strictly in order, so the random access the offsets bought was used only by unit tests.

One byte of length per clause instead, with an escape for clauses of 255 literals or more - in practice each query has about one, its top-level conjunction - and a forward cursor replacing clauseBegin/clauseEnd. Process peak on the formula above drops 23.4% (664.5 to 508.8 MB). Adopted ABC formulas keep their own clause-pointer array and are untouched; the cursor walks it behind the same interface.

Verified: CNF byte-identical against master on hard-set files under both the in-house and the adopted routes and across the fuzz corpus; full test suite green, including a new round-trip test whose clause lengths straddle the escape boundary in both directions.