### PR TITLE
Extract co-travelling operand groups before any pair is tallied

### DIFF
--- a/include/stp/Simplifier/CommonSubSum.h
+++ b/include/stp/Simplifier/CommonSubSum.h
@@ -166,7 +166,11 @@ class CommonSubSum
   // anyway -- so one wider addition holding it is enough to be worth doing.
   ankerl::unordered_dense::map<NodePair, uint32_t> realized;
 
+  // Whole shared chunks found in one pass, before any pair is tallied.
+  long chunked = 0;
+
   void collect(const ASTNode& n, ASTNodeSet& seen, ASTVec& plusNodes);
+  void extractCoTravellers();
   void markShareable();
   void markRealized(const ASTVec& v);
   void eligibleOf(const ASTVec& v, std::vector<uint64_t>& out) const;

--- a/lib/Simplifier/CommonSubSum.cpp
+++ b/lib/Simplifier/CommonSubSum.cpp
@@ -62,6 +62,115 @@ void CommonSubSum::collect(const ASTNode& n, ASTNodeSet& seen,
   }
 }
 
+// Operands with identical holder sets always travel together: every
+// addition holding one of them holds all of them, so the whole group is a
+// single shared sub-term and can be extracted in one step -- k operands
+// shared by h additions become h references to one k-ary chunk. Grouping
+// costs one holder list per operand and one map insertion, with no pair
+// tally at all, and it collapses what the greedy loop below would spend
+// k-1 rounds of full bookkeeping converging to. The loop still runs
+// afterwards: partial overlaps, where holder sets merely intersect, are
+// invisible here.
+//
+// An addition whose operands are exactly one group hash-conses to the
+// chunk itself, so it is left alone and the other holders come to
+// reference it -- the sub-multiset outcome, whole, in one step.
+void CommonSubSum::extractCoTravellers()
+{
+  // Holder lists build in ascending sum order, so each list arrives
+  // sorted. An operand that repeats inside any addition is left out: the
+  // chunk would need its multiplicity, and the greedy loop handles
+  // repeats already.
+  ankerl::unordered_dense::map<uint64_t, std::vector<uint32_t>> holders;
+  ankerl::unordered_dense::set<uint64_t> repeated;
+  for (uint32_t i = 0; i < sums.size(); i++)
+  {
+    const ASTVec& v = sums[i].ops;
+
+    // Two-operand additions sit out, as they do for the pair tally: with
+    // one in a class the rewrite nests the wider holder around it, which
+    // costs nothing at gate level but restructures additions other passes
+    // key on -- BV abstraction stops counting the nested chain. The
+    // realized-pair path in the greedy loop handles reusing them, gated on
+    // shareability.
+    if (v.size() < 3)
+      continue;
+
+    for (size_t j = 0; j < v.size(); j++)
+    {
+      if (j > 0 && v[j] == v[j - 1])
+      {
+        repeated.insert(v[j].GetNodeNum());
+        continue;
+      }
+      holders[v[j].GetNodeNum()].push_back(i);
+    }
+  }
+
+  // An ordered map keyed by the holder list itself: grouping and a
+  // deterministic order in one structure, with lookups that usually
+  // decide on the first element.
+  std::map<std::vector<uint32_t>, std::vector<uint64_t>> classes;
+  for (const auto& h : holders)
+    if (h.second.size() >= 2 && repeated.count(h.first) == 0)
+      classes[h.second].push_back(h.first);
+
+  for (auto& entry : classes)
+  {
+    std::vector<uint64_t>& members = entry.second;
+    if (members.size() < 2)
+      continue;
+    std::sort(members.begin(), members.end());
+
+    ASTVec chunkOps;
+    chunkOps.reserve(members.size());
+    for (const uint64_t num : members)
+      chunkOps.push_back(byNum[num]);
+
+    const ASTNode chunk =
+        booleanKind()
+            ? nf->CreateNode(kind, chunkOps)
+            : nf->CreateTerm(kind, chunkOps[0].GetValueWidth(), chunkOps);
+    byNum[chunk.GetNodeNum()] = chunk;
+
+    long replacedIn = 0;
+    for (const uint32_t si : entry.first)
+    {
+      // This addition is the chunk: leave it whole, and the replacements
+      // below make the other holders reference it.
+      if (sums[si].num == chunk.GetNodeNum())
+        continue;
+
+      ASTVec& v = sums[si].ops;
+      ASTVec next;
+      next.reserve(v.size() - members.size() + 1);
+      size_t mi = 0;
+      for (const ASTNode& op : v)
+      {
+        if (mi < members.size() && op.GetNodeNum() == members[mi])
+        {
+          mi++;
+          continue;
+        }
+        next.push_back(op);
+      }
+      assert(mi == members.size());
+      next.push_back(chunk);
+      std::sort(next.begin(), next.end(), byNodeNum);
+      v.swap(next);
+      replacedIn++;
+    }
+
+    if (replacedIn > 0)
+    {
+      const long k = (long)members.size();
+      const bool existing = sumIndex.find(chunk.GetNodeNum()) != sumIndex.end();
+      saved += (k - 1) * (replacedIn - (existing ? 0 : 1));
+      chunked++;
+    }
+  }
+}
+
 // Which operands are worth enumerating pairs of. An addition never gains an
 // operand it didn't start with -- a substitution only removes two and adds
 // the node built from them -- so an operand in one addition now is in one
