### PR TITLE
Recover shared half adders,

### DIFF
--- a/include/stp/AIG/Tseitin.h
+++ b/include/stp/AIG/Tseitin.h
@@ -70,6 +70,13 @@ bool matchMajority(const Manager& m, Node n, Lit& x, Lit& y, Lit& z);
 // over the operands: n = g & h. Structural only, as matchMajority is.
 bool matchXorAnd(const Manager& m, Node n, Lit& g, Lit& h);
 
+// The blaster's shared half adder: an exclusive-or whose interior
+// conjunction is itself the live carry. `carryQ` names which interior the
+// cone chose; (a, b) are that interior's own fanins, so n = a xor b and
+// carry = a & b hold structurally with no polarity cases.
+bool matchHalfAdder(const Manager& m, Node n, bool carryQ, Lit& a, Lit& b,
+                    Node& carry);
+
 // The leaves of the maximal AND rooted at `n`, appended to `into`.
 //
 // An AIG has no OR node: `a | b` is `!(!a & !b)`, one AND with the
@@ -142,6 +149,19 @@ public:
   // intermediates get no variables.
   bool xorAnd(Node n) const { return (xorAnd_[n >> 6] >> (n & 63)) & 1u; }
 
+  // A shared half adder's sum: the carry interior keeps its own gate, and
+  // the sum emits the four linking clauses that make the window over
+  // (a, b, sum, carry) propagation-complete. haCarryQ says which interior
+  // is the carry.
+  bool halfAdderSum(Node n) const
+  {
+    return (halfAdder_[n >> 6] >> (n & 63)) & 1u;
+  }
+  bool haCarryQ(Node n) const
+  {
+    return (haCarryQ_[n >> 6] >> (n & 63)) & 1u;
+  }
+
   // A recovered full adder: sum and carry defined together by one fourteen-
   // clause block over the operands -- the minimum propagation-complete
   // clause set for the relation, which the per-gate encodings are not. The
@@ -188,6 +208,8 @@ private:
   void setPatterned(Node n) { pattern_[n >> 6] |= 1ull << (n & 63); }
   void setMajority(Node n) { majority_[n >> 6] |= 1ull << (n & 63); }
   void setXorAnd(Node n) { xorAnd_[n >> 6] |= 1ull << (n & 63); }
+  void setHalfAdder(Node n) { halfAdder_[n >> 6] |= 1ull << (n & 63); }
+  void setHaCarryQ(Node n) { haCarryQ_[n >> 6] |= 1ull << (n & 63); }
   void setAbsorbed(Node n) { absorbed_[n >> 6] |= 1ull << (n & 63); }
   void setFaSum(Node n) { faSum_[n >> 6] |= 1ull << (n & 63); }
   void setFaCarry(Node n) { faCarry_[n >> 6] |= 1ull << (n & 63); }
@@ -198,6 +220,8 @@ private:
   std::vector<uint64_t> pattern_;
   std::vector<uint64_t> majority_;
   std::vector<uint64_t> xorAnd_;
+  std::vector<uint64_t> halfAdder_;
+  std::vector<uint64_t> haCarryQ_;
   std::vector<uint64_t> absorbed_;
   std::vector<uint64_t> faSum_;
   std::vector<uint64_t> faCarry_;
@@ -319,6 +343,21 @@ void writeTseitin(const Manager& m, const Cone& cone, Sink& sink)
       sink.clause(nx, lg);
       sink.clause(nx, lh);
       sink.clause(px, lg ^ 1, lh ^ 1);
+    }
+    else if (cone.halfAdderSum(n))
+    {
+      Lit a, b;
+      Node carry;
+      const bool matched =
+          matchHalfAdder(m, n, cone.haCarryQ(n), a, b, carry);
+      assert(matched);
+      (void)matched;
+      const int la = cnfLit(a), lb = cnfLit(b);
+      const int tv = static_cast<int>(2 * var[carry]);
+      sink.clause(nx, tv ^ 1);
+      sink.clause(la ^ 1, px, tv);
+      sink.clause(la, lb ^ 1, px);
+      sink.clause(la, lb, nx);
     }
     else if (cone.patterned(n))
     {

--- a/lib/AIG/Tseitin.cpp
+++ b/lib/AIG/Tseitin.cpp
@@ -239,6 +239,20 @@ bool matchXorAnd(const Manager& m, Node n, Lit& g, Lit& h)
   return false;
 }
 
