### PR TITLE
Send an application equated with another application to it in the pre-lowering pass

### DIFF
--- a/docs/uninterpreted-functions.rst
+++ b/docs/uninterpreted-functions.rst
@@ -32,19 +32,28 @@ ordinary term:
     through the applications (``--uf-propagate-equalities``, on by default).
     A symbol equated with a constant, another symbol, an application or any
     other term free of wide arithmetic becomes that; an application pinned
-    to a constant becomes the constant everywhere else; any asserted atom is
-    true wherever else it occurs. A query asserting ``x = y`` therefore
-    lowers ``(f x)`` and ``(f y)`` as one application, which is the
-    structural merge an e-graph solver gets at internalisation, a fact such
-    as ``(f 3) = 0`` reaches the arithmetic built on ``(f 3)``, and a bound
-    stated on ``x`` under ``x = a + b`` meets the sum. A symbol equated with
-    a term holding a multiplication or division at or above
+    to a constant becomes the constant everywhere else; two applications
+    equated become the earlier of the two everywhere else; any asserted
+    atom is true wherever else it occurs. A query asserting ``x = y``
+    therefore lowers ``(f x)`` and ``(f y)`` as one application, which is
+    the structural merge an e-graph solver gets at internalisation, a fact
+    such as ``(f 3) = 0`` reaches the arithmetic built on ``(f 3)``, and a
+    bound stated on ``x`` under ``x = a + b`` meets the sum. Merging two
+    equated applications is what makes a term built on either one term: a
+    verification query that computes a quantity through two accessors,
+    asserts that they agree, and takes the difference of a product of a
+    quotient of each has that difference fold to zero, where with each side
+    its own application it is two abstracted products of two abstracted
+    quotients that the refinement never pins. A symbol equated with a term
+    holding a multiplication or division at or above
     ``--bv-abstraction-width`` keeps naming it: pushed into every argument
     position, such a term would make each congruence premise a comparison
     of dividers. The defining conjunct is kept, so no model is lost or
-    invented. Once lowered, the scalars of an application are protected from
-    the simplifier -- a lemma is later encoded over exactly their SAT bits --
-    so this is the one point at which such a fact can cross an application.
+    invented, and an application that was merged away is still one the
+    congruence checker sees. Once lowered, the scalars of an application
+    are protected from the simplifier -- a lemma is later encoded over
+    exactly their SAT bits -- so this is the one point at which such a fact
+    can cross an application.
 
 *   The Boolean skeleton is asked what it forces at the start of every
     round (``--uf-skeleton-preproc``, on by default), and those facts are

