### PR TITLE
Refinement trail reuse: reach it from the C API, pin the growing variable range, record what was rejected

### DIFF
--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -362,6 +362,13 @@ public:
   // 8 solved 28 of the 42, 16 and unlimited solved 30, and with the
   // quotient-threshold schemas below unlimited solved 34. Setting 1
   // restricts each candidate to one installed congruence lemma.
+  //
+  // A cap that doubles after each refuted candidate was tried against a
+  // fixed one -- small while a candidate is still cheap to replace, growing
+  // as the rounds show it is not -- and landed within noise, in opposite
+  // directions on two corpus sweeps. That was measured while the fixed cap
+  // was still 8; against unlimited there is nothing left for a schedule to
+  // withhold.
   unsigned uf_lemmas_per_round = 0;
 
   // Whether to install a declaration's pairwise congruence constraints before
@@ -1219,6 +1226,18 @@ public:
   // the incremental driver's own gate switches reuse off, which is why
   // there is no size gate here. A solve that is never asked twice is
   // unaffected whatever this says.
+  //
+  // Turning CaDiCaL's lucky phases off is the obvious second cut, and it is
+  // not here because it was measured and did nothing. A refinement query is
+  // many-solve, so its per-call whole-assignment probe looks like a
+  // recurring tax by the same argument that retires the probe on the
+  // incremental driver's persistent solver -- but on a refinement-heavy
+  // uninterpreted-function query, one whose rounds a kept trail alone takes
+  // from 915 to 338, switching it off changed nothing measurable. What a
+  // round pays for is the re-descent itself, not a phase in front of it.
+  // (Measured on the pipeline as it stood before the uninterpreted-function
+  // work that followed, so the round counts are not today's; what they rule
+  // out does not depend on them.)
   bool refinement_trail_reuse = true;
 
   // How the batch pipeline seeds the free indices of an array's reads so

--- a/include/stp/c_interface.h
+++ b/include/stp/c_interface.h
@@ -642,7 +642,23 @@ enum ifaceflag_t
   //! C API's way to reach --uf-check-during-bv-refinement. Appended to
   //! preserve every published ordinal.
   //!
-  UF_CHECK_DURING_BV_REFINEMENT
+  UF_CHECK_DURING_BV_REFINEMENT,
+
+  //! Whether the batch pipeline's refinement loop keeps the SAT solver's
+  //! search trail from one of its solve calls to the next, so that a round
+  //! resumes where the last one stopped instead of re-deciding every
+  //! variable from the root before it reaches the clauses that refuted the
+  //! last candidate.
+  //!
+  //! `param_value` nonzero enables (the default), zero disables. This is the
+  //! C API's way to reach --refinement-trail-reuse, and covers every loop the
+  //! batch pipeline refines -- array reads, the bit-vector abstractions and
+  //! uninterpreted functions. It changes the search order only, so it cannot
+  //! change an answer; a backend without the mechanism declines it, and a
+  //! solve that is never asked twice is unaffected either way. Appended to
+  //! preserve every published ordinal.
+  //!
+  REFINEMENT_TRAIL_REUSE
 
 };
 

--- a/lib/Interface/c_interface.cpp
+++ b/lib/Interface/c_interface.cpp
@@ -619,6 +619,12 @@ void vc_setInterfaceFlags(VC vc, enum ifaceflag_t f, int param_value)
     case BV_TERM_ABSTRACTION_INC_BITBLAST:
       b->UserFlags.bv_term_abstraction_inc_bitblast = param_value != 0;
       break;
+    // Not one loop's knob but every one of them: the field gates the trail
+    // the batch pipeline keeps between the solve calls of array-read,
+    // bit-vector-abstraction and uninterpreted-function refinement alike.
+    case REFINEMENT_TRAIL_REUSE:
+      b->UserFlags.refinement_trail_reuse = param_value != 0;
+      break;
     case INCREMENTAL_PIECE_REWRITING:
       b->UserFlags.incremental_piece_rewriting = param_value != 0;
       break;

