### PR TITLE
Add multiplication encodings 17-23, --bb.mult-lemmas, a multiply tap and the new-high CNF rung

### DIFF
--- a/include/stp/AIG/Tseitin.h
+++ b/include/stp/AIG/Tseitin.h
@@ -99,9 +99,11 @@ void collectAndLeaves(const Manager& m, Node n, const std::vector<uint64_t>& abs
 // bench-hard for what each is worth.
 enum class Recover
 {
-  Nothing,        // plain Tseitin: three clauses for every AND node
-  Patterns,       // + XOR, if-then-else and full adders
-  PatternsAndAnds // + maximal n-ary ANDs, and so n-ary ORs, collapsed
+  Nothing,         // plain Tseitin: three clauses for every AND node
+  Patterns,        // + XOR, if-then-else and full adders
+  PatternsAndAnds, // + maximal n-ary ANDs, and so n-ary ORs, collapsed
+  Cells            // + every private cone of up to five leaves as the
+                   //   prime implicates of the function it computes
 };
 
 // Which nodes the CNF will talk about, and how many clauses that will take.
@@ -172,6 +174,20 @@ public:
     Lit a, b, c; // the operand literals
     Node sum;
   };
+  // A private cone -- up to five leaves, every interior node referenced
+  // only from inside it -- encoded as the prime implicates of the function
+  // its root computes over the leaves: one propagation-complete block, no
+  // variables for the interior. A clause literal is (index, negated) where
+  // index k = leaves.size() names the root.
+  struct Cell
+  {
+    std::vector<Node> leaves;
+    std::vector<std::vector<int8_t>> clauses; // entries: index*2 + negated
+    uint64_t literals = 0;
+  };
+  bool cellRoot(Node n) const { return (cell_[n >> 6] >> (n & 63)) & 1u; }
+  const Cell& cellAt(Node n) const { return cells_.at(n); }
+
   bool faSum(Node n) const { return (faSum_[n >> 6] >> (n & 63)) & 1u; }
   bool faCarry(Node n) const { return (faCarry_[n >> 6] >> (n & 63)) & 1u; }
   const FullAdder& faAt(Node carry) const { return fas_.at(carry); }
@@ -215,6 +231,10 @@ private:
   void setFaCarry(Node n) { faCarry_[n >> 6] |= 1ull << (n & 63); }
   void clearFa(Node carry);
   void findFullAdders(const Manager& m, const std::vector<uint8_t>& refs);
+  void setCell(Node n) { cell_[n >> 6] |= 1ull << (n & 63); }
+  bool tryCell(const Manager& m, Node n, const std::vector<uint8_t>& refs);
+  std::vector<uint64_t> cell_;
+  std::unordered_map<Node, Cell> cells_;
 
   std::vector<uint64_t> live_;
   std::vector<uint64_t> pattern_;
@@ -320,6 +340,30 @@ void writeTseitin(const Manager& m, const Cone& cone, Sink& sink,
       continue;
     }
 
+    if (cone.cellRoot(n))
+    {
+      const Cone::Cell& cell = cone.cellAt(n);
+      const size_t k = cell.leaves.size();
+      for (const std::vector<int8_t>& cl : cell.clauses)
+      {
+        clause.clear();
+        for (const int8_t e : cl)
+        {
+          const unsigned idx = static_cast<unsigned>(e) >> 1;
+          const int negated = e & 1;
+          if (idx == k)
+            clause.push_back(negated ? nx : px);
+          else
+          {
+            assert(var[cell.leaves[idx]] != 0);
+            clause.push_back(static_cast<int>(2 * var[cell.leaves[idx]]) |
+                             negated);
+          }
+        }
+        sink.clause(clause.data(), clause.size());
+      }
+      continue;
+    }
     if (cone.majorityCell(n))
     {
       Lit x, y, z;

--- a/include/stp/AIG/Tseitin.h
+++ b/include/stp/AIG/Tseitin.h
@@ -243,7 +243,8 @@ private:
 // DIMACS writer or one that feeds a live solver costs no indirection when it
 // arrives.
 template <class Sink>
-void writeTseitin(const Manager& m, const Cone& cone, Sink& sink)
+void writeTseitin(const Manager& m, const Cone& cone, Sink& sink,
+                  std::vector<uint32_t>* nodeVarOut = nullptr)
 {
   const uint32_t nCi = m.ciCount();
   const uint32_t nCo = m.outputCount();
@@ -422,11 +423,14 @@ void writeTseitin(const Manager& m, const Cone& cone, Sink& sink)
     }
   }
   sink.end();
+  if (nodeVarOut)
+    *nodeVarOut = var;
 }
 
 // Both passes, into a materialised CNF.
 CNF deriveTseitin(const Manager& m, unsigned namedOutputs = 0,
-                  Recover recover = Recover::PatternsAndAnds);
+                  Recover recover = Recover::PatternsAndAnds,
+                  std::vector<uint32_t>* nodeVarOut = nullptr);
 
 } // namespace aig
 } // namespace stp

--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -947,7 +947,6 @@ public:
     CNF_EFFORT_NEW_VERY_LOW,
     CNF_EFFORT_NEW_LOW,
     CNF_EFFORT_NEW_MEDIUM,
-    CNF_EFFORT_NEW_HIGH,
 
     // Mf_ManGenerateCnf again -- the same generator low, high and very-high
     // reach -- but over a Gia the blaster built itself rather than one
@@ -955,7 +954,11 @@ public:
     // against low is a comparison of the two backends and nothing else.
     CNF_EFFORT_GIA_LOW,
     CNF_EFFORT_GIA_HIGH,
-    CNF_EFFORT_GIA_VERY_HIGH
+    CNF_EFFORT_GIA_VERY_HIGH,
+
+    // new-medium's recovery plus prime-implicate blocks for private cones.
+    // On the end, as the note above requires, however much effort it spends.
+    CNF_EFFORT_NEW_HIGH
   };
 
   // Whether a level blasts through the Gia backend rather than ABC's Aig.

--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -898,6 +898,14 @@ public:
   bool fp_domain_row_bounds = false;
 
   int64_t multiplication_variant = 1;
+  // Conjoin to every multiply the prime implicates of the k-bit
+  // multiplication relation that its circuit cannot rederive by unit
+  // propagation: the odd-residue and 2-adic laws over the low k bits
+  // (2026-09-02 multiplication-encoding study). 0 = none, 3 = the six
+  // clauses that make the 3-bit relation refutation-complete, 4 = the 88
+  // that do the same for 4 bits. Sound at any width, since the low k
+  // product bits depend only on the low k operand bits.
+  int64_t multiplication_lemmas = 0;
 
   // If the bit-blaster discovers new constants, should the term simplifier be
   // re-run.

--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -947,6 +947,7 @@ public:
     CNF_EFFORT_NEW_VERY_LOW,
     CNF_EFFORT_NEW_LOW,
     CNF_EFFORT_NEW_MEDIUM,
+    CNF_EFFORT_NEW_HIGH,
 
     // Mf_ManGenerateCnf again -- the same generator low, high and very-high
     // reach -- but over a Gia the blaster built itself rather than one

--- a/include/stp/ToSat/BBNodeManagerLit.h
+++ b/include/stp/ToSat/BBNodeManagerLit.h
@@ -70,6 +70,12 @@ public:
     std::vector<BBNodeLit> a, s, r;
   };
   std::vector<ShiftTap> shiftTaps;
+  // Likewise one record per multiply, under STP_MULT_ANNOTATE.
+  struct MultTap
+  {
+    std::vector<BBNodeLit> x, y, r;
+  };
+  std::vector<MultTap> multTaps;
 
   int totalNumberOfNodes() { return static_cast<int>(mgr.andCount()); }
 

--- a/include/stp/ToSat/BBNodeManagerLit.h
+++ b/include/stp/ToSat/BBNodeManagerLit.h
@@ -61,6 +61,16 @@ public:
   typedef std::map<ASTNode, std::vector<BBNodeLit>> SymbolToBBNode;
   SymbolToBBNode symbolToBBNode;
 
+  // Diagnostic taps for the lazy-shift-oracle experiments: one record per
+  // symbolic-amount shift, filled by the blaster only when
+  // STP_SHIFT_ANNOTATE is set, written out by ToCNFTseitin.
+  struct ShiftTap
+  {
+    int kind; // 0 shl, 1 lshr, 2 ashr
+    std::vector<BBNodeLit> a, s, r;
+  };
+  std::vector<ShiftTap> shiftTaps;
+
   int totalNumberOfNodes() { return static_cast<int>(mgr.andCount()); }
 
   // Size the node array and strash table before anything is built. The

--- a/include/stp/ToSat/BitBlaster.h
+++ b/include/stp/ToSat/BitBlaster.h
@@ -159,6 +159,16 @@ template <class BBNode, class BBNodeManagerT> class BitBlaster
                            const ASTNode& n);
   BBNodeVec mult_normal(const BBNodeVec& x, const BBNodeVec& y,
                              BBNodeSet& support, const ASTNode& n);
