### PR TITLE
Keep comparator cells propagation-complete when their equality is shared

### DIFF
--- a/include/stp/AIG/Tseitin.h
+++ b/include/stp/AIG/Tseitin.h
@@ -70,6 +70,17 @@ bool matchMajority(const Manager& m, Node n, Lit& x, Lit& y, Lit& z);
 // over the operands: n = g & h. Structural only, as matchMajority is.
 bool matchXorAnd(const Manager& m, Node n, Lit& g, Lit& h);
 
+// The same two cells for a condition that stays live because something else
+// reads it. matchJointCell normalizes an ITE cell to the study templates
+// over (a, b, e, other, out) with e == (a == b): tSide false means
+// out = e ? other : b (the borrow-chain cell), true means out = e ? a :
+// other. matchXorAndJoint normalizes the bottom cell to out = !e & b.
+// Both verify the claim by evaluating the cone over every operand
+// assignment, so a polarity surprise declines instead of miscoding.
+bool matchJointCell(const Manager& m, Node n, Lit& a, Lit& b, Lit& e,
+                    Lit& other, bool& tSide);
+bool matchXorAndJoint(const Manager& m, Node n, Lit& a, Lit& b, Lit& e);
+
 // The leaves of the maximal AND rooted at `n`, appended to `into`.
 //
 // An AIG has no OR node: `a | b` is `!(!a & !b)`, one AND with the
@@ -142,6 +153,19 @@ public:
   // intermediates get no variables.
   bool xorAnd(Node n) const { return (xorAnd_[n >> 6] >> (n & 63)) & 1u; }
 
+  // The same two cells when the exclusive-or is shared: it keeps its
+  // variable and its own definition, and the cell emits the minimum linking
+  // clauses that keep the window propagation-complete with the equality
+  // inside it -- ten for the full cell, five for the bottom.
+  bool majorityLink(Node n) const
+  {
+    return (majorityLink_[n >> 6] >> (n & 63)) & 1u;
+  }
+  bool xorAndLink(Node n) const
+  {
+    return (xorAndLink_[n >> 6] >> (n & 63)) & 1u;
+  }
+
   // A recovered full adder: sum and carry defined together by one fourteen-
   // clause block over the operands -- the minimum propagation-complete
   // clause set for the relation, which the per-gate encodings are not. The
@@ -187,7 +211,9 @@ private:
   void setLive(Node n) { live_[n >> 6] |= 1ull << (n & 63); }
   void setPatterned(Node n) { pattern_[n >> 6] |= 1ull << (n & 63); }
   void setMajority(Node n) { majority_[n >> 6] |= 1ull << (n & 63); }
+  void setMajorityLink(Node n) { majorityLink_[n >> 6] |= 1ull << (n & 63); }
   void setXorAnd(Node n) { xorAnd_[n >> 6] |= 1ull << (n & 63); }
+  void setXorAndLink(Node n) { xorAndLink_[n >> 6] |= 1ull << (n & 63); }
   void setAbsorbed(Node n) { absorbed_[n >> 6] |= 1ull << (n & 63); }
   void setFaSum(Node n) { faSum_[n >> 6] |= 1ull << (n & 63); }
   void setFaCarry(Node n) { faCarry_[n >> 6] |= 1ull << (n & 63); }
@@ -197,7 +223,9 @@ private:
   std::vector<uint64_t> live_;
   std::vector<uint64_t> pattern_;
   std::vector<uint64_t> majority_;
+  std::vector<uint64_t> majorityLink_;
   std::vector<uint64_t> xorAnd_;
+  std::vector<uint64_t> xorAndLink_;
   std::vector<uint64_t> absorbed_;
   std::vector<uint64_t> faSum_;
   std::vector<uint64_t> faCarry_;
@@ -309,6 +337,36 @@ void writeTseitin(const Manager& m, const Cone& cone, Sink& sink)
       sink.clause(nx, lx, lz);
       sink.clause(nx, ly, lz);
     }
