### PR TITLE
Flatten and pair extraction across the AC operators: tests, counter fix, bitwise/Boolean extension

### DIFF
--- a/include/stp/Simplifier/CommonSubSum.h
+++ b/include/stp/Simplifier/CommonSubSum.h
@@ -49,6 +49,16 @@ THE SOFTWARE.
  otherwise-unused variables visible to unconstrained-variable elimination:
  in (a*b*c) and (a*b*d) the pair {a,b} is used nowhere else, and once
  (a*b) is a node of its own that pass collapses it to a fresh variable.
+
+ The other associative-commutative operators regroup just as freely:
+ BVXOR, BVAND, and the Boolean XOR, AND and OR run through the same
+ machinery, with the replacement built as a formula for the Boolean kinds.
+ BVOR never reaches the pass: the simplifying factory lowers it to
+ BVNOT/BVAND at creation, so its sharing is BVAND sharing by the time any
+ pass runs -- the kind is accepted for DAGs built without that factory.
+ A substitution can hand an idempotent or self-inverse kind a duplicate
+ operand -- extracting {a,b} from (a ^ b ^ (a ^ b)) arrives at the pair
+ node twice -- and the factory folds the rebuilt application soundly.
 */
 
 #ifndef COMMONSUBSUM_H_
@@ -67,10 +77,13 @@ class CommonSubSum
   STPMgr* stpMgr;
   NodeFactory* nf;
 
-  // The operator whose n-ary applications are rewritten: BVPLUS or BVMULT.
-  // Sums and products are tallied separately -- a pair shared between a sum
-  // and a product has no single node both could use.
+  // The operator whose n-ary applications are rewritten. Each kind is
+  // tallied separately -- a pair shared between a sum and a product has no
+  // single node both could use.
   const Kind kind;
+
+  // Boolean kinds build replacements as formulas, term kinds with a width.
+  bool booleanKind() const { return kind == XOR || kind == AND || kind == OR; }
 
   // Adders removed, counting the one spent building each shared sub-sum.
   long saved;
@@ -131,7 +144,9 @@ public:
   CommonSubSum(STPMgr* stp_, NodeFactory* nf_, Kind kind_)
       : stpMgr(stp_), nf(nf_), kind(kind_), saved(0), truncated(false)
   {
-    assert(kind == BVPLUS || kind == BVMULT);
+    assert(kind == BVPLUS || kind == BVMULT || kind == BVXOR ||
+           kind == BVAND || kind == BVOR || kind == XOR || kind == AND ||
+           kind == OR);
   }
 
   ASTNode topLevel(const ASTNode& n);

--- a/include/stp/Simplifier/Flatten.h
+++ b/include/stp/Simplifier/Flatten.h
@@ -46,7 +46,8 @@ class Flatten
   STPMgr* stpMgr;
   NodeFactory* nf;
 
-  std::unordered_map<uint64_t, uint8_t> shareCount;
+  // uint8_t wrapped: 257 references read back as 1, i.e. unshared.
+  std::unordered_map<uint64_t, uint32_t> shareCount;
   std::unordered_map<uint64_t, ASTNode> fromTo;
 
   int removed;

--- a/include/stp/Simplifier/Rewriting.h
+++ b/include/stp/Simplifier/Rewriting.h
@@ -42,7 +42,8 @@ class Rewriting
   STPMgr* stpMgr;
   NodeFactory* nf;
 
-  std::unordered_map<uint64_t, uint8_t> shareCount;
+  // uint8_t wrapped: 257 references read back as 1, i.e. unshared.
+  std::unordered_map<uint64_t, uint32_t> shareCount;
   std::unordered_map<uint64_t, ASTNode> fromTo;
 
   int removed;

--- a/lib/Incremental/IncrementalSolverImpl.h
+++ b/lib/Incremental/IncrementalSolverImpl.h
@@ -1357,10 +1357,11 @@ struct IncrementalSolver::Impl
         }
         if (pieceFlags.enable_common_subsum)
         {
-          CommonSubSum sums(bm, bm->defaultNodeFactory, BVPLUS);
-          trialOut = sums.topLevel(trialOut);
-          CommonSubSum products(bm, bm->defaultNodeFactory, BVMULT);
-          trialOut = products.topLevel(trialOut);
+          for (const Kind k : {BVPLUS, BVMULT, BVXOR, BVAND, XOR, AND, OR})
+          {
+            CommonSubSum cse(bm, bm->defaultNodeFactory, k);
+            trialOut = cse.topLevel(trialOut);
+          }
         }
       }
       // Unconstrained-variable elimination is deliberately NOT run on

--- a/lib/STPManager/STP.cpp
+++ b/lib/STPManager/STP.cpp
@@ -888,18 +888,21 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
   if (simp->hasUnappliedSubstitutions())
     inputToSat = simp->applySubstitutionMap(inputToSat);
 
-  // Extract sub-terms shared between additions, and between multiplies,
-  // ahead of unconstrained-variable elimination: a pair of otherwise-unused
-  // variables occurring only inside the shared node makes that node
-  // collapsible there. This also keeps the extraction ahead of the
-  // ConstantBitPropagation object built below, whose fixed-point map must
-  // describe the exact tree handed to ToSATAIG.
+  // Extract sub-terms shared between same-kind applications of each
+  // associative-commutative operator, ahead of unconstrained-variable
+  // elimination: a pair of otherwise-unused variables occurring only inside
+  // the shared node makes that node collapsible there. This also keeps the
+  // extraction ahead of the ConstantBitPropagation object built below,
+  // whose fixed-point map must describe the exact tree handed to ToSATAIG.
+  // BVOR is absent because the node factory lowers it to BVNOT/BVAND at
+  // creation, so its sharing is BVAND sharing by the time this runs.
   if (bm->UserFlags.enable_common_subsum)
   {
-    CommonSubSum sums(bm, bm->defaultNodeFactory, BVPLUS);
-    inputToSat = sums.topLevel(inputToSat);
-    CommonSubSum products(bm, bm->defaultNodeFactory, BVMULT);
-    inputToSat = products.topLevel(inputToSat);
+    for (const Kind k : {BVPLUS, BVMULT, BVXOR, BVAND, XOR, AND, OR})
+    {
+      CommonSubSum cse(bm, bm->defaultNodeFactory, k);
+      inputToSat = cse.topLevel(inputToSat);
+    }
     bm->ASTNodeStats("After Common Sub-term Extraction: ", inputToSat);
   }
 

