### PR TITLE
Decide nested conditionals against the branch condition

### DIFF
--- a/include/stp/NodeFactory/SimplifyingNodeFactory.h
+++ b/include/stp/NodeFactory/SimplifyingNodeFactory.h
@@ -85,6 +85,13 @@ private:
   const ASTNode& ASTUndefined;
 
   ASTNode CreateSimpleFormITE(ASTChildren children);
+
+  // A branch of an if-then-else knows its own condition. `branch` with the
+  // tests that condition decides taken out, or Null when it decides none of
+  // them. Never builds a node the branch did not already contain, so it
+  // cannot cost sharing: dropping one of three or more conjuncts, which
+  // would, is left to the sharing-aware Rewriting pass.
+  ASTNode decideBranch(const ASTNode& cond, bool holds, const ASTNode& branch);
   ASTNode CreateSimpleXor(ASTChildren children);
 
   ASTNode CreateSimpleAndOr(bool IsAnd, ASTChildren children);

--- a/include/stp/NodeFactory/SimplifyingNodeFactory.h
+++ b/include/stp/NodeFactory/SimplifyingNodeFactory.h
@@ -86,6 +86,18 @@ private:
 
   ASTNode CreateSimpleFormITE(ASTChildren children);
 
+  // What a condition known to hold (or known not to) says about another
+  // test: 1 that it holds, -1 that it does not, 0 nothing.
+  int decides(const ASTNode& cond, bool holds, const ASTNode& other);
+
+  // `n` with the occurrences of `t` it reaches within `budget` interior
+  // nodes replaced by `k`. Builds nothing along a path with no `t` under it,
+  // and running out of budget only leaves occurrences in place: every
+  // occurrence equals `k` where this is used, so replacing any subset of
+  // them preserves the meaning.
+  ASTNode substituteConstant(const ASTNode& n, const ASTNode& t,
+                             const ASTNode& k, int& budget);
+
   // A branch of an if-then-else knows its own condition. `branch` with the
   // tests that condition decides taken out, or Null when it decides none of
   // them. Never builds a node the branch did not already contain, so it

--- a/lib/NodeFactory/SimplifyingNodeFactory.cpp
+++ b/lib/NodeFactory/SimplifyingNodeFactory.cpp
@@ -1485,6 +1485,48 @@ ASTNode SimplifyingNodeFactory::handle_2_children(bool IsAnd,
   return ASTUndefined;
 }
 
+// (= t k1) and (= t k2) with distinct constants k1, k2 can't both hold, so
+// conjoined they are FALSE and their negations disjoined are TRUE. Called
+// only once two children of the annihilating polarity have been seen.
+static bool pinsATermTwice(const stp::ASTChildren& children, bool IsAnd)
+{
+  std::unordered_map<uint64_t, stp::ASTNode> pinned;
+  const Kind node_kind = IsAnd ? stp::AND : stp::OR;
+
+  // A child of the same kind contributes its own children conjunctively
+  // (resp. disjunctively), so a pinning literal one level down counts too.
+  auto pins = [&](const stp::ASTNode& n) {
+    if (!IsAnd && n.GetKind() != stp::NOT)
+      return false;
+    const stp::ASTNode& lit = IsAnd ? n : n[0];
+    if (lit.GetKind() != EQ)
+      return false;
+
+    for (int i = 0; i < 2; i++)
+      if (lit[i].GetKind() == stp::BVCONST &&
+          lit[1 - i].GetKind() != stp::BVCONST)
+      {
+        const auto entry = pinned.emplace(lit[1 - i].GetNodeNum(), lit[i]);
+        return !entry.second && stp::constantsDenoteDifferentValues(
+                                    entry.first->second, lit[i]);
+      }
+    return false;
+  };
+
+  for (const stp::ASTNode& n : children)
+  {
+    if (n.GetKind() == node_kind)
+    {
+      for (const stp::ASTNode& nested : n.GetChildren())
+        if (pins(nested))
+          return true;
+    }
+    else if (pins(n))
+      return true;
+  }
+  return false;
+}
+
 ASTNode SimplifyingNodeFactory::CreateSimpleAndOr(bool IsAnd,
                                                   const ASTChildren c)
 {
@@ -1514,6 +1556,7 @@ ASTNode SimplifyingNodeFactory::CreateSimpleAndOr(bool IsAnd,
 
   const Kind node_kind = IsAnd ? stp::AND : stp::OR;
   bool nested_same_kind = false;
+  size_t pinning_children = 0;
 
   const size_t num_children = children.size();
   for (size_t i = 0; i < num_children; i++)
@@ -1549,11 +1592,20 @@ ASTNode SimplifyingNodeFactory::CreateSimpleAndOr(bool IsAnd,
         new_children.push_back(curr);
       if (curr.GetKind() == node_kind)
         nested_same_kind = true;
+      const ASTNode& lit =
+          (!IsAnd && curr.GetKind() == stp::NOT) ? curr[0] : curr;
+      if (IsAnd == (curr.GetKind() == EQ) && lit.GetKind() == EQ &&
+          (lit[0].isConstant() || lit[1].isConstant()))
+        pinning_children++;
     }
   }
 
   const ASTChildren out =
       materialised ? ASTChildren(new_children) : children;
+
+  if ((pinning_children >= 2 || (pinning_children >= 1 && nested_same_kind)) &&
+      pinsATermTwice(out, IsAnd))
+    return annihilator;
 
   // A child of the same kind contributes its own children conjunctively
   // (resp. disjunctively), so a literal here and its negation one level
@@ -2110,6 +2162,98 @@ ASTNode SimplifyingNodeFactory::CreateSimpleXor(const ASTChildren children)
   return retval;
 }
 
