### PR TITLE
Recover full adders in the Tseitin writer as propagation-complete blocks

### DIFF
--- a/include/stp/AIG/Tseitin.h
+++ b/include/stp/AIG/Tseitin.h
@@ -30,6 +30,7 @@ THE SOFTWARE.
 
 #include <cassert>
 #include <cstdint>
+#include <unordered_map>
 #include <vector>
 
 namespace stp
@@ -78,7 +79,7 @@ void collectAndLeaves(const Manager& m, Node n, const std::vector<uint64_t>& abs
 enum class Recover
 {
   Nothing,        // plain Tseitin: three clauses for every AND node
-  Patterns,       // + XOR and if-then-else, four clauses instead of nine
+  Patterns,       // + XOR, if-then-else and full adders
   PatternsAndAnds // + maximal n-ary ANDs, and so n-ary ORs, collapsed
 };
 
@@ -113,6 +114,20 @@ public:
     return (pattern_[n >> 6] >> (n & 63)) & 1u;
   }
 
+  // A recovered full adder: sum and carry defined together by one fourteen-
+  // clause block over the operands -- the minimum propagation-complete
+  // clause set for the relation, which the per-gate encodings are not. The
+  // five interior nodes get no variables. Stored at the carry node, whose
+  // complement is the carry-out.
+  struct FullAdder
+  {
+    Lit a, b, c; // the operand literals
+    Node sum;
+  };
+  bool faSum(Node n) const { return (faSum_[n >> 6] >> (n & 63)) & 1u; }
+  bool faCarry(Node n) const { return (faCarry_[n >> 6] >> (n & 63)) & 1u; }
+  const FullAdder& faAt(Node carry) const { return fas_.at(carry); }
+
   uint32_t varCount() const { return nVars_; }
   uint64_t clauseCount() const { return nClauses_; }
   uint64_t literalCount() const { return nLiterals_; }
@@ -144,10 +159,18 @@ private:
   void setLive(Node n) { live_[n >> 6] |= 1ull << (n & 63); }
   void setPatterned(Node n) { pattern_[n >> 6] |= 1ull << (n & 63); }
   void setAbsorbed(Node n) { absorbed_[n >> 6] |= 1ull << (n & 63); }
+  void setFaSum(Node n) { faSum_[n >> 6] |= 1ull << (n & 63); }
+  void setFaCarry(Node n) { faCarry_[n >> 6] |= 1ull << (n & 63); }
+  void clearFa(Node carry);
+  void findFullAdders(const Manager& m, const std::vector<uint8_t>& refs);
 
   std::vector<uint64_t> live_;
   std::vector<uint64_t> pattern_;
   std::vector<uint64_t> absorbed_;
+  std::vector<uint64_t> faSum_;
+  std::vector<uint64_t> faCarry_;
+  std::unordered_map<Node, FullAdder> fas_;
+  std::unordered_map<Node, Node> carryOfSum_;
   uint64_t nClauses_ = 0;
   uint64_t nLiterals_ = 0;
   uint64_t nAnds_ = 0;
@@ -206,6 +229,39 @@ void writeTseitin(const Manager& m, const Cone& cone, Sink& sink)
     const uint32_t x = next++;
     var[n] = x;
     const int px = static_cast<int>(2 * x), nx = px | 1;
+
+    if (cone.faSum(n))
+      continue; // defined by its full adder's block, emitted at the carry
+
+    if (cone.faCarry(n))
+    {
+      // The fourteen-clause propagation-complete block for
+      //   s = a xor b xor c,  carry-out = majority(a, b, c)
+      // where the carry-out is the complement of this node. All twenty prime
+      // implicates minus the six parity clauses whose conflicts re-derive
+      // through the carry.
+      const Cone::FullAdder& fa = cone.faAt(n);
+      const int A = cnfLit(fa.a), B = cnfLit(fa.b), C = cnfLit(fa.c);
+      const int S = static_cast<int>(2 * var[fa.sum]);
+      const int T = nx, Tn = px; // t is the carry-out literal, so !node
+      sink.clause(C ^ 1, S, T);
+      sink.clause(B ^ 1, C ^ 1, T);
+      sink.clause(B ^ 1, S, T);
+      sink.clause(A ^ 1, C ^ 1, T);
+      sink.clause(A ^ 1, B ^ 1, T);
+      sink.clause(A ^ 1, S, T);
+      sink.clause(A, S ^ 1, Tn);
+      sink.clause(A, B, Tn);
+      sink.clause(A, C, Tn);
+      sink.clause(B, S ^ 1, Tn);
+      sink.clause(B, C, Tn);
+      sink.clause(C, S ^ 1, Tn);
+      const int q1[4] = {A ^ 1, B ^ 1, C ^ 1, S};
+      const int q2[4] = {A, B, C, S ^ 1};
+      sink.clause(q1, 4);
+      sink.clause(q2, 4);
+      continue;
+    }
 
     if (cone.patterned(n))
     {

--- a/lib/AIG/Tseitin.cpp
+++ b/lib/AIG/Tseitin.cpp
@@ -75,6 +75,91 @@ bool matchIte(const Manager& m, Node n, Lit& c, Lit& t, Lit& e)
   return true;
 }
 
+namespace
+{
+
+// n = !(p & q) ... no: n = !p' & !q' with q's fanins the complements of p's --
+// the AIG spelling of an exclusive-or over p's fanins. Returns the two fanin
+// nodes; which of them conjoins the operands positively is for the caller to
+// settle, since XOR(u,v) == XOR(!u,!v).
+bool xorShape(const Manager& m, Node n, Node& p, Node& q)
+{
+  if (!m.isAnd(n))
+    return false;
+  const Lit f0 = m.fanin0(n), f1 = m.fanin1(n);
+  if (!isNeg(f0) || !isNeg(f1))
+    return false;
+  p = nodeOf(f0);
+  q = nodeOf(f1);
+  if (!m.isAnd(p) || !m.isAnd(q))
+    return false;
+  const Lit pa = m.fanin0(p), pb = m.fanin1(p);
+  const Lit qa = m.fanin0(q), qb = m.fanin1(q);
+  return (qa == neg(pa) && qb == neg(pb)) || (qa == neg(pb) && qb == neg(pa));
+}
+
+// The structural match proposes; this disposes. Evaluates the two roots over
+// all eight operand assignments, only ever stepping on the seven nodes a full
+// adder owns, so any aliasing or polarity surprise the match missed fails
+// here instead of miscoding.
+bool verifyFullAdder(const Manager& m, Lit la, Lit lb, Lit lc, Node sum,
+                     Node carry, const Node allowed[10])
+{
+  struct Eval
+  {
+    const Manager& m;
+    const Node* allowed;
+    Node leaf[3];
+    bool val[3];
+    int depth = 0;
+    bool ok = true;
+
+    bool node(Node x)
+    {
+      for (int i = 0; i < 3; i++)
+        if (x == leaf[i])
+          return val[i];
+      if (++depth > 16)
+      {
+        ok = false;
+        return false;
+      }
+      bool inCone = false;
+      for (int i = 0; i < 10 && !inCone; i++)
+        inCone = allowed[i] == x;
+      if (!inCone || !m.isAnd(x))
+      {
+        ok = false;
+        return false;
+      }
+      const bool r = lit(m.fanin0(x)) && lit(m.fanin1(x));
+      --depth;
+      return r;
+    }
+    bool lit(Lit l) { return node(nodeOf(l)) ^ (isNeg(l) ? true : false); }
+  };
+
+  for (unsigned bits = 0; bits < 8; bits++)
+  {
+    Eval e{m, allowed, {nodeOf(la), nodeOf(lb), nodeOf(lc)},
+           {(bits & 1) != 0, (bits & 2) != 0, (bits & 4) != 0}};
+    const bool A = e.val[0] ^ (isNeg(la) ? true : false);
+    const bool B = e.val[1] ^ (isNeg(lb) ? true : false);
+    const bool C = e.val[2] ^ (isNeg(lc) ? true : false);
+    const bool s = e.node(sum);
+    const bool o = e.node(carry);
+    if (!e.ok || s != (A ^ B ^ C))
+      return false;
+    // The carry-out literal is the complement of the carry node.
+    const bool maj = (A && B) || (A && C) || (B && C);
+    if (o != !maj)
+      return false;
+  }
+  return true;
+}
+
+} // namespace
+
 void collectAndLeaves(const Manager& m, Node n,
                       const std::vector<uint64_t>& absorbed,
                       std::vector<Lit>& into, std::vector<Lit>& stack)
