### PR TITLE
Pin the model self-check's read evaluation under eager Ackermannisation

### DIFF
--- a/lib/Parser/smt2.y
+++ b/lib/Parser/smt2.y
@@ -350,8 +350,10 @@ namespace stp
 
   // STP's lowering layer intentionally treats a float's packed
   // representation as bits, but that is an internal implementation detail.
-  // At the SMT-LIB boundary a BV operator accepts only a BitVec-sorted term;
-  // callers must use fp.to_ieee_bv to expose a float's representation.
+  // At the SMT-LIB boundary a BV operator accepts only a BitVec-sorted
+  // term; no operator exposes a float's representation (fp.to_ieee_bv is
+  // not implemented -- and note it is underspecified for NaN, whose
+  // payload nothing else in the language can observe either).
   void checkBitVectorTerm(const ASTNode& n)
   {
     if (n.GetSourceSort().kind() != stp::SourceSort::Kind::BitVector)

--- a/tests/query-files/incremental-tests/ackermanize-model-self-check.smt2
+++ b/tests/query-files/incremental-tests/ackermanize-model-self-check.smt2
@@ -1,0 +1,33 @@
+; RUN: %solver --incremental=on --ackermanize -d %s | %OutputCheck %s
+; RUN: %solver --incremental=on -d %s | %OutputCheck %s
+; RUN: %solver --incremental=off --ackermanize -d %s | %OutputCheck %s
+;
+; The -d self-check re-evaluates the raw assertion stack against the model,
+; and under eager Ackermannisation the reads it meets were compiled away
+; before encoding: the evaluator must answer them from the recorded
+; observations, not from an invented completion. Three shapes an invented
+; value would break: a read the stack asserts directly, a read-over-write
+; whose fall-through lands on a base cell the stack never reads directly,
+; and a cache-backed re-check whose observations must be restored rather
+; than rebuilt. A wrong completion turns a genuine model into a self-check
+; abort, so every answer below must arrive.
+; CHECK: ^sat
+; CHECK: ^sat
+; CHECK: ^sat
+; CHECK: ^sat
+(set-logic QF_ABV)
+(declare-fun a () (Array (_ BitVec 8) (_ BitVec 8)))
+(declare-fun i () (_ BitVec 8))
+(declare-fun j () (_ BitVec 8))
+(push 1)
+(assert (= (select a i) #x05))
+(check-sat)
+(check-sat)
+(push 1)
+(assert (= (select (store a j #x09) i) #x05))
+(assert (distinct i j))
+(check-sat)
+(push 1)
+(assert (= (select a j) #x07))
+(check-sat)
+(exit)


### PR DESCRIPTION
Under `--ackermanize` the array reads of a query are compiled away before the solver sees them, so `-d` has to answer a read from the observations it recorded rather than from an invented completion. That path had no test at all, in any of the three shapes where it can go wrong: a directly asserted read, a read-over-write whose fall-through lands on a cell the stack never reads directly, and a cache-backed re-check whose observations are restored rather than gathered afresh. One query file covers all three under both array strategies. No behaviour changes.

The comment at the parser's bit-vector boundary is corrected while here. It said callers must use `fp.to_ieee_bv` to expose a float's representation; that operator is not implemented, and nothing else in the input language exposes those bits either, which is worth stating exactly since it is what makes a NaN's payload unobservable from the input language.