### PR TITLE
Emit propagation complete comparisons from CNF generator

### DIFF
--- a/include/stp/AIG/Tseitin.h
+++ b/include/stp/AIG/Tseitin.h
@@ -56,6 +56,20 @@ namespace aig
 // isAnd() has agreed, so c, t and e always name real nodes.
 bool matchIte(const Manager& m, Node n, Lit& c, Lit& t, Lit& e);
 
+// Is node `n` an if-then-else whose condition is an exclusive-or that shares
+// a node with one of the arms? Selecting between an arm and a literal the
+// condition already relates collapses the pair of gates to one three-literal
+// majority: n = maj(x, y, z). The borrow chain the comparators blast into is
+// made of exactly this cell. Structural only -- whether the condition's
+// nodes are private to `n` is the caller's to establish.
+bool matchMajority(const Manager& m, Node n, Lit& x, Lit& y, Lit& z);
+
+// Is node `n` an AND reading an exclusive-or against one of the
+// exclusive-or's own operands? Fixing the shared operand fixes what the
+// exclusive-or contributes, so the node is a plain two-literal conjunction
+// over the operands: n = g & h. Structural only, as matchMajority is.
+bool matchXorAnd(const Manager& m, Node n, Lit& g, Lit& h);
+
 // The leaves of the maximal AND rooted at `n`, appended to `into`.
 //
 // An AIG has no OR node: `a | b` is `!(!a & !b)`, one AND with the
@@ -114,6 +128,20 @@ public:
     return (pattern_[n >> 6] >> (n & 63)) & 1u;
   }
 
+  // A comparator/borrow cell: an ITE over a private exclusive-or that one
+  // arm shares a node with, encoded as the six prime implicates of the
+  // three-literal majority it computes. The exclusive-or and all four
+  // intermediates get no variables.
+  bool majorityCell(Node n) const
+  {
+    return (majority_[n >> 6] >> (n & 63)) & 1u;
+  }
+
+  // An AND over a private exclusive-or and one of its operands, collapsed
+  // to the two-literal conjunction it computes. The exclusive-or and its
+  // intermediates get no variables.
+  bool xorAnd(Node n) const { return (xorAnd_[n >> 6] >> (n & 63)) & 1u; }
+
   // A recovered full adder: sum and carry defined together by one fourteen-
   // clause block over the operands -- the minimum propagation-complete
   // clause set for the relation, which the per-gate encodings are not. The
@@ -158,6 +186,8 @@ public:
 private:
   void setLive(Node n) { live_[n >> 6] |= 1ull << (n & 63); }
   void setPatterned(Node n) { pattern_[n >> 6] |= 1ull << (n & 63); }
+  void setMajority(Node n) { majority_[n >> 6] |= 1ull << (n & 63); }
+  void setXorAnd(Node n) { xorAnd_[n >> 6] |= 1ull << (n & 63); }
   void setAbsorbed(Node n) { absorbed_[n >> 6] |= 1ull << (n & 63); }
   void setFaSum(Node n) { faSum_[n >> 6] |= 1ull << (n & 63); }
   void setFaCarry(Node n) { faCarry_[n >> 6] |= 1ull << (n & 63); }
@@ -166,6 +196,8 @@ private:
 
   std::vector<uint64_t> live_;
   std::vector<uint64_t> pattern_;
+  std::vector<uint64_t> majority_;
+  std::vector<uint64_t> xorAnd_;
   std::vector<uint64_t> absorbed_;
   std::vector<uint64_t> faSum_;
   std::vector<uint64_t> faCarry_;
@@ -263,7 +295,32 @@ void writeTseitin(const Manager& m, const Cone& cone, Sink& sink)
       continue;
     }
 