+// Whether two equalities pin one term to constants that differ, which no
+// assignment satisfies together. Node identity is not the test: a rounding
+// mode or float literal interns apart from the plain constant with its bits,
+// so the values go through constantsDenoteDifferentValues.
+static bool pinApart(const stp::ASTNode& a, const stp::ASTNode& b)
+{
+  if (a.GetKind() != EQ || b.GetKind() != EQ)
+    return false;
+
+  for (int i = 0; i < 2; i++)
+  {
+    if (a[i].GetKind() != stp::BVCONST || a[1 - i].GetKind() == stp::BVCONST)
+      continue;
+    for (int j = 0; j < 2; j++)
+    {
+      if (b[j].GetKind() != stp::BVCONST || b[1 - j].GetKind() == stp::BVCONST)
+        continue;
+      if (a[1 - i] == b[1 - j] &&
+          stp::constantsDenoteDifferentValues(a[i], b[j]))
+        return true;
+    }
+  }
+  return false;
+}
+
+// What a condition known to hold (or known not to) says about another test:
+// 1 that it holds, -1 that it does not, 0 nothing. Runs on every if-then-else
+// built, so it allocates nothing -- the polarity is a flag rather than a NOT
+// node around the condition.
+static int decides(const stp::ASTNode& cond, bool holds,
+                   const stp::ASTNode& other)
+{
+  if (cond == other)
+    return holds ? 1 : -1;
+  if (other.GetKind() == stp::NOT && other[0] == cond)
+    return holds ? -1 : 1;
+
+  // Knowing that y is 2 rules out y being 1; knowing it is *not* 2 says
+  // nothing about any other value.
+  if (!holds)
+    return 0;
+  if (other.GetKind() == stp::NOT)
+    return pinApart(cond, other[0]) ? 1 : 0;
+  return pinApart(cond, other) ? -1 : 0;
+}
+
+// See the declaration.
+ASTNode SimplifyingNodeFactory::decideBranch(const ASTNode& cond, bool holds,
+                                             const ASTNode& branch)
+{
+  if (branch.GetKind() == ITE)
+  {
+    const int d = decides(cond, holds, branch[0]);
+    if (d != 0)
+      return (d > 0) ? branch[1] : branch[2];
+    return ASTUndefined;
+  }
+
+  if (branch.GetKind() != stp::AND && branch.GetKind() != stp::OR)
+    return ASTUndefined;
+
+  // A decided child is either the annihilator of the node it sits in, which
+  // settles the whole branch, or its identity, which just goes. Only the
+  // cases that build nothing are taken.
+  const bool isAnd = (branch.GetKind() == stp::AND);
+  ASTNode survivor = ASTUndefined;
+  unsigned undecided = 0;
+  unsigned dropped = 0;
+
+  for (const stp::ASTNode& child : branch.GetChildren())
+  {
+    const int d = decides(cond, holds, child);
+    if (d == 0)
+    {
+      if (undecided++ == 0)
+        survivor = child;
+      continue;
+    }
+    if ((d < 0) == isAnd)
+      return isAnd ? ASTFalse : ASTTrue; // The annihilator settles it.
+    dropped++;
+  }
+
+  if (dropped == 0)
+    return ASTUndefined;
+  if (undecided == 0)
+    return isAnd ? ASTTrue : ASTFalse; // Every child was the identity.
+  if (undecided > 1)
+    return ASTUndefined; // A rebuild, so it costs sharing: not ours.
+  return survivor;
+}
+
 ASTNode SimplifyingNodeFactory::CreateSimpleFormITE(
     const ASTChildren children)
 {
@@ -2167,7 +2311,17 @@ ASTNode SimplifyingNodeFactory::CreateSimpleFormITE(
   }
   else
   {
-    retval = hashing.CreateNode(ITE, children);
+    // Each branch knows its own condition, so a test the condition decides
+    // goes. e.g. y=2 rules out y=1 without the two ever matching.
+    const ASTNode thenBranch = decideBranch(child0, true, child1);
+    const ASTNode elseBranch = decideBranch(child0, false, child2);
+
+    if (thenBranch == ASTUndefined && elseBranch == ASTUndefined)
+      retval = hashing.CreateNode(ITE, children);
+    else
+      retval = NodeFactory::CreateNode(
+          ITE, child0, (thenBranch == ASTUndefined) ? child1 : thenBranch,
+          (elseBranch == ASTUndefined) ? child2 : elseBranch);
   }
 
   if (debug_simplifyingNodeFactory)
@@ -3450,25 +3604,25 @@ ASTNode SimplifyingNodeFactory::CreateTerm(Kind kind, unsigned int width,
         result = children[2];
       else if (children[1] == children[2])
         result = children[1];
-      else if (children[2].GetKind() == ITE && (children[2][0] == children[0]))
+      // Each branch knows its own condition, so a nested multiplexer on a
+      // test the condition decides takes a fixed arm.
+      else if (decideBranch(children[0], true, children[1]) != ASTUndefined ||
+               decideBranch(children[0], false, children[2]) != ASTUndefined)
       {
-        if (stp::ARRAY_TYPE == children[2].GetType())
-          result = NodeFactory::CreateArrayTerm(
-              ITE, children[2].GetIndexWidth(), children[2].GetValueWidth(),
-              children[0], children[1], children[2][2]);
-        else
-          result = NodeFactory::CreateTerm(ITE, width, children[0], children[1],
-                                           children[2][2]);
-      }
-      else if (children[1].GetKind() == ITE && (children[1][0] == children[0]))
-      {
+        const ASTNode thn = decideBranch(children[0], true, children[1]);
+        const ASTNode els = decideBranch(children[0], false, children[2]);
+        const ASTNode& takenThen =
+            (thn == ASTUndefined) ? children[1] : thn;
+        const ASTNode& takenElse =
+            (els == ASTUndefined) ? children[2] : els;
+
         if (stp::ARRAY_TYPE == children[1].GetType())
           result = NodeFactory::CreateArrayTerm(
               ITE, children[1].GetIndexWidth(), children[1].GetValueWidth(),
-              children[0], children[1][1], children[2]);
+              children[0], takenThen, takenElse);
         else
-          result = NodeFactory::CreateTerm(ITE, width, children[0],
-                                           children[1][1], children[2]);
+          result = NodeFactory::CreateTerm(ITE, width, children[0], takenThen,
+                                           takenElse);
       }
       else if (children[0].GetKind() == stp::NOT)
       {

--- a/lib/NodeFactory/SimplifyingNodeFactory.cpp
+++ b/lib/NodeFactory/SimplifyingNodeFactory.cpp
@@ -2187,12 +2187,62 @@ static bool pinApart(const stp::ASTNode& a, const stp::ASTNode& b)
   return false;
 }
 
-// What a condition known to hold (or known not to) says about another test:
-// 1 that it holds, -1 that it does not, 0 nothing. Runs on every if-then-else
-// built, so it allocates nothing -- the polarity is a flag rather than a NOT
-// node around the condition.
-static int decides(const stp::ASTNode& cond, bool holds,
-                   const stp::ASTNode& other)
+// The non-constant side of an equality against a constant, or Null when the
+// node is not one.
+static stp::ASTNode pinnedTerm(const stp::ASTNode& n)
+{
+  if (n.GetKind() != EQ)
+    return stp::ASTNode();
+  for (int i = 0; i < 2; i++)
+    if (n[i].GetKind() == stp::BVCONST && n[1 - i].GetKind() != stp::BVCONST)
+      return n[1 - i];
+  return stp::ASTNode();
+}
+
+// See the declaration.
+ASTNode SimplifyingNodeFactory::substituteConstant(const ASTNode& n,
+                                                   const ASTNode& t,
+                                                   const ASTNode& k,
+                                                   int& budget)
+{
+  if (n == t)
+    return k;
+  if (n.Degree() == 0 || budget-- <= 0)
+    return n;
+
+  ASTVec children;
+  children.reserve(n.Degree());
+  bool changed = false;
+  for (const ASTNode& c : n)
+  {
+    children.push_back(substituteConstant(c, t, k, budget));
+    changed = changed || (children.back() != c);
+  }
+
+  // Nothing under here mentioned the term, so there is nothing to build.
+  if (!changed)
+    return n;
+
+  // Unqualified, so the rebuild comes back through this factory and every
+  // operator on the way folds.
+  if (n.GetType() == stp::BOOLEAN_TYPE)
+    return CreateNode(n.GetKind(), children);
+  return CreateArrayTerm(n.GetKind(), n.GetIndexWidth(), n.GetValueWidth(),
+                         children);
+}
+
+// How far substituteConstant walks before it gives up. Raising it to two
+// hundred decided 39 more tests across a sample of the hard set, so the
+// tests that fold are the small ones and the budget is there to stop the
+// rest costing anything.
+static const int substitution_budget = 40;
+
+// See the declaration. The cheap tests come first: they are a handful of
+// pointer comparisons, they run on every if-then-else built, and the
+// polarity is a flag rather than a NOT node around the condition, so they
+// allocate nothing.
+int SimplifyingNodeFactory::decides(const ASTNode& cond, bool holds,
+                                    const ASTNode& other)
 {
   if (cond == other)
     return holds ? 1 : -1;
@@ -2204,8 +2254,28 @@ static int decides(const stp::ASTNode& cond, bool holds,
   if (!holds)
     return 0;
   if (other.GetKind() == stp::NOT)
-    return pinApart(cond, other[0]) ? 1 : 0;
-  return pinApart(cond, other) ? -1 : 0;
+  {
+    if (pinApart(cond, other[0]))
+      return 1;
+  }
+  else if (pinApart(cond, other))
+    return -1;
+
+  // The term is pinned in this branch, so put the constant through the test
+  // and keep the answer only if the whole test folds. A verdict replaces the
+  // test with TRUE or FALSE, which deletes an edge and builds nothing; the
+  // substituted structure is dropped, which is what separates this from
+  // rewriting the branch under a context.
+  const ASTNode t = pinnedTerm(cond);
+  if (t.IsNull())
+    return 0;
+
+  const ASTNode& k = (cond[0].GetKind() == stp::BVCONST) ? cond[0] : cond[1];
+  int budget = substitution_budget;
+  const ASTNode folded = substituteConstant(other, t, k, budget);
+  if (!folded.isConstant())
+    return 0;
+  return (folded == ASTTrue) ? 1 : -1;
 }
 
 // See the declaration.

--- a/lib/Simplifier/Rewriting.cpp
+++ b/lib/Simplifier/Rewriting.cpp
@@ -761,6 +761,80 @@ namespace stp
                                     cond, other, c[2]);
        }
 