+    else if (cone.majorityLink(n))
+    {
+      Lit a, b, e, other;
+      bool tSide;
+      const bool matched = matchJointCell(m, n, a, b, e, other, tSide);
+      assert(matched);
+      (void)matched;
+      // The minimum linking sets from the comparator study: with the
+      // exclusive-or's own four clauses alongside (its patterned emission),
+      // the window over (a, b, e, other, out) is propagation-complete.
+      static const int8_t ESIDE[10][3] = {
+          {-3, -4, 5}, {-3, 4, -5}, {-2, -4, 5}, {-1, 3, -5}, {-1, 4, -5},
+          {1, -4, 5},  {1, -2, 5},  {1, 3, 5},   {2, 3, -5},  {2, 4, -5}};
+      static const int8_t TSIDE[10][3] = {
+          {-2, -4, 5}, {-1, -4, 5}, {-1, -3, 5}, {-1, -2, 5}, {1, 2, -5},
+          {1, 4, -5},  {2, -3, -5}, {2, 4, -5},  {3, -4, 5},  {3, 4, -5}};
+      const int base[6] = {0, cnfLit(a), cnfLit(b), cnfLit(e), cnfLit(other),
+                           px};
+      const int8_t(*tpl)[3] = tSide ? TSIDE : ESIDE;
+      for (int i = 0; i < 10; i++)
+      {
+        int lits[3];
+        for (int j = 0; j < 3; j++)
+        {
+          const int t = tpl[i][j];
+          lits[j] = base[t < 0 ? -t : t] ^ (t < 0 ? 1 : 0);
+        }
+        sink.clause(lits[0], lits[1], lits[2]);
+      }
+    }
     else if (cone.xorAnd(n))
     {
       Lit g, h;
@@ -319,6 +377,19 @@ void writeTseitin(const Manager& m, const Cone& cone, Sink& sink)
       sink.clause(nx, lg);
       sink.clause(nx, lh);
       sink.clause(px, lg ^ 1, lh ^ 1);
+    }
+    else if (cone.xorAndLink(n))
+    {
+      Lit a, b, e;
+      const bool matched = matchXorAndJoint(m, n, a, b, e);
+      assert(matched);
+      (void)matched;
+      const int la = cnfLit(a), lb = cnfLit(b), le = cnfLit(e);
+      sink.clause(le ^ 1, nx);
+      sink.clause(la ^ 1, nx);
+      sink.clause(lb, nx);
+      sink.clause(la, lb ^ 1, px);
+      sink.clause(la, le, px);
     }
     else if (cone.patterned(n))
     {

--- a/lib/AIG/Tseitin.cpp
+++ b/lib/AIG/Tseitin.cpp
@@ -239,6 +239,155 @@ bool matchXorAnd(const Manager& m, Node n, Lit& g, Lit& h)
   return false;
 }
 