@@ -304,6 +413,21 @@ bool CommonSubSum::extractOnePair()
   // deterministic. Stale snapshots are discarded on sight; a pair whose
   // live tally is >=2 always has a live snapshot, because the increment
   // that set the tally pushed one and only a winning pop consumes it.
+  // Stale snapshots can pile up faster than pops retire them -- an input
+  // whose every round repairs wide additions pushes thousands per round --
+  // and every pop then sifts down a heap that is mostly dead weight. Once
+  // the dead outnumber even the whole tally severalfold, rebuild the heap
+  // from the table: the same one-snapshot-per-pair state the initial
+  // heapify establishes, so nothing observable changes.
+  if (candidates.size() > 4 * occurrences.size() + 1024)
+  {
+    std::vector<Candidate> alive;
+    for (const auto& entry : occurrences)
+      if (entry.second >= 2)
+        alive.push_back({entry.second, entry.first});
+    candidates = decltype(candidates)(CandidateOrder(), std::move(alive));
+  }
+
   uint32_t best = 0;
   NodePair bestPair = 0;
   while (!candidates.empty())
@@ -475,6 +599,7 @@ ASTNode CommonSubSum::topLevel(const ASTNode& n)
   stpMgr->GetRunTimes()->start(RunTimes::CommonSubSum);
 
   saved = 0;
+  chunked = 0;
   truncated = false;
   sums.clear();
   sumIndex.clear();
@@ -509,6 +634,7 @@ ASTNode CommonSubSum::topLevel(const ASTNode& n)
     for (uint32_t i = 0; i < sums.size(); i++)
       sumIndex[sums[i].num] = i;
 
+    extractCoTravellers();
     markShareable();
 
     // A pair needs two shareable operands, so fewer than two shareable
@@ -551,7 +677,7 @@ ASTNode CommonSubSum::topLevel(const ASTNode& n)
 
   if (stpMgr->UserFlags.stats_flag)
     std::cerr << "{CommonSubSum} " << _kind_names[kind]
-              << " applications saved:" << saved
+              << " applications saved:" << saved << " Chunks:" << chunked
               << " Truncated:" << (truncated ? 1 : 0) << std::endl;
 
   sums.clear();

--- a/tests/unit-tests/CommonSubSum_Test.cpp
+++ b/tests/unit-tests/CommonSubSum_Test.cpp
@@ -171,13 +171,11 @@ TEST(CommonSubSum_Test, shared_pair_factored_into_one_node)
 
 // An addition whose operands are a sub-multiset of another's ends up being
 // the adder they have in common, rather than having it built twice:
-//   (v0 + v1 + v2), (v0 + v1 + v2 + v3)
-//     -->  s = (v0 + v1);  t = (s + v2);  t, (t + v3)
-// The greedy walks the smaller addition down to two operands and, at that
-// point, it *is* the pair the wider one still holds. Without counting a
-// two-operand addition as an adder others can reuse it votes for nothing
-// from there and stops one step short, leaving `t` built twice. This is the
-// shape stp#444 reduces to.
+//   (v0 + v1 + v2), (v0 + v1 + v2 + v3)  -->  t = (v0 + v1 + v2);  t, (t + v3)
+// {v0,v1,v2} occur in exactly the same additions, so the co-traveller step
+// takes the whole group at once: the chunk it builds hash-conses to the
+// smaller addition, which the wider one then references. This is the shape
+// stp#444 reduces to.
 TEST(CommonSubSum_Test, sub_multiset_sum_becomes_the_shared_node)
 {
   const std::string input = R"(
@@ -191,19 +189,15 @@ TEST(CommonSubSum_Test, sub_multiset_sum_becomes_the_shared_node)
   std::set<ASTNode> plusNodes, visited;
   collectPlusNodes(n, plusNodes, visited);
 
-  // s, t, and the wider addition rewritten around t: three binary adders
-  // for what arrived as a three-operand and a four-operand addition.
-  ASSERT_EQ(plusNodes.size(), 3u);
-  for (const ASTNode& p : plusNodes)
-    ASSERT_EQ(p.Degree(), 2u);
+  // The smaller addition, whole, and the wider one rewritten around it.
+  ASSERT_EQ(plusNodes.size(), 2u);
 
-  // The smaller addition is now a child of the wider one. That is the last
-  // extraction, and it is the one that does not happen without the change.
   const ASTNode& widest = *std::max_element(
       plusNodes.begin(), plusNodes.end(),
       [](const ASTNode& a, const ASTNode& b) {
         return a.GetNodeNum() < b.GetNodeNum();
       });
+  ASSERT_EQ(widest.Degree(), 2u);
 
   int shared = 0;
   for (const ASTNode& s : plusNodes)
@@ -268,13 +262,12 @@ TEST(CommonSubSum_Test, shared_pair_factored_into_one_product_node)
   ASSERT_EQ(shared, 1);
 }
 
