### PR TITLE
Leave an equality against a constant to its comparator

### DIFF
--- a/docs/bv-abstraction.rst
+++ b/docs/bv-abstraction.rst
@@ -33,7 +33,16 @@ least one of them:
 
 ``--bv-eq-abstraction``
   Abstract wide equalities, refining them through congruence closure at word
-  level.
+  level. An equality one side of which the blast knows entirely is left to
+  its comparator unless ``--bv-eq-abstraction-constant-side`` (off) admits
+  it: a comparison against a constant is one AND over the term's bits, which
+  the solver propagates through, where a record is a free Boolean the
+  refinement pins a round at a time. On the QF_FP flux-balance benchmarks,
+  whose mass-balance rows are 128-bit sums equated with zero, leaving them
+  to their comparators solves one more query of 275 and takes a sixth less
+  time over those both settings decide; on floating-point queries raised by
+  symbolic execution of numerical libraries it is worth three solves of
+  1,241 and 7% of the PAR2.
 
 ``--bv-abstraction-width`` is the floor for both: an operation narrower than
 this (64 bits by default) is encoded exactly, whatever else is set. Nothing

--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -613,6 +613,18 @@ public:
   int64_t aig_node_budget = -1;
 
   bool bv_eq_abstraction = false;
+  // Whether an equality one side of which the blast knows entirely is
+  // abstracted along with the rest (off). A comparison against a constant
+  // is one AND over the term's bits, which the solver propagates through;
+  // a record of it is a free Boolean the congruence refinement has to pin
+  // one round at a time, and buys nothing for the exact form it defers.
+  // On the QF_FP flux-balance benchmarks, whose mass-balance rows are
+  // 128-bit sums equated with zero, leaving those equalities to their
+  // comparators solves one more of 275 and takes a sixth less time over
+  // the queries both settings decide; on floating-point queries raised by
+  // symbolic execution of numerical libraries it is worth three solves of
+  // 1,241 and 7% of the PAR2.
+  bool bv_eq_abstraction_constant_side = false;
   // One width floor for both abstraction families: equalities and the
   // abstracted terms (comparisons, ITE, BVPLUS, BVMULT, BVDIV, BVMOD)
   // all abstract only at or above this operand width.

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -2216,8 +2216,12 @@ const BBNode BitBlaster<BBNode, BBNodeManagerT>::BBForm(const ASTNode& form,
           firstCandidateSighting(form))
         uf->coverage.bv_candidates[UserDefinedFlags::ABSTRACT_EQ]++;
 
+      // An equality against a constant is left to its comparator unless
+      // --bv-eq-abstraction-constant-side asks for a record.
       if (eqAbstractionAllowed() &&
-          left.size() >= uf->bv_abstraction_width)
+          left.size() >= uf->bv_abstraction_width &&
+          (uf->bv_eq_abstraction_constant_side ||
+           !(isConstant(left) || isConstant(right))))
       {
         // One Boolean per predicate, not per occurrence: see
         // abstractedFormulas_ for why the term families' registry does not

--- a/tests/query-files/misc-tests/bv-eq-abstraction-constant-side-left-exact.smt2
+++ b/tests/query-files/misc-tests/bv-eq-abstraction-constant-side-left-exact.smt2
@@ -1,0 +1,26 @@
+; An equality one side of which is a constant is not made a record by the
+; equality abstraction: a comparison against a constant is one AND over the
+; term's bits, which propagates, where a record is a free Boolean the
+; congruence refinement pins a round at a time. With the width floor at one
+; bit so that a 16-bit equality qualifies, the coverage line shows the
+; candidate and no record, and the answer comes from the comparator.
+;
+; RUN: %solver --incremental=off -s -t --bv-eq-abstraction=1 --bv-abstraction-width=1 %s 2>&1 | %OutputCheck %s
+; CHECK: Abstraction coverage \(candidates -> abstracted\): eq=2->1
+; CHECK: ^sat$
+;
+; --bv-eq-abstraction-constant-side admits it as a record beside the
+; symbolic one.
+; RUN: %solver --incremental=off -s -t --bv-eq-abstraction=1 --bv-abstraction-width=1 --bv-eq-abstraction-constant-side=1 %s 2>&1 | %OutputCheck --check-prefix=RECORD %s
+; RECORD: Abstraction coverage \(candidates -> abstracted\): eq=2->2
+; RECORD: ^sat$
+;
+; EXPECT: sat, sat
+(set-logic QF_BV)
+(declare-fun a () (_ BitVec 16))
+(declare-fun b () (_ BitVec 16))
+(declare-fun c () (_ BitVec 16))
+(assert (= (bvmul a b) #x0100))
+(assert (= (bvxor a c) (bvadd b c)))
+(assert (bvugt a #x0010))
+(check-sat)

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -371,6 +371,14 @@ void ExtraMain::create_options()
            "bit-blaster proxies non-input ones -- with fresh Boolean "
            "variables during bit-blasting, refining lazily via CEGAR",
            refinement_group);
+  bool_arg("--bv-eq-abstraction-constant-side",
+           bm->UserFlags.bv_eq_abstraction_constant_side,
+           "abstract an equality one side of which the blast knows "
+           "entirely; off by default, such an equality is lowered exactly, "
+           "since a comparison against a constant is one AND over the "
+           "term's bits, where a record is a free Boolean the refinement "
+           "pins a round at a time",
+           refinement_group);
   app.add_option("--bv-abstraction-width",
                  bm->UserFlags.bv_abstraction_width,
                  "minimum operand width at which --bv-eq-abstraction and "


### PR DESCRIPTION
`--bv-eq-abstraction` replaces a wide equality with a Boolean and refines it through congruence closure. Where one side is a constant the blast knows entirely, that record buys nothing it does not first have to pay for: the exact form is a single AND over the term's bits, which the solver propagates through from either direction, while the record is a free Boolean the refinement has to pin one candidate at a time. This is the same argument as the constant-operand cap in #1087, one step earlier — there the record is made and its allowance bounded, here it is not made.

Such an equality is no longer abstracted unless `--bv-eq-abstraction-constant-side` asks for it. The option is unreachable unless `--bv-eq-abstraction` is on, which it is not by default, so nothing changes for a stock run.

**Measurement.** On the QF_FP flux-balance benchmarks (the 20260824-LatendresseFP set), whose mass-balance rows are 128-bit sums equated with zero, leaving them to their comparators solves one more query of 275 at 120s and takes a sixth less time over the queries both settings decide. On 1,241 floating-point queries raised by symbolic execution of numerical libraries it is worth three solves and 7% of the PAR2 at 60s. Neither corpus loses a query to it.

A query file pins both directions, with the width floor at one bit so that a 16-bit equality qualifies: the coverage line counts the candidate and no record by default, and both as records when the option is given.

This and the companion PR for the term abstraction's constant operands touch the same four files; whichever lands second will want a trivial rebase.