### PR TITLE
Keep public build headers and include dependencies current

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -304,6 +304,7 @@ target_link_libraries(stp
 # own link line above, and the tests that call into ABC directly link it
 # themselves because a shared libstp localises its symbols.
 target_include_directories(stp SYSTEM INTERFACE
+    $<BUILD_INTERFACE:${STP_UNORDERED_DENSE_INCLUDE_DIR}>
     $<BUILD_INTERFACE:${SYMFPU_INCLUDE_DIRS}>
     $<BUILD_INTERFACE:${ABC_INCLUDE_DIR}>
 )

--- a/lib/Interface/CMakeLists.txt
+++ b/lib/Interface/CMakeLists.txt
@@ -44,6 +44,7 @@ if (NOT ("${PROJECT_BINARY_DIR}" STREQUAL "${PROJECT_SOURCE_DIR}"))
 
         # Custom command to generate this one legacy header
         add_custom_command(OUTPUT ${LEGACY_HEADER} PRE_BUILD
+                           DEPENDS "${PROJECT_SOURCE_DIR}/include/stp/${public_header}"
                            COMMAND ${CMAKE_COMMAND} -E make_directory ${HEADER_DEST}
                            COMMAND ${CMAKE_COMMAND} -E echo "LEGACY: Copying ${public_header} to ${HEADER_DEST}"
                            COMMAND ${CMAKE_COMMAND} -E copy_if_different "${PROJECT_SOURCE_DIR}/include/stp/${public_header}" ${LEGACY_HEADER}


### PR DESCRIPTION
Recopy public C and C++ headers whenever their source changes, and export the unordered_dense include directory to build-tree consumers of the stp target.
