### PR TITLE
Pin CaDiCaL in the tests that assume it is the default backend

### DIFF
--- a/tests/api/C/reason-unknown.cpp
+++ b/tests/api/C/reason-unknown.cpp
@@ -50,8 +50,15 @@ namespace
 // generic semiprime takes minutes. This square is decided in under a second
 // and costs a few thousand conflicts, so every budget here has something to
 // stop.
-void assertFactoring(VC vc)
+//
+// Both of those timings are CaDiCaL's, so the backend is pinned rather than
+// left to the build's default: CryptoMiniSat, the default wherever it is
+// compiled in, takes minutes over this same square. Returns false on a build
+// without CaDiCaL, and the caller skips.
+bool assertFactoring(VC vc)
 {
+  if (!vc_useCadical(vc))
+    return false;
   Type bv = vc_bvType(vc, 32);
   Expr x = vc_varExpr(vc, "x", bv);
   Expr y = vc_varExpr(vc, "y", bv);
@@ -62,6 +69,7 @@ void assertFactoring(VC vc)
                     vc_bvConstExprFromLL(vc, 64, 0x3fffffbb00001299ULL)));
   vc_assertFormula(vc, vc_bvGtExpr(vc, x, vc_bvConstExprFromInt(vc, 32, 1)));
   vc_assertFormula(vc, vc_bvGtExpr(vc, y, vc_bvConstExprFromInt(vc, 32, 1)));
+  return true;
 }
 
 std::string detail(VC vc)
@@ -85,7 +93,11 @@ TEST(reason_unknown, AnAnsweredQueryHasNoReason)
   EXPECT_EQ(REASON_UNKNOWN_NONE, vc_getReasonUnknown(vc));
   EXPECT_EQ("", detail(vc));
 
-  assertFactoring(vc);
+  if (!assertFactoring(vc))
+  {
+    vc_Destroy(vc);
+    GTEST_SKIP() << "CaDiCaL backend not compiled in";
+  }
   ASSERT_EQ(0, vc_query_with_timeout(vc, vc_falseExpr(vc), -1, -1));
   EXPECT_EQ(REASON_UNKNOWN_NONE, vc_getReasonUnknown(vc));
   EXPECT_EQ("", detail(vc));