+/*
+  A branch of an if-then-else knows its own condition, so a test the
+  condition decides can go. The SimplifyingNodeFactory already takes every
+  such test that costs nothing to remove -- a branch of a nested
+  multiplexer, or a conjunction that collapses to a constant or to its one
+  surviving conjunct. What is left for here is the case that rebuilds:
+
+    ITE(c, OR(c1, x, y), d)  -->  ITE(c, OR(x, y), d)   when c refutes c1
+
+  where the disjunction has three or more children, so dropping one builds a
+  node the branch did not contain. That is a loss unless the disjunction died
+  with it, which is what the share count decides.
+*/
+    if (c.GetKind() == ITE)
+      for (unsigned branch = 1; branch <= 2; branch++)
+      {
+        if (c.GetKind() != ITE)
+          continue;
+
+        const ASTNode inner = c[branch];
+        if ((inner.GetKind() != AND && inner.GetKind() != OR) ||
+            inner.Degree() < 3 || shareCount[inner.GetNodeNum()] > 1)
+          continue;
+
+        const ASTNode cond = c[0];
+        const ASTNode known = (branch == 1) ? cond : nf->CreateNode(NOT, cond);
+        const bool isAnd = (inner.GetKind() == AND);
+
+        // Whether `known` and `cond` can hold together. Delegated to the
+        // factory: conjoining them reaches every contradiction AND already
+        // folds, at the price of building the conjunction.
+        auto refutes = [&](const ASTNode& test) {
+          return nf->CreateNode(AND, known, test) == stpMgr->ASTFalse;
+        };
+
+        ASTVec kept;
+        bool annihilated = false;
+        for (const ASTNode& child : inner.GetChildren())
+        {
+          // A decided child is either the node's annihilator, which settles
+          // the branch, or its identity, which just goes.
+          if (refutes(isAnd ? child : nf->CreateNode(NOT, child)))
+          {
+            annihilated = true;
+            break;
+          }
+          if (!refutes(isAnd ? nf->CreateNode(NOT, child) : child))
+            kept.push_back(child);
+        }
+
+        if (!annihilated && kept.size() == inner.Degree())
+          continue;
+
+        // The collapsing cases are the factory's, but its test is the cheap
+        // syntactic one, so a branch it could not fold still lands here.
+        ASTNode replacement;
+        if (annihilated)
+          replacement = isAnd ? stpMgr->ASTFalse : stpMgr->ASTTrue;
+        else if (kept.empty())
+          replacement = isAnd ? stpMgr->ASTTrue : stpMgr->ASTFalse;
+        else if (kept.size() == 1)
+          replacement = kept[0];
+        else
+          replacement = nf->CreateNode(inner.GetKind(), kept);
+        const ASTNode thenBranch = (branch == 1) ? replacement : c[1];
+        const ASTNode elseBranch = (branch == 1) ? c[2] : replacement;
+
+        if (c.GetType() == BOOLEAN_TYPE)
+          c = nf->CreateNode(ITE, cond, thenBranch, elseBranch);
+        else
+          c = nf->CreateArrayTerm(ITE, c.GetIndexWidth(), c.GetValueWidth(),
+                                  cond, thenBranch, elseBranch);
+      }
+
     return c;
   }
 