@@ -97,6 +182,118 @@ void collectAndLeaves(const Manager& m, Node n,
   }
 }
 
+void Cone::clearFa(Node carry)
+{
+  const FullAdder fa = fas_.at(carry);
+  faCarry_[carry >> 6] &= ~(1ull << (carry & 63));
+  faSum_[fa.sum >> 6] &= ~(1ull << (fa.sum & 63));
+  fas_.erase(carry);
+  carryOfSum_.erase(fa.sum);
+}
+
+// One descending scan proposing full adders. The carry node is created after
+// the sum (fullAdder builds the sum tower first), so descending order meets
+// the carry first: a node of carry shape -- !(operand-conjunction | tower-
+// conjunction) -- files itself under (tower-conjunction, operand-conjunction),
+// and the sum tower that later mentions both claims it. The interior
+// reference counts must be exactly what a private cone gives (1,2,2,1,2):
+// anything shared with outside logic keeps the plain encoding, since the
+// block does not define the interiors.
+void Cone::findFullAdders(const Manager& m, const std::vector<uint8_t>& refs)
+{
+  std::unordered_map<uint64_t, Node> pending; // (mB << 32) | nA -> carry
+  const auto key = [](Node mB, Node nA) {
+    return (static_cast<uint64_t>(mB) << 32) | nA;
+  };
+
+  for (Node n = static_cast<Node>(m.nodeCount()); n-- > 1;)
+  {
+    if (refs[n] == 0 || !m.isAnd(n))
+      continue;
+    const Lit f0 = m.fanin0(n), f1 = m.fanin1(n);
+    if (!isNeg(f0) || !isNeg(f1))
+      continue;
+    const Node p = nodeOf(f0), q = nodeOf(f1);
+    if (!m.isAnd(p) || !m.isAnd(q))
+      continue;
+
+    // Carry candidacy: one fanin conjoins the operands, the other conjoins
+    // the operands' exclusive-or with the carry-in.
+    for (int pick = 0; pick < 2; pick++)
+    {
+      const Node mB = pick ? q : p;
+      const Node nA = pick ? p : q;
+      for (int side = 0; side < 2; side++)
+      {
+        const Node x = nodeOf(side ? m.fanin1(mB) : m.fanin0(mB));
+        Node u, v;
+        if (xorShape(m, x, u, v) && (u == nA || v == nA))
+          pending[key(mB, nA)] = n;
+      }
+    }
+
+    // Sum candidacy: the two-level exclusive-or tower whose inner conjunction
+    // a filed carry also uses.
+    Node m1, m2;
+    if (!xorShape(m, n, m1, m2))
+      continue;
+    for (int pick = 0; pick < 2 && !faSum(n); pick++)
+    {
+      const Node mB = pick ? m2 : m1;
+      const Node mOther = pick ? m1 : m2;
+      for (int side = 0; side < 2 && !faSum(n); side++)
+      {
+        const Lit xl = side ? m.fanin1(mB) : m.fanin0(mB);
+        const Lit lc = side ? m.fanin0(mB) : m.fanin1(mB);
+        const Node x1 = nodeOf(xl);
+        Node u, v;
+        if (!xorShape(m, x1, u, v))
+          continue;
+        for (int cand = 0; cand < 2; cand++)
+        {
+          const Node nA = cand ? v : u;
+          const Node n1 = cand ? u : v;
+          const auto it = pending.find(key(mB, nA));
+          if (it == pending.end())
+            continue;
+          const Node carry = it->second;
+
+          // The interiors must be private to the cone, and nothing may be
+          // claimed twice. refs saturates at 3, so == distinguishes an
+          // exact count from "more".
+          const Node interior[5] = {n1, nA, x1, mOther, mB};
+          const uint8_t want[5] = {1, 2, 2, 1, 2};
+          bool ok = !faSum(carry) && !faCarry(carry) && !faSum(n) &&
+                    !faCarry(n) && carry != n;
+          for (int i = 0; i < 5 && ok; i++)
+          {
+            const Node node = interior[i];
+            ok = refs[node] == want[i] && node != n && node != carry &&
+                 !faSum(node) && !faCarry(node);
+            for (int j = 0; j < i && ok; j++)
+              ok = interior[j] != node;
+          }
+          if (!ok)
+            continue;
+
+          const Lit la = m.fanin0(nA), lb = m.fanin1(nA);
+          const Node allowed[10] = {n1, nA, x1, mOther, mB,
+                                    n,  carry, 0, 0, 0};
+          if (!verifyFullAdder(m, la, lb, lc, n, carry, allowed))
+            continue;
+
+          setFaSum(n);
+          setFaCarry(carry);
+          fas_[carry] = FullAdder{la, lb, lc, n};
+          carryOfSum_[n] = carry;
+          pending.erase(it);
+          break;
+        }
+      }
+    }
+  }
+}
+
 Cone::Cone(const Manager& m, unsigned namedOutputs, Recover recover)
 {
   const uint32_t nCo = m.outputCount();
@@ -111,6 +308,8 @@ Cone::Cone(const Manager& m, unsigned namedOutputs, Recover recover)
   live_.assign(words, 0);
   pattern_.assign(words, 0);
   absorbed_.assign(words, 0);
+  faSum_.assign(words, 0);
+  faCarry_.assign(words, 0);
 
   // A pattern is only taken when it removes its two intermediates outright,
   // which needs to know whether anything else uses them. Nothing does if they
@@ -124,7 +323,8 @@ Cone::Cone(const Manager& m, unsigned namedOutputs, Recover recover)
   // is that a node's references are not all above the node that would absorb
   // it -- they are only all above the node itself.
   //
-  // One byte each, saturating at two, and it is gone when this constructor
+  // One byte each, saturating at three -- the full-adder match needs to tell
+  // an exact count of two from "more" -- and gone when this constructor
   // returns.
   const bool matchPatterns = recover != Recover::Nothing;
   const bool collapseAnds = recover == Recover::PatternsAndAnds;
@@ -134,7 +334,7 @@ Cone::Cone(const Manager& m, unsigned namedOutputs, Recover recover)
   {
     refs.assign(nNodes, 0);
     const auto bump = [&refs](Node x) {
-      if (x != 0 && refs[x] < 2)
+      if (x != 0 && refs[x] < 3)
         refs[x]++;
     };
     for (uint32_t i = 0; i < nCo; i++)
@@ -146,6 +346,8 @@ Cone::Cone(const Manager& m, unsigned namedOutputs, Recover recover)
       bump(nodeOf(m.fanin0(n)));
       bump(nodeOf(m.fanin1(n)));
     }
+
+    findFullAdders(m, refs);
   }
 
   for (uint32_t i = 0; i < nCo; i++)
@@ -158,10 +360,12 @@ Cone::Cone(const Manager& m, unsigned namedOutputs, Recover recover)
   // conjunction: absorbing it saves the parent two clauses, while folding it
   // saves five by removing both of its intermediates, and the two are
   // mutually exclusive.
+  const auto faMember = [&](Node x) { return faSum(x) || faCarry(x); };
   const auto wouldPattern = [&](Node x) {
     Lit c, t, e;
-    return matchPatterns && m.isAnd(x) &&
+    return matchPatterns && m.isAnd(x) && !faMember(x) &&
            refs[nodeOf(m.fanin0(x))] == 1 && refs[nodeOf(m.fanin1(x))] == 1 &&
+           !faMember(nodeOf(m.fanin0(x))) && !faMember(nodeOf(m.fanin1(x))) &&
            matchIte(m, x, c, t, e);
   };
 
