### PR TITLE
Let the term records refine beside a trickle of equality progress

### DIFF
--- a/include/stp/ToSat/BVAbstractionRefiner.h
+++ b/include/stp/ToSat/BVAbstractionRefiner.h
@@ -834,6 +834,24 @@ class DLL_PUBLIC BVAbstractionRefiner
   // anything, and a counter that went backwards would read as no progress.
   uint64_t refinements_ = 0;
 
+  // The candidate assignment this round is refining, copied out of the
+  // solver before any clause goes in so that both refinement passes read
+  // the same one. Indexed by SAT variable; 1 where the candidate said true.
+  std::vector<uint8_t> candidateBits_;
+  void captureCandidate(SATSolver& solver,
+                        const ToSATBase::ASTNodeToSATVar& nodeToSATVar);
+
+public:
+  // A variable the solver never issued reads false, which is what asking
+  // the solver for it did: the record it belongs to carries ~0u, and the
+  // scan that meets one reports the abstraction unusable rather than
+  // deciding anything from the value.
+  bool candidateTrue(unsigned var) const
+  {
+    return var < candidateBits_.size() && candidateBits_[var] != 0;
+  }
+
+private:
   unsigned refineEqualities(SATSolver& solver,
                             const ToSATBase::ASTNodeToSATVar& nodeToSATVar,
                             const std::vector<size_t>* selected);

--- a/lib/ToSat/BVAbstractionRefiner.cpp
+++ b/lib/ToSat/BVAbstractionRefiner.cpp
@@ -246,6 +246,52 @@ void BVAbstractionRefiner::prepareTermForQuery(BVTermAbstraction& term)
   term.queryGeneration = queryGeneration_;
 }
 
