### PR TITLE
Let a wide operation with a constant operand skip the record entirely

### DIFF
--- a/docs/bv-abstraction.rst
+++ b/docs/bv-abstraction.rst
@@ -145,6 +145,20 @@ every such record spent its thirty-two rounds on one dividend at a time
 before building an encoding that was cheap all along. Zero leaves the
 allowance uncapped.
 
+Whether such an operation is abstracted at all is
+``--bv-term-abstraction-constant-operands`` (on). Declined, a multiplication
+one of whose operands the blast knows entirely, or a division or remainder
+by such a divisor, is lowered exactly from the start: the constant's
+shift-and-add propagates from the other operand, where a record still costs
+a refinement round per candidate before it escalates to that same circuit.
+Measured, declining loses -- on the 1,029 queries of that same Certora
+corpus it solves 893 against 906 at 60 s, with 41 queries more than twice as
+slow against 23 faster -- because what decides it is the fraction of these
+operations a search needs exactly, and a query holding hundreds of them
+mostly never needs them. The knob is for the opposite shape, a query whose
+wide arithmetic is all by constants and all of it needed, where declining is
+worth five solves of 275 on the QF_FP flux-balance benchmarks.
+
 Two optional refinements of that allowance:
 
 ``--bv-term-abstraction-value-divisor``

--- a/include/stp/STPManager/UserDefinedFlags.h
+++ b/include/stp/STPManager/UserDefinedFlags.h
@@ -767,6 +767,26 @@ public:
   // at a time before building an encoding that was cheap all along. Such a
   // record's allowance is capped here; zero leaves it uncapped.
   unsigned bv_term_abstraction_constant_operand_limit = 1;
+  // Whether such an operation is abstracted at all (on). Declined, a
+  // multiplication one of whose operands the blast knows entirely, or a
+  // division or remainder by such a divisor, is lowered exactly from the
+  // start: the constant's shift-and-add propagates from the other operand,
+  // where a record costs a refinement round per candidate before it
+  // escalates to that same circuit.
+  //
+  // Measured, declining loses: on the 1,029 queries of
+  // QF_UFBV/20241113-Certora, where such a record is a 256-bit product by
+  // ten billion, it solves 893 against 906 at 60 s, with 41 queries running
+  // more than twice as slow against 23 faster; on two corpora of
+  // floating-point queries it is level. What decides it is the fraction of
+  // these operations a search needs exactly: declining builds every one of
+  // them up front, where a record escalates to the same circuit only when a
+  // candidate is refuted, and a query holding hundreds of them mostly never
+  // does. So the records stay and the cap above governs them, and the knob
+  // is for a query whose wide arithmetic is all by constants and all of it
+  // needed -- flux-balance models are the shape, where declining is worth
+  // five solves of 275.
+  bool bv_term_abstraction_constant_operands = true;
   // Escalate an abstracted BVMULT a piece at a time rather than all at once:
   // encode only the bits up to and a little past the lowest one the
   // candidate got wrong, and come back for more if that does not settle the

--- a/lib/ToSat/BitBlaster.cpp
+++ b/lib/ToSat/BitBlaster.cpp
@@ -1619,8 +1619,12 @@ const vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::BBTerm(
           firstCandidateSighting(term))
         uf->coverage.bv_candidates[UserDefinedFlags::ABSTRACT_MULT]++;
 