@@ -169,6 +373,32 @@ Cone::Cone(const Manager& m, unsigned namedOutputs, Recover recover)
   {
     if (!live(n) || !m.isAnd(n))
       continue;
+
+    // A recovered full adder defines its sum and carry in one block over the
+    // operands; the interiors stay dead. The carry has the higher id, so it
+    // is reached first, and by then every consumer of both roots has been
+    // processed -- if the sum never came live (its consumers folded it some
+    // other way), the recovery is dropped and both nodes take the ordinary
+    // path.
+    if (faCarry(n))
+    {
+      const FullAdder& fa = fas_.at(n);
+      if (live(fa.sum))
+      {
+        setLive(nodeOf(fa.a));
+        setLive(nodeOf(fa.b));
+        setLive(nodeOf(fa.c));
+        continue;
+      }
+      clearFa(n);
+    }
+    else if (faSum(n))
+    {
+      const Node carry = carryOfSum_.at(n);
+      if (live(carry))
+        continue; // operands were marked when the carry was reached
+      clearFa(carry);
+    }
 
     Lit c, t, e;
     if (wouldPattern(n))
@@ -193,7 +423,7 @@ Cone::Cone(const Manager& m, unsigned namedOutputs, Recover recover)
       const Node x = nodeOf(f);
       setLive(x);
       if (collapseAnds && !isNeg(f) && m.isAnd(x) && refs[x] == 1 &&
-          !wouldPattern(x))
+          !faMember(x) && !wouldPattern(x))
         setAbsorbed(x);
     }
   }
@@ -207,6 +437,14 @@ Cone::Cone(const Manager& m, unsigned namedOutputs, Recover recover)
     if (!live(n) || !m.isAnd(n) || absorbed(n))
       continue;
     ++nAnds_;
+    if (faSum(n))
+      continue; // priced with its carry's block
+    if (faCarry(n))
+    {
+      nClauses_ += 14;
+      nLiterals_ += 44;
+      continue;
+    }
     if (patterned(n))
     {
       nClauses_ += 4;

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -2372,7 +2372,22 @@ void BitBlaster<BBNode, BBNodeManagerT>::BBPlus2(BBNodeVec& sum,
   for (int i = 0; i < bitWidth; i++)
   {
     BBNode nextcin, s;
-    fullAdder(sum[i], y[i], cin, s, nextcin);
+    if (uf->adder_variant)
+      fullAdder(sum[i], y[i], cin, s, nextcin);
+    else
+    {
+      // The majority-carry form the addition network offers, selectable in
+      // the chain too so --bb.add-v1 compares the two full adders under
+      // either summation order. Named locals fix the node creation order,
+      // as in Majority().
+      const BBNode a = sum[i];
+      const BBNode b = y[i];
+      const BBNode ab = nf->CreateNode(AND, a, b);
+      const BBNode bc = nf->CreateNode(AND, b, cin);
+      const BBNode ac = nf->CreateNode(AND, a, cin);
+      nextcin = nf->CreateNode(OR, ab, bc, ac);
+      s = nf->CreateNode(XOR, nf->CreateNode(XOR, cin, b), a);
+    }
     sum[i] = s;
     cin = nextcin;
   }

--- a/tests/unit-tests/Tseitin_Test.cpp
+++ b/tests/unit-tests/Tseitin_Test.cpp
@@ -248,6 +248,25 @@ void checkExact(const aig::Manager& m, unsigned namedOutputs,
   }
 }
 
+// The blaster's full-adder spelling: two half adders sharing their carries,
+// with each XOR built so its inner conjunction is the half adder's carry.
+aig::Lit xorSharing(aig::Manager& m, aig::Lit a, aig::Lit b)
+{
+  const aig::Lit conj = m.And(a, b);
+  const aig::Lit disj = m.Or(a, b);
+  return m.And(disj, aig::neg(conj));
+}
+
+void fullAdder(aig::Manager& m, aig::Lit a, aig::Lit b, aig::Lit cin,
+               aig::Lit& sum, aig::Lit& carry)
+{
+  const aig::Lit axb = xorSharing(m, a, b);
+  const aig::Lit carry1 = m.And(a, b);
+  sum = xorSharing(m, axb, cin);
+  const aig::Lit carry2 = m.And(axb, cin);
+  carry = m.Or(carry1, carry2);
+}
+
 } // namespace
 
 // The headline: on random circuits, with every output named, the CNF says
@@ -357,6 +376,79 @@ TEST(Tseitin, SharedIntermediateDeclinesTheMerge)
 
 // Over random circuits the matcher must never make a formula bigger, on any
 // of the three measures, and must sometimes make it smaller.
+// A full adder collapses to the fourteen-clause block over its operands, sum
+// and carry -- the relation's minimum propagation-complete clause set -- and
+// the five interior nodes get no variables.
+TEST(Tseitin, FullAdderBecomesTheFourteenClauseBlock)
+{
+  aig::Manager m;
+  const aig::Lit a = m.createCi(), b = m.createCi(), c = m.createCi();
+  aig::Lit sum = aig::LIT_NULL, carry = aig::LIT_NULL;
+  fullAdder(m, a, b, c, sum, carry);
+  m.createOutput(sum);
+  m.createOutput(carry);
+
+  checkExact(m, 2, aig::Recover::Patterns);
+  checkExact(m, 2, aig::Recover::PatternsAndAnds);
+
+  // The block, plus two clauses tying each named output to its driver.
+  const CNF folded = aig::deriveTseitin(m, 2, aig::Recover::PatternsAndAnds);
+  EXPECT_EQ(folded.clauseCount(), 18u);
+  // 1 + three CIs + two named outputs + only the sum and carry nodes.
+  EXPECT_EQ(folded.varCount(), 8u);
+}
+
+// A ripple chain recovers every interior adder; the top bit's carry is dead,
+// so its sum falls back to the XOR patterns. Exactness is checked from every
+// input assignment, contradictions included.
+TEST(Tseitin, RippleCarryChainRecoversEveryFullAdder)
+{
+  aig::Manager m;
+  const unsigned width = 4;
+  std::vector<aig::Lit> a, b;
+  for (unsigned i = 0; i < width; i++)
+    a.push_back(m.createCi());
+  for (unsigned i = 0; i < width; i++)
+    b.push_back(m.createCi());
+
+  std::vector<aig::Lit> sums;
+  sums.push_back(xorSharing(m, a[0], b[0]));
+  aig::Lit cin = m.And(a[0], b[0]);
+  for (unsigned i = 1; i < width; i++)
+  {
+    aig::Lit s = aig::LIT_NULL, cout = aig::LIT_NULL;
+    fullAdder(m, a[i], b[i], cin, s, cout);
+    sums.push_back(s);
+    cin = cout; // the top carry is built and dropped, as the blaster does
+  }
+  for (const aig::Lit s : sums)
+    m.createOutput(s);
+
+  checkExact(m, width, aig::Recover::PatternsAndAnds);
+
+  const CNF plain = aig::deriveTseitin(m, width, aig::Recover::Nothing);
+  const CNF folded = aig::deriveTseitin(m, width, aig::Recover::PatternsAndAnds);
+  EXPECT_LT(folded.clauseCount(), plain.clauseCount());
+  EXPECT_LT(folded.varCount(), plain.varCount());
+}
+
+// An interior shared with outside logic keeps the plain encoding: the block
+// does not define the interiors, so absorbing one that something else reads
+// would leave it unconstrained.
+TEST(Tseitin, SharedFullAdderInteriorDeclinesTheBlock)
+{
+  aig::Manager m;
+  const aig::Lit a = m.createCi(), b = m.createCi(), c = m.createCi();
+  aig::Lit sum = aig::LIT_NULL, carry = aig::LIT_NULL;
+  fullAdder(m, a, b, c, sum, carry);
+  m.createOutput(sum);
+  m.createOutput(carry);
+  m.createOutput(m.And(a, b)); // the half adder's carry, hash-consed
+
+  checkExact(m, 3, aig::Recover::Patterns);
+  checkExact(m, 3, aig::Recover::PatternsAndAnds);
+}
+
 TEST(Tseitin, MatchingNeverCostsAnything)
 {
   uint64_t savedClauses = 0, savedLiterals = 0, savedVars = 0;

--- a/tools/propagator_bench/Bcp.cpp
+++ b/tools/propagator_bench/Bcp.cpp
@@ -157,6 +157,20 @@ struct BcpEncoding
   unsigned clauses() const { return (unsigned)cnf.clauseCount(); }
   unsigned variables() const { return cnf.varCount(); }
 
+  // A copy of the clauses and the symbol-bit variables, for a checker that
+  // propagates them itself rather than through a solver.
+  void material(vector<vector<int>>& outClauses,
+                vector<vector<unsigned>>& io, unsigned& nv) const
+  {
+    static_assert(NOT_ENCODED == BCP_NOT_ENCODED,
+                  "the header's sentinel is this class's contract");
+    outClauses.clear();
+    for (CNF::ClauseCursor c = cnf.clauses(); c.next();)
+      outClauses.push_back(vector<int>(c.begin(), c.end()));
+    io = vars;
+    nv = cnf.varCount();
+  }
+
 private:
   // constexpr, not const: resize() below binds it by reference, which needs
   // a definition, and in C++17 a constexpr static member is implicitly inline.
@@ -234,6 +248,13 @@ unsigned bcpVariables(const BcpEncoding* e)
   return e->variables();
 }
 