--- a/lib/Simplifier/CommonSubSum.cpp
+++ b/lib/Simplifier/CommonSubSum.cpp
@@ -261,7 +261,9 @@ bool CommonSubSum::extractOnePair()
   const ASTNode first = byNum[bestPair.first];
   const ASTNode second = byNum[bestPair.second];
   const ASTNode shared =
-      nf->CreateTerm(kind, first.GetValueWidth(), first, second);
+      booleanKind() ? nf->CreateNode(kind, first, second)
+                    : nf->CreateTerm(kind, first.GetValueWidth(), first,
+                                     second);
   byNum[shared.GetNodeNum()] = shared;
 
   // Before any operand list moves, so that the two stay in step.
@@ -350,7 +352,10 @@ ASTNode CommonSubSum::rebuild(const ASTNode& n,
     kids.reserve(replacement->second.size());
     for (const auto& k : replacement->second)
       kids.push_back(rebuild(k, changed, cache));
-    result = nf->CreateTerm(kind, n.GetValueWidth(), kids);
+    if (booleanKind())
+      result = nf->CreateNode(kind, kids);
+    else
+      result = nf->CreateTerm(kind, n.GetValueWidth(), kids);
   }
   else
   {
@@ -442,10 +447,9 @@ ASTNode CommonSubSum::topLevel(const ASTNode& n)
   }
 
   if (stpMgr->UserFlags.stats_flag)
-    std::cerr << "{CommonSubSum} "
-              << (kind == BVPLUS ? "Adders" : "Multipliers")
-              << " saved:" << saved << " Truncated:" << (truncated ? 1 : 0)
-              << std::endl;
+    std::cerr << "{CommonSubSum} " << _kind_names[kind]
+              << " applications saved:" << saved
+              << " Truncated:" << (truncated ? 1 : 0) << std::endl;
 
   operands.clear();
   byNum.clear();

--- a/tests/query-files/misc-tests/bvmul-shared-pair-collapse.smt2
+++ b/tests/query-files/misc-tests/bvmul-shared-pair-collapse.smt2
@@ -1,6 +1,6 @@
 ; RUN: %solver -s %s 2>&1 | %OutputCheck %s
 ; RUN: %solver -d %s | %OutputCheck --check-prefix=MODEL %s
-; CHECK: Multipliers saved:1
+; CHECK: BVMULT applications saved:1
 ; CHECK: ^sat
 ; MODEL: ^sat
 ; The pair {a, b} occurs only inside these two products. Sub-term

--- a/tests/query-files/misc-tests/common-subsum-bitwise.smt2
+++ b/tests/query-files/misc-tests/common-subsum-bitwise.smt2
@@ -1,0 +1,17 @@
+; RUN: %solver --flattening=true --common-subsum=true %s | %OutputCheck %s
+; CHECK-NEXT: ^unsat
+; Bitwise pair extraction must preserve values. The two bvands share the
+; operand pair {x,y} and the two bvxors share it too, so both kinds get
+; rebuilt around a shared node; the first equality forces x to all-ones,
+; which the final assert contradicts.
+(set-logic QF_BV)
+(declare-const x (_ BitVec 8))
+(declare-const y (_ BitVec 8))
+(declare-const z (_ BitVec 8))
+(declare-const w (_ BitVec 8))
+(assert (= (bvand x y z) (_ bv255 8)))
+(assert (= (bvand x y w) (_ bv255 8)))
+(assert (= (bvxor x y z) (_ bv7 8)))
+(assert (= (bvxor x y w) (_ bv9 8)))
+(assert (bvult x (_ bv255 8)))
+(check-sat)

--- a/tests/unit-tests/CommonSubSum_Test.cpp
+++ b/tests/unit-tests/CommonSubSum_Test.cpp
@@ -21,6 +21,7 @@ THE SOFTWARE.
 #include "stp/cpp_interface.h"
 #include "stp/Parser/parser.h"
 #include "stp/Simplifier/CommonSubSum.h"
+#include "stp/Simplifier/Flatten.h"
 #include <gtest/gtest.h>
 #include <set>
 
@@ -196,6 +197,121 @@ TEST(CommonSubSum_Test, shared_pair_factored_into_one_product_node)
       shared++;
   }
   ASSERT_EQ(shared, 1);