+  BBNodeVec mult_csaRows(const BBNodeVec& x, const BBNodeVec& y,
+                         BBNodeSet& support, const ASTNode& n);
+  BBNodeVec mult_dadda(vector<list<BBNode>>& products, BBNodeSet& support,
+                       const ASTNode& n);
+  void mult_radix4_hard(const BBNodeVec& x, const BBNodeVec& y,
+                        vector<list<BBNode>>& products, const ASTNode& n);
+  BBNodeVec BBMultVariant(const BBNodeVec& x, const BBNodeVec& y,
+                          BBNodeSet& support, const ASTNode& n);
+  void multLemmaBlock(const BBNodeVec& x, const BBNodeVec& y,
+                      const BBNodeVec& p, BBNodeSet& support);
 
   BBNodeVec batcher(const BBNodeVec& in);
   BBNodeVec mergeSorted(const BBNodeVec& in1,

--- a/lib/AIG/Tseitin.cpp
+++ b/lib/AIG/Tseitin.cpp
@@ -587,19 +587,27 @@ bool Cone::tryCell(const Manager& m, Node n, const std::vector<uint8_t>& refs)
     vals.clear();
     for (unsigned i = 0; i < k; i++)
       vals.push_back({leaves[i], ((r >> i) & 1u) != 0});
-    const auto value = [&](Lit l) {
+    // Every fanin of an interior node is either a leaf or an interior node
+    // of lower id, and `order` is ascending, so each lookup is already in
+    // `vals`. A miss would mean the cone is not closed, which would encode
+    // the wrong function -- refuse the cell rather than trust it.
+    bool closed = true;
+    const auto value = [&](Lit l) -> bool {
       const Node x = nodeOf(l);
-      bool v = false;
       for (const auto& e : vals)
         if (e.first == x)
-        {
-          v = e.second;
-          break;
-        }
-      return v ^ (isNeg(l) ? true : false);
+          return e.second != isNeg(l);
+      closed = false;
+      return false;
     };
     for (const Node x : order)
-      vals.push_back({x, value(m.fanin0(x)) && value(m.fanin1(x))});
+    {
+      const bool a = value(m.fanin0(x));
+      const bool b = value(m.fanin1(x));
+      vals.push_back({x, a && b});
+    }
+    if (!closed)
+      return false;
     if (vals.back().second)
       table |= 1u << r;
   }

--- a/lib/AIG/Tseitin.cpp
+++ b/lib/AIG/Tseitin.cpp
@@ -680,11 +680,12 @@ Cone::Cone(const Manager& m, unsigned namedOutputs, Recover recover)
   nVars_ = static_cast<uint32_t>(vars);
 }
 
-CNF deriveTseitin(const Manager& m, unsigned namedOutputs, Recover recover)
+CNF deriveTseitin(const Manager& m, unsigned namedOutputs, Recover recover,
+                  std::vector<uint32_t>* nodeVarOut)
 {
   const Cone cone(m, namedOutputs, recover);
   CNF cnf;
-  writeTseitin(m, cone, cnf);
+  writeTseitin(m, cone, cnf, nodeVarOut);
   return cnf;
 }
 

--- a/lib/AIG/Tseitin.cpp
+++ b/lib/AIG/Tseitin.cpp
@@ -23,6 +23,8 @@ THE SOFTWARE.
 ********************************************************************/
 
 #include "stp/AIG/Tseitin.h"
+#include <algorithm>
+#include <unordered_map>
 
 #include <limits>
 #include <stdexcept>
@@ -387,6 +389,235 @@ void Cone::findFullAdders(const Manager& m, const std::vector<uint8_t>& refs)
   }
 }
 
+
+// The prime implicates of a function of k <= 5 inputs, over the k inputs and
+// the output: every clause implied by output == f(inputs) with no implied
+// proper subclause. Aux-free, so the set is propagation-complete for the
+// cell. Cached by truth table.
+namespace
+{
+struct CellKey
+{
+  uint32_t table;
+  uint8_t k;
+  bool operator==(const CellKey& o) const
+  {
+    return table == o.table && k == o.k;
+  }
+};
+struct CellKeyHash
+{
+  size_t operator()(const CellKey& c) const
+  {
+    return (static_cast<size_t>(c.table) * 1000003u) ^ c.k;
+  }
+};
+
+const std::vector<std::vector<int8_t>>& primeImplicates(uint32_t table,
+                                                        unsigned k)
+{
+  static std::unordered_map<CellKey, std::vector<std::vector<int8_t>>,
+                            CellKeyHash>
+      cache;
+  const CellKey key{table, static_cast<uint8_t>(k)};
+  auto it = cache.find(key);
+  if (it != cache.end())
+    return it->second;
+
+  const unsigned nv = k + 1;
+  unsigned nCand = 1;
+  for (unsigned i = 0; i < nv; i++)
+    nCand *= 3;
+  // Candidate clause c (base-3 digits: 0 absent, 1 positive, 2 negative).
+  // A model is a row r (leaf bits) with output bit f(r); the clause is
+  // implied iff no model falsifies every literal.
+  std::vector<uint8_t> implied(nCand, 0);
+  std::vector<uint8_t> digits(nv);
+  for (unsigned c = 1; c < nCand; c++)
+  {
+    unsigned x = c;
+    for (unsigned i = 0; i < nv; i++)
+    {
+      digits[i] = x % 3;
+      x /= 3;
+    }
+    bool falsified = false;
+    for (unsigned r = 0; r < (1u << k) && !falsified; r++)
+    {
+      bool allFalse = true;
+      for (unsigned i = 0; i < nv && allFalse; i++)
+      {
+        if (digits[i] == 0)
+          continue;
+        const bool val = i < k ? ((r >> i) & 1u) : ((table >> r) & 1u);
+        const bool litTrue = digits[i] == 1 ? val : !val;
+        if (litTrue)
+          allFalse = false;
+      }
+      if (allFalse)
+        falsified = true;
+    }
+    implied[c] = falsified ? 0 : 1;
+  }
+  std::vector<std::vector<int8_t>> primes;
+  for (unsigned c = 1; c < nCand; c++)
+  {
+    if (!implied[c])
+      continue;
+    unsigned x = c, pow3 = 1;
+    bool prime = true;
+    for (unsigned i = 0; i < nv && prime; i++)
+    {
+      const unsigned d = x % 3;
+      x /= 3;
+      if (d != 0 && implied[c - d * pow3])
+        prime = false; // dropping literal i keeps it implied
+      pow3 *= 3;
+    }
+    if (!prime)
+      continue;
+    std::vector<int8_t> cl;
+    x = c;
+    for (unsigned i = 0; i < nv; i++)
+    {
+      const unsigned d = x % 3;
+      x /= 3;
+      if (d)
+        cl.push_back(static_cast<int8_t>(i * 2 + (d == 2 ? 1 : 0)));
+    }
+    primes.push_back(cl);
+  }
+  return cache.emplace(key, std::move(primes)).first->second;
+}
+} // namespace
+
+// Grow the largest private cone under n that keeps at most five leaves:
+// a leaf is expanded when every reference to it comes from inside the cone
+// (its saturating count is below three and equals the count seen here),
+// it is an AND, and it is not a recovered full adder's root. Interior nodes
+// of an accepted cell get no variables; the block over the leaves and the
+// root replaces their gates. Refused when the cone is a single gate or its
+// implicate set is bigger than four clauses per gate replaced.
+bool Cone::tryCell(const Manager& m, Node n, const std::vector<uint8_t>& refs)
+{
+  const unsigned K = 5;
+  if (!m.isAnd(n) || faSum(n) || faCarry(n))
+    return false;
+  std::vector<Node> interior{n};
+  std::vector<Node> leaves;
+  std::vector<std::pair<Node, uint8_t>> internal; // internal reference counts
+  const auto bumpInternal = [&](Node x) {
+    for (auto& e : internal)
+      if (e.first == x)
+      {
+        e.second++;
+        return;
+      }
+    internal.push_back({x, 1});
+  };
+  const auto internalRefs = [&](Node x) -> unsigned {
+    for (const auto& e : internal)
+      if (e.first == x)
+        return e.second;
+    return 0;
+  };
+  const auto addLeaf = [&](Node x) {
+    for (const Node l : leaves)
+      if (l == x)
+        return;
+    leaves.push_back(x);
+  };
+  for (const Lit f : {m.fanin0(n), m.fanin1(n)})
+  {
+    bumpInternal(nodeOf(f));
+    addLeaf(nodeOf(f));
+  }
+  const auto expandable = [&](Node x) {
+    return m.isAnd(x) && !faSum(x) && !faCarry(x) && refs[x] < 3 &&
+           refs[x] == internalRefs(x) && interior.size() < 12;
+  };
+  // Expand leaves whose fanins are already leaves first (no growth), then
+  // any other private leaf while the leaf budget allows.
+  bool progress = true;
+  while (progress)
+  {
+    progress = false;
+    for (size_t i = 0; i < leaves.size(); i++)
+    {
+      const Node x = leaves[i];
+      if (!expandable(x))
+        continue;
+      const Node a = nodeOf(m.fanin0(x)), b = nodeOf(m.fanin1(x));
+      unsigned growth = 0;
+      bool aLeaf = false, bLeaf = false;
+      for (const Node l : leaves)
+      {
+        if (l == a)
+          aLeaf = true;
+        if (l == b)
+          bLeaf = true;
+      }
+      if (!aLeaf)
+        growth++;
+      if (!bLeaf && b != a)
+        growth++;
+      if (leaves.size() - 1 + growth > K)
+        continue;
+      leaves.erase(leaves.begin() + i);
+      interior.push_back(x);
+      bumpInternal(a);
+      bumpInternal(b);
+      addLeaf(a);
+      addLeaf(b);
+      progress = true;
+      break;
+    }
+  }
+  if (interior.size() < 2 || leaves.size() > K)
+    return false;
+  // Truth table of the root over the leaves; interior nodes evaluate in
+  // increasing id order, which is fanin order.
+  std::vector<Node> order(interior);
+  std::sort(order.begin(), order.end());
+  const unsigned k = static_cast<unsigned>(leaves.size());
+  uint32_t table = 0;
+  std::vector<std::pair<Node, bool>> vals;
+  for (unsigned r = 0; r < (1u << k); r++)
+  {
+    vals.clear();
+    for (unsigned i = 0; i < k; i++)
+      vals.push_back({leaves[i], ((r >> i) & 1u) != 0});
+    const auto value = [&](Lit l) {
+      const Node x = nodeOf(l);
+      bool v = false;
+      for (const auto& e : vals)
+        if (e.first == x)
+        {
+          v = e.second;
+          break;
+        }
+      return v ^ (isNeg(l) ? true : false);
+    };
+    for (const Node x : order)
+      vals.push_back({x, value(m.fanin0(x)) && value(m.fanin1(x))});
+    if (vals.back().second)
+      table |= 1u << r;
+  }
+  const std::vector<std::vector<int8_t>>& primes = primeImplicates(table, k);
+  if (primes.size() > 4 * interior.size() + 2)
+    return false;
+  Cell cell;
+  cell.leaves = leaves;
+  cell.clauses = primes;
+  for (const auto& cl : primes)
+    cell.literals += cl.size();
+  cells_[n] = std::move(cell);
+  setCell(n);
+  for (const Node l : leaves)
+    setLive(l);
+  return true;
+}
+
 Cone::Cone(const Manager& m, unsigned namedOutputs, Recover recover)
 {
   const uint32_t nCo = m.outputCount();
@@ -424,7 +655,10 @@ Cone::Cone(const Manager& m, unsigned namedOutputs, Recover recover)
   // an exact count of two from "more" -- and gone when this constructor
   // returns.
   const bool matchPatterns = recover != Recover::Nothing;
-  const bool collapseAnds = recover == Recover::PatternsAndAnds;
+  const bool collapseAnds = recover == Recover::PatternsAndAnds ||
+                            recover == Recover::Cells;
+  const bool cells = recover == Recover::Cells;
+  cell_.assign(words, 0);
 
   std::vector<uint8_t> refs;
   if (matchPatterns)
@@ -522,6 +756,8 @@ Cone::Cone(const Manager& m, unsigned namedOutputs, Recover recover)
       clearFa(carry);
     }
 
