### PR TITLE
Keep the SAT trail between UF congruence refinement rounds

### DIFF
--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -414,6 +414,15 @@ public:
   // apart can only change how quickly an answer is found, never which answer.
   bool uf_phase_hints = false;
 
+  // Whether the batch solver keeps its trail between congruence refinement
+  // rounds. A round differs from the last only by the clauses the refuted
+  // candidate earned, so the search can resume on the kept trail,
+  // backtracking only as far as one of those clauses is falsified. Without
+  // this every round re-decides and re-propagates every variable from the
+  // root before it reaches the new clauses, a cost that grows with the
+  // encoding rather than with the lemma.
+  bool uf_trail_reuse = true;
+
   // The carrier width given to a sort introduced by (declare-sort S 0).
   //
   // An uninterpreted sort has no operations but equality, so a query

--- a/include/stp/Sat/Cadical.h
+++ b/include/stp/Sat/Cadical.h
@@ -124,7 +124,7 @@ public:
   bool disableEliminationAndShrinkingInternal() override;
   bool disableLuckyPhasesInternal() override;
 
-  bool enableTrailReuseInternal() override;
+  bool enableTrailReuseInternal(TrailReuse scope) override;
 
   void suggestPhase(uint32_t var, bool value) override;
   void declarePendingVariables() override;

--- a/include/stp/Sat/SATSolver.h
+++ b/include/stp/Sat/SATSolver.h
@@ -167,19 +167,30 @@ public:
     return enableBVAInternal();
   }
 
+  // What a backend may keep of its trail between two solve calls.
+  enum class TrailReuse
+  {
+    // The prefix of the trail that the next call's assumptions still
+    // imply. Only correct to rely on when the caller keeps its assumption
+    // order prefix-stable across calls, which the incremental driver does:
+    // assumptions are emitted in assertion stack order and push/pop only
+    // ever change the suffix.
+    AssumptionPrefix,
+    // Everything a clause added since the last call has not falsified.
+    // For a refinement loop, whose rounds differ only by the clauses the
+    // last candidate earned, the next search then resumes where the last
+    // one stopped instead of re-deciding every variable from the root.
+    Everything
+  };
+
   // Ask the backend to reuse the solver trail across incremental solve
-  // calls when consecutive assumption sequences share a prefix, instead of
-  // re-deciding and re-propagating from the root every call (CaDiCaL's
-  // incremental lazy backtracking). Only correct to rely on when the
-  // caller keeps its assumption order prefix-stable across calls, which
-  // the incremental driver does: assumptions are emitted in assertion
-  // stack order and push/pop only ever change the suffix. FALSE means the
-  // backend has no such mechanism -- a performance hint declined, not an
-  // error.
-  bool enableTrailReuse()
+  // calls (CaDiCaL's incremental lazy backtracking) instead of re-deciding
+  // and re-propagating from the root every call. FALSE means the backend
+  // has no such mechanism -- a performance hint declined, not an error.
+  bool enableTrailReuse(TrailReuse scope = TrailReuse::AssumptionPrefix)
   {
     assertConfigurable("enableTrailReuse");
-    return enableTrailReuseInternal();
+    return enableTrailReuseInternal(scope);
   }
 
   // Whether this backend can turn probe-based inprocessing off, and the
@@ -409,7 +420,7 @@ protected:
   // technique -- a performance hint declined, not an error.
   virtual bool setSearchBiasInternal(SearchBias /*bias*/) { return false; }
   virtual bool enableBVAInternal() { return false; }
-  virtual bool enableTrailReuseInternal() { return false; }
+  virtual bool enableTrailReuseInternal(TrailReuse /*scope*/) { return false; }
   virtual bool disableInprobingInternal() { return false; }
   virtual bool disableEliminationAndShrinkingInternal() { return false; }
   virtual bool disableLuckyPhasesInternal() { return false; }

--- a/include/stp/c_interface.h
+++ b/include/stp/c_interface.h
@@ -597,7 +597,18 @@ enum ifaceflag_t
   //!
   BV_TERM_ABSTRACTION_PLUS,
   BV_TERM_ABSTRACTION_ITE,
-  BV_TERM_ABSTRACTION_COMPARE
+  BV_TERM_ABSTRACTION_COMPARE,
+
+  //! Whether the SAT solver keeps its trail between congruence refinement
+  //! rounds, resuming the search where the refuted candidate left it
+  //! instead of re-deciding every variable from the root.
+  //!
+  //! `param_value` nonzero enables (the default), zero disables. This is
+  //! the C API's way to reach --uf-trail-reuse. It changes the search
+  //! order only, so it cannot change an answer. Appended to preserve every
+  //! published ordinal.
+  //!
+  UF_TRAIL_REUSE
 
 };
 

--- a/lib/Interface/c_interface.cpp
+++ b/lib/Interface/c_interface.cpp
@@ -546,6 +546,9 @@ void vc_setInterfaceFlags(VC vc, enum ifaceflag_t f, int param_value)
     case UF_PHASE_HINTS:
       b->UserFlags.uf_phase_hints = param_value != 0;
       break;