+bool bcpMaterial(const BcpEncoding* e, vector<vector<int>>& clauses,
+                 vector<vector<unsigned>>& io, unsigned& variables)
+{
+  e->material(clauses, io, variables);
+  return true;
+}
+
 } // namespace propbench
 
 #else // !USE_CRYPTOMINISAT
@@ -273,6 +294,12 @@ unsigned bcpClauses(const BcpEncoding*)
 unsigned bcpVariables(const BcpEncoding*)
 {
   return 0;
+}
+
+bool bcpMaterial(const BcpEncoding*, vector<vector<int>>&,
+                 vector<vector<unsigned>>&, unsigned&)
+{
+  return false;
 }
 
 } // namespace propbench

--- a/tools/propagator_bench/CMakeLists.txt
+++ b/tools/propagator_bench/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(propagator_bench
     Ops.cpp
     Cbitp.cpp
     Bcp.cpp
+    Consistency.cpp
     Domains.cpp
     Report.cpp
 )

--- a/tools/propagator_bench/Cbitp.cpp
+++ b/tools/propagator_bench/Cbitp.cpp
@@ -758,6 +758,14 @@ void runCbitp(STPMgr* mgr, const Config& cfg, vector<Row>& out)
       bcpEx = bcpExhaustiveCheck(mgr, op, cfg);
     }
 
+    ConsistencyCheck cons;
+    if (cfg.consistencyWidth > 0)
+    {
+      if (cfg.verbose)
+        std::cerr << "encoding consistency " << op.name << std::endl;
+      cons = consistencyCheck(mgr, op, cfg);
+    }
+
     const bool isBoolean =
         op.shape == Shape::BoolNary || op.shape == Shape::BoolUnary;
     vector<unsigned> widths = isBoolean ? vector<unsigned>{1} : cfg.widths;
@@ -807,6 +815,7 @@ void runCbitp(STPMgr* mgr, const Config& cfg, vector<Row>& out)
           row.witnessUnsound = t.unsound;
           row.precision = precision;
           row.bcpExhaustive = bcpEx;