+    if (cells && tryCell(m, n, refs))
+      continue;
     Lit c, t, e;
     if (wouldPattern(n))
     {
@@ -615,6 +851,13 @@ Cone::Cone(const Manager& m, unsigned namedOutputs, Recover recover)
     {
       nClauses_ += 14;
       nLiterals_ += 44;
+      continue;
+    }
+    if (cellRoot(n))
+    {
+      const Cell& cell = cells_.at(n);
+      nClauses_ += cell.clauses.size();
+      nLiterals_ += cell.literals;
       continue;
     }
     if (majorityCell(n))

--- a/lib/Interface/c_interface.cpp
+++ b/lib/Interface/c_interface.cpp
@@ -614,7 +614,7 @@ void vc_setInterfaceFlags(VC vc, enum ifaceflag_t f, int param_value)
       // has set any other level with no way back to the one it started with.
       // The bound tracks the enum, and the numbers in the message with it.
       if (param_value < 0 ||
-          param_value > stp::UserDefinedFlags::CNF_EFFORT_GIA_VERY_HIGH)
+          param_value > stp::UserDefinedFlags::CNF_EFFORT_NEW_HIGH)
         reportCAPIError("CNF_GENERATION_EFFORT takes an effort ordinal from "
                         "0 (very low) to 11 (gia very high)");
       else

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -4144,6 +4144,41 @@ vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::BBMultVariant(
       return buildAdditionNetworkResult(products, support, n);
     }
 