+}
+
+// A larger shared operand subset falls out of repeated pair extraction.
+// {v0,v1,v4,v6} is common to both sums, so two rounds pull out two shared
+// pairs; the smaller sum ends as exactly the sum of those pairs and the
+// larger one keeps them as operands:
+//   (v0+v1+v4+v6), (v0+v1+v2+v3+v4+v5+v6)
+//     -->  s1+s2, (s1+s2+v2+v3+v5)   with s1, s2 shared.
+TEST(CommonSubSum_Test, overlapping_operand_subset_cascades)
+{
+  const std::string input = R"(
+    (declare-fun v4 () (_ BitVec 20))
+    (declare-fun v5 () (_ BitVec 20))
+    (declare-fun v6 () (_ BitVec 20))
+    (assert (= (bvmul v2 (bvadd v0 v1 v4 v6)) (_ bv0 20)))
+    (assert (= (bvmul v3 (bvadd v0 v1 v2 v3 v4 v5 v6)) (_ bv33 20)))
+    )";
+
+  Context c;
+  ASTNode n = c.process(input);
+
+  std::set<ASTNode> plusNodes, visited;
+  collectPlusNodes(n, plusNodes, visited);
+
+  // The two shared pairs, the two-operand rewrite of the small sum, and the
+  // five-operand rewrite of the wide one.
+  ASSERT_EQ(plusNodes.size(), 4u);
+
+  std::multiset<unsigned> degrees;
+  int sharedTwice = 0;
+  for (const ASTNode& s : plusNodes)
+  {
+    degrees.insert(s.Degree());
+    int parents = 0;
+    for (const ASTNode& p : plusNodes)
+      for (const ASTNode& child : p.GetChildren())
+        if (child == s)
+          parents++;
+    if (parents == 2)
+      sharedTwice++;
+  }
+  EXPECT_EQ(degrees, (std::multiset<unsigned>{2, 2, 2, 5}));
+  EXPECT_EQ(sharedTwice, 2);
+}
+
+// A pair held by three sums is built once and referenced from all three.
+TEST(CommonSubSum_Test, pair_shared_by_three_sums_extracted_once)
+{
+  const std::string input = R"(
+    (declare-fun v4 () (_ BitVec 20))
+    (assert (= (bvmul v2 (bvadd v0 v1 v2)) (_ bv0 20)))
+    (assert (= (bvmul v3 (bvadd v0 v1 v3)) (_ bv33 20)))
+    (assert (= (bvmul v4 (bvadd v0 v1 v4)) (_ bv7 20)))
+    )";
+
+  Context c;
+  ASTNode n = c.process(input);
+
+  std::set<ASTNode> plusNodes, visited;
+  collectPlusNodes(n, plusNodes, visited);
+
+  ASSERT_EQ(plusNodes.size(), 4u);
+  int sharedByThree = 0;
+  for (const ASTNode& s : plusNodes)
+  {
+    ASSERT_EQ(s.Degree(), 2u);
+    int parents = 0;
+    for (const ASTNode& p : plusNodes)
+      for (const ASTNode& child : p.GetChildren())
+        if (child == s)
+          parents++;
+    if (parents == 3)
+      sharedByThree++;
+  }
+  EXPECT_EQ(sharedByThree, 1);
+}
+
+// Nesting hides the pair -- (v0 + (v1 + v2)) and (v1 + (v0 + v3)) share
+// {v0,v1} but no node, and two-operand sums are below the pass's reach --
+// so extraction only fires once Flatten has widened the sums. This is the
+// pipeline ordering the pass is written for.
+TEST(CommonSubSum_Test, flatten_exposes_pairs_hidden_by_nesting)
+{
+  const std::string input = R"(
+    (assert (= (bvmul v2 (bvadd v0 (bvadd v1 v2))) (_ bv0 20)))
+    (assert (= (bvmul v3 (bvadd v1 (bvadd v0 v3))) (_ bv33 20)))
+    )";
+
+  Context c;
+  ASTNode parsed = c.parse(input);
+
+  ASTNode untouched = c.subSum.topLevel(parsed);
+  EXPECT_EQ(untouched, parsed);
+
+  stp::Flatten flatten(&c.mgr, &c.snf);
+  ASTNode flat = flatten.topLevel(parsed);
+  ASTNode extracted = c.subSum.topLevel(flat);
+
+  std::set<ASTNode> plusNodes, visited;
+  collectPlusNodes(extracted, plusNodes, visited);
+
+  ASSERT_EQ(plusNodes.size(), 3u);
+  int shared = 0;
+  for (const ASTNode& s : plusNodes)
+  {
+    ASSERT_EQ(s.Degree(), 2u);
+    int parents = 0;
+    for (const ASTNode& p : plusNodes)
+      for (const ASTNode& child : p.GetChildren())
+        if (child == s)
+          parents++;
+    if (parents == 2)
+      shared++;
+  }
+  EXPECT_EQ(shared, 1);
 }
 
 // A pair shared between a sum and a product has no node both could use:

--- a/tests/unit-tests/CommonSubSum_Test.cpp
+++ b/tests/unit-tests/CommonSubSum_Test.cpp
@@ -84,7 +84,31 @@ struct Context
       std::cerr << "Post common sub-product " << n;
       return n;
     }
+
+   ASTNode processKind(stp::Kind k, std::string input)
+   {
+      ASTNode n = parse(input);
+      stp::CommonSubSum pass(&mgr, &snf, k);
+      return pass.topLevel(n);
+    }
 };
