### PR TITLE
Encode division by a constant through its defining relation, and escalate constant-operand abstractions early

### DIFF
--- a/docs/bv-abstraction.rst
+++ b/docs/bv-abstraction.rst
@@ -115,7 +115,11 @@ refinement has three tiers:
    stops enumerating and says what the operation is, using the same
    bit-blaster entry point an unabstracted query would have used -- with the
    operand bits the original blast already knew, so a multiply against a
-   literal does not become a fully symbolic multiplier.
+   literal does not become a fully symbolic multiplier, and a division by a
+   literal is its defining relation over such a multiply
+   (``--bb.div-by-const``, on from 64 bits): 37,000 clauses for a 256-bit
+   division by a 34-bit constant, where the restoring divider, which the
+   constant prunes only within each of its 256 levels, is 510,000.
 
 ``--bv-term-abstraction-schemas`` (on by default) governs the first tier. Off,
 each operation falls back on its own tier-2 or tier-3 behaviour, which is what

--- a/docs/bv-abstraction.rst
+++ b/docs/bv-abstraction.rst
@@ -135,6 +135,16 @@ sixty it is break-even; past that it collapses -- a 64-bit factorisation spent
 5816 rounds and ninety seconds on a query the unabstracted solve answers in
 five hundredths of one. Zero never escalates and enumerates without limit.
 
+A record one of whose operands the blast knew entirely -- a multiplication by
+a constant, a division or remainder by one -- has its allowance capped by
+``--bv-term-abstraction-constant-operand-limit`` (1). Its exact circuit is a
+constant's shift-and-add, tens of thousands of clauses at 256 bits where a
+symbolic operand costs half a million, so a blocking lemma, which rules out
+one operand pair, buys little against it: on the Certora verification queries
+every such record spent its thirty-two rounds on one dividend at a time
+before building an encoding that was cheap all along. Zero leaves the
+allowance uncapped.
+
 Two optional refinements of that allowance:
 
 ``--bv-term-abstraction-value-divisor``

--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -751,6 +751,15 @@ public:
   // after 16 bad candidates but before the old allowance, so repetition count
   // by itself could not identify when paying for an exact divider would help.
   unsigned bv_term_abstraction_divmod_value_limit = 0;
+  // A record one of whose operands the blast knew entirely -- a
+  // multiplication by a constant, a division or remainder by one -- has an
+  // exact encoding that is a constant's shift-and-add, tens of thousands of
+  // clauses at 256 bits where a symbolic operand costs half a million. The
+  // value-blocking allowance above was sized for the symbolic case, and on
+  // the Certora queries it spent thirty-two rounds ruling out one dividend
+  // at a time before building an encoding that was cheap all along. Such a
+  // record's allowance is capped here; zero leaves it uncapped.
+  unsigned bv_term_abstraction_constant_operand_limit = 1;
   // Escalate an abstracted BVMULT a piece at a time rather than all at once:
   // encode only the bits up to and a little past the lowest one the
   // candidate got wrong, and come back for more if that does not settle the

--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -908,6 +908,16 @@ public:
   // wherever the divisor is nonzero. The circuit computes nothing; every
   // quotient bit is the SAT solver's to find.
   bool division_by_multiplication = false;
+
+  // Encode a division or remainder by a constant through the defining
+  // relation, x = c*q + r with r < c, where the product is the constant's
+  // shift-and-add over the fresh quotient. The restoring divider prunes
+  // against a constant divisor only within each level, so at 256 bits a
+  // 34-bit constant still costs it 510,000 clauses; the relation is a row
+  // per set divisor bit, 22,000 clauses for the same operation. Below the
+  // width the divider is small either way and is left alone.
+  bool division_by_constant = true;
+  unsigned division_by_constant_width = 64;
   // Measurement arm: encode division and remainder as a free result
   // constrained only by the term abstraction's schema registry, asserted
   // eagerly, so the lemmas' propagation can be graded on its own. The

--- a/include/stp/ToSat/BitBlaster.h
+++ b/include/stp/ToSat/BitBlaster.h
@@ -248,8 +248,18 @@ template <class BBNode, class BBNodeManagerT> class BitBlaster
   void BBDivByMult(const BBNodeVec& x, const BBNodeVec& y, BBNodeVec& q,
                    BBNodeVec& r, BBNodeSet& support);
 