-    if (cone.patterned(n))
+    if (cone.majorityCell(n))
+    {
+      Lit x, y, z;
+      const bool matched = matchMajority(m, n, x, y, z);
+      assert(matched);
+      (void)matched;
+      const int lx = cnfLit(x), ly = cnfLit(y), lz = cnfLit(z);
+      sink.clause(px, lx ^ 1, ly ^ 1);
+      sink.clause(px, lx ^ 1, lz ^ 1);
+      sink.clause(px, ly ^ 1, lz ^ 1);
+      sink.clause(nx, lx, ly);
+      sink.clause(nx, lx, lz);
+      sink.clause(nx, ly, lz);
+    }
+    else if (cone.xorAnd(n))
+    {
+      Lit g, h;
+      const bool matched = matchXorAnd(m, n, g, h);
+      assert(matched);
+      (void)matched;
+      const int lg = cnfLit(g), lh = cnfLit(h);
+      sink.clause(nx, lg);
+      sink.clause(nx, lh);
+      sink.clause(px, lg ^ 1, lh ^ 1);
+    }
+    else if (cone.patterned(n))
     {
       Lit c, t, e;
       const bool matched = matchIte(m, n, c, t, e);

--- a/lib/AIG/Tseitin.cpp
+++ b/lib/AIG/Tseitin.cpp
@@ -160,6 +160,85 @@ bool verifyFullAdder(const Manager& m, Lit la, Lit lb, Lit lc, Node sum,
 
 } // namespace
 
+bool matchMajority(const Manager& m, Node n, Lit& x, Lit& y, Lit& z)
+{
+  Lit c, t, e;
+  if (!matchIte(m, n, c, t, e))
+    return false;
+  Node p, q;
+  if (!xorShape(m, nodeOf(c), p, q))
+    return false;
+
+  // The exclusive-or computes u xor v over its grandchild literals, so read
+  // through the edge `c` the condition is u == w.
+  const Lit u = m.fanin0(p);
+  const Lit v = m.fanin1(p);
+  const Lit w = isNeg(c) ? v : neg(v);
+
+  // n = (u == w) ? t : e. When an arm is a literal of u's or w's node the
+  // selection collapses: agreeing arms are the majority's two aligned
+  // inputs, the remaining arm is its third.
+  if (e == w || e == neg(u))
+  {
+    x = neg(u);
+    y = w;
+    z = t;
+  }
+  else if (e == u || e == neg(w))
+  {
+    x = u;
+    y = neg(w);
+    z = t;
+  }
+  else if (t == u || t == w)
+  {
+    x = u;
+    y = w;
+    z = e;
+  }
+  else if (t == neg(u) || t == neg(w))
+  {
+    x = neg(u);
+    y = neg(w);
+    z = e;
+  }
+  else
+    return false;
+  return true;
+}
+
+bool matchXorAnd(const Manager& m, Node n, Lit& g, Lit& h)
+{
+  if (!m.isAnd(n))
+    return false;
+  for (int side = 0; side < 2; side++)
+  {
+    const Lit fx = side ? m.fanin1(n) : m.fanin0(n);
+    const Lit fg = side ? m.fanin0(n) : m.fanin1(n);
+    Node p, q;
+    if (!xorShape(m, nodeOf(fx), p, q))
+      continue;
+    const Lit u = m.fanin0(p);
+    const Lit v = m.fanin1(p);
+    const Node gn = nodeOf(fg);
+    // n = (u xor v, read through fx) & fg. With fg on u's node the
+    // exclusive-or contributes only v's polarity, and symmetrically.
+    if (gn == nodeOf(u))
+    {
+      g = fg;
+      h = (!isNeg(fx) == (fg == u)) ? neg(v) : v;
+      return true;
+    }
+    if (gn == nodeOf(v))
+    {
+      g = fg;
+      h = (!isNeg(fx) == (fg == v)) ? neg(u) : u;
+      return true;
+    }
+  }
+  return false;
+}
+
 void collectAndLeaves(const Manager& m, Node n,
                       const std::vector<uint64_t>& absorbed,
                       std::vector<Lit>& into, std::vector<Lit>& stack)
@@ -307,6 +386,8 @@ Cone::Cone(const Manager& m, unsigned namedOutputs, Recover recover)
   const size_t words = static_cast<size_t>((nNodes + 63) / 64);
   live_.assign(words, 0);
   pattern_.assign(words, 0);
+  majority_.assign(words, 0);
+  xorAnd_.assign(words, 0);
   absorbed_.assign(words, 0);
   faSum_.assign(words, 0);
   faCarry_.assign(words, 0);
@@ -369,6 +450,20 @@ Cone::Cone(const Manager& m, unsigned namedOutputs, Recover recover)
            matchIte(m, x, c, t, e);
   };
 