+
+// How many of `nodes` appear as a child of exactly `wanted` of the others.
+static int nodesWithParents(const std::set<ASTNode>& nodes, int wanted)
+{
+  int matching = 0;
+  for (const ASTNode& s : nodes)
+  {
+    int parents = 0;
+    for (const ASTNode& p : nodes)
+      for (const ASTNode& child : p.GetChildren())
+        if (child == s)
+          parents++;
+    if (parents == wanted)
+      matching++;
+  }
+  return matching;
+}
 
 static void collectKindNodes(const ASTNode& n, stp::Kind kind,
                              std::set<ASTNode>& out,
@@ -342,4 +366,165 @@ TEST(CommonSubSum_Test, sum_and_product_do_not_pair)
       wideMults++;
   ASSERT_EQ(wideSums, 1);
   ASSERT_EQ(wideMults, 1);
+}
+
+// The same extraction applies to each associative-commutative kind. The
+// multiplies again keep the equalities from being solved word-level at node
+// creation, so the applications genuinely reach the pass.
+TEST(CommonSubSum_Test, shared_pair_factored_for_bvxor)
+{
+  const std::string input = R"(
+    (assert (= (bvmul v2 (bvxor v0 v1 v2)) (_ bv0 20)))
+    (assert (= (bvmul v3 (bvxor v0 v1 v3)) (_ bv33 20)))
+    )";
+
+  Context c;
+  ASTNode n = c.processKind(stp::BVXOR, input);
+
+  std::set<ASTNode> nodes, visited;
+  collectKindNodes(n, stp::BVXOR, nodes, visited);
+
+  ASSERT_EQ(nodes.size(), 3u);
+  for (const ASTNode& p : nodes)
+    ASSERT_EQ(p.Degree(), 2u);
+  EXPECT_EQ(nodesWithParents(nodes, 2), 1);
+}
+
+TEST(CommonSubSum_Test, shared_pair_factored_for_bvand)
+{
+  const std::string input = R"(
+    (assert (= (bvmul v2 (bvand v0 v1 v2)) (_ bv0 20)))
+    (assert (= (bvmul v3 (bvand v0 v1 v3)) (_ bv33 20)))
+    )";
+
+  Context c;
+  ASTNode n = c.processKind(stp::BVAND, input);
+
+  std::set<ASTNode> nodes, visited;
+  collectKindNodes(n, stp::BVAND, nodes, visited);
+
+  ASSERT_EQ(nodes.size(), 3u);
+  for (const ASTNode& p : nodes)
+    ASSERT_EQ(p.Degree(), 2u);
+  EXPECT_EQ(nodesWithParents(nodes, 2), 1);
+}
+
+// bvor never reaches the pass as BVOR: the factory lowers it to
+// BVNOT/BVAND at creation, so its shared pair surfaces -- negated -- in
+// the BVAND run.
+TEST(CommonSubSum_Test, bvor_reaches_extraction_as_bvand)
+{
+  const std::string input = R"(
+    (assert (= (bvmul v2 (bvor v0 v1 v2)) (_ bv0 20)))
+    (assert (= (bvmul v3 (bvor v0 v1 v3)) (_ bv33 20)))
+    )";
+
+  Context c;
+  ASTNode n = c.processKind(stp::BVAND, input);
+
+  std::set<ASTNode> nodes, visited;
+  collectKindNodes(n, stp::BVAND, nodes, visited);
+
+  ASSERT_EQ(nodes.size(), 3u);
+  for (const ASTNode& p : nodes)
+    ASSERT_EQ(p.Degree(), 2u);
+  EXPECT_EQ(nodesWithParents(nodes, 2), 1);
+}
+
+TEST(CommonSubSum_Test, shared_pair_factored_for_boolean_xor)
+{
+  const std::string input = R"(
+    (declare-fun a () Bool)
+    (declare-fun b () Bool)
+    (declare-fun p () Bool)
+    (declare-fun q () Bool)
+    (assert (xor a b p))
+    (assert (xor a b q))
+    )";
+
+  Context c;
+  ASTNode n = c.processKind(stp::XOR, input);
+
+  std::set<ASTNode> nodes, visited;
+  collectKindNodes(n, stp::XOR, nodes, visited);
+
+  ASSERT_EQ(nodes.size(), 3u);
+  for (const ASTNode& p : nodes)
+    ASSERT_EQ(p.Degree(), 2u);
+  EXPECT_EQ(nodesWithParents(nodes, 2), 1);
+}
+
+// The shared conjunctions sit under ORs so that the top-level conjunction
+// -- itself an AND, and too narrow to enumerate -- stays out of the way.
+TEST(CommonSubSum_Test, shared_pair_factored_for_boolean_and)
+{
+  const std::string input = R"(
+    (declare-fun a () Bool)
+    (declare-fun b () Bool)
+    (declare-fun p () Bool)
+    (declare-fun q () Bool)
+    (declare-fun r () Bool)
+    (declare-fun s () Bool)
+    (assert (or r (and a b p)))
+    (assert (or s (and a b q)))
+    )";
+
+  Context c;
+  ASTNode n = c.processKind(stp::AND, input);
+
+  std::set<ASTNode> nodes, visited;
+  collectKindNodes(n, stp::AND, nodes, visited);
+
+  // The top-level conjunction of the two asserts, the shared pair, and the
+  // two rewritten conjunctions.
+  ASSERT_EQ(nodes.size(), 4u);
+  EXPECT_EQ(nodesWithParents(nodes, 2), 1);
+}
+
+TEST(CommonSubSum_Test, shared_pair_factored_for_boolean_or)
+{
+  const std::string input = R"(
+    (declare-fun a () Bool)
+    (declare-fun b () Bool)
+    (declare-fun p () Bool)
+    (declare-fun q () Bool)
+    (assert (or a b p))
+    (assert (or a b q))
+    )";
+
+  Context c;
+  ASTNode n = c.processKind(stp::OR, input);
+
+  std::set<ASTNode> nodes, visited;
+  collectKindNodes(n, stp::OR, nodes, visited);
+
+  ASSERT_EQ(nodes.size(), 3u);
+  for (const ASTNode& p : nodes)
+    ASSERT_EQ(p.Degree(), 2u);
+  EXPECT_EQ(nodesWithParents(nodes, 2), 1);
+}
+
+// A substitution can hand a self-inverse kind its own pair node twice:
+// extracting {v0,v1} from (v0 ^ v1 ^ (v0 ^ v1)) removes both operands and
+// inserts the hash-consed pair beside the copy already there. The factory
+// folds the rebuilt application to zero, and the enclosing assert to true.
+TEST(CommonSubSum_Test, duplicate_arrival_collapses_soundly)
+{
+  const std::string input = R"(
+    (assert (= (bvmul v2 (bvxor v0 v1 v2)) (_ bv33 20)))
+    (assert (= (bvmul v3 (bvxor v0 v1 (bvxor v0 v1))) (_ bv0 20)))
+    )";
+
+  Context c;
+  ASTNode n = c.processKind(stp::BVXOR, input);
+
+  std::set<ASTNode> nodes, visited;
+  collectKindNodes(n, stp::BVXOR, nodes, visited);
+
+  // The second assert folded away; the first keeps the shared pair nested
+  // in its rewritten application.
+  ASSERT_EQ(nodes.size(), 2u);
+  for (const ASTNode& p : nodes)
+    ASSERT_EQ(p.Degree(), 2u);
+  EXPECT_EQ(nodesWithParents(nodes, 1), 1);
 }