--- a/tests/api/C/refinement-flags.cpp
+++ b/tests/api/C/refinement-flags.cpp
@@ -110,6 +110,8 @@ static_assert(UF_BV_TERM_ABSTRACTION == 38,
               "published interface-flag ordinal changed");
 static_assert(UF_CHECK_DURING_BV_REFINEMENT == 39,
               "published interface-flag ordinal changed");
+static_assert(REFINEMENT_TRAIL_REUSE == 40,
+              "published interface-flag ordinal changed");
 // The published prefix ends at CNF_AUTO_THRESHOLD. Everything this feature
 // adds -- three interface flags and three profile ordinals -- is new in this
 // series and deliberately NOT pinned here: nothing outside the tree has linked
@@ -169,6 +171,7 @@ TEST(refinement_flags, DefaultsAreTheOnesTheCommandLineDocuments)
   EXPECT_EQ(0u, flags(vc).bv_term_abstraction_value_divisor);
   EXPECT_EQ(0u, flags(vc).bv_term_abstraction_divmod_value_limit);
   EXPECT_FALSE(flags(vc).bv_term_abstraction_inc_bitblast);
+  EXPECT_TRUE(flags(vc).refinement_trail_reuse);
   vc_Destroy(vc);
 }
 
@@ -319,6 +322,13 @@ TEST(refinement_flags, EachFlagReachesTheFieldTheCLIWrites)
   EXPECT_TRUE(flags(vc).bv_term_abstraction_inc_bitblast);
   vc_setInterfaceFlags(vc, BV_TERM_ABSTRACTION_INC_BITBLAST, 0);
   EXPECT_FALSE(flags(vc).bv_term_abstraction_inc_bitblast);
+
+  // On by default, so the off direction is the one a client comes here for.
+  EXPECT_TRUE(flags(vc).refinement_trail_reuse);
+  vc_setInterfaceFlags(vc, REFINEMENT_TRAIL_REUSE, 0);
+  EXPECT_FALSE(flags(vc).refinement_trail_reuse);
+  vc_setInterfaceFlags(vc, REFINEMENT_TRAIL_REUSE, 1);
+  EXPECT_TRUE(flags(vc).refinement_trail_reuse);
 
   // Zero is a meaning of its own for both of these, not an absence: install
   // every conflict the candidate exposes, and a budget of no gates at all.

--- a/tests/unit-tests/TrailReuse_Test.cpp
+++ b/tests/unit-tests/TrailReuse_Test.cpp
@@ -159,6 +159,102 @@ TEST(TrailReuse, CadicalKeepsTrailAcrossRefinementRounds)
   EXPECT_EQ(seen.size(), 14u);
 }
 