+          row.consistency = cons;
 
           if (cfg.satCases > 0 && op.satCheckable)
           {

--- a/tools/propagator_bench/Consistency.cpp
+++ b/tools/propagator_bench/Consistency.cpp
@@ -1,0 +1,549 @@
+/********************************************************************
+ * AUTHORS: Trevor Hansen
+ *
+ * BEGIN DATE: September, 2026
+ *
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+********************************************************************/
+
+// Graded GAC / URC / PC verdicts for the bit-blasted encoding.
+//
+// The exhaustive check in Cbitp.cpp answers the arc-consistency question
+// through a fresh SAT solver per case. This one grades the answer and asks
+// the propagation-completeness question too -- every CNF variable,
+// auxiliaries included -- which multiplies the case count past what a solver
+// restart per case can afford. So it propagates the clauses itself: counting
+// unit propagation over occurrence lists, with the semantic side answered
+// from a solution table held as one bitset column per variable.
+//
+// The table is built by asserting every input pattern and propagating; the
+// encodings' auxiliaries are functions of the inputs, so each pattern yields
+// its row directly. Patterns unit propagation does not finish are completed
+// by enumeration, so an encoding is not required to evaluate forward under
+// unit propagation alone.
+
+#include "PropagatorBench.h"
+
+#include <algorithm>
+#include <fstream>
+#include <iostream>
+
+using namespace stp;
+
+namespace propbench
+{
+namespace
+{
+
+uint64_t pow3Capped(unsigned n, uint64_t cap)
+{
+  uint64_t r = 1;
+  for (unsigned i = 0; i < n; i++)
+  {
+    if (r > cap / 3)
+      return cap + 1;
+    r *= 3;
+  }
+  return r;
+}
+
+// Counting unit propagation. Small formulas, millions of calls: occurrence
+// lists and a resettable trail, nothing cleverer.
+struct UpEngine
+{
+  unsigned nVars = 0;
+  const vector<vector<int>>* clauses = nullptr;
+  vector<vector<unsigned>> occ; // literal 2v+neg -> clauses containing it
+  vector<int8_t> val;           // by variable: 0 unset, 1 true, -1 false
+  vector<unsigned> trail;
+  size_t base = 0; // trail length after the formula's own unit clauses
+  bool baseConflict = false;
+
+  void init(const vector<vector<int>>& cls, unsigned nv)
+  {
+    nVars = nv;
+    clauses = &cls;
+    occ.assign(2 * (size_t)nv, {});
+    for (unsigned ci = 0; ci < cls.size(); ci++)
+      for (int lit : cls[ci])
+        occ[lit].push_back(ci);
+    val.assign(nv, 0);
+    trail.clear();
+
+    // The formula's unit clauses, propagated once and kept: occurrence-driven
+    // propagation only ever revisits a clause when a literal in it just
+    // became false, so a clause that arrives unit has to be applied here.
+    for (const vector<int>& c : cls)
+      if (c.size() == 1 && !assign(c[0] >> 1, !(c[0] & 1)))
+      {
+        baseConflict = true;
+        return;
+      }
+    baseConflict = !propagate(0);
+    base = trail.size();
+  }
+
+  void undoTo(size_t mark)
+  {
+    while (trail.size() > mark)
+    {
+      val[trail.back()] = 0;
+      trail.pop_back();
+    }
+  }
+
+  // False when the variable is already fixed the other way.
+  bool assign(unsigned var, bool value)
+  {
+    if (val[var] != 0)
+      return (val[var] > 0) == value;
+    val[var] = value ? 1 : -1;
+    trail.push_back(var);
+    return true;
+  }
+
+  bool litTrue(int lit) const
+  {
+    const int8_t v = val[lit >> 1];
+    return v != 0 && (v > 0) == !(lit & 1);
+  }
+
+  // Propagates everything on the trail from `from`; false on conflict.
+  bool propagate(size_t from)
+  {
+    for (size_t head = from; head < trail.size(); head++)
+    {
+      const unsigned var = trail[head];
+      const unsigned falseLit = 2 * var + (val[var] > 0 ? 1 : 0);
+      for (unsigned ci : occ[falseLit])
+      {
+        const vector<int>& cls = (*clauses)[ci];
+        int unit = 0;
+        unsigned unassigned = 0;
+        bool satisfied = false;
+        for (int lit : cls)
+        {
+          const int8_t v = val[lit >> 1];
+          if (v == 0)
+          {
+            unit = lit;
+            if (++unassigned > 1)
+              break;
+          }
+          else if ((v > 0) == !(lit & 1))
+          {
+            satisfied = true;
+            break;
+          }
+        }
+        if (satisfied || unassigned > 1)
+          continue;
+        if (unassigned == 0)
+          return false;
+        assign(unit >> 1, !(unit & 1)); // unset, so it cannot fail
+      }
+    }
+    return true;
+  }
+};
+
+// The solution set, one bitset column per variable over the rows.
+struct Table
+{
+  bool ok = false;
+  unsigned nRows = 0;
+  unsigned words = 0;
+  vector<uint64_t> full;             // nRows bits set
+  vector<vector<uint64_t>> colTrue;  // by variable
+
+  static constexpr unsigned MAX_ROWS = 1u << 16;
+
+  void addRow(const UpEngine& up)
+  {
+    for (unsigned v = 1; v < up.nVars; v++)
+      if (up.val[v] > 0)
+        colTrue[v][nRows >> 6] |= 1ull << (nRows & 63);
+    nRows++;
+  }
+};
+
+// Enumerates every total solution extending the current trail. Unit
+// propagation has already run; branches only on what it left unset.
+bool enumerate(UpEngine& up, Table& t)
+{
+  unsigned branch = 0;
+  for (unsigned v = 1; v < up.nVars; v++)
+    if (up.val[v] == 0)
+    {
+      branch = v;
+      break;
+    }
+  if (branch == 0)
+  {
+    if (t.nRows >= Table::MAX_ROWS)
+      return false;
+    t.addRow(up);
+    return true;
+  }
+  for (int b = 0; b < 2; b++)
+  {
+    const size_t mark = up.trail.size();
+    if (up.assign(branch, b == 1) && up.propagate(mark))
+      if (!enumerate(up, t))
+        return false;
+    up.undoTo(mark);
+  }
+  return true;
+}
+
+// One scope's exhaustive-or-sampled sweep. `digits` is reused across calls.
+struct SweepCounts
+{
+  uint64_t cases = 0;
+  uint64_t contradictory = 0;
+  uint64_t missedConflict = 0;
+  uint64_t incomplete = 0;
+  uint64_t derivable = 0;
+  uint64_t derived = 0;
+  uint64_t unsound = 0;
+  vector<uint64_t> missedByUnset; // sized by the caller when it wants it
+};
+
+void oneCase(UpEngine& up, const Table& t, const vector<unsigned>& scope,
+             const vector<int8_t>& digits, SweepCounts& out)
+{
+  out.cases++;
+
+  // The rows this case still admits.
+  static thread_local vector<uint64_t> mask;
+  mask.assign(t.full.begin(), t.full.end());
+  bool any = false;
+  for (size_t i = 0; i < scope.size(); i++)
+  {
+    if (digits[i] == 0)
+      continue;
+    const vector<uint64_t>& col = t.colTrue[scope[i]];
+    for (unsigned w = 0; w < t.words; w++)
+      mask[w] &= (digits[i] > 0) ? col[w] : (t.full[w] & ~col[w]);
+  }
+  for (unsigned w = 0; w < t.words && !any; w++)
+    any = mask[w] != 0;
+
+  // Unit propagation on the same case.
+  const size_t mark = up.trail.size();
+  bool conflict = false;
+  for (size_t i = 0; i < scope.size() && !conflict; i++)
+    if (digits[i] != 0)
+      conflict = !up.assign(scope[i], digits[i] > 0);
+  if (!conflict)
+    conflict = !up.propagate(mark);
+
+  if (!any)
+  {
+    out.contradictory++;
+    if (!conflict)
+    {
+      out.missedConflict++;
+      if (!out.missedByUnset.empty())
+      {
+        unsigned unset = 0;
+        for (int8_t d : digits)
+          if (d == 0)
+            unset++;
+        out.missedByUnset[unset]++;
+      }
+    }
+    up.undoTo(mark);
+    return;
+  }
+
+  if (conflict)
+  {
+    out.unsound++;
+    up.undoTo(mark);
+    return;
+  }
+
+  // Implied literals of the unset scope variables, against what propagation
+  // fixed. Propagation only ever derives entailed literals, so a derived
+  // value disagreeing with an implied one means the table is wrong.
+  uint64_t derivableHere = 0, derivedHere = 0;
+  for (size_t i = 0; i < scope.size(); i++)
+  {
+    if (digits[i] != 0)
+      continue;
+    const vector<uint64_t>& col = t.colTrue[scope[i]];
+    bool alwaysTrue = true, alwaysFalse = true;
+    for (unsigned w = 0; w < t.words && (alwaysTrue || alwaysFalse); w++)
+    {
+      if (mask[w] & ~col[w])
+        alwaysTrue = false;
+      if (mask[w] & col[w])
+        alwaysFalse = false;
+    }
+    const int8_t got = up.val[scope[i]];
+    if (alwaysTrue || alwaysFalse)
+    {
+      derivableHere++;
+      if (got != 0)
+      {
+        if ((got > 0) == alwaysTrue)
+          derivedHere++;
+        else
+          out.unsound++;
+      }
+    }
+    else if (got != 0)
+      out.unsound++;
+  }
+  out.derivable += derivableHere;
+  out.derived += derivedHere;
+  if (derivedHere < derivableHere)
+    out.incomplete++;
+
+  up.undoTo(mark);
+}
+
+void sweepExhaustive(UpEngine& up, const Table& t,
+                     const vector<unsigned>& scope, SweepCounts& out)
+{
+  vector<int8_t> digits(scope.size(), -1);
+  bool done = scope.empty();
+  while (!done)
+  {
+    oneCase(up, t, scope, digits, out);
+    done = true;
+    for (size_t i = 0; i < digits.size(); i++)
+    {
+      if (++digits[i] <= 1)
+      {
+        done = false;
+        break;
+      }
+      digits[i] = -1;
+    }
+  }
+}
+
+void sweepSampled(UpEngine& up, const Table& t, const vector<unsigned>& scope,
+                  uint64_t samples, unsigned seed, SweepCounts& out)
+{
+  std::mt19937 rand(seed);
+  std::uniform_int_distribution<int> digit(-1, 1);
+  vector<int8_t> digits(scope.size());
+  for (uint64_t s = 0; s < samples; s++)
+  {
+    for (size_t i = 0; i < digits.size(); i++)
+      digits[i] = (int8_t)digit(rand);
+    oneCase(up, t, scope, digits, out);
+  }
+}
+
+} // namespace
+
+ConsistencyCheck consistencyCheck(STPMgr* mgr, const OpSpec& op,
+                                  const Config& cfg)
+{
+  ConsistencyCheck res;
+
+  const unsigned width = cfg.consistencyWidth;
+  const Layout l = layoutFor(op, width, cfg.arity);
+  if (!l.ok || l.packedBits() > 20)
+    return res;
+
+  BcpEncoding* enc = makeBcpEncoding(mgr, op, l);
+  if (enc == NULL)
+    return res;
+
+  vector<vector<int>> clauses;
+  vector<vector<unsigned>> io;
+  unsigned nVars = 0;
+  const bool got = bcpMaterial(enc, clauses, io, nVars);
+  destroyBcpEncoding(enc);
+  if (!got || io.empty())
+    return res;
+
+  UpEngine up;
+  up.init(clauses, nVars);
+  if (up.baseConflict)
+    return res; // the formula itself is unsatisfiable at level zero
+
+  // The solution table: every input pattern, propagated and completed. The
+  // inputs are every io entry but the last, which is the result.
+  vector<unsigned> inputBits;
+  for (size_t s = 0; s + 1 < io.size(); s++)
+    for (unsigned v : io[s])
+      if (v != BCP_NOT_ENCODED)
+        inputBits.push_back(v);
+  if (inputBits.size() > 20)
+    return res;
+
+  Table t;
+  t.nRows = 0;
+  {
+    // Built at the row cap's capacity, shrunk to fit afterwards: the sweeps
+    // scan every column word per case, so a loose capacity is paid millions
+    // of times.
+    t.words = Table::MAX_ROWS / 64;
+    t.colTrue.assign(nVars, vector<uint64_t>(t.words, 0));
+    const uint64_t patterns = 1ull << inputBits.size();
+    for (uint64_t p = 0; p < patterns; p++)
+    {
+      bool okPattern = true;
+      for (size_t i = 0; i < inputBits.size() && okPattern; i++)
+        okPattern = up.assign(inputBits[i], (p >> i) & 1);
+      if (okPattern)
+        okPattern = up.propagate(up.base);
+      if (!okPattern)
+        res.unsound++; // a concrete input the encoding refuses
+      else if (!enumerate(up, t))
+      {
+        up.undoTo(up.base);
+        return res; // hit the row cap; the check cannot be trusted
+      }
+      up.undoTo(up.base);
+    }
+    t.words = std::max((t.nRows + 63) / 64, 1u);
+    for (vector<uint64_t>& col : t.colTrue)
+      col.resize(t.words);
+    t.full.assign(t.words, 0);
+    for (unsigned r = 0; r < t.nRows; r++)
+      t.full[r >> 6] |= 1ull << (r & 63);
+  }
+  if (t.nRows == 0)
+    return res;
+
+  // Scopes: the input/output bits, and every variable the CNF mentions.
+  vector<unsigned> ioScope;
+  {
+    vector<bool> seen(nVars, false);
+    for (const vector<unsigned>& sym : io)
+      for (unsigned v : sym)
+        if (v != BCP_NOT_ENCODED && !seen[v])
+        {
+          seen[v] = true;
+          ioScope.push_back(v);
+        }
+  }
+  vector<unsigned> allScope;
+  {
+    vector<bool> seen(nVars, false);
+    for (unsigned v : ioScope)
+      seen[v] = true;
+    for (const vector<int>& cls : clauses)
+      for (int lit : cls)
+        seen[lit >> 1] = true;
+    for (unsigned v = 1; v < nVars; v++)
+      if (seen[v])
+        allScope.push_back(v);
+  }
+
+  res.ran = true;
+  res.width = width;
+  res.clauses = (unsigned)clauses.size();
+  for (const vector<int>& cls : clauses)
+    res.literals += (unsigned)cls.size();
+  res.variables = (unsigned)allScope.size();
+  res.ioVars = (unsigned)ioScope.size();
+
+  // The input/output sweep, always exhaustive: it is the definition of GAC
+  // and URC, and a sample of it would grade nothing.
+  if (pow3Capped((unsigned)ioScope.size(), cfg.consistencyCap) >
+      cfg.consistencyCap)
+  {
+    res.ran = false;
+    return res;
+  }
+  SweepCounts ioCounts;
+  ioCounts.missedByUnset.assign(ioScope.size() + 1, 0);
+  sweepExhaustive(up, t, ioScope, ioCounts);
+  res.ioCases = ioCounts.cases;
+  res.ioContradictory = ioCounts.contradictory;
+  res.gacIncomplete = ioCounts.incomplete;
+  res.gacDerivable = ioCounts.derivable;
+  res.gacDerived = ioCounts.derived;
+  res.urcMissed = ioCounts.missedConflict;
+  res.urcMissedByUnset = ioCounts.missedByUnset;
+  res.unsound += ioCounts.unsound;
+
+  // The all-variables sweep, exhaustive when it fits.
+  SweepCounts pcCounts;
+  res.pcExhaustive =
+      pow3Capped((unsigned)allScope.size(), cfg.consistencyCap) <=
+      cfg.consistencyCap;
+  if (res.pcExhaustive)
+    sweepExhaustive(up, t, allScope, pcCounts);
+  else
+    sweepSampled(up, t, allScope, cfg.pcSamples, cfg.seed, pcCounts);
+  res.pcRan = true;
+  res.pcCases = pcCounts.cases;
+  res.pcContradictory = pcCounts.contradictory;
+  res.pcIncomplete = pcCounts.incomplete;
+  res.pcDerivable = pcCounts.derivable;
+  res.pcDerived = pcCounts.derived;
+  res.pcMissedConflict = pcCounts.missedConflict;
+  res.unsound += pcCounts.unsound;
+
+  return res;
+}
+
+bool dumpEncoding(STPMgr* mgr, const OpSpec& op, const Config& cfg,
+                  const string& path)
+{
+  const Layout l = layoutFor(op, cfg.dumpWidth, cfg.arity);
+  if (!l.ok)
+    return false;
+
+  BcpEncoding* enc = makeBcpEncoding(mgr, op, l);
+  if (enc == NULL)
+    return false;
+
+  vector<vector<int>> clauses;
+  vector<vector<unsigned>> io;
+  unsigned nVars = 0;
+  const bool got = bcpMaterial(enc, clauses, io, nVars);
+  destroyBcpEncoding(enc);
+  if (!got)
+    return false;
+
+  std::ofstream f(path.c_str());
+  if (!f)
+    return false;
+
+  f << "c op " << op.name << " width " << cfg.dumpWidth << " arity "
+    << cfg.arity << " cnf " << (cfg.cnf.empty() ? "medium" : cfg.cnf) << "\n";
+  for (size_t s = 0; s < io.size(); s++)
+  {
+    f << "c sym " << s << (s + 1 == io.size() ? " result" : " child");
+    for (unsigned v : io[s])
+      f << " " << (v == BCP_NOT_ENCODED ? 0u : v);
+    f << "\n";
+  }
+  f << "p cnf " << (nVars > 0 ? nVars - 1 : 0) << " " << clauses.size()
+    << "\n";
+  for (const vector<int>& cls : clauses)
+  {
+    for (int lit : cls)
+      f << ((lit & 1) ? "-" : "") << (lit >> 1) << " ";
+    f << "0\n";
+  }
+  return true;
+}
+
+} // namespace propbench

--- a/tools/propagator_bench/PropagatorBench.h
+++ b/tools/propagator_bench/PropagatorBench.h
@@ -236,6 +236,55 @@ struct BcpExhaustive
   }
 };
 
