### PR TITLE
Stop --disable-simplifications selecting the simple CNF encoder

### DIFF
--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -1089,7 +1089,11 @@ public:
     enable_ite_context = false;
     distinct_ordering = false;
 
-    simple_cnf=true;
+    // simple_cnf is deliberately not set here. It used to be, which made
+    // "skip the word-level simplifications" silently also mean "use the
+    // worst CNF generator" -- Cnf_DeriveSimple, at about 1.9x the clauses
+    // of the cheapest real rung. The two are separate decisions; the CNF
+    // rung stays whatever --cnf-generation-effort says.
   }
 
   void disableSizeIncreasingSimplifications()


### PR DESCRIPTION
disableSimplifications() set simple_cnf as a side effect, so asking STP to skip the word-level simplifications silently also switched the CNF generator to Cnf_DeriveSimple - the weakest encoder available, at about 1.9x the clauses of the cheapest real rung, and one that stopped being reachable from the command line on its own some time ago. The two are separate decisions: skipping simplification says nothing about how much effort the CNF conversion should spend. With the coupling gone, --disable-simplifications leaves the CNF rung to --cnf-generation-effort like every other run; on one hard-set file that is 4.3M clauses through the ordinary ladder against 9.8M through Cnf_DeriveSimple.

The flag itself stays, because a benchmarking tool in the tree sets it directly; only the coupling goes.

Worth knowing before merging: anything that benchmarked STP under --disable-simplifications sees different (generally far smaller) CNFs from this commit on, so numbers taken across it are not comparable. Full test suite passes (179/179).