### PR TITLE
Correct roundToIntegral and the FMA invariant in the vendored SymFPU, and round an integer past the format to an infinity

### DIFF
--- a/cmake/FindSymFPU.cmake
+++ b/cmake/FindSymFPU.cmake
@@ -58,13 +58,13 @@ if(NOT SymFPU_FOUND_SYSTEM)
     endif()
 
     # stp/symfpu is a fork laid out like the ABC one: main tracks upstream and
-    # the `stp` branch, which this pins a commit of, carries STP's four
+    # the `stp` branch, which this pins a commit of, carries STP's seven
     # correctness fixes as commits. They used to be patch files applied at
     # configure time; as commits each one names what it fixes, and a bump is a
     # rebase in that repository where a conflict says which change upstream has
     # met.
-    set(SymFPU_COMMIT "d358a6defeace0cd44695e7d922fc62c2f8b8ee8")
-    set(SymFPU_CHECKSUM "2557cc598ebde7e6d673cbb7f48a6f0928a18e38bbd3a5b00d126c0f45ba79f1")
+    set(SymFPU_COMMIT "e457a07735f0d1f56cb543a3b3ff8f28551c02db")
+    set(SymFPU_CHECKSUM "f147b4b16cdab398bd3588d75e0fe524f7af0cf675997a62e7e1aff65e868ee4")
 
     ExternalProject_Add(
         SymFPU-EP

--- a/lib/NodeFactory/SimplifyingNodeFactory.cpp
+++ b/lib/NodeFactory/SimplifyingNodeFactory.cpp
@@ -273,6 +273,18 @@ static bool fpIsRoundToIntegral(const stp::ASTNode& n)
   return n.GetKind() == stp::FP_ROUNDTOINTEGRAL && n.Degree() == 2;
 }
 