+// Graded consistency of the bit-blasted encoding, from a self-contained unit
+// propagator over the generated clauses (Consistency.cpp). Three claims,
+// strongest last:
+//   URC  unit propagation refutes every inconsistent partial assignment of
+//        the operation's input/output bits
+//   GAC  URC, and every implied input/output literal is derived
+//   PC   both, quantified over every CNF variable, auxiliaries included
+struct ConsistencyCheck
+{
+  bool ran = false;
+  unsigned width = 0;
+  unsigned clauses = 0;
+  unsigned literals = 0;
+  unsigned variables = 0; // CNF variables, auxiliaries included
+  unsigned ioVars = 0;    // of them, input/output bits
+
+  // Over the input/output variables, exhaustively.
+  uint64_t ioCases = 0;
+  uint64_t ioContradictory = 0;
+  uint64_t gacIncomplete = 0; // cases that left an implied literal underived
+  uint64_t gacDerivable = 0;  // implied literals over all consistent cases
+  uint64_t gacDerived = 0;
+  uint64_t urcMissed = 0; // contradictory cases unit propagation let through
+  // urcMissed again, indexed by how many input/output bits the case left
+  // unset. A miss at index 0 is a fully assigned contradiction the encoding
+  // cannot see; misses only at high indices are the cheap kind.
+  vector<uint64_t> urcMissedByUnset;
+  uint64_t unsound = 0; // derived something no solution supports: a bug
+
+  // Over every variable: exhaustive when 3^variables fits the cap, else
+  // sampled -- a sample can prove PC absent, never present.
+  bool pcRan = false;
+  bool pcExhaustive = false;
+  uint64_t pcCases = 0;
+  uint64_t pcContradictory = 0;
+  uint64_t pcIncomplete = 0;
+  uint64_t pcDerivable = 0;
+  uint64_t pcDerived = 0;
+  uint64_t pcMissedConflict = 0;
+
+  bool urc() const { return ran && urcMissed == 0 && unsound == 0; }
+  bool gac() const { return urc() && gacIncomplete == 0; }
+  bool pc() const
+  {
+    return gac() && pcRan && pcExhaustive && pcIncomplete == 0 &&
+           pcMissedConflict == 0;
+  }
+};
+
 struct Row
 {
   Domain domain = Domain::Cbitp;
@@ -259,6 +308,7 @@ struct Row
   SatCheck sat;              // at this row's width
   BcpCheck bcp;              // against the bit-blasted encoding
   BcpExhaustive bcpExhaustive; // arc consistency of that encoding
+  ConsistencyCheck consistency; // graded GAC / URC / PC of that encoding
 };
 
 struct Config
@@ -281,6 +331,13 @@ struct Config
   unsigned bcpCases = 0;        // 0 disables the bit-blasted comparison
   double bcpBudgetSeconds = 5;  // a fresh solver and CNF load per case
   unsigned bcpExhaustiveWidth = 0; // 0 disables the arc-consistency check
+  string dumpCnf;          // write the encoding as DIMACS here and exit
+  unsigned dumpWidth = 64; // at this width
+  unsigned consistencyWidth = 0;   // 0 disables the graded GAC/URC/PC check
+  uint64_t consistencyCap = 20000000; // most exhaustive cases per scope
+  uint64_t pcSamples = 1000000; // sampled cases when 3^vars exceeds the cap
+  int adderVariant = -1;  // -1 leaves UserDefinedFlags::adder_variant alone
+  int bvplusVariant = -1; // likewise bvplus_variant
   unsigned seed = 42;
   // How the CNF that --bcp-check propagates over is generated. Empty leaves
   // STP's default (medium) alone. A different encoding of the same circuit