--- a/tests/unit-tests/Flatten_Test.cpp
+++ b/tests/unit-tests/Flatten_Test.cpp
@@ -378,6 +378,70 @@ TEST(Flatten_Test, ManyParentsIsStillShared)
   EXPECT_EQ(post, pre);
 }
 
+// A NOT among XOR operands is pulled above the XOR: the factory strips it
+// at creation and accumulates the parity, and flattening then widens the
+// stripped chain. Both groupings must meet at the same NOT(XOR(a,b,c)).
+TEST(Flatten_Test, XorFlattensThroughAPulledUpNot)
+{
+  const std::string input = R"(
+    (assert (= (xor a (not (xor b c))) (not (xor (xor a b) c))))
+    )";
+
+  Context c;
+  ASTNode pre = c.parse(input);
+  ASSERT_TRUE(hasSameKindEdge(pre, stp::XOR));
+  ASSERT_NE(pre, c.mgr.ASTTrue);
+  ASTNode post = c.flatten.topLevel(pre);
+  EXPECT_EQ(post, c.mgr.ASTTrue);
+}
+
+// The BVNOT analogue, odd parity: one BVNOT below meets one written above.
+TEST(Flatten_Test, BvxorFlattensThroughAPulledUpBvnot)
+{
+  const std::string input = R"(
+    (assert (= (bvxor v0 (bvnot (bvxor v1 v2)))
+               (bvnot (bvxor (bvxor v0 v1) v2))))
+    )";
+
+  Context c;
+  ASTNode pre = c.parse(input);
+  ASSERT_TRUE(hasSameKindEdge(pre, stp::BVXOR));
+  ASSERT_NE(pre, c.mgr.ASTTrue);
+  ASTNode post = c.flatten.topLevel(pre);
+  EXPECT_EQ(post, c.mgr.ASTTrue);
+}
+
+// Even parity: two pulled-up BVNOTs cancel and no BVNOT survives.
+TEST(Flatten_Test, TwoPulledUpBvnotsCancel)
+{
+  const std::string input = R"(
+    (assert (= (bvxor (bvnot v0) (bvnot (bvxor v1 v2)))
+               (bvxor v0 v1 v2)))
+    )";
+
+  Context c;
+  ASTNode pre = c.parse(input);
+  ASSERT_NE(pre, c.mgr.ASTTrue);
+  ASTNode post = c.flatten.topLevel(pre);
+  EXPECT_EQ(post, c.mgr.ASTTrue);
+}
+
+// Pulling the BVNOT up must not defeat the sharing rule: the xor chain the
+// strip exposes is still shared, so it stays nested.
+TEST(Flatten_Test, SharedChildExposedByBvnotStripStaysShared)
+{
+  const std::string input = R"(
+    (assert (= v3 (bvxor v2 (bvnot (bvxor v0 v1)))))
+    (assert (= v4 (bvxor v0 v1)))
+    )";
+
+  Context c;
+  ASTNode pre = c.parse(input);
+  ASSERT_TRUE(hasSameKindEdge(pre, stp::BVXOR));
+  ASTNode post = c.flatten.topLevel(pre);
+  EXPECT_EQ(post, pre);
+}
+
 // FP arithmetic is commutative but not associative under rounding, so no
 // FP kind may flatten. FP_ADD also carries its rounding mode as a child.
 TEST(Flatten_Test, FpAddChainIsLeftAlone)

--- a/tests/unit-tests/Flatten_Test.cpp
+++ b/tests/unit-tests/Flatten_Test.cpp
@@ -23,6 +23,7 @@ THE SOFTWARE.
 #include "stp/Simplifier/Flatten.h"
 #include <gtest/gtest.h>
 #include <stdio.h>
+#include <unordered_set>
 
 
   const std::string start_input = R"(
@@ -64,19 +65,50 @@ struct Context
     stp::GlobalParserInterface = &interface;
    }
    
-   ASTNode process(std::string input)
+   ASTNode parseRaw(std::string input)
    {
-      stp::SMT2ScanString((start_input + input).c_str());
+      stp::SMT2ScanString(input.c_str());
       stp::SMT2Parse();
       // TODO assert it was parsed properly.
       smt2lex_destroy();
-      ASTNode n = mgr.CreateNode(stp::AND, mgr.GetAsserts());
+      return mgr.CreateNode(stp::AND, mgr.GetAsserts());
+   }
+
+   ASTNode parse(std::string input)
+   {
+      return parseRaw(start_input + input);
+   }
+
+   ASTNode process(std::string input)
+   {
+      ASTNode n = parse(input);
       std::cerr << "Pre flatten " << n;
       n = flatten.topLevel(n);
       std::cerr << "Post flatten "<< n;
       return n;
     }
 };