@@ -99,13 +111,17 @@ TEST(reason_unknown, AnAnsweredQueryHasNoReason)
 TEST(reason_unknown, TheClockAndTheConflictBudgetAreToldApartByTheReason)
 {
   VC clock = vc_createValidityChecker();
-  assertFactoring(clock);
+  if (!assertFactoring(clock))
+  {
+    vc_Destroy(clock);
+    GTEST_SKIP() << "CaDiCaL backend not compiled in";
+  }
   EXPECT_EQ(3, vc_query_with_timeout(clock, vc_falseExpr(clock), -1, 0));
   EXPECT_EQ(REASON_UNKNOWN_TIMEOUT, vc_getReasonUnknown(clock));
   vc_Destroy(clock);
 
   VC conflicts = vc_createValidityChecker();
-  assertFactoring(conflicts);
+  ASSERT_TRUE(assertFactoring(conflicts));
   EXPECT_EQ(3, vc_query_with_timeout(conflicts, vc_falseExpr(conflicts), 0, -1));
   EXPECT_EQ(REASON_UNKNOWN_CONFLICT_BUDGET, vc_getReasonUnknown(conflicts));
   vc_Destroy(conflicts);
@@ -118,7 +134,11 @@ TEST(reason_unknown, TheAigBudgetIsNotReportedAsAClock)
 {
   VC vc = vc_createValidityChecker();
   vc_setInterfaceFlags(vc, AIG_NODE_BUDGET, 50);
-  assertFactoring(vc);
+  if (!assertFactoring(vc))
+  {
+    vc_Destroy(vc);
+    GTEST_SKIP() << "CaDiCaL backend not compiled in";
+  }
   EXPECT_EQ(3, vc_query_with_timeout(vc, vc_falseExpr(vc), -1, -1));
   EXPECT_EQ(REASON_UNKNOWN_AIG_BUDGET, vc_getReasonUnknown(vc));
 
@@ -134,7 +154,11 @@ TEST(reason_unknown, WithoutTheBudgetTheSameQueryIsDecided)
 {
   VC vc = vc_createValidityChecker();
   vc_setInterfaceFlags(vc, AIG_NODE_BUDGET, -1);
-  assertFactoring(vc);
+  if (!assertFactoring(vc))
+  {
+    vc_Destroy(vc);
+    GTEST_SKIP() << "CaDiCaL backend not compiled in";
+  }
   EXPECT_EQ(0, vc_query_with_timeout(vc, vc_falseExpr(vc), -1, -1));
   EXPECT_EQ(REASON_UNKNOWN_NONE, vc_getReasonUnknown(vc));
   vc_Destroy(vc);

--- a/tests/query-files/misc-tests/cnf-auto-under-bv-abstraction.smt2
+++ b/tests/query-files/misc-tests/cnf-auto-under-bv-abstraction.smt2
@@ -9,8 +9,8 @@
 ; REQUIRES: cadical
 ; RUN: %solver --cadical -s --bv-term-abstraction=1 %s 2>&1 | %OutputCheck --check-prefix=ABS %s
 ; RUN: %solver --cadical -s --bv-term-abstraction=1 --cnf-generation-effort auto %s 2>&1 | %OutputCheck --check-prefix=ABS %s
-; RUN: %solver -s --bv-term-abstraction=1 --cnf-generation-effort very-low %s 2>&1 | %OutputCheck --check-prefix=EXPLICIT %s
-; RUN: %solver -s %s 2>&1 | %OutputCheck --check-prefix=OFF %s
+; RUN: %solver --cadical -s --bv-term-abstraction=1 --cnf-generation-effort very-low %s 2>&1 | %OutputCheck --check-prefix=EXPLICIT %s
+; RUN: %solver --cadical -s %s 2>&1 | %OutputCheck --check-prefix=OFF %s
 ;
 ; ABS: ^cnf-auto: BV term abstraction on, chose gia-low$
 ; ABS: ^gia: [0-9]+ AND nodes, [0-9]+ inputs, LUT3$

--- a/tests/query-files/misc-tests/cnf-generation-effort-auto.smt2
+++ b/tests/query-files/misc-tests/cnf-generation-effort-auto.smt2
@@ -10,11 +10,13 @@
 ;
 ; The estimate-based resolution requires the CaDiCaL backend; other backends
 ; keep the older size-based choice, which the array-fallback test covers.
+; Compiled in -- what the gate below checks -- is not default: CryptoMiniSat
+; is the default wherever it is installed, so the auto runs say --cadical.
 ; REQUIRES: cadical
 ;
-; RUN: %solver --SMTLIB2 -s %s 2>&1 | %OutputCheck --check-prefix=SMALL %s
-; RUN: %solver --SMTLIB2 -s --cnf-generation-effort auto %s 2>&1 | %OutputCheck --check-prefix=SMALL %s
-; RUN: %solver --SMTLIB2 -s --cnf-generation-effort auto --cnf-auto-threshold 1 %s 2>&1 | %OutputCheck --check-prefix=BIG %s
+; RUN: %solver --SMTLIB2 -s --cadical %s 2>&1 | %OutputCheck --check-prefix=SMALL %s
+; RUN: %solver --SMTLIB2 -s --cadical --cnf-generation-effort auto %s 2>&1 | %OutputCheck --check-prefix=SMALL %s
+; RUN: %solver --SMTLIB2 -s --cadical --cnf-generation-effort auto --cnf-auto-threshold 1 %s 2>&1 | %OutputCheck --check-prefix=BIG %s
 ;
 ; SMALL: ^cnf-auto: estimated [0-9]+ AND nodes, chose gia-low$
 ; SMALL: ^gia: [0-9]+ AND nodes, [0-9]+ inputs, LUT3$


### PR DESCRIPTION
A build with CryptoMiniSat compiled in makes it the default SAT backend (the preference order in UserDefinedFlags), while three tests written against the stock CI build silently assumed the default is CaDiCaL. On such a build, two query-file tests from #1061 fail and one gtest binary runs into the ctest timeout, with no product change involved.

- `misc-tests/cnf-generation-effort-auto.smt2` and `misc-tests/cnf-auto-under-bv-abstraction.smt2`: the estimate-based resolution of `--cnf-generation-effort auto` only runs under CaDiCaL, so the `cnf-auto: estimated ... chose gia-low` line these tests check for never prints under another backend. The RUN lines that exercise the resolution now pass `--cadical`, which is what the note in `tests/query-files/lit.cfg` already prescribes: `REQUIRES: cadical` means compiled in, not default. The RUN lines over fixed effort levels are left alone -- they decide nothing and pass on any backend.
- `tests/api/C/reason-unknown.cpp`: the factoring constant was chosen for its timing on CaDiCaL (decided in under a second, a few thousand conflicts); CryptoMiniSat takes minutes over the same square, so the whole binary times out. `assertFactoring` now selects CaDiCaL through the C API (`vc_useCadical`) and returns whether it could, with the callers skipping on a build without it -- the same pattern the array-extensionality test uses. The pigeonhole tests stay on the build's default: their queries are tiny and backend-generic.

Verified on a build with both CaDiCaL and CryptoMiniSat 5.14.7 enabled: all 179 ctest targets pass, the reason-unknown binary completes in ~3 seconds, and no test is skipped.