--- a/lib/UninterpretedFunctions/UFPreLowering.cpp
+++ b/lib/UninterpretedFunctions/UFPreLowering.cpp
@@ -263,11 +263,28 @@ void readCandidates(const ASTNode& conjunct, size_t index,
       addCandidate(out, a, b, index, wideWidth, marks);
     else if (isScalarSymbol(b))
       addCandidate(out, b, a, index, wideWidth, marks);
-    // An application pinned to a constant. An application equated with a
-    // non-constant term is left alone: replacing it by that term would move
-    // the application into the equality alone and buy nothing, while the
-    // symbol case above already covers `(f x) = a` by sending `a` to
-    // `(f x)`.
+    // Two applications equated: the later goes, as for two symbols. Every
+    // term built on either is then one term built on the survivor, which
+    // is what a verification query needs when it computes the same value
+    // through two accessors and takes their difference: with each side its
+    // own application the difference is two wide products of two wide
+    // quotients, which an abstraction refines round after round, and with
+    // one application it is a term less itself. The equality is kept, so
+    // the application that goes is still one the congruence checker sees,
+    // its result pinned to the survivor's, its arguments still meeting
+    // every other application of its declaration. An application equated
+    // with any other non-constant term is left alone: replacing it by that
+    // term would move the application into the equality alone and buy
+    // nothing, while the symbol case above already covers `(f x) = a` by
+    // sending `a` to `(f x)`.
+    else if (isApplication(a) && isApplication(b))
+    {
+      if (a.GetNodeNum() > b.GetNodeNum())
+        addCandidate(out, a, b, index, wideWidth, marks);
+      else
+        addCandidate(out, b, a, index, wideWidth, marks);
+    }
+    // An application pinned to a constant.
     else if (isApplication(a) && b.isConstant())
       addCandidate(out, a, b, index, wideWidth, marks);
     else if (isApplication(b) && a.isConstant())

--- a/tests/query-files/uf/28-equated-applications-are-one-application.smt2
+++ b/tests/query-files/uf/28-equated-applications-are-one-application.smt2
@@ -1,0 +1,38 @@
+; Two applications the query equates are one application everywhere else:
+; the later goes to the earlier, so a term built on either is one term.
+;
+; A verification query computes the same quantity through two accessors,
+; asserts that they agree, and takes the difference of a product of a
+; quotient of each. With each side its own application that difference is
+; two abstracted 256-bit products of two abstracted quotients, which the
+; abstraction refines round after round without ever pinning the free
+; dividend; with one application it is a term less itself, and the query
+; folds to false before anything is abstracted.
+;
+; RUN: %solver -s -t --uninterpreted-functions --incremental=off %s 2>&1 | %OutputCheck %s
+; CHECK: UF: pre-lowering substituted 1 symbol\(s\) and 1 application\(s\)
+; CHECK: Abstraction coverage \(candidates -> abstracted\): eq=0->0 compare=0->0 ite=0->0 plus=0->0 mult=0->0 divmod=0->0
+; CHECK: ^unsat$
+;
+; The pass switched off, the two stay apart and each side is its own
+; product of its own quotient: four abstracted operations where the merged
+; query has none. The solve is not waited for -- with the sides apart it is
+; a hard SAT problem over the exact 256-bit encodings, which is the point.
+; RUN: %solver -s -t --uninterpreted-functions --incremental=off --uf-propagate-equalities=0 --exit-after-CNF %s 2>&1 | %OutputCheck --check-prefix=APART %s
+; APART-NOT: pre-lowering substituted
+; APART: Abstraction coverage \(candidates -> abstracted\): eq=2->0 compare=0->0 ite=0->0 plus=0->0 mult=2->2 divmod=2->2
+;
+; EXPECT: unsat, then no answer (exit after CNF)
+(set-logic QF_UFBV)
+(declare-fun f ((_ BitVec 256)) (_ BitVec 256))
+(declare-fun g ((_ BitVec 256)) (_ BitVec 256))
+(declare-const x (_ BitVec 256))
+(declare-const a (_ BitVec 256))
+(declare-const b (_ BitVec 256))
+(declare-const d (_ BitVec 256))
+(assert (= (f x) (g x)))
+(assert (= a (bvmul (_ bv10000000000 256) (bvudiv (f x) (_ bv10000000000 256)))))
+(assert (= b (bvmul (_ bv10000000000 256) (bvudiv (g x) (_ bv10000000000 256)))))
+(assert (= d (bvsub a b)))
+(assert (not (= d (_ bv0 256))))
+(check-sat)

--- a/tests/unit-tests/UFPreLowering_Test.cpp
+++ b/tests/unit-tests/UFPreLowering_Test.cpp
@@ -373,3 +373,67 @@ TEST(UFPreLowering, TheStructureIsReadAgainAfterEachRound)
   EXPECT_GE(stats.rounds, 2u);
 }
 
