### PR TITLE
Don't crash when an unusable CryptoMiniSat defines the target

### DIFF
--- a/cmake/FindCryptoMiniSat.cmake
+++ b/cmake/FindCryptoMiniSat.cmake
@@ -131,6 +131,46 @@ if(NOT CryptoMiniSat_FOUND_SYSTEM)
     # check_auto_download() is fatal by construction, and is reached only when
     # this was asked for by name. Otherwise the answer is the one AUTO asks
     # for: say nothing and build without it.
+    # A package consulted above can define the cryptominisat5 imported target
+    # and still be unusable: a config whose Targets file references imported
+    # targets that no longer exist -- a system CryptoMiniSat built against a
+    # since-removed CaDiCaL -- defines the target and then reports NOT FOUND,
+    # and a package rejected for its version defined it too. An imported
+    # target cannot be redefined, so no copy can be built here under that
+    # name; without this check the add_library() below aborts naming the
+    # collision but not the package that caused it.
+    if(TARGET cryptominisat5)
+        if(cryptominisat5_DIR)
+            set(_cms_who "the unusable package in '${cryptominisat5_DIR}'")
+        else()
+            set(_cms_who "something outside this find module")
+        endif()
+        set(_cms_why "")
+        if(cryptominisat5_NOT_FOUND_MESSAGE)
+            string(CONCAT _cms_why " Its config file reports: "
+                   "${cryptominisat5_NOT_FOUND_MESSAGE}.")
+        elseif(CryptoMiniSat_VERSION)
+            set(_cms_why " It is version ${CryptoMiniSat_VERSION}.")
+        endif()
+        string(CONCAT _cms_msg
+            "the cryptominisat5 imported target is already defined, by "
+            "${_cms_who}, so a CryptoMiniSat cannot be built here."
+            "${_cms_why}")
+        if(CryptoMiniSat_FIND_REQUIRED)
+            message(FATAL_ERROR "CryptoMiniSat was asked for, but ${_cms_msg} "
+                    "Repair or remove that installation, point "
+                    "-Dcryptominisat5_DIR at a usable copy, or configure with "
+                    "-DUSE_CRYPTOMINISAT=OFF.")
+        endif()
+        message(STATUS "Building without CryptoMiniSat: ${_cms_msg}")
+        unset(_cms_who)
+        unset(_cms_why)
+        unset(_cms_msg)
+        set(CryptoMiniSat_FOUND FALSE)
+        set(STP_CMS_FROM_PACKAGE FALSE)
+        return()
+    endif()
+
     check_ep_downloaded("CryptoMiniSat-EP")
     if(NOT CryptoMiniSat-EP_DOWNLOADED AND NOT ENABLE_AUTO_DOWNLOAD)
         if(CryptoMiniSat_FIND_REQUIRED)

--- a/include/stp/STPManager/STPManager.h
+++ b/include/stp/STPManager/STPManager.h
@@ -146,6 +146,13 @@ public:
 
   bool soft_timeout_expired;
 
+  // Fitted estimate of the AND nodes bit-blasting the formula will build,
+  // recorded by the top level from the difficulty score it computes anyway.
+  // The blasting managers use it to size their node and hash storage once
+  // instead of growing by doubling. 0 means no estimate; the score errs
+  // high, by up to about 2x on the hard set.
+  int64_t expected_blast_ands = 0;
+
   // One named element of a declared sort: the sort, the name the model gives
   // it, and the carrier pattern it stands for.
   struct UninterpretedElement

--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -894,14 +894,13 @@ public:
   // 3, 6 and 8; its cost grows steeply with LUT size for little further gain
   // past 6.
   //