+namespace
+{
+
+// Evaluates a cell's cone from leaf nodes, refusing to step outside
+// `allowed` -- the discipline verifyFullAdder applies. A leaf that aliases
+// another leaf reads the first one's value, which makes the verification
+// fail closed on degenerate shapes.
+struct CellEval
+{
+  const Manager& m;
+  const Node* allowed;
+  unsigned nAllowed;
+  const Node* leaf;
+  const bool* val;
+  unsigned nLeaf;
+  int depth = 0;
+  bool ok = true;
+
+  bool node(Node x)
+  {
+    for (unsigned i = 0; i < nLeaf; i++)
+      if (x == leaf[i])
+        return val[i];
+    if (++depth > 16)
+    {
+      ok = false;
+      return false;
+    }
+    bool inCone = false;
+    for (unsigned i = 0; i < nAllowed && !inCone; i++)
+      inCone = allowed[i] == x;
+    if (!inCone || !m.isAnd(x))
+    {
+      ok = false;
+      return false;
+    }
+    const bool r = lit(m.fanin0(x)) && lit(m.fanin1(x));
+    --depth;
+    return r;
+  }
+  bool lit(Lit l) { return node(nodeOf(l)) != isNeg(l); }
+};
+
+} // namespace
+
+bool matchJointCell(const Manager& m, Node n, Lit& a, Lit& b, Lit& e,
+                    Lit& other, bool& tSide)
+{
+  Lit c, t, el;
+  if (!matchIte(m, n, c, t, el))
+    return false;
+  Node p, q;
+  if (!xorShape(m, nodeOf(c), p, q))
+    return false;
+  const Lit u = m.fanin0(p);
+  const Lit v = m.fanin1(p);
+
+  // The edge of the condition node that is true when u and v agree, and the
+  // arms as that edge selects them.
+  e = litOf(nodeOf(c), true);
+  Lit onEq = t, onNeq = el;
+  if (!isNeg(c))
+    std::swap(onEq, onNeq);
+
+  if (onNeq == v || onNeq == neg(v) || onNeq == u || onNeq == neg(u))
+  {
+    // out = e ? other : b -- the borrow-chain cell.
+    tSide = false;
+    b = onNeq;
+    a = (onNeq == v) ? u : (onNeq == neg(v)) ? neg(u)
+        : (onNeq == u) ? v : neg(v);
+    other = onEq;
+  }
+  else if (onEq == u || onEq == neg(u) || onEq == v || onEq == neg(v))
+  {
+    // out = e ? a : other -- the agreeing arm is an operand.
+    tSide = true;
+    a = onEq;
+    b = (onEq == u) ? v : (onEq == neg(u)) ? neg(v)
+        : (onEq == v) ? u : neg(u);
+    other = onNeq;
+  }
+  else
+    return false;
+
+  // The structural match proposes; the evaluation disposes, over every
+  // assignment of the three operand nodes.
+  const Node allowed[6] = {n, nodeOf(m.fanin0(n)), nodeOf(m.fanin1(n)),
+                           nodeOf(c), p, q};
+  const Node leaves[3] = {nodeOf(a), nodeOf(b), nodeOf(other)};
+  for (unsigned bits = 0; bits < 8; bits++)
+  {
+    const bool vals[3] = {(bits & 1) != 0, (bits & 2) != 0, (bits & 4) != 0};
+    CellEval ev{m, allowed, 6, leaves, vals, 3};
+    const bool A = vals[0] != isNeg(a);
+    const bool B = vals[1] != isNeg(b);
+    const bool O = vals[2] != isNeg(other);
+    const bool E = (A == B);
+    const bool want = tSide ? (E ? A : O) : (E ? O : B);
+    if (ev.node(n) != want || ev.lit(e) != E || !ev.ok)
+      return false;
+  }
+  return true;
+}
+
+bool matchXorAndJoint(const Manager& m, Node n, Lit& a, Lit& b, Lit& e)
+{
+  if (!m.isAnd(n))
+    return false;
+  for (int side = 0; side < 2; side++)
+  {
+    const Lit fx = side ? m.fanin1(n) : m.fanin0(n);
+    const Lit fg = side ? m.fanin0(n) : m.fanin1(n);
+    Node p, q;
+    if (!xorShape(m, nodeOf(fx), p, q))
+      continue;
+    const Lit u = m.fanin0(p);
+    const Lit v = m.fanin1(p);
+    const Node gn = nodeOf(fg);
+    if (gn != nodeOf(u) && gn != nodeOf(v))
+      continue;
+    // Template: out = !e & b with e == (a == b). A positive read of the
+    // exclusive-or is the disagreeing case, so e is its complement edge.
+    e = litOf(nodeOf(fx), !isNeg(fx));
+    b = fg;
+    const bool agree = !isNeg(fx); // e true <=> u == v
+    if (gn == nodeOf(u))
+      a = ((fg == u) == agree) ? v : neg(v);
+    else
+      a = ((fg == v) == agree) ? u : neg(u);
+
+    const Node allowed[4] = {n, nodeOf(fx), p, q};
+    const Node leaves[2] = {nodeOf(a), nodeOf(b)};
+    bool verified = true;
+    for (unsigned bits = 0; bits < 4 && verified; bits++)
+    {
+      const bool vals[2] = {(bits & 1) != 0, (bits & 2) != 0};
+      CellEval ev{m, allowed, 4, leaves, vals, 2};
+      const bool A = vals[0] != isNeg(a);
+      const bool B = vals[1] != isNeg(b);
+      const bool E = (A == B);
+      verified = ev.node(n) == (!E && B) && ev.lit(e) == E && ev.ok;
+    }
+    if (verified)
+      return true;
+  }
+  return false;
+}
+
 void collectAndLeaves(const Manager& m, Node n,
                       const std::vector<uint64_t>& absorbed,
                       std::vector<Lit>& into, std::vector<Lit>& stack)
@@ -387,7 +536,9 @@ Cone::Cone(const Manager& m, unsigned namedOutputs, Recover recover)
   live_.assign(words, 0);
   pattern_.assign(words, 0);
   majority_.assign(words, 0);