+// The rounds above add clauses over variables the solver already had. The
+// refinement loop does more than that: it mints the variables its clauses
+// are written in. getEquals() takes a fresh variable for the equality it is
+// about to name and another for every bit of it, and getSatVariables()
+// takes and freezes a whole word for a leaf the blast never reached
+// (AbstractionRefinement.cpp). So the variable range grows while the solver
+// is holding the trail its last search left, which is a different path
+// through the backend from a clause over variables it has already sized its
+// structures for. Nothing above calls newVar() after the first solve; this
+// mints a round's worth every time, in the clause shape getEquals() emits,
+// and still requires every model exactly once.
+TEST(TrailReuse, CadicalGrowsTheVariableRangeUnderAKeptTrail)
+{
+  stp::Cadical s;
+#if defined(CADICAL_MAJOR) && CADICAL_MAJOR >= 3
+  EXPECT_TRUE(s.enableTrailReuse(SATSolver::TrailReuse::ALL));
+#else
+  // Older CaDiCaLs may decline the scope; the checks below then pin the
+  // ordinary re-descending path instead.
+  s.enableTrailReuse(SATSolver::TrailReuse::ALL);
+#endif
+
+  const unsigned n = 4;
+  std::vector<uint32_t> v;
+  for (unsigned i = 0; i < n; i++)
+  {
+    v.push_back(s.newVar());
+    // As the lowering does for a leaf a lemma may still be written over:
+    // an eliminated variable has no value to read back.
+    s.setFrozen(v.back());
+  }
+  const uint32_t before = s.nVars();
+
+  // Not all false, not all true: 14 of the 16 assignments remain.
+  SATSolver::vec_literals someTrue, someFalse;
+  for (unsigned i = 0; i < n; i++)
+  {
+    someTrue.push(SATSolver::mkLit(v[i], false));
+    someFalse.push(SATSolver::mkLit(v[i], true));
+  }
+  s.addClause(someTrue);
+  s.addClause(someFalse);
+
+  std::set<unsigned> seen;
+  bool timed_out = false;
+  unsigned rounds = 0;
+  while (s.solve(timed_out))
+  {
+    ASSERT_FALSE(timed_out);
+    unsigned model = 0;
+    for (unsigned i = 0; i < n; i++)
+      if (s.modelValue(v[i]) == s.true_literal())
+        model |= 1u << i;
+    EXPECT_NE(model, 0u) << "a model that falsifies the first clause";
+    EXPECT_NE(model, (1u << n) - 1) << "a model that falsifies the second";
+    EXPECT_TRUE(seen.insert(model).second)
+        << "model " << model << " was found twice: a blocking clause was "
+        << "lost across a trail kept over variables that did not exist "
+        << "when it was decided";
+
+    // Refute it the way getEquals() does, one polarity being all a blocking
+    // clause needs: a fresh variable per bit, forced true while that bit
+    // still agrees with the model just read, and a fresh variable standing
+    // for the whole agreement, which the unit then forbids. None of them is
+    // forced false, so every other assignment stays reachable -- and every
+    // one of them is minted while the solver holds a trail.
+    SATSolver::vec_literals agreement;
+    for (unsigned i = 0; i < n; i++)
+    {
+      const uint32_t agree = s.newVar();
+      s.setFrozen(agree);
+      SATSolver::vec_literals forced;
+      forced.push(SATSolver::mkLit(v[i], (model >> i) & 1u));
+      forced.push(SATSolver::mkLit(agree, false));
+      s.addClause(forced);
+      agreement.push(SATSolver::mkLit(agree, true));
+    }
+    const uint32_t same = s.newVar();
+    s.setFrozen(same);
+    agreement.push(SATSolver::mkLit(same, false));
+    s.addClause(agreement);
+
+    SATSolver::vec_literals block;
+    block.push(SATSolver::mkLit(same, true));
+    s.addClause(block);
+
+    ASSERT_LE(++rounds, 14u) << "more rounds than there are models";
+  }
+  EXPECT_FALSE(timed_out);
+  EXPECT_EQ(rounds, 14u) << "a model was never found";
+  EXPECT_EQ(seen.size(), 14u);
+  // n agreement bits and the variable naming them, every round: what the
+  // trail was kept across.
+  EXPECT_EQ(s.nVars(), before + 14u * (n + 1));
+}
+
 // The whole trail kept, then a call that does carry assumptions, and
 // units added between calls: the guard the batch pipeline assumes for
 // injectivity is exactly this mixture. Every verdict has to be right


### PR DESCRIPTION
Three changes salvaged from #1088, closed as superseded by #1085.

#1085 already shipped the mechanism #1088 carried — the `SATSolver::TrailReuse` scope, CaDiCaL's `ilb=2`, and the switch that turns it on — but for every loop the batch pipeline refines rather than only uninterpreted functions: `maybeRefinement` in `STP.cpp` includes `batchUFView->active()`, and that is the `needAbsRef` `ToSATAIG::CallSAT` gates on, so a UF query already gets the kept trail (`Refinement trail reuse: on` on the stats line of any QF_UFBV file). Three things in #1088 had no counterpart, and this is those three.

Please merge as separate commits rather than squashing: each message carries its own evidence and trailers.

### 1. Reach the refinement loop's trail reuse from the C API (`b22bdf51c`)