+  // An AND reading a private exclusive-or against one of the exclusive-or's
+  // own operands is a two-literal conjunction over the operands; the
+  // exclusive-or and its intermediates get no variables. The comparators'
+  // borrow chains bottom out in exactly this gate.
+  const auto wouldXorAnd = [&](Node x) {
+    Lit g, h;
+    if (!matchPatterns || !m.isAnd(x) || faMember(x) ||
+        !matchXorAnd(m, x, g, h))
+      return false;
+    const Lit f0 = m.fanin0(x);
+    const Node xn = nodeOf(g == f0 ? m.fanin1(x) : f0);
+    return refs[xn] == 1 && !faMember(xn);
+  };
+
   for (Node n = static_cast<Node>(nNodes); n-- > 1;)
   {
     if (!live(n) || !m.isAnd(n))
@@ -406,10 +501,38 @@ Cone::Cone(const Manager& m, unsigned namedOutputs, Recover recover)
       const bool matched = matchIte(m, n, c, t, e);
       assert(matched);
       (void)matched;
+
+      // The majority upgrade needs the exclusive-or private to this cell:
+      // its two references are the cell's own, so it dies with the cell and
+      // the majority block replaces both gates.
+      const Node cn = nodeOf(c);
+      Lit x, y, z;
+      if (m.isAnd(cn) && refs[cn] == 2 && !faMember(cn) &&
+          matchMajority(m, n, x, y, z))
+      {
+        setMajority(n);
+        setLive(nodeOf(x));
+        setLive(nodeOf(y));
+        setLive(nodeOf(z));
+        continue;
+      }
+
       setPatterned(n);
       setLive(nodeOf(c));
       setLive(nodeOf(t));
       setLive(nodeOf(e));
+      continue;
+    }
+
+    if (wouldXorAnd(n))
+    {
+      Lit g, h;
+      const bool matched = matchXorAnd(m, n, g, h);
+      assert(matched);
+      (void)matched;
+      setXorAnd(n);
+      setLive(nodeOf(g));
+      setLive(nodeOf(h));
       continue;
     }
 
@@ -423,7 +546,7 @@ Cone::Cone(const Manager& m, unsigned namedOutputs, Recover recover)
       const Node x = nodeOf(f);
       setLive(x);
       if (collapseAnds && !isNeg(f) && m.isAnd(x) && refs[x] == 1 &&
-          !faMember(x) && !wouldPattern(x))
+          !faMember(x) && !wouldPattern(x) && !wouldXorAnd(x))
         setAbsorbed(x);
     }
   }
@@ -443,6 +566,18 @@ Cone::Cone(const Manager& m, unsigned namedOutputs, Recover recover)
     {
       nClauses_ += 14;
       nLiterals_ += 44;
+      continue;
+    }
+    if (majorityCell(n))
+    {
+      nClauses_ += 6;
+      nLiterals_ += 18;
+      continue;
+    }
+    if (xorAnd(n))
+    {
+      nClauses_ += 3;
+      nLiterals_ += 7;
       continue;
     }
     if (patterned(n))

--- a/tests/unit-tests/Tseitin_Test.cpp
+++ b/tests/unit-tests/Tseitin_Test.cpp
@@ -177,13 +177,16 @@ void buildRandom(aig::Manager& m, std::mt19937& rng, unsigned nCi,
       return (rng() & 1) ? aig::neg(l) : l;
     };
     const unsigned which = rng() % 100;
+    // Sequenced: an argument list would draw them in whatever order the
+    // compiler evaluates it, and the circuits must not depend on that.
+    const aig::Lit p0 = pick(), p1 = pick(), p2 = pick();
     aig::Lit r;
     if (which < 25)
-      r = m.Xor(pick(), pick());
+      r = m.Xor(p0, p1);
     else if (which < 40)
-      r = m.Mux(pick(), pick(), pick());
+      r = m.Mux(p0, p1, p2);
     else
-      r = m.And(pick(), pick());
+      r = m.And(p0, p1);
     if (!aig::isConst(r))
       pool.push_back(r);
   }
@@ -342,6 +345,61 @@ TEST(Tseitin, MuxCostsFourClausesInsteadOfNine)
   EXPECT_EQ(folded.clauseCount(), 6u);
   EXPECT_EQ(folded.literalCount(), 16u);
   EXPECT_EQ(folded.varCount(), 1u + 3u + 1u + 1u);
