### PR TITLE
Make new-medium the default CNF conversion

### DIFF
--- a/docs/bv-abstraction.rst
+++ b/docs/bv-abstraction.rst
@@ -242,7 +242,7 @@ Which CNF generator
 The abstraction's search is many-solve: every refinement round is another
 call on a solver that keeps the whole CNF, and which CNF it keeps decides
 how that search goes far more than it decides one solve. With
-``--cnf-generation-effort`` at its default ``auto``, turning
+``--cnf-generation-effort`` at ``auto``, turning
 ``--bv-term-abstraction`` on therefore selects the Gia backend at its lowest
 rung (``gia-low``) rather than the size-based choice between ``very-low``
 and ``medium``, and ``-s`` says so:

--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -933,7 +933,7 @@ public:
            e == CNF_EFFORT_GIA_VERY_HIGH;
   }
 
-  enum CNFEffort cnf_effort = CNF_EFFORT_AUTO;
+  enum CNFEffort cnf_effort = CNF_EFFORT_NEW_MEDIUM;
 
   // AND-node count at or above which AUTO stops paying for CNF
   // minimisation: against the recorded estimate it selects NEW_MEDIUM

--- a/include/stp/c_interface.h
+++ b/include/stp/c_interface.h
@@ -487,13 +487,12 @@ enum ifaceflag_t
   //! 3 high, 4 very high. Higher is slower to generate and yields a smaller
   //! CNF.
   //!
-  //! 5 is auto, and is the default: it picks between very low and medium
-  //! from the size of the circuit, on the reasoning below. Ordinals 6 to 11
-  //! name rungs that blast the query with a different backend rather than
-  //! spending a different amount of effort -- 6, 7 and 8 the in-house
-  //! writer, 9, 10 and 11 the same generator as 1, 3 and 4 over a circuit
-  //! built without ABC. Auto never selects those; asking for one is an
-  //! explicit choice of backend.
+  //! 5 is auto: it picks a rung from the size of the circuit, on the
+  //! reasoning below. Ordinals 6 to 11 name rungs that blast the query with
+  //! a different backend rather than spending a different amount of effort
+  //! -- 6, 7 and 8 the in-house writer, 9, 10 and 11 the same generator as
+  //! 1, 3 and 4 over a circuit built without ABC. The default is 8, the
+  //! in-house writer's medium rung.
   //!
   //! It is a real trade and not a quality dial. A query whose search is
   //! trivial but whose circuit is large -- a floating-point square root over

--- a/tests/api/C/cnf-effort-flag.cpp
+++ b/tests/api/C/cnf-effort-flag.cpp
@@ -56,12 +56,13 @@ void countError(const char*)
 }
 } // namespace
 