+  // Division by a constant through the same relation, with the product a
+  // shift-and-add of the fresh quotient over the constant's set bits. The
+  // divisor must be entirely constant and nonzero.
+  void BBDivByConstant(const BBNodeVec& x, const BBNodeVec& y, BBNodeVec& q,
+                       BBNodeVec& r, BBNodeSet& support);
+
   // One (q, r) pair per operand pair: BVDIV and BVMOD of the same operands
   // must name the same fresh variables, which strashing cannot arrange.
+  // The pair is only as good as the relation asserted over it, which is
+  // conjoined into the root the pair was minted under, so the memo lives
+  // for one top-level BBForm: a blaster that outlives a root, as the
+  // incremental driver's does, starts the next one afresh.
   std::unordered_map<ASTNode, std::pair<BBNodeVec, BBNodeVec>,
                      ASTNode::ASTNodeHasher, ASTNode::ASTNodeEqual>
       divByMultMemo;

--- a/lib/Simplifier/DifficultyScore.cpp
+++ b/lib/Simplifier/DifficultyScore.cpp
@@ -23,6 +23,7 @@ THE SOFTWARE.
 ********************************************************************/
 
 #include "stp/Simplifier/DifficultyScore.h"
+#include "stp/STPManager/UserDefinedFlags.h"
 #include "stp/AST/AST.h"
 #include "stp/AST/ASTKind.h"
 #include "stp/Util/NodeIterator.h"
@@ -199,6 +200,44 @@ int64_t constantDivisionCost(bool dividendIsConstant,
   return score;
 }
 
+// A division or remainder by a constant from --bb.div-by-const-width is its
+// defining relation over the constant's shift-and-add rather than a divider:
+// a shifted copy of the fresh quotient per set divisor bit, summed at width
+// w+1 by full adders of seven nodes a bit, the remainder added the same way,
+// the sum's equality with the dividend, and the remainder's comparison with
+// the divisor over the divisor's span. At 64 bits by a constant of three set
+// bits the divider estimate above is 22,883 nodes and the relation builds
+// 2,562.
+int64_t constantDivisorRelationCost(const ASTNode& constant, int64_t w)
+{
+  const CBV cbv = constant.GetBVConst();
+  int64_t setBits = 0;
+  int64_t span = 0;
+  for (int64_t i = 0; i < w; i++)
+    if (CONSTANTBV::BitVector_bit_test(cbv, static_cast<unsigned>(i)))
+    {
+      setBits++;
+      span = i + 1;
+    }
+  return 7 * (w + 1) * setBits + 4 * w + 3 * span;
+}
+
+// Whether the blaster takes the relation for this divisor: the flag, the
+// width, and a divisor that is not zero -- a zero constant stays with the
+// divider, whose totalisation it needs.
+bool divisorTakesRelation(const UserDefinedFlags* flags,
+                          const ASTNode& divisor, int64_t w)
+{
+  if (flags == NULL || !flags->division_by_constant ||
+      w < static_cast<int64_t>(flags->division_by_constant_width))
+    return false;
+  const CBV cbv = divisor.GetBVConst();
+  for (int64_t i = 0; i < w; i++)
+    if (CONSTANTBV::BitVector_bit_test(cbv, static_cast<unsigned>(i)))
+      return true;
+  return false;
+}
+
 // The exponent and significand widths of a floating-point node. Lowering
 // leaves the natively-encoded predicates over packed bit-vector operands, so
 // the source sort is not always still there to ask; fall back to the standard
@@ -364,7 +403,7 @@ int64_t fpEval(const ASTNode& b, const Kind k)
 
 } // namespace
 