+
+// Two applications the query equates are one application everywhere else,
+// so a term built on either is one term. The query says (f x) = (g y) and
+// pins (f (f x)) and (f (g y)) to different values; merged, the two outer
+// applications are one, and its two values contradict in the next round.
+TEST(UFPreLowering, EquatedApplicationsMergeTheTermsBuiltOnThem)
+{
+  Fixture fx;
+  ASSERT_NE(nullptr, fx.f) << fx.diagnostic;
+  const UFDecl* g =
+      fx.context->declareFunction("g", {fx.bv8}, fx.bv8, &fx.diagnostic);
+  ASSERT_NE(nullptr, g) << fx.diagnostic;
+  const ASTNode x = fx.symbol("x");
+  const ASTNode y = fx.symbol("y");
+  const ASTNode fOfX = fx.apply(x);
+  const ASTNode gOfY = fx.context->apply(g, {y}, &fx.diagnostic);
+  ASSERT_FALSE(gOfY.IsNull()) << fx.diagnostic;
+  const ASTNode root = fx.factory->CreateNode(
+      AND, {fx.eq(fOfX, gOfY), fx.eq(fx.apply(fOfX), fx.constant(5)),
+            fx.eq(fx.apply(gOfY), fx.constant(6))});
+  ASSERT_NE(fx.manager.ASTFalse, root);
+
+  UFPreLowering pass(&fx.manager);
+  UFPreLoweringStats stats;
+  const ASTNode rewritten = pass.propagate(root, &stats);
+
+  EXPECT_GE(stats.applicationSubstitutions, 1u);
+  EXPECT_EQ(fx.manager.ASTFalse, rewritten);
+}
+
+// It is the later of the two that goes, and the equality is kept: the
+// application that went is still one the congruence checker sees, pinned to
+// the survivor, and a term that was built on it is built on the survivor.
+TEST(UFPreLowering, TheLaterOfTwoEquatedApplicationsGoesAndTheEqualityStays)
+{
+  Fixture fx;
+  ASSERT_NE(nullptr, fx.f) << fx.diagnostic;
+  const UFDecl* g =
+      fx.context->declareFunction("g", {fx.bv8}, fx.bv8, &fx.diagnostic);
+  ASSERT_NE(nullptr, g) << fx.diagnostic;
+  const ASTNode x = fx.symbol("x");
+  const ASTNode y = fx.symbol("y");
+  const ASTNode fOfX = fx.apply(x);
+  const ASTNode gOfY = fx.context->apply(g, {y}, &fx.diagnostic);
+  ASSERT_FALSE(gOfY.IsNull()) << fx.diagnostic;
+  ASSERT_LT(fOfX.GetNodeNum(), gOfY.GetNodeNum());
+  const ASTNode fOfGOfY = fx.apply(gOfY);
+  const ASTNode root = fx.factory->CreateNode(
+      AND, {fx.eq(fOfX, gOfY), fx.eq(fOfGOfY, fx.constant(5))});
+
+  UFPreLowering pass(&fx.manager);
+  UFPreLoweringStats stats;
+  const ASTNode rewritten = pass.propagate(root, &stats);
+
+  EXPECT_GE(stats.applicationSubstitutions, 1u);
+  const ASTNodeSet applications = applicationsIn(rewritten);
+  EXPECT_NE(applications.end(), applications.find(fOfX));
+  EXPECT_NE(applications.end(), applications.find(gOfY));
+  EXPECT_NE(applications.end(), applications.find(fx.apply(fOfX)));
+  EXPECT_EQ(applications.end(), applications.find(fOfGOfY));
+  const ASTNodeSet conjuncts = conjunctsOf(rewritten);
+  EXPECT_TRUE(conjuncts.find(fx.eq(fOfX, gOfY)) != conjuncts.end() ||
+              conjuncts.find(fx.eq(gOfY, fOfX)) != conjuncts.end());
+}


### PR DESCRIPTION
From looking at why 0730 of QF_UFBV/20241113-Certora stayed undecided at two minutes after #1087, when the same query in the form Bitwuzla's preprocessing leaves it is decided in three solver calls.

**Send an application equated with another application to it in the pre-lowering pass.** The query computes a quantity through two accessors, asserts that they agree, and takes the difference of a product of a quotient of each: `x322 = 10^10 * ((x925 x128) / 10^10)`, `x262 = 10^10 * ((x186 (x949 64 x128 0)) / 10^10)`, with `(x925 x128) = (x186 (x949 64 x128 0))` asserted and `x322 - x262` feeding a live sum. With each side its own application that difference is two abstracted 256-bit products of two abstracted quotients whose dividend is a free application result, and the refinement blocks one dividend value per round without ever pinning it: 1,542 solver calls in 150 seconds, 1,536 of them refuting the same two division records. The pass now sends the later of two equated applications to the earlier, as it does for two symbols, keeping the equality so the congruence checker still sees the application that went. The difference is then a term less itself, the records are never made, and 0730 is unsat in 22 seconds over three solver calls.

**Measurement.** The #1087 head and this commit run back to back on each file at 30s, over the families the pass can touch (every other family was unchanged in a whole-corpus run of the same kind): 859 solved before against 919 after, no answer disagreements. 20241113-Certora 807 -> 863 of 1029 (CPU 11,564s -> 11,073s), 20230314-Jaroslav-Bendik-Certora 21 -> 25 of 76, calc2 30 -> 30, btfnt 1 -> 1. Seventy files gained, the 0730 family most of them; ten lost, seven of them from answers at 19 to 28 seconds. The other three are search-path effects rather than anything structural: on 0777 the merge folds three products into others' and the solver's candidates then run a harder course (sat in 3.5s before, 32s after, the same nine-to-eleven rounds), and on 0807 the same three solver calls prove unsat in 26s instead of 16s.

**Measured and left out:** not abstracting a multiplication by a power of two (it is a shift). It makes 0730 faster still (14s), but over the 83 files whose result changed in the corpus run, the merge alone solves 43 where merge plus exemption solves 37 in more CPU time, and the exemption turns several quick answers into timeouts (a Jaroslav file from 5s, Certora 0104 from 20s) by changing which candidates the search produces. It is kept on a side branch.
