### PR TITLE
Speed up pair extraction's bookkeeping

### DIFF
--- a/include/stp/Simplifier/CommonSubSum.h
+++ b/include/stp/Simplifier/CommonSubSum.h
@@ -68,6 +68,7 @@ THE SOFTWARE.
 #include "stp/AST/AST.h"
 #include "stp/STPManager/STPManager.h"
 #include <map>
+#include <queue>
 
 namespace stp
 {
@@ -92,31 +93,66 @@ class CommonSubSum
   // partial extraction rather than a fixed point.
   bool truncated;
 
-  // Operand lists of the additions being rewritten, keyed by node number,
-  // and a way back from a node number to its node.
-  std::map<uint64_t, ASTVec> operands;
-  std::map<uint64_t, ASTNode> byNum;
-
-  typedef std::pair<uint64_t, uint64_t> NodePair;
-
-  // Node numbers are allocated densely from zero, so the raw pair has almost
-  // no entropy in its high bits. One multiply-xor spreads it over the whole
-  // word, which is what 'is_avalanching' promises the table.
-  struct PairHash
+  // Operand lists of the additions being rewritten, in ascending
+  // node-number order so every walk over them is deterministic, an index
+  // from node number to entry, and a way back from a node number to its
+  // node.
+  struct SumEntry
   {
-    using is_avalanching = void;
-    uint64_t operator()(const NodePair& p) const noexcept
-    {
-      return ankerl::unordered_dense::detail::wyhash::mix(
-          p.first + UINT64_C(0x9E3779B97F4A7C15), p.second);
-    }
+    uint64_t num;
+    ASTVec ops;
   };
+  std::vector<SumEntry> sums;
+  ankerl::unordered_dense::map<uint64_t, uint32_t> sumIndex;
+  ankerl::unordered_dense::map<uint64_t, ASTNode> byNum;
+
+  // A pair of node numbers in one word, ordered operand first. Node numbers
+  // are allocated densely from zero, so 32 bits apiece is far beyond any
+  // DAG that fits in memory; packing halves the tally entry and makes the
+  // key compare one word. Numeric order on the packed key is lexicographic
+  // order on the pair, so the tie-break reads straight off it.
+  typedef uint64_t NodePair;
+
+  static NodePair packPair(uint64_t a, uint64_t b)
+  {
+    assert(a < b);
+    assert(b < (uint64_t(1) << 32));
+    return (a << 32) | b;
+  }
 
   // How many of the additions hold each pair of operands. Only the tally is
   // kept: the additions holding the winning pair are recovered by a scan,
   // which is far cheaper than a list of them hanging off every pair. The
   // table is patched as additions change rather than rebuilt each round.
-  ankerl::unordered_dense::map<NodePair, uint32_t, PairHash> occurrences;
+  ankerl::unordered_dense::map<NodePair, uint32_t> occurrences;
+
+  // Tally snapshots, popped lazily: a snapshot only counts if it still
+  // matches the table, and every increment to >=2 pushes one, so the pair
+  // with the highest live tally always has a live snapshot. Replaces a
+  // full table scan per extraction round. Ordered highest tally first,
+  // lowest pair first within a tally, matching the scan's tie-break.
+  struct Candidate
+  {
+    uint32_t count;
+    NodePair pair;
+  };
+  struct CandidateOrder
+  {
+    bool operator()(const Candidate& a, const Candidate& b) const
+    {
+      if (a.count != b.count)
+        return a.count < b.count;
+      return a.pair > b.pair;
+    }
+  };
+  std::priority_queue<Candidate, std::vector<Candidate>, CandidateOrder>
+      candidates;
+
+  // While the initial tally is being built, counts only rise, so pushing a
+  // snapshot per increment floods the heap with entries that are stale the
+  // moment the next increment lands. The tally is heapified once instead,
+  // one snapshot per pair, and only the extraction rounds push.
+  bool tallying = false;
 
   // Operands worth pairing. A pair can only be shared by two additions if
   // each of its operands is, so an operand that starts out in one addition

--- a/lib/Simplifier/CommonSubSum.cpp
+++ b/lib/Simplifier/CommonSubSum.cpp
@@ -71,9 +71,9 @@ void CommonSubSum::markShareable()
 {
   ankerl::unordered_dense::map<uint64_t, uint32_t> holders;
 
-  for (const auto& sum : operands)
+  for (const auto& sum : sums)
   {
-    const ASTVec& v = sum.second;
+    const ASTVec& v = sum.ops;
 
     // A two-operand addition already *is* its own pair; extracting from it
     // would leave a one-child BVPLUS that rebuilds to itself. It is not a
@@ -121,20 +121,25 @@ void CommonSubSum::eligibleOf(const ASTVec& v, std::vector<uint64_t>& out) const
 
 bool CommonSubSum::bump(uint64_t a, uint64_t b)
 {
-  const NodePair key = (a < b) ? NodePair(a, b) : NodePair(b, a);
+  const NodePair key = (a < b) ? packPair(a, b) : packPair(b, a);
 
   // Checked only at the cap, so the ordinary path pays one lookup, not two.
   if (occurrences.size() >= PAIR_ENTRY_LIMIT &&
       occurrences.find(key) == occurrences.end())
     return false;
 
-  occurrences[key]++;
+  const uint32_t now = ++occurrences[key];
+
+  // A tally of one can't win, so its snapshot would only be heap churn.
+  // The initial build pushes nothing: it is heapified whole afterwards.
+  if (now >= 2 && !tallying)
+    candidates.push({now, key});
   return true;
 }
 
 void CommonSubSum::drop(uint64_t a, uint64_t b)
 {
-  const NodePair key = (a < b) ? NodePair(a, b) : NodePair(b, a);
+  const NodePair key = (a < b) ? packPair(a, b) : packPair(b, a);
   const auto it = occurrences.find(key);
 
   assert(it != occurrences.end() && it->second > 0);
@@ -211,9 +216,9 @@ bool CommonSubSum::promote(const ASTNode& n)
     return true;
 
   std::vector<uint64_t> eligible;
-  for (const auto& sum : operands)
+  for (const auto& sum : sums)
   {
-    const ASTVec& v = sum.second;
+    const ASTVec& v = sum.ops;
     if (!std::binary_search(v.begin(), v.end(), n, byNodeNum))
       continue;
 
@@ -229,9 +234,23 @@ bool CommonSubSum::promote(const ASTNode& n)
 // The tally over every addition, built once. Later rounds patch it.
 bool CommonSubSum::buildOccurrences()
 {
-  for (const auto& sum : operands)
-    if (!addPairs(sum.second))
+  tallying = true;
+  for (const auto& sum : sums)
+    if (!addPairs(sum.ops))
+    {
+      tallying = false;
       return false;
+    }
+  tallying = false;
+
+  // One live snapshot per pair. Heap layout doesn't reach the result: the
+  // comparator is a total order, so the sequence of pops is the same
+  // whatever order this vector arrives in.
+  std::vector<Candidate> live;
+  for (const auto& entry : occurrences)
+    if (entry.second >= 2)
+      live.push_back({entry.second, entry.first});
+  candidates = decltype(candidates)(CandidateOrder(), std::move(live));
 
   return true;
 }
@@ -240,26 +259,40 @@ bool CommonSubSum::buildOccurrences()
 // its own node. Returns false once no pair is shared, or a guard fires.
 bool CommonSubSum::extractOnePair()
 {
-  // Ties go to the lowest-numbered pair. The tally is a hash table, so
-  // without that the choice -- and with it the formula handed to the
-  // bit-blaster -- would depend on the table's layout.
+  // Ties go to the lowest-numbered pair -- the heap's order, not the hash
+  // table's layout, decides, so the formula handed to the bit-blaster is
+  // deterministic. Stale snapshots are discarded on sight; a pair whose
+  // live tally is >=2 always has a live snapshot, because the increment
+  // that set the tally pushed one and only a winning pop consumes it.
   uint32_t best = 0;
-  NodePair bestPair(0, 0);
-  for (const auto& entry : occurrences)
-    if (entry.second >= 2 &&
-        (entry.second > best ||
-         (entry.second == best && entry.first < bestPair)))
+  NodePair bestPair = 0;
+  while (!candidates.empty())
+  {
+    const Candidate top = candidates.top();
+    candidates.pop();
+    const auto live = occurrences.find(top.pair);
+    if (live == occurrences.end())
+      continue;
+    if (live->second == top.count)
     {
-      best = entry.second;
-      bestPair = entry.first;
+      best = top.count;
+      bestPair = top.pair;
+      break;
     }
+    // Stale, and the pair may hold no other snapshot: a tally that rose
+    // pushed one per step, but a tally that fell pushed nothing on the way
+    // down. Restore the live value or the pair goes invisible. Strictly
+    // smaller than what was discarded, so the loop makes progress.
+    if (live->second >= 2 && live->second < top.count)
+      candidates.push({live->second, top.pair});
+  }
 
   if (best < 2)
     return false;
 
   // Both operands sit in a common application, so they share its width.
-  const ASTNode first = byNum[bestPair.first];
-  const ASTNode second = byNum[bestPair.second];
+  const ASTNode first = byNum[bestPair >> 32];
+  const ASTNode second = byNum[bestPair & 0xffffffffu];
   const ASTNode shared =
       booleanKind() ? nf->CreateNode(kind, first, second)
                     : nf->CreateTerm(kind, first.GetValueWidth(), first,
@@ -273,20 +306,20 @@ bool CommonSubSum::extractOnePair()
     return false;
   }
 
-  std::vector<uint64_t> hits;
-  for (const auto& sum : operands)
+  std::vector<uint32_t> hits;
+  for (uint32_t i = 0; i < sums.size(); i++)
   {
-    const ASTVec& v = sum.second;
+    const ASTVec& v = sums[i].ops;
     if (v.size() >= 3 &&
         std::binary_search(v.begin(), v.end(), first, byNodeNum) &&
         std::binary_search(v.begin(), v.end(), second, byNodeNum))
-      hits.push_back(sum.first);
+      hits.push_back(i);
   }
 
   long applied = 0;
-  for (uint64_t sum : hits)
+  for (uint32_t sum : hits)
   {
-    ASTVec& v = operands[sum];
+    ASTVec& v = sums[sum].ops;
 
     // Locate both operands before removing either, so that a sum which
     // somehow lacks one of them is left untouched rather than rewritten
@@ -295,7 +328,8 @@ bool CommonSubSum::extractOnePair()
     ASTVec scratch = v;
     for (unsigned which = 0; which < 2 && found; which++)
     {
-      const uint64_t wanted = (which == 0) ? bestPair.first : bestPair.second;
+      const uint64_t wanted =
+          (which == 0) ? (bestPair >> 32) : (bestPair & 0xffffffffu);
       found = false;
       for (size_t i = 0; i < scratch.size(); i++)
         if (scratch[i].GetNodeNum() == wanted)
@@ -322,6 +356,13 @@ bool CommonSubSum::extractOnePair()
       break;
     }
   }
+
+  // The winner's own snapshot was consumed above. Should its tally still be
+  // live -- a hit skipped, or the pair also held by untouched additions --
+  // restore the snapshot so the invariant on the heap keeps holding.
+  const auto still = occurrences.find(bestPair);
+  if (still != occurrences.end() && still->second >= 2)
+    candidates.push({still->second, bestPair});
 
   if (applied < 2)
     return false;
@@ -389,10 +430,12 @@ ASTNode CommonSubSum::topLevel(const ASTNode& n)
 
   saved = 0;
   truncated = false;
-  operands.clear();
+  sums.clear();
+  sumIndex.clear();
   byNum.clear();
   occurrences.clear();
   shareable.clear();
+  candidates = decltype(candidates)();
 
   ASTNodeSet seen;
   ASTVec plusNodes;
@@ -401,31 +444,44 @@ ASTNode CommonSubSum::topLevel(const ASTNode& n)
   ASTNode result = n;
   if (plusNodes.size() >= 2)
   {
+    sums.reserve(plusNodes.size());
     for (const auto& p : plusNodes)
     {
       ASTVec v(p.GetChildren().begin(), p.GetChildren().end());
       std::sort(v.begin(), v.end(), byNodeNum);
-      operands[p.GetNodeNum()] = v;
       byNum[p.GetNodeNum()] = p;
       for (const auto& k : v)
         byNum[k.GetNodeNum()] = k;
+      sums.push_back({p.GetNodeNum(), std::move(v)});
     }
+
+    // Ascending node number, so iteration order -- and with it what lands
+    // in a capped tally -- doesn't depend on the walk.
+    std::sort(sums.begin(), sums.end(),
+              [](const SumEntry& a, const SumEntry& b) { return a.num < b.num; });
+    for (uint32_t i = 0; i < sums.size(); i++)
+      sumIndex[sums[i].num] = i;
 
     markShareable();
 
-    if (!buildOccurrences())
-      truncated = true;
-    else
+    // A pair needs two shareable operands, so fewer than two shareable
+    // operands means no round can fire.
+    if (shareable.size() >= 2)
     {
-      long round = 0;
-      for (; round < ROUND_LIMIT && extractOnePair(); round++)
-        ;
-
-      // Rounds are what bounds the greedy loop, not what it converges on:
-      // exhausting them leaves shared pairs behind just as the size guard
-      // does, so say so rather than report a fixed point.
-      if (round == ROUND_LIMIT)
+      if (!buildOccurrences())
         truncated = true;
+      else
+      {
+        long round = 0;
+        for (; round < ROUND_LIMIT && extractOnePair(); round++)
+          ;
+
+        // Rounds are what bounds the greedy loop, not what it converges on:
+        // exhausting them leaves shared pairs behind just as the size guard
+        // does, so say so rather than report a fixed point.
+        if (round == ROUND_LIMIT)
+          truncated = true;
+      }
     }
 
     if (saved > 0)
@@ -433,7 +489,7 @@ ASTNode CommonSubSum::topLevel(const ASTNode& n)
       std::map<uint64_t, ASTVec> changed;
       for (const auto& p : plusNodes)
       {
-        const ASTVec& v = operands[p.GetNodeNum()];
+        const ASTVec& v = sums[sumIndex[p.GetNodeNum()]].ops;
         if (v.size() != p.Degree())
           changed[p.GetNodeNum()] = v;
       }
@@ -451,10 +507,12 @@ ASTNode CommonSubSum::topLevel(const ASTNode& n)
               << " applications saved:" << saved
               << " Truncated:" << (truncated ? 1 : 0) << std::endl;
 
-  operands.clear();
+  sums.clear();
+  sumIndex.clear();
   byNum.clear();
   occurrences.clear();
   shareable.clear();
+  candidates = decltype(candidates)();
 
   stpMgr->GetRunTimes()->stop(RunTimes::CommonSubSum);
   return result;


### PR DESCRIPTION
Profiling CommonSubSum on synthetic sum sets showed two wide additions sharing 2000 operands spend half a minute in the pass, almost all of it hash-table traffic on the pair tally plus a full-table scan per extraction round. Three changes, none of which alters any result:

- **The winning pair comes from a lazy heap of tally snapshots** instead of a scan over the whole table each round. A snapshot only counts if it still matches the table; discarding a stale one re-pushes the live value, since a tally that fell pushed nothing on the way down. The initial tally is heapified whole rather than pushed per increment, which is what keeps monotonically-rising builds from flooding the heap. The heap's comparator is the same total order as the scan's tie-break, so the extraction sequence is unchanged.
- **The tally is keyed by both node numbers packed into one word**: the entry drops from 24 to 16 bytes and the key compare is one word. Node numbers are dense from zero, so 32 bits apiece is beyond any DAG that fits in memory; an assert guards it.
- **The operand lists live in a vector sorted by node number** rather than a std::map, with a flat index beside it, so the per-round holder scan walks contiguous memory and iteration order stays deterministic under the pair-table cap.

Interleaved A/B on Release builds, two rounds each: two wide additions sharing 2000 operands drop from ~46s to ~3.4s (~13x); the same shape at 5000 operands, where the pair cap fires, from ~10s to ~1s; a thousand overlapping 100-operand sums over a 500-symbol pool from ~18s to ~2.7s (~7x); disjoint no-sharing inputs and dense shifted-window inputs are unchanged within noise.

Equivalence: outputs are structurally identical to the old code on every benchmark shape and on 60 randomised configurations (compared by a node-number-independent structural hash), the unit suites pass, and the extraction sequence is provably the same -- the heap realises the identical (count, lowest-pair) argmax the scan computed.

One note for review: the snapshot-invariant argument is in the comments. The subtle case is a tally that falls below its only snapshot; the discard-repush in the winner loop is what keeps such pairs visible, and dropping it loses extractions (caught by structural comparison on small pool shapes during development).