-int64_t eval(const ASTNode& b)
+int64_t eval(const ASTNode& b, const UserDefinedFlags* flags)
 {
   const Kind k = b.GetKind();
 
@@ -461,21 +500,29 @@ int64_t eval(const ASTNode& b)
     case BVDIV:
     case BVMOD:
       // Restoring long division: a subtract and a select per quotient bit,
-      // over a remainder as wide as the dividend.
+      // over a remainder as wide as the dividend -- or, by a constant wide
+      // enough, the relation over the constant's shift-and-add.
       if (b[0].isConstant())
         return constantDivisionCost(true, b[0], lw);
       if (b[1].isConstant())
-        return constantDivisionCost(false, b[1], lw);
+        return divisorTakesRelation(flags, b[1], lw)
+                   ? constantDivisorRelationCost(b[1], lw)
+                   : constantDivisionCost(false, b[1], lw);
       return 20 * (lw - 1) * (lw - 1) + 29 * lw;
 
     case SBVDIV:
     case SBVREM:
     case SBVMOD:
-      // The unsigned circuit plus the sign fixups on either side of it.
+      // The unsigned circuit plus the sign fixups on either side of it. The
+      // magnitude of a constant divisor is a constant, so it takes the
+      // relation as the unsigned case does.
       if (b[0].isConstant())
         return constantDivisionCost(true, b[0], lw) + 12 * lw;
       if (b[1].isConstant())
-        return constantDivisionCost(false, b[1], lw) + 12 * lw;
+        return (divisorTakesRelation(flags, b[1], lw)
+                    ? constantDivisorRelationCost(b[1], lw)
+                    : constantDivisionCost(false, b[1], lw)) +
+               12 * lw;
       return 20 * (lw - 1) * (lw - 1) + 50 * lw;
 
     case BVLEFTSHIFT:
@@ -588,7 +635,7 @@ int64_t DifficultyScore::score(const ASTNode& top, STPMgr* mgr)
   while ((current = ni.next()) != ni.end())
     {
       evalCount++;
-      result += eval(current);
+      result += eval(current, &mgr->UserFlags);
     }
 
   cache.insert(std::make_pair(top.GetNodeNum(), result));

--- a/lib/ToSat/BVAbstractionRefiner.cpp
+++ b/lib/ToSat/BVAbstractionRefiner.cpp
@@ -1815,6 +1815,53 @@ BVAbstractionRefiner::divRemPairs(
   return pairs;
 }
 
+// Whether the blast knew an operand of the record entirely: either operand
+// of a multiplication, the divisor of a division or remainder -- a constant
+// dividend leaves the divider its full cost.
+static bool recordHasConstantOperand(const BVTermAbstraction& abs)
+{
+  const auto known = [&](unsigned op) {
+    const std::vector<signed char>& bits = abs.operandKnownBits[op];
+    if (bits.size() < abs.width)
+      return false;
+    for (unsigned i = 0; i < abs.width; ++i)
+      if (bits[i] < 0)
+        return false;
+    return true;
+  };
+  if (abs.opKind == BVMULT)
+    return known(0) || known(1);
+  if (abs.opKind == BVDIV || abs.opKind == BVMOD)
+    return known(1);
+  return false;
+}
+
+// The value-blocking allowance a record actually has: the width-scaled
+// allowance, capped for a record the blast knows one operand of entirely.
+// The refinement and the report read the same number.
+static unsigned effectiveValueLemmaAllowance(const UserDefinedFlags& uf,
+                                             const BVTermAbstraction& abs)
+{
+  unsigned limit = valueLemmaAllowance(uf, abs.width, abs.opKind);
+  const unsigned constantCap = uf.bv_term_abstraction_constant_operand_limit;
+  if (constantCap != 0 && recordHasConstantOperand(abs))
+    limit = (limit == 0) ? constantCap : std::min(limit, constantCap);
+  return limit;
+}
+
+// How many of an operand's bits the blast knew, which the report shows so
+// that a record whose escalation is a constant's shift-and-add can be told
+// from one whose escalation is a full circuit.
+static unsigned knownBitCount(const BVTermAbstraction& abs, unsigned op)
+{
+  unsigned count = 0;
+  if (op < 2)
+    for (const signed char bit : abs.operandKnownBits[op])
+      if (bit >= 0)
+        count++;
+  return count;
+}
+
 void BVAbstractionRefiner::reportRecords(std::ostream& out) const
 {
   std::vector<bool> isPaired(terms_.size(), false);
@@ -1846,9 +1893,8 @@ void BVAbstractionRefiner::reportRecords(std::ostream& out) const
     const bool hasValueAllowance =
         abs.opKind == BVMULT || abs.opKind == BVDIV || abs.opKind == BVMOD;
     const unsigned allowance =
-        hasValueAllowance
-            ? valueLemmaAllowance(bm->UserFlags, abs.width, abs.opKind)
-            : 0;
+        hasValueAllowance ? effectiveValueLemmaAllowance(bm->UserFlags, abs)
+                          : 0;
 
     out << "BV abstraction record: record=" << i
         << " node=" << abs.termNode.GetNodeNum()
@@ -1864,7 +1910,9 @@ void BVAbstractionRefiner::reportRecords(std::ostream& out) const
         << " blocking-literals=" << blockingLiterals
         << " exact-clauses=" << abs.exactClauses
         << " exact-vars=" << abs.exactVariables
-        << " exact-us=" << abs.exactMicroseconds << '\n';
+        << " exact-us=" << abs.exactMicroseconds
+        << " known=" << knownBitCount(abs, 0) << "/" << knownBitCount(abs, 1)
+        << '\n';
   }
 }
 