+bool matchHalfAdder(const Manager& m, Node n, bool carryQ, Lit& a, Lit& b,
+                    Node& carry)
+{
+  Node p, q;
+  if (!xorShape(m, n, p, q))
+    return false;
+  // n computes the exclusive-or of either interior's fanins; the carry is
+  // the interior the caller says is live, and it conjoins those fanins.
+  carry = carryQ ? q : p;
+  a = m.fanin0(carry);
+  b = m.fanin1(carry);
+  return true;
+}
+
 void collectAndLeaves(const Manager& m, Node n,
                       const std::vector<uint64_t>& absorbed,
                       std::vector<Lit>& into, std::vector<Lit>& stack)
@@ -388,6 +402,8 @@ Cone::Cone(const Manager& m, unsigned namedOutputs, Recover recover)
   pattern_.assign(words, 0);
   majority_.assign(words, 0);
   xorAnd_.assign(words, 0);
+  halfAdder_.assign(words, 0);
+  haCarryQ_.assign(words, 0);
   absorbed_.assign(words, 0);
   faSum_.assign(words, 0);
   faCarry_.assign(words, 0);
@@ -464,6 +480,17 @@ Cone::Cone(const Manager& m, unsigned namedOutputs, Recover recover)
     return refs[xn] == 1 && !faMember(xn);
   };
 
+  // An exclusive-or whose interior conjunction is itself read elsewhere is
+  // the blaster's shared half adder: sum and carry over the same operands.
+  // The increment chains bvneg and constant addends fold into are made of
+  // exactly this pair, and it is what the private-interior patterns decline.
+  const auto wouldHalfAdder = [&](Node x) {
+    Node p, q;
+    return matchPatterns && m.isAnd(x) && !faMember(x) &&
+           xorShape(m, x, p, q) &&
+           ((refs[p] > 1 && !faMember(p)) || (refs[q] > 1 && !faMember(q)));
+  };
+
   for (Node n = static_cast<Node>(nNodes); n-- > 1;)
   {
     if (!live(n) || !m.isAnd(n))
@@ -524,6 +551,27 @@ Cone::Cone(const Manager& m, unsigned namedOutputs, Recover recover)
       continue;
     }
 
+    if (!absorbed(n) && wouldHalfAdder(n))
+    {
+      Node p, q;
+      const bool shape = xorShape(m, n, p, q);
+      assert(shape);
+      (void)shape;
+      // The carry keeps its own gate for its consumers; the sum adds the
+      // four linking clauses that make the (a, b, sum, carry) window
+      // propagation-complete. The other interior dies unless someone else
+      // holds it.
+      const bool pShared = refs[p] > 1 && !faMember(p);
+      const Node carry = pShared ? p : q;
+      setHalfAdder(n);
+      if (!pShared)
+        setHaCarryQ(n);
+      setLive(nodeOf(m.fanin0(carry)));
+      setLive(nodeOf(m.fanin1(carry)));
+      setLive(carry);
+      continue;
+    }
+
     if (wouldXorAnd(n))
     {
       Lit g, h;
@@ -546,7 +594,8 @@ Cone::Cone(const Manager& m, unsigned namedOutputs, Recover recover)
       const Node x = nodeOf(f);
       setLive(x);
       if (collapseAnds && !isNeg(f) && m.isAnd(x) && refs[x] == 1 &&
-          !faMember(x) && !wouldPattern(x) && !wouldXorAnd(x))
+          !faMember(x) && !wouldPattern(x) && !wouldXorAnd(x) &&
+          !wouldHalfAdder(x))
         setAbsorbed(x);
     }
   }
@@ -578,6 +627,12 @@ Cone::Cone(const Manager& m, unsigned namedOutputs, Recover recover)
     {
       nClauses_ += 3;
       nLiterals_ += 7;
+      continue;
+    }
+    if (halfAdderSum(n))
+    {
+      nClauses_ += 4;
+      nLiterals_ += 11;
       continue;
     }
     if (patterned(n))

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -2446,8 +2446,11 @@ BitBlaster<BBNode, BBNodeManagerT>::BBAddOneBit(const BBNodeVec& x, BBNode cin)
   const typename BBNodeVec::const_iterator itend = x.end();
   for (typename BBNodeVec::const_iterator it = x.begin(); it < itend; it++)
   {
+    // The shared-conjunction spelling: the sum's inner AND *is* the carry,
+    // as in fullAdder(), which is the structure the Tseitin writer's
+    // half-adder recovery keys on.
     BBNode nextcin = nf->CreateNode(AND, *it, cin);
-    result.push_back(nf->CreateNode(XOR, *it, cin));
+    result.push_back(xorWithSharing(*it, cin));
     cin = nextcin;
   }
   return result;

