### PR TITLE
Read the source before releasing the target in ASTNode assignment

### DIFF
--- a/include/stp/AST/ASTNode.h
+++ b/include/stp/AST/ASTNode.h
@@ -167,24 +167,32 @@ public:
   // that self-assignment is safe.
   DLL_PUBLIC ASTNode& operator=(const ASTNode& n)
   {
-    if (n._int_node_ptr)
-      n._int_node_ptr->IncRef();
+    // Taken before the DecRef below: n may live inside this node's
+    // children, which are tail-allocated in the interior the DecRef can
+    // free -- `node = node[0]` on a sole owner reads n from freed storage
+    // otherwise.
+    ASTInternal* const other = n._int_node_ptr;
+    if (other)
+      other->IncRef();
 
     if (_int_node_ptr)
       _int_node_ptr->DecRef();
 
-    _int_node_ptr = n._int_node_ptr;
+    _int_node_ptr = other;
     return *this;
   }
 
   DLL_PUBLIC ASTNode& operator=(ASTNode&& n)
   {
+    // The same aliasing hazard as the copy assignment; stealing n's
+    // reference first also keeps a self-move harmless.
+    ASTInternal* const other = n._int_node_ptr;
+    n._int_node_ptr = 0;
+
     if (_int_node_ptr)
       _int_node_ptr->DecRef();
 
-    _int_node_ptr = n._int_node_ptr;
-
-    n._int_node_ptr = 0;
+    _int_node_ptr = other;
     return *this;
   }
 


### PR DESCRIPTION
Both ASTNode assignment operators released this node's reference before reading the source's pointer. When the source is a reference into this node's own children -- `node = node[0]` on a sole owner -- it lives in the interior's tail allocation, which the release frees, so the read lands in freed memory. Verified with AddressSanitizer on the flatten random-tree unit tests: an 8-byte read at offset 72 of the 80-byte ASTInterior block, freed two lines earlier by the same assignment's DecRef; allocators that poison freed memory (mimalloc in Debug) crash one line later on the poisoned pointer. Builds without poisoning pass by luck, which is why CI never saw it: freed memory still holds the old pointer value, UBSan cannot see heap use-after-free, and no CI job runs AddressSanitizer.

The hazard is old and not test-only. The copy form has released before reading since at least the 2009 file split, the move form since it was added in 2016, and the unwrap idiom runs in production -- `o = o[0]` in the simplifier and STPManager, `lhs = lhs[1]`/`rhs = rhs[1]` in the simplifying node factory -- protected today only by those nodes happening to hold extra references.

The copy form now takes the source's pointer before the release; the move form steals it first, which also keeps a self-move harmless. With the fix the full flatten suite runs clean under AddressSanitizer with the system allocator.