+    case UF_TRAIL_REUSE:
+      b->UserFlags.uf_trail_reuse = param_value != 0;
+      break;
     case DISTINCT_ORDERING:
       b->UserFlags.distinct_ordering = param_value != 0;
       break;

--- a/lib/STPManager/STP.cpp
+++ b/lib/STPManager/STP.cpp
@@ -1084,6 +1084,11 @@ STP::TopLevelSTPAux(SATSolver& NewSolver, const ASTNode& original_input,
     return bm->unknownResult();
 
   NewSolver.enableRefinement(maybeRefinement);
+  // A congruence round differs from the last only by the clauses its
+  // candidate earned, so the search resumes on the kept trail instead of
+  // re-deciding every variable from the root before it sees them.
+  if (batchUFView->active() && bm->UserFlags.uf_trail_reuse)
+    NewSolver.enableTrailReuse(SATSolver::TrailReuse::Everything);
 
   if (bm->UserFlags.stats_flag)
     bm->print_stats();

--- a/lib/Sat/Cadical.cpp
+++ b/lib/Sat/Cadical.cpp
@@ -276,13 +276,16 @@ bool Cadical::enableBVAInternal()
 // difference and keeps the shared trail, instead of re-deciding and
 // re-propagating everything from the root. Mode 1 restricts the kept
 // trail to the assumption prefix; measured equal to mode 2 on the
-// many-small-queries workloads this targets.
-bool Cadical::enableTrailReuseInternal()
+// many-small-queries workloads the incremental driver targets. Mode 2
+// also keeps the trail across clauses added between calls, backtracking
+// only as far as an added clause is falsified: what a refinement loop
+// with no assumptions needs, since mode 1 gives it nothing.
+bool Cadical::enableTrailReuseInternal(TrailReuse scope)
 {
   // Like factor, "ilb" may only be set while the solver is still in its
   // configuration window; the driver's size gate therefore works by
   // rebuilding onto a fresh solver rather than by toggling.
-  return s->set("ilb", 1);
+  return s->set("ilb", scope == TrailReuse::Everything ? 2 : 1);
 }
 
 bool Cadical::supportsInprobingControl() const

--- a/tests/api/C/refinement-flags.cpp
+++ b/tests/api/C/refinement-flags.cpp
@@ -143,6 +143,7 @@ TEST(refinement_flags, DefaultsAreTheOnesTheCommandLineDocuments)
   EXPECT_EQ(stp::UserDefinedFlags::UFEagerMode::AUTO, flags(vc).uf_eager_mode);
   EXPECT_EQ(256u, flags(vc).uf_eager_budget);
   EXPECT_FALSE(flags(vc).uf_phase_hints);
+  EXPECT_TRUE(flags(vc).uf_trail_reuse);
   EXPECT_EQ(16u, flags(vc).uf_sort_width);
   EXPECT_TRUE(flags(vc).distinct_ordering);
   EXPECT_EQ(-1, flags(vc).aig_node_budget);
@@ -190,6 +191,11 @@ TEST(refinement_flags, EachFlagReachesTheFieldTheCLIWrites)
   EXPECT_TRUE(flags(vc).uf_phase_hints);
   vc_setInterfaceFlags(vc, UF_PHASE_HINTS, 0);
   EXPECT_FALSE(flags(vc).uf_phase_hints);
+
+  vc_setInterfaceFlags(vc, UF_TRAIL_REUSE, 0);
+  EXPECT_FALSE(flags(vc).uf_trail_reuse);
+  vc_setInterfaceFlags(vc, UF_TRAIL_REUSE, 1);
+  EXPECT_TRUE(flags(vc).uf_trail_reuse);
 
   vc_setInterfaceFlags(vc, DISTINCT_ORDERING, 0);
   EXPECT_FALSE(flags(vc).distinct_ordering);

--- a/tests/unit-tests/TrailReuse_Test.cpp
+++ b/tests/unit-tests/TrailReuse_Test.cpp
@@ -90,4 +90,62 @@ TEST(TrailReuse, CadicalPrefixStableAssumptionRounds)
   EXPECT_FALSE(s.solveWithAssumptions(a1, timed_out));
 }
 