--- a/tests/query-files/misc-tests/aig-node-budget-core-pass.smt2
+++ b/tests/query-files/misc-tests/aig-node-budget-core-pass.smt2
@@ -5,13 +5,13 @@
 ; decides the verdict.
 ;
 ; Ten interleaved bvult atoms under an xor tree and three ites survive the
-; word-level simplifier as a propositional core of ~74 AND gates -- enough
-; for a budget of 40 to stop the pass. The blast that follows needs far more
-; than 40 for ten 8-bit comparisons, so it is stopped too and the query is
+; word-level simplifier as a propositional core of ~21 AND gates -- enough
+; for a budget of 20 to stop the pass. The blast that follows needs far more
+; than that for ten 8-bit comparisons, so it is stopped too and the query is
 ; abandoned; no budget can separate the two, since the pass is always the
 ; cheaper of them.
 ;
-; RUN: %solver --SMTLIB2 -s --aig-core-simplification=1 --aig-node-budget 40 %s 2>&1 >/dev/null | %OutputCheck --check-prefix=ABANDONED %s
+; RUN: %solver --SMTLIB2 -s --aig-core-simplification=1 --aig-node-budget 20 %s 2>&1 >/dev/null | %OutputCheck --check-prefix=ABANDONED %s
 ; RUN: %solver --SMTLIB2 --aig-core-simplification=1 %s | %OutputCheck --check-prefix=ANSWER %s
 ; RUN: %solver --SMTLIB2 %s | %OutputCheck --check-prefix=ANSWER %s
 ;

--- a/tests/unit-tests/Rewriting_Exhaustive_Test.cpp
+++ b/tests/unit-tests/Rewriting_Exhaustive_Test.cpp
@@ -604,24 +604,6 @@ TEST(Rewriting_Exhaustive, ite_chain_both_sides)
   c.checkEquivalent(top, c.run(top));
 }
 