+
+// Whether some node of kind k has a child of kind k.
+static bool hasSameKindEdge(const ASTNode& n, stp::Kind k)
+{
+  std::unordered_set<uint64_t> visited;
+  ASTVec stack{n};
+  while (!stack.empty())
+  {
+    const ASTNode node = stack.back();
+    stack.pop_back();
+    if (!visited.insert(node.GetNodeNum()).second)
+      continue;
+    for (const ASTNode& c : node.GetChildren())
+    {
+      if (node.GetKind() == k && c.GetKind() == k)
+        return true;
+      stack.push_back(c);
+    }
+  }
+  return false;
+}
 
 TEST(Flatten_Test , __LINE__)
 {
@@ -191,11 +223,176 @@ TEST(Flatten_Test, __LINE__)
 TEST(Flatten_Test, __LINE__)
 {
   const std::string input = R"(
-    (assert (= (bvadd v0 (bvadd v1 v0) v1 v0 ) 
+    (assert (= (bvadd v0 (bvadd v1 v0) v1 v0 )
                (bvadd v0 v0 (bvadd v1 v0 v1) )))
     )";
 
   Context c;
   ASTNode n = c.process(input);
   ASSERT_EQ(n, c.mgr.ASTTrue);
+}
+
+struct KindCase
+{
+  const char* name;
+  stp::Kind kind; // the kind whose nesting the input produces
+  std::string input;
+};
+
+// Every associative+commutative kind flattens an unshared same-kind child:
+// the two groupings meet at the same wide node, so the equality folds to
+// true when the parent is rebuilt.
+//
+// bvor is checked as BVAND because the simplifying factory lowers BVOR to
+// BVNOT/BVAND at creation; the nested chain it leaves behind is a BVAND one.
+TEST(Flatten_Test, EachKindFlattensAnUnsharedChild)
+{
+  const std::vector<KindCase> cases = {
+      {"and", stp::AND,
+       "(assert (= (and a (and b c)) (and (and a b) c)))"},
+      {"or", stp::OR,
+       "(assert (= (or a (or b c)) (or (or a b) c)))"},
+      {"xor", stp::XOR,
+       "(assert (= (xor a (xor b c)) (xor (xor a b) c)))"},
+      {"bvand", stp::BVAND,
+       "(assert (= (bvand v0 (bvand v1 v2)) (bvand (bvand v0 v1) v2)))"},
+      {"bvor", stp::BVAND,
+       "(assert (= (bvor v0 (bvor v1 v2)) (bvor (bvor v0 v1) v2)))"},
+      {"bvxor", stp::BVXOR,
+       "(assert (= (bvxor v0 (bvxor v1 v2)) (bvxor (bvxor v0 v1) v2)))"},
+      {"bvadd", stp::BVPLUS,
+       "(assert (= (bvadd v0 (bvadd v1 v2)) (bvadd (bvadd v0 v1) v2)))"},
+      {"bvmul", stp::BVMULT,
+       "(assert (= (bvmul v0 (bvmul v1 v2)) (bvmul (bvmul v0 v1) v2)))"},
+  };
+
+  for (const auto& tc : cases)
+  {
+    SCOPED_TRACE(tc.name);
+    Context c;
+    ASTNode pre = c.parse(tc.input);
+    // The factory must not have flattened at creation, or this proves nothing.
+    ASSERT_TRUE(hasSameKindEdge(pre, tc.kind));
+    ASSERT_NE(pre, c.mgr.ASTTrue);
+    ASTNode post = c.flatten.topLevel(pre);
+    EXPECT_EQ(post, c.mgr.ASTTrue);
+  }
+}
+
+// A same-kind child with two parents stays nested: merging it into one
+// parent would leave the other still referencing it, growing the DAG.
+// The second assertion is the second parent.
+TEST(Flatten_Test, NoKindFlattensASharedChild)
+{
+  const std::vector<KindCase> cases = {
+      // The nested ANDs sit under ORs: conjuncts of the top-level AND
+      // flatten irrespective of sharing, which is not what's under test.
+      {"and", stp::AND,
+       "(declare-fun d () Bool)(declare-fun e () Bool)"
+       "(assert (or b (and d (and a c))))"
+       "(assert (or e (and a c)))"},
+      {"or", stp::OR,
+       "(declare-fun d () Bool)"
+       "(assert (or b (or a c)))"
+       "(assert (or d (or a c)))"},
+      {"xor", stp::XOR,
+       "(declare-fun d () Bool)"
+       "(assert (xor b (xor a c)))"
+       "(assert (xor d (xor a c)))"},
+      {"bvand", stp::BVAND,
+       "(assert (= v3 (bvand v2 (bvand v0 v1))))"
+       "(assert (= v4 (bvand v0 v1)))"},
+      {"bvor", stp::BVAND,
+       "(assert (= v3 (bvor v2 (bvor v0 v1))))"
+       "(assert (= v4 (bvor v0 v1)))"},
+      {"bvxor", stp::BVXOR,
+       "(assert (= v3 (bvxor v2 (bvxor v0 v1))))"
+       "(assert (= v4 (bvxor v0 v1)))"},
+      {"bvadd", stp::BVPLUS,
+       "(assert (= v3 (bvadd v2 (bvadd v0 v1))))"
+       "(assert (= v4 (bvadd v0 v1)))"},
+      {"bvmul", stp::BVMULT,
+       "(assert (= v3 (bvmul v2 (bvmul v0 v1))))"
+       "(assert (= v4 (bvmul v0 v1)))"},
+  };
+
+  for (const auto& tc : cases)
+  {
+    SCOPED_TRACE(tc.name);
+    Context c;
+    ASTNode pre = c.parse(tc.input);
+    ASSERT_TRUE(hasSameKindEdge(pre, tc.kind));
+    ASTNode post = c.flatten.topLevel(pre);
+    EXPECT_EQ(post, pre);
+  }
+}
+
+// Conjuncts of the top-level AND flatten even when shared: the child node
+// survives under its other parent, so nothing is duplicated.
+TEST(Flatten_Test, TopLevelAndFlattensASharedConjunct)
+{
+  const std::string input = R"(
+    (declare-fun d () Bool)
+    (assert (and a b))
+    (assert (or d (and a b)))
+    )";
+
+  Context c;
+  ASTNode pre = c.parse(input);
+  ASSERT_TRUE(hasSameKindEdge(pre, stp::AND));
+  ASTNode post = c.flatten.topLevel(pre);
+
+  ASTNode a = c.mgr.LookupOrCreateSymbol("a");
+  ASTNode b = c.mgr.LookupOrCreateSymbol("b");
+  ASTNode d = c.mgr.LookupOrCreateSymbol("d");
+  ASTNode inner = c.mgr.CreateNode(stp::AND, a, b);
+  ASTNode expected =
+      c.mgr.CreateNode(stp::AND, a, b, c.mgr.CreateNode(stp::OR, d, inner));
+  EXPECT_EQ(post, expected);
+}
+
+// A node with 257 parents is shared however the count is stored: with the
+// old uint8_t counter the reference count wrapped to 1 and the node was
+// flattened into its first parent.
+TEST(Flatten_Test, ManyParentsIsStillShared)
+{
+  Context c;
+  const unsigned width = 20;
+  ASTNode v0 = c.mgr.CreateSymbol("m_v0", 0, width);
+  ASTNode v1 = c.mgr.CreateSymbol("m_v1", 0, width);
+  ASTNode shared = c.mgr.CreateTerm(stp::BVPLUS, width, v0, v1);
+
+  ASTVec conjuncts;
+  for (unsigned i = 0; i < 257; i++)
+  {
+    const std::string u_name = "m_u" + std::to_string(i);
+    const std::string w_name = "m_w" + std::to_string(i);
+    ASTNode u = c.mgr.CreateSymbol(u_name.c_str(), 0, width);
+    ASTNode w = c.mgr.CreateSymbol(w_name.c_str(), 0, width);
+    ASTNode parent = c.mgr.CreateTerm(stp::BVPLUS, width, u, shared);
+    conjuncts.push_back(c.mgr.CreateNode(stp::EQ, w, parent));
+  }
+  ASTNode pre = c.mgr.CreateNode(stp::AND, conjuncts);
+  ASSERT_TRUE(hasSameKindEdge(pre, stp::BVPLUS));
+  ASTNode post = c.flatten.topLevel(pre);
+  EXPECT_EQ(post, pre);
+}
+
+// FP arithmetic is commutative but not associative under rounding, so no
+// FP kind may flatten. FP_ADD also carries its rounding mode as a child.
+TEST(Flatten_Test, FpAddChainIsLeftAlone)
+{
+  const std::string input = R"(
+    (set-logic QF_FP)
+    (declare-fun f0 () (_ FloatingPoint 8 24))
+    (declare-fun f1 () (_ FloatingPoint 8 24))
+    (declare-fun f2 () (_ FloatingPoint 8 24))
+    (assert (fp.eq (fp.add RNE f0 (fp.add RNE f1 f2)) f0))
+    )";
+
+  Context c;
+  ASTNode pre = c.parseRaw(input);
+  ASSERT_TRUE(hasSameKindEdge(pre, stp::FP_ADD));
+  ASTNode post = c.flatten.topLevel(pre);
+  EXPECT_EQ(post, pre);
 }