+// The refinement loop's shape: plain solves with no assumptions at all,
+// each followed by clauses that reject the model just read, over fresh
+// variables the earlier calls never saw. With the trail kept across the
+// added clauses the solver resumes rather than re-descends, and every
+// model it publishes has to satisfy every clause added before the call.
+TEST(TrailReuse, CadicalClauseRoundsWithoutAssumptions)
+{
+  stp::Cadical s;
+  s.enableTrailReuse(SATSolver::TrailReuse::Everything);
+
+  bool timed_out = false;
+  const unsigned width = 6;
+  std::vector<uint32_t> bits;
+  for (unsigned i = 0; i < width; ++i)
+    bits.push_back(s.newVar());
+  // Something to decide: at least one bit set.
+  SATSolver::vec_literals any;
+  for (unsigned i = 0; i < width; ++i)
+    any.push(SATSolver::mkLit(bits[i], false));
+  s.addClause(any);
+
+  // Each round blocks the assignment just read, the way a congruence
+  // lemma refutes the candidate that earned it: a fresh helper stands
+  // for "the bits are as they were", is defined by clauses added now,
+  // and is then forbidden. 2^width - 1 assignments satisfy the first
+  // clause, so the loop ends with unsat after exactly that many models.
+  unsigned models = 0;
+  while (s.solve(timed_out))
+  {
+    ASSERT_FALSE(timed_out);
+    std::vector<bool> value(width);
+    bool anySet = false;
+    for (unsigned i = 0; i < width; ++i)
+    {
+      value[i] = s.modelValue(bits[i]) == s.true_literal();
+      anySet = anySet || value[i];
+    }
+    ASSERT_TRUE(anySet);
+    ++models;
+    ASSERT_LE(models, (1u << width) - 1);
+
+    const uint32_t same = s.newVar();
+    s.setFrozen(same);
+    // bits as read -> same
+    SATSolver::vec_literals imp;
+    for (unsigned i = 0; i < width; ++i)
+      imp.push(SATSolver::mkLit(bits[i], value[i]));
+    imp.push(SATSolver::mkLit(same, false));
+    s.addClause(imp);
+    // ~same
+    SATSolver::vec_literals block;
+    block.push(SATSolver::mkLit(same, true));
+    s.addClause(block);
+  }
+  ASSERT_FALSE(timed_out);
+  EXPECT_EQ(models, (1u << width) - 1);
+}
+
 #endif

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -512,6 +512,10 @@ void ExtraMain::create_options()
            "bias the first candidate so the congruence checker's scalars "
            "start out pairwise different (advisory; affects search order "
            "only)", refinement_group);
+  bool_arg("--uf-trail-reuse", bm->UserFlags.uf_trail_reuse,
+           "keep the SAT solver's trail between congruence refinement "
+           "rounds, resuming the search instead of re-deciding every "
+           "variable from the root", refinement_group);
   app.add_option("--uf-sort-width", bm->UserFlags.uf_sort_width,
                  "bit-vector width given to a sort introduced by "
                  "(declare-sort S 0); it bounds how many elements of that "


### PR DESCRIPTION
A UF congruence refinement round adds the lemmas the last candidate earned and asks the solver again. CaDiCaL backtracks to the root whenever a clause arrives after a solve, so every round unassigned the whole trail and re-decided every variable before it could see the new clauses. On the largest 20241113-Certora QF_UFBV file (2246.smt2: one predicate with 2,651 applications over 55 distinct argument terms, a 2.3M-clause encoding) that was 66k decisions and 437k propagations on a round that produced no conflict at all, 915 rounds, 287 s. The 349 ms per round was entirely this re-descent plus the repair of the eight new lemmas; STP's own checker and counterexample construction were 11 ms of it.

The batch driver now asks the backend for incremental lazy backtracking in its clause-scope mode (CaDiCaL `ilb=2`) when the query has an active UF view. `SATSolver::enableTrailReuse` gained a scope for this: the incremental driver keeps the assumption-prefix mode it measured, the refinement loop takes the mode that also keeps the trail across clauses added between calls, backtracking only as far as an added clause is falsified. `--uf-trail-reuse` (default on) and the C API flag `UF_TRAIL_REUSE` turn it off; other backends decline the hint as before. A unit test exercises the refinement-shaped loop (plain solves, model-blocking clauses over fresh variables added between them) under the new mode.

Measured over the local QF_UFBV corpus at a 60 s timeout, arms interleaved per file in one parallel run. Certora 2023/2024, calc2, btfnt (1,136 files): 566 solved against 538, +46/−18, geomean time ratio 0.835 on the 497 files over a second, 190 files faster than 0.8x and 38 slower than 1.25x. Goel-hwbench, Bouvier, Wolf (1,403 files): 1,361 solved either way, geomean 0.955, no file lost. No verdict disagreed in either sweep. On 2246.smt2 alone, unloaded: 915 rounds and 287 s to 338 rounds and 73 s at the default lemma cap; the round count falls as well as the per-round cost, because a candidate that moved only where the lemmas forced it exposes fewer new collisions than one rebuilt from saved phases through a restarted search.

Two things were tried on the same file and not shipped. Uncapping `--uf-lemmas-per-round` (already available) is the fastest single setting for this file at 59 s but a wash on the family (+17/−19 solved). A cap that doubled after each refuted candidate was within noise of the fixed cap in opposite directions on the two sweeps and no better here once the trail is kept. Disabling CaDiCaL's lucky phases, the obvious suspect for a per-call fixed cost, changed nothing. Array read refinement and bit-vector abstraction refinement add clauses between solves the same way and pay the same re-descent; the change is gated to UF until they are measured.