### PR TITLE
Drop references to files that exist only where they were written

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,8 +288,7 @@ jobs:
     # the implementation. gcc and clang each choose consistently but
     # differently, so their CNF differs on nine of the corpus's inputs, all
     # floating-point. That is an encoding difference, not a wrong answer, and
-    # the fix is to replace SymFPU rather than to rewrite it; see
-    # bench-hard/reports/2026-08-10-cnf-build-determinism.md. Comparing the
+    # the fix is to replace SymFPU rather than to rewrite it. Comparing the
     # two gcc legs still covers optimisation level and assertions, and holds
     # for every input with nothing excluded.
     - name: CNF manifest

--- a/include/stp/AIG/Tseitin.h
+++ b/include/stp/AIG/Tseitin.h
@@ -95,8 +95,7 @@ void collectAndLeaves(const Manager& m, Node n, const std::vector<uint64_t>& abs
                       std::vector<Lit>& into, std::vector<Lit>& stack);
 
 // What the writer recovers from the AIG before emitting. Each rung adds to
-// the one above it, and each is a strict size reduction -- see the report in
-// bench-hard for what each is worth.
+// the one above it, and each is a strict size reduction.
 enum class Recover
 {
   Nothing,         // plain Tseitin: three clauses for every AND node

--- a/lib/Simplifier/DifficultyScore.cpp
+++ b/lib/Simplifier/DifficultyScore.cpp
@@ -35,9 +35,9 @@ THE SOFTWARE.
  *
  * Every number below was measured, not guessed: each operation was built over
  * fresh symbols, bit-blasted on its own with BBNodeManagerAIG, and the
- * resulting AND-node count fitted against the bit-width. See
- * bench-hard/reports/2026-08-06-difficulty-scorer-vs-aig-size.md for the
- * sweep, the fits and the residuals.
+ * resulting AND-node count fitted against the bit-width. tools/difficulty_bench
+ * runs that sweep and prints the estimate against the measured count, which is
+ * how the fits are rechecked when the blaster changes.
  *
  * Two properties of the estimate are deliberate.
  *

--- a/tests/api/C/getbv.cpp
+++ b/tests/api/C/getbv.cpp
@@ -22,9 +22,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 **********************/
 
-/* g++ -I/home/vganesh/stp/c_interface simplify.c -L/home/vganesh/stp/lib -lstp
- * -g */
-
 #include "stp/c_interface.h"
 #include <cstdint>
 #include <gtest/gtest.h>

--- a/tests/api/C/simplify.cpp
+++ b/tests/api/C/simplify.cpp
@@ -22,9 +22,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 **********************/
 
-/* g++ -I/home/vganesh/stp/c_interface simplify.c -L/home/vganesh/stp/lib -lstp
- * -g */
-
 #include "stp/STPManager/STP.h"
 #include "stp/STPManager/STPManager.h"
 #include "stp/c_interface.h"

--- a/tests/api/C/stp-counterex.cpp
+++ b/tests/api/C/stp-counterex.cpp
@@ -22,9 +22,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 **********************/
 
-// g++ <this-filename> -I/home/vganesh/stp/c_interface
-// -L/home/vganesh/stp/lib -lstp -o cc
-
 #include "stp/c_interface.h"
 #include <gtest/gtest.h>
 #include <stdio.h>

--- a/tests/unit-tests/RemoveUnconstrained_Exhaustive_Test.cpp
+++ b/tests/unit-tests/RemoveUnconstrained_Exhaustive_Test.cpp
@@ -1047,7 +1047,8 @@ TEST(RemoveUnconstrained_GroundPath, square)
 {
   // (zx(x) * zx(x)) == 4: the zero-extension is BOTH operands of the
   // multiply -- a unary function of x through a duplicated operand.
-  // The dominant dup-path shape on the bench-hard set (Sage2 squaring).
+  // The dominant dup-path shape on the hard QF_BV benchmarks (Sage2
+  // squaring).
   checkGroundPath([](Context& c) {
     ASTNode zx = c.hf->CreateTerm(BVZX, 2 * W, c.bv(), c.konst(2 * W, 32));
     return c.hf->CreateNode(EQ, c.hf->CreateTerm(BVMULT, 2 * W, zx, zx),


### PR DESCRIPTION
Seven comments pointed a reader at something outside the repository:

- `.github/workflows/ci.yml` and `lib/Simplifier/DifficultyScore.cpp` each named a dated report under a private benchmark tree.
- `include/stp/AIG/Tseitin.h` and `tests/unit-tests/RemoveUnconstrained_Exhaustive_Test.cpp` named that tree without naming a file in it.
- `tests/api/C/getbv.cpp`, `tests/api/C/simplify.cpp` and `tests/api/C/stp-counterex.cpp` each carried a `g++` line against `/home/vganesh/stp/...`, written when the C interface lived in `c_interface/` and the library in `lib/`. Neither directory exists, the files are gtest cases built by CMake, and the command has not described how to build them for a long time.

None of them can be followed by anyone reading the repository, and the two that mattered were standing in for a finding rather than adding to one.

Where the reference stood in for a finding, the finding is now stated. Where a tool in the repository regenerates the numbers, that tool is named: `DifficultyScore.cpp` now points at `tools/difficulty_bench`, which runs the sweep the constants were fitted to and prints the estimate against the measured AND-node count. The stale `g++` lines are deleted rather than corrected.

Comments only -- no code changes, and nothing generated differs.