-  // AUTO picks between VERY_LOW and MEDIUM from the size of the AIG, because
-  // the trade the scale offers is only worth making when the SAT solver is
-  // what costs. Minimising the CNF is itself work, and on a large AIG it is
-  // most of the work: a floating-point query with three fp.div and two
-  // fp.sqrt blasts to 1.7M clauses, of which MEDIUM spends 1857ms generating
-  // and MiniSat then spends 137ms solving. VERY_LOW generates the same query
-  // in a fraction of that, and the larger CNF it leaves behind costs the
-  // solver almost nothing.
+  // AUTO resolves from the difficulty score when the top level recorded one
+  // (see ToSATAIG::bitblast): GIA_LOW below the threshold, NEW_MEDIUM at or
+  // above it, because minimising the CNF is itself work and on a large blast
+  // it is most of the work, while no measurement has found the smaller
+  // formula buying solve time. Where no estimate exists, under array
+  // refinement, or on a SAT backend other than CaDiCaL, it falls back to
+  // the older choice between VERY_LOW and MEDIUM from the built AIG's size.
   enum CNFEffort
   {
     CNF_EFFORT_VERY_LOW = 0,
@@ -913,9 +912,7 @@ public:
     // The in-house Tseitin writer, over the in-house AIG. Below very-low on
     // the scale and last in the enum, which are different facts: the ordinals
     // are the C interface's contract, so a new rung goes on the end however
-    // little effort it spends. AUTO never picks it -- AUTO chooses from the
-    // AIG's node count, which means blasting through ABC first, so reaching
-    // this rung has to be an explicit request.
+    // little effort it spends.
     CNF_EFFORT_NEW_VERY_LOW,
     CNF_EFFORT_NEW_LOW,
     CNF_EFFORT_NEW_MEDIUM,
@@ -924,10 +921,6 @@ public:
     // reach -- but over a Gia the blaster built itself rather than one
     // converted from an ABC Aig. Same LUT sizes, 3, 6 and 8, so gia-low
     // against low is a comparison of the two backends and nothing else.
-    //
-    // AUTO never picks these, for the reason it never picks the rungs above:
-    // it decides from ABC's Aig node count, which means blasting through ABC
-    // first, and the point of these is that no ABC Aig is built at all.
     CNF_EFFORT_GIA_LOW,
     CNF_EFFORT_GIA_HIGH,
     CNF_EFFORT_GIA_VERY_HIGH
@@ -942,7 +935,9 @@ public:
 
   enum CNFEffort cnf_effort = CNF_EFFORT_AUTO;
 
-  // AIG AND-node count at or above which AUTO drops to VERY_LOW.
+  // AND-node count at or above which AUTO stops paying for CNF
+  // minimisation: against the recorded estimate it selects NEW_MEDIUM
+  // there, and on the estimate-less fallback it drops MEDIUM to VERY_LOW.
   //
   // High on purpose. Over a floating-point corpus, timed net of the ~9.5ms a
   // process spends starting before it solves anything, VERY_LOW is the better

--- a/include/stp/ToSat/BBNodeManagerAIG.h
+++ b/include/stp/ToSat/BBNodeManagerAIG.h
@@ -262,6 +262,31 @@ public:
     aigMgr->fAddStrash = 1;
   }
 
+  // Swap in a strash table sized for the whole blast, before anything is
+  // built. Only the table: restarting the manager at the hinted size would
+  // also make its node-page chunk that large, which costs real memory --
+  // measured at +5-9% peak on large blasts -- while the table alone retires
+  // Aig_TableResize and runs at load factor <= 1 where the growth policy
+  // oscillates between 0.5 and 2. The table holds only AND nodes and none
+  // exist yet, so an empty replacement is the same table, larger.
+  void hintExpectedAnds(uint64_t n)
+  {
+    assert(Aig_ManNodeNum(aigMgr) == 0);
+    const uint64_t cap = 1ull << 26;
+    const uint64_t want = n + (n >> 4) + 1024;
+    // Half the expected count: the resize trigger is load factor 2, so this
+    // still never resizes, and it matches the table size the growth policy
+    // would have ended at (its jumps are 4x, landing near load 1.2) instead
+    // of paying ~60 MB over it for shorter chains.
+    const int slots = Abc_PrimeCudd((unsigned)((want < cap ? want : cap) / 2));
+    if (slots <= aigMgr->nTableSize)
+      return;
+    ABC_FREE(aigMgr->pTable);
+    aigMgr->nTableSize = slots;
+    aigMgr->pTable = ABC_ALLOC(Aig_Obj_t*, slots);
+    memset(aigMgr->pTable, 0, sizeof(Aig_Obj_t*) * slots);
+  }
+
   void stop()
   {
     if (aigMgr != NULL)

--- a/include/stp/ToSat/BBNodeManagerGia.h
+++ b/include/stp/ToSat/BBNodeManagerGia.h
@@ -100,6 +100,24 @@ public:
     giaMgr->fAddStrash = 1;
   }
 