-static bool contains(const ASTNode& n, const ASTNode& target, ASTNodeSet& seen)
-{
-  if (n == target)
-    return true;
-  if (!seen.insert(n).second)
-    return false;
-  for (const auto& c : n)
-    if (contains(c, target, seen))
-      return true;
-  return false;
-}
-
-static bool contains(const ASTNode& n, const ASTNode& target)
-{
-  ASTNodeSet seen;
-  return contains(n, target, seen);
-}
-
 /* Every decision that costs nothing is the SimplifyingNodeFactory's; what
    reaches this pass is the one that rebuilds. Dropping one child of a wider
    disjunction builds a node the branch did not contain, so the shared copy

--- a/tests/unit-tests/Rewriting_Exhaustive_Test.cpp
+++ b/tests/unit-tests/Rewriting_Exhaustive_Test.cpp
@@ -604,4 +604,43 @@ TEST(Rewriting_Exhaustive, ite_chain_both_sides)
   c.checkEquivalent(top, c.run(top));
 }
 
+static bool contains(const ASTNode& n, const ASTNode& target, ASTNodeSet& seen)
+{
+  if (n == target)
+    return true;
+  if (!seen.insert(n).second)
+    return false;
+  for (const auto& c : n)
+    if (contains(c, target, seen))
+      return true;
+  return false;
+}
+
+static bool contains(const ASTNode& n, const ASTNode& target)
+{
+  ASTNodeSet seen;
+  return contains(n, target, seen);
+}
+
+/* Every decision that costs nothing is the SimplifyingNodeFactory's; what
+   reaches this pass is the one that rebuilds. Dropping one child of a wider
+   disjunction builds a node the branch did not contain, so the shared copy
+   must survive and the node count must not rise. */
+TEST(Rewriting_Exhaustive, ite_shared_disjunction_is_not_rebuilt)
+{
+  Context c;
+  ASTNode y = c.bv(3);
+  ASTNode isTwo = c.hf->CreateNode(EQ, y, c.konst(2, 3));
+  ASTNode isOne = c.hf->CreateNode(EQ, y, c.konst(1, 3));
+  ASTNode p = c.boolean(), q = c.boolean(), r = c.boolean();
+  ASTNode inner = c.hf->CreateNode(OR, isOne, p, q);
+  ASTNode top = c.hf->CreateNode(
+      AND, c.hf->CreateNode(ITE, isTwo, inner, r), inner);
+
+  ASTNode after = c.run(top);
+  EXPECT_LE(c.mgr.NodeSize(after), c.mgr.NodeSize(top)) << after;
+  c.checkEquivalent(top, after);
+}
+
+
 } // namespace

--- a/tests/unit-tests/SimplifyingNodeFactory_Exhaustive_Test.cpp
+++ b/tests/unit-tests/SimplifyingNodeFactory_Exhaustive_Test.cpp
@@ -1270,4 +1270,106 @@ TEST(SimplifyingNodeFactory_Exhaustive, nary_mult_arity_survives)
   c.checkTerm(BVMULT, 3, ch, false);
 }
 
+/* A branch of an if-then-else knows its own condition, so a test the
+   condition decides goes. y=2 rules out y=1, which no match on the two
+   conditions can see. Nothing is built that the branch did not contain, so
+   these cost no sharing and belong here rather than in the Rewriting pass. */
+TEST(SimplifyingNodeFactory_Exhaustive, ite_condition_refutes_nested_ite)
+{
+  Context c;
+  ASTNode y = c.bv(3);
+  ASTNode isTwo = c.hf->CreateNode(EQ, y, c.konst(2, 3));
+  ASTNode isOne = c.hf->CreateNode(EQ, y, c.konst(1, 3));
+  ASTNode p = c.boolean(), q = c.boolean(), r = c.boolean();
+  ASTNode inner = c.hf->CreateNode(ITE, isOne, p, q);
+  c.checkNode(ITE, {isTwo, inner, r});
+}
+
+TEST(SimplifyingNodeFactory_Exhaustive, ite_condition_entails_nested_ite)
+{
+  Context c;
+  ASTNode y = c.bv(3);
+  ASTNode isTwo = c.hf->CreateNode(EQ, y, c.konst(2, 3));
+  ASTNode notOne =
+      c.hf->CreateNode(NOT, c.hf->CreateNode(EQ, y, c.konst(1, 3)));
+  ASTNode p = c.boolean(), q = c.boolean(), r = c.boolean();
+  ASTNode inner = c.hf->CreateNode(ITE, notOne, p, q);
+  c.checkNode(ITE, {isTwo, inner, r});
+}
+
+/* The same over terms, where the branches are bitvectors. */
+TEST(SimplifyingNodeFactory_Exhaustive, ite_term_condition_refutes_nested_ite)
+{
+  Context c;
+  ASTNode y = c.bv(3);
+  ASTNode isTwo = c.hf->CreateNode(EQ, y, c.konst(2, 3));
+  ASTNode isOne = c.hf->CreateNode(EQ, y, c.konst(1, 3));
+  ASTNode a = c.bv(3), b = c.bv(3), d = c.bv(3);
+  ASTNode inner = c.hf->CreateTerm(ITE, 3, isOne, a, b);
+  c.checkTerm(ITE, 3, {isTwo, inner, d});
+}
+
+/* The else branch knows the negated condition, which decides a repeat of the
+   condition itself but says nothing about any other value the term takes. */
+TEST(SimplifyingNodeFactory_Exhaustive, ite_else_branch_knows_the_negation)
+{
+  Context c;
+  ASTNode y = c.bv(3);
+  ASTNode isTwo = c.hf->CreateNode(EQ, y, c.konst(2, 3));
+  ASTNode p = c.boolean(), q = c.boolean(), r = c.boolean();
+  ASTNode inner = c.hf->CreateNode(ITE, isTwo, p, q);
+  c.checkNode(ITE, {isTwo, r, inner});
+}
+
+TEST(SimplifyingNodeFactory_Exhaustive, ite_else_branch_learns_no_other_value)
+{
+  Context c;
+  ASTNode y = c.bv(3);
+  ASTNode isTwo = c.hf->CreateNode(EQ, y, c.konst(2, 3));
+  ASTNode isOne = c.hf->CreateNode(EQ, y, c.konst(1, 3));
+  ASTNode p = c.boolean(), q = c.boolean(), r = c.boolean();
+  ASTNode inner = c.hf->CreateNode(ITE, isOne, p, q);
+  c.checkNode(ITE, {isTwo, r, inner}, false);
+}
+
+/* Boolean normalisation turns most nested conditionals into a conjunction or
+   a disjunction before anything else sees them, so those carry the rule too.
+   Only the collapsing cases are taken here: a two-child node leaves its one
+   survivor, and a decided annihilator settles the branch outright. */
+TEST(SimplifyingNodeFactory_Exhaustive, ite_condition_refutes_a_disjunct)
+{
+  Context c;
+  ASTNode y = c.bv(3);
+  ASTNode isTwo = c.hf->CreateNode(EQ, y, c.konst(2, 3));
+  ASTNode isOne = c.hf->CreateNode(EQ, y, c.konst(1, 3));
+  ASTNode p = c.boolean(), r = c.boolean();
+  ASTNode inner = c.hf->CreateNode(OR, isOne, p);
+  c.checkNode(ITE, {isTwo, inner, r});
+}
+
+TEST(SimplifyingNodeFactory_Exhaustive, ite_condition_refutes_a_conjunct)
+{
+  Context c;
+  ASTNode y = c.bv(3);
+  ASTNode isTwo = c.hf->CreateNode(EQ, y, c.konst(2, 3));
+  ASTNode isOne = c.hf->CreateNode(EQ, y, c.konst(1, 3));
+  ASTNode p = c.boolean(), q = c.boolean(), r = c.boolean();
+  ASTNode inner = c.hf->CreateNode(AND, isOne, p, q);
+  c.checkNode(ITE, {isTwo, inner, r});
+}
+
+/* Dropping one of three or more children rebuilds the node, which is a loss
+   when the node is shared, so the factory leaves it alone. */
+TEST(SimplifyingNodeFactory_Exhaustive, ite_wide_disjunction_is_left_alone)
+{
+  Context c;
+  ASTNode y = c.bv(3);
+  ASTNode isTwo = c.hf->CreateNode(EQ, y, c.konst(2, 3));
+  ASTNode isOne = c.hf->CreateNode(EQ, y, c.konst(1, 3));
+  ASTNode p = c.boolean(), q = c.boolean(), r = c.boolean();
+  ASTNode inner = c.hf->CreateNode(OR, isOne, p, q);
+  c.checkNode(ITE, {isTwo, inner, r}, false);
+}
+
+
 } // namespace