+// Whether every value of the format's top binade is an integer, which is
+// when 2^(eb-1) >= sb. Then rounding to an integer never leaves the finite
+// range. In the formats where it fails -- the exponent range narrower than
+// the significand, which no IEEE format has -- the top binade holds
+// non-integers whose rounding up is beyond the largest finite and is an
+// infinity, so a finite can round to an infinity there.
+static bool fpRoundToIntegralNeverOverflows(const stp::ASTNode& n)
+{
+  const unsigned eb = n.GetExpWidth(), sb = n.GetSigWidth();
+  return eb >= 1 && eb < 64 && ((unsigned long long)1 << (eb - 1)) >= sb;
+}
+
 bool SimplifyingNodeFactory::children_all_constants(
     const ASTChildren children) const
 {
@@ -1104,7 +1116,8 @@ ASTNode SimplifyingNodeFactory::CreateNode(Kind kind,
                ((t.GetKind() == stp::FP_SQRT && t.Degree() == 2) ||
                 fpIsSelfSum(t)))
         result = NodeFactory::CreateNode(kind, t[1]);
-      else if (kind == stp::FP_ISINFINITE && fpIsRoundToIntegral(t))
+      else if (kind == stp::FP_ISINFINITE && fpIsRoundToIntegral(t) &&
+               fpRoundToIntegralNeverOverflows(t))
         result = NodeFactory::CreateNode(kind, t[1]);
       else if (kind == stp::FP_ISSUBNORMAL && fpIsRoundToIntegral(t))
         result = ASTFalse;

--- a/tests/query-files/fp-tests/fma-literal-overflowing-product-symbols.smt2
+++ b/tests/query-files/fp-tests/fma-literal-overflowing-product-symbols.smt2
@@ -1,0 +1,15 @@
+; RUN: %solver %s | %OutputCheck %s
+;
+; The same overflowing fused multiply-add reached through symbols the
+; substitution pass resolves to literals, so the folder runs after
+; preprocessing rather than in the parser.
+; CHECK: ^sat
+(set-logic QF_FP)
+(declare-const x (_ FloatingPoint 3 9))
+(declare-const y (_ FloatingPoint 3 9))
+(declare-const z (_ FloatingPoint 3 9))
+(assert (= x (fp #b1 #b110 #b11111111)))
+(assert (= y (fp #b1 #b110 #b11111111)))
+(assert (= z (_ +zero 3 9)))
+(assert (= (fp.fma RNA x y z) (_ +oo 3 9)))
+(check-sat)

--- a/tests/query-files/fp-tests/fma-literal-overflowing-product.smt2
+++ b/tests/query-files/fp-tests/fma-literal-overflowing-product.smt2
@@ -1,0 +1,10 @@
+; RUN: %solver %s | %OutputCheck %s
+;
+; A fused multiply-add folded over literals whose product overflows the
+; format. SymFPU's addition-result invariant bounded the exponent one short
+; of what the product's exponent plus the carry reaches, and the folder's
+; assertion aborted the solver; the sum is the overflow it says it is.
+; CHECK: ^sat
+(set-logic QF_FP)
+(assert (= (fp.fma RNA (fp #b1 #b110 #b11111111) (fp #b1 #b110 #b11111111) (_ +zero 3 9)) (_ +oo 3 9)))
+(check-sat)

--- a/tests/query-files/fp-tests/fma-literal-overflowing-sum.smt2
+++ b/tests/query-files/fp-tests/fma-literal-overflowing-sum.smt2
@@ -1,0 +1,9 @@
+; RUN: %solver %s | %OutputCheck %s
+;
+; The addend pushes an already-overflowing product's exponent up by the
+; carry the invariant did not allow for; round-to-nearest-even overflows to
+; minus infinity.
+; CHECK: ^sat
+(set-logic QF_FP)
+(assert (= (fp.fma RNE (fp #b1 #b110 #b11111111) (fp #b0 #b110 #b11111110) (fp #b1 #b101 #b00000001)) (_ -oo 3 9)))
+(check-sat)

--- a/tests/query-files/fp-tests/round-to-integral-eb2-literal.smt2
+++ b/tests/query-files/fp-tests/round-to-integral-eb2-literal.smt2
@@ -1,0 +1,9 @@
+; RUN: %solver %s | %OutputCheck %s
+;
+; The constant folder takes the same SymFPU path as the symbolic encoding,
+; so the (2, 4) collar wrap also folded (fp.roundToIntegral RNE 1.0) to a
+; value other than 1.0 and answered unsat to a true equation.
+; CHECK: ^sat
+(set-logic QF_FP)
+(assert (= (fp.roundToIntegral RNE (fp #b0 #b01 #b000)) (fp #b0 #b01 #b000)))
+(check-sat)

--- a/tests/query-files/fp-tests/round-to-integral-eb2-sb4.smt2
+++ b/tests/query-files/fp-tests/round-to-integral-eb2-sb4.smt2
@@ -1,0 +1,15 @@
+; RUN: %solver %s | %OutputCheck %s
+;
+; fp.roundToIntegral in a format whose exponent field is two bits wide.
+; SymFPU's rounding collar widens the significand by one bit and shifts by
+; the exponent; with eb = 2 and sb a power of two, the width it computed for
+; that shift wrapped, and 1.0 rounded to something other than 1.0. Every
+; integer is its own rounding, so this is unsat in every mode.
+; CHECK: ^unsat
+(set-logic QF_FP)
+(declare-const x (_ FloatingPoint 2 4))
+(declare-const t (_ FloatingPoint 2 4))
+(assert (= t (fp.roundToIntegral RNE x)))
+(assert (= x (fp #b0 #b01 #b000)))
+(assert (not (= t (fp #b0 #b01 #b000))))
+(check-sat)

--- a/tests/query-files/fp-tests/round-to-integral-eb2-sb8.smt2
+++ b/tests/query-files/fp-tests/round-to-integral-eb2-sb8.smt2
@@ -1,0 +1,12 @@
+; RUN: %solver %s | %OutputCheck %s
+;
+; The same collar width wrap at the next power-of-two significand: 1.0 in
+; (2, 8) is an integer and rounds to itself.
+; CHECK: ^unsat
+(set-logic QF_FP)
+(declare-const x (_ FloatingPoint 2 8))
+(declare-const t (_ FloatingPoint 2 8))
+(assert (= t (fp.roundToIntegral RTZ x)))
+(assert (= x (fp #b0 #b01 #b0000000)))
+(assert (not (= t (fp #b0 #b01 #b0000000))))
+(check-sat)

--- a/tests/query-files/fp-tests/round-to-integral-overflow-literal.smt2
+++ b/tests/query-files/fp-tests/round-to-integral-overflow-literal.smt2
@@ -1,0 +1,11 @@
+; RUN: %solver %s | %OutputCheck %s
+;
+; The same rounding folded over a literal: the literal back-end aborted on
+; SymFPU's postcondition here before the result was made an infinity on
+; purpose. 3.75 in (2, 6) rounds up under RTP to 4, which is +oo there.
+; CHECK: ^sat
+(set-logic QF_FP)
+(assert (= (fp.roundToIntegral RTP (fp #b0 #b10 #b11000)) (_ +oo 2 6)))
+(assert (= (fp.roundToIntegral RTN (fp #b1 #b10 #b11000)) (_ -oo 2 6)))
+(assert (= (fp.roundToIntegral RTN (fp #b0 #b10 #b11000)) (fp #b0 #b10 #b10000)))
+(check-sat)

--- a/tests/query-files/fp-tests/round-to-integral-overflow-symbolic.smt2
+++ b/tests/query-files/fp-tests/round-to-integral-overflow-symbolic.smt2
@@ -1,0 +1,18 @@
+; RUN: %solver %s | %OutputCheck %s
+;
+; In a format whose exponent range is narrower than its significand the
+; top binade holds non-integers, and rounding one up is an integer the
+; format has no finite for: 3.5 in (2, 3) under RNE is 4, beyond the
+; largest finite 3. The result is the infinity of that sign, in the
+; symbolic encoding as in the literal one -- SymFPU's roundToIntegral left
+; an exponent one past the largest normal's, which packed to an infinity
+; by accident and was no infinity to its own flags, so a query asking for
+; one was unsat. Satisfiable, with x = 3.5.
+; CHECK: ^sat
+(set-logic QF_FP)
+(declare-const x (_ FloatingPoint 2 3))
+(declare-const t (_ FloatingPoint 2 3))
+(assert (= t (fp.roundToIntegral RNE x)))
+(assert (fp.isInfinite t))
+(assert (not (fp.isInfinite x)))
+(check-sat)

--- a/tests/query-files/fp-tests/round-to-integral-overflow-toward-zero.smt2
+++ b/tests/query-files/fp-tests/round-to-integral-overflow-toward-zero.smt2
@@ -1,0 +1,12 @@
+; RUN: %solver %s | %OutputCheck %s
+;
+; Rounding toward zero never leaves the top binade, so no finite rounds to
+; an infinity under it, in any format.
+; CHECK: ^unsat
+(set-logic QF_FP)
+(declare-const x (_ FloatingPoint 2 3))
+(declare-const t (_ FloatingPoint 2 3))
+(assert (= t (fp.roundToIntegral RTZ x)))
+(assert (fp.isInfinite t))
+(assert (not (fp.isInfinite x)))
+(check-sat)


### PR DESCRIPTION
Three floating-point defects found while exercising the tiny formats that the test suite and the fuzzers use, where the exponent field is two bits wide or the exponent range is narrower than the significand. None is reachable in an IEEE format, but all three are reachable in formats the input language accepts, and two of them answer a query wrongly rather than failing loudly.

**SymFPU roundToIntegral in two-bit-exponent formats.** The rounding collar widens the significand by one bit and shifts by the exponent; with `eb = 2` and a power-of-two significand the width computed for that shift wrapped, and `1.0` rounded to something that is not `1.0`. Both back-ends took the same path, so the constant folder agreed with the symbolic encoding and a true equation came back `unsat`. Three query files cover the literal fold and the symbolic encoding at `(2, 4)` and `(2, 8)`.

**The SymFPU FMA invariant that aborted the literal folder.** An FMA whose product overflows the format tripped a postcondition in the vendored copy rather than returning the value the standard asks for. Three query files: the overflowing product, the overflowing sum, and the same over symbols so that the symbolic path is covered beside the fold.

**Rounding an integer beyond the format.** Where `2^(eb-1) < sb` the top binade holds non-integers, and rounding one up is an integer the format has no finite for: `3.5` in `(2, 3)` is `4` under RNE, past the largest finite `3`. SymFPU left an unpacked float one exponent past the largest normal, which is no valid float — the symbolic encoding packed it, by the accident of its bits, to an infinity that its own flags did not consider infinite, so `fp.isInfinite` of it was false while equality with `+oo` was true. The node factory made it worse by folding `fp.isInfinite` over a rounding to the argument's answer outright. The value is now the infinity of the argument's sign, which the postcondition accepts and both back-ends agree on, and the folding rule is kept only for the formats where a rounding never overflows, which is `2^(eb-1) >= sb`. Three query files: the symbolic query, the same toward zero where no overflow is possible, and the folds that aborted.

Please merge as separate commits rather than squashing: each carries its own evidence and trailers.