+  // Restart at a hinted size, before anything is built: Gia_ManStart's
+  // object array is calloc'd so untouched pages cost nothing, and
+  // Gia_ManHashAlloc sizes the hash from nObjsAlloc, so one hint removes
+  // both resize ladders. Objects are ANDs plus CIs, hence the margin.
+  void hintExpectedAnds(uint64_t n)
+  {
+    assert(Gia_ManObjNum(giaMgr) == 1);
+    const uint64_t cap = 1ull << 26;
+    const uint64_t want = n + (n >> 4) + 1024;
+    const int objs = (int)(want < cap ? want : cap);
+    if (objs <= giaMgr->nObjsAlloc)
+      return;
+    Gia_ManStop(giaMgr);
+    giaMgr = Gia_ManStart(objs);
+    Gia_ManHashAlloc(giaMgr);
+    giaMgr->fAddStrash = 1;
+  }
+
   BBNodeManagerGia(const BBNodeManagerGia&) = delete;
   BBNodeManagerGia& operator=(const BBNodeManagerGia&) = delete;
 

--- a/include/stp/ToSat/BBNodeManagerLit.h
+++ b/include/stp/ToSat/BBNodeManagerLit.h
@@ -63,6 +63,16 @@ public:
 
   int totalNumberOfNodes() { return static_cast<int>(mgr.andCount()); }
 
+  // Size the node array and strash table before anything is built. The
+  // estimate errs high, which the power-of-two table rounding mostly absorbs;
+  // the margin covers the CIs, which the estimate does not count.
+  void hintExpectedAnds(uint64_t n)
+  {
+    const uint64_t cap = 1ull << 26;
+    const uint64_t want = n + (n >> 4) + 1024;
+    mgr.reserveNodes(want < cap ? want : cap);
+  }
+
   BBNodeManagerLit() = default;
   BBNodeManagerLit(const BBNodeManagerLit&) = delete;
   BBNodeManagerLit& operator=(const BBNodeManagerLit&) = delete;

--- a/lib/STPManager/STP.cpp
+++ b/lib/STPManager/STP.cpp
@@ -913,6 +913,7 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
   bm->TermsAlreadySeenMap_Clear();
 
   int64_t final_difficulty_score = difficulty.score(inputToSat, bm);
+  bm->expected_blast_ands = final_difficulty_score;
 
   // Simplification has to have taken a fifth off the score to count as having
   // helped. Written as an assignment now that the AIG node count is gone: it
@@ -946,6 +947,7 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
         keptConstants.insert(e);
 
     inputToSat = revert->toRevertTo;
+    bm->expected_blast_ands = initial_difficulty_score;
 
     // I do this to clear the substitution/solver map.
     // Not sure what would happen if it contained simplifications

--- a/lib/ToSat/ToSATAIG.cpp
+++ b/lib/ToSat/ToSATAIG.cpp
@@ -268,6 +268,13 @@ bool ToSATAIG::bitblastWith(const ASTNode& input, bool needAbsRef, CNF& cnf)
 
   ManagerT mgr;
   mgr.nodeBudget = bm->UserFlags.aig_node_budget;
+  if (bm->expected_blast_ands > 0)
+  {
+    mgr.hintExpectedAnds((uint64_t)bm->expected_blast_ands);
+    if (bm->UserFlags.stats_flag)
+      cerr << "blast-hint: " << bm->expected_blast_ands << " AND nodes"
+           << endl;
+  }
   BlasterT bb(&mgr, &simp, bm->defaultNodeFactory, &bm->UserFlags, cb,
                 allowAbstraction_);
 

--- a/lib/ToSat/ToSATAIG.cpp
+++ b/lib/ToSat/ToSATAIG.cpp
@@ -247,6 +247,37 @@ bool ToSATAIG::bitblast(const ASTNode& input, bool needAbsRef, CNF& cnf)
       std::cerr << "cnf-auto: BV term abstraction on, chose gia-low"
                 << std::endl;
   }