@@ -3035,7 +3083,14 @@ AbstractionRefinementResult BVAbstractionRefiner::refineTerms(
     // BVExactEncoder. Two independent encodings of a divider that agree
     // today are two that can stop agreeing, and these two already had: the
     // written-out one and BBDivMod disagreed about a zero divisor.
-    const unsigned limit = valueLemmaAllowance(bm->UserFlags, W, abs.opKind);
+    // A record the blast knows one operand of entirely has an exact
+    // encoding that is a constant's shift-and-add -- the multiplier prunes
+    // its rows to the constant's set bits, and a division by a constant
+    // goes through its defining relation over such a product -- so ruling
+    // out one operand pair per round is a poor bargain against it, and its
+    // allowance is capped. See
+    // UserDefinedFlags::bv_term_abstraction_constant_operand_limit.
+    const unsigned limit = effectiveValueLemmaAllowance(bm->UserFlags, abs);
     if (limit != 0 && abs.blockedThisQuery >= limit)
     {
       // A previous query may already have established that this mandatory

--- a/lib/ToSat/BVExactEncoder.cpp
+++ b/lib/ToSat/BVExactEncoder.cpp
@@ -404,7 +404,15 @@ void BVExactEncoder::encode(SATSolver& solver, const ASTNode& term,
   rewrite(mgr, bm->UserFlags.AIG_rewrites_iterations);
   assert(Aig_ManCheck(mgr.aigMgr));
   assert((unsigned)Aig_ManCoNum(mgr.aigMgr) == outputs);
-  assert((unsigned)Aig_ManCiNum(mgr.aigMgr) == ciVars.size());
+  // The operand inputs were created before the circuit, so they are the
+  // first ciVars.size() inputs whatever the circuit added after them. A
+  // relation encoding of a division -- by a constant, or through a
+  // multiplier -- adds inputs of its own: the quotient and remainder it
+  // constrains through its side outputs rather than computes. Those have no
+  // operand variable to take, and the splice below gives each a fresh solver
+  // variable, which is exactly what a witness of x = y*q + r, r < y needs:
+  // the pair is unique given the operands, so the result is still defined.
+  assert((unsigned)Aig_ManCiNum(mgr.aigMgr) >= ciVars.size());
 
   // Use the query's selected CNF strategy. All outputs are named rather than
   // asserted because the splice below connects each result bit explicitly

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -1884,6 +1884,14 @@ const BBNode BitBlaster<BBNode, BBNodeManagerT>::BBForm(const ASTNode& form)
 {
   fpNativeAddIsZeroFusions = 0;
 
+  // A quotient-remainder pair a relational division encoding minted for an
+  // earlier root is constrained only by the relation conjoined into that
+  // root; under a later root it would be a free pair. The incremental
+  // driver blasts many roots through one blaster, each under its own
+  // literal, so every root starts the memo afresh -- within a root the
+  // division and remainder of one operand pair still share the pair.
+  divByMultMemo.clear();
+
   if (uf->fp_native_domain &&
       (fpNativeDomainRoot.IsNull() || !(fpNativeDomainRoot == form)))
   {
@@ -3478,6 +3486,73 @@ void BitBlaster<BBNode, BBNodeManagerT>::BBDivByMult(const BBNodeVec& x,
       nf->CreateNode(OR, BBEQ(zero, y), BBBVLE(r, y, false, true)));
 }
 
+// Division by a constant through the defining relation. The divisor's bits
+// are all known and at least one is set, so y*q is a shifted copy of the
+// quotient per set divisor bit, summed at width w+1 where nothing can wrap:
+// the quotient has w-span+1 live bits, since q <= x/y < 2^w / 2^(span-1),
+// every row therefore fits in w bits, and the whole product is below
+// 2^(w+1). The product is then asserted below 2^w -- which is what makes
+// the pair unique together with r < y -- and x = y*q + r is asserted with
+// the sum's carry-out false. The remainder has span live bits, since it is
+// below the divisor. At 256 bits by a 34-bit constant this is eleven rows
+// against the restoring divider's 256 levels of subtract-compare-select,
+// each of which the constant prunes only to its own span.
+template <class BBNode, class BBNodeManagerT>
+void BitBlaster<BBNode, BBNodeManagerT>::BBDivByConstant(
+    const BBNodeVec& x, const BBNodeVec& y, BBNodeVec& q, BBNodeVec& r,
+    BBNodeSet& support)
+{
+  const unsigned w = x.size();
+  assert(y.size() == w);
+
+  unsigned span = 0;
+  for (unsigned i = 0; i < w; i++)
+  {
+    assert(y[i] == BBTrue || y[i] == BBFalse);
+    if (y[i] == BBTrue)
+      span = i + 1;
+  }
+  assert(span > 0);
+  const unsigned qBits = w - span + 1;
+
+  q = BBNodeVec(w, BBFalse);
+  r = BBNodeVec(w, BBFalse);
+  for (unsigned i = 0; i < qBits; i++)
+    q[i] = nf->CreateFreshInput();
+  for (unsigned i = 0; i < span; i++)
+    r[i] = nf->CreateFreshInput();
+
+  BBNodeVec acc(w + 1, BBFalse);
+  bool first = true;
+  for (unsigned i = 0; i < span; i++)
+  {
+    if (y[i] != BBTrue)
+      continue;
+    BBNodeVec row(w + 1, BBFalse);
+    for (unsigned j = 0; j < qBits; j++)
+      row[i + j] = q[j];
+    if (first)
+    {
+      acc = row;
+      first = false;
+    }
+    else
+      BBPlus2(acc, row, BBFalse);
+  }
+  support.insert(nf->CreateNode(NOT, acc[w]));
+  acc[w] = BBFalse;
+
+  BBNodeVec rExt(w + 1, BBFalse);
+  for (unsigned i = 0; i < span; i++)
+    rExt[i] = r[i];
+  BBPlus2(acc, rExt, BBFalse);
+  support.insert(nf->CreateNode(NOT, acc[w]));
+  const BBNodeVec accLow(acc.begin(), acc.begin() + w);
+  support.insert(BBEQ(accLow, x));
+
+  support.insert(BBBVLE(r, y, false, true));
+}
+
 template <class BBNode, class BBNodeManagerT>
 vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::BBExactBinaryOp(
     const ASTNode& term, const BBNodeVec& x, const BBNodeVec& y,
@@ -3533,7 +3608,20 @@ vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::BBExactBinaryOp(
     return t;
   }
 
-  if (uf->division_by_multiplication && !bothConstant)
+  bool divisorConstant = true;
+  bool divisorZero = true;
+  for (unsigned i = 0; i < width; i++)
+  {
+    if (!(y[i] == BBTrue || y[i] == BBFalse))
+      divisorConstant = false;
+    if (y[i] == BBTrue)
+      divisorZero = false;
+  }
+  const bool byConstant = uf->division_by_constant && !bothConstant &&
+                          divisorConstant && !divisorZero &&
+                          width >= uf->division_by_constant_width;
+
+  if (byConstant || (uf->division_by_multiplication && !bothConstant))
   {
     // BVDIV and BVMOD of one operand pair share one relation, keyed by the
     // quotient's node whichever of the two arrives first.
@@ -3548,7 +3636,10 @@ vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::BBExactBinaryOp(
     }
     else
     {
-      BBDivByMult(x, y, q, r, support);
+      if (byConstant)
+        BBDivByConstant(x, y, q, r, support);
+      else
+        BBDivByMult(x, y, q, r, support);
       divByMultMemo.emplace(key, std::make_pair(q, r));
     }
   }

--- a/tests/query-files/division-encodings/constant-divisor-across-incremental-blocks.smt2
+++ b/tests/query-files/division-encodings/constant-divisor-across-incremental-blocks.smt2
@@ -1,0 +1,38 @@
+; The relation's fresh quotient and remainder are constrained only by the
+; relation conjoined into the root they were minted under. The incremental
+; driver blasts every block through one blaster, so a remainder asked for in
+; a later block must not pick up the pair a popped block minted for the same
+; operands: before the memo was cleared per root, the second block below
+; came back sat with a free remainder, as did the old --bb.div-by-mult
+; relation. The third block reuses the division term itself across blocks.
+;
+; RUN: %solver --bb.div-by-const-width=8 --incremental=on %s | %OutputCheck %s
+; RUN: %solver --bb.div-by-const-width=8 --incremental=off %s | %OutputCheck %s
+; RUN: %solver --bb.div-by-const=0 --bb.div-by-mult=1 --incremental=on %s | %OutputCheck %s
+; CHECK: ^unsat$
+; CHECK: ^unsat$
+; CHECK: ^unsat$
+; CHECK: ^unsat$
+;
+; EXPECT: unsat, four times
+(set-logic QF_BV)
+(declare-const x (_ BitVec 8))
+(push 1)
+(assert (bvugt (bvudiv x #x0b) x))
+(check-sat)
+(pop 1)
+(push 1)
+(assert (bvuge (bvurem x #x0b) #x0b))
+(check-sat)
+(pop 1)
+(push 1)
+(assert (= (bvudiv x #x0b) #x01))
+(assert (bvugt x #x30))
+(check-sat)
+(pop 1)
+(push 1)
+(assert (= (bvurem x #x0b) #x01))
+(assert (bvult x #x0b))
+(assert (bvugt x #x01))
+(check-sat)
+(pop 1)

--- a/tests/query-files/division-encodings/constant-divisor-agrees-with-the-divider.smt2
+++ b/tests/query-files/division-encodings/constant-divisor-agrees-with-the-divider.smt2
@@ -1,0 +1,76 @@
+; A division or remainder by a constant is encoded through its defining
+; relation, x = c*q + r with r < c, the product a shift-and-add of the fresh
+; quotient over the constant's set bits. Each query below divides by the
+; constant twice: once written as the constant, which takes the relation,
+; and once as (c & d) | (c & e) under d | e = all ones, which is the constant
+; in every model but not one the simplifier or the constant-bit propagation
+; can see -- an equality pinning a symbol to c would be substituted, two
+; bounds on it are resolved by the domain analysis, and (c & d) | (c & ~d)
+; folds for c all ones -- so that side is the divider over a divisor the
+; blast does not know. The two disagreeing is unsatisfiable
+; exactly when the encodings agree on every dividend. At eight bits, with
+; the width threshold lowered to reach the relation, that is every dividend
+; and every constant of the shapes below: a power of two, an odd number,
+; three, all ones but the lowest, and the top bit alone. All ones is not
+; among them: (c & d) | (c & e) is then d | e, which the assertion pins.
+;
+; RUN: %solver --bb.div-by-const-width=8 %s | %OutputCheck %s
+; RUN: %solver --bb.div-by-const-width=8 --bb.div-by-mult=1 %s | %OutputCheck %s
+; RUN: %solver --bb.div-by-const-width=8 --incremental=on %s | %OutputCheck %s
+; CHECK: ^unsat$
+; CHECK: ^unsat$
+; CHECK: ^unsat$
+; CHECK: ^unsat$
+; CHECK: ^unsat$
+; CHECK: ^unsat$
+; CHECK: ^unsat$
+; CHECK: ^unsat$
+; CHECK: ^unsat$
+; CHECK: ^unsat$
+;
+; EXPECT: unsat, ten times
+(set-logic QF_BV)
+(declare-const x (_ BitVec 8))
+(declare-const d (_ BitVec 8))
+(declare-const e (_ BitVec 8))
+(assert (= (bvor d e) #xff))
+(push 1)
+(assert (distinct (bvudiv x #x10) (bvudiv x (bvor (bvand #x10 d) (bvand #x10 e)))))
+(check-sat)
+(pop 1)
+(push 1)
+(assert (distinct (bvurem x #x10) (bvurem x (bvor (bvand #x10 d) (bvand #x10 e)))))
+(check-sat)
+(pop 1)
+(push 1)
+(assert (distinct (bvudiv x #x0b) (bvudiv x (bvor (bvand #x0b d) (bvand #x0b e)))))
+(check-sat)
+(pop 1)
+(push 1)
+(assert (distinct (bvurem x #x0b) (bvurem x (bvor (bvand #x0b d) (bvand #x0b e)))))
+(check-sat)
+(pop 1)
+(push 1)
+(assert (distinct (bvudiv x #x03) (bvudiv x (bvor (bvand #x03 d) (bvand #x03 e)))))
+(check-sat)
+(pop 1)
+(push 1)
+(assert (distinct (bvurem x #x03) (bvurem x (bvor (bvand #x03 d) (bvand #x03 e)))))
+(check-sat)
+(pop 1)
+(push 1)
+(assert (distinct (bvudiv x #xfe) (bvudiv x (bvor (bvand #xfe d) (bvand #xfe e)))))
+(check-sat)
+(pop 1)
+(push 1)
+(assert (distinct (bvurem x #xfe) (bvurem x (bvor (bvand #xfe d) (bvand #xfe e)))))
+(check-sat)
+(pop 1)
+(push 1)
+(assert (distinct (bvudiv x #x80) (bvudiv x (bvor (bvand #x80 d) (bvand #x80 e)))))
+(check-sat)
+(pop 1)
+(push 1)
+(assert (distinct (bvurem x #x80) (bvurem x (bvor (bvand #x80 d) (bvand #x80 e)))))
+(check-sat)
+(pop 1)

--- a/tests/query-files/misc-tests/bv-abstraction-constant-operand-escalates-early.smt2
+++ b/tests/query-files/misc-tests/bv-abstraction-constant-operand-escalates-early.smt2
@@ -1,0 +1,32 @@
+; An abstracted division, remainder or multiplication one of whose operands
+; is a constant has an exact encoding that is the constant's shift-and-add
+; -- the multiplier prunes its rows to the constant's set bits, and a
+; division by a constant goes through its defining relation over such a
+; product -- tens of thousands of clauses at 256 bits where a symbolic
+; operand costs half a million. Ruling out one operand pair per round is a
+; poor bargain against that, so such a record's value-blocking allowance is
+; capped (--bv-term-abstraction-constant-operand-limit, one by default):
+; the first refuted candidate is blocked and the second escalates. The
+; schemas are off so that a blocking lemma is the only refinement short of
+; escalation, and -d re-derives the answer under the published model.
+;
+; RUN: %solver --incremental=off -d -s -t --bv-term-abstraction=1 --bv-abstraction-width=1 --bv-term-abstraction-schemas=0 --bb.div-by-const-width=1 %s 2>&1 | %OutputCheck %s
+; CHECK: BV abstraction: encoding BV(DIV|MOD|MULT) exactly after 1 blocking lemmas
+; CHECK: kind=BVDIV width=16 state=exact blocking=1 schemas=0 exact=1 exact-bits=16 allowance=1
+; CHECK: ^sat$
+;
+; Uncapped, the record draws on the ordinary allowance, here the round
+; ceiling of three.
+; RUN: %solver --incremental=off -d -s -t --bv-term-abstraction=1 --bv-abstraction-width=1 --bv-term-abstraction-schemas=0 --bv-term-abstraction-constant-operand-limit=0 --bv-term-abstraction-rounds=3 %s 2>&1 | %OutputCheck --check-prefix=UNCAPPED %s
+; UNCAPPED: kind=BVDIV width=16 state=(open|exact) blocking=[0-9]+ schemas=0 exact=[01] exact-bits=(0|16) allowance=3
+; UNCAPPED: ^sat$
+;
+; EXPECT: sat, sat
+(set-logic QF_BV)
+(declare-fun a () (_ BitVec 16))
+(declare-fun c () (_ BitVec 16))
+(assert (= (bvudiv a #x000b) c))
+(assert (= (bvurem a #x000b) #x0007))
+(assert (bvugt c #x0003))
+(assert (bvult a #x00ff))
+(check-sat)

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -628,6 +628,20 @@ void ExtraMain::create_options()
            "with the quotient bit from a dedicated comparator per row",
            bb_group);
 
+  bool_arg("--bb.div-by-const", bm->UserFlags.division_by_constant,
+           "encode a division or remainder by a constant through its "
+           "defining relation, x = c*q + r with r < c, where the product is "
+           "the constant's shift-and-add over the fresh quotient; a 256-bit "
+           "division by a 34-bit constant is 22k clauses this way against "
+           "510k as a divider",
+           bb_group);
+  app.add_option("--bb.div-by-const-width",
+                 bm->UserFlags.division_by_constant_width,
+                 "the width from which --bb.div-by-const applies; below it "
+                 "the divider is small either way")
+      ->group(bb_group)
+      ->capture_default_str();
+
   bool_arg("--bb.div-by-mult", bm->UserFlags.division_by_multiplication,
            "encode division and remainder through their defining relation: "
            "fresh quotient and remainder variables, x = y*q + r at double "

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -477,6 +477,14 @@ void ExtraMain::create_options()
                  "slower and no faster)")
       ->group(refinement_group)
       ->capture_default_str();
+  app.add_option("--bv-term-abstraction-constant-operand-limit",
+                 bm->UserFlags.bv_term_abstraction_constant_operand_limit,
+                 "cap on value-pair blocking rounds for an abstracted "
+                 "multiplication, division or remainder one of whose "
+                 "operands is a constant, whose exact encoding is a "
+                 "constant's shift-and-add (0: no cap)")
+      ->group(refinement_group)
+      ->capture_default_str();
   app.add_option("--bv-term-abstraction-divmod-value-limit",
                  bm->UserFlags.bv_term_abstraction_divmod_value_limit,
                  "independent cap on BVDIV/BVMOD value-pair blocking after "


### PR DESCRIPTION
Follow-up to #1086, aimed at the abstraction-heavy Certora files Bitwuzla still solves and STP does not. Nearly every wide division and multiplication there is by a constant such as 10^10, and the bit-vector abstraction spent its refinement on exactly those: on 0730, every one of the 307 value-blocking lemmas of a two-minute run was for an operation by 10^10, and the three divisions that escalated each cost 543,000 clauses of divider.

**Division by a constant through its defining relation** (`--bb.div-by-const`, on from 64 bits). The restoring divider prunes against a constant divisor only within each of its levels, so a 256-bit division by a 34-bit constant is 510,000 clauses. The relation `x = c*q + r`, `r < c`, with the product a shifted copy of the fresh quotient per set divisor bit, is 37,000 for the same operation and 9,700 for a division by 3. A query file checks it against the divider for every dividend of five constants at eight bits, with the reference side written so the blast cannot fold it, under both drivers.

This also fixes a latent fault in the relational encodings' memo: the quotient-remainder pair of one operand pair was shared across the incremental driver's blocks, so a remainder in a later block could pick up the pair a popped block had minted and answer sat with a free remainder (the old `--bb.div-by-mult`, off by default, had the same fault). The memo now lives for one top-level blast; a second query file reuses divisions and remainders across blocks.

The difficulty score estimates the relation's cost for such a divisor as the blaster now builds it.

**Value blocking capped for constant-operand records** (`--bv-term-abstraction-constant-operand-limit`, 1). A record the blast knows one operand of entirely has an exact encoding that is a constant's shift-and-add, so ruling out one operand pair per round is a poor bargain against it. Paired in one run on the 30 hardest Certora files at 60s: 28 solved with the cap against 26 without, in the same CPU time; a cap of four gives the same 28. The 160-file corpus sample is unchanged at 143 either way. The record report now shows the known bits of each operand and the capped allowance the refinement uses.

0730 itself is still not decided in two minutes: with the cap its run is ten solver calls rather than seventy, but each of the remaining ones is hard.