+    case 21:
+    {
+      // 14 and 19 together: a constant multiplier with a run of ones is
+      // Booth recoded and summed by the column network, and a symbolic
+      // pair takes the shift-add rows in canonical order, so both orders
+      // of one product share a circuit. Each half is the measured win for
+      // its operand class; nothing else changes.
+      if (mult_Booth_constant(x, y, support, products, n))
+        return buildAdditionNetworkResult(products, support, n);
+      bool xConst = true;
+      for (const BBNode& b : x)
+        if (b != BBTrue && b != BBFalse)
+          xConst = false;
+      if (!xConst && std::lexicographical_compare(y.begin(), y.end(),
+                                                  x.begin(), x.end()))
+        return mult_normal(y, x, support, n);
+      return mult_normal(x, y, support, n);
+    }
+
+    case 22:
+    {
+      // 21 with carry-save rows (17) in place of the ripple rows for the
+      // symbolic pair.
+      if (mult_Booth_constant(x, y, support, products, n))
+        return buildAdditionNetworkResult(products, support, n);
+      bool xConst = true;
+      for (const BBNode& b : x)
+        if (b != BBTrue && b != BBFalse)
+          xConst = false;
+      if (!xConst && std::lexicographical_compare(y.begin(), y.end(),
+                                                  x.begin(), x.end()))
+        return mult_csaRows(y, x, support, n);
+      return mult_csaRows(x, y, support, n);
+    }
+
     default:
     {
       cerr << "Unk variant" << uf->multiplication_variant;

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -1665,6 +1665,9 @@ const vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::BBTerm(
       else
       {
         result = BBExactBinaryOp(term, mpcd1, mpcd2, support);
+        static const bool tapMults = getenv("STP_MULT_ANNOTATE") != NULL;
+        if (tapMults)
+          recordMultTapHook(nf, mpcd1, mpcd2, result);
       }
       break;
     }
@@ -3615,11 +3618,338 @@ vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::BBSquare(
   return buildAdditionNetworkResult(products, support, n);
 }
 
+// The prime implicates of the k-bit multiplication relation that repair
+// unit propagation's refutation completeness at k=3 (six clauses) and k=4
+// (eighty-eight), from the 2026-09-02 encoding study's closure-guided
+// greedy. Each clause is a list of {vector (0 = x, 1 = y, 2 = product), bit,
+// negated} literals terminated by a negative vector index. They are
+// implicates of p = x*y mod 2^k, hence of every wider multiply, and of
+// y*x as well.
+struct MultLemmaLit
+{
+  int8_t vec, bit, neg;
+};
+static const MultLemmaLit MULT_LEMMAS_K3[] = {
+{0,2,1},{1,2,1},{2,0,1},{2,2,1},{-1,0,0},
+{0,2,1},{1,2,0},{2,0,1},{2,2,0},{-1,0,0},
+{0,2,0},{1,2,1},{2,0,1},{2,2,0},{-1,0,0},
+{0,2,0},{1,2,0},{2,0,1},{2,2,1},{-1,0,0},
+{0,1,1},{1,1,1},{2,0,0},{2,1,0},{2,2,0},{-1,0,0},
+{0,1,1},{0,2,1},{1,1,1},{1,2,1},{2,1,1},{2,2,1},{-1,0,0}
+};
+static const MultLemmaLit MULT_LEMMAS_K4[] = {
+{0,2,1},{1,2,1},{2,0,1},{2,2,1},{-1,0,0},
+{0,2,1},{1,2,0},{2,0,1},{2,2,0},{-1,0,0},
+{0,2,0},{1,2,1},{2,0,1},{2,2,0},{-1,0,0},
+{0,2,0},{1,2,0},{2,0,1},{2,2,1},{-1,0,0},
+{0,1,1},{1,1,1},{2,0,0},{2,1,0},{2,2,0},{-1,0,0},
+{0,2,1},{1,0,0},{1,3,1},{2,1,1},{2,3,1},{-1,0,0},
+{0,2,1},{1,0,0},{1,3,0},{2,1,1},{2,3,0},{-1,0,0},
+{0,0,0},{0,3,1},{1,2,1},{2,1,1},{2,3,1},{-1,0,0},
+{0,0,0},{0,3,1},{1,2,0},{2,1,1},{2,3,0},{-1,0,0},
+{0,0,0},{0,3,0},{1,2,1},{2,1,1},{2,3,0},{-1,0,0},
+{0,0,0},{0,3,0},{1,2,0},{2,1,1},{2,3,1},{-1,0,0},
+{0,2,0},{1,0,0},{1,3,0},{2,1,1},{2,3,1},{-1,0,0},
+{0,2,0},{1,0,0},{1,3,1},{2,1,1},{2,3,0},{-1,0,0},
+{0,3,1},{1,1,1},{1,2,1},{1,3,1},{2,0,1},{2,3,1},{-1,0,0},
+{0,1,1},{0,2,1},{0,3,1},{1,3,1},{2,0,1},{2,3,1},{-1,0,0},
+{0,1,1},{0,2,1},{0,3,1},{1,3,0},{2,0,1},{2,3,0},{-1,0,0},
+{0,3,0},{1,1,1},{1,2,1},{1,3,1},{2,0,1},{2,3,0},{-1,0,0},
+{0,1,1},{0,2,1},{0,3,0},{1,3,1},{2,0,1},{2,3,0},{-1,0,0},
+{0,1,1},{0,2,1},{0,3,0},{1,3,0},{2,0,1},{2,3,1},{-1,0,0},
+{0,3,0},{1,1,1},{1,2,1},{1,3,0},{2,0,1},{2,3,1},{-1,0,0},
+{0,3,0},{1,3,1},{2,0,1},{2,1,1},{2,2,0},{2,3,0},{-1,0,0},
+{0,3,0},{1,3,1},{2,0,1},{2,1,0},{2,2,1},{2,3,0},{-1,0,0},
+{0,3,0},{1,3,0},{2,0,1},{2,1,1},{2,2,0},{2,3,1},{-1,0,0},
+{0,3,0},{1,3,0},{2,0,1},{2,1,0},{2,2,1},{2,3,1},{-1,0,0},
+{0,2,0},{1,2,0},{2,1,0},{2,2,1},{2,3,1},{-1,0,0},
+{0,1,1},{0,2,1},{1,1,1},{1,2,1},{2,2,1},{2,3,1},{-1,0,0},
+{0,3,1},{1,1,1},{1,2,1},{1,3,0},{2,0,1},{2,3,0},{-1,0,0},
+{0,1,1},{0,2,1},{1,2,0},{2,0,0},{2,1,0},{2,2,1},{2,3,0},{-1,0,0},
+{0,2,0},{1,1,1},{1,2,1},{2,0,0},{2,1,0},{2,2,1},{2,3,0},{-1,0,0},
+{0,3,1},{1,3,0},{2,0,1},{2,1,1},{2,2,0},{2,3,0},{-1,0,0},
+{0,1,1},{0,2,1},{1,1,1},{1,2,1},{2,1,1},{2,2,1},{-1,0,0},
+{0,3,1},{1,3,0},{2,0,1},{2,1,0},{2,2,1},{2,3,0},{-1,0,0},
+{0,1,0},{0,2,1},{1,1,0},{1,2,1},{2,0,0},{2,2,0},{2,3,1},{-1,0,0},
+{0,1,1},{0,2,1},{1,1,0},{1,2,1},{2,0,0},{2,2,0},{2,3,0},{-1,0,0},
+{0,1,0},{0,3,1},{1,1,0},{1,3,1},{2,0,0},{2,2,1},{2,3,0},{-1,0,0},
+{0,1,0},{0,2,1},{1,1,1},{1,2,1},{2,0,0},{2,2,0},{2,3,0},{-1,0,0},
+{0,1,0},{0,2,1},{0,3,1},{1,1,0},{1,3,0},{2,2,0},{2,3,1},{-1,0,0},
+{0,1,0},{0,3,0},{1,1,0},{1,2,1},{1,3,1},{2,2,0},{2,3,1},{-1,0,0},
+{0,2,1},{0,3,1},{1,0,1},{1,1,1},{1,3,1},{2,1,0},{2,3,1},{-1,0,0},
+{0,1,1},{0,3,1},{1,2,0},{1,3,0},{2,1,0},{2,2,0},{2,3,1},{-1,0,0},
+{0,0,1},{0,1,1},{0,3,1},{1,2,1},{1,3,1},{2,1,0},{2,3,1},{-1,0,0},
+{0,2,0},{0,3,0},{1,1,1},{1,3,1},{2,1,0},{2,2,0},{2,3,1},{-1,0,0},
+{0,3,1},{1,3,1},{2,0,1},{2,1,1},{2,2,0},{2,3,1},{-1,0,0},
+{0,3,1},{1,3,1},{2,0,1},{2,1,0},{2,2,1},{2,3,1},{-1,0,0},
+{0,1,1},{0,3,1},{1,1,0},{1,2,1},{1,3,1},{2,0,0},{2,2,1},{2,3,1},{-1,0,0},
+{0,1,0},{0,2,1},{0,3,1},{1,1,1},{1,3,1},{2,0,0},{2,2,1},{2,3,1},{-1,0,0},
+{0,1,1},{0,3,0},{1,2,1},{1,3,0},{2,1,1},{2,2,1},{2,3,0},{-1,0,0},
+{0,0,1},{0,2,1},{0,3,1},{1,1,0},{1,3,1},{2,1,0},{2,2,0},{2,3,0},{-1,0,0},
+{0,1,0},{0,3,1},{1,0,1},{1,2,1},{1,3,1},{2,1,0},{2,2,0},{2,3,0},{-1,0,0},
+{0,2,1},{0,3,0},{1,1,1},{1,2,0},{1,3,1},{2,1,0},{2,3,0},{-1,0,0},
+{0,1,1},{0,3,1},{1,1,1},{1,2,0},{1,3,1},{2,2,0},{2,3,0},{-1,0,0},
+{0,1,1},{0,2,0},{1,2,1},{1,3,0},{2,0,0},{2,1,0},{2,3,0},{-1,0,0},
+{0,1,1},{0,2,0},{0,3,1},{1,1,1},{1,3,1},{2,2,0},{2,3,0},{-1,0,0},
+{0,1,1},{0,2,0},{0,3,1},{1,1,1},{1,3,0},{2,2,0},{2,3,1},{-1,0,0},
+{0,1,1},{0,3,0},{1,1,1},{1,2,0},{1,3,1},{2,2,0},{2,3,1},{-1,0,0},
+{0,1,1},{0,3,0},{1,2,0},{1,3,0},{2,0,0},{2,2,0},{2,3,1},{-1,0,0},
+{0,2,0},{0,3,0},{1,1,1},{1,3,0},{2,0,0},{2,2,0},{2,3,1},{-1,0,0},
+{0,2,1},{0,3,1},{1,1,1},{1,2,0},{1,3,0},{2,2,0},{2,3,0},{-1,0,0},
+{0,2,1},{0,3,1},{1,1,1},{1,3,0},{2,1,0},{2,2,0},{2,3,0},{-1,0,0},
+{0,2,1},{0,3,0},{1,1,1},{1,3,1},{2,1,1},{2,2,1},{2,3,1},{-1,0,0},
+{0,2,1},{0,3,0},{1,1,1},{1,2,0},{2,0,0},{2,1,0},{2,3,0},{-1,0,0},
+{0,2,1},{0,3,0},{1,1,1},{1,3,0},{2,1,1},{2,2,1},{2,3,0},{-1,0,0},
+{0,1,1},{0,3,1},{1,2,1},{1,3,0},{2,1,1},{2,2,1},{2,3,1},{-1,0,0},
+{0,1,1},{0,3,1},{1,2,1},{1,3,0},{2,1,0},{2,2,0},{2,3,0},{-1,0,0},
+{0,1,1},{0,3,1},{1,0,1},{1,2,0},{1,3,0},{2,2,1},{2,3,0},{-1,0,0},
+{0,1,1},{0,2,0},{0,3,0},{1,2,1},{1,3,1},{2,2,0},{2,3,0},{-1,0,0},
+{0,1,1},{0,2,0},{0,3,0},{1,1,1},{1,2,1},{1,3,1},{2,3,0},{-1,0,0},
+{0,1,1},{0,3,0},{1,2,1},{1,3,1},{2,1,0},{2,2,0},{2,3,0},{-1,0,0},
+{0,1,1},{0,3,0},{1,0,1},{1,2,0},{1,3,0},{2,2,1},{2,3,1},{-1,0,0},
+{0,0,1},{0,2,0},{0,3,0},{1,1,1},{1,3,1},{2,2,1},{2,3,0},{-1,0,0},
+{0,0,1},{0,2,0},{0,3,0},{1,1,1},{1,3,0},{2,2,1},{2,3,1},{-1,0,0},
+{0,0,1},{0,1,1},{0,3,0},{1,2,1},{1,3,1},{2,1,1},{2,2,1},{2,3,1},{-1,0,0},
+{0,1,1},{0,3,1},{1,0,1},{1,2,1},{1,3,1},{2,2,0},{2,3,1},{-1,0,0},
+{0,0,1},{0,2,1},{0,3,1},{1,1,1},{1,3,1},{2,2,0},{2,3,1},{-1,0,0},
+{0,0,1},{0,2,1},{0,3,0},{1,2,0},{1,3,0},{2,1,0},{2,3,1},{-1,0,0},
+{0,0,1},{0,1,1},{0,3,0},{1,1,0},{1,3,1},{2,2,0},{2,3,0},{-1,0,0},
+{0,0,1},{0,1,1},{0,3,0},{1,1,0},{1,3,0},{2,2,0},{2,3,1},{-1,0,0},
+{0,1,0},{0,3,1},{1,0,1},{1,1,1},{1,3,0},{2,2,0},{2,3,0},{-1,0,0},
+{0,1,0},{0,3,0},{1,0,1},{1,1,1},{1,3,0},{2,2,0},{2,3,1},{-1,0,0},
+{0,2,0},{0,3,1},{1,0,1},{1,2,1},{1,3,0},{2,1,0},{2,3,0},{-1,0,0},
+{0,2,0},{0,3,0},{1,0,1},{1,2,1},{1,3,0},{2,1,0},{2,3,1},{-1,0,0},
+{0,2,1},{0,3,1},{1,0,1},{1,1,1},{1,3,1},{2,1,1},{2,2,1},{2,3,0},{-1,0,0},
+{0,2,1},{0,3,1},{1,0,1},{1,1,1},{1,3,0},{2,1,1},{2,2,1},{2,3,1},{-1,0,0},
+{0,1,1},{0,2,0},{0,3,0},{1,0,1},{1,1,1},{1,3,0},{2,2,0},{2,3,0},{-1,0,0},
+{0,0,1},{0,1,1},{0,3,1},{1,2,1},{1,3,1},{2,1,1},{2,2,1},{2,3,0},{-1,0,0},
+{0,0,1},{0,1,1},{0,2,0},{0,3,1},{1,2,0},{1,3,1},{2,1,0},{2,3,0},{-1,0,0},
+{0,0,1},{0,1,1},{0,3,0},{1,1,1},{1,2,0},{1,3,0},{2,2,0},{2,3,0},{-1,0,0},
+{0,2,0},{0,3,1},{1,0,1},{1,1,1},{1,2,0},{1,3,1},{2,1,0},{2,3,0},{-1,0,0}
+};
+
+template <class BBNode, class BBNodeManagerT>
+void BitBlaster<BBNode, BBNodeManagerT>::multLemmaBlock(const BBNodeVec& x,
+                                                        const BBNodeVec& y,
+                                                        const BBNodeVec& p,
+                                                        BBNodeSet& support)
+{
+  const MultLemmaLit* table;
+  size_t count;
+  unsigned k;
+  if (uf->multiplication_lemmas == 3)
+  {
+    table = MULT_LEMMAS_K3;
+    count = sizeof(MULT_LEMMAS_K3) / sizeof(MULT_LEMMAS_K3[0]);
+    k = 3;
+  }
+  else if (uf->multiplication_lemmas == 4)
+  {
+    table = MULT_LEMMAS_K4;
+    count = sizeof(MULT_LEMMAS_K4) / sizeof(MULT_LEMMAS_K4[0]);
+    k = 4;
+  }
+  else
+    return;
+  if (x.size() < k)
+    return;
+
+  BBNode clause = BBFalse;
+  for (size_t i = 0; i < count; i++)
+  {
+    const MultLemmaLit& l = table[i];
+    if (l.vec < 0)
+    {
+      if (clause != BBTrue)
+        support.insert(clause);
+      clause = BBFalse;
+      continue;
+    }
+    const BBNodeVec& v = l.vec == 0 ? x : l.vec == 1 ? y : p;
+    BBNode lit = v[l.bit];
+    if (l.neg)
+      lit = nf->CreateNode(NOT, lit);
+    clause = nf->CreateNode(OR, clause, lit);
+  }
+}
+
+// The partial-product rows accumulated in carry-save form: every row after
+// the first goes through one layer of full adders against the running sum
+// and carry vectors, and a single ripple adder combines the two at the end.
+// The same full-adder count as the column network, arranged row by row
+// with the carry chain deferred to the last step -- the array multiplier
+// of the hardware textbooks.
+template <class BBNode, class BBNodeManagerT>
+vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::mult_csaRows(
+    const BBNodeVec& x, const BBNodeVec& y, BBNodeSet& /*support*/,
+    const ASTNode& n)
+{
+  const int bitWidth = n.GetValueWidth();
+  BBNodeVec ycopy(y);
+  BBNodeVec sum(bitWidth, BBFalse);
+  BBNodeVec carry(bitWidth, BBFalse);
+  bool first = true;
+
+  for (int i = 0; i < bitWidth; i++)
+  {
+    if (i > 0)
+      BBLShift(ycopy, 1);
+    if (x[i] == BBFalse)
+      continue;
+    const BBNodeVec row = BBAndBit(ycopy, x[i]);
+    if (first)
+    {
+      sum = row;
+      first = false;
+      continue;
+    }
+    BBNodeVec nextCarry(bitWidth, BBFalse);
+    for (int j = 0; j < bitWidth; j++)
+    {
+      BBNode s, c;
+      fullAdder(sum[j], carry[j], row[j], s, c);
+      sum[j] = s;
+      if (j + 1 < bitWidth)
+        nextCarry[j + 1] = c;
+    }
+    carry = nextCarry;
+  }
+  BBPlus2(sum, carry, BBFalse);
+  return sum;
+}
+
+// Dadda's reduction of the partial-product columns: stages with target
+// heights 2, 3, 4, 6, 9, 13, ... taken from the top, each column reduced to
+// the stage's height with as few adders as will do it (a half adder where
+// one bit too many, full adders otherwise), carries landing in the next
+// column of the same stage; then one ripple adder over the two rows left.
+// Fewer adders than the greedy column network, and a shallower tree.
+template <class BBNode, class BBNodeManagerT>
+vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::mult_dadda(
+    vector<list<BBNode>>& products, BBNodeSet& /*support*/, const ASTNode& n)
+{
+  const int bitWidth = n.GetValueWidth();
+  vector<vector<BBNode>> cols(bitWidth);
+  size_t maxHeight = 0;
+  for (int i = 0; i < bitWidth; i++)
+  {
+    for (const BBNode& b : products[i])
+      if (b != BBFalse)
+        cols[i].push_back(b);
+    products[i].clear();
+    maxHeight = std::max(maxHeight, cols[i].size());
+  }
+
+  vector<size_t> targets;
+  for (size_t d = 2; d < maxHeight; d = d + d / 2)
+    targets.push_back(d);
+
+  for (int t = (int)targets.size() - 1; t >= 0; t--)
+  {
+    const size_t d = targets[t];
+    vector<BBNode> carriesIn;
+    for (int i = 0; i < bitWidth; i++)
+    {
+      vector<BBNode> bits = cols[i];
+      bits.insert(bits.end(), carriesIn.begin(), carriesIn.end());
+      carriesIn.clear();
+      // The sums already produced stay in this column, so they count
+      // toward the stage's height along with the bits not yet reduced.
+      vector<BBNode> kept;
+      while (bits.size() + kept.size() > d)
+      {
+        BBNode s, c;
+        if (bits.size() + kept.size() == d + 1)
+        {
+          const BBNode a = bits.back();
+          bits.pop_back();
+          const BBNode b = bits.back();
+          bits.pop_back();
+          s = xorWithSharing(a, b);
+          c = nf->CreateNode(AND, a, b);
+        }
+        else
+        {
+          const BBNode a = bits.back();
+          bits.pop_back();
+          const BBNode b = bits.back();
+          bits.pop_back();
+          const BBNode cin = bits.back();
+          bits.pop_back();
+          fullAdder(a, b, cin, s, c);
+        }
+        kept.push_back(s);
+        if (i + 1 < bitWidth && c != BBFalse)
+          carriesIn.push_back(c);
+      }
+      bits.insert(bits.end(), kept.begin(), kept.end());
+      cols[i] = bits;
+    }
+  }
+
+  BBNodeVec rowA(bitWidth, BBFalse);
+  BBNodeVec rowB(bitWidth, BBFalse);
+  for (int i = 0; i < bitWidth; i++)
+  {
+    assert(cols[i].size() <= 2);
+    if (cols[i].size() > 0)
+      rowA[i] = cols[i][0];
+    if (cols[i].size() > 1)
+      rowB[i] = cols[i][1];
+  }
+  BBPlus2(rowA, rowB, BBFalse);
+  return rowA;
+}
+
+// Radix-4 without Booth: each pair of multiplier bits selects 0, y, 2y or
+// 3y, with 3y computed once by an adder. Half the rows of the AND array,
+// no negative digits, so no conditional inversion and no correction bit --
+// the question being whether modified Booth's propagation weakness is the
+// halving or the negation.
+template <class BBNode, class BBNodeManagerT>
+void BitBlaster<BBNode, BBNodeManagerT>::mult_radix4_hard(
+    const BBNodeVec& x, const BBNodeVec& y, vector<list<BBNode>>& products,
+    const ASTNode& n)
+{
+  const unsigned bitWidth = n.GetValueWidth();
+  booth_recoded.insert(n);
+
+  BBNodeVec y2(y);
+  BBLShift(y2, 1);
+  BBNodeVec y3(y);
+  BBPlus2(y3, y2, BBFalse);
+
+  for (unsigned base = 0; base < bitWidth; base += 2)
+  {
+    const BBNode& low = x[base];
+    const BBNode& high = (base + 1 < bitWidth) ? x[base + 1] : BBFalse;
+    for (unsigned j = 0; base + j < bitWidth; j++)
+    {
+      const BBNode whenHigh = nf->CreateNode(ITE, low, y3[j], y2[j]);
+      const BBNode whenLow = nf->CreateNode(AND, low, y[j]);
+      const BBNode bit = nf->CreateNode(ITE, high, whenHigh, whenLow);
+      if (bit != BBFalse)
+        products[base + j].push_back(bit);
+    }
+  }
+}
+
 template <class BBNode, class BBNodeManagerT>
 vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::BBMult(const BBNodeVec& _x,
                                                           const BBNodeVec& _y,
                                                           BBNodeSet& support,
                                                           const ASTNode& n)
+{
+  const BBNodeVec result = BBMultVariant(_x, _y, support, n);
+  if (uf->multiplication_lemmas != 0)
+    multLemmaBlock(_x, _y, result, support);
+  return result;
+}
+
+template <class BBNode, class BBNodeManagerT>
+vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::BBMultVariant(
+    const BBNodeVec& _x, const BBNodeVec& _y, BBNodeSet& support,
+    const ASTNode& n)
 {
 
   //  if (uf->isSet("print_on_mult", "0"))
@@ -3775,6 +4105,42 @@ vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::BBMult(const BBNodeVec& _x,
       // symbolic. This picks between them per multiply rather than per query.
       if (!mult_Booth_constant(x, y, support, products, n))
         mult_Booth_radix4(x, y, products, n);
+      return buildAdditionNetworkResult(products, support, n);
+    }
+
+    case 17:
+    {
+      return mult_csaRows(x, y, support, n);
+    }
+
+    case 18:
+    {
+      mult_Booth(_x, _y, support, n[0], n[1], products, n);
+      setColumnsToZero(products, support, n);
+      return mult_dadda(products, support, n);
+    }
+
+    case 19:
+    {
+      // Variant 1 with the operands of a symbolic-by-symbolic multiply in
+      // a canonical order. mult_normal iterates over the bits of x, so
+      // x*y and y*x build different circuits and never hash together;
+      // ordering the vectors makes the two orders one AIG node, which is
+      // what the Booth path's per-column sort achieves for the network
+      // variants.
+      bool xConst = true;
+      for (const BBNode& b : x)
+        if (b != BBTrue && b != BBFalse)
+          xConst = false;
+      if (!xConst && std::lexicographical_compare(y.begin(), y.end(),
+                                                  x.begin(), x.end()))
+        return mult_normal(y, x, support, n);
+      return mult_normal(x, y, support, n);
+    }
+
+    case 20:
+    {
+      mult_radix4_hard(x, y, products, n);
       return buildAdditionNetworkResult(products, support, n);
     }
 
@@ -7402,6 +7768,18 @@ static void recordShiftTapHook(BBNodeManagerLit* nf, int kind,
                                const std::vector<BBNodeLit>& r)
 {
   nf->shiftTaps.push_back(BBNodeManagerLit::ShiftTap{kind, a, s, r});
+}
+
+template <class M, class V>
+static void recordMultTapHook(M*, const V&, const V&, const V&)
+{
+}
+static void recordMultTapHook(BBNodeManagerLit* nf,
+                              const std::vector<BBNodeLit>& x,
+                              const std::vector<BBNodeLit>& y,
+                              const std::vector<BBNodeLit>& r)
+{
+  nf->multTaps.push_back(BBNodeManagerLit::MultTap{x, y, r});
 }
 
 std::ostream& operator<<(std::ostream& output, const BBNodeAIG& /*h*/)

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -4179,6 +4179,24 @@ vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::BBMultVariant(
       return mult_csaRows(x, y, support, n);
     }
 
+    case 23:
+    {
+      // 21 with the hard-triple radix-4 rows (20) for the symbolic pair,
+      // in canonical order.
+      if (mult_Booth_constant(x, y, support, products, n))
+        return buildAdditionNetworkResult(products, support, n);
+      bool xConst = true;
+      for (const BBNode& b : x)
+        if (b != BBTrue && b != BBFalse)
+          xConst = false;
+      if (!xConst && std::lexicographical_compare(y.begin(), y.end(),
+                                                  x.begin(), x.end()))
+        mult_radix4_hard(y, x, products, n);
+      else
+        mult_radix4_hard(x, y, products, n);
+      return buildAdditionNetworkResult(products, support, n);
+    }
+
     default:
     {
       cerr << "Unk variant" << uf->multiplication_variant;

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -3934,6 +3934,52 @@ void BitBlaster<BBNode, BBNodeManagerT>::mult_radix4_hard(
   }
 }
 
+// Which operand should supply the rows (or the radix-4 digits) of a
+// symbolic multiply. Cheaper first: fewer symbolic bits, then fewer
+// distinct literals -- a sign-extended operand repeats one literal across
+// its width, and rows drawn from it share their cells while rows drawn
+// against it do not -- then the lexicographic order, which only serves to
+// give both orders of one product the same circuit. Symmetric in the pair,
+// so x*y and y*x agree. Returns true when y should take x's role.
+// How many bits of a vector are symbolic, and how many distinct nodes they
+// are (a sign-extended value has many symbolic bits and few nodes).
+template <class BBNode>
+static void operandProfile(const std::vector<BBNode>& v, const BBNode& bbTrue,
+                           const BBNode& bbFalse, unsigned& symbolic,
+                           unsigned& distinct)
+{
+  symbolic = 0;
+  std::vector<BBNode> seen;
+  for (const BBNode& b : v)
+  {
+    if (b == bbTrue || b == bbFalse)
+      continue;
+    symbolic++;
+    if (std::find(seen.begin(), seen.end(), b) == seen.end())
+      seen.push_back(b);
+  }
+  distinct = seen.size();
+}
+
+template <class BBNode>
+static bool cheaperAsMultiplier(const std::vector<BBNode>& x,
+                                const std::vector<BBNode>& y,
+                                const BBNode& bbTrue, const BBNode& bbFalse)
+{
+  unsigned xs, xd, ys, yd;
+  operandProfile(x, bbTrue, bbFalse, xs, xd);
+  operandProfile(y, bbTrue, bbFalse, ys, yd);
+  if (xs == 0)
+    return false; // a constant multiplier already sits in x
+  if (ys == 0)
+    return true;
+  if (ys != xs)
+    return ys < xs;
+  if (yd != xd)
+    return yd < xd;
+  return std::lexicographical_compare(y.begin(), y.end(), x.begin(), x.end());
+}
+
 template <class BBNode, class BBNodeManagerT>
 vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::BBMult(const BBNodeVec& _x,
                                                           const BBNodeVec& _y,
@@ -4128,12 +4174,7 @@ vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::BBMultVariant(
       // ordering the vectors makes the two orders one AIG node, which is
       // what the Booth path's per-column sort achieves for the network
       // variants.
-      bool xConst = true;
-      for (const BBNode& b : x)
-        if (b != BBTrue && b != BBFalse)
-          xConst = false;
-      if (!xConst && std::lexicographical_compare(y.begin(), y.end(),
-                                                  x.begin(), x.end()))
+      if (cheaperAsMultiplier(x, y, BBTrue, BBFalse))
         return mult_normal(y, x, support, n);
       return mult_normal(x, y, support, n);
     }
@@ -4153,12 +4194,7 @@ vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::BBMultVariant(
       // its operand class; nothing else changes.
       if (mult_Booth_constant(x, y, support, products, n))
         return buildAdditionNetworkResult(products, support, n);
-      bool xConst = true;
-      for (const BBNode& b : x)
-        if (b != BBTrue && b != BBFalse)
-          xConst = false;
-      if (!xConst && std::lexicographical_compare(y.begin(), y.end(),
-                                                  x.begin(), x.end()))
+      if (cheaperAsMultiplier(x, y, BBTrue, BBFalse))
         return mult_normal(y, x, support, n);
       return mult_normal(x, y, support, n);
     }
@@ -4169,12 +4205,7 @@ vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::BBMultVariant(
       // symbolic pair.
       if (mult_Booth_constant(x, y, support, products, n))
         return buildAdditionNetworkResult(products, support, n);
-      bool xConst = true;
-      for (const BBNode& b : x)
-        if (b != BBTrue && b != BBFalse)
-          xConst = false;
-      if (!xConst && std::lexicographical_compare(y.begin(), y.end(),
-                                                  x.begin(), x.end()))
+      if (cheaperAsMultiplier(x, y, BBTrue, BBFalse))
         return mult_csaRows(y, x, support, n);
       return mult_csaRows(x, y, support, n);
     }
@@ -4182,18 +4213,21 @@ vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::BBMultVariant(
     case 23:
     {
       // 21 with the hard-triple radix-4 rows (20) for the symbolic pair,
-      // in canonical order.
+      // in canonical order -- unless an operand repeats a few literals
+      // across its width (a sign- or digit-extended value), where the AND
+      // rows of the shift-add path share their cells and the 3y adder and
+      // select cells cannot: there 21's rows are three times smaller.
       if (mult_Booth_constant(x, y, support, products, n))
         return buildAdditionNetworkResult(products, support, n);
-      bool xConst = true;
-      for (const BBNode& b : x)
-        if (b != BBTrue && b != BBFalse)
-          xConst = false;
-      if (!xConst && std::lexicographical_compare(y.begin(), y.end(),
-                                                  x.begin(), x.end()))
-        mult_radix4_hard(y, x, products, n);
-      else
-        mult_radix4_hard(x, y, products, n);
+      const bool swap = cheaperAsMultiplier(x, y, BBTrue, BBFalse);
+      const BBNodeVec& a = swap ? y : x;
+      const BBNodeVec& b = swap ? x : y;
+      unsigned as, ad, bs, bd;
+      operandProfile(a, BBTrue, BBFalse, as, ad);
+      operandProfile(b, BBTrue, BBFalse, bs, bd);
+      if (2 * ad < as || 2 * bd < bs)
+        return mult_normal(a, b, support, n);
+      mult_radix4_hard(a, b, products, n);
       return buildAdditionNetworkResult(products, support, n);
     }
 

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -35,6 +35,7 @@ THE SOFTWARE.
 #include "stp/Util/DagWalk.h"
 #include <algorithm>
 #include <cassert>
+#include <cstdlib>
 #include <deque>
 #include <cmath>
 #include <limits>
@@ -1239,6 +1240,12 @@ const vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::BBTerm(
       {
         temp_result[i] = nf->CreateNode(ITE, remainder, toFill, temp_result[i]);
       }
+
+      static const bool tapShifts = getenv("STP_SHIFT_ANNOTATE") != NULL;
+      if (tapShifts && !term[1].isConstant())
+        recordShiftTapHook(nf,
+                           k == BVLEFTSHIFT ? 0 : k == BVRIGHTSHIFT ? 1 : 2,
+                           bbarg1, bbarg2, temp_result);
 
       result = temp_result;
     }
@@ -7381,6 +7388,20 @@ BBNode BitBlaster<BBNode, BBNodeManagerT>::BBEQ(const BBNodeVec& left,
   }
   else
     return nf->CreateNode(IFF, *lit, *rit);
+}
+
+// Shift-tap hook for the lazy-oracle experiments: a no-op except on the
+// Lit manager, and only when STP_SHIFT_ANNOTATE is set.
+template <class M, class V>
+static void recordShiftTapHook(M*, int, const V&, const V&, const V&)
+{
+}
+static void recordShiftTapHook(BBNodeManagerLit* nf, int kind,
+                               const std::vector<BBNodeLit>& a,
+                               const std::vector<BBNodeLit>& s,
+                               const std::vector<BBNodeLit>& r)
+{
+  nf->shiftTaps.push_back(BBNodeManagerLit::ShiftTap{kind, a, s, r});
 }
 
 std::ostream& operator<<(std::ostream& output, const BBNodeAIG& /*h*/)

--- a/lib/ToSat/ToCNFAIG.cpp
+++ b/lib/ToSat/ToCNFAIG.cpp
@@ -247,6 +247,7 @@ CNF ToCNFAIG::derive_cnf(BBNodeManagerAIG& mgr, unsigned namedOutputs)
     case UserDefinedFlags::CNF_EFFORT_NEW_VERY_LOW:
     case UserDefinedFlags::CNF_EFFORT_NEW_LOW:
     case UserDefinedFlags::CNF_EFFORT_NEW_MEDIUM:
+    case UserDefinedFlags::CNF_EFFORT_NEW_HIGH:
       return fromAig(Cnf_DeriveFast(mgr.aigMgr, (int)namedOutputs));
 
     case UserDefinedFlags::CNF_EFFORT_GIA_LOW:

--- a/lib/ToSat/ToCNFTseitin.cpp
+++ b/lib/ToSat/ToCNFTseitin.cpp
@@ -53,9 +53,42 @@ void ToCNFTseitin::toCNF(const BBNodeLit& top, CNF& cnf,
     recover = aig::Recover::Patterns;
 
   const char* annPath = getenv("STP_SHIFT_ANNOTATE");
+  const char* multPath = getenv("STP_MULT_ANNOTATE");
   std::vector<uint32_t> nodeVar;
   cnf = aig::deriveTseitin(mgr.mgr, 0, recover,
-                           annPath ? &nodeVar : nullptr);
+                           (annPath || multPath) ? &nodeVar : nullptr);
+
+  // The literal id of one bit in writeDimacs numbering: t/f for a
+  // constant, 0 for a bit no variable reached, negative for a complement.
+  auto litId = [&](const BBNodeLit& bit, std::ostream& out) {
+    if (!bit.IsNull() && aig::isConst(bit.n))
+    {
+      out << " " << (bit.n == aig::LIT_TRUE ? "t" : "f");
+      return;
+    }
+    int id = 0;
+    if (!bit.IsNull())
+    {
+      const uint32_t v = nodeVar[aig::nodeOf(bit.n)];
+      if (v != 0)
+        id = aig::isNeg(bit.n) ? -(int)(v + 1) : (int)(v + 1);
+    }
+    out << " " << id;
+  };
+
+  if (multPath)
+  {
+    // One line per multiply: c mult W x_0..x_{W-1} y_0.. r_0..
+    std::ofstream ann(multPath);
+    for (const auto& tap : mgr.multTaps)
+    {
+      ann << "c mult " << tap.x.size();
+      for (const std::vector<BBNodeLit>* vec : {&tap.x, &tap.y, &tap.r})
+        for (const BBNodeLit& bit : *vec)
+          litId(bit, ann);
+      ann << "\n";
+    }
+  }
 
   if (annPath)
   {

--- a/lib/ToSat/ToCNFTseitin.cpp
+++ b/lib/ToSat/ToCNFTseitin.cpp
@@ -51,6 +51,8 @@ void ToCNFTseitin::toCNF(const BBNodeLit& top, CNF& cnf,
     recover = aig::Recover::Nothing;
   else if (uf.cnf_effort == UserDefinedFlags::CNF_EFFORT_NEW_LOW)
     recover = aig::Recover::Patterns;
+  else if (uf.cnf_effort == UserDefinedFlags::CNF_EFFORT_NEW_HIGH)
+    recover = aig::Recover::Cells;
 
   const char* annPath = getenv("STP_SHIFT_ANNOTATE");
   const char* multPath = getenv("STP_MULT_ANNOTATE");
@@ -148,6 +150,7 @@ void ToCNFTseitin::toCNF(const BBNodeLit& top, CNF& cnf,
   if (uf.stats_flag)
     std::cerr << (recover == aig::Recover::Nothing    ? "new-very-low CNF"
                   : recover == aig::Recover::Patterns ? "new-low CNF"
+                  : recover == aig::Recover::Cells    ? "new-high CNF"
                                                       : "new-medium CNF")
               << std::endl;
 }

--- a/lib/ToSat/ToCNFTseitin.cpp
+++ b/lib/ToSat/ToCNFTseitin.cpp
@@ -23,6 +23,8 @@ THE SOFTWARE.
 ********************************************************************/
 
 #include "stp/ToSat/ToCNFTseitin.h"
+#include <cstdlib>
+#include <fstream>
 
 #include "stp/AIG/Tseitin.h"
 
@@ -50,7 +52,42 @@ void ToCNFTseitin::toCNF(const BBNodeLit& top, CNF& cnf,
   else if (uf.cnf_effort == UserDefinedFlags::CNF_EFFORT_NEW_LOW)
     recover = aig::Recover::Patterns;
 
-  cnf = aig::deriveTseitin(mgr.mgr, 0, recover);
+  const char* annPath = getenv("STP_SHIFT_ANNOTATE");
+  std::vector<uint32_t> nodeVar;
+  cnf = aig::deriveTseitin(mgr.mgr, 0, recover,
+                           annPath ? &nodeVar : nullptr);
+
+  if (annPath)
+  {
+    // One line per symbolic-amount shift: variable ids in the numbering
+    // writeDimacs uses (internal var + 1); negative = the bit is the
+    // variable's complement; 0 = the bit reached no variable.
+    std::ofstream ann(annPath);
+    static const char* names[3] = {"shl", "lshr", "ashr"};
+    for (const auto& tap : mgr.shiftTaps)
+    {
+      ann << "c shift " << names[tap.kind] << " " << tap.a.size();
+      for (const std::vector<BBNodeLit>* vec : {&tap.a, &tap.s, &tap.r})
+        for (const BBNodeLit& bit : *vec)
+        {
+          if (!bit.IsNull() && aig::isConst(bit.n))
+          {
+            // constants matter to the oracle: t/f instead of a var id
+            ann << " " << (bit.n == aig::LIT_TRUE ? "t" : "f");
+            continue;
+          }
+          int id = 0;
+          if (!bit.IsNull())
+          {
+            const uint32_t v = nodeVar[aig::nodeOf(bit.n)];
+            if (v != 0)
+              id = aig::isNeg(bit.n) ? -(int)(v + 1) : (int)(v + 1);
+          }
+          ann << " " << id;
+        }
+      ann << "\n";
+    }
+  }
 
   // Each symbol maps to the variables its bits carry. ~0u for a bit that
   // reached no variable, which is the same sentinel fill_node_to_var writes

--- a/lib/ToSat/ToSATAIG.cpp
+++ b/lib/ToSat/ToSATAIG.cpp
@@ -321,7 +321,8 @@ bool ToSATAIG::bitblast(const ASTNode& input, bool needAbsRef, CNF& cnf)
   const enum UserDefinedFlags::CNFEffort e = bm->UserFlags.cnf_effort;
   if (e == UserDefinedFlags::CNF_EFFORT_NEW_VERY_LOW ||
       e == UserDefinedFlags::CNF_EFFORT_NEW_LOW ||
-      e == UserDefinedFlags::CNF_EFFORT_NEW_MEDIUM)
+      e == UserDefinedFlags::CNF_EFFORT_NEW_MEDIUM ||
+      e == UserDefinedFlags::CNF_EFFORT_NEW_HIGH)
     return bitblastWith<BBNodeLit, BBNodeManagerLit, BitBlasterLit,
                         ToCNFTseitin>(input, needAbsRef, cnf);
   if (UserDefinedFlags::isGiaEffort(bm->UserFlags.cnf_effort))

--- a/tests/api/C/cnf-effort-flag.cpp
+++ b/tests/api/C/cnf-effort-flag.cpp
@@ -131,6 +131,8 @@ TEST(cnf_effort_flag, EveryLevelIsReachable)
   vc_setInterfaceFlags(vc, CNF_GENERATION_EFFORT, 11);
   EXPECT_EQ(stp::UserDefinedFlags::CNF_EFFORT_GIA_VERY_HIGH,
             flags(vc).cnf_effort);
+  vc_setInterfaceFlags(vc, CNF_GENERATION_EFFORT, 12);
+  EXPECT_EQ(stp::UserDefinedFlags::CNF_EFFORT_NEW_HIGH, flags(vc).cnf_effort);
 
   vc_Destroy(vc);
 }
@@ -149,7 +151,7 @@ TEST(cnf_effort_flag, OutOfRangeIsRefusedAndLeavesTheLevelAlone)
   EXPECT_EQ(stp::UserDefinedFlags::CNF_EFFORT_HIGH, flags(vc).cnf_effort);
 
   // One past the last enumerator.
-  vc_setInterfaceFlags(vc, CNF_GENERATION_EFFORT, 12);
+  vc_setInterfaceFlags(vc, CNF_GENERATION_EFFORT, 13);
   EXPECT_EQ(stp::UserDefinedFlags::CNF_EFFORT_HIGH, flags(vc).cnf_effort);
   vc_setInterfaceFlags(vc, CNF_GENERATION_EFFORT, -1);
   EXPECT_EQ(stp::UserDefinedFlags::CNF_EFFORT_HIGH, flags(vc).cnf_effort);
@@ -161,12 +163,12 @@ TEST(cnf_effort_flag, OutOfRangeIsRefusedAndLeavesTheLevelAlone)
 
 // The level reaches the solve, and every one of them answers the same
 // question the same way. A level that changed a verdict would be a bug in
-// the generator, not a setting -- and since six of the twelve pick a whole
+// the generator, not a setting -- and since seven of the thirteen pick a whole
 // bit-blasting backend rather than an effort, this is where a backend that
 // encoded the query wrongly would be caught.
 TEST(cnf_effort_flag, EveryLevelDecidesTheSameQuery)
 {
-  for (int effort = 0; effort <= 11; ++effort)
+  for (int effort = 0; effort <= 12; ++effort)
   {
     VC vc = vc_createValidityChecker();
     vc_setInterfaceFlags(vc, CNF_GENERATION_EFFORT, effort);

--- a/tools/propagator_bench/PropagatorBench.h
+++ b/tools/propagator_bench/PropagatorBench.h
@@ -339,6 +339,7 @@ struct Config
   int adderVariant = -1;  // -1 leaves UserDefinedFlags::adder_variant alone
   int bvplusVariant = -1; // likewise bvplus_variant
   int multVariant = -1;   // likewise multiplication_variant
+  int multLemmas = -1;    // likewise multiplication_lemmas
   int divVariant1 = -1;   // likewise division_variant_1..4
   int divVariant2 = -1;
   int divVariant3 = -1;

--- a/tools/propagator_bench/main.cpp
+++ b/tools/propagator_bench/main.cpp
@@ -363,6 +363,8 @@ int main(int argc, char** argv)
       uf.cnf_effort = UF::CNF_EFFORT_NEW_LOW;
     else if (cfg.cnf == "new-medium")
       uf.cnf_effort = UF::CNF_EFFORT_NEW_MEDIUM;
+    else if (cfg.cnf == "new-high")
+      uf.cnf_effort = UF::CNF_EFFORT_NEW_HIGH;
     else if (cfg.cnf == "gia-low")
       uf.cnf_effort = UF::CNF_EFFORT_GIA_LOW;
     else if (cfg.cnf == "gia-high")

--- a/tools/propagator_bench/main.cpp
+++ b/tools/propagator_bench/main.cpp
@@ -123,6 +123,7 @@ void usage()
       << "  --bb.add-v2 0|1     UserDefinedFlags::bvplus_variant: 1 pairwise\n"
       << "                      ripple chains (default), 0 the addition\n"
       << "                      network\n"
+      << "  --bb.mult-lemmas K  UserDefinedFlags::multiplication_lemmas\n"
       << "  --bb.mult-v N       UserDefinedFlags::multiplication_variant:\n"
       << "                      1 shift-add ripple (default), 3 Booth +\n"
       << "                      addition network, 4 sorter, 6/7/8/9/13\n"
@@ -278,6 +279,8 @@ int main(int argc, char** argv)
     { cfg.bvplusVariant = atoi(value.c_str()); i++; }
     else if (arg == "--bb.mult-v")
     { cfg.multVariant = atoi(value.c_str()); i++; }
+    else if (arg == "--bb.mult-lemmas")
+    { cfg.multLemmas = atoi(value.c_str()); i++; }
     else if (arg == "--bb.div-v1")
     { cfg.divVariant1 = atoi(value.c_str()); i++; }
     else if (arg == "--bb.div-v2")
@@ -382,6 +385,8 @@ int main(int argc, char** argv)
     mgr->UserFlags.bvplus_variant = cfg.bvplusVariant != 0;
   if (cfg.multVariant >= 0)
     mgr->UserFlags.multiplication_variant = cfg.multVariant;
+  if (cfg.multLemmas >= 0)
+    mgr->UserFlags.multiplication_lemmas = cfg.multLemmas;
   if (cfg.divVariant1 >= 0)
     mgr->UserFlags.division_variant_1 = cfg.divVariant1 != 0;
   if (cfg.divVariant2 >= 0)

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -597,8 +597,21 @@ void ExtraMain::create_options()
             "16 chooses between 14 and 15 for each multiply. "
             "3, 4, 6, 7, 8, 9 and 13 Booth recode and differ in how the "
             "partial-product columns are summed. 5 uses the constant-bit "
-            "multiplication bounds, and needs --bb.mult-v2. Any other value "
+            "multiplication bounds, and needs --bb.mult-v2. 17 accumulates "
+            "the partial-product rows in carry-save form with one final "
+            "adder. 18 reduces the Booth-recoded columns as a Dadda tree. "
+            "19 is 1 with the operands of a symbolic multiply put in a "
+            "canonical order, so both orders of one product share a circuit. "
+            "20 is radix-4 with a hard triple, every row a select of "
+            "0, y, 2y or 3y. Any other value "
             "is an error, reported once bit-blasting reaches a multiply",
+            bb_group);
+
+  int64_arg("--bb.mult-lemmas", bm->UserFlags.multiplication_lemmas,
+            "conjoin to each multiply the low-bit residue implicates its "
+            "circuit cannot propagate: 0 (default) none, 3 the six clauses "
+            "that make the 3-bit relation refutation-complete, 4 the 88 for "
+            "4 bits",
             bb_group);
 
   bool_arg("--bb.mult-v2", bm->UserFlags.upper_multiplication_bound,

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -603,7 +603,8 @@ void ExtraMain::create_options()
             "19 is 1 with the operands of a symbolic multiply put in a "
             "canonical order, so both orders of one product share a circuit. "
             "20 is radix-4 with a hard triple, every row a select of "
-            "0, y, 2y or 3y. Any other value "
+            "0, y, 2y or 3y. 21 is 14 for a constant multiplier and 19 for a "
+            "symbolic one; 22 is 21 with carry-save rows. Any other value "
             "is an error, reported once bit-blasting reaches a multiply",
             bb_group);
 

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -604,7 +604,8 @@ void ExtraMain::create_options()
             "canonical order, so both orders of one product share a circuit. "
             "20 is radix-4 with a hard triple, every row a select of "
             "0, y, 2y or 3y. 21 is 14 for a constant multiplier and 19 for a "
-            "symbolic one; 22 is 21 with carry-save rows. Any other value "
+            "symbolic one; 22 is 21 with carry-save rows; 23 is 21 with the "
+            "hard-triple rows of 20. Any other value "
             "is an error, reported once bit-blasting reaches a multiply",
             bb_group);
 
@@ -778,7 +779,7 @@ void ExtraMain::create_options()
       ->group(misc_group);
   app.add_option("--cnf-generation-effort", cnf_effort,
                  "effort spent minimising the CNF: auto, very-low, low, "
-                 "medium, high, very-high, new-very-low, new-low, new-medium. "
+                 "medium, high, very-high, new-very-low, new-low, new-medium, new-high. "
                  "Higher is slower to "
                  "generate but yields a smaller CNF; auto picks gia-low or, "
                  "for large estimated blasts, new-medium, since minimising a "
@@ -1111,6 +1112,8 @@ int ExtraMain::parse_options(int argc, char** argv)
     bm->UserFlags.cnf_effort = UserDefinedFlags::CNF_EFFORT_NEW_LOW;
   else if (cnf_effort == "new-medium")
     bm->UserFlags.cnf_effort = UserDefinedFlags::CNF_EFFORT_NEW_MEDIUM;
+  else if (cnf_effort == "new-high")
+    bm->UserFlags.cnf_effort = UserDefinedFlags::CNF_EFFORT_NEW_HIGH;
   else if (cnf_effort == "gia-low")
     bm->UserFlags.cnf_effort = UserDefinedFlags::CNF_EFFORT_GIA_LOW;
   else if (cnf_effort == "gia-high")


### PR DESCRIPTION
Seven multiplication encodings, an eager residue-lemma flag, a multiply tap and a `new-high` CNF rung, from the September multiplication-encoding study. No default changes.

**Encodings.** `--bb.mult-variant` gains 17 (carry-save row accumulation with one final ripple), 18 (Dadda tree over the Booth columns), 19 (shift-add with the operands of a symbolic product in a canonical order, so `x*y` and `y*x` build one circuit), 20 (radix-4 with a hard triple: every row selects 0, y, 2y or 3y) and three combinations that take variant 14's Booth recoding for a constant multiplier and, for a symbolic pair, 19's canonical-order shift-add (21), 17's carry-save rows (22) or 20's hard-triple rows (23). The canonical-order variants choose the row operand by cost, fewer symbolic bits, then fewer distinct nodes, then lexicographic order, which is symmetric, so both orders of a product still share a circuit. Variant 23 falls back to shift-add rows when an operand repeats a few literals across its width, as a sign- or digit-extended value does: there the AND rows share their cells and the 3y adder and select cells cannot.

**Eager residue lemmas.** `--bb.mult-lemmas K` conjoins to every multiply the prime implicates of the K-bit multiplication relation that unit propagation over the circuit cannot rederive: six clauses at K=3, eighty-eight at K=4. It makes the 3- and 4-bit multipliers refutation complete and measures inert at 32 and 64 bits; it is here as a measured option, not a recommendation. `propagator_bench` passes it through.

**`new-high` rung.** `--cnf-generation-effort new-high` runs `new-medium`'s recovery and then, for every private cone of at most five leaves whose interior nodes are referenced only from inside it, evaluates the cone's truth table and emits the prime implicates of the function it computes as one block, with no variables for the interior. A guard refuses a cone whose implicate set exceeds four clauses per gate replaced; the full-adder recovery runs first and its roots are never absorbed; a cone whose fanin lookup misses is refused rather than encoded wrongly. The rung goes on the end of the enum, since the ordinals are the C interface's contract, and the cnf-effort-flag test gains the new ordinal.

**Taps.** `STP_SHIFT_ANNOTATE=<file>` and `STP_MULT_ANNOTATE=<file>` make the Tseitin writer emit one line per symbolic-amount shift or per multiply, naming the DIMACS variable of every operand and result bit (negative for a complement, t/f for a constant, 0 for a bit no variable reached). Diagnostic only: without the variable nothing is recorded or written.

**Measurements.** On the 88 multiply-carrying files of the >10 s QF_BV corpus (200 s budget, every arm interleaved through one scheduler, a duplicate-default arm giving a noise floor of ±1 file), variant 22 solved 54–56 files against the default's 49–50 in all five rounds and lost none. On the full 259-file corpus it solved 185 against 178, again losing none, with the duplicate default arm at exactly 178; the seven gained files span six families. Sampled propagation grading at 16, 32 and 64 bits shows every additive summation topology propagating within noise of the default, so the gain is structural (constant recoding, and one circuit for both operand orders) rather than a propagation-strength result. `new-high` is a strict 0.67× on variables and 1.38× on wall-clock corpus-wide, so it stays an option.

The default variant is unchanged pending a corpus-wide pass; that flip, and the difficulty-score refit it needs, come separately.

Tests: 179/179 (unit and lit), including the cnf-effort-flag ordinal check. Each new variant passes `propagator_bench --consistency` exhaustively at 3 and 4 bits and a sampled full-assignment check at 8–64 bits.