+  majorityLink_.assign(words, 0);
   xorAnd_.assign(words, 0);
+  xorAndLink_.assign(words, 0);
   absorbed_.assign(words, 0);
   faSum_.assign(words, 0);
   faCarry_.assign(words, 0);
@@ -450,18 +601,23 @@ Cone::Cone(const Manager& m, unsigned namedOutputs, Recover recover)
            matchIte(m, x, c, t, e);
   };
 
-  // An AND reading a private exclusive-or against one of the exclusive-or's
-  // own operands is a two-literal conjunction over the operands; the
-  // exclusive-or and its intermediates get no variables. The comparators'
-  // borrow chains bottom out in exactly this gate.
-  const auto wouldXorAnd = [&](Node x) {
-    Lit g, h;
+  // An AND reading an exclusive-or against one of the exclusive-or's own
+  // operands is a two-literal conjunction over the operands. The
+  // comparators' borrow chains bottom out in exactly this gate. A private
+  // exclusive-or dies with it; a shared one stays, and the gate emits the
+  // linking clauses instead.
+  const auto xorAndMatch = [&](Node x, Lit& g, Lit& h, Node& xn) {
     if (!matchPatterns || !m.isAnd(x) || faMember(x) ||
         !matchXorAnd(m, x, g, h))
       return false;
     const Lit f0 = m.fanin0(x);
-    const Node xn = nodeOf(g == f0 ? m.fanin1(x) : f0);
-    return refs[xn] == 1 && !faMember(xn);
+    xn = nodeOf(g == f0 ? m.fanin1(x) : f0);
+    return !faMember(xn);
+  };
+  const auto wouldXorAnd = [&](Node x) {
+    Lit g, h;
+    Node xn;
+    return xorAndMatch(x, g, h, xn);
   };
 
   for (Node n = static_cast<Node>(nNodes); n-- > 1;)
@@ -502,19 +658,34 @@ Cone::Cone(const Manager& m, unsigned namedOutputs, Recover recover)
       assert(matched);
       (void)matched;
 
-      // The majority upgrade needs the exclusive-or private to this cell:
-      // its two references are the cell's own, so it dies with the cell and
-      // the majority block replaces both gates.
       const Node cn = nodeOf(c);
-      Lit x, y, z;
-      if (m.isAnd(cn) && refs[cn] == 2 && !faMember(cn) &&
-          matchMajority(m, n, x, y, z))
+      if (m.isAnd(cn) && !faMember(cn))
       {
-        setMajority(n);
-        setLive(nodeOf(x));
-        setLive(nodeOf(y));
-        setLive(nodeOf(z));
-        continue;
+        // A private exclusive-or condition (its two references are the
+        // cell's own) dies with the cell: the majority block replaces both
+        // gates. A shared one keeps its variable and its own definition,
+        // and the cell instead adds the linking clauses that keep the
+        // window propagation-complete with the equality inside it.
+        Lit x, y, z;
+        if (refs[cn] == 2 && matchMajority(m, n, x, y, z))
+        {
+          setMajority(n);
+          setLive(nodeOf(x));
+          setLive(nodeOf(y));
+          setLive(nodeOf(z));
+          continue;
+        }
+        Lit a, b, e2, other;
+        bool tSide;
+        if (refs[cn] > 2 && matchJointCell(m, n, a, b, e2, other, tSide))
+        {
+          setMajorityLink(n);
+          setLive(nodeOf(a));
+          setLive(nodeOf(b));
+          setLive(cn);
+          setLive(nodeOf(other));
+          continue;
+        }
       }
 
       setPatterned(n);
@@ -524,16 +695,28 @@ Cone::Cone(const Manager& m, unsigned namedOutputs, Recover recover)
       continue;
     }
 
-    if (wouldXorAnd(n))
     {
       Lit g, h;
-      const bool matched = matchXorAnd(m, n, g, h);
-      assert(matched);
-      (void)matched;
-      setXorAnd(n);
-      setLive(nodeOf(g));
-      setLive(nodeOf(h));
-      continue;
+      Node xn;
+      if (xorAndMatch(n, g, h, xn))
+      {
+        if (refs[xn] == 1)
+        {
+          setXorAnd(n);
+          setLive(nodeOf(g));
+          setLive(nodeOf(h));
+          continue;
+        }
+        Lit a, b, e;
+        if (matchXorAndJoint(m, n, a, b, e))
+        {
+          setXorAndLink(n);
+          setLive(nodeOf(a));
+          setLive(nodeOf(b));
+          setLive(xn);
+          continue;
+        }
+      }
     }
 
     // Otherwise this is an AND, and each uncomplemented fanin that nothing