+      // A multiplication by a constant is left to its shift-and-add
+      // unless --bv-term-abstraction-constant-operands asks for a record.
       if (termAbstractionAllowed() && uf->bv_term_abstraction_mult &&
-          num_bits >= uf->bv_abstraction_width)
+          num_bits >= uf->bv_abstraction_width &&
+          (uf->bv_term_abstraction_constant_operands ||
+           !(isConstant(mpcd1) || isConstant(mpcd2))))
       {
         {
           BBNodeVec reused;
@@ -1692,8 +1696,11 @@ const vector<BBNode> BitBlaster<BBNode, BBNodeManagerT>::BBTerm(
           firstCandidateSighting(term))
         uf->coverage.bv_candidates[UserDefinedFlags::ABSTRACT_DIVMOD]++;
 
+      // A division or remainder by a constant likewise: its defining
+      // relation over a constant multiplier is the cheap circuit.
       if (termAbstractionAllowed() && uf->bv_term_abstraction_divmod &&
-          num_bits >= uf->bv_abstraction_width)
+          num_bits >= uf->bv_abstraction_width &&
+          (uf->bv_term_abstraction_constant_operands || !isConstant(dvsr)))
       {
         {
           BBNodeVec reused;

--- a/tests/query-files/misc-tests/bv-abstraction-constant-operand-policy.smt2
+++ b/tests/query-files/misc-tests/bv-abstraction-constant-operand-policy.smt2
@@ -1,0 +1,26 @@
+; A multiplication by a constant is a record like any other by default, with
+; the value-blocking allowance the constant-operand cap gives it.
+; --bv-term-abstraction-constant-operands=0 declines it instead: its exact
+; encoding is the constant's shift-and-add, which propagates from the other
+; operand, where a record spends a refinement round per candidate before
+; escalating to that same circuit. Declining loses on both measured corpora
+; as long as something else holds the wide products by constants, so the
+; default admits them; the knob is for a corpus where nothing does. The
+; width floor is at one bit here so that a 16-bit product qualifies.
+;
+; RUN: %solver --incremental=off -d -s -t --bv-term-abstraction=1 --bv-abstraction-width=1 --bv-term-abstraction-schemas=0 %s 2>&1 | %OutputCheck %s
+; CHECK: kind=BVMULT width=16
+; CHECK: ^sat$
+;
+; RUN: %solver --incremental=off -d -s -t --bv-term-abstraction=1 --bv-abstraction-width=1 --bv-term-abstraction-schemas=0 --bv-term-abstraction-constant-operands=0 %s 2>&1 | %OutputCheck --check-prefix=DECLINED %s
+; DECLINED-NOT: kind=BVMULT
+; DECLINED: ^sat$
+;
+; EXPECT: sat, sat
+(set-logic QF_BV)
+(declare-fun a () (_ BitVec 16))
+(declare-fun c () (_ BitVec 16))
+(assert (= (bvmul a #x000b) c))
+(assert (bvugt c #x0100))
+(assert (bvult a #x0100))
+(check-sat)

--- a/tools/stp/main.cpp
+++ b/tools/stp/main.cpp
@@ -477,6 +477,14 @@ void ExtraMain::create_options()
                  "slower and no faster)")
       ->group(refinement_group)
       ->capture_default_str();
+  bool_arg("--bv-term-abstraction-constant-operands",
+           bm->UserFlags.bv_term_abstraction_constant_operands,
+           "abstract a multiplication one of whose operands the blast knows "
+           "entirely, or a division or remainder by such a divisor (on by "
+           "default); declined, such an operation is lowered exactly, since "
+           "the constant's shift-and-add propagates where a record spends a "
+           "round per candidate before escalating to it",
+           refinement_group);
   app.add_option("--bv-term-abstraction-constant-operand-limit",
                  bm->UserFlags.bv_term_abstraction_constant_operand_limit,
                  "cap on value-pair blocking rounds for an abstracted "


### PR DESCRIPTION
Follow-up to #1087, whose `--bv-term-abstraction-constant-operand-limit` bounds what a record with a constant operand may spend on value blocking before it escalates to the exact circuit. The step past that is not to make the record at all: `--bv-term-abstraction-constant-operands`, on by default, so nothing changes unless it is given.

**The measurement says this is the wrong default, and the option is offered with the numbers that say so.** On the 1,029 queries of QF_UFBV/20241113-Certora — the corpus #1087 was built on, where such a record is a 256-bit product by ten billion — declining solves 893 against 906 at 60s, with 41 queries running more than twice as slow against 23 faster, and fourteen lost against one gained. On two corpora of floating-point queries it is level. So the records stay and the cap governs them.

What decides it is the fraction of these operations a search needs exactly. Declining builds every one of them up front; a record escalates to the same circuit only when a candidate is refuted, and a Certora query holds hundreds of them of which most never get there. The option is for the opposite shape, a query whose wide arithmetic is all by constants and all of it needed, as flux-balance models are: on the QF_FP benchmarks of that kind declining is worth five solves of 275.

I am content for this to be rejected on the strength of its own measurement — it is offered because the lever is cheap and the shape it suits is real, not because the default should move. A query file pins both directions with the width floor at one bit.

This and the companion PR for the equality abstraction's constant side touch the same four files; whichever lands second will want a trivial rebase.