+}
+
+// A MUX selecting between an arm and an operand of its own exclusive-or
+// condition -- the comparators' borrow cell -- is a three-literal majority:
+// one variable, its six prime implicates, and the exclusive-or vanishes.
+TEST(Tseitin, ComparatorCellBecomesTheMajorityBlock)
+{
+  aig::Manager m;
+  const aig::Lit l = m.createCi(), r = m.createCi(), prev = m.createCi();
+  m.createOutput(m.Mux(aig::neg(m.Xor(r, l)), prev, r));
+  ASSERT_EQ(m.andCount(), 6u);
+
+  const CNF folded = aig::deriveTseitin(m, 1, aig::Recover::PatternsAndAnds);
+  EXPECT_EQ(folded.clauseCount(), 6u + 2u);
+  EXPECT_EQ(folded.literalCount(), 18u + 4u);
+  EXPECT_EQ(folded.varCount(), 1u + 3u + 1u + 1u);
+
+  ASSERT_NO_FATAL_FAILURE(checkExact(m, 1, aig::Recover::PatternsAndAnds));
+}
+
+// The chain's bottom cell folds to an AND reading an exclusive-or against
+// one of the exclusive-or's own operands, which is the two-literal
+// conjunction the exclusive-or's other operand decides.
+TEST(Tseitin, XorAgainstItsOwnOperandCollapses)
+{
+  aig::Manager m;
+  const aig::Lit a = m.createCi(), b = m.createCi();
+  m.createOutput(m.And(m.Xor(a, b), a)); // = a & !b
+  ASSERT_EQ(m.andCount(), 4u);
+
+  const CNF folded = aig::deriveTseitin(m, 1, aig::Recover::PatternsAndAnds);
+  EXPECT_EQ(folded.clauseCount(), 3u + 2u);
+  EXPECT_EQ(folded.literalCount(), 7u + 4u);
+  EXPECT_EQ(folded.varCount(), 1u + 2u + 1u + 1u);
+
+  ASSERT_NO_FATAL_FAILURE(checkExact(m, 1, aig::Recover::PatternsAndAnds));
+}
+
+// The guard on both collapses: an exclusive-or something else also reads
+// keeps its variable, and the cell must fall back to the ordinary pattern.
+TEST(Tseitin, SharedConditionDeclinesTheMajorityBlock)
+{
+  aig::Manager m;
+  const aig::Lit l = m.createCi(), r = m.createCi(), prev = m.createCi();
+  const aig::Lit eq = aig::neg(m.Xor(r, l));
+  m.createOutput(m.Mux(eq, prev, r));
+  m.createOutput(eq);
+
+  const CNF folded = aig::deriveTseitin(m, 2, aig::Recover::PatternsAndAnds);
+  // An ITE block over the live exclusive-or, the exclusive-or's own block,
+  // and two tie clauses per named output.
+  EXPECT_EQ(folded.clauseCount(), 4u + 4u + 4u);
+  EXPECT_EQ(folded.varCount(), 1u + 3u + 2u + 2u);
+
+  ASSERT_NO_FATAL_FAILURE(checkExact(m, 2, aig::Recover::PatternsAndAnds));
 }
 
 // Exclusive-or is the same shape with a second complementary pair, and gets


### PR DESCRIPTION
First of three stacked changes splitting the earlier single review into its decision units; this one is the strict win. Follow-up to #1070: the same graded propagation measurement (`propagator_bench --consistency`), applied to every simple operation the blaster produces, showed the comparisons were the weak spot in the in-house Tseitin writer's output: bvult graded unit-refutation-broken (17/330 conflicts missed at width 3, some with only two bits unset, 57.6% of implied literals derived). The recoveries here apply to the new-low and new-medium rungs.

The borrow chain the comparisons blast into pairs each private equality with an if-then-else that selects between the chain and one of the equality's own operands; the pair computes a three-literal majority. Emitting the majority's six prime implicates in place of the two gates removes the equality's variable and clauses, and the chain's bottom cell collapses the same way to a two-literal conjunction. bvult/bvule/bvslt/bvsle/bvsgt/bvsge become propagation-complete, verified exhaustively over every CNF variable at widths 3–4 — while shrinking: 20 clauses/11 variables at width 3 against 28/14 before, 386/194 at width 64 against 516/258.

The six-clause cell is exactly optimal: the cell relation's minimum propagation-complete subset, computed exactly, is all six of its prime implicates, and its minimum unit-refutation-complete subset is the same six. Wider windows cost more per bit (14 clauses per two bits, 30 per three), aux-free encodings double their prime count per bit, and the divide-and-conquer layout stays short of propagation completeness at width 4 even with every block given all of its primes (790/9138 implied literals underivable) while being four times the size — this chain is the floor, not a local improvement.

Both recoveries fire only when the equality is private to the collapsed gate; a shared one declines to the ordinary patterns here, and the next change in the stack upgrades that case. The random-circuit tests also stop drawing operands inside argument lists, whose evaluation order the compiler chooses, so every toolchain tests the same circuits.

Verification: unit tests for both blocks and the decline guards, each checked exact over every input; a 208-file differential at new-medium is answer-identical; the graded consistency sweep is unchanged outside the comparator cones.