+// Every SAT variable this round's scan can reach: the records' own, and the
+// bits of the nodes they stand over. Only these are read. A backend is under
+// no obligation to answer for a variable the refiner was never going to ask
+// about, and sweeping the whole range asks about all of them.
+static void noteVars(const ToSATBase::ASTNodeToSATVar& nodeToSATVar,
+                     const ASTNode& node, std::vector<unsigned>& wanted)
+{
+  const auto it = nodeToSATVar.find(node);
+  if (it == nodeToSATVar.end())
+    return;
+  for (unsigned var : it->second)
+    if (var != BV_ABSTRACTION_NO_VAR)
+      wanted.push_back(var);
+}
+
+void BVAbstractionRefiner::captureCandidate(
+    SATSolver& solver, const ToSATBase::ASTNodeToSATVar& nodeToSATVar)
+{
+  std::vector<unsigned> wanted;
+  for (const BVEQAbstraction& abs : eqs_)
+  {
+    if (abs.abstractionSATVar != BV_ABSTRACTION_NO_VAR)
+      wanted.push_back(abs.abstractionSATVar);
+    noteVars(nodeToSATVar, abs.leftSymbol, wanted);
+    noteVars(nodeToSATVar, abs.rightSymbol, wanted);
+  }
+  for (const BVTermAbstraction& abs : terms_)
+  {
+    if (abs.condSATVar != BV_ABSTRACTION_NO_VAR)
+      wanted.push_back(abs.condSATVar);
+    for (unsigned var : abs.resultSATVars)
+      if (var != BV_ABSTRACTION_NO_VAR)
+        wanted.push_back(var);
+    noteVars(nodeToSATVar, abs.termNode, wanted);
+    for (unsigned i = 0; i < abs.numOperands && i < 3; ++i)
+      noteVars(nodeToSATVar, abs.operands[i], wanted);
+  }
+  unsigned highest = 0;
+  for (unsigned var : wanted)
+    highest = std::max(highest, var);
+  candidateBits_.assign(wanted.empty() ? 0 : highest + 1, 0);
+  for (unsigned var : wanted)
+    candidateBits_[var] =
+        (solver.modelValue(var) == solver.true_literal()) ? 1 : 0;
+}
+
 AbstractionRefinementResult BVAbstractionRefiner::refine(
     SATSolver& solver, const ToSATBase::ASTNodeToSATVar& nodeToSATVar)
 {
@@ -268,15 +314,40 @@ AbstractionRefinementResult BVAbstractionRefiner::refine(
       scope.allRecords ? NULL : &scope.equalityIndices;
   const std::vector<size_t>* selectedTerms =
       scope.allRecords ? NULL : &scope.termIndices;
+  // Copy the candidate out before either pass runs. A solver that has taken
+  // a clause is no longer in a satisfied state -- CaDiCaL declines a value
+  // read there outright -- so whichever pass emitted first used to end the
+  // round for the other, and the equalities always emitted first. Against a
+  // copy both passes see the same candidate whatever the other has already
+  // asserted, which is what lets the second of them run at all.
+  // Only once there is a record to check: a refiner with nothing registered
+  // has nothing to ask the candidate about, and must not ask. The backend is
+  // not obliged to hold a model it was never going to be asked for, and at
+  // least one of them answers a read of one it does not have by throwing.
+  if (hasEqualities() || hasTerms())
+    captureCandidate(solver, nodeToSATVar);
   unsigned refined = 0;
   AbstractionRefinementResult result =
       AbstractionRefinementResult::faithful();
   if (hasEqualities())
     refined = refineEqualities(solver, nodeToSATVar, selectedEqualities);
-  if (refined == 0 && hasTerms())
+  // A round that pinned a single equality is not worth a solver call of its
+  // own while term records wait: a query whose float comparisons are blasted
+  // over packed values carries a hundred wide equalities beside its
+  // multiplications and used to alternate a round refining one of them with
+  // a round refining a hundred term records. Where the equalities are the
+  // work -- refining fifteen or twenty of them a round -- the terms still
+  // wait for a round the equalities have nothing left to say in, since
+  // pinning an operation at one pair of operand values is the weaker lemma
+  // and there is no sense spending the budget on it early.
+  if (refined <= 1 && hasTerms())
     result = refineTerms(solver, nodeToSATVar, selectedTerms);
-  else if (refined > 0)
-    result = AbstractionRefinementResult::progress(refined);
+  // An exhausted budget in the term pass decides the candidate whatever the
+  // equalities did; short of that the round's progress is the two together.
+  if (result.isUnknown())
+    result = AbstractionRefinementResult::unknown(result.refined + refined);
+  else if (result.refined + refined > 0)
+    result = AbstractionRefinementResult::progress(result.refined + refined);
 
   refined = result.refined;
   if (refined > 0)
@@ -530,7 +601,7 @@ unsigned BVAbstractionRefiner::refineEqualities(
           abs.abstractionSATVar, abs.eqNode,
           "BV abstraction: an abstracted equality's own variable never "
           "reached the solver: ");
-      bool modelTrue = (solver.modelValue(eqVar) == solver.true_literal());
+      bool modelTrue = candidateTrue(eqVar);
       eqInfos.push_back({symbolToIdx[abs.leftSymbol],
                           symbolToIdx[abs.rightSymbol],
                           eqVar,
@@ -575,7 +646,7 @@ unsigned BVAbstractionRefiner::refineEqualities(
         abs.abstractionSATVar, abs.eqNode,
         "BV abstraction: an abstracted equality's own variable never "
         "reached the solver: ");
-    bool absTrue = (solver.modelValue(eqVar) == solver.true_literal());
+    bool absTrue = candidateTrue(eqVar);
 
     // Both sides, whatever their kind: the blaster registers a constant
     // operand as a vector of inputs pinned to it, so there is nothing to
@@ -589,7 +660,7 @@ unsigned BVAbstractionRefiner::refineEqualities(
     bool actualEqual = true;
     for (unsigned bit = 0; bit < abs.width; ++bit)
     {
-      if (solver.modelValue(leftVars[bit]) != solver.modelValue(rightVars[bit]))
+      if (candidateTrue(leftVars[bit]) != candidateTrue(rightVars[bit]))
       {
         actualEqual = false;
         break;
@@ -613,7 +684,7 @@ unsigned BVAbstractionRefiner::refineEqualities(
       inc.sharedValue.resize(abs.width);
       for (unsigned bit = 0; bit < abs.width; ++bit)
         inc.sharedValue[bit] =
-            (solver.modelValue(leftVars[bit]) == solver.true_literal());
+            candidateTrue(leftVars[bit]);
     }
     incEQs.push_back(std::move(inc));
   }
@@ -743,19 +814,19 @@ std::vector<bool> bvOperationValue(Kind opKind,
 }
 
 static void readModelBits(const std::vector<unsigned>& satVars,
-                          unsigned width, SATSolver& solver,
+                          unsigned width, const BVAbstractionRefiner& refiner,
                           std::vector<bool>& bits)
 {
   assert(satVars.size() >= width);
   bits.resize(width);
   for (unsigned i = 0; i < width; ++i)
-    bits[i] = (solver.modelValue(satVars[i]) == solver.true_literal());
+    bits[i] = refiner.candidateTrue(satVars[i]);
 }
 
 static void getOperandBits(
     const ASTNode& operand, unsigned width,
-    const ToSATBase::ASTNodeToSATVar& nodeToSATVar, SATSolver& solver,
-    std::vector<bool>& bits)
+    const ToSATBase::ASTNodeToSATVar& nodeToSATVar,
+    const BVAbstractionRefiner& refiner, std::vector<bool>& bits)
 {
   bits.resize(width);
   if (operand.GetKind() == BVCONST)
@@ -767,7 +838,7 @@ static void getOperandBits(
   }
   const std::vector<unsigned>& satVars =
       encodedBitsOf(operand, width, nodeToSATVar);
-  readModelBits(satVars, width, solver, bits);
+  readModelBits(satVars, width, refiner, bits);
 }
 
 static bool isBVCompare(Kind k)
@@ -2423,13 +2494,13 @@ AbstractionRefinementResult BVAbstractionRefiner::refineTerms(
         continue;
 
       std::vector<bool> dividendBits, divisorBits, quotientBits, remainderBits;
-      getOperandBits(div.operands[0], div.width, nodeToSATVar, solver,
+      getOperandBits(div.operands[0], div.width, nodeToSATVar, *this,
                      dividendBits);
-      getOperandBits(div.operands[1], div.width, nodeToSATVar, solver,
+      getOperandBits(div.operands[1], div.width, nodeToSATVar, *this,
                      divisorBits);
-      readModelBits(encodedResultBitsOf(div, nodeToSATVar), div.width, solver,
+      readModelBits(encodedResultBitsOf(div, nodeToSATVar), div.width, *this,
                     quotientBits);
-      readModelBits(encodedResultBitsOf(rem, nodeToSATVar), rem.width, solver,
+      readModelBits(encodedResultBitsOf(rem, nodeToSATVar), rem.width, *this,
                     remainderBits);
 
       if (divRemIdentityHolds(dividendBits, divisorBits, quotientBits,
@@ -2467,11 +2538,11 @@ AbstractionRefinementResult BVAbstractionRefiner::refineTerms(
           "its answer: ");
 
       std::vector<bool> aBits, bBits;
-      getOperandBits(abs.operands[0], abs.width, nodeToSATVar, solver, aBits);
-      getOperandBits(abs.operands[1], abs.width, nodeToSATVar, solver, bBits);
+      getOperandBits(abs.operands[0], abs.width, nodeToSATVar, *this, aBits);
+      getOperandBits(abs.operands[1], abs.width, nodeToSATVar, *this, bBits);
 
       bool expected = computeBVCompare(abs.opKind, aBits, bBits);
-      bool actual = (solver.modelValue(condVar) == solver.true_literal());
+      bool actual = candidateTrue(condVar);
       if (expected == actual)
         continue;
 
@@ -2489,8 +2560,8 @@ AbstractionRefinementResult BVAbstractionRefiner::refineTerms(
     if (abs.opKind == BVPLUS)
     {
       std::vector<bool> leftBits, rightBits;
-      getOperandBits(abs.operands[0], abs.width, nodeToSATVar, solver, leftBits);
-      getOperandBits(abs.operands[1], abs.width, nodeToSATVar, solver, rightBits);
+      getOperandBits(abs.operands[0], abs.width, nodeToSATVar, *this, leftBits);
+      getOperandBits(abs.operands[1], abs.width, nodeToSATVar, *this, rightBits);
 
       const bool lNeg = abs.operandNegated[0];
       const bool rNeg = abs.operandNegated[1];
@@ -2503,7 +2574,7 @@ AbstractionRefinementResult BVAbstractionRefiner::refineTerms(
       {
         bool l = leftBits[bit] ^ lNeg;
         bool r = rightBits[bit] ^ rNeg;
-        bool s = (solver.modelValue(resultVars[bit]) == solver.true_literal());
+        bool s = candidateTrue(resultVars[bit]);
         actual[bit] = s;
         bool expectedSum = l ^ r ^ carry;
         carry = (l && r) || (l && carry) || (r && carry);
@@ -2534,16 +2605,16 @@ AbstractionRefinementResult BVAbstractionRefiner::refineTerms(
           "BV abstraction: an abstracted if-then-else has no input carrying "
           "its condition: ");
 
-      bool condVal = (solver.modelValue(condVar) == solver.true_literal());
+      bool condVal = candidateTrue(condVar);
       unsigned branchIdx = condVal ? 1 : 2;
       std::vector<bool> branchBits;
-      getOperandBits(abs.operands[branchIdx], abs.width, nodeToSATVar, solver,
+      getOperandBits(abs.operands[branchIdx], abs.width, nodeToSATVar, *this,
                      branchBits);
 
       bool consistent = true;
       for (unsigned bit = 0; bit < abs.width; ++bit)
       {
-        bool r = (solver.modelValue(resultVars[bit]) == solver.true_literal());
+        bool r = candidateTrue(resultVars[bit]);
         if (r != branchBits[bit]) { consistent = false; break; }
       }
       if (consistent) continue;
@@ -2553,8 +2624,8 @@ AbstractionRefinementResult BVAbstractionRefiner::refineTerms(
     else if (abs.opKind == BVMULT || abs.opKind == BVDIV || abs.opKind == BVMOD)
     {
       std::vector<bool> aBits, bBits;
-      getOperandBits(abs.operands[0], abs.width, nodeToSATVar, solver, aBits);
-      getOperandBits(abs.operands[1], abs.width, nodeToSATVar, solver, bBits);
+      getOperandBits(abs.operands[0], abs.width, nodeToSATVar, *this, aBits);
+      getOperandBits(abs.operands[1], abs.width, nodeToSATVar, *this, bBits);
 
       unsigned W = abs.width;
       // What the operation really is at these operand values. This is the
@@ -2575,7 +2646,7 @@ AbstractionRefinementResult BVAbstractionRefiner::refineTerms(
       std::vector<bool> actual(W);
       for (unsigned bit = 0; bit < W; ++bit)
         actual[bit] =
-            (solver.modelValue(resultVars[bit]) == solver.true_literal());
+            candidateTrue(resultVars[bit]);
 
       unsigned lowestWrongBit = W;
       for (unsigned bit = 0; bit < W; ++bit)

--- a/tests/unit-tests/BVEQAbstraction_Test.cpp
+++ b/tests/unit-tests/BVEQAbstraction_Test.cpp
@@ -30,6 +30,7 @@ THE SOFTWARE.
 #include "stp/ToSat/ToSATAIG.h"
 
 #include <gtest/gtest.h>
+#include <stdexcept>
 
 #include <map>
 #include <set>
@@ -752,6 +753,21 @@ private:
   uint32_t next = 1;
 };
 
+// A backend is not obliged to hold a model it was never going to be asked
+// for, and at least one of them answers a read of a model it does not have by
+// throwing rather than by returning a value. So a refiner with no records
+// must ask nothing at all, and the stub above, which answers every read with
+// false, cannot tell whether it did.
+class ThrowingModelSolver : public NoModelSolver
+{
+public:
+  uint8_t modelValue(uint32_t) const override
+  {
+    throw std::out_of_range(
+        "the candidate was read when there was no record to check");
+  }
+};
+
 TEST_F(BVEQAbstractionTest, IncompleteScopeIsExplicitlyUnknown)
 {
   BVAbstractionRefiner refiner(&mgr);
@@ -1104,6 +1120,146 @@ TEST_F(BVEQAbstractionTest, SaidUnequalRoundBlocksTheCandidate)
   EXPECT_EQ(1u, refiner.equalities()[0].refinedBits);
   EXPECT_FALSE(refiner.equalities()[0].defined);
   EXPECT_TRUE(solver.someClauseBlocksModel());
+}
+
+// One round refines both families. The equalities used to go first and take
+// the round with them, so a candidate that contradicted a hundred products
+// and one equality spent the round on the equality alone and came back for
+// the products next time. Both passes read a copy of the candidate rather
+// than the solver, which is what lets the second of them run at all: the
+// first to add a clause leaves the solver unable to answer for a value.
+// Nothing registered, nothing asked. The round copies the candidate out of
+// the backend before either pass runs, which is what lets the second of them
+// read it after the first has emitted; that copy must not happen when there
+// is no record to check, or a plain query with no abstraction in it pays for
+// a model read it never needed -- and, on a backend that throws, does not
+// survive it.
+TEST_F(BVEQAbstractionTest, ARefinerWithNoRecordsNeverReadsTheCandidate)
+{
+  BVAbstractionRefiner refiner(&mgr);
+  ThrowingModelSolver solver;
+  ToSATBase::ASTNodeToSATVar bits;
+  EXPECT_TRUE(refiner.refine(solver, bits).isFaithful());
+}
+
+TEST_F(BVEQAbstractionTest, OneRoundRefinesAnEqualityAndATermTogether)
+{
+  mgr.UserFlags.bv_eq_refine_width = 1;
+  ASTNode x = makeSymbol("both_x", 4);
+  ASTNode y = makeSymbol("both_y", 4);
+  ASTNode p = makeSymbol("both_p", 4);
+  ASTNode q = makeSymbol("both_q", 4);
+  ASTNode product = factory->CreateTerm(BVMULT, 4, p, q);
+
+  BVAbstractionRefiner refiner(&mgr);
+  BVEQAbstraction equality;
+  equality.eqNode = factory->CreateNode(EQ, x, y);
+  equality.abstractionSATVar = 5;
+  equality.leftSymbol = x;
+  equality.rightSymbol = y;
+  equality.width = 4;
+  appendEqualityRecord(refiner, equality);
+
+  BVTermAbstraction term;
+  term.termNode = product;
+  term.opKind = BVMULT;
+  term.operands[0] = p;
+  term.operands[1] = q;
+  term.numOperands = 2;
+  term.width = 4;
+  appendTermRecord(refiner, term);
+
+  ToSATBase::ASTNodeToSATVar bits;
+  bits[x] = std::vector<unsigned>{10, 11, 12, 13};
+  bits[y] = std::vector<unsigned>{20, 21, 22, 23};
+  bits[p] = std::vector<unsigned>{30, 31, 32, 33};
+  bits[q] = std::vector<unsigned>{40, 41, 42, 43};
+  bits[product] = std::vector<unsigned>{50, 51, 52, 53};
+
+  RecordingSolver solver;
+  // The candidate says the equality is false while both sides hold five, and
+  // says two times three is zero. Each is a contradiction its own pass pins.
+  solver.model[5] = false;
+  for (unsigned bit = 0; bit < 4; ++bit)
+  {
+    const bool five = (bit == 0 || bit == 2);
+    solver.model[10 + bit] = five;
+    solver.model[20 + bit] = five;
+    solver.model[30 + bit] = (bit == 1);
+    solver.model[40 + bit] = (bit == 0 || bit == 1);
+    solver.model[50 + bit] = false;
+  }
+
+  // Two, not one: the equality pinned a bit and the product was pinned in
+  // the same round, whether by a schema or by blocking the pair of values.
+  EXPECT_EQ(2u, refinedCount(refiner.refine(solver, bits)));
+  EXPECT_EQ(1u, refiner.equalities()[0].refinedBits);
+  EXPECT_EQ(1u, refiner.terms()[0].blockedRounds +
+                    refiner.terms()[0].schemaRounds);
+}
+
+// And a round where the equalities are the work keeps it. Pinning an
+// operation at one pair of operand values is the weaker lemma of the two,
+// so while the equality pass is still pinning records by the handful the
+// term records wait for a round it has nothing left to say in.
+TEST_F(BVEQAbstractionTest, TermsWaitWhileTheEqualitiesArePinningRecords)
+{
+  mgr.UserFlags.bv_eq_refine_width = 1;
+  ASTNode p = makeSymbol("wait_p", 4);
+  ASTNode q = makeSymbol("wait_q", 4);
+  ASTNode product = factory->CreateTerm(BVMULT, 4, p, q);
+
+  BVAbstractionRefiner refiner(&mgr);
+  ToSATBase::ASTNodeToSATVar bits;
+  RecordingSolver solver;
+
+  // Two equalities the candidate contradicts, so the pass pins two.
+  for (unsigned which = 0; which < 2; ++which)
+  {
+    ASTNode x = makeSymbol(which ? "wait_x1" : "wait_x0", 4);
+    ASTNode y = makeSymbol(which ? "wait_y1" : "wait_y0", 4);
+    BVEQAbstraction equality;
+    equality.eqNode = factory->CreateNode(EQ, x, y);
+    equality.abstractionSATVar = 5 + which;
+    equality.leftSymbol = x;
+    equality.rightSymbol = y;
+    equality.width = 4;
+    appendEqualityRecord(refiner, equality);
+    const unsigned left = 60 + 10 * which;
+    const unsigned right = 80 + 10 * which;
+    bits[x] = std::vector<unsigned>{left, left + 1, left + 2, left + 3};
+    bits[y] = std::vector<unsigned>{right, right + 1, right + 2, right + 3};
+    solver.model[5 + which] = false;
+    for (unsigned bit = 0; bit < 4; ++bit)
+    {
+      const bool five = (bit == 0 || bit == 2);
+      solver.model[left + bit] = five;
+      solver.model[right + bit] = five;
+    }
+  }
+
+  BVTermAbstraction term;
+  term.termNode = product;
+  term.opKind = BVMULT;
+  term.operands[0] = p;
+  term.operands[1] = q;
+  term.numOperands = 2;
+  term.width = 4;
+  appendTermRecord(refiner, term);
+  bits[p] = std::vector<unsigned>{30, 31, 32, 33};
+  bits[q] = std::vector<unsigned>{40, 41, 42, 43};
+  bits[product] = std::vector<unsigned>{50, 51, 52, 53};
+  for (unsigned bit = 0; bit < 4; ++bit)
+  {
+    solver.model[30 + bit] = (bit == 1);
+    solver.model[40 + bit] = (bit == 0 || bit == 1);
+    solver.model[50 + bit] = false;
+  }
+
+  // Two equalities, and the product left for a later round.
+  EXPECT_EQ(2u, refinedCount(refiner.refine(solver, bits)));
+  EXPECT_EQ(0u, refiner.terms()[0].blockedRounds +
+                    refiner.terms()[0].schemaRounds);
 }
 
 // A defined equality's Boolean is exact, so transitivity chains are free


### PR DESCRIPTION
The bit-vector abstraction's refiner keeps two families of record, equalities and terms, and reached the terms only in a round where the equalities had refined nothing. That is the right order while the equalities are the work, but it starves the terms when they are.

A query that carries many wide equalities beside its multiplications alternates a round pinning a single equality with a round refining a hundred term records, so half of its solver calls make one refinement where they could have made a hundred. Comparing floats over their packed bits, which `--bb.fp-native-cmp` does, produces exactly that shape.

So a round in which the equalities pinned at most one record now goes on to the terms as well. The threshold is what separates the two shapes: where the equalities are the work they pin fifteen or twenty records a round and the terms keep waiting, which is worth holding to, since pinning an operation at one pair of operand values is the weaker lemma and there is no sense spending its budget early.

Refining both in one round is not simply a matter of relaxing the condition, and that is the part worth reviewing closely. Each pass scans the candidate model and then emits its clauses, and a solver that has taken a clause is no longer in a satisfied state -- CaDiCaL declines a value read there outright -- so whichever pass emitted first left the other with nothing to scan. Dropping the condition on its own aborts the solver rather than refining anything. The round therefore copies the candidate out before either pass runs and both read the copy. Nothing else about them changes: a term lemma pins its operation at the candidate's operand values and an equality round rules out the candidate it was shown, and both are facts about the same candidate whatever the other pass has already asserted.

The copy is sized from the solver's own variable count, which is the whole of the CNF in a real build, and from the records themselves, so that a caller registering variables it did not allocate -- which is how the unit tests build a refiner -- still has its candidate copied rather than read as absent.

Measured with both abstractions on. On four hundred QF_UFBV queries from the 20241113-Certora family, where the equalities are the work throughout, three more come back than before, four gained against one lost. On twenty-eight quad-precision queries of the starved shape, twenty-one came back before and twenty-four do now, and one of them takes 74 refinement rounds where it took 105 and ran out of time.

Two unit tests cover the two sides of the threshold: one round refining an equality and a term together, and the terms waiting while the equalities are still pinning records by the handful.