-TEST(cnf_effort_flag, TheDefaultIsAuto)
+TEST(cnf_effort_flag, TheDefaultIsNewMedium)
 {
   VC vc = vc_createValidityChecker();
-  EXPECT_EQ(stp::UserDefinedFlags::CNF_EFFORT_AUTO, flags(vc).cnf_effort);
-  // AUTO is not a level of its own at conversion time: it resolves to VERY_LOW
-  // or MEDIUM from the size of the AIG. The threshold has to be reachable, or
+  EXPECT_EQ(stp::UserDefinedFlags::CNF_EFFORT_NEW_MEDIUM,
+            flags(vc).cnf_effort);
+  // AUTO is not a level of its own at conversion time: it resolves to another
+  // rung from the size of the circuit. The threshold has to be reachable, or
   // the decision cannot be exercised or adjusted.
   EXPECT_GT(flags(vc).cnf_auto_threshold, 0u);
   vc_Destroy(vc);
@@ -108,9 +109,8 @@ TEST(cnf_effort_flag, EveryLevelIsReachable)
   vc_setInterfaceFlags(vc, CNF_GENERATION_EFFORT, 4);
   EXPECT_EQ(stp::UserDefinedFlags::CNF_EFFORT_VERY_HIGH, flags(vc).cnf_effort);
 
-  // Auto is a level like the others here, and the only one that matters to a
-  // caller that has already set another: it is the default, so without it
-  // there is no way back to where the checker started.
+  // Auto is a level like the others here: it spends no effort of its own,
+  // but a caller has to be able to hand the choice back to the solver.
   vc_setInterfaceFlags(vc, CNF_GENERATION_EFFORT, 5);
   EXPECT_EQ(stp::UserDefinedFlags::CNF_EFFORT_AUTO, flags(vc).cnf_effort);
 

--- a/tests/query-files/misc-tests/cnf-auto-array-fallback.smt2
+++ b/tests/query-files/misc-tests/cnf-auto-array-fallback.smt2
@@ -7,7 +7,7 @@
 ; Twelve reads at distinct symbolic indexes, so the read count is past the
 ; eager-encoding regime and the solve actually refines.
 ;
-; RUN: %solver --SMTLIB2 -s %s 2>&1 | %OutputCheck %s
+; RUN: %solver --SMTLIB2 -s --cnf-generation-effort auto %s 2>&1 | %OutputCheck %s
 ;
 ; CHECK-NOT: estimated
 ; CHECK: ^cnf-auto: [0-9]+ AIG nodes, chose medium$

--- a/tests/query-files/misc-tests/cnf-auto-under-bv-abstraction.smt2
+++ b/tests/query-files/misc-tests/cnf-auto-under-bv-abstraction.smt2
@@ -7,10 +7,9 @@
 ; a build without it keeps the size-based choice and has nothing to say, and
 ; a build whose default backend is CryptoMiniSat must ask for CaDiCaL.
 ; REQUIRES: cadical
-; RUN: %solver --cadical -s --bv-term-abstraction=1 %s 2>&1 | %OutputCheck --check-prefix=ABS %s
 ; RUN: %solver --cadical -s --bv-term-abstraction=1 --cnf-generation-effort auto %s 2>&1 | %OutputCheck --check-prefix=ABS %s
 ; RUN: %solver --cadical -s --bv-term-abstraction=1 --cnf-generation-effort very-low %s 2>&1 | %OutputCheck --check-prefix=EXPLICIT %s
-; RUN: %solver --cadical -s %s 2>&1 | %OutputCheck --check-prefix=OFF %s
+; RUN: %solver --cadical -s --cnf-generation-effort auto %s 2>&1 | %OutputCheck --check-prefix=OFF %s
 ;
 ; ABS: ^cnf-auto: BV term abstraction on, chose gia-low$
 ; ABS: ^gia: [0-9]+ AND nodes, [0-9]+ inputs, LUT3$

--- a/tests/query-files/misc-tests/cnf-generation-effort-auto.smt2
+++ b/tests/query-files/misc-tests/cnf-generation-effort-auto.smt2
@@ -14,7 +14,6 @@
 ; is the default wherever it is installed, so the auto runs say --cadical.
 ; REQUIRES: cadical
 ;
-; RUN: %solver --SMTLIB2 -s --cadical %s 2>&1 | %OutputCheck --check-prefix=SMALL %s
 ; RUN: %solver --SMTLIB2 -s --cadical --cnf-generation-effort auto %s 2>&1 | %OutputCheck --check-prefix=SMALL %s
 ; RUN: %solver --SMTLIB2 -s --cadical --cnf-generation-effort auto --cnf-auto-threshold 1 %s 2>&1 | %OutputCheck --check-prefix=BIG %s
 ;
@@ -42,11 +41,13 @@
 ; BADLEVEL: Unknown --cnf-generation-effort value 'nonsense'\. Expected one of: auto, very-low, low, medium, high, very-high, new-very-low, new-low, new-medium, gia-low, gia-high, gia-very-high\.
 ;
 ; The new-* rungs are a different generator over a different AIG, so they
-; say so rather than printing one of the ABC lines.
+; say so rather than printing one of the ABC lines. new-medium is the
+; default, so the bare run prints the same line.
 ;
 ; RUN: %solver --SMTLIB2 -s --cnf-generation-effort new-very-low %s 2>&1 | %OutputCheck --check-prefix=NEWVERYLOW %s
 ; RUN: %solver --SMTLIB2 -s --cnf-generation-effort new-low %s 2>&1 | %OutputCheck --check-prefix=NEWLOW %s
 ; RUN: %solver --SMTLIB2 -s --cnf-generation-effort new-medium %s 2>&1 | %OutputCheck --check-prefix=NEWMEDIUM %s
+; RUN: %solver --SMTLIB2 -s %s 2>&1 | %OutputCheck --check-prefix=NEWMEDIUM %s
 ;
 ; NEWVERYLOW-NOT: cnf-auto:
 ; NEWVERYLOW-NOT: advanced CNF

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -104,7 +104,7 @@ public:
 
   // Likewise for UserFlags.cnf_effort; always mapped, so it carries the
   // default spelling.
-  std::string cnf_effort = "auto";
+  std::string cnf_effort = "new-medium";
 
   // Likewise for the named mask of BV abstraction schema families.
   std::string bv_schema_groups = formatBVSchemaGroups(BV_SCHEMA_GROUP_DEFAULT);


### PR DESCRIPTION
The default `--cnf-generation-effort` was `auto`, which resolved to `gia-low` or `new-medium` from the recorded blast estimate and fell back to the older `very-low`/`medium` choice under array refinement, on SAT backends other than CaDiCaL, or with no estimate recorded. The default is now `new-medium` everywhere — the in-house Tseitin writer over the in-house AIG, with XOR, if-then-else and n-ary AND/OR recovery — for the command line and for embedders alike (both the `UserDefinedFlags` initializer and the CLI's mapped default string move, since the CLI always writes its string over the flags).

`auto` stays selectable and resolves exactly as before. The C interface documentation now names ordinal 8 as the default, and the paragraph claiming auto never selects the backend rungs — stale since auto started resolving to `gia-low`/`new-medium` — is corrected in passing.

Tests: the three query-file tests that exercised auto's resolution relied on it being the default; they now pass `--cnf-generation-effort auto` explicitly, the effort-menu test checks that a bare run prints the `new-medium` line, and the C API default test expects `CNF_EFFORT_NEW_MEDIUM`. Full ctest suite passes (179/179).