### PR TITLE
Let propagator_bench select the multiplication variant

### DIFF
--- a/tools/propagator_bench/PropagatorBench.h
+++ b/tools/propagator_bench/PropagatorBench.h
@@ -338,6 +338,7 @@ struct Config
   uint64_t pcSamples = 1000000; // sampled cases when 3^vars exceeds the cap
   int adderVariant = -1;  // -1 leaves UserDefinedFlags::adder_variant alone
   int bvplusVariant = -1; // likewise bvplus_variant
+  int multVariant = -1;   // likewise multiplication_variant
   unsigned seed = 42;
   // How the CNF that --bcp-check propagates over is generated. Empty leaves
   // STP's default (medium) alone. A different encoding of the same circuit

--- a/tools/propagator_bench/main.cpp
+++ b/tools/propagator_bench/main.cpp
@@ -123,6 +123,10 @@ void usage()
       << "  --bb.add-v2 0|1     UserDefinedFlags::bvplus_variant: 1 pairwise\n"
       << "                      ripple chains (default), 0 the addition\n"
       << "                      network\n"
+      << "  --bb.mult-v N       UserDefinedFlags::multiplication_variant:\n"
+      << "                      1 shift-add ripple (default), 3 Booth +\n"
+      << "                      addition network, 4 sorter, 6/7/8/9/13\n"
+      << "                      network variants, 15 radix-4 Booth\n"
       << "  --no-shift-bias     draw shift amounts uniformly, instead of\n"
       << "                      half of them from [0, width)\n"
       << "  --seed N            random seed (default 42)\n"
@@ -251,6 +255,8 @@ int main(int argc, char** argv)
     { cfg.adderVariant = atoi(value.c_str()); i++; }
     else if (arg == "--bb.add-v2")
     { cfg.bvplusVariant = atoi(value.c_str()); i++; }
+    else if (arg == "--bb.mult-v")
+    { cfg.multVariant = atoi(value.c_str()); i++; }
     else if (arg == "--cnf") { cfg.cnf = value; i++; }
     else if (arg == "--seed") { cfg.seed = atoi(value.c_str()); i++; }
     else if (arg == "--html") { cfg.html = value; i++; }
@@ -329,6 +335,8 @@ int main(int argc, char** argv)
     mgr->UserFlags.adder_variant = cfg.adderVariant != 0;
   if (cfg.bvplusVariant >= 0)
     mgr->UserFlags.bvplus_variant = cfg.bvplusVariant != 0;
+  if (cfg.multVariant >= 0)
+    mgr->UserFlags.multiplication_variant = cfg.multVariant;
 
   if (!cfg.dumpCnf.empty())
   {


### PR DESCRIPTION
Adds `--bb.mult-v N` to propagator_bench, setting `UserDefinedFlags::multiplication_variant` for the encoding that `--consistency`, `--bcp-check` and `--dump-cnf` build — the same pattern as `--bb.add-v1`/`--bb.add-v2` for the adder forms.

Grading bvmul's encodings needs it: the variant menu (shift-add, Booth + addition network, the sorter family, radix-4 Booth) spans 20x in clause count at w=64 and large differences in unit-propagation strength, and until now only the default variant was reachable from the tool. Used for the 2026-09-02 multiplication encoding-consistency study; no change to stp itself.