@@ -574,10 +757,22 @@ Cone::Cone(const Manager& m, unsigned namedOutputs, Recover recover)
       nLiterals_ += 18;
       continue;
     }
+    if (majorityLink(n))
+    {
+      nClauses_ += 10;
+      nLiterals_ += 30;
+      continue;
+    }
     if (xorAnd(n))
     {
       nClauses_ += 3;
       nLiterals_ += 7;
+      continue;
+    }
+    if (xorAndLink(n))
+    {
+      nClauses_ += 5;
+      nLiterals_ += 12;
       continue;
     }
     if (patterned(n))

--- a/tests/unit-tests/Tseitin_Test.cpp
+++ b/tests/unit-tests/Tseitin_Test.cpp
@@ -383,9 +383,11 @@ TEST(Tseitin, XorAgainstItsOwnOperandCollapses)
   ASSERT_NO_FATAL_FAILURE(checkExact(m, 1, aig::Recover::PatternsAndAnds));
 }
 
-// The guard on both collapses: an exclusive-or something else also reads
-// keeps its variable, and the cell must fall back to the ordinary pattern.
-TEST(Tseitin, SharedConditionDeclinesTheMajorityBlock)
+// A shared condition must not weaken the cell: the exclusive-or keeps its
+// variable and its own four clauses for the other reader, and the cell
+// emits the ten linking clauses that keep the window propagation-complete
+// with the equality inside it.
+TEST(Tseitin, SharedConditionEmitsTheLinkBlock)
 {
   aig::Manager m;
   const aig::Lit l = m.createCi(), r = m.createCi(), prev = m.createCi();
@@ -394,9 +396,45 @@ TEST(Tseitin, SharedConditionDeclinesTheMajorityBlock)
   m.createOutput(eq);
 
   const CNF folded = aig::deriveTseitin(m, 2, aig::Recover::PatternsAndAnds);
-  // An ITE block over the live exclusive-or, the exclusive-or's own block,
-  // and two tie clauses per named output.
-  EXPECT_EQ(folded.clauseCount(), 4u + 4u + 4u);
+  // The link block, the exclusive-or's own block, and two tie clauses per
+  // named output.
+  EXPECT_EQ(folded.clauseCount(), 10u + 4u + 4u);
+  EXPECT_EQ(folded.literalCount(), 30u + 12u + 8u);
+  EXPECT_EQ(folded.varCount(), 1u + 3u + 2u + 2u);
+
+  ASSERT_NO_FATAL_FAILURE(checkExact(m, 2, aig::Recover::PatternsAndAnds));
+}
+
+// The bottom cell under the same sharing: five linking clauses beside the
+// exclusive-or's four.
+TEST(Tseitin, SharedXorConjunctionEmitsTheLinkBlock)
+{
+  aig::Manager m;
+  const aig::Lit a = m.createCi(), b = m.createCi();
+  const aig::Lit x = m.Xor(a, b);
+  m.createOutput(m.And(x, a)); // = a & !b
+  m.createOutput(x);
+
+  const CNF folded = aig::deriveTseitin(m, 2, aig::Recover::PatternsAndAnds);
+  EXPECT_EQ(folded.clauseCount(), 5u + 4u + 4u);
+  EXPECT_EQ(folded.literalCount(), 12u + 12u + 8u);
+  EXPECT_EQ(folded.varCount(), 1u + 2u + 2u + 2u);
+
+  ASSERT_NO_FATAL_FAILURE(checkExact(m, 2, aig::Recover::PatternsAndAnds));
+}
+
+// The agreeing-arm variant: out = e ? a : z, the arm on the equal branch
+// being an operand of the exclusive-or.
+TEST(Tseitin, SharedConditionAgreeingArmLinks)
+{
+  aig::Manager m;
+  const aig::Lit a = m.createCi(), b = m.createCi(), z = m.createCi();
+  const aig::Lit eq = aig::neg(m.Xor(a, b));
+  m.createOutput(m.Mux(eq, a, z));
+  m.createOutput(eq);
+
+  const CNF folded = aig::deriveTseitin(m, 2, aig::Recover::PatternsAndAnds);
+  EXPECT_EQ(folded.clauseCount(), 10u + 4u + 4u);
   EXPECT_EQ(folded.varCount(), 1u + 3u + 2u + 2u);
 
   ASSERT_NO_FATAL_FAILURE(checkExact(m, 2, aig::Recover::PatternsAndAnds));
@@ -507,9 +545,15 @@ TEST(Tseitin, SharedFullAdderInteriorDeclinesTheBlock)
   checkExact(m, 3, aig::Recover::PatternsAndAnds);
 }
 