-// A larger shared operand subset falls out of repeated pair extraction.
-// {v0,v1,v4,v6} is common to both sums, so two rounds pull out two shared
-// pairs, and once the smaller sum has narrowed to exactly those pairs it
-// counts as an adder the wider one can reuse, so a third round finishes
-// the job:
+// A larger shared operand subset is one co-traveller class: {v0,v1,v4,v6}
+// occur in exactly the same two sums, so the whole group is taken in one
+// step. The chunk hash-conses to the smaller sum, which the wider one then
+// references -- no intermediate pair nodes at all:
 //   (v0+v1+v4+v6), (v0+v1+v2+v3+v4+v5+v6)
-//     -->  t = s1+s2;  t, (t+v2+v3+v5)   with s1, s2 under t alone.
+//     -->  t = (v0+v1+v4+v6);  t, (t+v2+v3+v5)
 TEST(CommonSubSum_Test, overlapping_operand_subset_cascades)
 {
   const std::string input = R"(
@@ -291,9 +284,8 @@ TEST(CommonSubSum_Test, overlapping_operand_subset_cascades)
   std::set<ASTNode> plusNodes, visited;
   collectPlusNodes(n, plusNodes, visited);
 
-  // The two pairs, the narrowed small sum over them, and the wide sum
-  // rewritten around the small one.
-  ASSERT_EQ(plusNodes.size(), 4u);
+  // The small sum, whole, and the wide sum rewritten around it.
+  ASSERT_EQ(plusNodes.size(), 2u);
 
   std::multiset<unsigned> degrees;
   int sharedOnce = 0;
@@ -308,10 +300,8 @@ TEST(CommonSubSum_Test, overlapping_operand_subset_cascades)
     if (parents == 1)
       sharedOnce++;
   }
-  EXPECT_EQ(degrees, (std::multiset<unsigned>{2, 2, 2, 4}));
-  // s1 and s2 sit under the small sum, and the small sum under the wide
-  // one: a chain, not two duplicated adders.
-  EXPECT_EQ(sharedOnce, 3);
+  EXPECT_EQ(degrees, (std::multiset<unsigned>{4, 4}));
+  EXPECT_EQ(sharedOnce, 1);
 }
 
 // A pair held by three sums is built once and referenced from all three.


### PR DESCRIPTION
This answers "don't find matched pairs -- find matched n-arity": operands that occur in exactly the same additions always travel together, so the whole group is one shared sub-term and can be taken in a single step. Grouping operands by their holder lists costs one hash per operand -- no pair tally -- and k operands shared by h additions become h references to one k-ary chunk. The chunk hash-conses to an addition whose operands are exactly the group, which resolves a sub-multiset whole in one step. The greedy pair loop still runs afterwards for partial overlaps, where holder sets merely intersect; those are invisible to grouping.

Two-operand additions sit out as holders, mirroring the pair tally's rule: a class routed through one nests the wider holder around it, and that restructuring stops BV abstraction counting the chain (caught by the abstraction query-file test).

A second, independent fix: on inputs whose every extraction round repairs wide additions, the winner heap accumulates stale snapshots far faster than pops retire them, and 73% of the pass was heap sift-down. Once the heap outgrows the whole tally severalfold it is rebuilt from the live table -- the same one-snapshot-per-pair state the initial heapify establishes, so the extraction sequence is unchanged.

Measured on hard-set files (-g 1, controlled on/off pairs, RelWithDebInfo):

- **altair1.10.asp**: the pass delta drops from ~10.5s to ~2s on this base, with identical extraction totals (93,475 AND + 37,280 OR applications). The remaining time is genuine greedy work: the AND sharing there is neighbour-overlap -- holder sets intersect heavily but are never identical (one AND chunk found), so grouping cannot shortcut it, while the heap compaction removes what was pure overhead.
- **sudoku.in5**: all 930 BVPLUS extractions become chunks; the delta drops from ~18s to ~1s.
- Two 2000-operand additions sharing all but one operand -- the synthetic worst case for the greedy -- go from seconds of rounds to one chunk in a millisecond.
- On shapes with no co-travelling groups (random overlapping pools, shifted windows) the greedy runs exactly as before and produces structurally identical results; the sub-multiset and cascade shapes now resolve to strictly better structure (the smaller addition becomes the shared node directly, no intermediate pair nodes), and their tests are updated to pin that.

All 170 unit-test suites and the 869 query-file tests pass.