--- a/tests/unit-tests/SimplifyingNodeFactory_Exhaustive_Test.cpp
+++ b/tests/unit-tests/SimplifyingNodeFactory_Exhaustive_Test.cpp
@@ -1372,4 +1372,77 @@ TEST(SimplifyingNodeFactory_Exhaustive, ite_wide_disjunction_is_left_alone)
 }
 
 
+/* Beyond matching the two conditions: the branch pins the term, so putting
+   the constant through the nested test decides anything that is a function
+   of it. Only the verdict is kept -- the substituted structure is thrown
+   away -- so this builds nothing and costs no sharing either. */
+TEST(SimplifyingNodeFactory_Exhaustive, ite_condition_folds_a_nested_test_true)
+{
+  Context c;
+  ASTNode y = c.bv(3);
+  ASTNode isTwo = c.hf->CreateNode(EQ, y, c.konst(2, 3));
+  // bvand(y, 6) < 4 is true at y = 2, and neither true nor false in general.
+  ASTNode test = c.hf->CreateNode(
+      BVLT, c.hf->CreateTerm(BVAND, 3, y, c.konst(6, 3)), c.konst(4, 3));
+  ASTNode p = c.boolean(), q = c.boolean(), r = c.boolean();
+  ASTNode inner = c.hf->CreateNode(ITE, test, p, q);
+  c.checkNode(ITE, {isTwo, inner, r});
+}
+
+TEST(SimplifyingNodeFactory_Exhaustive, ite_condition_folds_a_nested_test_false)
+{
+  Context c;
+  ASTNode y = c.bv(3);
+  ASTNode isTwo = c.hf->CreateNode(EQ, y, c.konst(2, 3));
+  // bvand(y, 6) < 2 is false at y = 2.
+  ASTNode test = c.hf->CreateNode(
+      BVLT, c.hf->CreateTerm(BVAND, 3, y, c.konst(6, 3)), c.konst(2, 3));
+  ASTNode p = c.boolean(), q = c.boolean(), r = c.boolean();
+  ASTNode inner = c.hf->CreateNode(ITE, test, p, q);
+  c.checkNode(ITE, {isTwo, inner, r});
+}
+
+/* The same over a disjunct, where a test that folds to true settles the
+   whole branch. */
+TEST(SimplifyingNodeFactory_Exhaustive, ite_condition_folds_a_disjunct)
+{
+  Context c;
+  ASTNode y = c.bv(3);
+  ASTNode isTwo = c.hf->CreateNode(EQ, y, c.konst(2, 3));
+  ASTNode test = c.hf->CreateNode(
+      BVLT, c.hf->CreateTerm(BVAND, 3, y, c.konst(6, 3)), c.konst(4, 3));
+  ASTNode p = c.boolean(), r = c.boolean();
+  ASTNode inner = c.hf->CreateNode(OR, test, p);
+  c.checkNode(ITE, {isTwo, inner, r});
+}
+
+/* A test mentioning another symbol does not fold, so nothing is taken and
+   the substituted nodes are dropped. */
+TEST(SimplifyingNodeFactory_Exhaustive, ite_condition_leaves_an_open_test)
+{
+  Context c;
+  ASTNode y = c.bv(3), z = c.bv(3);
+  ASTNode isTwo = c.hf->CreateNode(EQ, y, c.konst(2, 3));
+  ASTNode test = c.hf->CreateNode(
+      BVLT, c.hf->CreateTerm(BVAND, 3, y, c.konst(6, 3)), z);
+  ASTNode p = c.boolean(), q = c.boolean(), r = c.boolean();
+  ASTNode inner = c.hf->CreateNode(ITE, test, p, q);
+  c.checkNode(ITE, {isTwo, inner, r}, false);
+}
+
+/* The else branch knows only that the term is not that constant, which pins
+   nothing, so there is nothing to put through the test. */
+TEST(SimplifyingNodeFactory_Exhaustive, ite_else_branch_has_nothing_to_substitute)
+{
+  Context c;
+  ASTNode y = c.bv(3);
+  ASTNode isTwo = c.hf->CreateNode(EQ, y, c.konst(2, 3));
+  ASTNode test = c.hf->CreateNode(
+      BVLT, c.hf->CreateTerm(BVAND, 3, y, c.konst(6, 3)), c.konst(4, 3));
+  ASTNode p = c.boolean(), q = c.boolean(), r = c.boolean();
+  ASTNode inner = c.hf->CreateNode(ITE, test, p, q);
+  c.checkNode(ITE, {isTwo, r, inner}, false);
+}
+
+
 } // namespace