--- a/tests/unit-tests/Flatten_Test.cpp
+++ b/tests/unit-tests/Flatten_Test.cpp
@@ -22,6 +22,8 @@ THE SOFTWARE.
 #include "stp/Parser/parser.h"
 #include "stp/Simplifier/Flatten.h"
 #include <gtest/gtest.h>
+#include <algorithm>
+#include <random>
 #include <stdio.h>
 #include <unordered_set>
 
@@ -440,6 +442,91 @@ TEST(Flatten_Test, SharedChildExposedByBvnotStripStaysShared)
   ASSERT_TRUE(hasSameKindEdge(pre, stp::BVXOR));
   ASTNode post = c.flatten.topLevel(pre);
   EXPECT_EQ(post, pre);
+}
+
+// Random unshared xor trees with random negations sprinkled through them
+// must always come back completely flat: one xor over exactly the leaf
+// symbols, under at most one top negation whose presence matches the
+// parity of the negations inserted. The factory strips each negation at
+// creation and Flatten merges every unshared same-kind child, so any
+// survivor -- a nested xor, or a negation among the operands -- is a hole
+// in one of the two.
+//
+// Fixed seeds: the trees vary, the test does not.
+static void checkRandomXorTreesFlatten(bool boolean)
+{
+  const stp::Kind xorKind = boolean ? stp::XOR : stp::BVXOR;
+  const unsigned width = boolean ? 0 : 20;
+
+  for (uint32_t seed = 0; seed < 32; seed++)
+  {
+    SCOPED_TRACE(seed);
+    std::mt19937 rng(seed);
+    Context c;
+
+    auto negate = [&](const ASTNode& n) {
+      return boolean ? c.mgr.CreateNode(stp::NOT, n)
+                     : c.mgr.CreateTerm(stp::BVNOT, width, n);
+    };
+    auto join = [&](const ASTNode& a, const ASTNode& b) {
+      return boolean ? c.mgr.CreateNode(xorKind, a, b)
+                     : c.mgr.CreateTerm(xorKind, width, a, b);
+    };
+
+    const unsigned leaves = 2 + rng() % 12;
+    unsigned negations = 0;
+    ASTVec pool;
+    for (unsigned i = 0; i < leaves; i++)
+    {
+      const std::string name = "r" + std::to_string(i);
+      pool.push_back(c.mgr.CreateSymbol(name.c_str(), 0, width));
+    }
+
+    // Combine two random entries at a time, so every internal node is used
+    // exactly once: nothing is shared and everything may flatten.
+    while (pool.size() > 1)
+    {
+      ASTNode a = pool[rng() % pool.size()];
+      pool.erase(std::find(pool.begin(), pool.end(), a));
+      ASTNode b = pool[rng() % pool.size()];
+      pool.erase(std::find(pool.begin(), pool.end(), b));
+
+      if (rng() % 2)
+      {
+        a = negate(a);
+        negations++;
+      }
+      ASTNode combined = join(a, b);
+      if (rng() % 2)
+      {
+        combined = negate(combined);
+        negations++;
+      }
+      pool.push_back(combined);
+    }
+
+    ASTNode flat = c.flatten.topLevel(pool[0]);
+
+    if (negations % 2 == 1)
+    {
+      ASSERT_EQ(flat.GetKind(), boolean ? stp::NOT : stp::BVNOT);
+      flat = flat[0];
+    }
+    ASSERT_EQ(flat.GetKind(), xorKind);
+    ASSERT_EQ(flat.Degree(), leaves);
+    for (const ASTNode& child : flat.GetChildren())
+      EXPECT_EQ(child.GetKind(), stp::SYMBOL);
+  }
+}
+
+TEST(Flatten_Test, RandomXorTreesWithNotsFlattenCompletely)
+{
+  checkRandomXorTreesFlatten(true);
+}
+
+TEST(Flatten_Test, RandomBvxorTreesWithBvnotsFlattenCompletely)
+{
+  checkRandomXorTreesFlatten(false);
 }
 
 // FP arithmetic is commutative but not associative under rounding, so no

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -233,9 +233,10 @@ void ExtraMain::create_options()
            "Pure literals are replaced.", simp_group);
 
   bool_arg("--common-subsum", bm->UserFlags.enable_common_subsum,
-           "Factor sub-terms shared between n-ary bvadd nodes, and between "
-           "n-ary bvmul nodes, into a single shared node, so the adder or "
-           "multiplier is built once (needs --flattening)",
+           "Factor sub-terms shared between same-kind n-ary applications of "
+           "each associative-commutative operator (bvadd, bvmul, bvxor, "
+           "bvand, xor, and, or) into a single shared node, so the shared "
+           "circuit is built once (needs --flattening)",
            simp_group);
 
   bool_arg("--pair-extract", bm->UserFlags.enable_pair_extract,


### PR DESCRIPTION
The sharing-aware Flatten pass already flattens every associative-commutative kind — AND, OR, XOR, BVAND, BVOR, BVXOR, BVPLUS, BVMULT — and merges a same-kind child only when that child is unshared, so flattening never increases the node count. This PR pins that behaviour with per-kind unit tests, and fixes one case where the pass flattened a node it should not have.

New tests in the Flatten unit suite:

- **Each kind flattens an unshared child.** Two groupings of the same operands must meet at the same wide node, folding the equality to true. Each case first asserts the nested edge survived node creation, so a factory that starts flattening at creation turns the test into a failure rather than a vacuous pass. BVOR is asserted through BVAND edges because the simplifying factory lowers BVOR to BVNOT/BVAND at creation.
- **No kind flattens a shared child.** A same-kind child with two parents must stay nested, since merging it into one parent leaves the other still referencing it. The pass must return the input node unchanged.
- **Top-level conjuncts flatten irrespective of sharing.** The child survives under its other parent, so nothing is duplicated; the asymmetry is deliberate and now documented by a test.
- **Floating-point chains are left alone.** FP addition is commutative but not associative under rounding, and FP_ADD carries its rounding mode as a child.

The fix: the share counters in Flatten and Rewriting were uint8_t, so a node with 257 references wrapped back to a count of one and was treated as unshared — Flatten then merged a genuinely shared node into its first same-kind parent, and both passes stopped caching rewrites for such nodes, re-walking their subtrees once per parent. Widened to uint32_t; the unordered_map node allocation does not change size. The regression test builds a node with 257 parents and fails against the old counter.

All unit-test targets pass. The two query-file failures on this machine (the cnf-generation-effort auto tests) reproduce identically on an unmodified build: they assume the stock default SAT backend and fail on any build that compiles CryptoMiniSat in, which makes it the default. That is being handled separately.

A second commit extends the coverage to the behaviours around flattening. The factory strips NOT/BVNOT children of XOR/BVXOR at creation and folds the parity into one wrapping negation, and Flatten then widens the stripped chain: the odd and even parity cases are pinned, along with the sharing rule holding for a chain the strip exposes. For common sub-sum extraction: an overlapping operand subset cascades into multiple shared pairs over successive rounds, a pair held by three sums is built once and referenced three times, and extraction fires only after Flatten has widened nested sums.

Two further commits widen the scope:

**Fuzzed xor flattening through negations.** Random unshared xor/bvxor trees with negations sprinkled through them, 32 fixed seeds each, must always flatten to a single wide application over exactly the leaf symbols, under at most one top negation whose presence matches the parity of the negations inserted.

**Pair extraction extended to the bitwise and Boolean AC operators.** CommonSubSum ran only over BVPLUS and BVMULT; it now also runs over BVXOR, BVAND and the Boolean XOR, AND and OR, building Boolean replacements as formulas. BVOR is not instantiated because the node factory lowers it to BVNOT/BVAND at creation, so its sharing is BVAND sharing by the time the pass runs (a test pins that route). A substitution can hand a self-inverse kind its own pair node twice -- extracting {a,b} from (a ^ b ^ (a ^ b)) -- and the factory folds the rebuilt application soundly, also pinned by a test. The stats line now names the kind generically; the one query test grepping the old wording moves to the new one. Soundness checked with a 400-file differential sweep: answers are unchanged with the pass on and off.