+
+  // AUTO with an estimate in hand resolves before any backend is built,
+  // which is what lets it reach the rungs that never build an ABC Aig.
+  // Below the threshold, gia-low: the same Mf generation the old medium
+  // choice was paying for costs less than half medium's transient memory
+  // and no measurement across three campaigns has found the smaller cut
+  // enumeration buying solve time. At or above it, new-medium: there
+  // generation is most of the cost, and the in-house route generates in a
+  // fraction of the time at a quarter of the transient.
+  //
+  // Three fallthroughs keep today's behaviour where the evidence is thin.
+  // Array refinement still resolves from the ABC node count inside the ABC
+  // lowering, because the in-house rungs have not been measured under it.
+  // Solvers other than CaDiCaL keep the old scale -- MiniSat demonstrably
+  // cannot finish some proofs on gia-low CNF it finishes at the size-based
+  // rung. And with no estimate recorded (the incremental driver, direct
+  // API use) there is nothing to decide from. Written back rather than
+  // resolved locally so the abstraction splices convert at the same rung.
+  if (bm->UserFlags.cnf_effort == UserDefinedFlags::CNF_EFFORT_AUTO &&
+      !needAbsRef && bm->expected_blast_ands > 0 &&
+      bm->UserFlags.solver_to_use == UserDefinedFlags::CADICAL_SOLVER)
+  {
+    const bool large = (uint64_t)bm->expected_blast_ands >=
+                       bm->UserFlags.cnf_auto_threshold;
+    bm->UserFlags.cnf_effort = large ? UserDefinedFlags::CNF_EFFORT_NEW_MEDIUM
+                                     : UserDefinedFlags::CNF_EFFORT_GIA_LOW;
+    if (bm->UserFlags.stats_flag)
+      std::cerr << "cnf-auto: estimated " << bm->expected_blast_ands
+                << " AND nodes, chose " << (large ? "new-medium" : "gia-low")
+                << std::endl;
+  }
   const enum UserDefinedFlags::CNFEffort e = bm->UserFlags.cnf_effort;
   if (e == UserDefinedFlags::CNF_EFFORT_NEW_VERY_LOW ||
       e == UserDefinedFlags::CNF_EFFORT_NEW_LOW ||

--- a/tests/query-files/misc-tests/cnf-auto-array-fallback.smt2
+++ b/tests/query-files/misc-tests/cnf-auto-array-fallback.smt2
@@ -1,0 +1,41 @@
+; Under array read refinement, `auto` keeps the older size-based choice made
+; from the built ABC AIG's node count. The estimate-based resolution is for
+; the eager encodings only: the in-house and Gia rungs are unmeasured under
+; refinement, so a refining query must keep taking the ABC path whatever the
+; estimate says.
+;
+; Twelve reads at distinct symbolic indexes, so the read count is past the
+; eager-encoding regime and the solve actually refines.
+;
+; RUN: %solver --SMTLIB2 -s %s 2>&1 | %OutputCheck %s
+;
+; CHECK-NOT: estimated
+; CHECK: ^cnf-auto: [0-9]+ AIG nodes, chose medium$
+; CHECK: ^sat$
+(set-logic QF_ABV)
+(declare-fun a () (Array (_ BitVec 32) (_ BitVec 32)))
+(declare-fun i0 () (_ BitVec 32))
+(declare-fun i1 () (_ BitVec 32))
+(declare-fun i2 () (_ BitVec 32))
+(declare-fun i3 () (_ BitVec 32))
+(declare-fun i4 () (_ BitVec 32))
+(declare-fun i5 () (_ BitVec 32))
+(declare-fun i6 () (_ BitVec 32))
+(declare-fun i7 () (_ BitVec 32))
+(declare-fun i8 () (_ BitVec 32))
+(declare-fun i9 () (_ BitVec 32))
+(declare-fun i10 () (_ BitVec 32))
+(declare-fun i11 () (_ BitVec 32))
+(assert (bvult (select a i0) (select a i1)))
+(assert (bvult (select a i1) (select a i2)))
+(assert (bvult (select a i2) (select a i3)))
+(assert (bvult (select a i3) (select a i4)))
+(assert (bvult (select a i4) (select a i5)))
+(assert (bvult (select a i5) (select a i6)))
+(assert (bvult (select a i6) (select a i7)))
+(assert (bvult (select a i7) (select a i8)))
+(assert (bvult (select a i8) (select a i9)))
+(assert (bvult (select a i9) (select a i10)))
+(assert (bvult (select a i10) (select a i11)))
+(assert (bvugt (bvadd (select a i0) (select a i11)) #x00000010))
+(check-sat)

--- a/tests/query-files/misc-tests/cnf-auto-under-bv-abstraction.smt2
+++ b/tests/query-files/misc-tests/cnf-auto-under-bv-abstraction.smt2
@@ -1,6 +1,7 @@
 ; Under the BV term abstraction, `auto` resolves to the Gia backend at its
-; lowest rung before the size-based choice is made, and says so; an explicit
-; level is left alone, and so is a query the abstraction is not on for.
+; lowest rung before any other resolution, and says so; an explicit level is
+; left alone, and without the abstraction the estimate-based resolution
+; decides instead, printing its own line.
 ;
 ; The resolution below requires the CaDiCaL backend, so the test does too:
 ; a build without it keeps the size-based choice and has nothing to say, and
@@ -17,8 +18,8 @@
 ; EXPLICIT-NOT: cnf-auto:
 ; EXPLICIT-NOT: ^gia:
 ; EXPLICIT: ^sat$
-; OFF-NOT: chose gia-low
-; OFF: ^cnf-auto: [0-9]+ AIG nodes, chose medium$
+; OFF-NOT: BV term abstraction on
+; OFF: ^cnf-auto: estimated [0-9]+ AND nodes, chose gia-low$
 ; OFF: ^sat$
 (set-logic QF_BV)
 (declare-const x (_ BitVec 64))

--- a/tests/query-files/misc-tests/cnf-generation-effort-auto.smt2
+++ b/tests/query-files/misc-tests/cnf-generation-effort-auto.smt2
@@ -2,20 +2,26 @@
 ; UserFlags fields, and which way the decision goes on either side of the
 ; threshold.
 ;
-; The query is small -- a handful of AND gates -- so `auto` should leave it on
-; medium, where cut enumeration is cheap and the smaller CNF is worth having.
-; Moving the threshold down to one gate forces the other branch without needing
-; a query large enough to be slow, so this test says nothing about how many
-; gates a real query has and does not go stale when the default moves.
+; The query is small -- a handful of AND gates -- so `auto` resolves it to
+; gia-low from the recorded estimate. Moving the threshold down to one gate
+; forces the new-medium branch without needing a query large enough to be
+; slow, so this test says nothing about how many gates a real query has and
+; does not go stale when the default moves.
+;
+; The estimate-based resolution requires the CaDiCaL backend; other backends
+; keep the older size-based choice, which the array-fallback test covers.
+; REQUIRES: cadical
 ;
 ; RUN: %solver --SMTLIB2 -s %s 2>&1 | %OutputCheck --check-prefix=SMALL %s
 ; RUN: %solver --SMTLIB2 -s --cnf-generation-effort auto %s 2>&1 | %OutputCheck --check-prefix=SMALL %s
 ; RUN: %solver --SMTLIB2 -s --cnf-generation-effort auto --cnf-auto-threshold 1 %s 2>&1 | %OutputCheck --check-prefix=BIG %s
 ;
-; SMALL: ^cnf-auto: [0-9]+ AIG nodes, chose medium$
+; SMALL: ^cnf-auto: estimated [0-9]+ AND nodes, chose gia-low$
+; SMALL: ^gia: [0-9]+ AND nodes, [0-9]+ inputs, LUT3$
 ; SMALL: ^cnf: [0-9]+ clauses, [0-9]+ variables, [0-9]+ literals$
 ; SMALL: ^sat$
-; BIG: ^cnf-auto: [0-9]+ AIG nodes, chose very-low$
+; BIG: ^cnf-auto: estimated [0-9]+ AND nodes, chose new-medium$
+; BIG: ^new-medium CNF$
 ; BIG: ^sat$
 ;
 ; The fixed levels stay reachable and stay silent: nothing decides anything, so
@@ -34,8 +40,7 @@
 ; BADLEVEL: Unknown --cnf-generation-effort value 'nonsense'\. Expected one of: auto, very-low, low, medium, high, very-high, new-very-low, new-low, new-medium, gia-low, gia-high, gia-very-high\.
 ;
 ; The new-* rungs are a different generator over a different AIG, so they
-; say so rather than printing one of the ABC lines, and auto never reaches it:
-; auto decides from ABC's node count, which means blasting through ABC first.
+; say so rather than printing one of the ABC lines.
 ;
 ; RUN: %solver --SMTLIB2 -s --cnf-generation-effort new-very-low %s 2>&1 | %OutputCheck --check-prefix=NEWVERYLOW %s
 ; RUN: %solver --SMTLIB2 -s --cnf-generation-effort new-low %s 2>&1 | %OutputCheck --check-prefix=NEWLOW %s

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -737,18 +737,21 @@ void ExtraMain::create_options()
 
   const char* const misc_group = "Miscellaneous options";
   app.add_option("--cnf-auto-threshold", bm->UserFlags.cnf_auto_threshold,
-                 "AIG AND-node count at or above which --cnf-generation-effort "
-                 "auto drops from medium to very-low")
+                 "AND-node count at or above which --cnf-generation-effort "
+                 "auto stops minimising: it picks new-medium there and "
+                 "gia-low below, or on the estimate-less fallback drops "
+                 "medium to very-low")
       ->capture_default_str()
       ->group(misc_group);
   app.add_option("--cnf-generation-effort", cnf_effort,
                  "effort spent minimising the CNF: auto, very-low, low, "
                  "medium, high, very-high, new-very-low, new-low, new-medium. "
                  "Higher is slower to "
-                 "generate but yields a smaller CNF; auto picks between "
-                 "very-low and medium from the size of the AIG, since "
-                 "minimising a large one costs more than the solver saves, "
-                 "and gia-low when --bv-term-abstraction is on. "
+                 "generate but yields a smaller CNF; auto picks gia-low or, "
+                 "for large estimated blasts, new-medium, since minimising a "
+                 "large one costs more than the solver saves - falling back "
+                 "to the very-low/medium choice under array refinement, on "
+                 "solvers other than cadical, or with no estimate recorded. "
                  "The new-* rungs blast through STP's own AIG instead of "
                  "ABC's and write the CNF directly: new-very-low is plain "
                  "Tseitin, new-low recovers XOR and if-then-else, new-medium "


### PR DESCRIPTION
An installed CryptoMiniSat can be broken in a way its own CMake package half-survives: when the cadical/cadiback it was built against are uninstalled, its Targets file still runs far enough to define the cryptominisat5 imported target before noticing the missing targets and reporting NOT FOUND. cmake/FindCryptoMiniSat.cmake then falls to its build-here rung, whose add_library() aborts the configure with:

```
CMake Error at cmake/FindCryptoMiniSat.cmake:200 (add_library):
  add_library cannot create imported target "cryptominisat5" because another
  target with the same name already exists.
```

— an error that names neither the package at fault nor what is wrong with it. A second path reaches the same abort: a package that works but is rejected by the version check (older than 5.11) has defined the target too, so the fallback dies identically.

Imported targets cannot be redefined, so when the name is taken nothing can be built here; the fix is to say so instead of colliding. The fallback rung now checks for an existing cryptominisat5 target first:

- Under `-DUSE_CRYPTOMINISAT=ON` the configure stops with an error naming the package directory, the package's own reason when it gave one (or its version when that was the objection), and the ways out: repair or remove the installation, point `-Dcryptominisat5_DIR` at a usable copy, or configure with `-DUSE_CRYPTOMINISAT=OFF`.

```
CMake Error at cmake/FindCryptoMiniSat.cmake:160 (message):
  CryptoMiniSat was asked for, but the cryptominisat5 imported target is
  already defined, by the unusable package in
  '/usr/local/lib/cmake/cryptominisat5', so a CryptoMiniSat cannot be built
  here.  Its config file reports: The following imported targets are
  referenced, but are missing: cadiback cadical.  Repair or remove that
  installation, point -Dcryptominisat5_DIR at a usable copy, or configure
  with -DUSE_CRYPTOMINISAT=OFF.
```

- Under AUTO the build continues without CryptoMiniSat, as it does when none is installed, with a STATUS line carrying the same information.

Verified against a machine with exactly this broken package: AUTO now configures and generates cleanly with CryptoMiniSat in the disabled-features list, ON fails with the message above, a usable package is still found and used unchanged, and a synthetic 5.8 package reproduces the version-path crash on master and the clean skip with this change.