--- a/tests/unit-tests/SimplifyingNodeFactory_Test.cpp
+++ b/tests/unit-tests/SimplifyingNodeFactory_Test.cpp
@@ -1065,3 +1065,83 @@ TEST(SimplifyingNodeFactory_Test, bvand_nested_and_without_its_negation)
   ASSERT_NE(n, c.mgr.ASTTrue);
   ASSERT_NE(n, c.mgr.ASTFalse);
 }
+
+/* A branch of an if-then-else knows its own condition. Boolean ITEs used to
+   miss this: only the term version folded a nested test on the condition. */
+TEST(SimplifyingNodeFactory_Test, boolean_ite_nested_on_same_condition_then)
+{
+  const std::string input = R"(
+    (assert (= (ite a (ite a b c) (not b)) (ite a b (not b))) )
+    )";
+
+  Context c;
+  ASTNode n = c.process(input);
+  ASSERT_EQ(n, c.mgr.ASTTrue);
+}
+
+TEST(SimplifyingNodeFactory_Test, boolean_ite_nested_on_same_condition_else)
+{
+  const std::string input = R"(
+    (assert (= (ite a (not b) (ite a b c)) (ite a (not b) c)) )
+    )";
+
+  Context c;
+  ASTNode n = c.process(input);
+  ASSERT_EQ(n, c.mgr.ASTTrue);
+}
+
+/* Two equalities pinning one term to different constants can't both hold. */
+TEST(SimplifyingNodeFactory_Test, and_of_distinct_constant_equalities)
+{
+  const std::string input = R"(
+    (assert (and (= v0 (_ bv2 20)) (= v0 (_ bv1 20))) )
+    )";
+
+  Context c;
+  ASTNode n = c.process(input);
+  ASSERT_EQ(n, c.mgr.ASTFalse);
+}
+
+TEST(SimplifyingNodeFactory_Test, or_of_negated_distinct_constant_equalities)
+{
+  const std::string input = R"(
+    (assert (= (or (not (= v0 (_ bv2 20))) (not (= v0 (_ bv1 20)))) true) )
+    )";
+
+  Context c;
+  ASTNode n = c.process(input);
+  ASSERT_EQ(n, c.mgr.ASTTrue);
+}
+
+/* The second literal may sit one level down in a same-kind child, which
+   contributes its own children conjunctively. */
+TEST(SimplifyingNodeFactory_Test, and_of_distinct_constant_equalities_nested)
+{
+  const std::string input = R"(
+    (assert (and (and (= v0 (_ bv2 20)) a) (= v0 (_ bv1 20))) )
+    )";
+
+  Context c;
+  ASTNode n = c.process(input);
+  ASSERT_EQ(n, c.mgr.ASTFalse);
+}
+
+/* Same bits, two nodes: a rounding-mode literal interns apart from the plain
+   bitvector constant carrying it, so the two equalities below agree. A rule
+   that read "different constant nodes" as "different values" made this
+   unsatisfiable -- caught by the Python API's rounding-mode UF test. */
+TEST(SimplifyingNodeFactory_Test, rounding_mode_literal_agrees_with_its_carrier)
+{
+  Context c;
+  const ASTNode t = c.mgr.CreateSymbol("rm-term", 0, 5);
+  const ASTNode rm = c.mgr.CreateRMConst(1);
+  const ASTNode bits = c.mgr.CreateBVConst(5, 1);
+
+  ASSERT_NE(rm, bits);
+  ASSERT_TRUE(stp::constantsSameBits(rm, bits));
+
+  NodeFactory& f = c.snf;
+  const ASTNode conj = f.CreateNode(stp::AND, f.CreateNode(stp::EQ, t, rm),
+                                    f.CreateNode(stp::EQ, t, bits));
+  EXPECT_NE(conj, c.mgr.ASTFalse);
+}

--- a/tests/unit-tests/UFPreLowering_Test.cpp
+++ b/tests/unit-tests/UFPreLowering_Test.cpp
@@ -350,6 +350,12 @@ TEST(UFPreLowering, ASymbolEquatedWithAWideQuotientStaysItsName)
 // only through an equality with q, which is asserted. Reading q, then p,
 // then the definition takes rounds, and the structure sees the facts only
 // once p has been sent to true.
