### PR TITLE
Run pair extraction over the term kinds only

### DIFF
--- a/lib/Incremental/IncrementalSolverImpl.h
+++ b/lib/Incremental/IncrementalSolverImpl.h
@@ -1355,9 +1355,11 @@ struct IncrementalSolver::Impl
           StrengthReduction sr(bm->defaultNodeFactory, &pieceFlags);
           trialOut = sr.topLevel(trialOut, domain);
         }
+        // Term kinds only, for the reason given at the batch call site:
+        // Boolean regrouping is absorbed whole by AIG structural hashing.
         if (pieceFlags.enable_common_subsum)
         {
-          for (const Kind k : {BVPLUS, BVMULT, BVXOR, BVAND, XOR, AND, OR})
+          for (const Kind k : {BVPLUS, BVMULT, BVXOR, BVAND})
           {
             CommonSubSum cse(bm, bm->defaultNodeFactory, k);
             trialOut = cse.topLevel(trialOut);

--- a/lib/STPManager/STP.cpp
+++ b/lib/STPManager/STP.cpp
@@ -888,17 +888,22 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
   if (simp->hasUnappliedSubstitutions())
     inputToSat = simp->applySubstitutionMap(inputToSat);
 
-  // Extract sub-terms shared between same-kind applications of each
-  // associative-commutative operator, ahead of unconstrained-variable
+  // Extract sub-terms shared between same-kind applications of the
+  // associative-commutative term operators, ahead of unconstrained-variable
   // elimination: a pair of otherwise-unused variables occurring only inside
   // the shared node makes that node collapsible there. This also keeps the
   // extraction ahead of the ConstantBitPropagation object built below,
   // whose fixed-point map must describe the exact tree handed to ToSATAIG.
   // BVOR is absent because the node factory lowers it to BVNOT/BVAND at
   // creation, so its sharing is BVAND sharing by the time this runs.
+  // The Boolean kinds (XOR, AND, OR) are deliberately absent: their
+  // regrouping is absorbed whole by the AIG's structural hashing -- on
+  // altair1.10.asp the pass rewrote 130k Boolean applications, spent 22
+  // seconds, and the CNF came out identical -- so tallying them is pure
+  // cost. The pass itself still accepts those kinds.
   if (bm->UserFlags.enable_common_subsum)
   {
-    for (const Kind k : {BVPLUS, BVMULT, BVXOR, BVAND, XOR, AND, OR})
+    for (const Kind k : {BVPLUS, BVMULT, BVXOR, BVAND})
     {
       CommonSubSum cse(bm, bm->defaultNodeFactory, k);
       inputToSat = cse.topLevel(inputToSat);

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -234,9 +234,9 @@ void ExtraMain::create_options()
 
   bool_arg("--common-subsum", bm->UserFlags.enable_common_subsum,
            "Factor sub-terms shared between same-kind n-ary applications of "
-           "each associative-commutative operator (bvadd, bvmul, bvxor, "
-           "bvand, xor, and, or) into a single shared node, so the shared "
-           "circuit is built once (needs --flattening)",
+           "the associative-commutative term operators (bvadd, bvmul, bvxor, "
+           "bvand) into a single shared node, so the shared circuit is built "
+           "once (needs --flattening)",
            simp_group);
 
   bool_arg("--pair-extract", bm->UserFlags.enable_pair_extract,


### PR DESCRIPTION
The Boolean XOR/AND/OR instances of CommonSubSum spend large amounts of preprocessing time on the formulas that trigger them, and under the default pipeline that work is thrown away. The evidence, from controlled on/off pairs on hard-set files:

- **altair1.10.asp** (ASP encoding, one assert, ~9k nested and/or): with the pass on, the full solve takes 29.0s and the pass rewrites 93,475 AND and 37,455 OR applications; with the pass off, 6.9s. The final CNF is identical to the digit in both arms. The mechanism is not the AIG absorbing the regrouping: **both arms hit difficulty reversion** ("simplification made the problem harder, reverting"), so the same pre-simplification snapshot is blasted either way and the extraction never reaches the encoder at all. The 22 seconds buy work that is discarded wholesale. A profile puts 77% of the whole preprocessing run inside the pair tally for those two kinds. With this change the file is back to 7.0s, nothing fires, and the CNF is unchanged.
- **sudoku.in5** reverts the same way in both arms (930 BVPLUS adders extracted and then discarded, about 18s spent).
- For calibration, with reversion disabled so the extraction genuinely reaches the encoder, the Boolean extraction moves altair's CNF from 701,497 to 681,914 clauses (-2.8%). Whether that ever translates into solve time -- CNF size and time are known to anti-correlate on some instances -- is exactly the corpus-campaign question, and until it is measured the certain preprocessing cost dominates the speculative benefit.
- A controlled micro-benchmark (two 50-wide Boolean ANDs under one XOR, one shared leaf pair, shuffled orderings) shows that **no CNF rung discovers such sharing unaided**: 0 discoveries across 330 trials over all eleven effort rungs. Sharing exists only when a pass hands the encoder a shared node; the low rungs then keep it, the cut-based mappers neutralise a single pair, and the maximal-AND collapse of new-medium prices a live shared pair at one extra clause.

Only the pipeline instantiation narrows: the pass itself still accepts the Boolean kinds, and their unit tests drive them directly, so the machinery stays covered. The bvor route (factory-lowered to BVNOT/BVAND, reached through the BVAND instance) is unaffected.

The full unit suite and the query-file suite pass.