@@ -339,6 +396,26 @@ unsigned bcpVisibleFixed(const BcpEncoding* e,
 // The size of the CNF being propagated over, which is what --cnf changes.
 unsigned bcpClauses(const BcpEncoding* e);
 unsigned bcpVariables(const BcpEncoding* e);
+
+// The raw material the consistency checker propagates over itself: the
+// clauses (literals encoded 2*variable+negated, variables from 1) and the SAT
+// variable of every input/output bit -- the varying children in layout order,
+// then the result, BCP_NOT_ENCODED for bits the CNF never saw. False in a
+// build without CryptoMiniSat.
+constexpr unsigned BCP_NOT_ENCODED = ~((unsigned)0);
+bool bcpMaterial(const BcpEncoding* e, vector<vector<int>>& clauses,
+                 vector<vector<unsigned>>& io, unsigned& variables);
+
+// The graded GAC/URC/PC check, at cfg.consistencyWidth. See Consistency.cpp.
+ConsistencyCheck consistencyCheck(stp::STPMgr* mgr, const OpSpec& op,
+                                  const Config& cfg);
+
+// Writes the encoding of op at cfg.dumpWidth as DIMACS, with `c sym` header
+// lines mapping every input/output bit to its variable -- the varying
+// children in layout order, then the result, 0 for a bit the CNF never saw.
+// For drivers that append query clauses and hand the file to a SAT solver.
+bool dumpEncoding(stp::STPMgr* mgr, const OpSpec& op, const Config& cfg,
+                  const string& path);
 
 // ---------------------------------------------------------------------------
 // Reporting.

--- a/tools/propagator_bench/Report.cpp
+++ b/tools/propagator_bench/Report.cpp
@@ -122,6 +122,43 @@ string precisionDetail(const Row& r)
       o << ", " << e.unsound << " UNSOUND";
     o << ")";
   }
+  if (r.consistency.ran)
+  {
+    const ConsistencyCheck& k = r.consistency;
+    o << "; consistency w=" << k.width << " (" << k.clauses << " clauses/"
+      << k.variables << " vars, " << k.ioVars << " io): URC "
+      << (k.urc() ? "yes" : "NO");
+    if (k.urcMissed > 0)
+    {
+      unsigned worst = 0;
+      for (size_t u = 0; u < k.urcMissedByUnset.size(); u++)
+        if (k.urcMissedByUnset[u] > 0)
+        {
+          worst = (unsigned)u;
+          break;
+        }
+      o << " (" << k.urcMissed << "/" << k.ioContradictory
+        << " conflicts missed, some with only " << worst << " unset)";
+    }
+    o << ", GAC " << (k.gac() ? "yes" : "NO");
+    if (k.gacDerivable > 0)
+      o << " (" << fixed(100.0 * k.gacDerived / k.gacDerivable, 1)
+        << "% of implied literals over " << k.ioCases << " cases)";
+    o << ", PC ";
+    if (!k.pcRan)
+      o << "not checked";
+    else
+    {
+      o << (k.pc() ? "yes" : "NO") << " ("
+        << (k.pcExhaustive ? "exhaustive" : "sampled") << ", ";
+      if (k.pcDerivable > 0)
+        o << fixed(100.0 * k.pcDerived / k.pcDerivable, 1) << "% of literals, ";
+      o << k.pcMissedConflict << "/" << k.pcContradictory
+        << " conflicts missed)";
+    }
+    if (k.unsound > 0)
+      o << ", " << k.unsound << " UNSOUND";
+  }
   if (r.witnessUnsound > 0)
     o << "; " << r.witnessUnsound << " timed cases lost their solution";
   if (r.conflicts > 0)
@@ -209,7 +246,13 @@ void writeCsv(const Config& cfg, const vector<Row>& rows, const string& path)
        "exhaustive_width,exhaustive_cases,exhaustive_precise,"
        "exhaustive_unsound,exhaustive_missed_conflicts,deducible_bits,"
        "gained_bits,sat_cases,sat_precise,sat_unsound,"
-       "bcp_cases,bcp_bits,bcp_cbitp_bits,bcp_clauses,bcp_vars\n";
+       "bcp_cases,bcp_bits,bcp_cbitp_bits,bcp_clauses,bcp_vars,"
+       "cons_width,cons_clauses,cons_literals,cons_vars,cons_io_vars,"
+       "cons_urc,cons_gac,cons_pc,cons_io_cases,cons_io_contradictory,"
+       "cons_urc_missed,cons_urc_missed_min_unset,cons_gac_incomplete,"
+       "cons_gac_derivable,cons_gac_derived,cons_pc_mode,cons_pc_cases,"
+       "cons_pc_contradictory,cons_pc_missed_conflicts,cons_pc_incomplete,"
+       "cons_pc_derivable,cons_pc_derived,cons_unsound\n";
   for (const Row& r : rows)
   {
     f << name(r.domain) << "," << r.op << "," << name(r.direction) << ","
@@ -222,7 +265,25 @@ void writeCsv(const Config& cfg, const vector<Row>& rows, const string& path)
       << r.precision.gained << "," << r.sat.cases << "," << r.sat.precise
       << "," << r.sat.unsound << "," << r.bcp.cases << ","
       << fixed(r.bcp.bcpBits, 4) << "," << fixed(r.bcp.cbitpBits, 4) << ","
-      << r.bcp.clauses << "," << r.bcp.variables << "\n";
+      << r.bcp.clauses << "," << r.bcp.variables;
+
+    const ConsistencyCheck& k = r.consistency;
+    int minUnset = -1;
+    for (size_t u = 0; u < k.urcMissedByUnset.size() && minUnset < 0; u++)
+      if (k.urcMissedByUnset[u] > 0)
+        minUnset = (int)u;
+    f << "," << (k.ran ? k.width : 0) << "," << k.clauses << "," << k.literals
+      << "," << k.variables << "," << k.ioVars << ","
+      << (!k.ran ? "" : k.urc() ? "yes" : "no") << ","
+      << (!k.ran ? "" : k.gac() ? "yes" : "no") << ","
+      << (!k.pcRan ? "" : k.pc() ? "yes" : "no") << "," << k.ioCases << ","
+      << k.ioContradictory << "," << k.urcMissed << "," << minUnset << ","
+      << k.gacIncomplete << "," << k.gacDerivable << "," << k.gacDerived
+      << ","
+      << (!k.pcRan ? "" : k.pcExhaustive ? "exhaustive" : "sampled") << ","
+      << k.pcCases << "," << k.pcContradictory << "," << k.pcMissedConflict
+      << "," << k.pcIncomplete << "," << k.pcDerivable << "," << k.pcDerived
+      << "," << k.unsound << "\n";
   }
   (void)cfg;
   std::cout << "wrote " << path << std::endl;

--- a/tools/propagator_bench/main.cpp
+++ b/tools/propagator_bench/main.cpp
@@ -98,11 +98,31 @@ void usage()
       << "  --bcp-exhaustive W  check the bit-blasted encoding for arc\n"
       << "                      consistency at width W: every combination of\n"
       << "                      fixed bits, contradictory ones included\n"
-      << "  --cnf HOW           how to generate the CNF --bcp-check\n"
-      << "                      propagates over: simple, very-low, low,\n"
-      << "                      medium (STP's default), high, very-high.\n"
-      << "                      Different encodings of the same circuit can\n"
-      << "                      propagate differently\n"
+      << "  --consistency W     grade the encoding at width W: URC (every\n"
+      << "                      contradiction refuted by unit propagation),\n"
+      << "                      GAC (and every implied input/output literal\n"
+      << "                      derived), PC (both, over every CNF variable,\n"
+      << "                      auxiliaries included), each with how close\n"
+      << "  --consistency-cap N most exhaustive cases per scope (default\n"
+      << "                      20000000); the PC scope samples past it\n"
+      << "  --pc-samples N      sampled PC cases when over the cap\n"
+      << "                      (default 1000000)\n"
+      << "  --dump-cnf FILE     write the encoding of the one op named by\n"
+      << "                      --ops as DIMACS, with a header mapping the\n"
+      << "                      input/output bits to variables, and exit\n"
+      << "  --dump-width W      at this width (default 64)\n"
+      << "  --cnf HOW           how to generate the CNF --bcp-check and\n"
+      << "                      --consistency propagate over: simple,\n"
+      << "                      very-low, low, medium, high, very-high,\n"
+      << "                      new-very-low, new-low, new-medium, gia-low,\n"
+      << "                      gia-high, gia-very-high. Different encodings\n"
+      << "                      of the same circuit propagate differently\n"
+      << "  --bb.add-v1 0|1     UserDefinedFlags::adder_variant: 1 the\n"
+      << "                      shared-half-adder full adder (default), 0\n"
+      << "                      the majority-carry form\n"
+      << "  --bb.add-v2 0|1     UserDefinedFlags::bvplus_variant: 1 pairwise\n"
+      << "                      ripple chains (default), 0 the addition\n"
+      << "                      network\n"
       << "  --no-shift-bias     draw shift amounts uniformly, instead of\n"
       << "                      half of them from [0, width)\n"
       << "  --seed N            random seed (default 42)\n"
