### PR TITLE
Size the hinted Aig strash table at the estimate, not half of it

### DIFF
--- a/include/stp/ToSat/BBNodeManagerAIG.h
+++ b/include/stp/ToSat/BBNodeManagerAIG.h
@@ -274,11 +274,11 @@ public:
     assert(Aig_ManNodeNum(aigMgr) == 0);
     const uint64_t cap = 1ull << 26;
     const uint64_t want = n + (n >> 4) + 1024;
-    // Half the expected count: the resize trigger is load factor 2, so this
-    // still never resizes, and it matches the table size the growth policy
-    // would have ended at (its jumps are 4x, landing near load 1.2) instead
-    // of paying ~60 MB over it for shorter chains.
-    const int slots = Abc_PrimeCudd((unsigned)((want < cap ? want : cap) / 2));
+    // The full expected count, not a fraction of it: the chain walk is
+    // memory-bound, and a factor sweep put the knee here -- half this table
+    // costs 14-18% of blasting for at most 4% of process peak, while twice
+    // it buys back under half as much for memory that climbs faster.
+    const int slots = Abc_PrimeCudd((unsigned)(want < cap ? want : cap));
     if (slots <= aigMgr->nTableSize)
       return;
     ABC_FREE(aigMgr->pTable);


### PR DESCRIPTION
The pre-sized strash table from #1059 used half the recorded estimate, matching the size the organic growth policy would have reached, on the reasoning that a lower-load table trades memory for shorter chains. Profiling the strash hash reduction on the ABC fork showed why that reasoning undersold the table: the chain walk is memory-bound - the divide in Aig_Hash hides entirely behind the bucket load's cache miss - so chain length is the whole cost of the structural hash, and probe arithmetic none of it. That also means the fork-side hash-function change bought nothing (its PR says so), while the table size is worth a lot.

A factor sweep over three large blasts (three repetitions, medians, same binary with the factor as the only variable) puts the knee at the full estimate: against the half table it cuts 14-18% of Bit Blasting for at most 4% of process peak, and doubling past the estimate buys back under half as much time for memory that climbs faster (a 4x table reproduces the originally observed 22-29% blasting cut, at +14-16% peak). CNF byte-identical against master on hard-set files at very-low and medium - a table size can change probe order only.

The Gia backend's hinted hash is sized separately and was not re-tuned here; it is the natural follow-up if the same lever holds there.