### PR TITLE
Point the ABC pin at the iterative AIG-to-GIA copy

### DIFF
--- a/cmake/FindABC.cmake
+++ b/cmake/FindABC.cmake
@@ -79,10 +79,14 @@ if(NOT ABC_FOUND_SYSTEM)
         check_auto_download("ABC" "")
     endif()
 
-    # stp/abc is a fork: master tracks upstream untouched and the `stp` branch
-    # carries STP's changes as commits on top. To work on those, clone it and
+    # stp/abc is a fork: master tracks upstream untouched, and STP's changes
+    # sit as commits on top of an upstream revision. There are two lines of
+    # those. The `stp` branch is where they are reviewed, on a recent upstream;
+    # what is pinned here is the same set on the older upstream the pin has
+    # followed since PR #892, one tag per bump. Moving the pin to `stp` would
+    # bump the upstream base with it. To work on either, clone the fork and
     # point -DABC_DIR at a build of the clone. See docs/code-guide.rst.
-    set(ABC_GIT_TAG "bdacd898845aa91b2e2d650272b2ca35c1d4539f" CACHE STRING
+    set(ABC_GIT_TAG "b6e26a0fe6d813136687e9adf06c1c08d077d567" CACHE STRING
         "ABC revision to build when one has to be built")
     mark_as_advanced(ABC_GIT_TAG)
 

--- a/docs/code-guide.rst
+++ b/docs/code-guide.rst
@@ -47,11 +47,16 @@ own targets; the other two are small enough to be carried in the tree:
 
 -  ABC: The `ABC <https://github.com/berkeley-abc/abc>`__ package, used to
    build AIGs and convert them to CNF. Fetched from
-   `stp/abc <https://github.com/stp/abc>`__ rather than from ABC itself. That fork keeps two branches: ``master`` mirrors upstream
-   untouched, and ``stp`` -- the branch ``ABC_GIT_TAG`` in the top-level
-   ``CMakeLists.txt`` pins a commit of -- carries our changes as commits on
-   top of the upstream revision we have taken. Bumping ABC means rebasing
-   ``stp`` onto a newer ``master`` in that repository, then moving that pin.
+   `stp/abc <https://github.com/stp/abc>`__ rather than from ABC itself. In
+   that fork ``master`` mirrors upstream untouched and our changes sit as
+   commits on top of an upstream revision we have taken. There are two lines
+   of those: ``stp``, which is where they are reviewed and which sits on a
+   recent upstream, and the line ``ABC_GIT_TAG`` in ``cmake/FindABC.cmake``
+   pins, which carries the same set on the older upstream the pin has followed
+   so far. A change to ABC goes onto both, and each bump of the pin is held by
+   a tag named ``stp-at-<upstream>-pr<NNNN>``. Moving the pin onto ``stp``
+   would bump the upstream base along with it; bumping that base is its own
+   piece of work, and means rebasing ``stp`` onto a newer ``master`` first.
 
    To work on the fork, clone it, build ``libabc-pic`` in it, and configure
    with ``-DABC_DIR=<clone>``: the build then uses that copy and fetches


### PR DESCRIPTION
Moves `ABC_GIT_TAG` from bdacd8988 to b6e26a0fe — the same revision plus one commit, the explicit-stack rewrite of `Gia_ManFromAig_rec` (stp/abc#13). Held by the tag `stp-at-953930643-pr1109`, alongside `stp-at-953930643-pr1051` which holds the revision pinned until now.

`Gia_ManFromAig_rec()` descended through an AND node's fanins with one call frame per level, so what could be converted was bounded by the process stack rather than by the AIG: a chain overflows an 8MB stack somewhere between 170,000 and 180,000 levels. It is driven from an explicit stack now, in the order the recursion used, so the graph that comes out is unchanged — ids, `pNexts` and `pReprs` alike. STP's 178 tests pass against it, and `dch`, `&choice` and `dc2; dch -f` write byte-identical AIGER on the circuits checked.

This started as a patch applied to the cloned source with a `PATCH_COMMAND`, which is the wrong place for it twice over. `git apply` ran only on the ExternalProject path, so a build configured with `-DABC_DIR` against a clone of the fork — which is how the code guide says to work on ABC — compiled an ABC that differed from the one CI compiled. And it did not apply on Windows at all: actions/checkout takes STP with Git for Windows, whose autocrlf leaves the patch file CRLF, while the MSYS2 git that clones ABC leaves that tree LF, and `git apply` then rejects the hunk. The MSVC leg passed only because both sides are CRLF there.

The comment above the pin and the ABC entry in the code guide both said the pin follows the fork's `stp` branch. It does not, and has not since #892: `stp` sits on a newer upstream, and the pin follows the line carrying the same changes on the upstream revision taken in 2024. Both now say so, since moving the pin to `stp` would bump the upstream base with it.