@@ -218,6 +238,19 @@ int main(int argc, char** argv)
     { cfg.bcpBudgetSeconds = atof(value.c_str()); i++; }
     else if (arg == "--bcp-exhaustive")
     { cfg.bcpExhaustiveWidth = atoi(value.c_str()); i++; }
+    else if (arg == "--consistency")
+    { cfg.consistencyWidth = atoi(value.c_str()); i++; }
+    else if (arg == "--dump-cnf") { cfg.dumpCnf = value; i++; }
+    else if (arg == "--dump-width")
+    { cfg.dumpWidth = atoi(value.c_str()); i++; }
+    else if (arg == "--consistency-cap")
+    { cfg.consistencyCap = strtoull(value.c_str(), NULL, 10); i++; }
+    else if (arg == "--pc-samples")
+    { cfg.pcSamples = strtoull(value.c_str(), NULL, 10); i++; }
+    else if (arg == "--bb.add-v1")
+    { cfg.adderVariant = atoi(value.c_str()); i++; }
+    else if (arg == "--bb.add-v2")
+    { cfg.bvplusVariant = atoi(value.c_str()); i++; }
     else if (arg == "--cnf") { cfg.cnf = value; i++; }
     else if (arg == "--seed") { cfg.seed = atoi(value.c_str()); i++; }
     else if (arg == "--html") { cfg.html = value; i++; }
@@ -237,12 +270,15 @@ int main(int argc, char** argv)
     return 1;
   }
 
-  if ((cfg.bcpCases > 0 || cfg.bcpExhaustiveWidth > 0) && !bcpAvailable())
+  if ((cfg.bcpCases > 0 || cfg.bcpExhaustiveWidth > 0 ||
+       cfg.consistencyWidth > 0) &&
+      !bcpAvailable())
   {
     // Refuse rather than silently report nothing: the whole point of the
     // option is the comparison it makes.
-    std::cerr << "propagator_bench: --bcp-check/--bcp-exhaustive need a build with "
-                 "CryptoMiniSat (configure with -DNOCRYPTOMINISAT=OFF)\n";
+    std::cerr << "propagator_bench: --bcp-check/--bcp-exhaustive/--consistency "
+                 "need a build with CryptoMiniSat (configure with "
+                 "-DNOCRYPTOMINISAT=OFF)\n";
     return 1;
   }
 
@@ -267,12 +303,49 @@ int main(int argc, char** argv)
       uf.cnf_effort = UF::CNF_EFFORT_HIGH;
     else if (cfg.cnf == "very-high")
       uf.cnf_effort = UF::CNF_EFFORT_VERY_HIGH;
+    else if (cfg.cnf == "new-very-low")
+      uf.cnf_effort = UF::CNF_EFFORT_NEW_VERY_LOW;
+    else if (cfg.cnf == "new-low")
+      uf.cnf_effort = UF::CNF_EFFORT_NEW_LOW;
+    else if (cfg.cnf == "new-medium")
+      uf.cnf_effort = UF::CNF_EFFORT_NEW_MEDIUM;
+    else if (cfg.cnf == "gia-low")
+      uf.cnf_effort = UF::CNF_EFFORT_GIA_LOW;
+    else if (cfg.cnf == "gia-high")
+      uf.cnf_effort = UF::CNF_EFFORT_GIA_HIGH;
+    else if (cfg.cnf == "gia-very-high")
+      uf.cnf_effort = UF::CNF_EFFORT_GIA_VERY_HIGH;
     else
     {
       std::cerr << "propagator_bench: unknown --cnf value '" << cfg.cnf
-                << "' (simple, very-low, low, medium, high, very-high)\n";
+                << "' (simple, very-low, low, medium, high, very-high, "
+                   "new-very-low, new-low, new-medium, gia-low, gia-high, "
+                   "gia-very-high)\n";
       return 1;
     }
+  }
+
+  if (cfg.adderVariant >= 0)
+    mgr->UserFlags.adder_variant = cfg.adderVariant != 0;
+  if (cfg.bvplusVariant >= 0)
+    mgr->UserFlags.bvplus_variant = cfg.bvplusVariant != 0;
+
+  if (!cfg.dumpCnf.empty())
+  {
+    if (cfg.ops.size() != 1 || !bcpAvailable())
+    {
+      std::cerr << "propagator_bench: --dump-cnf needs exactly one --ops "
+                   "operation and a CryptoMiniSat build\n";
+      return 1;
+    }
+    if (!dumpEncoding(mgr, *findOp(cfg.ops[0]), cfg, cfg.dumpCnf))
+    {
+      std::cerr << "propagator_bench: could not encode " << cfg.ops[0]
+                << " at width " << cfg.dumpWidth << "\n";
+      return 1;
+    }
+    std::cout << "wrote " << cfg.dumpCnf << std::endl;
+    return 0;
   }
 
   vector<Row> rows;


### PR DESCRIPTION
Two pieces, one motivating the other.

## Measuring: propagator_bench --consistency

A new check grades one operation's bit-blasted CNF on the propagation ladder, each rung with a distance rather than just a verdict:

- **URC**: unit propagation refutes every inconsistent partial assignment of the input/output bits (misses histogrammed by how many bits were unset — a miss with 2 unset is much worse than one with 8).
- **GAC**: URC, plus every implied input/output literal derived (reported as % of implied literals).
- **PC**: both, quantified over every CNF variable, auxiliaries included; exhaustive when 3^vars fits a cap, sampled past it (a sample can prove PC absent, never present).

It propagates the clauses itself against a solution table (one bitset column per variable), so it affords millions of cases where the existing solver-per-case check could not. `--cnf` now accepts the new-* and gia-* levels, `--bb.add-v1`/`--bb.add-v2` select the adder variants, and `--dump-cnf` writes the encoding as DIMACS with an input/output variable map. `BBPlus2` now honours `adder_variant`, so the ripple chain can build the majority-carry full adder too (previously the flag reached only the addition network).

What it found for bvadd at width 3: every cut-mapped CNF level misses 12 of 6,636 contradictory partial assignments (some with only 3 bits unset) and derives 92.3% of implied literals, from either adder form — clause-count cut selection canonicalises away the structure that carried the propagation. The unmapped levels are conflict-propagating with the default shared-half-adder form (and not with the majority form), but still not arc-consistent, and the gap widens with width: at width 4 the mapped levels miss up to 1,448 conflicts while the unmapped ones miss none.

## Fixing: full-adder recovery in the Tseitin writer

The coupling implicates of a full adder span both outputs (from sum = 0 and carry-out = 0 all three operands are forced), so no per-gate or single-output-cut derivation can emit them. The writer's pattern recovery now recognises the full-adder cone — a descending pass files carry-shaped nodes, the sum tower claims them, and an eight-row truth-table evaluation over the closed seven-node cone confirms the match, so a polarity surprise fails the match rather than miscoding — and emits the relation's unique minimum propagation-complete clause set: the twelve ternary prime implicates plus the two extreme parity clauses, fourteen clauses over operands, sum and carry. The five interiors get no variables, which requires their reference counts to be exactly the private cone's (1,2,2,1,2); anything shared, and any cone whose sum or carry never comes live, keeps the plain encoding.

Results (new-medium):

| | before | after |
|---|---|---|
| bvadd w=3 | URC yes, 99.1% implied literals, 55 clauses | URC yes, **100.0%**, **48 clauses** |
| bvadd w=2, PC over all variables (exhaustive) | no | **yes** |
| bvadd w=64 | 1,641 clauses / 696 vars | **1,207 / 386** |
| bvsub | inherits | inherits (100.0%) |
| bvmul | 92.3% | 94.4% (its internal adders recover) |

On CaDiCaL 3.0.1 at width 64, on workloads composed at the DIMACS level: partial-assignment probes solve by propagation alone (zero conflicts, was 37–124 for the mapped levels), and the four-adder associativity miter drops from 7.5M to 1.3M ticks (37.6k to 8.8k conflicts) — the fastest of every configuration measured, stable under CNF scrambling.

## Validation

- New unit tests: the cone is checked exact from every input assignment (contradictions included), the fourteen-clause count and variable count are pinned, a ripple chain recovers every interior adder, and a shared interior declines the block.
- The independent CryptoMiniSat-based `--bcp-exhaustive` check agrees with the new engine everywhere, and reports bvadd arc-consistent at width 3 (19,683/19,683 cases) — the first configuration to pass it.
- Verdicts are unchanged on all 880 files of the query corpus, comparing this level against medium.