### PR TITLE
Complete the recovered ITE with its two condition-free prime implicates

### DIFF
--- a/include/stp/AIG/Tseitin.h
+++ b/include/stp/AIG/Tseitin.h
@@ -132,8 +132,10 @@ public:
   // In the cone, so it gets a variable and its defining clauses.
   bool live(Node n) const { return (live_[n >> 6] >> (n & 63)) & 1u; }
 
-  // Encoded as one four-clause ITE over its grandchildren rather than as
-  // three ANDs. Its two fanin nodes are then not live at all.
+  // Encoded as one ITE block over its grandchildren rather than as three
+  // ANDs: the six prime implicates of the relation (four when the arms
+  // share a node and it is an exclusive-or). Its two fanin nodes are then
+  // not live at all.
   bool patterned(Node n) const
   {
     return (pattern_[n >> 6] >> (n & 63)) & 1u;
@@ -402,6 +404,14 @@ void writeTseitin(const Manager& m, const Cone& cone, Sink& sink)
       sink.clause(px, lc ^ 1, lt ^ 1);
       sink.clause(nx, lc, le);
       sink.clause(px, lc, le ^ 1);
+      if (nodeOf(t) != nodeOf(e))
+      {
+        // The two prime implicates that skip the condition: agreeing arms
+        // decide the output while `c` is still unset. For an exclusive-or
+        // the arms share a node and both clauses are tautologies.
+        sink.clause(nx, lt, le);
+        sink.clause(px, lt ^ 1, le ^ 1);
+      }
     }
     else
     {

--- a/lib/AIG/Tseitin.cpp
+++ b/lib/AIG/Tseitin.cpp
@@ -777,8 +777,15 @@ Cone::Cone(const Manager& m, unsigned namedOutputs, Recover recover)
     }
     if (patterned(n))
     {
-      nClauses_ += 4;
-      nLiterals_ += 12;
+      Lit c, t, e;
+      const bool matched = matchIte(m, n, c, t, e);
+      assert(matched);
+      (void)matched;
+      // A genuine ITE carries the two condition-free prime implicates too;
+      // an exclusive-or's arms share a node, so for it they are tautologies.
+      const bool twoArms = nodeOf(t) != nodeOf(e);
+      nClauses_ += twoArms ? 6 : 4;
+      nLiterals_ += twoArms ? 18 : 12;
       continue;
     }
     leaves.clear();

--- a/tests/unit-tests/Tseitin_Test.cpp
+++ b/tests/unit-tests/Tseitin_Test.cpp
@@ -325,9 +325,10 @@ TEST(Tseitin, MixedAssertedAndNamedOutputs)
 }
 
 // The saving the matcher exists for, on the smallest circuit that has one.
-// A MUX is three AND nodes; encoded as an ITE it is one variable and four
-// clauses, and its two intermediates disappear entirely.
-TEST(Tseitin, MuxCostsFourClausesInsteadOfNine)
+// A MUX is three AND nodes; encoded as an ITE it is one variable and the
+// relation's six prime implicates, and its two intermediates disappear
+// entirely.
+TEST(Tseitin, MuxCostsSixClausesInsteadOfNine)
 {
   aig::Manager m;
   const aig::Lit c = m.createCi(), t = m.createCi(), e = m.createCi();
@@ -342,8 +343,8 @@ TEST(Tseitin, MuxCostsFourClausesInsteadOfNine)
   EXPECT_EQ(plain.literalCount(), 25u);
   EXPECT_EQ(plain.varCount(), 1u + 3u + 1u + 3u);
 
-  EXPECT_EQ(folded.clauseCount(), 6u);
-  EXPECT_EQ(folded.literalCount(), 16u);
+  EXPECT_EQ(folded.clauseCount(), 8u);
+  EXPECT_EQ(folded.literalCount(), 22u);
   EXPECT_EQ(folded.varCount(), 1u + 3u + 1u + 1u);
 }
 


### PR DESCRIPTION
Last of the stack, on top of #1072; the diff shows only this step. This is the one with a real trade in it, split out so it can be judged on wall-clock evidence separately from the strict wins beneath it.

The recovered ITE emitted only the four clauses that mention the condition, so agreeing arms could not decide the output while the condition was unset: ite graded 94.7–97.6% of implied literals derived at widths 1–4, and every multiplexer and barrel shifter inherited the gap. With the two condition-free prime implicates added the block is the relation's full prime set: ite grades unit-refutation and arc-consistency clean at widths 1–4 and propagation-complete exhaustively at widths 1–2, the shifters become refutation-clean, and probe-style workloads on mux cones solve by pure propagation. An exclusive-or's arms share a node, making both extra clauses tautologies, so xor/iff/bvxor/bvadd/eq are byte-identical.

The price is clause growth where multiplexers dominate: measured alone on a 40-file corpus it added 10.0% clauses, up to 40% on register-mux unrollings and nothing where no recovered ITEs occur; combined with the comparator recoveries beneath it the stack lands at +6.35% clauses and −4.09% variables overall. Denser clause sets tax search-heavy proofs even as they win propagation-bound ones, so whether this pays overall wants a solve-time round on the hard set before it becomes the default; the encoding-strength case for it is complete either way.

Verification: the mux unit test pins the six-clause block, the 208-file differential at new-medium is answer-identical, and the graded sweep is unchanged outside ITE cones.