+//
+// The refutation has to sit two merges deep. A round reads the structure to
+// a fixpoint, so a contradiction the first read can reach is answered in one
+// round: here round one only learns that y is 9, from f(x) and f(5) becoming
+// one application, and it takes a second round to substitute that and merge
+// f(y) with f(9), which pins one application to two constants.
 TEST(UFPreLowering, TheStructureIsReadAgainAfterEachRound)
 {
   Fixture fx;
@@ -358,9 +364,12 @@ TEST(UFPreLowering, TheStructureIsReadAgainAfterEachRound)
   const ASTNode p = fx.manager.CreateSourceSymbol("p", boolSort);
   const ASTNode q = fx.manager.CreateSourceSymbol("q", boolSort);
   const ASTNode x = fx.symbol("x");
+  const ASTNode y = fx.symbol("y");
   const ASTNode definition = fx.factory->CreateNode(
-      AND, fx.eq(fx.apply(x), fx.constant(9)),
-      fx.eq(fx.apply(fx.constant(5)), fx.constant(3)));
+      AND, {fx.eq(fx.apply(x), fx.constant(9)),
+            fx.eq(fx.apply(fx.constant(5)), y),
+            fx.eq(fx.apply(y), fx.constant(1)),
+            fx.eq(fx.apply(fx.constant(9)), fx.constant(2))});
   const ASTNode root = fx.factory->CreateNode(
       AND, {q, fx.factory->CreateNode(IFF, p, q),
             fx.factory->CreateNode(IFF, p, definition),


### PR DESCRIPTION
A branch of an if-then-else knows its own condition, so a test that condition decides can go. The node factory only matched conditions syntactically, and only for term-typed if-then-elses: `y = 2` left a nested `y = 1` in place, and a Boolean if-then-else did not fold even a nested test on the condition itself.

## What the factory takes

`decideBranch` takes every decision that builds nothing the branch did not already contain, so none of it can cost sharing:

- an arm of a nested multiplexer
- a conjunction or disjunction that collapses to a constant, or to its one surviving child

Dropping one of three or more conjuncts rebuilds the node, which is a loss when the node is shared, so that case is left to the sharing-aware Rewriting pass, which has the share count to say whether the conjunction died with it. There it decides the pair by conjoining the two conditions and looking for FALSE.

Whether one condition decides another is a ladder, and it reads like `chaseRead`'s: an identity, then two equalities pinning one term to constants compared by their bits, then the expensive test. The expensive rung here puts the branch's constant through the test and keeps the answer only if the whole test folds. Only the verdict survives — a decided test becomes TRUE or FALSE, which deletes an edge and builds nothing — and the substituted nodes are dropped. That is what separates it from rewriting the branch under a context, which restructures shared nodes and so has to be paid for.

Conjunctions get the underlying fact too: equalities pinning one term to different constants annihilate, and disjoined negations of them are true.

Constants are compared through `constantsDenoteDifferentValues` rather than by node identity. A rounding-mode literal interns apart from the plain bitvector constant carrying its bits, and reading that as "different value" made a satisfiable rounding-mode query unsat.

## Why the expensive rung is a substitution and not a conjunction

Both were measured over 1,151 files of a hard QF_BV set, 16.7M nested tests seen, alongside unsigned interval containment.

| | tests decided | factory calls |
|---|---:|---:|
| cheap rungs alone | 114,413 | 0 |
| conjoin the two conditions | 133,300 | 66.9M |
| substitute the constant | 6,329 | 2.2M |
| unsigned interval containment | 2,830 | negligible |

Conjoining decides nearly everything decidable — every cheap-rung and every interval decision is also one of its — but it pays four factory calls on every nested test seen, whether or not the query has anything to gain, and every call that does not fold leaves a node that is never freed. Substituting bails without allocating unless the condition is an equality against a constant, so it costs 0.13 calls per test seen. Interval containment decided 2,830, every one of which the cheap rungs already had, and is not implemented.

The budget of forty nodes on the substitution is where its value sits: raising it to two hundred decided 39 more tests across the whole sample. Running out of budget leaves occurrences of the term in place, which is sound — under the branch every occurrence equals the constant, so replacing any subset of them keeps the meaning.

## Effect

Small, and worth stating plainly. Over 355 files of the hard set, comparing CNF clause counts against the base commit: three files smaller by 522 clauses in total, none larger, 352 unchanged.

On those three, what fired was 24 substitutions and 17 annihilations of a conjunction pinning one term apart. The nested-multiplexer folds fired 12,306 times across the same three files and contributed nothing new, because every one was a term-typed if-then-else that already folded before this change.

It does collapse the shape it was built for outright, at parse time. `(ite (= y 2) (ite (= y 1) v (bvult (bvudiv (bvand y M) 100) 4096)) ...)` loses the inner test, and where the branch has been normalised into a disjunction it loses the whole division arm as well.

## Testing

- 183 of 183 in the suite.
- Nine new exhaustive-equivalence tests over the factory and one over the Rewriting pass: each builds the input with the hashing factory, creates the node through both factories, and checks the two agree on every assignment of their free variables. One of them caught a real bug in the first draft, which returned a single surviving child while silently dropping the others.
- Regression test for the rounding-mode literal agreeing with the plain constant carrying its bits.
- Differential sat/unsat sweep against the base commit over 2,500 fuzzed QF_BV files: 2,500 compared, no mismatches, none skipped. Run once per commit.

Two existing tests were calibrated against the weaker simplifier and are updated. The pre-lowering round-count test refuted its query in the first round once the factory could close a merged application pinned to two constants, so its facts now sit two merges deep; the comment says why. The AIG core budget test's propositional core is 21 gates rather than 74, so its budget moves with it.