`--refinement-trail-reuse` was reachable only from the command line. A client driving libstp through the C API had no way to turn it off, and it is on by default, so there was no way back to the behaviour such a client had before it shipped.

`REFINEMENT_TRAIL_REUSE` is appended to `ifaceflag_t` at ordinal 40, after `UF_CHECK_DURING_BV_REFINEMENT`, so every published ordinal keeps the value an installed header committed to. Its case sits with the batch refinement knobs rather than the UF ones, because the field gates array reads, the bit-vector abstractions and uninterpreted functions alike. #1088 reached the same field under a UF-only name and scope; the wider scope is what shipped, so the name says so.

The C API test pins the new ordinal beside the others, adds the default to the block capturing what a client inherits by setting nothing, and round-trips the flag in both directions — a case that fell through to the default arm would abort rather than fail, so the mapping needs pinning and not merely that the enumerator is accepted.

### 2. Grow the variable range between rounds in the trail reuse test (`247d59449`)

`CadicalKeepsTrailAcrossRefinementRounds` enumerates the fourteen models of a four-variable formula by blocking each one it reads. What it never does is call `newVar()` after its first solve: every clause it adds is written in variables the solver already had when it descended.

The loop it stands in for is not like that. `getEquals()` mints a fresh variable for the equality a lemma is about to name and another for every bit of it, and `getSatVariables()` mints and freezes a whole word for a leaf the blast never reached (`AbstractionRefinement.cpp`). Both run after a candidate has been read and before the next solve, so the variable range grows while the backend holds the trail its last search left — a different path through CaDiCaL from a clause over variables it has already sized its structures for.

The new case enumerates the same fourteen models but refutes each in the clause shape `getEquals()` emits: a fresh frozen variable per bit, forced true while that bit still agrees with the model just read, and a fresh frozen variable standing for the whole agreement, which a unit then forbids. Only the one polarity is forced, as in `getEquals()`, so no other assignment is cut off. Five variables a round, seventy across the loop, and the count is checked at the end alongside the requirement that every model appears exactly once. With the blocking unit's sign flipped, so that the refutation refutes nothing, it fails on the first repeated model.

### 3. Record what was measured around the kept trail and the lemma cap (`e21d1401a`)

Two settings tried in #1088 and rejected, neither rejection visible from the code, so both invite a second run.

**Lucky phases.** The argument for keeping a trail is that a round otherwise repeats the pre-search phases before it searches, and the incremental driver already retires one of those — CaDiCaL's lucky-phase probing — from its persistent solver on the ground that a many-solve session pays for it every call. A refinement query is many-solve too, so the same cut looks free, and the comment beside that retirement says only that the batch pipeline's single-solve instances keep it. Switching it off for a refinement query changed nothing: what the round pays for is the re-descent itself, not a phase in front of it.

**The lemma cap.** A cap that doubles after each refuted candidate — small while a candidate is still cheap to replace, growing as the rounds show it is not — landed within noise of the fixed one, in opposite directions on two corpus sweeps.

Both were measured on #1088's base, which predates #1086: the cap was still 8 when the doubling schedule was tried, and the round counts behind the lucky-phase measurement are not today's. Their numbers are deliberately not carried over — what each rules out does not depend on them, and the comments say which is which.

### Testing

`ctest` on this branch: 884 lit tests passed, 3 failed. Pristine master built in the identical configuration gives the same 884/3, failing the same three files (`fp-tests/native-tofp-symfpu-equivalence.smt2`, `fp-tests/roundtointegral-equal-widths.smt2`, `fp-tests/tofp-narrowing-exponent-range.smt2`) — pre-existing in that configuration and untouched by this branch. `refinement-flagsTests` 16/16, `TrailReuse_TestTests` 4/4. `git clang-format --diff master` reports no changes.

### Not in this branch

`--refinement-trail-reuse` has never been measured on QF_UFBV against a current head: #1085 measured QF_ABV, and #1088's QF_UFBV numbers were taken against a pipeline #1086 replaced. Nothing here depends on that number, but it is the one piece of evidence the flag is still missing.