--- a/tests/unit-tests/Tseitin_Test.cpp
+++ b/tests/unit-tests/Tseitin_Test.cpp
@@ -383,6 +383,26 @@ TEST(Tseitin, XorAgainstItsOwnOperandCollapses)
   ASSERT_NO_FATAL_FAILURE(checkExact(m, 1, aig::Recover::PatternsAndAnds));
 }
 
+// The blaster's shared half adder: an exclusive-or whose inner conjunction
+// is the live carry. The carry keeps its own gate, the sum adds the four
+// linking clauses, and the disjunction interior dies.
+TEST(Tseitin, SharedCarryHalfAdderLinks)
+{
+  aig::Manager m;
+  const aig::Lit a = m.createCi(), b = m.createCi();
+  const aig::Lit conj = m.And(a, b);
+  const aig::Lit disj = m.Or(a, b);
+  m.createOutput(m.And(disj, aig::neg(conj)));
+  m.createOutput(conj);
+
+  const CNF folded = aig::deriveTseitin(m, 2, aig::Recover::PatternsAndAnds);
+  EXPECT_EQ(folded.clauseCount(), 3u + 4u + 4u);
+  EXPECT_EQ(folded.literalCount(), 7u + 11u + 8u);
+  EXPECT_EQ(folded.varCount(), 1u + 2u + 2u + 2u);
+
+  ASSERT_NO_FATAL_FAILURE(checkExact(m, 2, aig::Recover::PatternsAndAnds));
+}
+
 // The guard on both collapses: an exclusive-or something else also reads
 // keeps its variable, and the cell must fall back to the ordinary pattern.
 TEST(Tseitin, SharedConditionDeclinesTheMajorityBlock)


### PR DESCRIPTION
This makes the unary minus propagation complete.

---

Status of the simple operations at new-medium on this branch, measured by the graded sweep (`propagator_bench --consistency`), each operation as an isolated `op(inputs) = result` cone with no sharing between cones (#1072 covers the shared-equality case for the comparisons):

| operation | grade on this branch |
|---|---|
| and/or/xor/not/implies/iff (arity 2–4) | **PC**, exhaustive |
| bvand/bvor/bvxor (arity 2–3), bvnot | **PC** (exhaustive to w=3; URC+GAC exhaustive and sampled-PC clean above) |
| sign_extend, zero_extend, concat, extract | **PC** (exhaustive where 3^vars fits) |
| eq | **PC** (exhaustive to w=4) |
| bvult/bvule/bvslt/bvsle/bvsgt/bvsge | **PC** (exhaustive to w=4 over every variable; width 64 certified against an exact borrow-automaton oracle, 28,500 sampled and adversarial cases, zero misses) |
| bvneg (this PR) | **PC** (exhaustive at w=3 over every variable; URC+GAC exhaustive and sampled-PC clean at w=4; 420k-case full-pipeline sweep clean) |
| bvadd, bvsub | URC+GAC clean at every tested width; PC proven exhaustively only at w=2, with zero misses in every sampled sweep above |
| ite (bv and boolean) | URC yes; GAC 94.7–97.6% — the two condition-free prime implicates are missing; #1073 completes it |
| bvshl/bvlshr | URC yes; GAC ~95.1% (mux layers; improves with #1073) |
| bvashr | URC yes; GAC 89.3% |
| x + constant | URC yes; GAC ~99.1% (the constant-one cells' OR-fused carry, a follow-on pattern) |
| bvmul | not URC: 108/8,586 conflicts missed at w=3 |
| bvudiv / bvurem | not URC: 117/9,728 and 2,505/9,178 conflicts missed at w=3, GAC 64.1% / 31.5% |

The multiplier and divider rows are context, not scope: they are the remaining structurally weak encodings after this branch, and none of the block recoveries here applies to them directly.