-TEST(Tseitin, MatchingNeverCostsAnything)
+// Matching never costs a variable, and pays for itself overall. It can cost
+// a few clauses on one circuit: every cell sharing one exclusive-or adds
+// its linking clauses beside the exclusive-or's own, which passes plain
+// Tseitin's count from the third sharer on -- bought deliberately, for
+// propagation completeness under sharing.
+TEST(Tseitin, MatchingNeverCostsVariablesAndSavesOverall)
 {
-  uint64_t savedClauses = 0, savedLiterals = 0, savedVars = 0;
+  int64_t savedClauses = 0, savedLiterals = 0;
+  uint64_t savedVars = 0;
   for (unsigned seed = 0; seed < 200; seed++)
   {
     std::mt19937 rng(seed);
@@ -521,15 +565,15 @@ TEST(Tseitin, MatchingNeverCostsAnything)
 
     const CNF plain = aig::deriveTseitin(m, 0, aig::Recover::Nothing);
     const CNF folded = aig::deriveTseitin(m, 0, aig::Recover::PatternsAndAnds);
-    ASSERT_LE(folded.clauseCount(), plain.clauseCount()) << seed;
-    ASSERT_LE(folded.literalCount(), plain.literalCount()) << seed;
     ASSERT_LE(folded.varCount(), plain.varCount()) << seed;
-    savedClauses += plain.clauseCount() - folded.clauseCount();
-    savedLiterals += plain.literalCount() - folded.literalCount();
+    savedClauses += static_cast<int64_t>(plain.clauseCount()) -
+                    static_cast<int64_t>(folded.clauseCount());
+    savedLiterals += static_cast<int64_t>(plain.literalCount()) -
+                     static_cast<int64_t>(folded.literalCount());
     savedVars += plain.varCount() - folded.varCount();
   }
-  EXPECT_GT(savedClauses, 0u);
-  EXPECT_GT(savedLiterals, 0u);
+  EXPECT_GT(savedClauses, 0);
+  EXPECT_GT(savedLiterals, 0);
   EXPECT_GT(savedVars, 0u);
 }
 


### PR DESCRIPTION
Second of the stack, on top of #1071; the diff shows only this step.

Sharing used to break the matching: a cell whose equality something else also reads (an eq over the same operands, two comparisons sharing xnors) fell back to the per-gate encoding, whose windows join on two variables and lose unit refutation. Now the match never declines. A private equality dies into the majority block as before; a shared one keeps its variable and its own four clauses for the other readers, and the cell emits the minimum linking set that makes the window over (operand, operand, equality, arm, out) propagation-complete with the equality inside it: ten clauses for the full cell (either arm orientation), five for the bottom conjunction.

The minimums are exact (computed over the joint relations' prime implicates), and chains of linked cells verify propagation-complete exhaustively at widths 3–4 over every variable with every equality shared. The obvious repair — emitting the majority block beside the live equality — is no better than the fallback (both still miss conflicts and ~6% of implied literals in that sweep): a block that never reads the live equality cannot couple to it, which is what the link clauses are for. Both joint matchers verify their normalization by evaluating the cone over every operand assignment, so a polarity surprise declines to the default encoding instead of miscoding.

Cost is +4 clauses per shared full cell and +2 per shared bottom against the old fallback, and nothing anywhere else: on a 40-file corpus the totals move by two hundredths of a percent, and the 208-file differential stays answer-identical. Because the link blocks can pass plain Tseitin's clause count from the third cell sharing one equality, the test that asserted matching never costs a clause now asserts the bounds that still hold: never a variable, and aggregate savings.

Unit tests cover both link templates, the shared bottom, and the agreeing-arm orientation, each exact over every input.
